### PR TITLE
fix(reporting): close remaining P0 reporting gaps from post-#549/#551 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -804,7 +804,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `func_contract_attribute_removed`, and `ctor_explicit_removed` are the
   removed-side counterpart — a trait *lost by* a persisting entity, which
   the plain `"_removed"` suffix rule alone misread as an entity
-  disappearing. All eight now classify as `"modified"` too.
+  disappearing. All eight now classify as `"modified"` too. A third audit
+  pass (Codex review, PR #557) found `func_virtual_removed` (the sibling of
+  `func_virtual_added`, an existing function losing its virtual-ness) and
+  `param_default_value_removed`/`python_api_default_removed` (an existing
+  parameter losing its default value) — the same pattern again; all three
+  now classify as `"modified"` too.
 
 - **Self-review polish on the `GateDecision`/`--secondary-format` work above
   (PR #557):** the native HTML report's "CI Gate" card computed pass/fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -781,6 +781,21 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   (CodeRabbit review, PR #557). All five are now `required` (the emitter
   already always populates them; this only tightens the contract).
 
+- **Self-review polish on the `GateDecision`/`--secondary-format` work above
+  (PR #557):** the native HTML report's "CI Gate" card computed pass/fail
+  via `severity.compute_exit_code()` directly instead of the canonical
+  `compute_gate_decision()` `reporter.py`/`sarif.py`/`cli_compare_release.py`
+  were all migrated to — now routed through it too, so all four gate-status
+  call sites share one computation. The primary and `--secondary-format`
+  render paths each independently resolved the tri-state `--demangle` flag
+  with a duplicated one-line rule; factored into a single
+  `cli_compare_helpers._resolve_demangle()` both call. `compute_gate_decision`'s
+  legacy (no `SeverityConfig`) branch was found to be unreachable from any
+  of its three production call sites (each already special-cases
+  `severity_config is None` itself, since their legacy-scheme needs differ
+  from an empty `blocking_categories`) — documented explicitly in its
+  docstring rather than silently left as untested-in-practice code.
+
 - **Clang plugin: `source_edges` collected but never reached the L5 graph,
   plus four related correctness gaps from an independent review of the
   ADR-038 C.8 canonical fact-set work (ADR-038 C.10-C.12).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -287,6 +287,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   change to either type; JSON/SARIF output shapes are byte-for-byte
   unchanged.
 
+- **Per-finding `recommended_action` in the `compare` JSON schema (2.3 → 2.4,
+  additive).** Each finding now carries a structured, machine-readable next
+  step derived from the same effective verdict/category resolution
+  `severity`/`operation`/`finding_id` already use:
+  `recompile_and_relink_required` (BREAKING), `recompile_required`
+  (API_BREAK), `verify_deployment_compatibility` (COMPATIBLE_WITH_RISK),
+  `review_recommended` (a COMPATIBLE quality issue), or `no_action_required`
+  (a COMPATIBLE addition) — closing the last remaining gap from the
+  post-#549/#551 reporting review's schema-2.3 ask ("structured operation
+  and recommended-action fields"). Set in both `_change_to_dict` and
+  `_leaf_entry` (the latter learned this the same way it learned
+  `operation`/`finding_id` — see the entry above from earlier this cycle).
+
 - **Canonical fact-set versioning and per-family coverage honesty for the
   Clang facts plugin (ADR-038 C.8).** Every `SourceAbiTu` record produced by
   the Clang facts plugin and the reference `clang.py` wrapper now carries a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -319,7 +319,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `--reconcile-build-context`/`--env-matrix`). The bundled GitHub Action
   (`action/run.sh`) now uses this instead of re-running the whole comparison
   a second time to get JSON for its sticky PR comment, halving the work for
-  a `compare` step that posts a PR comment with a non-json primary format.
+  a `compare` step that posts a PR comment with a non-json primary format —
+  a new `_is_release_style_operand` check skips the optimization when the
+  `old-library`/`new-library` inputs are directories or package archives
+  (`compare` fans those out through the same release engine internally
+  regardless of the Action's `mode` input, and that engine rejects
+  `--secondary-format`), so a directory/package comparison under
+  `mode: compare` keeps working instead of hard-failing (Codex review).
 
 - **Canonical fact-set versioning and per-family coverage honesty for the
   Clang facts plugin (ADR-038 C.8).** Every `SourceAbiTu` record produced by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,8 +308,10 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   instead of requiring a second full `abicheck compare` invocation just to
   get a different format. `--secondary-format` requires
   `--secondary-output` (writing two formats to the same stream would be
-  ambiguous) and always renders the full, unfiltered report — it ignores
-  `--show-only`/`--stat`, which describe only the primary format's display.
+  ambiguous), must point at a different file than `--output`/`-o` (else the
+  secondary render would silently overwrite the primary report), and always
+  renders the full, unfiltered report — it ignores `--show-only`/`--stat`,
+  which describe only the primary format's display.
   Not supported for directory/package (release) comparisons yet (rejected
   with a `UsageError`, same as `--exit-code-scheme`/
   `--reconcile-build-context`/`--env-matrix`). The bundled GitHub Action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -900,6 +900,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   Now derived from the same unfiltered set as `exit_code`, matching how
   SARIF's own `_severity_gate_properties` was already doing it correctly.
 
+- **`--report-mode leaf`'s root-type-change entries were missing the schema
+  2.3 `operation`/`finding_id` fields.** `_to_json_leaf`'s `_leaf_entry`
+  builds its own dict for root type changes rather than routing through
+  `_change_to_dict`, so those entries in `leaf_changes[]` (and the
+  backward-compat `changes[]` union) lacked `operation`/`finding_id` even
+  though non-type leaf entries and full-mode entries both have them —
+  breaking `finding_id` correlation for leaf-mode reports specifically.
+  `_leaf_entry` now sets both fields the same way `_change_to_dict` does.
+
 ### Documentation
 
 - **Example-catalog semantic-validation gaps from an external audit.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -795,7 +795,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `severity_config` and renders a separate "CI Gate: PASS/FAIL (exit N)" card
   alongside the renamed "Compatibility" banner (native report only — the
   ABICC-compatible `compat_html` layout is unchanged); `service.render_output`
-  forwards it through.
+  and the MCP server's `_render_output` (caught in review on this same PR —
+  its HTML branch had the identical gap) both forward it through. The
+  `test_html_template_golden.py` byte-identical goldens are regenerated for
+  the "Verdict" → "Compatibility" rename; the diff is exactly that label plus
+  one blank line for the (empty, since that fixture passes no
+  `severity_config`) gate-card slot.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -802,6 +802,83 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   one blank line for the (empty, since that fixture passes no
   `severity_config`) gate-card slot.
 
