### PR TITLE
fix: check selected Mach-O slice against WHEEL_ARCH claim in macOS deployment-target floor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,6 +213,13 @@ Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
   vector-math library (glibc 2.22+), which has no musl equivalent; a
   binary that only needs it (no `libc.so.6` DT_NEEDED entry) previously
   passed a musllinux claim unflagged (Codex review).
+  `check_macos_deployment_target_floor` no longer unconditionally skips
+  every fat/universal Mach-O: when `runtime_floors` also declares
+  `WHEEL_ARCH` and the selected slice (`MachoMetadata.cpu_type`) matches
+  that claim, the captured `min_os_version` unambiguously belongs to the
+  exact slice the wheel tag itself promises, so a real deployment-target
+  violation is no longer silently skipped just because the binary happens
+  to also carry other architecture slices (Codex review).
   Windows UCRT/runtime checks, CPU-ISA-baseline detection, the full
   per-tag closure policy, and end-to-end CLI auto-derivation from a
   compared wheel's own filename tag (every check above, including G10's

--- a/abicheck/diff_wheel_deployment.py
+++ b/abicheck/diff_wheel_deployment.py
@@ -96,16 +96,28 @@ def check_macos_deployment_target_floor(
     commonly has a genuinely higher real minimum (11.0, since Apple Silicon
     didn't exist before macOS 11) than its x86_64 slice, so attributing the
     single captured value to whichever slice the wheel tag claims isn't
-    reliable (Codex review #583, the deployment-target counterpart to the
-    same fat-binary ambiguity already handled for
+    reliable in general (Codex review #583, the deployment-target
+    counterpart to the same fat-binary ambiguity already handled for
     :func:`check_wheel_tag_architecture_mismatch` and
     :func:`abicheck.package.parse_macos_deployment_target_floor`).
+
+    Exception: when ``runtime_floors`` also declares a ``WHEEL_ARCH``
+    claim (see :func:`check_wheel_tag_architecture_mismatch`) *and* the
+    selected slice (:attr:`MachoMetadata.cpu_type`) matches that claim,
+    the captured ``min_os_version`` unambiguously belongs to the exact
+    slice the wheel tag itself promises — that's no longer a guess, so the
+    check still runs instead of skipping a real violation (Codex review
+    #583, follow-up).
     """
     if macho is None or not runtime_floors:
         return []
-    if len(getattr(macho, "cpu_types", None) or []) > 1:
-        return []
     floors = {k.upper(): v for k, v in runtime_floors.items()}
+    if len(getattr(macho, "cpu_types", None) or []) > 1:
+        claimed = (floors.get(_WHEEL_ARCH_KEY) or "").lower()
+        expected_cpu_types = _ARCH_CLAIM_TO_MACHO_CPU_TYPE.get(claimed)
+        selected_slice = (getattr(macho, "cpu_type", "") or "").upper()
+        if expected_cpu_types is None or selected_slice not in expected_cpu_types:
+            return []
     floor_raw = floors.get(_MACOS_DEPLOYMENT_TARGET_KEY)
     if not floor_raw:
         return []

--- a/tests/test_diff_wheel_deployment.py
+++ b/tests/test_diff_wheel_deployment.py
@@ -159,6 +159,57 @@ class TestMacosDeploymentTargetFloorUnit:
             == []
         )
 
+    def test_fat_binary_still_checked_when_selected_slice_matches_wheel_arch(
+        self,
+    ) -> None:
+        # Codex review #583, follow-up: when WHEEL_ARCH is also declared and
+        # matches the selected slice, min_os_version is no longer a guess —
+        # it unambiguously belongs to the exact slice the wheel tag claims,
+        # so a real violation must still be flagged rather than skipped.
+        macho = _macho(
+            cpu_type="X86_64",
+            cpu_types=["X86_64", "ARM64"],
+            min_os_version="11.0",
+        )
+        changes = check_macos_deployment_target_floor(
+            macho,
+            {"MACOS_DEPLOYMENT_TARGET": "10.9", "WHEEL_ARCH": "x86_64"},
+        )
+        assert len(changes) == 1
+        assert changes[0].kind is ChangeKind.MACOS_DEPLOYMENT_TARGET_RAISED
+
+    def test_fat_binary_skipped_when_selected_slice_does_not_match_wheel_arch(
+        self,
+    ) -> None:
+        # The selected slice (arm64, host-preferred) does not match the
+        # claimed x86_64 arch — its min_os_version can't be attributed to
+        # the x86_64 slice the wheel tag actually promises, so still skip.
+        macho = _macho(
+            cpu_type="ARM64",
+            cpu_types=["X86_64", "ARM64"],
+            min_os_version="11.0",
+        )
+        assert (
+            check_macos_deployment_target_floor(
+                macho,
+                {"MACOS_DEPLOYMENT_TARGET": "10.9", "WHEEL_ARCH": "x86_64"},
+            )
+            == []
+        )
+
+    def test_fat_binary_skipped_when_no_wheel_arch_declared(self) -> None:
+        macho = _macho(
+            cpu_type="X86_64",
+            cpu_types=["X86_64", "ARM64"],
+            min_os_version="11.0",
+        )
+        assert (
+            check_macos_deployment_target_floor(
+                macho, {"MACOS_DEPLOYMENT_TARGET": "10.9"}
+            )
+            == []
+        )
+
     def test_single_slice_binary_still_checked(self) -> None:
         macho = _macho(min_os_version="12.3", cpu_types=["X86_64"])
         changes = check_macos_deployment_target_floor(


### PR DESCRIPTION
## Summary

Follow-up fix to G27 (merged in #583): `check_macos_deployment_target_floor` now checks a fat/universal Mach-O's selected slice against a declared `WHEEL_ARCH` claim instead of unconditionally skipping every multi-slice binary.

## Motivation

`check_macos_deployment_target_floor` skipped the check entirely whenever a Mach-O carried more than one `cpu_types` slice, reasoning that `min_os_version` is only captured for the one slice `parse_macho_metadata` selected for the host, not per-slice — a legitimate general concern for fat binaries.

However, a Codex review round on #583 (after it merged) pointed out a real gap: when `runtime_floors` *also* declares a `WHEEL_ARCH` claim and the selected slice (`MachoMetadata.cpu_type`) matches that claim, the captured `min_os_version` unambiguously belongs to the exact slice the wheel tag itself promises — that's no longer a guess. Example: a `macosx_10_9_x86_64` wheel that accidentally ships a fat Mach-O parsed with `cpu_type='X86_64'`, `cpu_types=['X86_64', 'ARM64']`, and `min_os_version='11.0'` was silently passing despite its x86_64 slice exceeding the 10.9 promise.

## Changes

- `check_macos_deployment_target_floor` (`diff_wheel_deployment.py`): for a multi-slice Mach-O, only skips when `WHEEL_ARCH` is undeclared or doesn't match the selected slice; otherwise the check still runs.
- Added unit tests covering: fat binary where the selected slice matches `WHEEL_ARCH` (now flagged), doesn't match (still skipped), and no `WHEEL_ARCH` declared (still skipped, unchanged behavior).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Docs updated if user-visible behaviour changed (N/A — internal detector logic only)
- [x] Full fast test suite passes (16048 passed, 0 failed)
- [x] No new `mypy` or `ruff` errors introduced; `scripts/check_ai_readiness.py` clean (0 errors)

---
_Generated by [Claude Code](https://claude.ai/code/session_017abZCezU2Sw5aEKiMnvRvn)_