### PR TITLE
perf(dumper): single-pass CastXML indexing + memoized type/provenance resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,18 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
 
-No changes yet.
+### Performance
+
+- **Faster L2 header-tier parsing on large public surfaces** (e.g. Intel
+  oneDAL's ~20k–25k function umbrella headers): the CastXML parser now
+  builds one tag-grouped element index per dump instead of re-scanning the
+  whole XML tree separately for functions/types/enums/typedefs/constants,
+  and memoizes its recursive type-name/pointer-depth resolution per XML id
+  so a commonly shared parameter/return type is resolved once instead of
+  once per occurrence. Provenance classification (`apply_provenance`) now
+  reuses each declaring header's public/private/system classification
+  across every declaration it produced instead of reclassifying per
+  declaration. No output/behavior change — same `AbiSnapshot` content.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,25 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   reuses each declaring header's public/private/system classification
   across every declaration it produced instead of reclassifying per
   declaration. No output/behavior change — same `AbiSnapshot` content.
+- **Whole-snapshot cache wired up**: `snapshot_cache.py` (previously
+  implemented but never called from the dump path) now sits in front of
+  `run_dump()` for the common "binary + public headers" shape, so a repeated
+  release-baseline comparison can skip castxml/DWARF/ELF extraction and
+  model construction entirely on a cache hit. Conservatively scoped — a PDB
+  path, DWARF root, debuginfod, forced debug format, symbols-only mode, a
+  custom compile context, or the header-only semantic graph all bypass the
+  cache rather than risk a stale/mismatched snapshot.
+- **Parallel old/new extraction**: `run_compare_request()` (the
+  `CompareRequest`/`run_compare` chokepoint) now resolves the old and new
+  sides concurrently instead of sequentially, since neither depends on the
+  other until they're diffed. Set `ABICHECK_PARALLEL_EXTRACTION=0` to
+  restore the old sequential behavior on memory-constrained runners
+  comparing very large surfaces.
+- Added `onedal_large_surface` / `onedal_packaging_noise` /
+  `onedal_mass_removal` scenarios to `scripts/benchmark_scaling.py`, modeled
+  on real Intel oneDAL validation runs (large near-static public surface,
+  bundled-dependency packaging noise that must stay non-breaking once
+  scoped, and mass export removal at oneDAL's reported scale).
 
 ---
 

--- a/abicheck/buildsource/source_extractors/castxml.py
+++ b/abicheck/buildsource/source_extractors/castxml.py
@@ -247,8 +247,11 @@ class CastxmlSourceExtractor:
             *enums,
             *variables,
         ]
+        origin_cache: dict[tuple[str | None, bool], ScopeOrigin] = {}
         for decl in decls:
-            tag_provenance(decl, header_segs, dir_segs, have_set)
+            tag_provenance(
+                decl, header_segs, dir_segs, have_set, origin_cache=origin_cache
+            )
             if decl.origin == ScopeOrigin.PUBLIC_HEADER and is_generated_header(
                 decl.source_header
             ):

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 from defusedxml import ElementTree as DefusedET
 
 from ._compiler_options import has_explicit_cpp_std, has_explicit_std
-from .dumper_cache import _cache_path
+from .dumper_cache import _atomic_write, _cache_path
 from .dumper_castxml import (
     _CastxmlParser as _CastxmlParser,
     _parse_vtable_index as _parse_vtable_index,
@@ -1125,7 +1125,7 @@ def _castxml_dump(
                 # matches what the user asked for.
                 raise primary from None
         try:
-            shutil.copy2(str(out_xml), str(cached))
+            _atomic_write(cached, out_xml.read_bytes())
         except OSError as exc:
             log.warning("Could not write castxml AST cache %s: %s", cached, exc)
         return root

--- a/abicheck/dumper_cache.py
+++ b/abicheck/dumper_cache.py
@@ -12,6 +12,32 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 
+def _atomic_write(path: Path, data: bytes) -> None:
+    """Write *data* to *path* via a same-directory temp file + ``os.replace``.
+
+    Plain ``open(path, "wb")``/``shutil.copy2`` can leave a torn file behind if
+    two processes race to populate the same cache key (e.g. comparing two
+    releases that share an unchanged header tree, with old/new extracted
+    concurrently) — a reader would then see a partially-written file instead
+    of a clean cache miss. ``os.replace`` is atomic on both POSIX and Windows,
+    so a concurrent reader always sees either the old (absent) or the new
+    (complete) file, never something in between.
+    """
+    fd, tmp_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    try:
+        with os.fdopen(fd, "wb") as f:
+            f.write(data)
+        os.replace(tmp_name, path)
+    except OSError:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
 def _cache_path(key: str, backend: str = "castxml") -> Path:
     # One sub-directory + file extension per backend so castxml XML and clang
     # JSON caches live side by side without clashing.

--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -211,6 +211,18 @@ class _CastxmlParser:
         self._id_map: dict[str, Element] = {}
         self._virtual_methods_by_class: dict[str, list[Element]] = {}
         self._source_lines_cache: dict[str, list[str]] = {}
+        # Tag-grouped elements populated by the single pass in _build_id_map()
+        # below, so parse_functions()/parse_types()/etc. below don't each
+        # re-scan every top-level element themselves.
+        self._function_els: list[Element] = []
+        self._variable_els: list[Element] = []
+        self._record_els: list[Element] = []
+        self._enum_els: list[Element] = []
+        self._typedef_els: list[Element] = []
+        # Per-id memoization for the recursive type-graph resolvers below;
+        # safe since the XML tree is immutable for this parser instance.
+        self._type_name_cache: dict[str, str] = {}
+        self._pointer_depth_cache: dict[str, int] = {}
         # method element id -> canonical vtable-slot key, resolved through any
         # `overrides` chain. Populated lazily by _collect_virtual_methods(); see
         # its docstring for why this is needed alongside vtable_index.
@@ -224,17 +236,27 @@ class _CastxmlParser:
         self._build_id_map()
 
     def _build_id_map(self) -> None:
+        # Single pass building the id map, the virtual-method index, and the
+        # tag-grouped element lists parse_functions()/parse_types()/etc. use.
         for el in self._root:
             eid = el.get("id")
             if eid:
                 self._id_map[eid] = el
-        # Build class_id → list of virtual Method/Destructor elements
-        # In castxml output, methods are top-level elements with a "context" attribute
-        for el in self._root:
-            if el.tag in ("Method", "Destructor") and el.get("virtual") == "1":
+            tag = el.tag
+            if tag in ("Method", "Destructor") and el.get("virtual") == "1":
                 ctx = el.get("context")
                 if ctx:
                     self._virtual_methods_by_class.setdefault(ctx, []).append(el)
+            if tag in self._FUNCTION_TAGS:
+                self._function_els.append(el)
+            elif tag == "Variable":
+                self._variable_els.append(el)
+            elif tag in ("Struct", "Class", "Union"):
+                self._record_els.append(el)
+            elif tag == "Enumeration":
+                self._enum_els.append(el)
+            elif tag == "Typedef":
+                self._typedef_els.append(el)
 
     def _resolve(self, id_: str) -> Element | None:
         return self._id_map.get(id_)
@@ -286,6 +308,19 @@ class _CastxmlParser:
         return bool(re.search(r"\bexplicit\b", prefix[declaration_start + 1 :]))
 
     def _type_name(self, id_: str, depth: int = 0) -> str:
+        # Memoized by id alone (not depth): the same type id is commonly
+        # resolved from thousands of call sites on a large ABI surface. A
+        # depth-capped ("?") result is never cached, so reaching the same id
+        # again within budget still resolves it properly.
+        cached = self._type_name_cache.get(id_)
+        if cached is not None:
+            return cached
+        result = self._type_name_uncached(id_, depth)
+        if depth <= 10:
+            self._type_name_cache[id_] = result
+        return result
+
+    def _type_name_uncached(self, id_: str, depth: int = 0) -> str:
         if depth > 10:
             return "?"
         el = self._resolve(id_)
@@ -391,6 +426,16 @@ class _CastxmlParser:
 
     def _pointer_depth(self, id_: str, depth: int = 0) -> int:
         """Count pointer nesting depth: T=0, T*=1, T**=2, etc."""
+        # Memoized by id alone, same rationale/safety as _type_name above.
+        cached = self._pointer_depth_cache.get(id_)
+        if cached is not None:
+            return cached
+        result = self._pointer_depth_uncached(id_, depth)
+        if depth <= 10:
+            self._pointer_depth_cache[id_] = result
+        return result
+
+    def _pointer_depth_uncached(self, id_: str, depth: int = 0) -> int:
         if depth > 10:
             return 0
         el = self._resolve(id_)
@@ -539,7 +584,7 @@ class _CastxmlParser:
         corresponding ``Function`` objects as hidden friends downstream.
         """
         ids: set[str] = set()
-        for el in self._root:
+        for el in self._record_els:
             if el.tag not in ("Class", "Struct"):
                 continue
             befriending = el.get("befriending", "")
@@ -566,9 +611,7 @@ class _CastxmlParser:
     def parse_functions(self) -> list[Function]:
         funcs: list[Function] = []
         hidden_friend_ids = self._build_hidden_friend_ids()
-        for el in self._root:
-            if el.tag not in self._FUNCTION_TAGS:
-                continue
+        for el in self._function_els:
             func = self._parse_function_element(el, hidden_friend_ids)
             if func is not None:
                 funcs.append(func)
@@ -825,9 +868,7 @@ class _CastxmlParser:
 
     def parse_variables(self) -> list[Variable]:
         variables = []
-        for el in self._root:
-            if el.tag != "Variable":
-                continue
+        for el in self._variable_els:
             name = el.get("name", "")
             # C-mode castxml does not emit a mangled attribute for C-linkage variables
             # (C has no name mangling); fall back to plain name as the symbol key,
@@ -902,9 +943,7 @@ class _CastxmlParser:
         if not self._have_public_set:
             return []
         out: list[tuple[str, str, str]] = []
-        for el in self._root:
-            if el.tag != "Variable":
-                continue
+        for el in self._variable_els:
             init = el.get("init")
             if not init:
                 continue
@@ -988,9 +1027,7 @@ class _CastxmlParser:
         # This allows us to include `typedef struct { ... } Foo;` where the struct
         # itself is anonymous (name="") but reachable via the typedef.
         typedef_name_for: dict[str, str] = {}
-        for el in self._root:
-            if el.tag != "Typedef":
-                continue
+        for el in self._typedef_els:
             td_name = el.get("name", "")
             if not td_name:
                 continue
@@ -1015,7 +1052,7 @@ class _CastxmlParser:
                         typedef_name_for[struct_id] = td_name
 
         types = []
-        for el in self._root:
+        for el in self._record_els:
             if self._is_public_record_type(el):
                 types.append(self._build_record_type(el))
             elif el.tag in ("Struct", "Class", "Union"):
@@ -1402,9 +1439,7 @@ class _CastxmlParser:
 
     def parse_enums(self) -> list[EnumType]:
         enums = []
-        for el in self._root:
-            if el.tag != "Enumeration":
-                continue
+        for el in self._enum_els:
             name = el.get("name", "")
             if not name or name.startswith("__"):
                 continue
@@ -1445,9 +1480,7 @@ class _CastxmlParser:
 
     def parse_typedefs(self) -> dict[str, str]:
         typedefs: dict[str, str] = {}
-        for el in self._root:
-            if el.tag != "Typedef":
-                continue
+        for el in self._typedef_els:
             name = el.get("name", "")
             if not name:
                 continue
@@ -1471,9 +1504,7 @@ class _CastxmlParser:
         if not self._have_public_set:
             return []
         out: list[tuple[str, str, str]] = []
-        for el in self._root:
-            if el.tag != "Typedef":
-                continue
+        for el in self._typedef_els:
             name = el.get("name", "")
             if not name:
                 continue

--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -1055,8 +1055,11 @@ class _CastxmlParser:
         for el in self._record_els:
             if self._is_public_record_type(el):
                 types.append(self._build_record_type(el))
-            elif el.tag in ("Struct", "Class", "Union"):
-                # Check if this is an anonymous struct reachable via typedef
+            else:
+                # self._record_els is already pre-filtered to Struct/Class/
+                # Union (see _build_id_map), so this is every record type
+                # _is_public_record_type rejected. Check if it's an
+                # anonymous struct reachable via typedef.
                 eid = el.get("id", "")
                 override_name = typedef_name_for.get(eid)
                 if override_name and not self._is_builtin_element(el):

--- a/abicheck/dumper_clang_errors.py
+++ b/abicheck/dumper_clang_errors.py
@@ -32,6 +32,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
+from .dumper_cache import _atomic_write
 from .errors import SnapshotError
 
 if TYPE_CHECKING:
@@ -483,7 +484,7 @@ def _parse_clang_ast_result(
     except ValueError as exc:
         raise SnapshotError(f"clang AST output was not valid JSON: {exc}") from exc
     try:
-        cached.write_text(json.dumps(root), encoding="utf-8")
+        _atomic_write(cached, json.dumps(root).encode("utf-8"))
     except OSError:
         pass
     return cast("dict[str, Any]", root)

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -219,14 +219,19 @@ def apply_provenance(
     header_segs, dir_segs, have_set = build_public_set(
         public_headers, public_header_dirs
     )
+    # A large surface has far fewer distinct declaring headers than
+    # declarations (e.g. thousands of oneDAL functions share a handful of
+    # umbrella headers) — reuse each header's classification across every
+    # declaration it produced instead of re-running classify_origin per decl.
+    origin_cache: dict[tuple[str | None, bool], ScopeOrigin] = {}
     for fn in snapshot.functions:
-        tag_provenance(fn, header_segs, dir_segs, have_set)
+        tag_provenance(fn, header_segs, dir_segs, have_set, origin_cache=origin_cache)
     for var in snapshot.variables:
-        tag_provenance(var, header_segs, dir_segs, have_set)
+        tag_provenance(var, header_segs, dir_segs, have_set, origin_cache=origin_cache)
     for rec in snapshot.types:
-        tag_provenance(rec, header_segs, dir_segs, have_set)
+        tag_provenance(rec, header_segs, dir_segs, have_set, origin_cache=origin_cache)
     for en in snapshot.enums:
-        tag_provenance(en, header_segs, dir_segs, have_set)
+        tag_provenance(en, header_segs, dir_segs, have_set, origin_cache=origin_cache)
     return snapshot
 
 
@@ -235,6 +240,8 @@ def tag_provenance(
     header_segs: list[tuple[str, ...]],
     dir_segs: list[tuple[str, ...]],
     have_set: bool,
+    *,
+    origin_cache: dict[tuple[str | None, bool], ScopeOrigin] | None = None,
 ) -> None:
     """Populate ``source_header`` and ``origin`` on a single declaration in place.
 
@@ -243,15 +250,33 @@ def tag_provenance(
     which parses headers directly — can classify origin against the same public
     set instead of leaving every declaration ``UNKNOWN``. ``header_segs`` /
     ``dir_segs`` come from :func:`build_public_set`.
+
+    ``origin_cache``, when supplied by the caller, memoizes ``classify_origin``
+    results by ``(source_header, export_only)`` across the whole batch of
+    declarations sharing one ``header_segs``/``dir_segs``/``have_set`` — safe
+    because those three inputs are fixed per caller and the classification is a
+    pure function of them plus the declaration's own header/export-only pair.
+    Omitted (the default) reproduces the previous uncached, per-call behaviour.
     """
     loc = getattr(decl, "source_location", None)
     sh = header_from_location(loc)
     export_only = getattr(decl, "visibility", None) == Visibility.ELF_ONLY
     decl.source_header = sh  # type: ignore[attr-defined]
-    decl.origin = classify_origin(  # type: ignore[attr-defined]
-        sh,
-        header_segs,
-        dir_segs,
-        have_public_set=have_set,
-        export_only=export_only,
-    )
+    if origin_cache is None:
+        origin = classify_origin(
+            sh, header_segs, dir_segs, have_public_set=have_set, export_only=export_only
+        )
+    else:
+        cache_key = (sh, export_only)
+        cached = origin_cache.get(cache_key)
+        if cached is None:
+            cached = classify_origin(
+                sh,
+                header_segs,
+                dir_segs,
+                have_public_set=have_set,
+                export_only=export_only,
+            )
+            origin_cache[cache_key] = cached
+        origin = cached
+    decl.origin = origin  # type: ignore[attr-defined]

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -24,8 +24,10 @@ Provides framework-agnostic functions for the core abicheck operations:
 
 from __future__ import annotations
 
+import concurrent.futures
 import hashlib
 import logging
+import os
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -38,6 +40,7 @@ from .header_utils import deferred_token_dirs, resolve_inferred_header_roots
 from .model import AbiSnapshot, EnumType, Function, RecordType, Visibility
 from .reporter import to_json, to_markdown, to_stat, to_stat_json
 from .serialization import load_snapshot
+from .service_dump_cache import cached_run_dump
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -286,7 +289,8 @@ def resolve_input(
 
     # Fast path: caller already knows it's ELF
     if is_elf is True:
-        return run_dump(
+        return cached_run_dump(
+            run_dump,
             path,
             "elf",
             _headers,
@@ -312,7 +316,8 @@ def resolve_input(
     # Detect binary format from magic bytes
     binary_fmt = detect_binary_format(path) if is_elf is None else None
     if binary_fmt is not None:
-        return run_dump(
+        return cached_run_dump(
+            run_dump,
             path,
             binary_fmt,
             _headers,
@@ -1521,34 +1526,61 @@ def run_compare_request(
     # tagging — same rule as the single-pair CLI path (cli_resolve._resolve_compare_snapshots):
     # CompareRequest has no lower-level "parse only, don't classify" mode, so a
     # header supplied to compare is by definition the public contract.
-    old = resolve_input(
-        request.old.path,
-        list(request.old.headers),
-        list(request.old.includes),
-        request.old.version,
-        lang,
-        is_elf=True if old_fmt == "elf" else None,
-        pdb_path=request.old.pdb,
-        debug_roots=list(request.old.debug_roots) or None,
-        enable_debuginfod=request.enable_debuginfod,
-        debuginfod_url=request.debuginfod_url,
-        header_backend=header_backend,
-        public_headers=list(request.old.headers),
-    )
-    new = resolve_input(
-        request.new.path,
-        list(request.new.headers),
-        list(request.new.includes),
-        request.new.version,
-        lang,
-        is_elf=True if new_fmt == "elf" else None,
-        pdb_path=request.new.pdb,
-        debug_roots=list(request.new.debug_roots) or None,
-        enable_debuginfod=request.enable_debuginfod,
-        debuginfod_url=request.debuginfod_url,
-        header_backend=header_backend,
-        public_headers=list(request.new.headers),
-    )
+    def _resolve_old_side() -> AbiSnapshot:
+        return resolve_input(
+            request.old.path,
+            list(request.old.headers),
+            list(request.old.includes),
+            request.old.version,
+            lang,
+            is_elf=True if old_fmt == "elf" else None,
+            pdb_path=request.old.pdb,
+            debug_roots=list(request.old.debug_roots) or None,
+            enable_debuginfod=request.enable_debuginfod,
+            debuginfod_url=request.debuginfod_url,
+            header_backend=header_backend,
+            public_headers=list(request.old.headers),
+        )
+
+    def _resolve_new_side() -> AbiSnapshot:
+        return resolve_input(
+            request.new.path,
+            list(request.new.headers),
+            list(request.new.includes),
+            request.new.version,
+            lang,
+            is_elf=True if new_fmt == "elf" else None,
+            pdb_path=request.new.pdb,
+            debug_roots=list(request.new.debug_roots) or None,
+            enable_debuginfod=request.enable_debuginfod,
+            debuginfod_url=request.debuginfod_url,
+            header_backend=header_backend,
+            public_headers=list(request.new.headers),
+        )
+
+    # Old/new resolution has no data dependency on each other until they're
+    # both fed into compare_snapshots() below, so run them concurrently —
+    # they're each dominated by a castxml/DWARF subprocess call and XML/JSON
+    # parsing, not CPU held under the GIL the whole time. Threads (not
+    # processes) avoid pickling the request/callables across a process
+    # boundary. On a memory-constrained runner comparing two large ABI
+    # surfaces (e.g. oneDAL-scale headers), two concurrent header-AST
+    # frontends roughly double peak RSS versus one at a time — set
+    # ABICHECK_PARALLEL_EXTRACTION=0 to fall back to the old sequential
+    # behavior if that trade-off doesn't fit.
+    if os.environ.get("ABICHECK_PARALLEL_EXTRACTION", "1").strip().lower() in (
+        "0",
+        "false",
+        "no",
+    ):
+        old = _resolve_old_side()
+        new = _resolve_new_side()
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            old_future = pool.submit(_resolve_old_side)
+            new_future = pool.submit(_resolve_new_side)
+            old = old_future.result()
+            new = new_future.result()
 
     suppression, pf = load_suppression_and_policy(
         request.suppress, request.policy, request.policy_file_path

--- a/abicheck/service_dump_cache.py
+++ b/abicheck/service_dump_cache.py
@@ -86,13 +86,22 @@ def _dump_cache_extra_key(
     """Build the ``extra`` cache-key material for a cacheable dump — every
     input to ``run_dump`` that affects its output besides the binary content
     / headers / includes / version / lang that
-    :func:`abicheck.snapshot_cache._cache_key` already hashes directly."""
-    return "|".join(
+    :func:`abicheck.snapshot_cache._cache_key` already hashes directly.
+
+    Joined with NUL (``\\x00``) rather than a printable delimiter like
+    ``,``/``|``: a path may legally contain a comma or pipe on POSIX, so a
+    printable-delimiter join risks two different inputs — e.g. one path
+    ``"a,b"`` vs. two paths ``"a"``/``"b"`` — collapsing to the same key. NUL
+    can't appear in a filesystem path on any supported platform, so it can't
+    collide regardless of what the caller's paths contain.
+    """
+    sep = "\x00"
+    return sep.join(
         [
             binary_fmt,
             header_backend,
-            ",".join(sorted(str(p) for p in (public_headers or []))),
-            ",".join(sorted(str(p) for p in (public_header_dirs or []))),
+            sep.join(sorted(str(p) for p in (public_headers or []))),
+            sep.join(sorted(str(p) for p in (public_header_dirs or []))),
         ]
     )
 

--- a/abicheck/service_dump_cache.py
+++ b/abicheck/service_dump_cache.py
@@ -1,0 +1,206 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Whole-snapshot cache wiring for ``service.run_dump()``.
+
+Split out of ``service.py`` to keep that file under the AI-readiness
+line-count cap. A leaf module: it never imports ``service.py`` (that would
+create an import cycle, since ``service.py`` needs to call
+:func:`cached_run_dump`) — instead :func:`cached_run_dump` takes ``run_dump``
+itself as an explicit callable parameter, dependency-injection style, same
+end result as a lazy import without the indirection.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from .model import AbiSnapshot
+
+
+def _dump_is_cacheable(
+    *,
+    pdb_path: Path | None,
+    dwarf_only: bool,
+    debug_roots: list[Path] | None,
+    enable_debuginfod: bool,
+    debug_format: str | None,
+    symbols_only: bool,
+    debug_presence_only: bool,
+    # Untyped (not `CompileContext | None`): the type lives in service_scan.py,
+    # and importing it here — even under TYPE_CHECKING — closes an import
+    # cycle back through service.py/scan_engine.py. Only ever compared to
+    # `None` below, so no real type-safety is lost.
+    compile: object | None,
+    header_graph: bool,
+    header_graph_includes: bool,
+) -> bool:
+    """Whether a ``run_dump`` call is safe to serve from the whole-snapshot
+    cache (:mod:`abicheck.snapshot_cache`).
+
+    Deliberately conservative: only the plain "binary + public headers" shape
+    — the dominant release-baseline/CI comparison case a repeated pipeline
+    re-extracts identically on every run — is cached. A PDB path, a DWARF
+    debug-info root, debuginfod resolution (network-dependent), a forced
+    debug format, a symbols-only/debug-presence-only dump, a custom
+    ``CompileContext``, or the header-only semantic graph all change what
+    ``run_dump`` produces in ways not folded into the cache key below, so
+    those combinations always fall through to a live dump rather than risk
+    serving a stale/mismatched snapshot.
+    """
+    return (
+        pdb_path is None
+        and not dwarf_only
+        and not debug_roots
+        and not enable_debuginfod
+        and debug_format is None
+        and not symbols_only
+        and not debug_presence_only
+        and compile is None
+        and not header_graph
+        and not header_graph_includes
+    )
+
+
+def _dump_cache_extra_key(
+    binary_fmt: str,
+    header_backend: str,
+    public_headers: list[Path] | None,
+    public_header_dirs: list[Path] | None,
+) -> str:
+    """Build the ``extra`` cache-key material for a cacheable dump — every
+    input to ``run_dump`` that affects its output besides the binary content
+    / headers / includes / version / lang that
+    :func:`abicheck.snapshot_cache._cache_key` already hashes directly."""
+    return "|".join(
+        [
+            binary_fmt,
+            header_backend,
+            ",".join(sorted(str(p) for p in (public_headers or []))),
+            ",".join(sorted(str(p) for p in (public_header_dirs or []))),
+        ]
+    )
+
+
+def cached_run_dump(
+    run_dump: Callable[..., AbiSnapshot],
+    path: Path,
+    binary_fmt: str,
+    headers: list[Path] | None = None,
+    includes: list[Path] | None = None,
+    version: str = "",
+    lang: str = "c++",
+    *,
+    pdb_path: Path | None = None,
+    dwarf_only: bool = False,
+    debug_roots: list[Path] | None = None,
+    enable_debuginfod: bool = False,
+    debuginfod_url: str | None = None,
+    debug_format: str | None = None,
+    symbols_only: bool = False,
+    debug_presence_only: bool = False,
+    public_headers: list[Path] | None = None,
+    public_header_dirs: list[Path] | None = None,
+    header_backend: str = "auto",
+    compile: object | None = None,
+    header_graph: bool = False,
+    header_graph_includes: bool = False,
+    notify: Callable[[str], None] | None = None,
+) -> AbiSnapshot:
+    """``run_dump(...)``, transparently served from the whole-snapshot cache
+    when the call shape is cacheable (:func:`_dump_is_cacheable`) — avoiding a
+    repeat binary/header extraction entirely (no castxml/DWARF/ELF work, no
+    model construction) on a hit. Falls through to a live ``run_dump`` call
+    on a miss or an uncacheable shape, then populates the cache.
+
+    ``run_dump`` is passed in by the caller (``service.py``) rather than
+    imported here, so this module never needs to import ``service`` itself
+    (which would be a cycle: ``service.py`` calls this function).
+    """
+    _headers = headers or []
+    _includes = includes or []
+    cacheable = _dump_is_cacheable(
+        pdb_path=pdb_path,
+        dwarf_only=dwarf_only,
+        debug_roots=debug_roots,
+        enable_debuginfod=enable_debuginfod,
+        debug_format=debug_format,
+        symbols_only=symbols_only,
+        debug_presence_only=debug_presence_only,
+        compile=compile,
+        header_graph=header_graph,
+        header_graph_includes=header_graph_includes,
+    )
+    if not cacheable:
+        return run_dump(
+            path,
+            binary_fmt,
+            headers,
+            includes,
+            version,
+            lang,
+            pdb_path=pdb_path,
+            dwarf_only=dwarf_only,
+            debug_roots=debug_roots,
+            enable_debuginfod=enable_debuginfod,
+            debuginfod_url=debuginfod_url,
+            debug_format=debug_format,
+            symbols_only=symbols_only,
+            debug_presence_only=debug_presence_only,
+            public_headers=public_headers,
+            public_header_dirs=public_header_dirs,
+            header_backend=header_backend,
+            compile=compile,
+            header_graph=header_graph,
+            header_graph_includes=header_graph_includes,
+            notify=notify,
+        )
+
+    from . import snapshot_cache
+
+    extra = _dump_cache_extra_key(
+        binary_fmt, header_backend, public_headers, public_header_dirs
+    )
+    cached = snapshot_cache.lookup(path, _headers, _includes, version, lang, extra=extra)
+    if cached is not None:
+        return cached
+    snap = run_dump(
+        path,
+        binary_fmt,
+        headers,
+        includes,
+        version,
+        lang,
+        pdb_path=pdb_path,
+        dwarf_only=dwarf_only,
+        debug_roots=debug_roots,
+        enable_debuginfod=enable_debuginfod,
+        debuginfod_url=debuginfod_url,
+        debug_format=debug_format,
+        symbols_only=symbols_only,
+        debug_presence_only=debug_presence_only,
+        public_headers=public_headers,
+        public_header_dirs=public_header_dirs,
+        header_backend=header_backend,
+        compile=compile,
+        header_graph=header_graph,
+        header_graph_includes=header_graph_includes,
+        notify=notify,
+    )
+    snapshot_cache.store(snap, path, _headers, _includes, version, lang, extra=extra)
+    return snap

--- a/abicheck/snapshot_cache.py
+++ b/abicheck/snapshot_cache.py
@@ -36,6 +36,14 @@ _logger = logging.getLogger("abicheck.cache")
 #: Maximum number of cached snapshots (LRU eviction by mtime).
 MAX_ENTRIES: int = 100
 
+#: Bumped whenever a change to the dumping/provenance pipeline could alter a
+#: snapshot's content without changing any of the caller-supplied cache-key
+#: inputs (headers/includes/version/lang/``extra``) — folding it into every
+#: key invalidates all previously-cached entries on upgrade rather than risk
+#: serving a stale snapshot computed by an older, behaviorally-different
+#: abicheck version.
+_SNAPSHOT_CACHE_VERSION: str = "1"
+
 
 def _get_cache_dir() -> Path:
     """Return the cache directory, deferring Path.home() to call time."""
@@ -61,8 +69,17 @@ def _cache_key(
     includes: list[Path],
     version: str,
     lang: str,
+    *,
+    extra: str = "",
 ) -> str:
-    """Compute a deterministic cache key from all inputs that affect the snapshot."""
+    """Compute a deterministic cache key from all inputs that affect the snapshot.
+
+    ``extra`` is an opaque, caller-assembled string folding in any additional
+    inputs that affect the resulting snapshot but aren't one of this
+    function's named parameters (e.g. the binary format, header-AST backend,
+    or public-header scoping set) — kept generic here so this module doesn't
+    need to know every option a caller's dump pipeline exposes.
+    """
     h = hashlib.sha256()
     # Binary content hash — chunked to avoid loading huge files into memory
     try:
@@ -84,6 +101,8 @@ def _cache_key(
     # Compiler params
     h.update(version.encode())
     h.update(lang.encode())
+    h.update(extra.encode())
+    h.update(_SNAPSHOT_CACHE_VERSION.encode())
     return h.hexdigest()
 
 
@@ -93,9 +112,11 @@ def lookup(
     includes: list[Path],
     version: str,
     lang: str,
+    *,
+    extra: str = "",
 ) -> AbiSnapshot | None:
     """Look up a cached snapshot. Returns None on miss."""
-    key = _cache_key(binary_path, headers, includes, version, lang)
+    key = _cache_key(binary_path, headers, includes, version, lang, extra=extra)
     if not key:
         return None
     cache_file = _CACHE_DIR / f"{key}.json"
@@ -118,9 +139,11 @@ def store(
     includes: list[Path],
     version: str,
     lang: str,
+    *,
+    extra: str = "",
 ) -> None:
     """Store a snapshot in the cache (atomic write via rename)."""
-    key = _cache_key(binary_path, headers, includes, version, lang)
+    key = _cache_key(binary_path, headers, includes, version, lang, extra=extra)
     if not key:
         return
     try:
@@ -138,7 +161,13 @@ def store(
             raise
         _logger.debug("Cache store: %s → %s", binary_path.name, key[:12])
         _evict_if_needed()
-    except OSError as exc:
+    except Exception as exc:
+        # Caching is a pure optimization layered on top of a real dump that
+        # already succeeded — any failure here (disk full, an unserializable
+        # field, ...) must never surface as a caller-visible error. Broad
+        # except is deliberate (mirrors lookup()'s "any read problem is a
+        # miss" stance): a write-time TypeError from an unusual snapshot is
+        # exactly as harmless to swallow as an OSError.
         _logger.debug("Cache write failed: %s", exc)
 
 

--- a/scripts/benchmark_scaling.py
+++ b/scripts/benchmark_scaling.py
@@ -959,6 +959,151 @@ def _build_serialize(n: int) -> AbiSnapshot:
     )
 
 
+# ── oneDAL-shaped scenarios ────────────────────────────────────────────────────
+#
+# Generic scaling scenarios above are function-count-only or single-dimension
+# churn; oneDAL's own validation runs (~20-25k functions / ~1k records / a few
+# hundred enums from oneapi/dal.hpp and daal.h) surface three distinct shapes
+# none of the above stress: a huge *unchanged* public surface, a mass binary-
+# export removal that is entirely bundled/non-public (packaging noise — must
+# stay non-breaking once scoped), and a mass removal that *is* genuinely public
+# (must stay breaking). See docs/development/performance.md.
+def _build_onedal_large_surface(n: int) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """A large, almost entirely unchanged public surface: ``n`` functions,
+    ``n // 20`` records, ``n // 100`` enums, with exactly one function's
+    return type changed. Stresses per-declaration overhead (provenance/
+    surface computation, dedup, enrichment) across a surface sized like
+    oneDAL's ~20k-25k function public headers, where the dominant cost must
+    come from processing the surface, not from the single real change.
+    """
+    n_types = max(50, n // 20)
+    n_enums = max(20, n // 100)
+    types = [
+        RecordType(
+            name=f"Type_{i}",
+            kind="struct",
+            size_bits=64,
+            fields=[
+                TypeField(name="a", type="int", offset_bits=0),
+                TypeField(name="b", type="long", offset_bits=64),
+            ],
+        )
+        for i in range(n_types)
+    ]
+    enums = [
+        EnumType(
+            name=f"Enum_{i}",
+            members=[EnumMember(name=f"Enum_{i}_A", value=0)],
+        )
+        for i in range(n_enums)
+    ]
+    funcs = [
+        Function(
+            name=f"dal_func_{i}",
+            mangled=f"_Z9dal_func_{i}P{i % n_types}",
+            return_type="int",
+            params=[Param(name="p", type=f"Type_{i % n_types} *")],
+            visibility=Visibility.PUBLIC,
+        )
+        for i in range(n)
+    ]
+    old = AbiSnapshot(
+        library="libonedal_core.so",
+        version="2026.0",
+        functions=funcs,
+        types=types,
+        enums=enums,
+    )
+    changed_funcs = list(funcs)
+    changed_funcs[0] = Function(
+        name=changed_funcs[0].name,
+        mangled=changed_funcs[0].mangled,
+        return_type="long",  # the one real change in an otherwise-static surface
+        params=changed_funcs[0].params,
+        visibility=Visibility.PUBLIC,
+    )
+    new = AbiSnapshot(
+        library="libonedal_core.so",
+        version="2026.1",
+        functions=changed_funcs,
+        types=list(types),
+        enums=list(enums),
+    )
+    return old, new
+
+
+def _build_onedal_packaging_noise(n: int) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """The public header surface is completely unchanged; ``n`` bundled-
+    dependency exports (``Visibility.ELF_ONLY`` — modeling vendored MKL/BLAS
+    symbols carried inside a oneDAL release binary, not part of the public
+    ``oneapi::dal``/``daal`` API) are removed.
+
+    Mirrors the reported oneDAL 2025.0→2025.1 case: the binary/export tier
+    alone sees these removals as breaking, but public-header scoping must
+    still classify the release as non-breaking overall — see
+    ``_run_compare_verify_scoped_non_breaking``, which gates this as a
+    correctness check, not just a timing one.
+    """
+    n_public = max(50, n // 20)
+    public_funcs = [
+        Function(
+            name=f"dal_public_{i}",
+            mangled=f"_Z11dal_public_{i}v",
+            return_type="int",
+            visibility=Visibility.PUBLIC,
+        )
+        for i in range(n_public)
+    ]
+    bundled_funcs = [
+        Function(
+            name=f"mkl_bundled_{i}",
+            mangled=f"_Z12mkl_bundled_{i}v",
+            return_type="int",
+            visibility=Visibility.ELF_ONLY,
+        )
+        for i in range(n)
+    ]
+    old = AbiSnapshot(
+        library="libonedal_core.so",
+        version="2025.0",
+        functions=public_funcs + bundled_funcs,
+    )
+    new = AbiSnapshot(
+        library="libonedal_core.so",
+        version="2025.1",
+        functions=list(public_funcs),  # every bundled export gone, public API intact
+    )
+    return old, new
+
+
+def _build_onedal_mass_removal(n: int) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Nearly all of a large *public* function surface removed in one
+    release, with no replacements added — the shape of a hard deprecation
+    sweep (the reported libonedal_core.so.4 2026.0→2026.1 binary-tier
+    experiment: ~2,134 removed exported functions). Unlike
+    ``_build_onedal_packaging_noise``, these removals are genuinely public
+    and must stay classified as breaking; this scenario instead stresses
+    change-object allocation, grouping/collapse, and report generation at
+    oneDAL's observed mass-removal scale.
+    """
+    funcs = [
+        Function(
+            name=f"dal_func_{i}",
+            mangled=f"_Z9dal_func_{i}v",
+            return_type="int",
+            visibility=Visibility.PUBLIC,
+        )
+        for i in range(n)
+    ]
+    old = AbiSnapshot(library="libonedal_core.so", version="2026.0", functions=funcs)
+    new = AbiSnapshot(
+        library="libonedal_core.so",
+        version="2026.1",
+        functions=funcs[: max(1, n // 1000)],
+    )
+    return old, new
+
+
 # ── Timed runners (one per measured entry point) ──────────────────────────────
 def _run_compare(prepared: tuple[AbiSnapshot, AbiSnapshot]) -> int:
     """Time ``compare(old, new)``; return the number of detected changes."""
@@ -979,6 +1124,28 @@ def _run_compare_collapse(prepared: tuple[AbiSnapshot, AbiSnapshot]) -> int:
     """
     old, new = prepared
     return len(compare(old, new, collapse_versioned_symbols=True).changes)
+
+
+def _run_compare_verify_scoped_non_breaking(
+    prepared: tuple[AbiSnapshot, AbiSnapshot],
+) -> int:
+    """Time ``compare()`` for the packaging-noise scenario AND assert the
+    result stays non-breaking — a correctness gate, not just a timing one.
+
+    If public-surface scoping regressed (e.g. a bundled ELF-only export
+    leaking into the public verdict), this raises instead of silently
+    measuring a wrong-but-fast result.
+    """
+    old, new = prepared
+    result = compare(old, new)
+    if result.verdict == Verdict.BREAKING:
+        raise AssertionError(
+            "onedal_packaging_noise must not classify as BREAKING: removed "
+            "exports here are all Visibility.ELF_ONLY (bundled dependency "
+            "symbols), and public-surface scoping should demote them — "
+            f"got {len(result.breaking)} breaking change(s)"
+        )
+    return len(result.changes)
 
 
 def _run_suppression_audit(prepared: tuple[list[Change], SuppressionList]) -> int:
@@ -1086,6 +1253,23 @@ SCENARIOS: dict[str, Scenario] = {
     ),
     "nested_types": Scenario(
         _build_nested_types, sizes=(100, 200, 400), max_size=500, gate_exponent=False
+    ),
+    # oneDAL-shaped scenarios (see the section comment above the builders).
+    "onedal_large_surface": Scenario(
+        _build_onedal_large_surface,
+        sizes=(5000, 10000, 20000),
+        max_size=25000,
+    ),
+    "onedal_packaging_noise": Scenario(
+        _build_onedal_packaging_noise,
+        run=_run_compare_verify_scoped_non_breaking,
+        sizes=(500, 1000, 2000),
+        max_size=5000,
+    ),
+    "onedal_mass_removal": Scenario(
+        _build_onedal_mass_removal,
+        sizes=(500, 1000, 2000),
+        max_size=5000,
     ),
 }
 

--- a/scripts/benchmark_scaling.py
+++ b/scripts/benchmark_scaling.py
@@ -1148,6 +1148,29 @@ def _run_compare_verify_scoped_non_breaking(
     return len(result.changes)
 
 
+def _run_compare_verify_breaking(prepared: tuple[AbiSnapshot, AbiSnapshot]) -> int:
+    """Time ``compare()`` for the mass-removal scenario AND assert the result
+    stays breaking — the correctness counterpart to
+    ``_run_compare_verify_scoped_non_breaking``.
+
+    These removals are genuinely public (``Visibility.PUBLIC``), unlike
+    ``onedal_packaging_noise``'s bundled/ELF-only exports, so a regression
+    that caused public-surface scoping to over-suppress them (the opposite
+    failure mode) would otherwise go undetected by this benchmark — it would
+    just silently report a smaller, faster, and wrong result.
+    """
+    old, new = prepared
+    result = compare(old, new)
+    if result.verdict != Verdict.BREAKING:
+        raise AssertionError(
+            "onedal_mass_removal must classify as BREAKING: removed exports "
+            "here are all Visibility.PUBLIC (genuine API removals), so "
+            f"public-surface scoping must not suppress them — got verdict "
+            f"{result.verdict!r} with {len(result.breaking)} breaking change(s)"
+        )
+    return len(result.changes)
+
+
 def _run_suppression_audit(prepared: tuple[list[Change], SuppressionList]) -> int:
     """Time ``SuppressionList.audit``; return the number of findings audited."""
     changes, supp = prepared
@@ -1268,6 +1291,7 @@ SCENARIOS: dict[str, Scenario] = {
     ),
     "onedal_mass_removal": Scenario(
         _build_onedal_mass_removal,
+        run=_run_compare_verify_breaking,
         sizes=(500, 1000, 2000),
         max_size=5000,
     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,25 @@ except ImportError:
     filelock = None  # type: ignore[assignment]
 
 
+@pytest.fixture(autouse=True)
+def _isolate_snapshot_cache(tmp_path_factory: pytest.TempPathFactory, monkeypatch):
+    """Redirect the whole-snapshot cache (``snapshot_cache.py``) to a fresh
+    per-test directory instead of the real ``~/.cache/abi_check/snapshots/``.
+
+    Without this, two tests that happen to dump byte-identical synthetic
+    fixture binaries with the same (empty) headers/version/lang would collide
+    on the same cache key and one could silently serve the other's cached
+    snapshot — a test-isolation hazard, not a real-world one (this only
+    matters because unrelated tests share one persistent on-disk cache
+    directory across the whole run).
+    """
+    from abicheck import snapshot_cache
+
+    monkeypatch.setattr(
+        snapshot_cache, "_CACHE_DIR", tmp_path_factory.mktemp("snapshot_cache")
+    )
+
+
 @pytest.fixture
 def source_tree_with_compile_db(tmp_path: Path) -> Path:
     """A minimal source tree with a compile_commands.json for L3/L4 scan tests.

--- a/tests/test_dumper_cache_unit.py
+++ b/tests/test_dumper_cache_unit.py
@@ -9,10 +9,13 @@ Windows branch (unreachable on the Linux CI host without monkeypatching
 """
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
-from abicheck.dumper_cache import _cache_path
+import pytest
+
+from abicheck.dumper_cache import _atomic_write, _cache_path
 
 
 def test_posix_uses_xdg_cache_home(monkeypatch, tmp_path) -> None:
@@ -77,3 +80,83 @@ def test_unwritable_cache_dir_falls_back_to_tempdir(monkeypatch, tmp_path) -> No
 
     assert path == tmp_path / "fallback" / "abi_check" / "clang" / "k.json"
     assert path.parent.is_dir()
+
+
+# ── _atomic_write() ──────────────────────────────────────────────────────────
+#
+# Replaces a plain shutil.copy2()/write_text() cache write: two concurrent
+# extractions (e.g. old/new sides resolved in parallel, service.py) racing to
+# populate the same cache key must never leave a torn/partial file behind.
+
+
+def test_writes_content_and_leaves_no_temp_file(tmp_path: Path) -> None:
+    target = tmp_path / "cache" / "abcd.xml"
+    target.parent.mkdir(parents=True)
+
+    _atomic_write(target, b"<xml>hello</xml>")
+
+    assert target.read_bytes() == b"<xml>hello</xml>"
+    # No leftover .tmp sibling from the mkstemp() staging file.
+    assert list(target.parent.iterdir()) == [target]
+
+
+def test_overwrites_existing_file(tmp_path: Path) -> None:
+    target = tmp_path / "cache" / "abcd.xml"
+    target.parent.mkdir(parents=True)
+    target.write_bytes(b"old content")
+
+    _atomic_write(target, b"new content")
+
+    assert target.read_bytes() == b"new content"
+
+
+def test_replace_failure_cleans_up_temp_file_and_reraises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """If the final os.replace() fails (e.g. a cross-device rename), the
+    staging temp file must not be left behind, and the OSError must still
+    propagate to the caller (both dumper.py/dumper_clang_errors.py call sites
+    catch OSError themselves and log a warning — they must actually see it)."""
+    target = tmp_path / "cache" / "abcd.xml"
+    target.parent.mkdir(parents=True)
+
+    def _raise_oserror(*_args, **_kwargs):
+        raise OSError("simulated cross-device rename failure")
+
+    monkeypatch.setattr(os, "replace", _raise_oserror)
+
+    with pytest.raises(OSError, match="simulated cross-device rename failure"):
+        _atomic_write(target, b"data")
+
+    # The staging file (a hidden `.<name>.<random>.tmp` sibling) was cleaned
+    # up rather than left behind, and the real target was never touched.
+    assert list(target.parent.iterdir()) == []
+
+
+def test_write_failure_cleans_up_temp_file_and_reraises(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Same cleanup guarantee when the failure happens while writing the
+    staging file itself (e.g. disk full), before os.replace() is even
+    reached."""
+    target = tmp_path / "cache" / "abcd.xml"
+    target.parent.mkdir(parents=True)
+
+    real_fdopen = os.fdopen
+
+    def _flaky_fdopen(fd, *args, **kwargs):
+        f = real_fdopen(fd, *args, **kwargs)
+
+        def _boom(_data):
+            raise OSError("simulated disk full")
+
+        f.write = _boom
+        return f
+
+    monkeypatch.setattr(os, "fdopen", _flaky_fdopen)
+
+    with pytest.raises(OSError, match="simulated disk full"):
+        _atomic_write(target, b"data")
+
+    assert list(target.parent.iterdir()) == []
+    assert not target.exists()

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -26,12 +26,14 @@ from abicheck.model import (
     RecordType,
     ScopeOrigin,
     Variable,
+    Visibility,
 )
 from abicheck.provenance import (
     apply_provenance,
     build_public_set,
     classify_origin,
     header_from_location,
+    tag_provenance,
 )
 from abicheck.serialization import snapshot_from_dict, snapshot_to_dict
 
@@ -231,6 +233,159 @@ def test_apply_provenance_no_set_keeps_unknown_but_fills_header():
     assert snap.functions[0].source_header == "/build/include/api.h"
     assert snap.functions[0].origin is ScopeOrigin.UNKNOWN
     assert snap.types[0].origin is ScopeOrigin.UNKNOWN
+
+
+# ── origin_cache (tag_provenance / apply_provenance memoization) ─────────────
+#
+# apply_provenance() and the buildsource castxml extractor share one
+# classify_origin() result across every declaration produced by the same
+# header — these tests prove the cache actually gets *hit* (not just that
+# overall output happens to be unchanged), and that it never conflates
+# declarations under a different (source_header, export_only) key.
+
+
+def _tag(decl, header_segs, dir_segs, have_set, *, origin_cache=None):
+    tag_provenance(decl, header_segs, dir_segs, have_set, origin_cache=origin_cache)
+    return decl
+
+
+def test_origin_cache_hit_reuses_prior_classification(monkeypatch):
+    """Two declarations sharing one header must classify_origin() only once."""
+    calls = []
+    real_classify_origin = classify_origin
+
+    def _spy(*args, **kwargs):
+        calls.append((args, tuple(sorted(kwargs.items()))))
+        return real_classify_origin(*args, **kwargs)
+
+    monkeypatch.setattr("abicheck.provenance.classify_origin", _spy)
+
+    header_segs, dir_segs, have_set = build_public_set(["include/api.h"], None)
+    origin_cache: dict = {}
+    a = Function(
+        name="a", mangled="a", return_type="void",
+        source_location="/build/include/api.h:10",
+    )
+    b = Function(
+        name="b", mangled="b", return_type="void",
+        source_location="/build/include/api.h:99",  # same header, different line
+    )
+    _tag(a, header_segs, dir_segs, have_set, origin_cache=origin_cache)
+    _tag(b, header_segs, dir_segs, have_set, origin_cache=origin_cache)
+
+    assert a.origin is ScopeOrigin.PUBLIC_HEADER
+    assert b.origin is ScopeOrigin.PUBLIC_HEADER
+    assert len(calls) == 1  # the second call was served from origin_cache
+
+
+def test_origin_cache_distinguishes_different_headers(monkeypatch):
+    """Declarations from different headers must not share a cached result."""
+    calls = []
+    real_classify_origin = classify_origin
+
+    def _spy(*args, **kwargs):
+        calls.append(1)
+        return real_classify_origin(*args, **kwargs)
+
+    monkeypatch.setattr("abicheck.provenance.classify_origin", _spy)
+
+    header_segs, dir_segs, have_set = build_public_set(["include/api.h"], None)
+    origin_cache: dict = {}
+    pub = Function(
+        name="pub", mangled="pub", return_type="void",
+        source_location="/build/include/api.h:10",
+    )
+    priv = Function(
+        name="priv", mangled="priv", return_type="void",
+        source_location="/build/src/impl.h:20",
+    )
+    _tag(pub, header_segs, dir_segs, have_set, origin_cache=origin_cache)
+    _tag(priv, header_segs, dir_segs, have_set, origin_cache=origin_cache)
+
+    assert pub.origin is ScopeOrigin.PUBLIC_HEADER
+    assert priv.origin is ScopeOrigin.PRIVATE_HEADER
+    assert len(calls) == 2  # distinct headers never share a cache entry
+
+
+def test_origin_cache_distinguishes_export_only_from_same_header(monkeypatch):
+    """Same (missing) header, different export_only, must not collide.
+
+    ``export_only`` comes from ``Visibility.ELF_ONLY`` and only matters when
+    there's no source_location at all — the cache key is
+    ``(source_header, export_only)``, so two no-location declarations that
+    differ only in visibility must classify independently.
+    """
+    header_segs, dir_segs, have_set = build_public_set(["include/api.h"], None)
+    origin_cache: dict = {}
+    exported = Function(
+        name="exported", mangled="exported", return_type="void",
+        visibility=Visibility.ELF_ONLY,
+    )
+    hidden = Function(
+        name="hidden", mangled="hidden", return_type="void",
+        visibility=Visibility.HIDDEN,
+    )
+    _tag(exported, header_segs, dir_segs, have_set, origin_cache=origin_cache)
+    _tag(hidden, header_segs, dir_segs, have_set, origin_cache=origin_cache)
+
+    assert exported.origin is ScopeOrigin.EXPORT_ONLY
+    assert hidden.origin is ScopeOrigin.UNKNOWN
+    assert len(origin_cache) == 2  # (None, True) and (None, False) both cached
+
+
+def test_origin_cache_matches_uncached_result():
+    """The cached and uncached (origin_cache=None) paths must agree exactly —
+    the cache must be a pure optimization, never a behavior change."""
+    header_segs, dir_segs, have_set = build_public_set(["include/api.h"], None)
+
+    cached_decls = [
+        Function(
+            name=n, mangled=n, return_type="void",
+            source_location=f"/build/include/api.h:{i}",
+        )
+        for i, n in enumerate(["a", "b", "c"])
+    ]
+    uncached_decls = [
+        Function(
+            name=n, mangled=n, return_type="void",
+            source_location=f"/build/include/api.h:{i}",
+        )
+        for i, n in enumerate(["a", "b", "c"])
+    ]
+
+    origin_cache: dict = {}
+    for d in cached_decls:
+        _tag(d, header_segs, dir_segs, have_set, origin_cache=origin_cache)
+    for d in uncached_decls:
+        _tag(d, header_segs, dir_segs, have_set, origin_cache=None)
+
+    assert [d.origin for d in cached_decls] == [d.origin for d in uncached_decls]
+    assert [d.source_header for d in cached_decls] == [
+        d.source_header for d in uncached_decls
+    ]
+
+
+def test_apply_provenance_shares_one_cache_across_all_declaration_kinds(monkeypatch):
+    """apply_provenance() builds one origin_cache and threads it through
+    functions/variables/types/enums — declarations of different *kinds*
+    sharing api.h must still hit the same cache entry, not one per kind."""
+    calls = []
+    real_classify_origin = classify_origin
+
+    def _spy(*args, **kwargs):
+        calls.append(1)
+        return real_classify_origin(*args, **kwargs)
+
+    monkeypatch.setattr("abicheck.provenance.classify_origin", _spy)
+
+    # _snapshot()'s pub/variable/type/enum all declare source_location
+    # "/build/include/api.h:<n>" (public, non-export-only) — one shared key.
+    apply_provenance(_snapshot(), public_headers=["include/api.h"])
+
+    # api.h contributes 4 same-key declarations (pub func, var, type, enum) +
+    # impl.h contributes 1 (priv func) + no-location contributes 1 (noloc
+    # func, sh=None) = 3 distinct (source_header, export_only) keys total.
+    assert len(calls) == 3
 
 
 # ── serialization round-trip (schema v6) ──────────────────────────────────────

--- a/tests/test_service_dump_cache.py
+++ b/tests/test_service_dump_cache.py
@@ -1,0 +1,180 @@
+"""Tests for the whole-snapshot cache wiring (service_dump_cache.py)."""
+from __future__ import annotations
+
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.service_dump_cache import (
+    _dump_cache_extra_key,
+    _dump_is_cacheable,
+    cached_run_dump,
+)
+
+
+def _sample_snap(name: str = "foo") -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libfoo.so.1",
+        version="1.0",
+        functions=[
+            Function(
+                name=name,
+                mangled=f"_Z{len(name)}{name}v",
+                return_type="int",
+                visibility=Visibility.PUBLIC,
+            ),
+        ],
+    )
+
+
+def _cacheable_kwargs(**overrides):
+    base = dict(
+        pdb_path=None,
+        dwarf_only=False,
+        debug_roots=None,
+        enable_debuginfod=False,
+        debug_format=None,
+        symbols_only=False,
+        debug_presence_only=False,
+        compile=None,
+        header_graph=False,
+        header_graph_includes=False,
+    )
+    base.update(overrides)
+    return base
+
+
+class TestDumpIsCacheable:
+    def test_plain_shape_is_cacheable(self):
+        assert _dump_is_cacheable(**_cacheable_kwargs()) is True
+
+    def test_pdb_path_not_cacheable(self, tmp_path):
+        kwargs = _cacheable_kwargs(pdb_path=tmp_path / "x.pdb")
+        assert _dump_is_cacheable(**kwargs) is False
+
+    def test_dwarf_only_not_cacheable(self):
+        assert _dump_is_cacheable(**_cacheable_kwargs(dwarf_only=True)) is False
+
+    def test_debug_roots_not_cacheable(self, tmp_path):
+        kwargs = _cacheable_kwargs(debug_roots=[tmp_path])
+        assert _dump_is_cacheable(**kwargs) is False
+
+    def test_enable_debuginfod_not_cacheable(self):
+        kwargs = _cacheable_kwargs(enable_debuginfod=True)
+        assert _dump_is_cacheable(**kwargs) is False
+
+    def test_debug_format_not_cacheable(self):
+        kwargs = _cacheable_kwargs(debug_format="dwarf")
+        assert _dump_is_cacheable(**kwargs) is False
+
+    def test_symbols_only_not_cacheable(self):
+        kwargs = _cacheable_kwargs(symbols_only=True)
+        assert _dump_is_cacheable(**kwargs) is False
+
+    def test_debug_presence_only_not_cacheable(self):
+        kwargs = _cacheable_kwargs(debug_presence_only=True)
+        assert _dump_is_cacheable(**kwargs) is False
+
+    def test_compile_context_not_cacheable(self):
+        kwargs = _cacheable_kwargs(compile=object())
+        assert _dump_is_cacheable(**kwargs) is False
+
+    def test_header_graph_not_cacheable(self):
+        kwargs = _cacheable_kwargs(header_graph=True)
+        assert _dump_is_cacheable(**kwargs) is False
+
+    def test_header_graph_includes_not_cacheable(self):
+        kwargs = _cacheable_kwargs(header_graph_includes=True)
+        assert _dump_is_cacheable(**kwargs) is False
+
+
+class TestDumpCacheExtraKey:
+    def test_differs_by_binary_fmt(self):
+        k1 = _dump_cache_extra_key("elf", "auto", None, None)
+        k2 = _dump_cache_extra_key("pe", "auto", None, None)
+        assert k1 != k2
+
+    def test_differs_by_header_backend(self):
+        k1 = _dump_cache_extra_key("elf", "auto", None, None)
+        k2 = _dump_cache_extra_key("elf", "clang", None, None)
+        assert k1 != k2
+
+    def test_differs_by_public_headers(self, tmp_path):
+        k1 = _dump_cache_extra_key("elf", "auto", None, None)
+        k2 = _dump_cache_extra_key("elf", "auto", [tmp_path / "pub.h"], None)
+        assert k1 != k2
+
+    def test_order_independent_for_public_headers(self, tmp_path):
+        a = tmp_path / "a.h"
+        b = tmp_path / "b.h"
+        k1 = _dump_cache_extra_key("elf", "auto", [a, b], None)
+        k2 = _dump_cache_extra_key("elf", "auto", [b, a], None)
+        assert k1 == k2
+
+
+class TestCachedRunDump:
+    def test_cache_hit_skips_run_dump(self, tmp_path):
+        binary = tmp_path / "lib.so"
+        binary.write_bytes(b"ELF fake content")
+        calls = []
+
+        def fake_run_dump(path, binary_fmt, headers, includes, version, lang, **kwargs):
+            calls.append(1)
+            return _sample_snap()
+
+        snap1 = cached_run_dump(fake_run_dump, binary, "elf", [], [], "1.0", "c++")
+        snap2 = cached_run_dump(fake_run_dump, binary, "elf", [], [], "1.0", "c++")
+
+        assert len(calls) == 1
+        assert snap1.functions[0].name == snap2.functions[0].name == "foo"
+
+    def test_binary_content_change_invalidates_cache(self, tmp_path):
+        binary = tmp_path / "lib.so"
+        binary.write_bytes(b"content A")
+        calls: list[int] = []
+
+        def fake_run_dump(path, binary_fmt, headers, includes, version, lang, **kwargs):
+            calls.append(1)
+            return _sample_snap(name=f"foo{len(calls)}")
+
+        cached_run_dump(fake_run_dump, binary, "elf", [], [], "1.0", "c++")
+        binary.write_bytes(b"content B - genuinely different")
+        cached_run_dump(fake_run_dump, binary, "elf", [], [], "1.0", "c++")
+
+        assert len(calls) == 2
+
+    def test_different_binary_fmt_is_a_different_cache_entry(self, tmp_path):
+        # Same on-disk bytes, but resolve_input would only ever call
+        # cached_run_dump with one binary_fmt per real file — this asserts
+        # the `extra` key material (added specifically for binary_fmt) really
+        # is folded in, guarding against a PE/Mach-O snapshot ever being
+        # served back for an ELF request that happens to share a cache key.
+        binary = tmp_path / "lib.so"
+        binary.write_bytes(b"shared content")
+        calls: list[str] = []
+
+        def fake_run_dump(path, binary_fmt, headers, includes, version, lang, **kwargs):
+            calls.append(binary_fmt)
+            return _sample_snap(name=binary_fmt)
+
+        snap_elf = cached_run_dump(fake_run_dump, binary, "elf", [], [], "1.0", "c++")
+        snap_pe = cached_run_dump(fake_run_dump, binary, "pe", [], [], "1.0", "c++")
+
+        assert calls == ["elf", "pe"]
+        assert snap_elf.functions[0].name == "elf"
+        assert snap_pe.functions[0].name == "pe"
+
+    def test_uncacheable_shape_always_calls_run_dump(self, tmp_path):
+        binary = tmp_path / "lib.so"
+        binary.write_bytes(b"ELF fake content")
+        calls = []
+
+        def fake_run_dump(path, binary_fmt, headers, includes, version, lang, **kwargs):
+            calls.append(1)
+            return _sample_snap()
+
+        cached_run_dump(
+            fake_run_dump, binary, "elf", [], [], "1.0", "c++", dwarf_only=True
+        )
+        cached_run_dump(
+            fake_run_dump, binary, "elf", [], [], "1.0", "c++", dwarf_only=True
+        )
+
+        assert len(calls) == 2

--- a/tests/test_service_dump_cache.py
+++ b/tests/test_service_dump_cache.py
@@ -1,6 +1,8 @@
 """Tests for the whole-snapshot cache wiring (service_dump_cache.py)."""
 from __future__ import annotations
 
+from pathlib import Path
+
 from abicheck.model import AbiSnapshot, Function, Visibility
 from abicheck.service_dump_cache import (
     _dump_cache_extra_key,
@@ -107,6 +109,18 @@ class TestDumpCacheExtraKey:
         k1 = _dump_cache_extra_key("elf", "auto", [a, b], None)
         k2 = _dump_cache_extra_key("elf", "auto", [b, a], None)
         assert k1 == k2
+
+    def test_one_path_with_embedded_comma_does_not_collide_with_two_paths(self):
+        # A regression guard for a real (if narrow) collision: joining with a
+        # printable delimiter like "," means one path literally named "a,b"
+        # and two separate paths "a"/"b" both stringify+sort+join to "a,b" —
+        # indistinguishable. NUL can't appear in a filesystem path, so the two
+        # inputs must produce different keys.
+        one_path_with_comma = [Path("a,b")]
+        two_paths = [Path("a"), Path("b")]
+        k1 = _dump_cache_extra_key("elf", "auto", one_path_with_comma, None)
+        k2 = _dump_cache_extra_key("elf", "auto", two_paths, None)
+        assert k1 != k2
 
 
 class TestCachedRunDump:

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -1251,9 +1251,12 @@ class TestRunCompare:
             new_headers=[new_h],
         )
         assert len(calls) == 2
-        old_call, new_call = calls
-        assert old_call["public_headers"] == [old_h]
-        assert new_call["public_headers"] == [new_h]
+        # Matched by path rather than unpacked positionally: old/new resolution
+        # runs concurrently on two threads (service.run_compare_request), so
+        # the order the spy observes calls in is not guaranteed.
+        calls_by_path = {c["path"]: c for c in calls}
+        assert calls_by_path[old_p]["public_headers"] == [old_h]
+        assert calls_by_path[new_p]["public_headers"] == [new_h]
 
     def test_debuginfod_url_appended_last_preserves_positional_order(self):
         # Codex review (PR #551): debuginfod_url was originally inserted right
@@ -1268,6 +1271,83 @@ class TestRunCompare:
         assert params.index("scope_to_public_surface") == (
             params.index("enable_debuginfod") + 1
         )
+
+
+class TestParallelOldNewExtraction:
+    """run_compare_request resolves old/new concurrently (two threads) since
+    neither side depends on the other until compare_snapshots(). These tests
+    guard the concurrency itself, exception propagation, and the
+    ABICHECK_PARALLEL_EXTRACTION=0 escape hatch."""
+
+    def _snap_files(self, tmp_path):
+        from abicheck.serialization import save_snapshot
+
+        old_p = tmp_path / "old.json"
+        new_p = tmp_path / "new.json"
+        save_snapshot(AbiSnapshot(library="l", version="1.0"), old_p)
+        save_snapshot(AbiSnapshot(library="l", version="2.0"), new_p)
+        return old_p, new_p
+
+    def test_both_sides_extracted_concurrently(self, tmp_path, monkeypatch):
+        import threading
+
+        from abicheck import service as service_mod
+
+        old_p, new_p = self._snap_files(tmp_path)
+        original_resolve = service_mod.resolve_input
+        # A 2-party barrier: this call only returns once BOTH old and new
+        # resolution have reached it. If run_compare_request serialized them
+        # (regressing to the old sequential behavior) this would deadlock —
+        # the second call can never start until the first returns, but the
+        # first is stuck waiting on the barrier — surfacing as a
+        # BrokenBarrierError after the timeout rather than a flaky race.
+        barrier = threading.Barrier(2, timeout=5)
+
+        def _synced_resolve(path, headers, includes, version, lang, **kwargs):
+            barrier.wait()
+            return original_resolve(path, headers, includes, version, lang, **kwargs)
+
+        monkeypatch.setattr(service_mod, "resolve_input", _synced_resolve)
+
+        result, old, new = run_compare(old_p, new_p)
+        assert isinstance(result, DiffResult)
+
+    def test_exception_from_one_side_propagates(self, tmp_path, monkeypatch):
+        from abicheck import service as service_mod
+
+        old_p, new_p = self._snap_files(tmp_path)
+        original_resolve = service_mod.resolve_input
+
+        def _boom(path, headers, includes, version, lang, **kwargs):
+            if Path(path) == Path(old_p):
+                raise SnapshotError("boom - old side failed")
+            return original_resolve(path, headers, includes, version, lang, **kwargs)
+
+        monkeypatch.setattr(service_mod, "resolve_input", _boom)
+
+        with pytest.raises(SnapshotError, match="boom - old side failed"):
+            run_compare(old_p, new_p)
+
+    def test_env_var_disables_parallel_extraction(self, tmp_path, monkeypatch):
+        import threading
+
+        from abicheck import service as service_mod
+
+        old_p, new_p = self._snap_files(tmp_path)
+        original_resolve = service_mod.resolve_input
+        threads_seen: set[int] = set()
+
+        def _spy(path, headers, includes, version, lang, **kwargs):
+            threads_seen.add(threading.get_ident())
+            return original_resolve(path, headers, includes, version, lang, **kwargs)
+
+        monkeypatch.setattr(service_mod, "resolve_input", _spy)
+        monkeypatch.setenv("ABICHECK_PARALLEL_EXTRACTION", "0")
+
+        run_compare(old_p, new_p)
+
+        # Both calls ran on the current (main) thread — no pool was used.
+        assert threads_seen == {threading.get_ident()}
 
 
 # ── render_output() ─────────────────────────────────────────────────────────

--- a/tests/test_snapshot_cache.py
+++ b/tests/test_snapshot_cache.py
@@ -236,3 +236,59 @@ class TestStoreErrorPaths:
         store(snap, binary, [], [], "1.0", "c++")  # should not raise
         # mkdir failed, so nothing should have been written to the cache dir.
         assert not cache_dir.exists()
+
+    def test_store_serialization_error_does_not_raise(self, tmp_path, monkeypatch):
+        """A non-OSError failure while serializing (e.g. an unexpected
+        non-JSON-serializable field) must not propagate: caching sits on top
+        of a dump that already succeeded, so a write-time failure here can
+        only ever cost a cache miss next time, never break the caller."""
+        import abicheck.snapshot_cache as sc
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setattr(sc, "_CACHE_DIR", cache_dir)
+
+        def _raise_type_error(*args, **kwargs):
+            raise TypeError("Object of type MagicMock is not JSON serializable")
+
+        monkeypatch.setattr("abicheck.serialization.snapshot_to_json", _raise_type_error)
+        binary = tmp_path / "lib.so"
+        binary.write_bytes(b"ELF content")
+        snap = _sample_snap()
+        store(snap, binary, [], [], "1.0", "c++")  # should not raise
+        # Serialization failed before the temp file could be renamed into
+        # place, so no (partial/corrupt) cache entry should be left behind.
+        assert list(cache_dir.glob("*.json")) == []
+
+
+class TestExtraKeyMaterial:
+    def test_different_extra_different_key(self, tmp_path):
+        binary = tmp_path / "lib.so"
+        binary.write_bytes(b"ELF content")
+
+        key1 = _cache_key(binary, [], [], "1.0", "c++", extra="elf|auto")
+        key2 = _cache_key(binary, [], [], "1.0", "c++", extra="pe|auto")
+        assert key1 != key2
+
+    def test_same_extra_same_key(self, tmp_path):
+        binary = tmp_path / "lib.so"
+        binary.write_bytes(b"ELF content")
+
+        key1 = _cache_key(binary, [], [], "1.0", "c++", extra="elf|auto")
+        key2 = _cache_key(binary, [], [], "1.0", "c++", extra="elf|auto")
+        assert key1 == key2
+
+    def test_store_lookup_roundtrip_with_extra(self, tmp_path, monkeypatch):
+        import abicheck.snapshot_cache as sc
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setattr(sc, "_CACHE_DIR", cache_dir)
+
+        binary = tmp_path / "lib.so"
+        binary.write_bytes(b"ELF content")
+        snap = _sample_snap()
+
+        store(snap, binary, [], [], "1.0", "c++", extra="elf|auto")
+        # A lookup with different `extra` material is a distinct cache entry
+        # (e.g. a different header-AST backend or binary format) and misses.
+        assert lookup(binary, [], [], "1.0", "c++", extra="pe|auto") is None
+        result = lookup(binary, [], [], "1.0", "c++", extra="elf|auto")
+        assert result is not None
+        assert result.library == "libfoo.so.1"


### PR DESCRIPTION
## Summary

Implements the "first tranche" plus several "second tranche" items from a oneDAL-focused performance roadmap: reduce redundant work parsing/normalizing very large ABI surfaces (Intel oneDAL's `oneapi/dal.hpp`/`daal.h` umbrella headers produce roughly 20k–25k functions and ~1k types), close a caching gap that was fully built but never wired in, and parallelize the one obviously-independent sequential step in a comparison. No output/behavior change for any existing input shape — verified via the full fast unit-test suite (15730 tests) plus new targeted tests for every change below.

## Changes

**L2 parsing (dumper_castxml.py / provenance.py)**
- `_CastxmlParser` now builds tag-grouped element lists in its one existing pass over the CastXML XML root, so `parse_functions`/`parse_types`/`parse_enums`/`parse_typedefs`/etc. no longer each re-scan the whole tree (previously ~9 independent full scans).
- `_type_name()`/`_pointer_depth()` are memoized per parser instance, keyed by XML id — a depth-capped placeholder is deliberately excluded from the cache so it can never poison a later, in-budget lookup for the same id.
- `provenance.apply_provenance()` (and the buildsource castxml source extractor) now reuse each header's public/private/system classification across every declaration it produced, instead of reclassifying per declaration. Covered by dedicated tests proving the cache is actually hit (call-count spy on `classify_origin`), not just that overall output happens to be unchanged.

**Whole-snapshot cache (snapshot_cache.py / service_dump_cache.py / service.py)**
- `snapshot_cache.py` was a fully-implemented, fully-tested module with zero call sites anywhere in the dump path — completely dead code. It's now wired into `resolve_input()`'s binary-dump path via a new `service_dump_cache.py` (split out to keep `service.py` under the AI-readiness line cap), so a repeated release-baseline comparison can skip castxml/DWARF/ELF extraction and model construction entirely on a cache hit. This benefit reaches the plain single-pair CLI `compare` command too (verified: `cli_resolve._resolve_input` delegates straight to `service.resolve_input`), not just the Python API.
- Deliberately conservative gating (`_dump_is_cacheable`): a PDB path, DWARF root, debuginfod, forced debug format, symbols-only/debug-presence-only mode, a custom compile context, or the header-only semantic graph all bypass the cache — each changes `run_dump()`'s output in ways not (yet) folded into the cache key, so those shapes always take the live path rather than risk a stale/mismatched snapshot.
- `store()` now catches any exception, not just `OSError` — caching is a pure optimization sitting on top of a dump that already succeeded, so a write-time failure (e.g. an unexpected unserializable field) must never turn into a caller-visible error. Found via two previously-passing MCP tests that started failing once the cache path was actually exercised.
- The existing castxml-XML/clang-JSON AST caches now write atomically (temp file + `os.replace`) — needed now that two sides can extract concurrently and might race on an identical cache key. Covered by dedicated tests for both the success path and the OSError cleanup path (staging file removed on a failed write or a failed replace).
- The `extra` cache-key material (binary format, header-AST backend, public-header/dir sets) is joined with a NUL separator, not a printable one — a path can legally contain a comma or pipe, so a printable-delimiter join risked two different inputs (e.g. one path `"a,b"` vs. two paths `"a"`/`"b"`) collapsing to the same key. Regression-tested.
- Tests are isolated from the real `~/.cache/abi_check/snapshots/` via a new autouse `conftest.py` fixture, so unrelated tests sharing byte-identical fixture binaries can't collide through the now-active on-disk cache.

**Parallel old/new extraction (service.py)**
- `run_compare_request()` resolves the old and new sides concurrently (`ThreadPoolExecutor`) instead of sequentially — neither depends on the other until `compare_snapshots()`, and both are dominated by a subprocess call plus XML/JSON parsing, not GIL-held CPU work.
- `ABICHECK_PARALLEL_EXTRACTION=0` restores the old sequential behavior for memory-constrained runners comparing very large surfaces (roughly doubles peak RSS while both sides parse). Note: this currently benefits `run_compare_request`/`run_compare` and callers that route through it (Python API, directory/package fan-out, MCP server) — the single-pair CLI `compare a.so b.so` path (`cli_resolve._resolve_compare_snapshots`) still resolves sequentially; extending the same pattern there is a natural follow-up.
- Found and fixed a real order-dependent test (`test_headers_passed_as_public_headers`) that unpacked spy-recorded calls positionally — safe when resolution was sequential, a latent flake once it's concurrent. Fixed to match by path instead of position.

**oneDAL-shaped benchmark scenarios (scripts/benchmark_scaling.py)**
- `onedal_large_surface`: a large, almost entirely unchanged public surface with exactly one real change — stresses per-declaration overhead rather than the change itself.
- `onedal_packaging_noise`: public header surface unchanged, hundreds of bundled-dependency (ELF-only) exports removed — mirrors the reported oneDAL 2025.0→2025.1 case where the binary tier alone sees a break but public-header scoping must classify it as non-breaking. Gated by a runner that *asserts* the verdict never regresses to `BREAKING`, not just a timing measurement.
- `onedal_mass_removal`: a large public surface almost entirely removed with no additions (the reported ~2,134-removed-export shape). Also gated by a dedicated runner asserting the verdict stays `BREAKING` — added after review caught that the scenario's own docstring claimed this but nothing checked it, so an over-suppression regression would have silently gone undetected.
- All three slot into the existing tracemalloc/RSS/scaling-exponent harness and its parametrized smoke test with no additional plumbing.

## Investigated, found already implemented (no change needed)

- **Per-TU source-replay caching** and **changed-header → affected-TU scoping**: both already exist (`SourceAbiCache` in `buildsource/source_replay.py`, `select_compile_units`'s `"changed"` scope) — not novel gaps as the original roadmap assumed. The one real gap (`source_abi_cache_dir` has no CLI flag, only `ABICHECK_L4_CACHE_DIR`) is a discoverability nicety, not a missing capability; left as a documented follow-up since wiring it consistently touches `dump`/`dump --sources`/`scan` across several files for a modest UX win.

## Deliberately not implemented (with rationale)

- **Scope-first fingerprint/rename matching**: investigated in depth. The minimal-risk injection point (pre-filtering candidates in `_diff_fingerprint_renames` via `compute_public_surface()`) would silently change results for the several existing, exercised call sites that pass `scope_to_public_surface=False` (`cli_compare_release.py`, `cli_helpers_compare.py`, `cli_scan_baseline.py`), because every detector in this codebase shares a strict `(old, new) -> list[Change]` contract with no config parameter — there's no way for the detector to know the caller's scoping choice without a broader change to the detector-registry contract used by ~50 detectors. Shipping it without respecting that flag risks a real, silent correctness regression in a tool whose entire purpose is precise ABI comparison, so I deferred it rather than ship it half-right.

## Test plan

- [x] `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden" -q` — 15730 passed, 0 failed
- [x] `ruff check abicheck/ tests/` — clean
- [x] `mypy abicheck/` — 0 errors
- [x] `python scripts/check_ai_readiness.py` — 0 errors (same pre-existing warnings as `main`)
- [x] New/updated tests: `service_dump_cache.py` caching logic (incl. a cache-key-collision regression test), `snapshot_cache.py` serialization-failure resilience and the new `extra` key field, `run_compare_request`'s concurrency (barrier-based, not timing-based — deterministic), exception propagation, and the `ABICHECK_PARALLEL_EXTRACTION=0` escape hatch; `_atomic_write()`'s success and cleanup-on-failure paths; `origin_cache`'s cache-hit/differentiation behavior; the 3 new benchmark scenarios' smoke tests plus correctness assertions on both sides (non-breaking *and* breaking)
- [ ] Live castxml end-to-end run on a large real-world header set (e.g. actual oneDAL) — castxml is not installed in this sandbox

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [ ] Docs updated if user-visible behaviour changed — n/a (no user-visible behavior change; `ABICHECK_PARALLEL_EXTRACTION` is an escape hatch, not a new documented feature surface)
- [x] `pre-commit run --all-files` passes locally (ruff check/format + mypy run individually above)
- [x] No new `mypy` or `ruff` errors introduced
