### PR TITLE
fix: correct verdict-routing bugs and dependency-direction debt from architecture review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,26 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **SARIF and JUnit output could disagree with the JSON report and gate on a
+  `PolicyFile` verdict override.** Both renderers fell back to a finding's
+  *kind*'s default policy severity when no A4 per-finding override was set,
+  which ignored a `PolicyFile.overrides` entry that had moved the kind's
+  *effective* verdict — so a demoted `BREAKING` kind could still show SARIF
+  `"error"` / a JUnit `<failure>` even though the JSON report and exit code
+  correctly read it as compatible (and vice versa for an escalation). Both now
+  route through `DiffResult._effective_verdict_for_change`, the same canonical
+  per-finding verdict the JSON report and severity-aware exit code already use,
+  so a `PolicyFile` override, A4 pattern-aware demotion, and frozen-namespace
+  escalation guard all propagate identically to every native output channel.
+
+- **`snapshot_to_dict`/`snapshot_to_json` mutated the caller's `AbiSnapshot`.**
+  Serializing a snapshot reset its lazy lookup-index caches
+  (`_func_by_mangled`/`_var_by_mangled`/`_type_by_name`) to `None` on the
+  actual object passed in, not a copy — so calling `dump`/`to_json` after
+  building an index (e.g. via `.index()`) silently invalidated it out from
+  under the caller. Serialization now saves and restores those fields, making
+  the call observably pure.
+
 - **`scan`/`dump --sources` now seeds L2 header includes from the build.** A
   zero-config source scan whose public headers `#include` a dependency's headers
   (e.g. EPICS pvxs headers pulling in `<epicsTime.h>`) hard-failed the L2 parse
@@ -199,6 +219,25 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   vtable/typeinfo orphans 85 → 14.
 
 ### Changed
+
+- **`scan` engine core split out of the CLI into `scan_engine.py` (internal
+  only).** `service_scan.run_scan` (the typed Python/MCP scan API) previously
+  imported its shared orchestration core (`run_scan_core`,
+  `_BudgetOverflow`, `_EvidenceContractError`) from `cli_scan.py`, a Click
+  command module — the reverse of the intended frontend → service → engine
+  dependency direction. That core now lives in `scan_engine.py`, which has no
+  Click dependency; `cli_scan.py` (the CLI) and `service_scan.py` (the typed
+  service API) both depend on it independently instead of the service
+  reaching into a front-end module. No CLI, API, or output change.
+
+- **Post-processing pipeline now enforces its `ctx.kept` aliasing contract
+  explicitly (internal only).** `FilterRedundant` establishes `ctx.kept` as a
+  reference to the same list object later steps mutate in place; a future step
+  that instead rebinds the list without resyncing `ctx.kept` would have
+  silently dropped its suppression/demotion from the verdict.
+  `PostProcessingPipeline.run` now raises immediately if a step breaks that
+  invariant, instead of failing silently. No behaviour change for the current
+  pipeline (all existing steps already honour the contract).
 
 - **`merge` / `dump --inputs`: fold identical facts once (perf).** A per-TU Flow-2
   pack re-emits each public-header decl once per compile — a ~20× blow-up on

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -51,16 +51,24 @@ import subprocess
 import sys
 import time
 from collections.abc import Callable
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import click
 
