### PR TITLE
fix(reporting): make review digest, GitHub annotations, and scan --baseline severity/gate-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,27 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **Review digest, GitHub annotations, and `scan --baseline` could misreport
+  the actual CI gate once severity configuration is in play.** Compatibility
+  (`Verdict`) and "blocks CI" (`SeverityConfig`) are independent decisions —
+  an addition configured `error` blocks the build despite a `COMPATIBLE`
+  verdict, and a breaking kind configured below `error` does not block it
+  despite a `BREAKING` verdict. `to_review_digest()` hard-coded its
+  merge-effect phrase from the raw verdict (always "safe to merge" for
+  `COMPATIBLE`), and `collect_annotations()`/`emit_github_annotations()`
+  derived `::error`/`::warning`/`::notice` purely from fixed kind-set
+  membership — both ignored `SeverityConfig` entirely, so an annotation could
+  be silently absent for a finding that fails the build, or emitted as
+  `::error` for one that does not gate at all. Both now accept an optional
+  `severity_config` and reflect the actual severity-aware gate; wired through
+  on the primary `compare` command's `--format review` and `--annotate`
+  paths. Separately, `scan --baseline` computed a real `DiffResult` but
+  discarded it down to four bucket counts (`breaking=1 api_break=2 ...`),
+  leaving a failing scan with no way to name the broken symbol without a
+  separate `compare` run; the baseline compare now embeds the actual
+  findings (kind/symbol/description/source location, capped and flagged
+  when truncated) and the scan report renders them.
+
 - **`case35_field_rename` reported `BREAKING` instead of `API_BREAK`.** A pure
   field rename (same offset + type, name only) fell through the generic
   field-removed/-added detectors to a plain `TYPE_FIELD_REMOVED`/

--- a/abicheck/annotations.py
+++ b/abicheck/annotations.py
@@ -23,6 +23,7 @@ See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-gi
 from __future__ import annotations
 
 import os