+- **JUnit's `<failure type=...>` could say `"COMPATIBLE"` for a failure
+  `severity_config` itself caused.** `_is_failure` correctly decides pass/
+  fail from a finding's effective severity *category*, but `_failure_type`
+  still derived `type=` from the raw effective *verdict*
+  (`_VERDICT_TO_JUNIT_TYPE`, which has no `COMPATIBLE` entry and falls back
+  to the string `"COMPATIBLE"`) — so a `COMPATIBLE` addition promoted to
+  `error` both failed and reported `type="COMPATIBLE"`, contradicting the
+  very reason it failed. `_failure_type` (and `_add_failure`) now accept
+  `severity_config` and, when given, derive `type=` from the same effective
+  category `_is_failure` used (`ADDITION`/`QUALITY_ISSUE`/`BREAKING`, or
+  `API_BREAK`/`COMPATIBLE_WITH_RISK` recovered from kind-set membership for
+  the `POTENTIAL_BREAKING` category, which doesn't itself distinguish them).
+
+- **Review digest's "Top impacted symbols" used raw kind-set membership,
+  not each finding's effective verdict.** Every other part of
+  `to_review_digest` (the merge-effect phrase, the counts table) already
+  routes through `DiffResult._effective_verdict_for_change`/the `.breaking`/
+  `.source_breaks` properties; "Top impacted symbols" alone filtered by
+  `c.kind in breaking_set or c.kind in api_break_set` — kind-set membership,
+  which misses a per-finding override (A4 pattern-verdict modulation,
+  frozen-namespace guard) that moves a specific finding's verdict away from
+  (or into) BREAKING/API_BREAK independent of its raw kind. Fixed to filter
+  by `result._effective_verdict_for_change(c)` instead, so the section can
+  no longer list a finding the rest of the same digest reports as
+  compatible, or omit one it reports as breaking.
+
+- **Appcompat JSON's `relevant_changes[].severity` ignored the full
+  diff's `PolicyFile`/effective kind-sets.** `appcompat_to_json` read only
+  `full_diff.policy` (a bare string) and never threaded
+  `full_diff._effective_kind_sets()`/`full_diff.policy_file` into
+  `_change_to_dict`, so a per-finding severity there fell back to raw-kind
+  classification — able to contradict `full_library_verdict` on the very
+  same JSON document, which already honours the `PolicyFile` via
+  `full_diff.verdict`. Now threads both through, matching `to_json`'s own
+  `_change_to_dict` calls (fixed for the same reason in #549).
+
+- **The GitHub Action's job summary always wrapped the report in a code
+  fence, even for the (default) `format: markdown`.** `run.sh` unconditionally
+  wrapped `$ABICHECK_OUTPUT` in a ```` ``` ```` fence for the "Full report"
+  step-summary section, so GitHub rendered a markdown report as literal
+  code instead of formatted headings/tables/bold text. Now only non-markdown
+  formats (json/sarif/text/etc. — genuinely verbatim output) keep the fence.
+  (The action's PR-comment path re-running the comparison with `--format
+  json` when the primary run isn't already unfiltered JSON is unchanged —
+  eliminating that would need a CLI feature to emit multiple formats from
+  one invocation, which is out of scope here; the existing reuse-when-
+  possible check and the guards that skip the rerun entirely when no
+  comment will be posted are confirmed already working correctly.)
+
+- **Stack-check and release JSON were count-centric at the per-library
+  level**, e.g. `"abi_breaking": 3` / `"breaking": 3`, with no way to
+  identify *which* symbols broke without a separate `compare` run or (for
+  releases) the optional `--output-dir` per-library report file —
+  unlike `scan --baseline`'s JSON, already fixed the same way in #549.
+  `stack_report.stack_to_json` and `cli_compare_release`'s per-library
+  entries now embed a capped (10 per library), bucketed `findings` list
+  (kind/symbol/description/source_location) drawn from each library's
+  breaking/source-break/risk changes, with `findings_truncated: true` when
+  a library has more gating findings than the cap.
+
+- **The `compare` JSON schema (bumped 2.2 → 2.3, additive) gained a typed
+  gate summary and stable per-finding identity**, closing the remaining
+  reporting-review gaps that fit the project's own additive-schema
+  convention: each finding now carries `operation` (`added`/`removed`/
+  `modified`, derived from the same kind-suffix rule `--show-only` already
+  uses — extracted to a shared `operation_for_kind` so the two can't drift)
+  and `finding_id` (a stable SHA-256-derived fingerprint of
+  kind/symbol/old_value/new_value/source_location, letting a consumer
+  correlate the same finding across two report runs without relying on
+  array order; deliberately excludes policy-derived fields so it's stable
+  across `--policy`). The top-level `severity` object (present only when
+  `--severity-*` is active) gains `blocking`/`blocking_categories`, mirroring
+  SARIF's `severityGate` block. Not implemented: a per-finding "recommended
+  action" field — the report-level `release_recommendation` already covers
+  this at the release granularity, and a per-finding equivalent has no
+  clear-cut shape yet.
+
 ### Documentation
 
 - **Example-catalog semantic-validation gaps from an external audit.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -950,6 +950,20 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   severity categories instead, whenever a severity-aware exit-code scheme
   is active, matching whichever categories are actually configured `error`.
 
+- **`experimental_graduated` (schema `operation` field) misclassified as
+  `"modified"`.** Unlike the earlier `_OPERATION_OVERRIDES` misses (which
+  all had *some* add/remove synonym in their name), `experimental_graduated`
+  contains none — it's the dedicated case99 detector for "a stable name is
+  added alongside the still-present experimental alias" ("without the
+  dedicated detector the diff is just a `func_added`"), and is correctly in
+  the canonical `ADDITION_KINDS` registry set, but `operation_for_kind`'s
+  suffix rule had nothing to match on (Codex review on #557). Added to the
+  override table; also added a permanent regression test that cross-checks
+  every `ADDITION_KINDS` member classifies as `"added"`, catching this class
+  of miss for any future addition-kind whose name doesn't contain an
+  add/remove synonym (the word-matching sweep test added earlier this cycle
+  cannot catch these by construction).
+
 ### Documentation
 
 - **Example-catalog semantic-validation gaps from an external audit.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -909,6 +909,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   breaking `finding_id` correlation for leaf-mode reports specifically.
   `_leaf_entry` now sets both fields the same way `_change_to_dict` does.
 
+- **`compare-release --format json`'s per-library `findings` list ignored
+  severity-gated additions/quality issues.** It only ever walked the three
+  legacy verdict buckets (breaking/api_break/risk), so
+  `--severity-addition error` (or `--severity-quality-issues error`)
+  promoting a library's only findings to `error` produced
+  `severity.exit_code != 0` on that library with an empty `findings` list —
+  no way to tell which addition/quality-issue actually blocked the release.
+  `_release_finding_dicts` (via a new shared `_release_gating_buckets`
+  helper, also used for the truncation-cap count) now walks the four
+  severity categories instead, whenever a severity-aware exit-code scheme
+  is active, matching whichever categories are actually configured `error`.
+
 ### Documentation
 
 - **Example-catalog semantic-validation gaps from an external audit.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -306,12 +306,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   invocation (e.g. `--format markdown` for a human report alongside
   `--secondary-format json --secondary-output report.json` for tooling),
   instead of requiring a second full `abicheck compare` invocation just to
-  get a different format. `--secondary-format` requires
-  `--secondary-output` (writing two formats to the same stream would be
-  ambiguous), must point at a different file than `--output`/`-o` (else the
-  secondary render would silently overwrite the primary report), and always
-  renders the full, unfiltered report — it ignores `--show-only`/`--stat`,
-  which describe only the primary format's display.
+  get a different format. `--secondary-format` and `--secondary-output`
+  require each other (either alone is rejected — passing just
+  `--secondary-output` would otherwise silently produce no secondary
+  artifact at all), `--secondary-output` must point at a different file than
+  `--output`/`-o` (else the secondary render would silently overwrite the
+  primary report), and the secondary render always renders the full,
+  unfiltered report — it ignores `--show-only`/`--stat`, which describe only
+  the primary format's display.
   Not supported for directory/package (release) comparisons yet (rejected
   with a `UsageError`, same as `--exit-code-scheme`/
   `--reconcile-build-context`/`--env-matrix`). The bundled GitHub Action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -809,7 +809,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `func_virtual_added`, an existing function losing its virtual-ness) and
   `param_default_value_removed`/`python_api_default_removed` (an existing
   parameter losing its default value) — the same pattern again; all three
-  now classify as `"modified"` too.
+  now classify as `"modified"` too. A fourth pass (Codex review, PR #557)
+  found `virtual_method_added` itself — the identical layout-modification
+  pattern as `type_field_added` applied to virtual methods instead of
+  fields (a new virtual method on an already-existing class grows/relayouts
+  the vtable and breaks derived classes) — also reclassified.
 
 - **Self-review polish on the `GateDecision`/`--secondary-format` work above
   (PR #557):** the native HTML report's "CI Gate" card computed pass/fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -300,6 +300,23 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `_leaf_entry` (the latter learned this the same way it learned
   `operation`/`finding_id` — see the entry above from earlier this cycle).
 
+- **`compare --secondary-format`/`--secondary-output` — a second output
+  format from the same comparison run.** `compare` now computes its
+  `DiffResult` once and can render it into two formats/files in one
+  invocation (e.g. `--format markdown` for a human report alongside
+  `--secondary-format json --secondary-output report.json` for tooling),
+  instead of requiring a second full `abicheck compare` invocation just to
+  get a different format. `--secondary-format` requires
+  `--secondary-output` (writing two formats to the same stream would be
+  ambiguous) and always renders the full, unfiltered report — it ignores
+  `--show-only`/`--stat`, which describe only the primary format's display.
+  Not supported for directory/package (release) comparisons yet (rejected
+  with a `UsageError`, same as `--exit-code-scheme`/
+  `--reconcile-build-context`/`--env-matrix`). The bundled GitHub Action
+  (`action/run.sh`) now uses this instead of re-running the whole comparison
+  a second time to get JSON for its sticky PR comment, halving the work for
+  a `compare` step that posts a PR comment with a non-json primary format.
+
 - **Canonical fact-set versioning and per-family coverage honesty for the
   Clang facts plugin (ADR-038 C.8).** Every `SourceAbiTu` record produced by
   the Clang facts plugin and the reference `clang.py` wrapper now carries a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,22 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Added
 
+- **`GateDecision` / `CompatibilityDecision` — formal separation of "is this
+  compatible?" from "does this block CI?" (ADR-042).**
+  `abicheck.severity.compute_gate_decision()` is now the single canonical
+  computation for a report's gate summary (exit code, `blocking`,
+  `blocking_categories`), replacing three independent hand-rolled
+  categorize-then-filter-to-`error` implementations
+  (`reporter._build_severity_json`, `sarif._severity_gate_properties`,
+  `cli_compare_release._release_gating_buckets`) that had drifted apart from
+  each other — the root cause of two bugs fixed earlier in this cycle
+  (JSON's `blocking_categories` disagreeing with `exit_code` under
+  `--show-only`; release JSON's per-library `findings` missing
+  severity-gated additions). `CompatibilityDecision` is a plain alias for
+  the existing `Verdict` enum — purely additive, no behavior or public-API
+  change to either type; JSON/SARIF output shapes are byte-for-byte
+  unchanged.
+
 - **Canonical fact-set versioning and per-family coverage honesty for the
   Clang facts plugin (ADR-038 C.8).** Every `SourceAbiTu` record produced by
   the Clang facts plugin and the reference `clang.py` wrapper now carries a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -781,20 +781,36 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   (CodeRabbit review, PR #557). All five are now `required` (the emitter
   already always populates them; this only tightens the contract).
 
+- **`operation_for_kind()` misclassified five trait changes on an
+  already-existing entity as `"added"`** (Codex review, PR #557):
+  `func_noexcept_added`, `func_virtual_added`, `func_variadic_added`, and
+  `func_pure_virtual_added` each name a property *gained by an existing
+  function* ("Function became virtual: {name}", "noexcept specifier added:
+  {name}", …) — the same trait-change-on-a-persisting-entity pattern as the
+  existing `"*_lost_*"`/`"*_introduced"` overrides, just spelled with
+  `"_added"` — and `type_field_added` (a field inserted mid-struct, which
+  shifts every subsequent field's offset) modifies the type's existing
+  layout rather than merely adding something in isolation; the dedicated
+  append-at-end addition kind, `type_field_added_compatible`, is unaffected.
+  None of these five is in `ADDITION_KINDS`. All five now classify as
+  `"modified"` via `_OPERATION_OVERRIDES`, affecting both the JSON
+  `operation` field and `--show-only=added`/`--show-only=changed` (the two
+  share the same classifier by design).
+
 - **Self-review polish on the `GateDecision`/`--secondary-format` work above
   (PR #557):** the native HTML report's "CI Gate" card computed pass/fail
   via `severity.compute_exit_code()` directly instead of the canonical
-  `compute_gate_decision()` `reporter.py`/`sarif.py`/`cli_compare_release.py`
-  were all migrated to — now routed through it too, so all four gate-status
-  call sites share one computation. The primary and `--secondary-format`
-  render paths each independently resolved the tri-state `--demangle` flag
-  with a duplicated one-line rule; factored into a single
-  `cli_compare_helpers._resolve_demangle()` both call. `compute_gate_decision`'s
-  legacy (no `SeverityConfig`) branch was found to be unreachable from any
-  of its three production call sites (each already special-cases
-  `severity_config is None` itself, since their legacy-scheme needs differ
-  from an empty `blocking_categories`) — documented explicitly in its
-  docstring rather than silently left as untested-in-practice code.
+  `compute_gate_decision()` that `reporter.py`/`sarif.py`/
+  `cli_compare_release.py` were all migrated to — now routed through it too,
+  so all four gate-status call sites share one computation. The primary and
+  `--secondary-format` render paths each independently resolved the
+  tri-state `--demangle` flag with a duplicated one-line rule; factored into
+  a single `cli_compare_helpers._resolve_demangle()` that both call.
+  `compute_gate_decision`'s legacy (no `SeverityConfig`) branch was found to
+  be unreachable from any of its three production call sites (each already
+  special-cases `severity_config is None` itself, since their legacy-scheme
+  needs differ from an empty `blocking_categories`) — documented explicitly
+  in its docstring rather than silently left as untested-in-practice code.
 
 - **Clang plugin: `source_edges` collected but never reached the L5 graph,
   plus four related correctness gaps from an independent review of the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -702,6 +702,69 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **`finding_id` could collide for two distinct findings on the same symbol
+  (Codex review, PR #557).** Two findings of the same kind on the same
+  symbol with the same old/new value and no distinct source location (e.g.
+  `param_pointer_level_changed` on two different parameters of one
+  function, both going from pointer-depth 1 to 2) hashed to an identical
+  `finding_id`, defeating the correlation/waiver use case the field exists
+  for. `reporter._finding_id()` now also folds in `description` (which
+  embeds the per-finding detail — parameter name/index, member name, … —
+  that disambiguates them).
+
+- **`compare --secondary-format`/`--secondary-output` follow-ups (CodeRabbit
+  and Codex review, PR #557):**
+  - The secondary render forwarded the primary format's `--report-mode`
+    (e.g. `leaf`) instead of always using `full` as documented — a
+    `--secondary-format json` consumer combined with `--report-mode leaf`
+    got leaf-shaped JSON, not the full report the option promises. Now
+    hard-coded to `report_mode="full"` alongside the existing
+    `show_only=None, stat=False`.
+  - `--secondary-format` requiring `--secondary-output` was validated only
+    after `compare_snapshots()` and the primary report had already run — a
+    typo'd invocation burned the full comparison before failing with a
+    usage error. Moved next to its companion `--secondary-output`-requires-
+    `--secondary-format` check at the top of `run_compare()`.
+  - `--secondary-output` without `--secondary-format` was silently ignored
+    (no artifact, no error) — now rejected with the same fail-fast
+    `UsageError`.
+  - `--secondary-output` equal to `--output`/`-o` silently overwrote the
+    primary report with the secondary render — now rejected up front.
+  - The bundled GitHub Action's `mode: compare` unconditionally added
+    `--secondary-format json`, which the release fan-out engine rejects —
+    hard-failing a directory/package comparison that previously worked
+    under `mode: compare` regardless of the `mode` input. A new
+    `_is_release_style_operand` check (directory, or a recognized package
+    extension) skips the optimization for those operands.
+
+- **SARIF `_parse_source_location` still mishandled a path containing a
+  colon before the line separator** (e.g. a synthetic scheme like
+  `generated:headers/foo.h:42`), reading the whole string as the file with
+  no region — the earlier P0 fix only handled the Windows-drive-letter
+  special case (CodeRabbit review, PR #557). Rewritten to parse from the
+  right (`rsplit(":", 2)`): the file is whatever remains once a trailing
+  numeric `line[:column]` is peeled off, not a fixed prefix before the first
+  colon — this also subsumes the Windows drive-letter case without a
+  special branch.
+
+- **JUnit `type=` and GitHub annotation titles could mislabel a
+  POTENTIAL_BREAKING finding's API-Break-vs-Deployment-Risk subtype**
+  (CodeRabbit review, PR #557). Both recovered the subtype from raw
+  kind-set membership rather than the finding's actual effective verdict —
+  a per-finding `effective_verdict` override/modulation (A4 pattern-verdict,
+  PolicyFile) can move a finding between the two without changing which
+  kind-set its raw kind belongs to, so the label could contradict the
+  override's own intent. `junit_report._failure_type()` and
+  `annotations._title_for_change()` now derive the subtype from
+  `severity.effective_verdict_for_change()` instead.
+
+- **`compare_report.schema.json`'s `severity` object accepted an empty or
+  partial gate summary** — `config`/`categories`/`exit_code`/`blocking`/
+  `blocking_categories` were all optional, so a malformed report could pass
+  schema validation despite consumers expecting the complete gate summary
+  (CodeRabbit review, PR #557). All five are now `required` (the emitter
+  already always populates them; this only tightens the contract).
+
 - **Clang plugin: `source_edges` collected but never reached the L5 graph,
   plus four related correctness gaps from an independent review of the
   ADR-038 C.8 canonical fact-set work (ADR-038 C.10-C.12).**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -795,7 +795,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   None of these five is in `ADDITION_KINDS`. All five now classify as
   `"modified"` via `_OPERATION_OVERRIDES`, affecting both the JSON
   `operation` field and `--show-only=added`/`--show-only=changed` (the two
-  share the same classifier by design).
+  share the same classifier by design). A follow-up audit pass (Codex
+  review, PR #557) found eight more: `ctor_explicit_added`,
+  `mandatory_template_param_added`, `python_api_parameter_added`, and
+  `func_contract_attribute_added` describe an existing constructor/
+  template/function's signature or contract changing, not a new one
+  appearing; `func_noexcept_removed`, `func_variadic_removed`,
+  `func_contract_attribute_removed`, and `ctor_explicit_removed` are the
+  removed-side counterpart — a trait *lost by* a persisting entity, which
+  the plain `"_removed"` suffix rule alone misread as an entity
+  disappearing. All eight now classify as `"modified"` too.
 
 - **Self-review polish on the `GateDecision`/`--secondary-format` work above
   (PR #557):** the native HTML report's "CI Gate" card computed pass/fail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -745,6 +745,58 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   that isn't a return-type separator) — both are now handled by a shared
   `_holder_of` helper.
 
+- **`--show-only` disagreed with the effective verdict for a kind-level
+  `PolicyFile` override.** `ShowOnlyFilter._check_severity` already honoured a
+  per-change `effective_verdict` (A4 modulation), but fell back to bare
+  `policy_kind_sets(policy)` for everything else — never consulting
+  `PolicyFile.overrides` — so a kind moved to another verdict bucket by policy
+  (e.g. `func_removed` demoted to `COMPATIBLE`) was still filtered by its raw
+  kind, disagreeing with the JSON severity field and every other renderer.
+  `apply_show_only`/`ShowOnlyFilter.matches` now accept `kind_sets`/
+  `policy_file` and resolve through the same
+  `severity.effective_verdict_for_change` used by
+  `DiffResult._effective_verdict_for_change`; all six call sites (Markdown,
+  leaf, JSON's Markdown path, SARIF, JUnit, HTML) thread
+  `result._effective_kind_sets()`/`result.policy_file` through.
+
+- **GitHub annotations without `severity_config` classified by raw kind, not
+  effective verdict.** The severity-aware path (`_category_for_change_severity`)
+  already honoured per-change `effective_verdict` overrides; the legacy/default
+  path (no `SeverityConfig` configured) called `_classify_change(change.kind,
+  ...)` directly, so a finding demoted by a frozen-namespace guard or A4
+  pattern-verdict modulation could still emit `::error` at its raw severity —
+  contradicting `DiffResult.breaking`/`.compatible` and every other renderer.
+  `collect_annotations()` now always resolves each change's effective category
+  first (`_category_for_change_severity`) and dispatches the fixed
+  BREAKING→error/API_BREAK,RISK→warning/COMPATIBLE→notice mapping
+  (`_legacy_level_for_category`) from that, so both the annotation level and
+  title agree with the per-change override in either code path.
+
+- **SARIF `executionSuccessful` conflated "the tool ran" with "the ABI/severity
+  gate passed."** Per the SARIF spec, `executionSuccessful` reports whether
+  analysis *completed*, not whether it found blocking issues — the spec's own
+  example shows a successful run with `exitCode: 1` and warnings. `to_sarif()`
+  previously derived it from `result.verdict`/the severity gate's exit code,
+  so a completed `BREAKING` comparison reported `executionSuccessful: false`.
+  It is now unconditionally `true`; gate/verdict outcome is conveyed solely via
+  `exitCode`, `exitCodeDescription`, result `level`s, and
+  `properties.severityGate`, as it already was. While in the same function,
+  also fixed `_result_for`'s location parsing (a single `rsplit(":", 1)`
+  mishandled `file:line:column`, leaving `:line` stuck in the artifact URI and
+  never setting `startColumn`) and `_rule_for`'s `helpUri`, which pointed at a
+  nonexistent `docs/abi_breaking_cases_catalog.md` — now
+  `docs/reference/change-kinds.md`, which exists.
+
+- **Native HTML report had no way to show a configured severity gate.**
+  `generate_html_report`/`service.render_output`'s `html` branch never
+  accepted or forwarded `severity_config`, so a compatible addition configured
+  `error` rendered a green `Compatibility: COMPATIBLE` banner with no
+  indication the run still exits non-zero. `generate_html_report` now accepts
+  `severity_config` and renders a separate "CI Gate: PASS/FAIL (exit N)" card
+  alongside the renamed "Compatibility" banner (native report only — the
+  ABICC-compatible `compat_html` layout is unchanged); `service.render_output`
+  forwards it through.
+
 ### Documentation
 
 - **Example-catalog semantic-validation gaps from an external audit.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -734,8 +734,24 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
     `--secondary-format json`, which the release fan-out engine rejects —
     hard-failing a directory/package comparison that previously worked
     under `mode: compare` regardless of the `mode` input. A new
-    `_is_release_style_operand` check (directory, or a recognized package
-    extension) skips the optimization for those operands.
+    `_is_release_style_operand` check (directory, a recognized package
+    extension, or an extensionless RPM/Deb detected by magic bytes —
+    mirroring `package.py`'s own `is_package()` fallback, since
+    `classify_compare_operand()` uses it regardless of filename) skips the
+    optimization for those operands.
+  - The secondary render reused the *primary* format's resolved `--demangle`
+    default instead of resolving its own: pairing a machine primary format
+    (e.g. `--format json`) with a text `--secondary-format markdown`/`review`
+    got raw mangled C++ names in the secondary report even though
+    markdown/review default to demangling ON. `demangle` is now resolved
+    against `secondary_fmt` independently (honouring an explicit
+    `--demangle`/`--no-demangle` either way).
+  - The `finding_id` schema/docs contract still described the fingerprint as
+    a hash of `kind`/`symbol`/`old_value`/`new_value`/`source_location` only,
+    omitting `description` (added earlier in this same list to fix
+    same-symbol collisions) — a waiver/correlation tool following the
+    documented contract would compute different IDs than abicheck actually
+    emits. Docs and schema description updated to match.
 
 - **SARIF `_parse_source_location` still mishandled a path containing a
   colon before the line separator** (e.g. a synthetic scheme like

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -879,6 +879,27 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   this at the release granularity, and a per-finding equivalent has no
   clear-cut shape yet.
 
+- **Two Codex-review findings on the schema 2.3 additions above.**
+  `operation_for_kind()` classified purely by kind-name suffix, missing
+  several kinds that are semantically an addition/removal but spelled
+  differently (`symbol_version_required_added_compat` ends in
+  `_added_compat`, not `_added`; `experimental_removed_without_replacement`
+  and `func_deleted_dwarf` don't end in `_removed`/`_deleted`;
+  `cpu_dispatch_isa_dropped` — a whole ISA-dispatch family's concrete
+  symbols vanishing, case83 — ends in `_dropped`) — these now resolve via
+  an explicit `_OPERATION_OVERRIDES` table, checked before the suffix rule.
+  Deliberately excludes the `"*_lost_*"`/`"*_introduced"` families
+  (`field_lost_const`, `vptr_introduced`, ...): those name a trait
+  gained/lost on a persisting entity, which is "modified", not the entity
+  itself appearing/disappearing. Separately, JSON's `blocking_categories`
+  was derived from the possibly `--show-only`-filtered *display* `changes`
+  rather than the unfiltered gate set `exit_code` already uses — hiding the
+  one category actually responsible for a nonzero exit code (e.g.
+  `--show-only=breaking` while an addition promoted to `error` is what's
+  blocking) reported `blocking: true` alongside `blocking_categories: []`.
+  Now derived from the same unfiltered set as `exit_code`, matching how
+  SARIF's own `_severity_gate_properties` was already doing it correctly.
+
 ### Documentation
 
 - **Example-catalog semantic-validation gaps from an external audit.**

--- a/abicheck/annotations.py
+++ b/abicheck/annotations.py
@@ -174,6 +174,34 @@ def _category_for_change_severity(
     )
 
 
+def _legacy_level_for_category(
+    category: IssueCategory,
+    annotate_additions: bool,
+) -> str | None:
+    """Fixed-mapping annotation level, keyed off the *effective* category.
+
+    Mirrors the pre-severity-config behaviour documented on
+    :func:`_classify_change` (BREAKING -> error, API_BREAK/RISK -> warning,
+    COMPATIBLE -> notice iff *annotate_additions*), but is driven by each
+    change's effective verdict (via *category*) rather than raw kind-set
+    membership — so a per-finding override (frozen-namespace clamp, A4
+    pattern-verdict modulation) is respected even when no SeverityConfig is
+    in play.
+    """
+    from .severity import IssueCategory as _IssueCategory
+
+    if category == _IssueCategory.ABI_BREAKING:
+        return "error"
+    if category == _IssueCategory.POTENTIAL_BREAKING:
+        return "warning"
+    if annotate_additions and category in (
+        _IssueCategory.ADDITION,
+        _IssueCategory.QUALITY_ISSUES,
+    ):
+        return "notice"
+    return None
+
+
 def _annotation_level_for_category(
     category: IssueCategory,
     severity_config: SeverityConfig,
@@ -292,6 +320,12 @@ def collect_annotations(
     mirrors each finding's actually-configured severity so an annotation is
     never silently absent (or under/over-stated) for a finding that does (or
     does not) gate CI — see :func:`_annotation_level_for_category`.
+
+    Both branches classify through each change's *effective* category (via
+    :func:`_category_for_change_severity`, which honours
+    ``DiffResult._effective_verdict_for_change`` semantics) rather than raw
+    kind-set membership, so a per-finding override is never misreported —
+    see :func:`_legacy_level_for_category`.
     """
     kind_sets = diff_result._effective_kind_sets()
     breaking_set, api_break_set, compatible_set, risk_set = kind_sets
@@ -299,20 +333,16 @@ def collect_annotations(
     annotations: list[tuple[int, str]] = []
 
     for change in diff_result.changes:
-        category: IssueCategory | None = None
+        category = _category_for_change_severity(
+            change, kind_sets,
+            policy=diff_result.policy, policy_file=diff_result.policy_file,
+        )
         if severity_config is not None:
-            category = _category_for_change_severity(
-                change, kind_sets,
-                policy=diff_result.policy, policy_file=diff_result.policy_file,
-            )
             level = _annotation_level_for_category(
                 category, severity_config, annotate_additions,
             )
         else:
-            level = _classify_change(
-                change.kind, breaking_set, api_break_set, risk_set,
-                compatible_set, annotate_additions,
-            )
+            level = _legacy_level_for_category(category, annotate_additions)
         if level is None:
             continue
 

--- a/abicheck/annotations.py
+++ b/abicheck/annotations.py
@@ -31,6 +31,7 @@ from .checker import (
 )
 from .checker_policy import (
     ChangeKind,
+    Verdict,
 )
 
 if TYPE_CHECKING:
@@ -237,6 +238,7 @@ def _title_for_change(
     compatible_set: frozenset[ChangeKind],
     *,
     category: IssueCategory | None = None,
+    effective_verdict: Verdict | None = None,
 ) -> str:
     """Return the annotation title prefix, distinguishing API Break from Deployment Risk.
 
@@ -251,6 +253,13 @@ def _title_for_change(
     ``::error`` annotation as "Quality Issue" (or "ABI Addition"). Checking
     *category* first — the same effective classification that already drove
     the annotation *level* — keeps the title consistent with it.
+
+    *effective_verdict*, when given, resolves the POTENTIAL_BREAKING API
+    Break vs. Deployment Risk split instead of raw kind-set membership: a
+    per-change ``effective_verdict`` override/modulation (A4 pattern-verdict,
+    PolicyFile) can move a finding between the two without changing which
+    kind-set its raw *kind* belongs to, so kind-set membership alone could
+    label the title with the wrong subtype (CodeRabbit review, PR #557).
     """
     kind_label = kind.value
     if category is not None:
@@ -263,7 +272,15 @@ def _title_for_change(
         if category == _IssueCategory.ADDITION:
             return f"ABI Addition: {kind_label}"
         # POTENTIAL_BREAKING: distinguish API Break from Deployment Risk via
-        # the kind sets, since IssueCategory does not itself split the two.
+        # the finding's actual effective verdict when available (falling
+        # back to the kind sets only if it wasn't supplied), since
+        # IssueCategory does not itself split the two.
+        if effective_verdict is not None:
+            if effective_verdict == Verdict.API_BREAK:
+                return f"API Break: {kind_label}"
+            if effective_verdict == Verdict.COMPATIBLE_WITH_RISK:
+                return f"Deployment Risk: {kind_label}"
+            return f"Potential Break: {kind_label}"
         if kind in api_break_set:
             return f"API Break: {kind_label}"
         if kind in risk_set:
@@ -327,6 +344,8 @@ def collect_annotations(
     kind-set membership, so a per-finding override is never misreported —
     see :func:`_legacy_level_for_category`.
     """
+    from .severity import effective_verdict_for_change
+
     kind_sets = diff_result._effective_kind_sets()
     breaking_set, api_break_set, compatible_set, risk_set = kind_sets
 
@@ -349,6 +368,10 @@ def collect_annotations(
         title = _title_for_change(
             change.kind, breaking_set, api_break_set, risk_set, compatible_set,
             category=category,
+            effective_verdict=effective_verdict_for_change(
+                change, policy=diff_result.policy, kind_sets=kind_sets,
+                policy_file=diff_result.policy_file,
+            ),
         )
         line = _format_annotation(level, change, title, change.description)
         sort_key = _SEVERITY_ORDER.get(level, 99)

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1255,6 +1255,19 @@ def _embed_inline_source_side(
                 "(verdict + counts + release recommendation + manual-review banner) "
                 "suitable for a job summary or PR comment.",
 )
+@click.option("--secondary-format", "secondary_fmt",
+              type=click.Choice(["json", "markdown", "sarif", "html", "junit", "review"]),
+              default=None,
+              help="Emit a second output format from this same comparison run, "
+                   "without re-running the comparison a second time (e.g. a human "
+                   "--format markdown report alongside a --secondary-format json "
+                   "artifact for tooling). Requires --secondary-output (writing two "
+                   "formats to the same stream would be ambiguous). Always renders "
+                   "the full, unfiltered report (ignores --show-only/--stat). Not "
+                   "supported for directory/package (release) comparisons.")
+@click.option("--secondary-output", "secondary_output",
+              type=click.Path(dir_okay=False, path_type=Path), default=None,
+              help="File path to write --secondary-format's output to.")
 @click.option("--demangle/--no-demangle", default=None,
               help="Demangle C++ symbol names in markdown/review output (default "
                    "ON; use --no-demangle to turn off). json/sarif always keep raw "

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1267,7 +1267,9 @@ def _embed_inline_source_side(
                    "supported for directory/package (release) comparisons.")
 @click.option("--secondary-output", "secondary_output",
               type=click.Path(dir_okay=False, path_type=Path), default=None,
-              help="File path to write --secondary-format's output to.")
+              help="File path to write --secondary-format's output to. Must "
+                   "differ from --output/-o, or the secondary render would "
+                   "silently overwrite the primary report.")
 @click.option("--demangle/--no-demangle", default=None,
               help="Demangle C++ symbol names in markdown/review output (default "
                    "ON; use --no-demangle to turn off). json/sarif always keep raw "

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -182,6 +182,7 @@ def _reject_set_input_flags(
     exit_code_scheme: str | None,
     reconcile_build_context: bool,
     env_matrix_path: Path | None,
+    secondary_fmt: str | None = None,
 ) -> None:
     """Reject single-pair-only flags on a directory/package (release) compare.
 
@@ -207,6 +208,12 @@ def _reject_set_input_flags(
             "--env-matrix is not supported for directory/package (release) "
             "comparisons yet; it applies to single-file / snapshot inputs. "
             "Compare the libraries individually to use it."
+        )
+    if secondary_fmt is not None:
+        raise click.UsageError(
+            "--secondary-format is not supported for directory/package "
+            "(release) comparisons yet; it applies to single-file / snapshot "
+            "inputs. Compare the libraries individually to use it."
         )
 
 
@@ -457,6 +464,8 @@ def run_compare(
     probe_matrix_new: Path | None = None,
     header_graph: bool = False,
     header_graph_includes: bool = False,
+    secondary_fmt: str | None = None,
+    secondary_output: Path | None = None,
 ) -> None:
     """Run the single-pair (or set fan-out) ``compare`` flow and exit accordingly."""
     _setup_verbosity(verbose)
@@ -516,7 +525,7 @@ def run_compare(
         # resolved scheme from config but has no public CLI support for these
         # single-pair-only flags on set inputs — reject them loudly (ADR-037 D12).
         _reject_set_input_flags(
-            exit_code_scheme, reconcile_build_context, env_matrix_path
+            exit_code_scheme, reconcile_build_context, env_matrix_path, secondary_fmt,
         )
         _reject_compile_context_for_set_inputs(ctx, project_cfg)
         _reject_evidence_flags_for_set_inputs(ctx)
@@ -822,6 +831,30 @@ def run_compare(
     )
 
     _write_or_echo(output, text)
+
+    if secondary_fmt is not None:
+        if secondary_output is None:
+            raise click.UsageError(
+                "--secondary-format requires --secondary-output: writing two "
+                "output formats to the same stream would be ambiguous."
+            )
+        # Always the full, unfiltered report — ignores --show-only/--stat
+        # (which describe the *primary* format's display) so a --secondary-*
+        # consumer (e.g. a CI action rendering a PR-comment JSON from a
+        # markdown-format primary run) sees the complete change set the gate
+        # actually acted on, not whatever the primary format chose to filter
+        # down to. Reuses the same already-computed `result` — no second
+        # comparison run.
+        secondary_text = _render_output(
+            secondary_fmt, result, old, new,
+            follow_deps=follow_deps,
+            show_only=None, report_mode=report_mode,
+            show_impact=show_impact, stat=False,
+            severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
+            show_recommendation=recommend,
+            demangle=demangle,
+        )
+        _write_or_echo(secondary_output, secondary_text)
 
     _announce_exit_scheme(resolved_cfg.exit_code_scheme, fmt=fmt, stat=stat)
     _exit_with_severity_or_verdict(result, sev_config, resolved_cfg.exit_code_scheme)

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -470,6 +470,17 @@ def run_compare(
     """Run the single-pair (or set fan-out) ``compare`` flow and exit accordingly."""
     _setup_verbosity(verbose)
 
+    if (
+        secondary_output is not None
+        and output is not None
+        and secondary_output.resolve() == output.resolve()
+    ):
+        raise click.UsageError(
+            "--secondary-output must differ from --output/-o: writing both "
+            "formats to the same file would silently overwrite the primary "
+            "report with the secondary one."
+        )
+
     # ADR-037 D4: load the project config and merge CLI flags over it
     # (precedence CLI > config > built-in default) *before* dispatch, so both the
     # single-file and the directory/package fan-out paths share one resolution.

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -470,6 +470,11 @@ def run_compare(
     """Run the single-pair (or set fan-out) ``compare`` flow and exit accordingly."""
     _setup_verbosity(verbose)
 
+    if secondary_fmt is not None and secondary_output is None:
+        raise click.UsageError(
+            "--secondary-format requires --secondary-output: writing two "
+            "output formats to the same stream would be ambiguous."
+        )
     if secondary_output is not None and secondary_fmt is None:
         raise click.UsageError(
             "--secondary-output requires --secondary-format: with no format "
@@ -850,22 +855,18 @@ def run_compare(
     _write_or_echo(output, text)
 
     if secondary_fmt is not None:
-        if secondary_output is None:
-            raise click.UsageError(
-                "--secondary-format requires --secondary-output: writing two "
-                "output formats to the same stream would be ambiguous."
-            )
         # Always the full, unfiltered report — ignores --show-only/--stat
-        # (which describe the *primary* format's display) so a --secondary-*
-        # consumer (e.g. a CI action rendering a PR-comment JSON from a
-        # markdown-format primary run) sees the complete change set the gate
-        # actually acted on, not whatever the primary format chose to filter
-        # down to. Reuses the same already-computed `result` — no second
-        # comparison run.
+        # (which describe the *primary* format's display) and forces
+        # report_mode="full" (not the primary's --report-mode leaf) so a
+        # --secondary-* consumer (e.g. a CI action rendering a PR-comment
+        # JSON from a markdown-format primary run) sees the complete change
+        # set the gate actually acted on, not whatever the primary format
+        # chose to filter or group down to. Reuses the same already-computed
+        # `result` — no second comparison run.
         secondary_text = _render_output(
             secondary_fmt, result, old, new,
             follow_deps=follow_deps,
-            show_only=None, report_mode=report_mode,
+            show_only=None, report_mode="full",
             show_impact=show_impact, stat=False,
             severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
             show_recommendation=recommend,

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -470,6 +470,12 @@ def run_compare(
     """Run the single-pair (or set fan-out) ``compare`` flow and exit accordingly."""
     _setup_verbosity(verbose)
 
+    if secondary_output is not None and secondary_fmt is None:
+        raise click.UsageError(
+            "--secondary-output requires --secondary-format: with no format "
+            "given there is nothing to render, and the path would be silently "
+            "ignored."
+        )
     if (
         secondary_output is not None
         and output is not None

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -593,6 +593,11 @@ def run_compare(
         jobs_explicit=jobs_explicit, dso_only=dso_only, output_dir=output_dir
     )
 
+    # Preserved before _normalize_compare_options resolves `demangle` against
+    # the *primary* fmt below — the secondary render needs the same tri-state
+    # input resolved against `secondary_fmt` instead (see its call site).
+    demangle_explicit = demangle
+
     (
         collect_mode, headers, old_headers_only, new_headers_only,
         effective_debug_format, demangle, report_mode, show_impact,
@@ -863,6 +868,14 @@ def run_compare(
         # set the gate actually acted on, not whatever the primary format
         # chose to filter or group down to. Reuses the same already-computed
         # `result` — no second comparison run.
+        # Resolve demangle against secondary_fmt, not the primary-resolved
+        # value above — otherwise a machine primary format (e.g. json) paired
+        # with a markdown/review secondary format would wrongly inherit
+        # demangle=False into the secondary render (Codex review, PR #557).
+        secondary_demangle = (
+            secondary_fmt in {"markdown", "review"}
+            if demangle_explicit is None else demangle_explicit
+        )
         secondary_text = _render_output(
             secondary_fmt, result, old, new,
             follow_deps=follow_deps,
@@ -870,7 +883,7 @@ def run_compare(
             show_impact=show_impact, stat=False,
             severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
             show_recommendation=recommend,
-            demangle=demangle,
+            demangle=secondary_demangle,
         )
         _write_or_echo(secondary_output, secondary_text)
 

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -228,6 +228,24 @@ class _NormalizedCompareOptions(NamedTuple):
     show_impact: bool
 
 
+def _resolve_demangle(fmt: str, demangle: bool | None) -> bool:
+    """Resolve the tri-state ``--demangle`` flag against a specific format.
+
+    Default ON for the text formats whose renderer post-processes symbols
+    through ``demangle_text`` (markdown/review), OFF for machine formats
+    (json/sarif/junit) and HTML — the HTML renderer emits symbols
+    structurally and demangling its string would inject unescaped
+    ``<``/``>``/``&`` from C++ names and corrupt the markup. An explicit
+    flag always wins over the per-format default.
+
+    Shared by the primary render (:func:`_normalize_compare_options`) and
+    the ``--secondary-format`` render in :func:`run_compare`, each resolved
+    against its own format — a machine primary format paired with a text
+    secondary format (or vice versa) must not inherit the other's default.
+    """
+    return fmt in {"markdown", "review"} if demangle is None else demangle
+
+
 def _normalize_compare_options(
     resolved_cfg: ResolvedCompareConfig,
     *,
@@ -267,12 +285,7 @@ def _normalize_compare_options(
     else:
         effective_debug_format = debug_format
 
-    # Tri-state --demangle: default ON for the text formats whose renderer
-    # post-processes symbols through demangle_text (markdown/review), OFF for
-    # machine formats (json/sarif/junit) and HTML — the HTML renderer emits
-    # symbols structurally and demangling its string would inject unescaped
-    # '<'/'>'/'&' from C++ names and corrupt the markup. Explicit flag wins.
-    demangle_resolved = fmt in {"markdown", "review"} if demangle is None else demangle
+    demangle_resolved = _resolve_demangle(fmt, demangle)
 
     # --report-mode impact is sugar for "full" report with the impact table on.
     if report_mode == "impact":
@@ -872,10 +885,7 @@ def run_compare(
         # value above — otherwise a machine primary format (e.g. json) paired
         # with a markdown/review secondary format would wrongly inherit
         # demangle=False into the secondary render (Codex review, PR #557).
-        secondary_demangle = (
-            secondary_fmt in {"markdown", "review"}
-            if demangle_explicit is None else demangle_explicit
-        )
+        secondary_demangle = _resolve_demangle(secondary_fmt, demangle_explicit)
         secondary_text = _render_output(
             secondary_fmt, result, old, new,
             follow_deps=follow_deps,

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -799,24 +799,31 @@ def _release_gating_buckets(
     what blocked the release).
     """
     if severity_config is not None:
-        from .severity import SeverityLevel, categorize_changes
+        from .severity import categorize_changes, compute_gate_decision
 
-        categorized = categorize_changes(
+        kind_sets = diff._effective_kind_sets()
+        # compute_gate_decision (the single canonical gate computation, also
+        # used by reporter.py/sarif.py) decides *which* categories are
+        # actually blocking; categorize_changes supplies the change lists for
+        # them — a category with no findings never contributes an (empty)
+        # bucket, matching how JSON/SARIF's blocking_categories behave.
+        gate = compute_gate_decision(
             diff.changes,
+            severity_config,
             policy=diff.policy,
-            kind_sets=diff._effective_kind_sets(),
+            kind_sets=kind_sets,
             policy_file=diff.policy_file,
         )
-        return [
-            (name, cat_changes)
-            for name, cat_changes in (
-                ("abi_breaking", categorized.abi_breaking),
-                ("potential_breaking", categorized.potential_breaking),
-                ("quality_issues", categorized.quality_issues),
-                ("addition", categorized.addition),
-            )
-            if getattr(severity_config, name) == SeverityLevel.ERROR
-        ]
+        categorized = categorize_changes(
+            diff.changes, policy=diff.policy, kind_sets=kind_sets, policy_file=diff.policy_file,
+        )
+        cat_changes_by_name = {
+            "abi_breaking": categorized.abi_breaking,
+            "potential_breaking": categorized.potential_breaking,
+            "quality_issues": categorized.quality_issues,
+            "addition": categorized.addition,
+        }
+        return [(name, cat_changes_by_name[name]) for name in gate.blocking_categories]
     return [
         ("breaking", diff.breaking),
         ("api_break", diff.source_breaks),

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -773,6 +773,44 @@ def _validate_suppression_early(
         )
 
 
+# Cap on embedded per-library findings in release JSON — same rationale as
+# `cli_scan_baseline._MAX_BASELINE_FINDINGS` / `stack_report._MAX_STACK_FINDINGS_PER_LIBRARY`:
+# a bare count (``"breaking": 3``) leaves no way to identify which symbols
+# broke without a separate `compare` run, but embedding every finding for
+# every library in a large release could blow up the summary output.
+_MAX_RELEASE_FINDINGS_PER_LIBRARY = 10
+
+
+def _release_finding_dicts(diff: DiffResult) -> list[dict[str, object]]:
+    """Project a library's gating findings into small, capped dicts.
+
+    Same shape as ``cli_scan_baseline._baseline_finding_dicts`` /
+    ``stack_report._stack_finding_dicts``. Counts (not already-built dicts)
+    decide the cap so a large diff never builds more dicts than the cap can
+    ever keep.
+    """
+    findings: list[dict[str, object]] = []
+    for bucket_name, bucket_changes in (
+        ("breaking", diff.breaking),
+        ("api_break", diff.source_breaks),
+        ("risk", diff.risk),
+    ):
+        remaining = _MAX_RELEASE_FINDINGS_PER_LIBRARY - len(findings)
+        if remaining <= 0:
+            break
+        for c in bucket_changes[:remaining]:
+            findings.append(
+                {
+                    "bucket": bucket_name,
+                    "kind": c.kind.value,
+                    "symbol": c.symbol,
+                    "description": c.description,
+                    "source_location": c.source_location,
+                }
+            )
+    return findings
+
+
 def _strip_diff_results_and_adjust_verdict(
     library_results: list[dict[str, object]],
     removed_keys: list[str],
@@ -780,17 +818,33 @@ def _strip_diff_results_and_adjust_verdict(
 ) -> str:
     """Remove un-serialisable ``_diff_result`` entries and adjust the worst verdict.
 
-    After bundle analysis the stashed :class:`DiffResult` objects are no
-    longer needed.  Stripping them here keeps the summary formatter free of
-    any Python-only objects.  Additionally, if any library was *removed*
-    from the release and the verdict has not already been escalated, the
-    verdict is bumped to at least ``COMPATIBLE_WITH_RISK``.
+    Before the stashed :class:`DiffResult` objects are discarded, each
+    library entry gets a capped ``findings`` list (kind/symbol/description/
+    location) projected from it — otherwise the JSON summary is entirely
+    count-centric (``"breaking": 3``) with no way to identify which symbols
+    broke short of a separate `compare` run or the optional per-library
+    ``--output-dir`` report file. Stripping ``_diff_result`` itself keeps the
+    summary formatter free of any Python-only objects. Additionally, if any
+    library was *removed* from the release and the verdict has not already
+    been escalated, the verdict is bumped to at least
+    ``COMPATIBLE_WITH_RISK``.
 
     Returns the (possibly updated) *worst_verdict* string.
     """
     for entry in library_results:
-        if isinstance(entry, dict):
-            entry.pop("_diff_result", None)
+        if not isinstance(entry, dict):
+            continue
+        diff = entry.get("_diff_result")
+        if isinstance(diff, DiffResult):
+            total_gating = (
+                len(diff.breaking) + len(diff.source_breaks) + len(diff.risk)
+            )
+            findings = _release_finding_dicts(diff)
+            if findings:
+                entry["findings"] = findings
+                if total_gating > _MAX_RELEASE_FINDINGS_PER_LIBRARY:
+                    entry["findings_truncated"] = True
+        entry.pop("_diff_result", None)
     if removed_keys and _RELEASE_VERDICT_ORDER.get(
         worst_verdict, 0
     ) < _RELEASE_VERDICT_ORDER.get("COMPATIBLE_WITH_RISK", 0):

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 import click
 
 from .bundle import BundleDiffResult
-from .checker import DiffResult
+from .checker import Change, DiffResult
 from .cli import (
     _build_match_map,
     _collect_release_inputs,
@@ -781,20 +781,63 @@ def _validate_suppression_early(
 _MAX_RELEASE_FINDINGS_PER_LIBRARY = 10
 
 
-def _release_finding_dicts(diff: DiffResult) -> list[dict[str, object]]:
+def _release_gating_buckets(
+    diff: DiffResult,
+    severity_config: SeverityConfig | None,
+) -> list[tuple[str, list[Change]]]:
+    """Return the named (bucket, changes) groups that gate *diff*'s exit code.
+
+    Without *severity_config* (the legacy verdict-based exit-code scheme),
+    only the three verdict buckets that ever gate the legacy exit code are
+    used. With *severity_config* active, the release can instead exit
+    non-zero because a category that's normally compatible (additions,
+    quality issues) was promoted to ``error`` — e.g. ``--severity-addition
+    error`` — so every category the active config gates to ``error`` is
+    used instead (Codex review on #557: walking only the legacy buckets left
+    a library reporting ``severity.exit_code: 1`` with an empty ``findings``
+    list even though a specific addition/quality-issue finding was exactly
+    what blocked the release).
+    """
+    if severity_config is not None:
+        from .severity import SeverityLevel, categorize_changes
+
+        categorized = categorize_changes(
+            diff.changes,
+            policy=diff.policy,
+            kind_sets=diff._effective_kind_sets(),
+            policy_file=diff.policy_file,
+        )
+        return [
+            (name, cat_changes)
+            for name, cat_changes in (
+                ("abi_breaking", categorized.abi_breaking),
+                ("potential_breaking", categorized.potential_breaking),
+                ("quality_issues", categorized.quality_issues),
+                ("addition", categorized.addition),
+            )
+            if getattr(severity_config, name) == SeverityLevel.ERROR
+        ]
+    return [
+        ("breaking", diff.breaking),
+        ("api_break", diff.source_breaks),
+        ("risk", diff.risk),
+    ]
+
+
+def _release_finding_dicts(
+    diff: DiffResult,
+    severity_config: SeverityConfig | None = None,
+) -> list[dict[str, object]]:
     """Project a library's gating findings into small, capped dicts.
 
     Same shape as ``cli_scan_baseline._baseline_finding_dicts`` /
     ``stack_report._stack_finding_dicts``. Counts (not already-built dicts)
     decide the cap so a large diff never builds more dicts than the cap can
-    ever keep.
+    ever keep. See :func:`_release_gating_buckets` for which findings this
+    walks under a legacy vs. severity-aware exit-code scheme.
     """
     findings: list[dict[str, object]] = []
-    for bucket_name, bucket_changes in (
-        ("breaking", diff.breaking),
-        ("api_break", diff.source_breaks),
-        ("risk", diff.risk),
-    ):
+    for bucket_name, bucket_changes in _release_gating_buckets(diff, severity_config):
         remaining = _MAX_RELEASE_FINDINGS_PER_LIBRARY - len(findings)
         if remaining <= 0:
             break
@@ -815,6 +858,7 @@ def _strip_diff_results_and_adjust_verdict(
     library_results: list[dict[str, object]],
     removed_keys: list[str],
     worst_verdict: str,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
     """Remove un-serialisable ``_diff_result`` entries and adjust the worst verdict.
 
@@ -823,11 +867,15 @@ def _strip_diff_results_and_adjust_verdict(
     location) projected from it — otherwise the JSON summary is entirely
     count-centric (``"breaking": 3``) with no way to identify which symbols
     broke short of a separate `compare` run or the optional per-library
-    ``--output-dir`` report file. Stripping ``_diff_result`` itself keeps the
-    summary formatter free of any Python-only objects. Additionally, if any
-    library was *removed* from the release and the verdict has not already
-    been escalated, the verdict is bumped to at least
-    ``COMPATIBLE_WITH_RISK``.
+    ``--output-dir`` report file. *severity_config*, when the release's exit
+    code is severity-aware, is forwarded to :func:`_release_finding_dicts` so
+    a library gated by a promoted addition/quality-issue category (not one of
+    the legacy breaking/api_break/risk buckets) still gets a matching
+    finding, not an empty list next to a nonzero ``severity.exit_code``.
+    Stripping ``_diff_result`` itself keeps the summary formatter free of any
+    Python-only objects. Additionally, if any library was *removed* from the
+    release and the verdict has not already been escalated, the verdict is
+    bumped to at least ``COMPATIBLE_WITH_RISK``.
 
     Returns the (possibly updated) *worst_verdict* string.
     """
@@ -836,10 +884,11 @@ def _strip_diff_results_and_adjust_verdict(
             continue
         diff = entry.get("_diff_result")
         if isinstance(diff, DiffResult):
-            total_gating = (
-                len(diff.breaking) + len(diff.source_breaks) + len(diff.risk)
+            total_gating = sum(
+                len(cat_changes)
+                for _, cat_changes in _release_gating_buckets(diff, severity_config)
             )
-            findings = _release_finding_dicts(diff)
+            findings = _release_finding_dicts(diff, severity_config)
             if findings:
                 entry["findings"] = findings
                 if total_gating > _MAX_RELEASE_FINDINGS_PER_LIBRARY:
@@ -1270,7 +1319,7 @@ def compare_release_cmd(
 
         # Strip _diff_result from entries and bump verdict for removed libraries.
         worst_verdict = _strip_diff_results_and_adjust_verdict(
-            library_results, removed_keys, worst_verdict
+            library_results, removed_keys, worst_verdict, severity_config
         )
 
         # Build-configuration matrix findings (G2: probe -> compare-release).

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -1375,6 +1375,17 @@ COMPARE_FLAG_BUDGET_RAISES: dict[str, str] = {
         "top-level header) — opt-in separately since it costs more than "
         "--header-graph alone. Same per-run analysis-depth rationale."
     ),
+    "--secondary-format": (
+        "Emits a second output format from the same comparison run (e.g. a "
+        "--secondary-format json artifact alongside a --format markdown report), "
+        "so a CI caller (the GitHub Action's PR-comment JSON) no longer has to "
+        "re-invoke abicheck a second time. A per-run rendering choice, not a "
+        "stable project setting."
+    ),
+    "--secondary-output": (
+        "Companion to --secondary-format: the file path its output is written "
+        "to. Always used together, like -o/--output for --format."
+    ),
 }
 
 #: Derived ceiling — never hand-edit; add a ``COMPARE_FLAG_BUDGET_RAISES`` entry.

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -62,6 +62,7 @@ from .report_summary import compatibility_metrics
 
 if TYPE_CHECKING:
     from .checker import DiffResult
+    from .severity import SeverityConfig
 
 
 def _change_bucket(
@@ -653,6 +654,7 @@ def generate_html_report(
     *,
     show_only: str | None = None,
     show_impact: bool = False,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
     """Generate a standalone ABICC-compatible HTML ABI report.
 
@@ -666,6 +668,12 @@ def generate_html_report(
             changes (legacy behaviour).
         show_only: Optional --show-only filter string (display-only).
         show_impact: If True, append an impact summary table.
+        severity_config: Optional severity configuration. When given (native
+            report only — the ABICC-compatible ``compat_html`` layout is left
+            unchanged), a separate "CI Gate" headline card is rendered
+            alongside "Compatibility" so a configured severity gate (e.g. an
+            addition promoted to ``error``) is visible even when the
+            Compatibility verdict itself reads COMPATIBLE.
 
     Returns:
         Complete self-contained HTML document as a string.
@@ -684,7 +692,14 @@ def generate_html_report(
         from .checker import Change as _Change
         from .reporter import apply_show_only
         typed_changes = [c for c in all_changes if isinstance(c, _Change)]
-        filtered = apply_show_only(typed_changes, show_only, policy=result.policy)
+        _kind_sets_fn = getattr(result, "_effective_kind_sets", None)
+        filtered = apply_show_only(
+            typed_changes,
+            show_only,
+            policy=result.policy,
+            kind_sets=_kind_sets_fn() if _kind_sets_fn is not None else None,
+            policy_file=getattr(result, "policy_file", None),
+        )
         display_changes: list[object] = list(filtered)
     else:
         display_changes = all_changes
@@ -754,6 +769,36 @@ def generate_html_report(
         )
 
     verdict_icon = _verdict_icon(verdict)
+
+    gate_html = ""
+    if severity_config is not None:
+        from .severity import compute_exit_code
+
+        _eff_kind_sets_fn2 = getattr(result, "_effective_kind_sets", None)
+        gate_exit_code = compute_exit_code(
+            cast(list[HasKind], all_changes),
+            severity_config,
+            policy=getattr(result, "policy", None),
+            kind_sets=_eff_kind_sets_fn2() if callable(_eff_kind_sets_fn2) else None,
+            policy_file=getattr(result, "policy_file", None),
+        )
+        gate_passed = gate_exit_code == 0
+        gate_fg, gate_bg = (
+            ("#1b5e20", "#e8f5e9") if gate_passed else ("#b71c1c", "#ffebee")
+        )
+        gate_label = "PASS" if gate_passed else f"FAIL (exit {gate_exit_code})"
+        gate_icon = "✅" if gate_passed else "🛑"
+        gate_html = (
+            f"<div class='verdict-box' "
+            f"style='background:{gate_bg}; color:{gate_fg}; "
+            f"border-left:6px solid {gate_fg};'>"
+            f"<h2>{gate_icon} CI Gate: {h(gate_label)}</h2>"
+            f"<div class='bc-metric' style='font-size:0.85em; opacity:0.85;'>"
+            f"Reflects the configured severity gate — may differ from the "
+            f"Compatibility verdict above (e.g. an addition promoted to "
+            f"<code>error</code> still fails CI)."
+            f"</div></div>"
+        )
 
     summary_html = _summary_table(removed, changed, added, suppressed_count)
     nav_html = _nav_bar(removed, changed, added, suppressed_count)
@@ -825,7 +870,7 @@ def generate_html_report(
 </div>
 
 <div class="verdict-box" style="background:{bg}; color:{fg}; border-left:6px solid {fg};">
-  <h2>{verdict_icon} Verdict: {h(verdict)}</h2>
+  <h2>{verdict_icon} Compatibility: {h(verdict)}</h2>
   <div class="bc-metric">
     Binary Compatibility: <strong>{bc_pct:.1f}%</strong>
     <span style="font-size:0.82em; opacity:0.75">
@@ -840,6 +885,7 @@ def generate_html_report(
   </div>
 </div>
 
+{gate_html}
 {_confidence_html(result)}
 {nav_html}
 {summary_html}

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -772,21 +772,21 @@ def generate_html_report(
 
     gate_html = ""
     if severity_config is not None:
-        from .severity import compute_exit_code
+        from .severity import compute_gate_decision
 
         _eff_kind_sets_fn2 = getattr(result, "_effective_kind_sets", None)
-        gate_exit_code = compute_exit_code(
+        gate = compute_gate_decision(
             cast(list[HasKind], all_changes),
             severity_config,
             policy=getattr(result, "policy", None),
             kind_sets=_eff_kind_sets_fn2() if callable(_eff_kind_sets_fn2) else None,
             policy_file=getattr(result, "policy_file", None),
         )
-        gate_passed = gate_exit_code == 0
+        gate_passed = not gate.blocking
         gate_fg, gate_bg = (
             ("#1b5e20", "#e8f5e9") if gate_passed else ("#b71c1c", "#ffebee")
         )
-        gate_label = "PASS" if gate_passed else f"FAIL (exit {gate_exit_code})"
+        gate_label = "PASS" if gate_passed else f"FAIL (exit {gate.exit_code})"
         gate_icon = "✅" if gate_passed else "🛑"
         gate_html = (
             f"<div class='verdict-box' "

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -182,12 +182,23 @@ def _failure_type(
         if category == IssueCategory.POTENTIAL_BREAKING:
             # IssueCategory doesn't itself distinguish API break from
             # deployment risk (both fold into POTENTIAL_BREAKING) — recover
-            # that distinction from kind-set membership, mirroring
-            # annotations._title_for_change's analogous split.
-            _, api_break_set, _, risk_set = kind_sets
-            if change.kind in api_break_set:
+            # that distinction from the finding's *effective* verdict, not
+            # raw kind-set membership: a per-finding effective_verdict
+            # override/modulation (pattern-verdicts, PolicyFile) can move a
+            # change's verdict without changing which kind-set its raw kind
+            # belongs to, so kind-set membership alone could contradict the
+            # category already resolved above (CodeRabbit review, PR #557).
+            from .severity import effective_verdict_for_change
+
+            verdict = effective_verdict_for_change(
+                change,
+                policy=result.policy,
+                kind_sets=kind_sets,
+                policy_file=result.policy_file,
+            )
+            if verdict == Verdict.API_BREAK:
                 return "API_BREAK"
-            if change.kind in risk_set:
+            if verdict == Verdict.COMPATIBLE_WITH_RISK:
                 return "COMPATIBLE_WITH_RISK"
             return "POTENTIAL_BREAKING"
         return _CATEGORY_TO_JUNIT_TYPE.get(category.value, "COMPATIBLE")

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -140,15 +140,58 @@ def _is_failure(
     return False
 
 
-def _failure_type(change: Change, result: DiffResult, kind_sets: KindSets) -> str:
+_CATEGORY_TO_JUNIT_TYPE: dict[str, str] = {
+    "abi_breaking": "BREAKING",
+    "quality_issues": "QUALITY_ISSUE",
+    "addition": "ADDITION",
+}
+
+
+def _failure_type(
+    change: Change,
+    result: DiffResult,
+    kind_sets: KindSets,
+    severity_config: SeverityConfig | None = None,
+) -> str:
     """Return the ``type`` attribute for a ``<failure>`` element.
 
-    Uses the same canonical per-finding verdict as ``_is_failure`` so the
-    reported type always matches why the finding failed. Takes the caller's
-    precomputed *kind_sets* rather than recomputing them (``_build_testsuite``
-    already builds them once per report; ``DiffResult._effective_verdict_for_change``
-    would otherwise rebuild them per finding).
+    Uses the same canonical per-finding verdict/category as ``_is_failure``
+    so the reported type always matches why the finding failed. Takes the
+    caller's precomputed *kind_sets* rather than recomputing them
+    (``_build_testsuite`` already builds them once per report;
+    ``DiffResult._effective_verdict_for_change`` would otherwise rebuild them
+    per finding).
+
+    When *severity_config* is given, ``_is_failure`` decides pass/fail from
+    the finding's effective *category* (:func:`classify_effective_change`),
+    not its raw verdict — a COMPATIBLE addition promoted to ``error``
+    fails even though its verdict is COMPATIBLE. Without also deriving
+    ``type`` from that same category, such a failure would report
+    ``type="COMPATIBLE"`` (``_VERDICT_TO_JUNIT_TYPE``'s fallback for any
+    verdict it doesn't recognise), contradicting the very reason it failed.
     """
+    if severity_config is not None:
+        from .severity import IssueCategory, classify_effective_change
+
+        category = classify_effective_change(
+            change,
+            policy=result.policy,
+            kind_sets=kind_sets,
+            policy_file=result.policy_file,
+        )
+        if category == IssueCategory.POTENTIAL_BREAKING:
+            # IssueCategory doesn't itself distinguish API break from
+            # deployment risk (both fold into POTENTIAL_BREAKING) — recover
+            # that distinction from kind-set membership, mirroring
+            # annotations._title_for_change's analogous split.
+            _, api_break_set, _, risk_set = kind_sets
+            if change.kind in api_break_set:
+                return "API_BREAK"
+            if change.kind in risk_set:
+                return "COMPATIBLE_WITH_RISK"
+            return "POTENTIAL_BREAKING"
+        return _CATEGORY_TO_JUNIT_TYPE.get(category.value, "COMPATIBLE")
+
     from .severity import effective_verdict_for_change
 
     verdict = effective_verdict_for_change(
@@ -284,7 +327,7 @@ def _append_extra_failures(
         if _is_failure(c, result, kind_sets, severity_config):
             for tc in ts:
                 if tc.get("name") == c.symbol:
-                    _add_failure(tc, c, result, kind_sets)
+                    _add_failure(tc, c, result, kind_sets, severity_config)
                     break
 
 
@@ -350,7 +393,7 @@ def _maybe_add_failure(
 ) -> None:
     """Add a ``<failure>`` child to *tc* if the change is a failure."""
     if _is_failure(change, result, kind_sets, severity_config):
-        _add_failure(tc, change, result, kind_sets)
+        _add_failure(tc, change, result, kind_sets, severity_config)
 
 
 def _add_failure(
@@ -358,9 +401,10 @@ def _add_failure(
     change: Change,
     result: DiffResult,
     kind_sets: KindSets,
+    severity_config: SeverityConfig | None = None,
 ) -> None:
     """Append a ``<failure>`` element to testcase *tc*."""
-    ftype = _failure_type(change, result, kind_sets)
+    ftype = _failure_type(change, result, kind_sets, severity_config)
     description = change.description or change.kind.value.replace("_", " ")
     message = f"{change.kind.value}: {description}"
 

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -308,7 +308,13 @@ def _build_testsuite(
 
     changes = list(result.changes)
     if show_only:
-        changes = apply_show_only(changes, show_only, policy=result.policy)
+        changes = apply_show_only(
+            changes,
+            show_only,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
 
     change_by_symbol, extra_changes = _partition_changes(changes)
     all_symbols = _collect_all_symbols(old_snapshot, show_only, change_by_symbol)

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -382,7 +382,7 @@ def _render_output(
     """Render comparison result in the requested output format.
 
     *severity_config*, when given, is forwarded to every format that
-    supports it (json, sarif, markdown, stat) so an MCP caller passing
+    supports it (json, sarif, markdown, stat, html) so an MCP caller passing
     ``severity_*`` arguments to :func:`abi_compare` gets the same
     severity-aware report content the CLI's ``--severity-*`` flags produce —
     without it, the MCP surface had no severity configuration at all.
@@ -421,6 +421,7 @@ def _render_output(
             old_symbol_count=result.old_symbol_count,
             show_only=show_only,
             show_impact=show_impact,
+            severity_config=severity_config,
         )
     return to_markdown(
         result,

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -278,15 +278,18 @@ def _to_json_leaf(
             "severity": _effective_severity_label(
                 c, eff_sets, policy=result.policy, policy_file=result.policy_file,
             ),
-            # Schema 2.3 fields (Codex review on #557): _leaf_entry builds its
-            # own dict rather than routing through _change_to_dict, so root
-            # type changes in leaf_changes[]/changes[] were missing
-            # operation/finding_id even though non-type leaf entries (via
-            # _change_to_dict below) and full-mode entries both have them —
-            # breaking a consumer relying on finding_id correlation across
-            # --report-mode leaf and full-mode reports.
+            # Schema 2.3/2.4 fields (Codex review on #557): _leaf_entry builds
+            # its own dict rather than routing through _change_to_dict, so
+            # root type changes in leaf_changes[]/changes[] were missing
+            # operation/finding_id/recommended_action even though non-type
+            # leaf entries (via _change_to_dict below) and full-mode entries
+            # all have them — breaking a consumer relying on finding_id
+            # correlation across --report-mode leaf and full-mode reports.
             "operation": operation_for_kind(c.kind.value),
             "finding_id": _finding_id(c),
+            "recommended_action": _recommended_action_for_change(
+                c, policy=result.policy, kind_sets=eff_sets, policy_file=result.policy_file,
+            ),
             "affected_count": len(c.affected_symbols) if c.affected_symbols else 0,
             "affected_symbols": c.affected_symbols or [],
             "caused_count": c.caused_count,
@@ -663,6 +666,53 @@ def _finding_id(c: object) -> str:
     return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
 
 
+_VERDICT_TO_RECOMMENDED_ACTION: dict[Verdict, str] = {
+    Verdict.BREAKING: "recompile_and_relink_required",
+    Verdict.API_BREAK: "recompile_required",
+    Verdict.COMPATIBLE_WITH_RISK: "verify_deployment_compatibility",
+}
+
+
+def _recommended_action_for_change(
+    c: object,
+    *,
+    policy: str | None,
+    kind_sets: KindSets | None,
+    policy_file: object | None,
+) -> str:
+    """Return a structured, machine-readable next step for *c* (schema 2.4).
+
+    Derived from the same effective verdict/category resolution
+    ``severity``/``operation``/``finding_id`` already use, so it can never
+    disagree with them for the same finding:
+
+    - ``BREAKING`` → ``recompile_and_relink_required`` (binary ABI break)
+    - ``API_BREAK`` → ``recompile_required`` (source-level break only)
+    - ``COMPATIBLE_WITH_RISK`` → ``verify_deployment_compatibility``
+    - ``COMPATIBLE`` additions → ``no_action_required``
+    - ``COMPATIBLE`` non-additions (quality issues) → ``review_recommended``
+    """
+    from .severity import (
+        IssueCategory,
+        classify_effective_change,
+        effective_verdict_for_change,
+    )
+
+    verdict = effective_verdict_for_change(
+        cast(HasKind, c), policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+    )
+    action = _VERDICT_TO_RECOMMENDED_ACTION.get(verdict)
+    if action is not None:
+        return action
+    # COMPATIBLE: distinguish a genuine addition (nothing to do) from a
+    # quality issue (compatible, but worth a look) via the same category
+    # classification the severity JSON block uses.
+    category = classify_effective_change(
+        cast(HasKind, c), policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+    )
+    return "no_action_required" if category == IssueCategory.ADDITION else "review_recommended"
+
+
 def _change_to_dict(
     c: object,
     *,
@@ -714,6 +764,9 @@ def _change_to_dict(
     if isinstance(kind, ChangeKind):
         d["operation"] = operation_for_kind(kind.value)
         d["finding_id"] = _finding_id(c)
+        d["recommended_action"] = _recommended_action_for_change(
+            c, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+        )
     if evidence_status is not None:
         d["evidence_status"] = evidence_status.value
     # Impact explanation

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -255,7 +255,13 @@ def _to_json_leaf(
     summary = build_summary(result)
     changes = list(result.changes)
     if show_only:
-        changes = apply_show_only(changes, show_only, policy=result.policy)
+        changes = apply_show_only(
+            changes,
+            show_only,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
     type_changes = [c for c in changes if c.kind in _ROOT_TYPE_CHANGE_KINDS]
     non_type_changes = [c for c in changes if c.kind not in _ROOT_TYPE_CHANGE_KINDS]
 
@@ -579,7 +585,13 @@ def to_json(
 
     changes = list(result.changes)
     if show_only:
-        changes = apply_show_only(changes, show_only, policy=result.policy)
+        changes = apply_show_only(
+            changes,
+            show_only,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
 
     d = _build_json_base(result)
     _add_abi_surface_breakdown(d, result)

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import TYPE_CHECKING, cast
 
@@ -71,6 +72,7 @@ from .reporter_markdown import (
     _section_severity_label as _section_severity_label,
     _to_markdown_leaf as _to_markdown_leaf,
     apply_show_only as apply_show_only,
+    operation_for_kind as operation_for_kind,
     to_markdown as to_markdown,
     to_review_digest as to_review_digest,
     to_stat as to_stat,
@@ -625,6 +627,33 @@ def to_json(
     return json.dumps(d, indent=indent)
 
 
+def _finding_id(c: object) -> str:
+    """Stable per-finding fingerprint (schema 2.3, additive).
+
+    Deterministic across repeated runs of the same comparison, so a
+    consumer can tell "is this the same finding" across two report runs
+    (e.g. to correlate a suppression/waiver, or diff two CI runs' findings)
+    without relying on array order or index — neither of which abicheck
+    guarantees stays stable release to release.
+
+    Derived only from fields that identify the finding's *identity* (kind,
+    symbol, old/new value, source location) — deliberately excluding
+    ``severity``/``evidence_status``, which are policy-derived and would
+    make the same underlying finding hash differently under a different
+    ``--policy``.
+    """
+    key = "\x1f".join(
+        [
+            str(getattr(getattr(c, "kind", None), "value", getattr(c, "kind", ""))),
+            str(getattr(c, "symbol", None) or ""),
+            str(getattr(c, "old_value", None) or ""),
+            str(getattr(c, "new_value", None) or ""),
+            str(getattr(c, "source_location", None) or ""),
+        ]
+    )
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+
+
 def _change_to_dict(
     c: object,
     *,
@@ -673,6 +702,9 @@ def _change_to_dict(
         "new_value": getattr(c, "new_value", None),
         "severity": severity,
     }
+    if isinstance(kind, ChangeKind):
+        d["operation"] = operation_for_kind(kind.value)
+        d["finding_id"] = _finding_id(c)
     if evidence_status is not None:
         d["evidence_status"] = evidence_status.value
     # Impact explanation
@@ -767,10 +799,29 @@ def _build_severity_json(
         policy_file=policy_file,
     )
 
+    # ``blocking``/``blocking_categories`` (schema 2.3, additive): a typed,
+    # auditable gate summary mirroring SARIF's ``severityGate`` block
+    # (``sarif._severity_gate_properties``) — without them, a JSON consumer
+    # had to independently recompute "which category is actually failing the
+    # build" from ``config``/``categories`` itself; this makes that answer a
+    # first-class, versioned part of the report.
+    blocking_categories = [
+        name
+        for name, cat_changes in (
+            ("abi_breaking", categorized.abi_breaking),
+            ("potential_breaking", categorized.potential_breaking),
+            ("quality_issues", categorized.quality_issues),
+            ("addition", categorized.addition),
+        )
+        if cat_changes and config_dict[name] == "error"
+    ]
+
     return {
         "config": config_dict,
         "categories": categories,
         "exit_code": exit_code,
+        "blocking": exit_code != 0,
+        "blocking_categories": blocking_categories,
     }
 
 
@@ -817,10 +868,20 @@ def appcompat_to_json(result: object, indent: int = 2) -> str:
         getattr(getattr(result, "full_diff", None), "policy", "strict_abi")
         or "strict_abi"
     )
+    # Thread the full_diff's PolicyFile/effective kind_sets through, mirroring
+    # to_json's _change_to_dict calls (reporter.py _add_changes_block) —
+    # without them, a per-finding severity here falls back to raw-kind
+    # classification and can contradict full_library_verdict below, which
+    # already honours the PolicyFile via full_diff.verdict.
+    _kind_sets_fn = getattr(full_diff, "_effective_kind_sets", None)
+    appcompat_kind_sets = _kind_sets_fn() if callable(_kind_sets_fn) else None
+    appcompat_policy_file = getattr(full_diff, "policy_file", None)
     d["relevant_changes"] = [
         _change_to_dict(
             c,
             policy=appcompat_policy,
+            kind_sets=appcompat_kind_sets,
+            policy_file=appcompat_policy_file,
             evidence_status_override=EvidenceStatus.CONSUMER_PROVEN,
         )
         for c in breaking

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -805,13 +805,28 @@ def _build_severity_json(
     # had to independently recompute "which category is actually failing the
     # build" from ``config``/``categories`` itself; this makes that answer a
     # first-class, versioned part of the report.
+    #
+    # Must be derived from *exit_changes* (the unfiltered gate set), not
+    # ``categorized`` above (built from the possibly --show-only-filtered
+    # *display* ``changes``) — otherwise hiding the one category that's
+    # actually failing the build (e.g. ``--show-only=breaking`` when an
+    # addition promoted to ``error`` is what's blocking) would report
+    # ``blocking: true`` alongside ``blocking_categories: []`` (Codex review
+    # on #557).
+    gate_categorized = (
+        categorized
+        if exit_changes is changes
+        else categorize_changes(
+            exit_changes, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+        )
+    )
     blocking_categories = [
         name
         for name, cat_changes in (
-            ("abi_breaking", categorized.abi_breaking),
-            ("potential_breaking", categorized.potential_breaking),
-            ("quality_issues", categorized.quality_issues),
-            ("addition", categorized.addition),
+            ("abi_breaking", gate_categorized.abi_breaking),
+            ("potential_breaking", gate_categorized.potential_breaking),
+            ("quality_issues", gate_categorized.quality_issues),
+            ("addition", gate_categorized.addition),
         )
         if cat_changes and config_dict[name] == "error"
     ]

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -649,10 +649,18 @@ def _finding_id(c: object) -> str:
     guarantees stays stable release to release.
 
     Derived only from fields that identify the finding's *identity* (kind,
-    symbol, old/new value, source location) — deliberately excluding
-    ``severity``/``evidence_status``, which are policy-derived and would
-    make the same underlying finding hash differently under a different
-    ``--policy``.
+    symbol, old/new value, source location, description) — deliberately
+    excluding ``severity``/``evidence_status``, which are policy-derived and
+    would make the same underlying finding hash differently under a
+    different ``--policy``.
+
+    ``description`` is included as a discriminator: two findings of the same
+    kind on the same symbol with the same old/new value and no distinct
+    source location (e.g. ``param_pointer_level_changed`` on two different
+    parameters of one function, both going from pointer-depth 1 to 2) would
+    otherwise collide on an identical id even though they are different
+    findings — ``description`` embeds the per-finding detail (parameter
+    name/index, member name, …) that disambiguates them.
     """
     key = "\x1f".join(
         [
@@ -661,6 +669,7 @@ def _finding_id(c: object) -> str:
             str(getattr(c, "old_value", None) or ""),
             str(getattr(c, "new_value", None) or ""),
             str(getattr(c, "source_location", None) or ""),
+            str(getattr(c, "description", None) or ""),
         ]
     )
     return hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -764,7 +764,7 @@ def _build_severity_json(
     *kind_sets* from ``DiffResult._effective_kind_sets()`` includes
     PolicyFile overrides.
     """
-    from .severity import SeverityLevel, categorize_changes, compute_exit_code
+    from .severity import SeverityLevel, categorize_changes, compute_gate_decision
 
     categorized = categorize_changes(
         changes,
@@ -797,17 +797,6 @@ def _build_severity_json(
         },
     }
 
-    # Exit code uses the full unfiltered change set so --show-only
-    # does not affect it.
-    exit_changes = all_changes if all_changes is not None else changes
-    exit_code = compute_exit_code(
-        exit_changes,
-        severity_config,
-        policy=policy,
-        kind_sets=kind_sets,
-        policy_file=policy_file,
-    )
-
     # ``blocking``/``blocking_categories`` (schema 2.3, additive): a typed,
     # auditable gate summary mirroring SARIF's ``severityGate`` block
     # (``sarif._severity_gate_properties``) — without them, a JSON consumer
@@ -815,37 +804,30 @@ def _build_severity_json(
     # build" from ``config``/``categories`` itself; this makes that answer a
     # first-class, versioned part of the report.
     #
-    # Must be derived from *exit_changes* (the unfiltered gate set), not
-    # ``categorized`` above (built from the possibly --show-only-filtered
-    # *display* ``changes``) — otherwise hiding the one category that's
-    # actually failing the build (e.g. ``--show-only=breaking`` when an
-    # addition promoted to ``error`` is what's blocking) would report
-    # ``blocking: true`` alongside ``blocking_categories: []`` (Codex review
-    # on #557).
-    gate_categorized = (
-        categorized
-        if exit_changes is changes
-        else categorize_changes(
-            exit_changes, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
-        )
+    # Derived from *exit_changes* (the unfiltered gate set), not ``changes``
+    # (the possibly --show-only-filtered *display* set) — otherwise hiding
+    # the one category that's actually failing the build (e.g.
+    # ``--show-only=breaking`` when an addition promoted to ``error`` is
+    # what's blocking) would report ``blocking: true`` alongside
+    # ``blocking_categories: []`` (Codex review on #557). Routed through
+    # ``compute_gate_decision`` — the single canonical gate computation —
+    # rather than hand-rolling exit_code and blocking_categories as two
+    # independent computations that could drift apart from each other.
+    exit_changes = all_changes if all_changes is not None else changes
+    gate = compute_gate_decision(
+        exit_changes,
+        severity_config,
+        policy=policy,
+        kind_sets=kind_sets,
+        policy_file=policy_file,
     )
-    blocking_categories = [
-        name
-        for name, cat_changes in (
-            ("abi_breaking", gate_categorized.abi_breaking),
-            ("potential_breaking", gate_categorized.potential_breaking),
-            ("quality_issues", gate_categorized.quality_issues),
-            ("addition", gate_categorized.addition),
-        )
-        if cat_changes and config_dict[name] == "error"
-    ]
 
     return {
         "config": config_dict,
         "categories": categories,
-        "exit_code": exit_code,
-        "blocking": exit_code != 0,
-        "blocking_categories": blocking_categories,
+        "exit_code": gate.exit_code,
+        "blocking": gate.blocking,
+        "blocking_categories": list(gate.blocking_categories),
     }
 
 

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -278,6 +278,15 @@ def _to_json_leaf(
             "severity": _effective_severity_label(
                 c, eff_sets, policy=result.policy, policy_file=result.policy_file,
             ),
+            # Schema 2.3 fields (Codex review on #557): _leaf_entry builds its
+            # own dict rather than routing through _change_to_dict, so root
+            # type changes in leaf_changes[]/changes[] were missing
+            # operation/finding_id even though non-type leaf entries (via
+            # _change_to_dict below) and full-mode entries both have them —
+            # breaking a consumer relying on finding_id correlation across
+            # --report-mode leaf and full-mode reports.
+            "operation": operation_for_kind(c.kind.value),
+            "finding_id": _finding_id(c),
             "affected_count": len(c.affected_symbols) if c.affected_symbols else 0,
             "affected_symbols": c.affected_symbols or [],
             "caused_count": c.caused_count,

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -127,14 +127,39 @@ _REMOVED_SUFFIXES = (
     "_const_overload",
 )
 
+# Kinds whose name doesn't end in one of the suffixes above but still name a
+# concrete symbol/entity appearing or disappearing (Codex review on #557:
+# operation_for_kind() reported these as "modified"). Checked before the
+# suffix rule. Deliberately does NOT include kinds naming a *property*
+# gained/lost on an entity that still exists — e.g. the "*_lost_*" family
+# (`field_lost_const`, `func_lost_inline`, ...) or the "*_introduced" family
+# (`vptr_introduced`, `static_tls_introduced`, ...): those are trait changes
+# on a persisting entity, which is what "modified" means here, not an
+# addition/removal of the entity itself.
+_OPERATION_OVERRIDES: dict[str, str] = {
+    # Ends in "_added_compat", not "_added"/"_added_compatible".
+    "symbol_version_required_added_compat": "added",
+    # Ends in "_removed_without_replacement", not "_removed".
+    "experimental_removed_without_replacement": "removed",
+    # Ends in "_deleted_dwarf", not "_deleted".
+    "func_deleted_dwarf": "removed",
+    # A whole ISA-dispatch family's concrete symbols vanish (case83), not a
+    # property change on a persisting symbol.
+    "cpu_dispatch_isa_dropped": "removed",
+}
+
 
 def operation_for_kind(kind_val: str) -> str:
     """Classify a ``ChangeKind.value`` string into "added"/"removed"/"modified".
 
-    A kind is "added"/"removed" when its name ends with one of the
-    corresponding suffixes above; every other kind (parameter/type/layout
-    changes, renames, etc.) is "modified".
+    A kind is "added"/"removed" when it is listed in ``_OPERATION_OVERRIDES``
+    or its name ends with one of the corresponding suffixes above; every
+    other kind (parameter/type/layout changes, renames, trait gained/lost on
+    a persisting entity, etc.) is "modified".
     """
+    override = _OPERATION_OVERRIDES.get(kind_val)
+    if override is not None:
+        return override
     if any(kind_val.endswith(s) for s in _ADDED_SUFFIXES):
         return "added"
     if any(kind_val.endswith(s) for s in _REMOVED_SUFFIXES):

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -157,41 +157,43 @@ class ShowOnlyFilter:
             actions=frozenset(actions),
         )
 
-    def _check_severity(self, change: Change, policy: str) -> bool:
-        """Return True if *change* matches the severity filter."""
+    def _check_severity(
+        self,
+        change: Change,
+        policy: str,
+        kind_sets: KindSets | None = None,
+        policy_file: object | None = None,
+    ) -> bool:
+        """Return True if *change* matches the severity filter.
+
+        Resolves through ``severity.effective_verdict_for_change`` — the same
+        canonical resolver ``DiffResult._effective_verdict_for_change`` uses —
+        so both an A4 per-finding ``effective_verdict`` override (ADR-027) and
+        a kind-level ``PolicyFile.overrides`` entry are honoured. Without this,
+        `--show-only` could disagree with the JSON severity field and
+        filtered_summary counts for any change whose effective category
+        differs from its raw kind's policy bucket (a demoted opaque/PIMPL
+        layout change, or a kind moved by a policy-file override).
+        """
         if not self.severities:
             return True
-        breaking_set, api_break_set, compat_set, risk_set = _policy_kind_sets(policy)
-        # Honour an A4 per-finding effective_verdict override (ADR-027): a
-        # demoted opaque/PIMPL layout change must be filtered by its *effective*
-        # category, so `--show-only=breaking` excludes it — consistent with the
-        # JSON severity field and filtered_summary counts (which already route
-        # through effective_category). Without this the severity filter would
-        # leak a demoted finding it was meant to exclude.
-        eff = getattr(change, "effective_verdict", None)
-        if isinstance(eff, Verdict):
-            # NB: this maps to the CLI --show-only token vocabulary (hyphenated
-            # "api-break"), which intentionally differs from the JSON-field
-            # labels in _VERDICT_TO_SEVERITY_LABEL (underscored "api_break").
-            # The two are deliberately separate label spaces — keep them in sync
-            # by intent, not by sharing a dict.
-            label = {
-                Verdict.BREAKING: "breaking",
-                Verdict.API_BREAK: "api-break",
-                Verdict.COMPATIBLE_WITH_RISK: "risk",
-                Verdict.COMPATIBLE: "compatible",
-            }.get(eff)
-            return label in self.severities
-        severity_map = {
-            "breaking": breaking_set,
-            "api-break": api_break_set,
-            "risk": risk_set,
-            "compatible": compat_set,
-        }
-        return any(
-            sev in self.severities and change.kind in kind_set
-            for sev, kind_set in severity_map.items()
+        from .severity import effective_verdict_for_change
+
+        eff = effective_verdict_for_change(
+            change, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
         )
+        # NB: this maps to the CLI --show-only token vocabulary (hyphenated
+        # "api-break"), which intentionally differs from the JSON-field
+        # labels in _VERDICT_TO_SEVERITY_LABEL (underscored "api_break").
+        # The two are deliberately separate label spaces — keep them in sync
+        # by intent, not by sharing a dict.
+        label = {
+            Verdict.BREAKING: "breaking",
+            Verdict.API_BREAK: "api-break",
+            Verdict.COMPATIBLE_WITH_RISK: "risk",
+            Verdict.COMPATIBLE: "compatible",
+        }.get(eff)
+        return label in self.severities
 
     def _check_element(self, kind_val: str) -> bool:
         """Return True if *kind_val* matches the element filter."""
@@ -281,9 +283,15 @@ class ShowOnlyFilter:
             return True
         return False
 
-    def matches(self, change: Change, policy: str = "strict_abi") -> bool:
+    def matches(
+        self,
+        change: Change,
+        policy: str = "strict_abi",
+        kind_sets: KindSets | None = None,
+        policy_file: object | None = None,
+    ) -> bool:
         """Return True if *change* passes this filter."""
-        if not self._check_severity(change, policy):
+        if not self._check_severity(change, policy, kind_sets, policy_file):
             return False
         if not self._check_element(change.kind.value):
             return False
@@ -294,10 +302,24 @@ def apply_show_only(
     changes: Sequence[Change],
     show_only: str,
     policy: str = "strict_abi",
+    kind_sets: KindSets | None = None,
+    policy_file: object | None = None,
 ) -> list[Change]:
-    """Filter changes according to a --show-only token string."""
+    """Filter changes according to a --show-only token string.
+
+    *kind_sets* / *policy_file*, when supplied by the caller (typically
+    ``result._effective_kind_sets()`` / ``result.policy_file``), let the
+    severity dimension resolve through the same effective-verdict logic as
+    the rest of the report — including kind-level ``PolicyFile.overrides``
+    and per-finding ``effective_verdict`` — so the filter never disagrees
+    with the JSON severity field for the same change.
+    """
     filt = ShowOnlyFilter.parse(show_only)
-    return [c for c in changes if filt.matches(c, policy=policy)]
+    return [
+        c
+        for c in changes
+        if filt.matches(c, policy=policy, kind_sets=kind_sets, policy_file=policy_file)
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -442,7 +464,13 @@ def _to_markdown_leaf(
 
     changes = list(result.changes)
     if show_only:
-        changes = apply_show_only(changes, show_only, policy=result.policy)
+        changes = apply_show_only(
+            changes,
+            show_only,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
         lines.append(
             f"> Filtered by: `--show-only {show_only}` ({len(changes)} of {len(result.changes)} changes shown)"
         )
@@ -952,7 +980,13 @@ def to_markdown(
     # Apply show-only filter if provided (display-only, does not affect verdict)
     changes = list(result.changes)
     if show_only:
-        changes = apply_show_only(changes, show_only, policy=result.policy)
+        changes = apply_show_only(
+            changes,
+            show_only,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
 
     # Build the render-ready view once (C2/ADR-036): canonical verdict-axis
     # classification + summary in one place, shared across formats.

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -146,6 +146,11 @@ _OPERATION_OVERRIDES: dict[str, str] = {
     # A whole ISA-dispatch family's concrete symbols vanish (case83), not a
     # property change on a persisting symbol.
     "cpu_dispatch_isa_dropped": "removed",
+    # A stable name is added alongside the still-present experimental alias
+    # (case99) -- without the dedicated detector this would just be a plain
+    # func_added; ADDITION_KINDS already classifies it as an addition
+    # (Codex review on #557).
+    "experimental_graduated": "added",
 }
 
 

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -151,6 +151,28 @@ _OPERATION_OVERRIDES: dict[str, str] = {
     # func_added; ADDITION_KINDS already classifies it as an addition
     # (Codex review on #557).
     "experimental_graduated": "added",
+    # These four end in "_added" but each names a trait *gained by an
+    # existing, persisting function* ("Function became virtual: {name}",
+    # "noexcept specifier added: {name}", "Function became variadic (gained
+    # ...): {name}" -- verified against their diff_symbols.py descriptions
+    # and change_registry.py entries, none of which set is_addition=True /
+    # belong to ADDITION_KINDS) -- the same "*_lost_*"/"*_introduced" trait-
+    # change pattern above, just spelled with "_added" (Codex review, PR
+    # #557). `func_pure_virtual_added` ("Function became pure virtual:
+    # {name}") is the identical pattern applied to its sibling kind
+    # `func_virtual_became_pure`, which already classifies correctly as
+    # "modified" since it doesn't end in "_added".
+    "func_noexcept_added": "modified",
+    "func_virtual_added": "modified",
+    "func_variadic_added": "modified",
+    "func_pure_virtual_added": "modified",
+    # A field inserted into an existing struct/class shifts every
+    # subsequent field's offset -- this modifies the *layout of the
+    # existing type*, not merely a new field appearing in isolation.
+    # `type_field_added_compatible` (append-at-end, no offset shift) is the
+    # dedicated addition-kind carve-out and is unaffected by this override
+    # (it doesn't end in plain "_added"). (Codex review, PR #557.)
+    "type_field_added": "modified",
 }
 
 

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -173,6 +173,13 @@ _OPERATION_OVERRIDES: dict[str, str] = {
     # dedicated addition-kind carve-out and is unaffected by this override
     # (it doesn't end in plain "_added"). (Codex review, PR #557.)
     "type_field_added": "modified",
+    # The identical layout-modification pattern applied to virtual methods
+    # instead of fields: a new virtual method on an already-existing class
+    # grows/relayouts the vtable (gains a hidden vtable pointer if it had
+    # none, or a new slot otherwise), breaking derived classes compiled
+    # against the old layout -- KDE's "do not add virtuals to a non-leaf
+    # class" rule. Not in ADDITION_KINDS (Codex review, PR #557).
+    "virtual_method_added": "modified",
     # More of the same trait-gained-by-a-persisting-entity pattern, found on
     # a second audit pass (Codex review, PR #557): a constructor/conversion
     # operator gaining `explicit` (`ctor_explicit_added`), a template

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -197,6 +197,17 @@ _OPERATION_OVERRIDES: dict[str, str] = {
     "func_variadic_removed": "modified",
     "func_contract_attribute_removed": "modified",
     "ctor_explicit_removed": "modified",
+    # A third audit pass turned up more of the same (Codex review, PR #557):
+    # `func_virtual_removed` ("Vtable entry removed" -- the sibling of
+    # `func_virtual_added` above, an existing function losing its
+    # virtual-ness) and `param_default_value_removed`/
+    # `python_api_default_removed` (an existing parameter of an existing
+    # function/method losing its default value, making a previously
+    # optional argument mandatory) all describe a trait lost by a
+    # persisting entity, not the entity itself disappearing.
+    "func_virtual_removed": "modified",
+    "param_default_value_removed": "modified",
+    "python_api_default_removed": "modified",
 }
 
 

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -173,6 +173,30 @@ _OPERATION_OVERRIDES: dict[str, str] = {
     # dedicated addition-kind carve-out and is unaffected by this override
     # (it doesn't end in plain "_added"). (Codex review, PR #557.)
     "type_field_added": "modified",
+    # More of the same trait-gained-by-a-persisting-entity pattern, found on
+    # a second audit pass (Codex review, PR #557): a constructor/conversion
+    # operator gaining `explicit` (`ctor_explicit_added`), a template
+    # parameter that was defaulted/deduced becoming mandatory
+    # (`mandatory_template_param_added`), a Python-visible function gaining
+    # a new *required* parameter (`python_api_parameter_added`), and a
+    # function gaining a semantic contract attribute like nonnull/noreturn
+    # (`func_contract_attribute_added`) all describe an already-existing
+    # callable/template's signature or contract changing, not a new one
+    # appearing. None of these four is in ADDITION_KINDS either.
+    "ctor_explicit_added": "modified",
+    "mandatory_template_param_added": "modified",
+    "python_api_parameter_added": "modified",
+    "func_contract_attribute_added": "modified",
+    # Removed-side counterparts of the trait-change pattern: these end in
+    # plain "_removed" (so the suffix rule alone reports "removed"), but
+    # each names a trait *lost by* an entity that still exists — mirroring
+    # `func_noexcept_added`/`func_variadic_added`/etc. above, just the
+    # opposite direction of the same specifier gain/loss (Codex review, PR
+    # #557).
+    "func_noexcept_removed": "modified",
+    "func_variadic_removed": "modified",
+    "func_contract_attribute_removed": "modified",
+    "ctor_explicit_removed": "modified",
 }
 
 

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -114,6 +114,33 @@ def to_stat(result: DiffResult, *, severity_config: SeverityConfig | None = None
 # Show-only filter
 # ---------------------------------------------------------------------------
 
+# Kind-name suffixes that identify an additive vs. a removal finding — shared
+# between ShowOnlyFilter's "added"/"removed"/"changed" action tokens and the
+# JSON report's structured per-finding "operation" field (schema 2.3), so the
+# two never drift apart.
+_ADDED_SUFFIXES = ("_added", "_added_compatible")
+_REMOVED_SUFFIXES = (
+    "_removed",
+    "_deleted",
+    "_elf_only",
+    "_elf_fallback",
+    "_const_overload",
+)
+
+
+def operation_for_kind(kind_val: str) -> str:
+    """Classify a ``ChangeKind.value`` string into "added"/"removed"/"modified".
+
+    A kind is "added"/"removed" when its name ends with one of the
+    corresponding suffixes above; every other kind (parameter/type/layout
+    changes, renames, etc.) is "modified".
+    """
+    if any(kind_val.endswith(s) for s in _ADDED_SUFFIXES):
+        return "added"
+    if any(kind_val.endswith(s) for s in _REMOVED_SUFFIXES):
+        return "removed"
+    return "modified"
+
 
 @dataclass(frozen=True)
 class ShowOnlyFilter:
@@ -262,26 +289,13 @@ class ShowOnlyFilter:
         """Return True if *kind_val* matches the action filter."""
         if not actions:
             return True
-        _ADDED_SUFFIXES = ("_added", "_added_compatible")
-        _REMOVED_SUFFIXES = (
-            "_removed",
-            "_deleted",
-            "_elf_only",
-            "_elf_fallback",
-            "_const_overload",
+        op = operation_for_kind(kind_val)
+        # NB: "changed" (the --show-only token) maps to operation "modified".
+        return (
+            (op == "added" and "added" in actions)
+            or (op == "removed" and "removed" in actions)
+            or (op == "modified" and "changed" in actions)
         )
-        if "added" in actions and any(kind_val.endswith(s) for s in _ADDED_SUFFIXES):
-            return True
-        if "removed" in actions and any(
-            kind_val.endswith(s) for s in _REMOVED_SUFFIXES
-        ):
-            return True
-        if "changed" in actions and not (
-            any(kind_val.endswith(s) for s in _ADDED_SUFFIXES)
-            or any(kind_val.endswith(s) for s in _REMOVED_SUFFIXES)
-        ):
-            return True
-        return False
 
     def matches(
         self,
@@ -903,10 +917,18 @@ def to_review_digest(
         "",
     ]
 
-    # Top impacted symbols (breaking + API), capped for readability.
-    breaking_set, api_break_set, _, _ = result._effective_kind_sets()
+    # Top impacted symbols (breaking + API), capped for readability. Filters
+    # by each change's *effective* verdict (DiffResult._effective_verdict_for_change)
+    # rather than raw kind-set membership, so a per-finding override (A4
+    # pattern-verdict modulation, frozen-namespace guard) is reflected here
+    # the same way it already is in the counts table and merge-effect phrase
+    # above — otherwise this section could list a finding the rest of the
+    # digest reports as compatible, or omit one it reports as breaking.
     impacted = [
-        c for c in result.changes if c.kind in breaking_set or c.kind in api_break_set
+        c
+        for c in result.changes
+        if result._effective_verdict_for_change(c)
+        in (Verdict.BREAKING, Verdict.API_BREAK)
     ]
     if impacted:
         lines += ["**Top impacted symbols:**", ""]

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -247,44 +247,25 @@ def _severity_gate_properties(
     Mirrors the categories/exit-code contract of JSON's ``severity`` block
     (:func:`abicheck.reporter._build_severity_json`) so a SARIF consumer can
     tell *why* the invocation's exit code is what it is without
-    cross-referencing the JSON report separately.
+    cross-referencing the JSON report separately. Both routed through
+    :func:`abicheck.severity.compute_gate_decision` — the single canonical
+    gate computation — so ``exitCode``/``blocking``/``blockingCategories``
+    can never independently drift apart from each other or from JSON's
+    equivalent block.
     """
-    from abicheck.severity import (
-        IssueCategory,
-        SeverityLevel,
-        categorize_changes,
-        compute_exit_code,
-    )
+    from abicheck.severity import compute_gate_decision
 
-    eff_sets = result._effective_kind_sets()
-    exit_code = compute_exit_code(
+    gate = compute_gate_decision(
         result.changes,
         severity_config,
         policy=result.policy,
-        kind_sets=eff_sets,
+        kind_sets=result._effective_kind_sets(),
         policy_file=result.policy_file,
     )
-    categorized = categorize_changes(
-        result.changes,
-        policy=result.policy,
-        kind_sets=eff_sets,
-        policy_file=result.policy_file,
-    )
-    by_category = {
-        IssueCategory.ABI_BREAKING: categorized.abi_breaking,
-        IssueCategory.POTENTIAL_BREAKING: categorized.potential_breaking,
-        IssueCategory.QUALITY_ISSUES: categorized.quality_issues,
-        IssueCategory.ADDITION: categorized.addition,
-    }
-    blocking_categories = [
-        cat.value
-        for cat, cat_changes in by_category.items()
-        if cat_changes and severity_config.level_for(cat) == SeverityLevel.ERROR
-    ]
     return {
-        "exitCode": exit_code,
-        "blocking": exit_code != 0,
-        "blockingCategories": blocking_categories,
+        "exitCode": gate.exit_code,
+        "blocking": gate.blocking,
+        "blockingCategories": list(gate.blocking_categories),
         "config": {
             "abi_breaking": severity_config.abi_breaking.value,
             "potential_breaking": severity_config.potential_breaking.value,

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -122,28 +122,43 @@ def _severity(
 def _parse_source_location(loc: str) -> tuple[str, int | None, int | None]:
     """Parse a ``file[:line[:column]]`` source location for a SARIF region.
 
-    A single ``rsplit(":", 1)`` mishandles ``file:line:column`` — it peels
-    off only the column, leaving ``file:line`` as the artifact URI and never
-    populating ``startColumn``. This walks from the left instead, treating a
-    single-letter first segment followed by a path separator as a Windows
-    drive letter (so ``C:\\foo\\bar.h:42`` still splits into file + line, not
-    ``C`` + ``\\foo\\bar.h:42``).
+    Parses from the right rather than assuming the file is everything
+    before the *first* colon — a path can itself contain colons (a
+    synthetic/virtual scheme like ``generated:headers/foo.h:42``, or a
+    Windows drive letter like ``C:\\foo\\bar.h:42``), and the file is
+    whatever colon segments remain once the trailing numeric line[:column]
+    is peeled off, not a fixed prefix.
+
+    ``loc.rsplit(":", 2)`` gives at most the last two colon-separated
+    segments as candidates for line/column:
+
+    * If the middle segment is numeric, it's the line and everything before
+      it (which may itself contain colons) is the file; the last segment is
+      the column if it's numeric too, otherwise it's dropped (a malformed
+      trailing column shouldn't hide a good line number).
+    * If the middle segment *isn't* numeric, the split point assumed too few
+      file-side colons (e.g. the drive-letter or ``generated:`` cases above)
+      — recombine it into the file and treat the last segment as the line.
+    * Fewer than two colons: fall back to a single trailing split for
+      ``file:line``.
+
+    Any shape that doesn't resolve to a numeric line returns the location
+    unchanged with no region.
     """
-    parts = loc.split(":")
-    if len(parts) >= 3 and len(parts[0]) == 1 and parts[0].isalpha() and parts[1][:1] in ("\\", "/"):
-        file_part = parts[0] + ":" + parts[1]
-        rest = parts[2:]
-    elif len(parts) >= 2:
-        file_part = parts[0]
-        rest = parts[1:]
-    else:
+    three = loc.rsplit(":", 2)
+    if len(three) == 3:
+        file_part, mid, last = three
+        if mid.isdigit():
+            column = int(last) if last.isdigit() else None
+            return file_part, int(mid), column
+        if last.isdigit():
+            return f"{file_part}:{mid}", int(last), None
         return loc, None, None
 
-    if not (rest and rest[0].isdigit()):
-        return loc, None, None
-    line = int(rest[0])
-    column = int(rest[1]) if len(rest) >= 2 and rest[1].isdigit() else None
-    return file_part, line, column
+    two = loc.rsplit(":", 1)
+    if len(two) == 2 and two[1].isdigit():
+        return two[0], int(two[1]), None
+    return loc, None, None
 
 
 def _rule_for(kind: ChangeKind) -> dict[str, Any]:

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -119,12 +119,39 @@ def _severity(
     return entry.severity
 
 
+def _parse_source_location(loc: str) -> tuple[str, int | None, int | None]:
+    """Parse a ``file[:line[:column]]`` source location for a SARIF region.
+
+    A single ``rsplit(":", 1)`` mishandles ``file:line:column`` — it peels
+    off only the column, leaving ``file:line`` as the artifact URI and never
+    populating ``startColumn``. This walks from the left instead, treating a
+    single-letter first segment followed by a path separator as a Windows
+    drive letter (so ``C:\\foo\\bar.h:42`` still splits into file + line, not
+    ``C`` + ``\\foo\\bar.h:42``).
+    """
+    parts = loc.split(":")
+    if len(parts) >= 3 and len(parts[0]) == 1 and parts[0].isalpha() and parts[1][:1] in ("\\", "/"):
+        file_part = parts[0] + ":" + parts[1]
+        rest = parts[2:]
+    elif len(parts) >= 2:
+        file_part = parts[0]
+        rest = parts[1:]
+    else:
+        return loc, None, None
+
+    if not (rest and rest[0].isdigit()):
+        return loc, None, None
+    line = int(rest[0])
+    column = int(rest[1]) if len(rest) >= 2 and rest[1].isdigit() else None
+    return file_part, line, column
+
+
 def _rule_for(kind: ChangeKind) -> dict[str, Any]:
     """Produce a SARIF reportingDescriptor for a ChangeKind."""
     rule_id = kind.value
     severity = policy_for(kind).severity
     doc_slug = policy_for(kind).doc_slug
-    help_uri = f"https://github.com/abicheck/abicheck/blob/main/docs/abi_breaking_cases_catalog.md#{doc_slug}"
+    help_uri = f"https://github.com/abicheck/abicheck/blob/main/docs/reference/change-kinds.md#{doc_slug}"
     impact = impact_for(kind)
     full_desc = (
         impact if impact else f"ABI change detected: {rule_id.replace('_', ' ')}"
@@ -158,17 +185,15 @@ def _result_for(
     # Build physical location — prefer source header over .so when available
     phys_loc: dict[str, Any]
     if change.source_location:
-        # Parse "header.h:42" into file + line
-        parts = change.source_location.rsplit(":", 1)
-        uri = parts[0]
+        uri, line, column = _parse_source_location(change.source_location)
         phys_loc = {
             "artifactLocation": {"uri": uri, "uriBaseId": "%SRCROOT%"},
         }
-        if len(parts) == 2:
-            try:
-                phys_loc["region"] = {"startLine": int(parts[1])}
-            except ValueError:
-                pass
+        if line is not None:
+            region: dict[str, int] = {"startLine": line}
+            if column is not None:
+                region["startColumn"] = column
+            phys_loc["region"] = region
     else:
         phys_loc = {
             "artifactLocation": {"uri": library, "uriBaseId": "%SRCROOT%"},
@@ -277,19 +302,34 @@ def to_sarif(
 ) -> dict[str, Any]:
     """Convert a DiffResult to a SARIF 2.1.0 document (dict).
 
-    *severity_config*, when given, drives the invocation's ``exitCode`` /
-    ``executionSuccessful`` from the actual severity-aware gate instead of
-    inferring "passed" purely from ``result.verdict`` — compatibility and
-    "blocks CI" are independent decisions once severity configuration is in
-    play (e.g. an addition configured ``error`` blocks the build despite a
-    ``COMPATIBLE`` verdict). A ``severityGate`` properties block is added so
-    the reason is auditable in the SARIF document itself.
+    *severity_config*, when given, drives the invocation's ``exitCode`` from
+    the actual severity-aware gate instead of inferring it purely from
+    ``result.verdict`` — compatibility and "blocks CI" are independent
+    decisions once severity configuration is in play (e.g. an addition
+    configured ``error`` blocks the build despite a ``COMPATIBLE`` verdict).
+    A ``severityGate`` properties block is added so the reason is auditable
+    in the SARIF document itself.
+
+    ``executionSuccessful`` is unrelated to any of this: per the SARIF spec
+    it reports whether the *analysis tool ran to completion*, not whether it
+    found blocking issues — the spec's own example shows a successful run
+    with ``exitCode: 1`` and warnings alongside ``executionSuccessful: true``.
+    A completed comparison (breaking, gate-failing, or otherwise) is always a
+    successful execution here; gate/verdict outcome belongs solely in
+    ``exitCode``, ``exitCodeDescription``, result ``level``\\ s, and
+    ``properties.severityGate``.
     """
     tool_version = _tool_version()
 
     changes = list(result.changes)
     if show_only:
-        changes = apply_show_only(changes, show_only, policy=result.policy)
+        changes = apply_show_only(
+            changes,
+            show_only,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
 
     # Collect unique rules used
     rules_seen: dict[str, dict[str, Any]] = {}
@@ -307,13 +347,6 @@ def to_sarif(
         else None
     )
 
-    # Overall ABI verdict as a notification
-    invocation_success = (
-        severity_gate["exitCode"] == 0
-        if severity_gate is not None
-        else result.verdict != Verdict.BREAKING
-    )
-
     return {
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
         "version": "2.1.0",
@@ -329,7 +362,10 @@ def to_sarif(
                 },
                 "invocations": [
                     {
-                        "executionSuccessful": invocation_success,
+                        # Always true: this reports the SARIF tool run, which
+                        # completed. It must not encode the ABI/severity gate
+                        # outcome — see the docstring above.
+                        "executionSuccessful": True,
                         # Exit codes mirror abicheck compare CLI contract when no
                         # severity_config is given: BREAKING=4 (mapped to SARIF 1),
                         # API_BREAK=2, others=0. COMPATIBLE_WITH_RISK intentionally

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -67,7 +67,15 @@ from typing import Any
 #:       mirroring SARIF's ``severityGate`` block, so a consumer no longer
 #:       has to independently recompute "what's actually failing the build"
 #:       from ``config``/``categories``.
-REPORT_SCHEMA_VERSION = "2.3"
+#: 2.4 — added the optional per-finding ``recommended_action`` key: a
+#:       structured, machine-readable next step derived from the same
+#:       effective verdict/category resolution ``severity``/``operation``
+#:       already use — ``recompile_and_relink_required`` (BREAKING),
+#:       ``recompile_required`` (API_BREAK), ``verify_deployment_compatibility``
+#:       (COMPATIBLE_WITH_RISK), ``review_recommended`` (COMPATIBLE quality
+#:       issue), or ``no_action_required`` (COMPATIBLE addition). Additive
+#:       optional key.
+REPORT_SCHEMA_VERSION = "2.4"
 
 #: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as
 #: ``scan_schema_version`` at the top level of both public scan dict shapes:

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -54,7 +54,20 @@ from typing import Any
 #:       epistemic status (derived from its kind's intrinsic category, not
 #:       the policy-resolved verdict), or set explicitly for appcompat/
 #:       plugin-check consumer-proven findings. Additive optional key.
-REPORT_SCHEMA_VERSION = "2.2"
+#: 2.3 — three additive optional keys: per-finding ``finding_id`` (a stable,
+#:       deterministic fingerprint hashed from kind/symbol/old_value/
+#:       new_value/source_location — lets a consumer correlate the same
+#:       finding across two report runs without relying on array order) and
+#:       ``operation`` ("added"/"removed"/"modified", derived from the
+#:       kind's own suffix classification — the same one --show-only's
+#:       added/removed/changed tokens already use); and, on the top-level
+#:       ``severity`` object (only present when severity_config is active),
+#:       ``blocking`` (bool) and ``blocking_categories`` (list of category
+#:       names actually gating the exit code) — a typed gate summary
+#:       mirroring SARIF's ``severityGate`` block, so a consumer no longer
+#:       has to independently recompute "what's actually failing the build"
+#:       from ``config``/``categories``.
+REPORT_SCHEMA_VERSION = "2.3"
 
 #: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as
 #: ``scan_schema_version`` at the top level of both public scan dict shapes:

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -274,6 +274,17 @@
         "finding_id": {
           "type": "string",
           "description": "Stable, deterministic fingerprint (sha256 of kind/symbol/old_value/new_value/source_location, truncated to 16 hex chars) — lets a consumer correlate the same finding across two report runs without relying on array order. Excludes policy-derived fields (severity, evidence_status) so the same underlying finding hashes identically under any --policy."
+        },
+        "recommended_action": {
+          "type": "string",
+          "description": "Structured, machine-readable next step, derived from the same effective verdict/category resolution 'severity'/'operation' already use.",
+          "enum": [
+            "recompile_and_relink_required",
+            "recompile_required",
+            "verify_deployment_compatibility",
+            "review_recommended",
+            "no_action_required"
+          ]
         }
       }
     }

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -71,7 +71,24 @@
         "total_changes": { "type": "integer", "minimum": 0 }
       }
     },
-    "severity": { "type": "object" },
+    "severity": {
+      "type": "object",
+      "description": "Present only when --severity-* configuration was active. config/categories mirror the resolved SeverityConfig and per-category counts; blocking/blocking_categories (schema 2.3) are a typed gate summary mirroring SARIF's severityGate block.",
+      "additionalProperties": true,
+      "properties": {
+        "config": { "type": "object" },
+        "categories": { "type": "object" },
+        "exit_code": { "type": "integer", "minimum": 0 },
+        "blocking": { "type": "boolean" },
+        "blocking_categories": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["abi_breaking", "potential_breaking", "quality_issues", "addition"]
+          }
+        }
+      }
+    },
     "changes": {
       "type": "array",
       "items": { "$ref": "#/$defs/change" }
@@ -248,7 +265,16 @@
           "items": { "type": "string" }
         },
         "caused_by_type": { "type": "string" },
-        "caused_count": { "type": "integer", "minimum": 0 }
+        "caused_count": { "type": "integer", "minimum": 0 },
+        "operation": {
+          "type": "string",
+          "description": "Structured classification of the finding derived from its kind's own suffix (the same classification --show-only's added/removed/changed tokens use): 'added'/'removed' kinds map directly, everything else (parameter/type/layout changes, renames, etc.) is 'modified'.",
+          "enum": ["added", "removed", "modified"]
+        },
+        "finding_id": {
+          "type": "string",
+          "description": "Stable, deterministic fingerprint (sha256 of kind/symbol/old_value/new_value/source_location, truncated to 16 hex chars) — lets a consumer correlate the same finding across two report runs without relying on array order. Excludes policy-derived fields (severity, evidence_status) so the same underlying finding hashes identically under any --policy."
+        }
       }
     }
   }

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -74,6 +74,7 @@
     "severity": {
       "type": "object",
       "description": "Present only when --severity-* configuration was active. config/categories mirror the resolved SeverityConfig and per-category counts; blocking/blocking_categories (schema 2.3) are a typed gate summary mirroring SARIF's severityGate block.",
+      "required": ["config", "categories", "exit_code", "blocking", "blocking_categories"],
       "additionalProperties": true,
       "properties": {
         "config": { "type": "object" },

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -274,7 +274,7 @@
         },
         "finding_id": {
           "type": "string",
-          "description": "Stable, deterministic fingerprint (sha256 of kind/symbol/old_value/new_value/source_location, truncated to 16 hex chars) — lets a consumer correlate the same finding across two report runs without relying on array order. Excludes policy-derived fields (severity, evidence_status) so the same underlying finding hashes identically under any --policy."
+          "description": "Stable, deterministic fingerprint (sha256 of kind/symbol/old_value/new_value/source_location/description, truncated to 16 hex chars) — lets a consumer correlate the same finding across two report runs without relying on array order. description disambiguates otherwise-identical findings on the same symbol (e.g. the same pointer-depth change on two different parameters). Excludes policy-derived fields (severity, evidence_status) so the same underlying finding hashes identically under any --policy."
         },
         "recommended_action": {
           "type": "string",

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -1694,6 +1694,7 @@ def render_output(
             old_symbol_count=result.old_symbol_count,
             show_only=show_only,
             show_impact=show_impact,
+            severity_config=severity_config,
         )
 
     if fmt == "junit":

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -584,3 +584,113 @@ def categorize_changes(
         quality_issues=quality,
         addition=adds,
     )
+
+
+# ---------------------------------------------------------------------------
+# Formal compatibility/gate separation (architectural recommendation from the
+# post-#549/#551 reporting review)
+# ---------------------------------------------------------------------------
+
+#: The compatibility axis is already exactly ``Verdict``: NO_CHANGE/
+#: COMPATIBLE/COMPATIBLE_WITH_RISK/API_BREAK/BREAKING answer "is this ABI/API
+#: compatible?" and nothing else. This alias gives that question a name
+#: distinct from the gate question below, without introducing a second enum
+#: or touching any existing ``Verdict`` call site (purely additive — no
+#: behavior or public-API change, just a second name for callers that want
+#: to say "compatibility decision" explicitly).
+CompatibilityDecision = Verdict
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """The CI-gate outcome — a decision formally distinct from compatibility.
+
+    A :data:`CompatibilityDecision` (== ``Verdict``) answers "is this
+    ABI/API compatible?". A ``GateDecision`` answers "does this block CI?" —
+    a genuinely separate question once severity configuration is in play: an
+    addition can gate CI (``--severity-addition error``) while its
+    compatibility decision stays ``COMPATIBLE``; a breaking kind can pass CI
+    (``--severity-preset info-only``) while its compatibility decision stays
+    ``BREAKING``. Renderers should read gate status from here rather than
+    inferring it from compatibility wording — the exact confusion this type
+    was introduced to close off.
+
+    Attributes:
+        scheme: ``"legacy"`` (verdict-only exit code — no ``SeverityConfig``
+            was supplied) or ``"severity"`` (severity-aware exit code).
+        exit_code: The resolved process exit code under this scheme.
+        blocking: ``exit_code != 0``, named separately so callers don't need
+            to know the exit-code convention.
+        blocking_categories: The :class:`IssueCategory` names actually
+            responsible for a nonzero ``exit_code``. Always empty under the
+            ``"legacy"`` scheme, which has no per-category configuration to
+            single one out — legacy exit codes key off the single overall
+            verdict.
+    """
+
+    scheme: str
+    exit_code: int
+    blocking: bool
+    blocking_categories: tuple[str, ...]
+
+
+def compute_gate_decision(
+    changes: Sequence[HasKind],
+    severity_config: SeverityConfig | None,
+    *,
+    policy: str | None = None,
+    kind_sets: KindSets | None = None,
+    policy_file: object | None = None,
+    legacy_exit_code: int = 0,
+) -> GateDecision:
+    """Compute the single, canonical :class:`GateDecision` for *changes*.
+
+    Without *severity_config* the gate is the legacy verdict-based scheme:
+    the caller supplies *legacy_exit_code* (typically from
+    :func:`legacy_exit_code` or a flow-specific floor, e.g. removed-library
+    escalation) and no category can be singled out as "the" blocker.
+
+    With *severity_config*, ``exit_code`` (via :func:`compute_exit_code`)
+    and ``blocking_categories`` (via :func:`categorize_changes`) are both
+    derived from the same *changes*/*kind_sets*/*policy_file*, so they can
+    never disagree with each other the way two independently-computed
+    values could — the root cause of two real bugs this function replaces
+    the duplicated logic for: JSON's ``severity.blocking_categories``
+    disagreeing with ``exit_code`` under ``--show-only`` (it was derived
+    from the display-filtered changes instead of the unfiltered gate set),
+    and release JSON's per-library ``findings`` list missing
+    severity-gated additions (it only ever walked the legacy verdict
+    buckets). Route every gate computation through this one function
+    instead of hand-rolling the categorize-then-filter-to-error pattern
+    again.
+    """
+    if severity_config is None:
+        return GateDecision(
+            scheme="legacy",
+            exit_code=legacy_exit_code,
+            blocking=legacy_exit_code != 0,
+            blocking_categories=(),
+        )
+
+    exit_code = compute_exit_code(
+        changes, severity_config, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+    )
+    categorized = categorize_changes(
+        changes, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+    )
+    blocking_categories = tuple(
+        cat.value
+        for cat, cat_changes in (
+            (IssueCategory.ABI_BREAKING, categorized.abi_breaking),
+            (IssueCategory.POTENTIAL_BREAKING, categorized.potential_breaking),
+            (IssueCategory.QUALITY_ISSUES, categorized.quality_issues),
+            (IssueCategory.ADDITION, categorized.addition),
+        )
+        if cat_changes and severity_config.level_for(cat) == SeverityLevel.ERROR
+    )
+    return GateDecision(
+        scheme="severity",
+        exit_code=exit_code,
+        blocking=exit_code != 0,
+        blocking_categories=blocking_categories,
+    )

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -648,7 +648,20 @@ def compute_gate_decision(
     Without *severity_config* the gate is the legacy verdict-based scheme:
     the caller supplies *legacy_exit_code* (typically from
     :func:`legacy_exit_code` or a flow-specific floor, e.g. removed-library
-    escalation) and no category can be singled out as "the" blocker.
+    escalation) and no category can be singled out as "the" blocker
+    (``blocking_categories`` is always empty in this scheme — there is no
+    per-category configuration to single one out from). None of this
+    function's three current call sites (``reporter._build_severity_json``,
+    ``sarif._severity_gate_properties``, ``cli_compare_release._release_gating_buckets``)
+    actually reach this branch — each already special-cases
+    ``severity_config is None`` itself before calling in, since their
+    own legacy-scheme needs differ from an empty ``blocking_categories``
+    (e.g. ``_release_gating_buckets``'s legacy branch needs three fixed
+    *named* buckets — breaking/api_break/risk — to walk, which this
+    branch's empty tuple can't supply). The legacy branch exists so a
+    caller that only ever wants a single, uniform :class:`GateDecision`
+    regardless of scheme has one to call — see ``tests/test_severity.py``'s
+    ``TestComputeGateDecision`` for its own direct coverage.
 
     With *severity_config*, ``exit_code`` (via :func:`compute_exit_code`)
     and ``blocking_categories`` (via :func:`categorize_changes`) are both

--- a/abicheck/stack_report.py
+++ b/abicheck/stack_report.py
@@ -29,6 +29,43 @@ _VERDICT_EMOJI = {
     StackVerdict.FAIL: "❌",
 }
 
+# Cap on embedded per-library findings in stack JSON — mirrors
+# `cli_scan_baseline._MAX_BASELINE_FINDINGS`'s rationale: a large diff must
+# not blow up the always-on stack-check output, but a bare count
+# (`abi_breaking: 3`) leaves no way to tell *which* symbols broke without a
+# separate `compare` run.
+_MAX_STACK_FINDINGS_PER_LIBRARY = 10
+
+
+def _stack_finding_dicts(diff: object) -> list[dict[str, object]]:
+    """Project a library's gating findings (breaking/api_break/risk) into
+    small, capped dicts — same shape as `cli_scan_baseline._baseline_finding_dicts`.
+
+    Counts (not already-built dicts) decide the cap so a large diff never
+    builds more dicts than the cap can ever keep.
+    """
+    findings: list[dict[str, object]] = []
+    for bucket_name, bucket_changes in (
+        ("breaking", getattr(diff, "breaking", [])),
+        ("api_break", getattr(diff, "source_breaks", [])),
+        ("risk", getattr(diff, "risk", [])),
+    ):
+        remaining = _MAX_STACK_FINDINGS_PER_LIBRARY - len(findings)
+        if remaining <= 0:
+            break
+        for c in bucket_changes[:remaining]:
+            kind = getattr(c, "kind", None)
+            findings.append(
+                {
+                    "bucket": bucket_name,
+                    "kind": getattr(kind, "value", str(kind)),
+                    "symbol": getattr(c, "symbol", None),
+                    "description": getattr(c, "description", None),
+                    "source_location": getattr(c, "source_location", None),
+                }
+            )
+    return findings
+
 
 def stack_to_json(result: StackCheckResult, indent: int = 2) -> str:
     """Render a StackCheckResult as JSON."""
@@ -84,6 +121,18 @@ def stack_to_json(result: StackCheckResult, indent: int = 2) -> str:
             # Per-library confidence and evidence tiers
             if sc.abi_diff:
                 diff = sc.abi_diff
+                # Preserve the actual findings (kind/symbol/description/
+                # location), not just their counts — a stack check used to
+                # report e.g. "abi_breaking: 3" for a library with no way to
+                # tell which symbols broke without a separate `compare` run.
+                total_gating = (
+                    len(diff.breaking) + len(diff.source_breaks) + len(diff.risk)
+                )
+                stack_findings = _stack_finding_dicts(diff)
+                if stack_findings:
+                    sc_dict["findings"] = stack_findings
+                    if total_gating > _MAX_STACK_FINDINGS_PER_LIBRARY:
+                        sc_dict["findings_truncated"] = True
                 conf = getattr(diff, "confidence", None)
                 if conf is not None:
                     sc_dict["confidence"] = conf.value if hasattr(conf, "value") else str(conf)

--- a/action/run.sh
+++ b/action/run.sh
@@ -199,6 +199,17 @@ elif [[ "$MODE" == "compare" ]]; then
     CMD+=(-o "$OUTPUT_FILE")
   fi
 
+  # Render a second, always-unfiltered JSON report from this same run for the
+  # sticky PR comment (--secondary-format), instead of re-invoking abicheck a
+  # second time just to get JSON. Only needed when the primary format isn't
+  # already JSON — a json primary is reused as-is (see _can_reuse_primary_json
+  # below). compare-release/appcompat don't build CMD through this branch, so
+  # they keep using the rerun fallback.
+  if [[ "$FORMAT" != "json" ]]; then
+    PR_JSON=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-json.XXXXXX")
+    CMD+=(--secondary-format json --secondary-output "$PR_JSON")
+  fi
+
   add_single_flag "--policy" "${INPUT_POLICY:-}"
   add_single_flag "--policy-file" "${INPUT_POLICY_FILE:-}"
   add_single_flag "--suppress" "${INPUT_SUPPRESS:-}"
@@ -862,9 +873,14 @@ _maybe_post_pr_comment() {
   echo "::group::abicheck PR comment"
   # Template-based mktemp (X's at the end) — portable across GNU and BSD/macOS,
   # unlike the GNU-only --suffix option.
-  PR_JSON=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-json.XXXXXX")
+  if [[ -z "${PR_JSON:-}" ]]; then
+    PR_JSON=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-json.XXXXXX")
+  fi
   PR_BODY=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-body.XXXXXX")
-  if _can_reuse_primary_json; then
+  if [[ -s "$PR_JSON" ]]; then
+    : # Already populated by the primary run's --secondary-format (compare
+      # mode, non-json primary format) — nothing left to do.
+  elif _can_reuse_primary_json; then
     # The primary run already produced a faithful JSON report — reuse it instead
     # of re-running the whole comparison.
     cp "$OUTPUT_FILE" "$PR_JSON"

--- a/action/run.sh
+++ b/action/run.sh
@@ -65,14 +65,17 @@ add_single_flag() {
   fi
 }
 
-# A directory, or a file whose name matches a recognized package extension
-# (mirrors package.py's is_package() name-suffix check; extensionless
-# RPM/Deb detected only by magic bytes is not covered here). `compare` fans
-# such an operand out through the release engine internally regardless of
-# the Action's MODE, and the release engine rejects --secondary-format
-# (Codex review, PR #557) — used to skip the --secondary-format optimization
-# for compare mode's PR-comment JSON rather than let it hard-fail a
-# directory/package comparison that used to work.
+# A directory, a file whose name matches a recognized package extension, or
+# an extensionless RPM/Deb detected by magic bytes (mirrors package.py's
+# is_package(), including its magic-byte fallback — abicheck/package.py:547-554
+# — since classify_compare_operand() delegates to it regardless of filename;
+# a name-suffix-only check here would still let the Action add
+# --secondary-format for such an operand and have the CLI reject it, Codex
+# review, PR #557). `compare` fans such an operand out through the release
+# engine internally regardless of the Action's MODE, and the release engine
+# rejects --secondary-format — used to skip the --secondary-format
+# optimization for compare mode's PR-comment JSON rather than let it
+# hard-fail a directory/package comparison that used to work.
 _is_release_style_operand() {
   local path="$1"
   [[ -d "$path" ]] && return 0
@@ -84,6 +87,16 @@ _is_release_style_operand() {
     *.rpm | *.deb | *.tar | *.tar.gz | *.tar.xz | *.tar.bz2 | *.tar.zst | *.tgz | *.conda | *.whl)
       return 0
       ;;
+  esac
+  [[ -f "$path" ]] || return 1
+  # Extensionless RPM (0xedabeedb lead magic) / Deb (ar archive "!<arch>\n")
+  # packages — read the first 8 bytes as hex (binary-safe; a bash string
+  # would truncate at an embedded NUL) and compare.
+  local magic
+  magic=$(od -An -tx1 -N 8 "$path" 2>/dev/null | tr -d ' \n')
+  case "$magic" in
+    edabeedb*) return 0 ;;          # RPM lead magic (first 4 bytes)
+    213c617263683e0a) return 0 ;;   # "!<arch>\n" (Deb ar archive, 8 bytes)
   esac
   return 1
 }

--- a/action/run.sh
+++ b/action/run.sh
@@ -65,6 +65,29 @@ add_single_flag() {
   fi
 }
 
+# A directory, or a file whose name matches a recognized package extension
+# (mirrors package.py's is_package() name-suffix check; extensionless
+# RPM/Deb detected only by magic bytes is not covered here). `compare` fans
+# such an operand out through the release engine internally regardless of
+# the Action's MODE, and the release engine rejects --secondary-format
+# (Codex review, PR #557) — used to skip the --secondary-format optimization
+# for compare mode's PR-comment JSON rather than let it hard-fail a
+# directory/package comparison that used to work.
+_is_release_style_operand() {
+  local path="$1"
+  [[ -d "$path" ]] && return 0
+  # Portable lowercasing: ${path,,} is bash-4+ only, but this script also
+  # supports macOS's stock (GPLv2-frozen) bash 3.2 (see add_flag above).
+  local lower
+  lower=$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]')
+  case "$lower" in
+    *.rpm | *.deb | *.tar | *.tar.gz | *.tar.xz | *.tar.bz2 | *.tar.zst | *.tgz | *.conda | *.whl)
+      return 0
+      ;;
+  esac
+  return 1
+}
+
 # ---------------------------------------------------------------------------
 # Build the abicheck command
 # ---------------------------------------------------------------------------
@@ -204,8 +227,14 @@ elif [[ "$MODE" == "compare" ]]; then
   # second time just to get JSON. Only needed when the primary format isn't
   # already JSON — a json primary is reused as-is (see _can_reuse_primary_json
   # below). compare-release/appcompat don't build CMD through this branch, so
-  # they keep using the rerun fallback.
-  if [[ "$FORMAT" != "json" ]]; then
+  # they keep using the rerun fallback. MODE=compare dispatches through the
+  # same release-fan-out engine internally when the operands are directories
+  # or packages (regardless of the Action's MODE), and that engine rejects
+  # --secondary-format — skip it there too, so a directory/package compare
+  # under MODE=compare keeps working instead of hard-failing (Codex review).
+  if [[ "$FORMAT" != "json" ]] \
+     && ! _is_release_style_operand "${INPUT_OLD_LIBRARY:-}" \
+     && ! _is_release_style_operand "${INPUT_NEW_LIBRARY:-}"; then
     PR_JSON=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-json.XXXXXX")
     CMD+=(--secondary-format json --secondary-output "$PR_JSON")
   fi

--- a/action/run.sh
+++ b/action/run.sh
@@ -758,14 +758,23 @@ if [[ "${INPUT_ADD_JOB_SUMMARY:-true}" == "true" && "$MODE" != "dump" && "$MODE"
     fi
     echo ""
 
-    # If output was captured (no output-file), include it in summary
+    # If output was captured (no output-file), include it in summary. A
+    # markdown report is embedded as-is so GitHub renders its headings/
+    # tables/bold text in the step summary, instead of being wrapped in a
+    # code fence (which would make it display as literal ``` text). Every
+    # other format (json/sarif/text/review/etc.) is genuinely verbatim
+    # output, so it keeps the fence.
     if [[ -n "$ABICHECK_OUTPUT" ]]; then
       echo "<details>"
       echo "<summary>Full report</summary>"
       echo ""
-      echo '```'
-      echo "$ABICHECK_OUTPUT"
-      echo '```'
+      if [[ "${FORMAT:-markdown}" == "markdown" ]]; then
+        echo "$ABICHECK_OUTPUT"
+      else
+        echo '```'
+        echo "$ABICHECK_OUTPUT"
+        echo '```'
+      fi
       echo "</details>"
     fi
   } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/development/adr/042-compatibility-and-gate-decision-separation.md
