### PR TITLE
fix(examples): stop full-matrix summary check from flagging KINDS_MISMATCH as drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -344,6 +344,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   that isn't a return-type separator) — both are now handled by a shared
   `_holder_of` helper.
 
+- **`Examples Validation`'s "Full example matrix" job failed on every push to
+  `main`.** `validation/scripts/collect_full_example_matrix.py` recomputed
+  each gcc/clang/build-source artifact's `summary` as a plain `Counter` over
+  each result's `status`, but `tests/validate_examples.py`'s
+  `_summary_counts()` layers two reported-only advisory tallies
+  (`KINDS_MISMATCH`, `CATEGORY_COLLAPSED`) on top of a case's own
+  `PASS`/`XFAIL`/`SKIP` status. The expanded `expected_kinds` scoping above
+  surfaced non-zero `KINDS_MISMATCH` counts for the first time, so the
+  recomputed summary diverged from the artifact's and the job failed with an
+  `ARTIFACT ERROR` despite every case lane actually passing. The recompute
+  now mirrors the same advisory-tally logic for those three lanes.
+
 ### Documentation
 
 - **Example-catalog semantic-validation gaps from an external audit.**

--- a/tests/test_review_comment_regressions.py
+++ b/tests/test_review_comment_regressions.py
@@ -161,6 +161,42 @@ def test_full_matrix_runtime_build_error_is_an_artifact_error() -> None:
     assert errors == ["runtime: failing runner statuses for: case01"]
 
 
+@pytest.mark.parametrize("label", ["gcc", "clang", "build_source"])
+def test_full_matrix_summary_check_tolerates_kinds_mismatch_advisory_key(
+    label: str,
+) -> None:
+    """A PASS row flagged kinds_strict=mismatch adds a KINDS_MISMATCH tally to
+    tests/validate_examples.py's summary alongside the row's own PASS/XFAIL
+    status (see _summary_counts). That is a reported-only advisory signal, not
+    a second status, so it must not be flagged as a summary/results mismatch.
+    """
+    matrix = _load_script("validation/scripts/collect_full_example_matrix.py")
+    cases = {"case01", "case02"}
+    payload = _artifact(matrix, label, cases)
+    payload["summary"] = {"PASS": 2, "KINDS_MISMATCH": 1}
+    payload["results"] = [
+        {"case_id": "case01", "status": "PASS", "kinds_strict": "mismatch"},
+        {"case_id": "case02", "status": "PASS", "kinds_strict": "match"},
+    ]
+    errors = matrix._artifact_errors(label, payload, expected_cases=cases)
+    assert not any("summary=" in error for error in errors)
+
+
+@pytest.mark.parametrize("label", ["gcc", "clang", "build_source"])
+def test_full_matrix_summary_check_still_catches_real_drift(label: str) -> None:
+    """The advisory-key tolerance must not swallow genuine summary/results drift."""
+    matrix = _load_script("validation/scripts/collect_full_example_matrix.py")
+    cases = {"case01", "case02"}
+    payload = _artifact(matrix, label, cases)
+    payload["summary"] = {"PASS": 2, "KINDS_MISMATCH": 5}
+    payload["results"] = [
+        {"case_id": "case01", "status": "PASS", "kinds_strict": "mismatch"},
+        {"case_id": "case02", "status": "PASS", "kinds_strict": "match"},
+    ]
+    errors = matrix._artifact_errors(label, payload, expected_cases=cases)
+    assert any("summary=" in error for error in errors)
+
+
 def _proof_artifact(matrix: ModuleType) -> dict[str, object]:
     owners = sorted(matrix.SPECIAL_PROOFS)
     return {

--- a/validation/scripts/collect_full_example_matrix.py
+++ b/validation/scripts/collect_full_example_matrix.py
@@ -248,6 +248,26 @@ def _artifact_errors(
             if isinstance(row, dict) and row.get("status") is not None
         )
     )
