### PR TITLE
fix: detect DWARF-shaped leaf-only alternatives in vtable ancestry check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,6 +283,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   share this leaf — so a `Base::foo()` → `ns::Base::foo()` (or `ns::Derived`
   via a leaf-only `Base` base entry) slot replacement is no longer
   misclassified as an override reuse.
+- **case185 follow-up #2: DWARF-shaped leaf-alternative detection.**
+  `_leaf_has_qualified_alternative()` (above) only inspected
+  `RecordType.qualified_name`, but `dwarf_snapshot.py` stores an
+  already-qualified spelling directly as `RecordType.name` and leaves
+  `qualified_name` unset, while its inheritance edges still keep only the
+  base DIE's leaf name — the same ambiguity, produced by the other backend.
+  The helper now checks both `name` and `qualified_name` on each candidate
+  record so a competing namespaced type is found regardless of which
+  backend produced it.
 - **Vendored-library SONAME normalization, remaining half (G9).**
   `strip_vendor_hash()` now also normalizes the embedded ELF SONAME (not just
   the on-disk filename) in `bundle.py`'s cohort-scoped `BUNDLE_SONAME_SKEW`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -292,6 +292,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   The helper now checks both `name` and `qualified_name` on each candidate
   record so a competing namespaced type is found regardless of which
   backend produced it.
