### PR TITLE
fix: bound runtime version parsing

### DIFF
--- a/abicheck/diff_versioning.py
+++ b/abicheck/diff_versioning.py
@@ -58,14 +58,12 @@ def _parse_dotted_numeric_version(text: str) -> tuple[int, ...] | None:
     for part in parts:
         if (
             not part
+            or not part.isascii()
             or not part.isdigit()
             or len(part) > _MAX_VERSION_COMPONENT_DIGITS
         ):
             return None
-        try:
-            parsed.append(int(part))
-        except ValueError:
-            return None
+        parsed.append(int(part))
     return tuple(parsed) if parsed else None
 
 

--- a/abicheck/diff_versioning.py
+++ b/abicheck/diff_versioning.py
@@ -35,10 +35,38 @@ from .elf_metadata import ElfMetadata
 _INTERNAL_VERSION_NODE_TOKENS = ("PRIVATE", "INTERNAL")
 
 _UNPARSEABLE_VERSION: tuple[int, ...] = (2**31,)
+_MAX_VERSION_COMPONENT_DIGITS = 9
 """Sentinel returned by :func:`_parse_abi_version_tag` for non-numeric tags
 like ``GLIBC_PRIVATE``.  Sorts *above* any real version so that a new
 non-numeric requirement is always treated as potentially BREAKING — never
 silently COMPAT."""
+
+
+def _parse_dotted_numeric_version(text: str) -> tuple[int, ...] | None:
+    """Parse a dotted numeric version safely, or return ``None``.
+
+    Version tags and declared runtime floors can come from untrusted ELF
+    metadata or snapshots.  Keep integer conversion bounded so pathological
+    digit strings are treated like malformed versions rather than aborting the
+    comparison via Python's integer-conversion guard (or burning CPU/memory on
+    runtimes without one).
+    """
+    parts = text.split(".")
+    if not parts:
+        return None
+    parsed: list[int] = []
+    for part in parts:
+        if (
+            not part
+            or not part.isdigit()
+            or len(part) > _MAX_VERSION_COMPONENT_DIGITS
+        ):
+            return None
+        try:
+            parsed.append(int(part))
+        except ValueError:
+            return None
+    return tuple(parsed) if parsed else None
 
 
 def _parse_abi_version_tag(ver: str) -> tuple[int, ...]:
@@ -48,8 +76,8 @@ def _parse_abi_version_tag(ver: str) -> tuple[int, ...]:
     Only the numeric suffix after the last ``_`` is used:
     ``GLIBC_2.34`` → ``(2, 34)``, ``GLIBCXX_3.4.19`` → ``(3, 4, 19)``.
 
-    Returns :data:`_UNPARSEABLE_VERSION` for non-numeric tags such as
-    ``GLIBC_PRIVATE`` — a very large sentinel that always compares as newer
+    Returns :data:`_UNPARSEABLE_VERSION` for non-numeric or malformed tags such
+    as ``GLIBC_PRIVATE`` — a very large sentinel that always compares as newer
     than any real version, so such tags are conservatively treated as BREAKING.
 
     Canonical home: previously lived in ``diff_platform_elf_symbols``; moved