+    if label in {"gcc", "clang", "build_source"}:
+        # tests/validate_examples.py's _summary_counts() layers two reported-only,
+        # non-blocking advisory tallies on top of the per-status counts: rows whose
+        # kinds_strict/category_strict signal is off (a case can be PASS/XFAIL for
+        # its verdict yet still flagged here for expected_kinds drift). Mirror that
+        # so a summary carrying those keys isn't flagged as an artifact mismatch.
+        collapsed = sum(
+            1
+            for row in results
+            if isinstance(row, dict) and row.get("category_strict") == "collapsed"
+        )
+        if collapsed:
+            actual_summary["CATEGORY_COLLAPSED"] = collapsed
+        kinds_mismatch = sum(
+            1
+            for row in results
+            if isinstance(row, dict) and row.get("kinds_strict") == "mismatch"
+        )
+        if kinds_mismatch:
+            actual_summary["KINDS_MISMATCH"] = kinds_mismatch
     if data.get("summary") != actual_summary:
         errors.append(
             f"{label}: summary={data.get('summary')!r}, recomputed {actual_summary!r}"


### PR DESCRIPTION
## Summary

Fixes the "Full example matrix" job in the `Examples Validation` workflow, which has failed on every push to `main` since #547 merged.

## Motivation

`main`'s `Examples Validation` workflow currently fails its "Full example matrix" job on every push (see run [29381977243](https://github.com/abicheck/abicheck/actions/runs/29381977243/job/87249879883)):

```
ARTIFACT ERROR: gcc: summary={'PASS': 145, 'XFAIL': 4, 'SKIP': 32, 'KINDS_MISMATCH': 22}, recomputed {'PASS': 145, 'XFAIL': 4, 'SKIP': 32}
ARTIFACT ERROR: clang: summary={'PASS': 145, 'XFAIL': 5, 'SKIP': 31, 'KINDS_MISMATCH': 24}, recomputed {'PASS': 145, 'XFAIL': 5, 'SKIP': 31}
```

`tests/validate_examples.py`'s `_summary_counts()` layers two reported-only, non-blocking advisory tallies (`KINDS_MISMATCH`, `CATEGORY_COLLAPSED`) on top of each result's own `PASS`/`XFAIL`/`SKIP` status — a case can be `PASS` for its verdict yet still get tallied under `KINDS_MISMATCH` if its `expected_kinds` audit signal is off. `validation/scripts/collect_full_example_matrix.py`'s artifact-summary recompute only counted the `status` field, so it never accounted for those two extra keys. #547 expanded `expected_kinds` scoping across the catalog, which pushed `KINDS_MISMATCH` from 0 to a non-zero count for the first time and exposed this latent bug — turning an intentionally reported-only signal into a hard CI failure that blocks every push.

I confirmed this reading job logs for the last several `main` CI runs via the GitHub Actions API; every push since 9ca0431 (#547) has failed this job.

Note: while investigating I also found the nightly `Examples Validation (nightly cross-platform)` workflow has been failing on Linux AArch64 (both gcc and clang) since 2026-07-13, with several genuine `FAIL` cases (e.g. `case171_static_tls_introduced`, `case129_struct_return_convention`, `case60_base_class_position_changed`) that look like real architecture-specific detection gaps rather than a script bug. I don't have aarch64 hardware or `castxml` in this environment to investigate that safely, so it's out of scope for this PR — flagging it separately for a follow-up with access to an aarch64 runner.

## Changes

- `validation/scripts/collect_full_example_matrix.py`: for the `gcc`/`clang`/`build_source` lanes, mirror `_summary_counts()`'s `CATEGORY_COLLAPSED`/`KINDS_MISMATCH` derivation before comparing against the artifact's `summary`, so the check tolerates the known advisory keys while still catching genuine drift.
- `tests/test_review_comment_regressions.py`: regression tests covering both the false-positive case (advisory key present, no real drift) and that real summary/results drift is still caught.
- `CHANGELOG.md`: note under `[Unreleased] / Fixed`.

## Test plan

- [x] `python -m pytest tests/test_review_comment_regressions.py -q` — 39 passed (new tests included)
- [x] `python -m pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden" -q` — 14275 passed, 26 skipped, 4 xfailed
- [x] `ruff check validation/scripts/collect_full_example_matrix.py tests/test_review_comment_regressions.py` — clean
- [x] `mypy validation/scripts/collect_full_example_matrix.py` — no issues
- [x] `python scripts/check_ai_readiness.py` — 0 errors (only pre-existing warnings)

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [ ] Docs updated if user-visible behaviour changed (n/a — CI-internal script fix)
- [x] No new `mypy` or `ruff` errors introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_01Dub9GEkr1DEMhLKaLFojYe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed example validation workflow failures caused by advisory validation counts being omitted from summary checks.
  - Full example matrix results now correctly recognize category-collapsed and kind-mismatch advisory tallies.
  - Prevented false artifact errors when all example validation lanes pass.
  - Preserved detection of genuine discrepancies between reported summaries and validation results.

- **Tests**
  - Added regression coverage for advisory tally handling and real summary drift detection.

- **Documentation**
  - Added a changelog entry describing the workflow fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->