### PR TITLE
fix(ci): recognize KINDS_MISMATCH/CATEGORY_COLLAPSED in full example matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,6 +302,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **CI's "Full example matrix" gate false-failed on every PR after #547.**
+  `tests/validate_examples.py::_summary_counts` overlays two secondary,
+  independent tallies onto a run's summary dict — `CATEGORY_COLLAPSED`
+  (`category_strict == "collapsed"`) and `KINDS_MISMATCH`
+  (`kinds_strict == "mismatch"`) — alongside the primary pass/fail status
+  counts; a case can be `PASS` *and* contribute to one of these. But
+  `validation/scripts/collect_full_example_matrix.py`'s cross-check
+  recomputed the artifact's summary from per-case `status` alone, so it
+  never matched the artifact's own (legitimately correct) summary the
+  moment any case tripped either signal — 22 gcc / 24 clang cases,
+  reliably, on every run. The recomputation now overlays the same two
+  tallies from each row's `category_strict`/`kinds_strict` fields.
+
 - **`case35_field_rename` reported `BREAKING` instead of `API_BREAK`.** A pure
   field rename (same offset + type, name only) fell through the generic
   field-removed/-added detectors to a plain `TYPE_FIELD_REMOVED`/

--- a/tests/test_review_comment_regressions.py
+++ b/tests/test_review_comment_regressions.py
@@ -154,6 +154,40 @@ def test_full_matrix_artifact_rejects_partial_duplicate_and_stale_catalog() -> N
     assert any("missing case ids: case02" in error for error in errors)
 
 
+def test_full_matrix_artifact_summary_accounts_for_kinds_mismatch_and_category_collapsed() -> (
+    None
+):
+    """PR #547 added KINDS_MISMATCH/CATEGORY_COLLAPSED as secondary overlay
+    tallies in tests/validate_examples.py::_summary_counts -- a case can be
+    PASS *and* contribute to one of these (they measure a stricter,
+    independent signal, not the primary pass/fail status). The by-status-only
+    recomputation must account for both, or a clean artifact whose summary
+    legitimately includes them always reads as an ARTIFACT ERROR."""
+    matrix = _load_script("validation/scripts/collect_full_example_matrix.py")
+    cases = {"case01", "case02", "case03"}
+    payload = _artifact(matrix, "gcc", cases)
+    payload["summary"] = {"PASS": 3, "KINDS_MISMATCH": 1, "CATEGORY_COLLAPSED": 1}
+    payload["results"] = [
+        {"case_id": "case01", "status": "PASS", "kinds_strict": "mismatch"},
+        {"case_id": "case02", "status": "PASS", "category_strict": "collapsed"},
+        {"case_id": "case03", "status": "PASS"},
+    ]
+    errors = matrix._artifact_errors("gcc", payload, expected_cases=cases)
+    assert not any("summary=" in error for error in errors)
+
+
+def test_full_matrix_artifact_summary_mismatch_still_caught() -> None:
+    """A genuinely wrong KINDS_MISMATCH/CATEGORY_COLLAPSED count must still be
+    flagged -- the fix must not blanket-ignore these keys."""
+    matrix = _load_script("validation/scripts/collect_full_example_matrix.py")
+    cases = {"case01"}
+    payload = _artifact(matrix, "gcc", cases)
+    payload["summary"] = {"PASS": 1, "KINDS_MISMATCH": 1}  # no row actually mismatched
+    payload["results"] = [{"case_id": "case01", "status": "PASS"}]
+    errors = matrix._artifact_errors("gcc", payload, expected_cases=cases)
+    assert any("summary=" in error for error in errors)
+
+
 def test_full_matrix_runtime_build_error_is_an_artifact_error() -> None:
     matrix = _load_script("validation/scripts/collect_full_example_matrix.py")
     payload = _artifact(matrix, "runtime", {"case01"}, status="BUILD_ERROR")

--- a/validation/scripts/collect_full_example_matrix.py
+++ b/validation/scripts/collect_full_example_matrix.py
@@ -248,6 +248,28 @@ def _artifact_errors(
             if isinstance(row, dict) and row.get("status") is not None
         )
     )