+++ b/docs/development/adr/042-compatibility-and-gate-decision-separation.md
@@ -1,0 +1,119 @@
+# ADR-042: Formal separation of CompatibilityDecision and GateDecision
+
+## Status
+
+Accepted — implemented for the JSON/SARIF/`compare-release` gate summaries
+(`abicheck.severity.GateDecision`/`compute_gate_decision`). Other renderers
+(HTML's CI Gate card, the MCP server, JUnit) still compute an exit code
+inline via `compute_exit_code` — see "Rollout" below.
+
+## Context
+
+A post-#549/#551 reporting review found the same pattern recurring:
+independent renderers computed a report's "does this block CI?" answer from
+one code path and its "which category is actually responsible?" answer from
+a *different* code path, and the two could disagree:
+
+- JSON's `severity.blocking_categories` was derived from the (possibly
+  `--show-only`-filtered) *display* change set, while `severity.exit_code`
+  was correctly derived from the unfiltered gate set — hiding the one
+  category actually responsible for a nonzero exit code reported
+  `blocking: true` next to `blocking_categories: []`.
+- `compare-release --format json`'s per-library `findings` list only ever
+  walked the three legacy verdict buckets (breaking/api_break/risk), so a
+  library gated by `--severity-addition error` reported a nonzero
+  `severity.exit_code` with an empty `findings` list.
+
+Both bugs had the same root cause: "is this compatible?" and "does this
+block CI?" are two different questions, and the codebase had no single type
+for the second one — every caller re-derived it by categorizing changes and
+checking `severity_config.level_for(category) == ERROR` inline, with enough
+copies (`reporter._build_severity_json`, `sarif._severity_gate_properties`,
+`cli_compare_release._release_gating_buckets`) that they drifted apart.
+
+This is the same shape of problem ADR-036 solved for the *verdict axis*
+(`ReportModel`, `DiffResult._effective_verdict_for_change`) — but ADR-036's
+"canonical report severity = the verdict axis" is exactly the assumption
+this review found broken: once `SeverityConfig` is active, "blocks CI" is
+no longer a function of the verdict axis alone (an addition, verdict
+`COMPATIBLE`, can block; a breaking kind, verdict `BREAKING`, can pass under
+a demoted preset). ADR-036 remains correct for the *display/bucketing*
+question it addresses; this ADR is scoped to the *gate* question layered on
+top of it once severity configuration is in play.
+
+## Decision
+
+1. **`CompatibilityDecision` is a name, not a new type.** It is a plain
+   alias for the existing `Verdict` enum
+   (`abicheck.severity.CompatibilityDecision = Verdict`). `Verdict` already
+   answers exactly "is this ABI/API compatible?" and nothing else — ADR-036
+   already established it as the canonical axis for that question.
+   Introducing a second enum with the same five members would just be
+   another thing to keep in sync; the alias exists purely so call sites that
+   want to say "compatibility decision" explicitly can, without touching any
+   existing `Verdict` usage anywhere in the codebase (zero behavior change).
+
+2. **`GateDecision` is new** (`abicheck.severity.GateDecision`, a frozen
+   dataclass): `scheme` (`"legacy"` | `"severity"`), `exit_code`, `blocking`
+   (`exit_code != 0`), `blocking_categories` (the `IssueCategory` names
+   actually responsible — always empty under `"legacy"`, which has no
+   per-category configuration to single one out).
+
+3. **One computation function, `compute_gate_decision`**, replaces every
+   hand-rolled "categorize, then filter to `level == ERROR`" call site.
+   `exit_code` (via the existing `compute_exit_code`) and
+   `blocking_categories` (via the existing `categorize_changes`) are derived
+   from the *same* `changes`/`kind_sets`/`policy_file` arguments in one call,
+   so they cannot independently drift the way two separate call sites could.
+   `reporter._build_severity_json`, `sarif._severity_gate_properties`, and
+   `cli_compare_release._release_gating_buckets` all now call it instead of
+   reimplementing the categorize-and-filter loop.
+
+4. **Renderers should read gate status from `GateDecision`, never infer it
+   from `CompatibilityDecision`/`Verdict` wording** — a `COMPATIBLE` verdict
+   does not imply `blocking=False` once severity configuration promotes an
+   addition to `error`, and a `BREAKING` verdict does not imply
+   `blocking=True` under a demoted preset. This is the same discipline
+   ADR-036 established for the *display* axis, extended to the *gate* axis.
+
+5. **No public-API break.** `Verdict`, `DiffResult`, `compute_exit_code`,
+   and `categorize_changes` are all unchanged and still directly usable —
+   `GateDecision`/`compute_gate_decision` are additive, and `reporter.py`'s
+   `d["severity"]` / `sarif.py`'s `severityGate` JSON/SARIF shapes are
+   byte-for-byte unchanged (schema stays 2.3; this is an internal
+   implementation refactor, not a schema bump).
+
+## Consequences
+
+- The class of bug that motivated this ADR (gate exit code and blocking
+  category list computed from different inputs) is now structurally
+  prevented at the three sites that were actually affected, rather than
+  fixed one-off each time a new renderer reimplements the pattern.
+- `html_report.py`'s CI Gate card, `mcp_server.py`'s exit-code computation,
+  and `junit_report.py`'s per-change `_is_failure` still call
+  `compute_exit_code`/`classify_effective_change` directly rather than
+  `compute_gate_decision` — they only ever needed the exit code (or a
+  per-change category, not a whole-report `blocking_categories` list), so
+  there was no duplicated-computation bug to fix there. They are candidates
+  to adopt `GateDecision` for API consistency in a future pass, not because
+  they are currently wrong.
+- `compare-release`'s per-library `findings` projection
+  (`_release_gating_buckets`) needs the actual `Change` objects per blocking
+  category, not just `GateDecision`'s category names, so it calls
+  `categorize_changes` a second time to look up the change lists for the
+  categories `compute_gate_decision` names as blocking. This is a
+  deliberate, small duplication traded for keeping `GateDecision` itself
+  lean (names and counts, not full object references) — see
+  `cli_compare_release._release_gating_buckets`.
+
+## Rollout
+
+Not a phased rollout in the ADR-036 sense (no golden-snapshot risk — the
+JSON/SARIF/release-JSON shapes are unchanged). Remaining candidates to adopt
+`GateDecision` are opportunistic follow-ups, not required work:
+
+- `html_report.py`'s CI Gate card could expose `GateDecision.blocking`
+  instead of comparing `exit_code != 0` inline.
+- `mcp_server.py`'s severity-aware exit-code computation could return a
+  `GateDecision` instead of a bare int, if a future MCP tool surface wants
+  `blocking_categories` too.

