### PR TITLE
refactor(benchmark): drop compat/strict harness lanes, verify clang plugin builds

### DIFF
--- a/docs/development/abicc-parity-status.md
+++ b/docs/development/abicc-parity-status.md
@@ -233,67 +233,73 @@ has any concept of Linux kABI manifests or an L5 source-dependency graph, so
 those rows are a structural "N/A", not a false negative — nothing to score
 against.
 
-### abicheck's own modes on the same 11 cases
+### abicheck's two evidence depths on the same 11 cases
 
-The table above uses abicheck's native `compare` command (the actual product
-surface for these cases — 9/9, 100%). abicheck ships three other entry
-points benchmarked alongside it; their scores on this batch aren't a second
-opinion on detection capability, they're each mode doing exactly what it's
-designed to do:
+The table above uses abicheck's native `compare` command at **L2** (binary +
+headers — the actual product surface for these cases, 9/9, 100%). The
+benchmark harness (`scripts/benchmark_comparison.py`) also runs abicheck at
+**L3-L5** (`abicheck_full`, the Clang-plugin-instrumented lane: builds each
+case with `contrib/abicheck-clang-plugin`, captures per-declaration source
+facts, and merges that pack before comparing) — the two depths that actually
+matter for a tool-vs-tool comparison. (The harness previously also
+benchmarked the `abicheck compat`/`compat -s` ABICC-drop-in CLI modes as
+separate columns; those remain real product features — see
+[How each tool analyses ABI](../reference/tool-comparison.md#how-each-tool-analyses-abi)
+— but they wrap the same `compare` detection engine behind a different exit
+code, so they were dropped from this cross-tool benchmark as redundant with
+the `compare` row.)
 
-| ChangeKind | Expected | `abicheck compare` | `abicheck compat` | `compat -s` (strict) | `abicheck_full` (L3-L5 plugin) |
-|---|---|---|---|---|---|
-| `static_tls_introduced` | COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | BREAKING | ERROR (infra) |
-| `vtable_thunk_offset_changed` | BREAKING | ✅ BREAKING | ✅ BREAKING | ✅ BREAKING | ERROR (infra) |
-| `vtt_slot_count_changed` | BREAKING | ✅ BREAKING | ✅ BREAKING | ✅ BREAKING | ERROR (infra) |
-| `secondary_vtable_group_changed` | BREAKING | ✅ BREAKING | ✅ BREAKING | ✅ BREAKING | ERROR (infra) |
-| `long_double_abi_changed` | BREAKING | ✅ BREAKING | ✅ BREAKING | ✅ BREAKING | ERROR (infra) |
-| `unnamed_type_in_public_abi` | COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | BREAKING | ERROR (infra) |
-| `cet_protection_weakened` | COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | BREAKING | ERROR (infra) |
-| `symbol_binding_lost_unique` | COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | BREAKING | ERROR (infra) |
+| ChangeKind | Expected | `abicheck` (L2) | `abicheck_full` (L3-L5) |
+|---|---|---|---|
+| `static_tls_introduced` | COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK |
+| `vtable_thunk_offset_changed` | BREAKING | ✅ BREAKING | ✅ BREAKING |
+| `vtt_slot_count_changed` | BREAKING | ✅ BREAKING | ✅ BREAKING |
+| `secondary_vtable_group_changed` | BREAKING | ✅ BREAKING | ✅ BREAKING |
+| `kabi_crc_changed` | BREAKING | ✅ (verified directly — see note above) | N/A — no compilable source (`Module.symvers` fixture) |
+| `kabi_symbol_namespace_changed` | BREAKING | ✅ (verified directly — see note above) | N/A — no compilable source (`Module.symvers` fixture) |
+| `long_double_abi_changed` | BREAKING | ✅ BREAKING | ✅ BREAKING |
+| `unnamed_type_in_public_abi` | COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK |
+| `cet_protection_weakened` | COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK |
+| `symbol_binding_lost_unique` | COMPATIBLE_WITH_RISK | ✅ COMPATIBLE_WITH_RISK | ❌ NO_CHANGE |
+| `public_to_internal_dependency` | (L5 cross-check finding) | ✅ MATCH | ✅ MATCH |
 
-- **`abicheck compat`** (`abicheck/compat/cli.py`, the ABICC drop-in-replacement
-  CLI — takes ABICC-format XML descriptors, invoked via `compat check`) —
-  **8/8 (100%), same detection accuracy as native `compare`.** Its *report
-  text* prints the precise verdict (`Verdict: COMPATIBLE_WITH_RISK`) for all
-  four RISK cases, confirmed by inspecting the raw output directly — nothing
-  about compat mode's detection is coarser. What *is* coarser, by design, is
-  its **exit code**: compat mode's exit scheme (0/1/2, mirroring ABICC's own
-  compatible/incompatible/API-break codes) has no separate "risk" bucket, so
-  `COMPATIBLE_WITH_RISK` and `COMPATIBLE` both exit 0 — a CI gate keyed only
-  on exit code, not report text, would treat them the same. (This table
-  originally under-reported compat mode as 4/8 because
-  `scripts/benchmark_comparison.py`'s own scoring script only parsed the exit
-  code plus a couple of substring checks and never looked for
-  `compatible_with_risk` in the text — a benchmark-harness bug, now fixed;
-  it did not reflect a real gap in the tool.)
-- **`compat -s`/strict** (the `-s` strict flag, documented to promote
-  `API_BREAK` → `BREAKING`) — **4/8 (50%), and notably these are the same
-  four RISK cases, now promoted via the exit code all the way to `BREAKING`
-  (confirmed: exit code 1, not just report text).** That's a wider promotion
-  than the flag's stated `API_BREAK`→`BREAKING` description — strict mode is
-  treating any non-`NO_CHANGE` finding as a hard release gate, which is a
-  legitimate "when in doubt, block the release" security-conscious policy
-  choice for a CI gate, but means strict mode over-calls exactly the four
-  cases whose whole teaching point is "compatible but should not silently
-  ship" (CET, TLS, GNU_UNIQUE, the lambda leak) as full breaks — worth
-  knowing if you wire `-s` into a release gate expecting graduated severity
-  rather than a binary pass/fail.
-- **`abicheck_full`** (the Clang-plugin-instrumented L3–L5 lane, builds each
-  case with `contrib/abicheck-clang-plugin` and merges the resulting source
-  pack before comparing) — reported `ERROR` for every case in this run,
-  **including pre-existing catalog cases (verified against case01/case02)**,
-  because the clang plugin wasn't built in the environment that produced
-  this table. This is a local toolchain gap in how the table was generated,
-  not a result to read anything into; rerun with the plugin built
-  (`contrib/abicheck-clang-plugin/`) to get real L3+ numbers for this batch.
+**abicheck (L2): 9/9 scored (100%).** **abicheck_full (L3-L5): 8/9 scored
+(89%)** — case175/176 are excluded from `abicheck_full`'s own denominator for
+the same structural reason as every other tool's row (no compiled `.so` to
+build against a `Module.symvers` fixture).
+
+- **`symbol_binding_lost_unique` is a real, structural miss for the L3-L5
+  lane, not a benchmark-harness bug.** `abicheck_full` can only load
+  `contrib/abicheck-clang-plugin` into **Clang** (a Clang AST plugin is
+  ABI-locked to the loading compiler, per ADR-038 C.5 — there is no GCC
+  equivalent), so `_build_plugin_side()` always compiles the case's v1/v2
+  targets with `clang`/`clang++`, regardless of which compiler the L2 lane
+  used. `STB_GNU_UNIQUE` is a GCC-specific COMDAT-guard-variable binding —
+  verified empirically (this session) that Clang never emits it, at any
+  optimization level, for identical source. So the very ELF fact case180
+  demonstrates is invisible to a clang-only build, independent of how good
+  the plugin's fact capture is. The L2 lane sees it because it dumps the
+  case's real prebuilt `.so` (built with whichever compiler the example's
+  `CMakeLists.txt`/CI matrix selected — GCC for this case), not a
+  plugin-instrumented rebuild.
+- The Clang facts plugin itself needs `llvm-{N}-dev`/`libclang-{N}-dev` (not
+  just the `clang`/`clang++` binaries) to configure — `find_package(LLVM
+  REQUIRED CONFIG)` needs `LLVMConfig.cmake`, which only ships in the `-dev`
+  package. Verified building and running it end-to-end in this session
+  (`cmake -S contrib/abicheck-clang-plugin -B build/plugin ... && cmake
+  --build build/plugin`, then the C.6 differential-conformance test in
+  `contrib/abicheck-clang-plugin/tests/conformance.py`) — this is also what
+  `.github/workflows/clang-plugin.yml` installs on every matrix leg.
+  `scripts/benchmark_comparison.py`'s `_find_or_build_abicheck_plugin()`
+  builds the plugin on demand the same way once those packages are present;
+  no harness code change was needed, only the missing system packages.
 
 Reproduce: `PYTHONPATH=. python3 scripts/benchmark_comparison.py --cases
 case171 case172 case173 case174 case175 case176 case177 case178 case179
-case180 case181` (add `--freeze abidiff abidiff_headers abicc_dumper
-abicc_xml` only when re-running against the **full** catalog — passing it
-alongside `--cases` overwrites the entire frozen file with just the
-filtered subset).
+case180 case181 --tools abicheck abicheck_full` (add `--freeze abidiff
+abidiff_headers abicc_dumper abicc_xml` only when re-running against the
+**full** catalog — passing it alongside `--cases` overwrites the entire
+frozen file with just the filtered subset).
 
 ---
 

--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -389,7 +389,7 @@ often would it tell me the truth?"*
 ```bash
 python3 scripts/benchmark_comparison.py \
   --tools abicheck abicheck_full abidiff abidiff_headers abicc_dumper abicc_xml \