@@ -58,8 +86,8 @@ def _parse_abi_version_tag(ver: str) -> tuple[int, ...]:
     """
     parts = ver.rsplit("_", 1)
     numeric = parts[-1] if len(parts) > 1 else ver
-    result = tuple(int(x) for x in numeric.split(".") if x.isdigit())
-    return result if result else _UNPARSEABLE_VERSION
+    result = _parse_dotted_numeric_version(numeric)
+    return result if result is not None else _UNPARSEABLE_VERSION
 
 # Change kinds whose ``symbol`` field is itself a version-node name (not a
 # symbol name) — for these, the node-name marker test applies directly.
@@ -239,10 +267,9 @@ def apply_runtime_floor_contract(
         # caller can hand a prebuilt dict straight to compare(); truncating a
         # "2.28-1" to (2,) here would silently flip verdicts, so a malformed
         # floor leaves the finding at its default instead (Codex review #510).
-        floor_parts = floor.split(".")
-        if not floor_parts or not all(p.isdigit() for p in floor_parts):
+        floor_tuple = _parse_dotted_numeric_version(floor)
+        if floor_tuple is None:
             continue
-        floor_tuple = tuple(int(p) for p in floor_parts)
         if required == _UNPARSEABLE_VERSION:
             continue
         if required <= floor_tuple:

--- a/abicheck/environment_matrix.py
+++ b/abicheck/environment_matrix.py
@@ -59,6 +59,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .diff_versioning import _parse_dotted_numeric_version
+
 log = logging.getLogger(__name__)
 
 
@@ -175,11 +177,11 @@ def _parse_runtime_floors(floors_raw: object) -> dict[str, str]:
         # contract parses with int() per component, so a "2.28-1" or "2.x"
         # would silently truncate to (2,) and flip verdicts. Reject
         # malformed text here instead (Codex review #510).
-        components = floor.split(".")
-        if not components or not all(p.isdigit() for p in components):
+        if _parse_dotted_numeric_version(floor) is None:
             raise ValueError(
                 f"'runtime_floors.{key}' must be a dotted numeric version "
-                f"(digits and dots only, e.g. '2.28'), got {value!r}"
+                f"(digits and dots only, e.g. '2.28'), with each component "
+                f"at most 9 digits, got {value!r}"
             )
         runtime_floors[str(key).upper()] = floor
     return runtime_floors

--- a/tests/test_environment_drift.py
+++ b/tests/test_environment_drift.py
@@ -141,6 +141,29 @@ class TestRuntimeFloorRaised:
         changes = _diff_elf_symbol_versioning(self._old(), new)
         assert ChangeKind.RUNTIME_FLOOR_RAISED not in _kinds(changes)
 
+    def test_overlong_unchanged_version_tag_is_unparseable_not_crash(self) -> None:
+        malicious = "GLIBC_" + ("9" * 5000)
+        old = _elf(
+            needed=["libc.so.6"],
+            versions_required={"libc.so.6": ["GLIBC_2.28", malicious]},
+        )
+        new = _elf(
+            needed=["libc.so.6"],
+            versions_required={"libc.so.6": ["GLIBC_2.28", malicious]},
+        )
+        changes = _diff_elf_symbol_versioning(old, new)
+        assert ChangeKind.RUNTIME_FLOOR_RAISED not in _kinds(changes)
+
+    def test_malformed_partial_version_tag_is_unparseable_not_floor(self) -> None:
+        new = _elf(
+            needed=["libc.so.6"],
+            versions_required={
+                "libc.so.6": ["GLIBC_2.17", "GLIBC_2.28", "GLIBC_2.28-1"]
+            },
+        )
+        changes = _diff_elf_symbol_versioning(self._old(), new)
+        assert ChangeKind.RUNTIME_FLOOR_RAISED not in _kinds(changes)
+
     def test_floor_is_risk_verdict_through_compare(self) -> None:
         new = _elf(
             needed=["libc.so.6"],
@@ -237,6 +260,13 @@ class TestRuntimeFloorContract:
         ))
         assert result.verdict is Verdict.COMPATIBLE_WITH_RISK
 
+    def test_overlong_direct_floor_left_at_default_not_crash(self) -> None:
+        old, new = self._pair()
+        result = compare(old, new, env_matrix=EnvironmentMatrix(
+            runtime_floors={"GLIBC": "9" * 5000}
+        ))
+        assert result.verdict is Verdict.COMPATIBLE_WITH_RISK
+
     def test_floor_keys_case_insensitive(self) -> None:
         changes = [
             c for c in compare(*self._pair()).changes
@@ -294,7 +324,9 @@ class TestEnvironmentMatrixRuntimeFloors:
         m = EnvironmentMatrix.from_dict({"runtime_floors": {"GLIBC": 3}})
         assert m.runtime_floors == {"GLIBC": "3"}
 
-    @pytest.mark.parametrize("bad", ["2.28-1", "2.x", "v2.28", "2..28", ""])
+    @pytest.mark.parametrize(
+        "bad", ["2.28-1", "2.x", "v2.28", "2..28", "", "9" * 5000]
+    )
     def test_partially_numeric_floor_rejected(self, bad: str) -> None:
         # The floor contract parses per dot-component with int(); a floor like
         # "2.28-1" would silently truncate to (2,) and flip verdicts — reject

--- a/tests/test_environment_drift.py
+++ b/tests/test_environment_drift.py
@@ -33,7 +33,10 @@ from abicheck.diff_platform_elf_dynamic import (
 )
 from abicheck.diff_platform_elf_symbols import _diff_elf_symbol_versioning
 from abicheck.diff_time64 import _diff_time64_abi
-from abicheck.diff_versioning import apply_runtime_floor_contract
+from abicheck.diff_versioning import (
+    _parse_dotted_numeric_version,
+    apply_runtime_floor_contract,
+)
 from abicheck.elf_metadata import ElfImport, ElfMetadata
 from abicheck.environment_matrix import EnvironmentMatrix
 from abicheck.model import AbiSnapshot
@@ -59,6 +62,26 @@ def _snap(elf: ElfMetadata, **kwargs) -> AbiSnapshot:
 
 def _kinds(changes) -> set[ChangeKind]:
     return {c.kind for c in changes}
+
+
+class TestDottedNumericVersionParser:
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [("2", (2,)), ("2.34", (2, 34)), ("3.4.123456789", (3, 4, 123456789))],
+    )
+    def test_valid_versions(self, text: str, expected: tuple[int, ...]) -> None:
+        assert _parse_dotted_numeric_version(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        ["", ".", "2.", ".2", "2..34", "2.x", "2.34-1", "²", "١"],
+    )
+    def test_invalid_versions(self, text: str) -> None:
+        assert _parse_dotted_numeric_version(text) is None
+
+    def test_component_digit_bound(self) -> None:
+        assert _parse_dotted_numeric_version("9" * 9) == (999999999,)
+        assert _parse_dotted_numeric_version("9" * 10) is None
 
 
 # ── RUNTIME_FLOOR_RAISED synthesis ───────────────────────────────────────────
@@ -198,6 +221,18 @@ class TestRuntimeFloorContract:
                      if c.kind is ChangeKind.RUNTIME_FLOOR_RAISED)
         assert floor.effective_verdict is Verdict.COMPATIBLE
         assert floor.modulation_rule == "runtime_floor_contract"
+
+    def test_valid_direct_floor_is_applied(self) -> None:
+        old, new = self._pair()
+        result = compare(
+            old,
+            new,
+            env_matrix=EnvironmentMatrix(runtime_floors={"GLIBC": "2.34"}),
+        )
+        floor = next(
+            c for c in result.changes if c.kind is ChangeKind.RUNTIME_FLOOR_RAISED
+        )
+        assert floor.effective_verdict is Verdict.COMPATIBLE
 
     def test_requirement_above_floor_is_breaking(self) -> None:
         old, new = self._pair()


### PR DESCRIPTION
### Motivation
- Prevent unbounded `int()` conversion on attacker-controlled ABI version components that can raise exceptions or consume excessive resources and abort comparisons.  
- Ensure runtime-floor synthesis and declared `runtime_floors` validation treat malformed or overlong numeric components as unparseable instead of crashing.  

### Description
- Add `_MAX_VERSION_COMPONENT_DIGITS = 9` and a safe parser `_parse_dotted_numeric_version(text: str) -> tuple[int, ...] | None` in `abicheck/diff_versioning.py` that bounds component length and catches conversion failures.  
- Replace direct unbounded `int()` conversions in `_parse_abi_version_tag` with the safe parser so malformed or overlong tags return the `_UNPARSEABLE_VERSION` sentinel.  
- Use the same safe parser in `apply_runtime_floor_contract` to avoid crashing on prebuilt/malicious floor values.  
- Reuse the safe parser in `abicheck/environment_matrix._parse_runtime_floors` to reject environment matrix floor components that are malformed or exceed the digit limit and surface a clear `ValueError`.  
- Add regression tests in `tests/test_environment_drift.py` covering unchanged overlong malicious tags, malformed partial tags, overlong direct floor values, and environment-matrix rejection of overlong numeric components.  

### Testing
- Ran targeted environment-drift tests: `python -m pytest tests/test_environment_drift.py::TestRuntimeFloorRaised tests/test_environment_drift.py::TestRuntimeFloorContract tests/test_environment_drift.py::TestEnvironmentMatrixRuntimeFloors -q` and observed the tests pass (`32 passed`).  
- Ran a broader subset: `python -m pytest tests/test_environment_drift.py tests/test_sprint2_elf.py -q` and observed `120 passed`.  
- Attempted full test run `python -m pytest -q`, which aborted during collection due to a missing optional test dependency (`hypothesis`) in the environment; this is unrelated to the change itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51e464a278832ba4ce7177be9c4eef)