### PR TITLE
test(export-accounting): cover bounded length parsing

### DIFF
--- a/abicheck/buildsource/export_accounting.py
+++ b/abicheck/buildsource/export_accounting.py
@@ -228,6 +228,8 @@ def _mangled_owner_namespace(symbol: str) -> str | None:
     parsed = _read_decimal_length(rest, 0)
     if parsed is not None:
         length, name_start = parsed
+        if length > len(rest) - name_start:
+            return None
         name = rest[name_start : name_start + length]
         if name and re.match(r"[A-Za-z_]\w*", name):
             return name
@@ -408,6 +410,8 @@ def _nested_component(symbol: str, index: int) -> str | None:
                 i += 1
                 continue
             length, j = parsed
+            if length > len(rest) - j:
+                return None
             name = rest[j : j + length]
             i = j + length
             if depth == 0:
@@ -642,6 +646,8 @@ def _entity_owner_is_internal(symbol: str) -> bool:
                 i += 1
                 continue
             length, j = parsed
+            if length > len(rest) - j:
+                return False
             i = j + length
             if depth == 0:
                 components.append(rest[j : j + length])
@@ -691,6 +697,8 @@ def _has_template_args(symbol: str) -> bool:
                     i += 1
                     continue
                 length, j = parsed
+                if length > len(rest) - j:
+                    return False
                 i = j + length  # skip the source-name characters
             else:
                 i += 1
@@ -701,5 +709,7 @@ def _has_template_args(symbol: str) -> bool:
     if parsed is None:
         return False
     length, name_start = parsed
+    if length > len(rest) - name_start:
+        return False
     end = name_start + length
     return end < len(rest) and rest[end] == "I"

--- a/tests/test_crosscheck.py
+++ b/tests/test_crosscheck.py
@@ -375,6 +375,32 @@ def test_exported_not_public_malformed_long_length_is_conservative():
     assert counters["undeclared_export"] == 1
 
 
+@pytest.mark.parametrize(
+    "text, start, expected",
+    [
+        ("3foo", 0, (3, 1)),
+        ("x03foo", 1, (3, 3)),
+        ("0", 0, (0, 1)),
+        ("foo", 0, None),
+        ("3foo", 4, None),
+        ("٣foo", 0, None),  # Itanium lengths are ASCII decimal digits only.
+    ],
+)
+def test_read_decimal_length(text, start, expected):
+    from abicheck.buildsource.export_accounting import _read_decimal_length
+
+    assert _read_decimal_length(text, start) == expected
+
+
+def test_read_decimal_length_consumes_overlong_digit_run_without_int_conversion():
+    from abicheck.buildsource.export_accounting import _read_decimal_length
+
+    digits = "9" * 5000
+    length, end = _read_decimal_length(digits + "name", 0) or (None, None)
+    assert length is not None and length > len(digits) + 4
+    assert end == len(digits)
+
+
 def test_exported_not_public_accounting_sums_to_all_exports():
     # The accounting partitions the whole export table — documented API +
     # compiler artifact + every undocumented reason == number of exports, so the
@@ -757,6 +783,9 @@ def test_external_dependency_origin_msvc_scopes(symbol, self_names, expected):
         # template arguments on a component are skipped, not counted as components.
         ("_ZN3lib3BoxIiE3barEv", 1, "Box"),
         ("_ZN3lib3BoxIiE3barEv", 2, "bar"),
+        ("_ZN999nameE", 0, None),  # length runs beyond malformed input
+        ("_ZN" + ("9" * 5000) + "nameE", 0, None),
+        ("_ZN٣nameE", 0, None),  # non-ASCII digit is not a length field
         ("_Z3fooi", 0, None),  # un-nested name has no nested components
     ],
 )
@@ -794,6 +823,9 @@ def test_nested_component(symbol, index, expected):
         # misclassified (Codex review).
         ("_ZL4mainv", "undeclared_export"),  # un-nested, no leading length digit
         ("_ZN3foo", "undeclared_export"),  # truncated nested name (no closing E)
+        ("_ZN999nameE", "undeclared_export"),  # length runs past input
+        ("_ZN" + ("9" * 5000) + "nameE", "undeclared_export"),
+        ("_Z" + ("9" * 5000) + "nameI", "undeclared_export"),
         ("_ZN3lib10InitEngineEv", "undeclared_export"),
         ("_ZN3lib9InterfaceEv", "undeclared_export"),
         # a template argument in a *parameter* type does not make the entity a


### PR DESCRIPTION
Follow-up coverage for the bounded Itanium length parser merged in #528. Adds direct decimal parser tests plus malformed, oversized, and non-ASCII inputs.\n\nTests: `python -m pytest -q tests/test_crosscheck.py` (190 passed)