### PR TITLE
perf(dwarf): share one DWARFInfo across metadata + snapshot passes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+### Performance
+
+- **DWARF-only dumps reuse one open `DWARFInfo` across all extraction passes.**
+  The basic-metadata, advanced-metadata, and snapshot-builder passes previously
+  opened the ELF and built a `DWARFInfo` independently, so a large C++ library's
+  DIEs were parsed multiple times from cold caches (the F5b finding from the pvxs
+  validation). A shared `DwarfSession` now threads one open handle through all
+  three passes; the snapshot walk hits the DIE cache the metadata passes warmed
+  instead of re-parsing. Output is byte-for-byte identical (validated A/B on real
+  compiled binaries); the redundant snapshot DIE walk drops from a full cold
+  parse to near-free on the measured fixtures. Internal only — no CLI or API
+  surface change.
+
 ### Added
 
 - **`compare --profile` run profiles (ADR-040 Lever 3).** A single `--profile`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   instead of re-parsing. Output is byte-for-byte identical (validated A/B on real
   compiled binaries); the redundant snapshot DIE walk drops from a full cold
   parse to near-free on the measured fixtures. Internal only — no CLI or API
-  surface change.
+  surface change. `tests/test_perf_dwarf_session_scaling.py` (new,
+  `integration`) guards the win going forward: a same-binary A/B timing
+  comparison (session reuse must stay reliably faster than independent opens)
+  and a CU-count scaling exponent gate on the production `dwarf_only` dump
+  path, compiling multi-CU C++ binaries that reproduce the pvxs
+  repeated-type-across-CUs pattern.
 
 ### Added
 

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1599,30 +1599,32 @@ def _dump_elf(
         _elf_classify_symbols(elf_meta, exported_dynamic, library_name=so_path.name)
     )
     # A DWARF metadata parse that finds real debug info leaves its open
-    # DwarfSession here so the snapshot build below can reuse the same
-    # DWARFInfo (and its warm DIE cache) rather than re-parsing every DIE
-    # from a second open (F5b). The session is closed in the finally below on
-    # every exit path; the built snapshot holds extracted model objects, not
-    # live DIE references, so closing after it is returned is safe.
+    # DwarfSession in ``_dwarf_session_out`` so the snapshot build below can
+    # reuse the same DWARFInfo (and its warm DIE cache) rather than re-parsing
+    # every DIE from a second open (F5b). Metadata resolution and the snapshot
+    # attempt run inside the try; the finally closes any opened session on every
+    # exit path (including an exception during resolution), so no descriptor
+    # leaks. The built snapshot holds extracted model objects, not live DIE
+    # references, so closing after it is returned is safe.
     _dwarf_session_out: list[DwarfSession] = []
-    if symbols_only or debug_presence_only:
-        from .dwarf_presence import cheap_debug_presence_metadata
-        dwarf_meta, dwarf_adv = cheap_debug_presence_metadata(
-            so_path,
-            debug_format=debug_format,
-        )
-    else:
-        dwarf_meta, dwarf_adv = _resolve_debug_metadata(
-            so_path, debug_format, _session_out=_dwarf_session_out,
-        )
-    dwarf_session = _dwarf_session_out[0] if _dwarf_session_out else None
-    profile_hint = _lang_to_profile(lang)
-    # ADR-003: Updated fallback chain
-    # --dwarf-only → force DWARF mode regardless of headers
-    # no headers + DWARF available -> DWARF-only mode with type-aware checks
-    # no headers + no DWARF -> symbols-only mode
     dwarf_only_types: list[RecordType] = []
     try:
+        if symbols_only or debug_presence_only:
+            from .dwarf_presence import cheap_debug_presence_metadata
+            dwarf_meta, dwarf_adv = cheap_debug_presence_metadata(
+                so_path,
+                debug_format=debug_format,
+            )
+        else:
+            dwarf_meta, dwarf_adv = _resolve_debug_metadata(
+                so_path, debug_format, _session_out=_dwarf_session_out,
+            )
+        dwarf_session = _dwarf_session_out[0] if _dwarf_session_out else None
+        profile_hint = _lang_to_profile(lang)
+        # ADR-003: Updated fallback chain
+        # --dwarf-only → force DWARF mode regardless of headers
+        # no headers + DWARF available -> DWARF-only mode with type-aware checks
+        # no headers + no DWARF -> symbols-only mode
         if not (symbols_only or debug_presence_only) and (
             dwarf_only or (not headers and dwarf_meta.has_dwarf)
         ):
@@ -1640,8 +1642,8 @@ def _dump_elf(
                 dwarf_only_types, profile_hint,
             )
     finally:
-        if dwarf_session is not None:
-            dwarf_session.close()
+        for _sess in _dwarf_session_out:
+            _sess.close()
 
     parser = _header_ast_parser(
         headers, extra_includes, backend=header_backend, compiler=compiler,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -49,6 +49,7 @@ from xml.etree.ElementTree import (
 if TYPE_CHECKING:
     from .dwarf_advanced import AdvancedDwarfMetadata
     from .dwarf_metadata import DwarfMetadata
+    from .dwarf_unified import DwarfSession
     from .elf_metadata import ElfMetadata
 
 from defusedxml import ElementTree as DefusedET
@@ -66,6 +67,14 @@ from .dumper_clang_errors import (
     _parse_clang_ast_result,
     diagnose_header_compile_failure,
     retry_excluding_error_headers,
+)
+from .dumper_debug import (
+    # DWARF/BTF/CTF format resolution + the kernel-binary heuristic live in the
+    # sibling module (dumper.py is at the file-size cap); re-exported here so
+    # ``dumper._is_kernel_binary`` / ``dumper._resolve_debug_metadata`` remain
+    # valid bare-name calls in ``_dump_elf`` and test patch targets.
+    _is_kernel_binary as _is_kernel_binary,
+    _resolve_debug_metadata as _resolve_debug_metadata,
 )
 from .dumper_sysinc import (
     _auto_system_includes_enabled as _auto_system_includes_enabled,
@@ -1323,97 +1332,6 @@ def dump(
     return apply_provenance(snapshot, public_headers, public_header_dirs)
 
 
-def _is_kernel_binary(path: Path) -> bool:
-    """Heuristic: is this a kernel binary (vmlinux, *.ko, *.ko.xz, *.ko.zst)?"""
-    name = path.name
-    if name == "vmlinux":
-        return True
-    suffixes = path.suffixes  # e.g. ['.ko', '.xz']
-    suffix_str = "".join(suffixes)
-    if suffix_str in (".ko", ".ko.xz", ".ko.zst", ".ko.gz"):
-        return True
-    # Check for .modinfo section (kernel module indicator)
-    try:
-        from elftools.elf.elffile import ELFFile
-        with open(path, "rb") as f:
-            elf = ELFFile(f)  # type: ignore[no-untyped-call]
-            return elf.get_section_by_name(".modinfo") is not None  # type: ignore[no-untyped-call]
-    except Exception:  # noqa: BLE001
-        return False
-
-
-def _resolve_debug_metadata(
-    so_path: Path,
-    debug_format: str | None,
-) -> tuple[DwarfMetadata, AdvancedDwarfMetadata]:
-    """Resolve debug metadata using the specified or auto-detected format.
-
-    Returns (dwarf_meta, dwarf_adv) — the same types as parse_dwarf().
-    BTF/CTF data is converted to DwarfMetadata for checker compatibility.
-    """
-    from .dwarf_advanced import AdvancedDwarfMetadata
-
-    if debug_format == "btf":
-        from .btf_metadata import parse_btf_metadata
-        btf = parse_btf_metadata(so_path)
-        if not btf.has_btf:
-            log.warning("BTF requested but no .BTF section in %s", so_path)
-        return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
-
-    if debug_format == "ctf":
-        from .ctf_metadata import parse_ctf_metadata
-        ctf = parse_ctf_metadata(so_path)
-        if not ctf.has_ctf:
-            log.warning("CTF requested but no .ctf section in %s", so_path)
-        return ctf.to_dwarf_metadata(), AdvancedDwarfMetadata()
-
-    if debug_format == "dwarf":
-        from .dwarf_unified import parse_dwarf
-        return parse_dwarf(so_path)
-
-    if debug_format is not None:
-        raise ValueError(
-            f"Invalid debug_format {debug_format!r}; expected 'dwarf', 'btf', or 'ctf'."
-        )
-
-    # Auto-detect: kernel binaries prefer BTF, userspace prefers DWARF
-    from .btf_metadata import has_btf_section, parse_btf_metadata
-    from .ctf_metadata import has_ctf_section, parse_ctf_metadata
-    from .dwarf_unified import parse_dwarf
-
-    is_kernel = _is_kernel_binary(so_path)
-
-    if is_kernel:
-        # BTF > DWARF > CTF for kernel binaries
-        if has_btf_section(so_path):
-            btf = parse_btf_metadata(so_path)
-            if btf.has_btf:
-                log.info("Using BTF debug info from %s (kernel binary)", so_path)
-                return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
-
-    # DWARF > BTF > CTF for userspace (or kernel fallback)
-    dwarf_meta, dwarf_adv = parse_dwarf(so_path)
-    if dwarf_meta.has_dwarf:
-        return dwarf_meta, dwarf_adv
-
-    # Fallback to BTF if DWARF not available
-    if has_btf_section(so_path):
-        btf = parse_btf_metadata(so_path)
-        if btf.has_btf:
-            log.info("No DWARF, falling back to BTF in %s", so_path)
-            return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
-
-    # Fallback to CTF
-    if has_ctf_section(so_path):
-        ctf = parse_ctf_metadata(so_path)
-        if ctf.has_ctf:
-            log.info("No DWARF/BTF, falling back to CTF in %s", so_path)
-            return ctf.to_dwarf_metadata(), AdvancedDwarfMetadata()
-
-    # No debug info at all — return empty DWARF metadata
-    return dwarf_meta, dwarf_adv
-
-
 _ELF_VIS_MAP: dict[str, ElfVisibility] = {
     "default": ElfVisibility.DEFAULT,
     "protected": ElfVisibility.PROTECTED,
@@ -1516,6 +1434,7 @@ def _try_dwarf_snapshot(
     profile_hint: str | None,
     headers: list[Path],
     dwarf_only: bool,
+    session: DwarfSession | None = None,
 ) -> tuple[AbiSnapshot | None, list[RecordType]]:
     """Attempt to build a snapshot from DWARF debug info.
 
@@ -1523,6 +1442,10 @@ def _try_dwarf_snapshot(
     used directly, *snapshot* is non-None.  When DWARF produced no symbols
     (and *dwarf_only* is False), *snapshot* is None and *dwarf_only_types*
     carries the partial type list for the symbol-only fallback path.
+
+    *session*, when provided, is the open :class:`DwarfSession` from the
+    metadata parse; the snapshot DIE walk reuses it instead of re-opening
+    ``so_path`` (F5b). The caller retains ownership and closes it.
     """
     from .dwarf_snapshot import build_snapshot_from_dwarf
 
@@ -1540,6 +1463,7 @@ def _try_dwarf_snapshot(
         dwarf_adv,
         version=version,
         language_profile=profile_hint,
+        session=session,
     )
     # If DWARF produced functions (or was explicitly forced), use it.
     if snap.functions or snap.variables or dwarf_only:
@@ -1674,6 +1598,13 @@ def _dump_elf(
     exported_dynamic, exported_dynamic_funcs, exported_dynamic_objects, exported_dynamic_tls = (
         _elf_classify_symbols(elf_meta, exported_dynamic, library_name=so_path.name)
     )
+    # A DWARF metadata parse that finds real debug info leaves its open
+    # DwarfSession here so the snapshot build below can reuse the same
+    # DWARFInfo (and its warm DIE cache) rather than re-parsing every DIE
+    # from a second open (F5b). The session is closed in the finally below on
+    # every exit path; the built snapshot holds extracted model objects, not
+    # live DIE references, so closing after it is returned is safe.
+    _dwarf_session_out: list[DwarfSession] = []
     if symbols_only or debug_presence_only:
         from .dwarf_presence import cheap_debug_presence_metadata
         dwarf_meta, dwarf_adv = cheap_debug_presence_metadata(
@@ -1681,28 +1612,36 @@ def _dump_elf(
             debug_format=debug_format,
         )
     else:
-        dwarf_meta, dwarf_adv = _resolve_debug_metadata(so_path, debug_format)
+        dwarf_meta, dwarf_adv = _resolve_debug_metadata(
+            so_path, debug_format, _session_out=_dwarf_session_out,
+        )
+    dwarf_session = _dwarf_session_out[0] if _dwarf_session_out else None
     profile_hint = _lang_to_profile(lang)
     # ADR-003: Updated fallback chain
     # --dwarf-only → force DWARF mode regardless of headers
     # no headers + DWARF available -> DWARF-only mode with type-aware checks
     # no headers + no DWARF -> symbols-only mode
     dwarf_only_types: list[RecordType] = []
-    if not (symbols_only or debug_presence_only) and (
-        dwarf_only or (not headers and dwarf_meta.has_dwarf)
-    ):
-        snap, dwarf_only_types = _try_dwarf_snapshot(
-            so_path, elf_meta, dwarf_meta, dwarf_adv,
-            version, profile_hint, headers, dwarf_only,
-        )
-        if snap is not None:
-            return snap
-    if symbols_only or not headers:
-        return _build_symbol_only_snapshot(
-            so_path, version, elf_meta, dwarf_meta, dwarf_adv,
-            exported_dynamic_funcs, exported_dynamic_objects, exported_dynamic_tls,
-            dwarf_only_types, profile_hint,
-        )
+    try:
+        if not (symbols_only or debug_presence_only) and (
+            dwarf_only or (not headers and dwarf_meta.has_dwarf)
+        ):
+            snap, dwarf_only_types = _try_dwarf_snapshot(
+                so_path, elf_meta, dwarf_meta, dwarf_adv,
+                version, profile_hint, headers, dwarf_only,
+                session=dwarf_session,
+            )
+            if snap is not None:
+                return snap
+        if symbols_only or not headers:
+            return _build_symbol_only_snapshot(
+                so_path, version, elf_meta, dwarf_meta, dwarf_adv,
+                exported_dynamic_funcs, exported_dynamic_objects, exported_dynamic_tls,
+                dwarf_only_types, profile_hint,
+            )
+    finally:
+        if dwarf_session is not None:
+            dwarf_session.close()
 
     parser = _header_ast_parser(
         headers, extra_includes, backend=header_backend, compiler=compiler,

--- a/abicheck/dumper_debug.py
+++ b/abicheck/dumper_debug.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Debug-format resolution for the ELF dump path.
+
+Split out of ``dumper.py`` (which sits at the file-size cap) to keep the
+kernel-binary heuristic and the DWARF/BTF/CTF selection logic in one coherent
+place. ``dumper`` re-imports both names, so ``abicheck.dumper._is_kernel_binary``
+and ``abicheck.dumper._resolve_debug_metadata`` remain valid patch targets.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .dwarf_advanced import AdvancedDwarfMetadata
+    from .dwarf_metadata import DwarfMetadata
+    from .dwarf_unified import DwarfSession
+
+log = logging.getLogger(__name__)
+
+
+def _is_kernel_binary(path: Path) -> bool:
+    """Heuristic: is this a kernel binary (vmlinux, *.ko, *.ko.xz, *.ko.zst)?"""
+    name = path.name
+    if name == "vmlinux":
+        return True
+    suffixes = path.suffixes  # e.g. ['.ko', '.xz']
+    suffix_str = "".join(suffixes)
+    if suffix_str in (".ko", ".ko.xz", ".ko.zst", ".ko.gz"):
+        return True
+    # Check for .modinfo section (kernel module indicator)
+    try:
+        from elftools.elf.elffile import ELFFile
+        with open(path, "rb") as f:
+            elf = ELFFile(f)  # type: ignore[no-untyped-call]
+            return elf.get_section_by_name(".modinfo") is not None  # type: ignore[no-untyped-call]
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _resolve_debug_metadata(
+    so_path: Path,
+    debug_format: str | None,
+    *,
+    _session_out: list[DwarfSession] | None = None,
+) -> tuple[DwarfMetadata, AdvancedDwarfMetadata]:
+    """Resolve debug metadata using the specified or auto-detected format.
+
+    Returns (dwarf_meta, dwarf_adv) — the same types as parse_dwarf().
+    BTF/CTF data is converted to DwarfMetadata for checker compatibility.
+
+    ``_session_out`` (internal): when a list is supplied and the resolved
+    format is real DWARF, the still-open :class:`DwarfSession` is appended to
+    it so a subsequent snapshot build can reuse the same open ``DWARFInfo``
+    (F5b: avoid re-parsing every DIE). The caller must close it. BTF/CTF and
+    no-debug paths leave the list untouched (session stays ``None``).
+    """
+    from .dwarf_advanced import AdvancedDwarfMetadata
+
+    if debug_format == "btf":
+        from .btf_metadata import parse_btf_metadata
+        btf = parse_btf_metadata(so_path)
+        if not btf.has_btf:
+            log.warning("BTF requested but no .BTF section in %s", so_path)
+        return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
+
+    if debug_format == "ctf":
+        from .ctf_metadata import parse_ctf_metadata
+        ctf = parse_ctf_metadata(so_path)
+        if not ctf.has_ctf:
+            log.warning("CTF requested but no .ctf section in %s", so_path)
+        return ctf.to_dwarf_metadata(), AdvancedDwarfMetadata()
+
+    if debug_format == "dwarf":
+        from .dwarf_unified import parse_dwarf
+        return parse_dwarf(so_path, _session_out=_session_out)
+
+    if debug_format is not None:
+        raise ValueError(
+            f"Invalid debug_format {debug_format!r}; expected 'dwarf', 'btf', or 'ctf'."
+        )
+
+    # Auto-detect: kernel binaries prefer BTF, userspace prefers DWARF
+    from .btf_metadata import has_btf_section, parse_btf_metadata
+    from .ctf_metadata import has_ctf_section, parse_ctf_metadata
+    from .dwarf_unified import parse_dwarf
+
+    is_kernel = _is_kernel_binary(so_path)
+
+    if is_kernel:
+        # BTF > DWARF > CTF for kernel binaries
+        if has_btf_section(so_path):
+            btf = parse_btf_metadata(so_path)
+            if btf.has_btf:
+                log.info("Using BTF debug info from %s (kernel binary)", so_path)
+                return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
+
+    # DWARF > BTF > CTF for userspace (or kernel fallback)
+    dwarf_meta, dwarf_adv = parse_dwarf(so_path, _session_out=_session_out)
+    if dwarf_meta.has_dwarf:
+        return dwarf_meta, dwarf_adv
+
+    # Fallback to BTF if DWARF not available
+    if has_btf_section(so_path):
+        btf = parse_btf_metadata(so_path)
+        if btf.has_btf:
+            log.info("No DWARF, falling back to BTF in %s", so_path)
+            return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
+
+    # Fallback to CTF
+    if has_ctf_section(so_path):
+        ctf = parse_ctf_metadata(so_path)
+        if ctf.has_ctf:
+            log.info("No DWARF/BTF, falling back to CTF in %s", so_path)
+            return ctf.to_dwarf_metadata(), AdvancedDwarfMetadata()
+
+    # No debug info at all — return empty DWARF metadata
+    return dwarf_meta, dwarf_adv

--- a/abicheck/dwarf_snapshot.py
+++ b/abicheck/dwarf_snapshot.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     from .buildsource.pack import BuildSourcePack
     from .dwarf_advanced import AdvancedDwarfMetadata
     from .dwarf_metadata import DwarfMetadata
+    from .dwarf_unified import DwarfSession
     from .elf_metadata import ElfMetadata
 
 log = logging.getLogger(__name__)
@@ -84,6 +85,7 @@ def build_snapshot_from_dwarf(
     *,
     version: str = "unknown",
     language_profile: str | None = None,
+    session: DwarfSession | None = None,
 ) -> AbiSnapshot:
     """Build a complete AbiSnapshot from DWARF, no headers required.
 
@@ -94,13 +96,19 @@ def build_snapshot_from_dwarf(
         dwarf_adv: Pre-parsed DWARF advanced metadata.
         version: Version label for the snapshot.
         language_profile: "c" | "cpp" | None.
+        session: Optional pre-opened :class:`~abicheck.dwarf_unified.DwarfSession`
+            (as produced while parsing ``dwarf_meta``/``dwarf_adv``). When given,
+            the DIE walk reuses that open ``DWARFInfo`` — hitting the cache the
+            metadata passes warmed — instead of opening ``elf_path`` a second
+            time. Output is byte-for-byte identical either way; the caller owns
+            the session's lifetime.
 
     Returns:
         AbiSnapshot with functions, variables, types, enums, and typedefs
         populated from DWARF. elf_only_mode=False (full type info available).
     """
     builder = _DwarfSnapshotBuilder(elf_path, elf_meta)
-    builder.extract()
+    builder.extract(session=session)
 
     snapshot = AbiSnapshot(
         library=elf_path.name,
@@ -345,29 +353,23 @@ class _DwarfSnapshotBuilder:
         self._logged_type_dups: set[str] = set()
         self._logged_enum_dups: set[str] = set()
 
-    def extract(self) -> None:
-        """Open the ELF, walk DWARF, and populate result lists."""
+    def extract(self, session: DwarfSession | None = None) -> None:
+        """Walk DWARF and populate result lists.
+
+        When *session* is provided, its already-open ``DWARFInfo`` is reused
+        (the metadata passes warmed the DIE cache); otherwise the ELF is opened
+        here. Both paths produce identical results.
+        """
+        if session is not None:
+            self._walk_dwarf(session.dwarf)
+            return
+
         try:
             with open(self._elf_path, "rb") as f:
                 elf = ELFFile(f)  # type: ignore[no-untyped-call]
                 if not has_real_dwarf_info(elf):
                     return
-                dwarf = elf.get_dwarf_info()  # type: ignore[no-untyped-call]
-
-                # First pass: extract all functions, variables, types, enums, typedefs
-                for CU in dwarf.iter_CUs():
-                    try:
-                        self._process_cu(CU)
-                    except Exception as exc:  # noqa: BLE001
-                        log.warning(
-                            "dwarf_snapshot: skipping CU in %s: %s",
-                            self._elf_path,
-                            exc,
-                        )
-
-                # Second pass: filter types to only those reachable from
-                # exported symbols (transitive closure)
-                self._filter_types_by_reachability()
+                self._walk_dwarf(elf.get_dwarf_info())  # type: ignore[no-untyped-call]
 
         except (ELFError, OSError, ValueError) as exc:
             log.warning(
@@ -375,6 +377,26 @@ class _DwarfSnapshotBuilder:
                 self._elf_path,
                 exc,
             )
+
+    def _walk_dwarf(self, dwarf: Any) -> None:
+        """Walk every CU of *dwarf*, then filter to exported reachability.
+
+        Shared by the open-here and reuse-session paths of :meth:`extract`.
+        """
+        # First pass: extract all functions, variables, types, enums, typedefs
+        for CU in dwarf.iter_CUs():
+            try:
+                self._process_cu(CU)
+            except Exception as exc:  # noqa: BLE001
+                log.warning(
+                    "dwarf_snapshot: skipping CU in %s: %s",
+                    self._elf_path,
+                    exc,
+                )
+
+        # Second pass: filter types to only those reachable from
+        # exported symbols (transitive closure)
+        self._filter_types_by_reachability()
 
     def _process_cu(self, CU: Any) -> None:
         """Walk all DIEs in one Compilation Unit."""

--- a/abicheck/dwarf_unified.py
+++ b/abicheck/dwarf_unified.py
@@ -138,7 +138,11 @@ def open_dwarf_session(so_path: Path) -> DwarfSession | None:
             dwarf=dwarf,
             arch=_normalize_arch(elf),
         )
-    except (ELFError, OSError, ValueError) as exc:
+    except Exception as exc:  # noqa: BLE001 - never raise; always release the handle
+        # pyelftools can raise beyond (ELFError, OSError, ValueError) on corrupt
+        # DWARF (struct.error, KeyError, …). The legacy parse_dwarf used a
+        # ``with open()`` block that closed on *any* exception; match that here
+        # so the "never raises" contract holds and no descriptor leaks.
         log.warning("parse_dwarf: failed to open/parse %s: %s", so_path, exc)
         f.close()
         return None
@@ -202,7 +206,16 @@ def parse_dwarf(
     if session is None:
         return DwarfMetadata(), AdvancedDwarfMetadata()
 
-    meta, adv = parse_dwarf_from_session(session)
+    try:
+        meta, adv = parse_dwarf_from_session(session)
+    except Exception as exc:  # noqa: BLE001 - never raise; mirror the legacy top-level guard
+        # parse_dwarf_from_session guards each CU, but iter_CUs() itself can
+        # raise on malformed/truncated CU headers before the per-CU try runs.
+        # Close the session and fall back to empty metadata (the caller then
+        # degrades to symbol-only) rather than leaking the handle / aborting.
+        log.warning("parse_dwarf: failed to parse CUs in %s: %s", so_path, exc)
+        session.close()
+        return DwarfMetadata(), AdvancedDwarfMetadata()
 
     if _session_out is not None:
         _session_out.append(session)

--- a/abicheck/dwarf_unified.py
+++ b/abicheck/dwarf_unified.py
@@ -20,10 +20,21 @@ iteration, cutting file I/O and CU-header parsing overhead roughly in half.
 Note: each module still performs its own DIE-tree walk per CU; a unified
 DIE walker (further ~30-40% CPU gain) is a planned follow-up.
 
+A :class:`DwarfSession` lets a *third* pass — ``dwarf_snapshot``'s snapshot
+build — reuse the same open ``DWARFInfo`` instead of opening the ELF again.
+pyelftools caches parsed DIEs, so that reuse turns the snapshot's full-tree
+walk from a cold re-parse into cache hits (F5b, pvxs validation) with
+byte-for-byte identical output. ``dumper._dump_elf`` opens one session, runs
+the metadata passes, hands it to the snapshot build, then closes it.
+
 Public API
 ----------
 parse_dwarf(so_path) -> tuple[DwarfMetadata, AdvancedDwarfMetadata]
     Single entry point used by dumper.dump().
+open_dwarf_session(so_path) -> DwarfSession | None
+    Open the ELF/DWARFInfo once for reuse across passes (caller closes).
+parse_dwarf_from_session(session) -> tuple[DwarfMetadata, AdvancedDwarfMetadata]
+    Run the metadata passes over an already-open session.
 
 Backward-compatible shims (used by existing callers / tests):
     parse_dwarf_metadata(so_path) -> DwarfMetadata
@@ -39,7 +50,9 @@ from __future__ import annotations
 import logging
 import os
 import stat
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any, BinaryIO
 
 from elftools.common.exceptions import ELFError
 from elftools.elf.elffile import ELFFile
@@ -56,10 +69,120 @@ log = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Shared DWARF session — one ELF open + one DWARFInfo, reusable across passes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DwarfSession:
+    """An open ELF file and its ``DWARFInfo``, shareable across parse passes.
+
+    pyelftools caches parsed DIEs *inside* each ``CompileUnit`` (and caches the
+    CU objects across ``iter_CUs()``), so a second full-tree walk over the same
+    ``DWARFInfo`` is served from that cache instead of re-parsing every DIE.
+    The three DWARF passes (basic metadata, advanced metadata, snapshot build)
+    each walk every DIE, and when they open the file independently they build
+    three *separate* ``DWARFInfo`` objects that share no cache — the redundant
+    re-parse that F5b (pvxs validation) measured. Threading one session through
+    all three collapses that to a single parse; the later passes hit the cache
+    the first warmed, byte-for-byte identical output.
+
+    The caller owns the lifetime: call :meth:`close` (or reuse it and close it)
+    exactly once when done.
+    """
+
+    path: Path
+    _file: BinaryIO
+    elf: Any  # elftools.elf.elffile.ELFFile
+    dwarf: Any  # elftools.dwarf.dwarfinfo.DWARFInfo
+    arch: str
+
+    def close(self) -> None:
+        try:
+            self._file.close()
+        except OSError:
+            pass
+
+
+def open_dwarf_session(so_path: Path) -> DwarfSession | None:
+    """Open *so_path* and return a :class:`DwarfSession`, or ``None``.
+
+    Returns ``None`` (having released any handle) when the path is not a
+    regular file, carries no real DWARF, or cannot be opened/parsed — the same
+    conditions under which :func:`parse_dwarf` yields empty metadata. Never
+    raises. The caller must :meth:`~DwarfSession.close` a non-``None`` result.
+    """
+    try:
+        f = open(so_path, "rb")
+    except OSError as exc:
+        log.warning("parse_dwarf: failed to open/parse %s: %s", so_path, exc)
+        return None
+    try:
+        st = os.fstat(f.fileno())
+        if not stat.S_ISREG(st.st_mode):
+            log.warning("parse_dwarf: not a regular file: %s", so_path)
+            f.close()
+            return None
+
+        elf = ELFFile(f)  # type: ignore[no-untyped-call]
+
+        if not has_real_dwarf_info(elf):
+            log.debug("parse_dwarf: no DWARF info in %s", so_path)
+            f.close()
+            return None
+
+        dwarf = elf.get_dwarf_info()  # type: ignore[no-untyped-call]
+        return DwarfSession(
+            path=Path(so_path),
+            _file=f,
+            elf=elf,
+            dwarf=dwarf,
+            arch=_normalize_arch(elf),
+        )
+    except (ELFError, OSError, ValueError) as exc:
+        log.warning("parse_dwarf: failed to open/parse %s: %s", so_path, exc)
+        f.close()
+        return None
+
+
+def parse_dwarf_from_session(
+    session: DwarfSession,
+) -> tuple[DwarfMetadata, AdvancedDwarfMetadata]:
+    """Run the basic + advanced metadata passes over an open *session*.
+
+    Behaviourally identical to the DWARF branch of :func:`parse_dwarf`; split
+    out so the snapshot build can reuse the same session (and its warm DIE
+    cache) instead of opening the ELF a second time.
+    """
+    meta = DwarfMetadata(has_dwarf=True)
+    adv = AdvancedDwarfMetadata(has_dwarf=True)
+    adv.target_arch = session.arch
+
+    # Per-binary type-resolution cache: (cu_offset, die_offset) → (type_name, byte_size).
+    # DIE offsets are only unique within one ELF file — do not share across binaries.
+    type_cache: dict[tuple[int, int], tuple[str, int]] = {}
+
+    for CU in session.dwarf.iter_CUs():
+        try:
+            _meta_process_cu(CU, meta, type_cache)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("parse_dwarf: meta CU skipped in %s: %s", session.path, exc)
+        try:
+            _adv_process_cu(CU, adv)
+        except (ELFError, OSError, ValueError, KeyError) as exc:
+            log.warning("parse_dwarf: adv CU skipped in %s: %s", session.path, exc)
+
+    return meta, adv
+
+
+# ---------------------------------------------------------------------------
 # Unified single-pass entry point
 # ---------------------------------------------------------------------------
 
-def parse_dwarf(so_path: Path) -> tuple[DwarfMetadata, AdvancedDwarfMetadata]:
+def parse_dwarf(
+    so_path: Path,
+    *,
+    _session_out: list[DwarfSession] | None = None,
+) -> tuple[DwarfMetadata, AdvancedDwarfMetadata]:
     """Open *so_path* once and extract both DwarfMetadata and AdvancedDwarfMetadata.
 
     Replaces two separate calls to ``parse_dwarf_metadata(so_path)`` and
@@ -68,47 +191,24 @@ def parse_dwarf(so_path: Path) -> tuple[DwarfMetadata, AdvancedDwarfMetadata]:
 
     Returns (DwarfMetadata(), AdvancedDwarfMetadata()) on any error.
     Never raises.
+
+    ``_session_out`` (internal): when a list is supplied and real DWARF is
+    present, the still-open :class:`DwarfSession` is appended to it for the
+    caller to reuse (e.g. the DWARF snapshot build) and then close. When it is
+    ``None`` (the default, and every external caller) the session is closed
+    before returning, so behaviour is unchanged.
     """
-    empty = DwarfMetadata(), AdvancedDwarfMetadata()
+    session = open_dwarf_session(so_path)
+    if session is None:
+        return DwarfMetadata(), AdvancedDwarfMetadata()
 
-    try:
-        with open(so_path, "rb") as f:
-            st = os.fstat(f.fileno())
-            if not stat.S_ISREG(st.st_mode):
-                log.warning("parse_dwarf: not a regular file: %s", so_path)
-                return empty
+    meta, adv = parse_dwarf_from_session(session)
 
-            elf = ELFFile(f)  # type: ignore[no-untyped-call]
-
-            if not has_real_dwarf_info(elf):
-                log.debug("parse_dwarf: no DWARF info in %s", so_path)
-                return empty
-
-            meta = DwarfMetadata(has_dwarf=True)
-            adv = AdvancedDwarfMetadata(has_dwarf=True)
-            adv.target_arch = _normalize_arch(elf)
-
-            dwarf = elf.get_dwarf_info()  # type: ignore[no-untyped-call]
-
-            # Per-binary type-resolution cache: (cu_offset, die_offset) → (type_name, byte_size).
-            # DIE offsets are only unique within one ELF file — do not share across binaries.
-            type_cache: dict[tuple[int, int], tuple[str, int]] = {}
-
-            for CU in dwarf.iter_CUs():
-                try:
-                    _meta_process_cu(CU, meta, type_cache)
-                except Exception as exc:  # noqa: BLE001
-                    log.warning("parse_dwarf: meta CU skipped in %s: %s", so_path, exc)
-                try:
-                    _adv_process_cu(CU, adv)
-                except (ELFError, OSError, ValueError, KeyError) as exc:
-                    log.warning("parse_dwarf: adv CU skipped in %s: %s", so_path, exc)
-
-            return meta, adv
-
-    except (ELFError, OSError, ValueError) as exc:
-        log.warning("parse_dwarf: failed to open/parse %s: %s", so_path, exc)
-        return empty
+    if _session_out is not None:
+        _session_out.append(session)
+    else:
+        session.close()
+    return meta, adv
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dumper_unit.py
+++ b/tests/test_dumper_unit.py
@@ -233,7 +233,9 @@ class TestResolveDebugMetadata:
         from abicheck.dwarf_metadata import DwarfMetadata
 
         expected = (DwarfMetadata(has_dwarf=True), AdvancedDwarfMetadata())
-        monkeypatch.setattr("abicheck.dwarf_unified.parse_dwarf", lambda _path: expected)
+        monkeypatch.setattr(
+            "abicheck.dwarf_unified.parse_dwarf", lambda _path, **_kw: expected
+        )
 
         assert _resolve_debug_metadata(tmp_path / "lib.so", "dwarf") is expected
 

--- a/tests/test_dumper_unit.py
+++ b/tests/test_dumper_unit.py
@@ -18,6 +18,7 @@ from abicheck.dumper import (
     _castxml_available,
     _castxml_dump,
     _CastxmlParser,
+    _is_kernel_binary,
     _parse_vtable_index,
     _pyelftools_exported_symbols,
     _resolve_debug_metadata,
@@ -242,6 +243,148 @@ class TestResolveDebugMetadata:
     def test_invalid_debug_format_raises_value_error(self, tmp_path):
         with pytest.raises(ValueError, match="Invalid debug_format"):
             _resolve_debug_metadata(tmp_path / "lib.so", "invalid")
+
+    def test_forced_btf_missing_section_still_returns(self, tmp_path, monkeypatch):
+        """Forced BTF with no .BTF section logs a warning and returns empty."""
+        from abicheck.btf_metadata import BtfMetadata
+
+        monkeypatch.setattr(
+            "abicheck.btf_metadata.parse_btf_metadata",
+            lambda _p: BtfMetadata(has_btf=False),
+        )
+        dwarf_meta, _ = _resolve_debug_metadata(tmp_path / "lib.so", "btf")
+        assert not dwarf_meta.has_dwarf
+
+    def test_forced_ctf_missing_section_still_returns(self, tmp_path, monkeypatch):
+        """Forced CTF with no .ctf section logs a warning and returns empty."""
+        from abicheck.ctf_metadata import CtfMetadata
+
+        monkeypatch.setattr(
+            "abicheck.ctf_metadata.parse_ctf_metadata",
+            lambda _p: CtfMetadata(has_ctf=False),
+        )
+        dwarf_meta, _ = _resolve_debug_metadata(tmp_path / "lib.so", "ctf")
+        assert not dwarf_meta.has_dwarf
+
+    def test_auto_kernel_prefers_btf(self, tmp_path, monkeypatch):
+        """Auto-detect on a kernel binary with a .BTF section prefers BTF."""
+        from abicheck.btf_metadata import BtfMetadata
+
+        monkeypatch.setattr("abicheck.dumper_debug._is_kernel_binary", lambda _p: True)
+        monkeypatch.setattr("abicheck.btf_metadata.has_btf_section", lambda _p: True)
+        monkeypatch.setattr(
+            "abicheck.btf_metadata.parse_btf_metadata",
+            lambda _p: BtfMetadata(has_btf=True),
+        )
+        dwarf_meta, _ = _resolve_debug_metadata(tmp_path / "vmlinux", None)
+        assert dwarf_meta.has_dwarf  # BTF converted to DwarfMetadata
+
+    def test_auto_falls_back_to_btf_when_no_dwarf(self, tmp_path, monkeypatch):
+        """Userspace binary with no DWARF but a .BTF section falls back to BTF."""
+        from abicheck.btf_metadata import BtfMetadata
+        from abicheck.dwarf_advanced import AdvancedDwarfMetadata
+        from abicheck.dwarf_metadata import DwarfMetadata
+
+        monkeypatch.setattr("abicheck.dumper_debug._is_kernel_binary", lambda _p: False)
+        monkeypatch.setattr(
+            "abicheck.dwarf_unified.parse_dwarf",
+            lambda _p, **_k: (DwarfMetadata(), AdvancedDwarfMetadata()),
+        )
+        monkeypatch.setattr("abicheck.btf_metadata.has_btf_section", lambda _p: True)
+        monkeypatch.setattr(
+            "abicheck.btf_metadata.parse_btf_metadata",
+            lambda _p: BtfMetadata(has_btf=True),
+        )
+        dwarf_meta, _ = _resolve_debug_metadata(tmp_path / "lib.so", None)
+        assert dwarf_meta.has_dwarf
+
+    def test_auto_falls_back_to_ctf_when_no_dwarf_or_btf(self, tmp_path, monkeypatch):
+        """No DWARF and no BTF but a .ctf section falls back to CTF."""
+        from abicheck.ctf_metadata import CtfMetadata
+        from abicheck.dwarf_advanced import AdvancedDwarfMetadata
+        from abicheck.dwarf_metadata import DwarfMetadata
+
+        monkeypatch.setattr("abicheck.dumper_debug._is_kernel_binary", lambda _p: False)
+        monkeypatch.setattr(
+            "abicheck.dwarf_unified.parse_dwarf",
+            lambda _p, **_k: (DwarfMetadata(), AdvancedDwarfMetadata()),
+        )
+        monkeypatch.setattr("abicheck.btf_metadata.has_btf_section", lambda _p: False)
+        monkeypatch.setattr("abicheck.ctf_metadata.has_ctf_section", lambda _p: True)
+        monkeypatch.setattr(
+            "abicheck.ctf_metadata.parse_ctf_metadata",
+            lambda _p: CtfMetadata(has_ctf=True),
+        )
+        dwarf_meta, _ = _resolve_debug_metadata(tmp_path / "lib.so", None)
+        assert dwarf_meta.has_dwarf
+
+    @pytest.mark.parametrize("btf_section_present", [False, True])
+    def test_auto_kernel_btf_absent_falls_through_to_dwarf(
+        self, tmp_path, monkeypatch, btf_section_present
+    ):
+        """Kernel binary with no usable BTF falls through to DWARF — covers both
+        the section-absent and the section-present-but-empty fall-through edges."""
+        from abicheck.btf_metadata import BtfMetadata
+        from abicheck.dwarf_advanced import AdvancedDwarfMetadata
+        from abicheck.dwarf_metadata import DwarfMetadata
+
+        monkeypatch.setattr("abicheck.dumper_debug._is_kernel_binary", lambda _p: True)
+        monkeypatch.setattr(
+            "abicheck.btf_metadata.has_btf_section", lambda _p: btf_section_present
+        )
+        monkeypatch.setattr(
+            "abicheck.btf_metadata.parse_btf_metadata",
+            lambda _p: BtfMetadata(has_btf=False),
+        )
+        monkeypatch.setattr(
+            "abicheck.dwarf_unified.parse_dwarf",
+            lambda _p, **_k: (DwarfMetadata(has_dwarf=True), AdvancedDwarfMetadata()),
+        )
+        dwarf_meta, _ = _resolve_debug_metadata(tmp_path / "vmlinux", None)
+        assert dwarf_meta.has_dwarf  # came from DWARF, not BTF
+
+    def test_auto_returns_empty_when_no_debug_info(self, tmp_path, monkeypatch):
+        """No usable DWARF/BTF/CTF → empty DwarfMetadata (has_dwarf False).
+
+        BTF and CTF sections are *present but empty* so the ``has_btf``/``has_ctf``
+        fall-through edges are exercised, not just the section-absent ones."""
+        from abicheck.btf_metadata import BtfMetadata
+        from abicheck.ctf_metadata import CtfMetadata
+        from abicheck.dwarf_advanced import AdvancedDwarfMetadata
+        from abicheck.dwarf_metadata import DwarfMetadata
+
+        monkeypatch.setattr("abicheck.dumper_debug._is_kernel_binary", lambda _p: False)
+        monkeypatch.setattr(
+            "abicheck.dwarf_unified.parse_dwarf",
+            lambda _p, **_k: (DwarfMetadata(), AdvancedDwarfMetadata()),
+        )
+        monkeypatch.setattr("abicheck.btf_metadata.has_btf_section", lambda _p: True)
+        monkeypatch.setattr(
+            "abicheck.btf_metadata.parse_btf_metadata",
+            lambda _p: BtfMetadata(has_btf=False),
+        )
+        monkeypatch.setattr("abicheck.ctf_metadata.has_ctf_section", lambda _p: True)
+        monkeypatch.setattr(
+            "abicheck.ctf_metadata.parse_ctf_metadata",
+            lambda _p: CtfMetadata(has_ctf=False),
+        )
+        dwarf_meta, _ = _resolve_debug_metadata(tmp_path / "lib.so", None)
+        assert not dwarf_meta.has_dwarf
+
+
+class TestIsKernelBinary:
+    def test_vmlinux_name(self, tmp_path):
+        assert _is_kernel_binary(tmp_path / "vmlinux") is True
+
+    @pytest.mark.parametrize("name", ["mod.ko", "mod.ko.xz", "mod.ko.zst", "mod.ko.gz"])
+    def test_ko_suffixes(self, tmp_path, name):
+        assert _is_kernel_binary(tmp_path / name) is True
+
+    def test_plain_so_is_not_kernel(self, tmp_path):
+        """A regular .so with no .modinfo section is not a kernel binary."""
+        so = tmp_path / "libfoo.so"
+        so.write_bytes(b"not an elf")
+        assert _is_kernel_binary(so) is False
 
 
 # ── _pyelftools_exported_symbols ────────────────────────────────────────

--- a/tests/test_dwarf_unified.py
+++ b/tests/test_dwarf_unified.py
@@ -20,8 +20,11 @@ import pytest
 from abicheck.dwarf_advanced import AdvancedDwarfMetadata  # noqa: E402
 from abicheck.dwarf_metadata import DwarfMetadata  # noqa: E402
 from abicheck.dwarf_unified import (  # noqa: E402
+    DwarfSession,
+    open_dwarf_session,
     parse_advanced_dwarf,
     parse_dwarf,
+    parse_dwarf_from_session,
     parse_dwarf_metadata,
 )
 
@@ -234,3 +237,145 @@ class TestSingleOpen:
         assert len(open_calls) == 1, (
             f"Expected 1 file open, got {len(open_calls)}: {open_calls}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Shared DWARF session — one open reused across the metadata + snapshot passes
+# ---------------------------------------------------------------------------
+
+_SESSION_SRC = """
+    #include <string>
+    #include <vector>
+    namespace demo {
+    enum class Color { Red, Green, Blue };
+    struct Point { int x; int y; double z; };
+    template <typename T> struct Box { T value; std::vector<T> hist; };
+    struct Registry { std::vector<Box<int>> counters; Color tint; };
+    }
+    extern "C" int demo_area(int n) { int s = 0; for (int i = 0; i < n; ++i) s += i; return s; }
+    extern "C" demo::Point demo_origin_pt(void) { return demo::Point{1, 2, 3.0}; }
+    extern "C" demo::Color demo_pick_color(void) { return demo::Color::Green; }
+    extern int demo_global; int demo_global = 7;
+"""
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="ELF DWARF tests require Linux (macOS/Windows compilers produce Mach-O/PE)")
+class TestDwarfSession:
+    """open_dwarf_session + parse_dwarf_from_session must match the one-shot API,
+    and reusing a session for the snapshot build must be byte-for-byte identical."""
+
+    def test_session_parse_matches_parse_dwarf(self, tmp_path: Path) -> None:
+        _require_tool("g++")
+        so = _compile_so(tmp_path, "libsess", _SESSION_SRC, lang="cpp")
+
+        meta_a, adv_a = parse_dwarf(so)
+
+        sess = open_dwarf_session(so)
+        assert isinstance(sess, DwarfSession)
+        try:
+            meta_b, adv_b = parse_dwarf_from_session(sess)
+        finally:
+            sess.close()
+
+        # Identical metadata regardless of whether the file was opened once
+        # (session) or once per call (parse_dwarf).
+        assert meta_a.structs == meta_b.structs
+        assert meta_a.enums == meta_b.enums
+        assert adv_a.target_arch == adv_b.target_arch
+        assert adv_a.calling_conventions == adv_b.calling_conventions
+        assert adv_a.packed_structs == adv_b.packed_structs
+
+    def test_snapshot_via_session_is_byte_identical(self, tmp_path: Path) -> None:
+        """build_snapshot_from_dwarf(session=…) must serialize identically to the
+        legacy re-open path — the core correctness bar for the single-pass merge."""
+        _require_tool("g++")
+        from abicheck.dwarf_snapshot import build_snapshot_from_dwarf
+        from abicheck.elf_metadata import parse_elf_metadata
+        from abicheck.serialization import snapshot_to_json
+
+        so = _compile_so(tmp_path, "libsesssnap", _SESSION_SRC, lang="cpp")
+        elf_meta = parse_elf_metadata(so)
+
+        # Path A: independent opens (legacy).
+        meta_a, adv_a = parse_dwarf(so)
+        snap_a = build_snapshot_from_dwarf(so, elf_meta, meta_a, adv_a, version="t")
+
+        # Path B: one shared session reused by the snapshot walk.
+        sess = open_dwarf_session(so)
+        assert sess is not None
+        try:
+            meta_b, adv_b = parse_dwarf_from_session(sess)
+            snap_b = build_snapshot_from_dwarf(
+                so, elf_meta, meta_b, adv_b, version="t", session=sess
+            )
+        finally:
+            sess.close()
+
+        assert snapshot_to_json(snap_a) == snapshot_to_json(snap_b)
+        # And the snapshot genuinely exercised the type/function/enum paths.
+        assert snap_b.types
+        assert snap_b.functions
+        assert snap_b.enums
+
+    def test_snapshot_usable_after_session_closed(self, tmp_path: Path) -> None:
+        """The built snapshot holds extracted model objects, not live DIEs, so it
+        stays fully serializable after the session file handle is closed."""
+        _require_tool("g++")
+        from abicheck.dwarf_snapshot import build_snapshot_from_dwarf
+        from abicheck.elf_metadata import parse_elf_metadata
+        from abicheck.serialization import snapshot_to_json
+
+        so = _compile_so(tmp_path, "libsessclose", _SESSION_SRC, lang="cpp")
+        elf_meta = parse_elf_metadata(so)
+        sess = open_dwarf_session(so)
+        assert sess is not None
+        meta, adv = parse_dwarf_from_session(sess)
+        snap = build_snapshot_from_dwarf(so, elf_meta, meta, adv, session=sess)
+        sess.close()  # close BEFORE serializing
+        assert snapshot_to_json(snap)  # must not raise / must be non-empty
+
+    def test_open_dwarf_session_none_cases(self, tmp_path: Path) -> None:
+        """Non-regular / non-ELF / missing inputs return None (no leaked handle)."""
+        assert open_dwarf_session(tmp_path) is None  # directory
+        assert open_dwarf_session(tmp_path / "missing.so") is None  # nonexistent
+        bad = tmp_path / "not_elf.so"
+        bad.write_bytes(b"not an ELF file")
+        assert open_dwarf_session(bad) is None
+
+    def test_close_is_safe_to_call(self, tmp_path: Path) -> None:
+        _require_tool("g++")
+        so = _compile_so(tmp_path, "libsessdbl", _SESSION_SRC, lang="cpp")
+        sess = open_dwarf_session(so)
+        assert sess is not None
+        sess.close()
+        # Double close must not raise.
+        sess.close()
+
+    def test_snapshot_reuses_session_without_reopening(self, tmp_path: Path) -> None:
+        """When a session is supplied, the snapshot build must NOT open the ELF
+        again — the whole point of the single-pass merge."""
+        _require_tool("g++")
+        from abicheck.dwarf_snapshot import build_snapshot_from_dwarf
+        from abicheck.elf_metadata import parse_elf_metadata
+
+        so = _compile_so(tmp_path, "libsessreopen", _SESSION_SRC, lang="cpp")
+        elf_meta = parse_elf_metadata(so)
+        sess = open_dwarf_session(so)
+        assert sess is not None
+        meta, adv = parse_dwarf_from_session(sess)
+
+        reopens: list[str] = []
+        original_open = open
+
+        def counting_open(path, mode="r", **kwargs):  # type: ignore[override]
+            if "rb" in str(mode) and str(so) in str(path):
+                reopens.append(str(path))
+            return original_open(path, mode, **kwargs)
+
+        try:
+            with patch("builtins.open", side_effect=counting_open):
+                build_snapshot_from_dwarf(so, elf_meta, meta, adv, session=sess)
+        finally:
+            sess.close()
+
+        assert reopens == [], f"snapshot re-opened the ELF despite a session: {reopens}"

--- a/tests/test_dwarf_unified.py
+++ b/tests/test_dwarf_unified.py
@@ -405,14 +405,18 @@ class TestDwarfSession:
     def test_close_swallows_file_error(self) -> None:
         """close() must not propagate an OSError from the underlying handle."""
 
+        calls: list[bool] = []
+
         class _BadFile:
             def close(self) -> None:
+                calls.append(True)
                 raise OSError("handle already gone")
 
         sess = DwarfSession(
             path=Path("x"), _file=_BadFile(), elf=None, dwarf=None, arch="x86_64"  # type: ignore[arg-type]
         )
         sess.close()  # must not raise
+        assert calls == [True], "close() should still attempt to close the handle"
 
     def test_snapshot_reuses_session_without_reopening(self, tmp_path: Path) -> None:
         """When a session is supplied, the snapshot build must NOT open the ELF

--- a/tests/test_dwarf_unified.py
+++ b/tests/test_dwarf_unified.py
@@ -9,6 +9,8 @@ compilers produce Mach-O/PE, and DWARF parsing requires ELF.
 """
 from __future__ import annotations
 
+import os
+import struct
 import subprocess
 import sys
 import textwrap
@@ -342,6 +344,55 @@ class TestDwarfSession:
         bad.write_bytes(b"not an ELF file")
         assert open_dwarf_session(bad) is None
 
+    def test_open_session_never_raises_and_no_leak_on_unexpected_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """pyelftools can raise beyond (ELFError, OSError, ValueError) on corrupt
+        DWARF; open_dwarf_session must still return None and release the handle
+        (the "never raises" / no-descriptor-leak contract, F-D-leak review)."""
+        from abicheck import dwarf_unified as du
+
+        so = tmp_path / "corrupt.so"
+        so.write_bytes(b"\x7fELF" + b"\x00" * 128)
+
+        def boom(*_a: object, **_k: object) -> object:
+            raise struct.error("truncated header")  # not in the narrow tuple
+
+        monkeypatch.setattr(du, "ELFFile", boom)
+
+        def nfds() -> int:
+            try:
+                return len(os.listdir("/proc/self/fd"))
+            except OSError:
+                return -1
+
+        base = nfds()
+        for _ in range(30):
+            assert du.open_dwarf_session(so) is None  # must not raise
+        assert nfds() - base <= 1, "open_dwarf_session leaked a file descriptor"
+
+    def test_parse_dwarf_survives_cu_iteration_failure(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """iter_CUs() can raise on malformed CU headers before the per-CU guard
+        runs. parse_dwarf must swallow it, close the session (not hand it back),
+        and return empty metadata so the dumper degrades to symbol-only."""
+        _require_tool("g++")
+        from abicheck import dwarf_unified as du
+
+        so = _compile_so(tmp_path, "libcuerr", _SESSION_SRC, lang="cpp")
+
+        def boom(_session: object) -> object:
+            raise ValueError("iter_CUs blew up")
+
+        monkeypatch.setattr(du, "parse_dwarf_from_session", boom)
+
+        out: list = []
+        meta, adv = du.parse_dwarf(so, _session_out=out)  # must not raise
+        assert not meta.has_dwarf
+        assert not adv.has_dwarf
+        assert out == [], "failed parse must close the session, not append it"
+
     def test_close_is_safe_to_call(self, tmp_path: Path) -> None:
         _require_tool("g++")
         so = _compile_so(tmp_path, "libsessdbl", _SESSION_SRC, lang="cpp")
@@ -350,6 +401,18 @@ class TestDwarfSession:
         sess.close()
         # Double close must not raise.
         sess.close()
+
+    def test_close_swallows_file_error(self) -> None:
+        """close() must not propagate an OSError from the underlying handle."""
+
+        class _BadFile:
+            def close(self) -> None:
+                raise OSError("handle already gone")
+
+        sess = DwarfSession(
+            path=Path("x"), _file=_BadFile(), elf=None, dwarf=None, arch="x86_64"  # type: ignore[arg-type]
+        )
+        sess.close()  # must not raise
 
     def test_snapshot_reuses_session_without_reopening(self, tmp_path: Path) -> None:
         """When a session is supplied, the snapshot build must NOT open the ELF

--- a/tests/test_perf_dwarf_session_scaling.py
+++ b/tests/test_perf_dwarf_session_scaling.py
@@ -1,0 +1,193 @@
+"""Integration: DwarfSession sharing — regression + scaling guard.
+
+Closes a gap left by the DWARF-session merge (PR #525, F5b follow-up): that
+change was validated once, manually, on a single hand-built fixture — not by
+anything committed to the repo, so nothing in CI would catch a regression back
+to independent per-pass ELF opens, and the win was never checked at scale.
+
+This file compiles *real* multi-CU C++ binaries reproducing the pvxs
+pathology that motivated the change — the same ``std::``/template type
+repeated across many compilation units, each pulling in its own physical DIE
+subtree — and:
+
+- ``test_session_reuse_faster_than_independent_opens`` — a same-binary,
+  same-process A/B comparison. Guards the actual mechanism: sharing one
+  ``DWARFInfo`` across the metadata + snapshot passes must stay reliably
+  faster than the legacy independent-open path. Deliberately conservative
+  (a fraction of the ~8x measured in validation) so it flags a real
+  regression to "no sharing" without flaking on noisy CI runners.
+- ``test_dwarf_only_dump_scaling_with_cu_count_stays_subquadratic`` — the
+  production ``dumper.dump(..., dwarf_only=True)`` entry point, timed at a
+  growing compilation-unit count, mirroring the sub-quadratic exponent gate
+  ``test_perf_dump_scaling.py`` already applies to single-CU symbol/struct
+  growth — but scaling the axis this PR actually touches (CU count), which
+  that file's generator does not exercise.
+
+``scripts/benchmark_scaling.py`` (the PR-vs-base regression lane in
+``.github/workflows/performance.yml``) is not extended for this: it builds
+``AbiSnapshot`` objects directly and deliberately never invokes a real
+compiler (see ``test_benchmark_scaling.py``), so it cannot exercise DWARF
+parsing at all. This file's ``integration`` marker is what wires it into
+every PR instead — ``ci.yml``'s ``integration-tests`` job runs `-m
+integration` unconditionally on every push/PR, no path filter required.
+
+Requires ``g++`` on Linux (gcc/g++ produce Mach-O/PE elsewhere).
+"""
+
+from __future__ import annotations
+
+import math
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="ELF DWARF tests require Linux (macOS/Windows compilers produce Mach-O/PE)",
+    ),
+]
+
+
+def _require_tool(name: str) -> None:
+    import shutil
+    if shutil.which(name) is None:
+        pytest.skip(f"{name} not found in PATH")
+
+
+_HEADER_SRC = """
+    #pragma once
+    #include <vector>
+    #include <string>
+    #include <map>
+    namespace scale {
+    struct Point { int x; int y; double z; };
+    template <typename T> struct Box { T value; std::vector<T> history; std::string label; };
+    struct Registry { std::map<std::string, Box<int>> items; Point origin; };
+    }
+"""
+
+
+def _compile_multi_cu_lib(tmp_path: Path, label: str, n_cus: int) -> Path:
+    """Build a single .so from *n_cus* translation units that all
+    ``#include`` the same header — so the same template/std:: type subtree
+    gets its own physical DIEs re-emitted in every CU (the pvxs pathology:
+    F5b measured this at 33 CUs / 4046 types on real libpvxs)."""
+    src_dir = tmp_path / label
+    src_dir.mkdir()
+    header = src_dir / "shared.h"
+    header.write_text(_HEADER_SRC, encoding="utf-8")
+
+    cpp_files = []
+    for i in range(n_cus):
+        cpp = src_dir / f"cu{i}.cpp"
+        cpp.write_text(
+            f'#include "shared.h"\n'
+            f"extern \"C\" int use_{i}(void) {{\n"
+            f"    scale::Box<int> b;\n"
+            f"    b.value = {i};\n"
+            f"    b.history.push_back({i});\n"
+            f"    return (int)b.history.size() + {i};\n"
+            f"}}\n",
+            encoding="utf-8",
+        )
+        cpp_files.append(cpp)
+
+    so_file = src_dir / f"lib{label}.so"
+    r = subprocess.run(
+        ["g++", "-shared", "-fPIC", "-g", "-Og", "-o", str(so_file)]
+        + [str(c) for c in cpp_files],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        pytest.skip(f"g++ compilation failed: {r.stderr[:300]}")
+    with open(so_file, "rb") as f:
+        if f.read(4) != b"\x7fELF":
+            pytest.skip("compiled binary is not ELF (non-Linux platform)")
+    return so_file
+
+
+def test_session_reuse_faster_than_independent_opens(tmp_path: Path) -> None:
+    """Regression guard for the actual mechanism this PR introduced.
+
+    Runs the legacy (independent-open) path and the current production
+    (shared-session) path back-to-back on the *same* compiled binary in the
+    same process, so both see identical OS/filesystem cache state. If a
+    future change silently drops session reuse (e.g. build_snapshot_from_dwarf
+    stops honoring ``session=``), this fails deterministically rather than
+    relying on the byte-identical correctness tests (which don't check speed).
+    """
+    _require_tool("g++")
+    from abicheck.dwarf_advanced import parse_advanced_dwarf
+    from abicheck.dwarf_metadata import parse_dwarf_metadata
+    from abicheck.dwarf_snapshot import build_snapshot_from_dwarf
+    from abicheck.dwarf_unified import open_dwarf_session, parse_dwarf_from_session
+    from abicheck.elf_metadata import parse_elf_metadata
+
+    so = _compile_multi_cu_lib(tmp_path, "cmp", n_cus=14)
+    elf_meta = parse_elf_metadata(so)
+
+    # Legacy: three independent ELF opens (pre-DwarfSession behaviour).
+    t0 = time.perf_counter()
+    dwarf_meta = parse_dwarf_metadata(so)
+    dwarf_adv = parse_advanced_dwarf(so)
+    legacy_snap = build_snapshot_from_dwarf(so, elf_meta, dwarf_meta, dwarf_adv, version="legacy")
+    legacy_elapsed = max(time.perf_counter() - t0, 1e-4)
+
+    # Current production path: one shared DwarfSession across all three passes.
+    t1 = time.perf_counter()
+    sess = open_dwarf_session(so)
+    assert sess is not None
+    meta2, adv2 = parse_dwarf_from_session(sess)
+    session_snap = build_snapshot_from_dwarf(
+        so, elf_meta, meta2, adv2, version="session", session=sess
+    )
+    sess.close()
+    session_elapsed = max(time.perf_counter() - t1, 1e-4)
+
+    # Sanity: both paths actually extracted the same real work, not near-empty
+    # snapshots that would make the timing comparison meaningless.
+    assert len(legacy_snap.types) == len(session_snap.types)
+    assert legacy_snap.types
+
+    # Validation measured ~8x on a comparable fixture; require only a modest,
+    # CI-noise-tolerant fraction of that so this doesn't flake on a busy
+    # runner while still catching a full regression to "no sharing" (where
+    # session_elapsed would be >= legacy_elapsed, not meaningfully less).
+    assert session_elapsed < legacy_elapsed * 0.85, (
+        f"DwarfSession reuse ({session_elapsed:.4f}s) is not reliably faster "
+        f"than independent opens ({legacy_elapsed:.4f}s) — the DWARFInfo-"
+        f"sharing win appears to have regressed"
+    )
+
+
+def test_dwarf_only_dump_scaling_with_cu_count_stays_subquadratic(tmp_path: Path) -> None:
+    """The production dwarf_only dump() path must not go quadratic as the
+    number of compilation units grows — guards against a hidden O(n^2) in the
+    session/cache path itself (e.g. a per-CU cache lookup that degrades),
+    which the single-CU symbol/struct scaling in test_perf_dump_scaling.py
+    cannot see because it never varies CU count.
+    """
+    _require_tool("g++")
+    from abicheck.dumper import dump
+
+    timings: list[tuple[int, float]] = []
+    for n_cus in (8, 32):
+        so = _compile_multi_cu_lib(tmp_path, f"scale{n_cus}", n_cus=n_cus)
+        start = time.perf_counter()
+        snap = dump(so, [], dwarf_only=True)
+        elapsed = max(time.perf_counter() - start, 1e-3)
+        timings.append((n_cus, elapsed))
+        assert snap.functions, f"expected exported functions at n_cus={n_cus}"
+
+    (n1, t1), (n2, t2) = timings
+    exponent = math.log(t2 / t1) / math.log(n2 / n1)
+    # True quadratic would be ~2.0; matches the generous bound used by the
+    # sibling single-CU scaling test to avoid flaking on shared CI runners.
+    assert exponent < 1.9, (
+        f"dwarf_only dump CU-count scaling exponent {exponent:.2f} regressed toward O(n^2)"
+    )

--- a/tests/test_perf_dwarf_session_scaling.py
+++ b/tests/test_perf_dwarf_session_scaling.py
@@ -98,11 +98,14 @@ def _compile_multi_cu_lib(tmp_path: Path, label: str, n_cus: int) -> Path:
         cpp_files.append(cpp)
 
     so_file = src_dir / f"lib{label}.so"
-    r = subprocess.run(
-        ["g++", "-shared", "-fPIC", "-g", "-Og", "-o", str(so_file)]
-        + [str(c) for c in cpp_files],
-        capture_output=True, text=True,
-    )
+    try:
+        r = subprocess.run(
+            ["g++", "-shared", "-fPIC", "-g", "-Og", "-o", str(so_file)]
+            + [str(c) for c in cpp_files],
+            capture_output=True, text=True, timeout=60,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip("g++ compilation timed out after 60s")
     if r.returncode != 0:
         pytest.skip(f"g++ compilation failed: {r.stderr[:300]}")
     with open(so_file, "rb") as f:


### PR DESCRIPTION
## Summary

Thread one open `DWARFInfo` through all three DWARF extraction passes so a DWARF-only dump parses each DIE once instead of once per pass — byte-for-byte identical output.

## Motivation

DWARF-only dumps ran the basic-metadata, advanced-metadata, and snapshot-builder passes as three independent ELF opens, each building its own `DWARFInfo` with a cold DIE cache. On a large C++ surface the same `std::`/template subtrees get re-parsed once per pass — the **F5b** finding from the pvxs validation (`validation/pvxs-abi-validation-2026-07.md`), where the snapshot pass alone was ~30 s on `libpvxs`, dominated by DIE re-parse. This is the "single-pass merge" step of that follow-up.

The naive "skip already-seen types" fix was measured **wrong** in F5b (dropped 195 types — later CUs contribute nested members the first didn't). This change instead shares the parse handle, which changes *no* output: pyelftools caches parsed DIEs within a CU and caches CU objects across `iter_CUs()`, so a later pass over the same `DWARFInfo` is served from the cache the earlier passes warmed.

## Changes

- **`dwarf_unified`** — add `DwarfSession` (one open ELF + one `DWARFInfo`), `open_dwarf_session`, and `parse_dwarf_from_session`. `parse_dwarf` keeps its exact 2-tuple contract and closes by default; an internal `_session_out` sink hands the still-open session back for reuse.
- **`dwarf_snapshot`** — `build_snapshot_from_dwarf` / `extract` accept an optional `session` and walk its `DWARFInfo` instead of re-opening the ELF. The built snapshot holds extracted model objects (no live DIE refs), so it stays valid after the session closes.
- **`dumper._dump_elf`** — opens one session via `_resolve_debug_metadata(..., _session_out=…)`, reuses it for the snapshot build, and closes it in a `finally` on every exit path (snapshot / symbol-only / header).
- **`dumper_debug`** (new) — `_resolve_debug_metadata` + `_is_kernel_binary` moved out of `dumper.py` (which was at the 2000-line hard cap) and re-exported so `dumper._is_kernel_binary` / `dumper._resolve_debug_metadata` remain valid bare-name calls and test patch targets.
- Tests: session byte-identical guarantee, reuse-without-reopen, post-close serializability, and `open_dwarf_session` edge cases.

### Validation (A/B on real compiled binaries)

On a 9-CU C++ fixture (repeated template/`std::` types across CUs, like pvxs):

| | before (independent opens) | after (shared session) |
|---|---|---|
| snapshot build | ~0.58 s | **~0.07 s** |

Snapshot, basic-metadata, and advanced-metadata JSON are **byte-for-byte identical** across (a) pre-refactor baseline vs refactored, and (b) no-session vs session paths. End-to-end `compare`/`dump` verified; no fd leak across repeated dumps. No CLI or public-API surface change.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Docs updated if user-visible behaviour changed (n/a — internal only; module docstrings updated)
- [x] No new `mypy` or `ruff` errors introduced (`mypy abicheck/` clean, `ruff check abicheck/ tests/` clean, AI-readiness 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqUUSp8wT2FSqPQodvwpeh

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqUUSp8wT2FSqPQodvwpeh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved DWARF-only dump performance by reusing parsed debug information across multiple extraction passes.
  * Reduced redundant debug-information processing while keeping results byte-for-byte identical.
* **Reliability**
  * More robust debug metadata resolution, with safer handling when requested formats or debug sections are missing.
* **Tests**
  * Added new session-sharing and performance integration coverage, including timing comparisons, scaling guards, and byte-identical snapshot verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->