+- **case185 follow-up #3: owner's own identity false-flagged as a
+  competing alternative.** The DWARF-shaped fix above widened
+  `_leaf_has_qualified_alternative()` to scan `RecordType.name` too, but for
+  a class that inherits from a global type sharing its own leaf (e.g.
+  `namespace ns { struct Base : ::Base { ... }; }` — DWARF-shaped: the
+  owner's own `name` is `ns::Base`, its base list still bare `Base`), the
+  scan found the *owner's own record* as a "competing alternative" to
+  itself, wrongly rejecting a genuine override-slot reuse as
+  `TYPE_VTABLE_CHANGED`. The exclude set now also covers the owner's own
+  identity, not just the literal bare-ancestor spelling.
 - **Vendored-library SONAME normalization, remaining half (G9).**
   `strip_vendor_hash()` now also normalizes the embedded ELF SONAME (not just
   the on-disk filename) in `bundle.py`'s cohort-scoped `BUNDLE_SONAME_SKEW`

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -375,7 +375,7 @@ def _owner_descends_from(owner: str, ancestor: str, types: dict[str, RecordType]
         # way still corroborates and rejects the ambiguous leaf match.
         return not any(t.qualified_name == qualified for t in types.values())
 
-    def _leaf_has_qualified_alternative(leaf: str, exclude: str) -> bool:
+    def _leaf_has_qualified_alternative(leaf: str, *excludes: str) -> bool:
         """True if some *other* record's qualified spelling shares this leaf.
 
         Used when matching a bare ``ancestor`` against a leaf-only ``bases``
@@ -393,12 +393,21 @@ def _owner_descends_from(owner: str, ancestor: str, types: dict[str, RecordType]
         already-qualified spelling directly as ``name``, leaving
         ``qualified_name`` unset) -- checking only one field misses whichever
         backend produced the competing record.
+
+        ``excludes`` must cover both the literal ``ancestor`` spelling AND
+        the owning record's own identity (``owner``): a class that inherits
+        from a global type sharing its own leaf (e.g. ``ns::Base : ::Base``)
+        has a ``name``/``qualified_name`` that itself matches this leaf --
+        that's the record whose base list is being interpreted, not a
+        competing alternative, and excluding only the bare ancestor would
+        wrongly treat the owner's own qualified identity as proof of
+        ambiguity, hiding a genuine override-slot reuse.
         """
         for t in types.values():
             for candidate in (t.name, t.qualified_name):
                 if (
                     candidate
-                    and candidate != exclude
+                    and candidate not in excludes
                     and candidate.rsplit("::", 1)[-1] == leaf
                 ):
                     return True
@@ -430,7 +439,7 @@ def _owner_descends_from(owner: str, ancestor: str, types: dict[str, RecordType]
     if leaf_ancestor not in bases:
         return False
     if ancestor_is_leaf:
-        return not _leaf_has_qualified_alternative(leaf_ancestor, ancestor)
+        return not _leaf_has_qualified_alternative(leaf_ancestor, ancestor, owner)
     return _leaf_match_trustworthy(ancestor)
 
 

--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -376,7 +376,7 @@ def _owner_descends_from(owner: str, ancestor: str, types: dict[str, RecordType]
         return not any(t.qualified_name == qualified for t in types.values())
 
     def _leaf_has_qualified_alternative(leaf: str, exclude: str) -> bool:
-        """True if some *other* record's qualified_name shares this leaf.
+        """True if some *other* record's qualified spelling shares this leaf.
 
         Used when matching a bare ``ancestor`` against a leaf-only ``bases``
         entry: ``_leaf_match_trustworthy`` above can only ask "does this
@@ -386,13 +386,23 @@ def _owner_descends_from(owner: str, ancestor: str, types: dict[str, RecordType]
         record (e.g. ``ns::Base``) exist for this same leaf, proving the
         base list's bare, unqualified entry could plausibly mean that one
         instead of the literal bare ``exclude`` spelling.
+
+        Checks both ``RecordType.qualified_name`` (CastXML: ``name`` stays
+        bare, the namespaced spelling lives in this separate field) and
+        ``RecordType.name`` itself (DWARF: ``dwarf_snapshot.py`` stores the
+        already-qualified spelling directly as ``name``, leaving
+        ``qualified_name`` unset) -- checking only one field misses whichever
+        backend produced the competing record.
         """
-        return any(
-            t.qualified_name
-            and t.qualified_name != exclude
-            and t.qualified_name.rsplit("::", 1)[-1] == leaf
-            for t in types.values()
-        )
+        for t in types.values():
+            for candidate in (t.name, t.qualified_name):
+                if (
+                    candidate
+                    and candidate != exclude
+                    and candidate.rsplit("::", 1)[-1] == leaf
+                ):
+                    return True
+        return False
 
     if leaf_owner == leaf_ancestor and (owner_is_leaf or ancestor_is_leaf):
         # Reaching here with BOTH sides bare would mean owner == ancestor

--- a/tests/test_vtable_severity.py
+++ b/tests/test_vtable_severity.py
@@ -348,3 +348,19 @@ class TestOwnerDescendsFrom:
             "Base": RecordType(name="Base", qualified_name="ns::Base", kind="class"),
         }
         assert not _owner_descends_from("ns::Derived", "Base", types)
+
+    def test_bare_ancestor_not_trusted_against_leaf_only_base_dwarf_shaped(
+        self,
+    ) -> None:
+        """Same ambiguity as the CastXML-shaped test above, but shaped the
+        way DWARF snapshots store it: ``dwarf_snapshot.py`` records
+        ``RecordType.name`` as the already-qualified spelling itself
+        (``qualified_name`` stays unset), while inheritance edges still keep
+        only the base DIE's leaf name. The competing ``ns::Base`` record must
+        still be found via ``name``, not just ``qualified_name`` -- checking
+        only one field would miss whichever backend produced it."""
+        types = {
+            "ns::Derived": RecordType(name="ns::Derived", kind="class", bases=["Base"]),
+            "ns::Base": RecordType(name="ns::Base", kind="class"),
+        }
+        assert not _owner_descends_from("ns::Derived", "Base", types)

--- a/tests/test_vtable_severity.py
+++ b/tests/test_vtable_severity.py
@@ -364,3 +364,18 @@ class TestOwnerDescendsFrom:
             "ns::Base": RecordType(name="ns::Base", kind="class"),
         }
         assert not _owner_descends_from("ns::Derived", "Base", types)
+
+    def test_owner_sharing_ancestor_leaf_is_not_treated_as_own_alternative(
+        self,
+    ) -> None:
+        """A class that inherits from a global type sharing its own leaf
+        (``namespace ns { struct Base : ::Base { ... }; }``, DWARF-shaped:
+        the owner's own ``name`` is ``ns::Base``, its base list still bare
+        ``Base``) is a valid, unambiguous inheritance -- the owner record's
+        own qualified identity must not be mistaken for a *competing*
+        alternative to itself, or a genuine override-slot reuse gets
+        reported as a spurious ``TYPE_VTABLE_CHANGED``."""
+        types = {
+            "ns::Base": RecordType(name="ns::Base", kind="class", bases=["Base"]),
+        }
+        assert _owner_descends_from("ns::Base", "Base", types)


### PR DESCRIPTION
## Summary

Follow-up to #575: `_leaf_has_qualified_alternative()` only checked `RecordType.qualified_name`, missing the equivalent DWARF-shaped ambiguity. Found by Codex review after #575 had already merged.

## Motivation

`_leaf_has_qualified_alternative()` (added in #575) detects whether some *other*, differently-qualified record shares a leaf name — evidence that a leaf-only `bases` entry could plausibly mean that other, namespaced class instead of a literal bare ancestor. It only inspected `RecordType.qualified_name`, which is a CastXML-only convention (CastXML keeps `name` bare and puts the namespaced spelling in the separate `qualified_name` field).

`dwarf_snapshot.py` does the opposite: it stores the already-qualified spelling directly as `RecordType.name` and leaves `qualified_name` unset, while inheritance edges still keep only the base DIE's leaf name (same leaf-only ambiguity, different backend). A competing `ns::Base` record in a DWARF-derived snapshot was therefore invisible to the check, so `_owner_descends_from("ns::Derived", "Base", …)` could still wrongly return `True` and suppress a real `TYPE_VTABLE_CHANGED` for a `Base::foo()` → `ns::Derived::foo()` slot replacement in DWARF/symbol-derived snapshots.

## Changes

- `_leaf_has_qualified_alternative()` now checks both `RecordType.name` and `RecordType.qualified_name` on each candidate record.
- Add `test_bare_ancestor_not_trusted_against_leaf_only_base_dwarf_shaped` in `tests/test_vtable_severity.py::TestOwnerDescendsFrom`, reproducing the DWARF-shaped scenario.
- `CHANGELOG.md` entry under `[Unreleased] → Fixed`.

## Test plan

- [x] `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` — 15691 passed
- [x] `mypy abicheck/` — clean
- [x] `ruff check abicheck/ tests/` — clean
- [x] New test confirmed to fail against the pre-fix code, pass against the fix
- [x] `scripts/benchmark_comparison.py --cases case185 --tools abicheck --skip-abicc` — still COMPATIBLE (no regression)

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [ ] Docs updated if user-visible behaviour changed (internal detector-agreement fix, no user-visible behavior change beyond correctness)
- [x] No new `mypy` or `ruff` errors introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_018kKQS7XEHivaHXSXHV7oCH)_