### PR TITLE
fix(cli): close depth-inference and used-by dedup gaps from post-#570 review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- `compare --used-by`/`--required-symbol(s)`'s default markdown/text/review
+  report now names the actual missing symbol/version/entrypoint and any
+  scoped-only change (e.g. `PE_ORDINAL_RETARGETED`) that failed the gate,
+  instead of only printing a bare count — matching the detail already present
+  in JSON/SARIF/JUnit output (Codex review).
 - `compare` no longer silently discards explicit `--sources`/`--build-info`
   when `--depth` is omitted: the collect mode is now inferred from those
   inputs (`--depth` > `.abicheck.yml` `source.method` > inferred from

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,21 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **MCP `abi_compare`**: a `--used-by`/`--required-symbol` response's
+  `summary` (`total_changes`/`breaking`/`api_breaks`/`risk_changes`/
+  `compatible`) is now recomputed after scoped-only changes and
+  missing-contract labels are folded into `changes`, instead of only
+  reflecting `result.changes` from before the fold-in — a run gated purely
+  by one of these (e.g. a missing required symbol) used to report
+  `total_changes: 0` alongside a `BREAKING` verdict and nonzero `exit_code`
+  (CodeRabbit review).
+- **GitHub Action**: a scan-mode `audit: true` run no longer fetches
+  `abi-baseline` at all — it was always discarded (`--against` is omitted
+  for audit-only runs), so an unavailable release could needlessly fail a
+  run that never used the baseline (Codex + CodeRabbit review). Also:
+  a release with more than one `*.abicheck.json` asset is now rejected as
+  ambiguous instead of silently picking an arbitrary one via `find | head
+  -1`, which could compare against the wrong library (CodeRabbit review).
 - `--depth source`/`--sources` findings from the L5 source graph
   (`SOURCE_TO_BINARY_MAPPING_CHANGED`, `EXPORTED_SYMBOL_SOURCE_OWNER_CHANGED`)
   now localize `source_location` to the declaration's actual declaring file
@@ -200,14 +215,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   New `gateScope`/`gateVerdict`/`gateExitCode` fields are added
   alongside the existing `scopedVerdict`/`abicheck.scoped_verdict`
   names, kept as aliases.
-- **GitHub Action**: the scan-only `audit`/`estimate` inputs are replaced
-  by a single cross-mode `dry-run` input, matching the CLI's own
-  pre-1.0 no-alias policy (ADR-043). `dry-run: 'true'` now maps to
-  `--dry-run` for every mode (`dump`, `compare`, `scan`, `deps-tree`,
-  `deps-compare`) and skips writing `-o`/`--secondary-output` for that
-  step. Forcing scan's single-build hygiene lint (the old `audit: 'true'`)
-  is now done by simply omitting `against`/`abi-baseline` on that step —
-  `scan` already runs audit-only whenever no baseline is given.
+- **GitHub Action**: added a single cross-mode `dry-run` input, the
+  preferred replacement for the scan-only `audit`/`estimate` inputs.
+  `dry-run: 'true'` now maps to `--dry-run` for every mode (`dump`,
+  `compare`, `scan`, `deps-tree`, `deps-compare`) and skips writing
+  `-o`/`--secondary-output` for that step. Forcing scan's single-build
+  hygiene lint (the old `audit: 'true'`) can also be done by simply
+  omitting `against`/`abi-baseline` on that step — `scan` already runs
+  audit-only whenever no baseline is given. `audit`/`estimate` themselves
+  remain functional (scan-only) deprecated aliases — see below.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   bundled-dependency packaging noise that must stay non-breaking once
   scoped, and mass export removal at oneDAL's reported scale).
 
+### Added
+
+- `compare --help-all`: a second-level `--help` disclosure tier (G21.8
+  collapse M2). Plain `compare --help` now shows only a curated common
+  subset of the ~62 options (inputs, output/format, `--show-only`, policy,
+  the `--used-by`/`--required-symbol` scoped gate, `--depth`/`--sources`/
+  `--build-info`, `--scope-public-headers`, `--verbose`, `--dry-run`, …),
+  with a footer noting how many advanced options are hidden and pointing to
+  `--help-all` for the full surface. Every option keeps working unqualified
+  either way — this only changes default help-screen visibility, not
+  behavior.
+
 ### Changed
 
 - `--depth`/`--sources`/`--build-info`/`--header-graph`/`--dry-run` `--help`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,26 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   bundled-dependency packaging noise that must stay non-breaking once
   scoped, and mass export removal at oneDAL's reported scale).
 
+### Fixed
+
+- `compare` no longer silently discards explicit `--sources`/`--build-info`
+  when `--depth` is omitted: the collect mode is now inferred from those
+  inputs (`--depth` > `.abicheck.yml` `source.method` > inferred from
+  `--sources`/`--build-info` > off), matching `scan`'s input-driven "auto"
+  depth. `compare --dry-run` now reports this effective/inferred depth
+  instead of only echoing back the raw `--depth` string.
+- `compare --used-by`'s severity-summary dedup across multiple apps now
+  keys findings by semantic identity instead of Python `id()`, fixing
+  double-counting of `PE_ORDINAL_RETARGETED` findings (each app's
+  `scope_diff_to_app` call constructs its own `Change` object for the same
+  underlying ordinal retarget).
+- `compare --dry-run` now rejects `--secondary-output`/`--secondary-format`
+  (previously accepted and silently never written, since a dry run exits
+  before the secondary render runs).
+- Fixed two stale CLI warnings referencing removed `--depth full`/`--max`
+  values, and a GitHub Action baseline-fetch error message pointing at a
+  nonexistent `--output-name` flag.
+
 ---
 
 ## [0.5.0] — 2026-07-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,21 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   values, and a GitHub Action baseline-fetch error message pointing at a
   nonexistent `--output-name` flag.
 
+### Changed
+
+- `compare --format sarif/junit` now follow the scoped `--used-by`/
+  `--required-symbol` gate instead of always reflecting the full,
+  unscoped library diff: the scoped exit code drives the SARIF
+  document's own `exitCode` and JUnit's `failures` count, findings
+  outside the gate's relevance are downgraded (SARIF level `"note"`,
+  JUnit non-failing) and marked so a consumer can tell "not severe"
+  from "out of scope", and a missing required symbol/version/entrypoint
+  (which has no backing diff `Change`) now gets its own synthetic
+  result/testcase so the gate's exit code is never left unexplained.
+  New `gateScope`/`gateVerdict`/`gateExitCode` fields are added
+  alongside the existing `scopedVerdict`/`abicheck.scoped_verdict`
+  names, kept as aliases.
+
 ---
 
 ## [0.5.0] — 2026-07-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   Missing-contract results also now separate `relevantToGate` (always
   true — scope membership) from `blocksGate` (severity-dependent), instead
   of conflating the two.
+- The same "scoped-only change"/uncovered-missing-label gap applied to
+  `compare --format json`'s `changes` array and the MCP `abi_compare`
+  tool's `changes` field, not just SARIF/JUnit: a `--used-by`/
+  `--required-symbol` run whose only gated issue was one of these reported
+  an empty `changes` array despite a nonzero scoped exit code/verdict. This
+  mattered in practice for the GitHub Action's `--on changes` PR-comment
+  gate, which buckets purely off that array and would silently skip
+  posting for exactly the runs that most needed one.
 - `dump -o`'s evidence-depth line and `compare`'s `old_evidence_depth`/
   `new_evidence_depth` no longer overstate `source`/`build` when a layer
   ran but linked no real facts (e.g. an inline source-ABI pass that finds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- **GitHub Action**: `dry-run: true` no longer hard-fails (`exit 1`) when
+  combined with `abi-baseline` and the release/token/`*.abicheck.json` asset
+  is unavailable — the baseline auto-fetch ran before the mode branch ever
+  consulted `INPUT_DRY_RUN`, contradicting `dry-run`'s documented "always
+  exits 0" preview contract (Codex review). A fetch failure now reports a
+  warning and continues under `--dry-run`; if no other `old-library`/
+  `against` was independently given (nothing left to preview), the step
+  exits 0 with a notice instead of falling through to a hard failure.
+  Non-`--dry-run` behavior is unchanged.
 - `compare --used-by`/`--required-symbol(s)`'s default markdown/text/review
   report now names the actual missing symbol/version/entrypoint and any
   scoped-only change (e.g. `PE_ORDINAL_RETARGETED`) that failed the gate,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,19 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 - Fixed two stale CLI warnings referencing removed `--depth full`/`--max`
   values, and a GitHub Action baseline-fetch error message pointing at a
   nonexistent `--output-name` flag.
+- `--used-by`/`--required-symbol`'s missing-contract SARIF/JUnit synthesis
+  no longer double-reports a missing symbol/entrypoint that is already
+  covered by a relevant `Change` (e.g. a removed symbol is both "missing"
+  and a `FUNC_REMOVED` finding), and now respects severity-config
+  demotion of `abi_breaking` instead of always emitting `level: "error"`/
+  a failing testcase.
+
+### Added
+
+- `dump -o` now prints the evidence depth a snapshot actually reached
+  (`binary`/`headers`/`build`/`source`, computed from what it carries
+  rather than the requested `--depth`); `compare`'s JSON report gains
+  matching `old_evidence_depth`/`new_evidence_depth` fields.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   bundled-dependency packaging noise that must stay non-breaking once
   scoped, and mass export removal at oneDAL's reported scale).
 
+### Changed
+
+- `--depth`/`--sources`/`--build-info`/`--header-graph`/`--dry-run` `--help`
+  text on `dump`/`compare`/`scan`, and their rich-click option-panel titles,
+  no longer reference the internal ADR-033 evidence-layer vocabulary
+  (`L0`-`L5`) with no explanation of what it means — reworded to plain terms
+  tied to the public `--depth` ladder (`binary`/`headers`/`build`/`source`).
+  Text only; no option, default, or behavior changes.
+
 ### Fixed
 
 - `compare` no longer silently discards explicit `--sources`/`--build-info`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   no reachable declarations because clang was unavailable) — depth is now
   computed from the same payload-emptiness check the CLI's own coverage
   warnings use, not mere non-`None` presence.
+- `compare`'s `old_evidence_depth`/`new_evidence_depth` JSON fields now
+  account for an out-of-band `--old/new-sources`/`--old/new-build-info`
+  *pack directory*, not just each side's embedded snapshot payload — a pack
+  directory (unlike a raw checkout, which gets embedded before this point)
+  is resolved separately and was previously invisible to this calculation,
+  so a compare run using only such a pack reported `binary`/`headers`
+  even though its build/source findings came from real evidence.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   re-surface a scoped-only finding the filter excluded. Fixed the same way
   (the `--secondary-format` render and the MCP top-level `changes` summary
   are unaffected — both are deliberately always-unfiltered by design).
+- `--show-only` in both `compare --format sarif` and `compare --format json`
+  now also applies to synthesized missing-contract results (a required
+  symbol/version simply absent from the new library) — these have no
+  backing `Change`/`ChangeKind` so they can't run through the same filter as
+  ordinary findings, but a `--show-only` run excluding breaking findings
+  previously still uploaded/serialized the (by-default-blocking) synthetic
+  result regardless.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,21 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   and a `FUNC_REMOVED` finding), and now respects severity-config
   demotion of `abi_breaking` instead of always emitting `level: "error"`/
   a failing testcase.
+- `--used-by`/`--required-symbol` scoping can find a `Change` relevant
+  (e.g. `PE_ORDINAL_RETARGETED`, synthesized fresh per app/host and never
+  added to the base library diff) that previously drove the gate's exit
+  code with no corresponding SARIF result or JUnit testcase to explain it.
+  These "scoped-only" changes are now rendered like any other finding, and
+  count toward `relevantFindingCount`/`abicheck.relevant_finding_count`.
+  Missing-contract results also now separate `relevantToGate` (always
+  true — scope membership) from `blocksGate` (severity-dependent), instead
+  of conflating the two.
+- `dump -o`'s evidence-depth line and `compare`'s `old_evidence_depth`/
+  `new_evidence_depth` no longer overstate `source`/`build` when a layer
+  ran but linked no real facts (e.g. an inline source-ABI pass that finds
+  no reachable declarations because clang was unavailable) — depth is now
+  computed from the same payload-emptiness check the CLI's own coverage
+  warnings use, not mere non-`None` presence.
 
 ### Added
 
@@ -88,6 +103,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   New `gateScope`/`gateVerdict`/`gateExitCode` fields are added
   alongside the existing `scopedVerdict`/`abicheck.scoped_verdict`
   names, kept as aliases.
+- **GitHub Action**: the scan-only `audit`/`estimate` inputs are replaced
+  by a single cross-mode `dry-run` input, matching the CLI's own
+  pre-1.0 no-alias policy (ADR-043). `dry-run: 'true'` now maps to
+  `--dry-run` for every mode (`dump`, `compare`, `scan`, `deps-tree`,
+  `deps-compare`) and skips writing `-o`/`--secondary-output` for that
+  step. Forcing scan's single-build hygiene lint (the old `audit: 'true'`)
+  is now done by simply omitting `against`/`abi-baseline` on that step —
+  `scan` already runs audit-only whenever no baseline is given.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Changed
 
+- **Breaking:** `compare --profile release` renamed to `--profile
+  release-cut` (CLI audit finding). `compare`'s directory/package fan-out
+  mode is *also* informally branded "release" throughout
+  (`compare_release_cmd`, the "Release (directory/package inputs)" help
+  panel) — an unrelated concept that only shared the word. `--profile` was
+  already rejected outright on directory/package operands with a clear
+  usage error, so this was never a live bug, just a naming collision worth
+  disambiguating. Update any script/CI config using `--profile release`.
 - `--depth`/`--sources`/`--build-info`/`--header-graph`/`--dry-run` `--help`
   text on `dump`/`compare`/`scan`, and their rich-click option-panel titles,
   no longer reference the internal ADR-033 evidence-layer vocabulary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   only a warning, so `estimate: true` would otherwise silently run a real
   scan instead of the preview it used to produce, and `audit: true` would
   silently stop forcing a baseline-less hygiene lint once a baseline is
-  configured — both fail open rather than loud.
+  configured — both fail open rather than loud. The `estimate` alias is
+  scoped to scan mode only (matching its historical scope) — it has no
+  effect set on a `compare`/`dump`/`deps-tree`/`deps-compare` step, rather
+  than silently turning that step into a `--dry-run` no-op (Codex review
+  follow-up).
 
 ### Fixed
 
@@ -120,6 +124,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   `--used-by --show-only ...` run no longer uploads a scoped-only finding
   the filter was supposed to exclude (JUnit already applied `--show-only`
   to these consistently; only SARIF had the gap).
+- `compare --format json`'s scoped-only changes had the identical
+  `--show-only` gap as SARIF — the JSON `changes` array's own filtering only
+  ever touched `result.changes`, so a `--used-by --show-only ...` run could
+  re-surface a scoped-only finding the filter excluded. Fixed the same way
+  (the `--secondary-format` render and the MCP top-level `changes` summary
+  are unaffected — both are deliberately always-unfiltered by design).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ### Fixed
 
+- `--depth source`/`--sources` findings from the L5 source graph
+  (`SOURCE_TO_BINARY_MAPPING_CHANGED`, `EXPORTED_SYMBOL_SOURCE_OWNER_CHANGED`)
+  now localize `source_location` to the declaration's actual declaring file
+  when the graph resolves one, instead of always carrying the generic
+  `[L5_SOURCE_GRAPH]` evidence-tier tag (CLI audit finding). The graph's
+  `SOURCE_DECLARES` edges already had the real file; these two families
+  simply weren't using it.
 - **GitHub Action**: `dry-run: true` no longer hard-fails (`exit 1`) when
   combined with `abi-baseline` and the release/token/`*.abicheck.json` asset
   is unavailable — the baseline auto-fetch ran before the mode branch ever

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,12 +130,12 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   re-surface a scoped-only finding the filter excluded. Fixed the same way
   (the `--secondary-format` render and the MCP top-level `changes` summary
   are unaffected — both are deliberately always-unfiltered by design).
-- `--show-only` in both `compare --format sarif` and `compare --format json`
-  now also applies to synthesized missing-contract results (a required
-  symbol/version simply absent from the new library) — these have no
-  backing `Change`/`ChangeKind` so they can't run through the same filter as
-  ordinary findings, but a `--show-only` run excluding breaking findings
-  previously still uploaded/serialized the (by-default-blocking) synthetic
+- `--show-only` in `compare --format sarif`/`json`/`junit` now also applies
+  to synthesized missing-contract results (a required symbol/version simply
+  absent from the new library) — these have no backing `Change`/`ChangeKind`
+  so they can't run through the same filter as ordinary findings, but a
+  `--show-only` run excluding breaking findings previously still uploaded,
+  serialized, or failed the testsuite on the (by-default-blocking) synthetic
   result regardless.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   (`L0`-`L5`) with no explanation of what it means — reworded to plain terms
   tied to the public `--depth` ladder (`binary`/`headers`/`build`/`source`).
   Text only; no option, default, or behavior changes.
+- **GitHub Action**: reinstated the `estimate`/`audit` inputs, dropped
+  outright in an earlier `[Unreleased]` change, as deprecated *functional*
+  aliases for `dry-run`/omitting `against` (mirroring the existing
+  `allow-build-query` no-op precedent), instead of removing them (Codex
+  review). Silently dropping an Action input a workflow still sets is worse
+  than a hard CLI error: GitHub Actions accepts an undeclared input with
+  only a warning, so `estimate: true` would otherwise silently run a real
+  scan instead of the preview it used to produce, and `audit: true` would
+  silently stop forcing a baseline-less hygiene lint once a baseline is
+  configured — both fail open rather than loud.
 
 ### Fixed
 
@@ -105,6 +115,11 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   is resolved separately and was previously invisible to this calculation,
   so a compare run using only such a pack reported `binary`/`headers`
   even though its build/source findings came from real evidence.
+- `compare --format sarif`'s scoped-only changes (e.g. `PE_ORDINAL_RETARGETED`)
+  now respect `--show-only`, matching `result.changes`'s own filtering — a
+  `--used-by --show-only ...` run no longer uploads a scoped-only finding
+  the filter was supposed to exclude (JUnit already applied `--show-only`
+  to these consistently; only SARIF had the gap).
 
 ### Added
 

--- a/abicheck/buildsource/source_graph_findings.py
+++ b/abicheck/buildsource/source_graph_findings.py
@@ -755,6 +755,12 @@ def _mapping_drift_findings(
     old_map, new_map = _decl_to_symbol(old), _decl_to_symbol(new)
     old_decls = {n.id for n in old.nodes if n.kind == "source_decl"}
     new_decls = {n.id for n in new.nodes if n.kind == "source_decl"}
+    # The declaring file for each decl (CLI audit finding: reports for this
+    # family used to carry only the generic "[L5_SOURCE_GRAPH]" evidence-tier
+    # tag as `source_location`, never an actual file -- decl_declaring_files
+    # already resolves the real declaring file via SOURCE_DECLARES edges, so
+    # there was no need to leave it as a bare provenance tag.
+    new_decl_files = decl_declaring_files(new)
     for decl in sorted(old_decls & new_decls):
         old_sym, new_sym = old_map.get(decl, ""), new_map.get(decl, "")
         if old_sym != new_sym:
@@ -771,7 +777,7 @@ def _mapping_drift_findings(
                     ),
                     old_value=old_labels.get(old_sym, old_sym),
                     new_value=new_labels.get(new_sym, new_sym),
-                    source_location=boundary,
+                    source_location=new_decl_files.get(decl, boundary),
                 )
             )
     return findings
@@ -1358,9 +1364,14 @@ def _symbol_owner_findings(
     new: SourceGraphSummary,
     old_labels: dict[str, str],
     new_labels: dict[str, str],
-    boundary: str,
+    boundary: str,  # unused here; kept for signature parity with sibling _*_findings helpers
 ) -> list[Change]:
-    """An exported symbol whose *declaring* file moved between versions."""
+    """An exported symbol whose *declaring* file moved between versions.
+
+    Unlike its siblings this family always has a concrete new declaring file
+    on hand, so it uses that as ``source_location`` instead of the generic
+    ``boundary`` evidence-tier tag every other family falls back to.
+    """
     from ..checker_policy import ChangeKind
     from ..checker_types import Change
 
