### PR TITLE
fix(export-accounting): bound mangled length parsing

### DIFF
--- a/abicheck/buildsource/export_accounting.py
+++ b/abicheck/buildsource/export_accounting.py
@@ -159,6 +159,31 @@ _THUNK_PREFIX_RE = re.compile(r"^_ZT[hvc](?:[hv]?n?\d+_)+")
 _NESTED_QUALIFIERS_RE = re.compile(r"^[rVK]*[RO]?")
 
 
+def _read_decimal_length(text: str, start: int) -> tuple[int, int] | None:
+    """Read an Itanium source-name length without unbounded ``int()`` conversion.
+
+    Exported symbol names can come from untrusted binaries/snapshots. Feeding an
+    arbitrary digit run to :func:`int` can raise on modern Python when it exceeds
+    the interpreter's integer-string limit (and is needless work on older
+    runtimes). Accumulate only while the length can still address ``text``; a
+    longer run is still safe and simply skips past the end of the malformed name.
+    """
+    if start >= len(text) or not ("0" <= text[start] <= "9"):
+        return None
+    i = start
+    length = 0
+    limit = len(text)
+    while i < len(text) and "0" <= text[i] <= "9":
+        digit = ord(text[i]) - ord("0")
+        length = length * 10 + digit
+        i += 1
+        if length > limit:
+            while i < len(text) and "0" <= text[i] <= "9":
+                i += 1
+            return length, i
+    return length, i
+
+
 def _encoding_after_prefixes(symbol: str) -> str:
     """Strip ``_Z`` and any vtable/typeinfo/guard-variable/thunk prefix.
 
@@ -200,9 +225,12 @@ def _mangled_owner_namespace(symbol: str) -> str | None:
         return None  # un-nested top-level name — no namespace owner
     if rest.startswith(_STD_SUBSTITUTIONS):
         return "std"
-    m = re.match(r"(\d+)([A-Za-z_]\w*)", rest)
-    if m:
-        return m.group(2)[: int(m.group(1))]
+    parsed = _read_decimal_length(rest, 0)
+    if parsed is not None:
+        length, name_start = parsed
+        name = rest[name_start : name_start + length]
+        if name and re.match(r"[A-Za-z_]\w*", name):
+            return name
     return None
 
 
@@ -374,11 +402,12 @@ def _nested_component(symbol: str, index: int) -> str | None:
                 break
             depth -= 1
             i += 1
-        elif c.isdigit():
-            j = i
-            while j < len(rest) and rest[j].isdigit():
-                j += 1
-            length = int(rest[i:j])
+        elif "0" <= c <= "9":
+            parsed = _read_decimal_length(rest, i)
+            if parsed is None:
+                i += 1
+                continue
+            length, j = parsed
             name = rest[j : j + length]
             i = j + length
             if depth == 0:
@@ -607,11 +636,12 @@ def _entity_owner_is_internal(symbol: str) -> bool:
                 break
             depth -= 1
             i += 1
-        elif c.isdigit():
-            j = i
-            while j < len(rest) and rest[j].isdigit():
-                j += 1
-            length = int(rest[i:j])
+        elif "0" <= c <= "9":
+            parsed = _read_decimal_length(rest, i)
+            if parsed is None:
+                i += 1
+                continue
+            length, j = parsed
             i = j + length
             if depth == 0:
                 components.append(rest[j : j + length])
@@ -655,18 +685,21 @@ def _has_template_args(symbol: str) -> bool:
                     return saw_template  # depth-0 ``E`` closes the nested name
                 depth -= 1
                 i += 1
-            elif c.isdigit():
-                j = i
-                while j < len(rest) and rest[j].isdigit():
-                    j += 1
-                i = j + int(rest[i:j])  # skip the source-name characters
+            elif "0" <= c <= "9":
+                parsed = _read_decimal_length(rest, i)
+                if parsed is None:
+                    i += 1
+                    continue
+                length, j = parsed
+                i = j + length  # skip the source-name characters
             else:
                 i += 1
         return saw_template
     # Un-nested ``_Z<len><name>…``: a template iff the single name is followed by an
     # ``I`` template-args opener (``_Z9transformIdEv``); the tail is the signature.
-    m = re.match(r"(\d+)", rest)
-    if not m:
+    parsed = _read_decimal_length(rest, 0)
+    if parsed is None:
         return False
-    end = m.end() + int(m.group(1))
+    length, name_start = parsed
+    end = name_start + length
     return end < len(rest) and rest[end] == "I"

--- a/tests/test_crosscheck.py
+++ b/tests/test_crosscheck.py
@@ -362,6 +362,19 @@ def test_exported_not_public_marks_template_instantiation():
     assert counters["template_instantiation"] == 1
 
 
+def test_exported_not_public_malformed_long_length_is_conservative():
+    # Malformed Itanium length fields come from untrusted export tables. They must
+    # not abort the audit when the digit run exceeds Python's int-string limit.
+    malformed = "_ZN" + ("9" * 5000) + "Av"
+    snap = _snap(elf=_elf("_Z3fooi", malformed))
+    snap.functions = [_public_fn()]
+    res = run_crosschecks(snap, CrosscheckConfig(max_per_check=0))
+    hits = _findings_of(res, ChangeKind.EXPORTED_NOT_PUBLIC)
+    assert [c.symbol for c in hits] == [malformed]
+    counters = _coverage(res, CHECK_EXPORTED_NOT_PUBLIC)["counters"]
+    assert counters["undeclared_export"] == 1
+
+
 def test_exported_not_public_accounting_sums_to_all_exports():
     # The accounting partitions the whole export table — documented API +
     # compiler artifact + every undocumented reason == number of exports, so the


### PR DESCRIPTION
### Motivation

- The export-accounting mangled-name parser used unbounded `int()` conversions on attacker-controlled Itanium length fields, which can raise `ValueError` (Python integer-string conversion limit) and abort `run_crosschecks` when processing malformed exports. 
- The intent is to make symbol classification robust to untrusted/ malformed export names and to conservatively classify unparseable names rather than crashing the audit/CI job.

### Description

- Add a safe reader ` _read_decimal_length(text, start)` that accumulates decimal digits without calling `int()` on an unbounded run and bounds/skips overly-large runs. 
- Replace the previous `int()`-based length parsing in the Itanium helpers with the new reader in ` _mangled_owner_namespace`, `_nested_component`, `_entity_owner_is_internal`, and `_has_template_args` so all Itanium source-name length fields are parsed safely. 
- Preserve existing classification logic and fallback behavior; malformed/oversize length fields are handled conservatively so the export is still accounted (e.g. as an `undeclared_export`) instead of aborting. 
- Add a regression test `test_exported_not_public_malformed_long_length_is_conservative` that supplies a 5000-digit length field and asserts the audit does not crash and classifies the export conservatively.

### Testing

- Ran the targeted tests: `pytest tests/test_crosscheck.py::test_exported_not_public_malformed_long_length_is_conservative tests/test_crosscheck.py::test_exported_not_public_marks_external_dependency_leak tests/test_crosscheck.py::test_exported_not_public_marks_template_instantiation`, and all passed. 
- Ran the full crosscheck test file with `pytest tests/test_crosscheck.py` and observed `177 passed` for that module. 
- Ran static checks with `ruff` on the modified files and received no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51e2e5969c832b876034b55680d493)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed or excessively long exported symbol names.
  * Prevented parsing failures when inspecting invalid C++-style symbols.
  * Ensured malformed symbols are conservatively reported by export checks.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->