+    # `tests/validate_examples.py::_summary_counts` overlays two secondary,
+    # non-status tallies onto the same summary dict: CATEGORY_COLLAPSED
+    # (category_strict == "collapsed") and KINDS_MISMATCH (kinds_strict ==
+    # "mismatch") — a case can be e.g. PASS *and* contribute to one of these,
+    # since they measure a stricter, independent signal, not the primary
+    # pass/fail status. Recompute both here too, or the artifact's own
+    # summary (which legitimately includes them) never matches this
+    # by-status-only recomputation whenever any case trips either signal.
+    category_collapsed = sum(
+        1
+        for row in results
+        if isinstance(row, dict) and row.get("category_strict") == "collapsed"
+    )
+    if category_collapsed:
+        actual_summary["CATEGORY_COLLAPSED"] = category_collapsed
+    kinds_mismatch = sum(
+        1
+        for row in results
+        if isinstance(row, dict) and row.get("kinds_strict") == "mismatch"
+    )
+    if kinds_mismatch:
+        actual_summary["KINDS_MISMATCH"] = kinds_mismatch
     if data.get("summary") != actual_summary:
         errors.append(
             f"{label}: summary={data.get('summary')!r}, recomputed {actual_summary!r}"


### PR DESCRIPTION
## Summary

~~Fixes the "Full example matrix" CI job, which has failed on every PR since #547~~

**Closing as redundant.** While this PR was open, #550 landed on `main` and independently fixed the exact same `KINDS_MISMATCH`/`CATEGORY_COLLAPSED` cross-check bug (same root cause: `_summary_counts` in `tests/validate_examples.py` overlays two secondary diagnostic tallies onto the summary dict, which `collect_full_example_matrix.py`'s recomputation didn't account for). #550's fix is structurally cleaner — it separates the pure status-count comparison from a distinct diagnostic-summary comparison, giving a more precise error message on mismatch.

Verified: this branch's two regression tests pass unmodified against `main`'s current (post-#550) version of `collect_full_example_matrix.py`, confirming the fix is complete and there's nothing left here to contribute.

No further action needed — the underlying CI failure is already resolved on `main`.

## Motivation

`tests/validate_examples.py::_summary_counts` (added in #547) overlays two secondary, independent tallies onto a run's summary dict — `CATEGORY_COLLAPSED` (`category_strict == "collapsed"`) and `KINDS_MISMATCH` (`kinds_strict == "mismatch"`) — alongside the primary pass/fail status counts. A case can be `PASS` *and* still contribute to one of these, since they measure a stricter, independent signal, not the primary outcome.

`validation/scripts/collect_full_example_matrix.py`'s cross-check recomputed the artifact's summary from per-case `status` alone, so it never matched the artifact's own (legitimately correct) summary the moment any case tripped either signal — reliably 22 gcc / 24 clang cases, on every run:

```
ARTIFACT ERROR: gcc: summary={'PASS': 145, 'XFAIL': 4, 'SKIP': 32, 'KINDS_MISMATCH': 22}, recomputed {'PASS': 145, 'XFAIL': 4, 'SKIP': 32}
ARTIFACT ERROR: clang: summary={'PASS': 145, 'XFAIL': 5, 'SKIP': 31, 'KINDS_MISMATCH': 24}, recomputed {'PASS': 145, 'XFAIL': 5, 'SKIP': 31}
```

## Changes

- `validation/scripts/collect_full_example_matrix.py`: `_artifact_errors` now overlays the same two tallies onto its recomputed summary, from each row's `category_strict`/`kinds_strict` fields — mirroring `_summary_counts` exactly.
- `tests/test_review_comment_regressions.py`: two new regression tests — a clean artifact whose summary legitimately includes `KINDS_MISMATCH`/`CATEGORY_COLLAPSED` no longer reports an `ARTIFACT ERROR`, and a genuinely wrong count is still caught.
- `CHANGELOG.md`: new `### Fixed` entry under `[Unreleased]`.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Docs updated if user-visible behaviour changed (n/a — no user-visible/doc changes)
- [x] `pre-commit run --all-files` passes locally (ruff + mypy + ai-readiness gate all clean)
- [x] No new `mypy` or `ruff` errors introduced
