### PR TITLE
fix(macho): bound export trie traversal

### DIFF
--- a/abicheck/macho_metadata.py
+++ b/abicheck/macho_metadata.py
@@ -225,6 +225,11 @@ _EXPORT_SYMBOL_FLAGS_REEXPORT = 0x08
 _EXPORT_SYMBOL_FLAGS_STUB_AND_RESOLVER = 0x10
 
 _TRIE_MAX_DEPTH = 128
+_TRIE_MAX_NODES = 100_000
+_TRIE_MAX_CHILDREN = 200_000
+_TRIE_MAX_RESULTS = 50_000
+_TRIE_MAX_SYMBOL_LENGTH = 4_096
+_TRIE_MAX_SYMBOL_BYTES = 1_000_000
 
 
 def _read_uleb128(data: bytes, off: int) -> tuple[int, int]:
@@ -253,13 +258,20 @@ def _walk_export_trie(data: bytes) -> list[tuple[str, int]]:
     """
     results: list[tuple[str, int]] = []
     visited: set[int] = set()
+    child_entries = 0
+    symbol_bytes = 0
 
     def visit(off: int, prefix: str, depth: int) -> None:
+        nonlocal child_entries, symbol_bytes
         if depth > _TRIE_MAX_DEPTH or off in visited or off >= len(data):
             return
+        if len(visited) >= _TRIE_MAX_NODES:
+            raise ValueError("export trie node budget exceeded")
         visited.add(off)
         terminal_size, pos = _read_uleb128(data, off)
         if terminal_size > 0:
+            if len(results) >= _TRIE_MAX_RESULTS:
+                raise ValueError("export trie result budget exceeded")
             flags, _ = _read_uleb128(data, pos)
             results.append((prefix, flags))
         # The terminal payload occupies exactly terminal_size bytes after the
@@ -268,11 +280,20 @@ def _walk_export_trie(data: bytes) -> list[tuple[str, int]]:
         if pos >= len(data):
             return
         child_count = data[pos]
+        if child_entries + child_count > _TRIE_MAX_CHILDREN:
+            raise ValueError("export trie child-entry budget exceeded")
+        child_entries += child_count
         pos += 1
         for _ in range(child_count):
             end = data.find(b"\x00", pos)
             if end < 0:
                 return
+            edge_bytes = end - pos
+            if len(prefix) + edge_bytes > _TRIE_MAX_SYMBOL_LENGTH:
+                raise ValueError("export trie symbol-name budget exceeded")
+            symbol_bytes += edge_bytes
+            if symbol_bytes > _TRIE_MAX_SYMBOL_BYTES:
+                raise ValueError("export trie symbol data budget exceeded")
             edge = data[pos:end].decode("utf-8", errors="replace")
             pos = end + 1
             child_off, pos = _read_uleb128(data, pos)

--- a/tests/test_platform_coverage_gaps.py
+++ b/tests/test_platform_coverage_gaps.py
@@ -477,6 +477,31 @@ class TestMachoExportTrieBudgets:
         with pytest.raises(ValueError, match="result budget"):
             _walk_export_trie(root + leaf)
 
+    def test_node_budget_is_enforced_before_visiting_child(self, monkeypatch):
+        monkeypatch.setattr("abicheck.macho_metadata._TRIE_MAX_NODES", 1)
+        root = b"\x00\x01a\x00" + self._uleb(5)
+        leaf = b"\x01\x00\x00"
+
+        with pytest.raises(ValueError, match="node budget"):
+            _walk_export_trie(root + leaf)
+
+    def test_cumulative_symbol_byte_budget_is_enforced(self, monkeypatch):
+        monkeypatch.setattr("abicheck.macho_metadata._TRIE_MAX_SYMBOL_BYTES", 3)
+        root = b"\x00\x01ab\x00" + self._uleb(6)
+        middle = b"\x00\x01cd\x00" + self._uleb(12)
+        leaf = b"\x01\x00\x00"
+
+        with pytest.raises(ValueError, match="symbol data budget"):
+            _walk_export_trie(root + middle + leaf)
+
+    def test_cumulative_symbol_byte_budget_allows_exact_boundary(self, monkeypatch):
+        monkeypatch.setattr("abicheck.macho_metadata._TRIE_MAX_SYMBOL_BYTES", 4)
+        root = b"\x00\x01ab\x00" + self._uleb(6)
+        middle = b"\x00\x01cd\x00" + self._uleb(12)
+        leaf = b"\x01\x00\x00"
+
+        assert _walk_export_trie(root + middle + leaf) == [("abcd", 0)]
+
     def test_symbol_name_length_budget_is_enforced(self, monkeypatch):
         monkeypatch.setattr("abicheck.macho_metadata._TRIE_MAX_SYMBOL_LENGTH", 1)
         root = b"\x00\x01ab\x00" + self._uleb(6)

--- a/tests/test_platform_coverage_gaps.py
+++ b/tests/test_platform_coverage_gaps.py
@@ -30,6 +30,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 # ============================================================================
 # pdb_utils.py — coverage gaps
 # ============================================================================
@@ -335,6 +337,7 @@ from abicheck.macho_metadata import (
     _dylib_name_from_cmd,
     _select_header,
     _version_field_to_str,
+    _walk_export_trie,
     parse_macho_metadata,
 )
 
@@ -438,6 +441,49 @@ class TestSelectHeader:
         with patch("abicheck.macho_metadata.platform.machine", return_value="x86_64"):
             result = _select_header(macho)
         assert result is hdr1
+
+
+class TestMachoExportTrieBudgets:
+    """Export trie traversal refuses inputs that exceed resource budgets."""
+
+    @staticmethod
+    def _uleb(value: int) -> bytes:
+        out = bytearray()
+        while True:
+            byte = value & 0x7F
+            value >>= 7
+            if value:
+                byte |= 0x80
+            out.append(byte)
+            if not value:
+                return bytes(out)
+
+    def test_child_entry_budget_is_enforced(self, monkeypatch):
+        monkeypatch.setattr("abicheck.macho_metadata._TRIE_MAX_CHILDREN", 1)
+        leaf1 = b"\x01\x00\x00"
+        leaf2 = b"\x01\x00\x00"
+        root_prefix = b"\x00\x02a\x00"
+        first_off = len(root_prefix) + 1 + len(b"b\x00") + 1
+        root = root_prefix + self._uleb(first_off) + b"b\x00" + self._uleb(first_off + len(leaf1))
+
+        with pytest.raises(ValueError, match="child-entry budget"):
+            _walk_export_trie(root + leaf1 + leaf2)
+
+    def test_result_budget_is_enforced(self, monkeypatch):
+        monkeypatch.setattr("abicheck.macho_metadata._TRIE_MAX_RESULTS", 1)
+        root = b"\x01\x00\x01a\x00" + self._uleb(6)
+        leaf = b"\x01\x00\x00"
+
+        with pytest.raises(ValueError, match="result budget"):
+            _walk_export_trie(root + leaf)
+
+    def test_symbol_name_length_budget_is_enforced(self, monkeypatch):
+        monkeypatch.setattr("abicheck.macho_metadata._TRIE_MAX_SYMBOL_LENGTH", 1)
+        root = b"\x00\x01ab\x00" + self._uleb(6)
+        leaf = b"\x01\x00\x00"
+
+        with pytest.raises(ValueError, match="symbol-name budget"):
+            _walk_export_trie(root + leaf)
 
 
 class TestParseMachoMetadataNonRegularFile:


### PR DESCRIPTION
### Motivation
- The Mach-O dyld export-trie walker previously traversed and collected every visited node and terminal entry without bounding node/result cardinality or symbol-name data, allowing a crafted trie (under the existing 64 MiB raw-cap) to exhaust CPU/memory and cause DoS. 
- Introduce conservative traversal budgets so untrusted binaries cannot force excessive memory or runtime while preserving the caller behavior that treats malformed/unreadable tries as skipped metadata.

### Description
- Add explicit traversal budgets: `_TRIE_MAX_NODES`, `_TRIE_MAX_CHILDREN`, `_TRIE_MAX_RESULTS`, `_TRIE_MAX_SYMBOL_LENGTH`, and `_TRIE_MAX_SYMBOL_BYTES` in `abicheck/macho_metadata.py` and initialize per-traversal counters. 
- Enforce budgets inside `_walk_export_trie` by raising `ValueError` when node, child-entry, result-entry, or symbol-data budgets are exceeded, and keep the existing depth/visited/offset guards. 
- Add unit tests in `tests/test_platform_coverage_gaps.py` that verify child-entry, result-entry, and symbol-name length budgets trigger `ValueError` as expected.

### Testing
- Ran `python -m pytest tests/test_platform_coverage_gaps.py::TestMachoExportTrieBudgets -q` and the new budget tests passed (`3 passed`).
- Ran `python -m pytest tests/test_platform_coverage_gaps.py -q` and the file-level tests passed (`74 passed`).
- Ran the repository test-suite with `python -m pytest -q` and the suite completed successfully (`13791 passed, 424 skipped, 4 xfailed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51e4647bd4832b9ce3544f292e2b33)