### PR TITLE
fix(clang-plugin): close P1 gaps from latest-main plugin review (ADR-038 C.10-C.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -432,6 +432,39 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **Clang plugin: `source_edges` collected but never reached the L5 graph,
+  plus four related correctness gaps from an independent review of the
+  ADR-038 C.8 canonical fact-set work (ADR-038 C.10-C.12).**
+  `SourceAbiTu.source_edges` (call/type-relationship facts the plugin and the
+  reference `clang.py` extractor both collect during their existing frontend
+  pass) was serialized and round-tripped but `SourceAbiSurface` had no edge
+  field at all, so nothing ever folded them into the L5 graph — the separate
+  `call_graph`/`type_graph` Clang AST replay passes remained the only
+  producer of those edges end-to-end. `source_link.link_source_abi()` now
+  folds them onto a new `SourceAbiSurface.source_edges`, and
+  `source_graph.fold_source_edges()` consumes it from inside
+  `build_source_graph()`; the separate replay passes are skipped when a
+  full-scope `source_edges` collection is already confirmed complete.
+  Fixing this exposed (and required fixing) a callee-identity bug in
+  `call_graph.py`: clang's compact `referencedDecl` stub never carries
+  `mangledName` (verified against a real Clang 18 AST dump), so an
+  overloaded/constructor/destructor callee collapsed onto one bare-name
+  endpoint; it now builds an id-index from full declarations in the same
+  walk, mirroring `type_graph.py`'s existing fix. Also fixed: opaque
+  inline/template body-hash diffs are now suppressed (not silently computed
+  from possibly-incomparable hashes) when the two sides' fact-set
+  producer/version disagree (`fact_set.FactCompatibility`), with a
+  `hash_recipe_id` override for producers proven equivalent via the C.6
+  differential conformance test; the plugin's fact filename/`tu_id` now fold
+  in the target/library identity so two libraries sharing one `out=`
+  directory no longer silently clobber each other's facts, and
+  `abicheck inputs validate` rejects a pack mixing more than one target;
+  `compact_inputs_pack()` rejects an `--output-filename` colliding with an
+  unrecognized pre-existing file instead of silently overwriting it; and a
+  public typedef whose underlying type can't be determined from the JSON
+  dump now records a diagnostic instead of silently vanishing from `types`
+  coverage.
+
 - **Review digest, GitHub annotations, and `scan --baseline` could misreport
   the actual CI gate once severity configuration is in play.** Compatibility
   (`Verdict`) and "blocks CI" (`SeverityConfig`) are independent decisions —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -443,9 +443,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   producer of those edges end-to-end. `source_link.link_source_abi()` now
   folds them onto a new `SourceAbiSurface.source_edges`, and
   `source_graph.fold_source_edges()` consumes it from inside
-  `build_source_graph()`; the separate replay passes are skipped when a
-  full-scope `source_edges` collection is already confirmed complete.
-  Fixing this exposed (and required fixing) a callee-identity bug in
+  `build_source_graph()`; the separate `call_graph`/`type_graph` replay
+  passes remain enabled unconditionally (a review found that skipping them
+  would drop the `dst_file`/project-file provenance those passes attach,
+  which the decl-dependency crosscheck needs to classify a callee/type as
+  project-internal — see ADR-038 C.10). Fixing this exposed (and required
+  fixing) a callee-identity bug in
   `call_graph.py`: clang's compact `referencedDecl` stub never carries
   `mangledName` (verified against a real Clang 18 AST dump), so an
   overloaded/constructor/destructor callee collapsed onto one bare-name

--- a/abicheck/buildsource/call_graph.py
+++ b/abicheck/buildsource/call_graph.py
@@ -173,13 +173,48 @@ def _find_referenced_decl(node: dict[str, Any]) -> dict[str, Any] | None:
     return None
 
 
+def _resolve_ref_callee_identity(
+    ref: dict[str, Any], id_index: Mapping[str, str]
+) -> str:
+    """Resolve a ``referencedDecl``/``referencedMemberDecl`` stub to its real identity.
+
+    clang's compact ``referencedDecl`` never carries ``mangledName`` even when
+    the full declaration elsewhere in the same TU does — verified against a
+    real Clang 17/18 ``-ast-dump=json`` for an overloaded ``int f(int)``/
+    ``double f(double)`` pair: both call sites' stubs are
+    ``{"kind": "FunctionDecl", "name": "f", "type": {"qualType": ...}}`` with
+    no ``mangledName``, differing only in ``id`` and ``type.qualType``
+    (latest-main Clang plugin review, PR1b — the plugin itself already
+    resolves callees from the live ``FunctionDecl*``, so this asymmetry was
+    Flow B/the JSON-AST replay's alone). Keying solely off the stub's own
+    identity therefore collapses every overload/constructor/destructor onto
+    one bare name.
+
+    *id_index* is built during the same AST walk from every full
+    ``FunctionDecl``/``CXXMethodDecl``/... node seen (keyed by clang's own
+    per-node ``id``, mirroring ``type_graph._resolve_ref_identity``'s
+    established id-index pattern), so a stub's ``id`` — always present, even
+    on an otherwise-incomplete stub — resolves to the real mangled identity
+    recorded when that same declaration was visited in full elsewhere in the
+    TU (its prototype or definition, whichever textually precedes this call
+    per C/C++ declare-before-use). Falls back to the stub's own (almost
+    always name-only) identity when its ``id`` was not indexed — a forward
+    reference to a declaration this walk has not (yet) seen in full, or a
+    hand-built/malformed AST fixture; a known, best-effort limitation,
+    identical in spirit to ``type_graph``'s documented ADR-041 P1 gap.
+    """
+    node_id = str(ref.get("id") or "")
+    indexed = id_index.get(node_id, "")
+    return indexed or _identity(ref)
+
+
 def _classify_call(
-    call_node: dict[str, Any], ref: dict[str, Any] | None
+    call_node: dict[str, Any], ref: dict[str, Any] | None, id_index: Mapping[str, str]
 ) -> tuple[str, str, str]:
     """Return ``(callee_identity, call_kind, resolution)`` for one call site."""
     if ref is None:
         return "", CALL_KIND_UNKNOWN, RESOLUTION_UNKNOWN
-    callee = _identity(ref)
+    callee = _resolve_ref_callee_identity(ref, id_index)
     ref_kind = str(ref.get("kind", ""))
     if not callee:
         return "", CALL_KIND_UNKNOWN, RESOLUTION_UNKNOWN
@@ -221,6 +256,7 @@ def _enter_function_scope(
     caller_file: str,
     cur_file: str,
     decl_files: dict[str, str],
+    id_index: dict[str, str],
 ) -> tuple[str, str]:
     """Return the ``(caller, caller_file)`` scope after a function-decl node, recording its definition file."""
     ident = _identity(node) or caller
@@ -230,15 +266,29 @@ def _enter_function_scope(
     # Record the definition file so a callee-only leaf helper resolves it.
     if ident and _has_function_body(node):
         decl_files[ident] = cur_file
+    # Index this full declaration by clang's own per-node id so a later call
+    # site's compact referencedDecl stub (which never carries mangledName,
+    # see _resolve_ref_callee_identity) can resolve back to the real
+    # identity. Every FunctionDecl/CXXMethodDecl/... node is indexed, not
+    # only ones with a body, so a pure prototype still resolves callers of
+    # a not-yet-defined declaration.
+    node_id = str(node.get("id") or "")
+    real_ident = _identity(node)
+    if node_id and real_ident:
+        id_index.setdefault(node_id, real_ident)
     return caller, caller_file
 
 
 def _append_call_edge(
-    node: dict[str, Any], caller: str, caller_file: str, edges: list[CallEdge]
+    node: dict[str, Any],
+    caller: str,
+    caller_file: str,
+    edges: list[CallEdge],
+    id_index: dict[str, str],
 ) -> None:
     """Resolve one call expression's callee and append the edge (unresolved/self calls dropped)."""
     ref = _find_referenced_decl(node)
-    callee, call_kind, resolution = _classify_call(node, ref)
+    callee, call_kind, resolution = _classify_call(node, ref, id_index)
     if callee and callee != caller:
         edges.append(CallEdge(caller, callee, call_kind, resolution, caller_file))
 
@@ -250,6 +300,7 @@ def _walk_calls(
     cur_file: str,
     edges: list[CallEdge],
     decl_files: dict[str, str],
+    id_index: dict[str, str],
 ) -> None:
     """Recursive AST walk tracking the nearest enclosing function as the *caller*."""
     if not isinstance(node, dict):
@@ -260,12 +311,12 @@ def _walk_calls(
     kind = str(node.get("kind", ""))
     if kind in _FUNCTION_DECL_KINDS:
         caller, caller_file = _enter_function_scope(
-            node, caller, caller_file, cur_file, decl_files
+            node, caller, caller_file, cur_file, decl_files, id_index
         )
     if kind in _CALL_EXPR_KINDS and caller:
-        _append_call_edge(node, caller, caller_file, edges)
+        _append_call_edge(node, caller, caller_file, edges, id_index)
     for child in node.get("inner", []) or []:
-        _walk_calls(child, caller, caller_file, cur_file, edges, decl_files)
+        _walk_calls(child, caller, caller_file, cur_file, edges, decl_files, id_index)
 
 
 def _fill_callee_files(
@@ -307,7 +358,12 @@ def parse_clang_ast_calls(ast: dict[str, Any]) -> list[CallEdge]:
     # location sits on the sibling FunctionDecl), so ``callee_file`` is filled from
     # this map after the walk, not from the reference node (Codex review).
     decl_files: dict[str, str] = {}
-    _walk_calls(ast, "", "", "", edges, decl_files)
+    # clang AST node id -> mangled-or-bare identity, built from every full
+    # FunctionDecl/CXXMethodDecl/... node seen, so a call site's compact
+    # referencedDecl stub can resolve its real (mangled, overload-distinct)
+    # identity instead of the stub's own name-only fallback (PR1b).
+    id_index: dict[str, str] = {}
+    _walk_calls(ast, "", "", "", edges, decl_files, id_index)
     return _dedupe_edges(_fill_callee_files(edges, decl_files))
 
 

--- a/abicheck/buildsource/fact_set.py
+++ b/abicheck/buildsource/fact_set.py
@@ -75,6 +75,40 @@ class FactSetIssue:
     message: str
 
 
+@dataclass(frozen=True)
+class FactCompatibility:
+    """Structured comparability verdict for one old/new ``fact_set`` pair.
+
+    ``check_fact_set_compatibility`` reports *what* differs as prose-bearing
+    :class:`FactSetIssue` rows; nothing previously packaged that into a
+    boolean a diff pass could act on, so ``source_diff.diff_source_abi`` used
+    to emit a "these hashes may be unreliable" finding and then unconditionally
+    diff the (possibly incomparable) opaque hashes anyway (P1 gating gap,
+    latest-main Clang plugin review). This type is that missing verdict:
+
+    - ``structured_facts_comparable``: compiler-neutral facts (signatures,
+      declarations, type shapes) — false only on a ``fact_set`` name/version
+      mismatch, since those change what the mandatory-family contract even
+      promises.
+    - ``opaque_hashes_comparable``: producer-specific body/template hashes
+      (``inline_body_changed``, ``template_body_changed``) — false on a
+      producer/producer_version/compiler_version mismatch too, since the
+      canonicalization recipe can change independently of ``fact_set.version``
+      (rule 3 in the module docstring), *unless* both sides declare the same
+      :func:`hash_recipe_id`, which overrides a producer/version mismatch that
+      a differential conformance run (ADR-038 C.6) has proven irrelevant.
+    - ``source_edges_comparable``: plugin/replay-produced graph edge endpoint
+      identities share the same producer-dependent-recipe risk as opaque
+      hashes (endpoint identity is derived from the same AST-dump recipe), so
+      it is gated identically.
+    """
+
+    structured_facts_comparable: bool
+    opaque_hashes_comparable: bool
+    source_edges_comparable: bool
+    issues: tuple[FactSetIssue, ...]
+
+
 def rollup_coverage(tus: list[SourceAbiTu]) -> dict[str, str]:
     """Worst-of-across-TUs coverage state per fact family.
 
@@ -266,3 +300,93 @@ def check_fact_set_compatibility(
                 )
 
     return issues
+
+
+#: A mismatch in the mandatory-family *contract itself* (rules 1/2) always
+#: invalidates everything -- it means the two sides don't even agree on what
+#: the fact set promises to collect, which no declared hash_recipe_id can
+#: paper over. Never overridable by a matching hash_recipe_id.
+_HARD_BLOCKING_RULES = frozenset(
+    {"fact_set_name_mismatch", "fact_set_version_mismatch"}
+)
+
+#: FactSetIssue rules whose presence means opaque body/template hashes may
+#: not be byte-comparable across the old/new pair (rule 3: producer/
+#: producer_version/compiler_version identify the canonicalization recipe
+#: that produced the opaque hashes). These *are* overridable by a matching
+#: hash_recipe_id -- a differential conformance run can prove two different
+#: producer identities emit byte-comparable hashes.
+_RECIPE_OVERRIDABLE_RULES = frozenset(
+    {"producer_mismatch", "producer_version_mismatch", "compiler_version_mismatch"}
+)
+
+#: source_edges endpoint identities are derived from the same producer/
+#: compiler-dependent AST-dump recipe as opaque hashes (mangled-name
+#: resolution, canonicalization), so they are gated by the same rule set.
+_SOURCE_EDGE_OVERRIDABLE_RULES = _RECIPE_OVERRIDABLE_RULES
+
+#: Only a mismatch in the mandatory-family *contract itself* invalidates
+#: compiler-neutral structured facts (signatures, declarations, type shapes);
+#: a different producer/compiler can still extract the same structured facts
+#: correctly even if its opaque-hash recipe differs.
+_STRUCTURED_FACT_INVALIDATING_RULES = _HARD_BLOCKING_RULES
+
+
+def hash_recipe_id(fact_set: dict[str, Any]) -> str:
+    """Stable id for the opaque-hash canonicalization recipe a ``fact_set`` used.
+
+    Two sides reporting the *same* recipe id have declared — typically because
+    a differential conformance run (ADR-038 C.6) proved it — that their
+    opaque body/template hashes are byte-comparable even when their producer
+    name/version differs formally, which is more precise than treating any
+    producer-name difference as inherently incompatible. Absent an explicit
+    ``"hash_recipe_id"`` field, falls back to the ``producer``/
+    ``producer_version``/``compiler_version`` triple
+    :func:`check_fact_set_compatibility` already keys its rule-3 checks on, so
+    fact-sets recorded before this field existed still compare consistently
+    (two such fact-sets only share a fallback recipe id when they'd already
+    pass rule 3 with no issues).
+    """
+    recipe = fact_set.get("hash_recipe_id")
+    if isinstance(recipe, str) and recipe:
+        return recipe
+    return "|".join(
+        str(fact_set.get(key, ""))
+        for key in ("producer", "producer_version", "compiler_version")
+    )
+
+
+def check_fact_compatibility(
+    old_fact_set: dict[str, Any], new_fact_set: dict[str, Any]
+) -> FactCompatibility:
+    """Structured, actionable comparability verdict (ADR-038 C.8 / PR2 gating).
+
+    Wraps :func:`check_fact_set_compatibility` so a diff pass can gate
+    specific evidence categories instead of only reporting prose that nothing
+    downstream reads. A matching :func:`hash_recipe_id` on both sides
+    overrides an otherwise-invalidating producer/producer_version/
+    compiler_version mismatch for ``opaque_hashes_comparable`` and
+    ``source_edges_comparable`` specifically — those two sides have declared
+    they use the same canonicalization recipe despite differing producer
+    identity strings.
+
+    When one or both sides carry no ``fact_set`` at all (a pre-C.8 producer),
+    :func:`check_fact_set_compatibility` reports only the informational
+    ``fact_set_unknown`` warning — not one of the invalidating rules — so
+    every category stays comparable here too, preserving the existing
+    forward-compat behavior of never gating a pre-C.8 baseline's findings.
+    """
+    issues = check_fact_set_compatibility(old_fact_set, new_fact_set)
+    rules = {issue.rule for issue in issues}
+    same_recipe = bool(old_fact_set) and bool(new_fact_set)
+    if same_recipe:
+        same_recipe = hash_recipe_id(old_fact_set) == hash_recipe_id(new_fact_set)
+    hard_blocked = bool(rules & _HARD_BLOCKING_RULES)
+    return FactCompatibility(
+        structured_facts_comparable=not hard_blocked,
+        opaque_hashes_comparable=not hard_blocked
+        and (same_recipe or not (rules & _RECIPE_OVERRIDABLE_RULES)),
+        source_edges_comparable=not hard_blocked
+        and (same_recipe or not (rules & _SOURCE_EDGE_OVERRIDABLE_RULES)),
+        issues=tuple(issues),
+    )

--- a/abicheck/buildsource/fact_set.py
+++ b/abicheck/buildsource/fact_set.py
@@ -89,7 +89,17 @@ class FactCompatibility:
     - ``structured_facts_comparable``: compiler-neutral facts (signatures,
       declarations, type shapes) — false only on a ``fact_set`` name/version
       mismatch, since those change what the mandatory-family contract even
-      promises.
+      promises. This specifically gates *existence/removal* claims (an
+      identity present old, absent new): under a contract mismatch, absence
+      may only mean the old contract never mandated collecting that family,
+      not that the entity disappeared. It does **not** gate a *content*
+      comparison for an identity present on **both** sides — a signature/type
+      hash means the same thing regardless of which mandatory-family contract
+      collected it, so those comparisons remain valid even under this flag
+      (a review found the previous wording implied otherwise while nothing
+      consumed it that way; `source_diff.py`'s removal-detection loops in
+      `_diff_generated`/`_diff_typedefs`/`_diff_macros` are what this
+      actually gates).
     - ``opaque_hashes_comparable``: producer-specific body/template hashes
       (``inline_body_changed``, ``template_body_changed``) — false on a
       producer/producer_version/compiler_version mismatch too, since the

--- a/abicheck/buildsource/fact_set.py
+++ b/abicheck/buildsource/fact_set.py
@@ -312,12 +312,20 @@ _HARD_BLOCKING_RULES = frozenset(
 
 #: FactSetIssue rules whose presence means opaque body/template hashes may
 #: not be byte-comparable across the old/new pair (rule 3: producer/
-#: producer_version/compiler_version identify the canonicalization recipe
-#: that produced the opaque hashes). These *are* overridable by a matching
-#: hash_recipe_id -- a differential conformance run can prove two different
-#: producer identities emit byte-comparable hashes.
+#: producer_version/compiler_version/compiler_family identify the
+#: canonicalization recipe that produced the opaque hashes -- a different
+#: compiler family mangles/canonicalizes differently even when the abicheck
+#: producer identity matches, same reasoning as a compiler_version drift).
+#: These *are* overridable by a matching hash_recipe_id -- a differential
+#: conformance run can prove two different producer/compiler identities emit
+#: byte-comparable hashes.
 _RECIPE_OVERRIDABLE_RULES = frozenset(
-    {"producer_mismatch", "producer_version_mismatch", "compiler_version_mismatch"}
+    {
+        "producer_mismatch",
+        "producer_version_mismatch",
+        "compiler_family_mismatch",
+        "compiler_version_mismatch",
+    }
 )
 
 #: source_edges endpoint identities are derived from the same producer/
@@ -341,18 +349,25 @@ def hash_recipe_id(fact_set: dict[str, Any]) -> str:
     name/version differs formally, which is more precise than treating any
     producer-name difference as inherently incompatible. Absent an explicit
     ``"hash_recipe_id"`` field, falls back to the ``producer``/
-    ``producer_version``/``compiler_version`` triple
+    ``producer_version``/``compiler_family``/``compiler_version`` quadruple
     :func:`check_fact_set_compatibility` already keys its rule-3 checks on, so
     fact-sets recorded before this field existed still compare consistently
     (two such fact-sets only share a fallback recipe id when they'd already
-    pass rule 3 with no issues).
+    pass rule 3 with no issues). ``compiler_family`` is included so a gcc vs.
+    clang pair can never fall back to the same recipe id even when producer/
+    producer_version/compiler_version otherwise match.
     """
     recipe = fact_set.get("hash_recipe_id")
     if isinstance(recipe, str) and recipe:
         return recipe
     return "|".join(
         str(fact_set.get(key, ""))
-        for key in ("producer", "producer_version", "compiler_version")
+        for key in (
+            "producer",
+            "producer_version",
+            "compiler_family",
+            "compiler_version",
+        )
     )
 
 

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -1554,29 +1554,6 @@ def _make_source_extractor(
 # ── L5: source graph ──────────────────────────────────────────────────────────
 
 
-def _source_edges_confirmed(surface: SourceAbiSurface | None) -> bool:
-    """Whether *surface*'s rolled-up ``source_edges`` fact family is confirmed
-    complete or legitimately empty (ADR-038 C.9 / latest-main Clang plugin
-    review, PR1).
-
-    When true, the L4 frontend invocation already walked the AST for call/
-    type relationships (folded into the graph by
-    ``source_graph.fold_source_edges`` inside ``build_source_graph``), so a
-    *full-scope* separate call/type-graph replay pass would just re-parse the
-    same TUs for edges already present -- see the caller's ``broad_pass``
-    check for why a narrowed scope is never skipped this way.
-    ``partial``/``failed``/``unsupported`` (a producer that has not, or never
-    will, adopt the C.9 protocol) and a surface with no fact_set at all both
-    return ``False``, leaving the replay passes as the fallback.
-    """
-    if surface is None:
-        return False
-    states = surface.coverage.get("fact_family_states")
-    if not isinstance(states, dict):
-        return False
-    return states.get("source_edges") in ("complete", "empty-confirmed")
-
-
 def _build_inline_graph(
     merged: BuildEvidence,
     surface: SourceAbiSurface | None,
@@ -1621,34 +1598,34 @@ def _build_inline_graph(
             fold_type_graph,
         )
 
-        # A full/target-scope call+type-graph pass is redundant once the L4
-        # frontend invocation already produced complete source_edges for this
-        # same broad scope (ADR-038 C.9 / PR1) -- build_source_graph() above
-        # already folded them in via fold_source_edges. A narrowed scope
-        # (changed_paths / call_graph_units) is never skipped: narrowed
-        # source_edges only proves completeness for the TUs L4 actually
-        # parsed, same as extractor_pass_fully_covered's full/narrowed split.
-        broad_pass = not changed_paths and call_graph_units is None
-        if broad_pass and _source_edges_confirmed(surface):
-            graph.extractor_passes["call_graph"] = True
-            graph.extractor_passes["type_graph"] = True
-        else:
-            fold_call_graph(
-                graph,
-                merged,
-                clang_bin,
-                extractors,
-                changed_paths,
-                scoped_units=call_graph_units,
-            )
-            fold_type_graph(
-                graph,
-                merged,
-                clang_bin,
-                extractors,
-                changed_paths,
-                scoped_units=call_graph_units,
-            )
+        # NOTE: this always runs the replay passes even when `surface`'s
+        # source_edges are already confirmed complete (build_source_graph()
+        # above already folded those in via fold_source_edges) -- an earlier
+        # revision skipped the replay in that case, but the raw source_edges
+        # wire format carries only bare endpoint identities, not the
+        # dst_file/project-file provenance fold_call_graph/fold_type_graph
+        # attach via `project_files` (`defined_in_project`). Without that
+        # provenance, `crosscheck.public_to_internal_dependency` cannot
+        # classify an unannotated callee/referenced node as internal, so a
+        # public-to-internal dependency addition would silently go
+        # undetected (Codex review). The replay stays unconditional until
+        # source_edges carries equivalent provenance end-to-end.
+        fold_call_graph(
+            graph,
+            merged,
+            clang_bin,
+            extractors,
+            changed_paths,
+            scoped_units=call_graph_units,
+        )
+        fold_type_graph(
+            graph,
+            merged,
+            clang_bin,
+            extractors,
+            changed_paths,
+            scoped_units=call_graph_units,
+        )
         fold_include_graph(
             graph,
             merged,

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -1554,6 +1554,29 @@ def _make_source_extractor(
 # ── L5: source graph ──────────────────────────────────────────────────────────
 
 
+def _source_edges_confirmed(surface: SourceAbiSurface | None) -> bool:
+    """Whether *surface*'s rolled-up ``source_edges`` fact family is confirmed
+    complete or legitimately empty (ADR-038 C.9 / latest-main Clang plugin
+    review, PR1).
+
+    When true, the L4 frontend invocation already walked the AST for call/
+    type relationships (folded into the graph by
+    ``source_graph.fold_source_edges`` inside ``build_source_graph``), so a
+    *full-scope* separate call/type-graph replay pass would just re-parse the
+    same TUs for edges already present -- see the caller's ``broad_pass``
+    check for why a narrowed scope is never skipped this way.
+    ``partial``/``failed``/``unsupported`` (a producer that has not, or never
+    will, adopt the C.9 protocol) and a surface with no fact_set at all both
+    return ``False``, leaving the replay passes as the fallback.
+    """
+    if surface is None:
+        return False
+    states = surface.coverage.get("fact_family_states")
+    if not isinstance(states, dict):
+        return False
+    return states.get("source_edges") in ("complete", "empty-confirmed")
+
+
 def _build_inline_graph(
     merged: BuildEvidence,
     surface: SourceAbiSurface | None,
@@ -1598,22 +1621,34 @@ def _build_inline_graph(
             fold_type_graph,
         )
 
-        fold_call_graph(
-            graph,
-            merged,
-            clang_bin,
-            extractors,
-            changed_paths,
-            scoped_units=call_graph_units,
-        )
-        fold_type_graph(
-            graph,
-            merged,
-            clang_bin,
-            extractors,
-            changed_paths,
-            scoped_units=call_graph_units,
-        )
+        # A full/target-scope call+type-graph pass is redundant once the L4
+        # frontend invocation already produced complete source_edges for this
+        # same broad scope (ADR-038 C.9 / PR1) -- build_source_graph() above
+        # already folded them in via fold_source_edges. A narrowed scope
+        # (changed_paths / call_graph_units) is never skipped: narrowed
+        # source_edges only proves completeness for the TUs L4 actually
+        # parsed, same as extractor_pass_fully_covered's full/narrowed split.
+        broad_pass = not changed_paths and call_graph_units is None
+        if broad_pass and _source_edges_confirmed(surface):
+            graph.extractor_passes["call_graph"] = True
+            graph.extractor_passes["type_graph"] = True
+        else:
+            fold_call_graph(
+                graph,
+                merged,
+                clang_bin,
+                extractors,
+                changed_paths,
+                scoped_units=call_graph_units,
+            )
+            fold_type_graph(
+                graph,
+                merged,
+                clang_bin,
+                extractors,
+                changed_paths,
+                scoped_units=call_graph_units,
+            )
         fold_include_graph(
             graph,
             merged,

--- a/abicheck/buildsource/inputs_emit.py
+++ b/abicheck/buildsource/inputs_emit.py
@@ -144,49 +144,84 @@ def init_inputs_pack(
     names the *same* target across its per-TU invocations). A caller that
     omits ``library``/``version`` (leaves it ``""``) is never treated as a
     conflict either way, preserving callers that do not always know it yet.
+
+    The very first creation is claimed atomically (write-temp + ``os.link``):
+    an ``is_file()``-then-write TOCTOU let two racing first-TU invocations for
+    two *different* targets sharing one out= directory both observe no
+    manifest yet, both skip the library/version agreement check above, and
+    have the second writer silently win with neither call ever raising
+    (Codex review; same fix shape as the Clang plugin's ``ensureManifest``).
+    ``os.link`` is all-or-nothing — it fails with ``FileExistsError`` without
+    ever creating a partial file at the destination if it already exists — so
+    the loser always re-reads a fully-written manifest, never a torn one.
     """
     root = Path(root)
     mpath = root / INPUTS_MANIFEST_NAME
-    if mpath.is_file():
+    # Only `root` itself -- not source_facts/ -- so a rejected wrong-kind
+    # pack below is still left with no new files of ours (CodeRabbit review,
+    # P2); tempfile.mkstemp(dir=root) below needs root to already exist.
+    root.mkdir(parents=True, exist_ok=True)
+
+    if not mpath.is_file():
+        # Best-effort: skip the claim attempt when a manifest is already
+        # visible (the common case after the pack's first TU) -- the
+        # exclusivity guarantee is os.link() below, not this check.
+        new_manifest = InputsManifest(
+            library=library, version=version, created_by=created_by, created_at=_now()
+        )
+        manifest_json = (
+            json.dumps(new_manifest.to_dict(), indent=2, sort_keys=True) + "\n"
+        )
+        fd, tmp = tempfile.mkstemp(dir=str(root), prefix=".manifest.", suffix=".tmp")
         try:
-            data = json.loads(mpath.read_text(encoding="utf-8"))
-        except (ValueError, OSError):
-            data = None
-        if isinstance(data, dict):
-            if data.get("kind") != INPUTS_KIND:
-                # A syntactically valid manifest naming a different (or no)
-                # kind names a real, different pack (e.g. a BuildSourcePack
-                # directory a build was mistakenly pointed at) -- not a
-                # "malformed" one, so it is not swallowed the way the
-                # fallback below swallows a truncated/corrupted manifest.
-                # Raised BEFORE any write to root (mkdir included below) so
-                # an unrelated/wrong-kind pack is left completely untouched,
-                # not just its manifest (CodeRabbit review, P2).
-                raise ValueError(
-                    f"{mpath} does not declare kind: {INPUTS_KIND} — not a "
-                    "Flow-2 abicheck_inputs pack."
-                )
-            existing_library = str(data.get("library") or "")
-            if library and existing_library and library != existing_library:
-                raise ValueError(
-                    f"{mpath} already names library {existing_library!r}; this "
-                    f"call named {library!r}. Two different targets must not "
-                    "share one abicheck_inputs pack directory -- use a separate "
-                    "out= directory per target/configuration/architecture."
-                )
-            existing_version = str(data.get("version") or "")
-            if version and existing_version and version != existing_version:
-                raise ValueError(
-                    f"{mpath} already names version {existing_version!r}; this "
-                    f"call named {version!r}. Two different versions must not "
-                    "share one abicheck_inputs pack directory -- use a fresh "
-                    "out= directory per build."
-                )
+            with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as fh:
+                fh.write(manifest_json)
+            os.link(tmp, mpath)
+        except FileExistsError:
+            pass  # lost the race -- fall through and validate the winner's manifest
+        else:
             (root / SOURCE_FACTS_DIR).mkdir(parents=True, exist_ok=True)
-            return InputsManifest.from_dict(data)
-        # Defensive: a manifest left partial/malformed by a non-atomic writer
-        # on an old pack (our writes are atomic) re-initializes rather than
-        # raising and losing this TU's facts.
+            return new_manifest
+        finally:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+
+    try:
+        data = json.loads(mpath.read_text(encoding="utf-8"))
+    except (ValueError, OSError):
+        data = None
+    if isinstance(data, dict):
+        if data.get("kind") != INPUTS_KIND:
+            # A syntactically valid manifest naming a different (or no)
+            # kind names a real, different pack (e.g. a BuildSourcePack
+            # directory a build was mistakenly pointed at) -- not a
+            # "malformed" one, so it is not swallowed the way the
+            # fallback below swallows a truncated/corrupted manifest.
+            raise ValueError(
+                f"{mpath} does not declare kind: {INPUTS_KIND} — not a "
+                "Flow-2 abicheck_inputs pack."
+            )
+        existing_library = str(data.get("library") or "")
+        if library and existing_library and library != existing_library:
+            raise ValueError(
+                f"{mpath} already names library {existing_library!r}; this "
+                f"call named {library!r}. Two different targets must not "
+                "share one abicheck_inputs pack directory -- use a separate "
+                "out= directory per target/configuration/architecture."
+            )
+        existing_version = str(data.get("version") or "")
+        if version and existing_version and version != existing_version:
+            raise ValueError(
+                f"{mpath} already names version {existing_version!r}; this "
+                f"call named {version!r}. Two different versions must not "
+                "share one abicheck_inputs pack directory -- use a fresh "
+                "out= directory per build."
+            )
+        (root / SOURCE_FACTS_DIR).mkdir(parents=True, exist_ok=True)
+        return InputsManifest.from_dict(data)
+    # Defensive: a manifest left partial/malformed by a non-atomic writer
+    # on an old pack (our writes are atomic) re-initializes rather than
+    # raising and losing this TU's facts.
     (root / SOURCE_FACTS_DIR).mkdir(parents=True, exist_ok=True)
     manifest = InputsManifest(
         library=library, version=version, created_by=created_by, created_at=_now()

--- a/abicheck/buildsource/inputs_emit.py
+++ b/abicheck/buildsource/inputs_emit.py
@@ -87,17 +87,27 @@ def _write_manifest(root: Path, manifest: InputsManifest) -> None:
         raise
 
 
-def facts_filename(source: str) -> str:
+def facts_filename(source: str, *, library: str = "") -> str:
     """Deterministic, collision-resistant ``source_facts`` filename for a TU.
 
     ``<stem>.<short-hash>.jsonl`` — the stem keeps it human-readable, the hash of
     the full source path keeps two same-named TUs in different directories from
     colliding (and lets parallel wrapper invocations each own a file).
+
+    *library* — the owning target's identity (``init_inputs_pack``'s
+    ``library=``) — is folded into the hash alongside the source path when
+    given, so the *same* source file compiled into two different libraries
+    that share one ``abicheck_inputs/`` pack root gets two distinct files
+    instead of the second compile silently overwriting the first's facts
+    (latest-main Clang plugin review, PR3 target isolation). Omitting
+    *library* keeps the pre-existing, library-blind filename for a caller
+    that only ever emits one target into a given pack root.
     """
     import hashlib
 
     stem = Path(source).name or "tu"
-    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:12]
+    digest_input = f"{library}\0{source}" if library else source
+    digest = hashlib.sha256(digest_input.encode("utf-8")).hexdigest()[:12]
     return f"{stem}.{digest}.jsonl"
 
 
@@ -110,8 +120,11 @@ def init_inputs_pack(
 ) -> InputsManifest:
     """Create the pack directory + manifest if absent; return the manifest.
 
-    Idempotent: if a manifest already exists it is loaded and returned unchanged,
-    so repeated per-TU wrapper invocations share one pack without clobbering it.
+    Idempotent for repeated calls naming the **same** target: if a manifest
+    already exists and its ``library``/``version`` agree with (or leave
+    unspecified) the ones passed here, it is loaded and returned unchanged, so
+    repeated per-TU wrapper invocations across one build share one pack
+    without clobbering it.
 
     Raises ``ValueError`` if an existing manifest.json does not declare
     ``kind: abicheck_inputs`` — e.g. a :class:`~.pack.BuildSourcePack`
@@ -122,6 +135,16 @@ def init_inputs_pack(
     directory (CodeRabbit review, P2) — this is the very first point of
     contact for a build's pack, so the check matters more here than anywhere
     downstream.
+
+    Also raises ``ValueError`` when an existing manifest names a *different*
+    non-empty ``library`` or ``version`` than this call (latest-main Clang
+    plugin review, PR3): the manifest is otherwise first-writer-wins, so two
+    different targets/versions built into one shared ``out=``/pack directory
+    would silently inherit whichever one ran first — an operational
+    correctness risk, not a legitimate shared-pack scenario (which always
+    names the *same* target across its per-TU invocations). A caller that
+    omits ``library``/``version`` (leaves it ``""``) is never treated as a
+    conflict either way, preserving callers that do not always know it yet.
     """
     root = Path(root)
     mpath = root / INPUTS_MANIFEST_NAME
@@ -143,6 +166,22 @@ def init_inputs_pack(
                 raise ValueError(
                     f"{mpath} does not declare kind: {INPUTS_KIND} — not a "
                     "Flow-2 abicheck_inputs pack."
+                )
+            existing_library = str(data.get("library") or "")
+            if library and existing_library and library != existing_library:
+                raise ValueError(
+                    f"{mpath} already names library {existing_library!r}; this "
+                    f"call named {library!r}. Two different targets must not "
+                    "share one abicheck_inputs pack directory -- use a separate "
+                    "out= directory per target/configuration/architecture."
+                )
+            existing_version = str(data.get("version") or "")
+            if version and existing_version and version != existing_version:
+                raise ValueError(
+                    f"{mpath} already names version {existing_version!r}; this "
+                    f"call named {version!r}. Two different versions must not "
+                    "share one abicheck_inputs pack directory -- use a fresh "
+                    "out= directory per build."
                 )
             (root / SOURCE_FACTS_DIR).mkdir(parents=True, exist_ok=True)
             return InputsManifest.from_dict(data)
@@ -357,13 +396,6 @@ def compact_inputs_pack(
     facts_dir = root / SOURCE_FACTS_DIR
     facts_dir.mkdir(parents=True, exist_ok=True)
     output_path = facts_dir / output_filename
-    # Whether output_path already held a (valid, from a prior successful
-    # compaction) merge before this run's os.replace() below -- needed to
-    # decide, on a later manifest-write failure, whether cleaning it up
-    # would discard only this run's not-yet-published output or also a
-    # legitimate prior compaction's result a rerun happened to overwrite in
-    # place (same output_filename as last time).
-    output_path_preexisted = output_path.exists()
 
     # Captured before ANY discovery/read step below, not just the per-file
     # record reads -- _iter_source_fact_files() itself can append a
@@ -391,11 +423,41 @@ def compact_inputs_pack(
     # -- both findings, the second reproduced empirically by a regression
     # test on some filesystems).
     prior_files: list[Path] = []
+    recognized_prior_path: Path | None = None
     if manifest.last_compacted:
         candidate = _safe_pack_path(root, manifest.last_compacted, sink)
         if candidate is not None:
             candidate = candidate.resolve()
+            recognized_prior_path = candidate
             prior_files = [f for f in originals if f.resolve() == candidate]
+
+    # output_path already existing is legitimate ONLY when it IS the
+    # recognized prior compaction's own file (a rerun reusing the same
+    # --output-filename/--compress as last time) -- not merely "some file
+    # happens to already sit at this path". A bare `output_path.exists()`
+    # check used to treat an operator's --output-filename colliding with an
+    # ordinary pre-existing file (an untouched per-TU original, a hand-placed
+    # file, any stray leftover manifest.last_compacted does not point at) as
+    # if it were a legitimate previous compaction -- so the os.replace()
+    # below silently overwrote that unrelated file with this run's merge,
+    # and a subsequent manifest-write failure then left the clobbered
+    # replacement in place (rollback skips deletion for anything
+    # "pre-existing") while the caller only saw an exception implying no
+    # lasting effect (latest-main Clang plugin review, PR4). Reject the
+    # collision outright instead of trying to back up and restore an
+    # arbitrary file's prior content -- simpler and safer, per the review's
+    # own recommendation.
+    output_path_preexisted = (
+        recognized_prior_path is not None
+        and output_path.resolve() == recognized_prior_path
+    )
+    if output_path.exists() and not output_path_preexisted:
+        raise ValueError(
+            f"{output_path} already exists and is not this pack's recognized "
+            "prior compaction output (manifest.last_compacted) -- refusing to "
+            "overwrite an unrelated file. Choose a different --output-filename "
+            "or remove the conflicting file first."
+        )
 
     def _last_record_wins(
         files: list[Path],

--- a/abicheck/buildsource/inputs_emit.py
+++ b/abicheck/buildsource/inputs_emit.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 import contextlib
 import datetime as _dt
 import gzip
+import hashlib
 import json
 import os
 import shutil
@@ -103,8 +104,6 @@ def facts_filename(source: str, *, library: str = "") -> str:
     *library* keeps the pre-existing, library-blind filename for a caller
     that only ever emits one target into a given pack root.
     """
-    import hashlib
-
     stem = Path(source).name or "tu"
     digest_input = f"{library}\0{source}" if library else source
     digest = hashlib.sha256(digest_input.encode("utf-8")).hexdigest()[:12]
@@ -389,7 +388,11 @@ def compact_inputs_pack(
     # case). Normalize to the canonical .jsonl extension before the
     # optional .gz suffix, matching every other producer in this codebase,
     # unless the caller already used a recognized extension.
-    base = output_filename[: -len(".gz")] if output_filename.endswith(".gz") else output_filename
+    base = (
+        output_filename[: -len(".gz")]
+        if output_filename.endswith(".gz")
+        else output_filename
+    )
     if not (base.endswith(".jsonl") or base.endswith(".json")):
         base = f"{base}.jsonl"
     output_filename = f"{base}.gz" if compress else base

--- a/abicheck/buildsource/inputs_pack.py
+++ b/abicheck/buildsource/inputs_pack.py
@@ -186,7 +186,8 @@ class InputsManifest:
         return cls(
             kind=_opt_str(d.get("kind"), INPUTS_KIND),
             abicheck_inputs_version=int(
-                d.get("abicheck_inputs_version", ABICHECK_INPUTS_VERSION) or ABICHECK_INPUTS_VERSION
+                d.get("abicheck_inputs_version", ABICHECK_INPUTS_VERSION)
+                or ABICHECK_INPUTS_VERSION
             ),
             library=_opt_str(d.get("library")),
             version=_opt_str(d.get("version")),
@@ -339,7 +340,9 @@ def _iter_source_fact_files(
         # both ways). The pack-wide "zero readable TU records" diagnostic
         # still catches a genuinely fact-less pack.
         if explicit and len(files) == before and not is_existing_dir:
-            sink.append(f"source_facts entry resolved to no readable fact files: {entry}")
+            sink.append(
+                f"source_facts entry resolved to no readable fact files: {entry}"
+            )
     # Re-validate each discovered file on its *resolved* path: a file inside an
     # in-pack directory can itself be a symlink pointing outside the pack, which
     # the per-entry guard above does not catch (Codex review). Drop any escapee
@@ -360,13 +363,16 @@ def _iter_source_fact_files(
     return sorted(set(safe))
 
 
-def _parse_tu_records(text: str, source: str, diagnostics: list[str]) -> list[SourceAbiTu]:
+def _parse_tu_records(
+    text: str, source: str, diagnostics: list[str]
+) -> list[SourceAbiTu]:
     """Parse one ``source_facts`` file into :class:`SourceAbiTu` records.
 
     Accepts JSON-Lines (one TU object per line, the preferred form), a single
     JSON array of TU objects, or a single TU object. Malformed lines are skipped
     with a diagnostic rather than aborting the whole ingest (forward-compat).
     """
+
     def _convert(obj: Any, where: str) -> SourceAbiTu | None:
         """Convert one record, skipping (not aborting) a schema-invalid TU.
 
@@ -416,7 +422,9 @@ def _parse_tu_records(text: str, source: str, diagnostics: list[str]) -> list[So
         try:
             obj = json.loads(line)
         except ValueError as exc:
-            diagnostics.append(f"{source}:{lineno}: skipped malformed JSON line ({exc})")
+            diagnostics.append(
+                f"{source}:{lineno}: skipped malformed JSON line ({exc})"
+            )
             continue
         if isinstance(obj, dict):
             tu = _convert(obj, f"{source}:{lineno}")
@@ -554,7 +562,9 @@ def read_source_facts(
     return fresh_tus + surviving_prior
 
 
-def _load_build_evidence(root: Path, manifest: InputsManifest, diagnostics: list[str]) -> BuildEvidence | None:
+def _load_build_evidence(
+    root: Path, manifest: InputsManifest, diagnostics: list[str]
+) -> BuildEvidence | None:
     """Parse the pack's compile DB into L3 build evidence, if present."""
     rel = manifest.compile_db or DEFAULT_COMPILE_DB_REL
     compile_db = _safe_pack_path(root, rel, diagnostics)  # refuse absolute/escaping
@@ -619,9 +629,20 @@ def ingest_inputs_pack(
 
     graph = None
     if surface is not None or has_build:
-        from .source_graph import build_source_graph
+        from .source_graph import (
+            build_source_graph,
+            mark_source_edges_extractor_coverage,
+        )
 
-        graph = build_source_graph(build_evidence or BuildEvidence(), source_abi=surface)
+        graph = build_source_graph(
+            build_evidence or BuildEvidence(), source_abi=surface
+        )
+        # No call/type-graph replay ever runs for an ingested Flow-2 pack (pure
+        # parsing, ADR-035 D5) -- translate a confirmed-complete source_edges
+        # rollup into the same extractor-pass coverage a replay would have
+        # recorded, or the decl-dependency crosscheck reads "never ran" and
+        # suppresses a real finding as a coverage artifact (Codex review).
+        mark_source_edges_extractor_coverage(graph, surface)
         graph.finalize()
 
     extractor = ExtractorRecord(
@@ -631,7 +652,11 @@ def ingest_inputs_pack(
         status="ok" if (tus or has_build) and not diagnostics else "partial",
         detail=(
             f"Flow-2 ingest: {len(tus)} source-fact TUs"
-            + (f", L3 from {manifest.compile_db or DEFAULT_COMPILE_DB_REL}" if has_build else "")
+            + (
+                f", L3 from {manifest.compile_db or DEFAULT_COMPILE_DB_REL}"
+                if has_build
+                else ""
+            )
             + (f", {len(diagnostics)} skipped/diagnostic" if diagnostics else "")
             + (f" (produced by {manifest.created_by})" if manifest.created_by else "")
         ),

--- a/abicheck/buildsource/inputs_validate.py
+++ b/abicheck/buildsource/inputs_validate.py
@@ -30,7 +30,12 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from .fact_set import incomplete_families, rollup_coverage, rollup_fact_set
+from .fact_set import (
+    check_fact_set_compatibility,
+    incomplete_families,
+    rollup_coverage,
+    rollup_fact_set,
+)
 from .inputs_pack import (
     INPUTS_KIND,
     InputsManifest,
@@ -87,6 +92,76 @@ def _duplicate_tu_ids(tus: list[SourceAbiTu]) -> list[str]:
     return sorted(dupes)
 
 
+def _target_id_issues(tus: list[SourceAbiTu], manifest: InputsManifest) -> list[str]:
+    """Target/library isolation errors (latest-main Clang plugin review, PR3).
+
+    A pack is one target/configuration/architecture's evidence; nothing here
+    checks that today, so two targets built into one shared ``out=``
+    directory silently mix TUs with no signal a downstream ``merge``/
+    ``compare`` could ever detect. Two checks:
+
+    - More than one distinct non-empty ``tu.target_id`` in the same pack —
+      the exact same-source/two-library collision the plugin's first-writer-
+      wins ``ensureManifest``/``facts_filename`` allowed.
+    - A TU's ``target_id`` disagreeing with ``target://<manifest.library>``
+      when the manifest names a library — a producer stamping a different
+      target than the pack it was told to write into.
+
+    TUs with no ``target_id`` at all (a pre-target-isolation producer) are
+    not flagged either way — this is additive validation, not a new
+    hard requirement on every producer.
+    """
+    issues: list[str] = []
+    target_ids = sorted({tu.target_id for tu in tus if tu.target_id})
+    if len(target_ids) > 1:
+        issues.append(
+            "pack mixes more than one target_id across its TU records: "
+            f"{', '.join(target_ids)} — two different targets/libraries must "
+            "not share one abicheck_inputs pack; use a separate out= "
+            "directory per target/configuration/architecture."
+        )
+    expected = f"target://{manifest.library}" if manifest.library else ""
+    if expected:
+        mismatched = sorted(
+            {tu.target_id for tu in tus if tu.target_id and tu.target_id != expected}
+        )
+        if mismatched:
+            issues.append(
+                f"pack manifest names library {manifest.library!r} (expected "
+                f"target_id {expected!r}) but TU record(s) name a different "
+                f"target_id: {', '.join(mismatched)} — this pack's evidence does "
+                "not agree on which target it describes."
+            )
+    return issues
+
+
+def _fact_set_recipe_issues(tus: list[SourceAbiTu]) -> list[str]:
+    """Hard fact-set-contract mismatches *within one pack's* TU records.
+
+    ``rollup_fact_set`` already reports "TUs disagree" as a soft warning
+    (mixed producer/producer_version is routine — different TUs replayed at
+    different times). A ``fact_set`` **name** or **version** mismatch between
+    two TUs in the *same* pack is stronger: it means the pack literally does
+    not agree on what mandatory-family contract it collected under, which
+    ``check_fact_set_compatibility``'s rule 1/2 already treats as an "error"
+    for an old/new comparison — the same severity applies just as much within
+    one pack (latest-main Clang plugin review, PR3).
+    """
+    distinct = list({tuple(sorted(tu.fact_set.items())) for tu in tus if tu.fact_set})
+    if len(distinct) < 2:
+        return []
+    fact_sets = [dict(d) for d in distinct]
+    seen_rules: set[str] = set()
+    issues: list[str] = []
+    for i, a in enumerate(fact_sets):
+        for b in fact_sets[i + 1 :]:
+            for issue in check_fact_set_compatibility(a, b):
+                if issue.severity == "error" and issue.rule not in seen_rules:
+                    seen_rules.add(issue.rule)
+                    issues.append(f"{issue.rule}: {issue.message}")
+    return issues
+
+
 def validate_inputs_pack(root: Path | str) -> InputsValidationReport:
     """Validate one ``abicheck_inputs/`` pack directory; never raises for a
     structurally-readable pack — problems are reported, not thrown. Raises
@@ -132,6 +207,9 @@ def validate_inputs_pack(root: Path | str) -> InputsValidationReport:
             f"{len(dupes)} duplicate tu_id(s) across source-fact files (a race-free "
             f"per-TU filename should make this impossible): {', '.join(dupes)}"
         )
+
+    report.errors.extend(_target_id_issues(tus, manifest))
+    report.errors.extend(_fact_set_recipe_issues(tus))
 
     # Prefer the per-TU rollup over the manifest-declared fact_set: a plugin
     # that stamps manifest.json up front cannot know whether every TU later

--- a/abicheck/buildsource/inputs_validate.py
+++ b/abicheck/buildsource/inputs_validate.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 from .fact_set import (
     check_fact_set_compatibility,
@@ -147,10 +148,12 @@ def _fact_set_recipe_issues(tus: list[SourceAbiTu]) -> list[str]:
     for an old/new comparison — the same severity applies just as much within
     one pack (latest-main Clang plugin review, PR3).
     """
-    distinct = list({tuple(sorted(tu.fact_set.items())) for tu in tus if tu.fact_set})
-    if len(distinct) < 2:
+    fact_sets: list[dict[str, Any]] = []
+    for tu in tus:
+        if tu.fact_set and tu.fact_set not in fact_sets:
+            fact_sets.append(dict(tu.fact_set))
+    if len(fact_sets) < 2:
         return []
-    fact_sets = [dict(d) for d in distinct]
     seen_rules: set[str] = set()
     issues: list[str] = []
     for i, a in enumerate(fact_sets):

--- a/abicheck/buildsource/source_abi.py
+++ b/abicheck/buildsource/source_abi.py
@@ -457,6 +457,15 @@ class SourceAbiSurface:
     reachable_macros: list[SourceEntity] = field(default_factory=list)
     reachable_templates: list[SourceEntity] = field(default_factory=list)
     reachable_inline_bodies: list[SourceEntity] = field(default_factory=list)
+    #: Deduplicated ``source_edges`` folded across every linked TU (ADR-038
+    #: C.9 / latest-main Clang plugin review, PR1): call/reference/type-shape
+    #: relationships collected during the *same* L4 frontend invocation that
+    #: produced the entities above, in the same ``{edge, src, dst, provenance,
+    #: confidence, attrs}`` shape as ``SourceAbiTu.source_edges`` (which itself
+    #: mirrors ``source_graph.GraphEdge.to_dict()``). ``build_source_graph``
+    #: folds these into the L5 graph so a plugin/replay producer's edges are
+    #: no longer serialized-but-unused dead data.
+    source_edges: list[dict[str, Any]] = field(default_factory=list)
     #: decl_to_binary_symbol maps qualified_name -> exported symbol ("" when the
     #: declaration has no exported symbol, i.e. a public decl that is not shipped)
     mappings: dict[str, Any] = field(
@@ -495,6 +504,7 @@ class SourceAbiSurface:
                 name: [e.to_dict() for e in bucket]
                 for name, bucket in self.reachable_buckets().items()
             },
+            "source_edges": list(self.source_edges),
             "mappings": {
                 "source_decl_to_binary_symbol": dict(
                     self.mappings.get("source_decl_to_binary_symbol", {})
@@ -577,6 +587,7 @@ class SourceAbiSurface:
             reachable_macros=_ents("macros"),
             reachable_templates=_ents("templates"),
             reachable_inline_bodies=_ents("inline_bodies"),
+            source_edges=list(d.get("source_edges", [])),
             mappings=mappings,
             odr_conflicts=list(d.get("odr_conflicts", [])),
             unmatched=unmatched,

--- a/abicheck/buildsource/source_abi.py
+++ b/abicheck/buildsource/source_abi.py
@@ -169,6 +169,17 @@ def _string_dict(raw: Any) -> dict[str, str]:
     return {str(k): str(v) for k, v in raw.items()}
 
 
+def _edge_list(raw: Any) -> list[dict[str, Any]]:
+    """Defensive parse for a ``source_edges`` field (CodeRabbit review):
+    ``list(None)`` raises and ``list("...")`` yields character entries, so a
+    malformed/forward-versioned persisted value must not abort loading or
+    poison the graph with junk entries -- only well-formed dict rows survive.
+    """
+    if not isinstance(raw, list):
+        return []
+    return [dict(edge) for edge in raw if isinstance(edge, dict)]
+
+
 @dataclass
 class SourceLocation:
     """Where a source entity was declared, with provenance origin (ADR-030 D4)."""
@@ -400,9 +411,7 @@ class SourceAbiTu:
         # would poison cache dependency tracking (CodeRabbit review). Coerce to a
         # clean list of non-empty strings.
         rf_raw = d.get("read_files")
-        read_files = (
-            [str(p) for p in rf_raw if p] if isinstance(rf_raw, list) else []
-        )
+        read_files = [str(p) for p in rf_raw if p] if isinstance(rf_raw, list) else []
         fs_raw = d.get("fact_set")
         fact_set = dict(fs_raw) if isinstance(fs_raw, dict) else {}
 
@@ -422,7 +431,7 @@ class SourceAbiTu:
             templates=_ents("templates"),
             inline_bodies=_ents("inline_bodies"),
             constexpr_values=_ents("constexpr_values"),
-            source_edges=list(d.get("source_edges", [])),
+            source_edges=_edge_list(d.get("source_edges")),
             diagnostics=list(d.get("diagnostics", [])),
             read_files=read_files,
             fact_set=fact_set,
@@ -587,7 +596,7 @@ class SourceAbiSurface:
             reachable_macros=_ents("macros"),
             reachable_templates=_ents("templates"),
             reachable_inline_bodies=_ents("inline_bodies"),
-            source_edges=list(d.get("source_edges", [])),
+            source_edges=_edge_list(d.get("source_edges")),
             mappings=mappings,
             odr_conflicts=list(d.get("odr_conflicts", [])),
             unmatched=unmatched,

--- a/abicheck/buildsource/source_diff.py
+++ b/abicheck/buildsource/source_diff.py
@@ -239,12 +239,13 @@ def _diff_fact_coverage(
         )
     if has_signal and not compat.structured_facts_comparable:
         suppression += (
-            " generated_header_changed/public_typedef_removed/public_macro_removed "
-            "removal detection is suppressed for this comparison because the "
-            "fact_set name/version mismatch means an entity's absence may only "
-            "reflect the old contract never collecting its family, not an "
-            "actual removal; content-change findings for entities present on "
-            "both sides are unaffected."
+            " generated_header_changed/public_typedef_removed/public_macro_removed/"
+            "inline_function_removed/uninstantiated_template_removed removal "
+            "detection is suppressed for this comparison because the fact_set "
+            "name/version mismatch means an entity's absence may only reflect "
+            "the old contract never collecting its family, not an actual "
+            "removal; content-change findings for entities present on both "
+            "sides are unaffected."
         )
 
     return [
@@ -725,8 +726,9 @@ def _diff_inline_bodies(
     old_i = _by_identity(old.reachable_inline_bodies)
     new_i = _by_identity(new.reachable_inline_bodies)
     changes: list[Change] = []
-    # Existence (removal) is not hash-derived, so it stays gated only by
-    # opaque_hashes_comparable below, not this loop's body-hash comparison.
+    # Existence (removal) is not hash-derived, so it is gated separately below
+    # (structured_facts_comparable), not by opaque_hashes_comparable which only
+    # covers this loop's body-hash comparison.
     for key in (
         sorted(set(old_i) & set(new_i)) if compat.opaque_hashes_comparable else ()
     ):
@@ -765,7 +767,16 @@ def _diff_inline_bodies(
     # diff's job to report (ADR-028 D3 authority rule: L3-L5 never duplicates an
     # artifact-proven break) — skip it here.
     old_exports = set(old.roots.get("exported_symbols", []))
-    inline_removals = sorted(set(old_i) - set(new_i)) if _surface_has_facts(new) else []
+    # Skipped entirely when the new surface carries no facts (L4 extraction
+    # failed) or the two sides used incompatible fact-set contracts: an entity's
+    # absence there may only reflect the old contract never mandating collection
+    # of the inline-bodies family, not an actual removal (Codex review, mirrors
+    # the same gate on _diff_generated/_diff_typedefs/_diff_macros).
+    inline_removals = (
+        sorted(set(old_i) - set(new_i))
+        if _surface_has_facts(new) and compat.structured_facts_comparable
+        else []
+    )
     for key in inline_removals:
         ov = old_i[key]
         if key in new_decl_ids or (ov.mangled_name and ov.mangled_name in new_exports):
@@ -799,7 +810,18 @@ def _diff_templates(
     old_t = _by_identity(old.reachable_templates)
     new_t = _by_identity(new.reachable_templates)
     changes: list[Change] = []
-    for key in sorted(set(old_t) - set(new_t)):
+    # Removal is skipped when the new surface carries no facts (L4 extraction
+    # failed) or the two sides used incompatible fact-set contracts: an
+    # entity's absence there may only reflect the old contract never mandating
+    # collection of the templates family, not an actual removal (Codex
+    # review, mirrors the same gate on
+    # _diff_generated/_diff_typedefs/_diff_macros/_diff_inline_bodies).
+    template_removals = (
+        sorted(set(old_t) - set(new_t))
+        if _surface_has_facts(new) and compat.structured_facts_comparable
+        else []
+    )
+    for key in template_removals:
         ov = old_t[key]
         name = ov.qualified_name
         changes.append(
@@ -814,7 +836,8 @@ def _diff_templates(
                 source_location=_loc(ov),
             )
         )
-    # Body-hash comparison only -- existence (removal, above) is not gated.
+    # Body-hash comparison is gated separately (opaque_hashes_comparable);
+    # existence (removal, above) is gated by structured_facts_comparable instead.
     for key in (
         sorted(set(old_t) & set(new_t)) if compat.opaque_hashes_comparable else ()
     ):

--- a/abicheck/buildsource/source_diff.py
+++ b/abicheck/buildsource/source_diff.py
@@ -33,7 +33,7 @@ import re
 
 from ..checker_policy import ChangeKind
 from ..checker_types import Change
-from .fact_set import check_fact_set_compatibility, incomplete_families
+from .fact_set import FactCompatibility, check_fact_compatibility, incomplete_families
 from .source_abi import (
     COVERAGE_STATES,
     EVIDENCE_TIER_L4,
@@ -147,7 +147,16 @@ def _coerce_coverage_states(family_states: dict[str, object]) -> dict[str, str]:
     }
 
 
-def _diff_fact_coverage(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change]:
+def _surface_fact_set(surface: SourceAbiSurface) -> dict[str, object]:
+    """The rolled-up ``fact_set`` a surface's ``coverage`` carries, or ``{}``."""
+    cov = surface.coverage if isinstance(surface.coverage, dict) else {}
+    raw = cov.get("fact_set")
+    return dict(raw) if isinstance(raw, dict) else {}
+
+
+def _diff_fact_coverage(
+    old: SourceAbiSurface, new: SourceAbiSurface, compat: FactCompatibility
+) -> list[Change]:
     """ADR-038 C.8: flag incompatible or incomplete L4 fact-set evidence.
 
     Fires only when there is something to report: at least one side carries a
@@ -185,9 +194,7 @@ def _diff_fact_coverage(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Ch
     new_families = new_families_raw if isinstance(new_families_raw, dict) else {}
 
     has_signal = bool(old_fact_set or new_fact_set or old_families or new_families)
-    issues = (
-        check_fact_set_compatibility(old_fact_set, new_fact_set) if has_signal else []
-    )
+    issues = list(compat.issues) if has_signal else []
     # A serialized surface's fact_family_states can come from a hand-written
     # or forward-versioned source_abi.json, not just rollup_coverage()'s own
     # output -- so its per-family values are not guaranteed to already be one
@@ -214,6 +221,16 @@ def _diff_fact_coverage(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Ch
             f"new side mandatory family/families incomplete: {', '.join(new_incomplete)}"
         )
 
+    suppression = ""
+    if has_signal and not compat.opaque_hashes_comparable:
+        suppression = (
+            " Opaque body/template hash findings (inline_body_changed, "
+            "template_body_changed) are suppressed for this comparison because "
+            "the producer/producer_version/compiler_version recipe differs and "
+            "no matching hash_recipe_id was declared on both sides; "
+            "source_edges reconciliation is skipped for the same reason."
+        )
+
     return [
         Change(
             kind=ChangeKind.SOURCE_FACT_COVERAGE_INCOMPLETE,
@@ -224,7 +241,7 @@ def _diff_fact_coverage(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Ch
                 + "; ".join(parts)
                 + ". Per ADR-038 C.8, treat this pair's other source-replay "
                 "findings as unreliable until re-collected with a consistent, "
-                "complete fact set."
+                "complete fact set." + suppression
             ),
             old_value=str(old_fact_set or old_incomplete or ""),
             new_value=str(new_fact_set or new_incomplete or ""),
@@ -239,15 +256,16 @@ def diff_source_abi(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change
     The result is an ordinary list of :class:`Change` objects ready to fold into
     a ``DiffResult`` and run through the existing verdict/policy pipeline.
     """
+    compat = check_fact_compatibility(_surface_fact_set(old), _surface_fact_set(new))
     changes: list[Change] = []
-    changes.extend(_diff_fact_coverage(old, new))
+    changes.extend(_diff_fact_coverage(old, new, compat))
     changes.extend(_diff_generated(old, new))
     changes.extend(_diff_typedefs(old, new))
     changes.extend(_diff_macros(old, new))
     changes.extend(_diff_concepts(old, new))
     changes.extend(_diff_declarations(old, new))
-    changes.extend(_diff_inline_bodies(old, new))
-    changes.extend(_diff_templates(old, new))
+    changes.extend(_diff_inline_bodies(old, new, compat))
+    changes.extend(_diff_templates(old, new, compat))
     changes.extend(_diff_mappings(old, new))
     changes.extend(_diff_provenance(old, new))
     changes.extend(_diff_odr(old, new))
@@ -660,11 +678,17 @@ def _diff_declarations(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Cha
 # -- inline bodies -----------------------------------------------------------
 
 
-def _diff_inline_bodies(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change]:
+def _diff_inline_bodies(
+    old: SourceAbiSurface, new: SourceAbiSurface, compat: FactCompatibility
+) -> list[Change]:
     old_i = _by_identity(old.reachable_inline_bodies)
     new_i = _by_identity(new.reachable_inline_bodies)
     changes: list[Change] = []
-    for key in sorted(set(old_i) & set(new_i)):
+    # Existence (removal) is not hash-derived, so it stays gated only by
+    # opaque_hashes_comparable below, not this loop's body-hash comparison.
+    for key in (
+        sorted(set(old_i) & set(new_i)) if compat.opaque_hashes_comparable else ()
+    ):
         ov, nv = old_i[key], new_i[key]
         name = nv.qualified_name
         if ov.body_hash != nv.body_hash:
@@ -728,7 +752,9 @@ def _diff_inline_bodies(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Ch
 # -- templates ---------------------------------------------------------------
 
 
-def _diff_templates(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change]:
+def _diff_templates(
+    old: SourceAbiSurface, new: SourceAbiSurface, compat: FactCompatibility
+) -> list[Change]:
     old_t = _by_identity(old.reachable_templates)
     new_t = _by_identity(new.reachable_templates)
     changes: list[Change] = []
@@ -747,7 +773,10 @@ def _diff_templates(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change
                 source_location=_loc(ov),
             )
         )
-    for key in sorted(set(old_t) & set(new_t)):
+    # Body-hash comparison only -- existence (removal, above) is not gated.
+    for key in (
+        sorted(set(old_t) & set(new_t)) if compat.opaque_hashes_comparable else ()
+    ):
         ov, nv = old_t[key], new_t[key]
         name = nv.qualified_name
         if ov.body_hash != nv.body_hash:

--- a/abicheck/buildsource/source_diff.py
+++ b/abicheck/buildsource/source_diff.py
@@ -226,9 +226,16 @@ def _diff_fact_coverage(
         suppression = (
             " Opaque body/template hash findings (inline_body_changed, "
             "template_body_changed) are suppressed for this comparison because "
-            "the producer/producer_version/compiler_version recipe differs and "
-            "no matching hash_recipe_id was declared on both sides; "
-            "source_edges reconciliation is skipped for the same reason."
+            "the fact-set compatibility verdict does not establish "
+            "byte-comparable recipes (a name/version mismatch, or a "
+            "producer/producer_version/compiler_version/compiler_family "
+            "difference with no matching hash_recipe_id declared on both "
+            "sides)."
+        )
+    if has_signal and not compat.source_edges_comparable:
+        suppression += (
+            " source_edges reconciliation is skipped because endpoint "
+            "identities are not comparable across the two sides."
         )
 
     return [

--- a/abicheck/buildsource/source_diff.py
+++ b/abicheck/buildsource/source_diff.py
@@ -237,6 +237,15 @@ def _diff_fact_coverage(
             " source_edges reconciliation is skipped because endpoint "
             "identities are not comparable across the two sides."
         )
+    if has_signal and not compat.structured_facts_comparable:
+        suppression += (
+            " generated_header_changed/public_typedef_removed/public_macro_removed "
+            "removal detection is suppressed for this comparison because the "
+            "fact_set name/version mismatch means an entity's absence may only "
+            "reflect the old contract never collecting its family, not an "
+            "actual removal; content-change findings for entities present on "
+            "both sides are unaffected."
+        )
 
     return [
         Change(
@@ -266,9 +275,9 @@ def diff_source_abi(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change
     compat = check_fact_compatibility(_surface_fact_set(old), _surface_fact_set(new))
     changes: list[Change] = []
     changes.extend(_diff_fact_coverage(old, new, compat))
-    changes.extend(_diff_generated(old, new))
-    changes.extend(_diff_typedefs(old, new))
-    changes.extend(_diff_macros(old, new))
+    changes.extend(_diff_generated(old, new, compat))
+    changes.extend(_diff_typedefs(old, new, compat))
+    changes.extend(_diff_macros(old, new, compat))
     changes.extend(_diff_concepts(old, new))
     changes.extend(_diff_declarations(old, new))
     changes.extend(_diff_inline_bodies(old, new, compat))
@@ -386,7 +395,9 @@ def _diff_provenance(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Chang
 # -- generated headers -------------------------------------------------------
 
 
-def _diff_generated(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change]:
+def _diff_generated(
+    old: SourceAbiSurface, new: SourceAbiSurface, compat: FactCompatibility
+) -> list[Change]:
     """Flag any generated public entity whose content changed (ADR-030 D6).
 
     Generated declarations land in ``reachable_declarations`` while generated
@@ -401,7 +412,12 @@ def _diff_generated(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change
     the normal declaration diff intentionally skips generated entities and there
     is no removal diff for ``reachable_types``, so without the removal pass a
     generated config header dropping a public record/enum/typedef/decl would
-    produce no L4 finding at all.
+    produce no L4 finding at all. The removal loop is additionally skipped when
+    ``compat.structured_facts_comparable`` is false (a fact_set name/version
+    mismatch): an entity's absence there may only mean the old contract never
+    mandated collecting its family, not that it was actually removed (Codex
+    review). Content-change detection is not gated -- an identity present on
+    both sides means the same thing regardless of contract version.
     """
     changes: list[Change] = []
     for old_bucket, new_bucket in (
@@ -433,7 +449,11 @@ def _diff_generated(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change
                         source_location=_loc(nv),
                     )
                 )
-        for key in sorted(set(old_b) - set(new_b)):
+        for key in (
+            sorted(set(old_b) - set(new_b))
+            if compat.structured_facts_comparable
+            else ()
+        ):
             ov = old_b[key]
             if _is_generated(ov):
                 name = ov.qualified_name
@@ -457,7 +477,9 @@ def _diff_generated(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change
 # -- typedefs / aliases ------------------------------------------------------
 
 
-def _diff_typedefs(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change]:
+def _diff_typedefs(
+    old: SourceAbiSurface, new: SourceAbiSurface, compat: FactCompatibility
+) -> list[Change]:
     """Flag a public typedef/alias whose underlying type changed (ADR-030 D6).
 
     Typedef entities ride in ``reachable_types`` (kind ``typedef``); a bare
@@ -494,10 +516,15 @@ def _diff_typedefs(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change]
     # Removal: a public typedef present old, gone new. A bare typedef emits no
     # symbol, so the artifact diff is blind; consumer source that named the alias
     # no longer compiles (a source/API break). Generated typedefs are reported as
-    # generated_header_changed by _diff_generated, so skip them here. Skip
-    # entirely when the new surface carries no facts (L4 extraction failed) so
-    # evidence absence is not read as removal.
-    for key in sorted(set(old_t) - set(new_t)) if _surface_has_facts(new) else []:
+    # generated_header_changed by _diff_generated, so skip them here. Skipped
+    # entirely when the new surface carries no facts (L4 extraction failed) or
+    # the two sides used incompatible fact-set contracts (Codex review) so
+    # evidence absence is not read as removal in either case.
+    for key in (
+        sorted(set(old_t) - set(new_t))
+        if _surface_has_facts(new) and compat.structured_facts_comparable
+        else []
+    ):
         ov = old_t[key]
         if _is_generated(ov):
             continue
@@ -522,7 +549,9 @@ def _diff_typedefs(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change]
 # -- macros ------------------------------------------------------------------
 
 
-def _diff_macros(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change]:
+def _diff_macros(
+    old: SourceAbiSurface, new: SourceAbiSurface, compat: FactCompatibility
+) -> list[Change]:
     old_m = _by_identity(old.reachable_macros)
     new_m = _by_identity(new.reachable_macros)
     changes: list[Change] = []
@@ -548,8 +577,13 @@ def _diff_macros(old: SourceAbiSurface, new: SourceAbiSurface) -> list[Change]:
     # one. Macros never reach the binary, so no artifact layer sees the removal —
     # only the source-replay surface does. Source that referenced it no longer
     # compiles (a source/API break). Skipped when the new surface carries no
-    # facts (L4 extraction failed) so evidence absence is not read as removal.
-    for key in sorted(set(old_m) - set(new_m)) if _surface_has_facts(new) else []:
+    # facts (L4 extraction failed) or the two sides used incompatible fact-set
+    # contracts (Codex review) so evidence absence is not read as removal.
+    for key in (
+        sorted(set(old_m) - set(new_m))
+        if _surface_has_facts(new) and compat.structured_facts_comparable
+        else []
+    ):
         ov = old_m[key]
         name = ov.qualified_name
         changes.append(

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -1082,6 +1082,94 @@ def _augment_with_source_abi(
         )
         header_declares(ent, mid, conf)
 
+    fold_source_edges(graph, surface.source_edges)
+
+
+def _source_edge_endpoint_ids(
+    kind: str, src: str, dst: str
+) -> tuple[str, str, str, str]:
+    """Map a raw ``source_edges`` row's ``(kind, src, dst)`` identities onto
+    graph node ids/kinds, mirroring the id scheme
+    ``call_graph.augment_graph_with_calls``/``type_graph.augment_graph_with_types``
+    already use — so an edge folded from L4 facts lands on the same
+    ``decl://``/``type://`` node a separate call/type-graph replay pass (or L4
+    declaration enrichment) would have created, rather than a disconnected
+    duplicate.
+    """
+    if kind == "DECL_HAS_TYPE":
+        return _decl_node_id(src), "source_decl", _type_node_id(dst), "record_type"
+    if kind in ("TYPE_INHERITS", "TYPE_HAS_FIELD_TYPE"):
+        return _type_node_id(src), "record_type", _type_node_id(dst), "record_type"
+    # DECL_CALLS_DECL / DECL_REFERENCES_DECL / any unrecognized-but-preserved kind.
+    return _decl_node_id(src), "source_decl", _decl_node_id(dst), "source_decl"
+
+
+def fold_source_edges(
+    graph: SourceGraphSummary, source_edges: list[dict[str, Any]]
+) -> int:
+    """Fold ``SourceAbiSurface.source_edges`` into *graph* (ADR-038 C.9 / PR1).
+
+    Closes the gap where a Clang-plugin/replay-collected ``source_edges`` fact
+    was serialized onto ``SourceAbiTu``/``SourceAbiSurface`` but never reached
+    the L5 graph (latest-main Clang plugin review): ``DECL_CALLS_DECL``,
+    ``DECL_REFERENCES_DECL``, ``DECL_HAS_TYPE``, ``TYPE_HAS_FIELD_TYPE``, and
+    ``TYPE_INHERITS`` rows collected during the *same* L4 frontend invocation
+    are folded in exactly like a separate ``call_graph``/``type_graph`` replay
+    pass would, using the identical node-id scheme -- so an edge here
+    reconciles with (de-duplicates against, via ``add_edge``'s
+    ``(src, dst, kind)`` key) one already present from L4 declaration
+    enrichment or a separate replay pass, first-writer-wins.
+
+    Malformed rows (missing edge-kind/src/dst, or a non-dict entry from a
+    hand-edited/forward-versioned pack) are skipped rather than raising --
+    ``source_edges`` is best-effort collected evidence (ADR-028 D7), never a
+    reason to abort the rest of the graph build. Returns the number of edges
+    actually added (excludes rows that duplicated an edge already present).
+    """
+    added = 0
+    for row in source_edges:
+        if not isinstance(row, dict):
+            continue
+        kind = str(row.get("edge") or row.get("kind") or "")
+        src_ident = str(row.get("src") or "")
+        dst_ident = str(row.get("dst") or "")
+        if not kind or not src_ident or not dst_ident:
+            continue
+        src_id, src_kind, dst_id, dst_kind = _source_edge_endpoint_ids(
+            kind, src_ident, dst_ident
+        )
+        confidence = str(row.get("confidence") or CONF_UNKNOWN)
+        provenance = str(row.get("provenance") or "source_edges")
+        for node_id, node_kind, ident in (
+            (src_id, src_kind, src_ident),
+            (dst_id, dst_kind, dst_ident),
+        ):
+            if not graph.has_node(node_id):
+                graph.add_node(
+                    GraphNode(
+                        id=node_id,
+                        kind=node_kind,
+                        label=ident,
+                        provenance=provenance,
+                        confidence=confidence,
+                    )
+                )
+        before = len(graph.edges)
+        attrs_raw = row.get("attrs")
+        graph.add_edge(
+            GraphEdge(
+                src=src_id,
+                dst=dst_id,
+                kind=kind,
+                provenance=provenance,
+                confidence=confidence,
+                attrs=dict(attrs_raw) if isinstance(attrs_raw, dict) else {},
+            )
+        )
+        if len(graph.edges) > before:
+            added += 1
+    return added
+
 
 # ── Phase 5 (seed): structural graph-to-graph diff ──────────────────────────
 

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -1171,6 +1171,42 @@ def fold_source_edges(
     return added
 
 
+def mark_source_edges_extractor_coverage(
+    graph: SourceGraphSummary, surface: SourceAbiSurface | None
+) -> None:
+    """Translate a confirmed-complete ``source_edges`` rollup into
+    ``call_graph``/``type_graph`` extractor-pass coverage (Codex review).
+
+    ``fold_source_edges`` (called from :func:`build_source_graph`) never
+    touches ``graph.extractor_passes`` itself -- when a caller runs the
+    ``call_graph``/``type_graph`` replay right after building the graph
+    (``inline._build_inline_graph``, ``cli_buildsource_helpers``), that
+    replay's own ``extractor_pass_fully_covered()``/``narrowed_pass_confirmed()``
+    tracking is strictly more precise (it knows full-vs-narrowed scope; a bare
+    ``source_edges`` rollup does not) and must be the sole source of truth —
+    do not call this alongside it. But a caller that folds ``source_edges``
+    and never runs a replay at all (``inputs_pack.ingest_inputs_pack``
+    ingesting a build-emitted Flow-2 pack; ``cli_buildsource_merge``'s
+    export-relink graph rebuild) leaves both flags permanently unset even
+    though the AST was genuinely, completely walked for these edge kinds --
+    ``source_graph_findings._common_dependency_edge_kinds``/
+    ``_dependency_kinds_covered`` then read that as "no pass ever ran" and
+    suppress a real ``PUBLIC_API_INTERNAL_DEPENDENCY_ADDED`` finding as a
+    coverage artifact instead of reporting it. A Flow-2 pack always reflects
+    whatever the build compiled (never a `changed_paths`-narrowed subset the
+    way an inline scan can be), so a confirmed-complete rollup here is safe
+    to treat as full-scope coverage.
+    """
+    if surface is None:
+        return
+    families = surface.coverage.get("fact_family_states")
+    if not isinstance(families, dict):
+        return
+    if families.get("source_edges") in ("complete", "empty-confirmed"):
+        graph.extractor_passes["call_graph"] = True
+        graph.extractor_passes["type_graph"] = True
+
+
 # ── Phase 5 (seed): structural graph-to-graph diff ──────────────────────────
 
 

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+from typing import Any
 
 from .fact_set import rollup_coverage, rollup_fact_set
 from .source_abi import SourceAbiSurface, SourceAbiTu, SourceEntity
@@ -1148,7 +1149,21 @@ def link_source_abi(
     state = _LinkState()
     state.export_index = _build_export_index(exported)
     state.exact_index = _build_exact_index(exported)
+    seen_edge_keys: set[tuple[str, str, str]] = set()
+    source_edges: list[dict[str, Any]] = []
     for tu in tus:
+        for edge in tu.source_edges:
+            if not isinstance(edge, dict):
+                continue
+            edge_key = (
+                str(edge.get("edge", "")),
+                str(edge.get("src", "")),
+                str(edge.get("dst", "")),
+            )
+            if not all(edge_key) or edge_key in seen_edge_keys:
+                continue
+            seen_edge_keys.add(edge_key)
+            source_edges.append(edge)
         for header in tu.public_header_roots:
             surface.mappings["public_header_to_target"][header] = (
                 tu.target_id or target_id
@@ -1180,6 +1195,11 @@ def link_source_abi(
             state.public_decl_ids.append(entity.id)
             _route_entity(entity, surface, state, exported)
 
+    # ADR-038 C.9 / PR1: fold every TU's collected graph-edge facts up to the
+    # surface (deduplicated above by (edge, src, dst) across TUs that share a
+    # public header), so build_source_graph() can consume them directly instead
+    # of them being serialized-but-unused dead data.
+    surface.source_edges = source_edges
     surface.roots["public_header_declarations"] = sorted(set(state.public_decl_ids))
     # Second-tier: rescue decls whose mangled name differs textually from the
     # export (ABI-tag / substitution drift) via demangled identity.

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -1155,12 +1155,22 @@ def link_source_abi(
         for edge in tu.source_edges:
             if not isinstance(edge, dict):
                 continue
-            edge_key = (
-                str(edge.get("edge", "")),
-                str(edge.get("src", "")),
-                str(edge.get("dst", "")),
+            edge_name, edge_src, edge_dst = (
+                edge.get("edge"),
+                edge.get("src"),
+                edge.get("dst"),
             )
-            if not all(edge_key) or edge_key in seen_edge_keys:
+            if not (
+                isinstance(edge_name, str)
+                and edge_name
+                and isinstance(edge_src, str)
+                and edge_src
+                and isinstance(edge_dst, str)
+                and edge_dst
+            ):
+                continue
+            edge_key = (edge_name, edge_src, edge_dst)
+            if edge_key in seen_edge_keys:
                 continue
             seen_edge_keys.add(edge_key)
             source_edges.append(edge)

--- a/abicheck/cc_wrapper.py
+++ b/abicheck/cc_wrapper.py
@@ -169,7 +169,9 @@ def emit_facts_for_command(
         except Exception as exc:
             click.echo(f"abicheck-cc: skipped facts for {cu.source}: {exc}", err=True)
             continue
-        append_source_facts(inputs_dir, [tu], filename=facts_filename(cu.source))
+        append_source_facts(
+            inputs_dir, [tu], filename=facts_filename(cu.source, library=library)
+        )
         if first is None:
             first = tu
     return first

--- a/abicheck/cli_buildsource_merge.py
+++ b/abicheck/cli_buildsource_merge.py
@@ -235,7 +235,10 @@ def _relink_combined_against_exports(
     ):
         from .buildsource.build_evidence import BuildEvidence
         from .buildsource.inline import build_inline_coverage
-        from .buildsource.source_graph import build_source_graph
+        from .buildsource.source_graph import (
+            build_source_graph,
+            mark_source_edges_extractor_coverage,
+        )
         from .buildsource.source_link import relink_surface_exports
 
         relink_surface_exports(combined.source_abi, base_exports)
@@ -244,6 +247,14 @@ def _relink_combined_against_exports(
             combined.source_graph = build_source_graph(
                 combined.build_evidence or BuildEvidence(),
                 source_abi=combined.source_abi,
+            )
+            # This rebuild starts a fresh graph with no extractor_passes of its
+            # own (a Flow-2 ingest's own call to this helper doesn't survive a
+            # rebuild) -- reapply it so a confirmed-complete source_edges
+            # rollup still reads as coverage here, not just at initial ingest
+            # (Codex review).
+            mark_source_edges_extractor_coverage(
+                combined.source_graph, combined.source_abi
             )
         extractors = tuple(combined.manifest.extractors)
         has_build = combined.build_evidence is not None and bool(

--- a/abicheck/cli_buildsource_merge.py
+++ b/abicheck/cli_buildsource_merge.py
@@ -256,6 +256,15 @@ def _relink_combined_against_exports(
             mark_source_edges_extractor_coverage(
                 combined.source_graph, combined.source_abi
             )
+            # build_source_graph() already called finalize() once (computing
+            # graph.coverage's call_edges/type_edges/reference_edges
+            # "collected" flags from extractor_passes as of that moment);
+            # mark_source_edges_extractor_coverage() above mutates
+            # extractor_passes afterward, so finalize() must re-run or the
+            # serialized coverage summary still says "collected: false" even
+            # though the pass flags are now true (Codex review; mirrors
+            # ingest_inputs_pack's own re-finalize after the same call).
+            combined.source_graph.finalize()
         extractors = tuple(combined.manifest.extractors)
         has_build = combined.build_evidence is not None and bool(
             combined.build_evidence.compile_units or combined.build_evidence.targets

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -3121,30 +3121,35 @@ private:
         ",\n  \"source_facts\": [\"source_facts\"],\n  \"version\": " + jsonStr(Version) +
         "\n}\n";
 
-    // Atomically claim manifest.json itself instead of exists()-then-rename():
-    // CD_CreateNew fails with file_exists if another parallel compile already
-    // created (or is concurrently creating) it, so "does a manifest already
-    // exist" and "claim the right to create it" become one indivisible
-    // syscall. The previous exists()-check + tmp-file-rename had a TOCTOU gap
-    // — two racing first-compiles of two different targets sharing one out=
-    // directory could both observe no manifest yet, both skip
-    // checkManifestTargetAgreement, and have the second rename() silently
-    // clobber the first's manifest with no warning ever firing (CodeRabbit
-    // review). Same exclusive-create primitive claimFirstRootsWarning/
-    // claimFirstInferenceNote already use for this file's other
-    // once-across-parallel-compiles claims.
+    // Write the full manifest to a private temp file first, then publish it
+    // via create_hard_link() -- an all-or-nothing claim of manifest.json
+    // itself, exactly like os.link() in the Python inputs_emit wrapper's
+    // equivalent fix. An earlier revision of this fix claimed manifestPath
+    // directly via openFile(..., CD_CreateNew, ...) and wrote the content
+    // into it afterward: that leaves a window where the file exists but is
+    // still empty/partial, so a losing concurrent compile's file_exists
+    // check could immediately call checkManifestTargetAgreement() on a
+    // torn read, fail json::parse, and silently skip the cross-target
+    // warning it exists to give (Codex review) -- the very race this fix
+    // was meant to close, just moved one step later. create_hard_link()
+    // only ever leaves manifestPath as "absent" or "fully written," never
+    // partial, so a loser's read is always complete.
+    llvm::SmallString<128> tmp;
     int fd = -1;
-    std::error_code ec = llvm::sys::fs::openFile(
-        manifestPath, fd, llvm::sys::fs::CD_CreateNew, llvm::sys::fs::FA_Write,
-        llvm::sys::fs::OF_None);
-    if (ec == std::errc::file_exists) {
-      checkManifestTargetAgreement(manifestPath);
-      return;
-    }
-    if (ec)
+    if (llvm::sys::fs::createUniqueFile(
+            llvm::Twine(OutDir) + "/.manifest.%%%%%%.tmp", fd, tmp))
       return; // unexpected error: best-effort, never abort the compile
-    llvm::raw_fd_ostream os(fd, /*shouldClose=*/true);
-    os << manifest;
+    {
+      llvm::raw_fd_ostream os(fd, /*shouldClose=*/true);
+      os << manifest;
+    }
+    std::error_code ec = llvm::sys::fs::create_hard_link(tmp, manifestPath);
+    llvm::sys::fs::remove(tmp);
+    if (ec == std::errc::file_exists)
+      checkManifestTargetAgreement(manifestPath);
+    // Any other error (including success) needs no further action here:
+    // success published the manifest; an unexpected error is best-effort
+    // and never aborts the compile.
   }
 
   std::string OutDir;

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -299,9 +299,12 @@ std::string familyCoverageState(bool entitiesPresent, bool diagnosticsSeen,
 // Whether any diagnostic in `diags` contains one of `substrs` — the plugin's
 // existing per-family "JSON dump failed" diagnostics (emitted where an
 // individual declaration's dump/canonicalization failed, see
-// VisitFunctionDecl/emitConstexprVar/emitDataVariable/emitType/emitTemplate/
-// emitClassTemplateMemberPatterns) double as the coverage signal, so no new
-// state has to be threaded through the visitor.
+// VisitFunctionDecl/emitConstexprVar/emitDataVariable/emitType/
+// VisitTypedefNameDecl/emitTemplate/emitClassTemplateMemberPatterns) double
+// as the coverage signal, so no new state has to be threaded through the
+// visitor. Every post-classification early return that can drop an
+// otherwise-accessible entity should insert one of these -- a return with no
+// diagnostic is invisible to family coverage (PR4 audit).
 bool anyDiagContains(const std::set<std::string> &diags,
                      std::initializer_list<const char *> substrs) {
   for (const std::string &d : diags)
@@ -2144,8 +2147,19 @@ public:
           if (auto dq = t->getString("desugaredQualType"))
             underlying = dq->str();
       }
-    if (underlying.empty())
+    if (underlying.empty()) {
+      // A publicly-visible typedef whose JSON dump was absent/non-object, or
+      // lacked both qualType and desugaredQualType, is silently dropped here
+      // -- no diagnostic, and "types" coverage only watches for "record/enum
+      // type_hash unavailable" (below), so a batch of failed typedefs
+      // alongside one successfully-collected record/enum still reported
+      // types as "complete", hiding the missing typedefs entirely
+      // (latest-main Clang plugin review, PR4). Record a diagnostic and fold
+      // it into the same family so a comparison sees partial/failed
+      // coverage instead of a silent gap.
+      Diags.insert("typedef facts unavailable (JSON dump/type spelling failed)");
       return true;
+    }
     std::string name = scopedName(td);
     Entity e;
     e.id = H({"typedef", name, underlying});
@@ -2610,8 +2624,15 @@ public:
     std::string source = resolveMainSource(sm);
     const std::string &ctxHash = CtxHash;
     std::string cfg = ctxHash.substr(std::string("sha256:").size(), 12);
-    std::string tuId = "cu://" + source + "#cfg:" + cfg;
     std::string targetId = Library.empty() ? "" : "target://" + Library;
+    // Fold the target/library identity into tu_id (not just the separate
+    // target_id field) so two different libraries compiling the *same*
+    // source+compile-context never collide on one tu_id — the exact
+    // same-source/two-library ambiguity a shared tu_id would otherwise leave
+    // undetectable downstream (latest-main Clang plugin review, PR3).
+    std::string tuId = Library.empty()
+                            ? "cu://" + source + "#cfg:" + cfg
+                            : "cu://" + source + "#cfg:" + cfg + "#target:" + Library;
 
     // P1 #15-16: every file the preprocessor actually opened for this TU —
     // captured from the SourceManager it already built, not a second pass.
@@ -2875,9 +2896,15 @@ private:
         {"variables", familyCoverageState(
                           !variables.empty(),
                           anyDiagContains(diags, {"variable facts unavailable"}))},
+        // "typedef facts unavailable" (PR4) included alongside the
+        // record/enum diagnostic: VisitTypedefNameDecl() also pushes into
+        // `types`, so a JSON-dump failure there must count toward this
+        // family's diagnostic check too, the same reasoning already applied
+        // to "functions" above for class-template member patterns.
         {"types", familyCoverageState(
                       !types.empty(),
-                      anyDiagContains(diags, {"record/enum type_hash unavailable"}))},
+                      anyDiagContains(diags, {"record/enum type_hash unavailable",
+                                               "typedef facts unavailable"}))},
         {"macros", familyCoverageState(!macros.empty(), /*diagnosticsSeen=*/false)},
         // "class-template member facts unavailable" deliberately excluded
         // here: emitClassTemplateMemberPatterns() pushes a failed member's
@@ -2933,20 +2960,29 @@ private:
         ",\"read_files\":" + jsonStrArray(readFiles) + ",\"fact_set\":" + factSet +
         ",\"coverage\":" + coverage + "}";
 
-    // Per-TU, deterministic filename keyed by source path AND compile context.
-    // Including the context hash keeps distinct ABI-relevant compile variants of
-    // the same source (e.g. SIMD/feature builds) in separate files — one is not
-    // erased by another — while a rebuild of the *same* variant overwrites its
-    // own file (truncate), so no stale/duplicate records accumulate. Ingest
-    // globs `source_facts/*.jsonl`, so the filename shape is free.
+    // Per-TU, deterministic filename keyed by source path, compile context,
+    // AND target/library identity. Including the context hash keeps distinct
+    // ABI-relevant compile variants of the same source (e.g. SIMD/feature
+    // builds) in separate files — one is not erased by another — while a
+    // rebuild of the *same* variant overwrites its own file (truncate), so no
+    // stale/duplicate records accumulate. Including the library identity
+    // additionally prevents two different targets that happen to compile the
+    // *same* source file with the *same* compile context (a common object
+    // shared into two libraries) from clobbering each other when both point
+    // `out=` at one shared directory (latest-main Clang plugin review, PR3) —
+    // previously the filename hashed only the source path, so the later
+    // compile's facts silently overwrote the earlier target's. Ingest globs
+    // `source_facts/*.jsonl`, so the filename shape is free.
     std::string cfg = (ctxHash.rfind("sha256:", 0) == 0)
                           ? ctxHash.substr(std::string("sha256:").size(), 12)
                           : ctxHash.substr(0, 12);
     llvm::StringRef stem = llvm::sys::path::filename(source);
+    std::string pathAndLibraryHash =
+        sha256Hex(Library.empty() ? source : (Library + "\x1f" + source))
+            .substr(0, 12);
     std::string factsFile = factsDir + "/" +
                             (stem.empty() ? std::string("tu") : stem.str()) +
-                            "." + sha256Hex(source).substr(0, 12) + "." + cfg +
-                            ".jsonl";
+                            "." + pathAndLibraryHash + "." + cfg + ".jsonl";
     std::ofstream out(factsFile, std::ios::trunc);
     if (!out)
       return false;
@@ -3010,10 +3046,62 @@ private:
     return true;
   }
 
+  // Loudly flag (never abort the compile over) an existing manifest naming a
+  // different non-empty library/version than this invocation — the exact
+  // same-source/two-library collision a silent first-writer-wins manifest
+  // allowed (latest-main Clang plugin review, PR3): the manifest would keep
+  // describing whichever target/version compiled first while later targets'
+  // facts (now isolated per-target by writeTu's filename fix) accumulate
+  // underneath it, describing a library manifest.json never claims to be.
+  // A stderr warning, not a hard error, matches every other best-effort
+  // diagnostic in this plugin (ADR-028 D7: source-fact collection never
+  // aborts the build it is instrumenting) — the fix is an operational one
+  // (one out= directory per target/configuration/architecture), not
+  // something this TU's compile can itself repair.
+  void checkManifestTargetAgreement(const std::string &manifestPath) {
+    auto bufOrErr = llvm::MemoryBuffer::getFile(manifestPath);
+    if (!bufOrErr)
+      return;
+    auto parsed = llvm::json::parse((*bufOrErr)->getBuffer());
+    if (!parsed) {
+      llvm::consumeError(parsed.takeError());
+      return;
+    }
+    const Object *obj = parsed->getAsObject();
+    if (!obj)
+      return;
+    if (!Library.empty()) {
+      if (auto existing = obj->getString("library"))
+        if (!existing->empty() && *existing != Library)
+          llvm::errs()
+              << "abicheck-facts: WARNING: " << manifestPath
+              << " already names library " << *existing
+              << "; this compile names " << Library
+              << ". Two different targets must not share one "
+                 "abicheck_inputs pack directory -- use a separate out= "
+                 "directory per target/configuration/architecture, or "
+                 "downstream `abicheck inputs validate` will reject this "
+                 "pack.\n";
+    }
+    if (!Version.empty()) {
+      if (auto existing = obj->getString("version"))
+        if (!existing->empty() && *existing != Version)
+          llvm::errs()
+              << "abicheck-facts: WARNING: " << manifestPath
+              << " already names version " << *existing
+              << "; this compile names " << Version
+              << ". Two different versions must not share one "
+                 "abicheck_inputs pack directory -- use a fresh out= "
+                 "directory per build.\n";
+    }
+  }
+
   void ensureManifest() {
     std::string manifestPath = OutDir + "/manifest.json";
-    if (llvm::sys::fs::exists(manifestPath))
+    if (llvm::sys::fs::exists(manifestPath)) {
+      checkManifestTargetAgreement(manifestPath);
       return;
+    }
     std::string createdBy =
         std::string("abicheck-clang-plugin ") + kPluginVersion;
     // ADR-038 C.8: the pack-level fact_set mirrors every TU record's — one

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -3098,10 +3098,7 @@ private:
 
   void ensureManifest() {
     std::string manifestPath = OutDir + "/manifest.json";
-    if (llvm::sys::fs::exists(manifestPath)) {
-      checkManifestTargetAgreement(manifestPath);
-      return;
-    }
+    llvm::sys::fs::create_directories(OutDir);
     std::string createdBy =
         std::string("abicheck-clang-plugin ") + kPluginVersion;
     // ADR-038 C.8: the pack-level fact_set mirrors every TU record's — one
@@ -3124,17 +3121,30 @@ private:
         ",\n  \"source_facts\": [\"source_facts\"],\n  \"version\": " + jsonStr(Version) +
         "\n}\n";
 
-    llvm::SmallString<128> tmp;
+    // Atomically claim manifest.json itself instead of exists()-then-rename():
+    // CD_CreateNew fails with file_exists if another parallel compile already
+    // created (or is concurrently creating) it, so "does a manifest already
+    // exist" and "claim the right to create it" become one indivisible
+    // syscall. The previous exists()-check + tmp-file-rename had a TOCTOU gap
+    // — two racing first-compiles of two different targets sharing one out=
+    // directory could both observe no manifest yet, both skip
+    // checkManifestTargetAgreement, and have the second rename() silently
+    // clobber the first's manifest with no warning ever firing (CodeRabbit
+    // review). Same exclusive-create primitive claimFirstRootsWarning/
+    // claimFirstInferenceNote already use for this file's other
+    // once-across-parallel-compiles claims.
     int fd = -1;
-    if (llvm::sys::fs::createUniqueFile(
-            llvm::Twine(OutDir) + "/.manifest.%%%%%%.tmp", fd, tmp))
+    std::error_code ec = llvm::sys::fs::openFile(
+        manifestPath, fd, llvm::sys::fs::CD_CreateNew, llvm::sys::fs::FA_Write,
+        llvm::sys::fs::OF_None);
+    if (ec == std::errc::file_exists) {
+      checkManifestTargetAgreement(manifestPath);
       return;
-    {
-      llvm::raw_fd_ostream os(fd, /*shouldClose=*/true);
-      os << manifest;
     }
-    if (llvm::sys::fs::rename(tmp, manifestPath))
-      llvm::sys::fs::remove(tmp);
+    if (ec)
+      return; // unexpected error: best-effort, never abort the compile
+    llvm::raw_fd_ostream os(fd, /*shouldClose=*/true);
+    os << manifest;
   }
 
   std::string OutDir;

--- a/contrib/abicheck-clang-plugin/tests/conformance.py
+++ b/contrib/abicheck-clang-plugin/tests/conformance.py
@@ -121,7 +121,11 @@ def _edge_keys(tus: list) -> set[tuple[str, str, str]]:
             if not isinstance(row, dict):
                 continue
             keys.add(
-                (str(row.get("edge", "")), str(row.get("src", "")), str(row.get("dst", "")))
+                (
+                    str(row.get("edge", "")),
+                    str(row.get("src", "")),
+                    str(row.get("dst", "")),
+                )
             )
     return keys
 
@@ -221,11 +225,16 @@ def _compare_fact_set(plugin_tus: list, wrapper_tus: list) -> list[str]:
 
 
 def _compare_coverage(plugin_tus: list, wrapper_tus: list) -> list[str]:
-    from abicheck.buildsource.source_abi import (
-        FACT_FAMILIES,
-        INCOMPLETE_COVERAGE_STATES,
-    )
+    from abicheck.buildsource.source_abi import COVERAGE_STATES, FACT_FAMILIES
 
+    # A mandatory family's coverage state must be an explicit, documented
+    # value ("unsupported" is a legitimate one -- e.g. the plugin never
+    # collects read_files -- so it is not itself a warning). But `None` (the
+    # TU's coverage dict never mentioned this family at all) or an
+    # unrecognized string a newer/older producer emits is a real conformance
+    # gap this check previously missed, since neither is in
+    # INCOMPLETE_COVERAGE_STATES ("partial"/"failed" only) -- every mandatory
+    # family must at least be explicitly reported on (CodeRabbit review).
     warnings: list[str] = []
     for label, tus in (("plugin", plugin_tus), ("clang backend", wrapper_tus)):
         for tu in tus:
@@ -233,7 +242,7 @@ def _compare_coverage(plugin_tus: list, wrapper_tus: list) -> list[str]:
                 continue
             for family in FACT_FAMILIES:
                 state = tu.coverage.get(family)
-                if state in INCOMPLETE_COVERAGE_STATES:
+                if state not in COVERAGE_STATES or state in ("partial", "failed"):
                     warnings.append(
                         f"{label} TU {tu.tu_id} family {family!r} reported "
                         f"{state!r} coverage on the C.6 fixture"
@@ -357,7 +366,11 @@ def main(argv: list[str] | None = None) -> int:
     # Only auto-created temp dirs are ours to delete; a caller-supplied --work
     # is owned by the caller and must never be rmtree'd (Codex review).
     created_tmp = args.work is None
-    work = Path(args.work).resolve() if args.work else Path(tempfile.mkdtemp(prefix="abicheck-c6-"))
+    work = (
+        Path(args.work).resolve()
+        if args.work
+        else Path(tempfile.mkdtemp(prefix="abicheck-c6-"))
+    )
     work.mkdir(parents=True, exist_ok=True)
     shutil.copytree(FIXTURES / "include", work / "include", dirs_exist_ok=True)
     shutil.copyfile(FIXTURES / "widget.cpp", work / "widget.cpp")
@@ -395,9 +408,11 @@ def main(argv: list[str] | None = None) -> int:
             for e in errors:
                 print(f"  - {e}", file=sys.stderr)
             return 1
-        print("\nC.6 conformance PASSED: plugin surface is entity-equivalent "
-              "to the clang backend (entities, source_edges, read_files, "
-              "fact_set).")
+        print(
+            "\nC.6 conformance PASSED: plugin surface is entity-equivalent "
+            "to the clang backend (entities, source_edges, read_files, "
+            "fact_set)."
+        )
         return 0
     finally:
         if created_tmp and not args.keep:

--- a/contrib/abicheck-clang-plugin/tests/conformance.py
+++ b/contrib/abicheck-clang-plugin/tests/conformance.py
@@ -20,6 +20,30 @@
 # warns, not fails): operator-adjacent spacing of function-like macros is the one
 # documented soft edge (ADR-038 C.7), reconciled here rather than gated.
 #
+# Side-channel comparisons (latest-main Clang plugin review, PR1b/PR2/PR4):
+# the entity comparison above proves the existing entity contract; it says
+# nothing about the newer source_edges/read_files/fact_set/coverage channels.
+# Extended here, each scoped to what can be asserted without a hand-verified
+# oracle for every AST-implicit declaration the two producers might walk
+# differently:
+#   - source_edges: the two overload-resolved DECL_CALLS_DECL edges the
+#     `overload(int)`/`overload(double)` fixture exists to exercise are
+#     required from BOTH producers (errors if missing); any additional
+#     divergence elsewhere in the edge set is reported as informational only
+#     (ADR-041 P1, a broader concern than the overload-identity regression
+#     this fixture targets).
+#   - read_files: both producers must have read the fixture's own primary
+#     source and header (a required subset, not exact equality — the two
+#     collection mechanisms are not guaranteed to enumerate transitively-
+#     included system headers identically).
+#   - fact_set: both producers must declare the same canonical name/version/
+#     compiler_family (the "same fact-set semantic recipe" ADR-038 C.8 keys
+#     comparison-compatibility on).
+#   - coverage: neither producer should report partial/failed for a
+#     mandatory family on this clean fixture (informational warning, since a
+#     real future regression here is exactly what this extension exists to
+#     catch, but the exact expected states are not hand-verified per-family).
+#
 # Runs only where a matching clang is available; it is never a required
 # abicheck-CI gate (it lives in the separate `clang-plugin` workflow).
 
@@ -50,17 +74,171 @@ COMPARED_FIELDS = (
 )
 
 
-def _load_entities(pack_dir: Path) -> dict[tuple[str, str], object]:
-    """Fold a pack's per-TU dumps into a {(kind, identity): entity} map."""
+def _load_tus(pack_dir: Path) -> list:
+    """Load a pack's per-TU dumps (``SourceAbiTu`` records) as-is."""
     from abicheck.buildsource.inputs_pack import load_inputs_manifest, read_source_facts
 
     manifest = load_inputs_manifest(pack_dir)
-    tus = read_source_facts(pack_dir, manifest)
+    return read_source_facts(pack_dir, manifest)
+
+
+def _load_entities(tus: list) -> dict[tuple[str, str], object]:
+    """Fold a pack's per-TU dumps into a {(kind, identity): entity} map."""
     out: dict[tuple[str, str], object] = {}
     for tu in tus:
         for e in tu.all_entities():
             out[(e.kind, e.identity())] = e
     return out
+
+
+#: DECL_CALLS_DECL edges the overload regression fixture (widget.cpp/hpp's
+#: overload(int)/overload(double)/callOverloadInt/callOverloadDouble) must
+#: produce identically from both producers -- the PR1b regression target:
+#: clang's compact `referencedDecl` carries no `mangledName` (verified against
+#: a real Clang 17/18 JSON AST dump), so a naive resolver collapses both
+#: overloads onto one bare-name endpoint instead of their distinct mangled
+#: identities.
+_REQUIRED_CALL_EDGES: frozenset[tuple[str, str, str]] = frozenset(
+    {
+        (
+            "DECL_CALLS_DECL",
+            "_ZN4demo15callOverloadIntEv",
+            "_ZN4demo8overloadEi",
+        ),
+        (
+            "DECL_CALLS_DECL",
+            "_ZN4demo18callOverloadDoubleEv",
+            "_ZN4demo8overloadEd",
+        ),
+    }
+)
+
+
+def _edge_keys(tus: list) -> set[tuple[str, str, str]]:
+    keys: set[tuple[str, str, str]] = set()
+    for tu in tus:
+        for row in tu.source_edges:
+            if not isinstance(row, dict):
+                continue
+            keys.add(
+                (str(row.get("edge", "")), str(row.get("src", "")), str(row.get("dst", "")))
+            )
+    return keys
+
+
+def _compare_source_edges(
+    plugin_tus: list, wrapper_tus: list
+) -> tuple[list[str], list[str]]:
+    """Required overload-resolved edges (errors) + informational-only extras."""
+    errors: list[str] = []
+    warnings: list[str] = []
+    plugin_edges = _edge_keys(plugin_tus)
+    wrapper_edges = _edge_keys(wrapper_tus)
+    for key in sorted(_REQUIRED_CALL_EDGES):
+        if key not in plugin_edges:
+            errors.append(
+                f"plugin source_edges is missing required overload-resolved "
+                f"edge {key} -- does the plugin still resolve callees by "
+                "mangled identity?"
+            )
+        if key not in wrapper_edges:
+            errors.append(
+                f"clang-backend source_edges is missing required "
+                f"overload-resolved edge {key} -- PR1b referencedDecl "
+                "id-index resolution regression?"
+            )
+    # Any OTHER divergence (implicit/builtin declarations the two producers
+    # are not guaranteed to walk identically -- e.g. compiler-injected
+    # __int128_t-style typedefs) is reported but not gated: reconciling that
+    # is the broader ADR-041 P1 concern, not the overload-identity regression
+    # this fixture targets.
+    extra_plugin = sorted(plugin_edges - wrapper_edges - _REQUIRED_CALL_EDGES)
+    extra_wrapper = sorted(wrapper_edges - plugin_edges - _REQUIRED_CALL_EDGES)
+    if extra_plugin:
+        warnings.append(
+            f"plugin source_edges has {len(extra_plugin)} edge(s) absent from "
+            f"the clang backend (informational, not gated): {extra_plugin[:5]}"
+        )
+    if extra_wrapper:
+        warnings.append(
+            f"clang-backend source_edges has {len(extra_wrapper)} edge(s) "
+            f"absent from the plugin (informational, not gated): {extra_wrapper[:5]}"
+        )
+    return errors, warnings
+
+
+#: The fixture's own primary files -- both producers must have read at least
+#: these (a required subset, not exact read_files equality).
+_REQUIRED_READ_FILES = frozenset({"widget.cpp", "widget.hpp"})
+
+
+def _compare_read_files(plugin_tus: list, wrapper_tus: list) -> list[str]:
+    def _basenames(tus: list) -> set[str]:
+        return {Path(f).name for tu in tus for f in tu.read_files}
+
+    errors: list[str] = []
+    plugin_files = _basenames(plugin_tus)
+    wrapper_files = _basenames(wrapper_tus)
+    for name in sorted(_REQUIRED_READ_FILES):
+        if name not in plugin_files:
+            errors.append(f"plugin read_files is missing required file {name!r}")
+        if name not in wrapper_files:
+            errors.append(f"clang-backend read_files is missing required file {name!r}")
+    return errors
+
+
+def _compare_fact_set(plugin_tus: list, wrapper_tus: list) -> list[str]:
+    from abicheck.buildsource.source_abi import (
+        SOURCE_ABI_FACT_SET_NAME,
+        SOURCE_ABI_FACT_SET_VERSION,
+    )
+
+    errors: list[str] = []
+    for label, tus in (("plugin", plugin_tus), ("clang backend", wrapper_tus)):
+        for tu in tus:
+            if not tu.fact_set:
+                errors.append(f"{label} TU {tu.tu_id} carries no fact_set identity")
+                continue
+            name = tu.fact_set.get("name")
+            if name != SOURCE_ABI_FACT_SET_NAME:
+                errors.append(
+                    f"{label} TU {tu.tu_id} fact_set.name={name!r}, expected "
+                    f"{SOURCE_ABI_FACT_SET_NAME!r}"
+                )
+            version = tu.fact_set.get("version")
+            if version != SOURCE_ABI_FACT_SET_VERSION:
+                errors.append(
+                    f"{label} TU {tu.tu_id} fact_set.version={version!r}, expected "
+                    f"{SOURCE_ABI_FACT_SET_VERSION!r}"
+                )
+            family = tu.fact_set.get("compiler_family")
+            if family != "clang":
+                errors.append(
+                    f"{label} TU {tu.tu_id} fact_set.compiler_family={family!r}, "
+                    "expected 'clang'"
+                )
+    return errors
+
+
+def _compare_coverage(plugin_tus: list, wrapper_tus: list) -> list[str]:
+    from abicheck.buildsource.source_abi import (
+        FACT_FAMILIES,
+        INCOMPLETE_COVERAGE_STATES,
+    )
+
+    warnings: list[str] = []
+    for label, tus in (("plugin", plugin_tus), ("clang backend", wrapper_tus)):
+        for tu in tus:
+            if not tu.fact_set:
+                continue
+            for family in FACT_FAMILIES:
+                state = tu.coverage.get(family)
+                if state in INCOMPLETE_COVERAGE_STATES:
+                    warnings.append(
+                        f"{label} TU {tu.tu_id} family {family!r} reported "
+                        f"{state!r} coverage on the C.6 fixture"
+                    )
+    return warnings
 
 
 def _run(cmd: list[str], *, cwd: Path, env: dict[str, str] | None = None) -> None:
@@ -188,8 +366,10 @@ def main(argv: list[str] | None = None) -> int:
         plugin_pack = _compile_with_plugin(work, plugin, args.clangxx)
         wrapper_pack = _compile_with_wrapper(work, args.clangxx)
 
-        plugin_ents = _load_entities(plugin_pack)
-        wrapper_ents = _load_entities(wrapper_pack)
+        plugin_tus = _load_tus(plugin_pack)
+        wrapper_tus = _load_tus(wrapper_pack)
+        plugin_ents = _load_entities(plugin_tus)
+        wrapper_ents = _load_entities(wrapper_tus)
         print(
             f"\nplugin emitted {len(plugin_ents)} entities; "
             f"clang backend emitted {len(wrapper_ents)}",
@@ -197,6 +377,17 @@ def main(argv: list[str] | None = None) -> int:
         )
 
         errors, warnings = _compare(plugin_ents, wrapper_ents)
+
+        # Side-channel comparisons (PR1b/PR2/PR4): source_edges, read_files,
+        # fact_set, and coverage -- none of which the entity comparison above
+        # touches at all (see module docstring).
+        edge_errors, edge_warnings = _compare_source_edges(plugin_tus, wrapper_tus)
+        errors.extend(edge_errors)
+        warnings.extend(edge_warnings)
+        errors.extend(_compare_read_files(plugin_tus, wrapper_tus))
+        errors.extend(_compare_fact_set(plugin_tus, wrapper_tus))
+        warnings.extend(_compare_coverage(plugin_tus, wrapper_tus))
+
         for w in warnings:
             print(f"::warning::{w}")
         if errors:
@@ -205,7 +396,8 @@ def main(argv: list[str] | None = None) -> int:
                 print(f"  - {e}", file=sys.stderr)
             return 1
         print("\nC.6 conformance PASSED: plugin surface is entity-equivalent "
-              "to the clang backend.")
+              "to the clang backend (entities, source_edges, read_files, "
+              "fact_set).")
         return 0
     finally:
         if created_tmp and not args.keep:

--- a/contrib/abicheck-clang-plugin/tests/fixtures/include/widget.hpp
+++ b/contrib/abicheck-clang-plugin/tests/fixtures/include/widget.hpp
@@ -65,6 +65,14 @@ const int gConstInternal = 3;          // namespace const w/o extern: internal -
 int add(int a, int b = 1);             // default arg (literal int)
 bool toggle(bool on = true);           // default arg (literal bool)
 
+// ADR-038 C.6 PR1b regression fixture: overload(int)/overload(double) share a
+// bare name; callOverloadInt/callOverloadDouble each call one of them so both
+// producers' source_edges must resolve the correct overload (see widget.cpp).
+int overload(int x);
+double overload(double x);
+int callOverloadInt();
+double callOverloadDouble();
+
 inline int square(int n) { return n * n; }  // inline body -> body hash
 
 // A PUBLIC inline function whose body declares a local type. Both producers

--- a/contrib/abicheck-clang-plugin/tests/fixtures/widget.cpp
+++ b/contrib/abicheck-clang-plugin/tests/fixtures/widget.cpp
@@ -12,4 +12,16 @@ int add(int a, int b) { return a + b; }
 bool toggle(bool on) { return !on; }
 void Widget::Impl::run() {}
 
+// ADR-038 C.6 PR1b regression fixture: an overloaded callee resolved through
+// clang's compact `referencedDecl` (no `mangledName` on the stub -- verified
+// against real Clang 17/18 JSON AST dumps) must not collapse `overload(int)`
+// and `overload(double)` onto one bare-name `source_edges` endpoint. Both
+// producers (plugin: live FunctionDecl*; clang backend replay: the id-index
+// fix in call_graph.py) must resolve these to their distinct mangled
+// identities so the two `source_edges` sets stay equivalent.
+int overload(int x) { return x; }
+double overload(double x) { return x; }
+int callOverloadInt() { return overload(1); }
+double callOverloadDouble() { return overload(1.0); }
+
 }  // namespace demo

--- a/contrib/abicheck-clang-plugin/tests/scan_flow.py
+++ b/contrib/abicheck-clang-plugin/tests/scan_flow.py
@@ -16,7 +16,13 @@
 #      dependency in the plugin CI lane);
 #   3. `abicheck merge`s the plugin-emitted pack into the binary baseline (the
 #      real ingest path, no re-parse) and asserts the L4 source-ABI + L5 graph
-#      layers were folded in with a non-empty set of source entities;
+#      layers were folded in with a non-empty set of source entities, AND that
+#      the specific DECL_CALLS_DECL edges the fixture's overload(int)/
+#      overload(double) calls produce are actually present in the embedded L5
+#      graph (latest-main Clang plugin review, PR1: previously only L4 entity
+#      counts were asserted here, so this test could pass even if
+#      source_edges never reached the graph at all — the exact gap that
+#      review found);
 #   4. `abicheck compare`s the merged baseline against itself and asserts a
 #      clean (exit 0) verdict — proving the folded baseline is a valid, stable
 #      comparison input.
@@ -71,6 +77,40 @@ def _count_entities(obj: object) -> int:
         for item in obj:
             total += _count_entities(item)
     return total
+
+
+#: The embedded L5 graph edges the fixture's overload(int)/overload(double)
+#: calls (widget.cpp/hpp) must produce -- source_graph.fold_source_edges maps
+#: a DECL_CALLS_DECL row's raw src/dst identity onto a `decl://<identity>`
+#: graph node id (the same scheme call_graph.augment_graph_with_calls uses).
+#: Asserting these are present in the *graph*, not merely that L4 entity
+#: counts are non-zero, is what the latest-main Clang plugin review's PR1
+#: finding asked for: "coverage['source_edges'] == 'complete' describes
+#: collection success, not end-to-end availability."
+_REQUIRED_GRAPH_EDGES = frozenset(
+    {
+        (
+            "DECL_CALLS_DECL",
+            "decl://_ZN4demo15callOverloadIntEv",
+            "decl://_ZN4demo8overloadEi",
+        ),
+        (
+            "DECL_CALLS_DECL",
+            "decl://_ZN4demo18callOverloadDoubleEv",
+            "decl://_ZN4demo8overloadEd",
+        ),
+    }
+)
+
+
+def _graph_edge_keys(build_source: dict) -> set[tuple[str, str, str]]:
+    edges = (build_source.get("source_graph") or {}).get("edges") or []
+    keys: set[tuple[str, str, str]] = set()
+    for e in edges:
+        if not isinstance(e, dict):
+            continue
+        keys.add((str(e.get("edge", "")), str(e.get("src", "")), str(e.get("dst", ""))))
+    return keys
 
 
 def _compile_shared_lib_with_plugin(work: Path, plugin: Path, clangxx: str) -> Path:
@@ -145,6 +185,17 @@ def main(argv: list[str] | None = None) -> int:
         if folded <= 0:
             raise SystemExit("merged baseline folded zero source entities from the pack")
 
+        # PR1: a non-empty L4 entity count alone does not prove source_edges
+        # ever reached the L5 graph -- assert the specific edges the
+        # fixture's overload calls must produce are actually present.
+        graph_edges = _graph_edge_keys(build_source)
+        missing_edges = sorted(_REQUIRED_GRAPH_EDGES - graph_edges)
+        if missing_edges:
+            raise SystemExit(
+                "merged baseline's embedded L5 graph is missing required "
+                f"DECL_CALLS_DECL edge(s) from source_edges: {missing_edges}"
+            )
+
         # 4. The merged baseline must be a valid comparison input (self-compare
         #    is compatible → exit 0 under the legacy verdict scheme).
         _run(
@@ -153,7 +204,9 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(
             f"\nPlugin injection scan validation PASSED: plugin pack ingested via merge "
-            f"({folded} source entities folded) and the baseline compares clean."
+            f"({folded} source entities folded, {len(graph_edges)} L5 graph edges "
+            "including the required DECL_CALLS_DECL overload edges) and the "
+            "baseline compares clean."
         )
         return 0
     finally:

--- a/docs/development/adr/038-build-integrated-fact-collection-variants.md
+++ b/docs/development/adr/038-build-integrated-fact-collection-variants.md
@@ -702,20 +702,35 @@ to remove. This is now closed:
   an edge collected this way lands on the same graph node a separate replay
   pass would have created — `add_edge`'s `(src, dst, kind)` de-dup key
   reconciles the two for free, first-writer-wins.
-- **The separate replay passes are skipped when redundant.**
-  `inline._build_inline_graph()` now checks whether the rolled-up
-  `source_edges` fact family is `complete`/`empty-confirmed` for a *full*
-  (unnarrowed) L4 replay scope; when so, `fold_call_graph()`/
-  `fold_type_graph()` are skipped entirely (their edges are already present
-  via `fold_source_edges`), and `SourceGraphSummary.extractor_passes` is
-  stamped as if they had run, so `crosscheck.py`'s decl-dependency checks see
-  confirmed coverage. A *narrowed* L4 scope (`changed_paths`/headers-only)
-  never skips the replay — narrowed `source_edges` collection only proves
-  completeness for the TUs L4 actually parsed, the identical reasoning
-  `extractor_pass_fully_covered()` already applies to distinguish full from
-  narrowed coverage. `fold_include_graph()` (a different edge kind,
-  `COMPILE_UNIT_INCLUDES_FILE`) is never gated by this — it is unrelated to
-  `source_edges`.
+- **The separate replay passes are still always run — not yet skipped.** An
+  earlier revision of this fix skipped `fold_call_graph()`/`fold_type_graph()`
+  once the rolled-up `source_edges` fact family was `complete`/
+  `empty-confirmed` for a full (unnarrowed) L4 replay scope, on the theory
+  that their edges were already present via `fold_source_edges`. A review of
+  that revision found the flaw: the raw `source_edges` wire format
+  (`{edge, src, dst, provenance, confidence, attrs}`) carries only bare
+  endpoint identities, never the `dst_file`/project-file provenance
+  `fold_call_graph`/`fold_type_graph` attach via `project_files`
+  (`GraphNode.attrs["defined_in_project"]`). `source_graph.
+  is_internal_dependency_node()` (shared with `crosscheck.py`'s
+  `public_to_internal_dependency`) requires that provenance — or the L4
+  surface's own `decl_to_file` mapping, which only covers *public* reachable
+  declarations — to classify an unannotated node as project-internal. A
+  private helper/type only ever reached via `source_edges` (never itself
+  part of the public surface) would therefore stay unclassified, silently
+  suppressing a real `PUBLIC_API_INTERNAL_DEPENDENCY_ADDED`/crosscheck
+  finding. The skip is reverted: both replay passes run unconditionally
+  whenever `with_call_graph` is set, exactly as before this ADR's edges-fold
+  work; `fold_source_edges` still runs (always, via `build_source_graph()`)
+  and reconciles with the replay's edges via the same `(src, dst, kind)`
+  de-dup key, so it remains a net addition (it can supply edges when a
+  narrower/cheaper collection ran without a full replay, e.g. a Plugin
+  injection-only pack with no `clang++` on the merge host) — it is just not
+  (yet) a substitute for the replay's provenance. Making `source_edges`
+  itself carry equivalent `dst_file`/`caller_file` provenance end-to-end (in
+  both the plugin's wire format and `clang_source_edges.build_source_edges()`)
+  is the natural follow-up that would let this optimization return safely;
+  tracked as future work, not bundled into this fix.
 
 **Identity normalization (the second half of the same review finding).**
 Even with the fold wired up, the Clang JSON-AST replay's callee identity was

--- a/docs/development/adr/038-build-integrated-fact-collection-variants.md
+++ b/docs/development/adr/038-build-integrated-fact-collection-variants.md
@@ -442,9 +442,42 @@ library *with the plugin active* (one build both links the `.so` and drops
 `abicheck_inputs/` beside it), then drives the real user pipeline — `abicheck
 dump` the binary (L0/L1), `abicheck merge` the plugin pack into the baseline
 (asserting the L4 source-ABI and L5 graph layers were ingested with a non-empty
-entity set), and `abicheck compare` the merged baseline against itself (asserting
-a clean verdict). This proves a plugin-emitted pack is *consumable by the
-ordinary scan*, not merely entity-equivalent to the clang backend.
+entity set, **and** that the specific `DECL_CALLS_DECL` edges the fixture's
+calls produce are present in the embedded L5 graph — not merely that L4 entity
+counts are non-zero), and `abicheck compare` the merged baseline against itself
+(asserting a clean verdict). This proves a plugin-emitted pack is *consumable
+by the ordinary scan*, not merely entity-equivalent to the clang backend.
+
+**Side channels beyond entity equivalence.** The entity comparison above
+proves the L4 *entity* contract; it says nothing about `source_edges`,
+`read_files`, `fact_set`, or per-family `coverage` — the exact gap a review of
+an earlier revision of this ADR's implementation flagged (the "does not cover
+the newly mandatory channels" finding). `conformance.py` now also asserts:
+
+- **`source_edges` parity for a planted overload regression.** The fixture
+  (`widget.hpp`/`widget.cpp`) declares `overload(int)`/`overload(double)` and
+  two callers, one per overload — exactly the shape whose
+  `referencedDecl` resolution C.6's original scope did not exercise (see
+  C.10). Both producers' `(edge, src, dst)` triples for these two calls are
+  required to match (an error if either is missing); any *other* divergence
+  in the edge set (e.g. compiler-implicit builtin-typedef edges the two
+  producers are not guaranteed to walk identically) is reported but not
+  gated — reconciling that is the broader, still-open concern C.10 tracks,
+  not this regression target.
+- **`read_files`** — both producers must have read the fixture's own primary
+  source and header (a required subset, not exact equality: the two
+  collection mechanisms are not guaranteed to enumerate transitively-included
+  system headers identically).
+- **`fact_set`** — both producers must declare the same canonical
+  `name`/`version`/`compiler_family` (the fields
+  `check_fact_set_compatibility()` keys comparison-compatibility on, C.8).
+- **`coverage`** — informational: neither producer should report
+  `partial`/`failed` for a mandatory family on this clean fixture.
+
+This is still not full parity coverage of every C.6 field (source locations,
+`names`/`relations`/`ownership` are not compared), but it closes the specific
+gap the review named: the LLVM 16/17/18 green matrix now also exercises the
+edge/read-file/fact-set contract the entity comparison alone left unproven.
 
 ### C.7 — Non-goals / limitations
 
@@ -566,10 +599,11 @@ per function body plus `SourceManager::fileinfo_begin()/end()`, the `clang.py`
 wrapper via `clang_source_edges.build_source_edges()` reusing
 `call_graph.py`'s/`type_graph.py`'s existing pure AST parsers on the JSON AST
 it already parsed. Edge identity is `(kind, src, dst)`, deduplicated per TU;
-each producer's edges are self-consistent but not required to be
-byte-identical across producers (same D0 philosophy as C.6 entity
-equivalence — compared for *coverage*, not byte-for-byte parity, since C.6
-does not compare `source_edges`/`read_files`).
+each producer's edges are self-consistent. C.6 now compares a targeted,
+planted-regression subset of `source_edges` (an overload-call fixture) rather
+than the full set byte-for-byte — see C.6 and C.10 for why full parity is not
+yet asserted end-to-end, and C.10 for where these edges go once collected
+(folded into the L5 graph, not merely serialized).
 
 `buildsource/fact_set.py` implements the comparison-compatibility rules over
 these fields: `rollup_fact_set()`/`rollup_coverage()` fold per-TU records up
@@ -638,6 +672,200 @@ facts file write always precedes the profiling emission textually. The
 existing per-TU replay cache (`source_replay.SourceAbiCache`,
 `ABICHECK_L4_CACHE_DIR`, D8) was already covered by this invariance —
 caching serializes/deserializes the same `SourceAbiTu` records verbatim.
+
+### C.10 — `source_edges` reach the L5 graph, not just the pack
+
+C.8 (#15-18) made both producers *collect* `source_edges` during their
+existing frontend pass. A subsequent review of an earlier revision of this
+ADR's implementation found the gap that collection left open: `SourceAbiTu.
+source_edges` was serialized and round-tripped, but `SourceAbiSurface` — the
+linked, per-library object `build_source_graph()` actually reads — had no
+edge field at all, so nothing ever folded them into the L5 graph. The
+separate `call_graph`/`type_graph` Clang AST replay passes remained the only
+producer of `DECL_CALLS_DECL`/`DECL_REFERENCES_DECL`/`DECL_HAS_TYPE`/
+`TYPE_HAS_FIELD_TYPE`/`TYPE_INHERITS` edges end-to-end — a second, separate
+frontend invocation over the same TUs, exactly the cost this feature exists
+to remove. This is now closed:
+
+- **`SourceAbiSurface.source_edges`** (`source_abi.py`) is a new field in the
+  same `{edge, src, dst, provenance, confidence, attrs}` shape as
+  `SourceAbiTu.source_edges` (which itself mirrors `GraphEdge.to_dict()`).
+  `source_link.link_source_abi()` folds every linked TU's `source_edges` into
+  it, deduplicating by `(edge, src, dst)` across TUs that share a public
+  header — the same dedup precedent already applied to entities.
+- **`source_graph.fold_source_edges()`** consumes
+  `SourceAbiSurface.source_edges` from inside `build_source_graph()` (always,
+  not behind a flag — the graph is already built whenever a source surface
+  exists). Endpoint identities are mapped onto the identical `decl://`/
+  `type://` node-id scheme `call_graph.augment_graph_with_calls()`/
+  `type_graph.augment_graph_with_types()` already use for the replay path, so
+  an edge collected this way lands on the same graph node a separate replay
+  pass would have created — `add_edge`'s `(src, dst, kind)` de-dup key
+  reconciles the two for free, first-writer-wins.
+- **The separate replay passes are skipped when redundant.**
+  `inline._build_inline_graph()` now checks whether the rolled-up
+  `source_edges` fact family is `complete`/`empty-confirmed` for a *full*
+  (unnarrowed) L4 replay scope; when so, `fold_call_graph()`/
+  `fold_type_graph()` are skipped entirely (their edges are already present
+  via `fold_source_edges`), and `SourceGraphSummary.extractor_passes` is
+  stamped as if they had run, so `crosscheck.py`'s decl-dependency checks see
+  confirmed coverage. A *narrowed* L4 scope (`changed_paths`/headers-only)
+  never skips the replay — narrowed `source_edges` collection only proves
+  completeness for the TUs L4 actually parsed, the identical reasoning
+  `extractor_pass_fully_covered()` already applies to distinguish full from
+  narrowed coverage. `fold_include_graph()` (a different edge kind,
+  `COMPILE_UNIT_INCLUDES_FILE`) is never gated by this — it is unrelated to
+  `source_edges`.
+
+**Identity normalization (the second half of the same review finding).**
+Even with the fold wired up, the Clang JSON-AST replay's callee identity was
+unreliable: `call_graph._identity()` read `referencedDecl.get("mangledName")
+or .get("name")`, but a real Clang 17/18 `-ast-dump=json`'s compact
+`referencedDecl` stub for an overloaded callee never carries `mangledName` —
+verified against a live compile of `int f(int)`/`double f(double)` (both
+call sites' stubs are `{"kind": "FunctionDecl", "name": "f", "type": {...}}`,
+differing only in `id` and `type.qualType`). Keying solely off the stub
+therefore collapsed every overload (and, by the same mechanism,
+distinguishably-named constructors/destructors) onto one bare-name endpoint —
+producer-dependent and silently wrong, since the plugin's own callee
+resolution (over the live `FunctionDecl*`) does not share this limitation.
+`type_graph.py` had already solved the identical problem for its own
+`DECL_REFERENCES_DECL`/`DECL_HAS_TYPE` edges (`_resolve_ref_identity()`, an
+earlier review) but `call_graph.py` never received the equivalent fix. It now
+does: `parse_clang_ast_calls()` builds an `id_index: dict[str, str]` from
+every full `FunctionDecl`/`CXXMethodDecl`/`CXXConstructorDecl`/
+`CXXDestructorDecl`/`CXXConversionDecl` node seen during the same walk (keyed
+by clang's own per-node `id`, present even on an otherwise-incomplete
+`referencedDecl` stub), and `_resolve_ref_callee_identity()` resolves a call
+site's stub through that index before falling back to the stub's own
+(name-only) identity. Verified end-to-end against a live Clang 18 compile of
+the `overload(int)`/`overload(double)` pair now planted in the C.6 fixture
+(`widget.hpp`/`widget.cpp`) — see C.6.
+
+**Still open:** a forward reference to a declaration this walk has not yet
+seen in full (rare — C/C++ requires a visible declaration before a call) and
+constructors/destructors reached through a route the id-index does not cover
+remain a documented best-effort limitation, matching `type_graph.py`'s own
+documented gap in the same spirit. Fully general resolution needs a stable
+scope-qualified identity for every declaration, not just ones an `id` happens
+to disambiguate — tracked as future work, not blocking this fix.
+
+### C.11 — Gating opaque-hash comparability on producer/version agreement
+
+C.8's `check_fact_set_compatibility()` already *reported* — via
+`SOURCE_FACT_COVERAGE_INCOMPLETE` — that a producer/producer-version/
+compiler-version mismatch makes opaque body/template hashes unreliable. But
+`source_diff.diff_source_abi()` emitted that finding and then **unconditionally**
+ran `_diff_inline_bodies()`/`_diff_templates()`'s hash comparisons anyway, so a
+comparison could report both "these hashes may be unreliable" and a concrete
+`INLINE_BODY_CHANGED`/`TEMPLATE_BODY_CHANGED` computed from the very hashes
+just flagged as unreliable — the second finding still feeding reports,
+policies, and gates.
+
+`buildsource/fact_set.py` now exposes a structured verdict,
+`FactCompatibility` (`check_fact_compatibility()`), wrapping
+`check_fact_set_compatibility()`'s issue list into three booleans:
+`structured_facts_comparable` (false only on a `fact_set` name/version
+mismatch — the mandatory-family contract itself), `opaque_hashes_comparable`,
+and `source_edges_comparable` (both false on a `producer`/`producer_version`/
+`compiler_version` mismatch too, since the canonicalization recipe can change
+independently of `fact_set.version`). `diff_source_abi()` computes this once
+per comparison and threads it into `_diff_inline_bodies()`/`_diff_templates()`,
+which skip their hash-diff branch (not their existence/removal branch —
+`INLINE_FUNCTION_REMOVED`/`UNINSTANTIATED_TEMPLATE_REMOVED` are not
+hash-derived and are never suppressed) when `opaque_hashes_comparable` is
+false. `_diff_fact_coverage()`'s `SOURCE_FACT_COVERAGE_INCOMPLETE` finding now
+says explicitly, in that case, that the hash findings were suppressed and why.
+
+**`hash_recipe_id`** (`fact_set.hash_recipe_id()`) is the escape hatch the
+review asked for: two fact-sets declaring the *same* explicit
+`"hash_recipe_id"` are treated as opaque-hash-comparable regardless of a
+`producer`/`producer_version`/`compiler_version` mismatch — a differential
+conformance run (C.6) proving two differently-named producers emit
+byte-comparable hashes is more precise than treating any producer-identity
+difference as inherently incompatible. Absent an explicit field, the fallback
+recipe id is the `producer`/`producer_version`/`compiler_version` triple
+`check_fact_set_compatibility()` already keys its rule on, so old fact-sets
+recorded before this field existed keep comparing exactly as before. A
+`fact_set.name`/`version` mismatch is never overridable this way — that is
+the mandatory-family contract itself, not a hashing-recipe detail.
+
+### C.12 — Target/pack isolation
+
+The plugin's per-TU fact filename was keyed on source path + compile-context
+hash only, and `ensureManifest()`/the wrapper's `init_inputs_pack()` were
+first-writer-wins: an existing `manifest.json` was loaded and returned
+unchanged with no check that the current invocation's library/version
+agreed. Two different libraries built from a shared object file
+(`common.cpp` compiled into both `libA`/`libB`) into one shared `out=`
+directory would therefore silently collide — same filename, same manifest,
+whichever compile ran last winning, with nothing downstream able to tell.
+
+- **Filenames and `tu_id` now include the target/library identity.** The
+  plugin's per-TU fact filename folds a hash of `library + "\x1f" + source`
+  (falling back to source-path-only when no `library=` is configured) instead
+  of the source path alone; `tu_id` gains a `#target:<library>` suffix when a
+  library is configured. The `inputs_emit.facts_filename()`/`cc_wrapper.py`
+  path (the non-plugin producer) gets the identical fix — the same bug
+  existed independently in both producers' filename schemes.
+- **An existing manifest is validated, not silently trusted.** The plugin's
+  `ensureManifest()` now reads an existing `manifest.json` and prints a loud
+  (never build-aborting — this runs inside a real compile invocation)
+  stderr warning when its `library`/`version` disagree with the current
+  invocation's. `inputs_emit.init_inputs_pack()` (the batch/wrapper path,
+  which is not embedded in an active compile and can afford to be stricter)
+  raises `ValueError` on the same disagreement instead — idempotent only for
+  a repeated call naming the *same* library/version, never a silently
+  different one.
+- **`abicheck inputs validate` rejects pack-level target inconsistency.**
+  `inputs_validate.py` now errors when a pack's TU records name more than one
+  distinct non-empty `target_id`, or when a TU's `target_id` disagrees with
+  `target://<manifest.library>` — the exact same-source/two-library collision
+  surfaced as a validation error instead of a silent merge-time ambiguity. It
+  also promotes a `fact_set` **name/version** mismatch *within one pack's* TU
+  records from `rollup_fact_set()`'s existing soft "TUs disagree" warning to
+  an error (routine `producer`/`producer_version` drift across TUs stays a
+  warning; only a hard mandatory-family-contract mismatch is promoted).
+- **A related, narrower fix to `compact_inputs_pack()`'s rollback.** The
+  compactor's "was this output path pre-existing" check used to be a bare
+  `Path.exists()`, which could not distinguish a genuine prior compaction
+  (`manifest.last_compacted`) from an operator's `--output-filename`
+  coincidentally colliding with an ordinary pre-existing file — silently
+  letting the merge overwrite that unrelated file, and (on a subsequent
+  manifest-write failure) leaving the clobbered replacement in place because
+  the rollback branch treated "pre-existing" as "leave it alone." The check
+  is now tied to the resolved identity of `manifest.last_compacted`; a
+  collision with anything else is rejected outright (a `ValueError`) before
+  any write happens — simpler and safer than trying to back up and restore
+  an arbitrary file's prior content.
+- **Also closed:** a public typedef whose JSON-dump-derived underlying type
+  could not be determined was silently dropped with no diagnostic, and
+  `types` coverage only watched for the unrelated "record/enum type_hash
+  unavailable" diagnostic — so a batch of failed typedefs alongside one
+  successfully-collected record/enum still reported `types: complete`. The
+  plugin now records a `"typedef facts unavailable"` diagnostic on this path,
+  folded into the same family coverage check.
+- **Still open, deliberately not addressed here:** the standardized
+  `abicheck_inputs/<target>/<configuration>/<architecture>/` directory layout
+  the review sketched as the fuller structural fix. The validation above
+  makes a collision loud and rejected rather than silent, which is the
+  correctness-critical half; standardizing the on-disk layout is a larger,
+  purely-organizational change better done once real deployments show what
+  layout convention they actually need, and is left for a follow-up ADR
+  amendment rather than bundled into this correctness fix.
+
+**Performance re-measurement — explicitly not done here.** A prior review of
+the plugin (`README.md`'s published 143-TU/four-core LLVM benchmark) measured
+an earlier, narrower collector; the current collector additionally performs
+per-function call/reference sub-walks, type-relationship collection,
+read-file enumeration, and richer serialization, none of which that
+benchmark's 2.39× figure reflects. Re-running it is explicitly out of scope
+for this change: it requires an instrumented LLVM build and controlled
+wall-clock/RSS measurement this environment cannot perform, and fabricating a
+number would be worse than stating the gap plainly. Treat the published
+figure as **historical evidence for the pruned parser it measured, not a
+verified measurement of the current collector** until someone re-runs the
+same benchmark end-to-end and updates `README.md`.
 
 ---
 

--- a/docs/development/adr/038-build-integrated-fact-collection-variants.md
+++ b/docs/development/adr/038-build-integrated-fact-collection-variants.md
@@ -731,6 +731,34 @@ to remove. This is now closed:
   both the plugin's wire format and `clang_source_edges.build_source_edges()`)
   is the natural follow-up that would let this optimization return safely;
   tracked as future work, not bundled into this fix.
+- **The Flow-2 ingestion path (`inputs_pack.ingest_inputs_pack`) has no
+  replay fallback at all, so the provenance gap above is not just an
+  optimization risk there — it is the only edge source.** A follow-up review
+  found that a Flow-2-ingested pack's graph never marked `extractor_passes`
+  for `call_graph`/`type_graph` at all (`fold_source_edges` never touches
+  it), so `source_graph_findings._common_dependency_edge_kinds()` treated a
+  genuinely complete-but-zero-edge family as "never examined" and suppressed
+  a real finding as a coverage artifact. `source_graph.
+  mark_source_edges_extractor_coverage()` closes that half — applied only at
+  `ingest_inputs_pack` and the export-relink graph rebuild in
+  `cli_buildsource_merge.py` (the two call sites that never run a replay
+  afterward; `inline._build_inline_graph`/`cli_buildsource_helpers` already
+  track this precisely via the replay itself and must not call it, since a
+  bare `source_edges` rollup can't tell full-scope from narrowed). But this
+  only fixes the *pass-coverage* gate (`_dependency_kinds_covered`) — it does
+  **not** fix the separate *node-classification* gate
+  `is_internal_dependency_node()` still applies per-node: a Flow-2-ingested
+  node from `fold_source_edges` alone still carries no `defined_in_project`
+  attr and, being genuinely private, is never covered by the L4 surface's own
+  `decl_to_file` (which only maps *public* reachable declarations). Both
+  gates must pass for `PUBLIC_API_INTERNAL_DEPENDENCY_ADDED` to fire on such
+  a node, so for a Flow-2-only pack (no compile DB / no replay ever
+  possible), a public-API-to-private-helper dependency collected only via
+  `source_edges` still cannot be detected end-to-end. Closing this
+  fully requires the same producer-side wire-format change described above
+  (both the plugin and `clang_source_edges.build_source_edges()` emitting
+  `dst_file`); until then this is a known, accepted limitation of the
+  ingestion-only path specifically (Codex review).
 
 **Identity normalization (the second half of the same review finding).**
 Even with the fold wired up, the Clang JSON-AST replay's callee identity was

--- a/docs/development/adr/041-compiler-facts-semantic-impact-graph.md
+++ b/docs/development/adr/041-compiler-facts-semantic-impact-graph.md
@@ -1056,18 +1056,30 @@ there is no equivalent "should this be automatic" question for them.
 
 ### P1 — stronger ABI/API intelligence
 
-1. **Move type/reference extraction into Plugin injection (the ADR-038 plugin).**
-   `contrib/abicheck-clang-plugin/` already rides the compiler's own AST for
-   the L4 entity facts (functions/types/macros/hashes) with **zero extra
-   frontend passes** — the plugin hardcodes `"source_edges": []` today. Once
-   it emits `TYPE_INHERITS`/`TYPE_HAS_FIELD_TYPE`/`DECL_HAS_TYPE`/
+1. ~~**Move type/reference extraction into Plugin injection (the ADR-038
+   plugin).**~~ — **done, ADR-038 C.9/C.10.** The plugin emits
+   `TYPE_INHERITS`/`TYPE_HAS_FIELD_TYPE`/`DECL_HAS_TYPE`/
    `DECL_REFERENCES_DECL`/`DECL_CALLS_DECL` into `source_edges` during the
-   *real* product compile, `inputs_pack.py`'s ingest path folds them for free
-   and both `call_graph.py`'s and `type_graph.py`'s standalone replay passes
-   become optional (CI/no-build-integration fallback only) rather than the
-   only source. This is the direct fix for the "two separate expensive AST
-   passes" limitation above, and for the wider "AST replay vs. compiler facts
-   during build" tension the original proposal opens with.
+   real product compile (a `CallRefVisitor` sub-walk per function body, no
+   second frontend pass), and the reference `clang.py` extractor does the
+   same by reusing `call_graph.py`'s/`type_graph.py`'s pure AST parsers on
+   the JSON AST it already parsed (ADR-038 C.8). What ADR-038 C.10 closes on
+   top of that collection: `source_graph.fold_source_edges()` now actually
+   folds these into the L5 graph (previously serialized-but-unused —
+   `SourceAbiSurface` had no edge field at all), and
+   `inline._build_inline_graph()` skips the separate `call_graph`/
+   `type_graph` replay passes when a full-scope `source_edges` collection is
+   already confirmed complete, per-TU/full-vs-narrowed the same way
+   `extractor_pass_fully_covered()` already gates `SourceGraphSummary.
+   extractor_passes`. A narrowed L4 scope still runs the replay passes
+   (narrowed `source_edges` only proves completeness for the TUs L4 actually
+   parsed), and `fold_include_graph()` (a different edge kind) is never
+   gated by this. ADR-038 C.10 also fixed the callee-identity resolution bug
+   this depended on: `call_graph.py`'s JSON-AST replay used to resolve an
+   overloaded callee's compact `referencedDecl` stub by bare name (real
+   Clang never puts `mangledName` on that stub), collapsing overloads onto
+   one endpoint; it now builds an id-index from the full declarations seen
+   in the same walk, mirroring the fix `type_graph.py` already had.
 2. **Object/link provenance graph.** New node kinds
    (`object_file`/`archive_member`/`static_library`/`linker_script`/
    `version_script`/`export_map`/`comdat_group`) and edges

--- a/docs/development/adr/041-compiler-facts-semantic-impact-graph.md
+++ b/docs/development/adr/041-compiler-facts-semantic-impact-graph.md
@@ -1066,20 +1066,20 @@ there is no equivalent "should this be automatic" question for them.
    the JSON AST it already parsed (ADR-038 C.8). What ADR-038 C.10 closes on
    top of that collection: `source_graph.fold_source_edges()` now actually
    folds these into the L5 graph (previously serialized-but-unused —
-   `SourceAbiSurface` had no edge field at all), and
-   `inline._build_inline_graph()` skips the separate `call_graph`/
-   `type_graph` replay passes when a full-scope `source_edges` collection is
-   already confirmed complete, per-TU/full-vs-narrowed the same way
-   `extractor_pass_fully_covered()` already gates `SourceGraphSummary.
-   extractor_passes`. A narrowed L4 scope still runs the replay passes
-   (narrowed `source_edges` only proves completeness for the TUs L4 actually
-   parsed), and `fold_include_graph()` (a different edge kind) is never
-   gated by this. ADR-038 C.10 also fixed the callee-identity resolution bug
-   this depended on: `call_graph.py`'s JSON-AST replay used to resolve an
-   overloaded callee's compact `referencedDecl` stub by bare name (real
-   Clang never puts `mangledName` on that stub), collapsing overloads onto
-   one endpoint; it now builds an id-index from the full declarations seen
-   in the same walk, mirroring the fix `type_graph.py` already had.
+   `SourceAbiSurface` had no edge field at all). It does **not** (yet) let
+   `inline._build_inline_graph()` skip the separate `call_graph`/
+   `type_graph` replay passes: a first attempt at that optimization was
+   reverted after a review found the raw `source_edges` wire format carries
+   no `dst_file`/project-file provenance, which `crosscheck.
+   public_to_internal_dependency` needs to classify an unannotated node as
+   internal — see ADR-038 C.10's "still always run" note for the full
+   reasoning and the follow-up this leaves open. ADR-038 C.10 did fix the
+   callee-identity resolution bug the edges depend on regardless:
+   `call_graph.py`'s JSON-AST replay used to resolve an overloaded callee's
+   compact `referencedDecl` stub by bare name (real Clang never puts
+   `mangledName` on that stub), collapsing overloads onto one endpoint; it
+   now builds an id-index from the full declarations seen in the same walk,
+   mirroring the fix `type_graph.py` already had.
 2. **Object/link provenance graph.** New node kinds
    (`object_file`/`archive_member`/`static_library`/`linker_script`/
    `version_script`/`export_map`/`comdat_group`) and edges

--- a/examples/case149_xcheck_odr_variant/snapshot.abi.json
+++ b/examples/case149_xcheck_odr_variant/snapshot.abi.json
@@ -50,6 +50,7 @@
         "public_header_declarations": []
       },
       "schema_version": 1,
+      "source_edges": [],
       "target_id": "",
       "unmatched": {
         "decls_without_symbol": [],

--- a/examples/case156_public_macro_removed/new.json
+++ b/examples/case156_public_macro_removed/new.json
@@ -46,6 +46,7 @@
     "public_header_declarations": []
   },
   "schema_version": 1,
+  "source_edges": [],
   "target_id": "",
   "unmatched": {
     "decls_without_symbol": [],

--- a/examples/case156_public_macro_removed/old.json
+++ b/examples/case156_public_macro_removed/old.json
@@ -68,6 +68,7 @@
     "public_header_declarations": []
   },
   "schema_version": 1,
+  "source_edges": [],
   "target_id": "",
   "unmatched": {
     "decls_without_symbol": [],

--- a/examples/case157_inline_function_removed/new.json
+++ b/examples/case157_inline_function_removed/new.json
@@ -46,6 +46,7 @@
     "public_header_declarations": []
   },
   "schema_version": 1,
+  "source_edges": [],
   "target_id": "",
   "unmatched": {
     "decls_without_symbol": [],

--- a/examples/case157_inline_function_removed/old.json
+++ b/examples/case157_inline_function_removed/old.json
@@ -68,6 +68,7 @@
     "public_header_declarations": []
   },
   "schema_version": 1,
+  "source_edges": [],
   "target_id": "",
   "unmatched": {
     "decls_without_symbol": [],

--- a/examples/case158_public_typedef_removed/new.json
+++ b/examples/case158_public_typedef_removed/new.json
@@ -46,6 +46,7 @@
     "public_header_declarations": []
   },
   "schema_version": 1,
+  "source_edges": [],
   "target_id": "",
   "unmatched": {
     "decls_without_symbol": [],

--- a/examples/case158_public_typedef_removed/old.json
+++ b/examples/case158_public_typedef_removed/old.json
@@ -68,6 +68,7 @@
     "public_header_declarations": []
   },
   "schema_version": 1,
+  "source_edges": [],
   "target_id": "",
   "unmatched": {
     "decls_without_symbol": [],

--- a/tests/test_call_graph.py
+++ b/tests/test_call_graph.py
@@ -83,6 +83,106 @@ def _func(name: str, mangled: str, body: list[dict]) -> dict:
 # ── parser ──────────────────────────────────────────────────────────────────
 
 
+def _real_ref(node_id: str, name: str, qualtype: str) -> dict:
+    """A *realistic* compact ``referencedDecl`` stub -- no ``mangledName``,
+    matching real Clang 17/18 ``-ast-dump=json`` output (verified against a
+    live compile of an overloaded ``int f(int)``/``double f(double)`` pair,
+    latest-main Clang plugin review PR1b). Unlike ``_ref()`` (used by the
+    other parser tests), this never attaches a mangled name, so it exercises
+    the id-index fallback rather than the stub's own identity."""
+    return {"kind": "FunctionDecl", "id": node_id, "name": name, "type": {"qualType": qualtype}}
+
+
+def _call_via_ref(ref: dict) -> dict:
+    return {
+        "kind": "CallExpr",
+        "inner": [
+            {
+                "kind": "ImplicitCastExpr",
+                "inner": [{"kind": "DeclRefExpr", "referencedDecl": ref}],
+            }
+        ],
+    }
+
+
+def test_parse_resolves_overloaded_callee_via_id_index() -> None:
+    """A real (mangledName-less) referencedDecl stub must resolve to the
+    correct overload's mangled identity via the id-index built from the full
+    FunctionDecl nodes elsewhere in the AST, not collapse both overloads onto
+    the shared bare name "f" (PR1b)."""
+    ast = {
+        "kind": "TranslationUnitDecl",
+        "inner": [
+            {
+                "kind": "FunctionDecl",
+                "id": "0x1",
+                "name": "f",
+                "mangledName": "_Z1fi",
+                "type": {"qualType": "int (int)"},
+            },
+            {
+                "kind": "FunctionDecl",
+                "id": "0x2",
+                "name": "f",
+                "mangledName": "_Z1fd",
+                "type": {"qualType": "double (double)"},
+            },
+            _func(
+                "g",
+                "_Z1gv",
+                [
+                    _call_via_ref(_real_ref("0x1", "f", "int (int)")),
+                    _call_via_ref(_real_ref("0x2", "f", "double (double)")),
+                ],
+            ),
+        ],
+    }
+    edges = parse_clang_ast_calls(ast)
+    assert {e.callee for e in edges} == {"_Z1fi", "_Z1fd"}
+
+
+def test_parse_resolves_via_prototype_seen_before_definition() -> None:
+    """The id-index must resolve through a pure prototype (no body), not only
+    a full definition -- a forward-declared function called before its own
+    definition appears later in the TU."""
+    ast = {
+        "kind": "TranslationUnitDecl",
+        "inner": [
+            {
+                "kind": "FunctionDecl",
+                "id": "0x1",
+                "name": "helper",
+                "mangledName": "_Z6helperi",
+                "type": {"qualType": "int (int)"},
+            },  # prototype only, no CompoundStmt
+            _func(
+                "caller", "_Zcaller", [_call_via_ref(_real_ref("0x1", "helper", "int (int)"))]
+            ),
+        ],
+    }
+    edges = parse_clang_ast_calls(ast)
+    assert edges == [CallEdge("_Zcaller", "_Z6helperi")]
+
+
+def test_parse_falls_back_to_bare_name_when_id_unindexed() -> None:
+    """A referencedDecl whose id was never seen elsewhere in this AST (e.g. a
+    system/library declaration clang did not include in full) still resolves
+    to *something* -- the documented best-effort fallback -- rather than
+    silently dropping the edge."""
+    ast = {
+        "kind": "TranslationUnitDecl",
+        "inner": [
+            _func(
+                "caller",
+                "_Zcaller",
+                [_call_via_ref(_real_ref("0xdeadbeef", "puts", "int (const char *)"))],
+            ),
+        ],
+    }
+    edges = parse_clang_ast_calls(ast)
+    assert edges == [CallEdge("_Zcaller", "puts")]
+
+
 def test_parse_direct_call() -> None:
     ast = {
         "kind": "TranslationUnitDecl",

--- a/tests/test_fact_set.py
+++ b/tests/test_fact_set.py
@@ -778,3 +778,140 @@ def test_diff_matching_recipe_id_keeps_hash_diffs_despite_producer_mismatch() ->
     )
     changes = diff_source_abi(old, new)
     assert ChangeKind.INLINE_BODY_CHANGED in {c.kind for c in changes}
+
+
+# -- diff_source_abi: gating removal detection on structured_facts_comparable -
+
+
+def _macro_entity(qualified_name: str, value: str) -> object:
+    from abicheck.buildsource.source_abi import SourceEntity
+
+    return SourceEntity(
+        id=qualified_name, kind="macro", qualified_name=qualified_name, value=value
+    )
+
+
+def _typedef_entity(qualified_name: str, type_hash: str, value: str = "int") -> object:
+    from abicheck.buildsource.source_abi import SourceEntity
+
+    return SourceEntity(
+        id=qualified_name,
+        kind="typedef",
+        qualified_name=qualified_name,
+        type_hash=type_hash,
+        value=value,
+    )
+
+
+def _generated_entity(qualified_name: str, value: str) -> object:
+    from abicheck.buildsource.source_abi import SourceEntity, SourceLocation
+
+    return SourceEntity(
+        id=qualified_name,
+        kind="constexpr",
+        qualified_name=qualified_name,
+        value=value,
+        visibility="generated",
+        source_location=SourceLocation(path="gen/cfg.h", line=1, origin="GENERATED"),
+    )
+
+
+def _unrelated_entity() -> object:
+    """A decl unrelated to the removal under test, keeping
+    ``_surface_has_facts(new)`` true so the removal-suppression assertion is
+    isolated to the fact-set-mismatch gate, not the separate no-facts-at-all
+    gate (mirrors the existing inline-body-removal test's own convention)."""
+    from abicheck.buildsource.source_abi import SourceEntity
+
+    return SourceEntity(id="decl://keep", kind="function", qualified_name="keep")
+
+
+def test_diff_suppresses_macro_removed_on_fact_set_name_mismatch() -> None:
+    """A fact_set NAME mismatch means the two sides don't agree on the
+    mandatory-family contract, so a macro's absence may only reflect the old
+    contract never collecting macros -- not a real removal (Codex review)."""
+    old_fs = default_fact_set(producer="p", producer_version="1")
+    new_fs = dict(old_fs)
+    new_fs["name"] = "some-other-fact-set"
+    old = _surface(
+        coverage={"fact_set": old_fs, "fact_family_states": {}},
+        reachable_macros=[_macro_entity("FOO", "1")],
+    )
+    # An unrelated declaration keeps _surface_has_facts(new) True (L4 ran on
+    # the new side too) without resurrecting the removed macro.
+    new = _surface(
+        coverage={"fact_set": new_fs, "fact_family_states": {}},
+        reachable_declarations=[_unrelated_entity()],
+    )
+    changes = diff_source_abi(old, new)
+    assert ChangeKind.PUBLIC_MACRO_REMOVED not in {c.kind for c in changes}
+
+
+def test_diff_suppresses_typedef_removed_on_fact_set_version_mismatch() -> None:
+    old_fs = default_fact_set(producer="p", producer_version="1")
+    new_fs = dict(old_fs)
+    new_fs["version"] = 999
+    old = _surface(
+        coverage={"fact_set": old_fs, "fact_family_states": {}},
+        reachable_types=[_typedef_entity("Widget_t", "h1")],
+    )
+    new = _surface(
+        coverage={"fact_set": new_fs, "fact_family_states": {}},
+        reachable_declarations=[_unrelated_entity()],
+    )
+    changes = diff_source_abi(old, new)
+    assert ChangeKind.PUBLIC_TYPEDEF_REMOVED not in {c.kind for c in changes}
+
+
+def test_diff_suppresses_generated_header_removal_on_fact_set_name_mismatch() -> None:
+    old_fs = default_fact_set(producer="p", producer_version="1")
+    new_fs = dict(old_fs)
+    new_fs["name"] = "some-other-fact-set"
+    old = _surface(
+        coverage={"fact_set": old_fs, "fact_family_states": {}},
+        reachable_declarations=[_generated_entity("cfg::KMax", "64")],
+    )
+    new = _surface(coverage={"fact_set": new_fs, "fact_family_states": {}})
+    changes = diff_source_abi(old, new)
+    assert ChangeKind.GENERATED_HEADER_CHANGED not in {c.kind for c in changes}
+
+
+def test_diff_still_reports_content_changes_on_fact_set_name_mismatch() -> None:
+    """Removal detection is suppressed on a contract mismatch, but a content
+    comparison for an identity present on *both* sides stays meaningful
+    regardless -- a type_hash/value means the same thing under any
+    mandatory-family contract."""
+    old_fs = default_fact_set(producer="p", producer_version="1")
+    new_fs = dict(old_fs)
+    new_fs["name"] = "some-other-fact-set"
+    old = _surface(
+        coverage={"fact_set": old_fs, "fact_family_states": {}},
+        reachable_macros=[_macro_entity("FOO", "1")],
+        reachable_types=[_typedef_entity("Widget_t", "h1")],
+    )
+    new = _surface(
+        coverage={"fact_set": new_fs, "fact_family_states": {}},
+        reachable_macros=[_macro_entity("FOO", "2")],
+        reachable_types=[_typedef_entity("Widget_t", "h2")],
+    )
+    changes = diff_source_abi(old, new)
+    kinds = {c.kind for c in changes}
+    assert ChangeKind.PUBLIC_MACRO_VALUE_CHANGED in kinds
+    assert ChangeKind.PUBLIC_TYPEDEF_TARGET_CHANGED in kinds
+
+
+def test_diff_still_reports_removals_when_fact_sets_match() -> None:
+    fs = default_fact_set(producer="p", producer_version="1")
+    old = _surface(
+        coverage={"fact_set": fs, "fact_family_states": {}},
+        reachable_macros=[_macro_entity("FOO", "1")],
+        reachable_types=[_typedef_entity("Widget_t", "h1")],
+    )
+    new = _surface(
+        coverage={"fact_set": dict(fs), "fact_family_states": {}},
+        reachable_declarations=[_unrelated_entity()],
+    )
+    changes = diff_source_abi(old, new)
+    kinds = {c.kind for c in changes}
+    assert ChangeKind.PUBLIC_MACRO_REMOVED in kinds
+    assert ChangeKind.PUBLIC_TYPEDEF_REMOVED in kinds

--- a/tests/test_fact_set.py
+++ b/tests/test_fact_set.py
@@ -492,7 +492,9 @@ def test_diff_degrades_on_non_dict_nested_coverage_metadata() -> None:
     alone doesn't catch that (a non-empty non-dict value is still truthy),
     so this must not raise AttributeError, matching the defensive handling
     every other optional field here already gets (Codex review, P2)."""
-    old = _surface(coverage={"fact_set": "not-a-dict", "fact_family_states": "also-bad"})
+    old = _surface(
+        coverage={"fact_set": "not-a-dict", "fact_family_states": "also-bad"}
+    )
     new = _surface(coverage={"fact_set": ["also", "not", "a", "dict"]})
     changes = diff_source_abi(old, new)  # must not raise
     assert isinstance(changes, list)
@@ -554,9 +556,21 @@ def test_hash_recipe_id_explicit_field_wins() -> None:
     assert hash_recipe_id(fs) == "clang-json-canonical-v3"
 
 
-def test_hash_recipe_id_falls_back_to_producer_triple() -> None:
+def test_hash_recipe_id_falls_back_to_producer_quadruple() -> None:
     fs = default_fact_set(producer="p", producer_version="1", compiler_version="18")
-    assert hash_recipe_id(fs) == "p|1|18"
+    assert hash_recipe_id(fs) == "p|1|clang|18"
+
+
+def test_hash_recipe_id_fallback_differs_across_compiler_families() -> None:
+    """A gcc and a clang fact_set with otherwise-identical producer/
+    producer_version/compiler_version must never collide on the same
+    fallback recipe id -- their canonicalization/mangling differs."""
+    clang_fs = default_fact_set(
+        producer="p", producer_version="1", compiler_version="18"
+    )
+    gcc_fs = dict(clang_fs)
+    gcc_fs["compiler_family"] = "gcc"
+    assert hash_recipe_id(clang_fs) != hash_recipe_id(gcc_fs)
 
 
 def test_check_fact_compatibility_matching_fact_sets_all_comparable() -> None:
@@ -572,12 +586,30 @@ def test_check_fact_compatibility_producer_mismatch_blocks_opaque_and_edges_only
     None
 ):
     old = default_fact_set(producer="abicheck-clang-plugin", producer_version="0.4")
-    new = default_fact_set(producer="abicheck-cc-clang-extractor", producer_version="0.6")
+    new = default_fact_set(
+        producer="abicheck-cc-clang-extractor", producer_version="0.6"
+    )
     compat = check_fact_compatibility(old, new)
     assert compat.structured_facts_comparable
     assert not compat.opaque_hashes_comparable
     assert not compat.source_edges_comparable
     assert any(i.rule == "producer_mismatch" for i in compat.issues)
+
+
+def test_check_fact_compatibility_compiler_family_mismatch_blocks_opaque_and_edges_only() -> (
+    None
+):
+    """A gcc-vs-clang pair must not be treated as byte-comparable: different
+    compiler families mangle/canonicalize differently even when the
+    abicheck producer identity and version otherwise match."""
+    old = default_fact_set(producer="p", producer_version="1")
+    new = dict(old)
+    new["compiler_family"] = "gcc"
+    compat = check_fact_compatibility(old, new)
+    assert compat.structured_facts_comparable
+    assert not compat.opaque_hashes_comparable
+    assert not compat.source_edges_comparable
+    assert any(i.rule == "compiler_family_mismatch" for i in compat.issues)
 
 
 def test_check_fact_compatibility_name_mismatch_blocks_everything() -> None:
@@ -599,7 +631,9 @@ def test_check_fact_compatibility_matching_recipe_id_overrides_producer_mismatch
     rather than forcing every future comparison to suppress unnecessarily."""
     old = default_fact_set(producer="abicheck-clang-plugin", producer_version="0.4")
     old["hash_recipe_id"] = "clang-json-canonical-v3"
-    new = default_fact_set(producer="abicheck-cc-clang-extractor", producer_version="0.6")
+    new = default_fact_set(
+        producer="abicheck-cc-clang-extractor", producer_version="0.6"
+    )
     new["hash_recipe_id"] = "clang-json-canonical-v3"
     compat = check_fact_compatibility(old, new)
     assert compat.opaque_hashes_comparable

--- a/tests/test_fact_set.py
+++ b/tests/test_fact_set.py
@@ -27,8 +27,11 @@ from abicheck.buildsource import (
     link_source_abi,
 )
 from abicheck.buildsource.fact_set import (
+    FactCompatibility,
     FactSetIssue,
+    check_fact_compatibility,
     check_fact_set_compatibility,
+    hash_recipe_id,
     incomplete_families,
     rollup_coverage,
     rollup_fact_set,
@@ -540,3 +543,204 @@ def test_source_fact_coverage_incomplete_is_risk_kind() -> None:
     from abicheck.checker_policy import RISK_KINDS
 
     assert ChangeKind.SOURCE_FACT_COVERAGE_INCOMPLETE in RISK_KINDS
+
+
+# -- hash_recipe_id / check_fact_compatibility (PR2 gating) ------------------
+
+
+def test_hash_recipe_id_explicit_field_wins() -> None:
+    fs = default_fact_set(producer="p", producer_version="1", compiler_version="18")
+    fs["hash_recipe_id"] = "clang-json-canonical-v3"
+    assert hash_recipe_id(fs) == "clang-json-canonical-v3"
+
+
+def test_hash_recipe_id_falls_back_to_producer_triple() -> None:
+    fs = default_fact_set(producer="p", producer_version="1", compiler_version="18")
+    assert hash_recipe_id(fs) == "p|1|18"
+
+
+def test_check_fact_compatibility_matching_fact_sets_all_comparable() -> None:
+    fs = default_fact_set(producer="p", producer_version="1", compiler_version="18")
+    compat = check_fact_compatibility(fs, dict(fs))
+    assert compat.structured_facts_comparable
+    assert compat.opaque_hashes_comparable
+    assert compat.source_edges_comparable
+    assert compat.issues == ()
+
+
+def test_check_fact_compatibility_producer_mismatch_blocks_opaque_and_edges_only() -> (
+    None
+):
+    old = default_fact_set(producer="abicheck-clang-plugin", producer_version="0.4")
+    new = default_fact_set(producer="abicheck-cc-clang-extractor", producer_version="0.6")
+    compat = check_fact_compatibility(old, new)
+    assert compat.structured_facts_comparable
+    assert not compat.opaque_hashes_comparable
+    assert not compat.source_edges_comparable
+    assert any(i.rule == "producer_mismatch" for i in compat.issues)
+
+
+def test_check_fact_compatibility_name_mismatch_blocks_everything() -> None:
+    old = default_fact_set(producer="p", producer_version="1")
+    new = dict(old)
+    new["name"] = "some-other-fact-set"
+    compat = check_fact_compatibility(old, new)
+    assert not compat.structured_facts_comparable
+    assert not compat.opaque_hashes_comparable
+    assert not compat.source_edges_comparable
+
+
+def test_check_fact_compatibility_matching_recipe_id_overrides_producer_mismatch() -> (
+    None
+):
+    """A differential conformance run (ADR-038 C.6) can prove two differently
+    named producers emit byte-comparable opaque hashes; declaring the same
+    hash_recipe_id on both sides should override the producer-mismatch gate
+    rather than forcing every future comparison to suppress unnecessarily."""
+    old = default_fact_set(producer="abicheck-clang-plugin", producer_version="0.4")
+    old["hash_recipe_id"] = "clang-json-canonical-v3"
+    new = default_fact_set(producer="abicheck-cc-clang-extractor", producer_version="0.6")
+    new["hash_recipe_id"] = "clang-json-canonical-v3"
+    compat = check_fact_compatibility(old, new)
+    assert compat.opaque_hashes_comparable
+    assert compat.source_edges_comparable
+    # The producer_mismatch issue is still reported for visibility even though
+    # it's overridden -- callers that want the raw prose still see it.
+    assert any(i.rule == "producer_mismatch" for i in compat.issues)
+
+
+def test_check_fact_compatibility_one_side_empty_stays_comparable() -> None:
+    """A pre-C.8 producer (no fact_set at all) must not gate anything -- only
+    the informational fact_set_unknown warning fires (forward-compat)."""
+    fs = default_fact_set(producer="p", producer_version="1")
+    compat = check_fact_compatibility(fs, {})
+    assert compat.structured_facts_comparable
+    assert compat.opaque_hashes_comparable
+    assert compat.source_edges_comparable
+
+
+def test_fact_compatibility_is_frozen() -> None:
+    compat = FactCompatibility(True, True, True, ())
+    with pytest.raises(AttributeError):
+        compat.opaque_hashes_comparable = False  # type: ignore[misc]
+
+
+# -- diff_source_abi: gating INLINE_BODY_CHANGED/TEMPLATE_BODY_CHANGED ------
+
+
+def _inline_entity(body_hash: str) -> object:
+    from abicheck.buildsource.source_abi import SourceEntity
+
+    return SourceEntity(
+        id="f",
+        kind="inline",
+        qualified_name="ns::f",
+        mangled_name="_Z1fv",
+        body_hash=body_hash,
+    )
+
+
+def _template_entity(body_hash: str) -> object:
+    from abicheck.buildsource.source_abi import SourceEntity
+
+    return SourceEntity(
+        id="T",
+        kind="template",
+        qualified_name="ns::T",
+        signature_hash="sig",
+        body_hash=body_hash,
+    )
+
+
+def test_diff_suppresses_inline_body_changed_on_producer_mismatch() -> None:
+    old_fs = default_fact_set(producer="abicheck-clang-plugin", producer_version="0.4")
+    new_fs = default_fact_set(
+        producer="abicheck-cc-clang-extractor", producer_version="0.6"
+    )
+    old = _surface(
+        coverage={"fact_set": old_fs, "fact_family_states": {}},
+        reachable_inline_bodies=[_inline_entity("hash-a")],
+    )
+    new = _surface(
+        coverage={"fact_set": new_fs, "fact_family_states": {}},
+        reachable_inline_bodies=[_inline_entity("hash-b")],
+    )
+    changes = diff_source_abi(old, new)
+    assert ChangeKind.INLINE_BODY_CHANGED not in {c.kind for c in changes}
+    coverage_finding = next(
+        c for c in changes if c.kind == ChangeKind.SOURCE_FACT_COVERAGE_INCOMPLETE
+    )
+    assert "suppressed" in coverage_finding.description
+
+
+def test_diff_suppresses_template_body_changed_on_producer_mismatch() -> None:
+    old_fs = default_fact_set(producer="abicheck-clang-plugin", producer_version="0.4")
+    new_fs = default_fact_set(
+        producer="abicheck-cc-clang-extractor", producer_version="0.6"
+    )
+    old = _surface(
+        coverage={"fact_set": old_fs, "fact_family_states": {}},
+        reachable_templates=[_template_entity("hash-a")],
+    )
+    new = _surface(
+        coverage={"fact_set": new_fs, "fact_family_states": {}},
+        reachable_templates=[_template_entity("hash-b")],
+    )
+    changes = diff_source_abi(old, new)
+    assert ChangeKind.TEMPLATE_BODY_CHANGED not in {c.kind for c in changes}
+
+
+def test_diff_still_reports_inline_body_changed_when_compatible() -> None:
+    fs = default_fact_set(producer="p", producer_version="1", compiler_version="18")
+    old = _surface(
+        coverage={"fact_set": fs, "fact_family_states": {}},
+        reachable_inline_bodies=[_inline_entity("hash-a")],
+    )
+    new = _surface(
+        coverage={"fact_set": dict(fs), "fact_family_states": {}},
+        reachable_inline_bodies=[_inline_entity("hash-b")],
+    )
+    changes = diff_source_abi(old, new)
+    assert ChangeKind.INLINE_BODY_CHANGED in {c.kind for c in changes}
+
+
+def test_diff_still_reports_inline_function_removed_on_producer_mismatch() -> None:
+    """Removal is an existence check, not a hash comparison -- it must not be
+    suppressed by an opaque-hash incompatibility (only *_BODY_CHANGED is)."""
+    old_fs = default_fact_set(producer="abicheck-clang-plugin", producer_version="0.4")
+    new_fs = default_fact_set(
+        producer="abicheck-cc-clang-extractor", producer_version="0.6"
+    )
+    old = _surface(
+        coverage={"fact_set": old_fs, "fact_family_states": {}},
+        reachable_inline_bodies=[_inline_entity("hash-a")],
+    )
+    # An unrelated declaration keeps _surface_has_facts(new) True (L4 ran on
+    # the new side too) without resurrecting the removed inline function.
+    from abicheck.buildsource.source_abi import SourceEntity
+
+    new = _surface(
+        coverage={"fact_set": new_fs, "fact_family_states": {}},
+        reachable_declarations=[SourceEntity(id="g", qualified_name="ns::g")],
+    )
+    changes = diff_source_abi(old, new)
+    assert ChangeKind.INLINE_FUNCTION_REMOVED in {c.kind for c in changes}
+
+
+def test_diff_matching_recipe_id_keeps_hash_diffs_despite_producer_mismatch() -> None:
+    old_fs = default_fact_set(producer="abicheck-clang-plugin", producer_version="0.4")
+    old_fs["hash_recipe_id"] = "clang-json-canonical-v3"
+    new_fs = default_fact_set(
+        producer="abicheck-cc-clang-extractor", producer_version="0.6"
+    )
+    new_fs["hash_recipe_id"] = "clang-json-canonical-v3"
+    old = _surface(
+        coverage={"fact_set": old_fs, "fact_family_states": {}},
+        reachable_inline_bodies=[_inline_entity("hash-a")],
+    )
+    new = _surface(
+        coverage={"fact_set": new_fs, "fact_family_states": {}},
+        reachable_inline_bodies=[_inline_entity("hash-b")],
+    )
+    changes = diff_source_abi(old, new)
+    assert ChangeKind.INLINE_BODY_CHANGED in {c.kind for c in changes}

--- a/tests/test_fact_set.py
+++ b/tests/test_fact_set.py
@@ -915,3 +915,58 @@ def test_diff_still_reports_removals_when_fact_sets_match() -> None:
     kinds = {c.kind for c in changes}
     assert ChangeKind.PUBLIC_MACRO_REMOVED in kinds
     assert ChangeKind.PUBLIC_TYPEDEF_REMOVED in kinds
+
+
+def test_diff_suppresses_inline_function_removed_on_fact_set_name_mismatch() -> None:
+    """Same reasoning as the macro/typedef/generated-header removal gates: a
+    fact_set NAME mismatch means an inline function's absence may only
+    reflect the old contract never collecting the inline-bodies family, not a
+    real removal (Codex review -- this gate previously only covered
+    generated/typedef/macro removals, leaving inline/template removals
+    ungated)."""
+    old_fs = default_fact_set(producer="p", producer_version="1")
+    new_fs = dict(old_fs)
+    new_fs["name"] = "some-other-fact-set"
+    old = _surface(
+        coverage={"fact_set": old_fs, "fact_family_states": {}},
+        reachable_inline_bodies=[_inline_entity("hash-a")],
+    )
+    new = _surface(
+        coverage={"fact_set": new_fs, "fact_family_states": {}},
+        reachable_declarations=[_unrelated_entity()],
+    )
+    changes = diff_source_abi(old, new)
+    assert ChangeKind.INLINE_FUNCTION_REMOVED not in {c.kind for c in changes}
+
+
+def test_diff_suppresses_template_removed_on_fact_set_version_mismatch() -> None:
+    old_fs = default_fact_set(producer="p", producer_version="1")
+    new_fs = dict(old_fs)
+    new_fs["version"] = 999
+    old = _surface(
+        coverage={"fact_set": old_fs, "fact_family_states": {}},
+        reachable_templates=[_template_entity("hash-a")],
+    )
+    new = _surface(
+        coverage={"fact_set": new_fs, "fact_family_states": {}},
+        reachable_declarations=[_unrelated_entity()],
+    )
+    changes = diff_source_abi(old, new)
+    assert ChangeKind.UNINSTANTIATED_TEMPLATE_REMOVED not in {c.kind for c in changes}
+
+
+def test_diff_still_reports_inline_and_template_removals_when_fact_sets_match() -> None:
+    fs = default_fact_set(producer="p", producer_version="1")
+    old = _surface(
+        coverage={"fact_set": fs, "fact_family_states": {}},
+        reachable_inline_bodies=[_inline_entity("hash-a")],
+        reachable_templates=[_template_entity("hash-b")],
+    )
+    new = _surface(
+        coverage={"fact_set": dict(fs), "fact_family_states": {}},
+        reachable_declarations=[_unrelated_entity()],
+    )
+    changes = diff_source_abi(old, new)
+    kinds = {c.kind for c in changes}
+    assert ChangeKind.INLINE_FUNCTION_REMOVED in kinds
+    assert ChangeKind.UNINSTANTIATED_TEMPLATE_REMOVED in kinds

--- a/tests/test_inline_changed_paths.py
+++ b/tests/test_inline_changed_paths.py
@@ -196,101 +196,26 @@ def test_inline_graph_no_call_edges_when_clang_absent(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
-# PR1: skip the separate call/type-graph replay when source_edges is complete
-# (ADR-038 C.9 / latest-main Clang plugin review)
+# PR1: fold_source_edges augments the graph; the call/type-graph replay
+# passes still always run (ADR-038 C.10 / latest-main Clang plugin review)
 # --------------------------------------------------------------------------- #
 
 
-def test_inline_graph_skips_call_type_graph_when_source_edges_confirmed(monkeypatch):
-    """A broad-scope L4 replay that already produced confirmed-complete
-    source_edges must not re-run the separate call/type-graph frontend
-    replay passes -- build_source_graph() already folded those edges in via
-    fold_source_edges."""
-    from abicheck.buildsource import call_graph, type_graph
+def test_inline_graph_folds_source_edges_and_still_runs_replay(monkeypatch):
+    """fold_source_edges (inside build_source_graph) adds the surface's
+    source_edges to the graph, but the separate call/type-graph replay
+    passes must still run unconditionally -- even when source_edges rolls
+    up as confirmed-complete.
 
-    called = {"call": False, "type": False}
-
-    class _FakeCallExtractor:
-        def __init__(self, *a, **k):
-            self.clang_bin = "clang++"
-            self.diagnostics: list[str] = []
-
-        def available(self) -> bool:
-            called["call"] = True
-            return True
-
-        def extract_from_build(self, build):
-            return []
-
-    class _FakeTypeExtractor:
-        def __init__(self, *a, **k):
-            self.clang_bin = "clang++"
-            self.diagnostics: list[str] = []
-
-        def available(self) -> bool:
-            called["type"] = True
-            return True
-
-        def extract_from_build(self, build):
-            return []
-
-    monkeypatch.setattr(call_graph, "ClangCallGraphExtractor", _FakeCallExtractor)
-    monkeypatch.setattr(type_graph, "ClangTypeGraphExtractor", _FakeTypeExtractor)
-
-    merged = _build_with_one_unit()
-    surface = SourceAbiSurface(library="libfoo.so", target_id="target://libfoo")
-    surface.source_edges = [{"edge": "DECL_CALLS_DECL", "src": "a", "dst": "b"}]
-    surface.coverage["fact_family_states"] = {"source_edges": "complete"}
-    graph = inline._build_inline_graph(
-        merged, surface=surface, with_call_graph=True, clang_bin="clang", extractors=[]
-    )
-    assert graph is not None
-    # The edge reached the graph via fold_source_edges (inside build_source_graph),
-    # not the (skipped) call-graph replay.
-    assert any(e.kind == "DECL_CALLS_DECL" for e in graph.edges)
-    assert called == {"call": False, "type": False}
-    # Still credited as a confirmed, full pass -- crosscheck.py's decl-dependency
-    # reads must not treat this as unexamined territory.
-    assert graph.extractor_passes["call_graph"] is True
-    assert graph.extractor_passes["type_graph"] is True
-
-
-def test_inline_graph_does_not_skip_when_source_edges_incomplete(monkeypatch):
-    """partial/failed/unsupported (or no fact_set at all) source_edges
-    coverage must not suppress the separate call-graph replay -- only a
-    confirmed complete/empty-confirmed rollup does."""
-    from abicheck.buildsource import call_graph
-    from abicheck.buildsource.call_graph import CallEdge
-
-    class _FakeCallExtractor:
-        def __init__(self, *a, **k):
-            self.clang_bin = "clang++"
-            self.diagnostics: list[str] = []
-
-        def available(self) -> bool:
-            return True
-
-        def extract_from_build(self, build) -> list[CallEdge]:
-            return [CallEdge("caller", "callee", "direct", "exact")]
-
-    monkeypatch.setattr(call_graph, "ClangCallGraphExtractor", _FakeCallExtractor)
-    merged = _build_with_one_unit()
-    surface = SourceAbiSurface(library="libfoo.so", target_id="target://libfoo")
-    surface.coverage["fact_family_states"] = {"source_edges": "partial"}
-    graph = inline._build_inline_graph(
-        merged, surface=surface, with_call_graph=True, clang_bin="clang", extractors=[]
-    )
-    assert graph is not None
-    assert any(e.kind == "DECL_CALLS_DECL" for e in graph.edges)
-
-
-def test_inline_graph_narrowed_scope_does_not_skip_despite_confirmed_source_edges(
-    monkeypatch,
-):
-    """A changed-path-narrowed run must still run the call-graph replay even
-    when source_edges rolls up as complete for that narrow scope -- narrowed
-    source_edges only proves completeness for the TUs L4 actually parsed, the
-    same reasoning extractor_pass_fully_covered already applies."""
+    An earlier revision skipped the replay in that case as a performance
+    optimization, but the raw source_edges wire format carries only bare
+    endpoint identities, not the dst_file/project-file provenance
+    fold_call_graph/fold_type_graph attach via `project_files`
+    (`defined_in_project`). Without that provenance,
+    crosscheck.public_to_internal_dependency cannot classify an unannotated
+    callee/referenced node as internal, so skipping the replay would
+    silently miss a public-to-internal dependency addition (Codex review on
+    PR #560). This test locks in that the replay is never skipped this way."""
     from abicheck.buildsource import call_graph
     from abicheck.buildsource.call_graph import CallEdge
 
@@ -306,24 +231,23 @@ def test_inline_graph_narrowed_scope_does_not_skip_despite_confirmed_source_edge
             return True
 
         def extract_from_build(self, build) -> list[CallEdge]:
-            return []
+            return [CallEdge("caller", "callee", "direct", "exact")]
 
     monkeypatch.setattr(call_graph, "ClangCallGraphExtractor", _FakeCallExtractor)
-    merged = BuildEvidence(
-        compile_units=[CompileUnit(id="cu://src/a.cpp", source="src/a.cpp")]
-    )
+    merged = _build_with_one_unit()
     surface = SourceAbiSurface(library="libfoo.so", target_id="target://libfoo")
+    surface.source_edges = [{"edge": "DECL_CALLS_DECL", "src": "a", "dst": "b"}]
     surface.coverage["fact_family_states"] = {"source_edges": "complete"}
     graph = inline._build_inline_graph(
-        merged,
-        surface=surface,
-        with_call_graph=True,
-        clang_bin="clang",
-        extractors=[],
-        changed_paths=("src/a.cpp",),
+        merged, surface=surface, with_call_graph=True, clang_bin="clang", extractors=[]
     )
     assert graph is not None
+    # fold_source_edges's edge is present...
+    assert any(e.src == "decl://a" and e.dst == "decl://b" for e in graph.edges)
+    # ...and the replay still ran (not skipped) and folded its own edge too.
     assert called["call"] is True
+    assert any(e.src == "decl://caller" and e.dst == "decl://callee" for e in graph.edges)
+    assert graph.extractor_passes["call_graph"] is True
 
 
 def test_inline_call_graph_scoped_to_changed_tus(monkeypatch):

--- a/tests/test_inline_changed_paths.py
+++ b/tests/test_inline_changed_paths.py
@@ -195,6 +195,137 @@ def test_inline_graph_no_call_edges_when_clang_absent(monkeypatch):
     assert any(r.name == "call_graph:clang" and r.status == "failed" for r in rows)
 
 
+# --------------------------------------------------------------------------- #
+# PR1: skip the separate call/type-graph replay when source_edges is complete
+# (ADR-038 C.9 / latest-main Clang plugin review)
+# --------------------------------------------------------------------------- #
+
+
+def test_inline_graph_skips_call_type_graph_when_source_edges_confirmed(monkeypatch):
+    """A broad-scope L4 replay that already produced confirmed-complete
+    source_edges must not re-run the separate call/type-graph frontend
+    replay passes -- build_source_graph() already folded those edges in via
+    fold_source_edges."""
+    from abicheck.buildsource import call_graph, type_graph
+
+    called = {"call": False, "type": False}
+
+    class _FakeCallExtractor:
+        def __init__(self, *a, **k):
+            self.clang_bin = "clang++"
+            self.diagnostics: list[str] = []
+
+        def available(self) -> bool:
+            called["call"] = True
+            return True
+
+        def extract_from_build(self, build):
+            return []
+
+    class _FakeTypeExtractor:
+        def __init__(self, *a, **k):
+            self.clang_bin = "clang++"
+            self.diagnostics: list[str] = []
+
+        def available(self) -> bool:
+            called["type"] = True
+            return True
+
+        def extract_from_build(self, build):
+            return []
+
+    monkeypatch.setattr(call_graph, "ClangCallGraphExtractor", _FakeCallExtractor)
+    monkeypatch.setattr(type_graph, "ClangTypeGraphExtractor", _FakeTypeExtractor)
+
+    merged = _build_with_one_unit()
+    surface = SourceAbiSurface(library="libfoo.so", target_id="target://libfoo")
+    surface.source_edges = [{"edge": "DECL_CALLS_DECL", "src": "a", "dst": "b"}]
+    surface.coverage["fact_family_states"] = {"source_edges": "complete"}
+    graph = inline._build_inline_graph(
+        merged, surface=surface, with_call_graph=True, clang_bin="clang", extractors=[]
+    )
+    assert graph is not None
+    # The edge reached the graph via fold_source_edges (inside build_source_graph),
+    # not the (skipped) call-graph replay.
+    assert any(e.kind == "DECL_CALLS_DECL" for e in graph.edges)
+    assert called == {"call": False, "type": False}
+    # Still credited as a confirmed, full pass -- crosscheck.py's decl-dependency
+    # reads must not treat this as unexamined territory.
+    assert graph.extractor_passes["call_graph"] is True
+    assert graph.extractor_passes["type_graph"] is True
+
+
+def test_inline_graph_does_not_skip_when_source_edges_incomplete(monkeypatch):
+    """partial/failed/unsupported (or no fact_set at all) source_edges
+    coverage must not suppress the separate call-graph replay -- only a
+    confirmed complete/empty-confirmed rollup does."""
+    from abicheck.buildsource import call_graph
+    from abicheck.buildsource.call_graph import CallEdge
+
+    class _FakeCallExtractor:
+        def __init__(self, *a, **k):
+            self.clang_bin = "clang++"
+            self.diagnostics: list[str] = []
+
+        def available(self) -> bool:
+            return True
+
+        def extract_from_build(self, build) -> list[CallEdge]:
+            return [CallEdge("caller", "callee", "direct", "exact")]
+
+    monkeypatch.setattr(call_graph, "ClangCallGraphExtractor", _FakeCallExtractor)
+    merged = _build_with_one_unit()
+    surface = SourceAbiSurface(library="libfoo.so", target_id="target://libfoo")
+    surface.coverage["fact_family_states"] = {"source_edges": "partial"}
+    graph = inline._build_inline_graph(
+        merged, surface=surface, with_call_graph=True, clang_bin="clang", extractors=[]
+    )
+    assert graph is not None
+    assert any(e.kind == "DECL_CALLS_DECL" for e in graph.edges)
+
+
+def test_inline_graph_narrowed_scope_does_not_skip_despite_confirmed_source_edges(
+    monkeypatch,
+):
+    """A changed-path-narrowed run must still run the call-graph replay even
+    when source_edges rolls up as complete for that narrow scope -- narrowed
+    source_edges only proves completeness for the TUs L4 actually parsed, the
+    same reasoning extractor_pass_fully_covered already applies."""
+    from abicheck.buildsource import call_graph
+    from abicheck.buildsource.call_graph import CallEdge
+
+    called = {"call": False}
+
+    class _FakeCallExtractor:
+        def __init__(self, *a, **k):
+            self.clang_bin = "clang++"
+            self.diagnostics: list[str] = []
+
+        def available(self) -> bool:
+            called["call"] = True
+            return True
+
+        def extract_from_build(self, build) -> list[CallEdge]:
+            return []
+
+    monkeypatch.setattr(call_graph, "ClangCallGraphExtractor", _FakeCallExtractor)
+    merged = BuildEvidence(
+        compile_units=[CompileUnit(id="cu://src/a.cpp", source="src/a.cpp")]
+    )
+    surface = SourceAbiSurface(library="libfoo.so", target_id="target://libfoo")
+    surface.coverage["fact_family_states"] = {"source_edges": "complete"}
+    graph = inline._build_inline_graph(
+        merged,
+        surface=surface,
+        with_call_graph=True,
+        clang_bin="clang",
+        extractors=[],
+        changed_paths=("src/a.cpp",),
+    )
+    assert graph is not None
+    assert called["call"] is True
+
+
 def test_inline_call_graph_scoped_to_changed_tus(monkeypatch):
     # A PR/--since scan scopes the call-graph pass to the changed compile units —
     # parsing every TU of a large compile DB would defeat the targeted PR cost

--- a/tests/test_inline_changed_paths.py
+++ b/tests/test_inline_changed_paths.py
@@ -246,7 +246,9 @@ def test_inline_graph_folds_source_edges_and_still_runs_replay(monkeypatch):
     assert any(e.src == "decl://a" and e.dst == "decl://b" for e in graph.edges)
     # ...and the replay still ran (not skipped) and folded its own edge too.
     assert called["call"] is True
-    assert any(e.src == "decl://caller" and e.dst == "decl://callee" for e in graph.edges)
+    assert any(
+        e.src == "decl://caller" and e.dst == "decl://callee" for e in graph.edges
+    )
     assert graph.extractor_passes["call_graph"] is True
 
 
@@ -304,7 +306,9 @@ def test_inline_call_graph_scoped_to_changed_tus(monkeypatch):
     assert graph.narrowed_scope["call_graph"] == frozenset({"src/a.cpp"})
 
 
-def test_inline_call_graph_scoped_with_diagnostics_does_not_confirm_narrowed_pass(monkeypatch):
+def test_inline_call_graph_scoped_with_diagnostics_does_not_confirm_narrowed_pass(
+    monkeypatch,
+):
     # Fifteenth Codex review: narrowed_passes now doubles as "this narrowed
     # scope's zero-edge family is trustworthy" (not just "discount this run's
     # edges elsewhere"), so a narrowed run that hit a per-TU diagnostic (a

--- a/tests/test_inputs_emit.py
+++ b/tests/test_inputs_emit.py
@@ -63,7 +63,7 @@ def _tu(name: str, *, mangled: str, source: str = "src/foo.cpp") -> SourceAbiTu:
         visibility="public_header",
     )
     return SourceAbiTu(
-        tu_id=f"cu://{source}", target_id="target://libfoo", source=source,
+        tu_id=f"cu://{source}", target_id="target://libfoo.so", source=source,
         public_header_roots=[f"include/{name}.h"], functions=[ent],
     )
 
@@ -126,10 +126,46 @@ def test_init_recovers_from_partial_manifest(tmp_path: Path) -> None:
 def test_init_inputs_pack_is_idempotent(tmp_path: Path) -> None:
     pack = tmp_path / "abicheck_inputs"
     m1 = init_inputs_pack(pack, library="libfoo.so", created_by="abicheck-cc")
-    m2 = init_inputs_pack(pack, library="OTHER", created_by="OTHER")
-    # Second call loads the existing manifest, does not clobber it.
+    # A repeated call naming the *same* library (created_by may vary -- not
+    # part of the target-isolation identity) loads the existing manifest.
+    m2 = init_inputs_pack(pack, library="libfoo.so", created_by="OTHER")
     assert m2.library == m1.library == "libfoo.so"
     assert m2.created_by == "abicheck-cc"
+
+
+def test_init_inputs_pack_rejects_conflicting_library(tmp_path: Path) -> None:
+    """PR3 target isolation (latest-main Clang plugin review): a second
+    invocation naming a *different* library against the same pack root is
+    exactly the same-source/two-library collision the prior first-writer-
+    wins manifest allowed -- raise instead of silently keeping the first
+    library's identity."""
+    pack = tmp_path / "abicheck_inputs"
+    init_inputs_pack(pack, library="libfoo.so", created_by="abicheck-cc")
+    with pytest.raises(ValueError, match="library"):
+        init_inputs_pack(pack, library="libbar.so", created_by="abicheck-cc")
+    # The pack must be untouched by the rejected call.
+    assert json.loads((pack / "manifest.json").read_text())["library"] == "libfoo.so"
+
+
+def test_init_inputs_pack_rejects_conflicting_version(tmp_path: Path) -> None:
+    pack = tmp_path / "abicheck_inputs"
+    init_inputs_pack(
+        pack, library="libfoo.so", version="1.0", created_by="abicheck-cc"
+    )
+    with pytest.raises(ValueError, match="version"):
+        init_inputs_pack(
+            pack, library="libfoo.so", version="2.0", created_by="abicheck-cc"
+        )
+
+
+def test_init_inputs_pack_allows_unspecified_library_or_version(tmp_path: Path) -> None:
+    """Omitting library/version (the default "") is never treated as a
+    conflict either way -- only two *different* non-empty values collide."""
+    pack = tmp_path / "abicheck_inputs"
+    init_inputs_pack(pack, library="libfoo.so", version="1.0", created_by="abicheck-cc")
+    m = init_inputs_pack(pack, created_by="abicheck-cc")  # no library/version passed
+    assert m.library == "libfoo.so"
+    assert m.version == "1.0"
 
 
 def test_init_inputs_pack_rejects_wrong_kind_manifest(tmp_path: Path) -> None:
@@ -693,7 +729,7 @@ def test_compact_rerun_never_treats_empty_tu_id_as_a_match(tmp_path: Path) -> No
             ),
             visibility="public_header",
         )
-        return SourceAbiTu(tu_id="", target_id="target://libfoo", functions=[ent])
+        return SourceAbiTu(tu_id="", target_id="target://libfoo.so", functions=[ent])
 
     append_source_facts(
         pack, [_no_id_tu("foo", "_Z3foov")], filename=facts_filename("foo")
@@ -800,7 +836,7 @@ def test_compact_skips_on_duplicate_fresh_tu_id(tmp_path: Path) -> None:
     # or third-party pack instead).
     other = SourceAbiTu(
         tu_id="cu://src/x.cpp",
-        target_id="target://libfoo",
+        target_id="target://libfoo.so",
         functions=[
             SourceEntity(
                 id="decl://bar", kind="function", qualified_name="bar",
@@ -1200,6 +1236,58 @@ def test_compact_keeps_preexisting_output_on_rerun_manifest_write_failure(
     # fresh foo2 wins, bar carried forward, extra merged in from its
     # explicit file entry -- none lost despite the manifest write failure.
     assert names == {"_Z4foo2v", "_Z3barv", "_Z5extrav"}
+
+
+def test_compact_rejects_output_filename_colliding_with_unrelated_file(
+    tmp_path: Path,
+) -> None:
+    """PR4 (latest-main Clang plugin review): an operator's --output-filename
+    coincidentally matching an ordinary pre-existing file (here, an untouched
+    per-TU original from a normal build -- never a published compaction
+    result manifest.last_compacted points at) must be rejected outright
+    rather than silently overwritten by the merge. A bare
+    `output_path.exists()` check used to treat this as "a legitimate prior
+    compaction rerun," letting os.replace() clobber the unrelated file, and
+    a later manifest-write failure would then leave that clobbered
+    replacement in place (rollback skips deletion for anything
+    "pre-existing")."""
+    pack = tmp_path / "abicheck_inputs"
+    init_inputs_pack(pack, library="libfoo.so", created_by="abicheck-cc")
+    # An ordinary per-TU original that happens to share its name with the
+    # --output-filename this call will request. manifest.last_compacted is
+    # unset (compaction has never run), so this file is definitely not a
+    # recognized prior compaction output.
+    collision_name = "collide.jsonl"
+    append_source_facts(
+        pack, [_tu("foo", mangled="_Z3foov")], filename=collision_name
+    )
+    original_bytes = (pack / "source_facts" / collision_name).read_bytes()
+
+    with pytest.raises(ValueError, match="already exists"):
+        compact_inputs_pack(pack, output_filename=collision_name)
+
+    # The collision must be rejected before any write -- the original file's
+    # content survives untouched, and the manifest is not repointed.
+    assert (pack / "source_facts" / collision_name).read_bytes() == original_bytes
+    assert load_inputs_manifest(pack).last_compacted == ""
+
+
+def test_compact_reruns_with_recognized_prior_output_without_raising(
+    tmp_path: Path,
+) -> None:
+    """The rejection above must not regress the legitimate rerun case: reusing
+    the SAME output_filename as a real prior compaction (recognized via
+    manifest.last_compacted) is not a collision."""
+    pack = tmp_path / "abicheck_inputs"
+    init_inputs_pack(pack, library="libfoo.so", created_by="abicheck-cc")
+    append_source_facts(
+        pack, [_tu("foo", mangled="_Z3foov")], filename=facts_filename("src/foo.cpp")
+    )
+    first = compact_inputs_pack(pack, output_filename="merged.jsonl")
+    assert first is not None
+    # Rerunning with the identical output_filename must not raise.
+    second = compact_inputs_pack(pack, output_filename="merged.jsonl")
+    assert second == first
 
 
 def test_compact_keep_originals_when_requested(tmp_path: Path) -> None:

--- a/tests/test_inputs_emit.py
+++ b/tests/test_inputs_emit.py
@@ -59,12 +59,17 @@ def _tu(name: str, *, mangled: str, source: str = "src/foo.cpp") -> SourceAbiTu:
         qualified_name=name,
         mangled_name=mangled,
         signature_hash="sig1",
-        source_location=SourceLocation(path=f"include/{name}.h", line=3, origin="PUBLIC_HEADER"),
+        source_location=SourceLocation(
+            path=f"include/{name}.h", line=3, origin="PUBLIC_HEADER"
+        ),
         visibility="public_header",
     )
     return SourceAbiTu(
-        tu_id=f"cu://{source}", target_id="target://libfoo.so", source=source,
-        public_header_roots=[f"include/{name}.h"], functions=[ent],
+        tu_id=f"cu://{source}",
+        target_id="target://libfoo.so",
+        source=source,
+        public_header_roots=[f"include/{name}.h"],
+        functions=[ent],
     )
 
 
@@ -73,14 +78,24 @@ def _tu(name: str, *, mangled: str, source: str = "src/foo.cpp") -> SourceAbiTu:
 
 def test_write_inputs_pack_round_trips_through_ingest(tmp_path: Path) -> None:
     cdb = tmp_path / "compile_commands.json"
-    cdb.write_text(json.dumps([
-        {"directory": str(tmp_path), "file": "src/foo.cpp",
-         "arguments": ["c++", "-std=c++17", "-c", "src/foo.cpp"]}
-    ]))
+    cdb.write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "file": "src/foo.cpp",
+                    "arguments": ["c++", "-std=c++17", "-c", "src/foo.cpp"],
+                }
+            ]
+        )
+    )
     root = write_inputs_pack(
         tmp_path / "abicheck_inputs",
-        library="libfoo.so", version="1.0", created_by="test",
-        tus=[_tu("foo", mangled="_Z3foov")], compile_db=cdb,
+        library="libfoo.so",
+        version="1.0",
+        created_by="test",
+        tus=[_tu("foo", mangled="_Z3foov")],
+        compile_db=cdb,
     )
     ingested = ingest_inputs_pack(root)
     assert ingested.tu_count == 1
@@ -94,9 +109,14 @@ def test_incremental_init_then_append_round_trips(tmp_path: Path) -> None:
     pack = tmp_path / "abicheck_inputs"
     init_inputs_pack(pack, library="libfoo.so", version="1.0", created_by="abicheck-cc")
     # Two per-TU appends, as a wrapper would do across two compile invocations.
-    append_source_facts(pack, [_tu("foo", mangled="_Z3foov")], filename=facts_filename("src/foo.cpp"))
-    append_source_facts(pack, [_tu("bar", mangled="_Z3barv", source="src/bar.cpp")],
-                        filename=facts_filename("src/bar.cpp"))
+    append_source_facts(
+        pack, [_tu("foo", mangled="_Z3foov")], filename=facts_filename("src/foo.cpp")
+    )
+    append_source_facts(
+        pack,
+        [_tu("bar", mangled="_Z3barv", source="src/bar.cpp")],
+        filename=facts_filename("src/bar.cpp"),
+    )
     ingested = ingest_inputs_pack(pack)
     assert ingested.tu_count == 2
     names = {e.qualified_name for e in ingested.pack.source_abi.reachable_declarations}
@@ -116,7 +136,9 @@ def test_init_recovers_from_partial_manifest(tmp_path: Path) -> None:
     # not raise (which would lose this TU's facts in the wrapper's best-effort path).
     pack = tmp_path / "abicheck_inputs"
     (pack / "source_facts").mkdir(parents=True)
-    (pack / "manifest.json").write_text('{"kind": "abicheck_inputs"', encoding="utf-8")  # truncated JSON
+    (pack / "manifest.json").write_text(
+        '{"kind": "abicheck_inputs"', encoding="utf-8"
+    )  # truncated JSON
     m = init_inputs_pack(pack, library="libfoo.so", created_by="abicheck-cc")
     assert m.library == "libfoo.so"
     # Manifest is now valid and round-trips.
@@ -149,9 +171,7 @@ def test_init_inputs_pack_rejects_conflicting_library(tmp_path: Path) -> None:
 
 def test_init_inputs_pack_rejects_conflicting_version(tmp_path: Path) -> None:
     pack = tmp_path / "abicheck_inputs"
-    init_inputs_pack(
-        pack, library="libfoo.so", version="1.0", created_by="abicheck-cc"
-    )
+    init_inputs_pack(pack, library="libfoo.so", version="1.0", created_by="abicheck-cc")
     with pytest.raises(ValueError, match="version"):
         init_inputs_pack(
             pack, library="libfoo.so", version="2.0", created_by="abicheck-cc"
@@ -166,6 +186,73 @@ def test_init_inputs_pack_allows_unspecified_library_or_version(tmp_path: Path) 
     m = init_inputs_pack(pack, created_by="abicheck-cc")  # no library/version passed
     assert m.library == "libfoo.so"
     assert m.version == "1.0"
+
+
+def test_init_inputs_pack_race_loser_validates_against_winner(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Two racing first-TU invocations for *different* libraries sharing one
+    out= directory must not let the second one silently win: simulate the
+    exists()-then-write TOCTOU by making this call's os.link() lose to a
+    manifest a "concurrent" process publishes in between -- the loser must
+    re-read and validate against it (raising on the library conflict), not
+    blindly overwrite it (Codex review)."""
+    import os as os_module
+
+    pack = tmp_path / "abicheck_inputs"
+    real_link = os_module.link
+
+    def _racing_link(src, dst, *a, **k):
+        # Simulate a concurrent winner publishing its own manifest for a
+        # *different* library right before our os.link() call runs.
+        Path(dst).parent.mkdir(parents=True, exist_ok=True)
+        Path(dst).write_text(
+            json.dumps(
+                {
+                    "kind": "abicheck_inputs",
+                    "abicheck_inputs_version": 1,
+                    "library": "libbar.so",
+                    "version": "",
+                }
+            )
+        )
+        raise FileExistsError(17, "File exists")
+
+    monkeypatch.setattr(os_module, "link", _racing_link)
+    with pytest.raises(ValueError, match="library"):
+        init_inputs_pack(pack, library="libfoo.so", created_by="abicheck-cc")
+    monkeypatch.setattr(os_module, "link", real_link)
+    # The "winner"'s manifest must be exactly what it published -- our losing
+    # call must never have overwritten it.
+    assert json.loads((pack / "manifest.json").read_text())["library"] == "libbar.so"
+
+
+def test_init_inputs_pack_race_loser_agreeing_target_succeeds(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """The same race, but the concurrent winner named the *same* library --
+    the loser must load and return it cleanly instead of raising."""
+    import os as os_module
+
+    pack = tmp_path / "abicheck_inputs"
+
+    def _racing_link(src, dst, *a, **k):
+        Path(dst).parent.mkdir(parents=True, exist_ok=True)
+        Path(dst).write_text(
+            json.dumps(
+                {
+                    "kind": "abicheck_inputs",
+                    "abicheck_inputs_version": 1,
+                    "library": "libfoo.so",
+                    "version": "",
+                }
+            )
+        )
+        raise FileExistsError(17, "File exists")
+
+    monkeypatch.setattr(os_module, "link", _racing_link)
+    m = init_inputs_pack(pack, library="libfoo.so", created_by="abicheck-cc")
+    assert m.library == "libfoo.so"
 
 
 def test_init_inputs_pack_rejects_wrong_kind_manifest(tmp_path: Path) -> None:
@@ -423,7 +510,8 @@ def test_compact_root_directory_scan_does_not_destroy_manifest(
     manifest.source_facts = ["."]
     _write_manifest(pack, manifest)
     (pack / "root.jsonl").write_text(
-        json.dumps(_tu("foo", mangled="_Z3foov", source="src/foo.cpp").to_dict()) + "\n",
+        json.dumps(_tu("foo", mangled="_Z3foov", source="src/foo.cpp").to_dict())
+        + "\n",
         encoding="utf-8",
     )
 
@@ -461,7 +549,8 @@ def test_compact_ancestor_directory_entry_does_not_lose_merged_facts(
     manifest.source_facts = ["."]
     _write_manifest(pack, manifest)
     (pack / "root.jsonl").write_text(
-        json.dumps(_tu("foo", mangled="_Z3foov", source="src/foo.cpp").to_dict()) + "\n",
+        json.dumps(_tu("foo", mangled="_Z3foov", source="src/foo.cpp").to_dict())
+        + "\n",
         encoding="utf-8",
     )
 
@@ -558,8 +647,7 @@ def test_compact_rerun_recognizes_stale_output_across_a_filename_change(
     assert second_out != first_out
     assert not first_out.exists()  # merged away by remove_originals
     assert (
-        load_inputs_manifest(pack).last_compacted
-        == "source_facts/compacted.jsonl.gz"
+        load_inputs_manifest(pack).last_compacted == "source_facts/compacted.jsonl.gz"
     )
 
     ingested = ingest_inputs_pack(pack)
@@ -705,7 +793,10 @@ def test_read_drops_all_prior_carry_forward_on_lossy_fresh_read(
     # prior "bar" survives -- not just the TU whose fresh write failed.
     assert tus == []
     assert any("skipped malformed JSON line" in d for d in diagnostics)
-    assert any("no prior-compaction record can be safely carried forward" in d for d in diagnostics)
+    assert any(
+        "no prior-compaction record can be safely carried forward" in d
+        for d in diagnostics
+    )
 
     report = validate_inputs_pack(pack)
     assert report.tu_count == 0
@@ -722,8 +813,11 @@ def test_compact_rerun_never_treats_empty_tu_id_as_a_match(tmp_path: Path) -> No
 
     def _no_id_tu(name: str, mangled: str) -> SourceAbiTu:
         ent = SourceEntity(
-            id=f"decl://{name}", kind="function", qualified_name=name,
-            mangled_name=mangled, signature_hash="sig1",
+            id=f"decl://{name}",
+            kind="function",
+            qualified_name=name,
+            mangled_name=mangled,
+            signature_hash="sig1",
             source_location=SourceLocation(
                 path=f"include/{name}.h", line=3, origin="PUBLIC_HEADER"
             ),
@@ -774,7 +868,9 @@ def test_compact_skips_entirely_on_lossy_read(tmp_path: Path) -> None:
     assert out is None
 
     remaining = sorted(p.name for p in (pack / "source_facts").glob("*.jsonl"))
-    assert remaining == sorted(["bad.jsonl", facts_filename("src/foo.cpp")])  # unchanged
+    assert remaining == sorted(
+        ["bad.jsonl", facts_filename("src/foo.cpp")]
+    )  # unchanged
     assert any("compaction was skipped entirely" in d for d in diagnostics)
 
     # The good TU's facts are still readable directly (no merge happened,
@@ -839,8 +935,11 @@ def test_compact_skips_on_duplicate_fresh_tu_id(tmp_path: Path) -> None:
         target_id="target://libfoo.so",
         functions=[
             SourceEntity(
-                id="decl://bar", kind="function", qualified_name="bar",
-                mangled_name="_Z3barv", signature_hash="sig1",
+                id="decl://bar",
+                kind="function",
+                qualified_name="bar",
+                mangled_name="_Z3barv",
+                signature_hash="sig1",
                 source_location=SourceLocation(
                     path="include/bar.h", line=3, origin="PUBLIC_HEADER"
                 ),
@@ -879,7 +978,8 @@ def test_compact_directory_scan_manifest_stays_discoverable_after_rebuild(
     manifest.source_facts = ["source_facts"]  # mirrors ensureManifest()
     _write_manifest(pack, manifest)
     append_source_facts(
-        pack, [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
+        pack,
+        [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
         filename=facts_filename("src/foo.cpp"),
     )
     compact_inputs_pack(pack)
@@ -891,7 +991,8 @@ def test_compact_directory_scan_manifest_stays_discoverable_after_rebuild(
     # A later incremental build's fresh per-TU file lands in the same
     # directory; it must still be discovered.
     append_source_facts(
-        pack, [_tu("bar", mangled="_Z3barv", source="src/bar.cpp")],
+        pack,
+        [_tu("bar", mangled="_Z3barv", source="src/bar.cpp")],
         filename=facts_filename("src/bar.cpp"),
     )
     ingested = ingest_inputs_pack(pack)
@@ -914,14 +1015,16 @@ def test_compact_directory_scan_manifest_recognized_across_spellings(
     manifest.source_facts = [spelling]
     _write_manifest(pack, manifest)
     append_source_facts(
-        pack, [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
+        pack,
+        [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
         filename=facts_filename("src/foo.cpp"),
     )
     compact_inputs_pack(pack)
     assert load_inputs_manifest(pack).source_facts == [spelling]
 
     append_source_facts(
-        pack, [_tu("bar", mangled="_Z3barv", source="src/bar.cpp")],
+        pack,
+        [_tu("bar", mangled="_Z3barv", source="src/bar.cpp")],
         filename=facts_filename("src/bar.cpp"),
     )
     ingested = ingest_inputs_pack(pack)
@@ -945,9 +1048,7 @@ def test_compact_preserves_directory_entry_in_mixed_manifest(
     other_dir = pack / "extra_facts"
     other_dir.mkdir()
     (other_dir / "extra.jsonl").write_text(
-        json.dumps(
-            _tu("extra", mangled="_Z5extrav", source="src/extra.cpp").to_dict()
-        )
+        json.dumps(_tu("extra", mangled="_Z5extrav", source="src/extra.cpp").to_dict())
         + "\n",
         encoding="utf-8",
     )
@@ -955,7 +1056,8 @@ def test_compact_preserves_directory_entry_in_mixed_manifest(
     manifest.source_facts = ["source_facts", "extra_facts"]
     _write_manifest(pack, manifest)
     append_source_facts(
-        pack, [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
+        pack,
+        [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
         filename=facts_filename("src/foo.cpp"),
     )
     compact_inputs_pack(pack)
@@ -967,7 +1069,8 @@ def test_compact_preserves_directory_entry_in_mixed_manifest(
     # A later incremental build's fresh per-TU file lands in source_facts/;
     # it must still be discovered, and extra_facts/ is untouched.
     append_source_facts(
-        pack, [_tu("bar", mangled="_Z3barv", source="src/bar.cpp")],
+        pack,
+        [_tu("bar", mangled="_Z3barv", source="src/bar.cpp")],
         filename=facts_filename("src/bar.cpp"),
     )
     ingested = ingest_inputs_pack(pack)
@@ -1086,7 +1189,8 @@ def test_compact_preserves_originals_when_manifest_write_fails(
     manifest.source_facts = [f"source_facts/{facts_filename('src/foo.cpp')}"]
     _write_manifest(pack, manifest)
     original = append_source_facts(
-        pack, [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
+        pack,
+        [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
         filename=facts_filename("src/foo.cpp"),
     )
 
@@ -1127,7 +1231,8 @@ def test_compact_rolls_back_merged_output_when_manifest_write_fails(
     pack = tmp_path / "abicheck_inputs"
     init_inputs_pack(pack, library="libfoo.so", created_by="abicheck-cc")
     append_source_facts(
-        pack, [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
+        pack,
+        [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
         filename=facts_filename("src/foo.cpp"),
     )
 
@@ -1170,11 +1275,13 @@ def test_compact_keeps_preexisting_output_on_rerun_manifest_write_failure(
     pack = tmp_path / "abicheck_inputs"
     init_inputs_pack(pack, library="libfoo.so", created_by="abicheck-cc")
     append_source_facts(
-        pack, [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
+        pack,
+        [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")],
         filename=facts_filename("src/foo.cpp"),
     )
     append_source_facts(
-        pack, [_tu("bar", mangled="_Z3barv", source="src/bar.cpp")],
+        pack,
+        [_tu("bar", mangled="_Z3barv", source="src/bar.cpp")],
         filename=facts_filename("src/bar.cpp"),
     )
     first_out = compact_inputs_pack(pack)
@@ -1192,9 +1299,7 @@ def test_compact_keeps_preexisting_output_on_rerun_manifest_write_failure(
     # to rewrite the manifest, unrelated to last_compacted/prior-vs-fresh
     # dedup), so the failure path under test is actually exercised.
     (pack / "extra.jsonl").write_text(
-        json.dumps(
-            _tu("extra", mangled="_Z5extrav", source="src/extra.cpp").to_dict()
-        )
+        json.dumps(_tu("extra", mangled="_Z5extrav", source="src/extra.cpp").to_dict())
         + "\n",
         encoding="utf-8",
     )
@@ -1202,7 +1307,8 @@ def test_compact_keeps_preexisting_output_on_rerun_manifest_write_failure(
     manifest.source_facts = ["source_facts", "extra.jsonl"]
     _write_manifest(pack, manifest)
     append_source_facts(
-        pack, [_tu("foo2", mangled="_Z4foo2v", source="src/foo.cpp")],
+        pack,
+        [_tu("foo2", mangled="_Z4foo2v", source="src/foo.cpp")],
         filename=facts_filename("src/foo.cpp"),
     )
     import abicheck.buildsource.inputs_emit as inputs_emit_module
@@ -1222,8 +1328,7 @@ def test_compact_keeps_preexisting_output_on_rerun_manifest_write_failure(
     # reconstruct the right answer -- that would pass even if first_out
     # had been rolled back to its pre-rerun contents (CodeRabbit review).
     merged_records = [
-        json.loads(line)
-        for line in first_out.read_text(encoding="utf-8").splitlines()
+        json.loads(line) for line in first_out.read_text(encoding="utf-8").splitlines()
     ]
     merged_names = {
         function["mangled_name"]
@@ -1258,9 +1363,7 @@ def test_compact_rejects_output_filename_colliding_with_unrelated_file(
     # unset (compaction has never run), so this file is definitely not a
     # recognized prior compaction output.
     collision_name = "collide.jsonl"
-    append_source_facts(
-        pack, [_tu("foo", mangled="_Z3foov")], filename=collision_name
-    )
+    append_source_facts(pack, [_tu("foo", mangled="_Z3foov")], filename=collision_name)
     original_bytes = (pack / "source_facts" / collision_name).read_bytes()
 
     with pytest.raises(ValueError, match="already exists"):
@@ -1369,7 +1472,12 @@ def test_compile_unit_from_command_parses_flags(tmp_path: Path) -> None:
 
 
 def test_compile_unit_from_command_none_for_link_or_no_source(tmp_path: Path) -> None:
-    assert compile_unit_from_command(["c++", "-shared", "foo.o", "-o", "libfoo.so"], tmp_path) is None
+    assert (
+        compile_unit_from_command(
+            ["c++", "-shared", "foo.o", "-o", "libfoo.so"], tmp_path
+        )
+        is None
+    )
     assert compile_unit_from_command(["c++"], tmp_path) is None
 
 
@@ -1438,7 +1546,9 @@ def test_wrapper_swallows_extraction_errors() -> None:
         raise RuntimeError("extractor blew up")
 
     # A fact-extraction failure must never change the compiler's exit code.
-    rc = run_cc_wrapper(["c++", "-c", "src/foo.cpp"], runner=lambda c: _Proc(0), env={}, emit=boom)
+    rc = run_cc_wrapper(
+        ["c++", "-c", "src/foo.cpp"], runner=lambda c: _Proc(0), env={}, emit=boom
+    )
     assert rc == 0
 
 
@@ -1473,8 +1583,10 @@ def test_emit_appends_extracted_tu(tmp_path: Path, monkeypatch) -> None:
     )
     pack = tmp_path / "abicheck_inputs"
     tu = emit_facts_for_command(
-        ["c++", "-c", "src/foo.cpp"], tmp_path,
-        inputs_dir=pack, library="libfoo.so",
+        ["c++", "-c", "src/foo.cpp"],
+        tmp_path,
+        inputs_dir=pack,
+        library="libfoo.so",
     )
     assert tu is captured
     ingested = ingest_inputs_pack(pack)
@@ -1482,7 +1594,9 @@ def test_emit_appends_extracted_tu(tmp_path: Path, monkeypatch) -> None:
     assert ingested.manifest.created_by == "abicheck-cc"
 
 
-def test_emit_captures_all_sources_in_multi_source_compile(tmp_path: Path, monkeypatch) -> None:
+def test_emit_captures_all_sources_in_multi_source_compile(
+    tmp_path: Path, monkeypatch
+) -> None:
     # `gcc -c a.cpp b.cpp` builds both objects; both must contribute facts.
     def _extract(cu, *, public_header_roots, target_id=""):
         stem = Path(cu.source).stem
@@ -1497,8 +1611,10 @@ def test_emit_captures_all_sources_in_multi_source_compile(tmp_path: Path, monke
     )
     pack = tmp_path / "abicheck_inputs"
     emit_facts_for_command(
-        ["g++", "-std=c++17", "-c", "a.cpp", "b.cpp"], tmp_path,
-        inputs_dir=pack, library="libfoo.so",
+        ["g++", "-std=c++17", "-c", "a.cpp", "b.cpp"],
+        tmp_path,
+        inputs_dir=pack,
+        library="libfoo.so",
     )
     ingested = ingest_inputs_pack(pack)
     assert ingested.tu_count == 2
@@ -1509,12 +1625,16 @@ def test_emit_captures_all_sources_in_multi_source_compile(tmp_path: Path, monke
 def test_compile_units_capture_forced_language_source(tmp_path: Path) -> None:
     # `clang++ -x c++ -c generated` builds a real TU with no source extension;
     # forced-language discovery must still capture it.
-    units = compile_units_from_command(["clang++", "-x", "c++", "-c", "generated"], tmp_path)
+    units = compile_units_from_command(
+        ["clang++", "-x", "c++", "-c", "generated"], tmp_path
+    )
     assert [u.source for u in units] == ["generated"]
     assert units[0].language == "CXX"
 
 
-def test_emit_continues_after_per_tu_extraction_failure(tmp_path: Path, monkeypatch) -> None:
+def test_emit_continues_after_per_tu_extraction_failure(
+    tmp_path: Path, monkeypatch
+) -> None:
     # In `g++ -c a.cpp b.cpp`, a backend that raises on a.cpp must not drop b.cpp.
     def _extract(cu, *, public_header_roots, target_id=""):
         if Path(cu.source).stem == "a":
@@ -1531,7 +1651,10 @@ def test_emit_continues_after_per_tu_extraction_failure(tmp_path: Path, monkeypa
     )
     pack = tmp_path / "abicheck_inputs"
     emit_facts_for_command(
-        ["g++", "-c", "a.cpp", "b.cpp"], tmp_path, inputs_dir=pack, library="libfoo.so",
+        ["g++", "-c", "a.cpp", "b.cpp"],
+        tmp_path,
+        inputs_dir=pack,
+        library="libfoo.so",
     )
     ingested = ingest_inputs_pack(pack)
     names = {e.qualified_name for e in ingested.pack.source_abi.reachable_declarations}
@@ -1543,5 +1666,7 @@ def test_emit_none_when_no_backend(tmp_path: Path, monkeypatch) -> None:
         "abicheck.buildsource.source_extractors.resolver.select_source_backend",
         lambda extractor, **kw: (None, None),
     )
-    out = emit_facts_for_command(["c++", "-c", "src/foo.cpp"], tmp_path, inputs_dir=tmp_path / "pk")
+    out = emit_facts_for_command(
+        ["c++", "-c", "src/foo.cpp"], tmp_path, inputs_dir=tmp_path / "pk"
+    )
     assert out is None

--- a/tests/test_inputs_pack.py
+++ b/tests/test_inputs_pack.py
@@ -314,6 +314,36 @@ def test_dump_inputs_folds_pack_into_snapshot_like_merge(tmp_path: Path) -> None
     assert surface.coverage.get("unmatched_symbols", 1) == 0
 
 
+def test_dump_inputs_preserves_source_edges_coverage_across_export_relink(
+    tmp_path: Path,
+) -> None:
+    """embed_inputs_pack's export-relink rebuilds the L5 graph from scratch
+    (source-only packs carry no exported_symbols root) -- that rebuild must
+    reapply mark_source_edges_extractor_coverage(), or a confirmed-complete
+    source_edges rollup's call_graph/type_graph coverage -- correctly set at
+    ingest time -- is silently dropped and a real
+    PUBLIC_API_INTERNAL_DEPENDENCY_ADDED finding could be suppressed as a
+    coverage artifact downstream (Codex review)."""
+    from abicheck.buildsource.source_abi import FACT_FAMILIES, default_fact_set
+    from abicheck.cli_buildsource_merge import embed_inputs_pack
+    from abicheck.model import AbiSnapshot, Function
+
+    tu = _tu("foo", mangled="_Z3foov")
+    tu.fact_set = default_fact_set(producer="p", producer_version="1")
+    tu.coverage = dict.fromkeys(FACT_FAMILIES, "complete")
+    pack = _write_inputs_pack(tmp_path, [tu])  # no exported_symbols -> relink runs
+    snap = AbiSnapshot(library="libfoo.so", version="1.0")
+    snap.functions.append(Function(name="foo", mangled="_Z3foov", return_type="void"))
+
+    embed_inputs_pack(snap, pack, tmp_path / "out.json")
+
+    assert snap.build_source is not None
+    graph = snap.build_source.source_graph
+    assert graph is not None
+    assert graph.extractor_passes.get("call_graph") is True
+    assert graph.extractor_passes.get("type_graph") is True
+
+
 def test_write_snapshot_output_embeds_inputs_pack(tmp_path: Path) -> None:
     # The dump CLI seam: _write_snapshot_output(..., inputs_pack=pack) folds the
     # pack and serializes an embedded build_source (single-artifact UX), so a plain

--- a/tests/test_inputs_pack.py
+++ b/tests/test_inputs_pack.py
@@ -342,6 +342,12 @@ def test_dump_inputs_preserves_source_edges_coverage_across_export_relink(
     assert graph is not None
     assert graph.extractor_passes.get("call_graph") is True
     assert graph.extractor_passes.get("type_graph") is True
+    # build_source_graph() already called finalize() once before the
+    # coverage marking ran; the rebuild must re-finalize so the serialized
+    # coverage summary (not just the extractor_passes flag) reflects it too
+    # (Codex review).
+    assert graph.coverage["call_edges"]["collected"] is True
+    assert graph.coverage["type_edges"]["collected"] is True
 
 
 def test_write_snapshot_output_embeds_inputs_pack(tmp_path: Path) -> None:

--- a/tests/test_inputs_pack.py
+++ b/tests/test_inputs_pack.py
@@ -240,6 +240,45 @@ def test_ingest_links_source_facts_into_l4_surface(tmp_path: Path) -> None:
     assert "foo" in names
 
 
+def test_ingest_marks_call_type_graph_coverage_from_complete_source_edges(
+    tmp_path: Path,
+) -> None:
+    """No call/type-graph replay ever runs for an ingested Flow-2 pack (pure
+    parsing) -- a confirmed-complete source_edges rollup must still translate
+    into extractor_passes coverage, or a decl-dependency crosscheck would read
+    the graph as "no pass ever ran" and suppress a real
+    PUBLIC_API_INTERNAL_DEPENDENCY_ADDED finding as a coverage artifact
+    (Codex review)."""
+    from abicheck.buildsource.source_abi import FACT_FAMILIES, default_fact_set
+
+    tu = _tu("foo", mangled="_Z3foov")
+    tu.fact_set = default_fact_set(producer="p", producer_version="1")
+    tu.coverage = dict.fromkeys(FACT_FAMILIES, "complete")
+    pack = _write_inputs_pack(tmp_path, [tu])
+    ingested = ingest_inputs_pack(pack)
+    graph = ingested.pack.source_graph
+    assert graph is not None
+    assert graph.extractor_passes.get("call_graph") is True
+    assert graph.extractor_passes.get("type_graph") is True
+
+
+def test_ingest_does_not_mark_coverage_when_source_edges_incomplete(
+    tmp_path: Path,
+) -> None:
+    from abicheck.buildsource.source_abi import FACT_FAMILIES, default_fact_set
+
+    tu = _tu("foo", mangled="_Z3foov")
+    tu.fact_set = default_fact_set(producer="p", producer_version="1")
+    tu.coverage = dict.fromkeys(FACT_FAMILIES, "complete")
+    tu.coverage["source_edges"] = "partial"
+    pack = _write_inputs_pack(tmp_path, [tu])
+    ingested = ingest_inputs_pack(pack)
+    graph = ingested.pack.source_graph
+    assert graph is not None
+    assert not graph.extractor_passes.get("call_graph")
+    assert not graph.extractor_passes.get("type_graph")
+
+
 def test_ingest_with_explicit_exports_maps_decl_to_symbol(tmp_path: Path) -> None:
     pack = _write_inputs_pack(
         tmp_path,
@@ -405,12 +444,15 @@ def test_read_source_facts_excludes_manifest_from_root_directory_scan(
     a merged "original" -- destroying the pack's own manifest (Codex
     review, P2)."""
     pack = _write_inputs_pack(
-        tmp_path, [_tu("foo", mangled="_Z3foov")], manifest_extra={"source_facts": ["."]}
+        tmp_path,
+        [_tu("foo", mangled="_Z3foov")],
+        manifest_extra={"source_facts": ["."]},
     )
     # Root-level fact file, matching a producer that used "." as its
     # source_facts directory instead of the default source_facts/ subdir.
     (pack / "root.jsonl").write_text(
-        json.dumps(_tu("bar", mangled="_Z3barv", source="src/bar.cpp").to_dict()) + "\n",
+        json.dumps(_tu("bar", mangled="_Z3barv", source="src/bar.cpp").to_dict())
+        + "\n",
         encoding="utf-8",
     )
 
@@ -461,7 +503,7 @@ def test_read_source_facts_degrades_on_invalid_utf8_instead_of_crashing(
     # diagnostic like every other malformed-input case (CodeRabbit review,
     # P2).
     pack = _write_inputs_pack(tmp_path, [_tu("foo", mangled="_Z3foov")])
-    (pack / "source_facts" / "bad.jsonl").write_bytes(b"\xff\xfe{\"tu_id\":1}")
+    (pack / "source_facts" / "bad.jsonl").write_bytes(b'\xff\xfe{"tu_id":1}')
     diags: list[str] = []
     tus = read_source_facts(pack, diagnostics=diags)
     assert len(tus) == 1  # the good record still ingests
@@ -481,7 +523,9 @@ def test_read_source_facts_degrades_on_corrupt_gzip_instead_of_crashing(
     truncated = pack / "source_facts" / "truncated.jsonl.gz"
     truncated.write_bytes(good.read_bytes()[:5])  # valid header, no body
     corrupt = pack / "source_facts" / "corrupt.jsonl.gz"
-    corrupt.write_bytes(b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03" + b"not deflate data")
+    corrupt.write_bytes(
+        b"\x1f\x8b\x08\x00\x00\x00\x00\x00\x00\x03" + b"not deflate data"
+    )
 
     diags: list[str] = []
     tus = read_source_facts(pack, diagnostics=diags)

--- a/tests/test_inputs_validate.py
+++ b/tests/test_inputs_validate.py
@@ -25,7 +25,10 @@ from click.testing import CliRunner
 
 from abicheck.buildsource import SourceAbiTu, SourceEntity, SourceLocation
 from abicheck.buildsource.inputs_pack import ABICHECK_INPUTS_VERSION, INPUTS_KIND
-from abicheck.buildsource.inputs_validate import validate_inputs_pack
+from abicheck.buildsource.inputs_validate import (
+    _fact_set_recipe_issues,
+    validate_inputs_pack,
+)
 from abicheck.buildsource.source_abi import FACT_FAMILIES, default_fact_set
 from abicheck.cli import main
 
@@ -141,6 +144,20 @@ def test_duplicate_tu_id_is_an_error(tmp_path: Path) -> None:
     assert any("duplicate tu_id" in e for e in report.errors)
 
 
+def test_tus_with_no_tu_id_are_never_treated_as_duplicates(tmp_path: Path) -> None:
+    """A TU with no tu_id at all (an empty string is never a real shared
+    identity between otherwise-unrelated TUs) must not be flagged as a
+    duplicate of another equally id-less TU."""
+    fs = default_fact_set(producer="p", producer_version="1")
+    tu1 = _tu("a", fact_set=fs)
+    tu2 = _tu("b", fact_set=fs)
+    tu1.tu_id = ""
+    tu2.tu_id = ""
+    pack = _write_pack(tmp_path, [tu1, tu2])
+    report = validate_inputs_pack(pack)
+    assert report.duplicate_tu_ids == []
+
+
 def test_multiple_target_ids_is_an_error(tmp_path: Path) -> None:
     """PR3 target isolation (latest-main Clang plugin review): two different
     libraries' TUs sharing one pack is exactly the same-source/two-library
@@ -172,6 +189,16 @@ def test_target_id_matching_manifest_library_is_clean(tmp_path: Path) -> None:
     pack = _write_pack(tmp_path, [_tu("a", fact_set=fs, coverage=_full_coverage())])
     report = validate_inputs_pack(pack)
     assert not any("target_id" in e for e in report.errors)
+
+
+def test_no_manifest_library_skips_target_id_agreement_check(tmp_path: Path) -> None:
+    """When the manifest itself names no library, there is nothing to check a
+    TU's target_id against -- the agreement check is a no-op, not an error."""
+    fs = default_fact_set(producer="p", producer_version="1")
+    tu = _tu("a", fact_set=fs)
+    pack = _write_pack(tmp_path, [tu], manifest_extra={"library": ""})
+    report = validate_inputs_pack(pack)
+    assert not any("does not agree on which target" in e for e in report.errors)
 
 
 def test_missing_target_id_is_not_flagged(tmp_path: Path) -> None:
@@ -246,6 +273,40 @@ def test_mismatched_fact_set_name_is_an_error(tmp_path: Path) -> None:
     assert any("fact_set name is 'some-other-fact-set'" in e for e in report.errors)
 
 
+def test_fact_set_recipe_issues_tolerates_unhashable_nested_values() -> None:
+    """The dedup step must use dict equality, not hashing, so a nested
+    list/dict value in fact_set can't crash it (Codex review); a genuine
+    name-mismatch error must still surface."""
+    fs = default_fact_set(producer="p", producer_version="1")
+    fs["extra_field"] = {"nested": ["values"]}
+    other_fs = dict(fs)
+    other_fs["name"] = "some-other-fact-set"
+    tu1 = _tu("a", fact_set=fs)
+    tu2 = _tu("b", fact_set=other_fs)
+    issues = _fact_set_recipe_issues([tu1, tu2])  # must not raise
+    assert any("fact_set_name_mismatch" in i for i in issues)
+
+
+def test_fact_set_recipe_check_tolerates_unhashable_nested_values(
+    tmp_path: Path,
+) -> None:
+    """A forward-versioned fact_set may carry a nested list/dict value (e.g. a
+    structured hash_recipe_id or capability list); deduplicating candidate
+    fact_sets must not crash trying to hash one (Codex review)."""
+    fs = default_fact_set(producer="p", producer_version="1")
+    fs["extra_field"] = ["nested", "list"]
+    other_fs = dict(fs)
+    other_fs["producer_version"] = "2"
+    other_fs["extra_field"] = ["nested", "list"]
+    tu1 = _tu("a", fact_set=fs)
+    tu2 = _tu("b", fact_set=other_fs)
+    pack = _write_pack(tmp_path, [tu1, tu2])
+    report = validate_inputs_pack(pack)  # must not raise
+    assert any(
+        "do not agree on a single fact_set identity" in w for w in report.warnings
+    )
+
+
 def test_manifest_level_fact_set_used_when_present(tmp_path: Path) -> None:
     fs = default_fact_set(producer="abicheck-clang-plugin", producer_version="0.4")
     tu = _tu("a")  # no per-TU fact_set
@@ -293,9 +354,7 @@ def test_manifest_level_fact_set_used_when_no_tu_ever_stamped_one(
     # anywhere" pack), but no TU record actually backs mandatory-family
     # coverage completeness — that gap must still be surfaced, not silently
     # swallowed by the identity check passing (Codex review).
-    assert any(
-        "no TU record" in w and "coverage" in w for w in report.warnings
-    )
+    assert any("no TU record" in w and "coverage" in w for w in report.warnings)
 
 
 def test_incomplete_mandatory_family_warns(tmp_path: Path) -> None:
@@ -378,9 +437,7 @@ def test_report_to_dict_round_trips_shape(tmp_path: Path) -> None:
 
 def test_cli_validate_clean_pack_exits_zero(tmp_path: Path) -> None:
     fs = default_fact_set(producer="p", producer_version="1")
-    pack = _write_pack(
-        tmp_path, [_tu("a", fact_set=fs, coverage=_full_coverage())]
-    )
+    pack = _write_pack(tmp_path, [_tu("a", fact_set=fs, coverage=_full_coverage())])
     result = CliRunner().invoke(main, ["inputs", "validate", str(pack)])
     assert result.exit_code == 0, result.output
     assert "OK" in result.output
@@ -409,9 +466,7 @@ def test_cli_validate_bad_path_exits_usage_error(tmp_path: Path) -> None:
 
 def test_cli_validate_json_format(tmp_path: Path) -> None:
     fs = default_fact_set(producer="p", producer_version="1")
-    pack = _write_pack(
-        tmp_path, [_tu("a", fact_set=fs, coverage=_full_coverage())]
-    )
+    pack = _write_pack(tmp_path, [_tu("a", fact_set=fs, coverage=_full_coverage())])
     result = CliRunner().invoke(
         main, ["inputs", "validate", str(pack), "--format", "json"]
     )
@@ -423,9 +478,7 @@ def test_cli_validate_json_format(tmp_path: Path) -> None:
 
 def test_cli_validate_writes_to_output_file(tmp_path: Path) -> None:
     fs = default_fact_set(producer="p", producer_version="1")
-    pack = _write_pack(
-        tmp_path, [_tu("a", fact_set=fs, coverage=_full_coverage())]
-    )
+    pack = _write_pack(tmp_path, [_tu("a", fact_set=fs, coverage=_full_coverage())])
     out = tmp_path / "report.txt"
     result = CliRunner().invoke(main, ["inputs", "validate", str(pack), "-o", str(out)])
     assert result.exit_code == 0, result.output

--- a/tests/test_inputs_validate.py
+++ b/tests/test_inputs_validate.py
@@ -81,7 +81,10 @@ def _write_pack(
     manifest = {
         "kind": INPUTS_KIND,
         "abicheck_inputs_version": ABICHECK_INPUTS_VERSION,
-        "library": "libfoo.so",
+        # Matches _tu()'s/this file's fixture target_id ("target://libfoo") so
+        # the PR3 target-isolation check (target_id == target://<library>)
+        # does not false-positive on every fixture in this file.
+        "library": "libfoo",
         "version": "1.0",
         "created_by": "abicheck-clang-plugin 0.4",
     }
@@ -136,6 +139,84 @@ def test_duplicate_tu_id_is_an_error(tmp_path: Path) -> None:
     assert not report.ok
     assert tu1.tu_id in report.duplicate_tu_ids
     assert any("duplicate tu_id" in e for e in report.errors)
+
+
+def test_multiple_target_ids_is_an_error(tmp_path: Path) -> None:
+    """PR3 target isolation (latest-main Clang plugin review): two different
+    libraries' TUs sharing one pack is exactly the same-source/two-library
+    collision the plugin's first-writer-wins manifest/filename allowed."""
+    fs = default_fact_set(producer="p", producer_version="1")
+    tu1 = _tu("a", fact_set=fs)
+    tu2 = _tu("b", fact_set=fs)
+    tu2.target_id = "target://libbar"
+    pack = _write_pack(tmp_path, [tu1, tu2])
+    report = validate_inputs_pack(pack)
+    assert not report.ok
+    assert any("mixes more than one target_id" in e for e in report.errors)
+
+
+def test_target_id_disagreeing_with_manifest_library_is_an_error(
+    tmp_path: Path,
+) -> None:
+    fs = default_fact_set(producer="p", producer_version="1")
+    tu = _tu("a", fact_set=fs)
+    tu.target_id = "target://not-libfoo"
+    pack = _write_pack(tmp_path, [tu])
+    report = validate_inputs_pack(pack)
+    assert not report.ok
+    assert any("does not agree on which target" in e for e in report.errors)
+
+
+def test_target_id_matching_manifest_library_is_clean(tmp_path: Path) -> None:
+    fs = default_fact_set(producer="p", producer_version="1")
+    pack = _write_pack(tmp_path, [_tu("a", fact_set=fs, coverage=_full_coverage())])
+    report = validate_inputs_pack(pack)
+    assert not any("target_id" in e for e in report.errors)
+
+
+def test_missing_target_id_is_not_flagged(tmp_path: Path) -> None:
+    """A pre-target-isolation producer's TUs (no target_id at all) must not
+    be flagged -- this is additive validation, not a new hard requirement."""
+    fs = default_fact_set(producer="p", producer_version="1")
+    tu = _tu("a", fact_set=fs)
+    tu.target_id = ""
+    pack = _write_pack(tmp_path, [tu])
+    report = validate_inputs_pack(pack)
+    assert not any("target_id" in e for e in report.errors)
+
+
+def test_inconsistent_fact_set_recipe_within_pack_is_an_error(tmp_path: Path) -> None:
+    """A fact_set *name*/*version* mismatch between two TUs in the same pack
+    is a hard contract disagreement, not routine producer/version drift --
+    promoted to an error, not just rollup_fact_set's existing soft warning
+    (latest-main Clang plugin review, PR3)."""
+    fs_a = default_fact_set(producer="p", producer_version="1")
+    fs_b = dict(fs_a)
+    fs_b["version"] = 999
+    tu1 = _tu("a", fact_set=fs_a)
+    tu2 = _tu("b", fact_set=fs_b)
+    pack = _write_pack(tmp_path, [tu1, tu2])
+    report = validate_inputs_pack(pack)
+    assert not report.ok
+    assert any("fact_set_version_mismatch" in e for e in report.errors)
+
+
+def test_same_producer_different_producer_version_within_pack_is_not_an_error(
+    tmp_path: Path,
+) -> None:
+    """Routine producer-version drift across TUs stays a warning (via the
+    existing rollup_fact_set "TUs disagree" path) -- only a name/version
+    contract mismatch is promoted to an error."""
+    fs_a = default_fact_set(producer="p", producer_version="1")
+    fs_b = default_fact_set(producer="p", producer_version="2")
+    tu1 = _tu("a", fact_set=fs_a)
+    tu2 = _tu("b", fact_set=fs_b)
+    pack = _write_pack(tmp_path, [tu1, tu2])
+    report = validate_inputs_pack(pack)
+    assert not any(
+        "fact_set_version_mismatch" in e or "fact_set_name_mismatch" in e
+        for e in report.errors
+    )
 
 
 def test_no_fact_set_anywhere_warns_not_errors(tmp_path: Path) -> None:

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -258,6 +258,41 @@ def test_linker_dedups_identical_entities_across_tus() -> None:
     assert surface.odr_conflicts, "divergent same-name type must still conflict"
 
 
+def test_linker_folds_source_edges_across_tus() -> None:
+    """PR1: link_source_abi rolls tu.source_edges up onto the surface,
+    deduplicating byte-identical rows the same way repeated public-header
+    entities are deduplicated (Codex review's "deduplicate equivalent TU
+    copies" recommendation)."""
+    edge = {
+        "edge": "DECL_CALLS_DECL",
+        "src": "_ZN3foo3barEv",
+        "dst": "_ZN3foo3bazEv",
+        "provenance": "clang-plugin",
+        "confidence": "high",
+        "attrs": {},
+    }
+    tus = [SourceAbiTu(source_edges=[dict(edge)]) for _ in range(3)]
+    surface = link_source_abi(tus)
+    assert surface.source_edges == [edge]
+
+
+def test_linker_keeps_distinct_source_edges_from_different_tus() -> None:
+    tu_a = SourceAbiTu(
+        source_edges=[{"edge": "DECL_CALLS_DECL", "src": "a", "dst": "b"}]
+    )
+    tu_b = SourceAbiTu(
+        source_edges=[{"edge": "DECL_CALLS_DECL", "src": "a", "dst": "c"}]
+    )
+    surface = link_source_abi([tu_a, tu_b])
+    assert len(surface.source_edges) == 2
+
+
+def test_linker_skips_malformed_source_edges_rows() -> None:
+    tu = SourceAbiTu(source_edges=[{}, "not-a-dict", {"edge": "DECL_CALLS_DECL"}])
+    surface = link_source_abi([tu])
+    assert surface.source_edges == []
+
+
 def test_linker_keeps_unmangled_overloads_distinct() -> None:
     # castxml omits a mangled name for some decls (notably constructors), so two
     # public overloads share the bare qualified_name "Widget". identity() folds

--- a/tests/test_source_abi.py
+++ b/tests/test_source_abi.py
@@ -149,6 +149,39 @@ def test_source_abi_tu_from_dict_tolerates_missing_fields() -> None:
     assert tu.schema_version == SOURCE_ABI_VERSION
 
 
+def test_source_abi_tu_from_dict_tolerates_malformed_source_edges() -> None:
+    """A forward-versioned/hand-edited dump may carry ``source_edges: null``
+    or a stray string; ``list(None)`` raises and ``list("x")`` yields
+    character entries, either of which would abort loading or poison the
+    graph (CodeRabbit review)."""
+    assert (
+        SourceAbiTu.from_dict({"tu_id": "x", "source_edges": None}).source_edges == []
+    )
+    assert (
+        SourceAbiTu.from_dict({"tu_id": "x", "source_edges": "oops"}).source_edges == []
+    )
+    tu = SourceAbiTu.from_dict(
+        {
+            "tu_id": "x",
+            "source_edges": [
+                {"edge": "DECL_CALLS_DECL", "src": "a", "dst": "b"},
+                "junk",
+                1,
+            ],
+        }
+    )
+    assert tu.source_edges == [{"edge": "DECL_CALLS_DECL", "src": "a", "dst": "b"}]
+
+
+def test_source_abi_surface_from_dict_tolerates_malformed_source_edges() -> None:
+    surface = SourceAbiSurface.from_dict({"library": "libfoo.so", "source_edges": None})
+    assert surface.source_edges == []
+    surface = SourceAbiSurface.from_dict(
+        {"library": "libfoo.so", "source_edges": "oops"}
+    )
+    assert surface.source_edges == []
+
+
 def test_source_entity_from_dict_boolean_safe_api_relevant() -> None:
     # A hand-edited pack may carry the string "false"; bool("false") would be
     # True, so loading must parse it as a real boolean (CodeRabbit #335).
@@ -289,6 +322,21 @@ def test_linker_keeps_distinct_source_edges_from_different_tus() -> None:
 
 def test_linker_skips_malformed_source_edges_rows() -> None:
     tu = SourceAbiTu(source_edges=[{}, "not-a-dict", {"edge": "DECL_CALLS_DECL"}])
+    surface = link_source_abi([tu])
+    assert surface.source_edges == []
+
+
+def test_linker_rejects_non_string_edge_identity_fields() -> None:
+    """A malformed row with a null/structured identity field must not be
+    stringified into a bogus graph endpoint -- str(None) == "None" would
+    otherwise pass the truthiness check (CodeRabbit review)."""
+    tu = SourceAbiTu(
+        source_edges=[
+            {"edge": "DECL_CALLS_DECL", "src": None, "dst": "b"},
+            {"edge": "DECL_CALLS_DECL", "src": ["a"], "dst": "b"},
+            {"edge": None, "src": "a", "dst": "b"},
+        ]
+    )
     surface = link_source_abi([tu])
     assert surface.source_edges == []
 

--- a/tests/test_source_graph.py
+++ b/tests/test_source_graph.py
@@ -47,6 +47,7 @@ from abicheck.buildsource.source_graph import (
     build_source_graph,
     diff_source_graph,
     diff_source_graph_findings,
+    fold_source_edges,
 )
 from abicheck.checker_policy import RISK_KINDS, ChangeKind
 from abicheck.cli import main
@@ -282,6 +283,100 @@ def test_source_abi_degenerate_inputs_handled() -> None:
     assert not any(e.kind == "BINARY_EXPORTS_SYMBOL" for e in g.edges)
     # The blank mapping value is skipped; the real one becomes a symbol node.
     assert any(n.kind == "binary_symbol" and n.label == "_Zsym" for n in g.nodes)
+
+
+# ── PR1: source_edges fold (ADR-038 C.9) ────────────────────────────────────
+
+
+def test_fold_source_edges_call_edge_creates_decl_nodes() -> None:
+    g = SourceGraphSummary()
+    added = fold_source_edges(
+        g,
+        [
+            {
+                "edge": "DECL_CALLS_DECL",
+                "src": "_ZN3foo3barEv",
+                "dst": "_ZN3foo3bazEv",
+                "provenance": "clang-plugin",
+                "confidence": "high",
+                "attrs": {"call_kind": "direct"},
+            }
+        ],
+    )
+    assert added == 1
+    call_edges = [e for e in g.edges if e.kind == "DECL_CALLS_DECL"]
+    assert len(call_edges) == 1
+    assert call_edges[0].src == "decl://_ZN3foo3barEv"
+    assert call_edges[0].dst == "decl://_ZN3foo3bazEv"
+    assert call_edges[0].provenance == "clang-plugin"
+    assert call_edges[0].attrs == {"call_kind": "direct"}
+    assert {n.id for n in g.nodes} == {"decl://_ZN3foo3barEv", "decl://_ZN3foo3bazEv"}
+    assert all(n.kind == "source_decl" for n in g.nodes)
+
+
+def test_fold_source_edges_decl_has_type_maps_decl_and_type_nodes() -> None:
+    g = SourceGraphSummary()
+    fold_source_edges(
+        g, [{"edge": "DECL_HAS_TYPE", "src": "foo::field", "dst": "foo::Widget"}]
+    )
+    src_node = next(n for n in g.nodes if n.id == "decl://foo::field")
+    dst_node = next(n for n in g.nodes if n.id == "type://foo::Widget")
+    assert src_node.kind == "source_decl"
+    assert dst_node.kind == "record_type"
+
+
+def test_fold_source_edges_type_inherits_maps_both_sides_to_type_nodes() -> None:
+    g = SourceGraphSummary()
+    fold_source_edges(
+        g, [{"edge": "TYPE_INHERITS", "src": "foo::Derived", "dst": "foo::Base"}]
+    )
+    assert all(n.kind == "record_type" for n in g.nodes)
+
+
+def test_fold_source_edges_dedupes_against_call_graph_pass() -> None:
+    """An edge already folded by a separate call/type-graph pass must not be
+    duplicated -- first-writer-wins via add_edge's (src, dst, kind) key."""
+    g = SourceGraphSummary()
+    g.add_node(GraphNode(id="decl://a", kind="source_decl", provenance="call_graph"))
+    g.add_node(GraphNode(id="decl://b", kind="source_decl", provenance="call_graph"))
+    g.add_edge(
+        GraphEdge(
+            src="decl://a", dst="decl://b", kind="DECL_CALLS_DECL",
+            provenance="call_graph", confidence="high",
+        )
+    )
+    added = fold_source_edges(
+        g, [{"edge": "DECL_CALLS_DECL", "src": "a", "dst": "b", "confidence": "reduced"}]
+    )
+    assert added == 0
+    call_edges = [e for e in g.edges if e.kind == "DECL_CALLS_DECL"]
+    assert len(call_edges) == 1
+    assert call_edges[0].provenance == "call_graph"  # first writer wins
+
+
+def test_fold_source_edges_skips_malformed_rows() -> None:
+    g = SourceGraphSummary()
+    added = fold_source_edges(
+        g,
+        [
+            {"edge": "", "src": "a", "dst": "b"},
+            {"edge": "DECL_CALLS_DECL", "src": "", "dst": "b"},
+            {"edge": "DECL_CALLS_DECL", "src": "a", "dst": ""},
+            "not-a-dict",
+            {"edge": "DECL_CALLS_DECL", "src": "a", "dst": "b"},
+        ],
+    )
+    assert added == 1
+    assert len(g.edges) == 1
+
+
+def test_build_source_graph_folds_surface_source_edges() -> None:
+    s = _sample_surface()
+    s.source_edges = [
+        {"edge": "DECL_CALLS_DECL", "src": "_ZN3foo3barEv", "dst": "_ZN3foo3quxEv"}
+    ]
+    g = build_source_graph(BuildEvidence(), source_abi=s)
+    assert any(e.kind == "DECL_CALLS_DECL" for e in g.edges)
 
 
 def test_build_graph_without_surface_is_phase2_only() -> None:

--- a/tests/test_source_graph.py
+++ b/tests/test_source_graph.py
@@ -48,6 +48,7 @@ from abicheck.buildsource.source_graph import (
     diff_source_graph,
     diff_source_graph_findings,
     fold_source_edges,
+    mark_source_edges_extractor_coverage,
 )
 from abicheck.checker_policy import RISK_KINDS, ChangeKind
 from abicheck.cli import main
@@ -55,19 +56,27 @@ from abicheck.cli import main
 
 def _sample_build() -> BuildEvidence:
     b = BuildEvidence(generated_files=["gen/config.h"])
-    b.targets.append(Target(
-        id="target://libfoo", name="foo", kind=TargetKind.SHARED_LIBRARY,
-        source_files=["src/foo.cpp", "gen/config.h"],
-        public_headers=["include/foo.h"],
-        dependencies=["target://libbar", "sys://pthread"],
-        confidence=Confidence.HIGH,
-    ))
+    b.targets.append(
+        Target(
+            id="target://libfoo",
+            name="foo",
+            kind=TargetKind.SHARED_LIBRARY,
+            source_files=["src/foo.cpp", "gen/config.h"],
+            public_headers=["include/foo.h"],
+            dependencies=["target://libbar", "sys://pthread"],
+            confidence=Confidence.HIGH,
+        )
+    )
     b.targets.append(Target(id="target://libbar", name="bar"))
-    b.compile_units.append(CompileUnit(
-        id="cu://foo", source="src/foo.cpp", output="foo.o",
-        target_id="target://libfoo",
-        abi_relevant_flags=["-fvisibility=hidden", "-std=c++20"],
-    ))
+    b.compile_units.append(
+        CompileUnit(
+            id="cu://foo",
+            source="src/foo.cpp",
+            output="foo.o",
+            target_id="target://libfoo",
+            abi_relevant_flags=["-fvisibility=hidden", "-std=c++20"],
+        )
+    )
     return b
 
 
@@ -141,12 +150,20 @@ def test_empty_build_yields_empty_graph() -> None:
 
 def test_target_confidence_maps_onto_node_and_edges() -> None:
     b = BuildEvidence()
-    b.targets.append(Target(
-        id="target://red", source_files=["a.cpp"], confidence=Confidence.REDUCED,
-    ))
-    b.targets.append(Target(
-        id="target://unk", source_files=["b.cpp"], confidence=Confidence.UNKNOWN,
-    ))
+    b.targets.append(
+        Target(
+            id="target://red",
+            source_files=["a.cpp"],
+            confidence=Confidence.REDUCED,
+        )
+    )
+    b.targets.append(
+        Target(
+            id="target://unk",
+            source_files=["b.cpp"],
+            confidence=Confidence.UNKNOWN,
+        )
+    )
     g = build_source_graph(b)
     by_id = {n.id: n for n in g.nodes}
     assert by_id["target://red"].confidence == "reduced"
@@ -173,23 +190,37 @@ def test_compile_unit_without_source_emits_no_source_edge() -> None:
 # ── Phases 3-4: enrich from the L4 source surface ───────────────────────────
 
 
-def _entity(qn: str, kind: str, *, mangled: str = "", path: str = "include/foo.h",
-            origin: str = "PUBLIC_HEADER",
-            conf: LayerConfidence = LayerConfidence.HIGH) -> SourceEntity:
+def _entity(
+    qn: str,
+    kind: str,
+    *,
+    mangled: str = "",
+    path: str = "include/foo.h",
+    origin: str = "PUBLIC_HEADER",
+    conf: LayerConfidence = LayerConfidence.HIGH,
+) -> SourceEntity:
     return SourceEntity(
-        id=qn, kind=kind, qualified_name=qn, mangled_name=mangled,
+        id=qn,
+        kind=kind,
+        qualified_name=qn,
+        mangled_name=mangled,
         source_location=SourceLocation(path=path, line=1, origin=origin),
-        visibility="public_header", confidence=conf,
+        visibility="public_header",
+        confidence=conf,
     )
 
 
 def _sample_surface() -> SourceAbiSurface:
     s = SourceAbiSurface(library="libfoo.so", target_id="target://libfoo")
-    s.reachable_declarations.append(_entity("foo::bar", "function", mangled="_ZN3foo3barEv"))
+    s.reachable_declarations.append(
+        _entity("foo::bar", "function", mangled="_ZN3foo3barEv")
+    )
     s.reachable_types.append(_entity("foo::Widget", "record"))
     s.reachable_types.append(_entity("foo::Color", "enum"))
     s.reachable_types.append(_entity("foo::Alias", "typedef"))
-    s.reachable_macros.append(_entity("FOO_VERSION", "macro", conf=LayerConfidence.REDUCED))
+    s.reachable_macros.append(
+        _entity("FOO_VERSION", "macro", conf=LayerConfidence.REDUCED)
+    )
     # Keyed by entity identity (the mangled name for C++), exactly as
     # link_source_abi/relink_surface_exports persist it — not by qualified_name.
     s.mappings["source_decl_to_binary_symbol"] = {"_ZN3foo3barEv": "_ZN3foo3barEv"}
@@ -199,9 +230,13 @@ def _sample_surface() -> SourceAbiSurface:
 
 def test_source_abi_builds_public_reachability_slice() -> None:
     b = BuildEvidence()
-    b.targets.append(Target(
-        id="target://libfoo", public_headers=["include/foo.h"], confidence=Confidence.HIGH,
-    ))
+    b.targets.append(
+        Target(
+            id="target://libfoo",
+            public_headers=["include/foo.h"],
+            confidence=Confidence.HIGH,
+        )
+    )
     g = build_source_graph(b, source_abi=_sample_surface())
     edge_kinds = {e.kind for e in g.edges}
     # target -> header -> decl -> exported symbol, plus target -> symbol.
@@ -273,10 +308,15 @@ def test_source_abi_degenerate_inputs_handled() -> None:
     # location (so no SOURCE_DECLARES edge), and a blank symbol mapping value
     # (skipped) must all be tolerated without error.
     s = SourceAbiSurface(library="l", target_id="")
-    s.reachable_declarations.append(SourceEntity(
-        id="d", kind="function", qualified_name="loose", source_location=None,
-        confidence=LayerConfidence.UNKNOWN,
-    ))
+    s.reachable_declarations.append(
+        SourceEntity(
+            id="d",
+            kind="function",
+            qualified_name="loose",
+            source_location=None,
+            confidence=LayerConfidence.UNKNOWN,
+        )
+    )
     s.mappings["source_decl_to_binary_symbol"] = {"loose": "", "other": "_Zsym"}
     g = build_source_graph(BuildEvidence(), source_abi=s)
     assert not any(e.kind == "SOURCE_DECLARES" for e in g.edges)
@@ -341,12 +381,16 @@ def test_fold_source_edges_dedupes_against_call_graph_pass() -> None:
     g.add_node(GraphNode(id="decl://b", kind="source_decl", provenance="call_graph"))
     g.add_edge(
         GraphEdge(
-            src="decl://a", dst="decl://b", kind="DECL_CALLS_DECL",
-            provenance="call_graph", confidence="high",
+            src="decl://a",
+            dst="decl://b",
+            kind="DECL_CALLS_DECL",
+            provenance="call_graph",
+            confidence="high",
         )
     )
     added = fold_source_edges(
-        g, [{"edge": "DECL_CALLS_DECL", "src": "a", "dst": "b", "confidence": "reduced"}]
+        g,
+        [{"edge": "DECL_CALLS_DECL", "src": "a", "dst": "b", "confidence": "reduced"}],
     )
     assert added == 0
     call_edges = [e for e in g.edges if e.kind == "DECL_CALLS_DECL"]
@@ -379,6 +423,50 @@ def test_build_source_graph_folds_surface_source_edges() -> None:
     assert any(e.kind == "DECL_CALLS_DECL" for e in g.edges)
 
 
+def test_mark_source_edges_extractor_coverage_when_complete() -> None:
+    """A caller that folds source_edges but never runs a call/type-graph
+    replay (e.g. Flow-2 pack ingestion) must still translate a
+    confirmed-complete rollup into extractor_passes coverage, or the
+    decl-dependency crosscheck reads the graph as "no pass ever ran"
+    (Codex review)."""
+    s = _sample_surface()
+    s.coverage["fact_family_states"] = {"source_edges": "complete"}
+    g = SourceGraphSummary()
+    mark_source_edges_extractor_coverage(g, s)
+    assert g.extractor_passes["call_graph"] is True
+    assert g.extractor_passes["type_graph"] is True
+
+
+def test_mark_source_edges_extractor_coverage_empty_confirmed_also_counts() -> None:
+    s = _sample_surface()
+    s.coverage["fact_family_states"] = {"source_edges": "empty-confirmed"}
+    g = SourceGraphSummary()
+    mark_source_edges_extractor_coverage(g, s)
+    assert g.extractor_passes["call_graph"] is True
+
+
+def test_mark_source_edges_extractor_coverage_skips_when_incomplete() -> None:
+    s = _sample_surface()
+    s.coverage["fact_family_states"] = {"source_edges": "partial"}
+    g = SourceGraphSummary()
+    mark_source_edges_extractor_coverage(g, s)
+    assert "call_graph" not in g.extractor_passes
+    assert "type_graph" not in g.extractor_passes
+
+
+def test_mark_source_edges_extractor_coverage_handles_none_surface_and_malformed_states() -> (
+    None
+):
+    g = SourceGraphSummary()
+    mark_source_edges_extractor_coverage(g, None)  # must not raise
+    assert g.extractor_passes == {}
+
+    s = _sample_surface()
+    s.coverage["fact_family_states"] = "not-a-dict"
+    mark_source_edges_extractor_coverage(g, s)  # must not raise
+    assert g.extractor_passes == {}
+
+
 def test_build_graph_without_surface_is_phase2_only() -> None:
     g = build_source_graph(_sample_build())
     assert not any(n.kind == "source_decl" for n in g.nodes)
@@ -388,45 +476,66 @@ def test_build_graph_without_surface_is_phase2_only() -> None:
 def test_source_abi_round_trip_and_determinism() -> None:
     s = _sample_surface()
     g = build_source_graph(BuildEvidence(), source_abi=s)
-    assert SourceGraphSummary.from_dict(g.to_dict()).compute_graph_id() == g.compute_graph_id()
+    assert (
+        SourceGraphSummary.from_dict(g.to_dict()).compute_graph_id()
+        == g.compute_graph_id()
+    )
     assert build_source_graph(BuildEvidence(), source_abi=s).graph_id == g.graph_id
 
 
 # ── Phase 5: graph-derived risk findings (D6) ───────────────────────────────
 
 
-def _surface_with(decls, mapping, *, generated_header=None,
-                  target="target://libfoo") -> SourceAbiSurface:
+def _surface_with(
+    decls, mapping, *, generated_header=None, target="target://libfoo"
+) -> SourceAbiSurface:
     s = SourceAbiSurface(library="libfoo.so", target_id=target)
     for qn, path in decls:
-        s.reachable_declarations.append(SourceEntity(
-            id=qn, kind="function", qualified_name=qn,
-            source_location=SourceLocation(path=path, line=1, origin="PUBLIC_HEADER"),
-            visibility="public_header", confidence=LayerConfidence.HIGH,
-        ))
+        s.reachable_declarations.append(
+            SourceEntity(
+                id=qn,
+                kind="function",
+                qualified_name=qn,
+                source_location=SourceLocation(
+                    path=path, line=1, origin="PUBLIC_HEADER"
+                ),
+                visibility="public_header",
+                confidence=LayerConfidence.HIGH,
+            )
+        )
     s.mappings["source_decl_to_binary_symbol"] = dict(mapping)
     return s
 
 
 def _build_with_public_header(headers=("inc/foo.h",), generated=()) -> BuildEvidence:
     b = BuildEvidence(generated_files=list(generated))
-    b.targets.append(Target(
-        id="target://libfoo", public_headers=list(headers), confidence=Confidence.HIGH,
-    ))
+    b.targets.append(
+        Target(
+            id="target://libfoo",
+            public_headers=list(headers),
+            confidence=Confidence.HIGH,
+        )
+    )
     return b
 
 
 def test_all_three_graph_kinds_are_risk() -> None:
-    for k in (ChangeKind.PUBLIC_REACHABILITY_CHANGED,
-              ChangeKind.SOURCE_TO_BINARY_MAPPING_CHANGED,
-              ChangeKind.GENERATED_HEADER_REACHES_PUBLIC_API):
+    for k in (
+        ChangeKind.PUBLIC_REACHABILITY_CHANGED,
+        ChangeKind.SOURCE_TO_BINARY_MAPPING_CHANGED,
+        ChangeKind.GENERATED_HEADER_REACHES_PUBLIC_API,
+    ):
         assert k in RISK_KINDS
 
 
 def test_findings_mapping_changed_for_persisting_decl() -> None:
     b = _build_with_public_header()
-    old = build_source_graph(b, source_abi=_surface_with([("foo::b", "inc/foo.h")], {"foo::b": "_Zb"}))
-    new = build_source_graph(b, source_abi=_surface_with([("foo::b", "inc/foo.h")], {"foo::b": "_Zb2"}))
+    old = build_source_graph(
+        b, source_abi=_surface_with([("foo::b", "inc/foo.h")], {"foo::b": "_Zb"})
+    )
+    new = build_source_graph(
+        b, source_abi=_surface_with([("foo::b", "inc/foo.h")], {"foo::b": "_Zb2"})
+    )
     findings = diff_source_graph_findings(old, new)
     assert len(findings) == 1
     c = findings[0]
@@ -444,10 +553,18 @@ def test_findings_reachability_ignores_brand_new_or_removed_decls() -> None:
     # is already reported (at the correct COMPATIBLE severity) by the
     # ordinary addition/removal findings elsewhere in the pipeline.
     b = _build_with_public_header()
-    old = build_source_graph(b, source_abi=_surface_with(
-        [("foo::a", "inc/foo.h"), ("foo::gone", "inc/foo.h")], {"foo::a": "_Za"}))
-    new = build_source_graph(b, source_abi=_surface_with(
-        [("foo::a", "inc/foo.h"), ("foo::new", "inc/foo.h")], {"foo::a": "_Za"}))
+    old = build_source_graph(
+        b,
+        source_abi=_surface_with(
+            [("foo::a", "inc/foo.h"), ("foo::gone", "inc/foo.h")], {"foo::a": "_Za"}
+        ),
+    )
+    new = build_source_graph(
+        b,
+        source_abi=_surface_with(
+            [("foo::a", "inc/foo.h"), ("foo::new", "inc/foo.h")], {"foo::a": "_Za"}
+        ),
+    )
     kinds_syms = {(c.kind, c.symbol) for c in diff_source_graph_findings(old, new)}
     assert (ChangeKind.PUBLIC_REACHABILITY_CHANGED, "foo::new") not in kinds_syms
     assert (ChangeKind.PUBLIC_REACHABILITY_CHANGED, "foo::gone") not in kinds_syms
@@ -459,20 +576,36 @@ def test_findings_reachability_fires_for_persisting_decl_crossing_boundary() -> 
     # existing declaration crossing the public/private boundary, the
     # genuinely risk-worthy signal this finding exists for.
     b = _build_with_public_header()
-    old = build_source_graph(b, source_abi=_surface_with(
-        [("foo::a", "inc/foo.h"), ("foo::b", "")], {"foo::a": "_Za"}))
-    new = build_source_graph(b, source_abi=_surface_with(
-        [("foo::a", "inc/foo.h"), ("foo::b", "inc/foo.h")], {"foo::a": "_Za"}))
+    old = build_source_graph(
+        b,
+        source_abi=_surface_with(
+            [("foo::a", "inc/foo.h"), ("foo::b", "")], {"foo::a": "_Za"}
+        ),
+    )
+    new = build_source_graph(
+        b,
+        source_abi=_surface_with(
+            [("foo::a", "inc/foo.h"), ("foo::b", "inc/foo.h")], {"foo::a": "_Za"}
+        ),
+    )
     kinds_syms = {(c.kind, c.symbol) for c in diff_source_graph_findings(old, new)}
     assert (ChangeKind.PUBLIC_REACHABILITY_CHANGED, "foo::b") in kinds_syms
 
 
 def test_findings_reachability_fires_when_persisting_decl_leaves_closure() -> None:
     b = _build_with_public_header()
-    old = build_source_graph(b, source_abi=_surface_with(
-        [("foo::a", "inc/foo.h"), ("foo::b", "inc/foo.h")], {"foo::a": "_Za"}))
-    new = build_source_graph(b, source_abi=_surface_with(
-        [("foo::a", "inc/foo.h"), ("foo::b", "")], {"foo::a": "_Za"}))
+    old = build_source_graph(
+        b,
+        source_abi=_surface_with(
+            [("foo::a", "inc/foo.h"), ("foo::b", "inc/foo.h")], {"foo::a": "_Za"}
+        ),
+    )
+    new = build_source_graph(
+        b,
+        source_abi=_surface_with(
+            [("foo::a", "inc/foo.h"), ("foo::b", "")], {"foo::a": "_Za"}
+        ),
+    )
     kinds_syms = {(c.kind, c.symbol) for c in diff_source_graph_findings(old, new)}
     assert (ChangeKind.PUBLIC_REACHABILITY_CHANGED, "foo::b") in kinds_syms
 
@@ -480,7 +613,9 @@ def test_findings_reachability_fires_when_persisting_decl_leaves_closure() -> No
 def test_findings_empty_baseline_does_not_spam_reachability() -> None:
     # An empty old graph must not flag every new declaration as "entered".
     b = _build_with_public_header()
-    new = build_source_graph(b, source_abi=_surface_with([("foo::a", "inc/foo.h")], {"foo::a": "_Za"}))
+    new = build_source_graph(
+        b, source_abi=_surface_with([("foo::a", "inc/foo.h")], {"foo::a": "_Za"})
+    )
     findings = diff_source_graph_findings(SourceGraphSummary(), new)
     assert not any(c.kind == ChangeKind.PUBLIC_REACHABILITY_CHANGED for c in findings)
 
@@ -488,10 +623,15 @@ def test_findings_empty_baseline_does_not_spam_reachability() -> None:
 def test_findings_generated_header_reaches_public_api() -> None:
     # A public header that is also a generated file → reaches public API.
     old = build_source_graph(_build_with_public_header(headers=("inc/foo.h",)))
-    new = build_source_graph(_build_with_public_header(
-        headers=("inc/foo.h", "gen/config.h"), generated=("gen/config.h",)))
+    new = build_source_graph(
+        _build_with_public_header(
+            headers=("inc/foo.h", "gen/config.h"), generated=("gen/config.h",)
+        )
+    )
     findings = diff_source_graph_findings(old, new)
-    gen = [c for c in findings if c.kind == ChangeKind.GENERATED_HEADER_REACHES_PUBLIC_API]
+    gen = [
+        c for c in findings if c.kind == ChangeKind.GENERATED_HEADER_REACHES_PUBLIC_API
+    ]
     assert len(gen) == 1
     assert "gen/config.h" in gen[0].symbol
 
@@ -505,14 +645,18 @@ def test_owner_unchanged_across_different_absolute_checkout_roots() -> None:
     # false positive this produced across most of examples/, since the
     # catalog's own v1/v2 fixture convention is exactly this shape).
     old = build_source_graph(
-        _build_with_public_header(headers=("/old_root/inc/foo.h", "/old_root/inc/bar.h")),
+        _build_with_public_header(
+            headers=("/old_root/inc/foo.h", "/old_root/inc/bar.h")
+        ),
         source_abi=_surface_with(
             [("foo::a", "/old_root/inc/foo.h"), ("foo::c", "/old_root/inc/bar.h")],
             {"foo::a": "_Za", "foo::c": "_Zc"},
         ),
     )
     new = build_source_graph(
-        _build_with_public_header(headers=("/new_root/inc/foo.h", "/new_root/inc/bar.h")),
+        _build_with_public_header(
+            headers=("/new_root/inc/foo.h", "/new_root/inc/bar.h")
+        ),
         source_abi=_surface_with(
             [("foo::a", "/new_root/inc/foo.h"), ("foo::c", "/new_root/inc/bar.h")],
             {"foo::a": "_Za", "foo::c": "_Zc"},
@@ -531,16 +675,24 @@ def test_owner_changed_when_relative_path_actually_moves() -> None:
     b = _build_with_public_header(
         headers=("/root/inc/foo.h", "/root/inc/bar.h", "/root/inc/baz.h"),
     )
-    old = build_source_graph(b, source_abi=_surface_with(
-        [("foo::a", "/root/inc/foo.h"), ("foo::c", "/root/inc/bar.h")],
-        {"foo::a": "_Za", "foo::c": "_Zc"},
-    ))
-    new = build_source_graph(b, source_abi=_surface_with(
-        [("foo::a", "/root/inc/foo.h"), ("foo::c", "/root/inc/baz.h")],
-        {"foo::a": "_Za", "foo::c": "_Zc"},
-    ))
+    old = build_source_graph(
+        b,
+        source_abi=_surface_with(
+            [("foo::a", "/root/inc/foo.h"), ("foo::c", "/root/inc/bar.h")],
+            {"foo::a": "_Za", "foo::c": "_Zc"},
+        ),
+    )
+    new = build_source_graph(
+        b,
+        source_abi=_surface_with(
+            [("foo::a", "/root/inc/foo.h"), ("foo::c", "/root/inc/baz.h")],
+            {"foo::a": "_Za", "foo::c": "_Zc"},
+        ),
+    )
     findings = diff_source_graph_findings(old, new)
-    owner = [c for c in findings if c.kind == ChangeKind.EXPORTED_SYMBOL_SOURCE_OWNER_CHANGED]
+    owner = [
+        c for c in findings if c.kind == ChangeKind.EXPORTED_SYMBOL_SOURCE_OWNER_CHANGED
+    ]
     assert len(owner) == 1
     assert owner[0].symbol == "_Zc"
 
@@ -567,7 +719,8 @@ def test_owner_changed_when_sole_declaring_file_is_renamed_both_sides() -> None:
     )
     findings = diff_source_graph_findings(old, new)
     owner_syms = {
-        c.symbol for c in findings
+        c.symbol
+        for c in findings
         if c.kind == ChangeKind.EXPORTED_SYMBOL_SOURCE_OWNER_CHANGED
     }
     assert owner_syms == {"_Za", "_Zc"}
@@ -610,7 +763,8 @@ def test_owner_unchanged_when_only_one_persisting_symbol_declares() -> None:
     old = build_source_graph(
         _build_with_public_header(headers=("/root/old/lib.h",)),
         source_abi=_surface_with(
-            [("foo::a", "/root/old/lib.h")], {"foo::a": "_Za"},
+            [("foo::a", "/root/old/lib.h")],
+            {"foo::a": "_Za"},
         ),
     )
     new = build_source_graph(
@@ -628,14 +782,20 @@ def test_owner_unchanged_when_only_one_persisting_symbol_declares() -> None:
 
 def test_findings_identical_graphs_yield_nothing() -> None:
     b = _build_with_public_header()
-    g = build_source_graph(b, source_abi=_surface_with([("foo::a", "inc/foo.h")], {"foo::a": "_Za"}))
+    g = build_source_graph(
+        b, source_abi=_surface_with([("foo::a", "inc/foo.h")], {"foo::a": "_Za"})
+    )
     assert diff_source_graph_findings(g, g) == []
 
 
 def test_compare_graph_cli_surfaces_findings(tmp_path) -> None:
     b = _build_with_public_header()
-    old = build_source_graph(b, source_abi=_surface_with([("foo::b", "inc/foo.h")], {"foo::b": "_Zb"}))
-    new = build_source_graph(b, source_abi=_surface_with([("foo::b", "inc/foo.h")], {"foo::b": "_Zb2"}))
+    old = build_source_graph(
+        b, source_abi=_surface_with([("foo::b", "inc/foo.h")], {"foo::b": "_Zb"})
+    )
+    new = build_source_graph(
+        b, source_abi=_surface_with([("foo::b", "inc/foo.h")], {"foo::b": "_Zb2"})
+    )
     op, np = tmp_path / "o.json", tmp_path / "n.json"
     op.write_text(json.dumps(old.to_dict()))
     np.write_text(json.dumps(new.to_dict()))
@@ -645,7 +805,9 @@ def test_compare_graph_cli_surfaces_findings(tmp_path) -> None:
     assert "Graph-derived risk findings" in res.output
     assert "source_to_binary_mapping_changed" in res.output
 
-    res_json = CliRunner().invoke(main, ["graph", "compare", str(op), str(np), "--format", "json"])
+    res_json = CliRunner().invoke(
+        main, ["graph", "compare", str(op), str(np), "--format", "json"]
+    )
     payload = json.loads(res_json.output)
     assert payload["findings"][0]["kind"] == "source_to_binary_mapping_changed"
 
@@ -656,19 +818,34 @@ def test_compare_graph_cli_surfaces_findings(tmp_path) -> None:
 def test_build_option_reaches_public_symbol_edges_and_finding() -> None:
     def _build(flags):
         b = BuildEvidence()
-        b.targets.append(Target(id="target://libfoo", public_headers=["inc/foo.h"],
-                                confidence=Confidence.HIGH))
-        b.compile_units.append(CompileUnit(
-            id="cu://foo", source="src/foo.cpp", target_id="target://libfoo",
-            abi_relevant_flags=flags))
+        b.targets.append(
+            Target(
+                id="target://libfoo",
+                public_headers=["inc/foo.h"],
+                confidence=Confidence.HIGH,
+            )
+        )
+        b.compile_units.append(
+            CompileUnit(
+                id="cu://foo",
+                source="src/foo.cpp",
+                target_id="target://libfoo",
+                abi_relevant_flags=flags,
+            )
+        )
         return b
 
     surf = _surface_with([("foo::a", "inc/foo.h")], {"foo::a": "_Za"})
     old = build_source_graph(_build(["-std=c++20"]), source_abi=surf)
-    new = build_source_graph(_build(["-std=c++20", "-fvisibility=hidden"]), source_abi=surf)
+    new = build_source_graph(
+        _build(["-std=c++20", "-fvisibility=hidden"]), source_abi=surf
+    )
     assert any(e.kind == "BUILD_OPTION_AFFECTS_SYMBOL" for e in new.edges)
-    bo = [c for c in diff_source_graph_findings(old, new)
-          if c.kind == ChangeKind.BUILD_OPTION_REACHES_PUBLIC_SYMBOL]
+    bo = [
+        c
+        for c in diff_source_graph_findings(old, new)
+        if c.kind == ChangeKind.BUILD_OPTION_REACHES_PUBLIC_SYMBOL
+    ]
     assert len(bo) == 1
     assert "-fvisibility=hidden" in bo[0].symbol
     assert bo[0].source_location == f"[{EVIDENCE_TIER_L5}]"
@@ -680,19 +857,37 @@ def test_build_option_reaches_public_symbol_ignores_reused_flag_on_new_target() 
     def _build(targets):
         b = BuildEvidence()
         for tid, hdr in targets:
-            b.targets.append(Target(id=tid, public_headers=[hdr], confidence=Confidence.HIGH))
-            b.compile_units.append(CompileUnit(
-                id=f"cu://{tid}", source=f"src/{tid}.cpp", target_id=tid,
-                abi_relevant_flags=["-std=c++20"]))
+            b.targets.append(
+                Target(id=tid, public_headers=[hdr], confidence=Confidence.HIGH)
+            )
+            b.compile_units.append(
+                CompileUnit(
+                    id=f"cu://{tid}",
+                    source=f"src/{tid}.cpp",
+                    target_id=tid,
+                    abi_relevant_flags=["-std=c++20"],
+                )
+            )
         return b
 
-    old_surf = _surface_with([("foo::a", "inc/foo.h")], {"foo::a": "_Za"}, target="target://foo")
-    new_surf = _surface_with([("bar::b", "inc/bar.h")], {"bar::b": "_Zb"}, target="target://bar")
-    old = build_source_graph(_build([("target://foo", "inc/foo.h")]), source_abi=old_surf)
+    old_surf = _surface_with(
+        [("foo::a", "inc/foo.h")], {"foo::a": "_Za"}, target="target://foo"
+    )
+    new_surf = _surface_with(
+        [("bar::b", "inc/bar.h")], {"bar::b": "_Zb"}, target="target://bar"
+    )
+    old = build_source_graph(
+        _build([("target://foo", "inc/foo.h")]), source_abi=old_surf
+    )
     new = build_source_graph(
-        _build([("target://foo", "inc/foo.h"), ("target://bar", "inc/bar.h")]), source_abi=new_surf)
-    bo = [c for c in diff_source_graph_findings(old, new)
-          if c.kind == ChangeKind.BUILD_OPTION_REACHES_PUBLIC_SYMBOL]
+        _build([("target://foo", "inc/foo.h"), ("target://bar", "inc/bar.h")]),
+        source_abi=new_surf,
+    )
+    bo = [
+        c
+        for c in diff_source_graph_findings(old, new)
+        if c.kind == ChangeKind.BUILD_OPTION_REACHES_PUBLIC_SYMBOL
+    ]
     # -std=c++20 already existed in the old graph → no flag-drift finding.
     assert bo == []
 
@@ -701,10 +896,16 @@ def test_include_graph_public_header_drift_finding() -> None:
     from abicheck.buildsource.include_graph import augment_graph_with_includes
 
     b = BuildEvidence()
-    b.targets.append(Target(id="target://libfoo", public_headers=["inc/foo.h"],
-                            confidence=Confidence.HIGH))
-    b.compile_units.append(CompileUnit(id="cu://foo", source="src/foo.cpp",
-                                       target_id="target://libfoo"))
+    b.targets.append(
+        Target(
+            id="target://libfoo",
+            public_headers=["inc/foo.h"],
+            confidence=Confidence.HIGH,
+        )
+    )
+    b.compile_units.append(
+        CompileUnit(id="cu://foo", source="src/foo.cpp", target_id="target://libfoo")
+    )
     old = build_source_graph(b)
     # The old side must have *confirmed* include-graph coverage (a pass that
     # ran and genuinely found nothing) for its absence to be trusted evidence
@@ -715,8 +916,11 @@ def test_include_graph_public_header_drift_finding() -> None:
     new = build_source_graph(b)
     augment_graph_with_includes(new, {"cu://foo": ["inc/foo.h"]})
     new.finalize()
-    inc = [c for c in diff_source_graph_findings(old, new)
-           if c.kind == ChangeKind.INCLUDE_GRAPH_PUBLIC_HEADER_DRIFT]
+    inc = [
+        c
+        for c in diff_source_graph_findings(old, new)
+        if c.kind == ChangeKind.INCLUDE_GRAPH_PUBLIC_HEADER_DRIFT
+    ]
     assert len(inc) == 1
     assert inc[0].symbol == "inc/foo.h"
 
@@ -729,16 +933,25 @@ def test_include_graph_public_header_drift_suppressed_without_old_coverage() -> 
     from abicheck.buildsource.include_graph import augment_graph_with_includes
 
     b = BuildEvidence()
-    b.targets.append(Target(id="target://libfoo", public_headers=["inc/foo.h"],
-                            confidence=Confidence.HIGH))
-    b.compile_units.append(CompileUnit(id="cu://foo", source="src/foo.cpp",
-                                       target_id="target://libfoo"))
+    b.targets.append(
+        Target(
+            id="target://libfoo",
+            public_headers=["inc/foo.h"],
+            confidence=Confidence.HIGH,
+        )
+    )
+    b.compile_units.append(
+        CompileUnit(id="cu://foo", source="src/foo.cpp", target_id="target://libfoo")
+    )
     old = build_source_graph(b)  # no include data, no confirmed pass at all
     new = build_source_graph(b)
     augment_graph_with_includes(new, {"cu://foo": ["inc/foo.h"]})
     new.finalize()
-    inc = [c for c in diff_source_graph_findings(old, new)
-           if c.kind == ChangeKind.INCLUDE_GRAPH_PUBLIC_HEADER_DRIFT]
+    inc = [
+        c
+        for c in diff_source_graph_findings(old, new)
+        if c.kind == ChangeKind.INCLUDE_GRAPH_PUBLIC_HEADER_DRIFT
+    ]
     assert inc == []
 
 
@@ -751,13 +964,19 @@ def test_include_graph_public_header_drift_suppressed_for_narrowed_new_side() ->
     from abicheck.buildsource.include_graph import augment_graph_with_includes
 
     b = BuildEvidence()
-    b.targets.append(Target(id="target://libfoo",
-                            public_headers=["inc/foo.h", "inc/bar.h"],
-                            confidence=Confidence.HIGH))
-    b.compile_units.append(CompileUnit(id="cu://foo", source="src/foo.cpp",
-                                       target_id="target://libfoo"))
-    b.compile_units.append(CompileUnit(id="cu://bar", source="src/bar.cpp",
-                                       target_id="target://libfoo"))
+    b.targets.append(
+        Target(
+            id="target://libfoo",
+            public_headers=["inc/foo.h", "inc/bar.h"],
+            confidence=Confidence.HIGH,
+        )
+    )
+    b.compile_units.append(
+        CompileUnit(id="cu://foo", source="src/foo.cpp", target_id="target://libfoo")
+    )
+    b.compile_units.append(
+        CompileUnit(id="cu://bar", source="src/bar.cpp", target_id="target://libfoo")
+    )
     old = build_source_graph(b)
     augment_graph_with_includes(
         old, {"cu://foo": ["inc/foo.h"], "cu://bar": ["inc/bar.h"]}
@@ -771,22 +990,33 @@ def test_include_graph_public_header_drift_suppressed_for_narrowed_new_side() ->
     new.narrowed_passes["include_graph"] = True
     new.narrowed_scope["include_graph"] = frozenset({"src/foo.cpp"})
     new.finalize()
-    inc = [c for c in diff_source_graph_findings(old, new)
-           if c.kind == ChangeKind.INCLUDE_GRAPH_PUBLIC_HEADER_DRIFT]
+    inc = [
+        c
+        for c in diff_source_graph_findings(old, new)
+        if c.kind == ChangeKind.INCLUDE_GRAPH_PUBLIC_HEADER_DRIFT
+    ]
     assert inc == []
 
 
-def test_include_graph_public_header_drift_trusted_for_matching_narrowed_scope() -> None:
+def test_include_graph_public_header_drift_trusted_for_matching_narrowed_scope() -> (
+    None
+):
     # Two sides narrowed to the *identical* scope examined the exact same
     # compile units, so a header appearing in one but not the other within
     # that shared scope is real drift, not a coverage gap.
     from abicheck.buildsource.include_graph import augment_graph_with_includes
 
     b = BuildEvidence()
-    b.targets.append(Target(id="target://libfoo", public_headers=["inc/foo.h"],
-                            confidence=Confidence.HIGH))
-    b.compile_units.append(CompileUnit(id="cu://foo", source="src/foo.cpp",
-                                       target_id="target://libfoo"))
+    b.targets.append(
+        Target(
+            id="target://libfoo",
+            public_headers=["inc/foo.h"],
+            confidence=Confidence.HIGH,
+        )
+    )
+    b.compile_units.append(
+        CompileUnit(id="cu://foo", source="src/foo.cpp", target_id="target://libfoo")
+    )
     old = build_source_graph(b)
     old.narrowed_passes["include_graph"] = True
     old.narrowed_scope["include_graph"] = frozenset({"src/foo.cpp"})
@@ -796,8 +1026,11 @@ def test_include_graph_public_header_drift_trusted_for_matching_narrowed_scope()
     new.narrowed_passes["include_graph"] = True
     new.narrowed_scope["include_graph"] = frozenset({"src/foo.cpp"})
     new.finalize()
-    inc = [c for c in diff_source_graph_findings(old, new)
-           if c.kind == ChangeKind.INCLUDE_GRAPH_PUBLIC_HEADER_DRIFT]
+    inc = [
+        c
+        for c in diff_source_graph_findings(old, new)
+        if c.kind == ChangeKind.INCLUDE_GRAPH_PUBLIC_HEADER_DRIFT
+    ]
     assert len(inc) == 1
     assert inc[0].symbol == "inc/foo.h"
 
@@ -806,8 +1039,13 @@ def test_localize_symbol_walks_the_graph() -> None:
     from abicheck.buildsource.source_graph import localize_symbol
 
     b = BuildEvidence()
-    b.targets.append(Target(id="target://libfoo", public_headers=["include/foo.h"],
-                            confidence=Confidence.HIGH))
+    b.targets.append(
+        Target(
+            id="target://libfoo",
+            public_headers=["include/foo.h"],
+            confidence=Confidence.HIGH,
+        )
+    )
     g = build_source_graph(b, source_abi=_sample_surface())
     result = localize_symbol(g, "_ZN3foo3barEv")
     assert result["found"] is True
@@ -826,23 +1064,45 @@ def test_localize_symbol_absent_returns_empty() -> None:
 
 def test_explain_finding_cli(tmp_path) -> None:
     b = BuildEvidence()
-    b.targets.append(Target(id="target://libfoo", public_headers=["include/foo.h"],
-                            confidence=Confidence.HIGH))
+    b.targets.append(
+        Target(
+            id="target://libfoo",
+            public_headers=["include/foo.h"],
+            confidence=Confidence.HIGH,
+        )
+    )
     g = build_source_graph(b, source_abi=_sample_surface())
     graph_json = tmp_path / "g.json"
     graph_json.write_text(json.dumps(g.to_dict()))
 
-    res = CliRunner().invoke(main, [
-        "graph", "explain", "--sources", str(graph_json), "--symbol", "_ZN3foo3barEv",
-    ])
+    res = CliRunner().invoke(
+        main,
+        [
+            "graph",
+            "explain",
+            "--sources",
+            str(graph_json),
+            "--symbol",
+            "_ZN3foo3barEv",
+        ],
+    )
     assert res.exit_code == 0, res.output
     assert "target://libfoo" in res.output
     assert "foo::bar" in res.output
 
-    res_json = CliRunner().invoke(main, [
-        "graph", "explain", "--sources", str(graph_json),
-        "--symbol", "_ZN3foo3barEv", "--format", "json",
-    ])
+    res_json = CliRunner().invoke(
+        main,
+        [
+            "graph",
+            "explain",
+            "--sources",
+            str(graph_json),
+            "--symbol",
+            "_ZN3foo3barEv",
+            "--format",
+            "json",
+        ],
+    )
     payload = json.loads(res_json.output)
     assert payload["found"] is True
     assert "foo::bar" in payload["source_declarations"]
@@ -850,18 +1110,34 @@ def test_explain_finding_cli(tmp_path) -> None:
 
 def test_explain_finding_resolves_symbol_from_report(tmp_path) -> None:
     b = BuildEvidence()
-    b.targets.append(Target(id="target://libfoo", public_headers=["include/foo.h"],
-                            confidence=Confidence.HIGH))
+    b.targets.append(
+        Target(
+            id="target://libfoo",
+            public_headers=["include/foo.h"],
+            confidence=Confidence.HIGH,
+        )
+    )
     g = build_source_graph(b, source_abi=_sample_surface())
     graph_json = tmp_path / "g.json"
     graph_json.write_text(json.dumps(g.to_dict()))
     report = tmp_path / "report.json"
     report.write_text(json.dumps({"changes": [{"symbol": "_ZN3foo3barEv"}]}))
 
-    res = CliRunner().invoke(main, [
-        "graph", "explain", "--sources", str(graph_json),
-        "--report", str(report), "--finding-id", "0", "--format", "json",
-    ])
+    res = CliRunner().invoke(
+        main,
+        [
+            "graph",
+            "explain",
+            "--sources",
+            str(graph_json),
+            "--report",
+            str(report),
+            "--finding-id",
+            "0",
+            "--format",
+            "json",
+        ],
+    )
     assert res.exit_code == 0, res.output
     assert json.loads(res.output)["symbol"] == "_ZN3foo3barEv"
 
@@ -879,9 +1155,16 @@ def test_resolve_symbol_from_report_variants(tmp_path) -> None:
     from abicheck.cli_graph import _resolve_symbol_from_report
 
     report = tmp_path / "r.json"
-    report.write_text(json.dumps({"changes": [
-        {"symbol": "_ZN3foo3barEv"}, {"symbol": "_ZN3foo3bazEv"},
-    ]}))
+    report.write_text(
+        json.dumps(
+            {
+                "changes": [
+                    {"symbol": "_ZN3foo3barEv"},
+                    {"symbol": "_ZN3foo3bazEv"},
+                ]
+            }
+        )
+    )
     # index lookup
     assert _resolve_symbol_from_report(report, "1") == "_ZN3foo3bazEv"
     # substring match
@@ -931,7 +1214,8 @@ def test_explain_finding_text_symbol_absent(tmp_path) -> None:
     graph_json = tmp_path / "g.json"
     graph_json.write_text(json.dumps(g.to_dict()))
     res = CliRunner().invoke(
-        main, ["graph", "explain", "--sources", str(graph_json), "--symbol", "_Zmissing"]
+        main,
+        ["graph", "explain", "--sources", str(graph_json), "--symbol", "_Zmissing"],
     )
     assert res.exit_code == 0, res.output
     assert "symbol not present in the source graph" in res.output
@@ -1010,7 +1294,9 @@ def test_narrowed_scope_round_trips() -> None:
     g.narrowed_passes["type_graph"] = True
     g.narrowed_scope["type_graph"] = frozenset({"src/a.cpp", "src/b.cpp"})
     restored = SourceGraphSummary.from_dict(g.to_dict())
-    assert restored.narrowed_scope == {"type_graph": frozenset({"src/a.cpp", "src/b.cpp"})}
+    assert restored.narrowed_scope == {
+        "type_graph": frozenset({"src/a.cpp", "src/b.cpp"})
+    }
 
 
 def test_degraded_passes_round_trips() -> None:
@@ -1075,8 +1361,11 @@ def test_indexes_cover_forward_looking_symbol_and_decl_kinds() -> None:
     g = SourceGraphSummary()
     g.add_node(GraphNode(id="decl://foo", kind="source_decl"))
     g.add_node(GraphNode(id="sym://_Z3foov", kind="binary_symbol"))
-    g.add_edge(GraphEdge(src="decl://foo", dst="sym://_Z3foov",
-                         kind="SOURCE_DECL_MAPS_TO_SYMBOL"))
+    g.add_edge(
+        GraphEdge(
+            src="decl://foo", dst="sym://_Z3foov", kind="SOURCE_DECL_MAPS_TO_SYMBOL"
+        )
+    )
     idx = g.indexes()
     assert "sym://_Z3foov" in idx["by_binary_symbol"]
     assert "decl://foo" in idx["by_source_decl"]
@@ -1085,7 +1374,7 @@ def test_indexes_cover_forward_looking_symbol_and_decl_kinds() -> None:
 def test_to_dict_fills_graph_id_when_unset() -> None:
     g = SourceGraphSummary()
     g.add_node(GraphNode(id="x", kind="target"))
-    assert g.graph_id == ""               # not finalized
+    assert g.graph_id == ""  # not finalized
     assert g.to_dict()["graph_id"].startswith("sha256:")
 
 
@@ -1139,15 +1428,30 @@ def test_collect_evidence_summary_writes_graph_and_coverage(tmp_path) -> None:
     cdb = tmp_path / "compile_commands.json"
     src = tmp_path / "foo.cpp"
     src.write_text("int foo(){return 1;}\n")
-    cdb.write_text(json.dumps([{
-        "directory": str(tmp_path), "file": str(src),
-        "command": f"c++ -std=c++20 -fvisibility=hidden -c {src} -o foo.o",
-    }]))
+    cdb.write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src),
+                    "command": f"c++ -std=c++20 -fvisibility=hidden -c {src} -o foo.o",
+                }
+            ]
+        )
+    )
     out = tmp_path / "out.evidence"
-    res = CliRunner().invoke(main, [
-        "collect", "--compile-db", str(cdb),
-        "--source-graph", "summary", "-o", str(out),
-    ])
+    res = CliRunner().invoke(
+        main,
+        [
+            "collect",
+            "--compile-db",
+            str(cdb),
+            "--source-graph",
+            "summary",
+            "-o",
+            str(out),
+        ],
+    )
     assert res.exit_code == 0, res.output
     assert (out / "graph" / "source_graph_summary.json").is_file()
     pack = BuildSourcePack.load(out)
@@ -1188,7 +1492,10 @@ def test_compare_graph_identical(tmp_path) -> None:
 
 
 def test_compare_graph_missing_graph_errors(tmp_path) -> None:
-    res = CliRunner().invoke(main, ["graph", "compare", str(tmp_path / "nope.json"), str(tmp_path / "nope.json")])
+    res = CliRunner().invoke(
+        main,
+        ["graph", "compare", str(tmp_path / "nope.json"), str(tmp_path / "nope.json")],
+    )
     assert res.exit_code != 0
 
 
@@ -1196,24 +1503,38 @@ def _collect_pack(tmp_path, name: str, *, two_units: bool = False) -> str:
     """Run `collect --source-graph summary` and return the pack dir."""
     src = tmp_path / f"{name}.cpp"
     src.write_text("int x(){return 1;}\n")
-    entries = [{
-        "directory": str(tmp_path), "file": str(src),
-        "command": f"c++ -std=c++20 -fvisibility=hidden -c {src} -o {name}.o",
-    }]
+    entries = [
+        {
+            "directory": str(tmp_path),
+            "file": str(src),
+            "command": f"c++ -std=c++20 -fvisibility=hidden -c {src} -o {name}.o",
+        }
+    ]
     if two_units:
         src2 = tmp_path / f"{name}2.cpp"
         src2.write_text("int y(){return 2;}\n")
-        entries.append({
-            "directory": str(tmp_path), "file": str(src2),
-            "command": f"c++ -std=c++20 -c {src2} -o {name}2.o",
-        })
+        entries.append(
+            {
+                "directory": str(tmp_path),
+                "file": str(src2),
+                "command": f"c++ -std=c++20 -c {src2} -o {name}2.o",
+            }
+        )
     cdb = tmp_path / f"{name}_cc.json"
     cdb.write_text(json.dumps(entries))
     out = tmp_path / f"{name}.evidence"
-    res = CliRunner().invoke(main, [
-        "collect", "--compile-db", str(cdb),
-        "--source-graph", "summary", "-o", str(out),
-    ])
+    res = CliRunner().invoke(
+        main,
+        [
+            "collect",
+            "--compile-db",
+            str(cdb),
+            "--source-graph",
+            "summary",
+            "-o",
+            str(out),
+        ],
+    )
     assert res.exit_code == 0, res.output
     return str(out)
 
@@ -1233,14 +1554,33 @@ def test_compare_graph_pack_without_graph_errors(tmp_path) -> None:
     cdb = tmp_path / "cc.json"
     src = tmp_path / "z.cpp"
     src.write_text("int z(){return 0;}\n")
-    cdb.write_text(json.dumps([{
-        "directory": str(tmp_path), "file": str(src),
-        "command": f"c++ -c {src} -o z.o",
-    }]))
+    cdb.write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src),
+                    "command": f"c++ -c {src} -o z.o",
+                }
+            ]
+        )
+    )
     out = tmp_path / "nograph.evidence"
-    assert CliRunner().invoke(main, [
-        "collect", "--compile-db", str(cdb), "-o", str(out),
-    ]).exit_code == 0
+    assert (
+        CliRunner()
+        .invoke(
+            main,
+            [
+                "collect",
+                "--compile-db",
+                str(cdb),
+                "-o",
+                str(out),
+            ],
+        )
+        .exit_code
+        == 0
+    )
     res = CliRunner().invoke(main, ["graph", "compare", str(out), str(out)])
     assert res.exit_code != 0
     assert "no L5 source graph" in res.output
@@ -1276,9 +1616,16 @@ def test_collect_evidence_summary_without_build_is_partial(tmp_path) -> None:
     # --source-graph summary with no build adapter inputs yields an empty graph;
     # the L5 coverage row must read PARTIAL (ran, produced nothing), not PRESENT.
     out = tmp_path / "empty.evidence"
-    res = CliRunner().invoke(main, [
-        "collect", "--source-graph", "summary", "-o", str(out),
-    ])
+    res = CliRunner().invoke(
+        main,
+        [
+            "collect",
+            "--source-graph",
+            "summary",
+            "-o",
+            str(out),
+        ],
+    )
     assert res.exit_code == 0, res.output
     pack = BuildSourcePack.load(out)
     assert pack.source_graph is not None

--- a/tests/test_source_replay_validation.py
+++ b/tests/test_source_replay_validation.py
@@ -143,9 +143,13 @@ def _template_body_changed() -> tuple[SourceAbiSurface, SourceAbiSurface]:
 
 
 def _template_removed() -> tuple[SourceAbiSurface, SourceAbiSurface]:
+    # The new side carries an unrelated declaration so _surface_has_facts(new)
+    # is true (L4 extraction ran) without resurrecting the removed template --
+    # an entirely empty new surface is indistinguishable from "L4 didn't run"
+    # and would be (correctly) suppressed by the no-facts-at-all removal gate.
     return (
         _surface(reachable_templates=[_ent("maxv", "template", body_hash="a")]),
-        _surface(),
+        _surface(reachable_declarations=[_ent("keep", "function", mangled="_Z4keepv")]),
     )
 
 


### PR DESCRIPTION
## Summary

Implements the recommendations from the "Latest-main Clang plugin review" (reviewing commit `9c49163` / PR #548), which found the ADR-038 C.8 canonical fact-set work materially improved but flagged several P1/P2 correctness gaps. This PR closes the P1 items and the most impactful P2s; new ADR-038 sections (C.10-C.12) document what changed.

## Motivation

The review's core findings:
1. `source_edges` were collected by both producers but never reached the L5 graph (`SourceAbiSurface` had no edge field), so the separate `call_graph`/`type_graph` replay passes remained the only real edge source — defeating the plugin's zero-extra-parse goal.
2. The Clang JSON-AST replay resolved an overloaded callee's compact `referencedDecl` stub by bare name (verified: real Clang never puts `mangledName` on that stub), collapsing overloads/ctors/dtors onto one identity.
3. Incompatible opaque body/template hashes were flagged as unreliable (`SOURCE_FACT_COVERAGE_INCOMPLETE`) but then diffed anyway.
4. The plugin/wrapper's per-TU fact filename and manifest had no target/library isolation — two libraries sharing one `out=` directory could silently clobber each other's facts.
5. A compaction rollback edge case, a silently-dropped typedef diagnostic, and thin C.6/scan-flow test coverage of the newer channels.

## Changes

- **PR1 (source_edges → L5 graph):** `SourceAbiSurface.source_edges` (new field) + `source_link.link_source_abi()` folds/dedupes TU edges onto it; `source_graph.fold_source_edges()` consumes it inside `build_source_graph()`, using the same `decl://`/`type://` node-id scheme the replay passes use so edges reconcile instead of duplicating. `inline._build_inline_graph()` skips the separate `call_graph`/`type_graph` replay when a full-scope `source_edges` collection is already confirmed complete (narrowed scopes still run the replay).
- **PR1b (identity fix):** `call_graph.py`'s `parse_clang_ast_calls()` now builds an `id_index` from every full `FunctionDecl`/`CXXMethodDecl`/... node seen in the same walk, resolving a call site's compact stub through it before falling back to bare-name — mirroring `type_graph.py`'s existing fix. Verified end-to-end against a live Clang 18 compile of an `int f(int)`/`double f(double)` pair.
- **PR2 (hash gating):** `fact_set.FactCompatibility`/`check_fact_compatibility()` gate `INLINE_BODY_CHANGED`/`TEMPLATE_BODY_CHANGED` on producer/version comparability (existence/removal findings are never gated), with a `hash_recipe_id` override for producers proven equivalent via C.6.
- **PR3 (target isolation):** plugin fact filename + `tu_id` fold in the library identity; `ensureManifest()`/`init_inputs_pack()` validate an existing manifest against the current invocation (plugin: loud warning, never aborts the build; wrapper: hard error); `abicheck inputs validate` rejects multi-target packs and hard fact-set-recipe mismatches within one pack.
- **PR4:** `compact_inputs_pack()` rejects an `--output-filename` colliding with an unrecognized pre-existing file (instead of silently overwriting it, per the review's own recommended fix); a public typedef whose underlying type can't be determined now records a diagnostic folded into `types` coverage.
- **Test extension:** `conformance.py` (C.6) and `scan_flow.py` now cover `source_edges`/`read_files`/`fact_set`/`coverage`, including a planted overload-regression fixture, and assert the specific L5 graph edges are present (not just non-empty L4 entity counts).
- **ADR-038** gains C.10 (source_edges → L5 graph + identity fix), C.11 (hash gating), C.12 (target isolation + explicit note that the published 2.39× performance figure is *not* re-verified for the current collector — re-measuring requires an instrumented LLVM build this environment can't perform, so it's documented as an open gap rather than fabricated). **ADR-041**'s stale P1 roadmap item is updated to reflect completion.

## Testing

- Full fast lane: `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` — 14599 passed.
- `ruff check`, `mypy abicheck/`, `scripts/check_ai_readiness.py` — all clean (0 errors).
- The Python-side fixes (identity resolution, graph folding, hash gating, target-isolation validation) were also verified against **real Clang 18** compiles in this environment (live AST dumps, `abicheck-cc` wrapper runs, `abicheck dump`/`merge`/`compare` end-to-end) — not just unit tests against synthetic fixtures.
- The C++ plugin changes could not be compiled/linked in this sandbox (no full Clang C++ API headers available via apt — only `libclang-cpp` shared lib); the new code reuses the exact same LLVM API idioms (`MemoryBuffer::getFile`, `json::parse`+`consumeError`, `getAsObject`/`getString`) already compiling elsewhere in this file. The `clang-plugin` CI workflow will build and run the full plugin matrix (LLVM 16/17/18) against these changes.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Docs updated (ADR-038 C.10-C.12, ADR-041 roadmap)
- [x] `ruff`/`mypy` clean
- [ ] Plugin C++ build verified by CI (not buildable in this sandbox — see Testing)


---
_Generated by [Claude Code](https://claude.ai/code/session_01StWyhQn37w1gvG9uuWq86E)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Source dependency and call relationships are now included more completely in generated ABI graphs.
  * Overloaded function calls are resolved to the correct callee.
  * Fact comparisons now account for producer and hashing compatibility.

* **Bug Fixes**
  * Prevented misleading inline/template body-change findings when hashes cannot be reliably compared.
  * Improved diagnostics for unavailable public typedef information.
  * Prevented cross-target file collisions and unsafe pack overwrites.

* **Validation**
  * Packs containing conflicting targets, libraries, versions, or fact contracts are now rejected with clear errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->