--- a/docs/development/adr/index.md
+++ b/docs/development/adr/index.md
@@ -80,3 +80,4 @@ against the code as unverified, regardless of how confident it reads.
 | [039](039-build-context-reconciliation.md) | Build-Context Reconciliation of Context-Free Header-Parse Artifacts | Accepted — implemented |
 | [040](040-compare-surface-reduction.md) | `compare` Surface Reduction — Side-Aware Flags, Config Demotion, Run Profiles | Accepted — phased (Phase A landed) |
 | [041](041-compiler-facts-semantic-impact-graph.md) | Compiler-Facts Semantic Impact Graph — Roadmap and P0 Slice | Accepted — P0 slice 1 implemented |
+| [042](042-compatibility-and-gate-decision-separation.md) | Formal separation of CompatibilityDecision and GateDecision | Accepted — implemented for JSON/SARIF/compare-release gate summaries |

--- a/docs/schemas/v1/compare_report.schema.json
+++ b/docs/schemas/v1/compare_report.schema.json
@@ -71,7 +71,25 @@
         "total_changes": { "type": "integer", "minimum": 0 }
       }
     },
-    "severity": { "type": "object" },
+    "severity": {
+      "type": "object",
+      "description": "Present only when --severity-* configuration was active. config/categories mirror the resolved SeverityConfig and per-category counts; blocking/blocking_categories (schema 2.3) are a typed gate summary mirroring SARIF's severityGate block.",
+      "required": ["config", "categories", "exit_code", "blocking", "blocking_categories"],
+      "additionalProperties": true,
+      "properties": {
+        "config": { "type": "object" },
+        "categories": { "type": "object" },
+        "exit_code": { "type": "integer", "minimum": 0 },
+        "blocking": { "type": "boolean" },
+        "blocking_categories": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["abi_breaking", "potential_breaking", "quality_issues", "addition"]
+          }
+        }
+      }
+    },
     "changes": {
       "type": "array",
       "items": { "$ref": "#/$defs/change" }
@@ -248,7 +266,27 @@
           "items": { "type": "string" }
         },
         "caused_by_type": { "type": "string" },
