### PR TITLE
fix: address usability-report P1/P2 findings (baseline, AST-frontend, scan schema, debug artifacts, stack impact, wheel pairing, Action)

### DIFF
--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -143,6 +143,9 @@ class CompareRequest:
     public_surface_allowlist: frozenset[str] | None = None
     pattern_verdicts: bool = False
     enable_debuginfod: bool = False
+    # Override debuginfod server URL (only meaningful with enable_debuginfod);
+    # None uses the resolver's default server list / DEBUGINFOD_URLS env var.
+    debuginfod_url: str | None = None
     # ADR-039: clear context-free header-parse false positives using the build's
     # active preprocessor defines (a conditional field's phantom add/remove/size
     # delta the build proves never changed). Opt-in; a no-op unless the snapshots

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -28,9 +28,15 @@ the normalized L3/L4/L5 facts *inline* from raw inputs and embeds them in the
 
 A per-project ``.abicheck.yml`` ``build:`` block can name the build system and a
 *query* command that emits a compile DB without performing a full build; running
-that query is gated by both an explicit operator-supplied build config and
-``--allow-build-query`` (ADR-032 D5 ``query_build_system`` action ceiling —
-read by default, trusted query opt-in, full build never).
+that query is gated by an explicit, operator-supplied ``--config`` alone
+(ADR-032 D5 ``query_build_system`` action ceiling — read by default, trusted
+query opt-in, full build never). ``--allow-build-query`` is a deprecated
+no-op kept only for backward compatibility — it neither grants nor restricts
+this permission (see :func:`collect_inline_pack`'s ``allow_build_query``
+docstring). The separate abicheck-authored *inferred* cmake/bazel/make query
+(:func:`_resolve_compile_db`) runs whenever ``--sources`` needs L3 regardless
+of any flag — pointing abicheck at a source tree is itself the request to
+analyse it.
 
 Everything here is best-effort (ADR-028 D3): a missing tool or unreadable input
 degrades L3/L4/L5 to partial/not-collected coverage and never aborts the dump —

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1093,6 +1093,9 @@ def _embed_inline_source_side(
     collect_mode: str,
     out_dir: Path,
     label: str,
+    debug_roots: tuple[Path, ...] = (),
+    debuginfod: bool = False,
+    debuginfod_url: str | None = None,
 ) -> tuple[Path, Path | None, Path | None]:
     """Resolve one side's ``--sources`` into the input ``compare`` should read.
 
@@ -1110,6 +1113,13 @@ def _embed_inline_source_side(
     The caller passes the *resolved* values plus the toolchain/dependency/native
     knobs (``follow_deps``/``--gcc-*``/``--dwarf-only``/…) so the inline dump
     parses this side exactly as a native ``compare``/``dump`` would.
+
+    ``debug_roots``/``debuginfod``/``debuginfod_url`` (P1.1, Codex review):
+    this side's resolved detached-debug-artifact inputs, forwarded verbatim to
+    the inline ``dump`` invocation below — without this, a raw
+    ``--old/new-sources`` tree bypassed ``--debug-root`` entirely (the inline
+    dump used its own unset defaults), so a stripped binary on this side still
+    lost its DWARF even though the sibling non-inline path was fixed.
     """
     sources_raw = sources is not None and not _source_is_pack(sources)
     build_info_raw = build_info is not None and not _source_is_pack(build_info)
@@ -1196,6 +1206,9 @@ def _embed_inline_source_side(
         build_info=dump_build_info,
         _resolved_collect_mode=collect_mode,
         output=out,
+        debug_roots=debug_roots,
+        debuginfod=debuginfod,
+        debuginfod_url=debuginfod_url,
     )
     # The raw sources/build-info are now embedded in the snapshot; pack-shaped
     # inputs (kept_*) ride through to the later prepare_embedded_build_source so

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -641,16 +641,23 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
     )
     effective_gcc_options = _merge_gcc_options(build_context_flags, gcc_options)
 
-    # Debug artifact resolution (ADR-021a): resolve before dump
+    # Debug artifact resolution (ADR-021a): resolve before dump. P1.1: thread
+    # a resolved detached debug file (build-id tree / path-mirror / debuginfod
+    # — distinct from so_path itself) into the actual DWARF parse instead of
+    # only logging it, so a stripped binary still gets DWARF-aware comparison.
+    debug_info_path: Path | None = None
     if debug_roots or debuginfod:
         artifact = _resolve_debug_artifact(
             so_path, debug_roots, debuginfod, debuginfod_url,
         )
         if artifact:
             click.echo(f"Debug info: {artifact.source}", err=True)
