### PR TITLE
test(examples): scope macOS known_gap xfails to the observed wrong verdict

### DIFF
--- a/examples/ground_truth.json
+++ b/examples/ground_truth.json
@@ -164,6 +164,9 @@
    "known_gap_platforms": [
     "macos"
    ],
+   "known_gap_observed": [
+    "NO_CHANGE"
+   ],
    "min_evidence": "L0",
    "platforms": [
     "linux",
@@ -183,6 +186,9 @@
    "known_gap": "macOS integration-tests observes NO_CHANGE for this case as of commit 71b4f624e2b10d53ee662b555907280baad0982a (PR #555); see case100_experimental_removed_without_replacement's known_gap for the shared investigation notes. Linux (gcc and clang) remains the blocking detector lane.",
    "known_gap_platforms": [
     "macos"
+   ],
+   "known_gap_observed": [
+    "NO_CHANGE"
    ],
    "min_evidence": "L0",
    "platforms": [
@@ -421,6 +427,9 @@
    "known_gap": "macOS integration-tests observes NO_CHANGE for this case as of commit 71b4f624e2b10d53ee662b555907280baad0982a (PR #555); see case100_experimental_removed_without_replacement's known_gap for the shared investigation notes. Linux (gcc and clang) remains the blocking detector lane.",
    "known_gap_platforms": [
     "macos"
+   ],
+   "known_gap_observed": [
+    "NO_CHANGE"
    ],
    "min_evidence": "L0",
    "platforms": [
@@ -1577,6 +1586,9 @@
    "known_gap_platforms": [
     "macos"
    ],
+   "known_gap_observed": [
+    "NO_CHANGE"
+   ],
    "min_evidence": "L2",
    "platforms": [
     "linux",
@@ -2094,6 +2106,9 @@
    "known_gap_platforms": [
     "macos"
    ],
+   "known_gap_observed": [
+    "NO_CHANGE"
+   ],
    "min_evidence": "L1",
    "platforms": [
     "linux",
@@ -2581,6 +2596,9 @@
    "known_gap": "macOS integration-tests observes NO_CHANGE (instead of the expected func_added) for this case as of commit 71b4f624e2b10d53ee662b555907280baad0982a (PR #555); see case100_experimental_removed_without_replacement's known_gap for the shared investigation notes. Linux (gcc and clang) remains the blocking detector lane.",
    "known_gap_platforms": [
     "macos"
+   ],
+   "known_gap_observed": [
+    "NO_CHANGE"
    ]
   },
   "case48_leaf_struct_through_pointer": {
@@ -3002,6 +3020,9 @@
    "known_gap_platforms": [
     "macos"
    ],
+   "known_gap_observed": [
+    "NO_CHANGE"
+   ],
    "min_evidence": "L0",
    "platforms": [
     "linux",
@@ -3212,6 +3233,9 @@
    "known_gap_platforms": [
     "macos"
    ],
+   "known_gap_observed": [
+    "NO_CHANGE"
+   ],
    "min_evidence": "L0",
    "platforms": [
     "linux",
@@ -3272,6 +3296,9 @@
    "known_gap_platforms": [
     "macos"
    ],
+   "known_gap_observed": [
+    "NO_CHANGE"
+   ],
    "min_evidence": "L2",
    "platforms": [
     "linux",
@@ -3325,6 +3352,9 @@
    "known_gap": "macOS integration-tests observes COMPATIBLE (var_added/constant_added only, missing the cpo_kind_changed correlation) instead of BREAKING for this case as of commit 71b4f624e2b10d53ee662b555907280baad0982a (PR #555); see case100_experimental_removed_without_replacement's known_gap for the shared investigation notes. Linux (gcc and clang) remains the blocking detector lane.",
    "known_gap_platforms": [
     "macos"
+   ],
+   "known_gap_observed": [
+    "COMPATIBLE"
    ],
    "min_evidence": "L2",
    "platforms": [
@@ -3640,6 +3670,9 @@
    "known_gap": "macOS integration-tests observes NO_CHANGE for this case as of commit 71b4f624e2b10d53ee662b555907280baad0982a (PR #555); see case100_experimental_removed_without_replacement's known_gap for the shared investigation notes. Linux (gcc and clang) remains the blocking detector lane.",
    "known_gap_platforms": [
     "macos"
+   ],
+   "known_gap_observed": [
+    "NO_CHANGE"
    ],
    "min_evidence": "L0",
    "platforms": [

--- a/tests/test_example_autodiscovery.py
+++ b/tests/test_example_autodiscovery.py
@@ -117,6 +117,16 @@ KNOWN_GAP_PLATFORMS: dict[str, list[str]] = {
     for k, v in _gt_data["verdicts"].items()
     if v.get("known_gap_platforms")
 }
+# known_gap_observed: case_name → the specific wrong verdict(s) the gap
+# documents. When set, only THAT verdict xfails; any other mismatch (e.g. a
+# false positive in the opposite direction from what was actually observed)
+# is a real FAIL instead of being silently swept into the same known gap
+# (Codex review). Absent ⇒ any mismatch xfails (back-compat).
+KNOWN_GAP_OBSERVED: dict[str, list[str]] = {
+    k: list(v["known_gap_observed"])
+    for k, v in _gt_data["verdicts"].items()
+    if v.get("known_gap_observed")
+}
 # source_smoke: case_name → consumer compile/link proof declared in ground_truth.
 # These cases intentionally need validate_examples.py because plain dump+compare
 # cannot observe downstream source-only compile/link failures.
@@ -584,7 +594,8 @@ def _assert_verdict(
 ) -> None:
     """Assert that the verdict matches, handling known gaps as xfail."""
     if case_name in KNOWN_GAPS and _gap_applies(case_name, is_cpp):
-        if got != expected_verdict:
+        allowed_verdicts = KNOWN_GAP_OBSERVED.get(case_name)
+        if got != expected_verdict and (allowed_verdicts is None or got in allowed_verdicts):
             pytest.xfail(KNOWN_GAPS[case_name])
 
     assert got == expected_verdict, (

--- a/tests/test_validate_examples_unit.py
+++ b/tests/test_validate_examples_unit.py
@@ -173,6 +173,52 @@ class TestKnownGapToolchainScope:
         }
 
 
+class TestKnownGapVerdictScope:
+    """A known_gap must only excuse the SPECIFIC wrong verdict it documents.
+
+    Without this scope, any mismatch — including a false positive in the
+    opposite direction from what was actually observed (e.g. a case
+    documented as regressing to NO_CHANGE instead reports BREAKING) — would
+    be silently swept into the same known gap instead of failing (Codex
+    review on PR #567's macOS known_gap additions).
+    """
+
+    def test_unscoped_gap_excuses_any_mismatch(self):
+        result = _evaluate_verdict("case", "BREAKING", "COMPATIBLE", "some gap")
+        assert result.status == "XFAIL"
+
+    def test_scoped_gap_excuses_the_documented_verdict(self):
+        result = _evaluate_verdict(
+            "case", "BREAKING", "NO_CHANGE", "some gap", ["NO_CHANGE"]
+        )
+        assert result.status == "XFAIL"
+
+    def test_scoped_gap_does_not_excuse_a_different_mismatch(self):
+        result = _evaluate_verdict(
+            "case", "BREAKING", "COMPATIBLE", "some gap", ["NO_CHANGE"]
+        )
+        assert result.status == "FAIL"
+
+    def test_real_macos_cases_are_verdict_scoped(self):
+        gt = json.loads(_GROUND_TRUTH.read_text())["verdicts"]
+        verdict_scoped = {
+            "case22_method_const_changed": ["NO_CHANGE"],
+            "case47_inline_to_outlined": ["NO_CHANGE"],
+            "case71_inline_namespace_moved": ["NO_CHANGE"],
+            "case82_sycl_overload_set_removed": ["NO_CHANGE"],
+            "case85_internal_template_signature_changed": ["NO_CHANGE"],
+            "case88_cpo_kind_changed": ["COMPATIBLE"],
+            "case99_experimental_graduated": ["NO_CHANGE"],
+            "case100_experimental_removed_without_replacement": ["NO_CHANGE"],
+            "case101_inline_namespace_version_bumped": ["NO_CHANGE"],
+            "case110_concurrent_unordered_map_api_drift": ["NO_CHANGE"],
+            "case166_ref_qualifier_added": ["NO_CHANGE"],
+        }
+        for case_name, expected_verdicts in verdict_scoped.items():
+            assert gt[case_name]["known_gap_platforms"] == ["macos"]
+            assert gt[case_name]["known_gap_observed"] == expected_verdicts
+
+
 class TestBuildInfoVariantScope:
     def test_unscoped_build_info_applies_to_every_variant(self):
         entry = {"build_info": True}

--- a/tests/validate_examples.py
+++ b/tests/validate_examples.py
@@ -974,12 +974,20 @@ def _evaluate_verdict(
     expected_raw: str | None,
     got: str,
     known_gap: str | None,
+    known_gap_observed: list[str] | None = None,
 ) -> CaseResult:
-    """Compare *got* verdict against *expected_raw* and return a CaseResult."""
+    """Compare *got* verdict against *expected_raw* and return a CaseResult.
+
+    *known_gap_observed*, when set, restricts the xfail to the specific wrong
+    verdict(s) the gap documents — any other mismatch (e.g. a false positive
+    in the opposite direction from what was actually observed) is a real FAIL
+    instead of being silently swept into the same known gap (Codex review).
+    Absent ⇒ any mismatch xfails (back-compat).
+    """
     expected = expected_raw or "UNKNOWN"
     if got == expected:
         return CaseResult(name, "PASS", expected_raw, got, "")
-    if known_gap:
+    if known_gap and (not known_gap_observed or got in known_gap_observed):
         return CaseResult(name, "XFAIL", expected_raw, got, known_gap)
     return CaseResult(name, "FAIL", expected_raw, got, f"expected={expected!r} got={got!r}")
 
@@ -1222,11 +1230,9 @@ def run_case(
     # A producer-scoped known_gap only excuses a mismatch under the producer that
     # actually built the case (resolved per source language); on other producers
     # the gap is dropped so a regression FAILs rather than being xfailed.
-    known_gap = (
-        entry.get("known_gap")
-        if _gap_applies(entry, v1_src.suffix == ".cpp", variant)
-        else None
-    )
+    gap_applies = _gap_applies(entry, v1_src.suffix == ".cpp", variant)
+    known_gap = entry.get("known_gap") if gap_applies else None
+    known_gap_observed = entry.get("known_gap_observed") if gap_applies else None
 
     tmp = _case_work_dir(tmp_base, name, variant)
     tmp.mkdir(parents=True)
@@ -1310,7 +1316,7 @@ def run_case(
         build_info=build_info_present,
     )
     result = _evaluate_verdict(
-        name, expected_raw, got, known_gap,
+        name, expected_raw, got, known_gap, known_gap_observed,
     )._replace(variant=variant, source_layers=source_layers)
     if smoke_proof:
         combined = smoke_proof if not result.message else f"{smoke_proof} | {result.message}"


### PR DESCRIPTION
## Summary

Follow-up to #567 (already merged): addresses a Codex review comment on that PR by scoping the 11 macOS `known_gap` xfails to the specific wrong verdict actually observed, instead of blanket-excusing any mismatch.

## Motivation

[Codex review on #567](https://github.com/abicheck/abicheck/pull/567) flagged that the 11 macOS `known_gap` entries added there would excuse *any* verdict mismatch as the same documented gap — including a false positive in the opposite direction from what was actually observed (e.g. `case47_inline_to_outlined`/`case88_cpo_kind_changed`/`case99_experimental_graduated`, whose documented gap is a missed `COMPATIBLE`/addition finding, silently reporting a spurious `BREAKING` instead). That would mask a real future regression under the same "known gap" label.

## Changes

- Adds a `known_gap_observed` field to `ground_truth.json` (a list of the specific wrong verdict(s) the gap documents), alongside the existing `known_gap_toolchains`/`known_gap_platforms`/`known_gap_variants` scoping fields. Named `known_gap_observed` rather than `known_gap_verdicts` so it doesn't trip the ground-truth structural gate that forbids alternate case-truth-verdict aliases (`test_case_analysis_validation.py::test_every_case_has_one_depth_invariant_ground_truth`).
- Both harnesses now respect it: `tests/test_example_autodiscovery.py::_assert_verdict` and `tests/validate_examples.py::_evaluate_verdict` only xfail when the observed verdict matches the documented one; any other mismatch is a real `FAIL`. Absent stays back-compatible with every pre-existing `known_gap` entry (any mismatch still xfails, as before).
- Scopes all 11 cases from #567 to their actually-observed verdict (`NO_CHANGE` for all except `case88_cpo_kind_changed`, which observed `COMPATIBLE`).
- Adds `TestKnownGapVerdictScope` in `tests/test_validate_examples_unit.py` covering the new scoping behavior, including that an undocumented mismatch still hard-fails.

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] `CHANGELOG.md` updated (under `[Unreleased]`) — internal test-harness precision fix, no user-visible behavior change
- [ ] Docs updated if user-visible behaviour changed — n/a
- [x] `pre-commit run --all-files` passes locally (ruff check/format, ai-readiness gate, mypy via `python -m mypy abicheck/`)
- [x] No new `mypy` or `ruff` errors introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_01HB7MZza7vbXSSoinhoeZYL)_