### PR TITLE
fix: require explicit opt-in for source_smoke `run` mode

### DIFF
--- a/.github/workflows/examples-validation.yml
+++ b/.github/workflows/examples-validation.yml
@@ -72,12 +72,18 @@ jobs:
           python -c "import json; d=json.load(open('examples/ground_truth.json')); print('ground_truth.json OK:', len(d['verdicts']), 'cases')"
 
       - name: Run example cases (pytest autodiscovery)
+        env:
+          # This workflow checks out and executes repository-owned fixtures only.
+          ABICHECK_TRUSTED_SOURCE_SMOKE_RUN: "1"
         run: |
           PYTHONPATH=. pytest tests/test_example_autodiscovery.py -v --tb=short -m integration \
             --junit-xml=results/examples-autodiscovery-${{ matrix.toolchain }}.xml
 
       - name: Cross-check via validate_examples.py (full catalog)
         if: always()
+        env:
+          # Preserve the safe default for all other validator invocations.
+          ABICHECK_TRUSTED_SOURCE_SMOKE_RUN: "1"
         run: |
           PYTHONPATH=. python tests/validate_examples.py --toolchain ${{ matrix.toolchain }} --json \
             > results/validate_examples-${{ matrix.toolchain }}.json

--- a/abicheck/source_smoke.py
+++ b/abicheck/source_smoke.py
@@ -98,12 +98,14 @@ def run_source_smoke(
     work_dir: Path,
     compiler: str,
     timeout: float = 60.0,
+    allow_run: bool = False,
 ) -> SourceSmokeResult:
     """Run a two-sided consumer compile/link smoke check.
 
     Returns a structured result instead of raising for expected compiler
     failures.  Invalid smoke metadata raises ``ValueError`` because that is a
-    test/fixture bug, not a compatibility outcome.
+    test/fixture bug, not a compatibility outcome. Runtime execution is disabled
+    by default; callers must pass ``allow_run=True`` only for trusted fixtures.
     """
 
     work_dir.mkdir(parents=True, exist_ok=True)
@@ -114,6 +116,10 @@ def run_source_smoke(
         src = work_dir / f"{label}{source_suffix}"
         src.write_text(code, encoding="utf-8")
         mode = side.mode or spec.mode
+        if mode == "run" and not allow_run:
+            raise ValueError(
+                "source_smoke run mode requires explicit allow_run=True for trusted fixtures"
+            )
         exe = work_dir / f"{label}.out"
         if mode == "syntax":
             cmd = [compiler, f"-std={spec.standard}", "-I", str(case_dir), "-fsyntax-only", str(src)]

--- a/tests/test_source_smoke.py
+++ b/tests/test_source_smoke.py
@@ -155,7 +155,9 @@ def test_side_without_code_or_source_is_a_fixture_bug(tmp_path: Path) -> None:
     spec = SourceSmokeSpec(source=None, v1=SourceSmokeSide(code=None))
 
     with pytest.raises(ValueError, match="either code or top-level source"):
-        run_source_smoke(spec, case_dir=tmp_path, work_dir=tmp_path / "work", compiler="true")
+        run_source_smoke(
+            spec, case_dir=tmp_path, work_dir=tmp_path / "work", compiler="true"
+        )
 
 
 def test_unsupported_mode_raises(tmp_path: Path) -> None:
@@ -165,7 +167,9 @@ def test_unsupported_mode_raises(tmp_path: Path) -> None:
     )
 
     with pytest.raises(ValueError, match="unsupported source_smoke mode"):
-        run_source_smoke(spec, case_dir=tmp_path, work_dir=tmp_path / "work", compiler="true")
+        run_source_smoke(
+            spec, case_dir=tmp_path, work_dir=tmp_path / "work", compiler="true"
+        )
 
 
 def test_run_mode_checks_runtime_exit_code(tmp_path: Path) -> None:
@@ -185,9 +189,27 @@ def test_run_mode_checks_runtime_exit_code(tmp_path: Path) -> None:
         v2=SourceSmokeSide(code=app, lib_source="v2.cpp", expect="failure"),
     )
 
-    result = run_source_smoke(spec, case_dir=case, work_dir=tmp_path / "work", compiler=_cxx())
+    result = run_source_smoke(
+        spec,
+        case_dir=case,
+        work_dir=tmp_path / "work",
+        compiler=_cxx(),
+        allow_run=True,
+    )
 
     assert result.ok
+
+
+def test_run_mode_requires_explicit_trust_opt_in(tmp_path: Path) -> None:
+    spec = SourceSmokeSpec(
+        mode="run",
+        v1=SourceSmokeSide(code="int main() { return 0; }\n"),
+    )
+
+    with pytest.raises(ValueError, match="requires explicit allow_run=True"):
+        run_source_smoke(
+            spec, case_dir=tmp_path, work_dir=tmp_path / "work", compiler="true"
+        )
 
 
 def test_timeout_is_treated_as_a_failure(tmp_path: Path) -> None:
@@ -209,7 +231,12 @@ def test_timeout_is_treated_as_a_failure(tmp_path: Path) -> None:
     )
 
     result = run_source_smoke(
-        spec, case_dir=case, work_dir=tmp_path / "work", compiler=_cxx(), timeout=2.0
+        spec,
+        case_dir=case,
+        work_dir=tmp_path / "work",
+        compiler=_cxx(),
+        timeout=2.0,
+        allow_run=True,
     )
 
     assert not result.ok

--- a/tests/test_validate_examples_unit.py
+++ b/tests/test_validate_examples_unit.py
@@ -16,6 +16,7 @@ import pytest
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 import tests.validate_examples as ve  # noqa: E402
+from abicheck.source_smoke import SourceSmokeResult  # noqa: E402
 from tests.validate_examples import (  # noqa: E402
     ARTIFACT_VARIANTS,
     DEFAULT_ARTIFACT_VARIANT,
@@ -28,6 +29,7 @@ from tests.validate_examples import (  # noqa: E402
     _json_payload,
     _normalize_verdict,
     _result_to_json,
+    _run_source_smoke,
     _selected_variants,
     _source_layers_for_result,
     _sources_path,
@@ -45,6 +47,40 @@ _VALID_VERDICTS = frozenset(
     {"BREAKING", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "NO_CHANGE", "API_BREAK"}
 )
 _EXPECTED_CASE_COUNT = 181
+
+
+def test_source_smoke_run_mode_skips_without_trusted_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("ABICHECK_TRUSTED_SOURCE_SMOKE_RUN", raising=False)
+    monkeypatch.setattr(ve, "_find_compiler", lambda _cxx: "c++")
+    run = patch.object(ve, "run_source_smoke")
+
+    with run as mock_run:
+        result = _run_source_smoke(
+            "case", {"source_smoke": {"mode": "run"}}, tmp_path, tmp_path, "BREAKING"
+        )
+
+    assert result is not None and result.status == "SKIP"
+    assert "ABICHECK_TRUSTED_SOURCE_SMOKE_RUN=1" in result.message
+    mock_run.assert_not_called()
+
+
+def test_source_smoke_run_mode_executes_with_trusted_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ABICHECK_TRUSTED_SOURCE_SMOKE_RUN", "1")
+    monkeypatch.setattr(ve, "_find_compiler", lambda _cxx: "c++")
+    smoke_result = SourceSmokeResult(ok=True, failures=(), proof="trusted proof")
+
+    with patch.object(ve, "run_source_smoke", return_value=smoke_result) as mock_run:
+        result = _run_source_smoke(
+            "case", {"source_smoke": {"mode": "run"}}, tmp_path, tmp_path, "BREAKING"
+        )
+
+    assert result is not None and result.status == "PASS"
+    assert result.message == "trusted proof"
+    assert mock_run.call_args.kwargs["allow_run"] is True
 
 
 # ── _normalize_verdict ────────────────────────────────────────────────────

--- a/tests/validate_examples.py
+++ b/tests/validate_examples.py
@@ -1041,11 +1041,24 @@ def _run_source_smoke(
     if compiler is None:
         return CaseResult(name, "SKIP", expected_raw, None, "no compiler for source smoke")
 
+    allow_run = os.environ.get("ABICHECK_TRUSTED_SOURCE_SMOKE_RUN") == "1"
+    if not allow_run and (
+        spec.mode == "run" or spec.v1.mode == "run" or spec.v2.mode == "run"
+    ):
+        return CaseResult(
+            name,
+            "SKIP",
+            expected_raw,
+            None,
+            "source_smoke run mode requires ABICHECK_TRUSTED_SOURCE_SMOKE_RUN=1",
+        )
+
     result = run_source_smoke(
         spec,
         case_dir=case_dir,
         work_dir=tmp_base / f"{name}__source_smoke",
         compiler=compiler,
+        allow_run=allow_run,
     )
     if not result.ok:
         return CaseResult(name, "FAIL", expected_raw, None, "; ".join(result.failures))


### PR DESCRIPTION
### Motivation

- The `source_smoke` runner previously accepted `mode: "run"` from fixtures and executed the produced binaries, allowing untrusted example metadata to trigger arbitrary code execution during validation.  The change adds a trust gate to prevent accidental execution of untrusted artifacts.

### Description

- Add an `allow_run: bool = False` parameter to `run_source_smoke` and make it raise `ValueError` if a `run` mode is encountered without explicit opt-in via `allow_run=True` in the caller (file: `abicheck/source_smoke.py`).
- Update the examples validation harness to skip JSON-declared `mode: "run"` checks by default and only enable them when the environment variable `ABICHECK_TRUSTED_SOURCE_SMOKE_RUN=1` is set, and pass the `allow_run` flag through to `run_source_smoke` (file: `tests/validate_examples.py`).
- Update unit tests to opt in to `run` execution where intended by passing `allow_run=True` and add a regression test that verifies `run` mode is rejected when not explicitly allowed (file: `tests/test_source_smoke.py`).

### Testing

- Ran linter: `ruff check abicheck/source_smoke.py tests/validate_examples.py tests/test_source_smoke.py`, which passed. 
- Ran targeted pytest: `pytest -q tests/test_source_smoke.py tests/test_example_autodiscovery.py::test_example_source_smoke -q`, and the tests passed (all checks green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51e465b984832bbc6ee7c7cfff8eee)