-        "caused_count": { "type": "integer", "minimum": 0 }
+        "caused_count": { "type": "integer", "minimum": 0 },
+        "operation": {
+          "type": "string",
+          "description": "Structured classification of the finding derived from its kind's own suffix (the same classification --show-only's added/removed/changed tokens use): 'added'/'removed' kinds map directly, everything else (parameter/type/layout changes, renames, etc.) is 'modified'.",
+          "enum": ["added", "removed", "modified"]
+        },
+        "finding_id": {
+          "type": "string",
+          "description": "Stable, deterministic fingerprint (sha256 of kind/symbol/old_value/new_value/source_location/description, truncated to 16 hex chars) — lets a consumer correlate the same finding across two report runs without relying on array order. description disambiguates otherwise-identical findings on the same symbol (e.g. the same pointer-depth change on two different parameters). Excludes policy-derived fields (severity, evidence_status) so the same underlying finding hashes identically under any --policy."
+        },
+        "recommended_action": {
+          "type": "string",
+          "description": "Structured, machine-readable next step, derived from the same effective verdict/category resolution 'severity'/'operation' already use.",
+          "enum": [
+            "recompile_and_relink_required",
+            "recompile_required",
+            "verify_deployment_compatibility",
+            "review_recommended",
+            "no_action_required"
+          ]
+        }
       }
     }
   }

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -220,8 +220,9 @@ abicheck compare old.json new.json \
   --secondary-format json --secondary-output report.json
 ```
 
-- `--secondary-format` requires `--secondary-output` — writing two formats
-  to the same stream would be ambiguous.
+- `--secondary-format` and `--secondary-output` require each other — either
+  alone is rejected (passing just `--secondary-output` would otherwise
+  silently produce no secondary artifact at all).
 - `--secondary-output` must point at a different file than `--output`/`-o` —
   otherwise the secondary render would silently overwrite the primary report.
 - The secondary render always emits the full, unfiltered report: it ignores

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -206,6 +206,31 @@ interfaces each affects. Available in Markdown and HTML formats.
 abicheck compare old.json new.json --show-impact
 ```
 
+## A second output format from the same run (`--secondary-format`)
+
+`compare` computes its comparison once; `--secondary-format` renders that
+same result into a second format/file, instead of requiring a second
+`abicheck compare` invocation to get a different format:
+
+```bash
+# A markdown report for humans, plus a JSON artifact for tooling —
+# one comparison, two outputs.
+abicheck compare old.json new.json \
+  --format markdown \
+  --secondary-format json --secondary-output report.json
+```
+
+- `--secondary-format` requires `--secondary-output` — writing two formats
+  to the same stream would be ambiguous.
+- The secondary render always emits the full, unfiltered report: it ignores
+  `--show-only`/`--stat`, which describe only the primary format's display.
+- Not supported for directory/package (release) comparisons — the release
+  fan-out doesn't produce a single `DiffResult` to render twice. Compare the
+  libraries individually to use it.
+
+The bundled GitHub Action uses this to get JSON for its sticky PR comment
+without re-running the whole comparison a second time.
+
 ---
 
 ## Analysis confidence and evidence tier

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -310,6 +310,61 @@ stop?" — the two fields *can* disagree, and that's by design.
 }
 ```
 
+### Stable finding IDs and structured operation (`finding_id`, `operation`)
+
+Each finding in `changes[]` also carries:
+
+- **`operation`** — a structured `"added"` / `"removed"` / `"modified"`
+  classification, derived from the same kind-suffix rule `--show-only`'s
+  `added`/`removed`/`changed` tokens already use. Lets a consumer group or
+  filter findings by operation without hand-maintaining its own list of
+  `_added`/`_removed` kind-name suffixes.
+- **`finding_id`** — a stable, deterministic fingerprint (a truncated SHA-256
+  hash of `kind`/`symbol`/`old_value`/`new_value`/`source_location`) that
+  identifies *this finding* independent of its position in the `changes[]`
+  array. Two `compare` runs over the same underlying change produce the same
+  `finding_id`, so a consumer can correlate a finding across two report runs
+  (e.g. tracking a waiver, or diffing which findings are new between two CI
+  runs) without relying on array order or index, neither of which abicheck
+  guarantees stays stable release to release. `finding_id` deliberately
+  excludes policy-derived fields (`severity`, `evidence_status`) — the same
+  underlying finding hashes identically regardless of the active `--policy`.
+
+```json
+{
+  "kind": "func_removed",
+  "symbol": "_Z3foov",
+  "operation": "removed",
+  "finding_id": "3f2a9c8b1d4e5f60"
+}
+```
+
+### Typed gate summary (`severity.blocking`, `severity.blocking_categories`)
+
+When `--severity-*` configuration is active, the top-level `severity` object
+gets two additional fields alongside the existing `config`/`categories`/
+`exit_code`:
+
+- **`blocking`** — `true` when the severity-aware exit code is non-zero
+  (equivalent to `exit_code != 0`, provided as a named boolean so a consumer
+  doesn't have to know the exit-code convention).
+- **`blocking_categories`** — the list of category names (`abi_breaking`,
+  `potential_breaking`, `quality_issues`, `addition`) that both have findings
+  *and* are configured `error` — i.e. the categories actually responsible for
+  the non-zero exit code, mirroring SARIF's `properties.severityGate` block.
+
+```json
+{
+  "severity": {
+    "config": {"abi_breaking": "error", "potential_breaking": "warning", "quality_issues": "warning", "addition": "error"},
+    "categories": {"addition": {"severity": "error", "count": 1}},
+    "exit_code": 1,
+    "blocking": true,
+    "blocking_categories": ["addition"]
+  }
+}
+```
+
 ---
 
 ## JSON schema and stability guarantees

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -339,6 +339,29 @@ Each finding in `changes[]` also carries:
 }
 ```
 