@@ -1384,6 +1395,12 @@ def _symbol_owner_findings(
         new_key = _root_relative_key(new_owner[symbol], new_prefix_len)
         if old_key != new_key:
             label = new_labels.get(symbol, symbol)
+            # The symbol's new declaring file, already resolved as new_value
+            # below -- reuse it as source_location instead of the generic
+            # evidence-tier tag (CLI audit finding: this family reports a
+            # concrete file that moved, so the location shouldn't be a bare
+            # "[L5_SOURCE_GRAPH]" placeholder when the real one is on hand).
+            new_owner_label = new_labels.get(new_owner[symbol], new_owner[symbol])
             findings.append(
                 Change(
                     kind=ChangeKind.EXPORTED_SYMBOL_SOURCE_OWNER_CHANGED,
@@ -1391,14 +1408,14 @@ def _symbol_owner_findings(
                     description=(
                         f"Exported symbol {label!r} is now declared by a different "
                         f"file ({old_labels.get(old_owner[symbol], old_owner[symbol])} "
-                        f"→ {new_labels.get(new_owner[symbol], new_owner[symbol])}). The "
+                        f"→ {new_owner_label}). The "
                         "name and signature are unchanged, so the artifact diff is "
                         "quiet, but the file owning the declaration moved — review for "
                         "include-path, inlining, or ODR effects. Source-graph evidence."
                     ),
                     old_value=old_labels.get(old_owner[symbol], old_owner[symbol]),
-                    new_value=new_labels.get(new_owner[symbol], new_owner[symbol]),
-                    source_location=boundary,
+                    new_value=new_owner_label,
+                    source_location=new_owner_label,
                 )
             )
     return findings

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -491,9 +491,9 @@ def main() -> None:
                    "artifact checks without requiring castxml.")
 @click.option("--dry-run", "dry_run", is_flag=True, default=False,
               help="Resolve and validate the invocation -- classify inputs, discover "
-                   "config, show which data layers (L0-L5) are available -- and print "
-                   "a report without producing a snapshot. Writes nothing; incompatible "
-                   "with -o/--output.")
+                   "config, show which evidence depths (binary/headers/build/source) "
+                   "are available -- and print a report without producing a snapshot. "
+                   "Writes nothing; incompatible with -o/--output.")
 @click.option("--debug-format", "debug_format_opt",
               type=click.Choice(["auto", "dwarf", "btf", "ctf"], case_sensitive=False), default=None,
               help="Force the ELF debug format (auto=pick best available). "
@@ -1335,12 +1335,12 @@ def _embed_inline_source_side(
 @click.option("--ld-library-path", "ld_library_path", default="",
               help="Simulated LD_LIBRARY_PATH (with --follow-deps).")
 @click.option("--header-graph", is_flag=True, default=False,
-              help="Build and embed the L2 header-only semantic graph (ADR-041 addendum) "
+              help="Build and embed a header-only semantic graph (ADR-041 addendum) "
                    "for both sides from the parsed header AST alone (no build system "
                    "needed); the existing build-source-pack graph diff picks it up "
                    "automatically, so declaration reachability / internal-dependency "
                    "risk findings become available on an ordinary binary+headers compare, "
-                   "not just L3-L5 build-integrated runs. Degrades to declaration-visibility "
+                   "not just --depth build/source runs. Degrades to declaration-visibility "
                    "nodes only (no type/call edges) when clang is unavailable.")
 @click.option("--header-graph-includes", is_flag=True, default=False,
               help="With --header-graph, additionally run a per-header 'clang -M' pass to "
@@ -1351,7 +1351,7 @@ def _embed_inline_source_side(
               hidden=True,
               help="Disable redundancy filtering and show all changes including those "
                    "derived from root type changes. Demoted to config "
-                   "(scope.show_redundant, ADR-040 L2); --show-redundant/--no-show-redundant "
+                   "(scope.show_redundant, ADR-040); --show-redundant/--no-show-redundant "
                    "still overrides it either way.")
 @scope_options  # --scope-public-headers/--no- (ADR-037 D3); --show-filtered stays inline
 @click.option("--collapse-versioned-symbols", "collapse_versioned_symbols", is_flag=True, default=False,

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -45,7 +45,7 @@ from .cli_dump_helpers import (
     resolve_dump_compile_db,
     resolve_dump_debug_format,
 )
-from .cli_help import configure_rich_help
+from .cli_help import compare_help_options, configure_rich_help
 from .cli_helpers_compare import (  # noqa: F401  — re-exported to keep cli import sites stable
     _build_match_map as _build_match_map,
     _canonical_library_key as _canonical_library_key,
@@ -1221,6 +1221,7 @@ def _embed_inline_source_side(
 
 
 @main.command("compare")
+@compare_help_options  # curated --help + full --help-all (G21.8 collapse M2)
 @click.argument("old_input", type=click.Path(exists=True, path_type=Path))
 @click.argument("new_input", type=click.Path(exists=True, path_type=Path))
 # Set-input fan-out (ADR-037 D7): -j/--jobs, --dso-only, --output-dir only bite

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -340,10 +340,11 @@ def _write_snapshot_output(
                     f"collected but linked no facts: {', '.join(ran_empty)} — the "
                     "extractor ran but matched nothing; see the coverage rows for "
                     "the reason (commonly a public-header-roots mismatch, an "
-                    "unseeded `--depth source` that selected 0 TUs — use --max or "
-                    "--changed-path/--since — or the snapshot binary not matching "
-                    "--sources; a '0/N symbols matched' means source decls did not "
-                    "link to the binary's exports)"
+                    "unseeded `--depth source` that selected 0 TUs — use "
+                    "--changed-path/--since to seed a changed scope — or the "
+                    "snapshot binary not matching --sources; a '0/N symbols "
+                    "matched' means source decls did not link to the binary's "
+                    "exports)"
                 )
             click.echo(
                 "Warning: requested evidence layer(s) " + "; ".join(parts) + ".",
@@ -1153,7 +1154,7 @@ def _embed_inline_source_side(
         click.echo(
             f"Warning: --{label}-sources/--{label}-build-info was given but the "
             "selected --depth collects no evidence; ignoring it. Use --depth "
-            "build/source/full (or --max) to collect from it.",
+            "build or --depth source to collect from it.",
             err=True,
         )
         return input_path, kept_sources, kept_build_info

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -37,6 +37,7 @@ except ImportError:  # pragma: no cover - rich-click is a declared dependency
 from .checker import DiffResult, LibraryMetadata
 from .cli_audit import echo_filtered_surface, echo_reconciled
 from .cli_dump_helpers import (
+    evidence_depth_label,
     handle_non_elf_dump,
     perform_elf_dump,
     resolve_dump_collect_context,
@@ -360,6 +361,13 @@ def _write_snapshot_output(
     if output:
         _safe_write_output(output, result)
         click.echo(f"Snapshot written to {output}", err=True)
+        # Self-describing output (CLI-audit P2): report the evidence depth
+        # this snapshot actually reached -- computed from what it carries,
+        # not the requested --depth, so an explicit --depth source that
+        # collected nothing usable is never silently reported as if it had
+        # succeeded. Only alongside the file-write notice above (never for
+        # bare stdout output, which callers may pipe/parse as pure JSON).
+        click.echo(f"Resolved evidence depth: {evidence_depth_label(snap)}", err=True)
     else:
         click.echo(result)
 

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -687,6 +687,13 @@ def _apply_used_by_scoping(
     # the scoped gate instead of the full, unscoped library diff (CLI-audit
     # P1: "SARIF/JUnit computing pass/fail from the full library diff").
     relevant_finding_ids: set[str] = set()
+    # Union across ALL apps of relevant Change objects, keyed by finding id --
+    # not just their ids -- so scoped-only changes (e.g. PE_ORDINAL_RETARGETED,
+    # which scope_diff_to_app synthesizes fresh per app and never adds to
+    # result.changes) can still be rendered by SARIF/JUnit instead of only
+    # contributing to the gate's exit code with nothing to explain it (Codex
+    # review).
+    relevant_changes_by_id: dict[str, Any] = {}
     missing_labels: set[str] = set()
     for app in used_by_apps:
         scoped = scope_diff_to_app(
@@ -695,6 +702,9 @@ def _apply_used_by_scoping(
         )
         summaries.append(_app_compat_summary(scoped))
         relevant_finding_ids.update(_finding_id(c) for c in scoped.breaking_for_app)
+        relevant_changes_by_id.update(
+            {_finding_id(c): c for c in scoped.breaking_for_app}
+        )
         # A missing symbol/version already covered by a relevant Change (e.g.
         # FUNC_REMOVED) must not also become a synthetic missing-contract
         # finding -- that would double-report the same ABI break (Codex
@@ -735,6 +745,10 @@ def _apply_used_by_scoping(
     result.gate_scope = "used_by"  # type: ignore[attr-defined]
     result.scoped_relevant_finding_ids = frozenset(relevant_finding_ids)  # type: ignore[attr-defined]
     result.scoped_missing_labels = tuple(sorted(missing_labels))  # type: ignore[attr-defined]
+    _existing_ids = {_finding_id(c) for c in result.changes}
+    result.scoped_only_changes = tuple(  # type: ignore[attr-defined]
+        c for fid, c in relevant_changes_by_id.items() if fid not in _existing_ids
+    )
     if exit_code_scheme == "severity":
         categories, counts = _scoped_severity_summary(
             list(worst_changes.values()), worst_missing,
@@ -771,6 +785,12 @@ def _apply_required_symbol_scoping(
     result.scoped_missing_labels = tuple(sorted(  # type: ignore[attr-defined]
         uncovered_missing_symbols(scoped.missing_entrypoints, scoped.breaking_for_host)
     ))
+    # Scoped-only changes: relevant to the host contract but never added to
+    # result.changes (mirrors _apply_used_by_scoping's identical handling).
+    _existing_ids = {_finding_id(c) for c in result.changes}
+    result.scoped_only_changes = tuple(  # type: ignore[attr-defined]
+        c for c in scoped.breaking_for_host if _finding_id(c) not in _existing_ids
+    )
     exit_code = _scoped_exit_code(
         scoped, scoped.breaking_for_host, result, exit_code_scheme, sev_config,
         policy, policy_file,

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1544,6 +1544,66 @@ def _fold_evidence_depth_into_json(
     return json.dumps(payload, indent=2)
 
 
+def _resolve_scoped_gate_findings(
+    result: Any, severity_config: Any, show_only: str | None,
+) -> tuple[list[Any], list[str], bool, str]:
+    """Resolve the scoped-only ``Change``s and missing-contract labels relevant
+    to the ``--used-by``/``--required-symbol`` gate, deduped against
+    ``result.changes`` and filtered by ``--show-only``.
+
+    Factored out of the JSON branch below so markdown/text/review output can
+    render the identical actionable findings instead of only a bare count
+    (Codex review: a scoped run whose only gated issue was a missing contract
+    member or a scoped-only change like ``PE_ORDINAL_RETARGETED`` didn't name
+    either one in the default text report, unlike JSON/SARIF/JUnit).
+
+    Returns ``(scoped_only_changes, missing_labels, blocks, missing_kind)``.
+    """
+    from .reporter import _finding_id, apply_show_only
+    from .reporter_markdown import ShowOnlyFilter
+    from .severity import missing_contract_exit_code
+
+    existing_ids = {_finding_id(c) for c in result.changes}
+    eff_sets = result._effective_kind_sets()
+    scoped_only = list(getattr(result, "scoped_only_changes", ()) or ())
+    if show_only and scoped_only:
+        scoped_only = apply_show_only(
+            scoped_only,
+            show_only,
+            policy=result.policy,
+            kind_sets=eff_sets,
+            policy_file=result.policy_file,
+        )
+    scoped_only = [c for c in scoped_only if _finding_id(c) not in existing_ids]
+
+    gate_scope = getattr(result, "gate_scope", None)
+    missing_kind = (
+        "used_by_missing_symbol" if gate_scope == "used_by"
+        else "required_symbol_missing"
+    )
+    blocks = (
+        severity_config is None
+        or missing_contract_exit_code(severity_config) != 0
+    )
+    # A missing-contract label has no backing Change/ChangeKind, so it can't
+    # run through apply_show_only -- but --show-only's severity dimension
+    # still applies: without this, a --show-only run that excludes breaking
+    # findings would still include a blocking missing-contract entry the
+    # filter was meant to exclude (Codex review, mirrors the identical
+    # sarif.to_sarif fix). Element/action tokens don't cleanly apply to "a
+    # symbol is simply absent", so only the severity dimension is checked.
+    missing_severity_label = "breaking" if blocks else "compatible"
+    show_only_severities = (
+        ShowOnlyFilter.parse(show_only).severities if show_only else frozenset()
+    )
+    missing_labels = list(
+        getattr(result, "scoped_missing_labels", ()) or ()
+        if not show_only_severities or missing_severity_label in show_only_severities
+        else ()
+    )
+    return scoped_only, missing_labels, blocks, missing_kind
+
+
 def _fold_scoped_compat_into_text(
     text: str, fmt: str, result: Any, severity_config: Any = None,
     show_only: str | None = None,
@@ -1648,57 +1708,21 @@ def _fold_scoped_compat_into_text(
         # sarif.to_sarif/junit_report._build_testsuite's identical fold-in).
         changes_list = payload.get("changes")
         if isinstance(changes_list, list):
-            from .reporter import _change_to_dict, _finding_id, apply_show_only
-            from .reporter_markdown import ShowOnlyFilter
-            from .severity import missing_contract_exit_code
+            from .reporter import _change_to_dict
 
-            existing_ids = {_finding_id(c) for c in result.changes}
             eff_sets = result._effective_kind_sets()
-            scoped_only = list(getattr(result, "scoped_only_changes", ()) or ())
-            if show_only and scoped_only:
-                scoped_only = apply_show_only(
-                    scoped_only,
-                    show_only,
-                    policy=result.policy,
-                    kind_sets=eff_sets,
-                    policy_file=result.policy_file,
-                )
+            scoped_only, missing_labels, blocks, missing_kind = (
+                _resolve_scoped_gate_findings(result, severity_config, show_only)
+            )
             for c in scoped_only:
-                if _finding_id(c) not in existing_ids:
-                    changes_list.append(
-                        _change_to_dict(
-                            c,
-                            policy=result.policy or "strict_abi",
-                            kind_sets=eff_sets,
-                            policy_file=result.policy_file,
-                        )
+                changes_list.append(
+                    _change_to_dict(
+                        c,
+                        policy=result.policy or "strict_abi",
+                        kind_sets=eff_sets,
+                        policy_file=result.policy_file,
                     )
-            gate_scope = getattr(result, "gate_scope", None)
-            missing_kind = (
-                "used_by_missing_symbol" if gate_scope == "used_by"
-                else "required_symbol_missing"
-            )
-            blocks = (
-                severity_config is None
-                or missing_contract_exit_code(severity_config) != 0
-            )
-            # A missing-contract label has no backing Change/ChangeKind, so
-            # it can't run through apply_show_only -- but --show-only's
-            # severity dimension still applies: without this, a --show-only
-            # run that excludes breaking findings would still include a
-            # blocking missing-contract entry the filter was meant to
-            # exclude (Codex review, mirrors the identical sarif.to_sarif
-            # fix). Element/action tokens don't cleanly apply to "a symbol is
-            # simply absent", so only the severity dimension is checked.
-            missing_severity_label = "breaking" if blocks else "compatible"
-            show_only_severities = (
-                ShowOnlyFilter.parse(show_only).severities if show_only else frozenset()
-            )
-            missing_labels = (
-                getattr(result, "scoped_missing_labels", ()) or ()
-                if not show_only_severities or missing_severity_label in show_only_severities
-                else ()
-            )
+                )
             for label in missing_labels:
                 changes_list.append(
                     {
@@ -1760,6 +1784,14 @@ def _fold_scoped_compat_into_text(
                     f"{len(summary['missing_versions'])} version(s), "
                     f"{summary['relevant_change_count']} relevant change(s))"
                 )
+                # Name the actual missing symbols/versions, not just their
+                # count (Codex review) -- a human reading the default text
+                # report otherwise has no way to tell *which* symbol broke
+                # this app without re-running with --format json.
+                for sym in summary["missing_symbols"]:
+                    lines.append(f"  - missing symbol: `{sym}`")
+                for ver in summary["missing_versions"]:
+                    lines.append(f"  - missing version: `{ver}`")
         if required_symbols is not None:
             lines.append("## Scoped to --required-symbol(s) contract")
             lines.append(
@@ -1768,6 +1800,26 @@ def _fold_scoped_compat_into_text(
                 f"{len(required_symbols['required_entrypoints'])} required "
                 f"entrypoint(s))"
             )
+            for entrypoint in required_symbols["missing_entrypoints"]:
+                lines.append(f"  - missing entrypoint: `{entrypoint}`")
+        # Scoped-only changes (e.g. PE_ORDINAL_RETARGETED) and uncovered
+        # missing-contract labels are relevant to the scoped gate but never
+        # land in `result.changes` -- name them here too, mirroring the
+        # JSON/SARIF/JUnit fold-in, so a text/markdown/review reader sees the
+        # same actionable findings a JSON consumer would (Codex review).
+        scoped_only, missing_labels, blocks, _missing_kind = (
+            _resolve_scoped_gate_findings(result, severity_config, show_only)
+        )
+        if scoped_only or missing_labels:
+            lines.append("## Additional scoped-gate findings")
+            severity_tag = "breaking" if blocks else "compatible"
+            for label in missing_labels:
+                lines.append(
+                    f"- `{label}` is required but missing from the new "
+                    f"library ({severity_tag})"
+                )
+            for c in scoped_only:
+                lines.append(f"- {c.kind.value}: {c.description}")
         return "\n".join(lines)
 
     return text

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -661,6 +661,7 @@ def _apply_used_by_scoping(
                 f"library, not headers-only); {label} ({path}) is neither."
             )
 
+    from .appcompat import uncovered_missing_symbols
     from .reporter import _finding_id
 
     summaries = []
@@ -694,8 +695,16 @@ def _apply_used_by_scoping(
         )
         summaries.append(_app_compat_summary(scoped))
         relevant_finding_ids.update(_finding_id(c) for c in scoped.breaking_for_app)
-        missing_labels.update(scoped.missing_symbols)
-        missing_labels.update(scoped.missing_versions)
+        # A missing symbol/version already covered by a relevant Change (e.g.
+        # FUNC_REMOVED) must not also become a synthetic missing-contract
+        # finding -- that would double-report the same ABI break (Codex
+        # review, mirrors _scoped_severity_summary's own dedup below).
+        missing_labels.update(
+            uncovered_missing_symbols(
+                list(scoped.missing_symbols) + list(scoped.missing_versions),
+                scoped.breaking_for_app,
+            )
+        )
         exit_code = _scoped_exit_code(
             scoped, scoped.breaking_for_app, result, exit_code_scheme, sev_config,
             policy, policy_file,
@@ -743,7 +752,7 @@ def _apply_required_symbol_scoping(
     exit_code_scheme: str = "legacy", sev_config: Any = None,
 ) -> int:
     """Scope *result* to an explicit ``--required-symbol(s)`` contract (ADR-043)."""
-    from .appcompat import scope_diff_to_required_symbols
+    from .appcompat import scope_diff_to_required_symbols, uncovered_missing_symbols
     from .reporter import _finding_id
 
     scoped = scope_diff_to_required_symbols(
@@ -756,7 +765,12 @@ def _apply_required_symbol_scoping(
     result.scoped_relevant_finding_ids = frozenset(  # type: ignore[attr-defined]
         _finding_id(c) for c in scoped.breaking_for_host
     )
-    result.scoped_missing_labels = tuple(sorted(scoped.missing_entrypoints))  # type: ignore[attr-defined]
+    # An entrypoint already covered by a relevant Change must not also
+    # become a synthetic missing-contract finding (Codex review, mirrors
+    # _apply_used_by_scoping's identical dedup).
+    result.scoped_missing_labels = tuple(sorted(  # type: ignore[attr-defined]
+        uncovered_missing_symbols(scoped.missing_entrypoints, scoped.breaking_for_host)
+    ))
     exit_code = _scoped_exit_code(
         scoped, scoped.breaking_for_host, result, exit_code_scheme, sev_config,
         policy, policy_file,
@@ -1407,6 +1421,7 @@ def run_compare(
         demangle=demangle,
     )
     text = _fold_scoped_compat_into_text(text, fmt, result)
+    text = _fold_evidence_depth_into_json(text, fmt, old, new)
 
     _write_or_echo(output, text)
 
@@ -1434,6 +1449,7 @@ def run_compare(
             demangle=secondary_demangle,
         )
         secondary_text = _fold_scoped_compat_into_text(secondary_text, secondary_fmt, result)
+        secondary_text = _fold_evidence_depth_into_json(secondary_text, secondary_fmt, old, new)
         _write_or_echo(secondary_output, secondary_text)
 
     if scoped_exit_code is not None:
@@ -1446,6 +1462,32 @@ def run_compare(
 
     _announce_exit_scheme(resolved_cfg.exit_code_scheme, fmt=fmt, stat=stat)
     _exit_with_severity_or_verdict(result, sev_config, resolved_cfg.exit_code_scheme)
+
+
+def _fold_evidence_depth_into_json(text: str, fmt: str, old: Any, new: Any) -> str:
+    """Add ``old_evidence_depth``/``new_evidence_depth`` to a JSON report (CLI-audit P2).
+
+    Self-describing output: the evidence depth each side's snapshot *actually*
+    reached (``binary``/``headers``/``build``/``source``), computed from what
+    the snapshot carries rather than the requested ``--depth`` -- so a report
+    is never silently mismatched against what was actually collected. JSON
+    only; other formats already show depth-related context in their own
+    ways (or, for binary/structured formats, are left untouched per
+    :func:`_fold_scoped_compat_into_text`'s convention).
+    """
+    if fmt != "json":
+        return text
+    import json
+
+    from .cli_dump_helpers import evidence_depth_label
+
+    try:
+        payload = json.loads(text)
+    except ValueError:
+        return text
+    payload["old_evidence_depth"] = evidence_depth_label(old)
+    payload["new_evidence_depth"] = evidence_depth_label(new)
+    return json.dumps(payload, indent=2)
 
 
 def _fold_scoped_compat_into_text(text: str, fmt: str, result: Any) -> str:

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -264,6 +264,56 @@ def _resolve_demangle(fmt: str, demangle: bool | None) -> bool:
     return fmt in {"markdown", "review"} if demangle is None else demangle
 
 
+def _resolve_compare_collect_mode(
+    depth: str | None,
+    source_method: str | None,
+    old_sources: Path | None,
+    new_sources: Path | None,
+    old_build_info: Path | None,
+    new_build_info: Path | None,
+) -> tuple[str, str]:
+    """Resolve compare's source/build collect mode, plus a human label for it.
+
+    Precedence (ADR-037 D4/D5, extended by the P1 CLI-contract fix below):
+    explicit ``--depth`` > ``.abicheck.yml`` ``source.method`` > inferred from
+    raw ``--old/new-sources``/``--old/new-build-info`` given with neither of
+    the above > off.
+
+    The inferred rung closes a gap where passing ``--sources``/``--build-info``
+    with no ``--depth`` (and no ``source.method`` in config) silently resolved
+    to "off" and the inputs were ignored with a warning: an explicit
+    source/build-info input is itself a request to use it, so omitted depth
+    should not default to discarding it. This mirrors ``scan``'s own
+    "auto" depth, which is likewise input-driven rather than a fixed default.
+    The label is shown verbatim in ``compare --dry-run``'s "Resolved depth and
+    source scope" section so a dry run reports the *effective* depth, not just
+    the raw ``--depth`` string the user passed (or omitted).
+    """
+    if depth is not None:
+        return resolve_dump_depth(depth, "off"), f"--depth {depth}"
+    if source_method:
+        from .buildsource.scan_levels import SourceMethod, method_to_collect_mode
+        try:
+            mode = method_to_collect_mode(SourceMethod(source_method))
+        except ValueError:
+            raise click.UsageError(
+                f"source.method in .abicheck.yml is invalid: "
+                f"{source_method!r} (expected s0..s6 or auto)."
+            ) from None
+        return mode, f"source.method={source_method} (.abicheck.yml)"
+    if old_sources is not None or new_sources is not None:
+        return (
+            resolve_dump_depth("source", "off"),
+            "source (inferred: --old-sources/--new-sources given, no --depth)",
+        )
+    if old_build_info is not None or new_build_info is not None:
+        return (
+            resolve_dump_depth("build", "off"),
+            "build (inferred: --old-build-info/--new-build-info given, no --depth)",
+        )
+    return "off", "off (no --depth, no --sources/--build-info, no source.method)"
+
+
 def _normalize_compare_options(
     resolved_cfg: ResolvedCompareConfig,
     *,
@@ -279,15 +329,22 @@ def _normalize_compare_options(
     fmt: str,
     report_mode: str,
     show_impact: bool,
+    old_sources: Path | None = None,
+    new_sources: Path | None = None,
+    old_build_info: Path | None = None,
+    new_build_info: Path | None = None,
 ) -> _NormalizedCompareOptions:
     """Fold the compare option flags into their resolved, dispatch-ready values."""
     if annotate_additions and not annotate:
         raise click.UsageError("--annotate-additions requires --annotate")
 
     # Fold the --depth dial into the internal collect mode (ADR-037 D5), the
-    # same way `dump` does. With no preset, compare reads at "off"; --depth
-    # binary suppresses the L2 header AST (symbols-only).
-    collect_mode = resolve_dump_depth(depth, "off")
+    # same way `dump` does; when omitted, infer it from --sources/--build-info
+    # (or config source.method) rather than defaulting to "off" (P1 fix).
+    collect_mode, _ = _resolve_compare_collect_mode(
+        depth, resolved_cfg.source_method,
+        old_sources, new_sources, old_build_info, new_build_info,
+    )
     if depth == "binary":
         headers, old_headers_only, new_headers_only = (), (), ()
 
@@ -308,21 +365,6 @@ def _normalize_compare_options(
     if report_mode == "impact":
         report_mode = "full"
         show_impact = True
-
-    # ADR-037 D4: the precise S-axis lives in config (source.method). It sets the
-    # collection depth only when the user gave no explicit --depth signal
-    # (CLI > config).
-    if resolved_cfg.source_method and depth is None:
-        from .buildsource.scan_levels import SourceMethod, method_to_collect_mode
-        try:
-            collect_mode = method_to_collect_mode(
-                SourceMethod(resolved_cfg.source_method)
-            )
-        except ValueError:
-            raise click.UsageError(
-                f"source.method in .abicheck.yml is invalid: "
-                f"{resolved_cfg.source_method!r} (expected s0..s6 or auto)."
-            ) from None
 
     return _NormalizedCompareOptions(
         collect_mode, headers, old_headers_only, new_headers_only,
@@ -619,16 +661,24 @@ def _apply_used_by_scoping(
                 f"library, not headers-only); {label} ({path}) is neither."
             )
 
+    from .reporter import _finding_id
+
     summaries = []
     worst_exit = 0
     worst_verdict = None
     worst_verdict_rank = -1
-    # Keyed by id(change)/the missing string itself so a Change or missing
-    # symbol shared by two tied apps (e.g. both import the same removed
-    # symbol) collapses to one entry instead of being tallied once per app
-    # (Codex review) -- `_scoped_severity_summary` runs once at the end over
-    # this deduplicated union, not per app summed together.
-    worst_changes: dict[int, Any] = {}
+    # Keyed by the change's semantic identity (kind/symbol/old/new/location/
+    # description, via `_finding_id`) -- not id(change) -- so a Change or
+    # missing symbol shared by two tied apps (e.g. both import the same
+    # removed symbol) collapses to one entry instead of being tallied once
+    # per app (Codex review) -- `_scoped_severity_summary` runs once at the
+    # end over this deduplicated union, not per app summed together.
+    # `id()` alone under-deduplicates PE_ORDINAL_RETARGETED findings:
+    # `scope_diff_to_app` synthesizes a fresh `Change` object per app (via
+    # `_check_pe_ordinal_imports`), so two apps hitting the same ordinal
+    # retarget produce structurally-identical but object-distinct `Change`s
+    # that `id()` would double-count in the severity summary.
+    worst_changes: dict[str, Any] = {}
     worst_missing: set[str] = set()
     for app in used_by_apps:
         scoped = scope_diff_to_app(
@@ -649,10 +699,10 @@ def _apply_used_by_scoping(
         # one merely because their exit codes tied at 0 (Codex review).
         if exit_code_scheme == "severity":
             if exit_code > worst_exit:
-                worst_changes = {id(c): c for c in scoped.breaking_for_app}
+                worst_changes = {_finding_id(c): c for c in scoped.breaking_for_app}
                 worst_missing = set(scoped.missing_symbols) | set(scoped.missing_versions)
             elif exit_code == worst_exit:
-                worst_changes.update({id(c): c for c in scoped.breaking_for_app})
+                worst_changes.update({_finding_id(c): c for c in scoped.breaking_for_app})
                 worst_missing |= set(scoped.missing_symbols) | set(scoped.missing_versions)
         worst_exit = max(worst_exit, exit_code)
         rank = _verdict_severity_rank(scoped.verdict)
@@ -728,6 +778,7 @@ def _render_compare_dry_run(
     old_input: Path, new_input: Path,
     old_kind: str, new_kind: str,
     depth: str | None,
+    source_method: str | None = None,
     headers: tuple[Path, ...], includes: tuple[Path, ...],
     old_headers_only: tuple[Path, ...], new_headers_only: tuple[Path, ...],
     old_sources: Path | None, new_sources: Path | None,
@@ -748,11 +799,21 @@ def _render_compare_dry_run(
         f"old: {old_input} ({old_kind})",
         f"new: {new_input} ({new_kind})",
     )
+    # Effective depth (P1 fix): a dry run must report what the real run will
+    # actually do, not just echo the raw --depth string back — the same
+    # inference _normalize_compare_options applies (--depth > source.method >
+    # inferred from --sources/--build-info > off) drives this.
+    collect_mode, effective_depth_label = _resolve_compare_collect_mode(
+        depth, source_method, old_sources, new_sources, old_build_info, new_build_info,
+    )
     result.add(
         "Resolved depth and source scope",
-        f"requested depth: {depth or '(auto)'}",
+        f"requested depth: {depth or '(not given)'}",
+        f"effective depth: {effective_depth_label}",
+        f"effective collect mode: {collect_mode}",
         "source scope: target on each side (compare has no PR change seed)"
-        if depth == "source" else None,
+        if collect_mode in ("source-target", "source-changed", "graph-full")
+        else None,
     )
     all_headers = list(headers) + list(old_headers_only) + list(new_headers_only)
     result.add(
@@ -869,6 +930,12 @@ def run_compare(
     from .dry_run import reject_dry_run_with_output
 
     reject_dry_run_with_output(dry_run, output)
+    if dry_run and secondary_output is not None:
+        raise click.UsageError(
+            "--dry-run cannot be combined with --secondary-output: a dry run "
+            "performs no analysis and writes nothing, so there is no "
+            "secondary report to produce."
+        )
     _setup_verbosity(verbose)
 
     if secondary_fmt is not None and secondary_output is None:
@@ -976,7 +1043,8 @@ def run_compare(
         emit_dry_run(_render_compare_dry_run(
             old_input=old_input, new_input=new_input,
             old_kind=old_kind, new_kind=new_kind,
-            depth=depth, headers=headers, includes=includes,
+            depth=depth, source_method=resolved_cfg.source_method,
+            headers=headers, includes=includes,
             old_headers_only=old_headers_only, new_headers_only=new_headers_only,
             old_sources=old_sources, new_sources=new_sources,
             old_build_info=old_build_info, new_build_info=new_build_info,
@@ -1045,6 +1113,8 @@ def run_compare(
         debug_format_opt=debug_format_opt, debug_format=debug_format,
         demangle=demangle, fmt=fmt,
         report_mode=report_mode, show_impact=show_impact,
+        old_sources=old_sources, new_sources=new_sources,
+        old_build_info=old_build_info, new_build_info=new_build_info,
     )
 
     # L2 header compile context (compare↔dump↔scan parity, ADR-037 D3): the one

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -680,12 +680,22 @@ def _apply_used_by_scoping(
     # that `id()` would double-count in the severity summary.
     worst_changes: dict[str, Any] = {}
     worst_missing: set[str] = set()
+    # Union across ALL apps (not just the worst-exit-code one) of which
+    # findings this --used-by gate actually cares about -- SARIF/JUnit
+    # consult this to make their own result levels/failure counts follow
+    # the scoped gate instead of the full, unscoped library diff (CLI-audit
+    # P1: "SARIF/JUnit computing pass/fail from the full library diff").
+    relevant_finding_ids: set[str] = set()
+    missing_labels: set[str] = set()
     for app in used_by_apps:
         scoped = scope_diff_to_app(
             result, app, old_lib, new_lib,
             policy=policy, policy_file=policy_file,
         )
         summaries.append(_app_compat_summary(scoped))
+        relevant_finding_ids.update(_finding_id(c) for c in scoped.breaking_for_app)
+        missing_labels.update(scoped.missing_symbols)
+        missing_labels.update(scoped.missing_versions)
         exit_code = _scoped_exit_code(
             scoped, scoped.breaking_for_app, result, exit_code_scheme, sev_config,
             policy, policy_file,
@@ -713,6 +723,9 @@ def _apply_used_by_scoping(
     result.scoped_verdict = worst_verdict  # type: ignore[attr-defined]
     result.scoped_exit_code = worst_exit  # type: ignore[attr-defined]
     result.scoped_exit_code_scheme = exit_code_scheme  # type: ignore[attr-defined]
+    result.gate_scope = "used_by"  # type: ignore[attr-defined]
+    result.scoped_relevant_finding_ids = frozenset(relevant_finding_ids)  # type: ignore[attr-defined]
+    result.scoped_missing_labels = tuple(sorted(missing_labels))  # type: ignore[attr-defined]
     if exit_code_scheme == "severity":
         categories, counts = _scoped_severity_summary(
             list(worst_changes.values()), worst_missing,
@@ -731,6 +744,7 @@ def _apply_required_symbol_scoping(
 ) -> int:
     """Scope *result* to an explicit ``--required-symbol(s)`` contract (ADR-043)."""
     from .appcompat import scope_diff_to_required_symbols
+    from .reporter import _finding_id
 
     scoped = scope_diff_to_required_symbols(
         result, old, new, required_symbols,
@@ -738,6 +752,11 @@ def _apply_required_symbol_scoping(
     )
     result.required_symbols = _plugin_contract_summary(scoped)  # type: ignore[attr-defined]
     result.scoped_verdict = scoped.verdict  # type: ignore[attr-defined]
+    result.gate_scope = "required_symbol"  # type: ignore[attr-defined]
+    result.scoped_relevant_finding_ids = frozenset(  # type: ignore[attr-defined]
+        _finding_id(c) for c in scoped.breaking_for_host
+    )
+    result.scoped_missing_labels = tuple(sorted(scoped.missing_entrypoints))  # type: ignore[attr-defined]
     exit_code = _scoped_exit_code(
         scoped, scoped.breaking_for_host, result, exit_code_scheme, sev_config,
         policy, policy_file,

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1444,7 +1444,11 @@ def run_compare(
         text, fmt, result,
         severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
     )
-    text = _fold_evidence_depth_into_json(text, fmt, old, new)
+    text = _fold_evidence_depth_into_json(
+        text, fmt, old, new,
+        old_build_info=old_build_info, new_build_info=new_build_info,
+        old_sources=old_sources, new_sources=new_sources,
+    )
 
     _write_or_echo(output, text)
 
@@ -1475,7 +1479,11 @@ def run_compare(
             secondary_text, secondary_fmt, result,
             severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
         )
-        secondary_text = _fold_evidence_depth_into_json(secondary_text, secondary_fmt, old, new)
+        secondary_text = _fold_evidence_depth_into_json(
+            secondary_text, secondary_fmt, old, new,
+            old_build_info=old_build_info, new_build_info=new_build_info,
+            old_sources=old_sources, new_sources=new_sources,
+        )
         _write_or_echo(secondary_output, secondary_text)
 
     if scoped_exit_code is not None:
@@ -1490,29 +1498,48 @@ def run_compare(
     _exit_with_severity_or_verdict(result, sev_config, resolved_cfg.exit_code_scheme)
 
 
-def _fold_evidence_depth_into_json(text: str, fmt: str, old: Any, new: Any) -> str:
+def _fold_evidence_depth_into_json(
+    text: str, fmt: str, old: Any, new: Any,
+    old_build_info: Path | None = None, new_build_info: Path | None = None,
+    old_sources: Path | None = None, new_sources: Path | None = None,
+) -> str:
     """Add ``old_evidence_depth``/``new_evidence_depth`` to a JSON report (CLI-audit P2).
 
-    Self-describing output: the evidence depth each side's snapshot *actually*
-    reached (``binary``/``headers``/``build``/``source``), computed from what
-    the snapshot carries rather than the requested ``--depth`` -- so a report
-    is never silently mismatched against what was actually collected. JSON
-    only; other formats already show depth-related context in their own
-    ways (or, for binary/structured formats, are left untouched per
+    Self-describing output: the evidence depth each side *actually* reached
+    (``binary``/``headers``/``build``/``source``), computed from what was
+    resolved rather than the requested ``--depth`` -- so a report is never
+    silently mismatched against what was actually collected. JSON only; other
+    formats already show depth-related context in their own ways (or, for
+    binary/structured formats, are left untouched per
     :func:`_fold_scoped_compat_into_text`'s convention).
+
+    An out-of-band ``--old/new-build-info``/``--old/new-sources`` *pack
+    directory* (as opposed to a raw checkout, which gets embedded into the
+    snapshot before this point) is resolved via ``_resolve_side_pack`` and
+    never attached back to ``old``/``new`` themselves -- reading only
+    ``old.build_source``/``new.build_source`` would then report the
+    snapshot's own (absent or unrelated) embedded depth instead of the pack
+    that was actually used to produce this comparison's build/source
+    findings (Codex review). Re-resolving here is cheap (pure pack-directory
+    metadata load, no diffing) and mirrors the same resolution
+    ``prepare_embedded_build_source``/``diff_embedded_build_source`` already
+    performed to run the comparison itself.
     """
     if fmt != "json":
         return text
     import json
 
+    from .cli_buildsource_helpers import _resolve_side_pack
     from .cli_dump_helpers import evidence_depth_label
 
     try:
         payload = json.loads(text)
     except ValueError:
         return text
-    payload["old_evidence_depth"] = evidence_depth_label(old)
-    payload["new_evidence_depth"] = evidence_depth_label(new)
+    old_pack = _resolve_side_pack(old_build_info, old_sources, old)
+    new_pack = _resolve_side_pack(new_build_info, new_sources, new)
+    payload["old_evidence_depth"] = evidence_depth_label(old, old_pack)
+    payload["new_evidence_depth"] = evidence_depth_label(new, new_pack)
     return json.dumps(payload, indent=2)
 
 

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1440,7 +1440,10 @@ def run_compare(
         show_recommendation=recommend,
         demangle=demangle,
     )
-    text = _fold_scoped_compat_into_text(text, fmt, result)
+    text = _fold_scoped_compat_into_text(
+        text, fmt, result,
+        severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
+    )
     text = _fold_evidence_depth_into_json(text, fmt, old, new)
 
     _write_or_echo(output, text)
@@ -1468,7 +1471,10 @@ def run_compare(
             show_recommendation=recommend,
             demangle=secondary_demangle,
         )
-        secondary_text = _fold_scoped_compat_into_text(secondary_text, secondary_fmt, result)
+        secondary_text = _fold_scoped_compat_into_text(
+            secondary_text, secondary_fmt, result,
+            severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
+        )
         secondary_text = _fold_evidence_depth_into_json(secondary_text, secondary_fmt, old, new)
         _write_or_echo(secondary_output, secondary_text)
 
@@ -1510,13 +1516,20 @@ def _fold_evidence_depth_into_json(text: str, fmt: str, old: Any, new: Any) -> s
     return json.dumps(payload, indent=2)
 
 
-def _fold_scoped_compat_into_text(text: str, fmt: str, result: Any) -> str:
+def _fold_scoped_compat_into_text(
+    text: str, fmt: str, result: Any, severity_config: Any = None,
+) -> str:
     """Fold ``--used-by``/``--required-symbol(s)`` summaries into the rendered text.
 
     JSON gets the summaries as real keys (round-tripped through the existing
     payload); other text-based formats get a small appended section. Binary/
     structured formats (sarif, junit, html) are left untouched -- the full
     verdict they already carry stays authoritative for those consumers.
+
+    *severity_config* (when the run used a severity scheme) decides whether a
+    synthesized missing-contract entry is itself blocking, mirroring
+    ``sarif._missing_contract_result``/``junit_report``'s severity-aware
+    missing-contract handling.
     """
     used_by = getattr(result, "used_by", None)
     required_symbols = getattr(result, "required_symbols", None)
@@ -1584,6 +1597,59 @@ def _fold_scoped_compat_into_text(text: str, fmt: str, result: Any) -> str:
                     getattr(result, "scoped_blocking_categories", ()) or ()
                 ),
             }
+        # Scoped-only changes (e.g. PE_ORDINAL_RETARGETED, synthesized fresh
+        # per app/host by scope_diff_to_app/scope_diff_to_required_symbols)
+        # and uncovered missing-contract labels are relevant to the scoped
+        # gate but never land in `result.changes` -- without folding them
+        # into `changes` here too, a --used-by/--required-symbol run whose
+        # only gated issue is one of these reports an empty `changes` array
+        # despite a nonzero scoped exit code/verdict, so a JSON consumer
+        # (e.g. the GitHub Action's `--on changes` PR-comment gate, which
+        # buckets purely off this array) sees nothing to explain the failure
+        # and silently skips posting (Codex review, mirrors
+        # sarif.to_sarif/junit_report._build_testsuite's identical fold-in).
+        changes_list = payload.get("changes")
+        if isinstance(changes_list, list):
+            from .reporter import _change_to_dict, _finding_id
+            from .severity import missing_contract_exit_code
+
+            existing_ids = {_finding_id(c) for c in result.changes}
+            eff_sets = result._effective_kind_sets()
+            for c in getattr(result, "scoped_only_changes", ()) or ():
+                if _finding_id(c) not in existing_ids:
+                    changes_list.append(
+                        _change_to_dict(
+                            c,
+                            policy=result.policy or "strict_abi",
+                            kind_sets=eff_sets,
+                            policy_file=result.policy_file,
+                        )
+                    )
+            gate_scope = getattr(result, "gate_scope", None)
+            missing_kind = (
+                "used_by_missing_symbol" if gate_scope == "used_by"
+                else "required_symbol_missing"
+            )
+            blocks = (
+                severity_config is None
+                or missing_contract_exit_code(severity_config) != 0
+            )
+            for label in getattr(result, "scoped_missing_labels", ()) or ():
+                changes_list.append(
+                    {
+                        "kind": missing_kind,
+                        "symbol": label,
+                        "description": (
+                            f"Required symbol/version '{label}' is missing "
+                            "from the new library."
+                        ),
+                        "old_value": None,
+                        "new_value": None,
+                        "severity": "breaking" if blocks else "compatible",
+                        "relevant_to_gate": True,
+                        "blocks_gate": blocks,
+                    }
+                )
         return json.dumps(payload, indent=2)
 
     if fmt in ("markdown", "text", "review"):

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1443,6 +1443,7 @@ def run_compare(
     text = _fold_scoped_compat_into_text(
         text, fmt, result,
         severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
+        show_only=show_only,
     )
     text = _fold_evidence_depth_into_json(
         text, fmt, old, new,
@@ -1545,6 +1546,7 @@ def _fold_evidence_depth_into_json(
 
 def _fold_scoped_compat_into_text(
     text: str, fmt: str, result: Any, severity_config: Any = None,
+    show_only: str | None = None,
 ) -> str:
     """Fold ``--used-by``/``--required-symbol(s)`` summaries into the rendered text.
 
@@ -1557,6 +1559,15 @@ def _fold_scoped_compat_into_text(
     synthesized missing-contract entry is itself blocking, mirroring
     ``sarif._missing_contract_result``/``junit_report``'s severity-aware
     missing-contract handling.
+
+    *show_only*, when given, filters ``scoped_only_changes`` before they are
+    folded into the JSON ``changes`` array -- ``to_json`` already filtered
+    ``result.changes`` by the same tokens upstream, so leaving the
+    scoped-only fold-in unfiltered would let a `--show-only` run re-surface a
+    finding it explicitly excluded (Codex review, mirrors the identical
+    ``sarif.to_sarif`` fix). Pass ``None`` (the default) for a render that is
+    deliberately always-unfiltered, e.g. the ``--secondary-format`` render,
+    which ignores the primary format's own ``--show-only``.
     """
     used_by = getattr(result, "used_by", None)
     required_symbols = getattr(result, "required_symbols", None)
@@ -1637,12 +1648,21 @@ def _fold_scoped_compat_into_text(
         # sarif.to_sarif/junit_report._build_testsuite's identical fold-in).
         changes_list = payload.get("changes")
         if isinstance(changes_list, list):
-            from .reporter import _change_to_dict, _finding_id
+            from .reporter import _change_to_dict, _finding_id, apply_show_only
             from .severity import missing_contract_exit_code
 
             existing_ids = {_finding_id(c) for c in result.changes}
             eff_sets = result._effective_kind_sets()
-            for c in getattr(result, "scoped_only_changes", ()) or ():
+            scoped_only = list(getattr(result, "scoped_only_changes", ()) or ())
+            if show_only and scoped_only:
+                scoped_only = apply_show_only(
+                    scoped_only,
+                    show_only,
+                    policy=result.policy,
+                    kind_sets=eff_sets,
+                    policy_file=result.policy_file,
+                )
+            for c in scoped_only:
                 if _finding_id(c) not in existing_ids:
                     changes_list.append(
                         _change_to_dict(

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1649,6 +1649,7 @@ def _fold_scoped_compat_into_text(
         changes_list = payload.get("changes")
         if isinstance(changes_list, list):
             from .reporter import _change_to_dict, _finding_id, apply_show_only
+            from .reporter_markdown import ShowOnlyFilter
             from .severity import missing_contract_exit_code
 
             existing_ids = {_finding_id(c) for c in result.changes}
@@ -1681,7 +1682,24 @@ def _fold_scoped_compat_into_text(
                 severity_config is None
                 or missing_contract_exit_code(severity_config) != 0
             )
-            for label in getattr(result, "scoped_missing_labels", ()) or ():
+            # A missing-contract label has no backing Change/ChangeKind, so
+            # it can't run through apply_show_only -- but --show-only's
+            # severity dimension still applies: without this, a --show-only
+            # run that excludes breaking findings would still include a
+            # blocking missing-contract entry the filter was meant to
+            # exclude (Codex review, mirrors the identical sarif.to_sarif
+            # fix). Element/action tokens don't cleanly apply to "a symbol is
+            # simply absent", so only the severity dimension is checked.
+            missing_severity_label = "breaking" if blocks else "compatible"
+            show_only_severities = (
+                ShowOnlyFilter.parse(show_only).severities if show_only else frozenset()
+            )
+            missing_labels = (
+                getattr(result, "scoped_missing_labels", ()) or ()
+                if not show_only_severities or missing_severity_label in show_only_severities
+                else ()
+            )
+            for label in missing_labels:
                 changes_list.append(
                     {
                         "kind": missing_kind,

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -28,6 +28,7 @@ from .dumper import dump
 from .errors import AbicheckError
 
 if TYPE_CHECKING:
+    from .buildsource.pack import BuildSourcePack
     from .model import AbiSnapshot
     from .service_scan import CompileContext
 
@@ -180,16 +181,26 @@ def resolve_dump_depth(
     return level_to_collect_mode(method, evidence_depth, source_scope=SourceScope.TARGET)
 
 
-def evidence_depth_label(snap: AbiSnapshot) -> str:
+def evidence_depth_label(
+    snap: AbiSnapshot, build_source: BuildSourcePack | None = None,
+) -> str:
     """Report which evidence depth a snapshot *actually* carries (CLI-audit P2).
 
-    Computed purely from what the snapshot already holds -- ``binary``/
+    Computed purely from what was actually resolved -- ``binary``/
     ``headers``/``build``/``source`` -- rather than echoing back the
     requested ``--depth``: an explicit ``--depth source`` with no usable
     source facts still produces a snapshot that only reaches ``headers`` (or
     ``binary``), and this makes that honest instead of silently overstating
-    what was collected. Requires no new ``AbiSnapshot`` field -- it reads the
-    same ``from_headers``/``build_source`` data the snapshot already carries.
+    what was collected.
+
+    *build_source*, when given, overrides ``snap.build_source`` -- ``compare``
+    can resolve an out-of-band ``--old/new-sources``/``--old/new-build-info``
+    pack that is never attached back to the snapshot object itself
+    (``_resolve_side_pack`` returns it standalone); without this override, a
+    compare run using only out-of-band packs would report the depth of the
+    *unrelated* embedded (or absent) snapshot payload instead of the pack
+    that was actually used (Codex review). Defaults to ``snap.build_source``
+    for the plain single-artifact (embedded-only) case ``dump -o`` uses.
 
     Uses the same payload-emptiness checks as ``_write_snapshot_output``'s own
     fail-loud warning (``cli._layer_payload_empty``): a coverage row / field
@@ -201,7 +212,8 @@ def evidence_depth_label(snap: AbiSnapshot) -> str:
     """
     from .cli import _layer_payload_empty
 
-    build_source = snap.build_source
+    if build_source is None:
+        build_source = snap.build_source
     if build_source is not None and (
         not _layer_payload_empty(build_source, "L4")
         or not _layer_payload_empty(build_source, "L5")

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -190,13 +190,24 @@ def evidence_depth_label(snap: AbiSnapshot) -> str:
     ``binary``), and this makes that honest instead of silently overstating
     what was collected. Requires no new ``AbiSnapshot`` field -- it reads the
     same ``from_headers``/``build_source`` data the snapshot already carries.
+
+    Uses the same payload-emptiness checks as ``_write_snapshot_output``'s own
+    fail-loud warning (``cli._layer_payload_empty``): a coverage row / field
+    can be non-``None`` while the embedded payload carries no real facts (e.g.
+    ``_run_inline_source_abi`` returns an empty ``SourceAbiSurface()`` when
+    clang is unavailable after L3 was found) -- checking presence alone would
+    overstate ``source``/``build`` for a layer that ran but linked nothing
+    (CodeRabbit review).
     """
+    from .cli import _layer_payload_empty
+
     build_source = snap.build_source
     if build_source is not None and (
-        build_source.source_abi is not None or build_source.source_graph is not None
+        not _layer_payload_empty(build_source, "L4")
+        or not _layer_payload_empty(build_source, "L5")
     ):
         return "source"
-    if build_source is not None and build_source.build_evidence is not None:
+    if build_source is not None and not _layer_payload_empty(build_source, "L3"):
         return "build"
     if snap.from_headers:
         return "headers"

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -180,6 +180,29 @@ def resolve_dump_depth(
     return level_to_collect_mode(method, evidence_depth, source_scope=SourceScope.TARGET)
 
 
+def evidence_depth_label(snap: AbiSnapshot) -> str:
+    """Report which evidence depth a snapshot *actually* carries (CLI-audit P2).
+
+    Computed purely from what the snapshot already holds -- ``binary``/
+    ``headers``/``build``/``source`` -- rather than echoing back the
+    requested ``--depth``: an explicit ``--depth source`` with no usable
+    source facts still produces a snapshot that only reaches ``headers`` (or
+    ``binary``), and this makes that honest instead of silently overstating
+    what was collected. Requires no new ``AbiSnapshot`` field -- it reads the
+    same ``from_headers``/``build_source`` data the snapshot already carries.
+    """
+    build_source = snap.build_source
+    if build_source is not None and (
+        build_source.source_abi is not None or build_source.source_graph is not None
+    ):
+        return "source"
+    if build_source is not None and build_source.build_evidence is not None:
+        return "build"
+    if snap.from_headers:
+        return "headers"
+    return "binary"
+
+
 def render_dump_dry_run(
     *,
     so_path: Path | None,

--- a/abicheck/cli_help.py
+++ b/abicheck/cli_help.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Progressive-disclosure ``--help`` grouping (G21.8 / collapse M1).
+"""Progressive-disclosure ``--help`` grouping (G21.8 / collapse M1 + M2).
 
 The big commands carry dozens of options (``compare`` ~62, ``dump`` ~39); a flat
 list is the dominant source of perceived CLI complexity. rich-click renders the
@@ -27,11 +27,22 @@ render regardless of the program name — ``abicheck compare``, ``python -m
 abicheck compare``, or the ``main`` prog click uses under test. Unlisted options
 fall through to a default panel, and an unmatched command renders ungrouped — so
 this can never break a command, only prettify it.
+
+``compare`` additionally gets a second, orthogonal disclosure axis (M2): plain
+``compare --help`` shows only a curated common subset (see
+:data:`COMPARE_COMMON_OPTION_NAMES`), folding the long tail behind
+``compare --help-all``. See :func:`compare_help_options`.
 """
 
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
+from typing import TypeVar
+
+import click
+
+F = TypeVar("F", bound=Callable[..., object])
 
 # Per-command option panels. Options not listed here land in rich-click's
 # default trailing panel, so a new flag never has to be added here to work.
@@ -300,3 +311,133 @@ def configure_rich_help() -> None:
     # grouping panels (the actual M1 win) are unaffected; only colour is dropped,
     # so help text is deterministic everywhere.
     rich_click.rich_click.COLOR_SYSTEM = None
+
+
+# ── `compare --help-all` second-level disclosure (G21.8 / collapse M2) ───────
+#
+# The panels above (M1) already regroup all ~62 ``compare`` options so the flat
+# list isn't the whole story, but a first-time user still sees all ~62 in one
+# ``--help`` screen. This is a second axis, orthogonal to panels: a curated
+# subset of the everyday options stays on plain ``compare --help``; the long
+# tail (per-side toolchain overrides, build-config matrix idioms, release
+# knobs, …) is folded behind ``compare --help-all``. Purely presentational —
+# every option keeps working unqualified; only its default *visibility* in the
+# help screen changes.
+#
+# Dest names (``click.Option.name``), not flag strings: a few options share
+# aliases (``-o``/``--output``) or are on/off pairs (``--demangle``/
+# ``--no-demangle``) where only one dest exists either way.
+COMPARE_COMMON_OPTION_NAMES: frozenset[str] = frozenset(
+    {
+        # Inputs
+        "header",
+        "include",
+        "lang",
+        # Output & reporting
+        "output",
+        "fmt",
+        "show_only",
+        "stat",
+        "demangle",
+        # Policy & severity
+        "config",
+        "policy",
+        "policy_file_path",
+        "suppress",
+        "severity_preset",
+        # Scoped comparison (ADR-043) — headline feature, not a long-tail knob
+        "used_by_apps",
+        "required_symbols_opt",
+        "required_symbols_file",
+        # Build & source evidence
+        "depth",
+        "sources",
+        "build_info",
+        # Public-surface scoping
+        "scope_public_headers",
+        # Debug info -- only the coarse per-run override stays visible; the
+        # format/debuginfod/dwarf-only knobs are demoted to the `debug:`
+        # config block (ADR-040 L2) and already hidden regardless of tier.
+        "debug_root",
+        # Per-side overrides -- version labelling is routine for bare .so
+        # inputs; --pdb-path stays in the advanced tier.
+        "version",
+        # Universal
+        "verbose",
+        "dry_run",
+        # The help options themselves always stay visible
+        "help",
+        "help_all",
+    }
+)
+
+
+def _compare_help_callback(ctx: click.Context, _param: click.Parameter, value: bool) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+    cmd = ctx.command
+    original_params = cmd.params
+    # Filter the *params list* itself rather than flipping each Option's
+    # ``hidden`` flag: rich-click's OPTION_GROUPS panels (M1) resolve their
+    # members by name against ``command.get_params(ctx)`` at render time and
+    # include them regardless of ``hidden`` — that flag only affects options
+    # that fall through to the default catch-all panel, which is nearly none
+    # of compare's options once M1 grouped them all. Removing the advanced
+    # options from ``params`` for the duration of this render means the named
+    # panels simply can't find them, so they resolve to zero rows and rich-click
+    # drops the (now-empty) panel entirely. Arguments always stay.
+    common = [
+        p
+        for p in original_params
+        if isinstance(p, click.Argument) or p.name in COMPARE_COMMON_OPTION_NAMES
+    ]
+    hidden_count = len(original_params) - len(common)
+    cmd.params = common
+    try:
+        help_text = ctx.get_help()
+    finally:
+        cmd.params = original_params
+    click.echo(help_text, color=ctx.color)
+    click.echo(
+        f"\n{hidden_count} advanced option(s) hidden. "
+        "Run 'abicheck compare --help-all' to see every option."
+    )
+    ctx.exit()
+
+
+def _compare_help_all_callback(ctx: click.Context, _param: click.Parameter, value: bool) -> None:
+    if not value or ctx.resilient_parsing:
+        return
+    click.echo(ctx.get_help(), color=ctx.color)
+    ctx.exit()
+
+
+def compare_help_options(func: F) -> F:
+    """Replace ``compare``'s automatic ``--help`` with the curated/full pair.
+
+    Declaring our own ``--help`` here (rather than adding a *second* option)
+    is deliberate: Click only auto-adds its default help option when no
+    existing param already claims the ``--help`` flag string, so this one
+    decorator both replaces the default (curated) behaviour and adds the new
+    ``--help-all`` (full) escape hatch, with no risk of two competing
+    ``--help`` options.
+    """
+    func = click.option(
+        "--help-all",
+        is_flag=True,
+        default=False,
+        expose_value=False,
+        is_eager=True,
+        callback=_compare_help_all_callback,
+        help="Show every option, including advanced/less-common ones.",
+    )(func)
+    func = click.option(
+        "--help",
+        is_flag=True,
+        default=False,
+        expose_value=False,
+        is_eager=True,
+        callback=_compare_help_callback,
+        help="Show common options and exit. Use --help-all to see every option.",
+    )(func)
+    return func

--- a/abicheck/cli_help.py
+++ b/abicheck/cli_help.py
@@ -57,7 +57,7 @@ OPTION_GROUPS: dict[str, list[dict[str, object]]] = {
             ],
         },
         {
-            "name": "Toolchain (L2 header AST)",
+            "name": "Toolchain (header parsing)",
             "options": [
                 "--ast-frontend",
                 "--old-ast-frontend",
@@ -104,7 +104,7 @@ OPTION_GROUPS: dict[str, list[dict[str, object]]] = {
             "options": ["--debug-root"],
         },
         {
-            "name": "Build/source evidence (L3–L5)",
+            "name": "Build & source evidence (--depth build/source)",
             "options": [
                 "--build-info",
                 "--sources",
@@ -186,7 +186,7 @@ OPTION_GROUPS: dict[str, list[dict[str, object]]] = {
             ],
         },
         {
-            "name": "Build/source evidence (L3–L5)",
+            "name": "Build & source evidence (--depth build/source)",
             "options": [
                 "--depth",
                 "--build-info",
@@ -237,7 +237,7 @@ OPTION_GROUPS: dict[str, list[dict[str, object]]] = {
             "options": ["--crosscheck", "--risk-rules"],
         },
         {
-            "name": "Toolchain (L2 header AST)",
+            "name": "Toolchain (header parsing)",
             "options": [
                 "--lang",
                 "--ast-frontend",

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -1041,8 +1041,8 @@ def build_source_dump_options(func: F) -> F:
         type=DEPTH_PARAM,
         default=None,
         help="Evidence-depth dial (same vocabulary as `compare`/`scan --depth`): "
-        "binary=L0/L1 only, headers=+L2 AST (default), build=+L3 build context, "
-        "source=+L4 replay & the L5 graph.",
+        "binary=symbols only, headers=+header AST (default), build=+build "
+        "context, source=+source replay & call graph.",
     )(func)
     func = click.option(
         "--allow-build-query",
@@ -1091,17 +1091,17 @@ def build_source_dump_options(func: F) -> F:
         "sources",
         type=click.Path(exists=True, path_type=Path),
         default=None,
-        help="Source checkout to run L4 source ABI replay + the L5 graph over "
-        "and embed inline. (An existing pack directory — e.g. from the "
-        "abicheck-cc wrapper or Clang plugin — is auto-detected by its "
-        "manifest.json and loaded as that pack instead.)",
+        help="Source checkout to run source-ABI replay and build the call "
+        "graph over, embedding both inline. (An existing pack directory — e.g. "
+        "from the abicheck-cc wrapper or Clang plugin — is auto-detected by "
+        "its manifest.json and loaded as that pack instead.)",
     )(func)
     func = click.option(
         "--build-info",
         "build_info",
         type=click.Path(exists=True, path_type=Path),
         default=None,
-        help="Optional L3 build context: a build dir, a compile_commands.json, "
+        help="Optional build context: a build dir, a compile_commands.json, "
         "or a pre-captured pack. Auto-discovered inside the --sources tree when "
         "omitted.",
     )(func)
@@ -1134,16 +1134,16 @@ def evidence_options(func: F) -> F:
         "depth",
         type=DEPTH_PARAM,
         default=None,
-        help="Evidence-depth dial: binary=L0/L1 only, headers=+L2 AST (default), "
-        "build=+L3, source=+L4 replay & the L5 graph. Deeper-than-headers needs "
-        "--sources or --build-info.",
+        help="Evidence-depth dial: binary=symbols only, headers=+header AST "
+        "(default), build=+build context, source=+source replay & call graph. "
+        "Deeper-than-headers needs --sources or --build-info.",
     )(func)
     func = click.option(
         "--sources",
         "sources",
         multiple=True,
         type=SIDED_SOURCES_PARAM,
-        help="L4/L5 source: a raw source checkout (collected inline at --depth, "
+        help="Source checkout for --depth build/source (collected inline, "
         "embedding build/source/graph facts) or a pre-built `collect` pack, "
         "overriding embedded. Applies to both sides; scope to one with an "
         "'old='/'new=' prefix, repeating the flag per side "
@@ -1154,9 +1154,9 @@ def evidence_options(func: F) -> F:
         "build_info",
         multiple=True,
         type=SIDED_BUILD_INFO_PARAM,
-        help="Out-of-band L3 build-info: a build dir, a compile_commands.json, or "
-        "a pack, overriding embedded. Applies to both sides; scope to one with an "
-        "'old='/'new=' prefix, repeating the flag per side "
+        help="Out-of-band build context: a build dir, a compile_commands.json, "
+        "or a pack, overriding embedded. Applies to both sides; scope to one "
+        "with an 'old='/'new=' prefix, repeating the flag per side "
         "(e.g. --build-info old=b1 --build-info new=b2) (ADR-040).",
     )(func)
     return func

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -1387,10 +1387,20 @@ COMPARE_FLAG_BUDGET_RAISES: dict[str, str] = {
 COMPARE_FLAG_BUDGET = COMPARE_FLAG_BUDGET_BASE + len(COMPARE_FLAG_BUDGET_RAISES)
 
 
+#: Navigational meta-options excluded from the flag-count budget: they are
+#: not a per-run analysis input the ADR-037 D10.5 budget is bounding, just a
+#: help-screen escape hatch (G21.8 collapse M2's curated/full `compare --help`
+#: split, mirroring how Click's own auto-added ``--help`` was never a real
+#: ``cmd.params`` entry and so never counted either).
+_HELP_META_OPTION_NAMES = frozenset({"help", "help_all"})
+
+
 def count_visible_options(cmd: object) -> int:
     """Count a Click command's user-visible (non-hidden) options (ADR-037 D10.5)."""
     n = 0
     for p in getattr(cmd, "params", []):
+        if getattr(p, "name", None) in _HELP_META_OPTION_NAMES:
+            continue
         if getattr(p, "param_type_name", None) == "option" and not getattr(
             p, "hidden", False
         ):

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -1427,8 +1427,16 @@ COMPARE_PROFILES: dict[str, dict[str, object]] = {
         "exit_code_scheme": "severity",
     },
     # Release cut: deepest evidence, full Markdown report with a semver/SONAME
-    # recommendation appended — the "should I bump?" flow.
-    "release": {
+    # recommendation appended — the "should I bump?" flow. Named "release-cut"
+    # rather than bare "release" (CLI audit finding): compare's directory/
+    # package fan-out mode is *also* informally branded "release" throughout
+    # (compare_release_cmd, release_options, the "Release (directory/package
+    # inputs)" help panel) -- an unrelated concept that shares only the word.
+    # `_profile_targets_set_input` already rejects `--profile` on a directory/
+    # package operand with a clear error, so the collision was never a live
+    # bug, but a user skimming --help could reasonably (and wrongly) assume
+    # the two are related.
+    "release-cut": {
         "depth": "source",
         "fmt": "markdown",
         "recommend": True,
@@ -1478,9 +1486,12 @@ def profile_option(func: F) -> F:
         default=None,
         help="Run-profile preset bundling workflow defaults (ADR-040): "
         "'ci-gate' (headers depth, review digest, severity exit codes), "
-        "'release' (source depth, recommendation, Markdown), 'quick' "
-        "(symbols-only, one-line summary). Explicit flags override the profile; "
-        "single-pair compares only (configure release defaults in .abicheck.yml).",
+        "'release-cut' (source depth, recommendation, Markdown -- the "
+        "'should I bump semver?' flow; distinct from directory/package "
+        "'release' comparisons, which this profile does not apply to), "
+        "'quick' (symbols-only, one-line summary). Explicit flags override "
+        "the profile; single-pair compares only (configure release defaults "
+        "in .abicheck.yml).",
     )(func)
     return func
 

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -515,7 +515,8 @@ def _emit_scan_report(outcome: ScanOutcome, fmt: str, output: Path | None) -> No
     "build_info",
     type=click.Path(exists=True, path_type=Path),
     default=None,
-    help="Out-of-tree build dir / compile_commands.json / pack supplying L3.",
+    help="Out-of-tree build dir / compile_commands.json / pack supplying "
+    "build context.",
 )
 @click.option(
     "--compile-db",
@@ -549,8 +550,8 @@ def _emit_scan_report(outcome: ScanOutcome, fmt: str, output: Path | None) -> No
     type=DEPTH_PARAM,
     default=None,
     help="Evidence depth to collect -- the single dial, named by what you get: "
-    "binary (L0/L1 symbols only), headers (+L2 AST), build (+L3 build context), "
-    "source (+L4 replay & the L5 graph). Omit for 'auto' (risk-driven when a "
+    "binary (symbols only), headers (+header AST), build (+build context), "
+    "source (+source replay & call graph). Omit for 'auto' (risk-driven when a "
     "--since/--changed-path seed is present, else a sensible default). "
     "--depth source uses changed-path scope when --since/--changed-path is "
     "given, else the current library target -- never a zero-TU no-op.",

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -401,8 +401,22 @@ def _build_testsuite(
         changes, result, kind_sets, severity_config, relevant_ids=relevant_ids
     )
     missing_labels = getattr(result, "scoped_missing_labels", ()) or ()
+    # The missing-contract failure decision must follow the same severity
+    # decision as the gate's own exit code (severity.missing_contract_exit_code,
+    # which _scoped_exit_code floors on): under the legacy scheme (no
+    # severity_config) a missing contract member is unconditionally BREAKING,
+    # but under a scheme that demotes abi_breaking the scoped exit code can be
+    # 0 for the same missing member -- unconditionally failing here would mark
+    # a JUnit-consuming CI run failed even though the gate itself passed
+    # (Codex review).
+    missing_blocks = severity_config is None
+    if severity_config is not None:
+        from .severity import missing_contract_exit_code
+
+        missing_blocks = missing_contract_exit_code(severity_config) != 0
     total = (len(all_symbols) if all_symbols else len(change_by_symbol)) + len(missing_labels)
-    failure_count += len(missing_labels)
+    if missing_blocks:
+        failure_count += len(missing_labels)
 
     ts = ET.Element("testsuite")
     ts.set("name", result.library)
@@ -424,31 +438,41 @@ def _build_testsuite(
     _append_extra_failures(
         ts, extra_changes, result, kind_sets, severity_config, relevant_ids=relevant_ids
     )
-    _emit_missing_contract_testcases(ts, missing_labels, getattr(result, "gate_scope", None))
+    _emit_missing_contract_testcases(
+        ts, missing_labels, getattr(result, "gate_scope", None), blocks=missing_blocks
+    )
 
     return ts
 
 
 def _emit_missing_contract_testcases(
     ts: ET.Element, missing_labels: tuple[str, ...], gate_scope: str | None,
+    *, blocks: bool = True,
 ) -> None:
-    """Emit a failing ``<testcase>`` per missing required symbol/version/entrypoint.
+    """Emit a ``<testcase>`` per missing required symbol/version/entrypoint.
 
     A required contract member absent from the new library (--used-by's
     ``missing_symbols``/``missing_versions``, or --required-symbol's
-    ``missing_entrypoints``) is unconditionally BREAKING for the scoped gate,
-    but has no backing diff ``Change`` -- without a synthetic testcase the
-    gate's own ``failures`` count could be nonzero while nothing in the XML
-    explains why (CLI-audit P1, mirrors ``sarif._missing_contract_result``).
+    ``missing_entrypoints``) has no backing diff ``Change`` -- without a
+    synthetic testcase the gate's own ``failures`` count could be nonzero
+    while nothing in the XML explains why (CLI-audit P1, mirrors
+    ``sarif._missing_contract_result``).
+
+    *blocks* (the caller's severity-aware decision, mirroring
+    ``sarif._missing_contract_result``) decides whether the testcase gets a
+    ``<failure>`` child: a testcase always exists so the missing member is
+    still visible in the report, but only fails when the gate itself
+    considers it blocking.
     """
     classname = "used_by_contract" if gate_scope == "used_by" else "required_symbol_contract"
     for label in missing_labels:
         tc = ET.SubElement(ts, "testcase")
         tc.set("name", label)
         tc.set("classname", classname)
-        fail = ET.SubElement(tc, "failure")
-        fail.set("message", f"Required symbol/version '{label}' is missing from the new library.")
-        fail.set("type", "MISSING_CONTRACT_MEMBER")
+        if blocks:
+            fail = ET.SubElement(tc, "failure")
+            fail.set("message", f"Required symbol/version '{label}' is missing from the new library.")
+            fail.set("type", "MISSING_CONTRACT_MEMBER")
 
 
 def _add_scoped_properties(ts: ET.Element, result: DiffResult) -> None:

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -46,7 +46,7 @@ from typing import TYPE_CHECKING
 
 from .checker_policy import ChangeKind, Verdict
 from .checker_types import Change, DiffResult
-from .reporter import apply_show_only
+from .reporter import _finding_id, apply_show_only
 
 if TYPE_CHECKING:
     from .model import AbiSnapshot
@@ -95,6 +95,8 @@ def _is_failure(
     result: DiffResult,
     kind_sets: KindSets,
     severity_config: SeverityConfig | None = None,
+    *,
+    relevant_ids: frozenset[str] | None = None,
 ) -> bool:
     """Return True if the change should be a JUnit ``<failure>``.
 
@@ -117,7 +119,16 @@ def _is_failure(
     API_BREAK verdicts always fail. COMPATIBLE_WITH_RISK fails only when its
     per-kind severity is ``"error"`` (currently all RISK_KINDS default to
     ``"warning"``, so they pass).
+
+    *relevant_ids*, when not ``None``, means a ``--used-by``/``--required-symbol``
+    gate is active: a change whose :func:`abicheck.reporter._finding_id` is
+    absent from the set can never fail here regardless of its own severity --
+    it is out of scope for the gate this testsuite now reports (CLI-audit P1:
+    JUnit failures must follow the scoped gate, not just the full-library
+    verdict).
     """
+    if relevant_ids is not None and _finding_id(change) not in relevant_ids:
+        return False
     if severity_config is not None:
         from .severity import SeverityLevel, classify_effective_change
 
@@ -271,11 +282,13 @@ def _count_failures(
     result: DiffResult,
     kind_sets: KindSets,
     severity_config: SeverityConfig | None,
+    *,
+    relevant_ids: frozenset[str] | None = None,
 ) -> int:
     """Count distinct symbols that have at least one failing change."""
     symbols_with_failure: set[str] = set()
     for c in changes:
-        if _is_failure(c, result, kind_sets, severity_config):
+        if _is_failure(c, result, kind_sets, severity_config, relevant_ids=relevant_ids):
             symbols_with_failure.add(c.symbol)
     return len(symbols_with_failure)
 
@@ -287,6 +300,8 @@ def _emit_testcases(
     result: DiffResult,
     kind_sets: KindSets,
     severity_config: SeverityConfig | None,
+    *,
+    relevant_ids: frozenset[str] | None = None,
 ) -> None:
     """Append ``<testcase>`` elements to *ts* for every symbol in *all_symbols*.
 
@@ -305,6 +320,7 @@ def _emit_testcases(
                     result,
                     kind_sets,
                     severity_config,
+                    relevant_ids=relevant_ids,
                 )
     else:
         # No snapshot — only emit changed symbols
@@ -318,6 +334,7 @@ def _emit_testcases(
                 result,
                 kind_sets,
                 severity_config,
+                relevant_ids=relevant_ids,
             )
 
 
@@ -327,6 +344,8 @@ def _append_extra_failures(
     result: DiffResult,
     kind_sets: KindSets,
     severity_config: SeverityConfig | None,
+    *,
+    relevant_ids: frozenset[str] | None = None,
 ) -> None:
     """Append extra ``<failure>`` children to already-existing testcases.
 
@@ -335,7 +354,7 @@ def _append_extra_failures(
     ``<testcase>`` with the matching name and attach a new ``<failure>``.
     """
     for c in extra_changes:
-        if _is_failure(c, result, kind_sets, severity_config):
+        if _is_failure(c, result, kind_sets, severity_config, relevant_ids=relevant_ids):
             for tc in ts:
                 if tc.get("name") == c.symbol:
                     _add_failure(tc, c, result, kind_sets, severity_config)
@@ -372,9 +391,18 @@ def _build_testsuite(
 
     change_by_symbol, extra_changes = _partition_changes(changes)
     all_symbols = _collect_all_symbols(old_snapshot, show_only, change_by_symbol)
-    failure_count = _count_failures(changes, result, kind_sets, severity_config)
 
-    total = len(all_symbols) if all_symbols else len(change_by_symbol)
+    # When --used-by/--required-symbol scoping is active, relevant_ids makes
+    # failures follow the scoped gate rather than the full library verdict
+    # (CLI-audit P1 fix); None means no scoping is active, so behavior below
+    # is unchanged from before.
+    relevant_ids = getattr(result, "scoped_relevant_finding_ids", None)
+    failure_count = _count_failures(
+        changes, result, kind_sets, severity_config, relevant_ids=relevant_ids
+    )
+    missing_labels = getattr(result, "scoped_missing_labels", ()) or ()
+    total = (len(all_symbols) if all_symbols else len(change_by_symbol)) + len(missing_labels)
+    failure_count += len(missing_labels)
 
     ts = ET.Element("testsuite")
     ts.set("name", result.library)
@@ -391,26 +419,47 @@ def _build_testsuite(
         result,
         kind_sets,
         severity_config,
+        relevant_ids=relevant_ids,
     )
-    _append_extra_failures(ts, extra_changes, result, kind_sets, severity_config)
+    _append_extra_failures(
+        ts, extra_changes, result, kind_sets, severity_config, relevant_ids=relevant_ids
+    )
+    _emit_missing_contract_testcases(ts, missing_labels, getattr(result, "gate_scope", None))
 
     return ts
 
 
+def _emit_missing_contract_testcases(
+    ts: ET.Element, missing_labels: tuple[str, ...], gate_scope: str | None,
+) -> None:
+    """Emit a failing ``<testcase>`` per missing required symbol/version/entrypoint.
+
+    A required contract member absent from the new library (--used-by's
+    ``missing_symbols``/``missing_versions``, or --required-symbol's
+    ``missing_entrypoints``) is unconditionally BREAKING for the scoped gate,
+    but has no backing diff ``Change`` -- without a synthetic testcase the
+    gate's own ``failures`` count could be nonzero while nothing in the XML
+    explains why (CLI-audit P1, mirrors ``sarif._missing_contract_result``).
+    """
+    classname = "used_by_contract" if gate_scope == "used_by" else "required_symbol_contract"
+    for label in missing_labels:
+        tc = ET.SubElement(ts, "testcase")
+        tc.set("name", label)
+        tc.set("classname", classname)
+        fail = ET.SubElement(tc, "failure")
+        fail.set("message", f"Required symbol/version '{label}' is missing from the new library.")
+        fail.set("type", "MISSING_CONTRACT_MEMBER")
+
+
 def _add_scoped_properties(ts: ET.Element, result: DiffResult) -> None:
     """Append a ``<properties>`` block when ``--used-by``/``--required-symbol(s)``
-    scoping was requested (ADR-043).
+    scoping was requested (ADR-043 + CLI-audit P1).
 
-    JUnit's ``<testsuite>``/``<testcase>`` pass/fail counts above stay
-    computed from the full, unscoped library diff -- this format's binary/
-    structured contract intentionally keeps that authoritative for CI
-    dashboards that parse it. But the actual CLI process exits on the
-    *scoped* verdict floor when scoping is requested, which can legitimately
-    disagree with this testsuite's own failure count. Without this block a
-    JUnit consumer had no way to discover that disagreement -- this makes it
-    auditable, mirroring the human-format banner
-    (``_fold_scoped_compat_into_text``) without changing this testsuite's own
-    pass/fail semantics.
+    The scoped gate is authoritative for this testsuite's own ``failures``
+    count and each ``<testcase>``'s pass/fail status -- ``result.verdict``
+    (the full, unscoped library verdict) is still reported here as
+    ``abicheck.full_library_verdict`` for context, but no longer drives what
+    a JUnit-consuming CI dashboard treats as failing.
     """
     scoped_verdict = getattr(result, "scoped_verdict", None)
     if scoped_verdict is None:
@@ -422,33 +471,25 @@ def _add_scoped_properties(ts: ET.Element, result: DiffResult) -> None:
         p.set("name", name)
         p.set("value", value)
 
-    _prop("abicheck.scoped_verdict", scoped_verdict.value)
+    gate_scope = getattr(result, "gate_scope", None)
+    if gate_scope is not None:
+        _prop("abicheck.gate_scope", gate_scope)
+    _prop("abicheck.gate_verdict", scoped_verdict.value)
     _prop("abicheck.full_library_verdict", result.verdict.value)
+    # Back-compat alias for the property's original name.
+    _prop("abicheck.scoped_verdict", scoped_verdict.value)
+    relevant_ids = getattr(result, "scoped_relevant_finding_ids", None) or frozenset()
+    relevant_count = sum(1 for c in result.changes if _finding_id(c) in relevant_ids)
+    _prop("abicheck.relevant_finding_count", str(relevant_count))
+    _prop("abicheck.unrelated_finding_count", str(len(result.changes) - relevant_count))
     scoped_exit_code = getattr(result, "scoped_exit_code", None)
     scoped_exit_code_scheme = getattr(result, "scoped_exit_code_scheme", None)
-    # Under a severity scheme scoped_exit_code is NOT a fixed
-    # BREAKING->4/API_BREAK->2 mapping of scoped_verdict -- e.g.
-    # --severity-preset info-only can floor it at 0 even for a BREAKING
-    # scoped_verdict (Codex review) -- so state the actual computed value
-    # and scheme rather than implying a verdict->exit-code equivalence that
-    # only holds under the legacy scheme.
     if scoped_exit_code is not None:
+        _prop("abicheck.gate_exit_code", str(scoped_exit_code))
+        _prop("abicheck.gate_exit_code_scheme", str(scoped_exit_code_scheme))
+        # Back-compat aliases.
         _prop("abicheck.scoped_exit_code", str(scoped_exit_code))
         _prop("abicheck.scoped_exit_code_scheme", str(scoped_exit_code_scheme))
-        note = (
-            f"The CLI process exits {scoped_exit_code} under the "
-            f"{scoped_exit_code_scheme} exit-code scheme for this run -- "
-            f"this may differ from both scoped_verdict's legacy-scheme "
-            f"mapping and this testsuite's own failures count (which stays "
-            f"computed from the full library)."
-        )
-    else:
-        note = (
-            "The CLI process exit code for this run may differ from this "
-            "testsuite's own failures count (which stays computed from the "
-            "full library)."
-        )
-    _prop("abicheck.scoped_note", note)
     used_by = getattr(result, "used_by", None)
     if used_by is not None:
         _prop("abicheck.used_by_app_count", str(len(used_by)))
@@ -466,9 +507,11 @@ def _maybe_add_failure(
     result: DiffResult,
     kind_sets: KindSets,
     severity_config: SeverityConfig | None = None,
+    *,
+    relevant_ids: frozenset[str] | None = None,
 ) -> None:
     """Add a ``<failure>`` child to *tc* if the change is a failure."""
-    if _is_failure(change, result, kind_sets, severity_config):
+    if _is_failure(change, result, kind_sets, severity_config, relevant_ids=relevant_ids):
         _add_failure(tc, change, result, kind_sets, severity_config)
 
 

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -380,6 +380,14 @@ def _build_testsuite(
     kind_sets = result._effective_kind_sets()
 
     changes = list(result.changes)
+    # Scoped-only changes: scope_diff_to_app/scope_diff_to_required_symbols
+    # can synthesize a Change (e.g. PE_ORDINAL_RETARGETED) that is relevant
+    # to the gate but was never added to result.changes -- fold them into the
+    # same testcase pipeline (symbol grouping, failure decision via
+    # relevant_ids below) rather than a bespoke path, so a --used-by run
+    # that fails solely because of one of these still has a testcase/failure
+    # to explain it (Codex review).
+    changes += list(getattr(result, "scoped_only_changes", ()) or ())
     if show_only:
         changes = apply_show_only(
             changes,
@@ -503,9 +511,17 @@ def _add_scoped_properties(ts: ET.Element, result: DiffResult) -> None:
     # Back-compat alias for the property's original name.
     _prop("abicheck.scoped_verdict", scoped_verdict.value)
     relevant_ids = getattr(result, "scoped_relevant_finding_ids", None) or frozenset()
-    relevant_count = sum(1 for c in result.changes if _finding_id(c) in relevant_ids)
+    relevant_in_changes = sum(1 for c in result.changes if _finding_id(c) in relevant_ids)
+    # Scoped-only changes and missing-contract members are relevant by
+    # construction and never in result.changes, so they count toward
+    # relevant_finding_count but not unrelated_finding_count, which only
+    # counts irrelevant entries *within* result.changes (CodeRabbit review,
+    # mirrors sarif._scoped_gate_properties).
+    scoped_only_count = len(getattr(result, "scoped_only_changes", ()) or ())
+    missing_count = len(getattr(result, "scoped_missing_labels", ()) or ())
+    relevant_count = relevant_in_changes + scoped_only_count + missing_count
     _prop("abicheck.relevant_finding_count", str(relevant_count))
-    _prop("abicheck.unrelated_finding_count", str(len(result.changes) - relevant_count))
+    _prop("abicheck.unrelated_finding_count", str(len(result.changes) - relevant_in_changes))
     scoped_exit_code = getattr(result, "scoped_exit_code", None)
     scoped_exit_code_scheme = getattr(result, "scoped_exit_code_scheme", None)
     if scoped_exit_code is not None:

--- a/abicheck/junit_report.py
+++ b/abicheck/junit_report.py
@@ -422,6 +422,21 @@ def _build_testsuite(
         from .severity import missing_contract_exit_code
 
         missing_blocks = missing_contract_exit_code(severity_config) != 0
+    # A missing-contract label has no backing Change/ChangeKind, so it can't
+    # run through apply_show_only above -- but --show-only's severity
+    # dimension still applies: without this, a --show-only run excluding
+    # breaking findings would still count/emit a failing testcase for a
+    # missing required symbol the filter was meant to hide (Codex review,
+    # mirrors the identical sarif.to_sarif/_fold_scoped_compat_into_text
+    # fix). Element/action tokens don't cleanly apply to "a symbol is simply
+    # absent", so only the severity dimension is checked.
+    if show_only and missing_labels:
+        from .reporter_markdown import ShowOnlyFilter
+
+        missing_severity_label = "breaking" if missing_blocks else "compatible"
+        show_only_severities = ShowOnlyFilter.parse(show_only).severities
+        if show_only_severities and missing_severity_label not in show_only_severities:
+            missing_labels = ()
     total = (len(all_symbols) if all_symbols else len(change_by_symbol)) + len(missing_labels)
     if missing_blocks:
         failure_count += len(missing_labels)

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -1221,7 +1221,13 @@ def abi_compare(
                             f"Required symbol/version '{label}' is missing "
                             "from the new library."
                         ),
-                        "impact": None,
+                        # A missing-contract label has no ChangeKind to run
+                        # through _impact_category, but its severity is known
+                        # (blocks_gate) -- reuse the same "breaking"/
+                        # "compatible" label the CLI text report and severity
+                        # gate already use for this, so the summary tally
+                        # below has something to count it under.
+                        "impact": "breaking" if blocks else "compatible",
                         "old_value": None,
                         "new_value": None,
                         "source_location": None,
@@ -1229,6 +1235,24 @@ def abi_compare(
                         "blocks_gate": blocks,
                     }
                 )
+
+            # Recompute summary now that scoped-only changes/missing-contract
+            # labels were folded into "changes" above -- otherwise a run
+            # gated purely by one of these (e.g. a missing required symbol,
+            # or a scoped-only PE_ORDINAL_RETARGETED change) reports
+            # total_changes: 0 alongside a BREAKING verdict/nonzero exit_code,
+            # since the per-category counts were computed from result.changes
+            # before the fold-in (CodeRabbit review).
+            impact_tally = {"breaking": 0, "api_break": 0, "risk": 0, "compatible": 0}
+            for c in response["changes"]:
+                impact_tally[c["impact"]] = impact_tally.get(c["impact"], 0) + 1
+            response["summary"] = {
+                "breaking": impact_tally["breaking"],
+                "api_breaks": impact_tally["api_break"],
+                "risk_changes": impact_tally["risk"],
+                "compatible": impact_tally["compatible"],
+                "total_changes": len(response["changes"]),
+            }
 
         # Include rendered report
         rendered = _render_output(

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -996,6 +996,12 @@ def abi_compare(
             # result levels/failure counts follow the scoped gate (CLI-audit
             # P1), mirroring cli_compare_helpers._apply_used_by_scoping.
             relevant_finding_ids: set[str] = set()
+            # Union across ALL apps of relevant Change objects (not just
+            # ids) so scoped-only changes (e.g. PE_ORDINAL_RETARGETED,
+            # synthesized fresh per app and never added to result.changes)
+            # can still be rendered by SARIF/JUnit (Codex review, mirrors
+            # cli_compare_helpers._apply_used_by_scoping).
+            relevant_changes_by_id: dict[str, Any] = {}
             missing_labels: set[str] = set()
             for app in used_by:
                 app_path = _safe_read_path(app, label="used_by")
@@ -1009,6 +1015,9 @@ def abi_compare(
                     policy=active_policy, policy_file=pf,
                 )
                 relevant_finding_ids.update(_finding_id(c) for c in scoped.breaking_for_app)
+                relevant_changes_by_id.update(
+                    {_finding_id(c): c for c in scoped.breaking_for_app}
+                )
                 # A missing symbol/version already covered by a relevant
                 # Change (e.g. FUNC_REMOVED) must not also become a
                 # synthetic missing-contract finding (Codex review, mirrors
@@ -1067,6 +1076,10 @@ def abi_compare(
             result.gate_scope = "used_by"  # type: ignore[attr-defined]
             result.scoped_relevant_finding_ids = frozenset(relevant_finding_ids)  # type: ignore[attr-defined]
             result.scoped_missing_labels = tuple(sorted(missing_labels))  # type: ignore[attr-defined]
+            _existing_ids = {_finding_id(c) for c in result.changes}
+            result.scoped_only_changes = tuple(  # type: ignore[attr-defined]
+                c for fid, c in relevant_changes_by_id.items() if fid not in _existing_ids
+            )
             if severity_config is not None:
                 categories, counts = _scoped_severity_summary(
                     list(worst_changes.values()), worst_missing,
@@ -1116,6 +1129,12 @@ def abi_compare(
                     scoped_host.missing_entrypoints, scoped_host.breaking_for_host
                 )
             ))
+            # Scoped-only changes: relevant to the host contract but never
+            # added to result.changes (mirrors the used_by branch above).
+            _existing_ids = {_finding_id(c) for c in result.changes}
+            result.scoped_only_changes = tuple(  # type: ignore[attr-defined]
+                c for c in scoped_host.breaking_for_host if _finding_id(c) not in _existing_ids
+            )
             if severity_config is not None:
                 categories, counts = _scoped_severity_summary(
                     scoped_host.breaking_for_host, scoped_host.missing_entrypoints,

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -1178,6 +1178,57 @@ def abi_compare(
         }
         if scoped_key is not None:
             response[scoped_key] = scoped_payload
+            # Scoped-only changes/missing-contract labels are relevant to the
+            # scoped gate but never land in result.changes -- without folding
+            # them into the top-level "changes" array too, a --used-by/
+            # --required-symbol response whose only gated issue is one of
+            # these shows an empty "changes" list despite a scoped
+            # verdict/exit_code that blocks, leaving a caller that only reads
+            # this array with nothing to explain the failure (Codex review,
+            # mirrors the identical fold-in in
+            # cli_compare_helpers._fold_scoped_compat_into_text).
+            existing_ids = {_finding_id(c) for c in result.changes}
+            for c in getattr(result, "scoped_only_changes", ()) or ():
+                if _finding_id(c) not in existing_ids:
+                    response["changes"].append(
+                        {
+                            "kind": c.kind.value,
+                            "symbol": c.symbol,
+                            "description": c.description,
+                            "impact": _impact_category(c.kind, active_policy),
+                            "old_value": c.old_value,
+                            "new_value": c.new_value,
+                            "source_location": c.source_location,
+                        }
+                    )
+            from .severity import missing_contract_exit_code
+
+            missing_kind = (
+                "used_by_missing_symbol"
+                if getattr(result, "gate_scope", None) == "used_by"
+                else "required_symbol_missing"
+            )
+            blocks = (
+                severity_config is None
+                or missing_contract_exit_code(severity_config) != 0
+            )
+            for label in getattr(result, "scoped_missing_labels", ()) or ():
+                response["changes"].append(
+                    {
+                        "kind": missing_kind,
+                        "symbol": label,
+                        "description": (
+                            f"Required symbol/version '{label}' is missing "
+                            "from the new library."
+                        ),
+                        "impact": None,
+                        "old_value": None,
+                        "new_value": None,
+                        "source_location": None,
+                        "relevant_to_gate": True,
+                        "blocks_gate": blocks,
+                    }
+                )
 
         # Include rendered report
         rendered = _render_output(
@@ -1200,7 +1251,9 @@ def abi_compare(
             # --secondary-format behavior — otherwise a client reading
             # response["report"] sees the unscoped full-library verdict even
             # though the top-level verdict/exit_code are scoped (Codex review).
-            rendered = _fold_scoped_compat_into_text(rendered, output_format, result)
+            rendered = _fold_scoped_compat_into_text(
+                rendered, output_format, result, severity_config=severity_config,
+            )
         if output_format == "json":
             response["report"] = json.loads(rendered)
         else:

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -1253,6 +1253,7 @@ def abi_compare(
             # though the top-level verdict/exit_code are scoped (Codex review).
             rendered = _fold_scoped_compat_into_text(
                 rendered, output_format, result, severity_config=severity_config,
+                show_only=show_only,
             )
         if output_format == "json":
             response["report"] = json.loads(rendered)

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -953,7 +953,7 @@ def abi_compare(
         scoped_payload: Any = None
         scoped_verdict_value: str | None = None
         if used_by:
-            from .appcompat import scope_diff_to_app
+            from .appcompat import scope_diff_to_app, uncovered_missing_symbols
             from .service import detect_binary_format
 
             old_lib: Any = old_path if detect_binary_format(old_path) is not None else old_snap
@@ -1009,8 +1009,16 @@ def abi_compare(
                     policy=active_policy, policy_file=pf,
                 )
                 relevant_finding_ids.update(_finding_id(c) for c in scoped.breaking_for_app)
-                missing_labels.update(scoped.missing_symbols)
-                missing_labels.update(scoped.missing_versions)
+                # A missing symbol/version already covered by a relevant
+                # Change (e.g. FUNC_REMOVED) must not also become a
+                # synthetic missing-contract finding (Codex review, mirrors
+                # cli_compare_helpers._apply_used_by_scoping's dedup).
+                missing_labels.update(
+                    uncovered_missing_symbols(
+                        list(scoped.missing_symbols) + list(scoped.missing_versions),
+                        scoped.breaking_for_app,
+                    )
+                )
                 summaries.append(
                     {
                         "app": scoped.app_path,
@@ -1067,7 +1075,10 @@ def abi_compare(
                 result.scoped_blocking_categories = categories  # type: ignore[attr-defined]
                 result.scoped_severity_counts = counts  # type: ignore[attr-defined]
         elif required_symbols:
-            from .appcompat import scope_diff_to_required_symbols
+            from .appcompat import (
+                scope_diff_to_required_symbols,
+                uncovered_missing_symbols,
+            )
 
             scoped_host = scope_diff_to_required_symbols(
                 result, old_snap, new_snap, required_symbols,
@@ -1097,7 +1108,14 @@ def abi_compare(
             result.scoped_relevant_finding_ids = frozenset(  # type: ignore[attr-defined]
                 _finding_id(c) for c in scoped_host.breaking_for_host
             )
-            result.scoped_missing_labels = tuple(sorted(scoped_host.missing_entrypoints))  # type: ignore[attr-defined]
+            # An entrypoint already covered by a relevant Change must not
+            # also become a synthetic missing-contract finding (Codex
+            # review).
+            result.scoped_missing_labels = tuple(sorted(  # type: ignore[attr-defined]
+                uncovered_missing_symbols(
+                    scoped_host.missing_entrypoints, scoped_host.breaking_for_host
+                )
+            ))
             if severity_config is not None:
                 categories, counts = _scoped_severity_summary(
                     scoped_host.breaking_for_host, scoped_host.missing_entrypoints,

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -70,7 +70,7 @@ from .checker_policy import (
 )
 from .errors import AbicheckError
 from .model import AbiSnapshot
-from .reporter import to_json, to_markdown
+from .reporter import _finding_id, to_json, to_markdown
 from .serialization import snapshot_to_json
 from .service import compare_snapshots
 
@@ -978,13 +978,18 @@ def abi_compare(
             worst_exit = 0
             worst_verdict = None
             worst_verdict_rank = -1
-            # Keyed by id(change)/the missing string itself so a Change or
-            # missing symbol shared by two tied apps (e.g. both import the
-            # same removed symbol) collapses to one entry instead of being
-            # tallied once per app (Codex review) -- `_scoped_severity_summary`
-            # runs once at the end over this deduplicated union, not per app
-            # summed together.
-            worst_changes: dict[int, Any] = {}
+            # Keyed by the change's semantic identity (kind/symbol/old/new/
+            # location/description, via `_finding_id`) -- not id(change) --
+            # so a Change or missing symbol shared by two tied apps (e.g.
+            # both import the same removed symbol) collapses to one entry
+            # instead of being tallied once per app (Codex review) --
+            # `_scoped_severity_summary` runs once at the end over this
+            # deduplicated union, not per app summed together. `id()` alone
+            # under-deduplicates PE_ORDINAL_RETARGETED findings: each app's
+            # `scope_diff_to_app` call synthesizes a fresh `Change` object
+            # for the same underlying ordinal retarget (see
+            # `cli_compare_helpers._apply_used_by_scoping`).
+            worst_changes: dict[str, Any] = {}
             worst_missing: set[str] = set()
             for app in used_by:
                 app_path = _safe_read_path(app, label="used_by")
@@ -1019,10 +1024,10 @@ def abi_compare(
                 # independently -- see _verdict_severity_rank.
                 if severity_config is not None:
                     if app_exit > worst_exit:
-                        worst_changes = {id(c): c for c in scoped.breaking_for_app}
+                        worst_changes = {_finding_id(c): c for c in scoped.breaking_for_app}
                         worst_missing = set(scoped.missing_symbols) | set(scoped.missing_versions)
                     elif app_exit == worst_exit:
-                        worst_changes.update({id(c): c for c in scoped.breaking_for_app})
+                        worst_changes.update({_finding_id(c): c for c in scoped.breaking_for_app})
                         worst_missing |= set(scoped.missing_symbols) | set(scoped.missing_versions)
                 worst_exit = max(worst_exit, app_exit)
                 rank = _verdict_severity_rank(scoped.verdict)

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -991,6 +991,12 @@ def abi_compare(
             # `cli_compare_helpers._apply_used_by_scoping`).
             worst_changes: dict[str, Any] = {}
             worst_missing: set[str] = set()
+            # Union across ALL apps of which findings this --used-by gate
+            # cares about -- SARIF/JUnit consult this to make their own
+            # result levels/failure counts follow the scoped gate (CLI-audit
+            # P1), mirroring cli_compare_helpers._apply_used_by_scoping.
+            relevant_finding_ids: set[str] = set()
+            missing_labels: set[str] = set()
             for app in used_by:
                 app_path = _safe_read_path(app, label="used_by")
                 if not app_path.exists():
@@ -1002,6 +1008,9 @@ def abi_compare(
                     result, app_path, old_lib, new_lib,
                     policy=active_policy, policy_file=pf,
                 )
+                relevant_finding_ids.update(_finding_id(c) for c in scoped.breaking_for_app)
+                missing_labels.update(scoped.missing_symbols)
+                missing_labels.update(scoped.missing_versions)
                 summaries.append(
                     {
                         "app": scoped.app_path,
@@ -1047,6 +1056,9 @@ def abi_compare(
             result.scoped_exit_code = worst_exit  # type: ignore[attr-defined]
             scoped_scheme = "severity" if severity_config is not None else "legacy"
             result.scoped_exit_code_scheme = scoped_scheme  # type: ignore[attr-defined]
+            result.gate_scope = "used_by"  # type: ignore[attr-defined]
+            result.scoped_relevant_finding_ids = frozenset(relevant_finding_ids)  # type: ignore[attr-defined]
+            result.scoped_missing_labels = tuple(sorted(missing_labels))  # type: ignore[attr-defined]
             if severity_config is not None:
                 categories, counts = _scoped_severity_summary(
                     list(worst_changes.values()), worst_missing,
@@ -1081,6 +1093,11 @@ def abi_compare(
             result.scoped_exit_code = exit_code  # type: ignore[attr-defined]
             scoped_scheme = "severity" if severity_config is not None else "legacy"
             result.scoped_exit_code_scheme = scoped_scheme  # type: ignore[attr-defined]
+            result.gate_scope = "required_symbol"  # type: ignore[attr-defined]
+            result.scoped_relevant_finding_ids = frozenset(  # type: ignore[attr-defined]
+                _finding_id(c) for c in scoped_host.breaking_for_host
+            )
+            result.scoped_missing_labels = tuple(sorted(scoped_host.missing_entrypoints))  # type: ignore[attr-defined]
             if severity_config is not None:
                 categories, counts = _scoped_severity_summary(
                     scoped_host.breaking_for_host, scoped_host.missing_entrypoints,

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -39,7 +39,7 @@ from abicheck.checker_policy import (
     policy_for,
 )
 from abicheck.report_model import VERDICT_TO_SARIF_LEVEL as _VERDICT_TO_SARIF_LEVEL
-from abicheck.reporter import apply_show_only
+from abicheck.reporter import _finding_id, apply_show_only
 
 if TYPE_CHECKING:
     from abicheck.severity import SeverityConfig
@@ -186,8 +186,20 @@ def _result_for(
     change: Change,
     result: DiffResult,
     severity_config: SeverityConfig | None = None,
+    *,
+    relevant_ids: frozenset[str] | None = None,
 ) -> dict[str, Any]:
-    """Produce a SARIF result object for a Change."""
+    """Produce a SARIF result object for a Change.
+
+    *relevant_ids*, when not ``None``, means a ``--used-by``/``--required-symbol``
+    gate is active: a change whose :func:`_finding_id` is absent from the set is
+    not relevant to that gate, so its ``level`` is downgraded to ``"note"``
+    (informational, never blocks the scoped gate) regardless of its own
+    computed severity, and its ``properties.relevantToGate`` is set to
+    ``false`` so a consumer can distinguish "not severe" from "out of scope"
+    (CLI-audit P1: SARIF result levels must follow the scoped gate, not just
+    the full-library verdict).
+    """
     library, old_version, new_version = (
         result.library,
         result.old_version,
@@ -233,9 +245,16 @@ def _result_for(
     if evidence_status is not None:
         properties["evidenceStatus"] = evidence_status.value
 
+    level = _severity(change, result, severity_config)
+    if relevant_ids is not None:
+        is_relevant = _finding_id(change) in relevant_ids
+        properties["relevantToGate"] = is_relevant
+        if not is_relevant:
+            level = "note"
+
     return {
         "ruleId": change.kind.value,
-        "level": _severity(change, result, severity_config),
+        "level": level,
         "message": {
             "text": " ".join(msg_parts),
         },
@@ -290,20 +309,41 @@ def _severity_gate_properties(
     }
 
 
+def _missing_contract_result(label: str, gate_scope: str) -> dict[str, Any]:
+    """Synthesize a SARIF result for a missing required symbol/version/entrypoint.
+
+    A required contract member absent from the new library (--used-by's
+    ``missing_symbols``/``missing_versions``, or --required-symbol's
+    ``missing_entrypoints``) is unconditionally BREAKING for the scoped gate,
+    but it has no backing diff ``Change`` -- it was never in ``result.changes``
+    to begin with, so :func:`_result_for` never emits it. Without a synthetic
+    result the gate's own ``exitCode`` could be a nonzero (BREAKING) value
+    while ``results`` shows nothing to explain it (CLI-audit P1).
+    """
+    rule_id = (
+        "used_by_missing_symbol" if gate_scope == "used_by" else "required_symbol_missing"
+    )
+    return {
+        "ruleId": rule_id,
+        "level": "error",
+        "message": {
+            "text": f"Required symbol/version '{label}' is missing from the new library.",
+        },
+        "properties": {"relevantToGate": True, "missingContractMember": label},
+    }
+
+
 def _scoped_gate_properties(result: DiffResult) -> dict[str, Any] | None:
     """Build a ``scopedGate`` block when ``--used-by``/``--required-symbol(s)``
     scoping was requested (ADR-043).
 
-    The invocation's ``exitCode``/results above stay computed from the full,
-    unscoped library verdict (``result.verdict``) -- SARIF's binary/structured
-    contract intentionally keeps that authoritative for tooling that only
-    reads this format. But the actual CLI process exits on the *scoped*
-    verdict floor when scoping is requested, which can legitimately disagree
-    with the full-library verdict this document reports. Without this block a
-    SARIF consumer had no way to discover that disagreement -- this makes it
-    auditable in the document itself, mirroring the human-format banner
-    (``_fold_scoped_compat_into_text``) without changing SARIF's own gating
-    semantics.
+    The scoped gate (``result.scoped_verdict``/``scoped_exit_code``) is
+    authoritative for this document's own ``invocations[0].exitCode`` and each
+    result's ``level`` (CLI-audit P1 fix) -- ``result.verdict`` (the full,
+    unscoped library verdict) is still reported here as ``fullLibraryVerdict``
+    for context, but no longer drives what SARIF consumers treat as
+    blocking. This block also carries the relevant/unrelated finding counts so
+    a consumer can see how many of ``results`` actually gated this run.
     """
     scoped_verdict = getattr(result, "scoped_verdict", None)
     if scoped_verdict is None:
@@ -312,29 +352,22 @@ def _scoped_gate_properties(result: DiffResult) -> dict[str, Any] | None:
     required_symbols = getattr(result, "required_symbols", None)
     scoped_exit_code = getattr(result, "scoped_exit_code", None)
     scoped_exit_code_scheme = getattr(result, "scoped_exit_code_scheme", None)
-    # Under a severity scheme the scoped exit code is NOT a fixed
-    # BREAKING->4/API_BREAK->2 mapping of scopedVerdict -- e.g.
-    # --severity-preset info-only can floor it at 0 even for a BREAKING
-    # scopedVerdict (Codex review) -- so state the actual computed value and
-    # scheme rather than implying a verdict->exit-code equivalence that only
-    # holds under the legacy scheme.
-    note = (
-        f"The CLI process exits {scoped_exit_code} under the "
-        f"{scoped_exit_code_scheme} exit-code scheme for this "
-        f"--used-by/--required-symbol run -- this may differ from both "
-        f"scopedVerdict's legacy-scheme mapping and this document's own "
-        f"exitCode/results (which stay computed from the full library)."
-        if scoped_exit_code is not None
-        else "The CLI process exit code for this --used-by/--required-symbol "
-        "run may differ from this document's own exitCode/results (which "
-        "stay computed from the full library)."
-    )
+    gate_scope = getattr(result, "gate_scope", None)
+    relevant_ids = getattr(result, "scoped_relevant_finding_ids", None) or frozenset()
+    relevant_count = sum(1 for c in result.changes if _finding_id(c) in relevant_ids)
     block: dict[str, Any] = {
-        "scopedVerdict": scoped_verdict.value,
+        "gateScope": gate_scope,
+        "gateVerdict": scoped_verdict.value,
         "fullLibraryVerdict": result.verdict.value,
-        "note": note,
+        "relevantFindingCount": relevant_count,
+        "unrelatedFindingCount": len(result.changes) - relevant_count,
+        # Back-compat alias for the block's original field name.
+        "scopedVerdict": scoped_verdict.value,
     }
     if scoped_exit_code is not None:
+        block["gateExitCode"] = scoped_exit_code
+        block["gateExitCodeScheme"] = scoped_exit_code_scheme
+        # Back-compat aliases.
         block["scopedExitCode"] = scoped_exit_code
         block["scopedExitCodeScheme"] = scoped_exit_code_scheme
     if used_by is not None:
@@ -385,11 +418,23 @@ def to_sarif(
     rules_seen: dict[str, dict[str, Any]] = {}
     sarif_results: list[dict[str, Any]] = []
 
+    # When --used-by/--required-symbol scoping is active, relevant_ids makes
+    # each result's own level follow the scoped gate rather than the full
+    # library verdict (CLI-audit P1 fix); None means no scoping is active, so
+    # _result_for's existing full-library severity computation is unchanged.
+    relevant_ids = getattr(result, "scoped_relevant_finding_ids", None)
     for change in changes:
         rule_id = change.kind.value
         if rule_id not in rules_seen:
             rules_seen[rule_id] = _rule_for(change.kind)
-        sarif_results.append(_result_for(change, result, severity_config))
+        sarif_results.append(
+            _result_for(change, result, severity_config, relevant_ids=relevant_ids)
+        )
+
+    gate_scope = getattr(result, "gate_scope", None)
+    if gate_scope is not None:
+        for label in getattr(result, "scoped_missing_labels", ()) or ():
+            sarif_results.append(_missing_contract_result(label, gate_scope))
 
     severity_gate = (
         _severity_gate_properties(result, severity_config)
@@ -397,6 +442,7 @@ def to_sarif(
         else None
     )
     scoped_gate = _scoped_gate_properties(result)
+    scoped_exit_code = getattr(result, "scoped_exit_code", None)
 
     return {
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
@@ -423,9 +469,16 @@ def to_sarif(
                         # exits 0 — binary-compatible, deployment risk is surfaced
                         # via exitCodeDescription only. When severity_config *is*
                         # given, the exit code instead follows the severity-aware
-                        # gate (severityGate.exitCode below) — see docstring.
+                        # gate (severityGate.exitCode below). When --used-by/
+                        # --required-symbol scoping is active, the scoped gate
+                        # wins over both — it's what the CLI process actually
+                        # exits with (CLI-audit P1 fix; matches
+                        # cli_compare_helpers.run_compare's unconditional
+                        # sys.exit(scoped_exit_code) when scoping was requested).
                         "exitCode": (
-                            severity_gate["exitCode"]
+                            scoped_exit_code
+                            if scoped_exit_code is not None
+                            else severity_gate["exitCode"]
                             if severity_gate is not None
                             else (
                                 4
@@ -436,7 +489,9 @@ def to_sarif(
                             )
                         ),
                         "exitCodeDescription": (
-                            f"{result.verdict.value} (severity-gated)"
+                            f"{scoped_gate['gateVerdict']} (scoped: {scoped_gate['gateScope']})"
+                            if scoped_gate is not None
+                            else f"{result.verdict.value} (severity-gated)"
                             if severity_gate is not None
                             else result.verdict.value
                         ),

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -183,6 +183,28 @@ def _rule_for(kind: ChangeKind) -> dict[str, Any]:
     }
 
 
+def _missing_contract_rule(rule_id: str) -> dict[str, Any]:
+    """Produce a SARIF reportingDescriptor for a synthetic missing-contract rule id.
+
+    Mirrors :func:`_rule_for`'s shape so ``used_by_missing_symbol``/
+    ``required_symbol_missing`` results carry the same rule metadata as any
+    other -- without a matching entry in ``tool.driver.rules``, a SARIF
+    consumer that resolves annotations by rule id would have no metadata for
+    these synthetic findings (Codex review).
+    """
+    return {
+        "id": rule_id,
+        "name": "".join(w.capitalize() for w in rule_id.split("_")),
+        "shortDescription": {"text": rule_id.replace("_", " ").capitalize()},
+        "fullDescription": {
+            "text": "A required symbol/version/entrypoint is missing from the new library."
+        },
+        "helpUri": "https://github.com/abicheck/abicheck/blob/main/docs/reference/exit-codes.md",
+        "defaultConfiguration": {"level": "error"},
+        "properties": {"tags": ["abi", "binary-compatibility", "missing-contract"]},
+    }
+
+
 def _result_for(
     change: Change,
     result: DiffResult,
@@ -346,7 +368,16 @@ def _missing_contract_result(
         "message": {
             "text": f"Required symbol/version '{label}' is missing from the new library.",
         },
-        "properties": {"relevantToGate": blocks, "missingContractMember": label},
+        # relevantToGate is always true here -- a missing-contract member is
+        # in the --used-by/--required-symbol scope by construction, distinct
+        # from whether severity config makes it block (`blocksGate`). The two
+        # axes are orthogonal: severity decides blocking, not scope
+        # membership (CodeRabbit review).
+        "properties": {
+            "relevantToGate": True,
+            "blocksGate": blocks,
+            "missingContractMember": label,
+        },
     }
 
 
@@ -371,13 +402,22 @@ def _scoped_gate_properties(result: DiffResult) -> dict[str, Any] | None:
     scoped_exit_code_scheme = getattr(result, "scoped_exit_code_scheme", None)
     gate_scope = getattr(result, "gate_scope", None)
     relevant_ids = getattr(result, "scoped_relevant_finding_ids", None) or frozenset()
-    relevant_count = sum(1 for c in result.changes if _finding_id(c) in relevant_ids)
+    relevant_in_changes = sum(1 for c in result.changes if _finding_id(c) in relevant_ids)
+    # scoped-only changes (e.g. PE_ORDINAL_RETARGETED) and missing-contract
+    # members are relevant by construction -- they exist only because
+    # scope_diff_to_app/scope_diff_to_required_symbols found them relevant --
+    # and are never in result.changes, so they don't affect unrelatedFindingCount
+    # (which counts only irrelevant entries *within* result.changes) but do
+    # count toward relevantFindingCount (CodeRabbit review).
+    scoped_only_count = len(getattr(result, "scoped_only_changes", ()) or ())
+    missing_count = len(getattr(result, "scoped_missing_labels", ()) or ())
+    relevant_count = relevant_in_changes + scoped_only_count + missing_count
     block: dict[str, Any] = {
         "gateScope": gate_scope,
         "gateVerdict": scoped_verdict.value,
         "fullLibraryVerdict": result.verdict.value,
         "relevantFindingCount": relevant_count,
-        "unrelatedFindingCount": len(result.changes) - relevant_count,
+        "unrelatedFindingCount": len(result.changes) - relevant_in_changes,
         # Back-compat alias for the block's original field name.
         "scopedVerdict": scoped_verdict.value,
     }
@@ -448,9 +488,29 @@ def to_sarif(
             _result_for(change, result, severity_config, relevant_ids=relevant_ids)
         )
 
+    # Scoped-only changes: `scope_diff_to_app`/`scope_diff_to_required_symbols`
+    # can synthesize a Change (e.g. PE_ORDINAL_RETARGETED) that is relevant to
+    # the gate but was never added to `result.changes` -- without rendering
+    # these too, a --used-by run that fails solely because of one of these
+    # would report a nonzero gate exitCode with zero results to explain it
+    # (Codex review).
+    for change in getattr(result, "scoped_only_changes", ()) or ():
+        rule_id = change.kind.value
+        if rule_id not in rules_seen:
+            rules_seen[rule_id] = _rule_for(change.kind)
+        sarif_results.append(
+            _result_for(change, result, severity_config, relevant_ids=relevant_ids)
+        )
+
     gate_scope = getattr(result, "gate_scope", None)
     if gate_scope is not None:
         for label in getattr(result, "scoped_missing_labels", ()) or ():
+            rule_id = (
+                "used_by_missing_symbol" if gate_scope == "used_by"
+                else "required_symbol_missing"
+            )
+            if rule_id not in rules_seen:
+                rules_seen[rule_id] = _missing_contract_rule(rule_id)
             sarif_results.append(
                 _missing_contract_result(label, gate_scope, severity_config)
             )

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -40,6 +40,7 @@ from abicheck.checker_policy import (
 )
 from abicheck.report_model import VERDICT_TO_SARIF_LEVEL as _VERDICT_TO_SARIF_LEVEL
 from abicheck.reporter import _finding_id, apply_show_only
+from abicheck.reporter_markdown import ShowOnlyFilter
 from abicheck.severity import missing_contract_exit_code
 
 if TYPE_CHECKING:
@@ -517,16 +518,34 @@ def to_sarif(
 
     gate_scope = getattr(result, "gate_scope", None)
     if gate_scope is not None:
-        for label in getattr(result, "scoped_missing_labels", ()) or ():
-            rule_id = (
-                "used_by_missing_symbol" if gate_scope == "used_by"
-                else "required_symbol_missing"
-            )
-            if rule_id not in rules_seen:
-                rules_seen[rule_id] = _missing_contract_rule(rule_id)
-            sarif_results.append(
-                _missing_contract_result(label, gate_scope, severity_config)
-            )
+        # A missing-contract label has no backing Change/ChangeKind, so it
+        # can't run through apply_show_only (which resolves severity via
+        # effective_verdict_for_change) -- but --show-only's severity
+        # dimension still applies: without this, a --show-only run that
+        # excludes breaking findings would still upload an `error`-level
+        # missing-contract result the filter was meant to exclude (Codex
+        # review follow-up to the scoped_only_changes show-only fix above).
+        # Element/action tokens don't cleanly apply to "a symbol is simply
+        # absent", so only the severity dimension is checked here.
+        missing_severity = (
+            "breaking"
+            if severity_config is None or missing_contract_exit_code(severity_config) != 0
+            else "compatible"
+        )
+        show_only_severities = (
+            ShowOnlyFilter.parse(show_only).severities if show_only else frozenset()
+        )
+        if not show_only_severities or missing_severity in show_only_severities:
+            for label in getattr(result, "scoped_missing_labels", ()) or ():
+                rule_id = (
+                    "used_by_missing_symbol" if gate_scope == "used_by"
+                    else "required_symbol_missing"
+                )
+                if rule_id not in rules_seen:
+                    rules_seen[rule_id] = _missing_contract_rule(rule_id)
+                sarif_results.append(
+                    _missing_contract_result(label, gate_scope, severity_config)
+                )
 
     severity_gate = (
         _severity_gate_properties(result, severity_config)

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -493,8 +493,21 @@ def to_sarif(
     # the gate but was never added to `result.changes` -- without rendering
     # these too, a --used-by run that fails solely because of one of these
     # would report a nonzero gate exitCode with zero results to explain it
-    # (Codex review).
-    for change in getattr(result, "scoped_only_changes", ()) or ():
+    # (Codex review). Run them through the same `--show-only` filter as
+    # `result.changes` above -- otherwise a `--show-only additions` run would
+    # still upload a scoped-only breaking result the user explicitly asked
+    # to filter out, unlike the normal `result.changes` path (Codex review
+    # follow-up).
+    scoped_only_changes = list(getattr(result, "scoped_only_changes", ()) or ())
+    if show_only and scoped_only_changes:
+        scoped_only_changes = apply_show_only(
+            scoped_only_changes,
+            show_only,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
+    for change in scoped_only_changes:
         rule_id = change.kind.value
         if rule_id not in rules_seen:
             rules_seen[rule_id] = _rule_for(change.kind)

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -40,6 +40,7 @@ from abicheck.checker_policy import (
 )
 from abicheck.report_model import VERDICT_TO_SARIF_LEVEL as _VERDICT_TO_SARIF_LEVEL
 from abicheck.reporter import _finding_id, apply_show_only
+from abicheck.severity import missing_contract_exit_code
 
 if TYPE_CHECKING:
     from abicheck.severity import SeverityConfig
@@ -309,27 +310,43 @@ def _severity_gate_properties(
     }
 
 
-def _missing_contract_result(label: str, gate_scope: str) -> dict[str, Any]:
+def _missing_contract_result(
+    label: str, gate_scope: str, severity_config: SeverityConfig | None,
+) -> dict[str, Any]:
     """Synthesize a SARIF result for a missing required symbol/version/entrypoint.
 
     A required contract member absent from the new library (--used-by's
     ``missing_symbols``/``missing_versions``, or --required-symbol's
-    ``missing_entrypoints``) is unconditionally BREAKING for the scoped gate,
-    but it has no backing diff ``Change`` -- it was never in ``result.changes``
-    to begin with, so :func:`_result_for` never emits it. Without a synthetic
-    result the gate's own ``exitCode`` could be a nonzero (BREAKING) value
-    while ``results`` shows nothing to explain it (CLI-audit P1).
+    ``missing_entrypoints``) has no backing diff ``Change`` -- it was never in
+    ``result.changes`` to begin with, so :func:`_result_for` never emits it.
+    Without a synthetic result the gate's own ``exitCode`` could be a nonzero
+    (BREAKING) value while ``results`` shows nothing to explain it (CLI-audit
+    P1).
+
+    The level must follow the same severity decision as the gate's own exit
+    code (:func:`abicheck.severity.missing_contract_exit_code`, the function
+    ``_scoped_exit_code`` floors on): under the legacy scheme (no
+    *severity_config*) a missing contract member is unconditionally BREAKING,
+    but under a severity scheme that demotes ``abi_breaking`` (e.g.
+    ``--severity-preset info-only``), the scoped exit code can be 0 for the
+    same missing member -- emitting ``level: "error"`` regardless would let a
+    SARIF/code-scanning consumer flag/block a finding the gate itself passed
+    (Codex review).
     """
     rule_id = (
         "used_by_missing_symbol" if gate_scope == "used_by" else "required_symbol_missing"
     )
+    blocks = (
+        severity_config is None
+        or missing_contract_exit_code(severity_config) != 0
+    )
     return {
         "ruleId": rule_id,
-        "level": "error",
+        "level": "error" if blocks else "note",
         "message": {
             "text": f"Required symbol/version '{label}' is missing from the new library.",
         },
-        "properties": {"relevantToGate": True, "missingContractMember": label},
+        "properties": {"relevantToGate": blocks, "missingContractMember": label},
     }
 
 
@@ -434,7 +451,9 @@ def to_sarif(
     gate_scope = getattr(result, "gate_scope", None)
     if gate_scope is not None:
         for label in getattr(result, "scoped_missing_labels", ()) or ():
-            sarif_results.append(_missing_contract_result(label, gate_scope))
+            sarif_results.append(
+                _missing_contract_result(label, gate_scope, severity_config)
+            )
 
     severity_gate = (
         _severity_gate_properties(result, severity_config)

--- a/action.yml
+++ b/action.yml
@@ -235,11 +235,30 @@ inputs:
       performing any analysis or writing output (always exits 0). Maps to
       --dry-run; supported by every mode (compare, dump, scan, deps-tree,
       deps-compare). For scan, this also reports the projected per-layer
-      cost (formerly the separate --estimate flag, folded into the general
-      --dry-run report). To force a scan-mode single-build hygiene lint
-      instead of a baseline compare, simply omit against/abi-baseline for
-      that step — scan already runs audit-only whenever no against is
-      given (the old separate audit input was a redundant alias for this).
+      cost (the same preview the deprecated estimate input below used to
+      provide). To force a scan-mode single-build hygiene lint instead of a
+      baseline compare, simply omit against/abi-baseline for that step —
+      scan already runs audit-only whenever no against is given (the
+      deprecated audit input below is a functional alias for this).
+    required: false
+    default: 'false'
+  estimate:
+    description: >
+      Deprecated alias for dry-run (scan mode only, historical name).
+      Setting this to true is equivalent to dry-run: 'true'. Prefer dry-run
+      directly, which now applies to every mode, not just scan. Kept as a
+      functional (not just accepted-and-ignored) alias for backward
+      compatibility with existing workflows.
+    required: false
+    default: 'false'
+  audit:
+    description: >
+      Deprecated. scan mode only. Forces a one-build audit-only run (omits
+      --against) even when against/abi-baseline is configured elsewhere in
+      the workflow. Prefer simply omitting against/abi-baseline for the
+      step instead — scan already runs audit-only whenever no against is
+      given. Kept as a functional (not just accepted-and-ignored) alias for
+      backward compatibility with existing workflows.
     required: false
     default: 'false'
   crosscheck:
@@ -494,6 +513,8 @@ runs:
         INPUT_CHANGED_PATH: ${{ inputs.changed-path }}
         INPUT_BUDGET: ${{ inputs.budget }}
         INPUT_DRY_RUN: ${{ inputs.dry-run }}
+        INPUT_ESTIMATE: ${{ inputs.estimate }}
+        INPUT_AUDIT: ${{ inputs.audit }}
         INPUT_CROSSCHECK: ${{ inputs.crosscheck }}
         INPUT_RISK_RULES: ${{ inputs.risk-rules }}
         GH_TOKEN: ${{ inputs.github-token }}

--- a/action.yml
+++ b/action.yml
@@ -229,22 +229,17 @@ inputs:
       overflow (exit 5) — a budget never silently shrinks scope.
       Maps to scan --budget.
     required: false
-  audit:
+  dry-run:
     description: >
-      scan mode only. Force a single-build hygiene lint (intra-version
-      cross-source checks) even when an against baseline is configured (e.g.
-      via abi-baseline auto-fetch), by omitting scan's --against — scan
-      already runs audit-only whenever no against is given. The old --audit
-      CLI flag was removed (absence of --against now means audit-only,
-      presence means audit+compare — the two are no longer separate flags).
-    required: false
-    default: 'false'
-  estimate:
-    description: >
-      scan mode only. Dry-run: print the resolved depth/scope and the
-      projected per-layer cost for this project without scanning anything or
-      writing output (always exits 0). Maps to scan --dry-run (the old
-      --estimate CLI flag was folded into the general --dry-run report).
+      Resolve inputs/config and print what the run would do, without
+      performing any analysis or writing output (always exits 0). Maps to
+      --dry-run; supported by every mode (compare, dump, scan, deps-tree,
+      deps-compare). For scan, this also reports the projected per-layer
+      cost (formerly the separate --estimate flag, folded into the general
+      --dry-run report). To force a scan-mode single-build hygiene lint
+      instead of a baseline compare, simply omit against/abi-baseline for
+      that step — scan already runs audit-only whenever no against is
+      given (the old separate audit input was a redundant alias for this).
     required: false
     default: 'false'
   crosscheck:
@@ -498,8 +493,7 @@ runs:
         INPUT_SINCE: ${{ inputs.since }}
         INPUT_CHANGED_PATH: ${{ inputs.changed-path }}
         INPUT_BUDGET: ${{ inputs.budget }}
-        INPUT_AUDIT: ${{ inputs.audit }}
-        INPUT_ESTIMATE: ${{ inputs.estimate }}
+        INPUT_DRY_RUN: ${{ inputs.dry-run }}
         INPUT_CROSSCHECK: ${{ inputs.crosscheck }}
         INPUT_RISK_RULES: ${{ inputs.risk-rules }}
         GH_TOKEN: ${{ inputs.github-token }}

--- a/action/run.sh
+++ b/action/run.sh
@@ -128,12 +128,31 @@ FORCE_AUDIT_ONLY="${INPUT_AUDIT:-false}"
 
 # ---------------------------------------------------------------------------
 # Baseline auto-fetch: resolve INPUT_ABI_BASELINE → INPUT_OLD_LIBRARY
+#
+# A fetch failure (missing release/token/asset) reports and continues rather
+# than exiting 1 under --dry-run: dry-run is documented as "always exits 0"
+# (action.yml), but this block runs before any mode branch ever consults
+# INPUT_DRY_RUN, so an unavailable baseline used to hard-fail a preview run
+# before it ever got the chance to no-op (Codex review). BASELINE_FILE is
+# left unset in that case; the mode branches' existing required-input checks
+# still apply if no other old-library/against source was given.
 # ---------------------------------------------------------------------------
+_baseline_unavailable() {
+  local message="$1"
+  if [[ "${INPUT_DRY_RUN:-false}" == "true" ]]; then
+    echo "::warning::$message (continuing: --dry-run performs no analysis and never exits nonzero for an unresolved baseline)"
+    return 0
+  fi
+  echo "::error::$message"
+  exit 1
+}
+
 ABI_BASELINE="${INPUT_ABI_BASELINE:-}"
 if [[ -n "$ABI_BASELINE" && ( "$MODE" == "compare" || "$MODE" == "scan" ) ]]; then
   BASELINE_DIR=$(mktemp -d)
   # Clean up temp dir on exit (combined with STDERR_FILE cleanup later)
   _BASELINE_CLEANUP="$BASELINE_DIR"
+  BASELINE_FILE=""
   if [[ -f "$ABI_BASELINE" ]]; then
     # Direct file path — use it as-is (any name, e.g. abi-baseline.json), no
     # download and no *.abicheck.json pattern match (which would reject a
@@ -143,32 +162,44 @@ if [[ -n "$ABI_BASELINE" && ( "$MODE" == "compare" || "$MODE" == "scan" ) ]]; th
     if [[ "$ABI_BASELINE" == "latest-release" ]]; then
       echo "::group::Fetch ABI baseline from latest release"
       if ! gh release download --pattern '*.abicheck.json' -D "$BASELINE_DIR"; then
-        echo "::error::No ABI baseline found in latest release. Run 'abicheck dump path/to/libfoo.so -o libfoo.abicheck.json' in your release workflow and upload the resulting *.abicheck.json file as a release asset."
-        exit 1
+        _baseline_unavailable "No ABI baseline found in latest release. Run 'abicheck dump path/to/libfoo.so -o libfoo.abicheck.json' in your release workflow and upload the resulting *.abicheck.json file as a release asset."
       fi
       echo "::endgroup::"
     else
       # Treat as a tag name
       echo "::group::Fetch ABI baseline from release $ABI_BASELINE"
       if ! gh release download "$ABI_BASELINE" --pattern '*.abicheck.json' -D "$BASELINE_DIR"; then
-        echo "::error::No ABI baseline found in release '$ABI_BASELINE'. Ensure the release has a *.abicheck.json asset."
-        exit 1
+        _baseline_unavailable "No ABI baseline found in release '$ABI_BASELINE'. Ensure the release has a *.abicheck.json asset."
       fi
       echo "::endgroup::"
     fi
-    # Pick the first .abicheck.json found in the download dir.
-    BASELINE_FILE=$(find "$BASELINE_DIR" -name '*.abicheck.json' | head -1)
+    # Pick the first .abicheck.json found in the download dir (empty/absent
+    # when the download itself failed and _baseline_unavailable returned
+    # instead of exiting, e.g. under --dry-run).
+    BASELINE_FILE=$(find "$BASELINE_DIR" -name '*.abicheck.json' 2>/dev/null | head -1)
     if [[ -z "$BASELINE_FILE" ]]; then
-      echo "::error::No *.abicheck.json file found after download."
-      exit 1
+      _baseline_unavailable "No *.abicheck.json file found after download."
     fi
   fi
-  echo "Using ABI baseline: $BASELINE_FILE"
-  # compare consumes the baseline as old-library; scan consumes it as --against.
-  if [[ "$MODE" == "scan" ]]; then
-    INPUT_AGAINST="$BASELINE_FILE"
-  else
-    INPUT_OLD_LIBRARY="$BASELINE_FILE"
+  if [[ -n "$BASELINE_FILE" ]]; then
+    echo "Using ABI baseline: $BASELINE_FILE"
+    # compare consumes the baseline as old-library; scan consumes it as --against.
+    if [[ "$MODE" == "scan" ]]; then
+      INPUT_AGAINST="$BASELINE_FILE"
+    else
+      INPUT_OLD_LIBRARY="$BASELINE_FILE"
+    fi
+  elif [[ "${INPUT_DRY_RUN:-false}" == "true" ]]; then
+    # The fetch was tolerated above (dry-run never hard-fails on it), but if
+    # no other old-library/against was independently given there is nothing
+    # left to preview -- report and stop here rather than falling through to
+    # `${INPUT_OLD_LIBRARY:?...}` below, whose bash parameter-expansion abort
+    # would itself violate the documented "dry-run always exits 0" contract.
+    if [[ "$MODE" == "scan" && -z "${INPUT_AGAINST:-}" ]] ||
+       [[ "$MODE" == "compare" && -z "${INPUT_OLD_LIBRARY:-}" ]]; then
+      echo "::notice::--dry-run: no ABI baseline could be resolved and no other old-library/against was given, so there is nothing to preview."
+      exit 0
+    fi
   fi
 fi
 

--- a/action/run.sh
+++ b/action/run.sh
@@ -109,6 +109,24 @@ CMD=(abicheck)
 MODE="${INPUT_MODE:-compare}"
 
 # ---------------------------------------------------------------------------
+# Back-compat aliases: `estimate`/`audit` (pre-dry-run/scan-reshape inputs,
+# Codex review). Removing these outright (rather than keeping them as
+# functional aliases, like the existing `allow-build-query` no-op above)
+# would silently break existing workflows that still set them: GitHub
+# Actions drops an input the action.yml no longer declares with only a
+# warning, so `estimate: true` would otherwise silently run a real scan
+# instead of the preview it used to produce, and `audit: true` would
+# silently stop forcing a baseline-less hygiene lint once a
+# baseline/abi-baseline is configured -- a much worse failure mode than a
+# hard error, since nothing signals that the step is no longer doing what
+# the workflow author intended.
+# ---------------------------------------------------------------------------
+if [[ "${INPUT_ESTIMATE:-false}" == "true" ]]; then
+  INPUT_DRY_RUN="true"
+fi
+FORCE_AUDIT_ONLY="${INPUT_AUDIT:-false}"
+
+# ---------------------------------------------------------------------------
 # Baseline auto-fetch: resolve INPUT_ABI_BASELINE → INPUT_OLD_LIBRARY
 # ---------------------------------------------------------------------------
 ABI_BASELINE="${INPUT_ABI_BASELINE:-}"
@@ -402,11 +420,14 @@ elif [[ "$MODE" == "scan" ]]; then
   # scan's config flag is --config (not --build-config, which does not exist on
   # scan and hard-fails with exit 64). dump uses --config for the same input.
   add_single_flag "--config" "${INPUT_BUILD_CONFIG:-}"
-  # Omitting --against is already a one-build audit-only run (no separate
-  # audit flag needed or offered here); to force an audit-only run for one
-  # step despite an against/abi-baseline configured elsewhere in the
-  # workflow, simply don't set those inputs on this step.
-  add_single_flag "--against" "${INPUT_AGAINST:-}"
+  # Omitting --against is already a one-build audit-only run; the preferred
+  # way to force one for a single step is to simply not set against/
+  # abi-baseline there. The deprecated `audit: true` back-compat alias
+  # (above) achieves the same by skipping --against outright even when
+  # against/abi-baseline resolved to a value elsewhere in the workflow.
+  if [[ "$FORCE_AUDIT_ONLY" != "true" ]]; then
+    add_single_flag "--against" "${INPUT_AGAINST:-}"
+  fi
   add_single_flag "--lang" "${INPUT_LANG:-}"
 
   # Level selection — the modern --depth dial (omit for 'auto'). The deprecated

--- a/action/run.sh
+++ b/action/run.sh
@@ -202,9 +202,16 @@ if [[ "$MODE" == "dump" ]]; then
     CMD+=(--allow-build-query)
   fi
 
-  # Output file — required for dump in action context (otherwise stdout)
-  OUTPUT_FILE="${INPUT_OUTPUT_FILE:-abicheck-baseline.json}"
-  CMD+=(-o "$OUTPUT_FILE")
+  # dry-run performs no analysis and writes nothing, so it is mutually
+  # exclusive with -o/--output on the CLI -- skip the output file entirely
+  # when set, rather than passing both and letting the CLI reject it.
+  if [[ "${INPUT_DRY_RUN:-false}" == "true" ]]; then
+    CMD+=(--dry-run)
+  else
+    # Output file — required for dump in action context (otherwise stdout)
+    OUTPUT_FILE="${INPUT_OUTPUT_FILE:-abicheck-baseline.json}"
+    CMD+=(-o "$OUTPUT_FILE")
+  fi
 
 elif [[ "$MODE" == "compare" ]]; then
   # ── Compare mode ─────────────────────────────────────────────────────────
@@ -235,26 +242,36 @@ elif [[ "$MODE" == "compare" ]]; then
   FORMAT="${INPUT_FORMAT:-markdown}"
   CMD+=(--format "$FORMAT")
 
-  OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
-  if [[ "$FORMAT" == "sarif" && -z "$OUTPUT_FILE" ]]; then
-    OUTPUT_FILE="abicheck-results.sarif"
-  fi
-  if [[ -n "$OUTPUT_FILE" ]]; then
-    CMD+=(-o "$OUTPUT_FILE")
-  fi
+  # dry-run performs no analysis and writes nothing, so it is mutually
+  # exclusive with -o/--output AND --secondary-output/--secondary-format on
+  # the CLI -- skip both entirely when set, rather than passing them and
+  # letting the CLI reject the combination.
+  DRY_RUN="${INPUT_DRY_RUN:-false}"
+  if [[ "$DRY_RUN" == "true" ]]; then
+    CMD+=(--dry-run)
+  else
+    OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
+    if [[ "$FORMAT" == "sarif" && -z "$OUTPUT_FILE" ]]; then
+      OUTPUT_FILE="abicheck-results.sarif"
+    fi
+    if [[ -n "$OUTPUT_FILE" ]]; then
+      CMD+=(-o "$OUTPUT_FILE")
+    fi
 
-  # Render a second, always-unfiltered JSON report from this same run for the
-  # sticky PR comment (--secondary-format), instead of re-invoking abicheck a
-  # second time just to get JSON. Only needed when the primary format isn't
-  # already JSON — a json primary is reused as-is (see _can_reuse_primary_json
-  # below). The per-library release fan-out (directory/package operands)
-  # rejects --secondary-format, so it's skipped there too, falling back to
-  # the rerun path in _maybe_post_pr_comment (Codex review).
-  if [[ "$FORMAT" != "json" ]] \
-     && ! _is_release_style_operand "${INPUT_OLD_LIBRARY:-}" \
-     && ! _is_release_style_operand "${INPUT_NEW_LIBRARY:-}"; then
-    PR_JSON=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-json.XXXXXX")
-    CMD+=(--secondary-format json --secondary-output "$PR_JSON")
+    # Render a second, always-unfiltered JSON report from this same run for
+    # the sticky PR comment (--secondary-format), instead of re-invoking
+    # abicheck a second time just to get JSON. Only needed when the primary
+    # format isn't already JSON — a json primary is reused as-is (see
+    # _can_reuse_primary_json below). The per-library release fan-out
+    # (directory/package operands) rejects --secondary-format, so it's
+    # skipped there too, falling back to the rerun path in
+    # _maybe_post_pr_comment (Codex review).
+    if [[ "$FORMAT" != "json" ]] \
+       && ! _is_release_style_operand "${INPUT_OLD_LIBRARY:-}" \
+       && ! _is_release_style_operand "${INPUT_NEW_LIBRARY:-}"; then
+      PR_JSON=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-json.XXXXXX")
+      CMD+=(--secondary-format json --secondary-output "$PR_JSON")
+    fi
   fi
 
   add_single_flag "--policy" "${INPUT_POLICY:-}"
@@ -320,9 +337,13 @@ elif [[ "$MODE" == "deps-tree" ]]; then
   fi
   CMD+=(--format "$FORMAT")
 
-  OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
-  if [[ -n "$OUTPUT_FILE" ]]; then
-    CMD+=(-o "$OUTPUT_FILE")
+  if [[ "${INPUT_DRY_RUN:-false}" == "true" ]]; then
+    CMD+=(--dry-run)
+  else
+    OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
+    if [[ -n "$OUTPUT_FILE" ]]; then
+      CMD+=(-o "$OUTPUT_FILE")
+    fi
   fi
 
 elif [[ "$MODE" == "deps-compare" ]]; then
@@ -343,9 +364,13 @@ elif [[ "$MODE" == "deps-compare" ]]; then
   fi
   CMD+=(--format "$FORMAT")
 
-  OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
-  if [[ -n "$OUTPUT_FILE" ]]; then
-    CMD+=(-o "$OUTPUT_FILE")
+  if [[ "${INPUT_DRY_RUN:-false}" == "true" ]]; then
+    CMD+=(--dry-run)
+  else
+    OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
+    if [[ -n "$OUTPUT_FILE" ]]; then
+      CMD+=(-o "$OUTPUT_FILE")
+    fi
   fi
 
 elif [[ "$MODE" == "scan" ]]; then
@@ -377,14 +402,11 @@ elif [[ "$MODE" == "scan" ]]; then
   # scan's config flag is --config (not --build-config, which does not exist on
   # scan and hard-fails with exit 64). dump uses --config for the same input.
   add_single_flag "--config" "${INPUT_BUILD_CONFIG:-}"
-  # audit=true forces a one-build audit even when an against baseline is
-  # configured (e.g. via abi-baseline auto-fetch) — the old --audit flag
-  # ignored --baseline the same way; --against structurally cannot be
-  # combined with an audit-only run any more, so the emulation is to simply
-  # omit --against.
-  if [[ "${INPUT_AUDIT:-false}" != "true" ]]; then
-    add_single_flag "--against" "${INPUT_AGAINST:-}"
-  fi
+  # Omitting --against is already a one-build audit-only run (no separate
+  # audit flag needed or offered here); to force an audit-only run for one
+  # step despite an against/abi-baseline configured elsewhere in the
+  # workflow, simply don't set those inputs on this step.
+  add_single_flag "--against" "${INPUT_AGAINST:-}"
   add_single_flag "--lang" "${INPUT_LANG:-}"
 
   # Level selection — the modern --depth dial (omit for 'auto'). The deprecated
@@ -410,10 +432,11 @@ elif [[ "$MODE" == "scan" ]]; then
   fi
   CMD+=(--format "$FORMAT")
 
-  # estimate=true now maps to --dry-run (the old --estimate's cost-projection
-  # folded into the general dry-run report). A dry run writes nothing, so skip
-  # -o/--output entirely when it's set (they are mutually exclusive on scan).
-  if [[ "${INPUT_ESTIMATE:-false}" == "true" ]]; then
+  # dry-run maps directly to --dry-run (the cost-projection formerly under
+  # the separate --estimate flag is folded into the general dry-run report).
+  # A dry run writes nothing, so skip -o/--output entirely when it's set
+  # (they are mutually exclusive on scan).
+  if [[ "${INPUT_DRY_RUN:-false}" == "true" ]]; then
     CMD+=(--dry-run)
   else
     OUTPUT_FILE="${INPUT_OUTPUT_FILE:-}"
@@ -740,6 +763,10 @@ _maybe_post_pr_comment() {
     compare) ;;
     *) return 0 ;;
   esac
+  # A dry run performed no real comparison -- posting a comment would either
+  # show nothing (no PR_JSON) or silently trigger a second, real compare just
+  # to produce one, defeating the point of --dry-run. Skip entirely.
+  [[ "${INPUT_DRY_RUN:-false}" == "true" ]] && return 0
   [[ "${INPUT_PR_COMMENT_ON:-changes}" == "never" ]] && return 0
   [[ "$VERDICT" == "ERROR" ]] && return 0
   case "${GITHUB_EVENT_NAME:-}" in

--- a/action/run.sh
+++ b/action/run.sh
@@ -125,7 +125,7 @@ if [[ -n "$ABI_BASELINE" && ( "$MODE" == "compare" || "$MODE" == "scan" ) ]]; th
     if [[ "$ABI_BASELINE" == "latest-release" ]]; then
       echo "::group::Fetch ABI baseline from latest release"
       if ! gh release download --pattern '*.abicheck.json' -D "$BASELINE_DIR"; then
-        echo "::error::No ABI baseline found in latest release. Run 'abicheck dump --output-name auto' in your release workflow and upload the *.abicheck.json file as a release asset."
+        echo "::error::No ABI baseline found in latest release. Run 'abicheck dump path/to/libfoo.so -o libfoo.abicheck.json' in your release workflow and upload the resulting *.abicheck.json file as a release asset."
         exit 1
       fi
       echo "::endgroup::"

--- a/action/run.sh
+++ b/action/run.sh
@@ -148,7 +148,9 @@ _baseline_unavailable() {
 }
 
 ABI_BASELINE="${INPUT_ABI_BASELINE:-}"
-if [[ -n "$ABI_BASELINE" && ( "$MODE" == "compare" || "$MODE" == "scan" ) ]]; then
+if [[ -n "$ABI_BASELINE" \
+   && ( "$MODE" == "compare" || "$MODE" == "scan" ) \
+   && ! ( "$MODE" == "scan" && "$FORCE_AUDIT_ONLY" == "true" ) ]]; then
   BASELINE_DIR=$(mktemp -d)
   # Clean up temp dir on exit (combined with STDERR_FILE cleanup later)
   _BASELINE_CLEANUP="$BASELINE_DIR"
@@ -173,12 +175,24 @@ if [[ -n "$ABI_BASELINE" && ( "$MODE" == "compare" || "$MODE" == "scan" ) ]]; th
       fi
       echo "::endgroup::"
     fi
-    # Pick the first .abicheck.json found in the download dir (empty/absent
-    # when the download itself failed and _baseline_unavailable returned
-    # instead of exiting, e.g. under --dry-run).
-    BASELINE_FILE=$(find "$BASELINE_DIR" -name '*.abicheck.json' 2>/dev/null | head -1)
-    if [[ -z "$BASELINE_FILE" ]]; then
+    # Require exactly one *.abicheck.json in the download dir: `head -1`
+    # picking an arbitrary match on a multi-asset release could silently
+    # compare against the wrong library and produce an invalid verdict
+    # (Codex review). Built via a while/read loop (not `mapfile`, a bash 4+
+    # builtin) for macOS's stock (GPLv2-frozen) bash 3.2, same portability
+    # constraint as add_flag() above. An empty result also covers the
+    # download itself failing and _baseline_unavailable returning instead
+    # of exiting (e.g. under --dry-run).
+    BASELINE_FILES=()
+    while IFS= read -r _found; do
+      [[ -n "$_found" ]] && BASELINE_FILES+=("$_found")
+    done <<< "$(find "$BASELINE_DIR" -name '*.abicheck.json' 2>/dev/null)"
+    if [[ ${#BASELINE_FILES[@]} -eq 1 ]]; then
+      BASELINE_FILE="${BASELINE_FILES[0]}"
+    elif [[ ${#BASELINE_FILES[@]} -eq 0 ]]; then
       _baseline_unavailable "No *.abicheck.json file found after download."
+    else
+      _baseline_unavailable "Multiple *.abicheck.json assets found (${BASELINE_FILES[*]}); ambiguous which is the baseline. Publish exactly one *.abicheck.json asset per release, or pass abi-baseline a direct file path instead."
     fi
   fi
   if [[ -n "$BASELINE_FILE" ]]; then

--- a/action/run.sh
+++ b/action/run.sh
@@ -121,7 +121,7 @@ MODE="${INPUT_MODE:-compare}"
 # hard error, since nothing signals that the step is no longer doing what
 # the workflow author intended.
 # ---------------------------------------------------------------------------
-if [[ "${INPUT_ESTIMATE:-false}" == "true" ]]; then
+if [[ "$MODE" == "scan" && "${INPUT_ESTIMATE:-false}" == "true" ]]; then
   INPUT_DRY_RUN="true"
 fi
 FORCE_AUDIT_ONLY="${INPUT_AUDIT:-false}"

--- a/docs/development/adr/040-compare-surface-reduction.md
+++ b/docs/development/adr/040-compare-surface-reduction.md
@@ -116,7 +116,7 @@ that keeps casual invocations short without adding one flag per knob.
 
 ```text
 --profile ci-gate     # depth=headers, format=review, exit=severity
---profile release     # depth=full, recommend, format=markdown
+--profile release-cut # depth=full, recommend, format=markdown
 --profile quick       # depth=binary, stat
 ```
 
@@ -212,3 +212,14 @@ half-migrated with red tests.
 Each phase updates `COMPARE_FLAG_BUDGET_BASE` downward and the
 `_OPTION_SET_SNAPSHOT`; the `TestFlagBudget` ledger tests keep the count and
 its rationale in lockstep.
+
+* **Post-rollout rename (CLI audit finding).** The `release` profile was
+  renamed to `release-cut`: `compare`'s directory/package fan-out mode is
+  *also* informally branded "release" throughout (`compare_release_cmd`,
+  `release_options`, the "Release (directory/package inputs)" help panel) —
+  an unrelated concept that happened to share the same word. A user skimming
+  `--help` could reasonably assume `--profile release` targets that fan-out
+  mode, when it's actually the single-pair "should I bump semver?" bundle.
+  `_profile_targets_set_input` already rejected the combination with a clear
+  usage error, so this was never a live bug — just a naming collision worth
+  disambiguating while the profile vocabulary is still young.

--- a/docs/development/adr/040-compare-surface-reduction.md
+++ b/docs/development/adr/040-compare-surface-reduction.md
@@ -116,7 +116,7 @@ that keeps casual invocations short without adding one flag per knob.
 
 ```text
 --profile ci-gate     # depth=headers, format=review, exit=severity
---profile release-cut # depth=full, recommend, format=markdown
+--profile release-cut # depth=source, recommend, format=markdown
 --profile quick       # depth=binary, stat
 ```
 

--- a/docs/user-guide/cli-usage.md
+++ b/docs/user-guide/cli-usage.md
@@ -150,7 +150,7 @@ not a straitjacket.
 | Profile | Expands to | Use when |
 |---------|-----------|----------|
 | `ci-gate` | `--depth headers --format review --exit-code-scheme severity` | Blocking a PR in CI |
-| `release` | `--depth source --format markdown --recommend` | Deciding a version bump at release time |
+| `release-cut` | `--depth source --format markdown --recommend` | Deciding a version bump at release time |
 | `quick` | `--depth binary --stat` | A fast "just tell me" look |
 
 Precedence is **explicit flag > profile > project config > default**: a
@@ -168,8 +168,8 @@ usage error; configure release defaults (format, severity, scheme) in
 # CI gate — equivalent to the three flags in the table
 abicheck compare old.json new.json --profile ci-gate
 
-# Start from the release profile but force JSON output (explicit flag wins)
-abicheck compare old.json new.json --profile release --format json
+# Start from the release-cut profile but force JSON output (explicit flag wins)
+abicheck compare old.json new.json --profile release-cut --format json
 ```
 
 > `--show-only` filtering, `--show-redundant`, `--stat`, `--report-mode leaf`,

--- a/docs/user-guide/github-action-source-scans.md
+++ b/docs/user-guide/github-action-source-scans.md
@@ -88,7 +88,7 @@ for `auto` (risk-driven, best paired with `since:`):
     As of the ADR-043 pre-1.0 CLI reset all three are removed outright, not
     deprecated — the CLI's `--depth` no longer accepts `full`/`--mode`/
     `--source-method`/`--max` at all (a plain usage error). Use `depth`
-    (or `audit: 'true'`); `full` collapsed into `source`, since the two only
+    (omitting `against`/`abi-baseline` for an audit-only run); `full` collapsed into `source`, since the two only
     ever differed in replay *scope*, and an unseeded `depth: source` already
     resolves to the whole target. The mapping from the old axes is in the
     [Removed scan axes appendix](../concepts/evidence-and-detectability.md#appendix-removed-scan-axes-s0s6-mode-source-method-max).
@@ -105,14 +105,15 @@ Useful as a standing lint on the default branch:
           new-library: build/libfoo.so
           new-header: include/
           sources: .
-          audit: 'true'
+          # No `against`/`abi-baseline` on this step -- scan already runs
+          # audit-only whenever no baseline is given.
 ```
 
 ### Estimate cost before committing to a depth
 
-`estimate: 'true'` is a dry run — it prints the projected per-layer cost (TU
-count, seconds) and scans nothing, always exiting 0. Handy when sizing a budget
-for a large repo:
+`dry-run: 'true'` prints the resolved depth/scope and, in scan mode, the
+projected per-layer cost (TU count, seconds) — without scanning anything,
+always exiting 0. Handy when sizing a budget for a large repo:
 
 ```yaml
       - uses: abicheck/abicheck@v0.3.0
@@ -122,7 +123,7 @@ for a large repo:
           new-header: include/
           sources: .
           depth: source
-          estimate: 'true'
+          dry-run: 'true'
 ```
 
 ### Gate CI on a specific cross-source check

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -146,6 +146,8 @@ scan degrades gracefully and L0–L2 stay authoritative.
 | `format` | `markdown` (`text` for scan) | Output format: `markdown`, `json`, `sarif`, `html`. `sarif`/`html` are only available in `compare` mode when `old-library`/`new-library` are a single pair — a directory/package comparison rejects them with a clear error (choose `markdown` or `json` instead). `deps-tree`/`deps-compare` support only `markdown`/`json` and fall back to `markdown`; `scan` supports only `text`/`json` and falls back to `text`. |
 | `output-file` | — | Path to write report (auto-set for SARIF) |
 | `dry-run` | `false` | Resolve inputs/config and print what the run would do, without analyzing anything or writing output (always exits 0). Maps to `--dry-run`; supported by every mode. In scan mode this also prints the projected per-layer cost. |
+| `estimate` | `false` | **Deprecated.** scan mode only. Functional alias for `dry-run: 'true'` — prefer `dry-run` directly, which applies to every mode. |
+| `audit` | `false` | **Deprecated.** scan mode only. Forces a single-build hygiene lint by skipping `--against` even when `against`/`abi-baseline` is configured elsewhere in the workflow. Prefer omitting `against`/`abi-baseline` on the step instead — `scan` already runs audit-only whenever no baseline is given. |
 | `policy` | `strict_abi` | Built-in policy: `strict_abi`, `sdk_vendor`, `plugin_abi` |
 | `policy-file` | — | Custom YAML policy file |
 | `suppress` | — | YAML suppression file (supports `label`, `source_location`, `expires`) |

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -117,12 +117,10 @@ scan degrades gracefully and L0–L2 stay authoritative.
 | `build-config` | scan, dump | Trusted `.abicheck.yml`; its `build.query` runs automatically (operator-supplied = trusted). |
 | `allow-build-query` | scan, dump | **Deprecated, ignored.** Build queries now run automatically when `sources` is given; kept as a no-op for backward compatibility. |
 | `depth` | scan, dump | Evidence-depth dial: `binary`, `headers`, `build`, or `source`. Maps to `--depth`. Omit in scan mode for `auto` (risk-driven). |
-| `against` | scan | Previous build's dump/library to compare against (or use `abi-baseline` to auto-fetch one). Maps to `--against`. |
+| `against` | scan | Previous build's dump/library to compare against (or use `abi-baseline` to auto-fetch one). Maps to `--against`. Omit it (and `abi-baseline`) on a step to run a single-build hygiene lint instead — `scan` already runs audit-only whenever no baseline is given. |
 | `since` | scan | Focus the scan on files changed vs a git ref (e.g. `origin/main`). |
 | `changed-path` | scan | Changed path(s) to focus on (space-separated; alternative to `since`). |
 | `budget` | scan | Time guard (e.g. `15m`). The step **fails** on overflow (`verdict: BUDGET_OVERFLOW`) — a budget never silently shrinks scope. |
-| `audit` | scan | Single-build hygiene lint, no baseline (intra-version cross-source checks). |
-| `estimate` | scan | Dry-run: print projected per-layer cost and scan nothing (always exits 0). |
 | `crosscheck` | scan | Per-check severity overrides `KEY=LEVEL` (`off`/`info`/`warning`/`error`), space-separated. Promoting a check to `=error` makes a finding for it exit `2` (the API_BREAK tier); pair with `fail-on-api-break: true` to gate the step. |
 | `risk-rules` | scan | Path to a YAML file overriding the `risk_rules` profile. |
 
@@ -147,6 +145,7 @@ scan degrades gracefully and L0–L2 stay authoritative.
 |-------|---------|-------------|
 | `format` | `markdown` (`text` for scan) | Output format: `markdown`, `json`, `sarif`, `html`. `sarif`/`html` are only available in `compare` mode when `old-library`/`new-library` are a single pair — a directory/package comparison rejects them with a clear error (choose `markdown` or `json` instead). `deps-tree`/`deps-compare` support only `markdown`/`json` and fall back to `markdown`; `scan` supports only `text`/`json` and falls back to `text`. |
 | `output-file` | — | Path to write report (auto-set for SARIF) |
+| `dry-run` | `false` | Resolve inputs/config and print what the run would do, without analyzing anything or writing output (always exits 0). Maps to `--dry-run`; supported by every mode. In scan mode this also prints the projected per-layer cost. |
 | `policy` | `strict_abi` | Built-in policy: `strict_abi`, `sdk_vendor`, `plugin_abi` |
 | `policy-file` | — | Custom YAML policy file |
 | `suppress` | — | YAML suppression file (supports `label`, `source_location`, `expires`) |

--- a/docs/user-guide/migration-0.5.md
+++ b/docs/user-guide/migration-0.5.md
@@ -108,7 +108,7 @@ config `true`: `--no-dwarf-only` (restore header parsing), `--no-debuginfod`,
 
 ## Run profiles (Lever 3, additive)
 
-New in the same line of work: `--profile {ci-gate,release,quick}` bundles a
+New in the same line of work: `--profile {ci-gate,release-cut,quick}` bundles a
 workflow's common defaults into one token (explicit flags still win). It is
 additive — nothing to migrate — but it can replace habitual flag stacks. See
 [CLI usage](cli-usage.md).

--- a/tests/test_action_run_contract.py
+++ b/tests/test_action_run_contract.py
@@ -81,8 +81,13 @@ def _valid_flags(subcommand: str) -> set[str]:
     # would otherwise encode stdout as cp1252 and crash (exit 1) on those chars,
     # so force UTF-8 in the child too — not just in our decode.
     env = {**os.environ, "PYTHONUTF8": "1", "PYTHONIOENCODING": "utf-8"}
+    # `compare --help` only shows its curated common subset (G21.8 collapse
+    # M2); `--help-all` is the full surface and is what this test needs to
+    # validate action/run.sh's flags against. Other subcommands don't have
+    # the curated/full split, so they keep plain --help.
+    help_flag = "--help-all" if subcommand == "compare" else "--help"
     out = subprocess.run(
-        [sys.executable, "-m", "abicheck", *parts, "--help"],
+        [sys.executable, "-m", "abicheck", *parts, help_flag],
         capture_output=True, text=True, check=True,
         encoding="utf-8", errors="replace", env=env,
     ).stdout

--- a/tests/test_action_run_sh_dry_run_baseline.py
+++ b/tests/test_action_run_sh_dry_run_baseline.py
@@ -1,0 +1,144 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for ``action/run.sh``'s ``--dry-run``/``abi-baseline``
+interaction (Codex review).
+
+``dry-run`` is documented in ``action.yml`` as "always exits 0", but the
+baseline auto-fetch block used to run (and ``exit 1`` on a missing
+release/token/asset) before any mode branch ever consulted
+``INPUT_DRY_RUN`` -- so a workflow previewing its config with `dry-run: true`
+plus an `abi-baseline` that hadn't been published yet got a hard failure
+instead of the promised no-op preview.
+
+These tests extract the relevant fragment verbatim from run.sh (the same
+"parse the real file, don't hand-copy it" discipline as
+``test_action_run_sh_legacy_aliases.py``) rather than re-implementing the
+logic, and stub out ``gh`` (not available/authenticated in the test
+environment) with a shell function.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+RUN_SH = Path(__file__).resolve().parents[1] / "action" / "run.sh"
+_START_MARKER = "_baseline_unavailable() {"
+_END_MARKER = 'if [[ "$MODE" == "dump" ]]; then'
+
+
+def _baseline_region() -> str:
+    """The baseline auto-fetch block, extracted verbatim from run.sh."""
+    text = RUN_SH.read_text(encoding="utf-8")
+    start = text.index(_START_MARKER)
+    end = text.index(_END_MARKER, start)
+    return text[start:end]
+
+
+def _bash_executable() -> str:
+    """Resolve a real bash, bypassing Windows' WSL-launcher stub.
+
+    See ``test_action_run_sh_helpers._bash_executable`` for the full
+    rationale (GitHub windows-latest runners resolve a bare "bash" to a
+    non-functional WSL stub ahead of Git for Windows' real bash).
+    """
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
+_FAILING_GH_STUB = 'gh() { return 1; }\n'
+
+
+class TestDryRunToleratesUnavailableBaseline:
+    def _run(
+        self, env_extra: dict[str, str], *, gh_stub: str = _FAILING_GH_STUB,
+    ) -> subprocess.CompletedProcess[str]:
+        # MODE is set earlier in run.sh (outside the extracted region); the
+        # baseline block reads it, so the harness must set it too.
+        script = (
+            'MODE="${INPUT_MODE:-compare}"\n'
+            + gh_stub
+            + _baseline_region()
+            + '\necho "REACHED_END OLD_LIBRARY=${INPUT_OLD_LIBRARY:-} '
+            'AGAINST=${INPUT_AGAINST:-}"\n'
+        )
+        env = {**os.environ, **env_extra}
+        return subprocess.run(
+            [_bash_executable(), "-c", script],
+            capture_output=True, text=True, env=env, check=False,
+        )
+
+    def test_non_dry_run_still_fails_hard_on_unavailable_baseline(self) -> None:
+        """Baseline gate for real invocations is unchanged: still exit 1."""
+        result = self._run(
+            {"INPUT_MODE": "compare", "INPUT_ABI_BASELINE": "latest-release"}
+        )
+        assert result.returncode == 1
+        assert "REACHED_END" not in result.stdout
+
+    def test_dry_run_exits_0_instead_of_failing_on_unavailable_baseline(self) -> None:
+        """Regression: --dry-run must never hard-fail on a missing baseline
+        (action.yml documents dry-run as "always exits 0")."""
+        result = self._run({
+            "INPUT_MODE": "compare",
+            "INPUT_ABI_BASELINE": "latest-release",
+            "INPUT_DRY_RUN": "true",
+        })
+        assert result.returncode == 0, result.stderr
+        assert "::warning::" in result.stdout
+        # Nothing else to preview (no other old-library given) -- the block
+        # reports and exits before reaching the harness's trailing echo.
+        assert "REACHED_END" not in result.stdout
+
+    def test_dry_run_with_explicit_old_library_still_proceeds(self) -> None:
+        """An explicitly-given old-library must not be discarded just because
+        the (redundant) baseline fetch also failed under --dry-run."""
+        result = self._run({
+            "INPUT_MODE": "compare",
+            "INPUT_ABI_BASELINE": "latest-release",
+            "INPUT_DRY_RUN": "true",
+            "INPUT_OLD_LIBRARY": "libfoo.so.1",
+        })
+        assert result.returncode == 0, result.stderr
+        assert "REACHED_END OLD_LIBRARY=libfoo.so.1" in result.stdout
+
+    def test_scan_mode_dry_run_exits_0_instead_of_failing(self) -> None:
+        result = self._run(
+            {"INPUT_MODE": "scan", "INPUT_ABI_BASELINE": "latest-release",
+             "INPUT_DRY_RUN": "true"}
+        )
+        assert result.returncode == 0, result.stderr
+        assert "REACHED_END" not in result.stdout
+
+    def test_direct_file_path_baseline_unaffected(self, tmp_path: Path) -> None:
+        """A direct existing-file abi-baseline never calls gh at all — must
+        keep working exactly as before, dry-run or not."""
+        baseline = tmp_path / "abi-baseline.json"
+        baseline.write_text("{}")
+        result = self._run(
+            {"INPUT_MODE": "compare", "INPUT_ABI_BASELINE": str(baseline)},
+            gh_stub="",
+        )
+        assert result.returncode == 0, result.stderr
+        assert f"REACHED_END OLD_LIBRARY={baseline}" in result.stdout

--- a/tests/test_action_run_sh_dry_run_baseline.py
+++ b/tests/test_action_run_sh_dry_run_baseline.py
@@ -74,10 +74,12 @@ class TestDryRunToleratesUnavailableBaseline:
     def _run(
         self, env_extra: dict[str, str], *, gh_stub: str = _FAILING_GH_STUB,
     ) -> subprocess.CompletedProcess[str]:
-        # MODE is set earlier in run.sh (outside the extracted region); the
-        # baseline block reads it, so the harness must set it too.
+        # MODE/FORCE_AUDIT_ONLY are set earlier in run.sh (outside the
+        # extracted region); the baseline block reads both, so the harness
+        # must set them too.
         script = (
             'MODE="${INPUT_MODE:-compare}"\n'
+            'FORCE_AUDIT_ONLY="${INPUT_AUDIT:-false}"\n'
             + gh_stub
             + _baseline_region()
             + '\necho "REACHED_END OLD_LIBRARY=${INPUT_OLD_LIBRARY:-} '
@@ -142,3 +144,95 @@ class TestDryRunToleratesUnavailableBaseline:
         )
         assert result.returncode == 0, result.stderr
         assert f"REACHED_END OLD_LIBRARY={baseline}" in result.stdout
+
+
+# A gh stub whose call is detectable (touches a marker file) so tests can
+# assert the fetch never ran at all, not just that it "failed".
+_MARKER_GH_STUB = 'gh() { touch "$GH_CALLED_MARKER"; return 1; }\n'
+
+
+class TestAuditSkipsBaselineFetch:
+    def _run(
+        self, env_extra: dict[str, str], marker: Path,
+    ) -> subprocess.CompletedProcess[str]:
+        script = (
+            'MODE="${INPUT_MODE:-compare}"\n'
+            'FORCE_AUDIT_ONLY="${INPUT_AUDIT:-false}"\n'
+            + _MARKER_GH_STUB
+            + _baseline_region()
+            + '\necho "REACHED_END AGAINST=${INPUT_AGAINST:-}"\n'
+        )
+        env = {**os.environ, **env_extra, "GH_CALLED_MARKER": str(marker)}
+        return subprocess.run(
+            [_bash_executable(), "-c", script],
+            capture_output=True, text=True, env=env, check=False,
+        )
+
+    def test_audit_true_skips_baseline_fetch_entirely(self, tmp_path: Path) -> None:
+        """Regression (Codex + CodeRabbit review): audit: true discards
+        --against anyway (Line ~459), so fetching abi-baseline for a
+        scan-mode audit-only run is always wasted work -- and if the fetch
+        itself fails, it used to hard-fail a run that never needed the
+        baseline at all."""
+        marker = tmp_path / "gh_called"
+        result = self._run(
+            {"INPUT_MODE": "scan", "INPUT_ABI_BASELINE": "latest-release",
+             "INPUT_AUDIT": "true"},
+            marker,
+        )
+        assert result.returncode == 0, result.stderr
+        assert not marker.exists(), "gh was called despite audit:true"
+        assert "REACHED_END AGAINST=" in result.stdout
+
+    def test_audit_false_still_fetches_baseline(self, tmp_path: Path) -> None:
+        """Sanity: the skip is specific to audit:true, not a regression that
+        silently disables baseline fetching for ordinary scan runs."""
+        marker = tmp_path / "gh_called"
+        result = self._run(
+            {"INPUT_MODE": "scan", "INPUT_ABI_BASELINE": "latest-release"},
+            marker,
+        )
+        assert marker.exists(), "gh was not called for a non-audit scan run"
+        assert result.returncode == 1, result.stderr
+
+
+class TestAmbiguousBaselineAssets:
+    def _run(self, gh_body: str) -> subprocess.CompletedProcess[str]:
+        script = (
+            'MODE="${INPUT_MODE:-compare}"\n'
+            'FORCE_AUDIT_ONLY="${INPUT_AUDIT:-false}"\n'
+            f"gh() {{ {gh_body}; }}\n"
+            + _baseline_region()
+            + '\necho "REACHED_END OLD_LIBRARY=${INPUT_OLD_LIBRARY:-}"\n'
+        )
+        env = {**os.environ, "INPUT_MODE": "compare",
+               "INPUT_ABI_BASELINE": "latest-release"}
+        return subprocess.run(
+            [_bash_executable(), "-c", script],
+            capture_output=True, text=True, env=env, check=False,
+        )
+
+    def test_single_asset_still_resolves(self) -> None:
+        """Sanity: the ordinary one-asset case still works after switching
+        off `find | head -1`."""
+        result = self._run(
+            'local dir=""; while [[ $# -gt 0 ]]; do '
+            '[[ "$1" == "-D" ]] && dir="$2"; shift; done; '
+            'touch "$dir/lib.abicheck.json"'
+        )
+        assert result.returncode == 0, result.stderr
+        assert "REACHED_END OLD_LIBRARY=" in result.stdout
+        assert "lib.abicheck.json" in result.stdout
+
+    def test_multiple_assets_rejected_as_ambiguous(self) -> None:
+        """Regression (CodeRabbit review): a release with more than one
+        *.abicheck.json asset must not silently pick an arbitrary one via
+        `find | head -1` — that could compare against the wrong library."""
+        result = self._run(
+            'local dir=""; while [[ $# -gt 0 ]]; do '
+            '[[ "$1" == "-D" ]] && dir="$2"; shift; done; '
+            'touch "$dir/a.abicheck.json" "$dir/b.abicheck.json"'
+        )
+        assert result.returncode == 1
+        assert "Multiple *.abicheck.json assets found" in result.stdout
+        assert "REACHED_END" not in result.stdout

--- a/tests/test_action_run_sh_legacy_aliases.py
+++ b/tests/test_action_run_sh_legacy_aliases.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for ``action/run.sh``'s deprecated ``estimate``/``audit``
+back-compat aliases (Codex review).
+
+Removing the pre-dry-run/scan-reshape ``estimate``/``audit`` Action inputs
+outright (rather than keeping them as functional aliases, mirroring the
+existing ``allow-build-query`` no-op precedent) would silently break existing
+workflows that still set them: GitHub Actions drops an input the action.yml
+no longer declares with only a warning, so ``estimate: true`` would otherwise
+silently run a real scan instead of the preview it used to produce, and
+``audit: true`` would silently stop forcing a baseline-less hygiene lint once
+a baseline/abi-baseline is configured elsewhere in the workflow -- a much
+worse failure mode than a hard error.
+
+These tests extract the relevant fragments verbatim from run.sh (the same
+"parse the real file, don't hand-copy it" discipline as
+``test_action_run_sh_helpers.py``) rather than re-implementing the logic.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+RUN_SH = Path(__file__).resolve().parents[1] / "action" / "run.sh"
+_ALIAS_START_MARKER = 'MODE="${INPUT_MODE:-compare}"'
+_ALIAS_END_MARKER = 'FORCE_AUDIT_ONLY="${INPUT_AUDIT:-false}"'
+_SCAN_MODE_MARKER = 'elif [[ "$MODE" == "scan" ]]; then'
+_AGAINST_START_MARKER = 'add_single_flag "--config" "${INPUT_BUILD_CONFIG:-}"'
+_AGAINST_END_MARKER = 'add_single_flag "--lang" "${INPUT_LANG:-}"'
+
+
+def _alias_region() -> str:
+    """The mode/alias-normalization prelude, extracted verbatim from run.sh."""
+    text = RUN_SH.read_text(encoding="utf-8")
+    start = text.index(_ALIAS_START_MARKER)
+    end = text.index(_ALIAS_END_MARKER, start) + len(_ALIAS_END_MARKER)
+    return text[start:end]
+
+
+def _against_region() -> str:
+    """The scan-mode ``--against``/``FORCE_AUDIT_ONLY`` gating, extracted
+    verbatim from run.sh (excludes the closing marker line itself so the
+    harness controls what runs after).
+
+    ``--config`` also appears verbatim in the dump-mode branch, so the search
+    for the start/end markers is anchored to begin only after the scan-mode
+    branch itself starts, not the first (dump-mode) occurrence.
+    """
+    text = RUN_SH.read_text(encoding="utf-8")
+    scan_branch = text.index(_SCAN_MODE_MARKER)
+    start = text.index(_AGAINST_START_MARKER, scan_branch)
+    end = text.index(_AGAINST_END_MARKER, start)
+    return text[start:end]
+
+
+def _bash_executable() -> str:
+    """Resolve a real bash, bypassing Windows' WSL-launcher stub.
+
+    See ``test_action_run_sh_helpers._bash_executable`` for the full
+    rationale (GitHub windows-latest runners resolve a bare "bash" to a
+    non-functional WSL stub ahead of Git for Windows' real bash).
+    """
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
+class TestEstimateAliasesDryRun:
+    def _run(self, env_extra: dict[str, str]) -> str:
+        script = _alias_region() + "\necho \"DRY_RUN=$INPUT_DRY_RUN\"\n"
+        env = {**os.environ, **env_extra}
+        out = subprocess.run(
+            [_bash_executable(), "-c", script],
+            capture_output=True, text=True, env=env, check=True,
+        )
+        return out.stdout
+
+    def test_estimate_true_forces_dry_run(self) -> None:
+        out = self._run({"INPUT_ESTIMATE": "true"})
+        assert "DRY_RUN=true" in out
+
+    def test_no_estimate_leaves_dry_run_unset(self) -> None:
+        out = self._run({})
+        assert "DRY_RUN=" in out and "DRY_RUN=true" not in out
+
+    def test_explicit_dry_run_survives_without_estimate(self) -> None:
+        out = self._run({"INPUT_DRY_RUN": "true"})
+        assert "DRY_RUN=true" in out
+
+
+class TestAuditAliasSkipsAgainst:
+    def _run(self, env_extra: dict[str, str]) -> list[str]:
+        # add_single_flag is defined earlier in run.sh (line ~60); redefine a
+        # minimal equivalent here since we only extract the alias region, not
+        # the whole file, to keep the harness self-contained and fast.
+        harness = (
+            'add_single_flag() { [[ -n "$2" ]] && CMD+=("$1" "$2"); }\n'
+            "CMD=()\n"
+        )
+        script = harness + _against_region() + '\nprintf \'%s\\n\' "${CMD[@]}"\n'
+        env = {**os.environ, **env_extra}
+        out = subprocess.run(
+            [_bash_executable(), "-c", script],
+            capture_output=True, text=True, env=env, check=True,
+        )
+        return out.stdout.splitlines()
+
+    def test_audit_true_skips_against_even_when_configured(self) -> None:
+        cmd = self._run({"FORCE_AUDIT_ONLY": "true", "INPUT_AGAINST": "baseline.so"})
+        assert "--against" not in cmd
+
+    def test_audit_false_forwards_against(self) -> None:
+        cmd = self._run({"FORCE_AUDIT_ONLY": "false", "INPUT_AGAINST": "baseline.so"})
+        assert "--against" in cmd
+        assert "baseline.so" in cmd

--- a/tests/test_action_run_sh_legacy_aliases.py
+++ b/tests/test_action_run_sh_legacy_aliases.py
@@ -97,13 +97,24 @@ class TestEstimateAliasesDryRun:
         )
         return out.stdout
 
-    def test_estimate_true_forces_dry_run(self) -> None:
-        out = self._run({"INPUT_ESTIMATE": "true"})
+    def test_estimate_true_forces_dry_run_in_scan_mode(self) -> None:
+        out = self._run({"INPUT_MODE": "scan", "INPUT_ESTIMATE": "true"})
         assert "DRY_RUN=true" in out
 
     def test_no_estimate_leaves_dry_run_unset(self) -> None:
-        out = self._run({})
+        out = self._run({"INPUT_MODE": "scan"})
         assert "DRY_RUN=" in out and "DRY_RUN=true" not in out
+
+    def test_estimate_true_ignored_outside_scan_mode(self) -> None:
+        # Regression (Codex review): `estimate` was always scan-mode-only
+        # (its action.yml description and the pre-dry-run run.sh only ever
+        # consumed it inside the scan branch) -- a global normalization
+        # would silently turn `abicheck compare ...` into a --dry-run no-op
+        # for a workflow that (mistakenly or not) sets `estimate: true` on a
+        # compare/dump/deps-tree/deps-compare step, exiting green without
+        # running the actual ABI gate.
+        out = self._run({"INPUT_MODE": "compare", "INPUT_ESTIMATE": "true"})
+        assert "DRY_RUN=true" not in out
 
     def test_explicit_dry_run_survives_without_estimate(self) -> None:
         out = self._run({"INPUT_DRY_RUN": "true"})

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -557,6 +557,8 @@ _OPTION_SET_SNAPSHOT: dict[str, tuple[str, ...]] = {
         "--header",
         "--header-graph",
         "--header-graph-includes",
+        "--help",
+        "--help-all",
         "--include",
         "--include-private-dso",
         "--jobs",

--- a/tests/test_cli_dump_helpers_coverage.py
+++ b/tests/test_cli_dump_helpers_coverage.py
@@ -24,6 +24,7 @@ import click
 import pytest
 
 from abicheck.cli_dump_helpers import (
+    evidence_depth_label,
     handle_non_elf_dump,
     perform_elf_dump,
     resolve_dump_compile_context,
@@ -576,3 +577,82 @@ def test_perform_elf_dump_wraps_dump_errors(tmp_path: Path, monkeypatch) -> None
             _write,
         )
     assert "written" not in events
+
+
+# ── evidence_depth_label (CLI-audit P2 self-describing output) ──────────────
+
+
+def _pack(build_evidence=None, source_abi=None, source_graph=None):
+    from abicheck.buildsource.pack import BuildSourcePack
+
+    return BuildSourcePack(
+        root=Path("/nonexistent"),
+        build_evidence=build_evidence,
+        source_abi=source_abi,
+        source_graph=source_graph,
+    )
+
+
+def test_evidence_depth_label_binary_when_no_headers_no_build_source() -> None:
+    snap = AbiSnapshot(library="libfoo.so", version="1.0")
+    assert evidence_depth_label(snap) == "binary"
+
+
+def test_evidence_depth_label_headers_when_from_headers_set() -> None:
+    snap = AbiSnapshot(library="libfoo.so", version="1.0", from_headers=True)
+    assert evidence_depth_label(snap) == "headers"
+
+
+def test_evidence_depth_label_build_when_build_evidence_has_facts() -> None:
+    from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
+
+    snap = AbiSnapshot(library="libfoo.so", version="1.0", from_headers=True)
+    snap.build_source = _pack(
+        build_evidence=BuildEvidence(compile_units=[CompileUnit(id="cu1", source="a.c")])
+    )
+    assert evidence_depth_label(snap) == "build"
+
+
+def test_evidence_depth_label_source_when_source_abi_has_reachable_entities() -> None:
+    from abicheck.buildsource.build_evidence import BuildEvidence
+    from abicheck.buildsource.source_abi import SourceAbiSurface, SourceEntity
+
+    snap = AbiSnapshot(library="libfoo.so", version="1.0", from_headers=True)
+    snap.build_source = _pack(
+        build_evidence=BuildEvidence(),
+        source_abi=SourceAbiSurface(
+            reachable_declarations=[SourceEntity(id="foo", kind="function")]
+        ),
+    )
+    assert evidence_depth_label(snap) == "source"
+
+
+def test_evidence_depth_label_source_when_source_graph_has_nodes() -> None:
+    from abicheck.buildsource.source_graph import GraphNode, SourceGraphSummary
+
+    snap = AbiSnapshot(library="libfoo.so", version="1.0", from_headers=True)
+    snap.build_source = _pack(
+        source_graph=SourceGraphSummary(nodes=[GraphNode(id="n1", kind="function")])
+    )
+    assert evidence_depth_label(snap) == "source"
+
+
+def test_evidence_depth_label_does_not_overstate_empty_source_abi() -> None:
+    # Regression (CodeRabbit review): source_abi/source_graph/build_evidence
+    # can be present (non-None) but carry no real facts -- e.g.
+    # _run_inline_source_abi returns an empty SourceAbiSurface() when clang is
+    # unavailable after L3 was found. Presence alone must not overstate
+    # "source"/"build" for a layer that ran but linked nothing.
+    from abicheck.buildsource.build_evidence import BuildEvidence
+    from abicheck.buildsource.source_abi import SourceAbiSurface
+    from abicheck.buildsource.source_graph import SourceGraphSummary
+
+    snap = AbiSnapshot(library="libfoo.so", version="1.0", from_headers=True)
+    snap.build_source = _pack(
+        build_evidence=BuildEvidence(),  # no targets/compile_units
+        source_abi=SourceAbiSurface(),  # no reachable entities
+        source_graph=SourceGraphSummary(),  # no nodes
+    )
+    # All three layers are present but empty -- falls all the way back to
+    # "headers" (from_headers=True), not "source" or "build".
+    assert evidence_depth_label(snap) == "headers"

--- a/tests/test_cli_help.py
+++ b/tests/test_cli_help.py
@@ -10,9 +10,14 @@ from __future__ import annotations
 
 import io
 
+import click
 import pytest
+from click.testing import CliRunner
 
 from abicheck import cli_help
+from abicheck.cli import main
+from abicheck.model import AbiSnapshot
+from abicheck.serialization import snapshot_to_json
 
 
 def _cp1252_stream() -> io.TextIOWrapper:
@@ -75,3 +80,105 @@ def test_configure_rich_help_calls_ensure_utf8_streams(
     monkeypatch.setattr(cli_help, "_ensure_utf8_streams", lambda: calls.append(True))
     cli_help.configure_rich_help()
     assert calls == [True]
+
+
+# ── `compare --help-all` second-level disclosure (G21.8 / collapse M2) ───────
+
+
+class TestCompareHelpAllDisclosure:
+    def test_common_option_names_are_real_params(self) -> None:
+        """Every dest name in the curated set must be a real ``compare`` option.
+
+        Guards against typos/drift: a stale name here would silently mean that
+        option is no longer protected from being hidden in the curated view
+        (it would just vanish from ``--help`` instead of erroring loudly).
+        """
+        real_names = {
+            p.name for p in main.commands["compare"].params if isinstance(p, click.Option)
+        }
+        assert cli_help.COMPARE_COMMON_OPTION_NAMES <= real_names
+
+    def test_curated_help_hides_advanced_options(self) -> None:
+        out = CliRunner().invoke(main, ["compare", "--help"]).output
+        # A representative long-tail option from each folded panel.
+        for advanced_flag in (
+            "--gcc-path",
+            "--ast-frontend",
+            "--jobs",
+            "--severity-abi-breaking",
+            "--report-mode",
+            "--pdb-path",
+        ):
+            assert advanced_flag not in out, f"{advanced_flag} leaked into curated --help"
+
+    def test_curated_help_keeps_common_options(self) -> None:
+        out = CliRunner().invoke(main, ["compare", "--help"]).output
+        for common_flag in (
+            "--header",
+            "--include",
+            "--lang",
+            "--output",
+            "--format",
+            "--show-only",
+            "--config",
+            "--severity-preset",
+            "--used-by",
+            "--required-symbol",
+            "--depth",
+            "--sources",
+            "--build-info",
+            "--scope-public-headers",
+            "--verbose",
+            "--dry-run",
+        ):
+            assert common_flag in out, f"{common_flag} missing from curated --help"
+
+    def test_curated_help_reports_hidden_count_and_points_to_help_all(self) -> None:
+        result = CliRunner().invoke(main, ["compare", "--help"])
+        assert result.exit_code == 0
+        assert "advanced option(s) hidden" in result.output
+        assert "compare --help-all" in result.output
+
+    def test_help_all_shows_everything_curated_hides(self) -> None:
+        out = CliRunner().invoke(main, ["compare", "--help-all"]).output
+        for advanced_flag in (
+            "--gcc-path",
+            "--ast-frontend",
+            "--jobs",
+            "--severity-abi-breaking",
+            "--report-mode",
+            "--pdb-path",
+        ):
+            assert advanced_flag in out
+
+    def test_help_all_has_no_hidden_count_footer(self) -> None:
+        result = CliRunner().invoke(main, ["compare", "--help-all"])
+        assert result.exit_code == 0
+        assert "advanced option(s) hidden" not in result.output
+
+    def test_params_restored_after_curated_help(self) -> None:
+        """Rendering curated help must not permanently shrink ``compare``'s params."""
+        cmd = main.commands["compare"]
+        before = list(cmd.params)
+        CliRunner().invoke(main, ["compare", "--help"])
+        assert cmd.params == before
+
+    def test_advanced_option_still_functional_after_curated_help_render(
+        self, tmp_path
+    ) -> None:
+        """An option hidden from curated --help must still work when actually passed.
+
+        Renders curated help once first (which temporarily shrinks
+        ``compare``'s params list) to prove the restore in the ``finally``
+        block leaves the command fully functional for a real invocation.
+        """
+        CliRunner().invoke(main, ["compare", "--help"])
+        old = tmp_path / "old.json"
+        new = tmp_path / "new.json"
+        snap_json = snapshot_to_json(AbiSnapshot(library="x", version="1"))
+        old.write_text(snap_json, encoding="utf-8")
+        new.write_text(snap_json, encoding="utf-8")
+        result = CliRunner().invoke(
+            main, ["compare", str(old), str(new), "--gcc-path", "/usr/bin/gcc"]
+        )
+        assert result.exit_code == 0, result.output

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -159,6 +159,75 @@ class TestResolveDemangle:
         assert _resolve_demangle("markdown", False) is False
 
 
+# ── _resolve_compare_collect_mode (CLI-audit P1: --depth inference) ──────
+#
+# Precedence: explicit --depth > .abicheck.yml source.method > inferred from
+# raw --sources/--build-info > off. Before this fix, omitting --depth always
+# resolved to "off" even when --old-sources/--new-sources/--build-info were
+# explicitly given, so those inputs were silently ignored.
+
+class TestResolveCompareCollectMode:
+    def _call(self, depth=None, source_method=None, old_sources=None,
+              new_sources=None, old_build_info=None, new_build_info=None):
+        from abicheck.cli_compare_helpers import _resolve_compare_collect_mode
+
+        return _resolve_compare_collect_mode(
+            depth, source_method, old_sources, new_sources,
+            old_build_info, new_build_info,
+        )
+
+    def test_no_depth_no_inputs_is_off(self):
+        mode, label = self._call()
+        assert mode == "off"
+        assert "off" in label
+
+    def test_sources_given_no_depth_infers_source(self, tmp_path):
+        mode, label = self._call(old_sources=tmp_path / "src")
+        assert mode == "source-target"
+        assert "inferred" in label
+
+    def test_new_sources_alone_also_infers_source(self, tmp_path):
+        mode, _ = self._call(new_sources=tmp_path / "src")
+        assert mode == "source-target"
+
+    def test_build_info_given_no_depth_infers_build(self, tmp_path):
+        mode, label = self._call(old_build_info=tmp_path / "build")
+        assert mode == "build"
+        assert "inferred" in label
+
+    def test_sources_takes_precedence_over_build_info_when_both_given(self, tmp_path):
+        mode, _ = self._call(
+            old_sources=tmp_path / "src", old_build_info=tmp_path / "build",
+        )
+        assert mode == "source-target"
+
+    def test_explicit_depth_wins_over_inference(self, tmp_path):
+        # --depth binary explicitly requested despite raw --sources: the
+        # explicit choice must still suppress collection (with the CLI's own
+        # "ignoring it" warning), not be silently overridden by inference.
+        mode, label = self._call(depth="binary", old_sources=tmp_path / "src")
+        assert mode == "off"
+        assert "--depth binary" in label
+
+    def test_config_source_method_wins_over_inference(self, tmp_path):
+        # .abicheck.yml source.method applies when no --depth was given, even
+        # if raw --sources are also present (config > bare inference).
+        mode, label = self._call(source_method="s1", old_sources=tmp_path / "src")
+        assert mode == "build"
+        assert "source.method=s1" in label
+
+    def test_explicit_depth_wins_over_config_source_method(self, tmp_path):
+        mode, label = self._call(depth="source", source_method="s1")
+        assert mode == "source-target"
+        assert "--depth source" in label
+
+    def test_invalid_source_method_raises_usage_error(self):
+        import click
+
+        with pytest.raises(click.UsageError, match="source.method"):
+            self._call(source_method="not-a-method")
+
+
 # ── compare --secondary-format/--secondary-output ───────────────────────
 
 class TestCompareSecondaryFormat:
@@ -263,6 +332,22 @@ class TestCompareSecondaryFormat:
         ])
         assert result.exit_code == 64
         assert "--secondary-output must differ from --output/-o" in result.output
+
+    def test_dry_run_rejects_secondary_output(self, tmp_path):
+        # Regression (CLI-audit P2): --dry-run promises no output-file side
+        # effect and already rejects -o/--output, but --secondary-output was
+        # accepted and then silently never written (the dry run exits before
+        # the secondary render runs) — reject it the same way.
+        old_p, new_p = _write_snapshots(tmp_path)
+        secondary_out = tmp_path / "secondary.json"
+        runner = CliRunner()
+        result = runner.invoke(main, [
+            "compare", str(old_p), str(new_p), "--dry-run",
+            "--secondary-format", "json", "--secondary-output", str(secondary_out),
+        ])
+        assert result.exit_code == 64
+        assert "--dry-run cannot be combined with --secondary-output" in result.output
+        assert not secondary_out.exists()
 
 
 # ── compare with suppression ────────────────────────────────────────────

--- a/tests/test_compare_profiles.py
+++ b/tests/test_compare_profiles.py
@@ -100,13 +100,13 @@ class TestApplyProfileUnit:
             apply_compare_profile(_FakeCtx(explicit=set()), kwargs)
 
     def test_set_input_reject_is_usage_error_end_to_end(self, tmp_path: Path) -> None:
-        """`compare dir dir --profile release` exits as a usage error (64)."""
+        """`compare dir dir --profile release-cut` exits as a usage error (64)."""
         old_dir = tmp_path / "old"
         new_dir = tmp_path / "new"
         old_dir.mkdir()
         new_dir.mkdir()
         result = CliRunner().invoke(
-            main, ["compare", str(old_dir), str(new_dir), "--profile", "release"]
+            main, ["compare", str(old_dir), str(new_dir), "--profile", "release-cut"]
         )
         assert result.exit_code == 64, result.output
         assert "single-pair" in result.output

--- a/tests/test_config_review.py
+++ b/tests/test_config_review.py
@@ -208,7 +208,9 @@ class TestDebugFormatSelector:
 
 class TestReportModeImpact:
     def test_impact_in_choices(self):
-        out = CliRunner().invoke(main, ["compare", "--help"]).output
+        # --report-mode is in compare's advanced tier (G21.8 collapse M2),
+        # folded behind --help-all; plain --help only shows the common subset.
+        out = CliRunner().invoke(main, ["compare", "--help-all"]).output
         assert "impact" in out
 
     def test_impact_mode_runs(self, tmp_path):
@@ -234,15 +236,17 @@ class TestCompareReleaseDefaults:
         assert "--no-scope-public-headers" in opt.secondary_opts
 
     def test_jobs_default_zero(self):
-        out = CliRunner().invoke(main, ["compare", "--help"]).output
+        # --jobs is in compare's advanced/release tier (G21.8 collapse M2).
+        out = CliRunner().invoke(main, ["compare", "--help-all"]).output
         assert "auto-detect" in out
 
     def test_severity_options_present(self):
-        out = CliRunner().invoke(main, ["compare", "--help"]).output
+        out = CliRunner().invoke(main, ["compare", "--help-all"]).output
         # `compare` now drives directory/package (release) comparisons too. It
         # surfaces the full severity family (the coarse --severity-preset plus the
         # per-category overrides) — unlike the removed `compare-release` command,
-        # which hid the per-category knobs.
+        # which hid the per-category knobs. The per-category overrides are in
+        # the advanced tier (G21.8 collapse M2), folded behind --help-all.
         assert "--severity-preset" in out
         assert "--severity-abi-breaking" in out
 

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -265,7 +265,7 @@ class TestSmallHelpers:
         runner = CliRunner()
         compare_help = runner.invoke(main, ["compare", "--help"]).output
         assert "Per-side overrides" in compare_help
-        assert "Build/source evidence" in compare_help
+        assert "Build & source evidence" in compare_help
         dump_help = runner.invoke(main, ["dump", "--help"]).output
         assert "Toolchain" in dump_help and "Provenance" in dump_help
 

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1192,6 +1192,37 @@ class TestUsedByScoping:
         assert out.exists()
         assert "Report written to" in result.output
 
+    def test_default_markdown_names_uncovered_missing_symbol(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Codex review: the default (markdown) report must name the actual
+        missing symbol, not just its count -- otherwise a human reading the
+        default output has no way to tell which symbol broke the gate."""
+        res = self._result(verdict=Verdict.BREAKING, missing=["foo_removed"])
+        app, old, new = self._setup(tmp_path, monkeypatch)
+        self._patch_scope(monkeypatch, res)
+        result = _invoke("compare", str(old), str(new), "--used-by", str(app))
+        assert result.exit_code == 4
+        assert "missing symbol: `foo_removed`" in result.output
+        assert "## Additional scoped-gate findings" in result.output
+        assert "`foo_removed` is required but missing from the new library" in result.output
+
+    def test_default_markdown_names_scoped_only_change(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Codex review: a scoped-only Change (e.g. PE_ORDINAL_RETARGETED,
+        relevant to the gate but never added to result.changes) must be named
+        in the default text report too, mirroring the JSON/SARIF/JUnit fold-in."""
+        scoped_change = Change(
+            ChangeKind.PE_ORDINAL_RETARGETED, "MyExport", "ordinal changed from 5 to 7",
+        )
+        res = self._result(verdict=Verdict.BREAKING, breaking_for_app=[scoped_change])
+        app, old, new = self._setup(tmp_path, monkeypatch)
+        self._patch_scope(monkeypatch, res)
+        result = _invoke("compare", str(old), str(new), "--used-by", str(app))
+        assert "## Additional scoped-gate findings" in result.output
+        assert "pe_ordinal_retargeted: ordinal changed from 5 to 7" in result.output
+
     def test_severity_missing_symbols_default_preset_floors_at_4(
         self, tmp_path, monkeypatch
     ) -> None:

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1660,6 +1660,73 @@ class TestUsedByScoping:
         assert entry["severity"] == "compatible"
 
 
+class TestFoldEvidenceDepthOutOfBandPack:
+    """``_fold_evidence_depth_into_json`` with an out-of-band pack directory.
+
+    Regression (Codex review): an out-of-band ``--old/new-build-info``/
+    ``--old/new-sources`` *pack directory* (as opposed to a raw checkout,
+    which gets embedded into the snapshot before this point) is resolved via
+    ``_resolve_side_pack`` inside ``prepare_embedded_build_source`` /
+    ``diff_embedded_build_source`` but never attached back onto the snapshot
+    object itself -- so reading only ``snap.build_source`` for the JSON
+    ``old_evidence_depth``/``new_evidence_depth`` fields reported the
+    snapshot's own (absent) embedded depth instead of the pack that was
+    actually used to produce the comparison's build/source findings.
+    """
+
+    def test_out_of_band_pack_depth_beats_absent_embedded_snapshot(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        import json as json_mod
+
+        from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
+        from abicheck.buildsource.pack import BuildSourcePack
+        from abicheck.cli_compare_helpers import _fold_evidence_depth_into_json
+
+        old_snap = _snap("1.0", library="libfoo.so")
+        new_snap = _snap("2.0", library="libfoo.so")
+        assert old_snap.build_source is None
+        assert new_snap.build_source is None
+
+        pack = BuildSourcePack(
+            root=tmp_path,
+            build_evidence=BuildEvidence(
+                compile_units=[CompileUnit(id="cu1", source="a.c")]
+            ),
+        )
+        monkeypatch.setattr(
+            "abicheck.cli_buildsource_helpers._resolve_side_pack",
+            lambda build_info, sources, snap: pack,
+        )
+
+        text = json_mod.dumps({"changes": []})
+        result_text = _fold_evidence_depth_into_json(
+            text, "json", old_snap, new_snap,
+            old_build_info=tmp_path / "old_build", new_build_info=tmp_path / "new_build",
+        )
+        data = json_mod.loads(result_text)
+        assert data["old_evidence_depth"] == "build"
+        assert data["new_evidence_depth"] == "build"
+
+    def test_no_pack_args_falls_back_to_snapshot_embedded_depth(self) -> None:
+        # Without --old/new-build-info/--old/new-sources, behavior is
+        # unchanged: depth comes straight from each snapshot's own embedded
+        # build_source (or absence thereof).
+        import json as json_mod
+
+        from abicheck.cli_compare_helpers import _fold_evidence_depth_into_json
+
+        old_snap = _snap("1.0", library="libfoo.so")
+        new_snap = _snap("2.0", library="libfoo.so")
+        new_snap.from_headers = True
+
+        text = json_mod.dumps({"changes": []})
+        result_text = _fold_evidence_depth_into_json(text, "json", old_snap, new_snap)
+        data = json_mod.loads(result_text)
+        assert data["old_evidence_depth"] == "binary"
+        assert data["new_evidence_depth"] == "headers"
+
+
 class TestUsedByScopingWithSnapshotInputs:
     """`compare --used-by` OLD/NEW as saved JSON snapshots (ADR-043 follow-up).
 

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1367,6 +1367,47 @@ class TestUsedByScoping:
         assert result.exit_code == 4
         assert data["severity"]["categories"]["abi_breaking"]["count"] == 1
 
+    def test_multi_app_semantically_identical_change_not_double_counted(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Regression (CLI-audit P2): unlike the shared-object case above,
+        # `appcompat._check_pe_ordinal_imports` constructs a FRESH
+        # PE_ORDINAL_RETARGETED Change per `scope_diff_to_app` call, so two
+        # apps retargeting the same ordinal get two distinct Change objects
+        # with identical kind/symbol/description but different id() -- the
+        # old id()-keyed dedup in `_apply_used_by_scoping` would count that
+        # as two findings instead of one.
+        import abicheck.appcompat as appcompat_mod
+        from abicheck.appcompat import AppCompatResult
+
+        res1 = AppCompatResult(
+            app_path="/app1", old_lib_path="old.so", new_lib_path="new.so",
+            required_symbols={"foo"}, required_symbol_count=1,
+            breaking_for_app=[Change(ChangeKind.FUNC_REMOVED, "foo", "removed: foo")],
+            verdict=Verdict.BREAKING,
+        )
+        res2 = AppCompatResult(
+            app_path="/app2", old_lib_path="old.so", new_lib_path="new.so",
+            required_symbols={"foo"}, required_symbol_count=1,
+            breaking_for_app=[Change(ChangeKind.FUNC_REMOVED, "foo", "removed: foo")],
+            verdict=Verdict.BREAKING,
+        )
+        app1, old, new = self._setup(tmp_path, monkeypatch)
+        app2 = tmp_path / "app2"
+        app2.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        monkeypatch.setattr(
+            appcompat_mod, "scope_diff_to_app",
+            MagicMock(side_effect=[res1, res2]),
+        )
+        result = _invoke(
+            "compare", str(old), str(new),
+            "--used-by", str(app1), "--used-by", str(app2),
+            "--severity-preset", "default", "--format", "json",
+        )
+        data = json.loads(result.stdout)
+        assert result.exit_code == 4
+        assert data["severity"]["categories"]["abi_breaking"]["count"] == 1
+
     def test_severity_clean_exit_0(self, tmp_path, monkeypatch) -> None:
         res = self._result(verdict=Verdict.COMPATIBLE)
         app, old, new = self._setup(tmp_path, monkeypatch)

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1588,6 +1588,77 @@ class TestUsedByScoping:
         assert "abi_breaking" in data["full_severity"]["blocking_categories"]
         assert data["full_severity"]["categories"]["abi_breaking"]["count"] == 1
 
+    def test_json_scoped_only_change_is_included_in_changes(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Regression (Codex review): scope_diff_to_app can synthesize a fresh
+        # Change (e.g. PE_ORDINAL_RETARGETED) that is relevant to the gate but
+        # never lands in result.changes -- SARIF/JUnit already fold this into
+        # their own rendering (scoped_only_changes), but the JSON `changes`
+        # array (which the GitHub Action's `--on changes` PR-comment gate
+        # buckets off directly) did not, so a --used-by run whose only gated
+        # issue is one of these reported an empty `changes` array despite a
+        # nonzero scoped exit code.
+        scoped_only = Change(
+            kind=ChangeKind.PE_ORDINAL_RETARGETED,
+            symbol="ordinal:5",
+            description="ordinal 5 retargeted",
+            old_value="OldFunc", new_value="NewFunc",
+        )
+        res = self._result(verdict=Verdict.BREAKING, breaking_for_app=[scoped_only])
+        app, old, new = self._setup(tmp_path, monkeypatch)
+        self._patch_scope(monkeypatch, res)
+        result = _invoke(
+            "compare", str(old), str(new), "--used-by", str(app), "--format", "json",
+        )
+        assert result.exit_code == 4
+        data = json.loads(result.stdout)
+        assert data["full_verdict"] == "NO_CHANGE"
+        assert data["verdict"] == "BREAKING"
+        kinds = [c["kind"] for c in data["changes"]]
+        assert "pe_ordinal_retargeted" in kinds
+        entry = next(c for c in data["changes"] if c["kind"] == "pe_ordinal_retargeted")
+        assert entry["symbol"] == "ordinal:5"
+
+    def test_json_uncovered_missing_symbol_is_included_in_changes(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Same gap as above, for a missing required symbol/version with no
+        # backing Change at all (scoped_missing_labels, not scoped_only_changes).
+        res = self._result(verdict=Verdict.BREAKING, missing=["needed_symbol"])
+        app, old, new = self._setup(tmp_path, monkeypatch)
+        self._patch_scope(monkeypatch, res)
+        result = _invoke(
+            "compare", str(old), str(new), "--used-by", str(app), "--format", "json",
+        )
+        assert result.exit_code == 4
+        data = json.loads(result.stdout)
+        entry = next(
+            c for c in data["changes"] if c["kind"] == "used_by_missing_symbol"
+        )
+        assert entry["symbol"] == "needed_symbol"
+        assert entry["blocks_gate"] is True
+
+    def test_json_uncovered_missing_symbol_not_blocking_under_demoted_severity(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # A missing-contract entry must not claim blocks_gate=True when a
+        # severity config demotes abi_breaking below error (mirrors the
+        # SARIF/JUnit severity-aware missing-contract handling).
+        res = self._result(verdict=Verdict.BREAKING, missing=["needed_symbol"])
+        app, old, new = self._setup(tmp_path, monkeypatch)
+        self._patch_scope(monkeypatch, res)
+        result = _invoke(
+            "compare", str(old), str(new), "--used-by", str(app), "--format", "json",
+            "--severity-abi-breaking", "warning",
+        )
+        data = json.loads(result.stdout)
+        entry = next(
+            c for c in data["changes"] if c["kind"] == "used_by_missing_symbol"
+        )
+        assert entry["blocks_gate"] is False
+        assert entry["severity"] == "compatible"
+
 
 class TestUsedByScopingWithSnapshotInputs:
     """`compare --used-by` OLD/NEW as saved JSON snapshots (ADR-043 follow-up).

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1136,7 +1136,10 @@ class TestUsedByScoping:
 
         monkeypatch.setattr(appcompat_mod, "scope_diff_to_app", lambda *a, **k: result)
 
-    def _result(self, *, verdict=Verdict.COMPATIBLE, missing=None, breaking_for_app=None):
+    def _result(
+        self, *, verdict=Verdict.COMPATIBLE, missing=None, missing_versions=None,
+        breaking_for_app=None,
+    ):
         from abicheck.appcompat import AppCompatResult
 
         return AppCompatResult(
@@ -1147,7 +1150,7 @@ class TestUsedByScoping:
             required_symbol_count=1,
             breaking_for_app=breaking_for_app or [],
             missing_symbols=missing or [],
-            missing_versions=[],
+            missing_versions=missing_versions or [],
             verdict=verdict,
             symbol_coverage=100.0,
         )
@@ -1198,12 +1201,16 @@ class TestUsedByScoping:
         """Codex review: the default (markdown) report must name the actual
         missing symbol, not just its count -- otherwise a human reading the
         default output has no way to tell which symbol broke the gate."""
-        res = self._result(verdict=Verdict.BREAKING, missing=["foo_removed"])
+        res = self._result(
+            verdict=Verdict.BREAKING, missing=["foo_removed"],
+            missing_versions=["FOO_1.2"],
+        )
         app, old, new = self._setup(tmp_path, monkeypatch)
         self._patch_scope(monkeypatch, res)
         result = _invoke("compare", str(old), str(new), "--used-by", str(app))
         assert result.exit_code == 4
         assert "missing symbol: `foo_removed`" in result.output
+        assert "missing version: `FOO_1.2`" in result.output
         assert "## Additional scoped-gate findings" in result.output
         assert "`foo_removed` is required but missing from the new library" in result.output
 

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1253,11 +1253,27 @@ class TestUsedByScoping:
         monkeypatch.setattr(
             dumper_mod, "dump", MagicMock(side_effect=[old_snap, new_snap])
         )
-        res = self._result(
-            verdict=Verdict.BREAKING, missing=["_Z3foov"],
-            breaking_for_app=[Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")],
-        )
-        self._patch_scope(monkeypatch, res)
+
+        # Extract the REAL diff's FUNC_REMOVED Change (not a hand-built stub
+        # with different description/old_value text) so its finding id
+        # genuinely matches the one in result.changes -- otherwise the dedup
+        # this test targets would never engage, since _finding_id is content-
+        # based, not id()-based.
+        def _scoped_for(diff, *_args, **_kwargs):
+            from abicheck.appcompat import AppCompatResult
+
+            real_change = next(c for c in diff.changes if c.kind == ChangeKind.FUNC_REMOVED)
+            return AppCompatResult(
+                app_path="/app", old_lib_path=str(old), new_lib_path=str(new),
+                required_symbols={"_Z3foov"}, required_symbol_count=1,
+                missing_symbols=["_Z3foov"],
+                breaking_for_app=[real_change],
+                verdict=Verdict.BREAKING,
+            )
+
+        import abicheck.appcompat as appcompat_mod
+
+        monkeypatch.setattr(appcompat_mod, "scope_diff_to_app", _scoped_for)
         result = _invoke(
             "compare", str(old), str(new), "--used-by", str(app), "--format", "sarif",
         )

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1659,6 +1659,31 @@ class TestUsedByScoping:
         assert entry["blocks_gate"] is False
         assert entry["severity"] == "compatible"
 
+    def test_json_scoped_only_change_respects_show_only(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Regression (Codex review): to_json's own --show-only filtering
+        # only ever touched result.changes -- scoped_only_changes were
+        # appended to the JSON `changes` array unconditionally afterward, so
+        # a --used-by --show-only run could re-surface a finding the filter
+        # was supposed to exclude (mirrors the identical sarif.to_sarif fix).
+        scoped_only = Change(
+            kind=ChangeKind.PE_ORDINAL_RETARGETED,
+            symbol="ordinal:5",
+            description="ordinal 5 retargeted",
+            old_value="OldFunc", new_value="NewFunc",
+        )
+        res = self._result(verdict=Verdict.BREAKING, breaking_for_app=[scoped_only])
+        app, old, new = self._setup(tmp_path, monkeypatch)
+        self._patch_scope(monkeypatch, res)
+        result = _invoke(
+            "compare", str(old), str(new), "--used-by", str(app), "--format", "json",
+            "--show-only", "compatible",
+        )
+        data = json.loads(result.stdout)
+        kinds = [c["kind"] for c in data["changes"]]
+        assert "pe_ordinal_retargeted" not in kinds
+
 
 class TestFoldEvidenceDepthOutOfBandPack:
     """``_fold_evidence_depth_into_json`` with an out-of-band pack directory.

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1232,6 +1232,40 @@ class TestUsedByScoping:
         data = json.loads(result.stdout)
         assert data["severity"]["categories"]["abi_breaking"]["count"] == 1
 
+    def test_sarif_missing_symbol_covered_by_change_not_double_synthesized(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Regression (Codex review): "_Z3foov" is both a missing symbol
+        # (absent from new's exports) *and* the subject of a real, scoped
+        # FUNC_REMOVED Change in the actual diff -- the SARIF report must
+        # show one result for it, not two (the real Change plus a synthetic
+        # missing-contract entry double-reporting the same break).
+        from abicheck import dumper as dumper_mod
+
+        app = tmp_path / "app"
+        app.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        old = tmp_path / "old.so"
+        old.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        new = tmp_path / "new.so"
+        new.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        old_snap = _snap("1.0", library="libfoo.so")  # has foo/_Z3foov
+        new_snap = _snap("2.0", library="libfoo.so", funcs=[])  # foo removed
+        monkeypatch.setattr(
+            dumper_mod, "dump", MagicMock(side_effect=[old_snap, new_snap])
+        )
+        res = self._result(
+            verdict=Verdict.BREAKING, missing=["_Z3foov"],
+            breaking_for_app=[Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")],
+        )
+        self._patch_scope(monkeypatch, res)
+        result = _invoke(
+            "compare", str(old), str(new), "--used-by", str(app), "--format", "sarif",
+        )
+        data = json.loads(result.stdout)
+        sarif_results = data["runs"][0]["results"]
+        assert len(sarif_results) == 1
+        assert sarif_results[0]["ruleId"] == "func_removed"
+
     def test_severity_missing_symbols_only_floors_at_4(
         self, tmp_path, monkeypatch
     ) -> None:

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1684,6 +1684,38 @@ class TestUsedByScoping:
         kinds = [c["kind"] for c in data["changes"]]
         assert "pe_ordinal_retargeted" not in kinds
 
+    def test_json_missing_symbol_respects_show_only(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Regression (Codex review): a missing-contract label has no backing
+        # Change/ChangeKind so it can't run through apply_show_only -- but a
+        # --show-only run that excludes breaking findings must still not
+        # include the (default-blocking) missing-contract entry.
+        res = self._result(verdict=Verdict.BREAKING, missing=["needed_symbol"])
+        app, old, new = self._setup(tmp_path, monkeypatch)
+        self._patch_scope(monkeypatch, res)
+        result = _invoke(
+            "compare", str(old), str(new), "--used-by", str(app), "--format", "json",
+            "--show-only", "compatible",
+        )
+        data = json.loads(result.stdout)
+        kinds = [c["kind"] for c in data["changes"]]
+        assert "used_by_missing_symbol" not in kinds
+
+    def test_json_missing_symbol_shown_when_show_only_includes_breaking(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        res = self._result(verdict=Verdict.BREAKING, missing=["needed_symbol"])
+        app, old, new = self._setup(tmp_path, monkeypatch)
+        self._patch_scope(monkeypatch, res)
+        result = _invoke(
+            "compare", str(old), str(new), "--used-by", str(app), "--format", "json",
+            "--show-only", "breaking",
+        )
+        data = json.loads(result.stdout)
+        kinds = [c["kind"] for c in data["changes"]]
+        assert "used_by_missing_symbol" in kinds
+
 
 class TestFoldEvidenceDepthOutOfBandPack:
     """``_fold_evidence_depth_into_json`` with an out-of-band pack directory.

--- a/tests/test_dry_run_contract.py
+++ b/tests/test_dry_run_contract.py
@@ -104,6 +104,31 @@ class TestCompareDryRun:
         assert _CONTRACT_FOOTER in first.output
         assert "Command: compare" in first.output
 
+    def test_reports_effective_depth_not_just_raw_requested(self, tmp_path: Path) -> None:
+        # Regression (CLI-audit P1/P2): a dry run must report the *effective*
+        # depth the real run will use, not just echo back the raw --depth
+        # string. With no --depth given but a raw --sources tree, the real
+        # run now infers "source" (see TestResolveCompareCollectMode) --
+        # the dry run must show that inference, not "requested depth: (not
+        # given)" alone with no indication of what will actually happen.
+        old = tmp_path / "old.abi.json"
+        new = tmp_path / "new.abi.json"
+        _write_snapshot(old, "1.0")
+        _write_snapshot(new, "2.0")
+        tree = tmp_path / "src"
+        tree.mkdir()
+        result = CliRunner().invoke(
+            main,
+            [
+                "compare", str(old), str(new), "--dry-run",
+                "--sources", "old=" + str(tree),
+            ],
+        )
+        assert result.exit_code == 0
+        assert "requested depth: (not given)" in result.output
+        assert "effective depth: source" in result.output
+        assert "inferred" in result.output
+
 
 class TestDepsTreeDryRun:
     def test_writes_nothing_and_rejects_output(self, tmp_path: Path) -> None:

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -1427,3 +1427,25 @@ class TestScopedProperties:
         assert tc.get("name") == "_Z6vanishv"
         assert tc.get("classname") == "used_by_contract"
         assert tc.find("failure") is not None
+
+    def test_missing_contract_demoted_by_severity_config_does_not_fail(self) -> None:
+        # Regression (Codex review): under a severity config that demotes
+        # abi_breaking, the scoped exit code for a missing contract member
+        # is floored at 0 by missing_contract_exit_code -- the synthetic
+        # testcase must not fail in that case, or a JUnit-consuming CI would
+        # mark the run failed even though the gate itself passed.
+        from abicheck.severity import SeverityConfig, SeverityLevel
+
+        demoted = SeverityConfig(abi_breaking=SeverityLevel.WARNING)
+        r = _make_result([], verdict=Verdict.COMPATIBLE)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset()  # type: ignore[attr-defined]
+        r.scoped_missing_labels = ("_Z6vanishv",)  # type: ignore[attr-defined]
+        xml_str = to_junit_xml(r, severity_config=demoted)
+        root = _parse(xml_str)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "0"
+        tc = ts.find("testcase")
+        assert tc.get("name") == "_Z6vanishv"
+        assert tc.find("failure") is None

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -1455,6 +1455,36 @@ class TestScopedProperties:
         props = {p.get("name"): p.get("value") for p in ts.find("properties")}
         assert props["abicheck.relevant_finding_count"] == "1"
 
+    def test_missing_contract_respects_show_only(self) -> None:
+        # Regression (Codex review): scoped_missing_labels bypassed
+        # --show-only entirely -- a missing required symbol has no backing
+        # Change/ChangeKind so it can't run through apply_show_only, but a
+        # --show-only run that excludes breaking findings must not still
+        # count/emit a failing testcase for it.
+        r = _make_result([], verdict=Verdict.COMPATIBLE)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset()  # type: ignore[attr-defined]
+        r.scoped_missing_labels = ("_Z6vanishv",)  # type: ignore[attr-defined]
+        xml_str = to_junit_xml(r, show_only="compatible")
+        root = _parse(xml_str)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "0"
+        assert ts.get("tests") == "0"
+        assert ts.find("testcase") is None
+
+    def test_missing_contract_shown_when_show_only_includes_breaking(self) -> None:
+        r = _make_result([], verdict=Verdict.COMPATIBLE)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset()  # type: ignore[attr-defined]
+        r.scoped_missing_labels = ("_Z6vanishv",)  # type: ignore[attr-defined]
+        xml_str = to_junit_xml(r, show_only="breaking")
+        root = _parse(xml_str)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "1"
+        assert ts.find("testcase") is not None
+
     def test_scoped_only_change_gets_a_testcase(self) -> None:
         # Regression (Codex review): scope_diff_to_app synthesizes a fresh
         # Change (e.g. PE_ORDINAL_RETARGETED) that is relevant to the gate

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -1329,13 +1329,13 @@ class TestJUnitCLICompare:
 
 
 class TestScopedProperties:
-    """`--used-by`/`--required-symbol(s)` scoping (ADR-043) discoverability.
+    """`--used-by`/`--required-symbol(s)` scoping (ADR-043 + CLI-audit P1).
 
-    JUnit's own tests/failures counts stay computed from the full, unscoped
-    library diff (documented, intentional) -- but the CLI process exits on
-    the *scoped* verdict floor. Without a `<properties>` block a JUnit
-    consumer had no way to discover that the two could disagree (post-merge
-    PR #566 review)."""
+    The scoped gate is authoritative for this testsuite's own `failures`
+    count and each `<testcase>`'s pass/fail status when scoping is active --
+    `result.verdict` (the full, unscoped library verdict) is still reported
+    as `abicheck.full_library_verdict` for context, but no longer drives
+    what a JUnit-consuming CI dashboard treats as failing."""
 
     def test_no_properties_when_no_scoping(self) -> None:
         r = _make_result([], verdict=Verdict.BREAKING)
@@ -1347,6 +1347,7 @@ class TestScopedProperties:
     def test_properties_present_and_can_disagree_with_full_verdict(self) -> None:
         r = _make_result([], verdict=Verdict.BREAKING)
         r.scoped_verdict = Verdict.COMPATIBLE  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
         r.used_by = [{"app": "/bin/myapp", "verdict": "COMPATIBLE"}]  # type: ignore[attr-defined]
         xml_str = to_junit_xml(r)
         root = _parse(xml_str)
@@ -1354,7 +1355,8 @@ class TestScopedProperties:
         props = {
             p.get("name"): p.get("value") for p in ts.find("properties")
         }
-        assert props["abicheck.scoped_verdict"] == "COMPATIBLE"
+        assert props["abicheck.gate_scope"] == "used_by"
+        assert props["abicheck.gate_verdict"] == "COMPATIBLE"
         assert props["abicheck.full_library_verdict"] == "BREAKING"
         assert props["abicheck.used_by_app_count"] == "1"
 
@@ -1370,11 +1372,10 @@ class TestScopedProperties:
         }
         assert props["abicheck.required_symbol_contract_verdict"] == "BREAKING"
 
-    def test_note_states_actual_exit_code_under_severity_scheme(self) -> None:
-        # Regression: the note used to claim "exit code reflects
-        # scoped_verdict" unconditionally, wrong under a severity scheme --
-        # e.g. --severity-preset info-only can floor the scoped exit code at
-        # 0 even for a BREAKING scoped_verdict (Codex review).
+    def test_gate_exit_code_follows_severity_scheme(self) -> None:
+        # Under a severity scheme the scoped exit code can be floored at 0
+        # even for a BREAKING scoped verdict -- the properties must report
+        # the actual computed value/scheme.
         r = _make_result([], verdict=Verdict.BREAKING)
         r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
         r.scoped_exit_code = 0  # type: ignore[attr-defined]
@@ -1385,7 +1386,44 @@ class TestScopedProperties:
         props = {
             p.get("name"): p.get("value") for p in ts.find("properties")
         }
-        assert props["abicheck.scoped_exit_code"] == "0"
-        assert props["abicheck.scoped_exit_code_scheme"] == "severity"
-        assert "exits 0" in props["abicheck.scoped_note"]
-        assert "severity" in props["abicheck.scoped_note"]
+        assert props["abicheck.gate_exit_code"] == "0"
+        assert props["abicheck.gate_exit_code_scheme"] == "severity"
+
+    def test_irrelevant_change_does_not_fail_but_relevant_one_does(self) -> None:
+        # A change outside the --used-by/--required-symbol gate's relevance
+        # must not count as a JUnit failure -- it's out of scope for the
+        # gate this testsuite now reports (CLI-audit P1).
+        from abicheck.reporter import _finding_id
+
+        relevant = Change(ChangeKind.FUNC_REMOVED, "_Z3foov", "removed: foo")
+        irrelevant = Change(ChangeKind.FUNC_REMOVED, "_Z3barv", "removed: bar")
+        r = _make_result([relevant, irrelevant], verdict=Verdict.BREAKING)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset({_finding_id(relevant)})  # type: ignore[attr-defined]
+        xml_str = to_junit_xml(r)
+        root = _parse(xml_str)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "1"
+        tcs = {tc.get("name"): tc for tc in ts.findall("testcase")}
+        assert tcs["_Z3foov"].find("failure") is not None
+        assert tcs["_Z3barv"].find("failure") is None
+
+    def test_missing_contract_emits_a_failing_testcase(self) -> None:
+        # A required symbol absent from the new library has no backing diff
+        # Change -- without a synthetic testcase the gate's own `failures`
+        # count could be nonzero while nothing in the XML explains why.
+        r = _make_result([], verdict=Verdict.COMPATIBLE)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset()  # type: ignore[attr-defined]
+        r.scoped_missing_labels = ("_Z6vanishv",)  # type: ignore[attr-defined]
+        xml_str = to_junit_xml(r)
+        root = _parse(xml_str)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "1"
+        assert ts.get("tests") == "1"
+        tc = ts.find("testcase")
+        assert tc.get("name") == "_Z6vanishv"
+        assert tc.get("classname") == "used_by_contract"
+        assert tc.find("failure") is not None

--- a/tests/test_junit_report.py
+++ b/tests/test_junit_report.py
@@ -1449,3 +1449,35 @@ class TestScopedProperties:
         tc = ts.find("testcase")
         assert tc.get("name") == "_Z6vanishv"
         assert tc.find("failure") is None
+        # A missing-contract member still counts as relevant even when
+        # demoted (severity decides blocking, not scope membership --
+        # CodeRabbit review).
+        props = {p.get("name"): p.get("value") for p in ts.find("properties")}
+        assert props["abicheck.relevant_finding_count"] == "1"
+
+    def test_scoped_only_change_gets_a_testcase(self) -> None:
+        # Regression (Codex review): scope_diff_to_app synthesizes a fresh
+        # Change (e.g. PE_ORDINAL_RETARGETED) that is relevant to the gate
+        # but never added to result.changes -- without a testcase for it, a
+        # --used-by run that fails solely because of one of these would have
+        # no testcase/failure in the XML to explain it.
+        from abicheck.reporter import _finding_id
+
+        scoped_only = Change(
+            kind=ChangeKind.PE_ORDINAL_RETARGETED,
+            symbol="ordinal:5",
+            description="ordinal 5 retargeted",
+            old_value="OldFunc", new_value="NewFunc",
+        )
+        r = _make_result([], verdict=Verdict.COMPATIBLE)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset({_finding_id(scoped_only)})  # type: ignore[attr-defined]
+        r.scoped_only_changes = (scoped_only,)  # type: ignore[attr-defined]
+        xml_str = to_junit_xml(r)
+        root = _parse(xml_str)
+        ts = root.find("testsuite")
+        assert ts.get("failures") == "1"
+        tc = ts.find("testcase")
+        assert tc.get("name") == "ordinal:5"
+        assert tc.find("failure") is not None

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -1392,6 +1392,57 @@ class TestAbiCompare:
         report = data["report"]
         assert report["severity"]["categories"]["abi_breaking"]["count"] == 1
 
+    def test_used_by_multi_app_semantically_identical_change_not_double_counted(
+        self, tmp_path: Path, monkeypatch
+    ):
+        # Regression (CLI-audit P2): two apps whose scope_diff_to_app calls
+        # each synthesize their OWN fresh Change object for the same
+        # underlying finding (exactly what appcompat._check_pe_ordinal_imports
+        # does for PE_ORDINAL_RETARGETED -- one new Change per app, not a
+        # shared reference into the base diff) must still collapse to one
+        # entry. id()-based dedup would double-count these two
+        # structurally-identical-but-object-distinct Changes.
+        from abicheck.appcompat import AppCompatResult
+        from abicheck.checker import Change
+        from abicheck.checker_policy import ChangeKind
+
+        old = _make_snapshot("1.0", functions=[_pub_func("foo", "foo", "int")])
+        new = _make_snapshot("2.0", functions=[])
+        old_p, new_p = self._make_binary_pair(tmp_path)
+        app1 = tmp_path / "app1"
+        app1.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        app2 = tmp_path / "app2"
+        app2.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        def _scoped_for(*_args, **_kwargs):
+            # A fresh, distinct Change object per call -- same semantic
+            # identity (kind/symbol/description), different Python id().
+            change = Change(ChangeKind.FUNC_REMOVED, "foo", "removed: foo")
+            return AppCompatResult(
+                app_path="/app", old_lib_path=str(old_p), new_lib_path=str(new_p),
+                required_symbols={"foo"}, required_symbol_count=1,
+                breaking_for_app=[change], verdict=Verdict.BREAKING,
+            )
+
+        from abicheck import mcp_server
+
+        monkeypatch.setattr(
+            mcp_server, "_resolve_input",
+            MagicMock(side_effect=[old, new]),
+        )
+        import abicheck.appcompat as appcompat_mod
+
+        monkeypatch.setattr(appcompat_mod, "scope_diff_to_app", _scoped_for)
+
+        raw = abi_compare(
+            str(old_p), str(new_p), used_by=[str(app1), str(app2)],
+            severity_preset="default",
+        )
+        data = json.loads(raw)
+        assert data["exit_code"] == 4
+        report = data["report"]
+        assert report["severity"]["categories"]["abi_breaking"]["count"] == 1
+
     def test_used_by_rejects_non_binary_snapshot_input(self, tmp_path: Path):
         # --used-by needs real library binaries to parse app requirements
         # against; JSON snapshots must be rejected with a clear error rather

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -1319,6 +1319,40 @@ class TestAbiCompare:
         # The missing symbol itself (not a diff Change) still counts.
         assert report["severity"]["categories"]["abi_breaking"]["count"] == 1
 
+    def test_used_by_missing_symbol_only_summary_reflects_folded_changes(
+        self, tmp_path: Path, monkeypatch
+    ):
+        # Regression (CodeRabbit review): `summary` was computed from
+        # result.changes before scoped_missing_labels/scoped_only_changes get
+        # folded into the top-level "changes" array, so a run gated purely by
+        # a missing required symbol (no backing diff Change) reported
+        # total_changes: 0 alongside a BREAKING verdict/exit_code 4.
+        from abicheck.appcompat import AppCompatResult
+
+        kept = _pub_func("kept", "_Z4keptv", "int")
+        old = _make_snapshot("1.0", functions=[kept])
+        new = _make_snapshot("2.0", functions=[kept])
+        old_p, new_p = self._make_binary_pair(tmp_path)
+        app = tmp_path / "app"
+        app.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        scoped = AppCompatResult(
+            app_path=str(app), old_lib_path=str(old_p), new_lib_path=str(new_p),
+            required_symbols={"never_existed"}, required_symbol_count=1,
+            missing_symbols=["never_existed"], verdict=Verdict.BREAKING,
+        )
+        self._patch_used_by(monkeypatch, tmp_path, old, new, scoped)
+
+        raw = abi_compare(
+            str(old_p), str(new_p), used_by=[str(app)],
+            severity_preset="default",
+        )
+        data = json.loads(raw)
+        assert data["verdict"] == "BREAKING"
+        assert data["exit_code"] == 4
+        assert len(data["changes"]) == 1
+        assert data["summary"]["total_changes"] == len(data["changes"])
+        assert data["summary"]["breaking"] == 1
+
     def test_used_by_missing_symbol_covered_by_change_not_double_counted(
         self, tmp_path: Path, monkeypatch
     ):

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -1443,6 +1443,56 @@ class TestAbiCompare:
         report = data["report"]
         assert report["severity"]["categories"]["abi_breaking"]["count"] == 1
 
+    def test_used_by_scoped_only_change_included_in_top_level_and_report_changes(
+        self, tmp_path: Path, monkeypatch
+    ):
+        # Regression (Codex review): scope_diff_to_app can synthesize a Change
+        # (e.g. PE_ORDINAL_RETARGETED) relevant to the gate but never added to
+        # result.changes -- mirrors cli_compare_helpers's identical gap. Both
+        # the top-level response["changes"] and the embedded response["report"]
+        # (folded via _fold_scoped_compat_into_text) must carry it, not just
+        # SARIF/JUnit.
+        from abicheck.appcompat import AppCompatResult
+        from abicheck.checker import Change
+        from abicheck.checker_policy import ChangeKind
+
+        old = _make_snapshot("1.0")
+        new = _make_snapshot("2.0")
+        old_p, new_p = self._make_binary_pair(tmp_path)
+        app = tmp_path / "app"
+        app.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        scoped_only = Change(
+            kind=ChangeKind.PE_ORDINAL_RETARGETED,
+            symbol="ordinal:5", description="ordinal 5 retargeted",
+            old_value="OldFunc", new_value="NewFunc",
+        )
+
+        def _scoped_for(*_args, **_kwargs):
+            return AppCompatResult(
+                app_path="/app", old_lib_path=str(old_p), new_lib_path=str(new_p),
+                required_symbols={"foo"}, required_symbol_count=1,
+                breaking_for_app=[scoped_only], verdict=Verdict.BREAKING,
+            )
+
+        from abicheck import mcp_server
+
+        monkeypatch.setattr(
+            mcp_server, "_resolve_input",
+            MagicMock(side_effect=[old, new]),
+        )
+        import abicheck.appcompat as appcompat_mod
+
+        monkeypatch.setattr(appcompat_mod, "scope_diff_to_app", _scoped_for)
+
+        raw = abi_compare(str(old_p), str(new_p), used_by=[str(app)])
+        data = json.loads(raw)
+        assert data["exit_code"] == 4
+        top_kinds = [c["kind"] for c in data["changes"]]
+        assert "pe_ordinal_retargeted" in top_kinds
+        report_kinds = [c["kind"] for c in data["report"]["changes"]]
+        assert "pe_ordinal_retargeted" in report_kinds
+
     def test_used_by_rejects_non_binary_snapshot_input(self, tmp_path: Path):
         # --used-by needs real library binaries to parse app requirements
         # against; JSON snapshots must be rejected with a clear error rather

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -746,3 +746,36 @@ class TestScopedGate:
         assert doc["runs"][0]["results"] == []
         rule_ids = {rule["id"] for rule in doc["runs"][0]["tool"]["driver"]["rules"]}
         assert "pe_ordinal_retargeted" not in rule_ids
+
+    def test_missing_contract_respects_show_only(self) -> None:
+        # Regression (Codex review): scoped_missing_labels bypassed
+        # --show-only entirely -- a missing required symbol has no backing
+        # Change/ChangeKind, so it can't run through apply_show_only, but a
+        # --show-only run that excludes breaking findings must still not
+        # upload the `error`-level synthetic missing-contract result.
+        r = _make_result([], verdict=Verdict.COMPATIBLE)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.scoped_exit_code = 4  # type: ignore[attr-defined]
+        r.scoped_exit_code_scheme = "legacy"  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset()  # type: ignore[attr-defined]
+        r.scoped_missing_labels = ("_Z6vanishv",)  # type: ignore[attr-defined]
+        doc = to_sarif(r, show_only="compatible")
+        assert doc["runs"][0]["results"] == []
+        rule_ids = {rule["id"] for rule in doc["runs"][0]["tool"]["driver"]["rules"]}
+        assert "used_by_missing_symbol" not in rule_ids
+
+    def test_missing_contract_shown_when_show_only_includes_breaking(self) -> None:
+        # A --show-only that includes "breaking" (the default missing-
+        # contract severity) must still render the synthetic result.
+        r = _make_result([], verdict=Verdict.COMPATIBLE)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.scoped_exit_code = 4  # type: ignore[attr-defined]
+        r.scoped_exit_code_scheme = "legacy"  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset()  # type: ignore[attr-defined]
+        r.scoped_missing_labels = ("_Z6vanishv",)  # type: ignore[attr-defined]
+        doc = to_sarif(r, show_only="breaking")
+        results = doc["runs"][0]["results"]
+        assert len(results) == 1
+        assert results[0]["ruleId"] == "used_by_missing_symbol"

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -719,3 +719,30 @@ class TestScopedGate:
         scoped_gate = doc["runs"][0]["properties"]["scopedGate"]
         assert scoped_gate["relevantFindingCount"] == 1
         assert scoped_gate["unrelatedFindingCount"] == 0
+
+    def test_scoped_only_change_respects_show_only(self) -> None:
+        # Regression (Codex review): result.changes is filtered through
+        # apply_show_only above, but scoped_only_changes was appended
+        # unconditionally afterward -- a --show-only run that explicitly
+        # filters out a scoped-only breaking change (e.g. an app-relevant
+        # PE_ORDINAL_RETARGETED under --show-only compatible) must not still
+        # upload it, unlike the normal result.changes path.
+        from abicheck.reporter import _finding_id
+
+        scoped_only = Change(
+            kind=ChangeKind.PE_ORDINAL_RETARGETED,
+            symbol="ordinal:5",
+            description="ordinal 5 retargeted",
+            old_value="OldFunc", new_value="NewFunc",
+        )
+        r = _make_result([], verdict=Verdict.COMPATIBLE)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.scoped_exit_code = 4  # type: ignore[attr-defined]
+        r.scoped_exit_code_scheme = "legacy"  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset({_finding_id(scoped_only)})  # type: ignore[attr-defined]
+        r.scoped_only_changes = (scoped_only,)  # type: ignore[attr-defined]
+        doc = to_sarif(r, show_only="compatible")
+        assert doc["runs"][0]["results"] == []
+        rule_ids = {rule["id"] for rule in doc["runs"][0]["tool"]["driver"]["rules"]}
+        assert "pe_ordinal_retargeted" not in rule_ids

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -539,30 +539,44 @@ class TestSeverityGate:
 
 
 class TestScopedGate:
-    """`--used-by`/`--required-symbol(s)` scoping (ADR-043) discoverability.
+    """`--used-by`/`--required-symbol(s)` scoping (ADR-043 + CLI-audit P1).
 
-    SARIF's own exitCode/results stay computed from the full, unscoped
-    library verdict (documented, intentional) -- but the CLI process exits
-    on the *scoped* verdict floor. Without a `scopedGate` block a SARIF
-    consumer had no way to discover that the two could disagree (post-merge
-    PR #566 review)."""
+    The scoped gate (`scoped_verdict`/`scoped_exit_code`) is authoritative for
+    this document's own `invocations[0].exitCode` and each result's `level`
+    when scoping is active -- `result.verdict` (the full, unscoped library
+    verdict) is still reported as `fullLibraryVerdict` for context, but no
+    longer drives what a SARIF consumer treats as blocking."""
 
     def test_no_scoped_gate_when_no_scoping(self) -> None:
         r = _make_result([_breaking_change()], verdict=Verdict.BREAKING)
         doc = to_sarif(r)
         assert "scopedGate" not in doc["runs"][0]["properties"]
+        # No scoping -> results keep the full-library severity, unaffected.
+        assert doc["runs"][0]["results"][0]["level"] == "error"
 
-    def test_scoped_gate_present_and_can_disagree_with_full_verdict(self) -> None:
+    def test_scoped_gate_exit_code_wins_over_full_library_exit_code(self) -> None:
+        # The scoped gate can legitimately disagree with the full-library
+        # verdict (a --used-by app unaffected by an otherwise-BREAKING
+        # change) -- the document's own exitCode must follow the scoped gate,
+        # not the full library, since that's what the CLI process itself
+        # exits with.
         r = _make_result([_breaking_change()], verdict=Verdict.BREAKING)
         r.scoped_verdict = Verdict.COMPATIBLE  # type: ignore[attr-defined]
+        r.scoped_exit_code = 0  # type: ignore[attr-defined]
+        r.scoped_exit_code_scheme = "legacy"  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset()  # type: ignore[attr-defined]
         r.used_by = [{"app": "/bin/myapp", "verdict": "COMPATIBLE"}]  # type: ignore[attr-defined]
         doc = to_sarif(r)
         scoped_gate = doc["runs"][0]["properties"]["scopedGate"]
-        assert scoped_gate["scopedVerdict"] == "COMPATIBLE"
+        assert scoped_gate["gateVerdict"] == "COMPATIBLE"
         assert scoped_gate["fullLibraryVerdict"] == "BREAKING"
+        assert scoped_gate["gateScope"] == "used_by"
         assert scoped_gate["usedBy"] == r.used_by  # type: ignore[attr-defined]
-        # The document's own exitCode/results stay full-library (unchanged).
-        assert doc["runs"][0]["invocations"][0]["exitCode"] == 4
+        # The document's own exitCode now follows the scoped gate (0), not
+        # the full-library BREAKING verdict's exit code (4).
+        assert doc["runs"][0]["invocations"][0]["exitCode"] == 0
+        assert "COMPATIBLE" in doc["runs"][0]["invocations"][0]["exitCodeDescription"]
 
     def test_scoped_gate_carries_required_symbol_contract(self) -> None:
         r = _make_result([_breaking_change()], verdict=Verdict.BREAKING)
@@ -572,21 +586,65 @@ class TestScopedGate:
         scoped_gate = doc["runs"][0]["properties"]["scopedGate"]
         assert scoped_gate["requiredSymbolContract"]["verdict"] == "BREAKING"
 
-    def test_scoped_gate_note_states_actual_exit_code_under_severity_scheme(
-        self,
-    ) -> None:
-        # Regression: the note used to claim "the CLI process exit code
-        # reflects scopedVerdict" unconditionally, which is wrong under a
-        # severity scheme -- e.g. --severity-preset info-only can floor the
-        # scoped exit code at 0 even for a BREAKING scopedVerdict (Codex
-        # review). The note must state the actual computed value/scheme.
+    def test_scoped_gate_exit_code_follows_severity_scheme(self) -> None:
+        # Under a severity scheme (e.g. --severity-preset info-only) the
+        # scoped exit code can be floored at 0 even for a BREAKING scoped
+        # verdict -- the document's exitCode must reflect that actual
+        # computed value, not re-derive 4 from the verdict.
         r = _make_result([_breaking_change()], verdict=Verdict.BREAKING)
         r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
         r.scoped_exit_code = 0  # type: ignore[attr-defined]
         r.scoped_exit_code_scheme = "severity"  # type: ignore[attr-defined]
         doc = to_sarif(r)
         scoped_gate = doc["runs"][0]["properties"]["scopedGate"]
-        assert scoped_gate["scopedExitCode"] == 0
-        assert scoped_gate["scopedExitCodeScheme"] == "severity"
-        assert "exits 0" in scoped_gate["note"]
-        assert "severity" in scoped_gate["note"]
+        assert scoped_gate["gateExitCode"] == 0
+        assert scoped_gate["gateExitCodeScheme"] == "severity"
+        assert doc["runs"][0]["invocations"][0]["exitCode"] == 0
+
+    def test_irrelevant_change_downgraded_to_note_and_marked(self) -> None:
+        # A change outside the --used-by/--required-symbol gate's relevance
+        # must not read as an "error" in the SARIF results -- it's downgraded
+        # to "note" and marked relevantToGate: false so a consumer can tell
+        # "not severe" apart from "out of scope" (CLI-audit P1).
+        c = _breaking_change()
+        r = _make_result([c], verdict=Verdict.BREAKING)
+        r.scoped_verdict = Verdict.COMPATIBLE  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset()  # type: ignore[attr-defined]
+        doc = to_sarif(r)
+        result = doc["runs"][0]["results"][0]
+        assert result["level"] == "note"
+        assert result["properties"]["relevantToGate"] is False
+
+    def test_relevant_change_keeps_its_level_and_marked(self) -> None:
+        from abicheck.reporter import _finding_id
+
+        c = _breaking_change()
+        r = _make_result([c], verdict=Verdict.BREAKING)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset({_finding_id(c)})  # type: ignore[attr-defined]
+        doc = to_sarif(r)
+        result = doc["runs"][0]["results"][0]
+        assert result["level"] == "error"
+        assert result["properties"]["relevantToGate"] is True
+
+    def test_missing_contract_synthesizes_a_result(self) -> None:
+        # A required symbol absent from the new library has no backing diff
+        # Change -- without a synthetic result the scoped gate's own
+        # exitCode could be nonzero (BREAKING) while `results` shows nothing
+        # to explain it.
+        r = _make_result([], verdict=Verdict.COMPATIBLE)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.scoped_exit_code = 4  # type: ignore[attr-defined]
+        r.scoped_exit_code_scheme = "legacy"  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset()  # type: ignore[attr-defined]
+        r.scoped_missing_labels = ("_Z6vanishv",)  # type: ignore[attr-defined]
+        doc = to_sarif(r)
+        results = doc["runs"][0]["results"]
+        assert len(results) == 1
+        assert results[0]["ruleId"] == "used_by_missing_symbol"
+        assert results[0]["level"] == "error"
+        assert "_Z6vanishv" in results[0]["message"]["text"]
+        assert doc["runs"][0]["invocations"][0]["exitCode"] == 4

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -646,7 +646,17 @@ class TestScopedGate:
         assert len(results) == 1
         assert results[0]["ruleId"] == "used_by_missing_symbol"
         assert results[0]["level"] == "error"
+        assert results[0]["properties"]["relevantToGate"] is True
+        assert results[0]["properties"]["blocksGate"] is True
         assert "_Z6vanishv" in results[0]["message"]["text"]
+        # The synthetic rule id must be registered too (Codex review) --
+        # otherwise a SARIF consumer resolving annotations from
+        # tool.driver.rules has no metadata for this finding.
+        rule_ids = {rule["id"] for rule in doc["runs"][0]["tool"]["driver"]["rules"]}
+        assert "used_by_missing_symbol" in rule_ids
+        # Counted as relevant even with no backing Change (CodeRabbit review).
+        scoped_gate = doc["runs"][0]["properties"]["scopedGate"]
+        assert scoped_gate["relevantFindingCount"] == 1
 
     def test_missing_contract_demoted_by_severity_config_is_not_blocking(
         self,
@@ -670,5 +680,42 @@ class TestScopedGate:
         doc = to_sarif(r, severity_config=demoted)
         result = doc["runs"][0]["results"][0]
         assert result["level"] == "note"
-        assert result["properties"]["relevantToGate"] is False
+        # relevantToGate stays true -- a missing-contract member is always in
+        # the --used-by/--required-symbol scope by construction (that's an
+        # orthogonal question from whether severity makes it block, which
+        # blocksGate/level carry -- CodeRabbit review).
+        assert result["properties"]["relevantToGate"] is True
+        assert result["properties"]["blocksGate"] is False
         assert doc["runs"][0]["invocations"][0]["exitCode"] == 0
+
+    def test_scoped_only_change_is_rendered(self) -> None:
+        # Regression (Codex review): scope_diff_to_app synthesizes a fresh
+        # Change (e.g. PE_ORDINAL_RETARGETED) that is relevant to the gate
+        # but never added to result.changes -- without rendering it, a
+        # --used-by run that fails solely because of one of these would
+        # report a nonzero gate exitCode with zero results to explain it.
+        from abicheck.reporter import _finding_id
+
+        scoped_only = Change(
+            kind=ChangeKind.PE_ORDINAL_RETARGETED,
+            symbol="ordinal:5",
+            description="ordinal 5 retargeted",
+            old_value="OldFunc", new_value="NewFunc",
+        )
+        r = _make_result([], verdict=Verdict.COMPATIBLE)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.scoped_exit_code = 4  # type: ignore[attr-defined]
+        r.scoped_exit_code_scheme = "legacy"  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset({_finding_id(scoped_only)})  # type: ignore[attr-defined]
+        r.scoped_only_changes = (scoped_only,)  # type: ignore[attr-defined]
+        doc = to_sarif(r)
+        results = doc["runs"][0]["results"]
+        assert len(results) == 1
+        assert results[0]["ruleId"] == "pe_ordinal_retargeted"
+        assert results[0]["properties"]["relevantToGate"] is True
+        rule_ids = {rule["id"] for rule in doc["runs"][0]["tool"]["driver"]["rules"]}
+        assert "pe_ordinal_retargeted" in rule_ids
+        scoped_gate = doc["runs"][0]["properties"]["scopedGate"]
+        assert scoped_gate["relevantFindingCount"] == 1
+        assert scoped_gate["unrelatedFindingCount"] == 0

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -647,4 +647,28 @@ class TestScopedGate:
         assert results[0]["ruleId"] == "used_by_missing_symbol"
         assert results[0]["level"] == "error"
         assert "_Z6vanishv" in results[0]["message"]["text"]
-        assert doc["runs"][0]["invocations"][0]["exitCode"] == 4
+
+    def test_missing_contract_demoted_by_severity_config_is_not_blocking(
+        self,
+    ) -> None:
+        # Regression (Codex review): under a severity config that demotes
+        # abi_breaking (e.g. --severity-preset info-only), the scoped exit
+        # code for a missing contract member is floored at 0 by
+        # missing_contract_exit_code -- the synthetic result must not read
+        # as "error" in that case, or a code-scanning consumer would flag/
+        # block a finding the gate itself passed.
+        from abicheck.severity import SeverityConfig, SeverityLevel
+
+        demoted = SeverityConfig(abi_breaking=SeverityLevel.WARNING)
+        r = _make_result([], verdict=Verdict.COMPATIBLE)
+        r.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+        r.scoped_exit_code = 0  # type: ignore[attr-defined]
+        r.scoped_exit_code_scheme = "severity"  # type: ignore[attr-defined]
+        r.gate_scope = "used_by"  # type: ignore[attr-defined]
+        r.scoped_relevant_finding_ids = frozenset()  # type: ignore[attr-defined]
+        r.scoped_missing_labels = ("_Z6vanishv",)  # type: ignore[attr-defined]
+        doc = to_sarif(r, severity_config=demoted)
+        result = doc["runs"][0]["results"][0]
+        assert result["level"] == "note"
+        assert result["properties"]["relevantToGate"] is False
+        assert doc["runs"][0]["invocations"][0]["exitCode"] == 0

--- a/tests/test_source_graph.py
+++ b/tests/test_source_graph.py
@@ -906,7 +906,10 @@ def test_findings_mapping_changed_for_persisting_decl() -> None:
     c = findings[0]
     assert c.kind == ChangeKind.SOURCE_TO_BINARY_MAPPING_CHANGED
     assert c.old_value == "_Zb" and c.new_value == "_Zb2"
-    assert c.source_location == f"[{EVIDENCE_TIER_L5}]"
+    # CLI audit finding: source_location should localize to the declaration's
+    # actual declaring file, not the generic evidence-tier tag, when the
+    # graph resolves one via a SOURCE_DECLARES edge (it does here).
+    assert c.source_location == "inc/foo.h"
 
 
 def test_findings_reachability_ignores_brand_new_or_removed_decls() -> None:
@@ -1060,6 +1063,10 @@ def test_owner_changed_when_relative_path_actually_moves() -> None:
     ]
     assert len(owner) == 1
     assert owner[0].symbol == "_Zc"
+    # CLI audit finding: source_location should localize to the symbol's new
+    # declaring file, not the generic evidence-tier tag -- this family always
+    # has one on hand (it's the whole point of the finding).
+    assert owner[0].source_location == "/root/inc/baz.h"
 
 
 def test_owner_changed_when_sole_declaring_file_is_renamed_both_sides() -> None:


### PR DESCRIPTION
## Summary

Implements a scoped subset of fixes from a CLI audit against latest `main` (post-#570/ADR-043), focused on well-defined, verifiable P1/P2 gaps rather than the full audit's larger architectural asks (see "Not in this PR" below), plus several follow-up items from the audit's original "larger scope" bucket that turned out to be tractable, and fixes for review findings raised along the way.

## Motivation

The audit found that `compare` silently discarded explicit `--sources`/`--build-info` whenever `--depth` was omitted, that multi-app `--used-by` severity summaries could double-count PE ordinal-retarget findings, a few stale messages referenced removed CLI options, `compare --help` dumped all ~62 options in one flat screen, `--profile release` collided in name with the unrelated directory/package "release" comparison mode, and L5 source-graph findings never localized to a real file despite the resolver for it already existing.

## Changes

- **`compare` depth inference (P1):** omitting `--depth` used to always resolve the collect mode to `"off"`, even with explicit `--old/new-sources`/`--old/new-build-info` given — those inputs were silently ignored. Now the collect mode is inferred from those inputs when `--depth` and `.abicheck.yml`'s `source.method` are both absent (precedence: `--depth` > `source.method` > inferred from sources/build-info > off), mirroring `scan`'s own input-driven "auto" depth. New shared helper `_resolve_compare_collect_mode` in `cli_compare_helpers.py`.
- **`compare --dry-run` effective depth:** the dry-run report now shows the *effective* (post-inference) depth and collect mode, not just the raw `--depth` string echoed back.
- **`--used-by` multi-app dedup (P2):** the severity-summary dedup across tied apps keyed changes by `id()`, which under-deduplicates `PE_ORDINAL_RETARGETED` findings — `scope_diff_to_app` constructs a fresh `Change` object per app for the same underlying ordinal retarget, so two apps hitting the same retarget were double-counted. Now keyed by the change's semantic identity (reusing the existing `reporter._finding_id` fingerprint). Fixed in both `cli_compare_helpers.py` and the mirrored `mcp_server.py` path.
- **`--dry-run` + `--secondary-output`/`--secondary-format` (P2):** previously accepted and silently never written (the dry run exits before the secondary render runs); now rejected with a clear `UsageError`.
- **Scoped-gate reporting parity (SARIF/JSON/JUnit/text):** `--used-by`/`--required-symbol(s)` scoped-only changes (e.g. `PE_ORDINAL_RETARGETED`) and missing-contract labels now respect `--show-only` consistently across SARIF/JSON/JUnit, and the default markdown/text/review report now *names* the actual missing symbol/version/entrypoint and scoped-only change that failed the gate instead of only printing a bare count.
- **`compare --help-all`:** a second-level `--help` disclosure tier (G21.8 collapse M2). Plain `compare --help` now shows only a curated common subset of the ~62 options; the long tail is folded behind `--help-all`, with a footer noting how many advanced options are hidden.
- **`--profile release` renamed to `--profile release-cut`:** disambiguates the workflow-defaults bundle from `compare`'s unrelated directory/package "release" fan-out mode, which shared only the word.
- **Source-graph localization:** `SOURCE_TO_BINARY_MAPPING_CHANGED`/`EXPORTED_SYMBOL_SOURCE_OWNER_CHANGED` findings now carry the real declaring file as `source_location` instead of the generic `[L5_SOURCE_GRAPH]` evidence-tier tag, using the graph's existing `SOURCE_DECLARES` edges.
- **Out-of-band evidence depth:** `compare`'s JSON `evidence_depth` now reflects out-of-band `--sources`/`--build-info` packs, not just what's embedded in the snapshot.
- **GitHub Action:**
  - Restored `estimate`/`audit` as deprecated *functional* aliases (mirroring the existing `allow-build-query` no-op precedent) instead of removing them outright — GitHub Actions silently drops an undeclared input with only a warning, which is worse than a hard CLI error.
  - `dry-run: true` no longer hard-fails when combined with `abi-baseline` and the release/token/asset is unavailable — the baseline auto-fetch ran before the mode branch ever consulted `INPUT_DRY_RUN`, contradicting `dry-run`'s documented "always exits 0" contract.
- **Stale messages:** two CLI warnings referenced removed `--depth full`/`--max` values; the GitHub Action's baseline-fetch error message told users to run a nonexistent `abicheck dump --output-name auto`. Both fixed to reference real, current options.
- `CHANGELOG.md` entries under `[Unreleased]`.

## Not in this PR

A few audit findings are real but out of scope here — either large architectural changes or decisions that were already deliberately made and documented in-code (with prior review), so they warrant explicit discussion rather than a unilateral change in a fix PR:

- SARIF/JUnit computing pass/fail from the full-library verdict rather than the scoped `--used-by`/`--required-symbol` gate — already documented as intentional (both files carry explicit comments to this effect), with the scoped verdict exposed as metadata instead.
- The hidden `--allow-build-query` no-op flag — kept per an already-accepted ADR-032 amendment.
- `dump --depth source` without `--sources` producing a shallow dump with only a warning (not a hard error) — consistent with the codebase's existing "warn, don't hard-fail" philosophy elsewhere; changing it is a bigger behavior/compat call.
- `ctx.invoke`-based internal dispatch (`compare` → the unregistered `compare_release_cmd` engine) — investigated; a working-but-fragile pattern (two manually-synced signatures, no live bug today), not a targeted fix. Worth a real safety net (e.g. a param-parity test) opportunistically, but not a bug fix in itself.
- Debian `.symbols` auto-ingestion — investigated; the standalone CLI surface for this was removed entirely in the ADR-043 pre-1.0 reset (Python-API-only now), so wiring it back in is a net-new feature needing a product decision on scope, not a fix.

## Test plan

- [x] New unit tests covering: `_resolve_compare_collect_mode` precedence, `compare --dry-run` effective-depth reporting, `--dry-run` + `--secondary-output` rejection, multi-app `--used-by` dedup (CLI + MCP), `--show-only` parity for scoped-only changes/missing labels across SARIF/JSON/JUnit/text, `compare --help`/`--help-all` disclosure, the `--profile release-cut` rename, source-graph finding localization, and the Action's `dry-run`/`abi-baseline` interaction — all confirmed to fail against their respective pre-fix code.
- [x] Full fast suite: `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` — 15755 passed.
- [x] `ruff check abicheck/ tests/` — clean.
- [x] `mypy abicheck/` — clean (0 errors).
- [x] `python scripts/check_ai_readiness.py` — 0 errors (pre-existing warning set unchanged).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `compare` now infers and reports effective evidence depth when `--depth` isn’t provided, and `compare --dry-run` rejects secondary output options.
  * Scoped `--used-by/--required-symbol(s)` results are deduplicated correctly, with JUnit/SARIF and exit codes aligned to scoped gate behavior (including severity demotion).
  * Missing required-contract members are synthesized and filtered without double-reporting; scoped-only findings are included consistently.

* **New Features**
  * `dump`/`compare` JSON report evidence depth actually reached; SARIF/JUnit include richer scoped-gate metadata.

* **Documentation**
  * Updated changelog and CLI/GitHub Action docs, including `release-cut` profile naming and `compare --help/--help-all`.

* **Tests**
  * Added regression coverage for collect-mode resolution, scoping dedupe, output constraints, and GitHub Action dry-run behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->