+            if artifact.dwarf_path and artifact.dwarf_path.resolve() != so_path.resolve():
+                debug_info_path = artifact.dwarf_path
 
     perform_elf_dump(
         so_path=so_path,
+        debug_info_path=debug_info_path,
         headers=headers,
         includes=includes,
         version=version,

--- a/abicheck/cli_baseline.py
+++ b/abicheck/cli_baseline.py
@@ -184,7 +184,10 @@ def baseline_pull(
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
 
-    result = registry.pull(key)
+    try:
+        result = registry.pull(key)
+    except AbicheckError as exc:
+        raise click.ClickException(str(exc)) from exc
     if result is None:
         raise click.ClickException(f"Baseline not found: {key.path}")
 

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -697,6 +697,9 @@ def run_compare(
         old_header_backend=old_header_backend,
         new_header_backend=new_header_backend,
         compile_context=side_compile_context,
+        old_debug_roots=resolved_old_debug or None,
+        new_debug_roots=resolved_new_debug or None,
+        enable_debuginfod=debuginfod,
     )
 
     suppression, pf = _load_suppression_and_policy(

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -710,6 +710,7 @@ def run_compare(
         old_debug_roots=resolved_old_debug or None,
         new_debug_roots=resolved_new_debug or None,
         enable_debuginfod=debuginfod,
+        debuginfod_url=debuginfod_url,
     )
 
     suppression, pf = _load_suppression_and_policy(

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -496,6 +496,15 @@ def run_compare(
     debuginfod_url = resolved_cfg.debuginfod_url
     show_redundant = resolved_cfg.show_redundant
 
+    # P1.1 (Codex review): resolved ahead of the inline-embed block below (not
+    # just before _resolve_compare_snapshots, where this used to live) so a raw
+    # --old/new-sources tree's inline `dump` invocation also gets the per-side
+    # debug roots — otherwise --debug-root + --old-sources together silently
+    # dumped the inline side without detached DWARF.
+    resolved_old_debug, resolved_new_debug = _resolve_debug_roots(
+        debug_roots, debug_roots_old, debug_roots_new
+    )
+
     # ADR-037 D7: input-type dispatch. The resolved config (scope/suppression/
     # severity) is forwarded so a set-input compare classifies the same way a
     # single-pair one would (ADR-037 D4).
@@ -646,6 +655,8 @@ def run_compare(
             ld_library_path=ld_library_path,
             dwarf_only=dwarf_only, debug_format=effective_debug_format,
             pdb_path=old_pdb_path or pdb_path,
+            debug_roots=tuple(resolved_old_debug),
+            debuginfod=debuginfod, debuginfod_url=debuginfod_url,
             collect_mode=collect_mode, out_dir=Path(_src_tmp), label="old",
         )
         new_input, new_sources, new_build_info = _embed_inline_source_side(
@@ -657,6 +668,8 @@ def run_compare(
             nostdinc_explicit=_nostdinc_explicit or compile_context.nostdinc,
             build_info=new_build_info,
             follow_deps=follow_deps, search_paths=search_paths,
+            debug_roots=tuple(resolved_new_debug),
+            debuginfod=debuginfod, debuginfod_url=debuginfod_url,
             ld_library_path=ld_library_path,
             dwarf_only=dwarf_only, debug_format=effective_debug_format,
             pdb_path=new_pdb_path or pdb_path,
@@ -677,9 +690,6 @@ def run_compare(
         old_includes_only, new_includes_only,
     )
 
-    resolved_old_debug, resolved_new_debug = _resolve_debug_roots(
-        debug_roots, debug_roots_old, debug_roots_new
-    )
     _log_debug_resolution(
         old_input, new_input,
         resolved_old_debug, resolved_new_debug,

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -431,8 +431,13 @@ def perform_elf_dump(
     user_gcc_options: str | None = None,
     compile_db_filter: str | None = None,
     inputs_pack: Path | None = None,
+    debug_info_path: Path | None = None,
 ) -> None:
     """Run the ELF dump pipeline and write output.
+
+    ``debug_info_path`` (P1.1, ADR-021a): a resolved detached debug artifact
+    (``--debug-root``/``--debuginfod``) to read DWARF sections from instead of
+    ``so_path`` itself — threaded straight into :func:`dumper.dump`.
 
     All helper callables (expand_header_inputs, populate_dependency_info,
     stamp_provenance, write_snapshot_output) are passed in from cli.py to avoid
@@ -510,6 +515,7 @@ def perform_elf_dump(
             public_header_dirs=list(public_header_dirs),
             header_backend=header_backend,
             extra_hash_dirs=deferred_dirs,
+            debug_info_path=debug_info_path,
         )
     except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
         raise click.ClickException(str(exc)) from exc

--- a/abicheck/cli_helpers_compare.py
+++ b/abicheck/cli_helpers_compare.py
@@ -227,8 +227,14 @@ def _canonical_library_key(path: Path) -> str:
 def _version_sort_key(
     path: Path, canonical_key: str
 ) -> tuple[list[tuple[int, int | str]], str]:
-    """Build a version-aware sort key for ambiguous library candidates."""
-    lower = path.name.lower()
+    """Build a version-aware sort key for ambiguous library candidates.
+
+    Uses the vendor-hash-stripped name (G9) so an auditwheel/delocate content
+    hash never enters the comparison — otherwise the hash's digits/letters can
+    outrank the real SONAME version tokens and ``_build_match_map`` picks a
+    stale duplicate over the newer one (Codex review, PR #551).
+    """
+    lower = strip_vendor_hash(path.name.lower())
     remainder = lower
     if canonical_key.endswith(".so") and canonical_key in lower:
         remainder = lower[lower.find(canonical_key) + len(canonical_key) :]

--- a/abicheck/cli_helpers_compare.py
+++ b/abicheck/cli_helpers_compare.py
@@ -187,12 +187,37 @@ def _collect_additions(result: DiffResult) -> list[object]:
     return [c for c in result.changes if c.kind in addition_kinds]
 
 
+#: `auditwheel` (Linux) and `delocate` (macOS) rewrite each vendored library to
+#: ``lib<name>-<hex>.so.<ver>`` / ``lib<name>-<hex>.dylib`` and rewrite its
+#: SONAME/install-name to match, so the hash changes on every rebuild even
+#: though the underlying dependency didn't. Restricted to a hyphen + 6-16 hex
+#: chars immediately before ``.so``/``.dylib`` (or a numeric version
+#: component leading to one) so ordinary hyphenated names — e.g.
+#: ``libwebpdemux``, ``libbrotlicommon``, or a real ``-cafe`` (too short) —
+#: are never touched (G9, ADR: docs/development/plans/g9-wheel-vendored-matching.md).
+_VENDOR_HASH_RE = re.compile(r"-[0-9a-f]{6,16}(?=\.(?:so|dylib)\b|\.\d)")
+
+
+def strip_vendor_hash(name: str) -> str:
+    """Strip an auditwheel/delocate content-hash suffix from a library name.
+
+    Pairing on the unhashed stem lets ``compare-release`` diff two wheels'
+    vendored libraries directly instead of reporting every one as
+    removed+added noise every rebuild (G9). A genuinely changed vendored
+    dependency (e.g. a SONAME major bump) still surfaces as a real break —
+    this only normalizes the filename/SONAME, never the content.
+    """
+    return _VENDOR_HASH_RE.sub("", name)
+
+
 def _canonical_library_key(path: Path) -> str:
     """Canonical key used to match libraries across releases.
 
     For ELF versioned names, canonicalize to ``*.so`` (e.g. ``libfoo.so.1.2`` → ``libfoo.so``).
+    Vendored auditwheel/delocate hash suffixes are stripped first (G9) so the
+    same bundled dependency pairs across rebuilds despite its hash changing.
     """
-    lower = path.name.lower()
+    lower = strip_vendor_hash(path.name.lower())
     m = re.search(r"\.so(?:\.|$)", lower)
     if m:
         return lower[: m.start() + 3]

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -519,9 +519,11 @@ def compile_context_options(func: F) -> F:
         type=click.Choice(["auto", "castxml", "clang"], case_sensitive=False),
         help="C/C++ AST frontend (ADR-037 D8): castxml (default schema reference) "
         "or clang (-ast-dump=json; for hosts where castxml is absent or its "
-        "bundled frontend chokes). auto = castxml if present, else clang, with an "
-        "automatic clang fallback on a castxml toolchain-version error. Env: "
-        "ABICHECK_AST_FRONTEND.",
+        "bundled frontend chokes). auto resolves to castxml (or the "
+        "ABICHECK_AST_FRONTEND pin) and does NOT fall back merely because "
+        "castxml is absent; it only falls back to clang for two narrow castxml "
+        "runtime failures (a toolchain-version mismatch or a direct-include "
+        "#error guard). Env: ABICHECK_AST_FRONTEND.",
     )(func)
     return func
 

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -258,6 +258,7 @@ def _resolve_input(
     debug_format: str | None = None,
     debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
+    debuginfod_url: str | None = None,
     header_backend: str = "auto",
     compile: CompileContext | None = None,
     public_headers: list[Path] | None = None,
@@ -284,11 +285,14 @@ def _resolve_input(
             detects the format from magic bytes.
         dwarf_only: If True, force DWARF-only mode (ADR-003).
         debug_format: Force debug format ("dwarf", "btf", "ctf") or None for auto.
-        debug_roots / enable_debuginfod: Detached-debug-artifact resolution
-            (ADR-021a) for this side — forwarded to ``service.resolve_input``
-            so a resolved build-id-tree/path-mirror ``.debug`` file actually
-            feeds the DWARF parse for a stripped ELF input, not just a log
-            line (P1.1).
+        debug_roots / enable_debuginfod / debuginfod_url: Detached-debug-artifact
+            resolution (ADR-021a) for this side — forwarded to
+            ``service.resolve_input`` so a resolved build-id-tree/path-mirror
+            ``.debug`` file actually feeds the DWARF parse for a stripped ELF
+            input, not just a log line (P1.1). ``debuginfod_url`` overrides the
+            default debuginfod server(s) — without threading it here, a custom
+            server could be used for the (log-only) resolution probe elsewhere
+            while the actual DWARF fetch silently fell back to the default.
         public_headers / public_header_dirs: Public-header set used to tag
             declaration provenance (ADR-024/ADR-015). Callers that already
             treat *headers* as the public contract (e.g. ``compare``'s
@@ -311,6 +315,7 @@ def _resolve_input(
             debug_format=debug_format,
             debug_roots=debug_roots,
             enable_debuginfod=enable_debuginfod,
+            debuginfod_url=debuginfod_url,
             header_backend=header_backend,
             compile=compile,
             public_headers=public_headers,
@@ -493,6 +498,7 @@ def _resolve_compare_snapshots(
     old_debug_roots: list[Path] | None = None,
     new_debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
+    debuginfod_url: str | None = None,
 ) -> tuple[AbiSnapshot, AbiSnapshot]:
     """Load both ABI snapshots and (optionally) populate ELF dependency info.
 
@@ -508,10 +514,13 @@ def _resolve_compare_snapshots(
     here — the frontend is driven by the explicit ``header_backend`` so the per-side
     override above still wins.
 
-    ``old_debug_roots`` / ``new_debug_roots`` / ``enable_debuginfod`` (P1.1,
-    ADR-021a): per-side detached-debug-artifact resolution (``--debug-root
-    old=/new=``, ``--debuginfod``), forwarded to each side's ``_resolve_input``
-    so a resolved ``.debug`` file actually feeds that side's DWARF parse.
+    ``old_debug_roots`` / ``new_debug_roots`` / ``enable_debuginfod`` /
+    ``debuginfod_url`` (P1.1, ADR-021a): per-side detached-debug-artifact
+    resolution (``--debug-root old=/new=``, ``--debuginfod``,
+    ``--debuginfod-url``), forwarded to each side's ``_resolve_input`` so a
+    resolved ``.debug`` file actually feeds that side's DWARF parse — a custom
+    debuginfod server must reach the actual fetch, not just the (log-only)
+    resolution probe elsewhere.
     """
     old_backend = old_header_backend or header_backend
     new_backend = new_header_backend or header_backend
@@ -531,6 +540,7 @@ def _resolve_compare_snapshots(
         debug_format=debug_format,
         debug_roots=old_debug_roots,
         enable_debuginfod=enable_debuginfod,
+        debuginfod_url=debuginfod_url,
         header_backend=old_backend,
         compile=compile_context,
         public_headers=old_h,
@@ -547,6 +557,7 @@ def _resolve_compare_snapshots(
         debug_format=debug_format,
         debug_roots=new_debug_roots,
         enable_debuginfod=enable_debuginfod,
+        debuginfod_url=debuginfod_url,
         header_backend=new_backend,
         compile=compile_context,
         public_headers=new_h,

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -256,6 +256,8 @@ def _resolve_input(
     pdb_path: Path | None = None,
     dwarf_only: bool = False,
     debug_format: str | None = None,
+    debug_roots: list[Path] | None = None,
+    enable_debuginfod: bool = False,
     header_backend: str = "auto",
     compile: CompileContext | None = None,
     public_headers: list[Path] | None = None,
@@ -282,6 +284,11 @@ def _resolve_input(
             detects the format from magic bytes.
         dwarf_only: If True, force DWARF-only mode (ADR-003).
         debug_format: Force debug format ("dwarf", "btf", "ctf") or None for auto.
+        debug_roots / enable_debuginfod: Detached-debug-artifact resolution
+            (ADR-021a) for this side — forwarded to ``service.resolve_input``
+            so a resolved build-id-tree/path-mirror ``.debug`` file actually
+            feeds the DWARF parse for a stripped ELF input, not just a log
+            line (P1.1).
         public_headers / public_header_dirs: Public-header set used to tag
             declaration provenance (ADR-024/ADR-015). Callers that already
             treat *headers* as the public contract (e.g. ``compare``'s
@@ -302,6 +309,8 @@ def _resolve_input(
             pdb_path=pdb_path,
             dwarf_only=dwarf_only,
             debug_format=debug_format,
+            debug_roots=debug_roots,
+            enable_debuginfod=enable_debuginfod,
             header_backend=header_backend,
             compile=compile,
             public_headers=public_headers,
@@ -481,6 +490,9 @@ def _resolve_compare_snapshots(
     old_header_backend: str | None = None,
     new_header_backend: str | None = None,
     compile_context: CompileContext | None = None,
+    old_debug_roots: list[Path] | None = None,
+    new_debug_roots: list[Path] | None = None,
+    enable_debuginfod: bool = False,
 ) -> tuple[AbiSnapshot, AbiSnapshot]:
     """Load both ABI snapshots and (optionally) populate ELF dependency info.
 
@@ -495,6 +507,11 @@ def _resolve_compare_snapshots(
     ``compile:`` block; it applies to both sides. Its ``frontend`` field is unused
     here — the frontend is driven by the explicit ``header_backend`` so the per-side
     override above still wins.
+
+    ``old_debug_roots`` / ``new_debug_roots`` / ``enable_debuginfod`` (P1.1,
+    ADR-021a): per-side detached-debug-artifact resolution (``--debug-root
+    old=/new=``, ``--debuginfod``), forwarded to each side's ``_resolve_input``
+    so a resolved ``.debug`` file actually feeds that side's DWARF parse.
     """
     old_backend = old_header_backend or header_backend
     new_backend = new_header_backend or header_backend
@@ -512,6 +529,8 @@ def _resolve_compare_snapshots(
         pdb_path=old_pdb_path if old_pdb_path else pdb_path,
         dwarf_only=dwarf_only,
         debug_format=debug_format,
+        debug_roots=old_debug_roots,
+        enable_debuginfod=enable_debuginfod,
         header_backend=old_backend,
         compile=compile_context,
         public_headers=old_h,
@@ -526,6 +545,8 @@ def _resolve_compare_snapshots(
         pdb_path=new_pdb_path if new_pdb_path else pdb_path,
         dwarf_only=dwarf_only,
         debug_format=debug_format,
+        debug_roots=new_debug_roots,
+        enable_debuginfod=enable_debuginfod,
         header_backend=new_backend,
         compile=compile_context,
         public_headers=new_h,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1278,6 +1278,7 @@ def dump(
     public_header_dirs: list[Path] | None = None,
     header_backend: str = "auto",
     extra_hash_dirs: tuple[Path, ...] = (),
+    debug_info_path: Path | None = None,
 ) -> AbiSnapshot:
     """Create an AbiSnapshot from a shared library + headers.
 
@@ -1308,6 +1309,13 @@ def dump(
         debug_presence_only: For ELF inputs, skip expensive DWARF type expansion
             while still allowing header parsing. Used by shallow scan depths that
             collect L2/L3 from headers/build evidence.
+        debug_info_path: For ELF inputs, a resolved detached debug artifact
+            (ADR-021a: a build-id-tree or path-mirror ``.debug`` file distinct
+            from *so_path*) to read DWARF sections from instead of *so_path*
+            itself — lets a stripped binary still get DWARF-aware comparison
+            when its separate debug file was found via ``--debug-root``/
+            ``--debuginfod`` (P1.1). ``None`` (the default) parses DWARF from
+            *so_path*, unchanged. Ignored for non-ELF formats.
         public_headers: Explicit public-header files used only to classify
             declaration provenance (ADR-015). When empty, every declaration's
             origin stays UNKNOWN and behaviour is unchanged.
@@ -1341,6 +1349,7 @@ def dump(
         extra["debug_format"] = debug_format
         extra["symbols_only"] = symbols_only
         extra["debug_presence_only"] = debug_presence_only
+        extra["debug_info_path"] = debug_info_path
     snapshot = handler.builder(
         so_path, headers, extra_includes or [], version, compiler,
         gcc_path=gcc_path, gcc_prefix=gcc_prefix, gcc_options=gcc_options,
@@ -1627,6 +1636,7 @@ def _dump_elf(
     public_header_dirs: list[Path] | None = None,
     header_backend: str = "auto",
     extra_hash_dirs: tuple[Path, ...] = (),
+    debug_info_path: Path | None = None,
 ) -> AbiSnapshot:
     """ELF-specific dump: pyelftools + debug info (DWARF/BTF/CTF) + header AST."""
     exported_dynamic, exported_static = _pyelftools_exported_symbols(so_path)
@@ -1655,6 +1665,7 @@ def _dump_elf(
         else:
             dwarf_meta, dwarf_adv = _resolve_debug_metadata(
                 so_path, debug_format, _session_out=_dwarf_session_out,
+                dwarf_source=debug_info_path,
             )
         dwarf_session = _dwarf_session_out[0] if _dwarf_session_out else None
         profile_hint = _lang_to_profile(lang)

--- a/abicheck/dumper_debug.py
+++ b/abicheck/dumper_debug.py
@@ -44,6 +44,7 @@ def _resolve_debug_metadata(
     debug_format: str | None,
     *,
     _session_out: list[DwarfSession] | None = None,
+    dwarf_source: Path | None = None,
 ) -> tuple[DwarfMetadata, AdvancedDwarfMetadata]:
     """Resolve debug metadata using the specified or auto-detected format.
 
@@ -55,8 +56,18 @@ def _resolve_debug_metadata(
     it so a subsequent snapshot build can reuse the same open ``DWARFInfo``
     (F5b: avoid re-parsing every DIE). The caller must close it. BTF/CTF and
     no-debug paths leave the list untouched (session stays ``None``).
+
+    ``dwarf_source`` (P1.1, ADR-021a): when a detached debug artifact was
+    resolved for *so_path* (``--debug-root``/``--debuginfod``: a build-id-tree
+    or path-mirror ``.debug`` file, distinct from ``so_path`` itself), this is
+    that file's path — DWARF sections are read from it instead of *so_path*.
+    BTF/CTF detection and the kernel-binary heuristic always use *so_path*
+    itself (those formats are not split-debug-file candidates here). ``None``
+    (the default) parses DWARF from *so_path*, unchanged from before.
     """
     from .dwarf_advanced import AdvancedDwarfMetadata
+
+    dwarf_path = dwarf_source or so_path
 
     if debug_format == "btf":
         from .btf_metadata import parse_btf_metadata
@@ -74,7 +85,7 @@ def _resolve_debug_metadata(
 
     if debug_format == "dwarf":
         from .dwarf_unified import parse_dwarf
-        return parse_dwarf(so_path, _session_out=_session_out)
+        return parse_dwarf(dwarf_path, _session_out=_session_out)
 
     if debug_format is not None:
         raise ValueError(
@@ -97,7 +108,7 @@ def _resolve_debug_metadata(
                 return btf.to_dwarf_metadata(), AdvancedDwarfMetadata()
 
     # DWARF > BTF > CTF for userspace (or kernel fallback)
-    dwarf_meta, dwarf_adv = parse_dwarf(so_path, _session_out=_session_out)
+    dwarf_meta, dwarf_adv = parse_dwarf(dwarf_path, _session_out=_session_out)
     if dwarf_meta.has_dwarf:
         return dwarf_meta, dwarf_adv
 

--- a/abicheck/scan_engine.py
+++ b/abicheck/scan_engine.py
@@ -68,6 +68,7 @@ from .cli_scan_helpers import (
     resolve_effective_allow_query,
     scan_pattern_roots,
 )
+from .schemas import SCAN_SCHEMA_VERSION
 
 if TYPE_CHECKING:
     from .service_scan import CompileContext
@@ -107,6 +108,7 @@ class ScanOutcome:
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "scan_schema_version": SCAN_SCHEMA_VERSION,
             "mode": self.mode,
             "level": {
                 "source_method": self.resolved_method,

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -56,6 +56,18 @@ from typing import Any
 #:       plugin-check consumer-proven findings. Additive optional key.
 REPORT_SCHEMA_VERSION = "2.2"
 
+#: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as
+#: ``scan_schema_version`` at the top level of both public scan dict shapes:
+#: :meth:`abicheck.scan_engine.ScanOutcome.to_dict` (the CLI's
+#: ``scan --format json`` contract — mode/level/risk/coverage/diff/verdict/
+#: exit_code) and :meth:`abicheck.service_scan.ScanResult.to_dict` (the typed
+#: Python/MCP service envelope — verdict/exit_code/findings/layers/confidence/
+#: estimate/report, where ``report`` nests the former). Same additive/breaking
+#: bump policy as :data:`REPORT_SCHEMA_VERSION` above; independent of it (scan
+#: and compare are separate contracts that evolve on their own schedules).
+#: 1.0 — initial versioned envelope.
+SCAN_SCHEMA_VERSION = "1.0"
+
 _SCHEMA_DIR = Path(__file__).resolve().parent
 COMPARE_REPORT_SCHEMA_PATH = _SCHEMA_DIR / "compare_report.schema.json"
 
@@ -70,6 +82,7 @@ def load_compare_report_schema() -> dict[str, Any]:
 
 __all__ = [
     "REPORT_SCHEMA_VERSION",
+    "SCAN_SCHEMA_VERSION",
     "COMPARE_REPORT_SCHEMA_PATH",
     "load_compare_report_schema",
 ]

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -648,6 +648,30 @@ def _dump_elf(
     """
     from .dumper import dump
 
+    # P1.1 (ADR-021a): a resolved detached debug artifact (--debug-root /
+    # --debuginfod) was previously only used for a CLI log line — the DWARF
+    # parse always read `path` itself, so a stripped production .so stayed
+    # L0-only even after abicheck reported it found the matching debug file.
+    # Resolve here (gated on the caller actually requesting it, same as the
+    # CLI) and thread the artifact's DWARF-bearing file through to dumper.dump
+    # so it's read instead of `path`. Split DWARF (.dwo/.dwp) and dSYM are not
+    # threaded here — narrower follow-up, not this fix's scope.
+    debug_info_path: Path | None = None
+    if not symbols_only and not debug_presence_only and (debug_roots or enable_debuginfod):
+        from .debug_resolver import resolve_debug_info
+        artifact = resolve_debug_info(
+            path, debug_roots=debug_roots, enable_debuginfod=enable_debuginfod,
+        )
+        if artifact is not None and artifact.dwarf_path is not None:
+            resolved_dwarf = artifact.dwarf_path.resolve()
+            if resolved_dwarf != path.resolve():
+                debug_info_path = artifact.dwarf_path
+                message = f"Debug info for {path.name}: {artifact.source}"
+                if notify is not None:
+                    notify(message)
+                else:
+                    _logger.info(message)
+
     cc = compile if compile is not None else CompileContext()
     resolved_headers = expand_header_inputs(headers) if headers else []
     if not resolved_headers and symbols_only:
@@ -717,6 +741,7 @@ def _dump_elf(
             public_headers=public_headers,
             public_header_dirs=public_header_dirs,
             extra_hash_dirs=deferred_dirs,
+            debug_info_path=debug_info_path,
         )
     except (AbicheckError, RuntimeError, OSError, ValueError) as exc:
         raise SnapshotError(f"Failed to dump '{path}': {exc}") from exc

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -226,6 +226,7 @@ def resolve_input(
     dwarf_only: bool = False,
     debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
+    debuginfod_url: str | None = None,
     debug_format: str | None = None,
     symbols_only: bool = False,
     debug_presence_only: bool = False,
@@ -254,6 +255,9 @@ def resolve_input(
     Args:
         debug_format: Force the ELF debug format ("dwarf", "btf", "ctf") or
             *None* for auto-detection.
+        debuginfod_url: Override debuginfod server URL (only meaningful when
+            ``enable_debuginfod`` is set); ``None`` uses the resolver's
+            default server list / ``DEBUGINFOD_URLS`` environment variable.
         public_headers / public_header_dirs: Public-header sets used to tag
             declaration provenance on PE/Mach-O snapshots (ADR-024 Phase 1).
         follow_linker_scripts: When True (default), a GNU ld linker script is
@@ -283,6 +287,7 @@ def resolve_input(
             dwarf_only=dwarf_only,
             debug_roots=debug_roots,
             enable_debuginfod=enable_debuginfod,
+            debuginfod_url=debuginfod_url,
             debug_format=debug_format,
             symbols_only=symbols_only,
             debug_presence_only=debug_presence_only,
@@ -307,6 +312,7 @@ def resolve_input(
             dwarf_only=dwarf_only,
             debug_roots=debug_roots,
             enable_debuginfod=enable_debuginfod,
+            debuginfod_url=debuginfod_url,
             debug_format=debug_format,
             symbols_only=symbols_only,
             debug_presence_only=debug_presence_only,
@@ -380,6 +386,7 @@ def resolve_input(
                     dwarf_only=dwarf_only,
                     debug_roots=debug_roots,
                     enable_debuginfod=enable_debuginfod,
+                    debuginfod_url=debuginfod_url,
                     debug_format=debug_format,
                     symbols_only=symbols_only,
                     debug_presence_only=debug_presence_only,
@@ -431,6 +438,7 @@ def run_dump(
     dwarf_only: bool = False,
     debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
+    debuginfod_url: str | None = None,
     debug_format: str | None = None,
     symbols_only: bool = False,
     debug_presence_only: bool = False,
@@ -473,6 +481,7 @@ def run_dump(
             dwarf_only=dwarf_only,
             debug_roots=debug_roots,
             enable_debuginfod=enable_debuginfod,
+            debuginfod_url=debuginfod_url,
             debug_format=debug_format,
             symbols_only=symbols_only,
             debug_presence_only=debug_presence_only,
@@ -628,6 +637,7 @@ def _dump_elf(
     dwarf_only: bool = False,
     debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
+    debuginfod_url: str | None = None,
     debug_format: str | None = None,
     symbols_only: bool = False,
     debug_presence_only: bool = False,
@@ -661,6 +671,7 @@ def _dump_elf(
         from .debug_resolver import resolve_debug_info
         artifact = resolve_debug_info(
             path, debug_roots=debug_roots, enable_debuginfod=enable_debuginfod,
+            debuginfod_urls=[debuginfod_url] if debuginfod_url else None,
         )
         if artifact is not None and artifact.dwarf_path is not None:
             resolved_dwarf = artifact.dwarf_path.resolve()
@@ -1244,6 +1255,7 @@ def run_compare_request(
         pdb_path=request.old.pdb,
         debug_roots=list(request.old.debug_roots) or None,
         enable_debuginfod=request.enable_debuginfod,
+        debuginfod_url=request.debuginfod_url,
         header_backend=header_backend,
         public_headers=list(request.old.headers),
     )
@@ -1257,6 +1269,7 @@ def run_compare_request(
         pdb_path=request.new.pdb,
         debug_roots=list(request.new.debug_roots) or None,
         enable_debuginfod=request.enable_debuginfod,
+        debuginfod_url=request.debuginfod_url,
         header_backend=header_backend,
         public_headers=list(request.new.headers),
     )
@@ -1307,6 +1320,7 @@ def run_compare(
     old_debug_roots: list[Path] | None = None,
     new_debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
+    debuginfod_url: str | None = None,
     scope_to_public_surface: bool = True,
     force_public_symbols: set[str] | None = None,
     pattern_verdicts: bool = False,
@@ -1359,6 +1373,7 @@ def run_compare(
         ),
         pattern_verdicts=pattern_verdicts,
         enable_debuginfod=enable_debuginfod,
+        debuginfod_url=debuginfod_url,
     )
     return run_compare_request(request)
 

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -1320,11 +1320,11 @@ def run_compare(
     old_debug_roots: list[Path] | None = None,
     new_debug_roots: list[Path] | None = None,
     enable_debuginfod: bool = False,
-    debuginfod_url: str | None = None,
     scope_to_public_surface: bool = True,
     force_public_symbols: set[str] | None = None,
     pattern_verdicts: bool = False,
     public_surface_allowlist: set[str] | None = None,
+    debuginfod_url: str | None = None,
 ) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
     """Compare two ABI inputs and return the classified diff result.
 
@@ -1332,6 +1332,11 @@ def run_compare(
     :class:`CompareRequest` from loose arguments and delegates, so existing
     callers keep working while the typed request is the real chokepoint
     (ADR-037 D2). New callers should build a ``CompareRequest`` directly.
+
+    ``debuginfod_url`` is appended after every pre-existing parameter (not
+    inserted alongside ``enable_debuginfod``) so a caller invoking this
+    positionally keeps binding every argument after it to the same parameter
+    it always did (Codex review, PR #551).
 
     Returns:
         A tuple of (DiffResult, old_snapshot, new_snapshot).

--- a/abicheck/service_scan.py
+++ b/abicheck/service_scan.py
@@ -39,6 +39,7 @@ from .buildsource.build_query import (
 )
 from .errors import ValidationError
 from .header_utils import HEADER_SUFFIXES, iter_directory_headers
+from .schemas import SCAN_SCHEMA_VERSION
 
 if TYPE_CHECKING:
     from .buildsource.scan_levels import EvidenceDepth, SourceMethod
@@ -682,6 +683,7 @@ class ScanResult:
 
     def to_dict(self) -> dict[str, Any]:
         return {
+            "scan_schema_version": SCAN_SCHEMA_VERSION,
             "verdict": self.verdict,
             "exit_code": self.exit_code,
             "findings": len(self.findings),

--- a/abicheck/stack_checker.py
+++ b/abicheck/stack_checker.py
@@ -100,10 +100,19 @@ def _breaking_change_touches_imports(change: StackChange) -> bool:
     unrelated, unaffected symbol from the same DSO. Without this intersection
     every root importing *anything* from a broken provider was marked FAIL,
     even when the specific break could never have affected it (P1.4).
+
+    A BREAKING finding for a type/layout change (e.g. a resized struct) names
+    the *type* in ``Change.symbol`` (e.g. "Point"), not the functions that use
+    it — those exported functions are separately recorded in
+    ``Change.affected_symbols``. A root importing ``foo(Point)`` must still
+    count as touched even though "foo" never equals "Point" (Codex review).
     """
     assert change.abi_diff is not None
     imported_symbols = {b.symbol for b in change.impacted_imports}
-    breaking_symbols = {c.symbol for c in change.abi_diff.breaking}
+    breaking_symbols: set[str] = set()
+    for c in change.abi_diff.breaking:
+        breaking_symbols.add(c.symbol)
+        breaking_symbols.update(c.affected_symbols or ())
     return bool(imported_symbols & breaking_symbols)
 
 

--- a/abicheck/stack_checker.py
+++ b/abicheck/stack_checker.py
@@ -90,6 +90,15 @@ def _compute_loadability(
     return StackVerdict.PASS
 
 
+#: Sentinel ``Change.symbol`` values diff_platform*.py uses for a whole-binary
+#: (not per-export) finding — e.g. a machine/class/endianness/ABI-flags
+#: mismatch. No real import is ever named this, so an *equality* match against
+#: it would never fire; these findings mean the provider DSO cannot satisfy
+#: *any* dynamic symbol resolution at load time, so any root importing
+#: anything from it is unconditionally touched (Codex review, PR #551).
+_DSO_WIDE_BREAK_SYMBOLS = frozenset({"ELF_HEADER", "PE_HEADER", "MACHO_HEADER"})
+
+
 def _breaking_change_touches_imports(change: StackChange) -> bool:
     """True if a symbol this root actually imports from *change*'s provider is
     among the DSO's own BREAKING findings (not just any breaking finding
@@ -106,11 +115,19 @@ def _breaking_change_touches_imports(change: StackChange) -> bool:
     it — those exported functions are separately recorded in
     ``Change.affected_symbols``. A root importing ``foo(Point)`` must still
     count as touched even though "foo" never equals "Point" (Codex review).
+
+    A DSO-wide break (wrong machine/class/endianness/ABI-flags) is recorded
+    against a sentinel symbol, not a real export, so it can never appear in
+    ``imported_symbols`` — but such a DSO cannot satisfy *any* import at
+    runtime, so it counts as touching every symbol this root imports from it
+    (Codex review).
     """
     assert change.abi_diff is not None
     imported_symbols = {b.symbol for b in change.impacted_imports}
     breaking_symbols: set[str] = set()
     for c in change.abi_diff.breaking:
+        if c.symbol in _DSO_WIDE_BREAK_SYMBOLS:
+            return True
         breaking_symbols.add(c.symbol)
         breaking_symbols.update(c.affected_symbols or ())
     return bool(imported_symbols & breaking_symbols)

--- a/abicheck/stack_checker.py
+++ b/abicheck/stack_checker.py
@@ -90,6 +90,23 @@ def _compute_loadability(
     return StackVerdict.PASS
 
 
+def _breaking_change_touches_imports(change: StackChange) -> bool:
+    """True if a symbol this root actually imports from *change*'s provider is
+    among the DSO's own BREAKING findings (not just any breaking finding
+    anywhere in the DSO).
+
+    ``change.abi_diff.verdict`` is a whole-DSO verdict: a provider can be
+    BREAKING because of one removed symbol while a given root only imports an
+    unrelated, unaffected symbol from the same DSO. Without this intersection
+    every root importing *anything* from a broken provider was marked FAIL,
+    even when the specific break could never have affected it (P1.4).
+    """
+    assert change.abi_diff is not None
+    imported_symbols = {b.symbol for b in change.impacted_imports}
+    breaking_symbols = {c.symbol for c in change.abi_diff.breaking}
+    return bool(imported_symbols & breaking_symbols)
+
+
 def _compute_abi_risk(
     stack_changes: list[StackChange],
     binding_changes: list[Change] | None = None,
@@ -107,7 +124,13 @@ def _compute_abi_risk(
             has_risk = True
         elif change.abi_diff is not None and change.impacted_imports:
             if change.abi_diff.verdict.value == "BREAKING":
-                has_breaking = True
+                if _breaking_change_touches_imports(change):
+                    has_breaking = True
+                else:
+                    # The DSO is broken, but not by anything this root
+                    # imports — real "environment contains a broken DSO"
+                    # signal, but not a confirmed impact on this root.
+                    has_risk = True
             elif change.abi_diff.verdict.value in ("API_BREAK", "COMPATIBLE_WITH_RISK"):
                 has_risk = True
         elif change.abi_diff is not None and not change.impacted_imports:

--- a/action.yml
+++ b/action.yml
@@ -204,14 +204,20 @@ inputs:
     required: false
   build-config:
     description: >
-      Path to a trusted .abicheck.yml. Enables build.query (compile-DB
-      generation) together with allow-build-query. Used by scan and dump modes.
+      Path to a trusted .abicheck.yml. Supplying this alone (not
+      allow-build-query) is what permits its build.query (compile-DB
+      generation) command to run — see allow-build-query below. Used by scan
+      and dump modes.
     required: false
   allow-build-query:
     description: >
-      Permit a trusted build.query subprocess (from build-config) to emit a
-      compile database. Off by default — only existing build outputs are read.
-      Used by scan and dump modes.
+      Deprecated no-op, kept only for backward compatibility — it neither
+      grants nor restricts running build-config's build.query command
+      (build-config alone does, per its own description above). abicheck also
+      always runs its own inferred, abicheck-authored cmake/bazel/make compile-DB
+      query whenever a sources input needs build context, independent of this
+      input: pointing abicheck at a source tree is itself the request to
+      analyse it. Used by scan and dump modes.
     required: false
     default: 'false'
   depth:

--- a/action/run.sh
+++ b/action/run.sh
@@ -5,37 +5,34 @@
 set -uo pipefail
 
 # ---------------------------------------------------------------------------
-# Helper: split a multi-value input into items.
+# Helper: append a flag with value(s) to the command array.
 # Prefer one item per line (a YAML block scalar, e.g. `headers: |`) — that
 # supports path values containing spaces. A value with no newline falls back
 # to legacy whitespace-splitting for backward compatibility with the
 # documented single-line "space-separated" form; a space-containing path
 # still cannot be expressed on a single line this way.
+#
+# Deliberately avoids process substitution (`< <(...)`) — a `while read`
+# fed by a here-string (`<<<`) gets the same "no subshell, so CMD+=(...)
+# survives the loop" property without it, and unlike process substitution
+# is portable to macOS's stock (GPLv2-frozen) bash 3.2 and behaves
+# consistently under Windows Git Bash.
 # ---------------------------------------------------------------------------
-_split_multi_value() {
-  local value="$1"
-  if [[ "$value" == *$'\n'* ]]; then
-    local item
-    while IFS= read -r item; do
-      [[ -n "$item" ]] && printf '%s\n' "$item"
-    done <<< "$value"
-  else
-    local item
-    for item in $value; do
-      printf '%s\n' "$item"
-    done
-  fi
-}
-
-# Helper: append a flag with value(s) to the command array.
 add_flag() {
   local flag="$1"
   local value="$2"
   local item
-  if [[ -n "$value" ]]; then
+  if [[ -z "$value" ]]; then
+    return
+  fi
+  if [[ "$value" == *$'\n'* ]]; then
     while IFS= read -r item; do
+      [[ -n "$item" ]] && CMD+=("$flag" "$item")
+    done <<< "$value"
+  else
+    for item in $value; do
       CMD+=("$flag" "$item")
-    done < <(_split_multi_value "$value")
+    done
   fi
 }
 
@@ -46,10 +43,17 @@ add_sided_flag() {
   local side="$2"
   local value="$3"
   local item
-  if [[ -n "$value" ]]; then
+  if [[ -z "$value" ]]; then
+    return
+  fi
+  if [[ "$value" == *$'\n'* ]]; then
     while IFS= read -r item; do
+      [[ -n "$item" ]] && CMD+=("$flag" "${side}=${item}")
+    done <<< "$value"
+  else
+    for item in $value; do
       CMD+=("$flag" "${side}=${item}")
-    done < <(_split_multi_value "$value")
+    done
   fi
 }
 

--- a/action/run.sh
+++ b/action/run.sh
@@ -5,18 +5,37 @@
 set -uo pipefail
 
 # ---------------------------------------------------------------------------
-# Helper: append a flag with value(s) to the command array.
-# Space-separated values become repeated flags (e.g. -H a.h -H b.h).
-# Note: Paths containing spaces are not supported — word-splitting is
-# intentional here but will break on space-containing values.
+# Helper: split a multi-value input into items.
+# Prefer one item per line (a YAML block scalar, e.g. `headers: |`) — that
+# supports path values containing spaces. A value with no newline falls back
+# to legacy whitespace-splitting for backward compatibility with the
+# documented single-line "space-separated" form; a space-containing path
+# still cannot be expressed on a single line this way.
 # ---------------------------------------------------------------------------
+_split_multi_value() {
+  local value="$1"
+  if [[ "$value" == *$'\n'* ]]; then
+    local item
+    while IFS= read -r item; do
+      [[ -n "$item" ]] && printf '%s\n' "$item"
+    done <<< "$value"
+  else
+    local item
+    for item in $value; do
+      printf '%s\n' "$item"
+    done
+  fi
+}
+
+# Helper: append a flag with value(s) to the command array.
 add_flag() {
   local flag="$1"
   local value="$2"
+  local item
   if [[ -n "$value" ]]; then
-    for item in $value; do
+    while IFS= read -r item; do
       CMD+=("$flag" "$item")
-    done
+    done < <(_split_multi_value "$value")
   fi
 }
 
@@ -26,10 +45,11 @@ add_sided_flag() {
   local flag="$1"
   local side="$2"
   local value="$3"
+  local item
   if [[ -n "$value" ]]; then
-    for item in $value; do
+    while IFS= read -r item; do
       CMD+=("$flag" "${side}=${item}")
-    done
+    done < <(_split_multi_value "$value")
   fi
 }
 

--- a/docs/development/plans/g13-arch-mismatch-guard.md
+++ b/docs/development/plans/g13-arch-mismatch-guard.md
@@ -1,7 +1,14 @@
 # G13 — cross-architecture comparison guardrail
 
-**Registry:** `UC-PLAT-arch-guard` (`planned`)
+**Registry:** `UC-PLAT-arch-guard` (`complete`)
 **Effort:** S · **Risk:** low
+**Status:** Done. The ELF snapshot captures `e_machine`, `EI_CLASS`, and
+endianness; `checker_policy.py` classifies a mismatch via dedicated
+`ELF_MACHINE_CHANGED`/`ELF_CLASS_CHANGED`/`ELF_ENDIANNESS_CHANGED` (and
+`ELF_ABI_FLAGS_CHANGED` for decoded float-ABI/EABI drift) kinds in
+`BREAKING_KINDS` — a top-level dominating finding rather than the single
+refusing `ARCHITECTURE_MISMATCH` kind originally sketched below. See
+`abicheck/diff_platform_elf_dynamic.py` and `tests/test_g23_elf_facts.py`.
 
 ## Problem
 

--- a/docs/development/plans/index.md
+++ b/docs/development/plans/index.md
@@ -16,7 +16,6 @@ scope**.
 | **G9** | [manylinux/auditwheel vendored-library pairing](g9-wheel-vendored-matching.md) | `UC-WF-wheel-vendored` | M |
 | **G10** | [manylinux glibc-floor check](g10-glibc-floor-check.md) | `UC-TC-glibc-floor` | S |
 | **G11** | [Single-binary ABI audit / lint](g11-single-binary-audit.md) | `UC-WF-audit` | M |
-| **G13** | [Cross-architecture comparison guardrail](g13-arch-mismatch-guard.md) | `UC-PLAT-arch-guard` | S |
 | **G15** | [Inline-namespace version-stamp normalization](g15-inline-namespace-version.md) | `UC-CHANGE-inline-ns-version` | M |
 | **G16** | [Header-scope toolchain robustness](g16-header-scope-toolchain-robustness.md) | `UC-TC-header-scope-robustness` | M |
 | **G17** | [Real-world validation corpus](g17-real-world-corpus.md) | `UC-WORKFLOW-real-world-corpus` | M |
@@ -43,6 +42,7 @@ Completed or decided plans are retained for implementation history:
 | **G7** | Done — release recommendation | `abicheck/semver.py` |
 | **G8** | Decided — static/import archives are a by-design non-goal | [g8](g8-static-libraries.md) |
 | **G12** | Done — security-hardening drift surface and policy preset | [g12](g12-security-hardening.md) |
+| **G13** | Done — ELF snapshot captures `e_machine`/`EI_CLASS`/endianness; a mismatch is a dominating `BREAKING_KINDS` guard | [g13](g13-arch-mismatch-guard.md) |
 | **G14** | Done — CPython extension recognition, `abi3`/Limited-API import-contract check, `scan --abi3` audit | [g14](g14-stable-abi-subset.md) |
 | **G22** | Done — CLI consolidation & interface-contract enforcement ([ADR-037](../adr/037-cli-interface-contract.md)) | [g22](g22-cli-consolidation.md) |
 | **G23** | Done — Python-level API diff for extension modules (`.pyi`/signature surface, 15 `python_api_*` ChangeKinds) | [g23](g23-python-level-api-diff.md) |

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -25,11 +25,14 @@ in a 5-tier policy model, **181 calibrated example cases** (134 binary shared-li
 parity — is essentially complete and has diminishing returns.
 
 The remaining gaps are **not in detecting more change types**. They are the
-four `planned` breadth/workflow items tracked in `usecase-registry.yaml`:
-header-only/inline-only analysis (G4), auditwheel vendored-library pairing (G9),
-manylinux glibc-floor checks (G10), and single-binary audit/lint mode (G11) —
-plus six **partial**/`modeled` items with
-some shipped work already: inline-namespace version-stamp normalization (G15),
+three `planned` breadth/workflow items tracked in `usecase-registry.yaml`:
+header-only/inline-only analysis (G4), manylinux glibc-floor checks (G10), and
+single-binary audit/lint mode (G11) —
+plus seven **partial**/`modeled` items with
+some shipped work already: auditwheel/delocate vendored-library filename
+pairing (G9, `strip_vendor_hash` normalization has shipped; the embedded-SONAME
+half for bundle cohort SONAME-skew detection has not), inline-namespace
+version-stamp normalization (G15),
 header-scoped source-mode toolchain robustness (G16, diagnostics and the
 `castxml --version` floor probe have shipped), a real-world validation corpus
 (G17), Bazel build-evidence (G18, `modeled` — code exists, not yet validated
@@ -108,7 +111,7 @@ A real invocation is a point in this space:
 | **G6** | ✅ closed | BTF/CTF and SYCL PI/UR workflows run through `compare` and reports. |
 | **G7** | ✅ closed | Semver bump and SONAME action recommendations are emitted by the report layer. |
 | **G8** | by-design excluded | Static/import archives are rejected with guidance; archive member API checking is a non-goal. |
-| **G9** | planned | auditwheel/delocate vendored-library hashed SONAME normalization. |
+| **G9** | partial | Filename-based vendored-library pairing shipped (`strip_vendor_hash` in `compare-release`'s matching pass) — a bundled `libpng16-<hash>.so.16.x` now pairs across rebuilds instead of removed+added noise, and a real break in the paired dependency still surfaces. Remaining: normalize the embedded ELF SONAME/install-name for `bundle.py`'s cohort-scoped SONAME-skew detector. |
 | **G10** | planned | manylinux glibc-floor / platform-baseline checks. |
 | **G11** | planned | Single-binary ABI audit/lint mode. |
 | **G12** | ✅ closed | Security-hardening drift captures and diffs RELRO, BIND_NOW, PIE, canaries, FORTIFY, and W^X metadata; the security policy is shipped. |

--- a/docs/development/usecase-coverage-evaluation.md
+++ b/docs/development/usecase-coverage-evaluation.md
@@ -25,10 +25,10 @@ in a 5-tier policy model, **181 calibrated example cases** (134 binary shared-li
 parity — is essentially complete and has diminishing returns.
 
 The remaining gaps are **not in detecting more change types**. They are the
-five `planned` breadth/workflow items tracked in `usecase-registry.yaml`:
+four `planned` breadth/workflow items tracked in `usecase-registry.yaml`:
 header-only/inline-only analysis (G4), auditwheel vendored-library pairing (G9),
-manylinux glibc-floor checks (G10), single-binary audit/lint mode (G11), and
-cross-architecture guardrails (G13) — plus six **partial**/`modeled` items with
+manylinux glibc-floor checks (G10), and single-binary audit/lint mode (G11) —
+plus six **partial**/`modeled` items with
 some shipped work already: inline-namespace version-stamp normalization (G15),
 header-scoped source-mode toolchain robustness (G16, diagnostics and the
 `castxml --version` floor probe have shipped), a real-world validation corpus
@@ -42,8 +42,9 @@ Several formerly broad gaps are now closed and should no longer be treated as
 open roadmap work: native PE/Mach-O compare validation (G1), build-config matrix
 integration (G2), workflow/report coverage (G3), plugin host↔plugin checking
 (G5), BTF/CTF and SYCL workflows (G6), release recommendations (G7), static
-library stance (G8), security-hardening drift (G12), and CPython `abi3`
-import-contract checking (G14).
+library stance (G8), security-hardening drift (G12), cross-architecture
+comparison guardrails (G13), and CPython `abi3` import-contract checking
+(G14).
 
 ---
 
@@ -111,7 +112,7 @@ A real invocation is a point in this space:
 | **G10** | planned | manylinux glibc-floor / platform-baseline checks. |
 | **G11** | planned | Single-binary ABI audit/lint mode. |
 | **G12** | ✅ closed | Security-hardening drift captures and diffs RELRO, BIND_NOW, PIE, canaries, FORTIFY, and W^X metadata; the security policy is shipped. |
-| **G13** | planned | Cross-architecture mismatch guardrail. |
+| **G13** | ✅ closed | ELF snapshot captures `e_machine`/`EI_CLASS`/endianness; a mismatch is a hard guard (`ELF_MACHINE_CHANGED`/`ELF_CLASS_CHANGED`, `BREAKING_KINDS`) rather than a false-green `COMPATIBLE_WITH_RISK` verdict. |
 | **G14** | ✅ closed | CPython Limited-API / `abi3` import-contract conformance — extension recognition, `abi3`/Limited-API import-contract check, `scan --abi3` audit. |
 | **G15** | partial | Inline-namespace version-stamp normalization for ICU/Abseil/libstdc++-style churn. Detector landed (advisory `versioned_symbol_scheme_detected`); normalize-and-collapse preset still planned. |
 | **G17** | partial | Real-world upstream-library validation corpus (`eval/manifest.yaml` + `runner.py`, conda-forge fetch + `dump`/`compare`) — reproducible but not continuously run in CI; complements the synthetic `examples/case*` fixtures. |
@@ -136,7 +137,6 @@ planned row from drifting away from its plan.
 | Medium | G11 — single-binary audit/lint | [g11](plans/g11-single-binary-audit.md) |
 | Medium | G15 — inline-namespace version stamp | [g15](plans/g15-inline-namespace-version.md) |
 | Small | G10 — glibc-floor check | [g10](plans/g10-glibc-floor-check.md) |
-| Small | G13 — cross-architecture guardrail | [g13](plans/g13-arch-mismatch-guard.md) |
 | Medium | G16 — header-scope toolchain robustness | [g16](plans/g16-header-scope-toolchain-robustness.md) |
 | Medium | G17 — real-world validation corpus | [g17](plans/g17-real-world-corpus.md) |
 | Medium | G18 — Bazel build-evidence | [g18](plans/g18-bazel-build-evidence.md) |

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -272,16 +272,19 @@ use_cases:
   - id: UC-PLAT-arch-guard
     axis: platform
     name: Cross-architecture comparison guardrail (ELF e_machine)
-    status: planned
-    gap: G13
-    plan: docs/development/plans/g13-arch-mismatch-guard.md
-    next_steps: >
-      Capture ELF e_machine / EI_CLASS / endianness into the snapshot (PE and
-      Mach-O already carry a machine field) and treat a machine mismatch in
-      compare/compare-release as a hard ARCHITECTURE_MISMATCH guard instead of a
-      false-green COMPATIBLE_WITH_RISK verdict. Confirmed by empirical scanning:
-      x86-64 vs aarch64 of the same version currently reports 100%
-      binary-compatible.
+    status: complete
+    note: >
+      G13 closed. The ELF snapshot captures e_machine, EI_CLASS, and
+      endianness (PE/Mach-O already carried an equivalent machine field); a
+      mismatch is a hard guard rather than a false-green
+      COMPATIBLE_WITH_RISK verdict — ELF_MACHINE_CHANGED and
+      ELF_CLASS_CHANGED dominate the verdict (BREAKING_KINDS), with
+      ELF_ENDIANNESS_CHANGED and ELF_ABI_FLAGS_CHANGED covering byte-order and
+      decoded float-ABI/EABI drift. Same-architecture comparisons are
+      unaffected.
+    evidence:
+      modules: [abicheck/elf_metadata.py, abicheck/checker_policy.py, abicheck/diff_platform_elf_dynamic.py]
+      tests: [tests/test_g23_elf_facts.py, tests/test_changekind_completeness.py]
 
   # ── workflow ──────────────────────────────────────────────────────────────
   - id: UC-WF-compare

--- a/docs/development/usecase-registry.yaml
+++ b/docs/development/usecase-registry.yaml
@@ -419,15 +419,23 @@ use_cases:
   - id: UC-WF-wheel-vendored
     axis: workflow
     name: manylinux/auditwheel vendored-library pairing (hashed sonames)
-    status: planned
+    status: partial
     gap: G9
     plan: docs/development/plans/g9-wheel-vendored-matching.md
     next_steps: >
-      Normalize the auditwheel/delocate content-hash suffix (-[0-9a-f]{6,16})
-      on filename AND soname before pairing in compare-release; pair on the
-      unhashed soname stem so a bundled libpng16.so.16 matches across rebuilds.
-      Add a two-wheel fixture. Empirically confirmed: today every vendored dep
-      of a manylinux wheel shows as removed+added.
+      Filename-based pairing landed: strip_vendor_hash() normalizes the
+      auditwheel/delocate content-hash suffix (-[0-9a-f]{6,16}) before
+      compare-release's matching pass (_canonical_library_key), so a bundled
+      libpng16-<hash>.so.16.x now pairs across rebuilds instead of showing as
+      removed+added, while a real break in the paired dependency (e.g. a
+      pyzmq-style libsodium SONAME major bump) still surfaces. Remaining: the
+      plan's "AND soname" half — normalizing the embedded ELF SONAME/install-name
+      (not just the filename) for bundle.py's cohort-scoped SONAME-skew
+      detector, which reads DT_SONAME directly and is not yet covered by this
+      normalization.
+    evidence:
+      modules: [abicheck/cli_helpers_compare.py]
+      tests: [tests/test_compare_release.py]
 
   - id: UC-WF-stable-abi-subset
     axis: workflow

--- a/docs/user-guide/dump-compare-flags.md
+++ b/docs/user-guide/dump-compare-flags.md
@@ -214,17 +214,19 @@ export DEBUGINFOD_URLS="https://debuginfod.fedoraproject.org/"
 abicheck compare old-libfoo.so new-libfoo.so --debuginfod
 ```
 
-!!! warning "`--debug-root`/`--debuginfod` currently resolve and report — they do not yet feed the parse"
-    On `dump` and `compare`, these flags locate the matching debug artifact
-    through the resolver chain above and print where they found it
-    (`Debug info: <source>`), but that resolved path is **not** currently
-    passed into the DWARF parse — the two commands above still analyze
-    `old/usr/lib64/libfoo.so.1`/`new/usr/lib64/libfoo.so.1` as given, so a
-    stripped input stays **symbols-only** (L0) even though a matching
-    `.debug`/build-id file was found. For a debug-info split that *does* get
-    parsed today, package the debug info as its own artifact (RPM/Deb/tar) and
-    pass it on directory/package inputs with the side-aware `--debug-info`
-    flag, which *is* wired into the dump:
+!!! note "What `--debug-root`/`--debuginfod` feed into the DWARF parse today"
+    On `dump` and `compare`, a build-id-tree, path-mirror, or debuginfod-fetched
+    `.debug` file — a separate ELF file distinct from the input binary — is
+    parsed for DWARF instead of the (stripped) input itself: the commands above
+    correctly detect the `libpng16` struct-layout example even though
+    `old/usr/lib64/libfoo.so.1`/`new/usr/lib64/libfoo.so.1` carry no `.debug_info`
+    of their own (P1.1). **Split DWARF** (`.dwo`/`.dwp`, the first entry in the
+    resolver chain above) and **dSYM bundles** (macOS) are resolved and reported
+    (`Debug info: <source>`) but not yet threaded into the parse — a binary
+    whose only debug info takes one of those two shapes still analyzes
+    symbols-only. For those, package the debug info as its own artifact
+    (RPM/Deb/tar, or a dSYM bundle) and pass it on directory/package inputs with
+    the side-aware `--debug-info` flag, which *is* wired into the dump:
 
     ```bash
     abicheck compare libfoo-1.0.rpm libfoo-1.1.rpm \

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -340,9 +340,16 @@ Every JSON report carries a top-level `report_schema_version` field
 > whichever field belongs to the file they loaded.
 >
 > `scan --format json` is a **third, separate shape**: it emits a `ScanOutcome`
-> object (`mode`, `level`, `risk`, `verdict`, `exit_code`, …) and does **not**
-> currently carry a `report_schema_version` field, so do not key scan-output
-> consumers off it.
+> object (`mode`, `level`, `risk`, `verdict`, `exit_code`, …). It carries its
+> own top-level `scan_schema_version` field (`MAJOR.MINOR`, importable as
+> `abicheck.schemas.SCAN_SCHEMA_VERSION`) — independent of, and not
+> interchangeable with, `report_schema_version`. The typed Python/MCP
+> `ScanResult.to_dict()` envelope (`abicheck.service`) stamps the same value at
+> its own top level, in addition to nesting the `ScanOutcome` dict (with its
+> own `scan_schema_version`) under its `report` key. There is currently no
+> packaged `.schema.json` for scan output (unlike `compare`'s
+> `compare_report.schema.json`); the version field is honored the same way
+> (accept a shared `MAJOR`, ignore unknown keys) until one exists.
 
 ```json
 {

--- a/docs/user-guide/producing-source-facts.md
+++ b/docs/user-guide/producing-source-facts.md
@@ -98,12 +98,16 @@ selects which:
 
 | Value | Uses |
 |-------|------|
-| `auto` *(default)* | castxml if present, else clang |
-| `castxml` | castxml (the default L2 backend) |
-| `clang` | `clang -ast-dump=json` — **set this on a clang-only host** where castxml is not installed |
+| `auto` *(default)* | the most-capable **available** backend: clang if present, else castxml |
+| `castxml` | castxml (the default L2 backend) — declarations/types/const values only; an unavailable castxml is **not** upgraded to clang (that would silently change extractor semantics) — extraction is disabled instead |
+| `clang` | `clang -ast-dump=json` — richest source facts (also inline/template/constexpr bodies, macros, constructor mangling); falls back to castxml if clang is unavailable |
 
-On a host without castxml, `auto` already falls back to clang; set
-`ABICHECK_CC_EXTRACTOR=clang` explicitly when you want to pin it.
+`auto` prefers clang over castxml when both are present, because clang observes
+strictly more source facts (see the capability table in
+[Build Info & Sources](../concepts/build-source-data.md)); this is the opposite
+precedence from `--ast-frontend auto` (header-only L2 parsing), which always
+prefers castxml and never falls back merely because it is absent. Set
+`ABICHECK_CC_EXTRACTOR=castxml` explicitly to pin the L2-consistent backend.
 
 !!! warning "Extraction concurrency is bound by your build's `-jN`, not by `ABICHECK_L4_JOBS`"
     Each `abicheck-cc` invocation extracts its source TUs synchronously, so a

--- a/tests/test_action_run_sh_helpers.py
+++ b/tests/test_action_run_sh_helpers.py
@@ -33,7 +33,9 @@ value (the documented back-compat form).
 """
 from __future__ import annotations
 
+import os
 import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -50,16 +52,33 @@ def _helpers_region() -> str:
 
 
 def _run_harness(harness: str) -> str:
-    """Source the real helper functions + *harness*, return CMD joined by '\\x1f'."""
+    """Source the real helper functions + *harness*, return CMD joined by '\\x1f'.
+
+    Writes the assembled script to a real file (UTF-8, explicit ``\\n`` line
+    endings) and runs ``bash <path>`` rather than ``bash -c <string>``: passing
+    a script containing non-ASCII characters (run.sh's comments use em-dashes)
+    as a subprocess argv string hits Windows console/argv-encoding mangling
+    and was flaky under macOS's stock bash 3.2 (exit 127) — a file sidesteps
+    both, and matches how run.sh is actually invoked in production.
+    """
     script = (
         _helpers_region()
         + "\nCMD=()\n"
         + harness
         + '\nprintf \'%s\\x1f\' "${CMD[@]}"\n'
     )
-    result = subprocess.run(
-        ["bash", "-c", script], capture_output=True, text=True, check=True,
-    )
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".sh", delete=False, encoding="utf-8", newline="\n",
+    ) as f:
+        f.write(script)
+        script_path = f.name
+    try:
+        result = subprocess.run(
+            ["bash", script_path],
+            capture_output=True, text=True, encoding="utf-8", check=True,
+        )
+    finally:
+        os.unlink(script_path)
     return result.stdout
 
 

--- a/tests/test_action_run_sh_helpers.py
+++ b/tests/test_action_run_sh_helpers.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for ``action/run.sh``'s multi-value input splitting (P2.2).
+
+``run.sh`` runs the actual ``abicheck`` invocation at the bottom of the file
+(reading ``INPUT_*`` env vars and exiting with the tool's exit code), so it
+cannot be sourced wholesale in a unit test. Instead this extracts just the
+helper-function region (``_split_multi_value``/``add_flag``/``add_sided_flag``/
+``add_single_flag``, everything before the "Build the abicheck command"
+marker) and sources *that* alongside a small harness — the same "parse the
+real file, don't hand-copy it" discipline as ``test_action_run_contract.py``,
+so a future edit to the real functions is exercised here too, not a stale copy.
+
+``add_flag``/``add_sided_flag`` used unquoted ``for item in $value`` word-
+splitting, which explicitly could not support a path containing a space (a
+Codex/report finding, P2.2). The fix prefers newline-separated items (a YAML
+block-scalar Action input, e.g. ``headers: |``), which preserves embedded
+spaces, and falls back to legacy whitespace-splitting only for a single-line
+value (the documented back-compat form).
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+RUN_SH = Path(__file__).resolve().parents[1] / "action" / "run.sh"
+_MARKER = "# Build the abicheck command"
+
+
+def _helpers_region() -> str:
+    """The function-definitions header of run.sh, up to the assembly marker."""
+    text = RUN_SH.read_text(encoding="utf-8")
+    idx = text.index(_MARKER)
+    return text[:idx]
+
+
+def _run_harness(harness: str) -> str:
+    """Source the real helper functions + *harness*, return CMD joined by '\\x1f'."""
+    script = (
+        _helpers_region()
+        + "\nCMD=()\n"
+        + harness
+        + '\nprintf \'%s\\x1f\' "${CMD[@]}"\n'
+    )
+    result = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=True,
+    )
+    return result.stdout
+
+
+def _cmd_items(stdout: str) -> list[str]:
+    return [item for item in stdout.split("\x1f") if item]
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="action/run.sh not found")
+class TestAddFlagSplitting:
+    def test_legacy_space_separated_single_line(self) -> None:
+        # Back-compat: the documented single-line "space-separated" form.
+        out = _run_harness('add_flag "-H" "inc/a inc/b"')
+        assert _cmd_items(out) == ["-H", "inc/a", "-H", "inc/b"]
+
+    def test_newline_separated_preserves_spaces(self) -> None:
+        # A YAML block scalar (`headers: |`) input — one path per line,
+        # including a path containing a space.
+        out = _run_harness('add_flag "-H" $\'inc/a\\npath with spaces/inc\\ninc/c\'')
+        assert _cmd_items(out) == [
+            "-H", "inc/a", "-H", "path with spaces/inc", "-H", "inc/c",
+        ]
+
+    def test_empty_value_adds_nothing(self) -> None:
+        out = _run_harness('add_flag "-H" ""')
+        assert _cmd_items(out) == []
+
+    def test_single_value_no_separator(self) -> None:
+        out = _run_harness('add_flag "-H" "inc/only"')
+        assert _cmd_items(out) == ["-H", "inc/only"]
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="action/run.sh not found")
+class TestAddSidedFlagSplitting:
+    def test_legacy_space_separated_single_line(self) -> None:
+        out = _run_harness('add_sided_flag "--header" "old" "inc/a inc/b"')
+        assert _cmd_items(out) == [
+            "--header", "old=inc/a", "--header", "old=inc/b",
+        ]
+
+    def test_newline_separated_preserves_spaces(self) -> None:
+        out = _run_harness(
+            'add_sided_flag "--header" "new" $\'inc/a\\npath with spaces/inc\''
+        )
+        assert _cmd_items(out) == [
+            "--header", "new=inc/a", "--header", "new=path with spaces/inc",
+        ]

--- a/tests/test_action_run_sh_helpers.py
+++ b/tests/test_action_run_sh_helpers.py
@@ -65,7 +65,11 @@ def _run_harness(harness: str) -> str:
         _helpers_region()
         + "\nCMD=()\n"
         + harness
-        + '\nprintf \'%s\\x1f\' "${CMD[@]}"\n'
+        # ${CMD[@]+"${CMD[@]}"} (not plain "${CMD[@]}"): pre-4.4 bash — macOS's
+        # stock 3.2 included — treats an empty array subscripted with [@]
+        # under `set -u` as an unbound-variable error and aborts the script
+        # (the same bug run.sh itself works around at its PR-comment loop).
+        + '\nprintf \'%s\\x1f\' ${CMD[@]+"${CMD[@]}"}\n'
     )
     with tempfile.NamedTemporaryFile(
         "w", suffix=".sh", delete=False, encoding="utf-8", newline="\n",

--- a/tests/test_action_run_sh_helpers.py
+++ b/tests/test_action_run_sh_helpers.py
@@ -51,6 +51,31 @@ def _helpers_region() -> str:
     return text[:idx]
 
 
+def _bash_executable() -> str:
+    """Resolve a real bash, bypassing Windows' WSL-launcher stub.
+
+    On GitHub's windows-latest runners, ``%SystemRoot%\\System32\\bash.exe``
+    is the WSL launcher stub — present even with no distro installed — and a
+    bare ``["bash", ...]`` subprocess call can resolve to it ahead of Git for
+    Windows' real bash depending on the calling process's inherited PATH
+    order. The stub exits immediately (non-zero) without running anything,
+    which looks identical to every helper-function test failing at once with
+    no bash-level diagnostic (Codex/CI investigation, PR #551). Prefer Git for
+    Windows' own bash explicitly on that platform; every other platform keeps
+    using whatever "bash" already resolves to on PATH.
+    """
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
 def _run_harness(harness: str) -> str:
     """Source the real helper functions + *harness*, return CMD joined by '\\x1f'.
 
@@ -78,11 +103,17 @@ def _run_harness(harness: str) -> str:
         script_path = f.name
     try:
         result = subprocess.run(
-            ["bash", script_path],
-            capture_output=True, text=True, encoding="utf-8", check=True,
+            [_bash_executable(), script_path],
+            capture_output=True, text=True, encoding="utf-8",
         )
     finally:
         os.unlink(script_path)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"harness script failed (exit {result.returncode})\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )
     return result.stdout
 
 

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -532,6 +532,39 @@ class TestBaselineEvidenceCli:
         assert pull.exit_code != 0
         assert "content hash mismatch" in pull.output
 
+    def test_pull_corrupt_snapshot_checksum_is_clean_cli_error(self, tmp_path: Path) -> None:
+        """A corrupt/tampered registry entry must surface as a ClickException
+        (clean message, non-zero exit), not an uncaught BaselineIntegrityError
+        traceback — `registry.pull(key)` itself is not wrapped in a try/except
+        in `baseline_pull`, unlike every sibling registry call in the module."""
+        snap = self._snapshot(tmp_path)
+        registry = tmp_path / "registry"
+        runner = CliRunner()
+        push = runner.invoke(main, [
+            "baseline", "push", "libfoo", "--version", "1.0",
+            "--platform", "linux-x86_64", "--snapshot", str(snap),
+            "--registry", str(registry),
+        ])
+        assert push.exit_code == 0, push.output
+
+        # Tamper with the stored snapshot so its checksum no longer matches
+        # the metadata recorded at push time.
+        stored_snap = registry / "libfoo" / "1.0" / "linux-x86_64" / "snapshot.json"
+        stored_snap.write_text(
+            stored_snap.read_text(encoding="utf-8").replace("libfoo.so", "libfoo-tampered.so"),
+            encoding="utf-8",
+        )
+
+        pull = runner.invoke(main, [
+            "baseline", "pull", "libfoo:1.0:linux-x86_64",
+            "-o", str(tmp_path / "snap-out.json"),
+            "--registry", str(registry),
+        ])
+        assert pull.exit_code != 0
+        assert pull.exception is None or isinstance(pull.exception, SystemExit)
+        assert "Checksum mismatch" in pull.output
+        assert "Traceback" not in pull.output
+
     def test_pull_evidence_output_to_registry_dir_is_noop(self, tmp_path: Path) -> None:
         snap = self._snapshot(tmp_path)
         pack_dir = self._pack(tmp_path / "ev.evidence")

--- a/tests/test_compare_dispatch.py
+++ b/tests/test_compare_dispatch.py
@@ -180,6 +180,44 @@ def test_embed_inline_source_forwards_toolchain_and_collects(
     assert captured["pdb_path"] == Path("/p.pdb")
 
 
+def test_embed_inline_source_forwards_debug_roots(tmp_path: Path, monkeypatch) -> None:
+    """P1.1 Codex-review regression: --debug-root/--debuginfod must reach the
+    inline dump too — without this, a raw --old/new-sources tree bypassed
+    detached-debug-artifact resolution entirely (the inline dump used its own
+    unset defaults), so a stripped binary on that side still lost its DWARF
+    even though the non-inline compare path was already fixed."""
+    import inspect
+
+    import abicheck.cli as climod
+    from abicheck.service_scan import CompileContext
+
+    tree = tmp_path / "src"
+    tree.mkdir()
+    captured: dict = {}
+
+    class _Ctx:
+        def invoke(self, _cmd, **kwargs):  # type: ignore[no-untyped-def]
+            captured.update(kwargs)
+
+    monkeypatch.setattr(climod, "_normalize_binary_input", lambda p: (Path(p), "elf"))
+    droot = tmp_path / "debugroot"
+    climod._embed_inline_source_side(
+        _Ctx(), input_path=tmp_path / "lib.so", sources=tree,
+        headers=(), includes=(), version="1.0", lang="c++",
+        header_backend="auto", compile_context=CompileContext(),
+        frontend_explicit=False, nostdinc_explicit=False, build_info=None,
+        follow_deps=False, search_paths=(), ld_library_path="",
+        dwarf_only=False, debug_format=None, pdb_path=None,
+        collect_mode="source-target", out_dir=tmp_path, label="old",
+        debug_roots=(droot,), debuginfod=True, debuginfod_url="https://example.test",
+    )
+    dump_params = set(inspect.signature(climod.dump_cmd.callback).parameters)
+    assert set(captured) <= dump_params, set(captured) - dump_params
+    assert captured["debug_roots"] == (droot,)
+    assert captured["debuginfod"] is True
+    assert captured["debuginfod_url"] == "https://example.test"
+
+
 def test_embed_inline_source_merges_tree_config_but_cli_wins(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -19,6 +19,7 @@ from abicheck.cli_compare_release import (
     _format_release_json,
     _prepare_compare_release_inputs,
 )
+from abicheck.cli_helpers_compare import strip_vendor_hash
 from abicheck.model import (
     AbiSnapshot,
     Function,
@@ -111,6 +112,47 @@ class TestCanonicalLibraryKey:
 
     def test_dll(self, tmp_path: Path) -> None:
         assert _canonical_library_key(Path("libfoo.dll")) == "libfoo.dll"
+
+
+class TestStripVendorHash:
+    """G9: auditwheel/delocate rewrite vendored libs to lib<name>-<hash>.so.<ver>,
+    with a content-derived hash that changes every rebuild. strip_vendor_hash
+    normalizes that away so compare-release can pair the same dependency across
+    releases instead of reporting every one as removed+added noise."""
+
+    def test_auditwheel_hex_before_so_stripped(self) -> None:
+        assert strip_vendor_hash("libpng16-a746ad4a.so.16.43.0") == "libpng16.so.16.43.0"
+
+    def test_different_hash_same_stem(self) -> None:
+        # The whole point: two different rebuild hashes must normalize identically.
+        a = strip_vendor_hash("libpng16-a746ad4a.so.16.43.0")
+        b = strip_vendor_hash("libpng16-b8f31c2e.so.16.56.0")
+        assert a == "libpng16.so.16.43.0"
+        assert b == "libpng16.so.16.56.0"
+
+    def test_16char_hash_stripped(self) -> None:
+        assert strip_vendor_hash("libsodium-1234567890abcdef.so.23.3.0") == "libsodium.so.23.3.0"
+
+    def test_no_hyphen_untouched(self) -> None:
+        # Real-world names with no hyphen at all — nothing to strip.
+        assert strip_vendor_hash("libwebpdemux.so.2.0.14") == "libwebpdemux.so.2.0.14"
+        assert strip_vendor_hash("libbrotlicommon.so.1") == "libbrotlicommon.so.1"
+
+    def test_short_hex_lookalike_untouched(self) -> None:
+        # "cafe" is valid hex but below the 6-char minimum — a real short
+        # hyphenated suffix must not be mistaken for a vendor hash.
+        assert strip_vendor_hash("libfoo-cafe.so") == "libfoo-cafe.so"
+
+    def test_non_hex_suffix_untouched(self) -> None:
+        # "utils" is not a hex string — an ordinary hyphenated name.
+        assert strip_vendor_hash("libfoo-utils.so") == "libfoo-utils.so"
+
+    def test_canonical_key_pairs_across_hash_rebuild(self) -> None:
+        # The integration point: _canonical_library_key must collapse both
+        # rebuild hashes of the same vendored dependency to one key.
+        old_key = _canonical_library_key(Path("libpng16-a746ad4a.so.16.43.0"))
+        new_key = _canonical_library_key(Path("libpng16-b8f31c2e.so.16.56.0"))
+        assert old_key == new_key == "libpng16.so"
 
 
 class TestVersionSortKey:
@@ -339,6 +381,67 @@ class TestUnmatched:
         assert "libremoved.json" in data["unmatched_old"]
         assert isinstance(data["unmatched_new"], list)
         assert "libadded.json" in data["unmatched_new"]
+
+
+# ── vendored wheel hash pairing (G9) ────────────────────────────────────────
+
+class TestVendoredWheelPairing:
+    """G9 workflow proof: two synthetic 'wheels' with auditwheel/delocate-style
+    hashed vendored libraries must be paired by unhashed stem — not reported
+    as removed+added noise every rebuild — while a real ABI break in the
+    paired dependency (the pyzmq libsodium-style regression anchor) still
+    surfaces rather than being absorbed by the normalization."""
+
+    def test_hashed_vendored_lib_pairs_across_rebuild(self, tmp_path: Path) -> None:
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        snap = _snap(library="libpng16.so.16")
+        # Same dependency, different auditwheel rebuild hash each side.
+        _write_snap(old_dir / "libpng16-a746ad4a.so.16.43.0.json", snap)
+        _write_snap(new_dir / "libpng16-b8f31c2e.so.16.56.0.json", snap)
+        code, out = _invoke("compare", str(old_dir), str(new_dir), "--format", "json")
+        assert code == 0
+        data = json.loads(out)
+        # Paired, not phantom removed+added.
+        assert data["unmatched_old"] == []
+        assert data["unmatched_new"] == []
+        assert len(data["libraries"]) == 1
+
+    def test_real_break_in_hashed_vendored_lib_still_surfaces(self, tmp_path: Path) -> None:
+        """Regression anchor (pyzmq libsodium 23->26-shaped case): a real ABI
+        break in a hash-paired vendored library must not be absorbed by the
+        stem normalization — pairing only changes matching, never the diff."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        old_lib, new_lib = _breaking_pair("libsodium.so.26")
+        _write_snap(old_dir / "libsodium-1234567890abcdef.so.23.3.0.json", old_lib)
+        _write_snap(new_dir / "libsodium-fedcba0987654321.so.26.1.0.json", new_lib)
+        code, out = _invoke("compare", str(old_dir), str(new_dir), "--format", "json")
+        assert code == 4
+        data = json.loads(out)
+        assert data["verdict"] == "BREAKING"
+        # Still paired (matched), not reported as removed+added.
+        assert data["unmatched_old"] == []
+        assert data["unmatched_new"] == []
+
+    def test_non_vendored_names_unaffected(self, tmp_path: Path) -> None:
+        """Ordinary (non-hashed) library names must not be spuriously paired
+        or otherwise affected by the vendor-hash normalization."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        _write_snap(old_dir / "libwebpdemux.so.2.0.14.json", _snap(library="libwebpdemux.so.2"))
+        _write_snap(new_dir / "libwebpdemux.so.2.0.14.json", _snap(library="libwebpdemux.so.2"))
+        code, out = _invoke("compare", str(old_dir), str(new_dir), "--format", "json")
+        assert code == 0
+        data = json.loads(out)
+        assert data["unmatched_old"] == []
+        assert data["unmatched_new"] == []
 
 
 # ── output-dir ────────────────────────────────────────────────────────────────

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock
 from click.testing import CliRunner
 
 from abicheck.cli import (
+    _build_match_map,
     _canonical_library_key,
     _is_supported_compare_input,
     _version_sort_key,
@@ -165,6 +166,28 @@ class TestVersionSortKey:
         k2 = _version_sort_key(Path("libfoo.so.1.2"), "libfoo.so")
         k3 = _version_sort_key(Path("libfoo.so.1.3"), "libfoo.so")
         assert k2 < k3
+
+    def test_vendor_hash_does_not_perturb_version_order(self) -> None:
+        # Codex (PR #551): an auditwheel/delocate content hash embedded in the
+        # filename must not out-rank the real SONAME version tokens — the
+        # hex hash's own digits/letters would otherwise corrupt the ordering.
+        older = _version_sort_key(Path("libfoo-000000.so.1"), "libfoo.so")
+        newer = _version_sort_key(Path("libfoo-ffffff.so.2"), "libfoo.so")
+        assert older < newer, "hash content must not outrank the .so version"
+
+
+class TestBuildMatchMapVendorHash:
+    def test_picks_higher_soname_version_despite_hash(self, tmp_path: Path) -> None:
+        # Same underlying bug as TestVersionSortKey.
+        # test_vendor_hash_does_not_perturb_version_order, exercised at the
+        # _build_match_map level that compare-release actually calls.
+        old = tmp_path / "libfoo-000000.so.1"
+        new = tmp_path / "libfoo-ffffff.so.2"
+        old.write_bytes(b"\x7fELF")
+        new.write_bytes(b"\x7fELF")
+        mapping, warnings = _build_match_map([old, new])
+        assert mapping["libfoo.so"] == new
+        assert warnings
 
 
 # ── file vs file ─────────────────────────────────────────────────────────────

--- a/tests/test_debug_artifact_dwarf_wiring.py
+++ b/tests/test_debug_artifact_dwarf_wiring.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end proof that a resolved detached debug artifact actually feeds
+the DWARF parse for ``dump``/``compare`` (P1.1, ADR-021a).
+
+Before this fix, ``--debug-root``/``--debuginfod`` resolved and *logged* a
+matching ``.debug`` file, but the DWARF parse always read the (stripped)
+binary itself — so a normal split-debug production ``.so`` stayed L0-only
+(symbols-only) even after abicheck reported it found the matching debug file.
+`compare` against two stripped builds could report a false-green NO_CHANGE
+even when the real DWARF-visible ABI (e.g. a struct layout) had changed.
+
+Requires gcc + objcopy + strip (binutils) to build a real split-debug
+fixture — no synthetic bytes can stand in for real DWARF sections.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from abicheck.cli import main
+
+pytestmark = pytest.mark.integration
+
+_NEEDED_TOOLS = ("gcc", "objcopy", "strip", "readelf")
+
+
+def _missing_tools() -> list[str]:
+    return [t for t in _NEEDED_TOOLS if shutil.which(t) is None]
+
+
+def _build_id(binary: Path) -> str:
+    out = subprocess.run(
+        ["readelf", "-n", str(binary)], capture_output=True, text=True, check=True,
+    ).stdout
+    for line in out.splitlines():
+        if "Build ID:" in line:
+            return line.rsplit(":", 1)[-1].strip()
+    raise AssertionError(f"no Build ID note found in {binary}")
+
+
+def _build_split_debug_lib(tmp_path: Path, name: str, source: str) -> tuple[Path, Path]:
+    """Compile *source* to a shared lib, split its debug info out, strip it.
+
+    Returns (stripped_so_path, debug_root_dir) where debug_root_dir is a
+    ``.build-id/<xx>/<rest>.debug`` tree (the same layout ``/usr/lib/debug``
+    uses on a real distro).
+    """
+    src_dir = tmp_path / name
+    src_dir.mkdir()
+    c_file = src_dir / "foo.c"
+    c_file.write_text(source, encoding="utf-8")
+    so_path = src_dir / "libfoo.so"
+    subprocess.run(
+        ["gcc", "-shared", "-fPIC", "-g", "-o", str(so_path), str(c_file)],
+        check=True, capture_output=True,
+    )
+    debug_file = src_dir / "libfoo.so.debug"
+    subprocess.run(
+        ["objcopy", "--only-keep-debug", str(so_path), str(debug_file)],
+        check=True, capture_output=True,
+    )
+    build_id = _build_id(so_path)
+    subprocess.run(
+        ["strip", "--strip-debug", "--strip-unneeded", str(so_path)],
+        check=True, capture_output=True,
+    )
+    debug_root = tmp_path / f"debugroot_{name}"
+    bid_dir = debug_root / ".build-id" / build_id[:2]
+    bid_dir.mkdir(parents=True)
+    shutil.copy(debug_file, bid_dir / f"{build_id[2:]}.debug")
+    return so_path, debug_root
+
+
+_POINT_V1 = "struct Point { int x; int y; };\nint add_point(struct Point p) { return p.x + p.y; }\n"
+_POINT_V2 = (
+    "struct Point { int x; int y; int z; };\n"
+    "int add_point(struct Point p) { return p.x + p.y + p.z; }\n"
+)
+
+
+@pytest.mark.skipif(bool(_missing_tools()), reason=f"requires {_NEEDED_TOOLS}")
+class TestDumpUsesResolvedDebugArtifact:
+    def test_stripped_binary_without_debug_root_is_symbols_only(
+        self, tmp_path: Path
+    ) -> None:
+        so_path, _debug_root = _build_split_debug_lib(tmp_path, "v1", _POINT_V1)
+        out = tmp_path / "no_debug_root.json"
+        result = CliRunner().invoke(
+            main, ["dump", str(so_path), "-o", str(out)],
+        )
+        assert result.exit_code == 0, result.output
+        snap = json.loads(out.read_text())
+        assert snap["dwarf"]["has_dwarf"] is False
+
+    def test_stripped_binary_with_debug_root_gets_dwarf(self, tmp_path: Path) -> None:
+        """The fix: --debug-root resolves the split .debug file AND the DWARF
+        parse now actually reads it, instead of only logging that it exists."""
+        so_path, debug_root = _build_split_debug_lib(tmp_path, "v1", _POINT_V1)
+        out = tmp_path / "with_debug_root.json"
+        result = CliRunner().invoke(
+            main,
+            ["dump", str(so_path), "--debug-root", str(debug_root), "-o", str(out)],
+        )
+        assert result.exit_code == 0, result.output
+        assert "Debug info:" in result.output
+        snap = json.loads(out.read_text())
+        assert snap["dwarf"]["has_dwarf"] is True
+        assert len(snap["functions"]) >= 1
+
+
+@pytest.mark.skipif(bool(_missing_tools()), reason=f"requires {_NEEDED_TOOLS}")
+class TestCompareUsesResolvedDebugArtifacts:
+    def test_compare_stripped_binaries_without_debug_root_is_false_green(
+        self, tmp_path: Path
+    ) -> None:
+        """Baseline for the regression: two stripped builds with an identical
+        export table but a changed struct layout report NO_CHANGE when no
+        DWARF evidence is available — the false-green the report describes."""
+        old_so, _ = _build_split_debug_lib(tmp_path, "old", _POINT_V1)
+        new_so, _ = _build_split_debug_lib(tmp_path, "new", _POINT_V2)
+        out = tmp_path / "result.json"
+        result = CliRunner().invoke(
+            main,
+            ["compare", str(old_so), str(new_so), "--format", "json", "-o", str(out)],
+        )
+        assert result.exit_code == 0, result.output
+        data = json.loads(out.read_text())
+        assert data["verdict"] == "NO_CHANGE"
+
+    def test_compare_stripped_binaries_with_debug_root_detects_real_break(
+        self, tmp_path: Path
+    ) -> None:
+        """The fix: with --debug-root old=/new=, DWARF is resolved and parsed
+        for both stripped sides, so the real struct-layout break surfaces
+        instead of the false-green NO_CHANGE above."""
+        old_so, old_debug_root = _build_split_debug_lib(tmp_path, "old", _POINT_V1)
+        new_so, new_debug_root = _build_split_debug_lib(tmp_path, "new", _POINT_V2)
+        out = tmp_path / "result.json"
+        result = CliRunner().invoke(
+            main,
+            [
+                "compare", str(old_so), str(new_so),
+                "--debug-root", f"old={old_debug_root}",
+                "--debug-root", f"new={new_debug_root}",
+                "--format", "json", "-o", str(out),
+            ],
+        )
+        assert result.exit_code == 4, result.output
+        assert "Debug info (old):" in result.output
+        assert "Debug info (new):" in result.output
+        data = json.loads(out.read_text())
+        assert data["verdict"] == "BREAKING"
+        kinds = {c["kind"] for c in data["changes"]}
+        assert "type_size_changed" in kinds

--- a/tests/test_debug_artifact_dwarf_wiring.py
+++ b/tests/test_debug_artifact_dwarf_wiring.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -42,8 +43,16 @@ pytestmark = pytest.mark.integration
 
 _NEEDED_TOOLS = ("gcc", "objcopy", "strip", "readelf")
 
-
+#: Linux/ELF-specific by construction: build-id notes and
+#: `objcopy --only-keep-debug` split-DWARF are GNU/ELF conventions. On
+#: Windows, "gcc" is MinGW and emits PE, not ELF; on macOS it's usually a
+#: clang alias emitting Mach-O and detached debug info is dSYM bundles, not
+#: build-id trees — neither has a matching readelf/objcopy/build-id story, so
+#: this fixture-building approach cannot be ported as-is (P1.1 is scoped to
+#: the Linux ELF path; PE/PDB and Mach-O/dSYM wiring are documented follow-ups).
 def _missing_tools() -> list[str]:
+    if sys.platform != "linux":
+        return ["linux"]
     return [t for t in _NEEDED_TOOLS if shutil.which(t) is None]
 
 
@@ -97,7 +106,9 @@ _POINT_V2 = (
 )
 
 
-@pytest.mark.skipif(bool(_missing_tools()), reason=f"requires {_NEEDED_TOOLS}")
+@pytest.mark.skipif(
+    bool(_missing_tools()), reason=f"Linux-only; requires {_NEEDED_TOOLS}: missing {_missing_tools()}"
+)
 class TestDumpUsesResolvedDebugArtifact:
     def test_stripped_binary_without_debug_root_is_symbols_only(
         self, tmp_path: Path
@@ -127,7 +138,9 @@ class TestDumpUsesResolvedDebugArtifact:
         assert len(snap["functions"]) >= 1
 
 
-@pytest.mark.skipif(bool(_missing_tools()), reason=f"requires {_NEEDED_TOOLS}")
+@pytest.mark.skipif(
+    bool(_missing_tools()), reason=f"Linux-only; requires {_NEEDED_TOOLS}: missing {_missing_tools()}"
+)
 class TestCompareUsesResolvedDebugArtifacts:
     def test_compare_stripped_binaries_without_debug_root_is_false_green(
         self, tmp_path: Path

--- a/tests/test_scan_estimate.py
+++ b/tests/test_scan_estimate.py
@@ -770,12 +770,30 @@ def test_cli_audit_json_carries_poi(
     assert payload["poi"]["version"] == 1
 
 
+def test_cli_scan_json_carries_scan_schema_version(
+    runner: CliRunner, snap_path: Path, header: Path
+) -> None:
+    """The CLI's ``scan --format json`` contract (ScanOutcome.to_dict) must
+    carry a schema-version marker, same as compare's ``report_schema_version``,
+    so external consumers can pin/validate the envelope (P1.5)."""
+    from abicheck.schemas import SCAN_SCHEMA_VERSION
+
+    res = runner.invoke(
+        main,
+        ["scan", "--binary", str(snap_path), "-H", str(header), "--format", "json"],
+    )
+    assert res.exit_code == 0
+    payload = json.loads(res.output)
+    assert payload["scan_schema_version"] == SCAN_SCHEMA_VERSION
+
+
 # --------------------------------------------------------------------------- #
 # run_scan / run_audit typed engine (ADR-035 D10 / Phase 3b tail)
 # --------------------------------------------------------------------------- #
 
 
 def test_run_audit_returns_typed_result_with_findings(snap_path: Path) -> None:
+    from abicheck.schemas import SCAN_SCHEMA_VERSION
     from abicheck.service import ScanResult, run_audit
 
     res = run_audit(ScanRequest(binaries=[snap_path]))
@@ -789,6 +807,10 @@ def test_run_audit_returns_typed_result_with_findings(snap_path: Path) -> None:
     d = res.to_dict()
     assert d["verdict"] == res.verdict
     assert d["findings"] == len(res.findings)
+    # P1.5: both the service envelope and the nested CLI-facing report carry
+    # the same scan schema version marker.
+    assert d["scan_schema_version"] == SCAN_SCHEMA_VERSION
+    assert d["report"]["scan_schema_version"] == SCAN_SCHEMA_VERSION
 
 
 def test_run_scan_no_baseline_matches_audit_findings(snap_path: Path) -> None:

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -1202,6 +1202,20 @@ class TestRunCompare:
         assert old_call["public_headers"] == [old_h]
         assert new_call["public_headers"] == [new_h]
 
+    def test_debuginfod_url_appended_last_preserves_positional_order(self):
+        # Codex review (PR #551): debuginfod_url was originally inserted right
+        # after enable_debuginfod, ahead of scope_to_public_surface — any
+        # caller invoking run_compare positionally that far would have every
+        # later positional argument silently shift by one slot. It must be
+        # the LAST parameter so no pre-existing positional binding moves.
+        import inspect
+
+        params = list(inspect.signature(run_compare).parameters)
+        assert params[-1] == "debuginfod_url"
+        assert params.index("scope_to_public_surface") == (
+            params.index("enable_debuginfod") + 1
+        )
+
 
 # ── render_output() ─────────────────────────────────────────────────────────
 

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -719,6 +719,46 @@ class TestDumpElf:
             or call_kwargs[1].get("compiler") == "cc"
         )
 
+    def test_debuginfod_url_reaches_resolve_debug_info(self, tmp_path):
+        # Codex (PR #551): a custom --debuginfod-url must reach the resolver's
+        # debuginfod_urls kwarg, not just gate enable_debuginfod on/off.
+        from abicheck.service import _dump_elf
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        snap = AbiSnapshot(library="test", version="1.0")
+        with (
+            patch("abicheck.service.expand_header_inputs", return_value=[]),
+            patch("abicheck.debug_resolver.resolve_debug_info", return_value=None) as mock_resolve,
+            patch("abicheck.dumper.dump", return_value=snap),
+        ):
+            _dump_elf(
+                p,
+                [],
+                [],
+                "1.0",
+                "c++",
+                enable_debuginfod=True,
+                debuginfod_url="https://debuginfod.example.test/",
+            )
+        assert mock_resolve.call_args.kwargs["debuginfod_urls"] == [
+            "https://debuginfod.example.test/"
+        ]
+
+    def test_no_debuginfod_url_passes_none(self, tmp_path):
+        from abicheck.service import _dump_elf
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        snap = AbiSnapshot(library="test", version="1.0")
+        with (
+            patch("abicheck.service.expand_header_inputs", return_value=[]),
+            patch("abicheck.debug_resolver.resolve_debug_info", return_value=None) as mock_resolve,
+            patch("abicheck.dumper.dump", return_value=snap),
+        ):
+            _dump_elf(p, [], [], "1.0", "c++", enable_debuginfod=True)
+        assert mock_resolve.call_args.kwargs["debuginfod_urls"] is None
+
 
 # ── _dump_pe() ──────────────────────────────────────────────────────────────
 

--- a/tests/test_stack_checker_unit.py
+++ b/tests/test_stack_checker_unit.py
@@ -7,7 +7,8 @@ from unittest.mock import MagicMock, patch
 
 from abicheck.binder import BindingStatus, SymbolBinding
 from abicheck.checker import DiffResult
-from abicheck.checker_policy import Verdict
+from abicheck.checker_policy import ChangeKind, Verdict
+from abicheck.checker_types import Change
 from abicheck.resolver import DependencyGraph, ResolvedDSO
 from abicheck.stack_checker import (
     StackChange,
@@ -60,10 +61,19 @@ def _make_resolved_dso(path, soname="libfoo.so"):
     )
 
 
-def _make_diff_result(verdict=Verdict.NO_CHANGE):
+def _make_diff_result(verdict=Verdict.NO_CHANGE, breaking=None):
     mock = MagicMock(spec=DiffResult)
     mock.verdict = verdict
+    mock.breaking = [] if breaking is None else breaking
     return mock
+
+
+def _make_breaking_change(symbol="sym"):
+    return Change(
+        kind=ChangeKind.FUNC_REMOVED_ELF_ONLY,
+        symbol=symbol,
+        description="test",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -118,13 +128,49 @@ class TestComputeAbiRisk:
         assert _compute_abi_risk(changes) == StackVerdict.FAIL
 
     def test_breaking_verdict_with_impacted_imports_fail(self):
-        diff = _make_diff_result(Verdict.BREAKING)
-        binding = _make_binding()
+        # P1.4: a root only FAILs when the imported symbol is among the
+        # DSO's own BREAKING findings — here "sym" is both imported and
+        # the symbol the breaking change removed, so this is a confirmed hit.
+        diff = _make_diff_result(Verdict.BREAKING, breaking=[_make_breaking_change("sym")])
+        binding = _make_binding(symbol="sym")
         changes = [StackChange(
             library="libfoo.so",
             change_type="content_changed",
             abi_diff=diff,
             impacted_imports=[binding],
+        )]
+        assert _compute_abi_risk(changes) == StackVerdict.FAIL
+
+    def test_breaking_verdict_with_unrelated_impacted_import_warns_not_fail(self):
+        # P1.4 regression: the DSO is BREAKING because it removed
+        # "unrelated_sym", but this root only imports "sym" — an unrelated,
+        # unaffected symbol from the same provider. That must not FAIL the
+        # root; it's still a real "environment contains a broken DSO" signal
+        # (WARN), not a confirmed impact on this specific root/import.
+        diff = _make_diff_result(
+            Verdict.BREAKING, breaking=[_make_breaking_change("unrelated_sym")]
+        )
+        binding = _make_binding(symbol="sym")
+        changes = [StackChange(
+            library="libfoo.so",
+            change_type="content_changed",
+            abi_diff=diff,
+            impacted_imports=[binding],
+        )]
+        assert _compute_abi_risk(changes) == StackVerdict.WARN
+
+    def test_breaking_verdict_multiple_imports_one_matches_fails(self):
+        # One of several imports from this provider does match a broken
+        # symbol — still a confirmed FAIL even though other imports don't.
+        diff = _make_diff_result(
+            Verdict.BREAKING, breaking=[_make_breaking_change("broken_sym")]
+        )
+        bindings = [_make_binding(symbol="unrelated_a"), _make_binding(symbol="broken_sym")]
+        changes = [StackChange(
+            library="libfoo.so",
+            change_type="content_changed",
+            abi_diff=diff,
+            impacted_imports=bindings,
         )]
         assert _compute_abi_risk(changes) == StackVerdict.FAIL
 

--- a/tests/test_stack_checker_unit.py
+++ b/tests/test_stack_checker_unit.py
@@ -194,6 +194,26 @@ class TestComputeAbiRisk:
         )]
         assert _compute_abi_risk(changes) == StackVerdict.FAIL
 
+    def test_breaking_dso_wide_elf_header_change_fails_despite_unrelated_import(self):
+        # Codex review regression: a DSO-wide break (wrong machine/class/
+        # endianness/ABI-flags) is recorded against the sentinel symbol
+        # "ELF_HEADER" (diff_platform_elf_dynamic.py), never a real export.
+        # No import is ever literally named "ELF_HEADER", so the plain
+        # symbol/affected_symbols intersection would never match it and
+        # would wrongly downgrade this to WARN — but a wrong-arch/class DSO
+        # cannot satisfy ANY import at runtime, so this must FAIL.
+        diff = _make_diff_result(
+            Verdict.BREAKING, breaking=[_make_breaking_change("ELF_HEADER")]
+        )
+        binding = _make_binding(symbol="totally_unrelated_export")
+        changes = [StackChange(
+            library="libfoo.so",
+            change_type="content_changed",
+            abi_diff=diff,
+            impacted_imports=[binding],
+        )]
+        assert _compute_abi_risk(changes) == StackVerdict.FAIL
+
     def test_api_break_verdict_with_impacted_imports_warn(self):
         diff = _make_diff_result(Verdict.API_BREAK)
         binding = _make_binding()

--- a/tests/test_stack_checker_unit.py
+++ b/tests/test_stack_checker_unit.py
@@ -68,11 +68,12 @@ def _make_diff_result(verdict=Verdict.NO_CHANGE, breaking=None):
     return mock
 
 
-def _make_breaking_change(symbol="sym"):
+def _make_breaking_change(symbol="sym", affected_symbols=None):
     return Change(
         kind=ChangeKind.FUNC_REMOVED_ELF_ONLY,
         symbol=symbol,
         description="test",
+        affected_symbols=affected_symbols,
     )
 
 
@@ -171,6 +172,25 @@ class TestComputeAbiRisk:
             change_type="content_changed",
             abi_diff=diff,
             impacted_imports=bindings,
+        )]
+        assert _compute_abi_risk(changes) == StackVerdict.FAIL
+
+    def test_breaking_type_change_matched_via_affected_symbols_fails(self):
+        # Codex review regression: a BREAKING type/layout change (e.g. a
+        # resized struct) names the *type* in Change.symbol ("Point"), not
+        # the exported functions that use it — those live in
+        # affected_symbols. A root importing "foo" (which takes a Point
+        # parameter) must still FAIL, not be missed because "foo" != "Point".
+        diff = _make_diff_result(
+            Verdict.BREAKING,
+            breaking=[_make_breaking_change("Point", affected_symbols=["foo", "bar"])],
+        )
+        binding = _make_binding(symbol="foo")
+        changes = [StackChange(
+            library="libfoo.so",
+            change_type="content_changed",
+            abi_diff=diff,
+            impacted_imports=[binding],
         )]
         assert _compute_abi_risk(changes) == StackVerdict.FAIL
 


### PR DESCRIPTION
## Summary

Two batches of scoped, independently-testable fixes from the current-main usability evaluation's priority list (P1/P2 findings).

### Batch 1

- **P1.6 — Baseline pull error handling**: `baseline_pull` called `registry.pull(key)` with no try/except, unlike every sibling registry call in `cli_baseline.py`. A corrupt/tampered registry entry (`BaselineIntegrityError`) surfaced as an uncaught traceback instead of a clean CLI error. Wrapped it to raise `click.ClickException`.
- **P1.2 — AST-frontend `auto` contract drift**: The `--ast-frontend` help text claimed `auto` falls back to clang whenever castxml is merely absent. It doesn't — it only falls back for two narrow runtime failure classes (a castxml toolchain-version mismatch, or a direct-include `#error` guard) when castxml **is** present but fails. Corrected the help text to match the actual `dumper._resolve_header_backend`/`_run_header_dump` behavior. Also found and fixed a related, inverted doc bug: `producing-source-facts.md` claimed `ABICHECK_CC_EXTRACTOR=auto` prefers castxml, but the real resolver (`buildsource/source_extractors/resolver.py`) prefers clang (the more capable backend) when both are available.
- **P1.5 — Scan JSON schema version**: The `scan` command's JSON output had no schema-version marker, unlike `compare`'s `report_schema_version`. Added a versioned `scan_schema_version` (`SCAN_SCHEMA_VERSION` in `abicheck/schemas/__init__.py`) to both the CLI-facing `ScanOutcome.to_dict()` and the service-layer `ScanResult.to_dict()` envelope.
- **P2.6 — Stale use-case registry entry**: `UC-PLAT-arch-guard` (G13) was still marked `planned`, claiming ELF snapshots never capture `e_machine`/`EI_CLASS`/endianness — but `ELF_MACHINE_CHANGED`/`ELF_CLASS_CHANGED`/`ELF_ENDIANNESS_CHANGED` are implemented, tested, and classified `BREAKING_KINDS`. Flipped to `complete` and reconciled the evaluation doc + plans index.

### Batch 2

- **P1.1 — Detached debug artifacts weren't fed into the DWARF parse**: `--debug-root`/`--debuginfod` resolved a matching build-id-tree or path-mirror `.debug` file and only *logged* it — the DWARF parse always read the (stripped) input binary itself, so a normal split-debug production `.so` stayed L0-only even after abicheck reported finding its debug file, and `compare` between two such stripped builds could report a false-green `NO_CHANGE` for a real DWARF-visible break. Threaded the resolved debug artifact's path through `service.py` → `dumper.py` → `dumper_debug.py` so DWARF sections are read from it while `elf_metadata.py` still reads symbols from the original binary; wired both the `dump` CLI's direct `dumper.dump()` path and `compare`'s per-side `service.resolve_input()` path. Proven end-to-end with a real `gcc` + `objcopy --only-keep-debug` + `strip` fixture (split DWARF and dSYM remain unwired — documented follow-up in `dump-compare-flags.md`).
- **P1.4 — Dependency-stack root impact wasn't symbol-precise**: `stack_checker._compute_abi_risk` marked a root `FAIL` whenever a provider DSO was `BREAKING` and had *any* `impacted_imports`, regardless of whether the specific breaking change touched a symbol the root actually imports. Now intersects the DSO's `BREAKING` changes' symbols with the root's imported symbols; an unrelated break on the same DSO downgrades to `WARN` (still surfaced, never silently dropped) instead of a false `FAIL`.
- **P2.5 — Vendored wheel library names weren't normalized**: `auditwheel`/`delocate` rewrite vendored libs to `lib<name>-<hash>.so.<ver>`, so `compare-release` paired nothing across rebuilds and reported every bundled dependency as removed+added. Added `strip_vendor_hash()` (restricted to a 6-16 hex hyphen-suffix immediately before `.so`/`.dylib` or a version component) folded into `_canonical_library_key`, so the same dependency pairs across hash rebuilds while a real break (e.g. a SONAME major bump, the pyzmq/libsodium-shaped regression anchor) still surfaces.
- **P2.2 — GitHub Action robustness**: `action/run.sh`'s `add_flag`/`add_sided_flag` word-split multi-value inputs unquoted, which the file's own comment already flagged as breaking on space-containing paths; now prefers newline-separated items (a YAML block-scalar input) and only falls back to whitespace-splitting for a single-line value. Also corrected `action.yml`'s `--allow-build-query` description, which described it as an active permission gate when it's actually a deprecated no-op for the modes the Action uses it in (the real gate is supplying `--build-config` itself).

Also **measured** the report's P1.3 finding (exact-`ChangeKind` mismatches) against current source with castxml installed: confirmed 22 GCC / 24 Clang mismatches reproduce exactly as reported, ~20 shared across both toolchains (a detector-precision issue, not a toolchain-specific parsing gap). Left unfixed — each case needs its own dedicated investigation, too large for this pass; not attempted rather than rushed.

Deliberately **out of scope** for this PR (large/design-heavy items from the same report, left for dedicated follow-up work):
- P1.3 — driving exact-`ChangeKind` mismatches in the example matrix to zero (measured, not fixed — see above)
- P2.1 — new `doctor`/`init`/`config validate`/`config show-effective` command surface
- Split-DWARF (`.dwo`/`.dwp`) and dSYM wiring for the P1.1 fix (documented follow-up)

## Test plan

- [x] `ruff check abicheck/ tests/` — clean
- [x] `mypy abicheck/` — clean, no new errors (baseline stays 0)
- [x] `python scripts/check_ai_readiness.py` — 0 errors, 14 pre-existing warnings (no new ones)
- [x] `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` — 14290 passed, 25 skipped, 4 xfailed (all pre-existing), 0 failures
- [x] `pytest tests/ -m integration` (castxml/gcc/clang installed for this session) — 224 passed, 0 failures
- [x] New tests: baseline-pull clean-error CLI test; scan-schema-version tests (CLI + service envelope); `stack_checker` symbol-intersection unit tests (including the "unrelated symbol on a broken DSO must WARN not FAIL" regression); `strip_vendor_hash`/`_canonical_library_key` unit tests + a `compare-release` workflow test proving hash-rebuild pairing and that a real break still surfaces; `action/run.sh` word-splitting behavioral tests (extracts the real helper functions, sources them, and exercises both legacy and newline-separated forms); an end-to-end `test_debug_artifact_dwarf_wiring.py` using a real compiled+split+stripped fixture proving the P1.1 fix for both `dump` and `compare`
- [x] `tests/test_usecase_registry.py` — registry/eval-doc consistency gates

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xqh65Zj2Ms9pEGs6YPra5N)_