+### Recommended action per finding (`recommended_action`)
+
+Each finding also carries a structured, machine-readable next step, derived
+from the same effective verdict/category resolution `severity`/`operation`
+already use — so it can never disagree with them for the same finding:
+
+| `recommended_action` | When | Meaning |
+|---|---|---|
+| `recompile_and_relink_required` | verdict `BREAKING` | Binary ABI break — existing compiled consumers must be recompiled *and* relinked against the new library. |
+| `recompile_required` | verdict `API_BREAK` | Source-level break only — existing compiled binaries keep working, but source recompiling against the new headers will fail. |
+| `verify_deployment_compatibility` | verdict `COMPATIBLE_WITH_RISK` | Binary-compatible, but may fail to load in some deployment environments — needs manual verification, not a recompile. |
+| `review_recommended` | verdict `COMPATIBLE`, not an addition | A quality issue (e.g. an STL type exposed by value, missing SONAME) — compatible, but worth a look. |
+| `no_action_required` | verdict `COMPATIBLE`, an addition | New public API surface — purely additive, nothing to do. |
+
+```json
+{
+  "kind": "func_removed",
+  "symbol": "_Z3foov",
+  "severity": "breaking",
+  "recommended_action": "recompile_and_relink_required"
+}
+```
+
 ### Typed gate summary (`severity.blocking`, `severity.blocking_categories`)
 
 When `--severity-*` configuration is active, the top-level `severity` object

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -348,15 +348,19 @@ Each finding in `changes[]` also carries:
   filter findings by operation without hand-maintaining its own list of
   `_added`/`_removed` kind-name suffixes.
 - **`finding_id`** — a stable, deterministic fingerprint (a truncated SHA-256
-  hash of `kind`/`symbol`/`old_value`/`new_value`/`source_location`) that
-  identifies *this finding* independent of its position in the `changes[]`
-  array. Two `compare` runs over the same underlying change produce the same
-  `finding_id`, so a consumer can correlate a finding across two report runs
-  (e.g. tracking a waiver, or diffing which findings are new between two CI
-  runs) without relying on array order or index, neither of which abicheck
-  guarantees stays stable release to release. `finding_id` deliberately
-  excludes policy-derived fields (`severity`, `evidence_status`) — the same
-  underlying finding hashes identically regardless of the active `--policy`.
+  hash of `kind`/`symbol`/`old_value`/`new_value`/`source_location`/
+  `description`) that identifies *this finding* independent of its position
+  in the `changes[]` array. Two `compare` runs over the same underlying
+  change produce the same `finding_id`, so a consumer can correlate a
+  finding across two report runs (e.g. tracking a waiver, or diffing which
+  findings are new between two CI runs) without relying on array order or
+  index, neither of which abicheck guarantees stays stable release to
+  release. `description` is included specifically to disambiguate two
+  otherwise-identical findings on the same symbol (e.g. the same
+  pointer-depth change reported on two different parameters of one
+  function). `finding_id` deliberately excludes policy-derived fields
+  (`severity`, `evidence_status`) — the same underlying finding hashes
+  identically regardless of the active `--policy`.
 
 ```json
 {

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -222,6 +222,8 @@ abicheck compare old.json new.json \
 
 - `--secondary-format` requires `--secondary-output` — writing two formats
   to the same stream would be ambiguous.
+- `--secondary-output` must point at a different file than `--output`/`-o` —
+  otherwise the secondary render would silently overwrite the primary report.
 - The secondary render always emits the full, unfiltered report: it ignores
   `--show-only`/`--stat`, which describe only the primary format's display.
 - Not supported for directory/package (release) comparisons — the release

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -199,6 +199,7 @@ nav:
       - "039: Build-Context Reconciliation": development/adr/039-build-context-reconciliation.md
       - "040: compare Surface Reduction": development/adr/040-compare-surface-reduction.md
       - "041: Compiler-Facts Semantic Impact Graph": development/adr/041-compiler-facts-semantic-impact-graph.md
+      - "042: CompatibilityDecision/GateDecision Separation": development/adr/042-compatibility-and-gate-decision-separation.md
 
 # Agent instructions are repo-internal context, not published documentation.
 exclude_docs: |

--- a/tests/golden/html_template/main_report.html
+++ b/tests/golden/html_template/main_report.html
@@ -84,7 +84,7 @@ footer { margin: 20px 32px 32px; padding: 12px 16px; font-size: 0.8em;
 </div>
 
 <div class="verdict-box" style="background:#ffcdd2; color:#b71c1c; border-left:6px solid #b71c1c;">
-  <h2>🔴 Verdict: BREAKING</h2>
+  <h2>🔴 Compatibility: BREAKING</h2>
   <div class="bc-metric">
     Binary Compatibility: <strong>50.0%</strong>
     <span style="font-size:0.82em; opacity:0.75">
@@ -98,6 +98,7 @@ footer { margin: 20px 32px 32px; padding: 12px 16px; font-size: 0.8em;
     </span>
   </div>
 </div>
+
 
 
 <div class='nav'><a href='#removed' class='breaking'>⛔ Removed (1)</a><a href='#added' class='added'>✅ Added (1)</a></div>

--- a/tests/test_action_run_sh_helpers.py
+++ b/tests/test_action_run_sh_helpers.py
@@ -223,3 +223,27 @@ class TestIsReleaseStyleOperand:
         # extension by name — the required-args guard in run.sh catches a
         # genuinely missing operand before this check ever runs.
         assert not _run_predicate('_is_release_style_operand "/no/such/path.so"')
+
+    def test_extensionless_rpm_detected_by_magic_bytes(self, tmp_path) -> None:
+        # abicheck/package.py:is_package() classifies an extensionless RPM by
+        # its lead magic (0xedabeedb) regardless of filename — the Action's
+        # name-suffix-only precheck missed this, so it would still add
+        # --secondary-format for an operand the CLI goes on to reject
+        # (Codex review, PR #557).
+        f = tmp_path / "libfoo-release"
+        f.write_bytes(b"\xed\xab\xee\xdb\x00\x00\x03\x00" + b"\x00" * 90)
+        assert _run_predicate(f'_is_release_style_operand "{f}"')
+
+    def test_extensionless_deb_detected_by_magic_bytes(self, tmp_path) -> None:
+        # Deb packages are ar archives ("!<arch>\n" magic) — also detected
+        # without a .deb extension by package.py's is_package().
+        f = tmp_path / "libfoo-release"
+        f.write_bytes(b"!<arch>\n" + b"\x00" * 90)
+        assert _run_predicate(f'_is_release_style_operand "{f}"')
+
+    def test_extensionless_plain_binary_not_release_style(self, tmp_path) -> None:
+        # A real shared library's ELF magic (0x7f 'ELF') must not be
+        # mistaken for RPM/Deb.
+        f = tmp_path / "libfoo.so.1"
+        f.write_bytes(b"\x7fELF" + b"\x00" * 92)
+        assert not _run_predicate(f'_is_release_style_operand "{f}"')

--- a/tests/test_action_run_sh_helpers.py
+++ b/tests/test_action_run_sh_helpers.py
@@ -121,6 +121,26 @@ def _cmd_items(stdout: str) -> list[str]:
     return [item for item in stdout.split("\x1f") if item]
 
 
+def _run_predicate(call: str) -> bool:
+    """Source the real helper functions and evaluate a boolean-returning call
+    (e.g. an ``_is_release_style_operand "path"`` invocation), returning
+    whether it exited zero (true) or non-zero (false)."""
+    script = _helpers_region() + f"\nif {call}; then exit 0; else exit 1; fi\n"
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".sh", delete=False, encoding="utf-8", newline="\n",
+    ) as f:
+        f.write(script)
+        script_path = f.name
+    try:
+        result = subprocess.run(
+            [_bash_executable(), script_path],
+            capture_output=True, text=True, encoding="utf-8",
+        )
+    finally:
+        os.unlink(script_path)
+    return result.returncode == 0
+
+
 @pytest.mark.skipif(not RUN_SH.is_file(), reason="action/run.sh not found")
 class TestAddFlagSplitting:
     def test_legacy_space_separated_single_line(self) -> None:
@@ -160,3 +180,46 @@ class TestAddSidedFlagSplitting:
         assert _cmd_items(out) == [
             "--header", "new=inc/a", "--header", "new=path with spaces/inc",
         ]
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="action/run.sh not found")
+class TestIsReleaseStyleOperand:
+    """``compare`` mode now skips its --secondary-format optimization for
+    directory/package operands, since the release fan-out engine rejects
+    that flag — verified defect: it previously hard-failed a working
+    directory/package compare under MODE=compare (Codex review, PR #557)."""
+
+    def test_directory_is_release_style(self, tmp_path) -> None:
+        d = tmp_path / "libdir"
+        d.mkdir()
+        assert _run_predicate(f'_is_release_style_operand "{d}"')
+
+    def test_plain_file_is_not_release_style(self, tmp_path) -> None:
+        f = tmp_path / "libfoo.so.1"
+        f.write_text("", encoding="utf-8")
+        assert not _run_predicate(f'_is_release_style_operand "{f}"')
+
+    def test_json_snapshot_is_not_release_style(self, tmp_path) -> None:
+        f = tmp_path / "snapshot.json"
+        f.write_text("{}", encoding="utf-8")
+        assert not _run_predicate(f'_is_release_style_operand "{f}"')
+
+    @pytest.mark.parametrize("suffix", [
+        ".rpm", ".deb", ".tar", ".tar.gz", ".tar.xz", ".tar.bz2", ".tar.zst",
+        ".tgz", ".conda", ".whl",
+    ])
+    def test_package_extensions_are_release_style(self, tmp_path, suffix) -> None:
+        f = tmp_path / f"libfoo{suffix}"
+        f.write_text("", encoding="utf-8")
+        assert _run_predicate(f'_is_release_style_operand "{f}"')
+
+    def test_package_extension_matched_case_insensitively(self, tmp_path) -> None:
+        f = tmp_path / "libfoo.RPM"
+        f.write_text("", encoding="utf-8")
+        assert _run_predicate(f'_is_release_style_operand "{f}"')
+
+    def test_missing_path_is_not_release_style(self) -> None:
+        # A nonexistent path isn't a directory and doesn't match a package
+        # extension by name — the required-args guard in run.sh catches a
+        # genuinely missing operand before this check ever runs.
+        assert not _run_predicate('_is_release_style_operand "/no/such/path.so"')

--- a/tests/test_action_run_sh_pr_json.py
+++ b/tests/test_action_run_sh_pr_json.py
@@ -80,20 +80,29 @@ def _bash_executable() -> str:
     return "bash"
 
 
-def _run(harness: str) -> None:
+def _run(harness: str, env_extra: dict[str, str] | None = None) -> None:
     """Run the extracted function defs, then *harness* (which sets up
     PR_JSON/FORMAT/OUTPUT_FILE/CMD), then the extracted acquisition fragment
-    that consumes them — harness must execute before the fragment runs."""
+    that consumes them — harness must execute before the fragment runs.
+
+    *harness* should reference any filesystem paths via environment variable
+    expansion (e.g. ``PR_JSON="$TEST_PR_JSON"``) rather than embedding a
+    ``pathlib.Path``'s text directly — on Windows those paths use backslash
+    separators, and an unquoted or literal backslash embedded in a bash
+    script is an escape character (``\\a`` etc.), silently corrupting the
+    path. Passing paths through ``env`` instead sidesteps that entirely.
+    """
     script = _funcs_region() + "\n" + harness + "\n" + _fragment_region()
     with tempfile.NamedTemporaryFile(
         "w", suffix=".sh", delete=False, encoding="utf-8", newline="\n",
     ) as f:
         f.write(script)
         script_path = f.name
+    env = dict(os.environ, **(env_extra or {}))
     try:
         result = subprocess.run(
             [_bash_executable(), script_path],
-            capture_output=True, text=True, encoding="utf-8",
+            capture_output=True, text=True, encoding="utf-8", env=env,
         )
     finally:
         os.unlink(script_path)
@@ -114,13 +123,13 @@ class TestPrJsonAcquisition:
         pr_json.write_text('{"source": "secondary-format"}', encoding="utf-8")
         output_file = tmp_path / "primary.json"
         output_file.write_text('{"source": "primary-output-file"}', encoding="utf-8")
-        harness = f"""
-PR_JSON={pr_json}
-FORMAT=json
-OUTPUT_FILE={output_file}
-CMD=(abicheck compare old.json new.json --format json -o {output_file})
+        harness = """
+PR_JSON="$TEST_PR_JSON"
+FORMAT=markdown
+OUTPUT_FILE="$TEST_OUTPUT_FILE"
+CMD=(abicheck compare old.json new.json --format markdown -o "$TEST_OUTPUT_FILE")
 """
-        _run(harness)
+        _run(harness, {"TEST_PR_JSON": str(pr_json), "TEST_OUTPUT_FILE": str(output_file)})
         assert pr_json.read_text(encoding="utf-8") == '{"source": "secondary-format"}'
 
     def test_falls_back_to_reuse_when_pr_json_empty_and_format_json(self, tmp_path):
@@ -132,32 +141,37 @@ CMD=(abicheck compare old.json new.json --format json -o {output_file})
         pr_json.write_text("", encoding="utf-8")
         output_file = tmp_path / "primary.json"
         output_file.write_text('{"source": "primary-output-file"}', encoding="utf-8")
-        harness = f"""
-PR_JSON={pr_json}
+        harness = """
+PR_JSON="$TEST_PR_JSON"
 FORMAT=json
-OUTPUT_FILE={output_file}
-CMD=(abicheck compare old.json new.json --format json -o {output_file})
+OUTPUT_FILE="$TEST_OUTPUT_FILE"
+CMD=(abicheck compare old.json new.json --format json -o "$TEST_OUTPUT_FILE")
 """
-        _run(harness)
+        _run(harness, {"TEST_PR_JSON": str(pr_json), "TEST_OUTPUT_FILE": str(output_file)})
         assert pr_json.read_text(encoding="utf-8") == '{"source": "primary-output-file"}'
 
     def test_falls_back_to_rerun_when_pr_json_empty_and_not_reusable(self, tmp_path):
         # FORMAT isn't json (or --show-only/--stat is present) and PR_JSON
         # wasn't pre-populated — falls all the way through to _build_json_cmd
-        # and a rerun. Stub CMD[0] as a script that writes a sentinel to its
-        # last argument (where _build_json_cmd appends "-o $PR_JSON") so the
-        # rerun's execution is directly observable.
+        # and a rerun. Stub CMD[0]/[1] as `$TEST_BASH $TEST_STUB` — the same
+        # resolved bash the harness itself uses (a bare "bash" can resolve to
+        # Windows' non-functional WSL stub, see _bash_executable) running a
+        # script with no shebang/executable-bit dependency — that writes a
+        # sentinel to its last argument (where _build_json_cmd appends
+        # "-o $PR_JSON") so the rerun's execution is directly observable.
         pr_json = tmp_path / "pr.json"
         pr_json.write_text("", encoding="utf-8")
         stub = tmp_path / "stub.sh"
-        stub.write_text('#!/bin/bash\necho rerun-sentinel > "${@: -1}"\n',
-                         encoding="utf-8")
-        stub.chmod(0o755)
-        harness = f"""
-PR_JSON={pr_json}
+        stub.write_text('echo rerun-sentinel > "${@: -1}"\n', encoding="utf-8")
+        harness = """
+PR_JSON="$TEST_PR_JSON"
 FORMAT=markdown
 OUTPUT_FILE=
-CMD=({stub} compare old.json new.json --show-only added --format markdown)
+CMD=("$TEST_BASH" "$TEST_STUB" compare old.json new.json --show-only added --format markdown)
 """
-        _run(harness)
+        _run(harness, {
+            "TEST_PR_JSON": str(pr_json),
+            "TEST_STUB": str(stub),
+            "TEST_BASH": _bash_executable(),
+        })
         assert pr_json.read_text(encoding="utf-8").strip() == "rerun-sentinel"

--- a/tests/test_action_run_sh_pr_json.py
+++ b/tests/test_action_run_sh_pr_json.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for ``action/run.sh``'s sticky-PR-comment JSON acquisition.
+
+``compare`` mode now renders its PR-comment JSON as a second format from the
+*same* comparison run (``--secondary-format json --secondary-output``,
+abicheck's own ``--secondary-format`` CLI feature) instead of re-invoking
+abicheck a second time. This exercises the acquisition decision in
+``_maybe_post_pr_comment`` (extracted verbatim from run.sh, the same "parse
+the real file, don't hand-copy it" discipline as
+``test_action_run_sh_helpers.py``):
+
+- If ``PR_JSON`` was already populated by the primary run (compare mode, a
+  non-json primary format), it's used as-is — no copy, no rerun.
+- Otherwise (compare-release/appcompat, which don't build CMD with
+  --secondary-format), the original reuse-if-json-else-rerun logic applies
+  unchanged.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+RUN_SH = Path(__file__).resolve().parents[1] / "action" / "run.sh"
+_FUNCS_START_MARKER = "_can_reuse_primary_json() {"
+_FUNCS_END_MARKER = "_maybe_post_pr_comment() {"
+_FRAGMENT_START_MARKER = 'echo "::group::abicheck PR comment"'
+_FRAGMENT_END_MARKER = '"${PR_CMD_JSON[@]}" >/dev/null 2>/dev/null || true\n  fi'
+
+
+def _funcs_region() -> str:
+    """``_can_reuse_primary_json``/``_build_json_cmd`` — self-contained,
+    balanced function defs, extracted verbatim from run.sh."""
+    text = RUN_SH.read_text(encoding="utf-8")
+    return text[text.index(_FUNCS_START_MARKER):text.index(_FUNCS_END_MARKER)]
+
+
+def _fragment_region() -> str:
+    """The JSON-acquisition if/elif/else from inside ``_maybe_post_pr_comment``
+    (balanced on its own) — extracted verbatim from run.sh, without the
+    enclosing function's opening brace so it parses as standalone top-level
+    statements instead of an unclosed function body."""
+    text = RUN_SH.read_text(encoding="utf-8")
+    start = text.index(_FRAGMENT_START_MARKER)
+    end = text.index(_FRAGMENT_END_MARKER, start) + len(_FRAGMENT_END_MARKER)
+    return text[start:end]
+
+
+def _bash_executable() -> str:
+    """Resolve a real bash, bypassing Windows' WSL-launcher stub.
+
+    See ``test_action_run_sh_helpers._bash_executable`` for the full
+    rationale (GitHub windows-latest runners resolve a bare "bash" to a
+    non-functional WSL stub ahead of Git for Windows' real bash).
+    """
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
+def _run(harness: str) -> None:
+    """Run the extracted function defs, then *harness* (which sets up
+    PR_JSON/FORMAT/OUTPUT_FILE/CMD), then the extracted acquisition fragment
+    that consumes them — harness must execute before the fragment runs."""
+    script = _funcs_region() + "\n" + harness + "\n" + _fragment_region()
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".sh", delete=False, encoding="utf-8", newline="\n",
+    ) as f:
+        f.write(script)
+        script_path = f.name
+    try:
+        result = subprocess.run(
+            [_bash_executable(), script_path],
+            capture_output=True, text=True, encoding="utf-8",
+        )
+    finally:
+        os.unlink(script_path)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"harness script failed (exit {result.returncode})\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )
+
+
+class TestPrJsonAcquisition:
+    def test_prepopulated_pr_json_is_left_untouched(self, tmp_path):
+        # Simulates compare mode with a non-json primary format: PR_JSON was
+        # already written by the primary run's --secondary-format, so the
+        # acquisition block must not overwrite it via cp or a rerun.
+        pr_json = tmp_path / "pr.json"
+        pr_json.write_text('{"source": "secondary-format"}', encoding="utf-8")
+        output_file = tmp_path / "primary.json"
+        output_file.write_text('{"source": "primary-output-file"}', encoding="utf-8")
+        harness = f"""
+PR_JSON={pr_json}
+FORMAT=json
+OUTPUT_FILE={output_file}
+CMD=(abicheck compare old.json new.json --format json -o {output_file})
+"""
+        _run(harness)
+        assert pr_json.read_text(encoding="utf-8") == '{"source": "secondary-format"}'
+
+    def test_falls_back_to_reuse_when_pr_json_empty_and_format_json(self, tmp_path):
+        # Simulates compare-release/appcompat (which never populate PR_JSON
+        # up front): FORMAT is json, OUTPUT_FILE is a faithful unfiltered
+        # report, and no --show-only/--stat is present, so the primary
+        # output file is reused instead of rerunning.
+        pr_json = tmp_path / "pr.json"
+        pr_json.write_text("", encoding="utf-8")
+        output_file = tmp_path / "primary.json"
+        output_file.write_text('{"source": "primary-output-file"}', encoding="utf-8")
+        harness = f"""
+PR_JSON={pr_json}
+FORMAT=json
+OUTPUT_FILE={output_file}
+CMD=(abicheck compare old.json new.json --format json -o {output_file})
+"""
+        _run(harness)
+        assert pr_json.read_text(encoding="utf-8") == '{"source": "primary-output-file"}'
+
+    def test_falls_back_to_rerun_when_pr_json_empty_and_not_reusable(self, tmp_path):
+        # FORMAT isn't json (or --show-only/--stat is present) and PR_JSON
+        # wasn't pre-populated — falls all the way through to _build_json_cmd
+        # and a rerun. Stub CMD[0] as a script that writes a sentinel to its
+        # last argument (where _build_json_cmd appends "-o $PR_JSON") so the
+        # rerun's execution is directly observable.
+        pr_json = tmp_path / "pr.json"
+        pr_json.write_text("", encoding="utf-8")
+        stub = tmp_path / "stub.sh"
+        stub.write_text('#!/bin/bash\necho rerun-sentinel > "${@: -1}"\n',
+                         encoding="utf-8")
+        stub.chmod(0o755)
+        harness = f"""
+PR_JSON={pr_json}
+FORMAT=markdown
+OUTPUT_FILE=
+CMD=({stub} compare old.json new.json --show-only added --format markdown)
+"""
+        _run(harness)
+        assert pr_json.read_text(encoding="utf-8").strip() == "rerun-sentinel"

--- a/tests/test_action_run_sh_summary.py
+++ b/tests/test_action_run_sh_summary.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral test for ``action/run.sh``'s step-summary "Full report" block.
+
+Verified defect: the block unconditionally wrapped ``$ABICHECK_OUTPUT`` in a
+```` ``` ```` code fence, so a markdown-format report rendered as a literal
+code block in the GitHub Actions job summary instead of formatted Markdown
+(headings/tables/bold text). Extracts the real snippet from ``run.sh`` (the
+same "parse the real file, don't hand-copy it" discipline as
+``test_action_run_sh_helpers.py``) so a future edit to the real logic is
+exercised here too, not a stale copy.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+RUN_SH = Path(__file__).resolve().parents[1] / "action" / "run.sh"
+_START_MARKER = "# If output was captured"
+_END_MARKER = 'echo "</details>"\n    fi'
+
+
+def _summary_fence_region() -> str:
+    """The "Full report" step-summary snippet, extracted verbatim from run.sh.
+
+    Includes the trailing ``fi`` that closes the outer
+    ``if [[ -n "$ABICHECK_OUTPUT" ]]; then`` — without it the extracted
+    snippet is unbalanced and fails to parse as a standalone script.
+    """
+    text = RUN_SH.read_text(encoding="utf-8")
+    start = text.index(_START_MARKER)
+    end = text.index(_END_MARKER, start) + len(_END_MARKER)
+    return text[start:end]
+
+
+def _bash_executable() -> str:
+    """Resolve a real bash, bypassing Windows' WSL-launcher stub.
+
+    See ``test_action_run_sh_helpers._bash_executable`` for the full
+    rationale (GitHub windows-latest runners resolve a bare "bash" to a
+    non-functional WSL stub ahead of Git for Windows' real bash).
+    """
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
+def _run(fmt: str, output: str) -> str:
+    """Run the extracted snippet with FORMAT/ABICHECK_OUTPUT set, return stdout.
+
+    Values are passed via the subprocess environment (not embedded in the
+    script text) so no shell-quoting of arbitrary content is needed.
+    """
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".sh", delete=False, encoding="utf-8", newline="\n",
+    ) as f:
+        f.write(_summary_fence_region())
+        script_path = f.name
+    env = dict(os.environ, FORMAT=fmt, ABICHECK_OUTPUT=output)
+    try:
+        result = subprocess.run(
+            [_bash_executable(), script_path],
+            capture_output=True, text=True, encoding="utf-8", env=env,
+        )
+    finally:
+        os.unlink(script_path)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"harness script failed (exit {result.returncode})\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )
+    return result.stdout
+
+
+class TestStepSummaryFullReportFencing:
+    def test_markdown_format_not_fenced(self) -> None:
+        out = _run("markdown", "# Report\n\nSome **bold** text and a table.")
+        assert "```" not in out
+        assert "# Report" in out
+        assert "Some **bold** text" in out
+
+    def test_markdown_default_not_fenced(self) -> None:
+        """FORMAT unset (empty string) falls back to the markdown default."""
+        out = _run("", "# Report\n\nDefault format.")
+        assert "```" not in out
+
+    def test_json_format_still_fenced(self) -> None:
+        out = _run("json", '{"verdict": "COMPATIBLE"}')
+        assert "```" in out
+        assert '{"verdict": "COMPATIBLE"}' in out
+
+    def test_sarif_format_still_fenced(self) -> None:
+        out = _run("sarif", '{"$schema": "sarif"}')
+        assert "```" in out
+
+    def test_text_format_still_fenced(self) -> None:
+        out = _run("text", "Verdict: COMPATIBLE")
+        assert "```" in out

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -677,6 +677,27 @@ class TestSeverityConfigAwareAnnotations:
         _sort_key, line = annotations[0]
         assert "title=ABI Addition%3A func_added" in line
 
+    def test_potential_breaking_title_honours_effective_verdict_override(self):
+        """A raw-risk-set kind (SYMBOL_VERSION_REQUIRED_ADDED) whose
+        `effective_verdict` is overridden to API_BREAK must get an "API
+        Break" title, not "Deployment Risk" — the label raw kind-set
+        membership alone would produce, contradicting the override
+        (CodeRabbit review, PR #557)."""
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(
+            ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED, "f", "version req added",
+        )
+        c.effective_verdict = Verdict.API_BREAK
+        result = _result(Verdict.API_BREAK, [c])
+        cfg = resolve_severity_config("default", potential_breaking="error")
+
+        annotations = collect_annotations(result, severity_config=cfg)
+        assert len(annotations) == 1
+        _sort_key, line = annotations[0]
+        assert "title=API Break%3A symbol_version_required_added" in line
+        assert "Deployment Risk" not in line
+
     def test_frozen_namespace_floor_honoured_under_policy_override(self):
         """A policy-file override that demotes FUNC_REMOVED to COMPATIBLE must
         not silently downgrade a finding tagged frozen_namespace_violation —

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -259,7 +259,10 @@ class TestAppCompatResultVerdict:
 # ---------------------------------------------------------------------------
 
 class TestAppCompatReporters:
-    def _make_result(self, *, missing=None, breaking=None, irrelevant=None, verdict=None):
+    def _make_result(
+        self, *, missing=None, breaking=None, irrelevant=None, verdict=None,
+        policy_file=None,
+    ):
         return AppCompatResult(
             app_path="/usr/bin/myapp",
             old_lib_path="libfoo.so.1",
@@ -274,6 +277,7 @@ class TestAppCompatReporters:
                 old_version="1.0",
                 new_version="2.0",
                 library="libfoo",
+                policy_file=policy_file,
             ),
             verdict=verdict or Verdict.COMPATIBLE,
             symbol_coverage=100.0,
@@ -369,6 +373,22 @@ class TestAppCompatReporters:
         result = self._make_result(breaking=[change])
         data = json.loads(appcompat_to_json(result))
         assert data["relevant_changes"][0]["evidence_status"] == "consumer_proven"
+
+    def test_json_relevant_change_severity_honours_policy_file_override(self):
+        """A PolicyFile override on full_diff must be reflected in each
+        relevant_changes[].severity — verified defect: appcompat_to_json
+        never threaded kind_sets/policy_file into _change_to_dict, so a
+        finding's severity here could contradict full_library_verdict
+        (which does honour the override via full_diff.verdict/policy_file)."""
+        from abicheck.policy_file import PolicyFile
+
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED, symbol="foo_init", description="removed",
+        )
+        pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE})
+        result = self._make_result(breaking=[change], policy_file=pf)
+        data = json.loads(appcompat_to_json(result))
+        assert data["relevant_changes"][0]["severity"] == "compatible"
 
     def test_markdown_weak_mode(self):
         result = AppCompatResult(

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -594,6 +594,8 @@ _OPTION_SET_SNAPSHOT: dict[str, tuple[str, ...]] = {
         "--require-justification",
         "--scope-public-headers",
         "--search-path",
+        "--secondary-format",
+        "--secondary-output",
         "--severity-abi-breaking",
         "--severity-addition",
         "--severity-potential-breaking",

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -229,6 +229,20 @@ class TestCompareSecondaryFormat:
         assert result.exit_code == 64
         assert "--secondary-format requires --secondary-output" in result.output
 
+    def test_secondary_output_rejects_same_path_as_primary(self, tmp_path):
+        # Writing both formats to the same file would silently overwrite the
+        # primary report with the secondary one (Codex review, PR #557).
+        old_p, new_p = _write_snapshots(tmp_path)
+        same_path = tmp_path / "report"
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--format", "markdown",
+            "-o", str(same_path),
+            "--secondary-format", "json", "--secondary-output", str(same_path),
+        ])
+        assert result.exit_code == 64
+        assert "--secondary-output must differ from --output/-o" in result.output
+
 
 # ── compare with suppression ────────────────────────────────────────────
 

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -237,6 +237,24 @@ class TestCompareSecondaryFormat:
         assert "leaf_changes" not in parsed
         assert parsed["changes"]
 
+    def test_secondary_format_resolves_own_demangle_default(self, tmp_path):
+        # demangle is resolved per-format (markdown/review default ON, json/
+        # sarif/html/junit default OFF) — a machine primary format (json)
+        # must not force demangle=False onto a markdown/review secondary
+        # render just because that's the primary's own default
+        # (Codex review, PR #557).
+        old_p, new_p = _breaking_snapshots(tmp_path)
+        secondary_out = tmp_path / "secondary.md"
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--format", "json",
+            "--secondary-format", "markdown", "--secondary-output", str(secondary_out),
+        ])
+        assert result.exit_code == 4
+        secondary_text = secondary_out.read_text(encoding="utf-8")
+        assert "_Z3barv" not in secondary_text
+        assert "bar" in secondary_text
+
     def test_secondary_format_requires_secondary_output(self, tmp_path):
         old_p, new_p = _write_snapshots(tmp_path)
         runner = CliRunner()

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -188,6 +188,48 @@ class TestCompareHtml:
         assert "<html" in result.output.lower()
 
 
+# ── compare --secondary-format/--secondary-output ───────────────────────
+
+class TestCompareSecondaryFormat:
+    def test_writes_second_format_from_same_run(self, tmp_path):
+        old_p, new_p = _breaking_snapshots(tmp_path)
+        secondary_out = tmp_path / "secondary.json"
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--format", "markdown",
+            "--secondary-format", "json", "--secondary-output", str(secondary_out),
+        ])
+        assert result.exit_code == 4
+        assert "# ABI Report" in result.output
+        parsed = json.loads(secondary_out.read_text(encoding="utf-8"))
+        assert parsed["verdict"] == "BREAKING"
+
+    def test_secondary_format_ignores_show_only_filter(self, tmp_path):
+        # The secondary render always emits the full, unfiltered report even
+        # when the primary format's --show-only narrows the display.
+        old_p, new_p = _breaking_snapshots(tmp_path)
+        secondary_out = tmp_path / "secondary.json"
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--format", "markdown",
+            "--show-only", "added",
+            "--secondary-format", "json", "--secondary-output", str(secondary_out),
+        ])
+        assert result.exit_code == 4
+        parsed = json.loads(secondary_out.read_text(encoding="utf-8"))
+        assert parsed["changes"]
+
+    def test_secondary_format_requires_secondary_output(self, tmp_path):
+        old_p, new_p = _write_snapshots(tmp_path)
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--format", "markdown",
+            "--secondary-format", "json",
+        ])
+        assert result.exit_code == 64
+        assert "--secondary-format requires --secondary-output" in result.output
+
+
 # ── compare with suppression ────────────────────────────────────────────
 
 class TestCompareSuppression:

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -188,6 +188,28 @@ class TestCompareHtml:
         assert "<html" in result.output.lower()
 
 
+# ── _resolve_demangle (shared by primary and --secondary-format renders) ──
+
+class TestResolveDemangle:
+    def test_defaults_on_for_markdown_and_review(self):
+        from abicheck.cli_compare_helpers import _resolve_demangle
+
+        assert _resolve_demangle("markdown", None) is True
+        assert _resolve_demangle("review", None) is True
+
+    def test_defaults_off_for_machine_formats_and_html(self):
+        from abicheck.cli_compare_helpers import _resolve_demangle
+
+        for fmt in ("json", "sarif", "junit", "html"):
+            assert _resolve_demangle(fmt, None) is False
+
+    def test_explicit_flag_always_wins(self):
+        from abicheck.cli_compare_helpers import _resolve_demangle
+
+        assert _resolve_demangle("json", True) is True
+        assert _resolve_demangle("markdown", False) is False
+
+
 # ── compare --secondary-format/--secondary-output ───────────────────────
 
 class TestCompareSecondaryFormat:

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from abicheck.cli import main
@@ -197,11 +198,11 @@ class TestResolveDemangle:
         assert _resolve_demangle("markdown", None) is True
         assert _resolve_demangle("review", None) is True
 
-    def test_defaults_off_for_machine_formats_and_html(self):
+    @pytest.mark.parametrize("fmt", ["json", "sarif", "junit", "html"])
+    def test_defaults_off_for_machine_formats_and_html(self, fmt):
         from abicheck.cli_compare_helpers import _resolve_demangle
 
-        for fmt in ("json", "sarif", "junit", "html"):
-            assert _resolve_demangle(fmt, None) is False
+        assert _resolve_demangle(fmt, None) is False
 
     def test_explicit_flag_always_wins(self):
         from abicheck.cli_compare_helpers import _resolve_demangle

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -219,6 +219,24 @@ class TestCompareSecondaryFormat:
         parsed = json.loads(secondary_out.read_text(encoding="utf-8"))
         assert parsed["changes"]
 
+    def test_secondary_format_ignores_primary_report_mode(self, tmp_path):
+        # The secondary render always uses report_mode="full", not the
+        # primary's --report-mode leaf — a --secondary-format consumer
+        # expects the same full shape regardless of how the primary format
+        # groups its own display (Codex review, PR #557).
+        old_p, new_p = _breaking_snapshots(tmp_path)
+        secondary_out = tmp_path / "secondary.json"
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--format", "markdown",
+            "--report-mode", "leaf",
+            "--secondary-format", "json", "--secondary-output", str(secondary_out),
+        ])
+        assert result.exit_code == 4
+        parsed = json.loads(secondary_out.read_text(encoding="utf-8"))
+        assert "leaf_changes" not in parsed
+        assert parsed["changes"]
+
     def test_secondary_format_requires_secondary_output(self, tmp_path):
         old_p, new_p = _write_snapshots(tmp_path)
         runner = CliRunner()

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -229,6 +229,20 @@ class TestCompareSecondaryFormat:
         assert result.exit_code == 64
         assert "--secondary-format requires --secondary-output" in result.output
 
+    def test_secondary_output_requires_secondary_format(self, tmp_path):
+        # Passing --secondary-output alone would otherwise be silently
+        # ignored — no secondary artifact, no error (Codex review, PR #557).
+        old_p, new_p = _write_snapshots(tmp_path)
+        secondary_out = tmp_path / "secondary.json"
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--format", "markdown",
+            "--secondary-output", str(secondary_out),
+        ])
+        assert result.exit_code == 64
+        assert "--secondary-output requires --secondary-format" in result.output
+        assert not secondary_out.exists()
+
     def test_secondary_output_rejects_same_path_as_primary(self, tmp_path):
         # Writing both formats to the same file would silently overwrite the
         # primary report with the secondary one (Codex review, PR #557).

--- a/tests/test_compare_dispatch.py
+++ b/tests/test_compare_dispatch.py
@@ -644,6 +644,22 @@ class TestCompareDispatch:
         assert code != 0
         assert "--exit-code-scheme is not supported" in (out + err)
 
+    def test_secondary_format_rejected_on_set_inputs(self, tmp_path: Path) -> None:
+        # --secondary-format reuses the single comparison's DiffResult, which
+        # doesn't exist as a single object across the release fan-out.
+        old_dir = tmp_path / "old"
+        new_dir = tmp_path / "new"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        _write_snap(old_dir / "libfoo.json", _snap())
+        _write_snap(new_dir / "libfoo.json", _snap())
+        code, out, err = _invoke(
+            "compare", str(old_dir), str(new_dir),
+            "--secondary-format", "json", "--secondary-output", str(tmp_path / "sec.json"),
+        )
+        assert code != 0
+        assert "--secondary-format is not supported" in (out + err)
+
     def test_config_legacy_exit_scheme_applies_to_set_inputs(self, tmp_path: Path) -> None:
         # A project config may demote ABI-breaking findings to warnings for
         # reporting, while still pinning the process exit to the legacy verdict

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -334,7 +334,7 @@ class TestDirVsDir:
         _write_snap(old_dir / "libfoo.json", old)
         _write_snap(new_dir / "libfoo.json", new)
         code, out = _invoke("compare", str(old_dir), str(new_dir), "--format", "json")
-        assert code != 0
+        assert code == 4
         data = json.loads(out)
         lib = data["libraries"][0]
         assert lib["breaking"] == 1
@@ -359,7 +359,7 @@ class TestDirVsDir:
         _write_snap(old_dir / "libfoo.json", old)
         _write_snap(new_dir / "libfoo.json", new)
         code, out = _invoke("compare", str(old_dir), str(new_dir), "--format", "json")
-        assert code != 0
+        assert code == 4
         lib = json.loads(out)["libraries"][0]
         assert lib["breaking"] == 15
         assert len(lib["findings"]) == 10
@@ -386,10 +386,10 @@ class TestDirVsDir:
             "compare", str(old_dir), str(new_dir),
             "--format", "json", "--severity-addition", "error",
         )
-        assert code != 0
+        assert code == 1
         data = json.loads(out)
         lib = data["libraries"][0]
-        assert data["severity"]["exit_code"] != 0
+        assert data["severity"]["exit_code"] == 1
         assert "findings" in lib
         assert lib["findings"][0]["symbol"] == "_Z6new_apiv"
         assert lib["findings"][0]["bucket"] == "addition"

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -344,6 +344,27 @@ class TestDirVsDir:
         assert "findings_truncated" not in lib
         assert "_diff_result" not in lib
 
+    def test_json_output_findings_capped_and_flagged_truncated(self, tmp_path: Path) -> None:
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        old_funcs = [
+            Function(name=f"foo{i}", mangled=f"_Z4foo{i}v", return_type="int",
+                      visibility=Visibility.PUBLIC)
+            for i in range(15)
+        ]
+        old = _snap("1.0", old_funcs, library="libfoo.so")
+        new = _snap("2.0", [], library="libfoo.so")
+        _write_snap(old_dir / "libfoo.json", old)
+        _write_snap(new_dir / "libfoo.json", new)
+        code, out = _invoke("compare", str(old_dir), str(new_dir), "--format", "json")
+        assert code != 0
+        lib = json.loads(out)["libraries"][0]
+        assert lib["breaking"] == 15
+        assert len(lib["findings"]) == 10
+        assert lib["findings_truncated"] is True
+
     def test_breaking_overrides_api_break(self, tmp_path: Path) -> None:
         """Aggregate verdict is BREAKING even when another lib has API_BREAK."""
         old_dir = tmp_path / "old"

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -365,6 +365,35 @@ class TestDirVsDir:
         assert len(lib["findings"]) == 10
         assert lib["findings_truncated"] is True
 
+    def test_json_findings_include_severity_gated_addition(self, tmp_path: Path) -> None:
+        """Codex review on #557: when --severity-addition error promotes a
+        compatible-additions-only library to a nonzero severity exit code,
+        the per-library findings list — which only walked the legacy
+        breaking/api_break/risk buckets — must still include the addition
+        finding that's actually responsible for the gate, not report an
+        empty findings list next to severity.exit_code != 0."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        old = _snap("1.0", [], library="libfoo.so")
+        new_funcs = [Function(name="new_api", mangled="_Z6new_apiv", return_type="int",
+                              visibility=Visibility.PUBLIC)]
+        new = _snap("2.0", new_funcs, library="libfoo.so")
+        _write_snap(old_dir / "libfoo.json", old)
+        _write_snap(new_dir / "libfoo.json", new)
+        code, out = _invoke(
+            "compare", str(old_dir), str(new_dir),
+            "--format", "json", "--severity-addition", "error",
+        )
+        assert code != 0
+        data = json.loads(out)
+        lib = data["libraries"][0]
+        assert data["severity"]["exit_code"] != 0
+        assert "findings" in lib
+        assert lib["findings"][0]["symbol"] == "_Z6new_apiv"
+        assert lib["findings"][0]["bucket"] == "addition"
+
     def test_breaking_overrides_api_break(self, tmp_path: Path) -> None:
         """Aggregate verdict is BREAKING even when another lib has API_BREAK."""
         old_dir = tmp_path / "old"

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -320,6 +320,30 @@ class TestDirVsDir:
         assert data["verdict"] == "NO_CHANGE"
         assert len(data["libraries"]) == 2
 
