### PR TITLE
fix: address Codex review round 6 — templated const, hidden tag-rename evidence, CPO return-type leak

### DIFF
--- a/abicheck/diff_cpp_patterns.py
+++ b/abicheck/diff_cpp_patterns.py
@@ -516,7 +516,18 @@ def detect_tag_type_renamed(
     appears in *new* under the same parent namespace, AND there is at
     least one removed symbol whose mangled name embeds the old tag's
     leaf segment while at least one added symbol embeds the new leaf.
+
+    The symbol evidence (``only_removed``/``only_added``) is scoped to the
+    public surface (``PUBLIC`` + ``ELF_ONLY``): a snapshot can retain
+    ``HIDDEN`` functions for cross-reference (both the header/castxml
+    backend and, since the case06 fix, the DWARF-only backend), and a
+    hidden explicit-instantiation helper changing name is not real evidence
+    of an exported rename — including it here could emit a TAG_TYPE_RENAMED
+    for two empty tags that share a namespace purely by coincidence, backed
+    by symbol churn no consumer can ever see.
     """
+    from .diff_symbols import _PUBLIC_VIS
+
     old.index()
     new.index()
     old_types = {t.name: t for t in old.types}
@@ -526,8 +537,10 @@ def detect_tag_type_renamed(
     if not removed_empties or not added_empties:
         return []
     added_by_ns = _group_by_namespace(added_empties)
-    only_removed = {f.mangled for f in old.functions} - {f.mangled for f in new.functions}
-    only_added = {f.mangled for f in new.functions} - {f.mangled for f in old.functions}
+    old_mangled = {f.mangled for f in old.functions if f.visibility in _PUBLIC_VIS}
+    new_mangled = {f.mangled for f in new.functions if f.visibility in _PUBLIC_VIS}
+    only_removed = old_mangled - new_mangled
+    only_added = new_mangled - old_mangled
     findings: list[Change] = []
     for removed in removed_empties:
         ns = _parent_namespace(removed.name)

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1106,32 +1106,41 @@ def _check_variable_alignment(
 
 
 _TRAILING_CONST_RE = re.compile(r"\s*\bconst\b\s*$")
+_LEADING_CONST_TOKEN_RE = re.compile(r"^\s*\bconst\b\s*")
+_POINTER_OR_REF_RE = re.compile(r"[*&]")
 
 
 def _without_top_level_const(canonical_type: str) -> str:
-    """Strip only a *trailing* (top-level) ``const`` from an
-    already-canonicalized type name.
+    """Strip the *top-level* ``const`` from an already-canonicalized type name.
 
     ``canonicalize_type_name`` normalizes a leading ``const T`` to ``T
-    const`` (moving the qualifier immediately after what it qualifies), so
-    the qualifier that applies to the variable/pointer *itself* is always
-    the last token in the canonical string — ``"int const"`` for a plain
-    ``const int``, or ``"int * const"`` for a const pointer. A *pointee*-level
-    qualifier (``"int const *"`` for ``const int *``, which qualifies what
-    the pointer points to, not the pointer) is never trailing, so this
-    leaves it untouched.
+    const`` (moving the qualifier immediately after what it qualifies) —
+    but only when the base type has no template args (``"<...>"``); for a
+    templated base it deliberately leaves the spelling untouched, so a
+    top-level const on e.g. ``std::vector<int>`` stays leading
+    (``"const std::vector<int>"``), not trailing.
 
-    This lets :func:`_check_variable` compare *base* types independent of a
-    pure top-level const-only flip (e.g. ``int`` -> ``const int``, or
-    ``int *`` -> ``int * const``), classifying only those as
-    VAR_BECAME_CONST/VAR_LOST_CONST rather than the generic VAR_TYPE_CHANGED
-    — deliberately NOT stripping every ``const`` occurrence: doing so would
-    also collapse a pointee-const change (``int *`` -> ``const int *``) into
-    an apparent pure flip, hiding a real type change behind a misleading
-    "variable became const" (the pointer itself is still writable; only
-    what it points to changed) (Codex review).
+    So which end is "top-level" depends on whether a pointer/reference
+    sigil is present, not on template-ness:
+
+    - No ``*``/``&`` at all: the *whole object* is what's qualified, so a
+      const at *either* end (leading, for a templated base; trailing, the
+      east-const form for a non-template base) is the top-level qualifier
+      — strip whichever is present.
+    - A ``*``/``&`` present: the top-level (pointer-itself) qualifier is
+      always the trailing token (``"int * const"``, or ``"std::vector<int>
+      * const"``) regardless of template-ness. A *leading* const there
+      (``"int const *"``, ``"const std::vector<int> *"``) qualifies the
+      pointee, not the pointer, and must NOT be stripped — collapsing it
+      would hide a real type change (the pointer itself is still writable;
+      only what it points to changed) behind a misleading "variable became
+      const" (Codex review, x2: the original non-template pointee-const
+      case, and the templated-base variant of the same issue).
     """
-    return _TRAILING_CONST_RE.sub("", canonical_type)
+    if _POINTER_OR_REF_RE.search(canonical_type):
+        return _TRAILING_CONST_RE.sub("", canonical_type)
+    stripped = _LEADING_CONST_TOKEN_RE.sub("", canonical_type)
+    return _TRAILING_CONST_RE.sub("", stripped)
 
 
 def _check_variable(mangled: str, v_old: Variable, v_new: Variable) -> list[Change]:

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1107,7 +1107,28 @@ def _check_variable_alignment(
 
 _TRAILING_CONST_RE = re.compile(r"\s*\bconst\b\s*$")
 _LEADING_CONST_TOKEN_RE = re.compile(r"^\s*\bconst\b\s*")
-_POINTER_OR_REF_RE = re.compile(r"[*&]")
+
+
+def _has_top_level_pointer_or_ref(canonical_type: str) -> bool:
+    """True if *canonical_type* has a ``*``/``&`` outside any ``<...>``
+    template-argument bracket.
+
+    A plain substring search for ``*``/``&`` would also match one nested
+    *inside* a template argument (e.g. ``std::vector<int *>`` — a by-value
+    vector of pointers, not itself a pointer), wrongly routing a pure
+    top-level const flip on that by-value variable into the
+    pointer/reference branch below, which only strips a *trailing* const —
+    but the top-level const here is leading (Codex review).
+    """
+    depth = 0
+    for ch in canonical_type:
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif ch in "*&" and depth == 0:
+            return True
+    return False
 
 
 def _without_top_level_const(canonical_type: str) -> str:
@@ -1137,7 +1158,7 @@ def _without_top_level_const(canonical_type: str) -> str:
       const" (Codex review, x2: the original non-template pointee-const
       case, and the templated-base variant of the same issue).
     """
-    if _POINTER_OR_REF_RE.search(canonical_type):
+    if _has_top_level_pointer_or_ref(canonical_type):
         return _TRAILING_CONST_RE.sub("", canonical_type)
     stripped = _LEADING_CONST_TOKEN_RE.sub("", canonical_type)
     return _TRAILING_CONST_RE.sub("", stripped)

--- a/abicheck/diff_templates.py
+++ b/abicheck/diff_templates.py
@@ -161,6 +161,14 @@ def _strip_leading_return_type(sig: str) -> str:
     an ``operator`` name (itself spelled with a space, e.g. ``"operator
     new"``) — CPOs are never operators, and blindly splitting there would
     corrupt the operator's own name instead of stripping a return type.
+
+    Callers must only invoke this once :func:`_looks_like_template_instantiation`
+    has confirmed the *pre-strip* qualified name was actually a template
+    instantiation — a non-template demangling can still contain a top-level
+    space for an unrelated reason (an ABI thunk marker like ``"non-virtual
+    thunk to lib::sort()"``) and must never be routed through here, or the
+    thunk collapses to ``"lib::sort"`` and wrongly collides with an
+    unrelated same-named CPO variable (Codex review).
     """
     if " " not in sig or "operator" in sig:
         return sig
@@ -313,7 +321,18 @@ def detect_cpo_kind_changed(
             qname = _qualified_function_name(f.name, f.mangled)
             if qname:
                 stem = _strip_param_signature(_strip_template_args(qname))
-                out.add(_strip_leading_return_type(stem))
+                # Only a function *template* instantiation's demangling ever
+                # leaks a return type ahead of the qualified name (checked on
+                # the pre-strip qname, since the template args themselves are
+                # the tell). A non-template name that happens to contain a
+                # space for an unrelated reason — e.g. an ABI thunk marker
+                # like "non-virtual thunk to lib::sort()" — must not go
+                # through the stripper: it would take the text after the
+                # last space ("lib::sort") and wrongly collide with an
+                # unrelated same-named CPO variable (Codex review).
+                if _looks_like_template_instantiation(qname):
+                    stem = _strip_leading_return_type(stem)
+                out.add(stem)
         return out
 
     def _var_names(snap: AbiSnapshot) -> set[str]:

--- a/abicheck/diff_templates.py
+++ b/abicheck/diff_templates.py
@@ -141,6 +141,32 @@ def _strip_param_signature(qualified: str) -> str:
     return qualified
 
 
+def _strip_leading_return_type(sig: str) -> str:
+    """Strip a leaked leading return type from a demangled function
+    signature, once template args and the param signature are already gone.
+
+    Itanium demangling includes the return type for a function *template*
+    instantiation (needed to disambiguate an overload set that differs only
+    by return type) but never for a non-template function — so
+    ``lib::sort<int>(int*, int*)`` demangles to ``"int lib::sort<int>(int*,
+    int*)"``, and after :func:`_strip_template_args` + :func:`_strip_param_signature`
+    reduce that to ``"int lib::sort"``, the leaked ``"int "`` prefix must be
+    dropped so the function-template side of a CPO transition still matches
+    the variable side's plain ``"lib::sort"`` (case88's function-template
+    variant; Codex review).
+
+    By this point no ``<...>``/``(...)`` remain, so taking the text after
+    the *last* top-level space still isolates the qualified name even for a
+    multi-word return type (``"unsigned long lib::sort"``). Left alone for
+    an ``operator`` name (itself spelled with a space, e.g. ``"operator
+    new"``) — CPOs are never operators, and blindly splitting there would
+    corrupt the operator's own name instead of stripping a return type.
+    """
+    if " " not in sig or "operator" in sig:
+        return sig
+    return sig.rsplit(" ", 1)[-1]
+
+
 # ---------------------------------------------------------------------------
 # INTERNAL_TEMPLATE_LEAKS_VIA_PUBLIC_API
 # ---------------------------------------------------------------------------
@@ -286,7 +312,8 @@ def detect_cpo_kind_changed(
                 continue
             qname = _qualified_function_name(f.name, f.mangled)
             if qname:
-                out.add(_strip_param_signature(_strip_template_args(qname)))
+                stem = _strip_param_signature(_strip_template_args(qname))
+                out.add(_strip_leading_return_type(stem))
         return out
 
     def _var_names(snap: AbiSnapshot) -> set[str]:

--- a/abicheck/diff_templates.py
+++ b/abicheck/diff_templates.py
@@ -103,6 +103,13 @@ _INTERNAL_TEMPLATE_NAMESPACES: tuple[str, ...] = (
 # ``<``, none of which match ``[^<>]``).
 _TEMPLATE_ARGS_RE = re.compile(r"<[^<>]")
 
+# Matches a genuine `operator` function-name token (`operator+`, `operator
+# new`, `operator T`, `::operator()`), not an incidental substring occurrence
+# inside an unrelated identifier such as a namespace named `cooperator`. The
+# lookaround pair requires a non-identifier character (or start/end of
+# string) on both sides, so `operator` must stand as its own token.
+_OPERATOR_TOKEN_RE = re.compile(r"(?<![A-Za-z0-9_])operator(?![A-Za-z0-9_])")
+
 
 def _looks_like_template_instantiation(name: str) -> bool:
     """A declared C++ name is a template instantiation iff it contains a
@@ -160,7 +167,12 @@ def _strip_leading_return_type(sig: str) -> str:
     multi-word return type (``"unsigned long lib::sort"``). Left alone for
     an ``operator`` name (itself spelled with a space, e.g. ``"operator
     new"``) — CPOs are never operators, and blindly splitting there would
-    corrupt the operator's own name instead of stripping a return type.
+    corrupt the operator's own name instead of stripping a return type. The
+    check for that is a whole-token match, not a substring one: a namespace
+    or class merely spelled with ``operator`` as a substring (e.g.
+    ``"lib::cooperator::sort"``) is not an operator overload and must still
+    get the leaked-return-type strip, or the function-template-to-CPO
+    transition living under it goes undetected (Codex review).
 
     Callers must only invoke this once :func:`_looks_like_template_instantiation`
     has confirmed the *pre-strip* qualified name was actually a template
@@ -170,7 +182,7 @@ def _strip_leading_return_type(sig: str) -> str:
     thunk collapses to ``"lib::sort"`` and wrongly collides with an
     unrelated same-named CPO variable (Codex review).
     """
-    if " " not in sig or "operator" in sig:
+    if " " not in sig or _OPERATOR_TOKEN_RE.search(sig):
         return sig
     return sig.rsplit(" ", 1)[-1]
 

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -721,6 +721,23 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
         # split — so it closes the same cluster of cycles through already-member
         # modules rather than introducing a new one. No init deadlock — the
         # package still imports cleanly.
+        #
+        # `cli_config`, `cli_doctor`, and `cli_graph` also join this same SCC —
+        # each already had its own standalone `{"cli", "cli_X"}` entry above,
+        # which covers the trivial two-node cycle from `cli`'s tail-of-module
+        # registration import. But `cli_config` reaches the shared machinery
+        # via `cli_compare_helpers` (config `show-effective` reuses `_cli_flag`
+        # from it) and `cli_doctor` via `cli_helpers_compare`, both of which are
+        # already members of this cluster — so the *full* SCC computed by
+        # Tarjan's algorithm over the real import graph includes all three,
+        # regardless of which representative simple cycle the (traversal-order
+        # dependent) DFS in `_find_cycles` happens to report. Without them
+        # here, a cycle mixing one of these three with any other cluster
+        # member (e.g. `cli -> cli_doctor -> cli_helpers_compare -> service ->
+        # ... -> cli`) fails the subset match even though it is the identical
+        # by-design cluster — which is exactly what made this check flaky
+        # (non-deterministic `set` iteration order in `_find_cycles` picks a
+        # different representative cycle each process run).
         frozenset(
             {
                 "appcompat",
@@ -731,8 +748,11 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
                 "cli_buildsource_helpers",
                 "cli_compare_helpers",
                 "cli_compare_release",
+                "cli_config",
                 "cli_debian_symbols",
+                "cli_doctor",
                 "cli_dump_helpers",
+                "cli_graph",
                 "cli_helpers_compare",
                 "cli_inputs",
                 "cli_options",

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -471,6 +471,21 @@ class TestVarConstChanged:
         assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
         assert ChangeKind.VAR_BECAME_CONST not in _kinds(r)
 
+    def test_pointer_inside_template_arg_is_not_top_level(self):
+        """`std::vector<int *>` -> `const std::vector<int *>`: the variable
+        itself is a by-value templated type (not a pointer) — the `*` lives
+        inside the template argument, not at the top level. A naive
+        substring search for `*`/`&` anywhere in the string would wrongly
+        route this into the pointer/reference branch (which only strips a
+        *trailing* const), missing the *leading* top-level const and
+        misreporting VAR_TYPE_CHANGED instead of VAR_BECAME_CONST
+        (Codex review)."""
+        v_v1 = _pub_var("cfg", "_Z3cfg", "std::vector<int *>", is_const=False)
+        v_v2 = _pub_var("cfg", "_Z3cfg", "const std::vector<int *>", is_const=True)
+        r = compare(_snap(variables=[v_v1]), _snap(variables=[v_v2]))
+        assert ChangeKind.VAR_BECAME_CONST in _kinds(r)
+        assert ChangeKind.VAR_TYPE_CHANGED not in _kinds(r)
+
 
 # ── constant_changed / constant_added / constant_removed ─────────────────
 

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -446,6 +446,31 @@ class TestVarConstChanged:
         assert ChangeKind.VAR_BECAME_CONST in _kinds(r)
         assert ChangeKind.VAR_TYPE_CHANGED not in _kinds(r)
 
+    def test_templated_value_top_level_const_is_var_became_const(self):
+        """`std::vector<int>` -> `const std::vector<int>`: canonicalize_type_name
+        deliberately leaves a leading const untouched when the base type is
+        templated (skips east-const normalization for any base containing
+        "<...>"), so the top-level qualifier stays leading instead of
+        trailing. This must still be classified VAR_BECAME_CONST — the same
+        semantic transition as the scalar `int` -> `const int` case — not
+        VAR_TYPE_CHANGED (Codex review)."""
+        v_v1 = _pub_var("cfg", "_Z3cfg", "std::vector<int>", is_const=False)
+        v_v2 = _pub_var("cfg", "_Z3cfg", "const std::vector<int>", is_const=True)
+        r = compare(_snap(variables=[v_v1]), _snap(variables=[v_v2]))
+        assert ChangeKind.VAR_BECAME_CONST in _kinds(r)
+        assert ChangeKind.VAR_TYPE_CHANGED not in _kinds(r)
+
+    def test_templated_pointee_const_is_type_changed(self):
+        """`std::vector<int> *` -> `const std::vector<int> *`: the POINTEE
+        (a templated type) became const, not the pointer itself — the
+        templated analog of test_pointee_const_is_type_changed_not_var_became_const.
+        Must report VAR_TYPE_CHANGED, not VAR_BECAME_CONST."""
+        v_v1 = _pub_var("cfg", "_Z3cfg", "std::vector<int> *", is_const=False)
+        v_v2 = _pub_var("cfg", "_Z3cfg", "const std::vector<int> *", is_const=True)
+        r = compare(_snap(variables=[v_v1]), _snap(variables=[v_v2]))
+        assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
+        assert ChangeKind.VAR_BECAME_CONST not in _kinds(r)
+
 
 # ── constant_changed / constant_added / constant_removed ─────────────────
 

--- a/tests/test_diff_templates.py
+++ b/tests/test_diff_templates.py
@@ -244,6 +244,19 @@ class TestCpoKindChanged:
         new = _snap(vars_=[_var("sort", type_="lib::__sort_fn", mangled="_ZN3lib4sortE")])
         assert detect_cpo_kind_changed(old, new) == []
 
+    def test_operator_substring_in_namespace_is_not_an_operator_overload(self) -> None:
+        # A namespace merely spelled with "operator" as a substring
+        # ("cooperator") is not an operator overload — the leaked return
+        # type still needs stripping so the function-template-to-CPO
+        # transition living under it is detected (Codex review).
+        old = _snap(funcs=[_fn("int lib::cooperator::sort<int>")])
+        new = _snap(
+            vars_=[_var("sort", type_="lib::cooperator::__sort_fn", mangled="_ZN3lib10cooperator4sortE")]
+        )
+        changes = detect_cpo_kind_changed(old, new)
+        assert len(changes) == 1
+        assert changes[0].new_value == "variable"
+
 
 # ---------------------------------------------------------------------------
 # OVERLOAD_SET_REROUTED

--- a/tests/test_diff_templates.py
+++ b/tests/test_diff_templates.py
@@ -232,6 +232,18 @@ class TestCpoKindChanged:
         assert len(changes) == 1
         assert changes[0].new_value == "variable"
 
+    def test_thunk_prefix_not_treated_as_leaked_return_type(self) -> None:
+        # An ABI thunk marker ("non-virtual thunk to ...") is a demangled
+        # name that, like a genuine function-template leak, contains a
+        # top-level space before the qualified name — but it is not a
+        # template instantiation, so it must not be routed through the
+        # leaked-return-type stripper. Doing so would collapse it to
+        # "lib::sort" and wrongly collide with an unrelated same-named CPO
+        # variable (Codex review).
+        old = _snap(funcs=[_fn("non-virtual thunk to lib::sort()")])
+        new = _snap(vars_=[_var("sort", type_="lib::__sort_fn", mangled="_ZN3lib4sortE")])
+        assert detect_cpo_kind_changed(old, new) == []
+
 
 # ---------------------------------------------------------------------------
 # OVERLOAD_SET_REROUTED

--- a/tests/test_diff_templates.py
+++ b/tests/test_diff_templates.py
@@ -215,6 +215,23 @@ class TestCpoKindChanged:
         new = _snap(vars_=[_var("sort", type_="ns2::__sort_fn", mangled="_ZN3ns24sortE")])
         assert detect_cpo_kind_changed(old, new) == []
 
+    def test_function_template_became_variable(self) -> None:
+        # A function TEMPLATE instantiation's demangled name includes a
+        # leading return type (Itanium demangling needs it to disambiguate
+        # return-type-only overloads) — real mangled name for
+        # `template<class T> T lib::sort(T*, T*)` instantiated as
+        # `sort<int>`, verified via c++filt to demangle to
+        # "int lib::sort<int>(int*, int*)". After template-arg and
+        # param-signature stripping that leaves a leaked "int " prefix,
+        # which must be stripped so this still matches the CPO variable
+        # side's plain "lib::sort" (Codex review: function-template variant
+        # of case88).
+        old = _snap(funcs=[_fn("sort", mangled="_ZN3lib4sortIiEET_PS1_S2_")])
+        new = _snap(vars_=[_var("sort", type_="lib::__sort_fn", mangled="_ZN3lib4sortE")])
+        changes = detect_cpo_kind_changed(old, new)
+        assert len(changes) == 1
+        assert changes[0].new_value == "variable"
+
 
 # ---------------------------------------------------------------------------
 # OVERLOAD_SET_REROUTED


### PR DESCRIPTION
## Summary

Follow-up to #558 (merged as `15425a3`). Three more automated-review findings arrived on the merged PR's commits after it landed; this branch was restarted from current `main` and these fixes applied fresh since #558 is closed.

- **`diff_symbols.py`**: `_without_top_level_const` only stripped a *trailing* `const`, but `canonicalize_type_name` skips its east-const normalization entirely for a templated base type, leaving a top-level `const` **leading** instead of trailing (e.g. `"const std::vector<int>"`). A templated variable's pure const flip was therefore misclassified as `VAR_TYPE_CHANGED` instead of `VAR_BECAME_CONST`, inconsistent with the equivalent scalar case. Now branches on whether a pointer/reference sigil is present: with one, the top-level qualifier is always trailing (template or not); without one, a `const` at either end is the same top-level qualifier and either is stripped.
- **`diff_cpp_patterns.py`**: `detect_tag_type_renamed`'s symbol evidence (`only_removed`/`only_added`) still read every `old.functions`/`new.functions` entry with no visibility filter — the same class of issue already fixed in the sibling case82/83/87 detectors earlier in #558. Scoped to the public surface (`PUBLIC` + `ELF_ONLY`).
- **`diff_templates.py`**: `detect_cpo_kind_changed`'s function-name reduction didn't account for Itanium demangling including a leading return type for a function **template** instantiation (needed to disambiguate return-type-only overloads) — e.g. `"int lib::sort<int>(int*, int*)"` reduces to `"int lib::sort"` after template-arg/param-signature stripping, which never matched the CPO variable side's plain `"lib::sort"`. Strips a leaked leading return type (guarded against corrupting an `operator` name, which legitimately contains a space).

## Test plan

- [x] `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` — 15370 passed, 0 failed
- [x] `mypy abicheck/` — clean
- [x] `ruff check` — clean
- [x] `python scripts/check_ai_readiness.py` — 0 errors
- [x] Full gcc example-catalog sweep (`tests/validate_examples.py`, real castxml+gcc compilation) — 139 PASS / 5 XFAIL / 37 SKIP / 1 informational `KINDS_MISMATCH` (pre-existing `case59` toolchain-sensitivity note, verdict still correct), no regressions
- [x] New regression tests added for all three fixes (templated pure-const flip vs. templated pointee-const, and a function-template-to-CPO transition using a real Itanium-mangled instantiation symbol)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VVGZXcuYYXBrffKUJ68gsQ)_