### PR TITLE
chore: prepare 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
+No changes yet.
+
+---
+
+## [0.5.0] — 2026-07-16
+
 ### Removed
 
 - **Pre-1.0 CLI reset (ADR-043): the root command tree is now exactly 5
@@ -2693,4 +2699,5 @@ additional capabilities.
 [0.2.0]: https://github.com/abicheck/abicheck/releases/tag/v0.2.0
 [0.3.0]: https://github.com/abicheck/abicheck/releases/tag/v0.3.0
 [0.4.0]: https://github.com/abicheck/abicheck/releases/tag/v0.4.0
-[Unreleased]: https://github.com/abicheck/abicheck/compare/v0.4.0...HEAD
+[0.5.0]: https://github.com/abicheck/abicheck/releases/tag/v0.5.0
+[Unreleased]: https://github.com/abicheck/abicheck/compare/v0.5.0...HEAD

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "abicheck"
-version = "0.4.0"
+version = "0.5.0"
 description = "ABI compatibility checker for C/C++ shared libraries"
 readme = "README.md"
 license = {text = "Apache-2.0"}

--- a/tests/test_call_graph.py
+++ b/tests/test_call_graph.py
@@ -831,6 +831,9 @@ def test_extract_from_build_parallelizes_and_dedupes(monkeypatch) -> None:
     import abicheck.buildsource.call_graph as cg
 
     monkeypatch.setenv("ABICHECK_CALL_GRAPH_JOBS", "2")
+    # This test exercises parallel extraction, not the independently tested
+    # host-memory clamp. Pin the cap so low-RAM CI/dev hosts remain deterministic.
+    monkeypatch.setattr(cg, "_call_graph_mem_cap", lambda: 2)
     monkeypatch.setattr(cg.shutil, "which", lambda _b: "/usr/bin/clang++")
     seen_sources: list[str] = []
 


### PR DESCRIPTION
## Summary

- make the call-graph parallelism test deterministic on memory-constrained hosts by pinning the independently-tested memory cap
- bump the package version from 0.4.0 to 0.5.0
- finalize the accumulated Unreleased changelog as 0.5.0 (2026-07-16)
- reset Unreleased and update changelog release/compare links

## Verification

- `uv run pytest -q tests/test_call_graph.py::test_extract_from_build_parallelizes_and_dedupes --tb=short` — 1 passed
- `uv run ruff check abicheck tests` — passed
- `uv run mypy abicheck` — no issues in 230 source files
- unit/non-tool suite — 15,800 passed, 19 skipped, 4 xfailed
- `uv build` — produced 0.5.0 wheel and sdist
- `twine check dist/*` — passed
- installed package reports `abicheck.__version__ == "0.5.0"`

## Release gate

Merge only after the final main SHA (including #576 if accepted) is green across required CI and this branch is updated onto it.