+    def test_json_output_embeds_findings_not_just_counts(self, tmp_path: Path) -> None:
+        """A breaking library entry must embed which symbols broke, not just
+        a bare count — verified defect: release JSON was count-centric
+        (breaking/source_breaks/risk_changes as ints) with no way to identify
+        the actual findings without a separate `compare` run or
+        `--output-dir` (mirroring the `scan --baseline` / stack-check fix)."""
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        old, new = _breaking_pair("libfoo.so")
+        _write_snap(old_dir / "libfoo.json", old)
+        _write_snap(new_dir / "libfoo.json", new)
+        code, out = _invoke("compare", str(old_dir), str(new_dir), "--format", "json")
+        assert code != 0
+        data = json.loads(out)
+        lib = data["libraries"][0]
+        assert lib["breaking"] == 1
+        assert "findings" in lib
+        assert lib["findings"][0]["symbol"] == "_Z3barv"
+        assert lib["findings"][0]["bucket"] == "breaking"
+        assert "findings_truncated" not in lib
+        assert "_diff_result" not in lib
+
     def test_breaking_overrides_api_break(self, tmp_path: Path) -> None:
         """Aggregate verdict is BREAKING even when another lib has API_BREAK."""
         old_dir = tmp_path / "old"

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -801,6 +801,11 @@ class TestSeverityConfig:
         root = _parse(xml)
         ts = root.find("testsuite")
         assert ts.get("failures") == "1"
+        # Verified defect: the failure `type=` must not still say COMPATIBLE
+        # once severity_config is the reason it failed at all — it should
+        # name the category (ADDITION) that severity_config promoted.
+        fail = root.find(".//failure")
+        assert fail.get("type") == "ADDITION"
 
     def test_demoted_compatible_fails_under_strict_preset(self) -> None:
         """ADR-027 review: a --pattern-verdicts demotion to COMPATIBLE must
@@ -822,6 +827,11 @@ class TestSeverityConfig:
         # with the nonzero severity-aware exit code.
         strict_xml = _parse(to_junit_xml(result, severity_config=PRESET_STRICT))
         assert strict_xml.find("testsuite").get("failures") == "1"
+        # The failure type must reflect *why* it failed under the strict
+        # preset (a quality issue promoted to error), not the raw COMPATIBLE
+        # verdict it was demoted to.
+        fail = strict_xml.find(".//failure")
+        assert fail.get("type") == "QUALITY_ISSUE"
 
     def test_severity_config_demotes_breaking_to_pass(self) -> None:
         """When severity_config marks abi_breaking as 'warning', additions
@@ -858,6 +868,54 @@ class TestSeverityConfig:
         root = _parse(xml)
         ts = root.find("testsuite")
         assert ts.get("failures") == "0"
+
+    def test_failure_type_reflects_severity_category_not_raw_verdict(self) -> None:
+        """Verified defect: `_failure_type` ignored `severity_config` and
+        always derived `type=` from the raw effective *verdict*
+        (`_VERDICT_TO_JUNIT_TYPE`, which has no COMPATIBLE entry and falls
+        back to `"COMPATIBLE"`), even when `_is_failure` had already decided
+        pass/fail from the effective *category* instead. A COMPATIBLE
+        addition promoted to `error` therefore both failed and reported
+        `type="COMPATIBLE"` — self-contradictory. The type must instead name
+        the category (ADDITION) that made it fail."""
+        from abicheck.severity import resolve_severity_config
+
+        changes = [
+            Change(kind=ChangeKind.FUNC_ADDED, symbol="f", description="added"),
+        ]
+        result = _make_result(changes, verdict=Verdict.COMPATIBLE)
+        cfg = resolve_severity_config("default", addition="error")
+        xml = to_junit_xml(result, severity_config=cfg)
+        root = _parse(xml)
+        fail = root.find(".//failure")
+        assert fail.get("type") != "COMPATIBLE"
+        assert fail.get("type") == "ADDITION"
+
+    def test_failure_type_distinguishes_api_break_from_risk_under_severity_config(
+        self,
+    ) -> None:
+        """POTENTIAL_BREAKING covers both API_BREAK and RISK kinds; the JUnit
+        type= must still distinguish them (matching the legacy, no-severity-
+        config type mapping) rather than collapsing both to one generic
+        label."""
+        from abicheck.severity import resolve_severity_config
+
+        api_break = Change(
+            kind=ChangeKind.ENUM_MEMBER_RENAMED, symbol="E", description="renamed",
+        )
+        risk = Change(
+            kind=ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED, symbol="f",
+            description="version req added",
+        )
+        cfg = resolve_severity_config("default", potential_breaking="error")
+
+        api_result = _make_result([api_break], verdict=Verdict.API_BREAK)
+        api_xml = _parse(to_junit_xml(api_result, severity_config=cfg))
+        assert api_xml.find(".//failure").get("type") == "API_BREAK"
+
+        risk_result = _make_result([risk], verdict=Verdict.COMPATIBLE_WITH_RISK)
+        risk_xml = _parse(to_junit_xml(risk_result, severity_config=cfg))
+        assert risk_xml.find(".//failure").get("type") == "COMPATIBLE_WITH_RISK"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -917,6 +917,24 @@ class TestSeverityConfig:
         risk_xml = _parse(to_junit_xml(risk_result, severity_config=cfg))
         assert risk_xml.find(".//failure").get("type") == "COMPATIBLE_WITH_RISK"
 
+    def test_failure_type_potential_breaking_fallback_for_non_conforming_kind(
+        self,
+    ) -> None:
+        """Defensive fallback: a per-change `effective_verdict` override (A4)
+        can classify a finding as POTENTIAL_BREAKING without its *kind* being
+        a member of either api_break_set or risk_set (kind_sets is unaffected
+        by a per-change override, unlike a PolicyFile kind-level override) —
+        `_failure_type` must still return something, not raise/return None."""
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(kind=ChangeKind.FUNC_REMOVED, symbol="f", description="removed")
+        c.effective_verdict = Verdict.COMPATIBLE_WITH_RISK
+        result = _make_result([c], verdict=Verdict.COMPATIBLE_WITH_RISK)
+        cfg = resolve_severity_config("default", potential_breaking="error")
+        xml = to_junit_xml(result, severity_config=cfg)
+        fail = _parse(xml).find(".//failure")
+        assert fail.get("type") == "POTENTIAL_BREAKING"
+
 
 # ---------------------------------------------------------------------------
 # Error libraries in multi-suite

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -917,14 +917,18 @@ class TestSeverityConfig:
         risk_xml = _parse(to_junit_xml(risk_result, severity_config=cfg))
         assert risk_xml.find(".//failure").get("type") == "COMPATIBLE_WITH_RISK"
 
-    def test_failure_type_potential_breaking_fallback_for_non_conforming_kind(
+    def test_failure_type_honours_per_change_effective_verdict_override(
         self,
     ) -> None:
-        """Defensive fallback: a per-change `effective_verdict` override (A4)
-        can classify a finding as POTENTIAL_BREAKING without its *kind* being
-        a member of either api_break_set or risk_set (kind_sets is unaffected
-        by a per-change override, unlike a PolicyFile kind-level override) —
-        `_failure_type` must still return something, not raise/return None."""
+        """A per-change `effective_verdict` override (A4 pattern-verdict
+        modulation, PolicyFile) can classify a finding as POTENTIAL_BREAKING
+        without its *kind* being a member of either api_break_set or
+        risk_set (those sets classify by raw kind, unaffected by a
+        per-change override) — `_failure_type` must derive the API_BREAK vs.
+        COMPATIBLE_WITH_RISK subtype from the finding's actual effective
+        verdict, not from raw kind-set membership, so it doesn't fall back
+        to a generic label that contradicts the override's own intent
+        (CodeRabbit review, PR #557)."""
         from abicheck.severity import resolve_severity_config
 
         c = Change(kind=ChangeKind.FUNC_REMOVED, symbol="f", description="removed")
@@ -933,7 +937,26 @@ class TestSeverityConfig:
         cfg = resolve_severity_config("default", potential_breaking="error")
         xml = to_junit_xml(result, severity_config=cfg)
         fail = _parse(xml).find(".//failure")
-        assert fail.get("type") == "POTENTIAL_BREAKING"
+        assert fail.get("type") == "COMPATIBLE_WITH_RISK"
+
+    def test_failure_type_effective_verdict_wins_over_raw_kind_set(self) -> None:
+        """A raw-risk-set kind (SYMBOL_VERSION_REQUIRED_ADDED) whose
+        `effective_verdict` is overridden to API_BREAK must report
+        type="API_BREAK", not "COMPATIBLE_WITH_RISK" — the type it would get
+        from raw kind-set membership alone, which would contradict the
+        override (CodeRabbit review, PR #557)."""
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(
+            kind=ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED, symbol="f",
+            description="version req added",
+        )
+        c.effective_verdict = Verdict.API_BREAK
+        result = _make_result([c], verdict=Verdict.API_BREAK)
+        cfg = resolve_severity_config("default", potential_breaking="error")
+        xml = to_junit_xml(result, severity_config=cfg)
+        fail = _parse(xml).find(".//failure")
+        assert fail.get("type") == "API_BREAK"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -474,6 +474,25 @@ class TestRenderOutput:
         output = _render_output("html", result, old, new)
         assert "<html" in output.lower() or "<!doctype" in output.lower()
 
+    def test_html_format_forwards_severity_config(self):
+        """The MCP HTML branch must forward severity_config so the CI Gate
+        card renders — otherwise an MCP abi_compare call configured with
+        severity_* options reports a failing exit_code in the JSON wrapper
+        while the embedded HTML shows no gate at all."""
+        from abicheck.checker import Change, ChangeKind
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+        result, old, new = self._make_diff_result(
+            verdict=Verdict.COMPATIBLE, changes=[c],
+        )
+        cfg = resolve_severity_config("default", addition="error")
+        output = _render_output(
+            "html", result, old, new, severity_config=cfg,
+        )
+        assert "CI Gate" in output
+        assert "FAIL" in output
+
     def test_invalid_format_raises(self):
         result, old, new = self._make_diff_result()
         with pytest.raises(ValueError, match="Unknown output format"):

--- a/tests/test_report_filtering.py
+++ b/tests/test_report_filtering.py
@@ -408,6 +408,20 @@ class TestOperationForKind:
                     f"operation_for_kind() returned {op!r}"
                 )
 
+    def test_addition_kinds_all_classify_as_added(self):
+        """Authoritative cross-check against the canonical ADDITION_KINDS
+        registry set: every member must classify as operation "added".
+        Catches misses the word-matching sweep above cannot (e.g.
+        experimental_graduated, whose name contains no add/remove synonym
+        at all but is unambiguously an addition — case99: "without the
+        dedicated detector the diff is just a func_added" — Codex review
+        on #557)."""
+        from abicheck.checker_policy import ADDITION_KINDS
+        from abicheck.reporter_markdown import operation_for_kind
+
+        misses = [k.value for k in ADDITION_KINDS if operation_for_kind(k.value) != "added"]
+        assert not misses, f"ADDITION_KINDS members not classified as 'added': {misses}"
+
 
 # ---------------------------------------------------------------------------
 # Stat mode tests

--- a/tests/test_report_filtering.py
+++ b/tests/test_report_filtering.py
@@ -300,6 +300,45 @@ class TestApplyShowOnly:
         assert len(result) == 2
         assert all(c.kind.value.startswith("func_") for c in result)
 
+    def test_kind_level_policy_override_respected_without_policy_file(self):
+        """Without policy_file/kind_sets, a kind-level PolicyFile override is
+        invisible to the severity dimension — verified defect (P0 finding 1):
+        a func_removed demoted to COMPATIBLE by policy still counted as
+        'breaking' for --show-only purposes."""
+        from abicheck.policy_file import PolicyFile
+
+        c = Change(ChangeKind.FUNC_REMOVED, "foo", "removed: foo")
+        pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE})
+        result = DiffResult(
+            old_version="1.0", new_version="2.0", library="libtest.so",
+            changes=[c], verdict=Verdict.COMPATIBLE, policy_file=pf,
+        )
+
+        # Without threading kind_sets/policy_file, the override is invisible.
+        assert apply_show_only([c], "breaking") == [c]
+        assert apply_show_only([c], "compatible") == []
+
+        # Threading the effective kind_sets/policy_file (as every report
+        # renderer now does) makes --show-only agree with the effective
+        # verdict the rest of the report uses.
+        kind_sets = result._effective_kind_sets()
+        assert apply_show_only(
+            [c], "breaking", kind_sets=kind_sets, policy_file=pf,
+        ) == []
+        assert apply_show_only(
+            [c], "compatible", kind_sets=kind_sets, policy_file=pf,
+        ) == [c]
+
+    def test_per_finding_effective_verdict_still_respected(self):
+        """A per-change effective_verdict override (A4 modulation / frozen
+        namespace) keeps working once kind_sets/policy_file are threaded
+        through, since severity.effective_verdict_for_change checks it
+        before falling back to kind-level classification."""
+        c = Change(ChangeKind.FUNC_REMOVED, "foo", "removed: foo")
+        c.effective_verdict = Verdict.COMPATIBLE
+        assert apply_show_only([c], "breaking") == []
+        assert apply_show_only([c], "compatible") == [c]
+
 
 # ---------------------------------------------------------------------------
 # Stat mode tests

--- a/tests/test_report_filtering.py
+++ b/tests/test_report_filtering.py
@@ -376,14 +376,16 @@ class TestOperationForKind:
         assert operation_for_kind("vptr_introduced") == "modified"
         assert operation_for_kind("static_tls_introduced") == "modified"
 
