### PR TITLE
fix(idioms): harden Itanium destructor parsing

### DIFF
--- a/abicheck/idioms.py
+++ b/abicheck/idioms.py
@@ -446,11 +446,20 @@ _MSVC_DTOR_RE = re.compile(r"\?\?1|deleting destructor")
 def _skip_source_name(entry: str, i: int) -> int:
     """Skip a length-prefixed ``<source-name>`` starting at ``entry[i]``; return the next index."""
     # <source-name> ::= <decimal length> <identifier> — skip whole.
+    # Vtable entries can originate from untrusted snapshots or DWARF linkage
+    # names.  Accumulate the length incrementally instead of calling int() on
+    # the complete digit run, because Python rejects very long decimal strings
+    # once the integer-string conversion guard is exceeded.  Any declared name
+    # length beyond the remaining mangling consumes the rest of the entry.
     n = len(entry)
     j = i
+    name_len = 0
     while j < n and entry[j].isdigit():
+        name_len = name_len * 10 + (ord(entry[j]) - ord("0"))
         j += 1
-    return j + int(entry[i:j])
+        if name_len >= n - j:
+            return n
+    return min(n, j + name_len)
 
 
 def _skip_substitution(entry: str, i: int) -> int:

--- a/tests/test_castxml_ref_qualifier_vtable.py
+++ b/tests/test_castxml_ref_qualifier_vtable.py
@@ -274,6 +274,20 @@ def test_is_itanium_dtor_symbol_structural(entry: str, is_dtor: bool) -> None:
         "~Renderer",  # castxml fallback entry
     ],
 )
+
+
 def test_has_virtual_destructor_non_itanium_entries(entry: str) -> None:
     rec = RecordType(name="Renderer", kind="class", vtable=[entry])
     assert _has_virtual_destructor(rec)
+
+
+def test_is_itanium_dtor_symbol_rejects_oversized_source_name_length() -> None:
+    from abicheck.idioms import _is_itanium_dtor_symbol
+
+    assert not _is_itanium_dtor_symbol("_ZN" + "9" * 5000)
+
+
+def test_is_itanium_dtor_symbol_rejects_oversized_template_arg_source_name_length() -> None:
+    from abicheck.idioms import _is_itanium_dtor_symbol
+
+    assert not _is_itanium_dtor_symbol("_ZN3FooI" + "9" * 5000 + "EED1Ev")


### PR DESCRIPTION
### Motivation
- The structural Itanium mangling walker parsed untrusted decimal length fields with an unbounded `int()` conversion which can raise `ValueError` on very long digit runs and abort pattern analysis when `--pattern-verdicts` is enabled, allowing a denial-of-service against CI processing untrusted snapshots.
- The change aims to eliminate the unbounded conversion while preserving the destructor-detection heuristics and compatibility with existing valid manglings.

### Description
- Replace the `int(entry[i:j])` conversion in `_skip_source_name` with an incremental decimal accumulation to avoid Python's integer-string conversion limit and to bound processing on oversized runs.
- Treat declared source-name lengths that exceed the remaining mangling as consuming the rest of the entry instead of raising an exception, preventing parser crashes on malformed inputs.
- Add two regression tests to `tests/test_castxml_ref_qualifier_vtable.py` that assert oversized digit runs at top-level and inside template-argument groups do not trigger destructor detection or crashes.
- No change to the public API or to valid-mangling destructor recognition behaviour.

### Testing
- Ran `pytest -q tests/test_castxml_ref_qualifier_vtable.py`, which succeeded (41 passed).
- Ran `pytest -q` for the whole suite, which failed during collection due to the environment missing the `hypothesis` dependency, so full test-suite execution was not completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51e465181c832ba33b73673bbd9024)