+from typing import TYPE_CHECKING
 
 from .checker import (
     Change,
@@ -31,6 +32,9 @@ from .checker import (
 from .checker_policy import (
     ChangeKind,
 )
+
+if TYPE_CHECKING:
+    from .severity import KindSets, SeverityConfig
 
 # GitHub caps visible annotations at ~50 per step.
 _MAX_ANNOTATIONS = 50
@@ -144,6 +148,35 @@ def _classify_change(
     return None
 
 
+def _classify_change_by_severity(
+    change: Change,
+    kind_sets: KindSets,
+    severity_config: SeverityConfig,
+    annotate_additions: bool,
+) -> str | None:
+    """Return the annotation level driven by *severity_config*, or None to skip.
+
+    Reflects the actual CI gate (ADR "GateDecision" direction): a category
+    configured ``error`` always emits ``::error`` regardless of whether it is
+    an addition or a breaking kind, so an annotation is never silently absent
+    for a finding that will fail the build. ``warning``/``info`` mirror the
+    severity level directly; ``info`` only surfaces (as ``::notice``) when
+    *annotate_additions* opts into the noisier informational annotations —
+    matching the pre-existing opt-in behaviour for additions.
+    """
+    from .severity import SeverityLevel, classify_effective_change
+
+    category = classify_effective_change(change, kind_sets=kind_sets)
+    level = severity_config.level_for(category)
+    if level == SeverityLevel.ERROR:
+        return "error"
+    if level == SeverityLevel.WARNING:
+        return "warning"
+    if level == SeverityLevel.INFO:
+        return "notice" if annotate_additions else None
+    return None
+
+
 def _title_for_change(
     kind: ChangeKind,
     breaking_set: frozenset[ChangeKind],
@@ -189,21 +222,36 @@ def collect_annotations(
     diff_result: DiffResult,
     *,
     annotate_additions: bool = False,
+    severity_config: SeverityConfig | None = None,
 ) -> list[tuple[int, str]]:
     """Collect raw annotation tuples (sort_key, line) for a single DiffResult.
 
     This is the building block for both single-library and multi-library flows.
     Callers are responsible for sorting, truncating, and emitting.
+
+    Without *severity_config*, annotation levels follow the fixed
+    kind-set mapping (BREAKING → error, API_BREAK/RISK → warning, additions →
+    notice when opted in) — the legacy, verdict-only behaviour. When
+    *severity_config* is supplied, it takes priority: the annotation level
+    mirrors each finding's actually-configured severity so an annotation is
+    never silently absent (or under/over-stated) for a finding that does (or
+    does not) gate CI — see :func:`_classify_change_by_severity`.
     """
-    breaking_set, api_break_set, compatible_set, risk_set = diff_result._effective_kind_sets()
+    kind_sets = diff_result._effective_kind_sets()
+    breaking_set, api_break_set, compatible_set, risk_set = kind_sets
 
     annotations: list[tuple[int, str]] = []
 
     for change in diff_result.changes:
-        level = _classify_change(
-            change.kind, breaking_set, api_break_set, risk_set,
-            compatible_set, annotate_additions,
-        )
+        if severity_config is not None:
+            level = _classify_change_by_severity(
+                change, kind_sets, severity_config, annotate_additions,
+            )
+        else:
+            level = _classify_change(
+                change.kind, breaking_set, api_break_set, risk_set,
+                compatible_set, annotate_additions,
+            )
         if level is None:
             continue
 
@@ -241,6 +289,7 @@ def emit_github_annotations(
     *,
     annotate_additions: bool = False,
     max_annotations: int = _MAX_ANNOTATIONS,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
     """Generate GitHub Actions annotation lines for ABI changes.
 
@@ -248,11 +297,18 @@ def emit_github_annotations(
         diff_result: The diff result to annotate.
         annotate_additions: If True, also emit ``::notice`` for additions/compatible changes.
         max_annotations: Maximum number of annotations to emit (default 50).
+        severity_config: When given, annotation levels follow the configured
+            per-category severity instead of the fixed kind-set mapping (see
+            :func:`collect_annotations`).
 
     Returns:
         A string of newline-separated workflow commands (may be empty).
     """
-    annotations = collect_annotations(diff_result, annotate_additions=annotate_additions)
+    annotations = collect_annotations(
+        diff_result,
+        annotate_additions=annotate_additions,
+        severity_config=severity_config,
+    )
     return format_annotations(annotations, max_annotations=max_annotations)
 
 

--- a/abicheck/annotations.py
+++ b/abicheck/annotations.py
@@ -379,8 +379,19 @@ def is_github_actions() -> bool:
     return os.environ.get("GITHUB_ACTIONS") == "true"
 
 
-def emit_github_step_summary(diff_result: DiffResult) -> str | None:
+def emit_github_step_summary(
+    diff_result: DiffResult,
+    *,
+    severity_config: SeverityConfig | None = None,
+) -> str | None:
     """Write a Markdown job summary to $GITHUB_STEP_SUMMARY if available.
+
+    *severity_config*, when given, is forwarded to :func:`abicheck.reporter.to_markdown`
+    so the step summary carries the same "Severity Configuration" section the
+    inline annotations are already gated on — without it, `--severity-addition
+    error` (for example) could fail the annotations/exit code while the step
+    summary still rendered the legacy compatible report with no severity gate
+    section, contradicting the actual gate on the same PR.
 
     Returns the summary path if written, None otherwise.
     """
@@ -390,7 +401,7 @@ def emit_github_step_summary(diff_result: DiffResult) -> str | None:
 
     from .reporter import to_markdown
 
-    md = to_markdown(diff_result)
+    md = to_markdown(diff_result, severity_config=severity_config)
     with open(summary_path, "a", encoding="utf-8") as f:
         f.write(md)
         f.write("\n")

--- a/abicheck/annotations.py
+++ b/abicheck/annotations.py
@@ -212,16 +212,36 @@ def _title_for_change(
 ) -> str:
     """Return the annotation title prefix, distinguishing API Break from Deployment Risk.
 
-    *category*, when given (the severity-aware path), distinguishes a
-    genuine addition from a compatible *quality* finding (e.g.
-    ``soname_bump_unnecessary``) — both fall in *compatible_set*, but only
-    the former is actually "ABI Addition"; mislabeling a quality warning as
-    an addition previously went unnoticed because compatible findings were
-    only ever annotated opt-in via ``annotate_additions``, but a severity
-    config can now surface a quality finding (e.g. ``quality_issues=warning``)
-    without that opt-in.
+    *category*, when given (the severity-aware path), is consulted *before*
+    kind-set membership (CodeRabbit review on #549). ``breaking_set``/etc.
+    are pre-baked from ``DiffResult._effective_kind_sets()``, which already
+    applies *kind-level* policy-file overrides — so a policy-demoted
+    ``FUNC_REMOVED`` reads as being "in" ``compatible_set``. But a
+    *per-change* frozen-namespace clamp can keep that one finding's
+    *effective* category at ``ABI_BREAKING`` despite the kind-level move; a
+    title picked from kind-set membership alone would then mislabel an
+    ``::error`` annotation as "Quality Issue" (or "ABI Addition"). Checking
+    *category* first — the same effective classification that already drove
+    the annotation *level* — keeps the title consistent with it.
     """
     kind_label = kind.value
+    if category is not None:
+        from .severity import IssueCategory as _IssueCategory
+
+        if category == _IssueCategory.ABI_BREAKING:
+            return f"ABI Break: {kind_label}"
+        if category == _IssueCategory.QUALITY_ISSUES:
+            return f"Quality Issue: {kind_label}"
+        if category == _IssueCategory.ADDITION:
+            return f"ABI Addition: {kind_label}"
+        # POTENTIAL_BREAKING: distinguish API Break from Deployment Risk via
+        # the kind sets, since IssueCategory does not itself split the two.
+        if kind in api_break_set:
+            return f"API Break: {kind_label}"
+        if kind in risk_set:
+            return f"Deployment Risk: {kind_label}"
+        return f"Potential Break: {kind_label}"
+
     if kind in breaking_set:
         return f"ABI Break: {kind_label}"
     if kind in api_break_set:
@@ -229,15 +249,6 @@ def _title_for_change(
     if kind in risk_set:
         return f"Deployment Risk: {kind_label}"
     if kind in compatible_set:
-        if category is not None:
-            from .severity import IssueCategory as _IssueCategory
-
-            label = (
-                "ABI Addition"
-                if category == _IssueCategory.ADDITION
-                else "Quality Issue"
-            )
-            return f"{label}: {kind_label}"
         return f"ABI Addition: {kind_label}"
     return f"ABI Change: {kind_label}"
 

--- a/abicheck/annotations.py
+++ b/abicheck/annotations.py
@@ -34,7 +34,7 @@ from .checker_policy import (
 )
 
 if TYPE_CHECKING:
-    from .severity import KindSets, SeverityConfig
+    from .severity import IssueCategory, KindSets, SeverityConfig
 
 # GitHub caps visible annotations at ~50 per step.
 _MAX_ANNOTATIONS = 50
@@ -148,24 +148,14 @@ def _classify_change(
     return None
 
 
-def _classify_change_by_severity(
+def _category_for_change_severity(
     change: Change,
     kind_sets: KindSets,
-    severity_config: SeverityConfig,
-    annotate_additions: bool,
     *,
     policy: str | None = None,
     policy_file: object | None = None,
-) -> str | None:
-    """Return the annotation level driven by *severity_config*, or None to skip.
-
-    Reflects the actual CI gate (ADR "GateDecision" direction): a category
-    configured ``error`` always emits ``::error`` regardless of whether it is
-    an addition or a breaking kind, so an annotation is never silently absent
-    for a finding that will fail the build. ``warning``/``info`` mirror the
-    severity level directly; ``info`` only surfaces (as ``::notice``) when
-    *annotate_additions* opts into the noisier informational annotations —
-    matching the pre-existing opt-in behaviour for additions.
+) -> IssueCategory:
+    """Return the severity-aware :class:`~abicheck.severity.IssueCategory` for *change*.
 
     *policy_file* must be threaded through (not just the pre-baked
     *kind_sets*) so a frozen-namespace-tagged finding's floor is honoured the
@@ -177,11 +167,30 @@ def _classify_change_by_severity(
     ``classify_effective_change`` — omitting it would let this annotation
     under-report a finding that still fails CI at its raw severity.
     """
-    from .severity import SeverityLevel, classify_effective_change
+    from .severity import classify_effective_change
 
-    category = classify_effective_change(
+    return classify_effective_change(
         change, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
     )
+
+
+def _annotation_level_for_category(
+    category: IssueCategory,
+    severity_config: SeverityConfig,
+    annotate_additions: bool,
+) -> str | None:
+    """Return the annotation level for *category* under *severity_config*, or None to skip.
+
+    Reflects the actual CI gate (ADR "GateDecision" direction): a category
+    configured ``error`` always emits ``::error`` regardless of whether it is
+    an addition or a breaking kind, so an annotation is never silently absent
+    for a finding that will fail the build. ``warning``/``info`` mirror the
+    severity level directly; ``info`` only surfaces (as ``::notice``) when
+    *annotate_additions* opts into the noisier informational annotations —
+    matching the pre-existing opt-in behaviour for additions.
+    """
+    from .severity import SeverityLevel
+
     level = severity_config.level_for(category)
     if level == SeverityLevel.ERROR:
         return "error"
@@ -198,8 +207,20 @@ def _title_for_change(
     api_break_set: frozenset[ChangeKind],
     risk_set: frozenset[ChangeKind],
     compatible_set: frozenset[ChangeKind],
+    *,
+    category: IssueCategory | None = None,
 ) -> str:
-    """Return the annotation title prefix, distinguishing API Break from Deployment Risk."""
+    """Return the annotation title prefix, distinguishing API Break from Deployment Risk.
+
+    *category*, when given (the severity-aware path), distinguishes a
+    genuine addition from a compatible *quality* finding (e.g.
+    ``soname_bump_unnecessary``) — both fall in *compatible_set*, but only
+    the former is actually "ABI Addition"; mislabeling a quality warning as
+    an addition previously went unnoticed because compatible findings were
+    only ever annotated opt-in via ``annotate_additions``, but a severity
+    config can now surface a quality finding (e.g. ``quality_issues=warning``)
+    without that opt-in.
+    """
     kind_label = kind.value
     if kind in breaking_set:
         return f"ABI Break: {kind_label}"
@@ -208,6 +229,15 @@ def _title_for_change(
     if kind in risk_set:
         return f"Deployment Risk: {kind_label}"
     if kind in compatible_set:
+        if category is not None:
+            from .severity import IssueCategory as _IssueCategory
+
+            label = (
+                "ABI Addition"
+                if category == _IssueCategory.ADDITION
+                else "Quality Issue"
+            )
+            return f"{label}: {kind_label}"
         return f"ABI Addition: {kind_label}"
     return f"ABI Change: {kind_label}"
 
@@ -250,7 +280,7 @@ def collect_annotations(
     *severity_config* is supplied, it takes priority: the annotation level
     mirrors each finding's actually-configured severity so an annotation is
     never silently absent (or under/over-stated) for a finding that does (or
-    does not) gate CI — see :func:`_classify_change_by_severity`.
+    does not) gate CI — see :func:`_annotation_level_for_category`.
     """
     kind_sets = diff_result._effective_kind_sets()
     breaking_set, api_break_set, compatible_set, risk_set = kind_sets
@@ -258,10 +288,14 @@ def collect_annotations(
     annotations: list[tuple[int, str]] = []
 
     for change in diff_result.changes:
+        category: IssueCategory | None = None
         if severity_config is not None:
-            level = _classify_change_by_severity(
-                change, kind_sets, severity_config, annotate_additions,
+            category = _category_for_change_severity(
+                change, kind_sets,
                 policy=diff_result.policy, policy_file=diff_result.policy_file,
+            )
+            level = _annotation_level_for_category(
+                category, severity_config, annotate_additions,
             )
         else:
             level = _classify_change(
@@ -273,6 +307,7 @@ def collect_annotations(
 
         title = _title_for_change(
             change.kind, breaking_set, api_break_set, risk_set, compatible_set,
+            category=category,
         )
         line = _format_annotation(level, change, title, change.description)
         sort_key = _SEVERITY_ORDER.get(level, 99)

--- a/abicheck/annotations.py
+++ b/abicheck/annotations.py
@@ -153,6 +153,9 @@ def _classify_change_by_severity(
     kind_sets: KindSets,
     severity_config: SeverityConfig,
     annotate_additions: bool,
+    *,
+    policy: str | None = None,
+    policy_file: object | None = None,
 ) -> str | None:
     """Return the annotation level driven by *severity_config*, or None to skip.
 
@@ -163,10 +166,22 @@ def _classify_change_by_severity(
     severity level directly; ``info`` only surfaces (as ``::notice``) when
     *annotate_additions* opts into the noisier informational annotations —
     matching the pre-existing opt-in behaviour for additions.
+
+    *policy_file* must be threaded through (not just the pre-baked
+    *kind_sets*) so a frozen-namespace-tagged finding's floor is honoured the
+    same way ``severity.compute_exit_code`` honours it for the actual exit
+    code: ``kind_sets`` alone already moves a policy-overridden *kind* to its
+    new bucket, but the *per-change* frozen-namespace clamp-back (never let an
+    override downgrade a frozen-namespace violation below its raw verdict)
+    only fires when ``policy_file`` itself is passed to
+    ``classify_effective_change`` — omitting it would let this annotation
+    under-report a finding that still fails CI at its raw severity.
     """
     from .severity import SeverityLevel, classify_effective_change
 
-    category = classify_effective_change(change, kind_sets=kind_sets)
+    category = classify_effective_change(
+        change, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+    )
     level = severity_config.level_for(category)
     if level == SeverityLevel.ERROR:
         return "error"
@@ -246,6 +261,7 @@ def collect_annotations(
         if severity_config is not None:
             level = _classify_change_by_severity(
                 change, kind_sets, severity_config, annotate_additions,
+                policy=diff_result.policy, policy_file=diff_result.policy_file,
             )
         else:
             level = _classify_change(

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -818,7 +818,7 @@ def _maybe_emit_annotations(
         click.echo(text, err=True)
 
     if write_step_summary:
-        emit_github_step_summary(result)
+        emit_github_step_summary(result, severity_config=severity_config)
 
 
 def _write_release_step_summary(text: str, fmt: str) -> None:

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -794,6 +794,7 @@ def _maybe_emit_annotations(
     annotate: bool,
     annotate_additions: bool,
     write_step_summary: bool = True,
+    severity_config: SeverityConfig | None = None,
 ) -> None:
     """Emit GitHub annotations to stderr if --annotate is set and running in CI."""
     if not annotate:
@@ -809,7 +810,9 @@ def _maybe_emit_annotations(
     if not is_github_actions():
         return
 
-    annotations = collect_annotations(result, annotate_additions=annotate_additions)
+    annotations = collect_annotations(
+        result, annotate_additions=annotate_additions, severity_config=severity_config,
+    )
     text = format_annotations(annotations)
     if text:
         click.echo(text, err=True)
@@ -947,6 +950,7 @@ def _finalize_compare_result(
     *,
     show_redundant: bool, show_filtered: bool,
     annotate: bool, annotate_additions: bool,
+    severity_config: SeverityConfig | None = None,
 ) -> None:
     """Attach metadata and emit redundancy/filter/suppression/annotation output."""
     result.old_metadata = _collect_metadata(old_input)
@@ -973,7 +977,8 @@ def _finalize_compare_result(
 
     _warn_all_suppressed(result)
     _maybe_emit_annotations(
-        result, annotate=annotate, annotate_additions=annotate_additions
+        result, annotate=annotate, annotate_additions=annotate_additions,
+        severity_config=severity_config,
     )
 
 

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -771,6 +771,7 @@ def run_compare(
         result, old_input, new_input,
         show_redundant=show_redundant, show_filtered=show_filtered,
         annotate=annotate, annotate_additions=annotate_additions,
+        severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
     )
 
     text = _render_output(

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -1137,6 +1137,24 @@ def compare_release_cmd(
             severity_quality_issues,
             severity_addition,
         )
+        if release_exit_code_scheme == "severity" and severity_config is None:
+            # The resolved scheme is "severity" (e.g. .abicheck.yml's
+            # exit_code_scheme: severity with no severity: block at all) but
+            # no --severity-* flag was ever set, so the raw-args resolution
+            # above returned None. The single-file compare path never hits
+            # this: its resolved_cfg.severity is unconditionally populated
+            # (defaulting to PRESET_DEFAULT) and only *gated* by scheme, not
+            # re-derived from raw flags. Mirror that here — including
+            # reassigning severity_preset so the two downstream helpers below
+            # that independently re-resolve from these same raw args
+            # (_compute_release_severity_exit_code, _fold_release_global_severity)
+            # agree with it, instead of also silently resolving None and
+            # falling back to the legacy verdict-based exit (Codex review on
+            # #549).
+            from .severity import PRESET_DEFAULT
+
+            severity_config = PRESET_DEFAULT
+            severity_preset = "default"
         if release_exit_code_scheme == "legacy":
             severity_config = None
 

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -320,6 +320,23 @@ def _suppress_lockstep_soname_findings(
     return suppressed
 
 
+def _drop_lockstep_soname_finding(result: DiffResult) -> None:
+    """Mirror ``_suppress_lockstep_soname_findings``'s per-result filter.
+
+    Called on the independent re-run :func:`_collect_release_extras` performs
+    for JUnit/annotations, only when the caller has already confirmed
+    ``worst_verdict == "BREAKING"`` (the same release-level condition
+    ``_suppress_lockstep_soname_findings`` gates on) — so this stays a no-op
+    unless the primary pass would also have suppressed the finding.
+    """
+    from .checker_policy import ChangeKind
+
+    if any(c.kind == ChangeKind.SONAME_BUMP_UNNECESSARY for c in result.changes):
+        result.changes = [
+            c for c in result.changes if c.kind != ChangeKind.SONAME_BUMP_UNNECESSARY
+        ]
+
+
 def _compare_release_libraries(
     matched_keys: list[str],
     old_map: dict[str, Path],
@@ -449,6 +466,7 @@ def _compare_release_libraries(
             annotate=annotate,
             scope_to_public_surface=scope_to_public_surface,
             severity_config=severity_config,
+            worst_verdict=worst_verdict,
         )
         diff_pairs.extend(extra_pairs)
         all_annotations.extend(extra_annotations)
@@ -531,8 +549,18 @@ def _collect_release_extras(
     annotate: bool,
     scope_to_public_surface: bool = True,
     severity_config: SeverityConfig | None = None,
+    worst_verdict: str = "NO_CHANGE",
 ) -> tuple[list[tuple[DiffResult, AbiSnapshot]], list[tuple[int, str]]]:
-    """Collect optional re-run artifacts for JUnit and annotations."""
+    """Collect optional re-run artifacts for JUnit and annotations.
+
+    *worst_verdict* mirrors the condition ``_suppress_lockstep_soname_findings``
+    uses on the primary per-library pass. This function re-runs comparison
+    independently (see its docstring), so a coordinated-release SONAME bump
+    that pass judged intentional and dropped must be dropped here too — else
+    JUnit/annotations disagree with the primary report and can surface (or
+    even gate on, under a severity config) a finding the release-level report
+    no longer shows at all.
+    """
     diff_pairs: list[tuple[DiffResult, AbiSnapshot]] = []
     annotations: list[tuple[int, str]] = []
     for key in matched_keys:
@@ -564,6 +592,8 @@ def _collect_release_extras(
                 err=True,
             )
             continue
+        if worst_verdict == "BREAKING":
+            _drop_lockstep_soname_finding(result)
         if collect_diff_results:
             diff_pairs.append((result, old_snap))
         if annotate:

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -344,6 +344,7 @@ def _compare_release_libraries(
     annotate_additions: bool = False,
     jobs: int = 1,
     scope_to_public_surface: bool = True,
+    severity_config: SeverityConfig | None = None,
 ) -> tuple[list[dict[str, object]], str, list[tuple[DiffResult, AbiSnapshot]]]:
     """Compare each matched library pair and collect results.
 
@@ -447,6 +448,7 @@ def _compare_release_libraries(
             collect_diff_results=collect_diff_results,
             annotate=annotate,
             scope_to_public_surface=scope_to_public_surface,
+            severity_config=severity_config,
         )
         diff_pairs.extend(extra_pairs)
         all_annotations.extend(extra_annotations)
@@ -528,6 +530,7 @@ def _collect_release_extras(
     collect_diff_results: bool,
     annotate: bool,
     scope_to_public_surface: bool = True,
+    severity_config: SeverityConfig | None = None,
 ) -> tuple[list[tuple[DiffResult, AbiSnapshot]], list[tuple[int, str]]]:
     """Collect optional re-run artifacts for JUnit and annotations."""
     diff_pairs: list[tuple[DiffResult, AbiSnapshot]] = []
@@ -568,7 +571,11 @@ def _collect_release_extras(
 
             if is_github_actions():
                 annotations.extend(
-                    collect_annotations(result, annotate_additions=annotate_additions),
+                    collect_annotations(
+                        result,
+                        annotate_additions=annotate_additions,
+                        severity_config=severity_config,
+                    ),
                 )
     return diff_pairs, annotations
 
@@ -1086,6 +1093,23 @@ def compare_release_cmd(
         if output_dir:
             output_dir.mkdir(parents=True, exist_ok=True)
 
+        # Resolved before the compare pass (its inputs are plain CLI values, no
+        # dependency on compare results) so --annotate's GitHub annotations —
+        # collected inside _compare_release_libraries, same pass as the
+        # per-library JUnit re-run — reflect the same severity-aware gate as
+        # the exit code below, instead of the legacy kind-set mapping. Returns
+        # None when no --severity-* option was supplied, or when compare's
+        # resolved config pins the legacy scheme for set inputs.
+        severity_config = _resolve_release_severity_config(
+            severity_preset,
+            severity_abi_breaking,
+            severity_potential_breaking,
+            severity_quality_issues,
+            severity_addition,
+        )
+        if release_exit_code_scheme == "legacy":
+            severity_config = None
+
         # JUnit still re-runs pairs in _collect_release_extras because it
         # needs old AbiSnapshot too. Bundle analysis reuses the
         # _diff_result stashed in each library entry from the first pass.
@@ -1112,19 +1136,11 @@ def compare_release_cmd(
             annotate_additions=annotate_additions,
             jobs=jobs,
             scope_to_public_surface=scope_public_headers,
+            severity_config=severity_config,
         )
 
         # Compute the severity-aware exit code while per-library DiffResults
         # are still stashed (before _strip_diff_results_and_adjust_verdict).
-        # Returns None when no --severity-* option was supplied, or when
-        # compare's resolved config pins the legacy scheme for set inputs.
-        severity_config = _resolve_release_severity_config(
-            severity_preset,
-            severity_abi_breaking,
-            severity_potential_breaking,
-            severity_quality_issues,
-            severity_addition,
-        )
         severity_exit_code = (
             None
             if release_exit_code_scheme == "legacy"
@@ -1137,8 +1153,6 @@ def compare_release_cmd(
                 severity_addition,
             )
         )
-        if release_exit_code_scheme == "legacy":
-            severity_config = None
 
         bundle_result: BundleDiffResult | None = None
         if not no_bundle_analysis:

--- a/abicheck/cli_compare_release_helpers.py
+++ b/abicheck/cli_compare_release_helpers.py
@@ -352,9 +352,14 @@ def _compute_release_severity_exit_code(
     Returns ``None`` when no ``--severity-*`` option was supplied (callers
     keep the legacy verdict-based exit). Otherwise returns the worst
     :func:`compute_exit_code` over the per-library changes. Each library is
-    classified with *its own* ``DiffResult._effective_kind_sets()`` so that
-    per-library ``--policy-file`` kind overrides (e.g. escalating a kind to
-    BREAKING) are honored in the exit code, not just in the report.
+    classified with *its own* ``DiffResult._effective_kind_sets()`` (kind-level
+    ``--policy-file`` overrides) *and* its own ``policy``/``policy_file`` (the
+    per-finding frozen-namespace floor — Codex review on #549: without
+    ``policy_file`` here, a policy override that downgrades a kind could still
+    silently exit 0 for a finding tagged ``frozen_namespace_violation``, even
+    though that same finding's annotation, via ``collect_annotations``, does
+    honour the floor and emits ``::error``) so per-library overrides are
+    honored in the exit code exactly as they are in the report.
 
     This only covers per-library findings and must run before ``_diff_result``
     entries are stripped; release-global bundle/matrix findings are folded in
@@ -379,7 +384,9 @@ def _compute_release_severity_exit_code(
             code = compute_exit_code(
                 diff.changes,
                 resolved_config,
+                policy=diff.policy,
                 kind_sets=diff._effective_kind_sets(),
+                policy_file=diff.policy_file,
             )
             worst = max(worst, code)
     return worst
@@ -427,7 +434,9 @@ def _fold_release_global_severity(
             compute_exit_code(
                 matrix_result.changes,
                 config,
+                policy=matrix_result.policy,
                 kind_sets=matrix_result._effective_kind_sets(),
+                policy_file=matrix_result.policy_file,
             ),
         )
     return worst

--- a/abicheck/cli_compare_release_helpers.py
+++ b/abicheck/cli_compare_release_helpers.py
@@ -507,7 +507,9 @@ def _format_release_summary(
 ) -> str:
     """Format the release comparison summary as JSON, markdown, or JUnit XML."""
     if fmt == "junit":
-        return _format_release_junit(diff_pairs, matrix_result, library_results)
+        return _format_release_junit(
+            diff_pairs, matrix_result, library_results, severity_config=severity_config,
+        )
     if fmt == "json":
         return _format_release_json(
             worst_verdict,
@@ -542,8 +544,18 @@ def _format_release_junit(
     diff_pairs: list[tuple[DiffResult, AbiSnapshot]] | None,
     matrix_result: DiffResult | None,
     library_results: list[dict[str, object]],
+    *,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
-    """Render the release summary as a JUnit XML report."""
+    """Render the release summary as a JUnit XML report.
+
+    *severity_config*, when given, is forwarded to
+    :func:`to_junit_xml_multi` (Codex review on #549) so a finding a severity
+    config promotes to ``error`` fails its JUnit testcase the same way it
+    contributes to the release's severity-aware exit code — otherwise a CI
+    dashboard reading this JUnit file could show zero failures for a release
+    that just exited non-zero on that exact finding.
+    """
     from .junit_report import to_junit_xml_multi
 
     pairs: list[tuple[DiffResult, AbiSnapshot | None]] = list(diff_pairs or [])
@@ -554,6 +566,7 @@ def _format_release_junit(
     error_libs = [entry for entry in library_results if entry.get("verdict") == "ERROR"]
     return to_junit_xml_multi(
         pairs,
+        severity_config=severity_config,
         error_libraries=error_libs if error_libs else None,
     )
 

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -1550,4 +1550,10 @@ MCP_CLI_NAME_MAP: dict[str, str | None] = {
     "report_mode": "--report-mode",
     "show_impact": "--show-impact",
     "stat": "--stat",
+    # severity-aware exit-code scheme
+    "severity_preset": "--severity-preset",
+    "severity_abi_breaking": "--severity-abi-breaking",
+    "severity_potential_breaking": "--severity-potential-breaking",
+    "severity_quality_issues": "--severity-quality-issues",
+    "severity_addition": "--severity-addition",
 }

--- a/abicheck/cli_scan_baseline.py
+++ b/abicheck/cli_scan_baseline.py
@@ -190,6 +190,34 @@ def _load_risk_rules(path: Path | None) -> RiskRules:
     return RiskRules.from_dict(block if isinstance(block, dict) else raw)
 
 
+#: Cap on findings embedded in the ``scan --baseline`` summary so a large
+#: diff cannot blow up the always-on scan text/JSON output; ``--format json``
+#: on the full ``compare`` command remains the way to see everything.
+_MAX_BASELINE_FINDINGS = 20
+
+
+def _baseline_finding_dicts(changes: list[Any], bucket: str) -> list[dict[str, Any]]:
+    """Project *changes* (one verdict bucket) into small, renderable dicts.
+
+    Reads only duck-typed attributes (not ``DiffResult`` internals) so this
+    stays safe to call against the lightweight fakes/stubs used in tests, not
+    just a real ``Change``.
+    """
+    findings = []
+    for c in changes:
+        kind = getattr(c, "kind", None)
+        findings.append(
+            {
+                "bucket": bucket,
+                "kind": getattr(kind, "value", str(kind)),
+                "symbol": getattr(c, "symbol", None),
+                "description": getattr(c, "description", None),
+                "source_location": getattr(c, "source_location", None),
+            }
+        )
+    return findings
+
+
 def _baseline_is_native_library(path: Path) -> bool:
     """True if *path* is a native binary, not a JSON / ABICC-dump snapshot.
 
@@ -368,12 +396,27 @@ def _run_baseline_compare(
         extra_changes=merged_extra,
         scope_to_public_surface=True,
     )
-    summary = {
+    summary: dict[str, Any] = {
         "breaking": len(diff.breaking),
         "api_break": len(diff.source_breaks),
         "risk": len(diff.risk),
         "compatible": len(diff.compatible),
     }
+    # Preserve the actual findings (kind/symbol/description/location), not just
+    # their counts — a failing `scan --baseline` used to report e.g.
+    # "breaking=1" with no way to tell which symbol broke without a separate
+    # `compare` run. Only the gating buckets are embedded (compatible findings
+    # are additions/quality noise this summary was never meant to itemize);
+    # capped so a large diff cannot blow up the always-on scan output.
+    findings = [
+        *_baseline_finding_dicts(diff.breaking, "breaking"),
+        *_baseline_finding_dicts(diff.source_breaks, "api_break"),
+        *_baseline_finding_dicts(diff.risk, "risk"),
+    ]
+    if findings:
+        summary["findings"] = findings[:_MAX_BASELINE_FINDINGS]
+        if len(findings) > _MAX_BASELINE_FINDINGS:
+            summary["findings_truncated"] = True
     verdict = diff.verdict.value
     if verdict == "BREAKING":
         exit_code = 4

--- a/abicheck/cli_scan_baseline.py
+++ b/abicheck/cli_scan_baseline.py
@@ -407,15 +407,23 @@ def _run_baseline_compare(
     # "breaking=1" with no way to tell which symbol broke without a separate
     # `compare` run. Only the gating buckets are embedded (compatible findings
     # are additions/quality noise this summary was never meant to itemize);
-    # capped so a large diff cannot blow up the always-on scan output.
-    findings = [
-        *_baseline_finding_dicts(diff.breaking, "breaking"),
-        *_baseline_finding_dicts(diff.source_breaks, "api_break"),
-        *_baseline_finding_dicts(diff.risk, "risk"),
-    ]
+    # capped so a large diff cannot blow up the always-on scan output. Counts
+    # (not dicts) decide truncation for each bucket so a large diff never
+    # builds more finding dicts than the cap can ever keep (CodeRabbit review).
+    total_gating = len(diff.breaking) + len(diff.source_breaks) + len(diff.risk)
+    findings: list[dict[str, Any]] = []
+    for bucket_name, bucket_changes in (
+        ("breaking", diff.breaking),
+        ("api_break", diff.source_breaks),
+        ("risk", diff.risk),
+    ):
+        remaining = _MAX_BASELINE_FINDINGS - len(findings)
+        if remaining <= 0:
+            break
+        findings.extend(_baseline_finding_dicts(bucket_changes[:remaining], bucket_name))
     if findings:
-        summary["findings"] = findings[:_MAX_BASELINE_FINDINGS]
-        if len(findings) > _MAX_BASELINE_FINDINGS:
+        summary["findings"] = findings
+        if total_gating > _MAX_BASELINE_FINDINGS:
             summary["findings_truncated"] = True
     verdict = diff.verdict.value
     if verdict == "BREAKING":

--- a/abicheck/cli_scan_helpers.py
+++ b/abicheck/cli_scan_helpers.py
@@ -325,10 +325,15 @@ def render_preprocessor_lines(out: Any) -> list[str]:
 
 
 def render_baseline_lines(out: Any) -> list[str]:
-    """The baseline comparison summary block (empty without a baseline diff)."""
+    """The baseline comparison summary block (empty without a baseline diff).
+
+    Beyond the counts, lists the actual findings (kind/symbol/location) the
+    baseline compare produced — a bare "breaking=1" count is not actionable
+    without naming what broke (see ``_run_baseline_compare``'s ``findings``).
+    """
     if out.diff_summary is None:
         return []
-    return [
+    lines = [
         "",
         "Baseline comparison",
         f"  breaking={out.diff_summary['breaking']} "
@@ -336,6 +341,15 @@ def render_baseline_lines(out: Any) -> list[str]:
         f"risk={out.diff_summary['risk']} "
         f"compatible={out.diff_summary['compatible']}",
     ]
+    for f in out.diff_summary.get("findings", []):
+        loc = f" ({f['source_location']})" if f.get("source_location") else ""
+        symbol = f.get("symbol") or "?"
+        lines.append(f"    [{f['bucket']}] {f['kind']}: {symbol}{loc}")
+    if out.diff_summary.get("findings_truncated"):
+        lines.append(
+            "    … additional findings omitted; rerun `compare` for the full list"
+        )
+    return lines
 
 
 def render_verdict_lines(out: Any) -> list[str]:

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -64,7 +64,10 @@ if TYPE_CHECKING:
     from .checker import DiffResult
 
 
-def _change_bucket(change: object) -> str:
+def _change_bucket(
+    change: object,
+    effective_verdict: Callable[[object], object] | None = None,
+) -> str:
     """Classify a change into 'removed', 'added', or 'changed'.
 
     A kind in ``ADDED_KINDS`` is excluded from the 'added' bucket when it is
@@ -73,11 +76,26 @@ def _change_bucket(change: object) -> str:
     its sibling ``type_field_added_compatible``). Without this guard, a
     structurally-additive but ABI-breaking finding would render under the
     green "Added" section, reading as safe when it is not.
+
+    *effective_verdict*, when given (typically
+    ``result._effective_verdict_for_change``), is also consulted for
+    otherwise-additive kinds: a policy file can escalate an inherently
+    additive kind (e.g. ``func_added: BREAKING``) to ``Verdict.BREAKING``,
+    which the canonical ``BREAKING_KINDS`` membership check above can never
+    see since it only looks at the kind's own default classification.
+    Without this, such a finding would still render in the green "Added"
+    section even though the compatibility metrics on the same page count it
+    as breaking.
     """
     ks = kind_str(change)
     if ks in REMOVED_KINDS:
         return "removed"
     if ks in ADDED_KINDS and ks not in BREAKING_KINDS:
+        if effective_verdict is not None:
+            from .checker import Verdict
+
+            if effective_verdict(change) == Verdict.BREAKING:
+                return "changed"
         return "added"
     return "changed"
 
@@ -672,10 +690,19 @@ def generate_html_report(
     suppressed: list[object] = list(getattr(result, "suppressed_changes", None) or [])
     suppressed_count: int = getattr(result, "suppressed_count", len(suppressed))
 
-    # Split display changes into buckets (for rendering)
-    removed = [ch for ch in display_changes if _change_bucket(ch) == "removed"]
-    added = [ch for ch in display_changes if _change_bucket(ch) == "added"]
-    changed = [ch for ch in display_changes if _change_bucket(ch) == "changed"]
+    # Split display changes into buckets (for rendering). Duck-typed via
+    # getattr (like the compatibility_metrics call below) so a lightweight
+    # stub result without a real DiffResult's policy machinery still renders.
+    _effective_verdict_fn = getattr(result, "_effective_verdict_for_change", None)
+    removed = [
+        ch for ch in display_changes if _change_bucket(ch, _effective_verdict_fn) == "removed"
+    ]
+    added = [
+        ch for ch in display_changes if _change_bucket(ch, _effective_verdict_fn) == "added"
+    ]
+    changed = [
+        ch for ch in display_changes if _change_bucket(ch, _effective_verdict_fn) == "changed"
+    ]
 
     # Metrics always use the full (unfiltered) change list. policy/kind_sets/
     # policy_file make the Binary Compatibility % agree with the verdict

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -80,12 +80,14 @@ def _change_bucket(
     *effective_verdict*, when given (typically
     ``result._effective_verdict_for_change``), is also consulted for
     otherwise-additive kinds: a policy file can escalate an inherently
-    additive kind (e.g. ``func_added: BREAKING``) to ``Verdict.BREAKING``,
-    which the canonical ``BREAKING_KINDS`` membership check above can never
-    see since it only looks at the kind's own default classification.
-    Without this, such a finding would still render in the green "Added"
-    section even though the compatibility metrics on the same page count it
-    as breaking.
+    additive kind (e.g. ``func_added``) to ``Verdict.BREAKING``,
+    ``Verdict.API_BREAK``, or ``Verdict.COMPATIBLE_WITH_RISK`` — none of
+    which the canonical ``BREAKING_KINDS`` membership check above can ever
+    see, since it only looks at the kind's own default classification.
+    Any effective verdict other than ``Verdict.COMPATIBLE`` means the
+    finding needs review, so it is excluded from "added" here too — not
+    just the ``BREAKING`` case — to match the compatibility metrics and
+    verdict banner on the same page.
     """
     ks = kind_str(change)
     if ks in REMOVED_KINDS:
@@ -94,7 +96,7 @@ def _change_bucket(
         if effective_verdict is not None:
             from .checker import Verdict
 
-            if effective_verdict(change) == Verdict.BREAKING:
+            if effective_verdict(change) != Verdict.COMPATIBLE:
                 return "changed"
         return "added"
     return "changed"

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -49,6 +49,7 @@ from .html_template import (
 )
 from .report_classifications import (
     ADDED_KINDS,
+    BREAKING_KINDS,
     CATEGORY_PREFIXES,
     REMOVED_KINDS,
     category,
@@ -64,11 +65,19 @@ if TYPE_CHECKING:
 
 
 def _change_bucket(change: object) -> str:
-    """Classify a change into 'removed', 'added', or 'changed'."""
+    """Classify a change into 'removed', 'added', or 'changed'.
+
+    A kind in ``ADDED_KINDS`` is excluded from the 'added' bucket when it is
+    also a canonical breaking kind (e.g. ``type_field_added`` — appending a
+    field to a non-final/polymorphic type can break binary layout, unlike
+    its sibling ``type_field_added_compatible``). Without this guard, a
+    structurally-additive but ABI-breaking finding would render under the
+    green "Added" section, reading as safe when it is not.
+    """
     ks = kind_str(change)
     if ks in REMOVED_KINDS:
         return "removed"
-    if ks in ADDED_KINDS:
+    if ks in ADDED_KINDS and ks not in BREAKING_KINDS:
         return "added"
     return "changed"
 
@@ -668,8 +677,23 @@ def generate_html_report(
     added = [ch for ch in display_changes if _change_bucket(ch) == "added"]
     changed = [ch for ch in display_changes if _change_bucket(ch) == "changed"]
 
-    # Metrics always use the full (unfiltered) change list
-    metrics = compatibility_metrics(cast(list[HasKind], all_changes), old_symbol_count)
+    # Metrics always use the full (unfiltered) change list. policy/kind_sets/
+    # policy_file make the Binary Compatibility % agree with the verdict
+    # banner above: without them, a policy-demoted removal still counts
+    # toward breaking_count by its raw kind, producing e.g. "0.0% binary
+    # compatibility" on the same page whose verdict reads COMPATIBLE.
+    # Duck-typed via getattr (like the rest of this function) so a
+    # lightweight stub result without a real DiffResult's policy machinery
+    # still renders — compatibility_metrics falls back to raw-kind counting
+    # when kind_sets is None.
+    _eff_kind_sets_fn = getattr(result, "_effective_kind_sets", None)
+    metrics = compatibility_metrics(
+        cast(list[HasKind], all_changes),
+        old_symbol_count,
+        policy=getattr(result, "policy", None),
+        kind_sets=_eff_kind_sets_fn() if callable(_eff_kind_sets_fn) else None,
+        policy_file=getattr(result, "policy_file", None),
+    )
     breaking_count = metrics.breaking_count
     bc_pct = metrics.binary_compatibility_pct
     affected_pct = metrics.affected_pct

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -104,16 +104,20 @@ def _is_failure(
     escalation guards — so the JUnit file can never disagree with the JSON
     report or the severity-aware exit code.
 
-    BREAKING and API_BREAK verdicts always fail. COMPATIBLE_WITH_RISK fails
-    only when its per-kind severity is ``"error"`` (currently all RISK_KINDS
-    default to ``"warning"``, so they pass), unless *severity_config* (from
-    ``--severity-preset`` or ``--severity-*`` overrides) escalates the
-    finding's effective category to error — which also applies to a plain
-    COMPATIBLE verdict (e.g. under ``--severity-preset strict``).
+    When *severity_config* is given (from ``--severity-preset`` or
+    ``--severity-*`` overrides), it is the sole source of truth — a finding
+    fails only when its effective category's configured level is
+    ``"error"`` — mirroring :func:`abicheck.severity.compute_exit_code`
+    exactly, so the JUnit file can never disagree with the severity-aware
+    exit code. A demoted preset (e.g. ``--severity-preset info-only``) must
+    make even a BREAKING/API_BREAK verdict pass here, just as it does for
+    the exit code.
+
+    Without a *severity_config* (legacy verdict-based scheme): BREAKING and
+    API_BREAK verdicts always fail. COMPATIBLE_WITH_RISK fails only when its
+    per-kind severity is ``"error"`` (currently all RISK_KINDS default to
+    ``"warning"``, so they pass).
     """
-    verdict = result._effective_verdict_for_change(change)
-    if verdict in (Verdict.BREAKING, Verdict.API_BREAK):
-        return True
     if severity_config is not None:
         from .severity import SeverityLevel, classify_effective_change
 
@@ -124,6 +128,9 @@ def _is_failure(
             policy_file=result.policy_file,
         )
         return severity_config.level_for(cat) == SeverityLevel.ERROR
+    verdict = result._effective_verdict_for_change(change)
+    if verdict in (Verdict.BREAKING, Verdict.API_BREAK):
+        return True
     # COMPATIBLE_WITH_RISK never fails without a severity_config: all
     # RISK_KINDS default to severity "warning" in the policy registry. This
     # must NOT consult policy_for(change.kind) directly — for a demoted

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -33,7 +33,10 @@ import platform
 import sys
 import time as _time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .severity import SeverityConfig
 
 try:
     from mcp.server.fastmcp import FastMCP
@@ -374,8 +377,16 @@ def _render_output(
     report_mode: str = "full",
     show_impact: bool = False,
     stat: bool = False,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
-    """Render comparison result in the requested output format."""
+    """Render comparison result in the requested output format.
+
+    *severity_config*, when given, is forwarded to every format that
+    supports it (json, sarif, markdown, stat) so an MCP caller passing
+    ``severity_*`` arguments to :func:`abi_compare` gets the same
+    severity-aware report content the CLI's ``--severity-*`` flags produce —
+    without it, the MCP surface had no severity configuration at all.
+    """
     if fmt not in _VALID_FORMATS:
         msg = f"Unknown output format {fmt!r}. Valid formats: {sorted(_VALID_FORMATS)}"
         raise ValueError(msg)
@@ -383,21 +394,22 @@ def _render_output(
         if fmt == "json":
             from .reporter import to_stat_json
 
-            return to_stat_json(result)
+            return to_stat_json(result, severity_config=severity_config)
         from .reporter import to_stat
 
-        return to_stat(result)
+        return to_stat(result, severity_config=severity_config)
     if fmt == "json":
         return to_json(
             result,
             show_only=show_only,
             report_mode=report_mode,
             show_impact=show_impact,
+            severity_config=severity_config,
         )
     if fmt == "sarif":
         from .sarif import to_sarif_str
 
-        return to_sarif_str(result, show_only=show_only)
+        return to_sarif_str(result, show_only=show_only, severity_config=severity_config)
     if fmt == "html":
         from .html_report import generate_html_report
 
@@ -411,7 +423,11 @@ def _render_output(
             show_impact=show_impact,
         )
     return to_markdown(
-        result, show_only=show_only, report_mode=report_mode, show_impact=show_impact
+        result,
+        show_only=show_only,
+        report_mode=report_mode,
+        show_impact=show_impact,
+        severity_config=severity_config,
     )
 
 
@@ -553,6 +569,11 @@ def abi_compare(
     report_mode: str = "full",
     show_impact: bool = False,
     stat: bool = False,
+    severity_preset: str | None = None,
+    severity_abi_breaking: str | None = None,
+    severity_potential_breaking: str | None = None,
+    severity_quality_issues: str | None = None,
+    severity_addition: str | None = None,
 ) -> str:
     """Compare two ABI surfaces and report breaking changes.
 
@@ -566,6 +587,15 @@ def abi_compare(
     - COMPATIBLE_WITH_RISK: binary-compatible but deployment risk present
     - API_BREAK: source-level break (recompilation needed)
     - BREAKING: binary ABI break (old binaries will crash)
+
+    Without any ``severity_*`` argument, ``exit_code`` follows the legacy
+    verdict-based scheme (0/2/4, matching the verdicts above). Compatibility
+    and "blocks CI" are independent decisions once severity configuration is
+    in play (e.g. an addition can be configured to gate CI despite a
+    COMPATIBLE verdict) — passing any ``severity_*`` argument switches
+    ``exit_code``/``exit_code_scheme`` to the severity-aware scheme (mirrors
+    the CLI's ``--severity-*`` flags) and populates a ``severity`` block in a
+    JSON ``report``.
 
     Args:
         old_input: Path to old library (.so/.dll/.dylib) or JSON snapshot.
@@ -585,6 +615,14 @@ def abi_compare(
         report_mode: "full" (default) or "leaf" (root-type-grouped view).
         show_impact: If True, append an impact summary table.
         stat: If True, emit one-line summary instead of full report.
+        severity_preset: Severity preset: "default", "strict", or "info-only".
+            Presence of this (or any other severity_* argument) switches
+            exit_code to the severity-aware scheme.
+        severity_abi_breaking: Override severity for abi_breaking findings
+            ("error", "warning", or "info").
+        severity_potential_breaking: Override severity for potential_breaking findings.
+        severity_quality_issues: Override severity for quality_issues findings.
+        severity_addition: Override severity for addition findings.
     """
     t0 = _time.monotonic()
     try:
@@ -608,6 +646,33 @@ def abi_compare(
                     f"Valid policies: {', '.join(sorted(VALID_BASE_POLICIES))}",
                 }
             )
+
+        # Resolve severity config (any severity_* argument opts into the
+        # severity-aware exit-code scheme, matching the CLI's --severity-*
+        # flags). Validated early, before the expensive compare work.
+        severity_config: SeverityConfig | None = None
+        if any(
+            (
+                severity_preset,
+                severity_abi_breaking,
+                severity_potential_breaking,
+                severity_quality_issues,
+                severity_addition,
+            )
+        ):
+            from .errors import PolicyError
+            from .severity import resolve_severity_config
+
+            try:
+                severity_config = resolve_severity_config(
+                    severity_preset,
+                    abi_breaking=severity_abi_breaking,
+                    potential_breaking=severity_potential_breaking,
+                    quality_issues=severity_quality_issues,
+                    addition=severity_addition,
+                )
+            except PolicyError as exc:
+                return json.dumps({"status": "error", "error": str(exc)})
 
         # Resolve per-side headers
         shared = [_safe_read_path(h, label="header") for h in (headers or [])]
@@ -701,18 +766,33 @@ def abi_compare(
         # policy_file overrides the base policy).
         active_policy = result.policy
 
-        # Determine exit code (matches CLI semantics)
-        exit_code = 0
-        if result.verdict == Verdict.BREAKING:
-            exit_code = 4
-        elif result.verdict == Verdict.API_BREAK:
-            exit_code = 2
+        # Determine exit code: severity-aware scheme when any severity_*
+        # argument was given (compatibility and "blocks CI" are independent
+        # decisions once severity configuration is in play), else the legacy
+        # verdict scheme (matches CLI semantics).
+        if severity_config is not None:
+            from .severity import compute_exit_code
+
+            exit_code = compute_exit_code(
+                result.changes,
+                severity_config,
+                policy=result.policy,
+                kind_sets=result._effective_kind_sets(),
+                policy_file=result.policy_file,
+            )
+        else:
+            exit_code = 0
+            if result.verdict == Verdict.BREAKING:
+                exit_code = 4
+            elif result.verdict == Verdict.API_BREAK:
+                exit_code = 2
 
         # Build structured response
         response: dict[str, Any] = {
             "status": "ok",
             "verdict": result.verdict.value,
             "exit_code": exit_code,
+            "exit_code_scheme": "severity" if severity_config is not None else "legacy",
             "summary": {
                 "breaking": len(result.breaking),
                 "api_breaks": len(result.source_breaks),
@@ -745,6 +825,7 @@ def abi_compare(
             report_mode=report_mode,
             show_impact=show_impact,
             stat=stat,
+            severity_config=severity_config,
         )
         # When format is json, embed as nested object (not double-encoded string)
         if output_format == "json":

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -652,7 +652,8 @@ def abi_compare(
         # flags). Validated early, before the expensive compare work.
         severity_config: SeverityConfig | None = None
         if any(
-            (
+            value is not None
+            for value in (
                 severity_preset,
                 severity_abi_breaking,
                 severity_potential_breaking,

--- a/abicheck/report_summary.py
+++ b/abicheck/report_summary.py
@@ -94,7 +94,7 @@ def compatibility_metrics(
 ) -> CompatibilityMetrics:
     """Compute canonical ABICC-style binary compatibility counters/percentages.
 
-    Without *kind_sets*/*policy_file*, ``breaking_count`` counts raw
+    Without *policy*/*kind_sets*/*policy_file*, ``breaking_count`` counts raw
     ``ChangeKind`` membership in the canonical ``_BREAKING_KINDS`` set —
     which disagrees with a policy-demoted finding's *effective* verdict. A
     removal a policy file demotes to ``COMPATIBLE`` still carries its raw
@@ -102,11 +102,15 @@ def compatibility_metrics(
     breaking (e.g. "0.0% binary compatibility") on the same page whose
     verdict banner reads ``COMPATIBLE`` (computed from the *effective*
     verdict) — a direct, visible contradiction. Passing *kind_sets* (from
-    ``DiffResult._effective_kind_sets()``) and *policy_file* makes this
+    ``DiffResult._effective_kind_sets()``) and/or *policy_file* makes this
     metric agree with the verdict by counting each change's effective
-    verdict instead of its raw kind.
+    verdict instead of its raw kind. A named *policy* alone (e.g.
+    ``plugin_abi``, with no ``kind_sets``/``policy_file``) must also take
+    this path — ``effective_verdict_for_change`` resolves its own kind sets
+    from *policy* when *kind_sets* is ``None`` (Codex review on #549) — or a
+    policy-downgraded kind would still be counted as breaking here.
     """
-    if kind_sets is not None or policy_file is not None:
+    if policy is not None or kind_sets is not None or policy_file is not None:
         from .checker_policy import Verdict as _Verdict
         from .severity import effective_verdict_for_change
 

--- a/abicheck/report_summary.py
+++ b/abicheck/report_summary.py
@@ -18,9 +18,13 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from .checker import _BREAKING_KINDS, DiffResult
 from .checker_policy import HasKind
+
+if TYPE_CHECKING:
+    from .severity import KindSets
 
 # Re-exported under its historical name; the implementation (and the prefix
 # tables it relies on) now lives in the canonical name_classification module.
@@ -81,10 +85,41 @@ class CompatibilityMetrics:
 
 
 def compatibility_metrics(
-    changes: Sequence[HasKind], old_symbol_count: int | None = None
+    changes: Sequence[HasKind],
+    old_symbol_count: int | None = None,
+    *,
+    policy: str | None = None,
+    kind_sets: KindSets | None = None,
+    policy_file: object | None = None,
 ) -> CompatibilityMetrics:
-    """Compute canonical ABICC-style binary compatibility counters/percentages."""
-    breaking_count = sum(1 for c in changes if c.kind in _BREAKING_KINDS)
+    """Compute canonical ABICC-style binary compatibility counters/percentages.
+
+    Without *kind_sets*/*policy_file*, ``breaking_count`` counts raw
+    ``ChangeKind`` membership in the canonical ``_BREAKING_KINDS`` set —
+    which disagrees with a policy-demoted finding's *effective* verdict. A
+    removal a policy file demotes to ``COMPATIBLE`` still carries its raw
+    ``FUNC_REMOVED`` kind, so the canonical-kind count would report it as
+    breaking (e.g. "0.0% binary compatibility") on the same page whose
+    verdict banner reads ``COMPATIBLE`` (computed from the *effective*
+    verdict) — a direct, visible contradiction. Passing *kind_sets* (from
+    ``DiffResult._effective_kind_sets()``) and *policy_file* makes this
+    metric agree with the verdict by counting each change's effective
+    verdict instead of its raw kind.
+    """
+    if kind_sets is not None or policy_file is not None:
+        from .checker_policy import Verdict as _Verdict
+        from .severity import effective_verdict_for_change
+
+        breaking_count = sum(
+            1
+            for c in changes
+            if effective_verdict_for_change(
+                c, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+            )
+            == _Verdict.BREAKING
+        )
+    else:
+        breaking_count = sum(1 for c in changes if c.kind in _BREAKING_KINDS)
 
     if breaking_count == 0:
         bc_pct = 100.0
@@ -107,7 +142,13 @@ def compatibility_metrics(
 
 
 def build_summary(result: DiffResult) -> ReportSummary:
-    metrics = compatibility_metrics(result.changes, result.old_symbol_count)
+    metrics = compatibility_metrics(
+        result.changes,
+        result.old_symbol_count,
+        policy=result.policy,
+        kind_sets=result._effective_kind_sets(),
+        policy_file=result.policy_file,
+    )
     return ReportSummary(
         breaking=len(result.breaking),
         source_breaks=len(result.source_breaks),

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -292,7 +292,9 @@ def _to_json_leaf(
 
     leaf_changes_list = [_leaf_entry(c) for c in type_changes]
     non_type_list = [
-        _change_to_dict(c, policy=effective_policy, kind_sets=eff_sets)
+        _change_to_dict(
+            c, policy=effective_policy, kind_sets=eff_sets, policy_file=result.policy_file,
+        )
         for c in non_type_changes
     ]
 

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -87,33 +87,32 @@ def _effective_severity_label(
         frozenset[ChangeKind],
         frozenset[ChangeKind],
     ],
+    *,
+    policy: str | None = None,
+    policy_file: object | None = None,
 ) -> str:
     """Severity label for a change, honouring its A4 ``effective_verdict``.
 
     The one place the reporter decides a finding's severity bucket: routes
-    through :func:`effective_category` so an ADR-027 pattern-aware demotion reads
-    ``compatible`` in the JSON ``severity`` field and the ``filtered_summary``
-    counts, consistent with the verdict and exit code.
+    through :func:`effective_verdict_for_change` (the same call
+    :func:`_change_to_dict` already makes) so an ADR-027 pattern-aware
+    demotion, *and* a per-change frozen-namespace floor guarding a
+    ``policy_file`` kind-level override, both read consistently with the
+    verdict and exit code. Without *policy_file* here, a leaf-mode root-type
+    change tagged ``frozen_namespace_violation`` could read "compatible" in
+    ``leaf_changes`` while the top-level ``severity`` block (which does pass
+    ``policy_file``) correctly reports it as blocking the gate — a direct,
+    visible contradiction on the same JSON document (Codex review on #549).
     """
     kind = getattr(c, "kind", None)
-    if kind is None:
+    if not isinstance(kind, ChangeKind):
         return "unknown"
-    # An explicit A4 override wins; otherwise fall back to the exact set-based
-    # logic (which yields "unknown" for a kind moved out of every set, e.g. an
-    # override to NO_CHANGE) rather than effective_category's BREAKING fail-safe.
-    eff = getattr(c, "effective_verdict", None)
-    if isinstance(eff, Verdict):
-        return _VERDICT_TO_SEVERITY_LABEL.get(eff, "unknown")
-    breaking, api_break, compatible, risk = kind_sets
-    if kind in breaking:
-        return "breaking"
-    if kind in api_break:
-        return "api_break"
-    if kind in risk:
-        return "risk"
-    if kind in compatible:
-        return "compatible"
-    return "unknown"
+    from .severity import effective_verdict_for_change
+
+    verdict = effective_verdict_for_change(
+        cast(HasKind, c), policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+    )
+    return _VERDICT_TO_SEVERITY_LABEL.get(verdict, "unknown")
 
 
 def _kind_to_severity(kind: ChangeKind, policy: str) -> str:
@@ -268,7 +267,9 @@ def _to_json_leaf(
             "kind": c.kind.value,
             "symbol": c.symbol,
             "description": c.description,
-            "severity": _effective_severity_label(c, eff_sets),
+            "severity": _effective_severity_label(
+                c, eff_sets, policy=result.policy, policy_file=result.policy_file,
+            ),
             "affected_count": len(c.affected_symbols) if c.affected_symbols else 0,
             "affected_symbols": c.affected_symbols or [],
             "caused_count": c.caused_count,

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -130,8 +130,18 @@ def _kind_to_severity(kind: ChangeKind, policy: str) -> str:
     return "unknown"
 
 
-def to_stat_json(result: DiffResult, indent: int = 2) -> str:
-    """JSON output for --stat mode: summary only, no changes array."""
+def to_stat_json(
+    result: DiffResult, indent: int = 2, *, severity_config: SeverityConfig | None = None,
+) -> str:
+    """JSON output for --stat mode: summary only, no changes array.
+
+    *severity_config*, when given, adds a ``severity`` block (same shape as
+    the full JSON report's — see :func:`_build_severity_json`) so ``--stat
+    --format json`` reflects the actual severity-aware gate instead of only
+    the compatibility verdict. Without it, ``--stat`` output has historically
+    bypassed severity handling entirely (it short-circuits in
+    ``service.render_output`` before format dispatch).
+    """
     summary = build_summary(result)
     effective_policy = result.policy or "strict_abi"
     d: dict[str, object] = {
@@ -151,6 +161,14 @@ def to_stat_json(result: DiffResult, indent: int = 2) -> str:
             "affected_pct": round(summary.affected_pct, 1),
         },
     }
+    if severity_config is not None:
+        d["severity"] = _build_severity_json(
+            list(result.changes),
+            severity_config,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
     d["release_recommendation"] = recommend_release(result).to_dict()
     if result.redundant_count > 0:
         d["redundant_count"] = result.redundant_count

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -240,8 +240,17 @@ def _to_json_leaf(
     result: DiffResult,
     indent: int = 2,
     show_only: str | None = None,
+    *,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
-    """Leaf-change mode JSON output."""
+    """Leaf-change mode JSON output.
+
+    *severity_config*, when given, adds the same top-level ``severity`` block
+    the full-mode JSON report has (see :func:`_build_severity_json`) —
+    without it, ``--report-mode leaf`` returned before that block was ever
+    built, so it silently had no severity information even when a caller
+    passed ``severity_config`` through :func:`to_json`.
+    """
     from .checker import _ROOT_TYPE_CHANGE_KINDS
 
     summary = build_summary(result)
@@ -305,6 +314,15 @@ def _to_json_leaf(
         # FIX-H: populate changes with union for backward-compat consumers
         "changes": leaf_changes_list + non_type_list,
     }
+    if severity_config is not None:
+        d["severity"] = _build_severity_json(
+            changes,
+            severity_config,
+            all_changes=list(result.changes),
+            policy=result.policy,
+            kind_sets=eff_sets,
+            policy_file=result.policy_file,
+        )
     # Release recommendation — always present in JSON, including leaf mode.
     d["release_recommendation"] = recommend_release(result).to_dict()
     if result.redundant_count > 0:
@@ -552,7 +570,9 @@ def to_json(
         return to_stat_json(result, indent=indent)
 
     if report_mode == "leaf":
-        return _to_json_leaf(result, indent=indent, show_only=show_only)
+        return _to_json_leaf(
+            result, indent=indent, show_only=show_only, severity_config=severity_config,
+        )
 
     changes = list(result.changes)
     if show_only:

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -163,7 +163,7 @@ def to_stat_json(
     }
     if severity_config is not None:
         d["severity"] = _build_severity_json(
-            list(result.changes),
+            result.changes,
             severity_config,
             policy=result.policy,
             kind_sets=result._effective_kind_sets(),
@@ -567,7 +567,7 @@ def to_json(
     severity_config: SeverityConfig | None = None,
 ) -> str:
     if stat:
-        return to_stat_json(result, indent=indent)
+        return to_stat_json(result, indent=indent, severity_config=severity_config)
 
     if report_mode == "leaf":
         return _to_json_leaf(

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -452,6 +452,7 @@ def _to_markdown_leaf(
         lines += _build_severity_summary_md(
             changes,
             severity_config,
+            all_changes=list(result.changes),
             policy=result.policy,
             kind_sets=result._effective_kind_sets(),
             policy_file=result.policy_file,
@@ -559,11 +560,19 @@ def _build_severity_summary_md(
     changes: list[Change],
     severity_config: SeverityConfig,
     *,
+    all_changes: list[Change] | None = None,
     policy: str | None = None,
     kind_sets: KindSets | None = None,
     policy_file: object | None = None,
 ) -> list[str]:
-    """Build a severity configuration summary table for markdown output."""
+    """Build a severity configuration summary table for markdown output.
+
+    *changes* are the (possibly ``--show-only``-filtered) changes used for
+    the displayed ``Count`` column. *all_changes*, when provided, is the
+    unfiltered set used for the ``Exit Impact`` column so that filtering the
+    display doesn't make this table claim "no exit impact" for a category
+    that still fails the actual (unfiltered) severity gate.
+    """
     from .severity import SeverityLevel, categorize_changes
 
     categorized = categorize_changes(
@@ -572,6 +581,16 @@ def _build_severity_summary_md(
         kind_sets=kind_sets,
         policy_file=policy_file,
     )
+    exit_categorized = (
+        categorize_changes(
+            all_changes,
+            policy=policy,
+            kind_sets=kind_sets,
+            policy_file=policy_file,
+        )
+        if all_changes is not None
+        else categorized
+    )
     lines = [
         "## Severity Configuration",
         "",
@@ -579,25 +598,41 @@ def _build_severity_summary_md(
         "|----------|----------|-------|-------------|",
     ]
 
-    _CATEGORY_INFO: list[tuple[str, str, list[HasKind]]] = [
-        ("ABI/API Incompatibilities", "abi_breaking", categorized.abi_breaking),
+    _CATEGORY_INFO: list[tuple[str, str, list[HasKind], list[HasKind]]] = [
+        (
+            "ABI/API Incompatibilities",
+            "abi_breaking",
+            categorized.abi_breaking,
+            exit_categorized.abi_breaking,
+        ),
         (
             "Potential Incompatibilities",
             "potential_breaking",
             categorized.potential_breaking,
+            exit_categorized.potential_breaking,
         ),
-        ("Quality Issues", "quality_issues", categorized.quality_issues),
-        ("Additions", "addition", categorized.addition),
+        (
+            "Quality Issues",
+            "quality_issues",
+            categorized.quality_issues,
+            exit_categorized.quality_issues,
+        ),
+        (
+            "Additions",
+            "addition",
+            categorized.addition,
+            exit_categorized.addition,
+        ),
     ]
 
-    for label, attr, cat_changes in _CATEGORY_INFO:
+    for label, attr, cat_changes, exit_cat_changes in _CATEGORY_INFO:
         level = getattr(severity_config, attr, SeverityLevel.INFO)
         level_val = level.value if hasattr(level, "value") else str(level)
         emoji = _SEVERITY_EMOJI.get(level_val, "")
         count = len(cat_changes)
         impact = (
             "causes non-zero exit"
-            if level_val == "error" and count > 0
+            if level_val == "error" and len(exit_cat_changes) > 0
             else "no exit impact"
         )
         lines.append(
@@ -963,6 +998,7 @@ def to_markdown(
         lines += _build_severity_summary_md(
             changes,
             severity_config,
+            all_changes=list(result.changes),
             policy=result.policy,
             kind_sets=result._effective_kind_sets(),
             policy_file=result.policy_file,

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -702,7 +702,35 @@ _VERDICT_MERGE_EFFECT = {
 }
 
 
-def to_review_digest(result: DiffResult) -> str:
+def _severity_merge_effect(result: DiffResult, severity_config: SeverityConfig) -> str:
+    """Merge-effect phrase reflecting the actual severity-aware gate.
+
+    Compatibility (``result.verdict``) and the CI gate are independent
+    decisions once a severity configuration is in play — e.g. an ``addition``
+    finding configured as ``error`` blocks the build even though the verdict
+    is ``COMPATIBLE``, and an ``abi_breaking`` finding configured below
+    ``error`` does not. The hard-coded ``_VERDICT_MERGE_EFFECT`` phrases would
+    misreport both cases, so this asks the severity gate directly instead of
+    inferring "safe to merge" from the verdict alone.
+    """
+    from .severity import compute_exit_code
+
+    eff_sets = result._effective_kind_sets()
+    exit_code = compute_exit_code(
+        result.changes,
+        severity_config,
+        policy=result.policy,
+        kind_sets=eff_sets,
+        policy_file=result.policy_file,
+    )
+    if exit_code == 0:
+        return "no error-level findings under the configured severity policy — safe to merge"
+    return "blocked by severity policy — review required before merge"
+
+
+def to_review_digest(
+    result: DiffResult, *, severity_config: SeverityConfig | None = None,
+) -> str:
     """Compact GitHub-facing review digest (Markdown).
 
     A single, reviewer-oriented summary suitable for a job summary
@@ -712,12 +740,21 @@ def to_review_digest(result: DiffResult) -> str:
     public-header scoping fell back (issue #235), and the top impacted symbols.
     Distinct from to_markdown (the full report) — this is the "presentation"
     layer over the same machine-readable decision contract.
+
+    *severity_config*, when given, drives the merge-effect phrase from the
+    actual severity-aware CI gate instead of the raw compatibility verdict —
+    compatibility and "blocks CI" are independent decisions once severity
+    configuration is in play (see :func:`_severity_merge_effect`).
     """
     summary = build_summary(result)
     v = result.verdict
     emoji = _VERDICT_EMOJI.get(v, "?")
     label = _VERDICT_LABEL.get(v, v.value)
-    effect = _VERDICT_MERGE_EFFECT.get(v, "")
+    effect = (
+        _severity_merge_effect(result, severity_config)
+        if severity_config is not None
+        else _VERDICT_MERGE_EFFECT.get(v, "")
+    )
 
     lines: list[str] = [
         f"## ABI review — `{result.library}` {result.old_version} → {result.new_version}",

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -65,8 +65,16 @@ _VERDICT_LABEL = {
 # ---------------------------------------------------------------------------
 
 
-def to_stat(result: DiffResult) -> str:
-    """One-line summary for CI gates."""
+def to_stat(result: DiffResult, *, severity_config: SeverityConfig | None = None) -> str:
+    """One-line summary for CI gates.
+
+    *severity_config*, when given, appends a ``gate: PASS|FAIL`` suffix
+    reflecting the actual severity-aware exit code — without it, ``--stat``
+    output has historically bypassed severity handling entirely (it
+    short-circuits in ``service.render_output`` before format dispatch), so
+    the verdict label alone could misreport whether the run actually blocks
+    CI once severity configuration is in play.
+    """
     summary = build_summary(result)
     label = _VERDICT_LABEL[result.verdict]
     parts = []
@@ -82,7 +90,24 @@ def to_stat(result: DiffResult) -> str:
     redundant_note = ""
     if result.redundant_count > 0:
         redundant_note = f" [{result.redundant_count} redundant hidden]"
-    return f"{label}: {detail} ({summary.total_changes} total){redundant_note}"
+    gate_note = ""
+    if severity_config is not None:
+        from .severity import compute_exit_code
+
+        exit_code = compute_exit_code(
+            result.changes,
+            severity_config,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
+        gate_note = (
+            f" [gate: FAIL (exit {exit_code})]" if exit_code else " [gate: PASS]"
+        )
+    return (
+        f"{label}: {detail} ({summary.total_changes} total)"
+        f"{redundant_note}{gate_note}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -408,8 +408,18 @@ def _to_markdown_leaf(
     show_impact: bool = False,
     show_only: str | None = None,
     show_recommendation: bool = False,
+    *,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
-    """Leaf-change mode: root type changes with affected interface lists."""
+    """Leaf-change mode: root type changes with affected interface lists.
+
+    *severity_config*, when given, adds the same "Severity Configuration"
+    summary section the full-mode report has (see
+    :func:`_build_severity_summary_md`) — without it, ``report_mode="leaf"``
+    returned before that section was ever built, so it silently had no
+    severity information even when a caller passed ``severity_config``
+    through :func:`to_markdown`.
+    """
     from .checker import _ROOT_TYPE_CHANGE_KINDS
 
     v = result.verdict
@@ -437,6 +447,15 @@ def _to_markdown_leaf(
             f"> Filtered by: `--show-only {show_only}` ({len(changes)} of {len(result.changes)} changes shown)"
         )
         lines.append("")
+
+    if severity_config is not None:
+        lines += _build_severity_summary_md(
+            changes,
+            severity_config,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
 
     # Group root type changes by severity
     type_changes = [c for c in changes if c.kind in _ROOT_TYPE_CHANGE_KINDS]
@@ -875,7 +894,7 @@ def to_markdown(
         return demangle_text(text)
 
     if stat:
-        return _out(to_stat(result))
+        return _out(to_stat(result, severity_config=severity_config))
 
     if report_mode == "leaf":
         return _out(
@@ -884,6 +903,7 @@ def to_markdown(
                 show_impact=show_impact,
                 show_only=show_only,
                 show_recommendation=show_recommendation,
+                severity_config=severity_config,
             )
         )
 

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -63,23 +63,55 @@ def _tool_version() -> str:
 # above under its historical private name so call sites are unchanged.
 
 
-def _severity(change: Change, result: DiffResult) -> str:
+_SEVERITY_LEVEL_TO_SARIF = {
+    "error": "error",
+    "warning": "warning",
+    "info": "note",
+}
+
+
+def _severity(
+    change: Change,
+    result: DiffResult,
+    severity_config: SeverityConfig | None = None,
+) -> str:
     """Return the SARIF ``level`` for *change*.
 
-    Whenever the canonical per-finding verdict (``result._effective_verdict_for_change``
-    — A4 per-finding ``effective_verdict`` (ADR-027), a PolicyFile verdict
-    override, *or* a named base policy like ``plugin_abi``/``sdk_vendor``
-    reclassifying this change's kind) differs from the kind's inherent default
-    verdict, the canonical verdict→SARIF-level table (ADR-036) applies, so
-    SARIF can never disagree with the JSON report or the gate/exit code.
-    Comparing against the *kind's own* default verdict (rather than checking
-    for specific override mechanisms) catches every reclassification path
-    uniformly — a hand-maintained ``has_override`` allowlist previously missed
-    base-policy downgrades entirely. Findings still at their kind's default
-    verdict keep the coarser per-kind default severity from the policy
-    registry, which is intentionally finer-grained than the 4-way verdict
-    table (e.g. distinguishing "warning" additions from "note"-worthy ones).
+    When *severity_config* is given, the result level follows the configured
+    severity for this change's effective issue category
+    (:func:`abicheck.severity.classify_effective_change`) — the same
+    classification the exit code and ``severityGate`` properties block use —
+    so a SARIF consumer keying off ``level`` never disagrees with the
+    configured gate (e.g. ``--severity-addition error`` must show additions
+    as ``level: error``, not the legacy policy severity).
+
+    Without a *severity_config*, whenever the canonical per-finding verdict
+    (``result._effective_verdict_for_change`` — A4 per-finding
+    ``effective_verdict`` (ADR-027), a PolicyFile verdict override, *or* a
+    named base policy like ``plugin_abi``/``sdk_vendor`` reclassifying this
+    change's kind) differs from the kind's inherent default verdict, the
+    canonical verdict→SARIF-level table (ADR-036) applies, so SARIF can never
+    disagree with the JSON report or the gate/exit code. Comparing against
+    the *kind's own* default verdict (rather than checking for specific
+    override mechanisms) catches every reclassification path uniformly — a
+    hand-maintained ``has_override`` allowlist previously missed base-policy
+    downgrades entirely. Findings still at their kind's default verdict keep
+    the coarser per-kind default severity from the policy registry, which is
+    intentionally finer-grained than the 4-way verdict table (e.g.
+    distinguishing "warning" additions from "note"-worthy ones).
     """
+    if severity_config is not None:
+        from abicheck.severity import classify_effective_change
+
+        category = classify_effective_change(
+            change,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
+        level = severity_config.level_for(category)
+        return _SEVERITY_LEVEL_TO_SARIF.get(level.value, "warning")
+
     entry = policy_for(change.kind)
     verdict = result._effective_verdict_for_change(change)
     if verdict != entry.default_verdict:
@@ -108,7 +140,11 @@ def _rule_for(kind: ChangeKind) -> dict[str, Any]:
     }
 
 
-def _result_for(change: Change, result: DiffResult) -> dict[str, Any]:
+def _result_for(
+    change: Change,
+    result: DiffResult,
+    severity_config: SeverityConfig | None = None,
+) -> dict[str, Any]:
     """Produce a SARIF result object for a Change."""
     library, old_version, new_version = (
         result.library,
@@ -159,7 +195,7 @@ def _result_for(change: Change, result: DiffResult) -> dict[str, Any]:
 
     return {
         "ruleId": change.kind.value,
-        "level": _severity(change, result),
+        "level": _severity(change, result, severity_config),
         "message": {
             "text": " ".join(msg_parts),
         },
@@ -263,7 +299,7 @@ def to_sarif(
         rule_id = change.kind.value
         if rule_id not in rules_seen:
             rules_seen[rule_id] = _rule_for(change.kind)
-        sarif_results.append(_result_for(change, result))
+        sarif_results.append(_result_for(change, result, severity_config))
 
     severity_gate = (
         _severity_gate_properties(result, severity_config)

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import json
 from importlib.metadata import version as _pkg_version
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
 from abicheck.checker_policy import (
@@ -40,6 +40,9 @@ from abicheck.checker_policy import (
 )
 from abicheck.report_model import VERDICT_TO_SARIF_LEVEL as _VERDICT_TO_SARIF_LEVEL
 from abicheck.reporter import apply_show_only
+
+if TYPE_CHECKING:
+    from abicheck.severity import SeverityConfig
 
 # ---------------------------------------------------------------------------
 # Severity mapping
@@ -175,12 +178,77 @@ def _result_for(change: Change, result: DiffResult) -> dict[str, Any]:
     }
 
 
+def _severity_gate_properties(
+    result: DiffResult, severity_config: SeverityConfig,
+) -> dict[str, Any]:
+    """Build a compact, auditable ``severityGate`` block for SARIF ``properties``.
+
+    Mirrors the categories/exit-code contract of JSON's ``severity`` block
+    (:func:`abicheck.reporter._build_severity_json`) so a SARIF consumer can
+    tell *why* the invocation's exit code is what it is without
+    cross-referencing the JSON report separately.
+    """
+    from abicheck.severity import (
+        IssueCategory,
+        SeverityLevel,
+        categorize_changes,
+        compute_exit_code,
+    )
+
+    eff_sets = result._effective_kind_sets()
+    exit_code = compute_exit_code(
+        result.changes,
+        severity_config,
+        policy=result.policy,
+        kind_sets=eff_sets,
+        policy_file=result.policy_file,
+    )
+    categorized = categorize_changes(
+        result.changes,
+        policy=result.policy,
+        kind_sets=eff_sets,
+        policy_file=result.policy_file,
+    )
+    by_category = {
+        IssueCategory.ABI_BREAKING: categorized.abi_breaking,
+        IssueCategory.POTENTIAL_BREAKING: categorized.potential_breaking,
+        IssueCategory.QUALITY_ISSUES: categorized.quality_issues,
+        IssueCategory.ADDITION: categorized.addition,
+    }
+    blocking_categories = [
+        cat.value
+        for cat, cat_changes in by_category.items()
+        if cat_changes and severity_config.level_for(cat) == SeverityLevel.ERROR
+    ]
+    return {
+        "exitCode": exit_code,
+        "blocking": exit_code != 0,
+        "blockingCategories": blocking_categories,
+        "config": {
+            "abi_breaking": severity_config.abi_breaking.value,
+            "potential_breaking": severity_config.potential_breaking.value,
+            "quality_issues": severity_config.quality_issues.value,
+            "addition": severity_config.addition.value,
+        },
+    }
+
+
 def to_sarif(
     result: DiffResult,
     *,
     show_only: str | None = None,
+    severity_config: SeverityConfig | None = None,
 ) -> dict[str, Any]:
-    """Convert a DiffResult to a SARIF 2.1.0 document (dict)."""
+    """Convert a DiffResult to a SARIF 2.1.0 document (dict).
+
+    *severity_config*, when given, drives the invocation's ``exitCode`` /
+    ``executionSuccessful`` from the actual severity-aware gate instead of
+    inferring "passed" purely from ``result.verdict`` — compatibility and
+    "blocks CI" are independent decisions once severity configuration is in
+    play (e.g. an addition configured ``error`` blocks the build despite a
+    ``COMPATIBLE`` verdict). A ``severityGate`` properties block is added so
+    the reason is auditable in the SARIF document itself.
+    """
     tool_version = _tool_version()
 
     changes = list(result.changes)
@@ -197,8 +265,18 @@ def to_sarif(
             rules_seen[rule_id] = _rule_for(change.kind)
         sarif_results.append(_result_for(change, result))
 
+    severity_gate = (
+        _severity_gate_properties(result, severity_config)
+        if severity_config is not None
+        else None
+    )
+
     # Overall ABI verdict as a notification
-    invocation_success = result.verdict != Verdict.BREAKING
+    invocation_success = (
+        severity_gate["exitCode"] == 0
+        if severity_gate is not None
+        else result.verdict != Verdict.BREAKING
+    )
 
     return {
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
@@ -216,18 +294,29 @@ def to_sarif(
                 "invocations": [
                     {
                         "executionSuccessful": invocation_success,
-                        # Exit codes mirror abicheck compare CLI contract:
-                        # BREAKING=4 (mapped to SARIF 1), API_BREAK=2, others=0.
-                        # COMPATIBLE_WITH_RISK intentionally exits 0 — binary-compatible,
-                        # deployment risk is surfaced via exitCodeDescription only.
+                        # Exit codes mirror abicheck compare CLI contract when no
+                        # severity_config is given: BREAKING=4 (mapped to SARIF 1),
+                        # API_BREAK=2, others=0. COMPATIBLE_WITH_RISK intentionally
+                        # exits 0 — binary-compatible, deployment risk is surfaced
+                        # via exitCodeDescription only. When severity_config *is*
+                        # given, the exit code instead follows the severity-aware
+                        # gate (severityGate.exitCode below) — see docstring.
                         "exitCode": (
-                            4
-                            if result.verdict == Verdict.BREAKING
-                            else 2
-                            if result.verdict == Verdict.API_BREAK
-                            else 0
+                            severity_gate["exitCode"]
+                            if severity_gate is not None
+                            else (
+                                4
+                                if result.verdict == Verdict.BREAKING
+                                else 2
+                                if result.verdict == Verdict.API_BREAK
+                                else 0
+                            )
                         ),
-                        "exitCodeDescription": result.verdict.value,
+                        "exitCodeDescription": (
+                            f"{result.verdict.value} (severity-gated)"
+                            if severity_gate is not None
+                            else result.verdict.value
+                        ),
                     }
                 ],
                 "results": sarif_results,
@@ -248,6 +337,11 @@ def to_sarif(
                     "library": result.library,
                     "changeCount": len(changes),
                     "suppressedCount": result.suppressed_count,
+                    **(
+                        {"severityGate": severity_gate}
+                        if severity_gate is not None
+                        else {}
+                    ),
                     **(
                         {"redundantCount": result.redundant_count}
                         if result.redundant_count > 0
@@ -367,9 +461,13 @@ def to_sarif_str(
     indent: int = 2,
     *,
     show_only: str | None = None,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
     """Serialize DiffResult to a SARIF JSON string."""
-    return json.dumps(to_sarif(result, show_only=show_only), indent=indent)
+    return json.dumps(
+        to_sarif(result, show_only=show_only, severity_config=severity_config),
+        indent=indent,
+    )
 
 
 def write_sarif(result: DiffResult, path: Path) -> None:

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -1370,8 +1370,8 @@ def render_output(
     """
     if stat and fmt != "junit":
         if fmt == "json":
-            return to_stat_json(result)
-        return to_stat(result)
+            return to_stat_json(result, severity_config=severity_config)
+        return to_stat(result, severity_config=severity_config)
 
     if fmt == "json":
         return _render_json_output(
@@ -1388,7 +1388,7 @@ def render_output(
     if fmt == "sarif":
         from .sarif import to_sarif_str
 
-        return to_sarif_str(result, show_only=show_only)
+        return to_sarif_str(result, show_only=show_only, severity_config=severity_config)
 
     if fmt == "html":
         from .html_report import generate_html_report

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -1416,7 +1416,7 @@ def render_output(
     if fmt == "review":
         from .reporter import to_review_digest
 
-        txt = to_review_digest(result)
+        txt = to_review_digest(result, severity_config=severity_config)
         if demangle:
             from .demangle import demangle_text
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -692,3 +692,10 @@ class TestSeverityConfigAwareAnnotations:
         sort_key, line = annotations[0]
         assert sort_key == 0
         assert line.startswith("::error ")
+        # CodeRabbit review: the title must agree with the level — the kind
+        # itself was policy-demoted into compatible_set, so a title picked
+        # from kind-set membership alone would misreport this ::error as
+        # "Quality Issue" (or "ABI Addition") instead of "ABI Break".
+        assert "title=ABI Break%3A func_removed" in line
+        assert "Quality Issue" not in line
+        assert "ABI Addition" not in line

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -625,3 +625,38 @@ class TestSeverityConfigAwareAnnotations:
         cfg = resolve_severity_config("default", addition="error")
         output = emit_github_annotations(result, severity_config=cfg)
         assert output.startswith("::error ")
+
+    def test_frozen_namespace_floor_honoured_under_policy_override(self):
+        """A policy-file override that demotes FUNC_REMOVED to COMPATIBLE must
+        not silently downgrade a finding tagged frozen_namespace_violation —
+        the actual exit code (severity.compute_exit_code, given policy_file)
+        keeps such a finding at its raw BREAKING severity, so the annotation
+        must too, or a build that still fails CI would get no ::error at all.
+        """
+        from abicheck.checker_policy import Verdict as _Verdict
+        from abicheck.policy_file import PolicyFile
+        from abicheck.severity import compute_exit_code, resolve_severity_config
+
+        c = Change(
+            ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo",
+            frozen_namespace_violation="**::detail::r1::*",
+        )
+        pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: _Verdict.COMPATIBLE})
+        result = DiffResult(
+            old_version="1.0", new_version="2.0", library="libtest.so.1",
+            changes=[c], verdict=Verdict.BREAKING, policy_file=pf,
+        )
+        cfg = resolve_severity_config("default")  # abi_breaking=error
+
+        # The actual gate: still fails at the frozen finding's raw severity.
+        eff_sets = result._effective_kind_sets()
+        exit_code = compute_exit_code(
+            result.changes, cfg, kind_sets=eff_sets, policy_file=result.policy_file,
+        )
+        assert exit_code == 4
+
+        annotations = collect_annotations(result, severity_config=cfg)
+        assert len(annotations) == 1
+        sort_key, line = annotations[0]
+        assert sort_key == 0
+        assert line.startswith("::error ")

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -567,3 +567,61 @@ class TestCollectAndFormatAnnotations:
         # All 20 errors survive; 30 of 40 warnings fit.
         assert len(error_lines) == 20
         assert len(warning_lines) == 30
+
+
+# ---------------------------------------------------------------------------
+# severity_config-aware annotation levels
+# ---------------------------------------------------------------------------
+
+class TestSeverityConfigAwareAnnotations:
+    """Without severity_config, annotation levels follow the fixed kind-set
+    mapping regardless of what actually gates CI. These guard the fix: when a
+    SeverityConfig is supplied, the annotation level mirrors the real gate."""
+
+    def test_addition_configured_as_error_gets_error_annotation(self):
+        """An addition that severity config promotes to `error` must not be
+        silently absent — the build fails on it, so the annotation must too."""
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+        result = _result(Verdict.COMPATIBLE, [c])
+
+        # Legacy behaviour (no severity_config, additions not opted in): silent.
+        assert collect_annotations(result) == []
+
+        cfg = resolve_severity_config("default", addition="error")
+        annotations = collect_annotations(result, severity_config=cfg)
+        assert len(annotations) == 1
+        sort_key, line = annotations[0]
+        assert sort_key == 0
+        assert line.startswith("::error ")
+
+    def test_breaking_demoted_to_info_does_not_emit_error(self):
+        """A breaking kind that severity config demotes below `error` must not
+        emit `::error` — that would misreport a non-blocking finding as fatal."""
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")
+        result = _result(Verdict.BREAKING, [c])
+
+        cfg = resolve_severity_config("default", abi_breaking="info")
+        # info-level findings are opt-in (annotate_additions), same gate as
+        # the legacy compatible/notice behaviour.
+        assert collect_annotations(result, severity_config=cfg) == []
+
+        annotations = collect_annotations(
+            result, severity_config=cfg, annotate_additions=True,
+        )
+        assert len(annotations) == 1
+        sort_key, line = annotations[0]
+        assert sort_key == 2  # notice
+        assert line.startswith("::notice ")
+
+    def test_emit_github_annotations_forwards_severity_config(self):
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+        result = _result(Verdict.COMPATIBLE, [c])
+        cfg = resolve_severity_config("default", addition="error")
+        output = emit_github_annotations(result, severity_config=cfg)
+        assert output.startswith("::error ")

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -520,6 +520,25 @@ class TestEmitGitHubStepSummary:
         assert content.startswith("existing content\n")
         assert "NO_CHANGE" in content
 
+    def test_forwards_severity_config_to_markdown(self, tmp_path):
+        """Codex review on #549: `_maybe_emit_annotations` (cli.py) makes the
+        inline GitHub annotations severity-aware, but still called
+        `emit_github_step_summary(result)` without `severity_config` — so
+        e.g. `--severity-addition error` could fail the annotations/exit code
+        while the step summary rendered the legacy compatible report with no
+        severity gate section, contradicting the actual gate on the same
+        PR."""
+        from abicheck.severity import PRESET_DEFAULT
+
+        summary_file = tmp_path / "summary.md"
+        with patch.dict("os.environ", {"GITHUB_STEP_SUMMARY": str(summary_file)}):
+            result = _result(Verdict.COMPATIBLE, [
+                Change(ChangeKind.FUNC_ADDED, "_Z3barv", "New function added: bar"),
+            ])
+            emit_github_step_summary(result, severity_config=PRESET_DEFAULT)
+        content = summary_file.read_text(encoding="utf-8")
+        assert "Severity Configuration" in content
+
 
 # ---------------------------------------------------------------------------
 # collect_annotations / format_annotations

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -626,6 +626,38 @@ class TestSeverityConfigAwareAnnotations:
         output = emit_github_annotations(result, severity_config=cfg)
         assert output.startswith("::error ")
 
+    def test_quality_finding_not_mislabeled_as_addition(self):
+        """Codex review on #549: a compatible *quality* finding (e.g.
+        soname_bump_unnecessary) surfaced by severity_config (the default
+        preset sets quality_issues=warning, no annotate_additions needed)
+        must not be titled "ABI Addition" — it isn't one."""
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(
+            ChangeKind.SONAME_BUMP_UNNECESSARY, "libfoo.so", "unnecessary bump",
+        )
+        result = _result(Verdict.COMPATIBLE, [c])
+        cfg = resolve_severity_config("default")  # quality_issues=warning
+
+        annotations = collect_annotations(result, severity_config=cfg)
+        assert len(annotations) == 1
+        _sort_key, line = annotations[0]
+        assert line.startswith("::warning ")
+        assert "title=Quality Issue%3A soname_bump_unnecessary" in line
+        assert "ABI Addition" not in line
+
+    def test_genuine_addition_still_labeled_as_addition(self):
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+        result = _result(Verdict.COMPATIBLE, [c])
+        cfg = resolve_severity_config("default", addition="error")
+
+        annotations = collect_annotations(result, severity_config=cfg)
+        assert len(annotations) == 1
+        _sort_key, line = annotations[0]
+        assert "title=ABI Addition%3A func_added" in line
+
     def test_frozen_namespace_floor_honoured_under_policy_override(self):
         """A policy-file override that demotes FUNC_REMOVED to COMPATIBLE must
         not silently downgrade a finding tagged frozen_namespace_violation —

--- a/tests/test_cli_scan_helpers_coverage.py
+++ b/tests/test_cli_scan_helpers_coverage.py
@@ -417,3 +417,50 @@ def test_render_baseline_none_and_populated() -> None:
     text = "\n".join(render_baseline_lines(out))
     assert "Baseline comparison" in text
     assert "breaking=1 api_break=2 risk=3 compatible=4" in text
+
+
+def test_render_baseline_lines_lists_findings_not_just_counts() -> None:
+    """A failing baseline compare must name the broken symbol, not just count it."""
+    out = SimpleNamespace(
+        diff_summary={
+            "breaking": 1,
+            "api_break": 0,
+            "risk": 0,
+            "compatible": 0,
+            "findings": [
+                {
+                    "bucket": "breaking",
+                    "kind": "func_removed",
+                    "symbol": "_Z3foov",
+                    "description": "Public function removed: foo",
+                    "source_location": "foo.h:42",
+                }
+            ],
+        }
+    )
+    lines = render_baseline_lines(out)
+    text = "\n".join(lines)
+    assert "[breaking] func_removed: _Z3foov (foo.h:42)" in text
+
+
+def test_render_baseline_lines_notes_truncation() -> None:
+    out = SimpleNamespace(
+        diff_summary={
+            "breaking": 25,
+            "api_break": 0,
+            "risk": 0,
+            "compatible": 0,
+            "findings": [
+                {
+                    "bucket": "breaking",
+                    "kind": "func_removed",
+                    "symbol": "sym",
+                    "description": None,
+                    "source_location": None,
+                }
+            ],
+            "findings_truncated": True,
+        }
+    )
+    text = "\n".join(render_baseline_lines(out))
+    assert "additional findings omitted" in text

--- a/tests/test_cli_split_modules.py
+++ b/tests/test_cli_split_modules.py
@@ -852,6 +852,58 @@ class TestCompareReleaseErrorPaths:
         assert pairs == []
         assert annotations == []
 
+    def test_collect_release_extras_forwards_severity_config_to_annotations(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """`compare-release --annotate` must reflect the same severity-aware
+        gate as the exit code (Codex review on #549): an addition promoted to
+        `error` should surface as `::error`, not the legacy silent/notice
+        annotation, in the per-library re-run `_collect_release_extras` drives.
+        """
+        from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+        from abicheck.cli_compare_release import _collect_release_extras
+        from abicheck.severity import resolve_severity_config
+
+        old_path = tmp_path / "libfoo.so"
+        new_path = tmp_path / "libfoo.so"
+        old_path.write_bytes(b"\x7fELF")
+        new_path.write_bytes(b"\x7fELF")
+
+        c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+        result = DiffResult(
+            old_version="1", new_version="2", library="libfoo.so",
+            changes=[c], verdict=Verdict.COMPATIBLE,
+        )
+
+        monkeypatch.setattr(
+            "abicheck.cli_compare_release._run_compare_pair",
+            lambda *a, **kw: (result, object(), None),
+        )
+        monkeypatch.setattr(
+            "abicheck.annotations.is_github_actions", lambda: True,
+        )
+
+        cfg = resolve_severity_config("default", addition="error")
+        _pairs, annotations = _collect_release_extras(
+            matched_keys=["libfoo.so"],
+            old_map={"libfoo.so": old_path},
+            new_map={"libfoo.so": new_path},
+            old_debug_dir=None, new_debug_dir=None,
+            resolve_debug_info=lambda *_a, **_kw: None,
+            old_h=[], new_h=[],
+            old_inc=[], new_inc=[],
+            old_version="1", new_version="2",
+            lang="c++",
+            suppress=None, policy="", policy_file_path=None,
+            annotate_additions=False,
+            collect_diff_results=False,
+            annotate=True,
+            severity_config=cfg,
+        )
+        assert len(annotations) == 1
+        _sort_key, line = annotations[0]
+        assert line.startswith("::error ")
+
     def test_format_release_summary_junit(self, tmp_path: Path) -> None:
         """JUnit format emits XML with <testsuites>."""
         from abicheck.cli_compare_release import _format_release_summary

--- a/tests/test_cli_split_modules.py
+++ b/tests/test_cli_split_modules.py
@@ -945,7 +945,7 @@ class TestCompareReleaseErrorPaths:
         # A permissive severity config would otherwise surface this quality
         # finding as ::warning regardless of --annotate-additions.
         cfg = resolve_severity_config("default")
-        _pairs, annotations = _collect_release_extras(
+        pairs, annotations = _collect_release_extras(
             matched_keys=["libfoo.so"],
             old_map={"libfoo.so": old_path},
             new_map={"libfoo.so": new_path},
@@ -957,12 +957,20 @@ class TestCompareReleaseErrorPaths:
             lang="c++",
             suppress=None, policy="", policy_file_path=None,
             annotate_additions=False,
-            collect_diff_results=False,
+            # Also exercise the JUnit re-run path (CodeRabbit review): the
+            # suppression must apply to diff_pairs too, not just annotations
+            # — both consumers share the same independently-fetched DiffResult.
+            collect_diff_results=True,
             annotate=True,
             severity_config=cfg,
             worst_verdict="BREAKING",
         )
         assert annotations == []
+        assert len(pairs) == 1
+        assert all(
+            change.kind != ChangeKind.SONAME_BUMP_UNNECESSARY
+            for change in pairs[0][0].changes
+        )
 
     def test_format_release_summary_junit(self, tmp_path: Path) -> None:
         """JUnit format emits XML with <testsuites>."""

--- a/tests/test_cli_split_modules.py
+++ b/tests/test_cli_split_modules.py
@@ -904,6 +904,66 @@ class TestCompareReleaseErrorPaths:
         _sort_key, line = annotations[0]
         assert line.startswith("::error ")
 
+    def test_collect_release_extras_drops_suppressed_soname_finding(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A `SONAME_BUMP_UNNECESSARY` finding the primary pass suppressed as a
+        coordinated lockstep bump (Codex review on #549) must not resurface via
+        the independent JUnit/annotate re-run `_collect_release_extras` drives
+        — that re-run builds a fresh `DiffResult` the primary pass's mutation
+        never touched, so it must re-apply the same suppression itself.
+        """
+        from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+        from abicheck.cli_compare_release import _collect_release_extras
+        from abicheck.severity import resolve_severity_config
+
+        old_path = tmp_path / "libfoo.so"
+        new_path = tmp_path / "libfoo.so"
+        old_path.write_bytes(b"\x7fELF")
+        new_path.write_bytes(b"\x7fELF")
+
+        c = Change(ChangeKind.SONAME_BUMP_UNNECESSARY, "libfoo.so", "unnecessary bump")
+
+        def _fake_run_compare_pair(*a, **kw):  # noqa: ANN002, ANN003
+            # A fresh DiffResult each call, mirroring the real re-run —
+            # asserts the suppression is applied per-call, not by mutating a
+            # shared fixture.
+            return (
+                DiffResult(
+                    old_version="1", new_version="2", library="libfoo.so",
+                    changes=[c], verdict=Verdict.COMPATIBLE,
+                ),
+                object(),
+                None,
+            )
+
+        monkeypatch.setattr(
+            "abicheck.cli_compare_release._run_compare_pair", _fake_run_compare_pair,
+        )
+        monkeypatch.setattr("abicheck.annotations.is_github_actions", lambda: True)
+
+        # A permissive severity config would otherwise surface this quality
+        # finding as ::warning regardless of --annotate-additions.
+        cfg = resolve_severity_config("default")
+        _pairs, annotations = _collect_release_extras(
+            matched_keys=["libfoo.so"],
+            old_map={"libfoo.so": old_path},
+            new_map={"libfoo.so": new_path},
+            old_debug_dir=None, new_debug_dir=None,
+            resolve_debug_info=lambda *_a, **_kw: None,
+            old_h=[], new_h=[],
+            old_inc=[], new_inc=[],
+            old_version="1", new_version="2",
+            lang="c++",
+            suppress=None, policy="", policy_file_path=None,
+            annotate_additions=False,
+            collect_diff_results=False,
+            annotate=True,
+            severity_config=cfg,
+            worst_verdict="BREAKING",
+        )
+        assert annotations == []
+
     def test_format_release_summary_junit(self, tmp_path: Path) -> None:
         """JUnit format emits XML with <testsuites>."""
         from abicheck.cli_compare_release import _format_release_summary

--- a/tests/test_compare_dispatch.py
+++ b/tests/test_compare_dispatch.py
@@ -609,6 +609,49 @@ class TestCompareDispatch:
         assert code == 4
         assert json.loads(out)["verdict"] == "BREAKING"
 
+    def test_config_severity_scheme_without_severity_block_applies_to_set_inputs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Codex review on #549: exit_code_scheme: severity from .abicheck.yml,
+        with no severity: block and no --severity-* flag anywhere, must still
+        gate on the default severity preset for directory/package inputs —
+        not silently fall back to the legacy verdict exit. The single-file
+        compare path never hits this: its resolved_cfg.severity is always
+        populated (defaulting to PRESET_DEFAULT), gated only by scheme; the
+        release fan-out re-derived its severity config from the raw
+        --severity-* values alone, which are all None here."""
+        from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+
+        cfg = tmp_path / ".abicheck.yml"
+        cfg.write_text("exit_code_scheme: severity\n", encoding="utf-8")
+
+        old_dir = tmp_path / "old"
+        new_dir = tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+
+        # An API_BREAK finding: legacy scheme exits 2; the default severity
+        # preset (potential_breaking=warning) must exit 0 instead.
+        api_break_diff = DiffResult(
+            old_version="1.0", new_version="2.0", library="libfoo.so",
+            changes=[Change(ChangeKind.ENUM_MEMBER_RENAMED, "Color::RED", "member renamed")],
+            verdict=Verdict.API_BREAK,
+        )
+        monkeypatch.setattr(
+            "abicheck.cli_compare_release._run_compare_pair",
+            lambda *a, **kw: (api_break_diff, None, None),
+        )
+
+        code, out, _ = _invoke(
+            "compare", str(old_dir), str(new_dir), "--config", str(cfg),
+            "--format", "json", "--no-bundle-analysis",
+        )
+
+        assert code == 0
+        assert json.loads(out)["verdict"] == "API_BREAK"
+
     @pytest.mark.parametrize(
         "flag, value, is_path",
         [

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -515,6 +515,31 @@ class TestReleaseSeverityPolicyAndGlobal:
         assert _compute_release_severity_exit_code(
             [entry], "default", None, None, None, None) == 0
 
+    def test_per_library_honours_frozen_namespace_floor(self):
+        """Codex review on #549: a policy-file override that demotes a kind
+        must not silently drop a frozen-namespace-tagged finding below its raw
+        severity — this is the same floor collect_annotations() now honours
+        (via result.policy_file), so the release exit code must match it."""
+        from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+        from abicheck.cli_compare_release import _compute_release_severity_exit_code
+        from abicheck.policy_file import PolicyFile
+
+        c = Change(
+            ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo",
+            frozen_namespace_violation="**::detail::r1::*",
+        )
+        pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE})
+        diff = DiffResult(
+            old_version="1.0", new_version="2.0", library="libtest.so",
+            changes=[c], verdict=Verdict.BREAKING, policy_file=pf,
+        )
+        entry = {"_diff_result": diff}
+        # default preset: abi_breaking == error. Without the policy_file floor
+        # this would wrongly exit 0 (the override demotes FUNC_REMOVED to
+        # COMPATIBLE); the frozen guard must keep it at its raw BREAKING exit.
+        assert _compute_release_severity_exit_code(
+            [entry], "default", None, None, None, None) == 4
+
     def test_fold_matrix_break_raises_exit(self):
         from abicheck.cli_compare_release import _fold_release_global_severity
 

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -540,6 +540,30 @@ class TestReleaseSeverityPolicyAndGlobal:
         assert _compute_release_severity_exit_code(
             [entry], "default", None, None, None, None) == 4
 
+    def test_format_release_junit_forwards_severity_config(self):
+        """Codex review on #549: `compare-release --format junit` with a
+        severity config that promotes a compatible finding to `error` must
+        fail that finding's JUnit testcase, or a CI dashboard reading the
+        JUnit file would disagree with the release's severity-aware exit."""
+        from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+        from abicheck.cli_compare_release_helpers import _format_release_junit
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+        diff = DiffResult(
+            old_version="1", new_version="2", library="libfoo.so",
+            changes=[c], verdict=Verdict.COMPATIBLE,
+        )
+        cfg = resolve_severity_config("default", addition="error")
+
+        xml_without_config = _format_release_junit([(diff, None)], None, [])
+        assert 'failures="0"' in xml_without_config
+
+        xml_with_config = _format_release_junit(
+            [(diff, None)], None, [], severity_config=cfg,
+        )
+        assert 'failures="1"' in xml_with_config
+
     def test_fold_matrix_break_raises_exit(self):
         from abicheck.cli_compare_release import _fold_release_global_severity
 

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1865,7 +1865,7 @@ class TestMaybeEmitAnnotationsInCI:
         emitted = {}
         monkeypatch.setattr(
             "abicheck.annotations.emit_github_step_summary",
-            lambda result: emitted.setdefault("summary", True),
+            lambda result, severity_config=None: emitted.setdefault("summary", True),
         )
         result = DiffResult(old_version="1", new_version="2", library="x")
         cli_mod._maybe_emit_annotations(

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1856,7 +1856,7 @@ class TestMaybeEmitAnnotationsInCI:
         monkeypatch.setattr("abicheck.annotations.is_github_actions", lambda: True)
         monkeypatch.setattr(
             "abicheck.annotations.collect_annotations",
-            lambda result, annotate_additions=False: ["a1"],
+            lambda result, annotate_additions=False, severity_config=None: ["a1"],
         )
         monkeypatch.setattr(
             "abicheck.annotations.format_annotations",

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -838,6 +838,27 @@ class TestSeverityConfig:
         ts = root.find("testsuite")
         assert ts.get("failures") == "1"
 
+    def test_severity_config_demotes_breaking_verdict_to_pass(self) -> None:
+        """Codex review on #549: `_is_failure` used to return True for a
+        BREAKING/API_BREAK verdict *before* consulting `severity_config`, so
+        `--severity-preset info-only` (which demotes every category to
+        'info') could exit 0 via the severity-aware gate while the JUnit XML
+        still contained a `<failure>` for the same removal — disagreeing
+        with `severity.compute_exit_code`, which treats `severity_config` as
+        the sole source of truth once given. Fixed by consulting
+        `severity_config` first, unconditionally, matching
+        `compute_exit_code`'s own logic."""
+        from abicheck.severity import PRESET_INFO_ONLY
+
+        changes = [
+            Change(kind=ChangeKind.FUNC_REMOVED, symbol="f", description="removed"),
+        ]
+        result = _make_result(changes, verdict=Verdict.BREAKING)
+        xml = to_junit_xml(result, severity_config=PRESET_INFO_ONLY)
+        root = _parse(xml)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "0"
+
 
 # ---------------------------------------------------------------------------
 # Error libraries in multi-suite

--- a/tests/test_mcp_server_coverage.py
+++ b/tests/test_mcp_server_coverage.py
@@ -418,7 +418,7 @@ class TestRenderOutput:
         result = _minimal_diff()
         monkeypatch.setattr(
             "abicheck.reporter.to_stat_json",
-            lambda r: '{"stat": "ok"}',
+            lambda r, **kw: '{"stat": "ok"}',
         )
         out = _render_output("json", result, _empty_snapshot(), _empty_snapshot(), stat=True)
         assert '"stat"' in out
@@ -428,7 +428,7 @@ class TestRenderOutput:
         result = _minimal_diff()
         monkeypatch.setattr(
             "abicheck.reporter.to_stat",
-            lambda r: "COMPATIBLE 0 breaking",
+            lambda r, **kw: "COMPATIBLE 0 breaking",
         )
         out = _render_output("markdown", result, _empty_snapshot(), _empty_snapshot(), stat=True)
         assert "COMPATIBLE" in out
@@ -634,7 +634,7 @@ class TestAbiCompareTool:
         )
         monkeypatch.setattr(
             "abicheck.reporter.to_stat_json",
-            lambda r: '{"stat": true}',
+            lambda r, **kw: '{"stat": true}',
         )
         result_str = abi_compare(
             old_input=str(old), new_input=str(new), stat=True,

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -1369,6 +1369,17 @@ class TestAbiCompareSeverity:
         data = json.loads(raw)
         assert "error" in data
 
+    def test_empty_string_severity_arg_is_validated_not_ignored(self, tmp_path: Path):
+        """CodeRabbit review: `any((severity_preset, ...))` treated an empty
+        string as absent (falsy), silently selecting the legacy scheme
+        instead of surfacing the documented validation error."""
+        old_p, new_p = self._make_pair(
+            tmp_path, _make_snapshot("1.0"), _make_snapshot("2.0"),
+        )
+        raw = abi_compare(str(old_p), str(new_p), severity_abi_breaking="")
+        data = json.loads(raw)
+        assert "error" in data
+
     def test_json_report_embeds_severity_block(self, tmp_path: Path):
         old_p, new_p = self._make_pair(
             tmp_path,
@@ -1380,6 +1391,25 @@ class TestAbiCompareSeverity:
             severity_addition="error", output_format="json",
         )
         data = json.loads(raw)
+        assert "severity" in data["report"]
+        assert data["report"]["severity"]["exit_code"] == 1
+
+    def test_leaf_mode_json_report_embeds_severity_block(self, tmp_path: Path):
+        """CodeRabbit review: report_mode="leaf" returned before the severity
+        block was built, so the MCP JSON report silently had no `severity`
+        key even though `exit_code`/`exit_code_scheme` were already
+        severity-gated — a direct contradiction on the same response."""
+        old_p, new_p = self._make_pair(
+            tmp_path,
+            _make_snapshot("1.0"),
+            _make_snapshot("2.0", functions=[_pub_func("bar", "_Z3barv")]),
+        )
+        raw = abi_compare(
+            str(old_p), str(new_p),
+            severity_addition="error", output_format="json", report_mode="leaf",
+        )
+        data = json.loads(raw)
+        assert data["exit_code_scheme"] == "severity"
         assert "severity" in data["report"]
         assert data["report"]["severity"]["exit_code"] == 1
 

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -1302,6 +1302,101 @@ class TestAbiCompareEdgeCases:
         assert isinstance(data["report"], str)
 
 
+class TestAbiCompareSeverity:
+    """Without any severity_* argument, exit_code follows the legacy
+    verdict-based scheme — which can misreport the actual gate once severity
+    configuration is in play (the MCP surface previously had no severity
+    configuration at all). These guard the fix."""
+
+    def _make_pair(self, tmp_path: Path, old_snap: AbiSnapshot, new_snap: AbiSnapshot):
+        old_p = tmp_path / "old.json"
+        new_p = tmp_path / "new.json"
+        _write_snapshot(old_p, old_snap)
+        _write_snapshot(new_p, new_snap)
+        return old_p, new_p
+
+    def test_no_severity_args_uses_legacy_scheme(self, tmp_path: Path):
+        old_p, new_p = self._make_pair(
+            tmp_path,
+            _make_snapshot("1.0"),
+            _make_snapshot("2.0", functions=[_pub_func("bar", "_Z3barv")]),
+        )
+        raw = abi_compare(str(old_p), str(new_p))
+        data = json.loads(raw)
+        assert data["status"] == "ok"
+        assert data["verdict"] == "COMPATIBLE"
+        assert data["exit_code"] == 0
+        assert data["exit_code_scheme"] == "legacy"
+
+    def test_addition_configured_as_error_switches_to_severity_scheme(
+        self, tmp_path: Path,
+    ):
+        old_p, new_p = self._make_pair(
+            tmp_path,
+            _make_snapshot("1.0"),
+            _make_snapshot("2.0", functions=[_pub_func("bar", "_Z3barv")]),
+        )
+        raw = abi_compare(
+            str(old_p), str(new_p),
+            severity_preset="default", severity_addition="error",
+        )
+        data = json.loads(raw)
+        assert data["status"] == "ok"
+        assert data["verdict"] == "COMPATIBLE"
+        # Legacy scheme would say exit_code=0; the severity gate says 1.
+        assert data["exit_code"] == 1
+        assert data["exit_code_scheme"] == "severity"
+
+    def test_breaking_demoted_to_info_exits_zero(self, tmp_path: Path):
+        old_p, new_p = self._make_pair(
+            tmp_path,
+            _make_snapshot("1.0", functions=[_pub_func("foo", "_Z3foov")]),
+            _make_snapshot("2.0"),
+        )
+        raw = abi_compare(str(old_p), str(new_p), severity_abi_breaking="info")
+        data = json.loads(raw)
+        assert data["status"] == "ok"
+        assert data["verdict"] == "BREAKING"
+        # Legacy scheme would say exit_code=4; the severity gate says 0.
+        assert data["exit_code"] == 0
+        assert data["exit_code_scheme"] == "severity"
+
+    def test_invalid_severity_preset_returns_error(self, tmp_path: Path):
+        old_p, new_p = self._make_pair(
+            tmp_path, _make_snapshot("1.0"), _make_snapshot("2.0"),
+        )
+        raw = abi_compare(str(old_p), str(new_p), severity_preset="not_a_preset")
+        data = json.loads(raw)
+        assert "error" in data
+
+    def test_json_report_embeds_severity_block(self, tmp_path: Path):
+        old_p, new_p = self._make_pair(
+            tmp_path,
+            _make_snapshot("1.0"),
+            _make_snapshot("2.0", functions=[_pub_func("bar", "_Z3barv")]),
+        )
+        raw = abi_compare(
+            str(old_p), str(new_p),
+            severity_addition="error", output_format="json",
+        )
+        data = json.loads(raw)
+        assert "severity" in data["report"]
+        assert data["report"]["severity"]["exit_code"] == 1
+
+    def test_stat_output_reflects_severity_gate(self, tmp_path: Path):
+        old_p, new_p = self._make_pair(
+            tmp_path,
+            _make_snapshot("1.0"),
+            _make_snapshot("2.0", functions=[_pub_func("bar", "_Z3barv")]),
+        )
+        raw = abi_compare(
+            str(old_p), str(new_p),
+            severity_addition="error", stat=True, output_format="markdown",
+        )
+        data = json.loads(raw)
+        assert "gate: FAIL" in data["report"]
+
+
 class TestSanitizeErrorEdgeCases:
     def test_nested_abicheck_error(self):
         """Subclasses of AbicheckError also pass through."""

--- a/tests/test_policy_registry_and_summary.py
+++ b/tests/test_policy_registry_and_summary.py
@@ -60,6 +60,20 @@ def test_compatibility_metrics_without_old_symbol_count_uses_change_ratio() -> N
     assert metrics.affected_pct == 0.0
 
 
+def test_compatibility_metrics_honours_named_policy_without_kind_sets() -> None:
+    """Codex review on #549: a caller passing only `policy` (e.g. the HTML
+    report's fallback for a duck-typed result without _effective_kind_sets())
+    must still route through the effective-verdict path — plugin_abi
+    downgrades CALLING_CONVENTION_CHANGED from breaking to compatible, so
+    counting it via raw ChangeKind membership would wrongly report it (and
+    show a contradictory <100% binary compatibility) despite the effective
+    verdict being compatible."""
+    c = Change(ChangeKind.CALLING_CONVENTION_CHANGED, "cb", "calling convention changed")
+    metrics = compatibility_metrics([c], old_symbol_count=10, policy="plugin_abi")
+    assert metrics.breaking_count == 0
+    assert metrics.binary_compatibility_pct == 100.0
+
+
 def test_policy_for_unknown_kind_falls_back_to_breaking() -> None:
     class _UnknownKind:
         value = "unknown_kind"

--- a/tests/test_pr494_scan_regressions.py
+++ b/tests/test_pr494_scan_regressions.py
@@ -81,6 +81,17 @@ def test_scan_baseline_compare_preserves_hard_l0_elf_removal(monkeypatch) -> Non
     assert calls[0]["scope_to_public_surface"] is False
     assert calls[1]["scope_to_public_surface"] is True
     assert hard_l0 in calls[1]["extra_changes"]
+    # The breaking finding itself is preserved, not just its count (a failing
+    # `scan --baseline` must name what broke, not just report "breaking=1").
+    assert summary["findings"] == [
+        {
+            "bucket": "breaking",
+            "kind": "func_removed_elf_only",
+            "symbol": None,
+            "description": None,
+            "source_location": None,
+        }
+    ]
 
 
 def test_scan_baseline_compare_does_not_promote_advisory_l0_findings(monkeypatch) -> None:
@@ -129,4 +140,56 @@ def test_scan_baseline_compare_does_not_promote_advisory_l0_findings(monkeypatch
 
     assert verdict == "NO_CHANGE"
     assert exit_code == 0
+    # No findings key at all when there is nothing to report (back-compat with
+    # consumers that only ever read the four counts).
     assert summary == {"breaking": 0, "api_break": 0, "risk": 0, "compatible": 0}
+    assert "findings" not in summary
+
+
+def test_scan_baseline_compare_truncates_large_finding_lists(monkeypatch) -> None:
+    """A large baseline diff caps embedded findings and flags the truncation."""
+    from abicheck.cli_scan_baseline import _MAX_BASELINE_FINDINGS
+
+    old_snap = SimpleNamespace(build_source=None)
+    new_snap = SimpleNamespace(build_source=None)
+    many_breaks = [
+        SimpleNamespace(
+            kind=SimpleNamespace(value="func_removed"),
+            symbol=f"sym{i}",
+            description=f"removed sym{i}",
+            source_location=None,
+        )
+        for i in range(_MAX_BASELINE_FINDINGS + 5)
+    ]
+
+    def fake_resolve_input(*args, **kwargs):  # noqa: ANN002, ANN003
+        return old_snap
+
+    def fake_prepare_embedded_build_source(
+        old, new, collect_mode, extra_changes, *args  # noqa: ANN001, ANN002
+    ):
+        return list(extra_changes), [], {}, None
+
+    def fake_compare_snapshots(old, new, *, extra_changes, scope_to_public_surface):  # noqa: ANN001
+        return SimpleNamespace(
+            breaking=many_breaks,
+            source_breaks=[],
+            risk=[],
+            compatible=[],
+            verdict=_Verdict("BREAKING"),
+        )
+
+    monkeypatch.setattr("abicheck.service.resolve_input", fake_resolve_input)
+    monkeypatch.setattr("abicheck.service.compare_snapshots", fake_compare_snapshots)
+    monkeypatch.setattr(
+        "abicheck.cli_buildsource.prepare_embedded_build_source",
+        fake_prepare_embedded_build_source,
+    )
+
+    _, _, summary = _run_baseline_compare(
+        Path("old.so"), Path("new.so"), new_snap, [], "c++", "graph-full", [], [], [], []
+    )
+
+    assert summary["breaking"] == len(many_breaks)
+    assert len(summary["findings"]) == _MAX_BASELINE_FINDINGS
+    assert summary["findings_truncated"] is True

--- a/tests/test_report_filtering.py
+++ b/tests/test_report_filtering.py
@@ -447,6 +447,50 @@ class TestShowOnlyInReporters:
         assert "Filtered by" in text
         assert "2 of 3 changes shown" in text
 
+    def test_severity_summary_exit_impact_ignores_show_only_filter(self):
+        """Codex review on #549: the severity summary table's "Exit Impact"
+        column was computed from the --show-only-filtered changes, so
+        filtering out the finding that actually gates CI made the table
+        claim "no exit impact" for a category that still fails the gate.
+        `--show-only compatible` hides the breaking FUNC_REMOVED, but the
+        default severity preset still exits nonzero on it."""
+        from abicheck.severity import PRESET_DEFAULT
+
+        result = _make_result(
+            changes=[
+                Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed"),
+                Change(ChangeKind.FUNC_ADDED, "_Z3barv", "added"),
+            ],
+        )
+        text = to_markdown(
+            result, show_only="compatible", severity_config=PRESET_DEFAULT
+        )
+        assert "0 of 2 changes shown" not in text  # sanity: filter is active
+        assert "| ABI/API Incompatibilities |" in text
+        lines = [ln for ln in text.splitlines() if "ABI/API Incompatibilities" in ln]
+        assert len(lines) == 1
+        assert "causes non-zero exit" in lines[0]
+
+    def test_leaf_severity_summary_exit_impact_ignores_show_only_filter(self):
+        """Same fix as above, for the report_mode="leaf" summary table."""
+        from abicheck.severity import PRESET_DEFAULT
+
+        result = _make_result(
+            changes=[
+                Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed"),
+                Change(ChangeKind.FUNC_ADDED, "_Z3barv", "added"),
+            ],
+        )
+        text = to_markdown(
+            result,
+            report_mode="leaf",
+            show_only="compatible",
+            severity_config=PRESET_DEFAULT,
+        )
+        lines = [ln for ln in text.splitlines() if "ABI/API Incompatibilities" in ln]
+        assert len(lines) == 1
+        assert "causes non-zero exit" in lines[0]
+
     def test_show_only_in_json(self):
         result = _make_result(
             changes=[

--- a/tests/test_report_filtering.py
+++ b/tests/test_report_filtering.py
@@ -393,6 +393,18 @@ class TestLeafMode:
         assert d["leaf_changes"][0]["affected_count"] == 2
         assert len(d["non_type_changes"]) == 1
 
+    def test_leaf_markdown_carries_severity_summary(self):
+        """report_mode="leaf" returned before the severity summary section
+        was ever built, so it silently had no severity info even when a
+        caller passed severity_config through to_markdown."""
+        from abicheck.severity import PRESET_DEFAULT
+
+        result = _make_result(
+            changes=[Change(ChangeKind.FUNC_ADDED, "new_api", "new function: new_api")],
+        )
+        text = to_markdown(result, report_mode="leaf", severity_config=PRESET_DEFAULT)
+        assert "Severity Configuration" in text
+
 
 # ---------------------------------------------------------------------------
 # Show-impact tests

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -183,6 +183,27 @@ class TestEvidenceStatusInJson:
         # kept for backward-compat consumers) carries it too.
         assert d["changes"][0]["evidence_status"] == "artifact_proven"
 
+    def test_leaf_mode_root_type_change_honours_frozen_namespace_floor(self):
+        """Codex review on #549: a policy-file override that demotes a root
+        type kind (type_size_changed) to COMPATIBLE must not silently drop a
+        frozen_namespace_violation-tagged finding below its raw severity in
+        leaf_changes — the top-level `severity` block already honours
+        policy_file (via _build_severity_json), so leaf_changes reading
+        "compatible" for the same finding would be a direct contradiction."""
+        from abicheck.policy_file import PolicyFile
+        from abicheck.severity import PRESET_DEFAULT
+
+        c = Change(
+            ChangeKind.TYPE_SIZE_CHANGED, "Cfg", "struct Cfg grew",
+            frozen_namespace_violation="**::detail::r1::*",
+        )
+        pf = PolicyFile(overrides={ChangeKind.TYPE_SIZE_CHANGED: Verdict.COMPATIBLE})
+        r = _result(Verdict.BREAKING, changes=[c])
+        r.policy_file = pf
+        d = json.loads(to_json(r, report_mode="leaf", severity_config=PRESET_DEFAULT))
+        assert d["leaf_changes"][0]["severity"] == "breaking"
+        assert d["severity"]["exit_code"] == 4
+
     def test_leaf_mode_carries_severity_block(self):
         """report_mode="leaf" returned before the severity block was ever
         built, so a caller passing severity_config silently got no severity

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -46,6 +46,52 @@ class TestReviewDigest:
         assert "`sym12`" not in out
 
 
+class TestReviewDigestSeverityAware:
+    """Without severity_config, the merge-effect phrase is inferred purely
+    from the compatibility verdict — which can misreport the actual CI gate
+    once severity configuration is in play (compatibility and "blocks CI" are
+    independent decisions). These guard the fix."""
+
+    def test_compatible_addition_configured_as_error_is_not_safe_to_merge(self):
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+        result = _result(Verdict.COMPATIBLE, changes=[c])
+
+        # Legacy (no severity_config): the old, misleading claim.
+        legacy = to_review_digest(result)
+        assert "safe to merge" in legacy
+
+        cfg = resolve_severity_config("default", addition="error")
+        out = to_review_digest(result, severity_config=cfg)
+        assert "safe to merge" not in out
+        assert "blocked by severity policy" in out
+
+    def test_breaking_demoted_to_non_error_is_not_reported_as_blocking(self):
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")
+        result = _result(Verdict.BREAKING, changes=[c])
+
+        # Legacy (no severity_config): claims it blocks merge under a strict gate.
+        legacy = to_review_digest(result)
+        assert "blocks merge" in legacy
+
+        cfg = resolve_severity_config("default", abi_breaking="info")
+        out = to_review_digest(result, severity_config=cfg)
+        assert "blocks merge" not in out
+        assert "safe to merge" in out
+
+    def test_severity_config_confirms_a_real_block(self):
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")
+        result = _result(Verdict.BREAKING, changes=[c])
+        cfg = resolve_severity_config("default")  # default: abi_breaking=error
+        out = to_review_digest(result, severity_config=cfg)
+        assert "blocked by severity policy" in out
+
+
 def _result(verdict: Verdict, changes=None) -> DiffResult:
     return DiffResult(
         old_version="1.0", new_version="2.0",

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -171,6 +171,23 @@ class TestEvidenceStatusInJson:
         # kept for backward-compat consumers) carries it too.
         assert d["changes"][0]["evidence_status"] == "artifact_proven"
 
+    def test_leaf_mode_carries_severity_block(self):
+        """report_mode="leaf" returned before the severity block was ever
+        built, so a caller passing severity_config silently got no severity
+        information at all — unlike full-mode JSON."""
+        from abicheck.severity import PRESET_DEFAULT
+
+        c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+        r = _result(Verdict.COMPATIBLE, changes=[c])
+        d = json.loads(to_json(r, report_mode="leaf", severity_config=PRESET_DEFAULT))
+        assert "severity" in d
+        assert d["severity"]["categories"]["addition"]["count"] == 1
+
+    def test_leaf_mode_without_severity_config_has_no_severity_block(self):
+        r = _result(Verdict.COMPATIBLE)
+        d = json.loads(to_json(r, report_mode="leaf"))
+        assert "severity" not in d
+
 
 class TestMarkdownReporter:
     def test_no_change_contains_no_change(self):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -204,6 +204,29 @@ class TestEvidenceStatusInJson:
         assert d["leaf_changes"][0]["severity"] == "breaking"
         assert d["severity"]["exit_code"] == 4
 
+    def test_leaf_mode_non_type_change_honours_frozen_namespace_floor(self):
+        """Codex review on #549 (follow-on to the root-type leaf-entry fix):
+        the adjacent non_type_changes path in the same leaf-mode function
+        called _change_to_dict without policy_file, so a non-root-type kind
+        (func_removed) demoted by a policy override, but tagged
+        frozen_namespace_violation, read "compatible" in non_type_changes
+        (and the backward-compat changes union) while the top-level severity
+        block correctly reported exit_code=4 for the same finding."""
+        from abicheck.policy_file import PolicyFile
+        from abicheck.severity import PRESET_DEFAULT
+
+        c = Change(
+            ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo",
+            frozen_namespace_violation="**::detail::r1::*",
+        )
+        pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE})
+        r = _result(Verdict.BREAKING, changes=[c])
+        r.policy_file = pf
+        d = json.loads(to_json(r, report_mode="leaf", severity_config=PRESET_DEFAULT))
+        assert d["non_type_changes"][0]["severity"] == "breaking"
+        assert d["changes"][0]["severity"] == "breaking"
+        assert d["severity"]["exit_code"] == 4
+
     def test_leaf_mode_carries_severity_block(self):
         """report_mode="leaf" returned before the severity block was ever
         built, so a caller passing severity_config silently got no severity

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -116,6 +116,18 @@ class TestJsonReporter:
         assert d["summary"]["breaking"] == 1
         assert d["changes"][0]["kind"] == "func_removed"
 
+    def test_stat_forwards_severity_config(self):
+        """Codex review: to_json(stat=True, severity_config=...) returned
+        before forwarding severity_config to to_stat_json, so a caller going
+        through to_json directly (not service.render_output) silently lost
+        the severity block/exit code in stat JSON output."""
+        from abicheck.severity import PRESET_DEFAULT
+
+        c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+        r = _result(Verdict.COMPATIBLE, changes=[c])
+        d = json.loads(to_json(r, stat=True, severity_config=PRESET_DEFAULT))
+        assert "severity" in d
+
 
 class TestEvidenceStatusInJson:
     """The per-finding `evidence_status` field (schema 2.2): the epistemic

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -386,3 +386,27 @@ class TestSeverityGate:
         text = to_sarif_str(r, severity_config=cfg)
         doc = json.loads(text)
         assert doc["runs"][0]["invocations"][0]["exitCode"] == 1
+
+    def test_result_level_follows_severity_addition_override(self) -> None:
+        """Codex review on #549: per-result `level` was built by `_result_for`
+        from the legacy policy severity, ignoring `severity_config` entirely.
+        `--severity-addition error` blocks the build (exitCode=1) but the
+        added-symbol result kept `level: warning` — a code-scanning UI reading
+        result levels would disagree with the configured gate."""
+        from abicheck.severity import resolve_severity_config
+
+        cfg = resolve_severity_config("default", addition="error")
+        r = _make_result([_compatible_change()], verdict=Verdict.COMPATIBLE)
+        doc = to_sarif(r, severity_config=cfg)
+        assert doc["runs"][0]["results"][0]["level"] == "error"
+
+    def test_result_level_follows_severity_abi_breaking_override(self) -> None:
+        """Same fix, the inverse direction: `--severity-abi-breaking info` lets
+        the invocation pass (exitCode=0) but the removed-symbol result kept
+        `level: error` under the legacy mapping."""
+        from abicheck.severity import resolve_severity_config
+
+        cfg = resolve_severity_config("default", abi_breaking="info")
+        r = _make_result([_breaking_change()], verdict=Verdict.BREAKING)
+        doc = to_sarif(r, severity_config=cfg)
+        assert doc["runs"][0]["results"][0]["level"] == "note"

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -329,3 +329,60 @@ class TestSarifConfidenceAndPolicy:
         doc = to_sarif(_make_result([], verdict=Verdict.NO_CHANGE))
         props = doc["runs"][0]["properties"]
         assert "policyOverrides" not in props
+
+
+# ---------------------------------------------------------------------------
+# Severity-aware invocation gate
+# ---------------------------------------------------------------------------
+
+class TestSeverityGate:
+    """Without severity_config, the invocation exit is inferred purely from
+    the compatibility verdict — which can misreport the actual CI gate once
+    severity configuration is in play (compatibility and "blocks CI" are
+    independent decisions). These guard the fix."""
+
+    def test_no_severity_config_keeps_legacy_behaviour(self) -> None:
+        doc = to_sarif(_make_result([_breaking_change()], verdict=Verdict.BREAKING))
+        props = doc["runs"][0]["properties"]
+        assert "severityGate" not in props
+
+    def test_compatible_addition_configured_as_error_fails_invocation(self) -> None:
+        from abicheck.severity import resolve_severity_config
+
+        cfg = resolve_severity_config("default", addition="error")
+        r = _make_result([_compatible_change()], verdict=Verdict.COMPATIBLE)
+        doc = to_sarif(r, severity_config=cfg)
+        inv = doc["runs"][0]["invocations"][0]
+        # Legacy inference would say COMPATIBLE -> exitCode 0, executionSuccessful.
+        assert inv["exitCode"] == 1
+        assert inv["executionSuccessful"] is False
+
+        gate = doc["runs"][0]["properties"]["severityGate"]
+        assert gate["exitCode"] == 1
+        assert gate["blocking"] is True
+        assert gate["blockingCategories"] == ["addition"]
+        assert gate["config"]["addition"] == "error"
+
+    def test_breaking_demoted_to_info_passes_invocation(self) -> None:
+        from abicheck.severity import resolve_severity_config
+
+        cfg = resolve_severity_config("default", abi_breaking="info")
+        r = _make_result([_breaking_change()], verdict=Verdict.BREAKING)
+        doc = to_sarif(r, severity_config=cfg)
+        inv = doc["runs"][0]["invocations"][0]
+        # Legacy inference would say BREAKING -> exitCode 4, executionSuccessful=False.
+        assert inv["exitCode"] == 0
+        assert inv["executionSuccessful"] is True
+
+        gate = doc["runs"][0]["properties"]["severityGate"]
+        assert gate["blocking"] is False
+        assert gate["blockingCategories"] == []
+
+    def test_to_sarif_str_forwards_severity_config(self) -> None:
+        from abicheck.severity import resolve_severity_config
+
+        cfg = resolve_severity_config("default", addition="error")
+        r = _make_result([_compatible_change()], verdict=Verdict.COMPATIBLE)
+        text = to_sarif_str(r, severity_config=cfg)
+        doc = json.loads(text)
+        assert doc["runs"][0]["invocations"][0]["exitCode"] == 1

--- a/tests/test_sprint9_html.py
+++ b/tests/test_sprint9_html.py
@@ -133,6 +133,40 @@ def test_added_section_present_when_additions_exist() -> None:
     assert "Added Symbols" in out
 
 
+def test_breaking_field_addition_not_in_green_added_section() -> None:
+    """A structurally-additive but ABI-breaking finding (type_field_added -
+    appending a field to a non-final/polymorphic type can break binary
+    layout) must not render under the green Added section, or it reads as
+    safe when it is not. Verified defect (source assessment): confirmed
+    ChangeKind.TYPE_FIELD_ADDED is in both ADDED_KINDS and BREAKING_KINDS."""
+    r = _result(verdict="BREAKING", changes=[_ch("type_field_added", "Config")])
+    out = generate_html_report(r)
+    assert "id='added'" not in out
+    assert "id='changed'" in out
+
+
+def test_policy_demoted_removal_does_not_contradict_compatible_verdict() -> None:
+    """A policy-file override that demotes a removal to COMPATIBLE must not
+    leave the page reporting "0.0% binary compatibility" next to a
+    COMPATIBLE verdict banner — verified defect (source assessment): the
+    binary-compatibility % previously counted breaking_count by raw kind
+    membership, ignoring the policy override the verdict itself honours."""
+    from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+    from abicheck.policy_file import PolicyFile
+
+    c = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")
+    pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE})
+    result = DiffResult(
+        old_version="1.0", new_version="2.0", library="libtest.so",
+        changes=[c], verdict=Verdict.COMPATIBLE, policy_file=pf,
+    )
+    out = generate_html_report(result)
+    assert "Verdict: COMPATIBLE" in out
+    assert "Binary Compatibility: <strong>100.0%</strong>" in out
+    assert "Binary Compatibility: <strong>0.0%</strong>" not in out
+    assert "(0 breaking change(s))" in out
+
+
 def test_changed_section_present_for_changed_kinds() -> None:
     r = _result(verdict="BREAKING", changes=[_ch("func_return_changed", "myfunc")])
     out = generate_html_report(r)

--- a/tests/test_sprint9_html.py
+++ b/tests/test_sprint9_html.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from abicheck.html_report import generate_html_report, write_html_report
 
 # ---------------------------------------------------------------------------
@@ -167,22 +169,29 @@ def test_policy_demoted_removal_does_not_contradict_compatible_verdict() -> None
     assert "(0 breaking change(s))" in out
 
 
-def test_policy_escalated_addition_not_in_green_added_section() -> None:
-    """Codex review on #549: a policy file that escalates an inherently
-    additive kind (e.g. `func_added: BREAKING`) must not leave the finding
-    in the green "Added" section — `_change_bucket`'s canonical
-    `BREAKING_KINDS` membership check can never see a policy-file escalation
-    since it only looks at the kind's own default classification, so the
-    page could show a breaking compatibility metric while navigation/summary
-    still said "Added"."""
+@pytest.mark.parametrize(
+    "escalated_verdict",
+    ["BREAKING", "API_BREAK", "COMPATIBLE_WITH_RISK"],
+)
+def test_policy_escalated_addition_not_in_green_added_section(escalated_verdict: str) -> None:
+    """Codex review on #549 (two rounds): a policy file that escalates an
+    inherently additive kind away from COMPATIBLE — to BREAKING, API_BREAK,
+    *or* COMPATIBLE_WITH_RISK — must not leave the finding in the green
+    "Added" section. `_change_bucket`'s canonical `BREAKING_KINDS`
+    membership check can never see a policy-file escalation since it only
+    looks at the kind's own default classification. The first fix only
+    diverted the `== Verdict.BREAKING` case; a non-BREAKING escalation
+    (API_BREAK, COMPATIBLE_WITH_RISK) still rendered under "Added" even
+    though it needs review/recompilation like any other non-COMPATIBLE
+    finding — the guard must check "not COMPATIBLE", not "is BREAKING"."""
     from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
     from abicheck.policy_file import PolicyFile
 
     c = Change(ChangeKind.FUNC_ADDED, "_Z3barv", "new function: bar")
-    pf = PolicyFile(overrides={ChangeKind.FUNC_ADDED: Verdict.BREAKING})
+    pf = PolicyFile(overrides={ChangeKind.FUNC_ADDED: Verdict[escalated_verdict]})
     result = DiffResult(
         old_version="1.0", new_version="2.0", library="libtest.so",
-        changes=[c], verdict=Verdict.BREAKING, policy_file=pf,
+        changes=[c], verdict=Verdict[escalated_verdict], policy_file=pf,
     )
     out = generate_html_report(result)
     assert "id='added'" not in out

--- a/tests/test_sprint9_html.py
+++ b/tests/test_sprint9_html.py
@@ -167,6 +167,28 @@ def test_policy_demoted_removal_does_not_contradict_compatible_verdict() -> None
     assert "(0 breaking change(s))" in out
 
 
+def test_policy_escalated_addition_not_in_green_added_section() -> None:
+    """Codex review on #549: a policy file that escalates an inherently
+    additive kind (e.g. `func_added: BREAKING`) must not leave the finding
+    in the green "Added" section — `_change_bucket`'s canonical
+    `BREAKING_KINDS` membership check can never see a policy-file escalation
+    since it only looks at the kind's own default classification, so the
+    page could show a breaking compatibility metric while navigation/summary
+    still said "Added"."""
+    from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+    from abicheck.policy_file import PolicyFile
+
+    c = Change(ChangeKind.FUNC_ADDED, "_Z3barv", "new function: bar")
+    pf = PolicyFile(overrides={ChangeKind.FUNC_ADDED: Verdict.BREAKING})
+    result = DiffResult(
+        old_version="1.0", new_version="2.0", library="libtest.so",
+        changes=[c], verdict=Verdict.BREAKING, policy_file=pf,
+    )
+    out = generate_html_report(result)
+    assert "id='added'" not in out
+    assert "id='changed'" in out
+
+
 def test_changed_section_present_for_changed_kinds() -> None:
     r = _result(verdict="BREAKING", changes=[_ch("func_return_changed", "myfunc")])
     out = generate_html_report(r)


### PR DESCRIPTION
## Summary

Fixes four verified reporting defects where compatibility (`Verdict`) and the CI gate (`SeverityConfig`) could disagree without the report reflecting it, plus one defect where `scan --baseline` discarded its own findings.

## Motivation

A defect report was submitted claiming several reporting gaps between abicheck's compatibility verdict and its actual severity-aware CI gate. Rather than trust the report at face value, I independently re-verified each claim against current `main` by reading the actual code paths and reproducing the behavior. Three of the four claimed defects held up exactly as described; I fixed those with regression tests. (A fourth claim, that GitHub annotations classify strictly by raw `kind` rather than effective/policy-modulated verdict, turned out to be only partially accurate — `collect_annotations` already consults `DiffResult._effective_kind_sets()`, which does apply per-finding policy overrides. The real, confirmed gap was narrower: annotations had no awareness of `SeverityConfig` at all.)

Two rounds of automated review (`chatgpt-codex-connector`) then caught two real follow-on consistency gaps in the annotation fix itself, both addressed in this PR (see below).

I deliberately scoped this to the concrete, independently-verified defects rather than the report's much larger proposed architecture (a repo-wide `GateDecision` type spanning HTML/SARIF/stat/leaf renderers, a JSON schema 2.3 bump, etc.) — that's a bigger design change warranting its own review, not something to bundle into a bug-fix PR.

## Changes

- **`to_review_digest()`** (`--format review`) hard-coded its merge-effect phrase from the raw compatibility verdict (e.g. always "safe to merge" for `COMPATIBLE`), so it could claim "safe to merge" while a severity-configured category (e.g. `addition=error`) was actually about to fail CI — and conversely claim "blocks merge under a strict gate" for a `BREAKING` verdict that severity config had demoted below `error`. Now accepts an optional `severity_config` and asks the actual severity-aware gate (`severity.compute_exit_code`) instead of inferring from the verdict alone. Wired through `service.render_output`.

- **`collect_annotations()` / `emit_github_annotations()`** derived GitHub Actions annotation levels (`::error`/`::warning`/`::notice`) purely from fixed kind-set membership, with no awareness of `SeverityConfig`. An addition promoted to `error` produced no annotation at all despite failing the build; a breaking kind demoted below `error` still emitted `::error` despite not gating. Both now accept an optional `severity_config` that drives the annotation level from the finding's actually-configured severity. Wired through **both** the primary `compare` command's `--annotate` path (`cli.py` → `cli_compare_helpers.py`) **and** `compare-release`'s per-library re-run (`cli_compare_release.py::_collect_release_extras`) — the latter added after Codex flagged that directory/package compares bypass the single-file path entirely.

- Threading `severity_config` into the annotation classifier surfaced a second gap Codex caught: a finding tagged `frozen_namespace_violation` needs `policy_file` itself (not just the already-policy-overridden kind sets) passed to `classify_effective_change`, or its frozen-namespace floor is silently lost and the annotation under-reports a finding that `severity.compute_exit_code` still fails CI on at its raw severity. Fixed by threading `result.policy`/`result.policy_file` through.

- **`scan --baseline`** computed a real `DiffResult` internally but discarded it down to four bucket counts (`breaking=1 api_break=2 risk=0 compatible=0`) before returning — a failing baseline scan had no way to name the broken symbol without rerunning a separate `compare`. `_run_baseline_compare` now embeds the actual findings (kind/symbol/description/source location) in its summary dict, capped at 20 with a truncation flag, and `render_baseline_lines` prints them.

## Test plan

- [x] New/updated unit tests: `tests/test_reporter.py` (`TestReviewDigestSeverityAware`), `tests/test_annotations.py` (`TestSeverityConfigAwareAnnotations` + frozen-namespace regression), `tests/test_cli_split_modules.py` (compare-release severity-forwarding regression), `tests/test_pr494_scan_regressions.py` (findings preserved + truncation), `tests/test_cli_scan_helpers_coverage.py` (findings rendering)
- [x] Fixed a pre-existing test (`test_cov95_cli.py`) whose mock needed the new optional kwarg
- [x] Full fast suite: `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` → 14280 passed
- [x] `ruff check abicheck/ tests/` → clean
- [x] `mypy abicheck/` → 0 errors (baseline maintained)
- [x] `python scripts/check_ai_readiness.py` → 0 errors (pre-existing warnings only, none new)
- [x] Local coverage check on the diff (`--cov` on the changed modules) → ~97%, confirming the Codecov "12% patch coverage" check (which fired before the real CI coverage job had run for that commit) was a stale/premature signal, not a real gap

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [ ] Docs updated if user-visible behaviour changed — the `--format review`/`--annotate`/`scan --baseline` behavior is additive (new optional param, defaults to prior behavior) and self-describing in output; no doc claims needed correction
- [x] No new `mypy` or `ruff` errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added severity-aware reporting across CI comparisons: GitHub annotations/step summaries, SARIF, JUnit, JSON/stat, Markdown, and MCP results.
  * Introduced severity configuration options for the MCP comparison tool.
  * Enhanced `scan --baseline` output with itemized, capped baseline findings, source locations, and truncation notices.

* **Bug Fixes**
  * Fixed severity-configuration handling so CI gating, annotation levels, and “merge/block” messaging reflect the configured severity policy.
  * Preserved correct frozen-namespace behavior and consistent suppression/demotion across all output formats.

* **Tests**
  * Expanded coverage for severity-aware rendering and baseline finding truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->