-    def test_no_remaining_add_remove_synonym_misses(self):
+    @pytest.mark.parametrize("kind", list(ChangeKind), ids=lambda k: k.value)
+    def test_no_remaining_add_remove_synonym_misses(self, kind):
         """Systematic sweep: every ChangeKind whose name contains an add/
         remove synonym must classify as "added"/"removed", unless it is a
         known trait-change-on-persisting-entity exception (see the
-        docstring on _OPERATION_OVERRIDES)."""
+        docstring on _OPERATION_OVERRIDES). Parametrized (CodeRabbit review,
+        PR #557) so pytest reports each kind's failure independently instead
+        of aborting the whole sweep at the first miss."""
         import re
 
-        from abicheck.checker_policy import ChangeKind
         from abicheck.reporter_markdown import operation_for_kind
 
         trait_change_exceptions = {"python_abi3_dropped"}
@@ -392,21 +394,20 @@ class TestOperationForKind:
             r"|withdraw|retract|purge|delet|remov"
             r"|gain|introduc|new_|appear|creat"
         )
-        for kind in ChangeKind:
-            v = kind.value
-            # "_lost_*"/"_introduced" name a trait gained/lost on an entity
-            # that still exists, not the entity itself appearing/
-            # disappearing — see the docstring on _OPERATION_OVERRIDES.
-            if v in trait_change_exceptions or "_lost_" in v or v.endswith("_introduced"):
-                continue
-            if synonym.search(v) and "_added" not in v and "_removed" not in v:
-                # Not already covered by the plain suffix rule — must be a
-                # deliberate override, not a silent "modified" miss.
-                op = operation_for_kind(v)
-                assert op in ("added", "removed"), (
-                    f"{v!r} looks like an add/remove kind but "
-                    f"operation_for_kind() returned {op!r}"
-                )
+        v = kind.value
+        # "_lost_*"/"_introduced" name a trait gained/lost on an entity
+        # that still exists, not the entity itself appearing/
+        # disappearing — see the docstring on _OPERATION_OVERRIDES.
+        if v in trait_change_exceptions or "_lost_" in v or v.endswith("_introduced"):
+            return
+        if synonym.search(v) and "_added" not in v and "_removed" not in v:
+            # Not already covered by the plain suffix rule — must be a
+            # deliberate override, not a silent "modified" miss.
+            op = operation_for_kind(v)
+            assert op in ("added", "removed"), (
+                f"{v!r} looks like an add/remove kind but "
+                f"operation_for_kind() returned {op!r}"
+            )
 
     def test_addition_kinds_all_classify_as_added(self):
         """Authoritative cross-check against the canonical ADDITION_KINDS

--- a/tests/test_report_filtering.py
+++ b/tests/test_report_filtering.py
@@ -376,6 +376,32 @@ class TestOperationForKind:
         assert operation_for_kind("vptr_introduced") == "modified"
         assert operation_for_kind("static_tls_introduced") == "modified"
 
+    def test_added_suffix_trait_change_on_persisting_entity_is_modified(self):
+        """The same trait-change-on-a-persisting-entity pattern as above, but
+        spelled with an "_added" suffix instead of "_lost_"/"_introduced" —
+        the plain suffix rule alone would misclassify these as "added" even
+        though no new function/type appears; each names a trait gained by an
+        already-existing entity ("Function became virtual: {name}", "noexcept
+        specifier added: {name}", ...) and none is in ADDITION_KINDS
+        (Codex review, PR #557)."""
+        from abicheck.reporter_markdown import operation_for_kind
+
+        assert operation_for_kind("func_noexcept_added") == "modified"
+        assert operation_for_kind("func_virtual_added") == "modified"
+        assert operation_for_kind("func_variadic_added") == "modified"
+        assert operation_for_kind("func_pure_virtual_added") == "modified"
+
+    def test_field_added_mid_struct_is_modified_not_added(self):
+        """`type_field_added` (a field inserted into an existing struct,
+        shifting every subsequent field's offset) modifies the type's
+        existing layout — the safe append-at-end case has its own dedicated
+        addition kind, `type_field_added_compatible`, which is unaffected
+        (Codex review, PR #557)."""
+        from abicheck.reporter_markdown import operation_for_kind
+
+        assert operation_for_kind("type_field_added") == "modified"
+        assert operation_for_kind("type_field_added_compatible") == "added"
+
     @pytest.mark.parametrize("kind", list(ChangeKind), ids=lambda k: k.value)
     def test_no_remaining_add_remove_synonym_misses(self, kind):
         """Systematic sweep: every ChangeKind whose name contains an add/

--- a/tests/test_report_filtering.py
+++ b/tests/test_report_filtering.py
@@ -340,6 +340,75 @@ class TestApplyShowOnly:
         assert apply_show_only([c], "compatible") == [c]
 
 
+class TestOperationForKind:
+    """Codex review on #557: operation_for_kind() (shared by --show-only's
+    added/removed/changed tokens and the JSON `operation` field, schema 2.3)
+    only matched a fixed suffix list, misclassifying kinds that are still
+    semantically an addition/removal but spelled differently."""
+
+    def test_ordinary_added_removed_modified(self):
+        from abicheck.reporter_markdown import operation_for_kind
+
+        assert operation_for_kind("func_added") == "added"
+        assert operation_for_kind("func_removed") == "removed"
+        assert operation_for_kind("func_params_changed") == "modified"
+
+    def test_non_suffix_addition_kind(self):
+        from abicheck.reporter_markdown import operation_for_kind
+
+        assert operation_for_kind("symbol_version_required_added_compat") == "added"
+
+    def test_non_suffix_removal_kinds(self):
+        from abicheck.reporter_markdown import operation_for_kind
+
+        assert operation_for_kind("experimental_removed_without_replacement") == "removed"
+        assert operation_for_kind("func_deleted_dwarf") == "removed"
+        assert operation_for_kind("cpu_dispatch_isa_dropped") == "removed"
+
+    def test_trait_change_on_persisting_entity_is_modified_not_removed(self):
+        """A '_lost_*'/'_introduced' kind describes a property gained/lost on
+        an entity that still exists — that's "modified", not "added"/
+        "removed" (which name the entity itself appearing/disappearing)."""
+        from abicheck.reporter_markdown import operation_for_kind
+
+        assert operation_for_kind("field_lost_const") == "modified"
+        assert operation_for_kind("func_lost_inline") == "modified"
+        assert operation_for_kind("vptr_introduced") == "modified"
+        assert operation_for_kind("static_tls_introduced") == "modified"
+
+    def test_no_remaining_add_remove_synonym_misses(self):
+        """Systematic sweep: every ChangeKind whose name contains an add/
+        remove synonym must classify as "added"/"removed", unless it is a
+        known trait-change-on-persisting-entity exception (see the
+        docstring on _OPERATION_OVERRIDES)."""
+        import re
+
+        from abicheck.checker_policy import ChangeKind
+        from abicheck.reporter_markdown import operation_for_kind
+
+        trait_change_exceptions = {"python_abi3_dropped"}
+        synonym = re.compile(
+            r"drop|excis|eliminat|vanish|disappear|revok|discontinu"
+            r"|withdraw|retract|purge|delet|remov"
+            r"|gain|introduc|new_|appear|creat"
+        )
+        for kind in ChangeKind:
+            v = kind.value
+            # "_lost_*"/"_introduced" name a trait gained/lost on an entity
+            # that still exists, not the entity itself appearing/
+            # disappearing — see the docstring on _OPERATION_OVERRIDES.
+            if v in trait_change_exceptions or "_lost_" in v or v.endswith("_introduced"):
+                continue
+            if synonym.search(v) and "_added" not in v and "_removed" not in v:
+                # Not already covered by the plain suffix rule — must be a
+                # deliberate override, not a silent "modified" miss.
+                op = operation_for_kind(v)
+                assert op in ("added", "removed"), (
+                    f"{v!r} looks like an add/remove kind but "
+                    f"operation_for_kind() returned {op!r}"
+                )
+
+
 # ---------------------------------------------------------------------------
 # Stat mode tests
 # ---------------------------------------------------------------------------

--- a/tests/test_report_filtering.py
+++ b/tests/test_report_filtering.py
@@ -402,6 +402,17 @@ class TestOperationForKind:
         assert operation_for_kind("type_field_added") == "modified"
         assert operation_for_kind("type_field_added_compatible") == "added"
 
+    def test_virtual_method_added_is_modified_not_added(self):
+        """`virtual_method_added` is the identical layout-modification
+        pattern as `type_field_added` applied to virtual methods instead of
+        fields: a new virtual method on an already-existing class
+        grows/relayouts the vtable, breaking derived classes compiled
+        against the old layout — not a compatible added API surface
+        (Codex review, PR #557)."""
+        from abicheck.reporter_markdown import operation_for_kind
+
+        assert operation_for_kind("virtual_method_added") == "modified"
+
     def test_added_suffix_signature_or_contract_change_is_modified(self):
         """A second audit pass (Codex review, PR #557): a constructor gaining
         `explicit`, a template parameter becoming mandatory, a Python

--- a/tests/test_report_filtering.py
+++ b/tests/test_report_filtering.py
@@ -402,6 +402,31 @@ class TestOperationForKind:
         assert operation_for_kind("type_field_added") == "modified"
         assert operation_for_kind("type_field_added_compatible") == "added"
 
+    def test_added_suffix_signature_or_contract_change_is_modified(self):
+        """A second audit pass (Codex review, PR #557): a constructor gaining
+        `explicit`, a template parameter becoming mandatory, a Python
+        function gaining a required parameter, and a function gaining a
+        contract attribute all describe an already-existing callable/
+        template's signature or contract changing — not a new one
+        appearing. None is in ADDITION_KINDS."""
+        from abicheck.reporter_markdown import operation_for_kind
+
+        assert operation_for_kind("ctor_explicit_added") == "modified"
+        assert operation_for_kind("mandatory_template_param_added") == "modified"
+        assert operation_for_kind("python_api_parameter_added") == "modified"
+        assert operation_for_kind("func_contract_attribute_added") == "modified"
+
+    def test_removed_suffix_trait_loss_on_persisting_entity_is_modified(self):
+        """The removed-side counterpart: these end in plain "_removed" (so
+        the suffix rule alone reports "removed"), but each names a trait
+        *lost by* an entity that still exists (Codex review, PR #557)."""
+        from abicheck.reporter_markdown import operation_for_kind
+
+        assert operation_for_kind("func_noexcept_removed") == "modified"
+        assert operation_for_kind("func_variadic_removed") == "modified"
+        assert operation_for_kind("func_contract_attribute_removed") == "modified"
+        assert operation_for_kind("ctor_explicit_removed") == "modified"
+
     @pytest.mark.parametrize("kind", list(ChangeKind), ids=lambda k: k.value)
     def test_no_remaining_add_remove_synonym_misses(self, kind):
         """Systematic sweep: every ChangeKind whose name contains an add/

--- a/tests/test_report_filtering.py
+++ b/tests/test_report_filtering.py
@@ -427,6 +427,19 @@ class TestOperationForKind:
         assert operation_for_kind("func_contract_attribute_removed") == "modified"
         assert operation_for_kind("ctor_explicit_removed") == "modified"
 
+    def test_more_removed_suffix_trait_loss_on_persisting_entity_is_modified(self):
+        """A third audit pass (Codex review, PR #557): `func_virtual_removed`
+        (the sibling of `func_virtual_added`, an existing function losing
+        its virtual-ness) and `param_default_value_removed`/
+        `python_api_default_removed` (an existing parameter losing its
+        default value) are the same trait-lost-by-a-persisting-entity
+        pattern as the kinds above."""
+        from abicheck.reporter_markdown import operation_for_kind
+
+        assert operation_for_kind("func_virtual_removed") == "modified"
+        assert operation_for_kind("param_default_value_removed") == "modified"
+        assert operation_for_kind("python_api_default_removed") == "modified"
+
     @pytest.mark.parametrize("kind", list(ChangeKind), ids=lambda k: k.value)
     def test_no_remaining_add_remove_synonym_misses(self, kind):
         """Systematic sweep: every ChangeKind whose name contains an add/

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -241,6 +241,29 @@ class TestEvidenceStatusInJson:
         assert d["severity"]["blocking"] is False
         assert d["severity"]["blocking_categories"] == []
 
+    def test_blocking_categories_survives_show_only_hiding_the_blocker(self):
+        """Verified defect (Codex review on #557): blocking_categories was
+        derived from the *display* changes (post-show_only), while exit_code
+        already correctly used the unfiltered set. Hiding the one finding
+        that's actually blocking the build via --show-only must not make
+        blocking_categories silently empty out from under a still-nonzero
+        exit_code/blocking=true."""
+        from abicheck.severity import resolve_severity_config
+
+        addition = Change(ChangeKind.FUNC_ADDED, "s1", "added")
+        breaking = Change(ChangeKind.FUNC_REMOVED, "s2", "removed")
+        r = _result(Verdict.BREAKING, changes=[addition, breaking])
+        cfg = resolve_severity_config("default", addition="error")
+        # --show-only=breaking hides the ADDITION finding from `changes[]`,
+        # but it must not hide it from the gate summary: the addition is
+        # still what's configured to fail the build.
+        d = json.loads(to_json(r, show_only="breaking", severity_config=cfg))
+        assert d["severity"]["blocking"] is True
+        assert set(d["severity"]["blocking_categories"]) == {"abi_breaking", "addition"}
+        # The addition finding itself is correctly hidden from the display
+        # `changes[]` by --show-only — only the gate summary must see it.
+        assert len(d["changes"]) == 1
+
     def test_leaf_mode_root_type_change_carries_evidence_status(self):
         # Regression (Codex review): --report-mode leaf serializes root type
         # changes via a separate _leaf_entry() path, not _change_to_dict() —

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -167,9 +167,79 @@ class TestEvidenceStatusInJson:
         d = json.loads(to_json(r))
         assert d["changes"][0]["evidence_status"] == "not_checkable"
 
-    def test_report_schema_version_is_2_2(self):
+    def test_report_schema_version_is_2_3(self):
         d = json.loads(to_json(_result(Verdict.NO_CHANGE)))
-        assert d["report_schema_version"] == "2.2"
+        assert d["report_schema_version"] == "2.3"
+
+    def test_change_operation_field(self):
+        added = Change(ChangeKind.FUNC_ADDED, "s1", "added")
+        removed = Change(ChangeKind.FUNC_REMOVED, "s2", "removed")
+        modified = Change(ChangeKind.FUNC_PARAMS_CHANGED, "s3", "params changed")
+        r = _result(Verdict.BREAKING, changes=[added, removed, modified])
+        d = json.loads(to_json(r))
+        by_symbol = {c["symbol"]: c["operation"] for c in d["changes"]}
+        assert by_symbol == {"s1": "added", "s2": "removed", "s3": "modified"}
+
+    def test_finding_id_is_stable_and_deterministic(self):
+        """Same underlying finding -> same finding_id across independent runs."""
+        c1 = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")
+        c2 = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")
+        r1 = _result(Verdict.BREAKING, changes=[c1])
+        r2 = _result(Verdict.BREAKING, changes=[c2])
+        d1 = json.loads(to_json(r1))
+        d2 = json.loads(to_json(r2))
+        fid1 = d1["changes"][0]["finding_id"]
+        fid2 = d2["changes"][0]["finding_id"]
+        assert fid1 == fid2
+        assert isinstance(fid1, str) and len(fid1) == 16
+
+    def test_finding_id_differs_for_different_findings(self):
+        c1 = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")
+        c2 = Change(ChangeKind.FUNC_REMOVED, "_Z3barv", "removed: bar")
+        r = _result(Verdict.BREAKING, changes=[c1, c2])
+        d = json.loads(to_json(r))
+        assert d["changes"][0]["finding_id"] != d["changes"][1]["finding_id"]
+
+    def test_finding_id_unaffected_by_policy(self):
+        """finding_id excludes policy-derived fields — the same underlying
+        finding must hash identically regardless of --policy."""
+        from abicheck.policy_file import PolicyFile
+
+        c1 = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")
+        c2 = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")
+        pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE})
+        r1 = _result(Verdict.BREAKING, changes=[c1])
+        r2 = DiffResult(
+            old_version="1.0", new_version="2.0", library="libtest.so",
+            changes=[c2], verdict=Verdict.COMPATIBLE, policy_file=pf,
+        )
+        d1 = json.loads(to_json(r1))
+        d2 = json.loads(to_json(r2))
+        assert d1["changes"][0]["finding_id"] == d2["changes"][0]["finding_id"]
+        # Confirm the policy override really did take effect (different
+        # severity), so this is a meaningful same-ID-despite-different-
+        # policy check, not a vacuous one.
+        assert d1["changes"][0]["severity"] != d2["changes"][0]["severity"]
+
+    def test_severity_blocking_fields_present_when_configured(self):
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(ChangeKind.FUNC_ADDED, "s", "added")
+        r = _result(Verdict.COMPATIBLE, changes=[c])
+        cfg = resolve_severity_config("default", addition="error")
+        d = json.loads(to_json(r, severity_config=cfg))
+        assert d["severity"]["blocking"] is True
+        assert d["severity"]["blocking_categories"] == ["addition"]
+
+    def test_severity_blocking_false_when_no_error_level_findings(self):
+        from abicheck.severity import resolve_severity_config
+
+        c = Change(ChangeKind.FUNC_ADDED, "s", "added")
+        r = _result(Verdict.COMPATIBLE, changes=[c])
+        cfg = resolve_severity_config("default")
+        d = json.loads(to_json(r, severity_config=cfg))
+        assert d["severity"]["blocking"] is False
+        assert d["severity"]["blocking_categories"] == []
 
     def test_leaf_mode_root_type_change_carries_evidence_status(self):
         # Regression (Codex review): --report-mode leaf serializes root type

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -180,6 +180,15 @@ class TestEvidenceStatusInJson:
         by_symbol = {c["symbol"]: c["operation"] for c in d["changes"]}
         assert by_symbol == {"s1": "added", "s2": "removed", "s3": "modified"}
 
+    def test_change_operation_field_experimental_graduated(self):
+        """Codex review on #557: experimental_graduated (ADDITION_KINDS) was
+        misclassified as operation="modified" since its kind name contains
+        no "_added" suffix."""
+        c = Change(ChangeKind.EXPERIMENTAL_GRADUATED, "lib::sort", "graduated to stable")
+        r = _result(Verdict.COMPATIBLE, changes=[c])
+        d = json.loads(to_json(r))
+        assert d["changes"][0]["operation"] == "added"
+
     def test_change_recommended_action_field(self):
         breaking = Change(ChangeKind.FUNC_REMOVED, "s1", "removed")
         api_break = Change(ChangeKind.FIELD_RENAMED, "s2", "renamed")

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -167,9 +167,9 @@ class TestEvidenceStatusInJson:
         d = json.loads(to_json(r))
         assert d["changes"][0]["evidence_status"] == "not_checkable"
 
-    def test_report_schema_version_is_2_3(self):
+    def test_report_schema_version_is_2_4(self):
         d = json.loads(to_json(_result(Verdict.NO_CHANGE)))
-        assert d["report_schema_version"] == "2.3"
+        assert d["report_schema_version"] == "2.4"
 
     def test_change_operation_field(self):
         added = Change(ChangeKind.FUNC_ADDED, "s1", "added")
@@ -179,6 +179,43 @@ class TestEvidenceStatusInJson:
         d = json.loads(to_json(r))
         by_symbol = {c["symbol"]: c["operation"] for c in d["changes"]}
         assert by_symbol == {"s1": "added", "s2": "removed", "s3": "modified"}
+
+    def test_change_recommended_action_field(self):
+        breaking = Change(ChangeKind.FUNC_REMOVED, "s1", "removed")
+        api_break = Change(ChangeKind.FIELD_RENAMED, "s2", "renamed")
+        risk = Change(ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED, "s3", "version req added")
+        quality = Change(ChangeKind.VISIBILITY_LEAK, "s4", "visibility leak")
+        addition = Change(ChangeKind.FUNC_ADDED, "s5", "added")
+        r = _result(
+            Verdict.BREAKING,
+            changes=[breaking, api_break, risk, quality, addition],
+        )
+        d = json.loads(to_json(r))
+        by_symbol = {c["symbol"]: c["recommended_action"] for c in d["changes"]}
+        assert by_symbol == {
+            "s1": "recompile_and_relink_required",
+            "s2": "recompile_required",
+            "s3": "verify_deployment_compatibility",
+            "s4": "review_recommended",
+            "s5": "no_action_required",
+        }
+
+    def test_recommended_action_honours_policy_file_override(self):
+        """recommended_action must reflect the *effective* verdict (honouring
+        a PolicyFile override), not the kind's raw default verdict — same
+        resolver `severity`/`operation`/`finding_id` already use."""
+        from abicheck.policy_file import PolicyFile
+
+        c = Change(ChangeKind.FUNC_REMOVED, "s", "removed")
+        pf = PolicyFile(overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE})
+        r = DiffResult(
+            old_version="1.0", new_version="2.0", library="libtest.so",
+            changes=[c], verdict=Verdict.COMPATIBLE, policy_file=pf,
+        )
+        d = json.loads(to_json(r))
+        # func_removed is not itself an addition kind -> quality issue, not
+        # "no action required".
+        assert d["changes"][0]["recommended_action"] == "review_recommended"
 
     def test_finding_id_is_stable_and_deterministic(self):
         """Same underlying finding -> same finding_id across independent runs."""
@@ -295,6 +332,13 @@ class TestEvidenceStatusInJson:
         # the fingerprint must not depend on which report mode built it.
         full_d = json.loads(to_json(_result(Verdict.BREAKING, changes=[c])))
         assert full_d["changes"][0]["finding_id"] == d["leaf_changes"][0]["finding_id"]
+
+    def test_leaf_mode_root_type_change_carries_recommended_action(self):
+        c = Change(ChangeKind.TYPE_SIZE_CHANGED, "Cfg", "struct Cfg grew")
+        r = _result(Verdict.BREAKING, changes=[c])
+        d = json.loads(to_json(r, report_mode="leaf"))
+        assert d["leaf_changes"][0]["recommended_action"] == "recompile_and_relink_required"
+        assert d["changes"][0]["recommended_action"] == "recompile_and_relink_required"
 
     def test_leaf_mode_root_type_change_honours_frozen_namespace_floor(self):
         """Codex review on #549: a policy-file override that demotes a root

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -267,6 +267,27 @@ class TestEvidenceStatusInJson:
         # policy check, not a vacuous one.
         assert d1["changes"][0]["severity"] != d2["changes"][0]["severity"]
 
+    def test_finding_id_differs_for_same_kind_symbol_and_values(self):
+        """Two findings on the same symbol, same kind, same old/new value,
+        and no distinct source location (e.g. the same pointer-depth
+        transition on two different parameters of one function) must not
+        collide on finding_id — description carries the per-finding detail
+        (parameter name/index here) that disambiguates them (Codex review,
+        PR #557)."""
+        c1 = Change(
+            ChangeKind.PARAM_POINTER_LEVEL_CHANGED, "_Z3foov",
+            "Parameter 'x' pointer level changed from 1 to 2",
+            old_value="1", new_value="2",
+        )
+        c2 = Change(
+            ChangeKind.PARAM_POINTER_LEVEL_CHANGED, "_Z3foov",
+            "Parameter 'y' pointer level changed from 1 to 2",
+            old_value="1", new_value="2",
+        )
+        r = _result(Verdict.BREAKING, changes=[c1, c2])
+        d = json.loads(to_json(r))
+        assert d["changes"][0]["finding_id"] != d["changes"][1]["finding_id"]
+
     def test_severity_blocking_fields_present_when_configured(self):
         from abicheck.severity import resolve_severity_config
 

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -276,6 +276,26 @@ class TestEvidenceStatusInJson:
         # kept for backward-compat consumers) carries it too.
         assert d["changes"][0]["evidence_status"] == "artifact_proven"
 
+    def test_leaf_mode_root_type_change_carries_schema_2_3_fields(self):
+        """Codex review on #557: _leaf_entry() builds its own dict rather
+        than routing through _change_to_dict(), so root type changes in
+        leaf_changes[]/changes[] were missing the schema 2.3 `operation`/
+        `finding_id` fields present on non-type leaf entries and full-mode
+        entries — breaking finding_id correlation for leaf-mode reports."""
+        c = Change(ChangeKind.TYPE_SIZE_CHANGED, "Cfg", "struct Cfg grew")
+        r = _result(Verdict.BREAKING, changes=[c])
+        d = json.loads(to_json(r, report_mode="leaf"))
+        assert d["leaf_changes"][0]["operation"] == "modified"
+        assert isinstance(d["leaf_changes"][0]["finding_id"], str)
+        assert len(d["leaf_changes"][0]["finding_id"]) == 16
+        assert d["changes"][0]["operation"] == "modified"
+        assert d["changes"][0]["finding_id"] == d["leaf_changes"][0]["finding_id"]
+
+        # Same finding_id as full (non-leaf) mode for the identical change —
+        # the fingerprint must not depend on which report mode built it.
+        full_d = json.loads(to_json(_result(Verdict.BREAKING, changes=[c])))
+        assert full_d["changes"][0]["finding_id"] == d["leaf_changes"][0]["finding_id"]
+
     def test_leaf_mode_root_type_change_honours_frozen_namespace_floor(self):
         """Codex review on #549: a policy-file override that demotes a root
         type kind (type_size_changed) to COMPATIBLE must not silently drop a

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -132,6 +132,42 @@ class TestSeverityMapping:
 
 
 # ---------------------------------------------------------------------------
+# _parse_source_location (direct unit tests)
+# ---------------------------------------------------------------------------
+
+class TestParseSourceLocation:
+    def test_file_and_line(self) -> None:
+        from abicheck.sarif import _parse_source_location
+
+        assert _parse_source_location("include/foo.h:42") == ("include/foo.h", 42, None)
+
+    def test_file_line_column(self) -> None:
+        from abicheck.sarif import _parse_source_location
+
+        assert _parse_source_location("include/foo.h:42:7") == ("include/foo.h", 42, 7)
+
+    def test_windows_path_with_column(self) -> None:
+        from abicheck.sarif import _parse_source_location
+
+        assert _parse_source_location("C:\\foo\\bar.h:42:7") == ("C:\\foo\\bar.h", 42, 7)
+
+    def test_bare_filename_no_colon(self) -> None:
+        from abicheck.sarif import _parse_source_location
+
+        assert _parse_source_location("foo.h") == ("foo.h", None, None)
+
+    def test_non_numeric_line(self) -> None:
+        from abicheck.sarif import _parse_source_location
+
+        assert _parse_source_location("foo.h:notaline") == ("foo.h:notaline", None, None)
+
+    def test_column_non_numeric_still_yields_line(self) -> None:
+        from abicheck.sarif import _parse_source_location
+
+        assert _parse_source_location("foo.h:42:notacol") == ("foo.h", 42, None)
+
+
+# ---------------------------------------------------------------------------
 # Result content
 # ---------------------------------------------------------------------------
 
@@ -183,6 +219,28 @@ class TestResultContent:
         phys = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
         assert phys["artifactLocation"]["uri"] == "include/foo.h"
         assert phys["region"] == {"startLine": 42, "startColumn": 7}
+
+    def test_result_location_bare_filename_no_colon(self) -> None:
+        """A source_location with no colon at all has no line to extract."""
+        c = Change(
+            kind=ChangeKind.FUNC_REMOVED, symbol="_Z3foov", description="removed",
+            source_location="foo.h",
+        )
+        doc = to_sarif(_make_result([c]))
+        phys = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
+        assert phys["artifactLocation"]["uri"] == "foo.h"
+        assert "region" not in phys
+
+    def test_result_location_non_numeric_line(self) -> None:
+        """A source_location whose 'line' segment isn't numeric has no region."""
+        c = Change(
+            kind=ChangeKind.FUNC_REMOVED, symbol="_Z3foov", description="removed",
+            source_location="foo.h:notaline",
+        )
+        doc = to_sarif(_make_result([c]))
+        phys = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
+        assert phys["artifactLocation"]["uri"] == "foo.h:notaline"
+        assert "region" not in phys
 
     def test_result_location_windows_path_with_column(self) -> None:
         c = Change(

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -124,6 +124,12 @@ class TestSeverityMapping:
         rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
         assert rule["helpUri"].endswith("#func_added")
 
+    def test_rule_help_uri_points_at_real_doc(self) -> None:
+        """helpUri must reference a doc file that actually exists in the repo."""
+        doc = to_sarif(_make_result([_compatible_change()], verdict=Verdict.COMPATIBLE))
+        rule = doc["runs"][0]["tool"]["driver"]["rules"][0]
+        assert "docs/reference/change-kinds.md#" in rule["helpUri"]
+
 
 # ---------------------------------------------------------------------------
 # Result content
@@ -157,6 +163,37 @@ class TestResultContent:
         locs = doc["runs"][0]["results"][0]["locations"]
         assert locs[0]["physicalLocation"]["artifactLocation"]["uri"] == "libbar.so.2"
 
+    def test_result_location_file_and_line(self) -> None:
+        c = Change(
+            kind=ChangeKind.FUNC_REMOVED, symbol="_Z3foov", description="removed",
+            source_location="include/foo.h:42",
+        )
+        doc = to_sarif(_make_result([c]))
+        phys = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
+        assert phys["artifactLocation"]["uri"] == "include/foo.h"
+        assert phys["region"] == {"startLine": 42}
+
+    def test_result_location_file_line_column(self) -> None:
+        """A file:line:column location must not leak ':line' into the URI."""
+        c = Change(
+            kind=ChangeKind.FUNC_REMOVED, symbol="_Z3foov", description="removed",
+            source_location="include/foo.h:42:7",
+        )
+        doc = to_sarif(_make_result([c]))
+        phys = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
+        assert phys["artifactLocation"]["uri"] == "include/foo.h"
+        assert phys["region"] == {"startLine": 42, "startColumn": 7}
+
+    def test_result_location_windows_path_with_column(self) -> None:
+        c = Change(
+            kind=ChangeKind.FUNC_REMOVED, symbol="_Z3foov", description="removed",
+            source_location="C:\\include\\foo.h:42:7",
+        )
+        doc = to_sarif(_make_result([c]))
+        phys = doc["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
+        assert phys["artifactLocation"]["uri"] == "C:\\include\\foo.h"
+        assert phys["region"] == {"startLine": 42, "startColumn": 7}
+
     def test_result_properties(self) -> None:
         doc = to_sarif(_make_result([_breaking_change()]))
         props = doc["runs"][0]["results"][0]["properties"]
@@ -180,9 +217,16 @@ class TestResultContent:
 # ---------------------------------------------------------------------------
 
 class TestInvocation:
-    def test_invocation_breaking_not_successful(self) -> None:
+    def test_invocation_breaking_still_execution_successful(self) -> None:
+        """executionSuccessful reports the tool run, not the ABI/severity gate.
+
+        Per the SARIF spec, a completed analysis is a successful execution
+        even when it reports blocking findings — that outcome belongs in
+        exitCode/exitCodeDescription/result levels, not executionSuccessful.
+        """
         doc = to_sarif(_make_result([_breaking_change()], verdict=Verdict.BREAKING))
-        assert doc["runs"][0]["invocations"][0]["executionSuccessful"] is False
+        assert doc["runs"][0]["invocations"][0]["executionSuccessful"] is True
+        assert doc["runs"][0]["invocations"][0]["exitCode"] == 4
 
     def test_invocation_no_change_successful(self) -> None:
         doc = to_sarif(_make_result([], verdict=Verdict.NO_CHANGE))
@@ -353,9 +397,10 @@ class TestSeverityGate:
         r = _make_result([_compatible_change()], verdict=Verdict.COMPATIBLE)
         doc = to_sarif(r, severity_config=cfg)
         inv = doc["runs"][0]["invocations"][0]
-        # Legacy inference would say COMPATIBLE -> exitCode 0, executionSuccessful.
+        # Legacy inference would say COMPATIBLE -> exitCode 0.
         assert inv["exitCode"] == 1
-        assert inv["executionSuccessful"] is False
+        # executionSuccessful reports the tool run, not the gate outcome.
+        assert inv["executionSuccessful"] is True
 
         gate = doc["runs"][0]["properties"]["severityGate"]
         assert gate["exitCode"] == 1
@@ -370,7 +415,7 @@ class TestSeverityGate:
         r = _make_result([_breaking_change()], verdict=Verdict.BREAKING)
         doc = to_sarif(r, severity_config=cfg)
         inv = doc["runs"][0]["invocations"][0]
-        # Legacy inference would say BREAKING -> exitCode 4, executionSuccessful=False.
+        # Legacy inference would say BREAKING -> exitCode 4.
         assert inv["exitCode"] == 0
         assert inv["executionSuccessful"] is True
 

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -166,6 +166,29 @@ class TestParseSourceLocation:
 
         assert _parse_source_location("foo.h:42:notacol") == ("foo.h", 42, None)
 
+    def test_colon_in_path_prefix_still_yields_line(self) -> None:
+        # A synthetic/virtual path scheme (colon before the first colon that
+        # actually separates line info) — CodeRabbit review, PR #557. The
+        # naive "file is everything before the first colon" reading would
+        # treat "headers/foo.h" as the line and fail to parse a region.
+        from abicheck.sarif import _parse_source_location
+
+        assert _parse_source_location("generated:headers/foo.h:42") == (
+            "generated:headers/foo.h", 42, None,
+        )
+
+    def test_colon_in_path_prefix_with_column(self) -> None:
+        from abicheck.sarif import _parse_source_location
+
+        assert _parse_source_location("generated:headers/foo.h:42:7") == (
+            "generated:headers/foo.h", 42, 7,
+        )
+
+    def test_windows_path_no_column(self) -> None:
+        from abicheck.sarif import _parse_source_location
+
+        assert _parse_source_location("C:\\foo\\bar.h:42") == ("C:\\foo\\bar.h", 42, None)
+
 
 # ---------------------------------------------------------------------------
 # Result content

--- a/tests/test_severity.py
+++ b/tests/test_severity.py
@@ -361,3 +361,102 @@ class TestInfoOnlyAlias:
     def test_alias_resolves(self) -> None:
         from abicheck.severity import SEVERITY_PRESETS
         assert SEVERITY_PRESETS["info_only"] is SEVERITY_PRESETS["info-only"]
+
+
+# ---------------------------------------------------------------------------
+# GateDecision / compute_gate_decision / CompatibilityDecision
+# ---------------------------------------------------------------------------
+
+
+class TestCompatibilityDecision:
+    def test_is_verdict(self) -> None:
+        from abicheck.checker import Verdict
+        from abicheck.severity import CompatibilityDecision
+
+        assert CompatibilityDecision is Verdict
+
+
+class TestComputeGateDecision:
+    def test_legacy_scheme_uses_supplied_exit_code(self) -> None:
+        from abicheck.severity import compute_gate_decision
+
+        decision = compute_gate_decision([], None, legacy_exit_code=4)
+        assert decision.scheme == "legacy"
+        assert decision.exit_code == 4
+        assert decision.blocking is True
+        assert decision.blocking_categories == ()
+
+    def test_legacy_scheme_zero_exit_code_not_blocking(self) -> None:
+        from abicheck.severity import compute_gate_decision
+
+        decision = compute_gate_decision([], None, legacy_exit_code=0)
+        assert decision.scheme == "legacy"
+        assert decision.blocking is False
+
+    def test_severity_scheme_addition_promoted_to_error(self) -> None:
+        from abicheck.severity import compute_gate_decision, resolve_severity_config
+
+        cfg = resolve_severity_config("default", addition="error")
+        changes = [_FakeChange(ChangeKind.FUNC_ADDED)]
+        decision = compute_gate_decision(changes, cfg)
+        assert decision.scheme == "severity"
+        assert decision.blocking is True
+        assert decision.blocking_categories == ("addition",)
+        assert decision.exit_code != 0
+
+    def test_severity_scheme_no_error_level_findings(self) -> None:
+        from abicheck.severity import PRESET_DEFAULT, compute_gate_decision
+
+        changes = [_FakeChange(ChangeKind.FUNC_ADDED)]
+        decision = compute_gate_decision(changes, PRESET_DEFAULT)
+        assert decision.scheme == "severity"
+        assert decision.blocking is False
+        assert decision.blocking_categories == ()
+        assert decision.exit_code == 0
+
+    def test_matches_compute_exit_code(self) -> None:
+        """The gate decision's exit_code must never disagree with the
+        standalone compute_exit_code for the same inputs — it's derived
+        from it, not a parallel reimplementation."""
+        from abicheck.severity import (
+            PRESET_STRICT,
+            compute_exit_code,
+            compute_gate_decision,
+        )
+
+        changes = [
+            _FakeChange(ChangeKind.FUNC_REMOVED),
+            _FakeChange(ChangeKind.ENUM_MEMBER_RENAMED),
+            _FakeChange(ChangeKind.FUNC_ADDED),
+        ]
+        decision = compute_gate_decision(changes, PRESET_STRICT)
+        assert decision.exit_code == compute_exit_code(changes, PRESET_STRICT)
+
+    def test_multiple_blocking_categories(self) -> None:
+        from abicheck.severity import PRESET_STRICT, compute_gate_decision
+
+        changes = [
+            _FakeChange(ChangeKind.FUNC_REMOVED),
+            _FakeChange(ChangeKind.FUNC_ADDED),
+        ]
+        decision = compute_gate_decision(changes, PRESET_STRICT)
+        assert set(decision.blocking_categories) == {"abi_breaking", "addition"}
+
+    def test_single_input_keeps_exit_code_and_categories_in_sync(self) -> None:
+        """compute_gate_decision takes exactly one `changes` sequence used
+        for both exit_code and blocking_categories — by construction it
+        cannot reproduce the bug class this type replaces (two independent
+        call sites computing exit_code and blocking_categories from two
+        different change sets, e.g. one --show-only-filtered and one not,
+        and disagreeing as a result)."""
+        from abicheck.severity import compute_gate_decision, resolve_severity_config
+
+        cfg = resolve_severity_config("default", addition="error")
+        changes = [
+            _FakeChange(ChangeKind.ENUM_MEMBER_RENAMED),  # potential_breaking: warning
+            _FakeChange(ChangeKind.FUNC_ADDED),  # addition: error (overridden)
+        ]
+        decision = compute_gate_decision(changes, cfg)
+        assert decision.blocking is True
+        assert decision.blocking_categories == ("addition",)
+        assert "potential_breaking" not in decision.blocking_categories  # not error-level

--- a/tests/test_sprint9_html.py
+++ b/tests/test_sprint9_html.py
@@ -163,7 +163,7 @@ def test_policy_demoted_removal_does_not_contradict_compatible_verdict() -> None
         changes=[c], verdict=Verdict.COMPATIBLE, policy_file=pf,
     )
     out = generate_html_report(result)
-    assert "Verdict: COMPATIBLE" in out
+    assert "Compatibility: COMPATIBLE" in out
     assert "Binary Compatibility: <strong>100.0%</strong>" in out
     assert "Binary Compatibility: <strong>0.0%</strong>" not in out
     assert "(0 breaking change(s))" in out
@@ -482,3 +482,70 @@ def test_confidence_absent_without_attribute() -> None:
     out = generate_html_report(r)
     assert "<!DOCTYPE html>" in out
     # Should NOT crash — just skip the section
+
+
+# ---------------------------------------------------------------------------
+# severity_config-aware CI Gate card
+# ---------------------------------------------------------------------------
+
+def test_no_gate_card_without_severity_config() -> None:
+    """Without severity_config, the native report has no CI Gate card at all."""
+    from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+
+    c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+    result = DiffResult(
+        old_version="1.0", new_version="2.0", library="libtest.so",
+        changes=[c], verdict=Verdict.COMPATIBLE,
+    )
+    out = generate_html_report(result)
+    assert "CI Gate" not in out
+
+
+def test_gate_card_fails_for_addition_promoted_to_error() -> None:
+    """An addition promoted to `error` fails CI even though Compatibility
+    reads COMPATIBLE — the CI Gate card must surface that, unlike the
+    Compatibility banner alone (verified defect: P0 finding 4)."""
+    from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+    from abicheck.severity import resolve_severity_config
+
+    c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+    result = DiffResult(
+        old_version="1.0", new_version="2.0", library="libtest.so",
+        changes=[c], verdict=Verdict.COMPATIBLE,
+    )
+    cfg = resolve_severity_config("default", addition="error")
+    out = generate_html_report(result, severity_config=cfg)
+    assert "Compatibility: COMPATIBLE" in out
+    assert "CI Gate" in out
+    assert "FAIL (exit 1)" in out
+
+
+def test_gate_card_passes_when_no_error_level_findings() -> None:
+    from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+    from abicheck.severity import resolve_severity_config
+
+    c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+    result = DiffResult(
+        old_version="1.0", new_version="2.0", library="libtest.so",
+        changes=[c], verdict=Verdict.COMPATIBLE,
+    )
+    cfg = resolve_severity_config("default")
+    out = generate_html_report(result, severity_config=cfg)
+    assert "CI Gate" in out
+    assert "PASS" in out
+
+
+def test_gate_card_absent_from_abicc_compatible_layout() -> None:
+    """The ABICC-compatible layout (compat_html=True) is left unchanged even
+    when severity_config is supplied."""
+    from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+    from abicheck.severity import resolve_severity_config
+
+    c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+    result = DiffResult(
+        old_version="1.0", new_version="2.0", library="libtest.so",
+        changes=[c], verdict=Verdict.COMPATIBLE,
+    )
+    cfg = resolve_severity_config("default", addition="error")
+    out = generate_html_report(result, severity_config=cfg, compat_html=True)
+    assert "CI Gate" not in out

--- a/tests/test_stack_report.py
+++ b/tests/test_stack_report.py
@@ -19,6 +19,7 @@ import json
 from pathlib import Path
 
 from abicheck.binder import BindingStatus, SymbolBinding
+from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
 from abicheck.resolver import DependencyGraph, ResolvedDSO
 from abicheck.stack_checker import StackChange, StackCheckResult, StackVerdict
 from abicheck.stack_report import stack_to_json, stack_to_markdown
@@ -99,6 +100,51 @@ class TestStackToJson:
         data = json.loads(stack_to_json(result))
         assert "stack_changes" in data
         assert data["stack_changes"][0]["change_type"] == "added"
+
+    def test_stack_change_findings_embedded_not_just_counts(self):
+        """A content-changed library must embed which symbols broke, not just
+        a bare count — verified defect: JSON only had `abi_breaking: N`, with
+        no way to identify the actual findings without a separate `compare`
+        run (mirroring the `scan --baseline` fix)."""
+        diff = DiffResult(
+            old_version="1.0", new_version="2.0", library="libfoo.so",
+            changes=[
+                Change(ChangeKind.FUNC_REMOVED, "foo_init", "removed: foo_init"),
+            ],
+            verdict=Verdict.BREAKING,
+        )
+        result = _make_result(
+            stack_changes=[
+                StackChange(library="libfoo.so", change_type="content_changed", abi_diff=diff),
+            ],
+        )
+        data = json.loads(stack_to_json(result))
+        sc = data["stack_changes"][0]
+        assert sc["abi_breaking"] == 1
+        assert "findings" in sc
+        assert sc["findings"][0]["symbol"] == "foo_init"
+        assert sc["findings"][0]["kind"] == "func_removed"
+        assert sc["findings"][0]["bucket"] == "breaking"
+        assert "findings_truncated" not in sc
+
+    def test_stack_change_findings_capped_and_flagged_truncated(self):
+        changes = [
+            Change(ChangeKind.FUNC_REMOVED, f"foo_{i}", f"removed: foo_{i}")
+            for i in range(15)
+        ]
+        diff = DiffResult(
+            old_version="1.0", new_version="2.0", library="libfoo.so",
+            changes=changes, verdict=Verdict.BREAKING,
+        )
+        result = _make_result(
+            stack_changes=[
+                StackChange(library="libfoo.so", change_type="content_changed", abi_diff=diff),
+            ],
+        )
+        data = json.loads(stack_to_json(result))
+        sc = data["stack_changes"][0]
+        assert len(sc["findings"]) == 10
+        assert sc["findings_truncated"] is True
 
     def test_bindings_summary_in_json(self):
         result = _make_result()


### PR DESCRIPTION
## Summary

Fixes the four remaining P0 correctness gaps identified in the follow-up reporting review of #549/#551 (re-baselined at `9c49163`), plus two adjacent P1 items in the same SARIF code path.

## Motivation

The review found that despite #549/#551 making the review digest, annotations, SARIF, JUnit, and stat output severity/gate-aware, four cross-cutting correctness issues remained where a report could still disagree with the actual effective verdict or CI gate outcome for a given finding.

## Changes

- **`--show-only`** (`reporter_markdown.py`): `_check_severity`/`matches`/`apply_show_only` now accept `kind_sets`/`policy_file` and resolve through `severity.effective_verdict_for_change` — the same resolver `DiffResult._effective_verdict_for_change` uses — instead of only honouring a per-change `effective_verdict` while falling back to a bare kind-set lookup that ignored `PolicyFile.overrides`. Wired through all six call sites (Markdown, leaf, SARIF, JUnit, HTML).
- **GitHub annotations** (`annotations.py`): `collect_annotations()`'s legacy (no `SeverityConfig`) path always classifies through each change's effective category (`_category_for_change_severity`) now, via a new `_legacy_level_for_category` fixed mapping, instead of calling `_classify_change(change.kind, ...)` directly — so a frozen-namespace guard or A4 pattern-verdict modulation is reflected in both the annotation level and title.
- **SARIF `executionSuccessful`** (`sarif.py`): now unconditionally `true`, matching the spec's definition (the tool ran to completion) instead of encoding the ABI/severity gate outcome, which already has dedicated homes (`exitCode`, `exitCodeDescription`, result `level`s, `properties.severityGate`). Also fixed (same file, same review pass): `_result_for`'s `file:line:column` location parsing (a single `rsplit(":", 1)` corrupted the artifact URI and never set `startColumn`), and `_rule_for`'s `helpUri`, which pointed at a nonexistent `docs/abi_breaking_cases_catalog.md` — now `docs/reference/change-kinds.md`.
- **Native HTML report** (`html_report.py`, `service.py`): `generate_html_report` accepts `severity_config` and renders a separate "CI Gate: PASS/FAIL (exit N)" card alongside the renamed "Compatibility" banner, so a configured gate failure (e.g. an addition promoted to `error`) is visible even when the verdict itself reads `COMPATIBLE`. The ABICC-compatible (`compat_html=True`) layout is unchanged. `service.render_output` forwards `severity_config` through.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Docs updated if user-visible behaviour changed (n/a — no user-facing docs changed beyond the SARIF `helpUri` fix)
- [x] `pre-commit run --all-files` passes locally (`ruff check`, `mypy`, `scripts/check_ai_readiness.py` all clean)
- [x] No new `mypy` or `ruff` errors introduced

Full fast suite: 14,570 passed, 26 skipped, 4 xfailed. `mypy abicheck/`: clean. AI-readiness gate: 0 errors (same 14 pre-existing warnings as baseline).


---
_Generated by [Claude Code](https://claude.ai/code/session_011vR6zMZrCvsybF9Q7Ki2fq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secondary report rendering for `compare` (`--secondary-format/--secondary-output`) with strict validation and no overwrite of the primary output.
  * Extended compare JSON schemas with per-finding `finding_id`, `operation`, and `recommended_action`, plus severity-gate details (“CI Gate” support).
  * Added capped, severity-aware per-library findings to stack/release-style JSON outputs.

* **Bug Fixes**
  * Improved severity/policy-aware behavior across annotations, JUnit, SARIF, JSON, and GitHub summaries; aligned gating and `show-only` filtering with effective verdicts.

* **Documentation**
  * Updated user guides and schema docs for secondary output and the new compare-report fields/severity-gate structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->