-from .buildsource.crosscheck import ALL_CHECKS, CrosscheckConfig, run_crosschecks
-from .buildsource.pattern_scan import scan_files
-from .buildsource.poi import build_points_of_interest, resolve_symbol_tus
-from .buildsource.preprocessor_scan import run_preprocessor_scan
+from .buildsource.crosscheck import (  # noqa: F401 - CrosscheckConfig/run_crosschecks re-exported for tests
+    ALL_CHECKS,
+    CrosscheckConfig,
+    run_crosschecks,
+)
+from .buildsource.pattern_scan import scan_files  # noqa: F401 - re-export for tests
+from .buildsource.poi import (  # noqa: F401 - re-export for tests
+    build_points_of_interest,
+    resolve_symbol_tus,
+)
+from .buildsource.preprocessor_scan import (
+    run_preprocessor_scan,  # noqa: F401 - re-export for tests
+)
 from .buildsource.risk import RiskScore, score_changed_paths
 from .buildsource.scan_levels import (
     EvidenceDepth,
@@ -69,7 +77,10 @@ from .buildsource.scan_levels import (
     level_to_collect_mode,
     resolve_level,
 )
-from .checker_policy import API_BREAK_KINDS, BREAKING_KINDS
+from .checker_policy import (  # noqa: F401 - re-export for tests
+    API_BREAK_KINDS,
+    BREAKING_KINDS,
+)
 from .cli import _safe_write_output, _setup_verbosity, main
 from .cli_options import (
     compile_context_options,
@@ -82,12 +93,12 @@ from .cli_params import DEPTH_PARAM
 from .cli_scan_baseline import (
     _baseline_is_native_library,  # noqa: F401 - re-export for scan tests/service_scan
     _emit_estimate,
-    _expand_public_headers,
+    _expand_public_headers,  # noqa: F401 - re-export for tests
     _load_risk_rules,
     _public_provenance_set,
-    _run_baseline_compare,
+    _run_baseline_compare,  # noqa: F401 - re-export for scan tests
 )
-from .cli_scan_helpers import (
+from .cli_scan_helpers import (  # noqa: F401 - coverage/depth helpers re-exported for tests
     _intrinsic_coverage,
     _l3_collected,
     _pack_coverage,
@@ -105,8 +116,24 @@ from .cli_scan_helpers import (
     scan_pattern_roots,
 )
 
-if TYPE_CHECKING:
-    from .service_scan import CompileContext
+# The scan *engine* (classify → always-on tier → level → compare) lives in
+# scan_engine.py, not here — this module is a thin Click front-end over it
+# (ADR-037 D1: frontends depend on the engine, never the reverse).
+# service_scan.run_scan imports the same symbols from the same module, so the
+# CLI and the typed service API share one engine instead of the service
+# reaching into a front-end module (see scan_engine.py's module docstring).
+from .scan_engine import (  # noqa: F401 - several re-exported for tests/service_scan parity
+    ScanCoreResult,
+    ScanOutcome,
+    _audit_exit_code,
+    _BudgetOverflow,
+    _build_new_snapshot,
+    _build_scan_poi,
+    _crosscheck_severity_exit,
+    _EvidenceContractError,
+    _load_exports_for_poi,
+    run_scan_core,
+)
 
 #: Back-compat alias — the resolver moved to ``cli_options`` (ADR-037 D3: one
 #: resolver shared by compare/dump/scan). Kept importable from here for existing
@@ -236,70 +263,6 @@ def _parse_crosschecks(
     return frozenset(enabled), severities
 
 
-@dataclass
-class ScanOutcome:
-    """The composed result of a ``scan`` run, rendered to text or JSON.
-
-    Holds enough to print one coverage- and confidence-annotated report: the
-    resolved level, the risk score, the always-on tier results, the optional
-    baseline diff, and the combined verdict/exit code.
-    """
-
-    mode: str
-    resolved_method: str
-    depth: str | None
-    collect_mode: str
-    risk: RiskScore
-    auto: bool
-    changed_path_count: int
-    changed_path_source: str
-    coverage: list[dict[str, Any]] = field(default_factory=list)
-    pattern: dict[str, Any] = field(default_factory=dict)
-    preprocessor: dict[str, Any] = field(default_factory=dict)
-    crosscheck: dict[str, Any] = field(default_factory=dict)
-    crosscheck_severities: dict[str, str] = field(default_factory=dict)
-    poi: dict[str, Any] = field(default_factory=dict)
-    advisories: list[str] = field(default_factory=list)
-    stage_timings: dict[str, float] = field(default_factory=dict)
-    audit: bool = False
-    diff_summary: dict[str, Any] | None = None
-    verdict: str = "COMPATIBLE"
-    exit_code: int = 0
-    elapsed_s: float = 0.0
-    budget_s: float | None = None
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "mode": self.mode,
-            "level": {
-                "source_method": self.resolved_method,
-                "depth": self.depth,
-                "collect_mode": self.collect_mode,
-                "auto": self.auto,
-            },
-            "risk": self.risk.to_dict(),
-            "changed_paths": {
-                "count": self.changed_path_count,
-                "source": self.changed_path_source,
-            },
-            "coverage": list(self.coverage),
-            "pattern_scan": self.pattern,
-            "preprocessor_scan": self.preprocessor,
-            "crosscheck": self.crosscheck,
-            "crosscheck_severities": dict(self.crosscheck_severities),
-            "poi": self.poi,
-            "advisories": list(self.advisories),
-            "stage_timings": {
-                k: round(v, 3) for k, v in sorted(self.stage_timings.items())
-            },
-            "diff": self.diff_summary,
-            "verdict": self.verdict,
-            "exit_code": self.exit_code,
-            "elapsed_s": round(self.elapsed_s, 3),
-            "budget_s": self.budget_s,
-        }
-
-
 def _normalize_depth_inputs(
     depth: EvidenceDepth,
     headers: tuple[Path, ...],
@@ -325,191 +288,6 @@ def _render_text(out: ScanOutcome) -> str:
     lines += render_baseline_lines(out)
     lines += render_verdict_lines(out)
     return "\n".join(lines)
-
-
-def _build_new_snapshot(
-    binary: Path,
-    headers: list[Path],
-    includes: list[Path],
-    sources: Path | None,
-    collect_mode: str,
-    lang: str,
-    allow_build_query: bool,
-    changed_paths: tuple[str, ...] = (),
-    build_info: Path | None = None,
-    build_config: Path | None = None,
-    public_headers: list[Path] | None = None,
-    public_header_dirs: list[Path] | None = None,
-    compile_context: CompileContext | None = None,
-    defer_cleanup: list[Callable[[], None]] | None = None,
-    symbols_only: bool = False,
-    debug_presence_only: bool = False,
-) -> tuple[Any, list[Path]]:
-    """Dump the candidate's L0-L2 surface and embed L3-L5 inline at *collect_mode*.
-
-    Returns ``(snapshot, effective_includes)`` — the effective includes carry any
-    build-derived L2 seed so a ``--baseline`` compare can reuse the same context.
-
-    The resolved ``changed_paths`` (from ``--changed-path``/``--since``) are
-    threaded into the inline source replay so a ``source-changed`` collection
-    actually narrows to the affected TUs — the ADR-035 D7 POI-focused cost model —
-    instead of falling back to a full ``target`` replay.
-
-    ``build_info`` (an out-of-tree compile DB / build dir / pack) and
-    ``build_config`` (a trusted ``.abicheck.yml`` enabling ``build.query``) are
-    threaded through so a pinned s5/s6 scan can collect L3/L4 even when the build
-    context lives outside ``--sources`` — otherwise it silently degrades to
-    partial coverage (Codex review).
-    """
-    from .buildsource.l2_seed import seed_l2_includes
-    from .errors import AbicheckError
-    from .service import resolve_input
-
-    # L2 include fallback: when headers are given but the user passed no explicit
-    # -I, seed the build's include dirs so the aggregate public-header parse can
-    # resolve dependency headers (e.g. pvxs headers include EPICS Base's
-    # <epicsTime.h>). Shared with the dump path via seed_l2_includes.
-    #
-    # Keep the seed's temp-build-dir cleanups LOCAL (defer_cleanup=None), not on the
-    # outer scan list: the seed may run the inferred-CMake query, whose build dir is
-    # held under an exclusive flock until its cleanup runs. embed_build_source()
-    # below runs its *own* inferred query in the same function, so if we deferred the
-    # release to the outer drain (which happens after embed) that second query would
-    # block on our still-held lock until INFERRED_QUERY_TIMEOUT_S (600s) before
-    # falling back to a fresh dir. The finally below drains _l2_local_cleanups right
-    # after resolve_input() has consumed the seeded dirs, releasing the lock before
-    # L3/L4 collection replays the query (Codex review).
-    includes, _l2_local_cleanups = seed_l2_includes(
-        headers=headers,
-        includes=includes,
-        sources=sources,
-        build_info=build_info,
-        build_config=build_config,
-        defer_cleanup=None,
-        # -I dirs the user gave through --gcc-options/--gcc-option (carried on the
-        # CompileContext) are explicit too — pass them so the seed stays a no-op
-        # and the user's include search precedence is preserved (Codex review).
-        gcc_options=compile_context.gcc_options if compile_context else None,
-        gcc_option_tokens=(
-            compile_context.gcc_option_tokens if compile_context else ()
-        ),
-        # L2-only pins (--depth headers → collect_mode "off") requested no build/
-        # source evidence, so the include-dir seed must not run a build system just
-        # to hint headers. Passive DB discovery still applies; only the zero-config
-        # inferred cmake/make/bazel query is gated (Codex review).
-        allow_inferred_build_query=collect_mode != "off",
-    )
-
-    try:
-        snap = resolve_input(
-            binary,
-            headers,
-            includes,
-            version="",
-            lang=lang,
-            public_headers=public_headers,
-            public_header_dirs=public_header_dirs,
-            compile=compile_context,
-            symbols_only=symbols_only,
-            debug_presence_only=debug_presence_only,
-        )
-    except AbicheckError as exc:
-        raise click.ClickException(f"Failed to load --binary {binary}: {exc}") from exc
-    finally:
-        # The L2 parse has now consumed the build-derived include dirs (whether it
-        # succeeded or raised), so release any inferred-CMake temp build dir now —
-        # before embed_build_source() below replays its own inferred query — so its
-        # exclusive flock does not block that replay for 600s (see the seed call).
-        if _l2_local_cleanups:
-            from .buildsource.inline import _run_cleanups
-
-            _run_cleanups(_l2_local_cleanups)
-    # Collect evidence when there is something to collect from — a source tree OR
-    # an out-of-tree build-info input — at a non-"off" level.
-    if (sources is not None or build_info is not None) and collect_mode != "off":
-        from .cli_buildsource import embed_build_source
-
-        embed_build_source(
-            snap,
-            build_info=build_info,
-            sources=sources,
-            build_config=build_config,
-            allow_build_query=allow_build_query,
-            collect_mode=collect_mode,
-            changed_paths=changed_paths,
-            public_headers=tuple(
-                str(p) for p in _expand_public_headers(
-                    [*list(public_headers or ()), *list(public_header_dirs or ())]
-                )
-            ),
-            public_header_dirs=tuple(str(p) for p in (public_header_dirs or ())),
-            defer_cleanup=defer_cleanup,
-        )
-    # Return the *effective* includes (the seed above may have added build-derived
-    # dirs) so a --baseline compare header-parses the old native library with the
-    # same include context — else the baseline side fails on dependency headers the
-    # candidate resolved via the seed (Codex review).
-    return snap, includes
-
-
-def _load_exports_for_poi(path: Path | None, lang: str) -> Any | None:
-    """Best-effort cheap load for the D7 export-delta POI walk (ADR-035 D7).
-
-    Loads *path* **header-free** — so no castxml/L2 and no L3-L5 collection, just
-    the L0 export tables (and, for a JSON baseline, its embedded L5 graph). The
-    export-delta walk in ``build_points_of_interest`` needs both sides' export
-    tables *before* the expensive collection runs; this is how it gets the
-    candidate's. Returns ``None`` on any failure (a registry-ref baseline, a load
-    error, …) so POI focusing simply degrades to changed-paths/triggers/risk —
-    it must never break the scan. This is an L0/L1-only read (well below the L4
-    cost cliff); the one expensive collection still runs once, below.
-    """
-    if path is None:
-        return None
-    from .service import resolve_input
-
-    try:
-        return resolve_input(path, [], [], version="", lang=lang, symbols_only=True)
-    except Exception:  # noqa: BLE001 - best-effort focusing input, never fatal
-        return None
-
-
-def _crosscheck_severity_exit(findings: list[Any], severities: dict[str, str]) -> int:
-    """Exit-code floor from cross-checks the maintainer promoted to ``error``.
-
-    A cross-check stays advisory (exit 0) until the maintainer opts it into
-    gating with ``--crosscheck KEY=error`` (ADR-035 UX step 7 / D6). Once opted
-    in, a finding for that check raises the exit to the source-break tier (2) —
-    even for a RISK-class check — so the documented promotion path actually
-    gates CI. ``info``/``warning`` never gate.
-    """
-    gating = {k for k, level in severities.items() if level == "error"}
-    if gating and any(f.kind.value in gating for f in findings):
-        return 2
-    return 0
-
-
-def _audit_exit_code(
-    findings: list[Any], severities: dict[str, str]
-) -> tuple[str, int]:
-    """Verdict/exit for the no-baseline path from cross-source finding tiers.
-
-    Cross-source findings are never ``BREAKING`` on their own (authority rule), so
-    an audit can reach at most ``API_BREAK`` (exit 2); ``RISK`` stays advisory
-    (exit 0) unless the maintainer promoted that check to ``error`` (D6).
-    Adoption never starts by blocking merges (ADR-035 UX step 7).
-    """
-    # Defensive: a mis-partitioned kind would be caught by the import-time
-    # assertion, but never let a cross-source finding gate a BREAKING verdict.
-    assert not any(f.kind in BREAKING_KINDS for f in findings), (
-        "cross-source findings must never be BREAKING (ADR-035 D1 authority rule)"
-    )
-    has_api_break = any(f.kind in API_BREAK_KINDS for f in findings)
-    exit_code = max(
-        2 if has_api_break else 0,
-        _crosscheck_severity_exit(findings, severities),
-    )
-    return ("API_BREAK" if exit_code >= 2 else "COMPATIBLE"), exit_code
 
 
 def _resolve_changed_seed(
@@ -1086,452 +864,4 @@ def scan_cmd(
     _emit_scan_report(core.outcome, fmt, output)
 
 
-class _BudgetOverflow(Exception):
-    """Raised by ``run_scan_core`` when the scan exceeds ``--budget`` (ADR-035 D3).
-
-    A scan-engine signal (not a click concern): the budget is a *failure guard*
-    that never shrinks scope, so the core raises and the CLI maps it onto exit 5.
-    """
-
-    def __init__(self, message: str) -> None:
-        super().__init__(message)
-        self.message = message
-
-
-class _EvidenceContractError(Exception):
-    """Raised by ``run_scan_core`` when a *pinned* depth can't collect its evidence.
-
-    ADR-037 D5 (#2 auto-strict): an explicitly-pinned ``--depth``/``--source-method``
-    is a contract — if the requested source/build evidence is unavailable the scan
-    fails loudly rather than silently degrading to a shallower one. Like
-    :class:`_BudgetOverflow`, it is an engine signal the CLI maps onto an error
-    exit (a clean ``ClickException``, exit 1) and ``service.run_scan`` maps onto a
-    failed :class:`ScanResult`. The implicit ``auto`` default never raises it.
-    """
-
-    def __init__(self, message: str) -> None:
-        super().__init__(message)
-        self.message = message
-
-
-@dataclass
-class ScanCoreResult:
-    """The engine core's typed output — the rendered :class:`ScanOutcome` plus the
-    raw cross-source findings and the candidate snapshot, so ``service.run_scan``
-    can build a typed ``ScanResult`` without re-running anything."""
-
-    outcome: ScanOutcome
-    findings: list[Any]
-    snapshot: Any
-
-
-def _run_abi3_audit(
-    new_snap: Any,
-    abi3_floor: tuple[int, int],
-    binary: Path,
-    cc: Any,
-) -> None:
-    """Run the opt-in stable-ABI (abi3) audit, folding its findings into ``cc``.
-
-    A single-artifact audit of the candidate's CPython imports against a target
-    Py_LIMITED_API floor. Its findings ride the cross-check stream: they are
-    RISK ``python_stable_abi_violation`` rows, advisory by default (like every
-    single-artifact check) and gated only via ``--crosscheck
-    python_stable_abi_violation=error``. Requires the --binary to be a CPython
-    extension module; --abi3 on a plain library is a usage error.
-    """
-    py_ext = new_snap.python_ext
-    if py_ext is None or not py_ext.is_extension:
-        raise _EvidenceContractError(
-            f"--abi3 {abi3_floor[0]}.{abi3_floor[1]} was given but "
-            f"'{binary.name}' is not a recognisable CPython extension module "
-            "(no PyInit_* export and no CPython C-API imports). The stable-ABI "
-            "audit applies only to extension modules (Cython/pybind11/"
-            "nanobind/C)."
-        )
-    from .diff_python import audit_stable_abi_imports
-
-    abi3_findings = audit_stable_abi_imports(py_ext, abi3_floor)
-    cc.findings.extend(abi3_findings)
-    # Name the offending symbols in the coverage row (rendered verbatim in
-    # text and carried in JSON) so a CI artifact tells the user WHICH import
-    # to fix — the cross-check summary only reports a per-kind count, which
-    # would otherwise hide the symbol in Change.detail/new_value (Codex
-    # review). Capped so a pathological module cannot flood the report.
-    offending: list[str] = []
-    for f in abi3_findings:
-        offending.extend(f.new_value if isinstance(f.new_value, list) else [])
-    detail = (
-        f"{len(py_ext.cpython_imports)} CPython import(s) audited against "
-        f"Py_LIMITED_API {abi3_floor[0]}.{abi3_floor[1]}; "
-        f"{len(abi3_findings)} violation finding(s)"
-    )
-    if offending:
-        shown = ", ".join(offending[:20])
-        more = f" (+{len(offending) - 20} more)" if len(offending) > 20 else ""
-        detail += f" — outside the stable ABI: {shown}{more}"
-    cc.coverage.append({"layer": "abi3_audit", "status": "ran", "detail": detail})
-
-
-def _build_scan_poi(
-    baseline: Path | None,
-    seeded: bool,
-    collect_mode: str,
-    binary: Path,
-    lang: str,
-    changed: list[str],
-    risk: RiskScore,
-    pattern: Any,
-) -> tuple[Any, Any]:
-    """Build the D7 points-of-interest work-list + the baseline export view used.
-
-    Returns ``(poi, poi_baseline)``. The export-delta walk needs both sides'
-    export tables, so a cheap header-free L0 view of the candidate and baseline is
-    loaded only when there is a baseline to diff against (else a wasted parse).
-    """
-    needs_export_delta_poi = (
-        baseline is not None
-        and seeded
-        and collect_mode in {"source-changed", "graph-full"}
-    )
-    poi_baseline = (
-        _load_exports_for_poi(baseline, lang) if needs_export_delta_poi else None
-    )
-    poi_candidate = (
-        _load_exports_for_poi(binary, lang) if poi_baseline is not None else None
-    )
-    poi = build_points_of_interest(
-        changed_paths=changed,
-        risk=risk,
-        pattern_triggers=pattern.escalation_triggers,
-        baseline=poi_baseline,
-        candidate=poi_candidate,
-    )
-    return poi, poi_baseline
-
-
-def _append_replay_scope_advisory(
-    advisories: list[str], seeded: bool, collect_mode: str, sources: Path | None,
-) -> None:
-    """Advise (ADR-035 P3) when an unseeded run falls back to headers-only replay.
-
-    Only when L4 replay can actually run (a --sources tree is present) does the
-    headers-only fallback apply; firing otherwise would report a replay that never
-    happened (CodeRabbit review).
-    """
-    if not seeded and collect_mode == "source-changed" and sources is not None:
-        advisories.append(
-            "no --since/--changed-path seed; the L4 replay and the L5 call-graph "
-            "pass both cover the public-API surface (headers-only) instead of a "
-            "focused diff — cost grows with the project, not the change. Pass "
-            "--since <ref> or --changed-path to scope both to the changed TUs."
-        )
-
-
-def _check_scan_evidence_contract(
-    advisories: list[str],
-    new_snap: Any,
-    collect_mode: str,
-    pinned_explicit: bool,
-    sources: Path | None,
-    effective_build_info: Path | None,
-    eff_depth_enum: EvidenceDepth,
-    resolved: SourceMethod,
-) -> None:
-    """Fail-loud on a pinned depth with no evidence; else advise on missing L3.
-
-    ADR-037 D5 (#2 auto-strict): a depth the user *explicitly pinned* with no
-    source evidence at all (no --sources/--build-info, and the trusted --config
-    build.query flow produced no L3) is a usage-contract violation → raise. When a
-    source input *was* supplied but L3 still came back empty, that stays a pointed
-    advisory naming the remedy. The implicit 'auto' default never errors here.
-    """
-    if collect_mode == "off":
-        return
-    gave_source_input = sources is not None or effective_build_info is not None
-    l3 = _l3_collected(new_snap)
-    if pinned_explicit and not gave_source_input and not l3:
-        raise _EvidenceContractError(
-            f"pinned depth '{eff_depth_enum.value}' (source-method {resolved.value}) "
-            "needs source evidence, but no --sources/--build-info was given — there "
-            "is nothing to collect L3/L4/L5 from. Pass --sources <tree> or "
-            "--build-info <dir|compile_commands.json> (or a trusted --config plus "
-            "--allow-build-query), or drop the pin / use the default 'auto' for a "
-            "best-effort binary scan. (Pinned depths are a contract.)"
-        )
-    if gave_source_input and not l3:
-        advisories.append(
-            f"requested depth '{eff_depth_enum.value}' (source-method "
-            f"{resolved.value}) needs an L3 compile database, but none was found — "
-            "L3/L4/L5 were skipped. Provide one with --build-info/--compile-db (a "
-            "compile_commands.json or build dir), or a trusted --config plus "
-            "--allow-build-query to generate it."
-        )
-
-
-def _check_scan_budget(
-    budget: str | None, budget_s: float | None, elapsed: float,
-) -> None:
-    """Budget overflow FAILS, never shrinks scope (ADR-035 D3)."""
-    if budget_s is not None and elapsed > budget_s:
-        raise _BudgetOverflow(
-            f"error: --budget {budget} exceeded "
-            f"({elapsed:.1f}s > {budget_s:.0f}s). "
-            "Pin a shallower level or raise the budget; a budget never silently "
-            "shrinks the pinned scope."
-        )
-
-
-def run_scan_core(
-    *,
-    start: float,
-    binary: Path,
-    headers: list[Path],
-    includes: list[Path],
-    public_headers: list[Path],
-    public_header_dirs: list[Path],
-    sources: Path | None,
-    effective_build_info: Path | None,
-    build_config: Path | None,
-    baseline: Path | None,
-    lang: str,
-    allow_build_query: bool,
-    baseline_headers: list[Path] | None = None,
-    baseline_includes: list[Path] | None = None,
-    scan_mode: ScanMode,
-    resolved: SourceMethod,
-    eff_depth_enum: EvidenceDepth,
-    collect_mode: str,
-    changed: list[str],
-    changed_src: str,
-    seeded: bool,
-    risk: RiskScore,
-    is_auto: bool,
-    enabled_checks: frozenset[str],
-    severities: dict[str, str],
-    budget: str | None,
-    budget_s: float | None,
-    level_explicit: bool = False,
-    pinned_explicit: bool = False,
-    compile_context: CompileContext | None = None,
-    defer_cleanup: list[Callable[[], None]] | None = None,
-    abi3_floor: tuple[int, int] | None = None,
-) -> ScanCoreResult:
-    """The shared scan orchestration (classify → always-on tier → level → compare).
-
-    Pure of click/argv: it takes already-resolved inputs, runs the engine, and
-    returns a :class:`ScanCoreResult`. Raises :class:`_BudgetOverflow` on budget
-    overflow (the CLI maps it to exit 5). This is the one body the CLI,
-    ``service.run_scan``, and the MCP scan tool share (ADR-035 D10).
-    """
-    stage_timings: dict[str, float] = {}
-
-    def _record_stage(name: str, started: float) -> None:
-        stage_timings[name] = time.monotonic() - started
-
-    # --- always-on tier: compiler-free pattern pre-scan (S3) ------------------
-    # Runs *before* the snapshot build so its escalation triggers feed the D7
-    # points-of-interest work-list that focuses the (expensive) source replay.
-    # Scope: a *seeded* diff (even an empty one) confines the scan to the changed
-    # set — an empty seed (no-op PR) scans nothing, preserving the empty-diff
-    # scope; only a genuinely *unseeded* run (no --since/--changed-path) falls
-    # back to the whole-tree scan (Codex review).
-    pattern_roots = scan_pattern_roots(list(headers), sources, eff_depth_enum)
-    _stage = time.monotonic()
-    pattern = scan_files(pattern_roots, changed if seeded else None)
-    _record_stage("pattern_scan", _stage)
-
-    # --- D7 points-of-interest: cheap facts steer the expensive scan ----------
-    # Floor = the directly-changed paths (always included); the pattern triggers,
-    # risk score, and the L0↔L2 export deltas only *add* candidates, never drop a
-    # changed TU (ADR-035 D7). The export-delta walk needs both sides' export
-    # tables up front, so read a cheap, header-free L0 view of the candidate and
-    # baseline here (no castxml/L3-L5); the one expensive collection still runs
-    # once, below, with the resulting focus seed. The candidate view is only
-    # loaded when there is a baseline to diff it against — the delta walk consumes
-    # the two together, so loading it baseline-less would be a wasted L0/L1 parse.
-    _stage = time.monotonic()
-    poi, poi_baseline = _build_scan_poi(
-        baseline, seeded, collect_mode, binary, lang, changed, risk, pattern
-    )
-    _record_stage("poi", _stage)
-
-    # --- build the candidate snapshot (L0-L2 + inline L3-L5 at the level) ------
-    # An explicit --compile-db (a file) wins over --build-info (dir/pack) as the
-    # L3 source; both feed embed_build_source's build_info input. The POI path set
-    # focuses the replay — but ONLY when a real diff seed was supplied
-    # (``seeded``). Without --since/--changed-path the scan is broad by contract
-    # (the report says so), so passing pattern-trigger POIs as the changed set
-    # would wrongly narrow PR-mode replay to a single pattern-flagged TU and skip
-    # source-only checks elsewhere (Codex review). When seeded, the focusing
-    # work-list is the changed-path floor *plus* the TUs resolved from changed
-    # exports via the baseline's L5 graph (resolve_symbol_tus) — so a changed
-    # export with an unchanged header still points the replay at the one TU that
-    # emits it (ADR-035 D7, the focusing half).
-    symbol_tus = resolve_symbol_tus(poi, poi_baseline) if seeded else ()
-    replay_seed = (
-        tuple(dict.fromkeys((*poi.changed_paths(), *symbol_tus))) if seeded else ()
-    )
-    # ADR-035 P3: an unseeded s5/pr run cannot narrow 'source-changed' to a diff,
-    # so the L4 replay falls back to the public-API 'headers-only' surface
-    # (inline.collect_inline_pack). Record an advisory naming the cost + the knob
-    # that focuses it, rather than silently paying a broad replay (validation P3
-    # "no auto-warn"). Carried on the result (text + JSON) so it never pollutes a
-    # structured-format stdout.
-    advisories: list[str] = []
-    _append_replay_scope_advisory(advisories, seeded, collect_mode, sources)
-    effective_allow_query, _query_advisory = resolve_effective_allow_query(
-        allow_build_query, build_config, collect_mode, level_explicit, resolved
-    )
-    if _query_advisory is not None:
-        advisories.append(_query_advisory)
-
-    _stage = time.monotonic()
-    new_snap, eff_includes = _build_new_snapshot(
-        binary,
-        list(headers),
-        list(includes),
-        sources,
-        collect_mode,
-        lang,
-        effective_allow_query,
-        changed_paths=replay_seed,
-        build_info=effective_build_info,
-        build_config=build_config,
-        public_headers=list(public_headers),
-        public_header_dirs=list(public_header_dirs),
-        compile_context=compile_context,
-        defer_cleanup=defer_cleanup,
-        symbols_only=eff_depth_enum is EvidenceDepth.BINARY,
-        debug_presence_only=_uses_debug_presence_only(eff_depth_enum),
-    )
-    _record_stage("candidate_snapshot", _stage)
-    l4_cov = _source_abi_coverage(new_snap)
-    advisories.extend(l4_coverage_advisories(l4_cov))
-
-    # --- level-vs-evidence: fail-loud on missing input, advise otherwise ------
-    # A deep depth (build/source/full → collect_mode != "off") needs an L3 compile
-    # database; without one the L3/L4/L5 layers cannot be collected.
-    _check_scan_evidence_contract(
-        advisories, new_snap, collect_mode, pinned_explicit,
-        sources, effective_build_info, eff_depth_enum, resolved,
-    )
-
-    # --- conditional tier: S2 preprocessor pre-scan (D2) ----------------------
-    # Runs only when L3 build evidence + a preprocessor (`clang -E`) are present;
-    # otherwise the coverage row honestly reports it skipped (never clean). Emits
-    # advisory macro-divergence + private/generated-header-leak facts. Headers are
-    # expanded to the individual public header *files* (``-H include/`` accepts a
-    # directory) so the per-header leak pass preprocesses each header, not the
-    # directory as one bogus TU (Codex review).
-    pp_build = (
-        new_snap.build_source.build_evidence
-        if new_snap.build_source is not None
-        else None
-    )
-    _stage = time.monotonic()
-    preproc = run_preprocessor_scan(pp_build, _expand_public_headers(list(headers)))
-    _record_stage("preprocessor_scan", _stage)
-
-    # --- always-on tier: intra-version cross-source checks (D4) ---------------
-    # The resolved changed-path set is handed to the engine so
-    # ``public_to_internal_dependency`` can elevate a finding whose internal
-    # target was touched this revision (ADR-035 D4 "L5 reachability ↔ PR
-    # changed files").
-    # The changed-path set handed to the engine also carries the TUs the D7
-    # export-delta walk resolved (symbol_tus), so ``public_to_internal_dependency``
-    # elevates a finding whose internal target sits in a TU this revision touched
-    # *via a changed export* — not only the literally git-changed files.
-    _stage = time.monotonic()
-    cc = run_crosschecks(
-        new_snap,
-        CrosscheckConfig(
-            enabled=frozenset(enabled_checks),
-            changed_paths=frozenset(changed) | set(symbol_tus),
-        ),
-    )
-    _record_stage("crosschecks", _stage)
-
-    # --- stable-ABI (abi3) audit (opt-in via --abi3) --------------------------
-    if abi3_floor is not None:
-        _run_abi3_audit(new_snap, abi3_floor, binary, cc)
-
-    # --- pinned-level baseline comparison (if any) ----------------------------
-    diff_summary: dict[str, Any] | None = None
-    if baseline is not None and scan_mode is not ScanMode.AUDIT:
-        _stage = time.monotonic()
-        verdict, exit_code, diff_summary = _run_baseline_compare(
-            baseline,
-            binary,
-            new_snap,
-            [],
-            lang,
-            collect_mode,
-            list(headers),
-            # Effective (seeded) includes so the baseline native parse gets the same
-            # build-derived dependency include dirs as the candidate (Codex review).
-            list(eff_includes),
-            list(public_headers),
-            list(public_header_dirs),
-            compile_context=compile_context,
-            baseline_headers=baseline_headers,
-            baseline_includes=baseline_includes,
-            symbols_only=eff_depth_enum is EvidenceDepth.BINARY,
-            debug_presence_only=_uses_debug_presence_only(eff_depth_enum),
-        )
-        # A cross-check the maintainer promoted to `error` (D6) gates the exit
-        # even when the baseline diff itself is clean.
-        sev_exit = _crosscheck_severity_exit(cc.findings, severities)
-        if sev_exit > exit_code:
-            exit_code = sev_exit
-            # Keep the reported verdict in sync with the promoted exit code so a
-            # consumer keying off the verdict string isn't misled (Codex review).
-            # Only a non-breaking verdict is promoted — never downgrade a real
-            # BREAKING/API_BREAK from the artifact diff.
-            if verdict in ("NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK"):
-                verdict = "API_BREAK"
-        _record_stage("baseline_compare", _stage)
-    else:
-        if baseline is not None:
-            click.echo(
-                "note: --audit ignores --baseline (intra-version scan).", err=True
-            )
-        verdict, exit_code = _audit_exit_code(cc.findings, severities)
-
-    elapsed = time.monotonic() - start
-    _check_scan_budget(budget, budget_s, elapsed)
-
-    outcome = ScanOutcome(
-        mode=scan_mode.value,
-        resolved_method=resolved.value,
-        depth=eff_depth_enum.value,
-        collect_mode=collect_mode,
-        risk=risk,
-        auto=is_auto,
-        changed_path_count=len(changed),
-        changed_path_source=changed_src,
-        coverage=[
-            *_intrinsic_coverage(new_snap),
-            pattern.coverage().to_dict(),
-            preproc.coverage().to_dict(),
-            *_pack_coverage(new_snap),
-            *cc.coverage,
-        ],
-        pattern=pattern.to_dict(),
-        preprocessor=preproc.to_dict(),
-        crosscheck=cc.to_dict(),
-        crosscheck_severities=severities,
-        poi=poi.to_dict(),
-        advisories=advisories,
-        stage_timings=stage_timings,
-        audit=scan_mode is ScanMode.AUDIT,
-        diff_summary=diff_summary,
-        verdict=verdict,
-        exit_code=exit_code,
-        elapsed_s=elapsed,
-        budget_s=budget_s,
-    )
-    return ScanCoreResult(
-        outcome=outcome, findings=list(cc.findings), snapshot=new_snap
-    )
 

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -44,13 +44,13 @@ import io
 import xml.etree.ElementTree as ET
 from typing import TYPE_CHECKING
 
-from .checker_policy import ChangeKind, Verdict, policy_for
+from .checker_policy import ChangeKind, Verdict
 from .checker_types import Change, DiffResult
 from .reporter import apply_show_only
 
 if TYPE_CHECKING:
     from .model import AbiSnapshot
-    from .severity import SeverityConfig
+    from .severity import KindSets, SeverityConfig
 
 
 # ---------------------------------------------------------------------------
@@ -83,79 +83,64 @@ def _classname_for(change: Change) -> str:
 # ---------------------------------------------------------------------------
 
 
+_VERDICT_TO_JUNIT_TYPE: dict[Verdict, str] = {
+    Verdict.BREAKING: "BREAKING",
+    Verdict.API_BREAK: "API_BREAK",
+    Verdict.COMPATIBLE_WITH_RISK: "COMPATIBLE_WITH_RISK",
+}
+
+
 def _is_failure(
     change: Change,
-    breaking_set: frozenset[ChangeKind],
-    api_break_set: frozenset[ChangeKind],
-    risk_set: frozenset[ChangeKind],
+    result: DiffResult,
+    kind_sets: KindSets,
     severity_config: SeverityConfig | None = None,
 ) -> bool:
     """Return True if the change should be a JUnit ``<failure>``.
 
-    BREAKING and API_BREAK changes always fail.  COMPATIBLE_WITH_RISK
-    changes fail only when their per-kind severity is ``"error"``
-    (currently all RISK_KINDS default to ``"warning"``, so they pass).
+    Routes through ``DiffResult._effective_verdict_for_change`` — the single
+    canonical per-finding verdict, which honours PolicyFile overrides, the
+    A4 per-finding ``effective_verdict`` (ADR-027), and frozen-namespace
+    escalation guards — so the JUnit file can never disagree with the JSON
+    report or the severity-aware exit code.
 
-    When *severity_config* is provided (from ``--severity-preset`` or
-    ``--severity-*`` overrides), its level takes precedence so that
-    the JUnit output honours user-configured severity escalations.
+    BREAKING and API_BREAK verdicts always fail. COMPATIBLE_WITH_RISK fails
+    only when its per-kind severity is ``"error"`` (currently all RISK_KINDS
+    default to ``"warning"``, so they pass), unless *severity_config* (from
+    ``--severity-preset`` or ``--severity-*`` overrides) escalates the
+    finding's effective category to error — which also applies to a plain
+    COMPATIBLE verdict (e.g. under ``--severity-preset strict``).
     """
-    # Honour an A4 per-finding effective_verdict (ADR-027): a demoted opaque/
-    # PIMPL layout change reads compatible and must not be a JUnit failure.
-    eff = getattr(change, "effective_verdict", None)
-    if isinstance(eff, Verdict):
-        if eff in (Verdict.BREAKING, Verdict.API_BREAK):
-            return True
-        # COMPATIBLE_WITH_RISK / COMPATIBLE / NO_CHANGE are not hard breaks, so a
-        # JUnit failure here happens only when the user's severity preset
-        # escalates the finding's EFFECTIVE category to error. Route through the
-        # same classifier the severity-aware exit code uses
-        # (``classify_change_object``, which honours ``effective_verdict``) so the
-        # JUnit file never disagrees with the exit status — e.g. a
-        # ``--pattern-verdicts`` demotion to compatible, or the A3 bundle
-        # reachability demotion to risk, still fails under
-        # ``--severity-preset strict`` (ADR-027 review).
-        if severity_config is not None:
-            from .severity import SeverityLevel, classify_change_object
-
-            return (
-                severity_config.level_for(classify_change_object(change))
-                == SeverityLevel.ERROR
-            )
-        return False
-    if change.kind in breaking_set or change.kind in api_break_set:
+    verdict = result._effective_verdict_for_change(change)
+    if verdict in (Verdict.BREAKING, Verdict.API_BREAK):
         return True
     if severity_config is not None:
-        return severity_config.level_for_kind(change.kind).value == "error"
-    if change.kind in risk_set:
-        return policy_for(change.kind).severity == "error"
-    # Kinds not in any explicit set (e.g. newly added ChangeKinds): consult
-    # policy_for() which defaults to BREAKING/severity="error" for unknown
-    # kinds, ensuring fail-closed behaviour.
-    return policy_for(change.kind).severity == "error"
+        from .severity import SeverityLevel, classify_effective_change
+
+        cat = classify_effective_change(
+            change,
+            policy=result.policy,
+            kind_sets=kind_sets,
+            policy_file=result.policy_file,
+        )
+        return severity_config.level_for(cat) == SeverityLevel.ERROR
+    # COMPATIBLE_WITH_RISK never fails without a severity_config: all
+    # RISK_KINDS default to severity "warning" in the policy registry. This
+    # must NOT consult policy_for(change.kind) directly — for a demoted
+    # finding (A4 override or PolicyFile override) the *kind*'s own default
+    # severity can be "error" (e.g. a BREAKING kind demoted to risk), which
+    # would wrongly resurrect the pre-override severity.
+    return False
 
 
-def _failure_type(
-    change: Change,
-    breaking_set: frozenset[ChangeKind],
-    api_break_set: frozenset[ChangeKind],
-    risk_set: frozenset[ChangeKind],
-) -> str:
-    """Return the ``type`` attribute for a ``<failure>`` element."""
-    eff = getattr(change, "effective_verdict", None)
-    if isinstance(eff, Verdict):
-        return {
-            Verdict.BREAKING: "BREAKING",
-            Verdict.API_BREAK: "API_BREAK",
-            Verdict.COMPATIBLE_WITH_RISK: "COMPATIBLE_WITH_RISK",
-        }.get(eff, "COMPATIBLE")
-    if change.kind in breaking_set:
-        return "BREAKING"
-    if change.kind in api_break_set:
-        return "API_BREAK"
-    if change.kind in risk_set:
-        return "COMPATIBLE_WITH_RISK"
-    return "COMPATIBLE"
+def _failure_type(change: Change, result: DiffResult) -> str:
+    """Return the ``type`` attribute for a ``<failure>`` element.
+
+    Uses the same canonical per-finding verdict as ``_is_failure`` so the
+    reported type always matches why the finding failed.
+    """
+    verdict = result._effective_verdict_for_change(change)
+    return _VERDICT_TO_JUNIT_TYPE.get(verdict, "COMPATIBLE")
 
 
 # ---------------------------------------------------------------------------
@@ -212,15 +197,14 @@ def _collect_all_symbols(
 
 def _count_failures(
     changes: list[Change],
-    breaking_set: frozenset[ChangeKind],
-    api_break_set: frozenset[ChangeKind],
-    risk_set: frozenset[ChangeKind],
+    result: DiffResult,
+    kind_sets: KindSets,
     severity_config: SeverityConfig | None,
 ) -> int:
     """Count distinct symbols that have at least one failing change."""
     symbols_with_failure: set[str] = set()
     for c in changes:
-        if _is_failure(c, breaking_set, api_break_set, risk_set, severity_config):
+        if _is_failure(c, result, kind_sets, severity_config):
             symbols_with_failure.add(c.symbol)
     return len(symbols_with_failure)
 
@@ -229,9 +213,8 @@ def _emit_testcases(
     ts: ET.Element,
     all_symbols: dict[str, str],
     change_by_symbol: dict[str, Change],
-    breaking_set: frozenset[ChangeKind],
-    api_break_set: frozenset[ChangeKind],
-    risk_set: frozenset[ChangeKind],
+    result: DiffResult,
+    kind_sets: KindSets,
     severity_config: SeverityConfig | None,
 ) -> None:
     """Append ``<testcase>`` elements to *ts* for every symbol in *all_symbols*.
@@ -248,9 +231,8 @@ def _emit_testcases(
                 _maybe_add_failure(
                     tc,
                     change_by_symbol[sym],
-                    breaking_set,
-                    api_break_set,
-                    risk_set,
+                    result,
+                    kind_sets,
                     severity_config,
                 )
     else:
@@ -262,9 +244,8 @@ def _emit_testcases(
             _maybe_add_failure(
                 tc,
                 c,
-                breaking_set,
-                api_break_set,
-                risk_set,
+                result,
+                kind_sets,
                 severity_config,
             )
 
@@ -272,9 +253,8 @@ def _emit_testcases(
 def _append_extra_failures(
     ts: ET.Element,
     extra_changes: list[Change],
-    breaking_set: frozenset[ChangeKind],
-    api_break_set: frozenset[ChangeKind],
-    risk_set: frozenset[ChangeKind],
+    result: DiffResult,
+    kind_sets: KindSets,
     severity_config: SeverityConfig | None,
 ) -> None:
     """Append extra ``<failure>`` children to already-existing testcases.
@@ -284,10 +264,10 @@ def _append_extra_failures(
     ``<testcase>`` with the matching name and attach a new ``<failure>``.
     """
     for c in extra_changes:
-        if _is_failure(c, breaking_set, api_break_set, risk_set, severity_config):
+        if _is_failure(c, result, kind_sets, severity_config):
             for tc in ts:
                 if tc.get("name") == c.symbol:
-                    _add_failure(tc, c, breaking_set, api_break_set, risk_set)
+                    _add_failure(tc, c, result)
                     break
 
 
@@ -307,7 +287,7 @@ def _build_testsuite(
     When *show_only* is active, only the filtered changes are emitted
     (no unchanged snapshot symbols) so the test count matches the filter.
     """
-    breaking_set, api_break_set, _, risk_set = result._effective_kind_sets()
+    kind_sets = result._effective_kind_sets()
 
     changes = list(result.changes)
     if show_only:
@@ -315,9 +295,7 @@ def _build_testsuite(
 
     change_by_symbol, extra_changes = _partition_changes(changes)
     all_symbols = _collect_all_symbols(old_snapshot, show_only, change_by_symbol)
-    failure_count = _count_failures(
-        changes, breaking_set, api_break_set, risk_set, severity_config
-    )
+    failure_count = _count_failures(changes, result, kind_sets, severity_config)
 
     total = len(all_symbols) if all_symbols else len(change_by_symbol)
 
@@ -331,14 +309,11 @@ def _build_testsuite(
         ts,
         all_symbols,
         change_by_symbol,
-        breaking_set,
-        api_break_set,
-        risk_set,
+        result,
+        kind_sets,
         severity_config,
     )
-    _append_extra_failures(
-        ts, extra_changes, breaking_set, api_break_set, risk_set, severity_config
-    )
+    _append_extra_failures(ts, extra_changes, result, kind_sets, severity_config)
 
     return ts
 
@@ -346,25 +321,22 @@ def _build_testsuite(
 def _maybe_add_failure(
     tc: ET.Element,
     change: Change,
-    breaking_set: frozenset[ChangeKind],
-    api_break_set: frozenset[ChangeKind],
-    risk_set: frozenset[ChangeKind],
+    result: DiffResult,
+    kind_sets: KindSets,
     severity_config: SeverityConfig | None = None,
 ) -> None:
     """Add a ``<failure>`` child to *tc* if the change is a failure."""
-    if _is_failure(change, breaking_set, api_break_set, risk_set, severity_config):
-        _add_failure(tc, change, breaking_set, api_break_set, risk_set)
+    if _is_failure(change, result, kind_sets, severity_config):
+        _add_failure(tc, change, result)
 
 
 def _add_failure(
     tc: ET.Element,
     change: Change,
-    breaking_set: frozenset[ChangeKind],
-    api_break_set: frozenset[ChangeKind],
-    risk_set: frozenset[ChangeKind],
+    result: DiffResult,
 ) -> None:
     """Append a ``<failure>`` element to testcase *tc*."""
-    ftype = _failure_type(change, breaking_set, api_break_set, risk_set)
+    ftype = _failure_type(change, result)
     description = change.description or change.kind.value.replace("_", " ")
     message = f"{change.kind.value}: {description}"
 

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -133,13 +133,23 @@ def _is_failure(
     return False
 
 
-def _failure_type(change: Change, result: DiffResult) -> str:
+def _failure_type(change: Change, result: DiffResult, kind_sets: KindSets) -> str:
     """Return the ``type`` attribute for a ``<failure>`` element.
 
     Uses the same canonical per-finding verdict as ``_is_failure`` so the
-    reported type always matches why the finding failed.
+    reported type always matches why the finding failed. Takes the caller's
+    precomputed *kind_sets* rather than recomputing them (``_build_testsuite``
+    already builds them once per report; ``DiffResult._effective_verdict_for_change``
+    would otherwise rebuild them per finding).
     """
-    verdict = result._effective_verdict_for_change(change)
+    from .severity import effective_verdict_for_change
+
+    verdict = effective_verdict_for_change(
+        change,
+        policy=result.policy,
+        kind_sets=kind_sets,
+        policy_file=result.policy_file,
+    )
     return _VERDICT_TO_JUNIT_TYPE.get(verdict, "COMPATIBLE")
 
 
@@ -267,7 +277,7 @@ def _append_extra_failures(
         if _is_failure(c, result, kind_sets, severity_config):
             for tc in ts:
                 if tc.get("name") == c.symbol:
-                    _add_failure(tc, c, result)
+                    _add_failure(tc, c, result, kind_sets)
                     break
 
 
@@ -327,16 +337,17 @@ def _maybe_add_failure(
 ) -> None:
     """Add a ``<failure>`` child to *tc* if the change is a failure."""
     if _is_failure(change, result, kind_sets, severity_config):
-        _add_failure(tc, change, result)
+        _add_failure(tc, change, result, kind_sets)
 
 
 def _add_failure(
     tc: ET.Element,
     change: Change,
     result: DiffResult,
+    kind_sets: KindSets,
 ) -> None:
     """Append a ``<failure>`` element to testcase *tc*."""
-    ftype = _failure_type(change, result)
+    ftype = _failure_type(change, result, kind_sets)
     description = change.description or change.kind.value.replace("_", " ")
     message = f"{change.kind.value}: {description}"
 

--- a/abicheck/post_processing.py
+++ b/abicheck/post_processing.py
@@ -1235,8 +1235,33 @@ class PostProcessingPipeline:
             collapse_versioned_symbols=collapse_versioned_symbols,
             public_surface_allowlist=public_surface_allowlist,
         )
+        # ``FilterRedundant`` sets ``ctx.kept = kept`` — an *aliasing* contract,
+        # not a snapshot: every step from that point on is required to either
+        # leave ``changes`` untouched, mutate it in place (``changes[:] = ...``),
+        # or explicitly resync ``ctx.kept`` to whatever new list it returns (see
+        # ``DetectVersionedSymbolScheme``). If a future step instead rebinds
+        # ``changes = [c for c in changes if ...]`` without updating ``ctx.kept``,
+        # ``ctx.kept`` silently keeps pointing at the stale pre-filter list and
+        # any suppression/demotion recorded downstream is lost from the verdict
+        # with no visible error (this happened once already — see
+        # ``DetectCppPatterns``/``DemoteUnreachableInternalChurn``'s in-place
+        # comments). Enforce the invariant here instead of trusting every future
+        # step author to remember it.
+        kept_tracking_active = False
         for step in self.steps:
             changes = step.run(changes, ctx)
+            if step.name == FilterRedundant.name:
+                kept_tracking_active = True
+            elif kept_tracking_active and ctx.kept is not changes:
+                raise RuntimeError(
+                    f"post-processing step {step.name!r} broke the ctx.kept "
+                    "aliasing contract established by FilterRedundant: it "
+                    "returned a `changes` list that is not the same object as "
+                    "`ctx.kept`, which silently discards any suppression or "
+                    "demotion tracked via ctx.kept from the verdict. Fix the "
+                    "step to mutate `changes[:] = ...` in place, or to "
+                    "explicitly resync `ctx.kept = changes` before returning."
+                )
         # Ensure ctx.kept is set even if FilterRedundant didn't run
         if not ctx.kept and changes:
             ctx.kept = changes

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -59,22 +59,25 @@ def _tool_version() -> str:
 def _severity(change: Change, result: DiffResult) -> str:
     """Return the SARIF ``level`` for *change*.
 
-    On the override path — an A4 per-finding ``effective_verdict`` (ADR-027)
-    or a PolicyFile verdict override for this change's kind — the canonical
-    verdict→SARIF-level table (ADR-036) applies, routed through
-    ``result._effective_verdict_for_change`` so SARIF can never disagree
-    with the JSON report or the gate/exit code. Non-overridden findings keep
-    the coarser per-kind default severity from the policy registry.
+    Whenever the canonical per-finding verdict (``result._effective_verdict_for_change``
+    — A4 per-finding ``effective_verdict`` (ADR-027), a PolicyFile verdict
+    override, *or* a named base policy like ``plugin_abi``/``sdk_vendor``
+    reclassifying this change's kind) differs from the kind's inherent default
+    verdict, the canonical verdict→SARIF-level table (ADR-036) applies, so
+    SARIF can never disagree with the JSON report or the gate/exit code.
+    Comparing against the *kind's own* default verdict (rather than checking
+    for specific override mechanisms) catches every reclassification path
+    uniformly — a hand-maintained ``has_override`` allowlist previously missed
+    base-policy downgrades entirely. Findings still at their kind's default
+    verdict keep the coarser per-kind default severity from the policy
+    registry, which is intentionally finer-grained than the 4-way verdict
+    table (e.g. distinguishing "warning" additions from "note"-worthy ones).
     """
-    has_override = isinstance(
-        getattr(change, "effective_verdict", None), Verdict
-    ) or (
-        result.policy_file is not None and change.kind in result.policy_file.overrides
-    )
-    if has_override:
-        verdict = result._effective_verdict_for_change(change)
-        return _VERDICT_TO_SARIF_LEVEL.get(verdict, policy_for(change.kind).severity)
-    return policy_for(change.kind).severity
+    entry = policy_for(change.kind)
+    verdict = result._effective_verdict_for_change(change)
+    if verdict != entry.default_verdict:
+        return _VERDICT_TO_SARIF_LEVEL.get(verdict, entry.severity)
+    return entry.severity
 
 
 def _rule_for(kind: ChangeKind) -> dict[str, Any]:
@@ -84,7 +87,9 @@ def _rule_for(kind: ChangeKind) -> dict[str, Any]:
     doc_slug = policy_for(kind).doc_slug
     help_uri = f"https://github.com/abicheck/abicheck/blob/main/docs/abi_breaking_cases_catalog.md#{doc_slug}"
     impact = impact_for(kind)
-    full_desc = impact if impact else f"ABI change detected: {rule_id.replace('_', ' ')}"
+    full_desc = (
+        impact if impact else f"ABI change detected: {rule_id.replace('_', ' ')}"
+    )
     return {
         "id": rule_id,
         "name": "".join(w.capitalize() for w in rule_id.split("_")),
@@ -98,7 +103,11 @@ def _rule_for(kind: ChangeKind) -> dict[str, Any]:
 
 def _result_for(change: Change, result: DiffResult) -> dict[str, Any]:
     """Produce a SARIF result object for a Change."""
-    library, old_version, new_version = result.library, result.old_version, result.new_version
+    library, old_version, new_version = (
+        result.library,
+        result.old_version,
+        result.new_version,
+    )
     msg_parts = [change.description]
     if change.old_value or change.new_value:
         msg_parts.append(f"({change.old_value or '?'} → {change.new_value or '?'})")
@@ -232,14 +241,51 @@ def to_sarif(
                     "library": result.library,
                     "changeCount": len(changes),
                     "suppressedCount": result.suppressed_count,
-                    **({"redundantCount": result.redundant_count} if result.redundant_count > 0 else {}),
-                    **({"oldFile": {"path": result.old_metadata.path, "sha256": result.old_metadata.sha256, "sizeBytes": result.old_metadata.size_bytes}} if result.old_metadata is not None else {}),
-                    **({"newFile": {"path": result.new_metadata.path, "sha256": result.new_metadata.sha256, "sizeBytes": result.new_metadata.size_bytes}} if result.new_metadata is not None else {}),
+                    **(
+                        {"redundantCount": result.redundant_count}
+                        if result.redundant_count > 0
+                        else {}
+                    ),
+                    **(
+                        {
+                            "oldFile": {
+                                "path": result.old_metadata.path,
+                                "sha256": result.old_metadata.sha256,
+                                "sizeBytes": result.old_metadata.size_bytes,
+                            }
+                        }
+                        if result.old_metadata is not None
+                        else {}
+                    ),
+                    **(
+                        {
+                            "newFile": {
+                                "path": result.new_metadata.path,
+                                "sha256": result.new_metadata.sha256,
+                                "sizeBytes": result.new_metadata.size_bytes,
+                            }
+                        }
+                        if result.new_metadata is not None
+                        else {}
+                    ),
                     "confidence": result.confidence.value,
                     "evidenceTiers": list(result.evidence_tiers),
-                    **({"coverageWarnings": list(result.coverage_warnings)} if result.coverage_warnings else {}),
+                    **(
+                        {"coverageWarnings": list(result.coverage_warnings)}
+                        if result.coverage_warnings
+                        else {}
+                    ),
                     "policy": result.policy or "strict_abi",
-                    **({"policyOverrides": {k.value: v.value for k, v in result.policy_file.overrides.items()}} if result.policy_file and result.policy_file.overrides else {}),
+                    **(
+                        {
+                            "policyOverrides": {
+                                k.value: v.value
+                                for k, v in result.policy_file.overrides.items()
+                            }
+                        }
+                        if result.policy_file and result.policy_file.overrides
+                        else {}
+                    ),
                     # ADR-024 §D4/D5: header-scope ledger. Out-of-surface
                     # findings are disclosed here for auditability (never
                     # silently dropped) when --scope-public-headers is active.
@@ -255,8 +301,16 @@ def to_sarif(
                                         "kind": c.kind.value,
                                         "symbol": c.symbol,
                                         "description": c.description,
-                                        **({"sourceLocation": c.source_location} if c.source_location else {}),
-                                        **({"reason": c.surface_exclusion_reason} if c.surface_exclusion_reason else {}),
+                                        **(
+                                            {"sourceLocation": c.source_location}
+                                            if c.source_location
+                                            else {}
+                                        ),
+                                        **(
+                                            {"reason": c.surface_exclusion_reason}
+                                            if c.surface_exclusion_reason
+                                            else {}
+                                        ),
                                     }
                                     for c in result.out_of_surface_changes
                                 ],
@@ -277,8 +331,16 @@ def to_sarif(
                                         "kind": c.kind.value,
                                         "symbol": c.symbol,
                                         "description": c.description,
-                                        **({"sourceLocation": c.source_location} if c.source_location else {}),
-                                        **({"reason": c.surface_exclusion_reason} if c.surface_exclusion_reason else {}),
+                                        **(
+                                            {"sourceLocation": c.source_location}
+                                            if c.source_location
+                                            else {}
+                                        ),
+                                        **(
+                                            {"reason": c.surface_exclusion_reason}
+                                            if c.surface_exclusion_reason
+                                            else {}
+                                        ),
                                     }
                                     for c in result.reconciled_changes
                                 ],

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -56,12 +56,24 @@ def _tool_version() -> str:
 # above under its historical private name so call sites are unchanged.
 
 
-def _severity(change: Change) -> str:
-    # Honour an A4 per-finding effective_verdict (ADR-027): a demoted opaque/
-    # PIMPL layout change reports as a SARIF "note", not an "error".
-    eff = getattr(change, "effective_verdict", None)
-    if isinstance(eff, Verdict):
-        return _VERDICT_TO_SARIF_LEVEL.get(eff, policy_for(change.kind).severity)
+def _severity(change: Change, result: DiffResult) -> str:
+    """Return the SARIF ``level`` for *change*.
+
+    On the override path — an A4 per-finding ``effective_verdict`` (ADR-027)
+    or a PolicyFile verdict override for this change's kind — the canonical
+    verdict→SARIF-level table (ADR-036) applies, routed through
+    ``result._effective_verdict_for_change`` so SARIF can never disagree
+    with the JSON report or the gate/exit code. Non-overridden findings keep
+    the coarser per-kind default severity from the policy registry.
+    """
+    has_override = isinstance(
+        getattr(change, "effective_verdict", None), Verdict
+    ) or (
+        result.policy_file is not None and change.kind in result.policy_file.overrides
+    )
+    if has_override:
+        verdict = result._effective_verdict_for_change(change)
+        return _VERDICT_TO_SARIF_LEVEL.get(verdict, policy_for(change.kind).severity)
     return policy_for(change.kind).severity
 
 
@@ -84,10 +96,9 @@ def _rule_for(kind: ChangeKind) -> dict[str, Any]:
     }
 
 
-def _result_for(
-    change: Change, library: str, old_version: str, new_version: str
-) -> dict[str, Any]:
+def _result_for(change: Change, result: DiffResult) -> dict[str, Any]:
     """Produce a SARIF result object for a Change."""
+    library, old_version, new_version = result.library, result.old_version, result.new_version
     msg_parts = [change.description]
     if change.old_value or change.new_value:
         msg_parts.append(f"({change.old_value or '?'} → {change.new_value or '?'})")
@@ -129,7 +140,7 @@ def _result_for(
 
     return {
         "ruleId": change.kind.value,
-        "level": _severity(change),
+        "level": _severity(change, result),
         "message": {
             "text": " ".join(msg_parts),
         },
@@ -168,9 +179,7 @@ def to_sarif(
         rule_id = change.kind.value
         if rule_id not in rules_seen:
             rules_seen[rule_id] = _rule_for(change.kind)
-        sarif_results.append(
-            _result_for(change, result.library, result.old_version, result.new_version)
-        )
+        sarif_results.append(_result_for(change, result))
 
     # Overall ABI verdict as a notification
     invocation_success = result.verdict != Verdict.BREAKING

--- a/abicheck/scan_engine.py
+++ b/abicheck/scan_engine.py
@@ -1,0 +1,772 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``scan`` engine core (ADR-035 D10) — classify → always-on tier → pinned level
+→ optional baseline compare.
+
+:func:`run_scan_core` is "the one body the CLI, ``service.run_scan``, and the
+MCP scan tool share" (ADR-035 D10) — this module is where that body actually
+lives. It is deliberately free of ``@click.option`` decorators and argv
+parsing so it can be called directly from ``service_scan.run_scan`` without a
+front-end dependency: ``cli_scan.py`` (the Click command) and
+``service_scan.py`` (the typed request/result API) both import from here,
+never from each other.
+
+Historically this lived inside ``cli_scan.py`` alongside the ``scan`` Click
+command, which meant ``service_scan.run_scan`` had to reach into a
+front-end module (via a function-local import) to call it — the reverse of
+the intended frontend → service → engine dependency direction (ADR-037 D1).
+Splitting it out here removes that inversion; ``cli_scan.py`` now imports
+:func:`run_scan_core` from this module the same way ``service_scan.py`` does.
+
+One pre-existing exception to "no CLI concerns": :func:`_build_new_snapshot`
+raises ``click.ClickException`` on a resolve failure, and :func:`run_scan_core`
+prints a ``click.echo`` note when ``--baseline`` is combined with ``--audit``.
+Both predate this split and are left as-is (unrelated to the dependency-
+direction fix) — ``click.ClickException`` is a plain exception subclass safe
+to raise outside a running CLI context, and a future cleanup can route that
+note through the advisories list like every other cross-cutting message.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import click
+
+from .buildsource.crosscheck import CrosscheckConfig, run_crosschecks
+from .buildsource.pattern_scan import scan_files
+from .buildsource.poi import build_points_of_interest, resolve_symbol_tus
+from .buildsource.preprocessor_scan import run_preprocessor_scan
+from .buildsource.risk import RiskScore
+from .buildsource.scan_levels import EvidenceDepth, ScanMode, SourceMethod
+from .checker_policy import API_BREAK_KINDS, BREAKING_KINDS
+from .cli_scan_baseline import _expand_public_headers, _run_baseline_compare
+from .cli_scan_helpers import (
+    _intrinsic_coverage,
+    _l3_collected,
+    _pack_coverage,
+    _source_abi_coverage,
+    _uses_debug_presence_only,
+    l4_coverage_advisories,
+    resolve_effective_allow_query,
+    scan_pattern_roots,
+)
+
+if TYPE_CHECKING:
+    from .service_scan import CompileContext
+
+
+@dataclass
+class ScanOutcome:
+    """The composed result of a ``scan`` run, rendered to text or JSON.
+
+    Holds enough to print one coverage- and confidence-annotated report: the
+    resolved level, the risk score, the always-on tier results, the optional
+    baseline diff, and the combined verdict/exit code.
+    """
+
+    mode: str
+    resolved_method: str
+    depth: str | None
+    collect_mode: str
+    risk: RiskScore
+    auto: bool
+    changed_path_count: int
+    changed_path_source: str
+    coverage: list[dict[str, Any]] = field(default_factory=list)
+    pattern: dict[str, Any] = field(default_factory=dict)
+    preprocessor: dict[str, Any] = field(default_factory=dict)
+    crosscheck: dict[str, Any] = field(default_factory=dict)
+    crosscheck_severities: dict[str, str] = field(default_factory=dict)
+    poi: dict[str, Any] = field(default_factory=dict)
+    advisories: list[str] = field(default_factory=list)
+    stage_timings: dict[str, float] = field(default_factory=dict)
+    audit: bool = False
+    diff_summary: dict[str, Any] | None = None
+    verdict: str = "COMPATIBLE"
+    exit_code: int = 0
+    elapsed_s: float = 0.0
+    budget_s: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "level": {
+                "source_method": self.resolved_method,
+                "depth": self.depth,
+                "collect_mode": self.collect_mode,
+                "auto": self.auto,
+            },
+            "risk": self.risk.to_dict(),
+            "changed_paths": {
+                "count": self.changed_path_count,
+                "source": self.changed_path_source,
+            },
+            "coverage": list(self.coverage),
+            "pattern_scan": self.pattern,
+            "preprocessor_scan": self.preprocessor,
+            "crosscheck": self.crosscheck,
+            "crosscheck_severities": dict(self.crosscheck_severities),
+            "poi": self.poi,
+            "advisories": list(self.advisories),
+            "stage_timings": {
+                k: round(v, 3) for k, v in sorted(self.stage_timings.items())
+            },
+            "diff": self.diff_summary,
+            "verdict": self.verdict,
+            "exit_code": self.exit_code,
+            "elapsed_s": round(self.elapsed_s, 3),
+            "budget_s": self.budget_s,
+        }
+
+
+def _build_new_snapshot(
+    binary: Path,
+    headers: list[Path],
+    includes: list[Path],
+    sources: Path | None,
+    collect_mode: str,
+    lang: str,
+    allow_build_query: bool,
+    changed_paths: tuple[str, ...] = (),
+    build_info: Path | None = None,
+    build_config: Path | None = None,
+    public_headers: list[Path] | None = None,
+    public_header_dirs: list[Path] | None = None,
+    compile_context: CompileContext | None = None,
+    defer_cleanup: list[Callable[[], None]] | None = None,
+    symbols_only: bool = False,
+    debug_presence_only: bool = False,
+) -> tuple[Any, list[Path]]:
+    """Dump the candidate's L0-L2 surface and embed L3-L5 inline at *collect_mode*.
+
+    Returns ``(snapshot, effective_includes)`` — the effective includes carry any
+    build-derived L2 seed so a ``--baseline`` compare can reuse the same context.
+
+    The resolved ``changed_paths`` (from ``--changed-path``/``--since``) are
+    threaded into the inline source replay so a ``source-changed`` collection
+    actually narrows to the affected TUs — the ADR-035 D7 POI-focused cost model —
+    instead of falling back to a full ``target`` replay.
+
+    ``build_info`` (an out-of-tree compile DB / build dir / pack) and
+    ``build_config`` (a trusted ``.abicheck.yml`` enabling ``build.query``) are
+    threaded through so a pinned s5/s6 scan can collect L3/L4 even when the build
+    context lives outside ``--sources`` — otherwise it silently degrades to
+    partial coverage (Codex review).
+    """
+    from .buildsource.l2_seed import seed_l2_includes
+    from .errors import AbicheckError
+    from .service import resolve_input
+
+    # L2 include fallback: when headers are given but the user passed no explicit
+    # -I, seed the build's include dirs so the aggregate public-header parse can
+    # resolve dependency headers (e.g. pvxs headers include EPICS Base's
+    # <epicsTime.h>). Shared with the dump path via seed_l2_includes.
+    #
+    # Keep the seed's temp-build-dir cleanups LOCAL (defer_cleanup=None), not on the
+    # outer scan list: the seed may run the inferred-CMake query, whose build dir is
+    # held under an exclusive flock until its cleanup runs. embed_build_source()
+    # below runs its *own* inferred query in the same function, so if we deferred the
+    # release to the outer drain (which happens after embed) that second query would
+    # block on our still-held lock until INFERRED_QUERY_TIMEOUT_S (600s) before
+    # falling back to a fresh dir. The finally below drains _l2_local_cleanups right
+    # after resolve_input() has consumed the seeded dirs, releasing the lock before
+    # L3/L4 collection replays the query (Codex review).
+    includes, _l2_local_cleanups = seed_l2_includes(
+        headers=headers,
+        includes=includes,
+        sources=sources,
+        build_info=build_info,
+        build_config=build_config,
+        defer_cleanup=None,
+        # -I dirs the user gave through --gcc-options/--gcc-option (carried on the
+        # CompileContext) are explicit too — pass them so the seed stays a no-op
+        # and the user's include search precedence is preserved (Codex review).
+        gcc_options=compile_context.gcc_options if compile_context else None,
+        gcc_option_tokens=(
+            compile_context.gcc_option_tokens if compile_context else ()
+        ),
+        # L2-only pins (--depth headers → collect_mode "off") requested no build/
+        # source evidence, so the include-dir seed must not run a build system just
+        # to hint headers. Passive DB discovery still applies; only the zero-config
+        # inferred cmake/make/bazel query is gated (Codex review).
+        allow_inferred_build_query=collect_mode != "off",
+    )
+
+    try:
+        snap = resolve_input(
+            binary,
+            headers,
+            includes,
+            version="",
+            lang=lang,
+            public_headers=public_headers,
+            public_header_dirs=public_header_dirs,
+            compile=compile_context,
+            symbols_only=symbols_only,
+            debug_presence_only=debug_presence_only,
+        )
+    except AbicheckError as exc:
+        raise click.ClickException(f"Failed to load --binary {binary}: {exc}") from exc
+    finally:
+        # The L2 parse has now consumed the build-derived include dirs (whether it
+        # succeeded or raised), so release any inferred-CMake temp build dir now —
+        # before embed_build_source() below replays its own inferred query — so its
+        # exclusive flock does not block that replay for 600s (see the seed call).
+        if _l2_local_cleanups:
+            from .buildsource.inline import _run_cleanups
+
+            _run_cleanups(_l2_local_cleanups)
+    # Collect evidence when there is something to collect from — a source tree OR
+    # an out-of-tree build-info input — at a non-"off" level.
+    if (sources is not None or build_info is not None) and collect_mode != "off":
+        from .cli_buildsource import embed_build_source
+
+        embed_build_source(
+            snap,
+            build_info=build_info,
+            sources=sources,
+            build_config=build_config,
+            allow_build_query=allow_build_query,
+            collect_mode=collect_mode,
+            changed_paths=changed_paths,
+            public_headers=tuple(
+                str(p) for p in _expand_public_headers(
+                    [*list(public_headers or ()), *list(public_header_dirs or ())]
+                )
+            ),
+            public_header_dirs=tuple(str(p) for p in (public_header_dirs or ())),
+            defer_cleanup=defer_cleanup,
+        )
+    # Return the *effective* includes (the seed above may have added build-derived
+    # dirs) so a --baseline compare header-parses the old native library with the
+    # same include context — else the baseline side fails on dependency headers the
+    # candidate resolved via the seed (Codex review).
+    return snap, includes
+
+
+def _load_exports_for_poi(path: Path | None, lang: str) -> Any | None:
+    """Best-effort cheap load for the D7 export-delta POI walk (ADR-035 D7).
+
+    Loads *path* **header-free** — so no castxml/L2 and no L3-L5 collection, just
+    the L0 export tables (and, for a JSON baseline, its embedded L5 graph). The
+    export-delta walk in ``build_points_of_interest`` needs both sides' export
+    tables *before* the expensive collection runs; this is how it gets the
+    candidate's. Returns ``None`` on any failure (a registry-ref baseline, a load
+    error, …) so POI focusing simply degrades to changed-paths/triggers/risk —
+    it must never break the scan. This is an L0/L1-only read (well below the L4
+    cost cliff); the one expensive collection still runs once, below.
+    """
+    if path is None:
+        return None
+    from .service import resolve_input
+
+    try:
+        return resolve_input(path, [], [], version="", lang=lang, symbols_only=True)
+    except Exception:  # noqa: BLE001 - best-effort focusing input, never fatal
+        return None
+
+
+def _crosscheck_severity_exit(findings: list[Any], severities: dict[str, str]) -> int:
+    """Exit-code floor from cross-checks the maintainer promoted to ``error``.
+
+    A cross-check stays advisory (exit 0) until the maintainer opts it into
+    gating with ``--crosscheck KEY=error`` (ADR-035 UX step 7 / D6). Once opted
+    in, a finding for that check raises the exit to the source-break tier (2) —
+    even for a RISK-class check — so the documented promotion path actually
+    gates CI. ``info``/``warning`` never gate.
+    """
+    gating = {k for k, level in severities.items() if level == "error"}
+    if gating and any(f.kind.value in gating for f in findings):
+        return 2
+    return 0
+
+
+def _audit_exit_code(
+    findings: list[Any], severities: dict[str, str]
+) -> tuple[str, int]:
+    """Verdict/exit for the no-baseline path from cross-source finding tiers.
+
+    Cross-source findings are never ``BREAKING`` on their own (authority rule), so
+    an audit can reach at most ``API_BREAK`` (exit 2); ``RISK`` stays advisory
+    (exit 0) unless the maintainer promoted that check to ``error`` (D6).
+    Adoption never starts by blocking merges (ADR-035 UX step 7).
+    """
+    # Defensive: a mis-partitioned kind would be caught by the import-time
+    # assertion, but never let a cross-source finding gate a BREAKING verdict.
+    assert not any(f.kind in BREAKING_KINDS for f in findings), (
+        "cross-source findings must never be BREAKING (ADR-035 D1 authority rule)"
+    )
+    has_api_break = any(f.kind in API_BREAK_KINDS for f in findings)
+    exit_code = max(
+        2 if has_api_break else 0,
+        _crosscheck_severity_exit(findings, severities),
+    )
+    return ("API_BREAK" if exit_code >= 2 else "COMPATIBLE"), exit_code
+
+
+class _BudgetOverflow(Exception):
+    """Raised by ``run_scan_core`` when the scan exceeds ``--budget`` (ADR-035 D3).
+
+    A scan-engine signal (not a click concern): the budget is a *failure guard*
+    that never shrinks scope, so the core raises and the CLI maps it onto exit 5.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+class _EvidenceContractError(Exception):
+    """Raised by ``run_scan_core`` when a *pinned* depth can't collect its evidence.
+
+    ADR-037 D5 (#2 auto-strict): an explicitly-pinned ``--depth``/``--source-method``
+    is a contract — if the requested source/build evidence is unavailable the scan
+    fails loudly rather than silently degrading to a shallower one. Like
+    :class:`_BudgetOverflow`, it is an engine signal the CLI maps onto an error
+    exit (a clean ``ClickException``, exit 1) and ``service.run_scan`` maps onto a
+    failed :class:`ScanResult`. The implicit ``auto`` default never raises it.
+    """
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+@dataclass
+class ScanCoreResult:
+    """The engine core's typed output — the rendered :class:`ScanOutcome` plus the
+    raw cross-source findings and the candidate snapshot, so ``service.run_scan``
+    can build a typed ``ScanResult`` without re-running anything."""
+
+    outcome: ScanOutcome
+    findings: list[Any]
+    snapshot: Any
+
+
+def _run_abi3_audit(
+    new_snap: Any,
+    abi3_floor: tuple[int, int],
+    binary: Path,
+    cc: Any,
+) -> None:
+    """Run the opt-in stable-ABI (abi3) audit, folding its findings into ``cc``.
+
+    A single-artifact audit of the candidate's CPython imports against a target
+    Py_LIMITED_API floor. Its findings ride the cross-check stream: they are
+    RISK ``python_stable_abi_violation`` rows, advisory by default (like every
+    single-artifact check) and gated only via ``--crosscheck
+    python_stable_abi_violation=error``. Requires the --binary to be a CPython
+    extension module; --abi3 on a plain library is a usage error.
+    """
+    py_ext = new_snap.python_ext
+    if py_ext is None or not py_ext.is_extension:
+        raise _EvidenceContractError(
+            f"--abi3 {abi3_floor[0]}.{abi3_floor[1]} was given but "
+            f"'{binary.name}' is not a recognisable CPython extension module "
+            "(no PyInit_* export and no CPython C-API imports). The stable-ABI "
+            "audit applies only to extension modules (Cython/pybind11/"
+            "nanobind/C)."
+        )
+    from .diff_python import audit_stable_abi_imports
+
+    abi3_findings = audit_stable_abi_imports(py_ext, abi3_floor)
+    cc.findings.extend(abi3_findings)
+    # Name the offending symbols in the coverage row (rendered verbatim in
+    # text and carried in JSON) so a CI artifact tells the user WHICH import
+    # to fix — the cross-check summary only reports a per-kind count, which
+    # would otherwise hide the symbol in Change.detail/new_value (Codex
+    # review). Capped so a pathological module cannot flood the report.
+    offending: list[str] = []
+    for f in abi3_findings:
+        offending.extend(f.new_value if isinstance(f.new_value, list) else [])
+    detail = (
+        f"{len(py_ext.cpython_imports)} CPython import(s) audited against "
+        f"Py_LIMITED_API {abi3_floor[0]}.{abi3_floor[1]}; "
+        f"{len(abi3_findings)} violation finding(s)"
+    )
+    if offending:
+        shown = ", ".join(offending[:20])
+        more = f" (+{len(offending) - 20} more)" if len(offending) > 20 else ""
+        detail += f" — outside the stable ABI: {shown}{more}"
+    cc.coverage.append({"layer": "abi3_audit", "status": "ran", "detail": detail})
+
+
+def _build_scan_poi(
+    baseline: Path | None,
+    seeded: bool,
+    collect_mode: str,
+    binary: Path,
+    lang: str,
+    changed: list[str],
+    risk: RiskScore,
+    pattern: Any,
+) -> tuple[Any, Any]:
+    """Build the D7 points-of-interest work-list + the baseline export view used.
+
+    Returns ``(poi, poi_baseline)``. The export-delta walk needs both sides'
+    export tables, so a cheap header-free L0 view of the candidate and baseline is
+    loaded only when there is a baseline to diff against (else a wasted parse).
+    """
+    needs_export_delta_poi = (
+        baseline is not None
+        and seeded
+        and collect_mode in {"source-changed", "graph-full"}
+    )
+    poi_baseline = (
+        _load_exports_for_poi(baseline, lang) if needs_export_delta_poi else None
+    )
+    poi_candidate = (
+        _load_exports_for_poi(binary, lang) if poi_baseline is not None else None
+    )
+    poi = build_points_of_interest(
+        changed_paths=changed,
+        risk=risk,
+        pattern_triggers=pattern.escalation_triggers,
+        baseline=poi_baseline,
+        candidate=poi_candidate,
+    )
+    return poi, poi_baseline
+
+
+def _append_replay_scope_advisory(
+    advisories: list[str], seeded: bool, collect_mode: str, sources: Path | None,
+) -> None:
+    """Advise (ADR-035 P3) when an unseeded run falls back to headers-only replay.
+
+    Only when L4 replay can actually run (a --sources tree is present) does the
+    headers-only fallback apply; firing otherwise would report a replay that never
+    happened (CodeRabbit review).
+    """
+    if not seeded and collect_mode == "source-changed" and sources is not None:
+        advisories.append(
+            "no --since/--changed-path seed; the L4 replay and the L5 call-graph "
+            "pass both cover the public-API surface (headers-only) instead of a "
+            "focused diff — cost grows with the project, not the change. Pass "
+            "--since <ref> or --changed-path to scope both to the changed TUs."
+        )
+
+
+def _check_scan_evidence_contract(
+    advisories: list[str],
+    new_snap: Any,
+    collect_mode: str,
+    pinned_explicit: bool,
+    sources: Path | None,
+    effective_build_info: Path | None,
+    eff_depth_enum: EvidenceDepth,
+    resolved: SourceMethod,
+) -> None:
+    """Fail-loud on a pinned depth with no evidence; else advise on missing L3.
+
+    ADR-037 D5 (#2 auto-strict): a depth the user *explicitly pinned* with no
+    source evidence at all (no --sources/--build-info, and the trusted --config
+    build.query flow produced no L3) is a usage-contract violation → raise. When a
+    source input *was* supplied but L3 still came back empty, that stays a pointed
+    advisory naming the remedy. The implicit 'auto' default never errors here.
+    """
+    if collect_mode == "off":
+        return
+    gave_source_input = sources is not None or effective_build_info is not None
+    l3 = _l3_collected(new_snap)
+    if pinned_explicit and not gave_source_input and not l3:
+        raise _EvidenceContractError(
+            f"pinned depth '{eff_depth_enum.value}' (source-method {resolved.value}) "
+            "needs source evidence, but no --sources/--build-info was given — there "
+            "is nothing to collect L3/L4/L5 from. Pass --sources <tree> or "
+            "--build-info <dir|compile_commands.json> (or a trusted --config plus "
+            "--allow-build-query), or drop the pin / use the default 'auto' for a "
+            "best-effort binary scan. (Pinned depths are a contract.)"
+        )
+    if gave_source_input and not l3:
+        advisories.append(
+            f"requested depth '{eff_depth_enum.value}' (source-method "
+            f"{resolved.value}) needs an L3 compile database, but none was found — "
+            "L3/L4/L5 were skipped. Provide one with --build-info/--compile-db (a "
+            "compile_commands.json or build dir), or a trusted --config plus "
+            "--allow-build-query to generate it."
+        )
+
+
+def _check_scan_budget(
+    budget: str | None, budget_s: float | None, elapsed: float,
+) -> None:
+    """Budget overflow FAILS, never shrinks scope (ADR-035 D3)."""
+    if budget_s is not None and elapsed > budget_s:
+        raise _BudgetOverflow(
+            f"error: --budget {budget} exceeded "
+            f"({elapsed:.1f}s > {budget_s:.0f}s). "
+            "Pin a shallower level or raise the budget; a budget never silently "
+            "shrinks the pinned scope."
+        )
+
+
+def run_scan_core(
+    *,
+    start: float,
+    binary: Path,
+    headers: list[Path],
+    includes: list[Path],
+    public_headers: list[Path],
+    public_header_dirs: list[Path],
+    sources: Path | None,
+    effective_build_info: Path | None,
+    build_config: Path | None,
+    baseline: Path | None,
+    lang: str,
+    allow_build_query: bool,
+    baseline_headers: list[Path] | None = None,
+    baseline_includes: list[Path] | None = None,
+    scan_mode: ScanMode,
+    resolved: SourceMethod,
+    eff_depth_enum: EvidenceDepth,
+    collect_mode: str,
+    changed: list[str],
+    changed_src: str,
+    seeded: bool,
+    risk: RiskScore,
+    is_auto: bool,
+    enabled_checks: frozenset[str],
+    severities: dict[str, str],
+    budget: str | None,
+    budget_s: float | None,
+    level_explicit: bool = False,
+    pinned_explicit: bool = False,
+    compile_context: CompileContext | None = None,
+    defer_cleanup: list[Callable[[], None]] | None = None,
+    abi3_floor: tuple[int, int] | None = None,
+) -> ScanCoreResult:
+    """The shared scan orchestration (classify → always-on tier → level → compare).
+
+    Pure of click/argv: it takes already-resolved inputs, runs the engine, and
+    returns a :class:`ScanCoreResult`. Raises :class:`_BudgetOverflow` on budget
+    overflow (the CLI maps it to exit 5). This is the one body the CLI,
+    ``service.run_scan``, and the MCP scan tool share (ADR-035 D10).
+    """
+    stage_timings: dict[str, float] = {}
+
+    def _record_stage(name: str, started: float) -> None:
+        stage_timings[name] = time.monotonic() - started
+
+    # --- always-on tier: compiler-free pattern pre-scan (S3) ------------------
+    # Runs *before* the snapshot build so its escalation triggers feed the D7
+    # points-of-interest work-list that focuses the (expensive) source replay.
+    # Scope: a *seeded* diff (even an empty one) confines the scan to the changed
+    # set — an empty seed (no-op PR) scans nothing, preserving the empty-diff
+    # scope; only a genuinely *unseeded* run (no --since/--changed-path) falls
+    # back to the whole-tree scan (Codex review).
+    pattern_roots = scan_pattern_roots(list(headers), sources, eff_depth_enum)
+    _stage = time.monotonic()
+    pattern = scan_files(pattern_roots, changed if seeded else None)
+    _record_stage("pattern_scan", _stage)
+
+    # --- D7 points-of-interest: cheap facts steer the expensive scan ----------
+    # Floor = the directly-changed paths (always included); the pattern triggers,
+    # risk score, and the L0↔L2 export deltas only *add* candidates, never drop a
+    # changed TU (ADR-035 D7). The export-delta walk needs both sides' export
+    # tables up front, so read a cheap, header-free L0 view of the candidate and
+    # baseline here (no castxml/L3-L5); the one expensive collection still runs
+    # once, below, with the resulting focus seed. The candidate view is only
+    # loaded when there is a baseline to diff it against — the delta walk consumes
+    # the two together, so loading it baseline-less would be a wasted L0/L1 parse.
+    _stage = time.monotonic()
+    poi, poi_baseline = _build_scan_poi(
+        baseline, seeded, collect_mode, binary, lang, changed, risk, pattern
+    )
+    _record_stage("poi", _stage)
+
+    # --- build the candidate snapshot (L0-L2 + inline L3-L5 at the level) ------
+    # An explicit --compile-db (a file) wins over --build-info (dir/pack) as the
+    # L3 source; both feed embed_build_source's build_info input. The POI path set
+    # focuses the replay — but ONLY when a real diff seed was supplied
+    # (``seeded``). Without --since/--changed-path the scan is broad by contract
+    # (the report says so), so passing pattern-trigger POIs as the changed set
+    # would wrongly narrow PR-mode replay to a single pattern-flagged TU and skip
+    # source-only checks elsewhere (Codex review). When seeded, the focusing
+    # work-list is the changed-path floor *plus* the TUs resolved from changed
+    # exports via the baseline's L5 graph (resolve_symbol_tus) — so a changed
+    # export with an unchanged header still points the replay at the one TU that
+    # emits it (ADR-035 D7, the focusing half).
+    symbol_tus = resolve_symbol_tus(poi, poi_baseline) if seeded else ()
+    replay_seed = (
+        tuple(dict.fromkeys((*poi.changed_paths(), *symbol_tus))) if seeded else ()
+    )
+    # ADR-035 P3: an unseeded s5/pr run cannot narrow 'source-changed' to a diff,
+    # so the L4 replay falls back to the public-API 'headers-only' surface
+    # (inline.collect_inline_pack). Record an advisory naming the cost + the knob
+    # that focuses it, rather than silently paying a broad replay (validation P3
+    # "no auto-warn"). Carried on the result (text + JSON) so it never pollutes a
+    # structured-format stdout.
+    advisories: list[str] = []
+    _append_replay_scope_advisory(advisories, seeded, collect_mode, sources)
+    effective_allow_query, _query_advisory = resolve_effective_allow_query(
+        allow_build_query, build_config, collect_mode, level_explicit, resolved
+    )
+    if _query_advisory is not None:
+        advisories.append(_query_advisory)
+
+    _stage = time.monotonic()
+    new_snap, eff_includes = _build_new_snapshot(
+        binary,
+        list(headers),
+        list(includes),
+        sources,
+        collect_mode,
+        lang,
+        effective_allow_query,
+        changed_paths=replay_seed,
+        build_info=effective_build_info,
+        build_config=build_config,
+        public_headers=list(public_headers),
+        public_header_dirs=list(public_header_dirs),
+        compile_context=compile_context,
+        defer_cleanup=defer_cleanup,
+        symbols_only=eff_depth_enum is EvidenceDepth.BINARY,
+        debug_presence_only=_uses_debug_presence_only(eff_depth_enum),
+    )
+    _record_stage("candidate_snapshot", _stage)
+    l4_cov = _source_abi_coverage(new_snap)
+    advisories.extend(l4_coverage_advisories(l4_cov))
+
+    # --- level-vs-evidence: fail-loud on missing input, advise otherwise ------
+    # A deep depth (build/source/full → collect_mode != "off") needs an L3 compile
+    # database; without one the L3/L4/L5 layers cannot be collected.
+    _check_scan_evidence_contract(
+        advisories, new_snap, collect_mode, pinned_explicit,
+        sources, effective_build_info, eff_depth_enum, resolved,
+    )
+
+    # --- conditional tier: S2 preprocessor pre-scan (D2) ----------------------
+    # Runs only when L3 build evidence + a preprocessor (`clang -E`) are present;
+    # otherwise the coverage row honestly reports it skipped (never clean). Emits
+    # advisory macro-divergence + private/generated-header-leak facts. Headers are
+    # expanded to the individual public header *files* (``-H include/`` accepts a
+    # directory) so the per-header leak pass preprocesses each header, not the
+    # directory as one bogus TU (Codex review).
+    pp_build = (
+        new_snap.build_source.build_evidence
+        if new_snap.build_source is not None
+        else None
+    )
+    _stage = time.monotonic()
+    preproc = run_preprocessor_scan(pp_build, _expand_public_headers(list(headers)))
+    _record_stage("preprocessor_scan", _stage)
+
+    # --- always-on tier: intra-version cross-source checks (D4) ---------------
+    # The resolved changed-path set is handed to the engine so
+    # ``public_to_internal_dependency`` can elevate a finding whose internal
+    # target was touched this revision (ADR-035 D4 "L5 reachability ↔ PR
+    # changed files").
+    # The changed-path set handed to the engine also carries the TUs the D7
+    # export-delta walk resolved (symbol_tus), so ``public_to_internal_dependency``
+    # elevates a finding whose internal target sits in a TU this revision touched
+    # *via a changed export* — not only the literally git-changed files.
+    _stage = time.monotonic()
+    cc = run_crosschecks(
+        new_snap,
+        CrosscheckConfig(
+            enabled=frozenset(enabled_checks),
+            changed_paths=frozenset(changed) | set(symbol_tus),
+        ),
+    )
+    _record_stage("crosschecks", _stage)
+
+    # --- stable-ABI (abi3) audit (opt-in via --abi3) --------------------------
+    if abi3_floor is not None:
+        _run_abi3_audit(new_snap, abi3_floor, binary, cc)
+
+    # --- pinned-level baseline comparison (if any) ----------------------------
+    diff_summary: dict[str, Any] | None = None
+    if baseline is not None and scan_mode is not ScanMode.AUDIT:
+        _stage = time.monotonic()
+        verdict, exit_code, diff_summary = _run_baseline_compare(
+            baseline,
+            binary,
+            new_snap,
+            [],
+            lang,
+            collect_mode,
+            list(headers),
+            # Effective (seeded) includes so the baseline native parse gets the same
+            # build-derived dependency include dirs as the candidate (Codex review).
+            list(eff_includes),
+            list(public_headers),
+            list(public_header_dirs),
+            compile_context=compile_context,
+            baseline_headers=baseline_headers,
+            baseline_includes=baseline_includes,
+            symbols_only=eff_depth_enum is EvidenceDepth.BINARY,
+            debug_presence_only=_uses_debug_presence_only(eff_depth_enum),
+        )
+        # A cross-check the maintainer promoted to `error` (D6) gates the exit
+        # even when the baseline diff itself is clean.
+        sev_exit = _crosscheck_severity_exit(cc.findings, severities)
+        if sev_exit > exit_code:
+            exit_code = sev_exit
+            # Keep the reported verdict in sync with the promoted exit code so a
+            # consumer keying off the verdict string isn't misled (Codex review).
+            # Only a non-breaking verdict is promoted — never downgrade a real
+            # BREAKING/API_BREAK from the artifact diff.
+            if verdict in ("NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK"):
+                verdict = "API_BREAK"
+        _record_stage("baseline_compare", _stage)
+    else:
+        if baseline is not None:
+            click.echo(
+                "note: --audit ignores --baseline (intra-version scan).", err=True
+            )
+        verdict, exit_code = _audit_exit_code(cc.findings, severities)
+
+    elapsed = time.monotonic() - start
+    _check_scan_budget(budget, budget_s, elapsed)
+
+    outcome = ScanOutcome(
+        mode=scan_mode.value,
+        resolved_method=resolved.value,
+        depth=eff_depth_enum.value,
+        collect_mode=collect_mode,
+        risk=risk,
+        auto=is_auto,
+        changed_path_count=len(changed),
+        changed_path_source=changed_src,
+        coverage=[
+            *_intrinsic_coverage(new_snap),
+            pattern.coverage().to_dict(),
+            preproc.coverage().to_dict(),
+            *_pack_coverage(new_snap),
+            *cc.coverage,
+        ],
+        pattern=pattern.to_dict(),
+        preprocessor=preproc.to_dict(),
+        crosscheck=cc.to_dict(),
+        crosscheck_severities=severities,
+        poi=poi.to_dict(),
+        advisories=advisories,
+        stage_timings=stage_timings,
+        audit=scan_mode is ScanMode.AUDIT,
+        diff_summary=diff_summary,
+        verdict=verdict,
+        exit_code=exit_code,
+        elapsed_s=elapsed,
+        budget_s=budget_s,
+    )
+    return ScanCoreResult(
+        outcome=outcome, findings=list(cc.findings), snapshot=new_snap
+    )

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -74,11 +74,20 @@ def _sets_to_lists(obj: Any) -> Any:
 
 
 def snapshot_to_dict(snap: AbiSnapshot) -> dict[str, Any]:
-    # Reset cache fields to None before asdict() to prevent double-serialization.
-    snap._func_by_mangled = None
-    snap._var_by_mangled = None
-    snap._type_by_name = None
-    d = asdict(snap)
+    # asdict() would recursively copy the lazy lookup caches too (wasted work,
+    # and they're dropped below anyway). Clear them for the duration of the
+    # call and restore afterward so this function stays pure from the
+    # caller's perspective — snapshot_to_dict(snap) must not mutate `snap`,
+    # or invalidate an index a caller built and is still holding a reference
+    # to via the object it passed in.
+    saved_caches = (snap._func_by_mangled, snap._var_by_mangled, snap._type_by_name)
+    try:
+        snap._func_by_mangled = None
+        snap._var_by_mangled = None
+        snap._type_by_name = None
+        d = asdict(snap)
+    finally:
+        snap._func_by_mangled, snap._var_by_mangled, snap._type_by_name = saved_caches
     d.pop("_func_by_mangled", None)
     d.pop("_var_by_mangled", None)
     d.pop("_type_by_name", None)

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -728,7 +728,7 @@ def run_scan(req: ScanRequest) -> ScanResult:
     The single engine entry point behind the ``scan`` CLI and the MCP scan tool:
     it resolves the deterministic level from *req* (the same way
     :func:`estimate_scan` does), drives the shared orchestration core
-    (``cli_scan.run_scan_core`` — classify → always-on tier → pinned level →
+    (``scan_engine.run_scan_core`` — classify → always-on tier → pinned level →
     optional baseline compare), and folds the projected ``estimate_scan`` cost in
     so a caller can compare projected vs. actual. ``--budget`` overflow surfaces as
     ``exit_code`` 5 (the failure-guard contract; never shrinks scope).
@@ -744,12 +744,12 @@ def run_scan(req: ScanRequest) -> ScanResult:
         parse_user_depth,
     ) = _scan_imports()
     from .buildsource.crosscheck import ALL_CHECKS
-    from .cli_scan import (
+    from .cli_scan_baseline import _public_provenance_set
+    from .scan_engine import (
         _BudgetOverflow,
         _EvidenceContractError,
         run_scan_core,
     )
-    from .cli_scan_baseline import _public_provenance_set
 
     if len(req.binaries) != 1:
         raise ValueError("run_scan accepts exactly one binary")

--- a/docs/development/architecture-deepening-plan.md
+++ b/docs/development/architecture-deepening-plan.md
@@ -479,6 +479,236 @@ follow-up (unifying the stdlib-/runtime-RTTI skip sets) a natural home.
 
 ---
 
+### C11 — Decompose `AbiSnapshot` / `Change` / `DiffResult`
+
+> **Provenance.** Flagged by the static architecture review that produced PR
+> #536 (SARIF/JUnit verdict-routing fixes, `snapshot_to_dict` purity,
+> `ctx.kept` aliasing hardening, `service_scan`→`cli_scan` dependency-inversion
+> fix). The review named this "the full `AbiSnapshot`/`Change`/`DiffResult`
+> decomposition" and explicitly deferred it as multi-week, broad-blast-radius
+> work rather than an urgent bug. This candidate is the concrete plan for that
+> deferred item, added to this catalogue on request.
+
+**Problem.** Neither this document nor an existing ADR has previously proposed
+splitting these three types — **C10 addresses `model.py`'s *other* mixed
+concern** (name/type-string heuristics) and explicitly leaves `AbiSnapshot`'s
+own field/index shape untouched; **C2/ADR-036 ratified `DiffResult`
+`_effective_verdict_for_change` as the canonical verdict source**, which this
+candidate must reconcile with, not silently override. Each of the three types
+mixes responsibilities that today are only separable by convention:
+
+- **`AbiSnapshot`** (`model.py:339-576`, 576-line file, 38 fields) mixes (a)
+  raw parsed data, (b) ADR-015 schema-versioning/provenance fields bolted on
+  over time (`git_commit`, `build_mode`, `scope_fallback`,
+  `parsed_with_build_context`, …), and (c) **three mutable lazy index caches**
+  (`_func_by_mangled`, `_var_by_mangled`, `_type_by_name`) living as
+  `compare=False`/`repr=False` dataclass fields, populated by `index()` with
+  duplicate-detection side effects. The dataclass constructor is order-
+  sensitive/kw-only-patched in several places specifically to avoid breaking
+  positional callers as new fields were added (`model.py:364-372, 428, 436,
+  454, 459, 479, 489`) — a direct symptom of one type absorbing every new
+  cross-cutting concern. This same mutable-cache shape is exactly what PR
+  #536 fixed one symptom of: `serialization.snapshot_to_dict` used to reset
+  these caches on the caller's live object before `asdict()`.
+- **`Change`** (`checker_types.py:47-95`, 17 fields) is mostly a clean data
+  record, but **7 of its 17 fields exist only to carry policy/verdict-
+  modulation metadata** (`effective_verdict`, `modulation_reason`,
+  `modulation_rule`, `confidence`, `evidence_category`,
+  `frozen_namespace_violation`, `surface_exclusion_reason` — ADR-025/027 A4
+  pattern modulation, ADR-033 D9 evidence bucket) rather than facts about the
+  ABI change itself.
+- **`DiffResult`** (`checker_types.py:118-276`, 31 fields, 2 methods, 4
+  properties) owns the raw findings (`changes` + 4 sibling filtered lists)
+  **and** the policy that classifies them (`policy`, `policy_file`,
+  `_effective_kind_sets`) **and** the per-change verdict engine
+  (`_effective_verdict_for_change`) **and** display-ready buckets (`breaking`/
+  `source_breaks`/`compatible`/`risk` properties — each an **uncached O(n)
+  re-walk that recomputes `_effective_verdict_for_change` for every change on
+  every access**) **and** audit/observability trails (`pattern_modulations`,
+  `layer_coverage`, `evidence_metrics`). `_effective_kind_sets`/
+  `_effective_verdict_for_change`, though named as private methods, are called
+  directly from **~8 downstream modules** (`cli.py`, `reporter.py`,
+  `reporter_markdown.py`, `junit_report.py`, `sarif.py`, `annotations.py`,
+  `cli_appcompat.py`, `cli_compare_release_helpers.py`) plus `report_model.py`
+  — treated as public API without being designed as one. PR #536's SARIF fix
+  (`sarif.py::_severity`) is a direct symptom: it re-implemented its own
+  narrower "is this overridden" check instead of always deferring to the one
+  real verdict computation, and drifted out of sync with it.
+
+**Goal.** Increase depth at this seam — concentrate the verdict-computation
+and index-caching *behaviour* behind small interfaces instead of letting ~8
+call sites each know how to invoke `DiffResult`'s internals, while keeping
+`AbiSnapshot`'s ADR-015 canonical-interchange-model *contract* (the same
+importable, schema-versioned shape from `serialization.py`) unchanged from the
+outside.
+
+**Approach.** Three independent, separately-landable sub-efforts — mirroring
+how C2/C6/C10 were each staged — ordered by risk, not by dependency (only C
+depends on prior work):
+
+1. **Sub-effort A — Extract `AbiSnapshot`'s index caches into a
+   `SnapshotIndex` value object (composition).** `_func_by_mangled`/
+   `_var_by_mangled`/`_type_by_name` and the `index()` method move to a
+   dedicated helper; `AbiSnapshot.function_map`/`.variable_map`/
+   `.type_by_name()` become thin properties delegating to a
+   (lazily-constructed, not dataclass-field) `SnapshotIndex` instance stored
+   outside `__dict__`'s comparison/repr surface entirely, rather than via
+   `compare=False`/`repr=False` field tricks. `serialization.snapshot_to_dict`
+   is unaffected — the index was never part of the serialized shape. Self-
+   contained, mechanical, low risk; directly shrinks the shared-mutable-state
+   surface that produced the PR #536 serialization-purity bug.
+2. **Sub-effort B — Extract `DiffResult`'s verdict computation into a
+   standalone `verdict_service.py`.** `_effective_kind_sets`/
+   `_effective_verdict_for_change` become module-level functions taking
+   `(changes, policy, policy_file)` rather than methods reaching into `self`;
+   `DiffResult` keeps thin delegating methods for the ~8 existing call sites
+   (same re-export pattern C10 used for `model.py`). While extracting, fix the
+   uncached `breaking`/`source_breaks`/`compatible`/`risk` properties (e.g.
+   `functools.cached_property`, invalidated on `policy`/`policy_file`
+   reassignment — see risks). **This sub-effort requires an explicit decision
+   to supersede ADR-036 Decision #2** ("canonical report severity = each
+   finding's `result._effective_verdict_for_change(c)`," i.e. a `DiffResult`
+   method) with an ADR-036 addendum or new ADR recording that *relocating* the
+   one implementation is compatible with — not a reversal of — the "single
+   source of truth" goal ADR-036 was protecting against (multiple *disagreeing*
+   implementations), since the function itself doesn't change, only where it
+   lives. This is the load-bearing decision in this candidate and needs
+   sign-off before code starts, not after.
+3. **Sub-effort C — Split `Change`'s policy/verdict-modulation fields into a
+   nested `Change.modulation: PatternModulation | None`.** Lowest priority,
+   highest call-site risk (`Change(` appears at 48 sites in `abicheck/` across
+   12 modules outside the already-centralised `diff_*` family, and 724 sites
+   repo-wide including tests). **Sequence after C6 fully lands** — C6's
+   `make_change()` factory already shields most `diff_*` call sites from
+   `Change`'s exact field shape; splitting fields is far cheaper once
+   construction is centralised than while 12+ modules construct `Change`
+   directly.
+
+**Edge cases / risks.**
+- **ADR-015 tension.** ADR-015 Decision #1 fixes `AbiSnapshot` as *the*
+  canonical, schema-versioned interchange model. Sub-effort A must change only
+  internal storage, not `serialization.py`'s externally-visible schema —
+  verify with the existing serialization round-trip tests plus a byte-diff of
+  `snapshot_to_dict` output before/after.
+- **ADR-036 supersession (sub-effort B).** Silent drift here is exactly the
+  failure mode ADR-036 exists to prevent — do not relocate
+  `_effective_verdict_for_change` without a written decision record first.
+- **Cache invalidation correctness (sub-effort B).** PR #536's own regression
+  tests (`test_policy_file_override_propagates_across_channels`) construct a
+  `DiffResult` and then *mutate* `result.policy_file` after the fact to
+  exercise override behaviour — any caching of `_effective_kind_sets`/the
+  bucket properties must invalidate on `policy`/`policy_file` reassignment,
+  not just on first access, or that exact test pattern (and any caller relying
+  on it) silently breaks.
+- **Call-site fan-out is the real cost driver.** ~950 `AbiSnapshot(` and 724
+  `Change(` construction sites repo-wide (tests included), ~17 call/reference
+  sites for the two verdict methods. This is why the review called it multi-
+  week — this plan's answer is to slice it into the three sub-efforts above
+  rather than one PR, each independently shippable and gated the same way as
+  every other candidate (fast lane, mypy, ruff, ai-readiness, golden where
+  output can change).
+- Prefer additive/back-compat re-exports over removal at every step (the C10
+  pattern) — hundreds of test fixtures construct these types directly and
+  should not need to change in the same PR as the internal refactor.
+
+**Risk:** A low; B medium-high (blocked on an explicit ADR-036 supersession
+decision plus cache-correctness verification); C high call-site count, blocked
+on C6 completing first.
+
+---
+
+### C12 — `LayerProvider` keep-vs-delete decision
+
+> **Provenance.** The second item the architecture review that produced PR
+> #536 named and deferred: "the `LayerProvider` keep-vs-delete decision."
+> Unlike C11, this is not a decomposition — it is a binary call this document
+> lays out evidence for but does not make unilaterally.
+
+**Problem.** `abicheck/buildsource/providers.py` (127 lines) defines the
+ADR-035 D10 `LayerProvider` `Protocol` (`capabilities()`/`estimate()`/`run()`)
+plus its supporting value types (`ProviderCapabilities`,
+`ProviderCostEstimate`, `ScanContext`, `LayerFacts`), modeled explicitly on
+ADR-032's `DataExtractor` plugin protocol and intended to let every scan-
+ladder level (D2 pre-scan, L3 build, L4 replay, L5 graph, D4 cross-checks) be
+driven through one uniform, cost-estimable interface. In the current code:
+
+- **Zero production implementers.** The only other reference anywhere in the
+  repo is `tests/test_providers.py`'s single `_FakeProvider` fixture, which
+  exists purely to assert the `Protocol`'s structural typing works in
+  isolation — it is not exercised by any real scan path.
+- **The real orchestrator bypasses it.** `scan_engine.run_scan_core()` (the
+  shared engine core PR #536 extracted from `cli_scan.py`) imports and calls
+  the concrete collector functions directly —
+  `buildsource.crosscheck.run_crosschecks`, `buildsource.pattern_scan.
+  scan_files`, `buildsource.preprocessor_scan.run_preprocessor_scan`, etc.
+  (`scan_engine.py:53-57`) — never touching `providers.py`.
+- **The typed half of the same ADR section shipped, the protocol half
+  didn't.** `service_scan.py`'s `ScanRequest`/`ScanResult`/`run_scan()`/
+  `run_audit()` (ADR-035 D10's *other* deliverable) are real and wired up, but
+  never import `providers.py` either.
+- **Documentation has drifted from code.** `abicheck/buildsource/CLAUDE.md`'s
+  module map still describes `providers.py` as live and "driven by
+  `service.run_scan`" (ADR-035 D10, G19.7) — `service.run_scan` does not
+  exist; the real entry point (`service_scan.run_scan`) never touches this
+  module. ADR-035 D10 itself is still marked "Accepted — implemented" with no
+  note that this half diverged.
+
+This is the textbook shape of orphaned/partial-migration scaffolding: a typed
+contract with no implementers, no real callers, bypassed by the very
+orchestrator built to fulfill the ADR describing it, and misdocumented as
+load-bearing in the module map a contributor would read first.
+
+**Goal.** Close the gap between what ADR-035 D10 says and what
+`scan_engine.py`/`service_scan.py` actually do, and stop
+`buildsource/CLAUDE.md` asserting a wiring that isn't real — via whichever of
+the two paths below the maintainer picks.
+
+**Approach — this is a decision, not a mechanical refactor:**
+
+- **Option 1: Delete** `providers.py` + `tests/test_providers.py`; add an
+  ADR-035 addendum (or short new ADR) recording that D10's "Provider
+  protocol" sub-design was superseded by `scan_engine.run_scan_core()`'s
+  direct-call orchestration plus `service_scan`'s typed API, and why: every
+  level added so far (L3/L4/L5) has needed enough level-specific wiring in
+  `run_scan_core` that a shared 3-method `Protocol` wouldn't have saved
+  orchestration code, only added an indirection with no implementers. Correct
+  `buildsource/CLAUDE.md`'s module map in the same change. Lowest risk —
+  deletes code nothing depends on; the fast lane + ai-readiness gate confirm
+  no fallout.
+- **Option 2: Retrofit** — refactor `scan_engine.run_scan_core()`'s direct
+  collector calls into real `LayerProvider` implementations, registered and
+  dispatched uniformly, realizing ADR-035 D10's original design. Only
+  justified by a concrete near-term need for pluggable/external providers
+  (e.g. an ADR-032 manifest-driven external extractor reaching this level on
+  the actual roadmap) — otherwise this is speculative generality against this
+  repo's own stated convention ("Don't add features... beyond what the task
+  requires... Don't design for hypothetical future requirements," `/CLAUDE.md`).
+  Higher effort: touches the already-large `scan_engine.py` plus every D2/L3/
+  L4/L5 collector call site, and needs behaviour-preserving verification
+  across the scan pipeline (`Scan: --estimate dry run`, `Scan: baseline
+  comparison detects breaking change` CI jobs and friends).
+
+**Recommendation (non-binding).** Option 1, unless there is a known concrete
+near-future consumer needing the pluggable-provider indirection — the
+evidence (zero implementers after one full ADR cycle, a parallel path that
+already solved the same orchestration goal a different way) points at
+superseded scaffolding rather than a paused-but-needed migration. Cheap to
+redesign later with real requirements in hand if that changes; expensive to
+carry speculative unused abstraction now.
+
+**Edge cases / risks.**
+- Whichever option is chosen, `buildsource/CLAUDE.md`'s module map must be
+  corrected in the same PR — the current mismatch is itself a standing risk
+  (a contributor reading it will look for wiring that isn't there).
+- If deleted and a real need appears later, redesigning is cheap; this is a
+  low-regret decision either way for the code itself.
+
+**Risk:** low either way — isolated module, no real dependents. The only risk
+is in documentation/ADR correctness, not code breakage, so this candidate can
+land quickly once the maintainer picks an option.
+
+---
+
 ### N-A — One HTML page seam for the three native renderers *(implemented)*
 
 **Problem.** There was no HTML-page abstraction. `appcompat_html.py` and
@@ -551,6 +781,8 @@ C10 split model.py                 ◐ stage-2 done (name predicates + type-name
 C8  ABICC compat adapter           (parity-sensitive)
 C5  synthetic detectors → registry ⛔ deferred (entangled; net-negative)
 C6  Change factory                 ◐ inc 1 done (factory + 167 templates; all ~200 diff_* sites route via make_change)
+C12 LayerProvider keep-vs-delete   proposed (decision, not a refactor — low code risk, needs maintainer sign-off)
+C11 decompose Snapshot/Change/Diff proposed (sub-effort A low risk; B needs ADR-036 supersession; C blocked on C6)
 ```
 
 Rationale: C4 and C9 are mechanical and reversible — do them to build
@@ -558,6 +790,10 @@ confidence. C1 (done) unblocks C2 and C10. C2 is the largest locality payoff but
 carries visible-output risk, so it lands behind golden review before the
 churn-heavy C6. C8 is sequenced last among the structural items because ABICC
 parity is contractual and benefits from a stabilised shared layer underneath it.
+C12 is sequenced ahead of C11 despite the higher number: it's a pure decision
+with low code risk and no dependents, so it can resolve independently and
+quickly, whereas C11 is intentionally the last, biggest-blast-radius item —
+its sub-effort C is explicitly blocked on C6 completing first.
 
 ## Tracking
 
@@ -577,3 +813,5 @@ parity is contractual and benefits from a stabilised shared layer underneath it.
 | N-A | HTML page seam (`html_template`) — shared document chrome + footer for the three native renderers, byte-identical golden-locked | Done | #407 |
 | N-D | Unify stdlib/runtime RTTI prefix tables into one canonical `STDLIB_RTTI_PREFIXES` (verified: identical parity-corpus failure set; only effective delta is suppressing std::__cxx11 RTTI in L0 layout, which is toolchain-owned) | Done | #407 |
 | N-E | Structured `Change` value fields | Not needed — already satisfied: `make_change` routes `old=`/`new=` into `old_value`/`new_value` (offsets included) and reporters read those fields; zero prose-scraping found | — |
+| C11 | Decompose `AbiSnapshot`/`Change`/`DiffResult` (sub-effort A: `SnapshotIndex` extraction; B: `verdict_service.py` extraction, needs ADR-036 supersession; C: `Change.modulation` split, blocked on C6) | Proposed | — |
+| C12 | `LayerProvider` keep-vs-delete decision (`buildsource/providers.py` — zero implementers, bypassed by `scan_engine.run_scan_core`; delete-vs-retrofit call for the maintainer) | Proposed | — |

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -681,6 +681,24 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
         # exactly as `cli_scan` did before the split — so it joins the same SCC and
         # introduces no new *runtime* edge (`service_scan` re-imports
         # `_public_provenance_set` from it function-locally).
+        #
+        # `scan_engine` joins the same SCC (ADR-037 D1 dependency-direction fix):
+        # the scan engine core (classify → always-on tier → level → compare,
+        # `run_scan_core`) was split out of `cli_scan.py` into `scan_engine.py` so
+        # the CLI (`cli_scan.py`) and the typed service API (`service_scan.py`)
+        # both depend on one engine module instead of `service_scan.run_scan`
+        # reaching into a front-end module — that inversion is exactly what this
+        # split removes. What remains is a lateral engine-to-engine reference, not
+        # a frontend dependency: `service_scan.run_scan` imports `run_scan_core`/
+        # `_BudgetOverflow`/`_EvidenceContractError` from `scan_engine` (function-
+        # local, avoiding an init-order issue); `scan_engine` type-annotates
+        # `compile_context: CompileContext | None` with the type defined in
+        # `service_scan` (under `if TYPE_CHECKING`, so it never executes) and
+        # reaches `cli_buildsource.embed_build_source` / `cli_scan_baseline`
+        # helpers function-locally, exactly as `cli_scan.py` did before the
+        # split — so it closes the same cluster of cycles through already-member
+        # modules rather than introducing a new one. No init deadlock — the
+        # package still imports cleanly.
         frozenset(
             {
                 "appcompat",
@@ -704,6 +722,7 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
                 "cli_stack",
                 "cli_suggest",
                 "cli_surface",
+                "scan_engine",
                 "service",
                 "service_scan",
             }

--- a/tests/test_architecture_refactor.py
+++ b/tests/test_architecture_refactor.py
@@ -328,6 +328,66 @@ class TestPostProcessingPipeline:
         assert len(ctx.kept) == 1
         assert ctx.kept[0].kind == ChangeKind.FUNC_REMOVED
 
+    def test_kept_alias_violation_raises_runtime_error(self):
+        """A step that rebinds ``changes`` to a new list after FilterRedundant,
+        without resyncing ``ctx.kept``, must fail loudly.
+
+        Regression guard for the ``ctx.kept`` aliasing contract: FilterRedundant
+        sets ``ctx.kept = kept`` and later steps (DetectCppPatterns,
+        DemoteUnreachableInternalChurn) rely on that being the *same list
+        object* so their in-place suppression/demotion is visible through
+        ``ctx.kept``. A step that instead rebinds ``changes`` to a fresh list
+        (e.g. a list comprehension) without updating ``ctx.kept`` would
+        silently discard whatever was tracked there — this must raise instead.
+        """
+        import pytest
+
+        from abicheck.checker_policy import ChangeKind
+        from abicheck.checker_types import Change
+        from abicheck.model import AbiSnapshot
+        from abicheck.post_processing import FilterRedundant, PostProcessingPipeline
+
+        class _ReboundStep:
+            name = "rebinds_changes_bug"
+
+            def run(self, changes, ctx):
+                # Simulates the exact bug class the contract guards against:
+                # a fresh list instead of an in-place mutation or ctx.kept resync.
+                return [c for c in changes]
+
+        old = AbiSnapshot(library="test", version="1.0")
+        new = AbiSnapshot(library="test", version="2.0")
+        changes = [
+            Change(kind=ChangeKind.FUNC_ADDED, symbol="foo", description="added"),
+        ]
+        pipeline = PostProcessingPipeline([FilterRedundant(), _ReboundStep()])
+        with pytest.raises(RuntimeError, match="aliasing contract"):
+            pipeline.run(changes, old, new)
+
+    def test_kept_alias_preserved_through_default_pipeline(self):
+        """End-to-end regression: a finding demoted by
+        DemoteUnreachableInternalChurn (which runs after FilterRedundant) must
+        actually disappear from ``ctx.kept`` — not just from that step's own
+        return value — proving the ``ctx.kept`` alias survives every
+        intervening step (DetectInternalLeaks, EnrichAffectedSymbols, etc.)."""
+        from abicheck.checker_policy import ChangeKind
+        from abicheck.checker_types import Change
+        from abicheck.model import AbiSnapshot
+        from abicheck.post_processing import DEFAULT_PIPELINE
+
+        old = AbiSnapshot(library="test", version="1.0")
+        new = AbiSnapshot(library="test", version="2.0")
+        changes = [
+            Change(
+                kind=ChangeKind.TYPE_SIZE_CHANGED,
+                symbol="ns::detail::Private",
+                description="size changed",
+            ),
+        ]
+        ctx = DEFAULT_PIPELINE.run(changes, old, new)
+        assert any(c.symbol == "ns::detail::Private" for c in ctx.out_of_surface)
+        assert all(c.symbol != "ns::detail::Private" for c in ctx.kept)
+
     def test_custom_pipeline_with_subset_of_steps(self):
         """Custom pipeline with only some steps."""
         from abicheck.model import AbiSnapshot

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -895,11 +895,6 @@ class TestIntraTypeReachability:
         # A risk-demoted BUNDLE_INTRA_TYPE_CHANGED must follow its EFFECTIVE risk
         # category in JUnit, not the original breaking kind's severity — so by
         # default it is NOT a <failure> (Codex review).
-        from abicheck.checker_policy import (
-            API_BREAK_KINDS,
-            BREAKING_KINDS,
-            RISK_KINDS,
-        )
         from abicheck.junit_report import _is_failure
 
         demoted = Change(
@@ -909,12 +904,8 @@ class TestIntraTypeReachability:
             effective_verdict=Verdict.COMPATIBLE_WITH_RISK,
             modulation_reason="consumer-internal-use",
         )
-        assert not _is_failure(
-            demoted,
-            frozenset(BREAKING_KINDS),
-            frozenset(API_BREAK_KINDS),
-            frozenset(RISK_KINDS),
-        )
+        result = DiffResult(old_version="1.0", new_version="2.0", library="lib")
+        assert not _is_failure(demoted, result, result._effective_kind_sets())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -735,3 +735,57 @@ def test_run_compare_request_normalizes_lang(
     service.run_compare_request(req)
 
     assert seen_langs == ["c", "c"]
+
+
+# ── D1: service_scan must not depend on the CLI frontend ────────────────────
+#
+# service_scan.run_scan historically imported its shared scan-engine core
+# (run_scan_core / _BudgetOverflow / _EvidenceContractError) from cli_scan.py —
+# a Click command module — the reverse of the intended frontend → service →
+# engine dependency direction (ADR-037 D1). That engine core now lives in
+# scan_engine.py (no @click.option decorators, not registered as a command);
+# cli_scan.py (the CLI) and service_scan.py (the typed service API) both
+# import from it instead of service_scan reaching into the CLI module.
+
+
+def _imported_modules(path: Path) -> set[str]:
+    """Return every module name imported anywhere in *path* (module-level,
+    function-local, or under ``TYPE_CHECKING`` — all are real coupling, just
+    with different init-time consequences)."""
+    import ast
+
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            out.add(node.module)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                out.add(alias.name)
+    return out
+
+
+def test_service_scan_does_not_import_cli_scan() -> None:
+    """service_scan.py must never import from cli_scan.py (the Click ``scan``
+    command module) — the shared engine core lives in scan_engine.py, which
+    both cli_scan.py and service_scan.py depend on independently."""
+    import abicheck.service_scan as service_scan_mod
+
+    path = Path(service_scan_mod.__file__)
+    imported = _imported_modules(path)
+    assert "cli_scan" not in imported, (
+        "service_scan.py imports from cli_scan.py — this reintroduces the "
+        "service→CLI dependency inversion ADR-037 D1 / the scan_engine split "
+        "fixed. Import the needed symbols from abicheck.scan_engine instead."
+    )
+
+
+def test_cli_scan_reexports_the_real_scan_engine_functions() -> None:
+    """cli_scan.py's re-exported run_scan_core (etc.) are the *same objects*
+    as scan_engine's, not divergent copies — the CLI and the typed service API
+    both call one engine (ADR-037 D1)."""
+    from abicheck import cli_scan, scan_engine
+
+    assert cli_scan.run_scan_core is scan_engine.run_scan_core
+    assert cli_scan._BudgetOverflow is scan_engine._BudgetOverflow
+    assert cli_scan._EvidenceContractError is scan_engine._EvidenceContractError

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -211,8 +211,11 @@ def test_gate_flags_missing_decorator(
     gate.check_cli_contract(findings)
     msgs = [m for c, m in findings.errors if c == "cli-contract"]
     # severity/scope/output are missing → three coverage errors naming `compare`.
-    missing = {fam for fam in ("severity_options", "scope_options", "output_options")
-               if any(fam in m and "compare" in m for m in msgs)}
+    missing = {
+        fam
+        for fam in ("severity_options", "scope_options", "output_options")
+        if any(fam in m and "compare" in m for m in msgs)
+    }
     assert missing == {"severity_options", "scope_options", "output_options"}, msgs
 
 
@@ -260,7 +263,9 @@ def test_intentional_subset_decorator_is_not_flagged(
     monkeypatch.setattr(gate, "ROOT", tmp_path)
     monkeypatch.setattr(gate, "_VERDICT_CMD_MODULES", {"cli_synth.py": "synth"})
     monkeypatch.setattr(
-        gate, "_INTENTIONAL_SUBSET_DECORATORS", frozenset({("synth", "severity_options")})
+        gate,
+        "_INTENTIONAL_SUBSET_DECORATORS",
+        frozenset({("synth", "severity_options")}),
     )
 
     findings = gate.Findings()
@@ -413,9 +418,7 @@ def test_gate_flags_unmapped_mcp_param(
 
     pkg = tmp_path / "abicheck"
     pkg.mkdir()
-    (pkg / "cli_options.py").write_text(
-        "MCP_CLI_NAME_MAP = {'old_input': '--old'}\n"
-    )
+    (pkg / "cli_options.py").write_text("MCP_CLI_NAME_MAP = {'old_input': '--old'}\n")
     (pkg / "mcp_server.py").write_text(
         "def abi_compare(old_input, new_input, mystery_param='x'):\n    return ''\n"
     )
@@ -497,7 +500,9 @@ def test_ast_frontend_threads_to_l4_extractor(
     src = tmp_path / "src"
     src.mkdir()
     snap = AbiSnapshot(library="l", version="1")
-    cb.embed_build_source(snap, None, src, collect_mode="source-target", extractor="clang")
+    cb.embed_build_source(
+        snap, None, src, collect_mode="source-target", extractor="clang"
+    )
     assert captured.get("extractor") == "clang"
 
 
@@ -518,34 +523,123 @@ def test_project_config_flag_is_config_not_build_config(name: str) -> None:
 # A diff here in review means a flag was added or dropped — update deliberately.
 _OPTION_SET_SNAPSHOT: dict[str, tuple[str, ...]] = {
     "compare": (
-        "--annotate", "--annotate-additions", "--ast-frontend", "--btf", "--bundle-cohort", "--bundle-system-providers",
-        "--collapse-versioned-symbols", "--config", "--ctf", "--debug-format",
-        "--debug-root", "--debuginfod", "--debuginfod-url",
-        "--build-info", "--debug-info", "--demangle", "--depth", "--devel-pkg", "--dso-only", "--dwarf",
-        "--dwarf-only", "--env-matrix", "--exit-code-scheme", "--explain-patterns", "--fail-on-removed-library", "--follow-deps", "--format",
-        "--gcc-option", "--gcc-options", "--gcc-path", "--gcc-prefix", "--header", "--include",
-        "--include-private-dso", "--jobs", "--keep-extracted", "--lang", "--ld-library-path", "--manifest",
-        "--max", "--new-ast-frontend",
-        "--no-bundle-analysis", "--no-debuginfod", "--no-demangle", "--no-dwarf-only",
-        "--no-fail-on-removed-library", "--no-nostdinc",
-        "--no-pattern-verdicts", "--no-scope-public-headers", "--no-show-redundant",
-        "--nostdinc", "--old-ast-frontend",
-        "--output", "--output-dir",
-        "--pattern-verdicts", "--pdb-path", "--policy", "--policy-file", "--post-manifest", "--probe-matrix", "--profile",
-        "--public-symbol", "--public-symbols-list", "--recommend", "--reconcile-build-context", "--report-mode", "--require-justification", "--scope-public-headers",
-        "--search-path", "--severity-abi-breaking", "--severity-addition", "--severity-potential-breaking", "--severity-preset", "--severity-quality-issues",
-        "--show-filtered", "--show-impact", "--show-only", "--show-redundant", "--sources", "--stat", "--strict-suppressions",
-        "--suppress", "--surface-metrics", "--sysroot", "--verbose", "--version", "-H", "-I",
-        "-j", "-o", "-v",
+        "--annotate",
+        "--annotate-additions",
+        "--ast-frontend",
+        "--btf",
+        "--bundle-cohort",
+        "--bundle-system-providers",
+        "--collapse-versioned-symbols",
+        "--config",
+        "--ctf",
+        "--debug-format",
+        "--debug-root",
+        "--debuginfod",
+        "--debuginfod-url",
+        "--build-info",
+        "--debug-info",
+        "--demangle",
+        "--depth",
+        "--devel-pkg",
+        "--dso-only",
+        "--dwarf",
+        "--dwarf-only",
+        "--env-matrix",
+        "--exit-code-scheme",
+        "--explain-patterns",
+        "--fail-on-removed-library",
+        "--follow-deps",
+        "--format",
+        "--gcc-option",
+        "--gcc-options",
+        "--gcc-path",
+        "--gcc-prefix",
+        "--header",
+        "--include",
+        "--include-private-dso",
+        "--jobs",
+        "--keep-extracted",
+        "--lang",
+        "--ld-library-path",
+        "--manifest",
+        "--max",
+        "--new-ast-frontend",
+        "--no-bundle-analysis",
+        "--no-debuginfod",
+        "--no-demangle",
+        "--no-dwarf-only",
+        "--no-fail-on-removed-library",
+        "--no-nostdinc",
+        "--no-pattern-verdicts",
+        "--no-scope-public-headers",
+        "--no-show-redundant",
+        "--nostdinc",
+        "--old-ast-frontend",
+        "--output",
+        "--output-dir",
+        "--pattern-verdicts",
+        "--pdb-path",
+        "--policy",
+        "--policy-file",
+        "--post-manifest",
+        "--probe-matrix",
+        "--profile",
+        "--public-symbol",
+        "--public-symbols-list",
+        "--recommend",
+        "--reconcile-build-context",
+        "--report-mode",
+        "--require-justification",
+        "--scope-public-headers",
+        "--search-path",
+        "--severity-abi-breaking",
+        "--severity-addition",
+        "--severity-potential-breaking",
+        "--severity-preset",
+        "--severity-quality-issues",
+        "--show-filtered",
+        "--show-impact",
+        "--show-only",
+        "--show-redundant",
+        "--sources",
+        "--stat",
+        "--strict-suppressions",
+        "--suppress",
+        "--surface-metrics",
+        "--sysroot",
+        "--verbose",
+        "--version",
+        "-H",
+        "-I",
+        "-j",
+        "-o",
+        "-v",
     ),
     "appcompat": (
-        "--check-against", "--format", "--header", "--include", "--lang",
+        "--check-against",
+        "--format",
+        "--header",
+        "--include",
+        "--lang",
         "--list-required-symbols",
-        "--no-scope-public-headers", "--version",
-        "--output", "--policy", "--policy-file", "--scope-public-headers",
-        "--severity-abi-breaking", "--severity-addition", "--severity-potential-breaking",
-        "--severity-preset", "--severity-quality-issues", "--show-irrelevant", "--suppress",
-        "--verbose", "-H", "-I", "-o", "-v",
+        "--no-scope-public-headers",
+        "--version",
+        "--output",
+        "--policy",
+        "--policy-file",
+        "--scope-public-headers",
+        "--severity-abi-breaking",
+        "--severity-addition",
+        "--severity-potential-breaking",
+        "--severity-preset",
+        "--severity-quality-issues",
+        "--show-irrelevant",
+        "--suppress",
+        "--verbose",
+        "-H",
+        "-I",
+        "-o",
+        "-v",
     ),
 }
 
@@ -729,9 +823,7 @@ def test_run_compare_request_normalizes_lang(
 
     monkeypatch.setattr(service, "resolve_input", _spy_resolve_input)
 
-    req = CompareRequest(
-        old=InputSpec.of(old_p), new=InputSpec.of(new_p), lang="C"
-    )
+    req = CompareRequest(old=InputSpec.of(old_p), new=InputSpec.of(new_p), lang="C")
     service.run_compare_request(req)
 
     assert seen_langs == ["c", "c"]
@@ -757,8 +849,12 @@ def _imported_modules(path: Path) -> set[str]:
     tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     out: set[str] = set()
     for node in ast.walk(tree):
-        if isinstance(node, ast.ImportFrom) and node.module:
-            out.add(node.module)
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module:
+                out.add(module)
+            for alias in node.names:
+                out.add(f"{module}.{alias.name}" if module else alias.name)
         elif isinstance(node, ast.Import):
             for alias in node.names:
                 out.add(alias.name)
@@ -773,7 +869,7 @@ def test_service_scan_does_not_import_cli_scan() -> None:
 
     path = Path(service_scan_mod.__file__)
     imported = _imported_modules(path)
-    assert "cli_scan" not in imported, (
+    assert not {"cli_scan", "abicheck.cli_scan"} & imported, (
         "service_scan.py imports from cli_scan.py — this reintroduces the "
         "service→CLI dependency inversion ADR-037 D1 / the scan_engine split "
         "fixed. Import the needed symbols from abicheck.scan_engine instead."

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1357,7 +1357,9 @@ def test_scan_public_header_dir_forwarded_to_snapshot(
     # The CLI flag must reach the snapshot builder as public_header_dirs so
     # apply_provenance can classify origins (unlocking the leakage/RTTI/exported-
     # vs-public cross-checks).
-    import abicheck.cli_scan as cs
+    # _build_new_snapshot is called from within run_scan_core, which lives in
+    # scan_engine.py — patch it there, not on the cli_scan re-export.
+    import abicheck.scan_engine as cs
 
     pub = tmp_path / "pub"
     pub.mkdir()
@@ -1391,7 +1393,8 @@ def test_scan_lone_header_file_does_not_activate_provenance(
 ):
     # A lone -H file (no dir) must NOT activate provenance — empty sets reach the
     # snapshot builder so behaviour is unchanged.
-    import abicheck.cli_scan as cs
+    # _build_new_snapshot lives in scan_engine.py (called from run_scan_core).
+    import abicheck.scan_engine as cs
 
     umbrella = tmp_path / "all.hpp"
     umbrella.write_text("// umbrella\n", encoding="utf-8")
@@ -1436,7 +1439,8 @@ def test_export_delta_resolves_tu_into_replay_seed(monkeypatch, runner, tmp_path
     # `_Z3barv` → src/bar.cpp, and a candidate that *removes* that export, must
     # point the replay at src/bar.cpp — even though git only changed an unrelated
     # file. Proves the cheap L0 export delta steers the expensive scan's scope.
-    import abicheck.cli_scan as cs
+    # _build_new_snapshot lives in scan_engine.py (called from run_scan_core).
+    import abicheck.scan_engine as cs
     from abicheck.buildsource.pack import BuildSourcePack
     from abicheck.buildsource.source_graph import (
         GraphEdge,
@@ -1631,7 +1635,8 @@ def test_depth_headers_keeps_source_tree_out_of_pattern_scan(
     # Matrix runners may pass --sources to every depth. The headers rung is
     # L0/L1/L2-only: it should pattern-scan public headers, not the whole source
     # tree, and it should use the cheap binary surface instead of a DWARF DIE walk.
-    import abicheck.cli_scan as cs
+    # _build_new_snapshot lives in scan_engine.py (called from run_scan_core).
+    import abicheck.scan_engine as cs
 
     include = tmp_path / "include"
     include.mkdir()
@@ -1684,7 +1689,8 @@ def test_depth_binary_skips_export_delta_poi_loads(
     # The export-delta POI walk only focuses source replay. Effective binary
     # depth has no replay, so loading candidate+baseline L0 views would duplicate
     # native binary dumps and make "binary" scans unexpectedly expensive.
-    import abicheck.cli_scan as cs
+    # _load_exports_for_poi lives in scan_engine.py (called from run_scan_core).
+    import abicheck.scan_engine as cs
 
     def _unexpected(*args, **kwargs):
         raise AssertionError("binary depth must not load POI export snapshots")
@@ -1707,7 +1713,9 @@ def test_depth_binary_skips_export_delta_poi_loads(
 
 def test_export_delta_poi_load_is_symbols_only(monkeypatch, tmp_path):
     import abicheck.service as service
-    from abicheck import cli_scan as cs
+
+    # _load_exports_for_poi lives in scan_engine.py (called from run_scan_core).
+    from abicheck import scan_engine as cs
 
     captured: dict[str, object] = {}
 

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -248,14 +248,14 @@ class TestCompatibleWithRisk:
         tc = ts.find("testcase")
         assert tc.find("failure") is None
 
-    def test_risk_change_with_error_severity_fails(self) -> None:
-        """COMPATIBLE_WITH_RISK changes with overridden severity 'error' should fail.
-
-        We use a policy_file override to promote a RISK kind to severity 'error'.
+    def test_risk_change_with_severity_preset_escalation_fails(self) -> None:
+        """COMPATIBLE_WITH_RISK changes fail when a severity preset escalates
+        ``potential_breaking`` to 'error' — the real, supported mechanism.
+        RISK_KINDS have no per-kind severity in the policy registry (they are
+        all "warning" by construction); only a SeverityConfig can escalate
+        them to a JUnit failure without changing the finding's verdict.
         """
-        from unittest.mock import patch
-
-        from abicheck.checker_policy import PolicyEntry
+        from abicheck.severity import SeverityConfig, SeverityLevel
 
         changes = [
             Change(
@@ -265,20 +265,45 @@ class TestCompatibleWithRisk:
             ),
         ]
         result = _make_result(changes, verdict=Verdict.COMPATIBLE_WITH_RISK)
-        # Patch policy_for to return severity="error" for this kind
-        original_entry = PolicyEntry(
-            Verdict.COMPATIBLE_WITH_RISK,
-            "error",
-            "symbol_version_required_added",
-        )
-        with patch("abicheck.junit_report.policy_for", return_value=original_entry):
-            xml = to_junit_xml(result)
+        severity_config = SeverityConfig(potential_breaking=SeverityLevel.ERROR)
+        xml = to_junit_xml(result, severity_config=severity_config)
         root = _parse(xml)
         ts = root.find("testsuite")
         assert ts.get("failures") == "1"
         fail = root.find(".//failure")
         assert fail is not None
         assert fail.get("type") == "COMPATIBLE_WITH_RISK"
+
+    def test_risk_change_escalated_via_policy_file_fails(self) -> None:
+        """A PolicyFile override that promotes a RISK-kind's *verdict* to
+        BREAKING must fail in JUnit — even with no severity_config.
+
+        Regression test: JUnit's failure classification used to fall back to
+        ``policy_for(change.kind).severity`` for a kind not in the (override-
+        adjusted) breaking/api_break/risk sets, which silently ignored a
+        PolicyFile override that had moved the kind's *effective verdict*
+        without also being reflected in that per-kind severity lookup.
+        """
+        from abicheck.policy_file import PolicyFile
+
+        changes = [
+            Change(
+                kind=ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED,
+                symbol="libc.so.6",
+                description="New GLIBC_2.34 version requirement added",
+            ),
+        ]
+        result = _make_result(changes, verdict=Verdict.COMPATIBLE_WITH_RISK)
+        result.policy_file = PolicyFile(
+            overrides={ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED: Verdict.BREAKING}
+        )
+        xml = to_junit_xml(result)
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "1"
+        fail = root.find(".//failure")
+        assert fail is not None
+        assert fail.get("type") == "BREAKING"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_report_integrity.py
+++ b/tests/test_report_integrity.py
@@ -268,3 +268,26 @@ def test_policy_file_override_propagates_across_channels() -> None:
     assert sarif_severity(compatible, result) == "error"
     kind_sets = result._effective_kind_sets()
     assert _is_failure(compatible, result, kind_sets) is True
+
+
+def test_named_base_policy_downgrade_propagates_to_sarif() -> None:
+    """A named base policy (``plugin_abi``) that downgrades a kind away from
+    its strict_abi default must read as compatible in SARIF too — not just in
+    JSON/JUnit (regression test: SARIF's ``_severity`` only checked for an A4
+    ``effective_verdict`` or a ``PolicyFile.overrides`` entry, silently
+    ignoring the ``result.policy`` base-policy mechanism entirely, so a kind
+    downgraded by ``plugin_abi``/``sdk_vendor`` still showed SARIF ``"error"``
+    even though the JSON report and exit code correctly read it as compatible).
+    """
+    from abicheck.checker_policy import PLUGIN_ABI_DOWNGRADED_KINDS
+
+    kind = next(iter(PLUGIN_ABI_DOWNGRADED_KINDS))
+    change = Change(kind=kind, symbol="foo", description="calling convention changed")
+    result = _result()
+    result.policy = "plugin_abi"
+    result.changes = [change]
+
+    assert result._effective_verdict_for_change(change) == Verdict.COMPATIBLE
+    assert sarif_severity(change, result) == "note"
+    kind_sets = result._effective_kind_sets()
+    assert _is_failure(change, result, kind_sets) is False

--- a/tests/test_report_integrity.py
+++ b/tests/test_report_integrity.py
@@ -128,7 +128,7 @@ def test_native_channels_agree_on_breaking_boundary() -> None:
     model = ReportModel.from_result(result)
     assert model.changes, "expected at least one change to classify"
 
-    breaking_set, api_break_set, risk_set, _ = result._effective_kind_sets()
+    kind_sets = result._effective_kind_sets()
 
     for ch in model.changes:
         breaking = model.is_breaking_boundary(ch)
@@ -137,10 +137,10 @@ def test_native_channels_agree_on_breaking_boundary() -> None:
         assert (model.severity_label(ch) in ("breaking", "api_break")) == breaking
 
         # SARIF "error" iff breaking; non-breaking must not be "error".
-        assert (sarif_severity(ch) == "error") == breaking
+        assert (sarif_severity(ch, result) == "error") == breaking
 
         # JUnit failure iff breaking (no severity-config gate here).
-        assert _is_failure(ch, breaking_set, api_break_set, risk_set) == breaking
+        assert _is_failure(ch, result, kind_sets) == breaking
 
 
 def test_json_severity_matches_canonical_label() -> None:
@@ -181,6 +181,47 @@ def test_a4_override_propagates_across_channels() -> None:
     assert model.severity_label(demoted) == "compatible"
     assert model.is_breaking_boundary(demoted) is False
     # Override propagates to every native channel: not error, not failure.
-    assert sarif_severity(demoted) == "note"
-    breaking_set, api_break_set, risk_set, _ = result._effective_kind_sets()
-    assert _is_failure(demoted, breaking_set, api_break_set, risk_set) is False
+    assert sarif_severity(demoted, result) == "note"
+    kind_sets = result._effective_kind_sets()
+    assert _is_failure(demoted, result, kind_sets) is False
+
+
+def test_policy_file_override_propagates_across_channels() -> None:
+    """A PolicyFile override demoting a BREAKING kind to COMPATIBLE must read as
+    compatible in every native channel — SARIF and JUnit must not fall back to
+    the kind's default (pre-override) severity (regression test: SARIF's
+    ``_severity`` and JUnit's ``_is_failure`` used to consult only the A4
+    per-finding ``effective_verdict`` field and the kind's default policy
+    severity, silently ignoring a ``PolicyFile.overrides`` demotion/escalation).
+    """
+    from abicheck.policy_file import PolicyFile
+
+    result = _result()
+    breaking = next(
+        (c for c in result.changes if result._effective_verdict_for_change(c) == Verdict.BREAKING),
+        None,
+    )
+    assert breaking is not None, "fixture must produce a breaking change"
+
+    # Demote: a kind normally BREAKING is overridden to COMPATIBLE.
+    result.policy_file = PolicyFile(overrides={breaking.kind: Verdict.COMPATIBLE})
+    model = ReportModel.from_result(result)
+    assert model.verdict_of(breaking) == Verdict.COMPATIBLE
+    assert model.is_breaking_boundary(breaking) is False
+    assert sarif_severity(breaking, result) == "note"
+    kind_sets = result._effective_kind_sets()
+    assert _is_failure(breaking, result, kind_sets) is False
+
+    # Escalate: a compatible finding overridden up to BREAKING.
+    compatible = next(
+        (c for c in result.changes if result._effective_verdict_for_change(c) == Verdict.COMPATIBLE),
+        None,
+    )
+    assert compatible is not None, "fixture must produce a compatible change"
+    result.policy_file = PolicyFile(overrides={compatible.kind: Verdict.BREAKING})
+    model = ReportModel.from_result(result)
+    assert model.verdict_of(compatible) == Verdict.BREAKING
+    assert model.is_breaking_boundary(compatible) is True
+    assert sarif_severity(compatible, result) == "error"
+    kind_sets = result._effective_kind_sets()
+    assert _is_failure(compatible, result, kind_sets) is True

--- a/tests/test_report_integrity.py
+++ b/tests/test_report_integrity.py
@@ -49,7 +49,13 @@ from abicheck.sarif import _severity as sarif_severity
 
 
 def _fn(name: str, ret: str = "void") -> Function:
-    return Function(name=name, mangled=name, return_type=ret, params=[], visibility=Visibility.PUBLIC)
+    return Function(
+        name=name,
+        mangled=name,
+        return_type=ret,
+        params=[],
+        visibility=Visibility.PUBLIC,
+    )
 
 
 def _result():
@@ -70,7 +76,15 @@ def _result():
 # ── Canonical maps are total over the reportable verdicts ────────────────────
 
 
-@pytest.mark.parametrize("verdict", [Verdict.BREAKING, Verdict.API_BREAK, Verdict.COMPATIBLE_WITH_RISK, Verdict.COMPATIBLE])
+@pytest.mark.parametrize(
+    "verdict",
+    [
+        Verdict.BREAKING,
+        Verdict.API_BREAK,
+        Verdict.COMPATIBLE_WITH_RISK,
+        Verdict.COMPATIBLE,
+    ],
+)
 def test_canonical_maps_cover_every_reportable_verdict(verdict: Verdict) -> None:
     assert verdict in VERDICT_TO_SEVERITY_LABEL
     assert verdict in VERDICT_TO_SARIF_LEVEL
@@ -93,8 +107,12 @@ def test_presentation_table_is_exactly_the_reportable_verdicts() -> None:
 def test_single_table_is_the_source_of_truth() -> None:
     # The back-compat projections must be derived from VERDICT_PRESENTATION, not
     # a second hand-maintained copy.
-    assert VERDICT_TO_SEVERITY_LABEL == {v: p.severity_label for v, p in VERDICT_PRESENTATION.items()}
-    assert VERDICT_TO_SARIF_LEVEL == {v: p.sarif_level for v, p in VERDICT_PRESENTATION.items()}
+    assert VERDICT_TO_SEVERITY_LABEL == {
+        v: p.severity_label for v, p in VERDICT_PRESENTATION.items()
+    }
+    assert VERDICT_TO_SARIF_LEVEL == {
+        v: p.sarif_level for v, p in VERDICT_PRESENTATION.items()
+    }
 
 
 def test_presentation_internally_consistent() -> None:
@@ -102,7 +120,9 @@ def test_presentation_internally_consistent() -> None:
     # the one table — no row can say "breaking" on one axis and "compatible" on
     # another.
     for pres in VERDICT_PRESENTATION.values():
-        assert pres.breaking_boundary == (pres.severity_label in ("breaking", "api_break"))
+        assert pres.breaking_boundary == (
+            pres.severity_label in ("breaking", "api_break")
+        )
         assert pres.breaking_boundary == (pres.sarif_level == "error")
 
 
@@ -148,7 +168,9 @@ def test_json_severity_matches_canonical_label() -> None:
 
     result = _result()
     model = ReportModel.from_result(result)
-    by_symbol = {(c.kind.value, c.symbol): model.severity_label(c) for c in model.changes}
+    by_symbol = {
+        (c.kind.value, c.symbol): model.severity_label(c) for c in model.changes
+    }
 
     payload = json.loads(to_json(result))
     rendered = payload.get("changes", [])
@@ -167,7 +189,14 @@ def test_a4_override_propagates_across_channels() -> None:
     # COMPATIBLE must read as compatible in every native channel — this is the
     # exact divergence the unification prevents.
     result = _result()
-    breaking = next((c for c in result.changes if result._effective_verdict_for_change(c) == Verdict.BREAKING), None)
+    breaking = next(
+        (
+            c
+            for c in result.changes
+            if result._effective_verdict_for_change(c) == Verdict.BREAKING
+        ),
+        None,
+    )
     assert breaking is not None, "fixture must produce a breaking change"
 
     demoted = Change(
@@ -198,10 +227,29 @@ def test_policy_file_override_propagates_across_channels() -> None:
 
     result = _result()
     breaking = next(
-        (c for c in result.changes if result._effective_verdict_for_change(c) == Verdict.BREAKING),
+        (
+            c
+            for c in result.changes
+            if result._effective_verdict_for_change(c) == Verdict.BREAKING
+        ),
         None,
     )
     assert breaking is not None, "fixture must produce a breaking change"
+
+    # Capture the genuinely compatible change before any override is applied —
+    # once `breaking.kind` is demoted below, a lookup by Verdict.COMPATIBLE
+    # would risk matching the just-demoted change instead (they'd share a
+    # verdict at that point), weakening the escalation case below.
+    compatible = next(
+        (
+            c
+            for c in result.changes
+            if result._effective_verdict_for_change(c) == Verdict.COMPATIBLE
+        ),
+        None,
+    )
+    assert compatible is not None, "fixture must produce a compatible change"
+    assert compatible.kind != breaking.kind
 
     # Demote: a kind normally BREAKING is overridden to COMPATIBLE.
     result.policy_file = PolicyFile(overrides={breaking.kind: Verdict.COMPATIBLE})
@@ -213,11 +261,6 @@ def test_policy_file_override_propagates_across_channels() -> None:
     assert _is_failure(breaking, result, kind_sets) is False
 
     # Escalate: a compatible finding overridden up to BREAKING.
-    compatible = next(
-        (c for c in result.changes if result._effective_verdict_for_change(c) == Verdict.COMPATIBLE),
-        None,
-    )
-    assert compatible is not None, "fixture must produce a compatible change"
     result.policy_file = PolicyFile(overrides={compatible.kind: Verdict.BREAKING})
     model = ReportModel.from_result(result)
     assert model.verdict_of(compatible) == Verdict.BREAKING

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -644,7 +644,8 @@ def test_replay_seed_empty_without_diff_seed(
     # No --since/--changed-path → broad scope. Pattern-trigger POIs must NOT
     # narrow the replay seed (would skip source-only checks in other TUs) — the
     # seed stays empty so collect_inline_pack keeps the broad fallback (Codex).
-    import abicheck.cli_scan as cs
+    # _build_new_snapshot lives in scan_engine.py (called from run_scan_core).
+    import abicheck.scan_engine as cs
 
     captured: dict[str, object] = {}
     original = cs._build_new_snapshot
@@ -677,7 +678,8 @@ def test_replay_seed_used_when_changed_path_given(
 ) -> None:
     # An explicit --changed-path is a real diff seed → the POI floor feeds the
     # replay scope.
-    import abicheck.cli_scan as cs
+    # _build_new_snapshot lives in scan_engine.py (called from run_scan_core).
+    import abicheck.scan_engine as cs
 
     captured: dict[str, object] = {}
     original = cs._build_new_snapshot
@@ -839,7 +841,9 @@ def test_run_scan_binary_depth_suppresses_headers(
     # Codex P2: a programmatic ScanRequest(depth="binary", headers=[...]) must not
     # parse the L2 header AST — the service mirrors the CLI's `--depth binary`
     # header suppression so the collected evidence matches the reported depth.
-    import abicheck.cli_scan as cs
+    # run_scan_core lives in scan_engine.py; service_scan.run_scan imports it
+    # from there, not from cli_scan.
+    import abicheck.scan_engine as cs
     from abicheck.service import run_scan
 
     captured: dict[str, object] = {}
@@ -869,7 +873,9 @@ def test_run_scan_source_method_overrides_binary_keeps_headers(
     # Service parity with the CLI (Codex review): --source-method wins over --depth,
     # so source_method="s5" + depth="binary" resolves to a SOURCE scan that keeps
     # the header AST — suppression keys on the *resolved* depth, not the raw one.
-    import abicheck.cli_scan as cs
+    # run_scan_core lives in scan_engine.py; service_scan.run_scan imports it
+    # from there, not from cli_scan.
+    import abicheck.scan_engine as cs
     from abicheck.service import run_scan
 
     captured: dict[str, object] = {}

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -56,6 +56,24 @@ class TestSerialization:
         assert "_func_by_mangled" not in d
         assert "_var_by_mangled" not in d
 
+    def test_snapshot_to_dict_does_not_mutate_caller_snapshot(self):
+        """snapshot_to_dict must be pure: it used to reset the lazy lookup
+        caches on the caller's actual snapshot object (not a copy) as a side
+        effect, so calling it after the caller had built an index would
+        silently invalidate that index out from under them."""
+        snap = _sample_snap()
+        snap.index()
+        assert snap._func_by_mangled is not None
+        assert snap._var_by_mangled is not None
+        assert snap._type_by_name is not None
+
+        snapshot_to_dict(snap)
+
+        assert snap._func_by_mangled is not None
+        assert snap._var_by_mangled is not None
+        assert snap._type_by_name is not None
+        assert snap._func_by_mangled["_Z11sample_initv"].name == "sample_init"
+
     def test_is_inline_roundtrip(self):
         """is_inline=True must survive snapshot_to_dict → snapshot_from_dict roundtrip."""
         snap = AbiSnapshot(

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -1651,7 +1651,7 @@ def test_run_scan_runs_deferred_build_dir_cleanup(monkeypatch):
         return SimpleNamespace(outcome=outcome, findings=[])
 
     monkeypatch.setattr(_ss, "estimate_scan", lambda req: [])
-    monkeypatch.setattr("abicheck.cli_scan.run_scan_core", fake_core)
+    monkeypatch.setattr("abicheck.scan_engine.run_scan_core", fake_core)
 
     req = _ss.ScanRequest(binaries=[Path("libfoo.so")], depth="binary")
     res = _ss.run_scan(req)
@@ -1659,7 +1659,7 @@ def test_run_scan_runs_deferred_build_dir_cleanup(monkeypatch):
     assert ran["n"] == 1  # the finally ran the deferred cleanup on success
 
     # And it still runs when the core raises a budget overflow mid-scan.
-    from abicheck.cli_scan import _BudgetOverflow
+    from abicheck.scan_engine import _BudgetOverflow
 
     ran["n"] = 0
 
@@ -1667,7 +1667,7 @@ def test_run_scan_runs_deferred_build_dir_cleanup(monkeypatch):
         kw["defer_cleanup"].append(lambda: ran.__setitem__("n", ran["n"] + 1))
         raise _BudgetOverflow("over budget")
 
-    monkeypatch.setattr("abicheck.cli_scan.run_scan_core", raising_core)
+    monkeypatch.setattr("abicheck.scan_engine.run_scan_core", raising_core)
     res = _ss.run_scan(req)
     assert res.exit_code == 5  # budget overflow surfaced
     assert ran["n"] == 1  # finally still ran the cleanup on the raise path


### PR DESCRIPTION
## Summary

Fixes four problems surfaced and independently verified from a static architecture review, each with a dedicated regression test.

## Motivation

A review of the codebase's architecture flagged several concrete, falsifiable claims. Before acting on them, each was independently verified against the actual code (not taken on faith) using parallel research agents. Three were confirmed exactly as described (down to matching line numbers and source comments); one was mechanically correct but overstated in severity. This PR fixes all four.

## Changes

- **SARIF/JUnit verdict-routing bug (real correctness bug).** `sarif.py._severity` and `junit_report.py._is_failure`/`_failure_type` fell back to a finding's *kind*'s default policy severity whenever no A4 per-finding `effective_verdict` was set — silently ignoring a `PolicyFile.overrides` entry that had moved the kind's *effective* verdict. A demoted `BREAKING` kind could show SARIF `"error"` / a JUnit `<failure>` even though the JSON report and exit code correctly read it as compatible. Both now route through the canonical `DiffResult._effective_verdict_for_change`.
- **`snapshot_to_dict` mutated the caller's snapshot.** It reset the lazy lookup-index caches on the actual object passed in (not a copy) before calling `asdict()`. Now saves/restores them, making serialization observably pure.
- **Post-processing `ctx.kept` aliasing hazard hardened.** `FilterRedundant` establishes `ctx.kept` as a reference to the same list object several later steps must mutate in place; a future step that instead rebinds the list without resyncing `ctx.kept` would silently lose suppression/demotion from the verdict. `PostProcessingPipeline.run` now raises immediately if a step breaks that invariant.
- **`service_scan` → `cli_scan` dependency inversion fixed.** `service_scan.run_scan` (the typed Python/MCP API) imported its shared scan-engine core from `cli_scan.py`, a Click command module — the reverse of the intended frontend → service → engine direction. The engine core (`run_scan_core` and ~700 lines of helpers) is extracted into a new `scan_engine.py` with no Click dependency; both `cli_scan.py` and `service_scan.py` now depend on it independently. `cli_scan.py` also drops from 1537 to 867 lines, clearing the AI-readiness size warning.

## Test plan

- [x] New regression tests target each fix directly: cross-channel PolicyFile-override propagation (`test_report_integrity.py`), serialization purity (`test_serialization.py`), pipeline aliasing-contract enforcement (`test_architecture_refactor.py`), and a static AST guard against `service_scan` importing `cli_scan` again (`test_cli_contract.py`).
- [x] Full fast suite: 13,888 passed, 0 failed.
- [x] `mypy abicheck/`: 0 errors.
- [x] `ruff check abicheck/ tests/ scripts/`: clean.
- [x] `python scripts/check_ai_readiness.py`: clean (import-cycle allowlist updated to reflect `scan_engine`'s role in the existing documented SCC).
- [x] Manually smoke-tested both the `abicheck scan` CLI command and the `service_scan.run_scan` typed API end-to-end (not mocked) to confirm the extraction didn't change real behavior.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [ ] Docs updated if user-visible behaviour changed — no user-facing docs needed a change; the SARIF/JUnit fix makes existing documented behavior (ADR-036) actually match reality.
- [x] `pre-commit run --all-files` passes locally (mypy + ruff clean)
- [x] No new `mypy` or `ruff` errors introduced

## Out of scope

Deliberately not attempted here: the full `AbiSnapshot`/`Change`/`DiffResult` decomposition and the `LayerProvider` keep-vs-delete decision the review also raised. Both are multi-week, broad-blast-radius efforts the review itself frames as long-term consolidation rather than urgent bugs, and this repo's file-size caps make them too risky to do as a drive-by alongside these fixes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RxySmi5xw9ftqu91Pm8Vti)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SARIF and JUnit reports now consistently reflect effective finding verdicts, including policy overrides and severity adjustments.
  * Snapshot serialization no longer alters cached data in the original snapshot.

* **Refactor**
  * Shared scan processing is now used consistently across command-line and service-based scanning.
  * Pipeline validation now detects invalid result handling immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->