-  --skip-compat --freeze abidiff abidiff_headers abicc_dumper abicc_xml
+  --freeze abidiff abidiff_headers abicc_dumper abicc_xml
 ```
 
 | Tool | Correct / 170 | Accuracy | False positives | False negatives | Total time |
@@ -529,7 +529,15 @@ break).
 > **Historical.** Superseded by the [full-catalog benchmark](#full-catalog-benchmark-2026-07-12-all-170-cases)
 > above, which covers all 170 cases with a stricter denominator (SKIP/ERROR/TIMEOUT
 > count as misses) plus an FP/FN breakdown. Kept here for the original 74-case
-> release-pinned methodology and historical numbers.
+> release-pinned methodology and historical numbers. The harness has since
+> dropped the standalone `abicheck_compat`/`abicheck_strict` tool lanes (the
+> cross-tool comparison now benchmarks only the two evidence depths that
+> matter for tool-vs-tool comparison — `abicheck` at L2 and `abicheck_full`
+> at L3-L5); `abicheck compat`/`compat check -s` remain real CLI modes,
+> documented above under "How each tool analyses ABI", just no longer
+> re-benchmarked as separate harness columns. The `--tools`/`--skip-compat`
+> flags below reflect the harness as it existed at the time and are not
+> reproducible verbatim on the current script.
 
 Release-pinned scan status from `python3 scripts/benchmark_comparison.py --suite pinned74` on the original
 74-case benchmark subset. ABICC runs used `--abicc-timeout 20` to keep known hangs bounded.

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -5,7 +5,9 @@ Benchmark: abicheck vs ABICC vs abidiff on abicheck examples.
 
 Runs all tools on each example pair (v1/v2) and prints a comparison table.
 abidiff is run twice: without headers (ELF-only) and with --headers-dir.
-abicheck is run in two modes: compare (dump+compare pipeline) and compat (ABICC drop-in).
+abicheck is benchmarked at two evidence depths: ``abicheck`` (native
+compare, dump+compare pipeline over binary+headers — L2) and
+``abicheck_full`` (the Clang-plugin-instrumented L3-L5 lane).
 
 Two ABICC modes are supported:
   - abicc_xml:    legacy XML descriptor (no abi-dumper, fast but inaccurate)
@@ -21,7 +23,6 @@ Usage:
     python3 scripts/benchmark_comparison.py --abicc-timeout 60
     python3 scripts/benchmark_comparison.py --abicc-mode dumper
     python3 scripts/benchmark_comparison.py --skip-abicc
-    python3 scripts/benchmark_comparison.py --skip-compat
 """
 from __future__ import annotations
 
@@ -115,14 +116,8 @@ def _expected_or_unknown(value: object) -> str:
 EXPECTED: dict[str, str] = {
     k: _expected_or_unknown(v["expected"]) for k, v in _gt_data["verdicts"].items()
 }
-# Per-tool overrides sourced from ground_truth.json:
-#   expected_compat — compat mode can't emit API_BREAK (case31, case34)
-#   expected_abicc  — ABICC can't emit NO_CHANGE; NO_CHANGE→COMPATIBLE for scoring
-EXPECTED_COMPAT: dict[str, str] = {
-    k: v["expected_compat"]
-    for k, v in _gt_data["verdicts"].items()
-    if "expected_compat" in v
-}
+# Per-tool override sourced from ground_truth.json:
+#   expected_abicc — ABICC can't emit NO_CHANGE; NO_CHANGE→COMPATIBLE for scoring
 EXPECTED_ABICC: dict[str, str] = {
     k: ("COMPATIBLE" if EXPECTED[k] == "NO_CHANGE" else EXPECTED[k])
     for k, v in _gt_data["verdicts"].items()
@@ -768,136 +763,6 @@ def _abicheck_verdict_from_exit_code(returncode: int) -> str:
     }.get(returncode, "ERROR")
 
 
-def _write_compat_descriptor(so: Path, h: Path | None, ver: str, out: Path) -> None:
-    """Write an ABICC-format XML descriptor for abicheck compat."""
-    # NOTE: abicheck compat currently expects header file paths in <headers>
-    header = str(h) if h and h.exists() else ""
-    out.write_text(
-        f"<descriptor>\n"
-        f"  <version>{ver}</version>\n"
-        f"  <headers>{header}</headers>\n"
-        f"  <libs>{so}</libs>\n"
-        f"</descriptor>\n"
-    )
-
-
-# ── abicheck compat (ABICC XML drop-in) ──────────────────────────────────────
-def run_abicheck_compat(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
-                        case: str, rdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ToolResult:
-    """Run abicheck compat with ABICC-format XML descriptors."""
-    if not _HAS_ABICHECK:
-        return ToolResult(verdict="SKIP")
-
-    v1_xml = rdir / f"{case}_compat_v1.xml"
-    v2_xml = rdir / f"{case}_compat_v2.xml"
-    _write_compat_descriptor(v1_so, v1_h, "v1", v1_xml)
-    _write_compat_descriptor(v2_so, v2_h, "v2", v2_xml)
-
-    _t0 = time.monotonic()
-    try:
-        r = subprocess.run(
-            [_PYTHON, "-m", "abicheck.cli", "compat", "check", "-lib", case,
-             "-old", str(v1_xml), "-new", str(v2_xml)],
-            capture_output=True, text=True, timeout=timeout, env=_ABICHECK_ENV,
-        )
-    except subprocess.TimeoutExpired:
-        return ToolResult(verdict="TIMEOUT", elapsed_ms=(time.monotonic() - _t0) * 1000)
-    elapsed_ms = (time.monotonic() - _t0) * 1000
-
-    out = r.stdout + r.stderr
-    (rdir / f"{case}_abicheck_compat.txt").write_text(out)
-
-    # compat exit codes (from abicheck/cli.py compat command):
-    #   0 = NO_CHANGE or COMPATIBLE
-    #   1 = BREAKING
-    #   2 = API_BREAK (source-level break, binary compatible)
-    if r.returncode == 1:
-        verdict = "BREAKING"
-    elif r.returncode == 2:
-        verdict = "API_BREAK"
-    elif r.returncode == 0:
-        # Exit code 0 covers NO_CHANGE / COMPATIBLE / COMPATIBLE_WITH_RISK alike
-        # (matching ABICC's compatible/incompatible exit-code scheme, which has
-        # no separate "risk" exit bucket) -- but abicheck compat's own text
-        # output still prints the precise verdict ("Verdict: COMPATIBLE_WITH_RISK"),
-        # so check for it before falling back to the coarser NO_CHANGE/COMPATIBLE
-        # substring checks (previously this always collapsed risk findings to
-        # plain COMPATIBLE, understating what compat mode actually reports).
-        out_lower = out.lower()
-        if "verdict: compatible_with_risk" in out_lower:
-            verdict = "COMPATIBLE_WITH_RISK"
-        elif "verdict: no_change" in out_lower or "no changes" in out_lower or "identical" in out_lower:
-            verdict = "NO_CHANGE"
-        else:
-            verdict = "COMPATIBLE"
-    else:
-        verdict = "ERROR"
-
-    changes = [ln.strip() for ln in out.splitlines()
-               if any(k in ln for k in ("removed", "added", "changed")) and ln.strip()]
-    return ToolResult(verdict=verdict, changes=changes[:8], raw_output=out,
-                      elapsed_ms=elapsed_ms)
-
-
-# ── abicheck compat strict mode ───────────────────────────────────────────────
-def run_abicheck_strict(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
-                        case: str, rdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ToolResult:
-    """Run abicheck compat in strict mode (-s flag promotes API_BREAK→BREAKING)."""
-    if not _HAS_ABICHECK:
-        return ToolResult(verdict="SKIP")
-
-    # Reuse XML descriptors already created by run_abicheck_compat (same files)
-    v1_xml = rdir / f"{case}_compat_v1.xml"
-    v2_xml = rdir / f"{case}_compat_v2.xml"
-
-    # If XMLs don't exist yet, create them (fallback)
-    if not v1_xml.exists() or not v2_xml.exists():
-        _write_compat_descriptor(v1_so, v1_h, "v1", v1_xml)
-        _write_compat_descriptor(v2_so, v2_h, "v2", v2_xml)
-
-    _t0 = time.monotonic()
-    try:
-        r = subprocess.run(
-            [_PYTHON, "-m", "abicheck.cli", "compat", "check", "-lib", case,
-             "-old", str(v1_xml), "-new", str(v2_xml),
-             "-report-path", str(rdir / f"{case}_strict_report.html"),
-             "-s"],
-            capture_output=True, text=True, timeout=timeout, env=_ABICHECK_ENV,
-        )
-    except subprocess.TimeoutExpired:
-        return ToolResult(verdict="TIMEOUT", elapsed_ms=(time.monotonic() - _t0) * 1000)
-    elapsed_ms = (time.monotonic() - _t0) * 1000
-
-    out = r.stdout + r.stderr
-    (rdir / f"{case}_abicheck_strict.txt").write_text(out)
-
-    # strict mode exit codes: same as compat but API_BREAK is promoted to BREAKING (exit 1)
-    #   0 = NO_CHANGE or COMPATIBLE
-    #   1 = BREAKING (includes promoted API_BREAK)
-    #   2 = API_BREAK (shouldn't occur with -s, but handle defensively)
-    if r.returncode == 1:
-        verdict = "BREAKING"
-    elif r.returncode == 2:
-        verdict = "API_BREAK"
-    elif r.returncode == 0:
-        # Same rationale as run_abicheck_compat above: check for the precise
-        # COMPATIBLE_WITH_RISK text before falling back to coarser buckets.
-        out_lower = out.lower()
-        if "verdict: compatible_with_risk" in out_lower:
-            verdict = "COMPATIBLE_WITH_RISK"
-        elif "verdict: no_change" in out_lower or "no changes" in out_lower or "identical" in out_lower:
-            verdict = "NO_CHANGE"
-        else:
-            verdict = "COMPATIBLE"
-    else:
-        verdict = "ERROR"
-
-    changes = [ln.strip() for ln in out.splitlines()
-               if any(k in ln for k in ("removed", "added", "changed")) and ln.strip()]
-    return ToolResult(verdict=verdict, changes=changes[:8], raw_output=out,
-                      elapsed_ms=elapsed_ms)
-
-
 # ── abidiff ───────────────────────────────────────────────────────────────────
 def run_abidiff(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
                 case: str, rdir: Path,
@@ -1087,8 +952,6 @@ def run_abidiff_headers(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path 
 TOOL_REGISTRY: list[Tool] = [
     Tool("abicheck", run_abicheck, "abicheck", 12, "expected"),
     Tool("abicheck_full", run_abicheck_full, "ac-full", 12, "expected"),
-    Tool("abicheck_compat", run_abicheck_compat, "ac-compat", 12, "expected_compat"),
-    Tool("abicheck_strict", run_abicheck_strict, "ac-strict", 14, "expected"),
     Tool("abidiff", run_abidiff, "abidiff", 12, "expected"),
     Tool("abidiff_headers", run_abidiff_headers, "abidiff+hdr", 12, "expected"),
     Tool("abicc_dumper", run_abicc_dumper, "ABICC(dump)", 12, "expected_abicc", show_slowest=True),
@@ -1125,8 +988,8 @@ def _correct(verdict: str, expected: str) -> str:
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Benchmark abicheck vs abidiff vs ABICC")
     p.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT,
-                   help="Timeout per tool call for abicheck/abicheck_compat/"
-                        f"abicheck_strict/abidiff(+headers) (default: {DEFAULT_TIMEOUT}s)")
+                   help="Timeout per tool call for abicheck/abidiff(+headers) "
+                        f"(default: {DEFAULT_TIMEOUT}s)")
     p.add_argument("--abicc-timeout", type=int, default=DEFAULT_ABICC_TIMEOUT,
                    help="Timeout per ABICC call — ABICC is the slowest tool and can "
                         f"hang, so keep this bounded (default: {DEFAULT_ABICC_TIMEOUT}s)")
@@ -1138,14 +1001,12 @@ def parse_args() -> argparse.Namespace:
                    help="ABICC mode: xml (legacy XML descriptor), dumper (abi-dumper workflow), or both (default: both)")
     p.add_argument("--skip-abicc", action="store_true",
                    help="Skip ABICC entirely")
-    p.add_argument("--skip-compat", action="store_true",
-                   help="Skip abicheck compat column")
     p.add_argument("--cases", nargs="+", metavar="CASE",
                    help="Run only these case prefixes (e.g. case09 case16)")
     p.add_argument("--suite", choices=["all", "pinned74"], default="all",
                    help="Case suite to run: all catalog cases, or the historical 74-case release-pinned subset")
     p.add_argument("--tools", nargs="+", metavar="TOOL",
-                   choices=["abicheck", "abicheck_full", "abicheck_compat", "abicheck_strict",
+                   choices=["abicheck", "abicheck_full",
                             "abidiff", "abidiff_headers", "abicc_dumper", "abicc_xml"],
                    help="Run only selected tools")
     p.add_argument("--case64-toolchain", choices=["auto", "gcc", "clang"], default="auto",
@@ -1184,11 +1045,8 @@ def _error_entry(case_name: str, expected: str) -> dict[str, Any]:
     return {
         "case": case_name,
         "expected": expected,
-        "expected_compat": EXPECTED_COMPAT.get(case_name, expected),
         "abicheck": "ERROR",
         "abicheck_full": "ERROR",
-        "abicheck_compat": "ERROR",
-        "abicheck_strict": "ERROR",
         "abidiff": "ERROR",
         "abidiff_headers": "ERROR",
         "abicc_dumper": "ERROR",
@@ -1652,19 +1510,6 @@ def _print_abicheck_divergences(results: list[dict]) -> None:
             print(f"    {r['case']:<40} got={r['abicheck']} expected={r['expected']}")
 
 
-def _print_strict_compat_divergences(results: list[dict]) -> None:
-    """Print cases where abicheck_strict differs from abicheck_compat."""
-    print("\n  Cases where abicheck_strict differs from abicheck_compat:")
-    for r in results:
-        ac_s = r.get("abicheck_strict", "SKIP")
-        ac_c = r.get("abicheck_compat", "SKIP")
-        if ac_s in ("SKIP", "ERROR", "TIMEOUT") or ac_c in ("SKIP", "ERROR", "TIMEOUT"):
-            continue
-        if ac_s != ac_c:
-            exp = r.get("expected", "?")
-            print(f"    {r['case']:<40} compat={ac_c} strict={ac_s} expected={exp}")
-
-
 def _print_slowest_cases(results: list[dict], active_tools: list[Any]) -> None:
     """Print top-10 slowest cases for each tool flagged with show_slowest."""
     for tool_obj in active_tools:
@@ -1686,9 +1531,6 @@ def _print_accuracy_summary(results: list[dict], active_tools: list[Any], select
     if "abicheck" in selected_tools:
         _print_abicheck_divergences(results)
 
-    if "abicheck_strict" in selected_tools and "abicheck_compat" in selected_tools:
-        _print_strict_compat_divergences(results)
-
     _print_slowest_cases(results, active_tools)
 
 
@@ -1698,17 +1540,13 @@ def _resolve_selected_tools(args: Any) -> set[str]:
     """Return the set of tool names to run, honoring high-level on/off switches."""
     use_dumper = not args.skip_abicc and args.abicc_mode in ("dumper", "both")
     use_xml = not args.skip_abicc and args.abicc_mode in ("xml", "both")
-    use_compat = not args.skip_compat
 
     selected: set[str] = set(args.tools or [
-        "abicheck", "abicheck_full", "abicheck_compat", "abicheck_strict",
+        "abicheck", "abicheck_full",
         "abidiff", "abidiff_headers", "abicc_dumper", "abicc_xml",
     ])
 
     # honor high-level switches even if tool is listed explicitly
-    if not use_compat:
-        selected.discard("abicheck_compat")
-        selected.discard("abicheck_strict")
     if not use_dumper:
         selected.discard("abicc_dumper")
     if not use_xml:
@@ -1732,8 +1570,6 @@ def _skip_row_entry(name: str, expected: str) -> dict[str, Any]:
         "expected": expected,
         "abicheck": "SKIP",
         "abicheck_full": "SKIP",
-        "abicheck_compat": "SKIP",
-        "abicheck_strict": "SKIP",
         "abidiff": "SKIP",
         "abidiff_headers": "SKIP",
         "abicc_dumper": "SKIP",
@@ -1802,7 +1638,7 @@ def _run_tools_for_case(
                 case_dir=case_dir, v1_src=v1_src, v2_src=v2_src,
                 build_dir=build_dir, timeout=abicheck_full_timeout,
             )
-        elif t.name in ("abicheck", "abicheck_compat", "abicheck_strict"):
+        elif t.name == "abicheck":
             tool_results[t.name] = t.run_fn(v1_so, v2_so, v1_h_abicheck, v2_h_abicheck, name, rdir,
                                             timeout=timeout)
         elif t.name in ("abicc_dumper", "abicc_xml"):
@@ -1822,7 +1658,6 @@ def _build_result_entry(
     entry: dict[str, Any] = {
         "case": name,
         "expected": expected,
-        "expected_compat": EXPECTED_COMPAT.get(name, expected),
         "expected_abicc": EXPECTED_ABICC.get(name, expected),
     }
     for t in TOOL_REGISTRY:

--- a/tests/test_benchmark_smoke.py
+++ b/tests/test_benchmark_smoke.py
@@ -11,6 +11,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 SCRIPTS_DIR = Path(__file__).parent.parent / "scripts"
 
 
@@ -89,18 +91,15 @@ def test_parse_args_abicc_mode_xml():
     assert args.abicc_mode == "xml"
 
 
-def test_parse_args_skip_compat():
+def test_parse_args_rejects_removed_compat_strict_tools(capsys):
+    """abicheck_compat/abicheck_strict were retired from the harness — only
+    the two evidence-depth lanes (abicheck/abicheck_full) remain benchmarked."""
     mod = _load_benchmark()
-    with patch("sys.argv", ["benchmark_comparison.py", "--skip-compat"]):
-        args = mod.parse_args()
-    assert args.skip_compat is True
-
-
-def test_parse_args_skip_compat_default_false():
-    mod = _load_benchmark()
-    with patch("sys.argv", ["benchmark_comparison.py"]):
-        args = mod.parse_args()
-    assert args.skip_compat is False
+    with patch("sys.argv", ["benchmark_comparison.py", "--tools", "abicheck_compat"]):
+        with pytest.raises(SystemExit) as exc:
+            mod.parse_args()
+    assert exc.value.code != 0
+    capsys.readouterr()  # silence argparse's usage/error message in test output
 
 
 def test_parse_args_pinned_suite():


### PR DESCRIPTION
## Summary

Follow-up to #539: simplifies `scripts/benchmark_comparison.py` to benchmark only the two evidence depths that matter for a cross-tool comparison (`abicheck` at L2, `abicheck_full` at L3-L5), and verifies the Clang facts plugin actually builds and runs so `abicheck_full` produces real results instead of an infra-gap placeholder.

## Motivation

`scripts/benchmark_comparison.py` benchmarked abicheck through four separate entry points: `compare`, `compat`, `compat -s`/strict, and `abicheck_full`. `compat` and `compat -s` wrap the same `compare()` detection engine behind ABICC-style exit codes — they add no independent detection signal to a tool-vs-tool comparison, just a different exit-code mapping of the same verdict. Keeping them as separate benchmark columns was redundant and inflated the harness surface for no comparative value.

Separately, `docs/development/abicc-parity-status.md`'s "abicheck's own modes" table for cases 171–181 (added in #539) reported `abicheck_full` as `ERROR (infra)` for every case, because the Clang facts plugin (`contrib/abicheck-clang-plugin`) hadn't actually been built in the environment that produced the table. That's a real gap in the evidence behind the doc, not just cosmetic.

## Changes

- `scripts/benchmark_comparison.py`: removed `run_abicheck_compat`/`run_abicheck_strict`, their `TOOL_REGISTRY` entries, the `--skip-compat` flag, `EXPECTED_COMPAT`, and all downstream table/CLI/dispatch references. The harness now benchmarks `abicheck` (L2) and `abicheck_full` (L3-L5) only.
- `tests/test_benchmark_smoke.py`: replaced the two `--skip-compat` argparse tests with one asserting `--tools abicheck_compat` is now rejected (the choice was removed).
- Verified `contrib/abicheck-clang-plugin` builds and runs for real: `find_package(LLVM REQUIRED CONFIG)` needs `LLVMConfig.cmake`, which only ships in the `llvm-{N}-dev` package (not just the `clang`/`clang++` binaries). With that installed, the plugin configures, builds, and passes its C.6 differential-conformance test unmodified — no harness code change was needed, only the missing system packages (the same ones `.github/workflows/clang-plugin.yml` already installs on every matrix leg).
- `docs/development/abicc-parity-status.md`: rewrote the "abicheck's own modes" section to drop the compat/strict columns and replaced the `ERROR (infra)` placeholder with real L3-L5 results from a re-run against a built plugin, including a genuine structural miss (`symbol_binding_lost_unique`/`STB_GNU_UNIQUE`, which only GCC emits — the plugin can only be loaded by Clang as the host compiler per ADR-038 C.5, so `abicheck_full` always rebuilds targets with clang and structurally cannot see this GCC-only ELF fact) documented as such rather than hidden.
- `docs/reference/tool-comparison.md`: annotated the historical 74-case pinned benchmark section to note the retired tool names — `abicheck compat`/`-s` remain real CLI features (see "How each tool analyses ABI"), just no longer separate benchmark columns; fixed the current full-catalog benchmark's reproduce command (dropped the now-nonexistent `--skip-compat` flag).

## Verification

- `ruff check scripts/benchmark_comparison.py tests/test_benchmark_smoke.py` — clean.
- `ruff format --check` on both files still fails, but that predates this change (verified against the pre-edit versions via `git show`) — pre-existing repo-wide style drift, not introduced here.
- `mypy abicheck/` — 0 errors (the CI gate; `scripts/` isn't in its scope).
- `python scripts/check_ai_readiness.py` — 0 errors, 12 pre-existing file-size warnings unrelated to this change.
- `pytest tests/test_benchmark_smoke.py` — 27 passed.
- `mkdocs build --strict` — builds clean (pre-existing unrelated INFO-level anchor notices only).
- Built the Clang plugin end-to-end (`cmake -S contrib/abicheck-clang-plugin -B build/plugin ... && cmake --build build/plugin`), ran `contrib/abicheck-clang-plugin/tests/conformance.py` (C.6 differential conformance — passed), then re-ran `scripts/benchmark_comparison.py --cases case171..case181 --tools abicheck abicheck_full` against the real plugin to get the corrected doc numbers.

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] `CHANGELOG.md` updated — skipped: this is an internal dev-script/doc change with no user-visible library behavior change
- [x] Docs updated (`docs/development/abicc-parity-status.md`, `docs/reference/tool-comparison.md`)
- [x] `pre-commit`-equivalent checks pass locally (ruff check, mypy, ai-readiness)
- [x] No new `mypy` or `ruff` errors introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_016RdL68tkDLGWep9fSBgydn)_