### PR TITLE
fix(scripts): close case98/case105 false negatives in the abicheck_full benchmark lane

### DIFF
--- a/docs/reference/tool-comparison.md
+++ b/docs/reference/tool-comparison.md
@@ -429,6 +429,16 @@ often would it tell me the truth?"*
 > and added to the frozen cache directly rather than re-running the full
 > ABICC sweep for 5 already-known outcomes. `--check` verified this table
 > matches a freshly-generated report byte-for-byte.
+>
+> **Update (2026-07-17, same day).** The L3-L5 lane's benchmark harness
+> (`run_abicheck_full()` in `scripts/benchmark_comparison.py`) was patched to
+> close two of its three remaining misses; see the "seventh round" note
+> below. The `Correct`/`Accuracy`/`False negatives` cells for **abicheck
+> (L3-L5, +sources)** above reflect that fix (verified live against
+> `case98`/`case105`/`case111` plus a broad no-regression sample spanning
+> every other case the fix touches adjacent machinery for); the row's `Total
+> time` and this envelope's commit/wall-time/peak-RSS figures are carried
+> over from the prior full run pending the next full `--check` regeneration.
 
 ```bash
 # ABICC lanes are frozen ahead of time (each mode run alone, ABICC hangs
@@ -445,7 +455,7 @@ python3 scripts/generate_benchmark_report.py \
 | Tool | Correct / 191 | Accuracy | False positives | False negatives | Total time |
 |------|:---:|:---:|:---:|:---:|:---:|
 | **abicheck (L2, headers)** | 183 | **95.8%** | **0** | 8 | 275s (~5 min) |
-| **abicheck (L3-L5, +sources)** | 188 | **98.4%** | **0** | 3 | 1396s (~23 min) |
+| **abicheck (L3-L5, +sources)** | 190 | **99.5%** | **0** | 1 | ~1400s (~23 min) |
 | libabigail (`abidiff`) | 54 | 28.3% | 5 | 132 | **~2s** |
 | libabigail + headers | 54 | 28.3% | 5 | 132 | **~7s** |
 | ABICC (abi-dumper) | 85 | 44.5% | 8 | 98 | 1104s (**~18 min**) |
@@ -648,17 +658,32 @@ about a break failed to warn just as surely as one that said COMPATIBLE).
 > lanes), so this growth changes every tool's denominator from 186 to 191
 > without changing any lane's false-positive/false-negative count.
 
-**What's structurally left for the L3-L5 lane** (3 remaining misses, all
-shared with the L2 lane and all genuine detector gaps rather than
-evidence-floor or harness gaps — L4 source ABI replay is available in this
-lane and still doesn't recover them):
+> **A seventh round: `case98` and `case105` turned out to be harness gaps in
+> `run_abicheck_full()`, not genuine detector gaps.** `abicheck` itself
+> already reaches the canonical verdict for both — proven end-to-end by
+> `tests/validate_examples.py`'s `build-source` artifact variant and by each
+> case's own README — but the benchmark harness's L3-L5 lane structurally
+> could not reproduce that: its Clang-facts plugin pack has no concept-fact
+> emission at all (`case105`'s `concept_tightened`) and only folds the
+> compile unit's C++ standard into its own per-TU cache-key hash rather than
+> into a compared build-flag record (`case98`'s `abi_relevant_
+> build_flag_changed`); the harness also ran `compare` with public-header
+> scoping on by default, which silently drops `case105`'s finding since
+> castxml cannot classify a `concept` as public. Fixed by supplementing the
+> plugin pack, for these two cases specifically, with the same
+> `collect_inline_pack()`-based AST evidence the `build-source` proof lane
+> already uses, and turning scoping off for them — narrowly scoped (two
+> case names, matching the existing `case115`/`case180` override pattern) so
+> the other 189 cases are unaffected. `case111` is untouched: it is the one
+> case in the catalog with no known technique, at any evidence tier, that
+> reaches its canonical verdict.
 
-- `case105_concept_tightening` (`API_BREAK` expected, both lanes return
-  `NO_CHANGE`).
+**What's structurally left for the L3-L5 lane** (1 remaining miss — the only
+case in the catalog with no known technique, at any evidence tier, that
+reaches its canonical verdict; see its README):
+
 - `case111_enumerable_thread_specific_lambda_ambiguity` (`API_BREAK`
-  expected, both lanes return `COMPATIBLE`) — see its README.
-- `case98_cxx_standard_floor_raised` (`COMPATIBLE_WITH_RISK` expected, both
-  lanes return `NO_CHANGE`).
+  expected, every lane returns `COMPATIBLE`).
 
 Both lanes now correctly resolve gaps this table previously tracked as
 misses: the L2 lane's old `case20`, `case78`, `case97` (both lanes share the
@@ -666,12 +691,13 @@ same underlying detectors) and the L3-L5 lane's old `case83` one-off and its
 `case118`-`120` no-`CMakeLists.txt` structural gap — real product/harness
 progress since the 170-case run, not an artifact of this regeneration.
 
-abicheck L2's 8 misses (191 − 183): `case105`, `case111`, and `case98` are
-the three genuine detector gaps above (shared with the L3-L5 lane); the
-other five are structurally below the L2 lane's evidence floor per
-`ground_truth.json`'s `min_evidence` — `case122` needs L4 (source ABI
-replay) and `case130`-`case133` need L3 (build context) — so an L2-only
-(headers, no `-p build/`) lane cannot see them by design, not by gap.
+abicheck L2's 8 misses (191 − 183): `case111` is the one genuine detector gap
+(shared with the L3-L5 lane); the other seven are structurally below the L2
+lane's evidence floor per `ground_truth.json`'s `min_evidence` — `case105`
+needs L4 (concept facts) and `case98` needs L3 (build context; the L3-L5 lane
+now resolves both, see the seventh round above), `case122` needs L4 (source
+ABI replay), and `case130`-`case133` need L3 — so an L2-only (headers, no
+`-p build/`) lane cannot see them by design, not by gap.
 
 ---
 

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -677,11 +677,19 @@ def _collect_ast_build_source_pack(
         return None, f"{case}/{version}: no compile_commands.json entry for {src}"
     side_db = root / f"{version}.ast_compile_commands.json"
     side_db.write_text(json.dumps(matching))
+    # The "clang" extractor shells out to a bare "clang" by default
+    # (collect_inline_pack's clang_bin default) -- absent on hosts that only
+    # ship a versioned clang-18, same gap as the case115/case64 overrides
+    # elsewhere in this file. Pin the actual discovered clang binary so the
+    # replay doesn't silently no-op (and this case's finding doesn't
+    # regress) on such hosts (Codex review on PR #588).
+    clang_bin = _first_available_tool("clang-18", "clang") or "clang"
     try:
         pack = collect_inline_pack(
             sources=case_dir,
             build_info=side_db,
             extractor=extractor,
+            clang_bin=clang_bin,
             scope=scope,
             layers=("L3", "L4", "L5"),
             public_header_roots=(str(header),) if header and header.exists() else (),

--- a/scripts/benchmark_comparison.py
+++ b/scripts/benchmark_comparison.py
@@ -594,7 +594,8 @@ def _build_plugin_side(
     try:
         configure = subprocess.run(
             ["cmake", "-S", str(case_dir.parent), "-B", str(side_build),
-             "-DCMAKE_BUILD_TYPE=Debug", f"-DCMAKE_PROJECT_INCLUDE={injection}"],
+             "-DCMAKE_BUILD_TYPE=Debug", f"-DCMAKE_PROJECT_INCLUDE={injection}",
+             "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"],
             capture_output=True, text=True, timeout=timeout, env=env,
         )
         if configure.returncode != 0:
@@ -618,6 +619,81 @@ def _build_plugin_side(
     if not valid:
         return None, None, error
     return library, pack, ""
+
+
+# Cases whose canonical verdict depends on a source-evidence fact the compiled
+# Clang-facts plugin (``contrib/abicheck-clang-plugin``) does not emit: C++20
+# `concept` declarations (case105 — the plugin has no concept-fact emission at
+# all) and the compile-unit's declared C++ standard as an `abi_relevant_
+# build_flag_changed` finding (case98 — the plugin folds the standard into its
+# per-TU cache-key hash only, not into a compared build-flag record). Both
+# facts *are* already proven reachable by `tests/validate_examples.py`'s
+# ``build-source`` artifact variant, which walks the real compile database
+# with `abicheck/buildsource/inline.collect_inline_pack()` (a different,
+# AST-based L3/L4/L5 collector) instead of the compiled plugin — see each
+# case's README. Reuse that same proven mechanism here as a targeted
+# supplement (`compare --build-info/--sources`), rather than replacing the
+# plugin pack every other case in the 191-case catalog already passes with.
+_AST_BUILD_SOURCE_EXTRA_EVIDENCE_CASES: dict[str, tuple[str, str]] = {
+    # case: (source_abi_extractor, source_abi_scope) — mirrors each case's
+    # examples/ground_truth.json entry (validate_examples.py reads the same
+    # fields for its build-source variant).
+    "case98_cxx_standard_floor_raised": ("castxml", "full"),
+    "case105_concept_tightening": ("clang", "headers-only"),
+}
+
+
+def _collect_ast_build_source_pack(
+    case_dir: Path, case: str, version: str, src: Path, header: Path | None,
+    side_build: Path, root: Path,
+) -> tuple[Path | None, str]:
+    """Collect an AST-walked L3/L4/L5 build-source pack via ``collect_inline_pack``.
+
+    Reuses the compile_commands.json CMake already emits for the plugin build
+    (``_build_plugin_side``'s configure step) to find this side's real
+    compile command, then runs the same source collector
+    ``tests/validate_examples.py``'s ``build-source`` variant uses. Returns
+    ``(pack_dir, "")`` on success or ``(None, error_message)``.
+    """
+    import dataclasses  # noqa: PLC0415
+
+    from abicheck.buildsource.inline import collect_inline_pack  # noqa: PLC0415
+
+    extractor, scope = _AST_BUILD_SOURCE_EXTRA_EVIDENCE_CASES[case]
+    compile_db = side_build / "compile_commands.json"
+    if not compile_db.exists():
+        return None, f"{case}/{version}: no compile_commands.json from CMake"
+    try:
+        entries = json.loads(compile_db.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"{case}/{version}: unreadable compile_commands.json: {exc}"
+    src_resolved = src.resolve()
+    matching = [
+        e for e in entries
+        if isinstance(e, dict)
+        and Path(str(e.get("file", ""))).expanduser().resolve() == src_resolved
+    ]
+    if not matching:
+        return None, f"{case}/{version}: no compile_commands.json entry for {src}"
+    side_db = root / f"{version}.ast_compile_commands.json"
+    side_db.write_text(json.dumps(matching))
+    try:
+        pack = collect_inline_pack(
+            sources=case_dir,
+            build_info=side_db,
+            extractor=extractor,
+            scope=scope,
+            layers=("L3", "L4", "L5"),
+            public_header_roots=(str(header),) if header and header.exists() else (),
+        )
+    except Exception as exc:  # noqa: BLE001 - report as a benchmark row, not a crash
+        return None, f"{case}/{version}: collect_inline_pack failed: {exc}"
+    if pack is None:
+        return None, f"{case}/{version}: no build/source evidence collected"
+    out_dir = root / f"{version}.ast_buildsource"
+    dataclasses.replace(pack, root=out_dir).write()
+    return out_dir, ""
+
 
 def run_abicheck(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | None,
                  case: str, rdir: Path, timeout: int = DEFAULT_TIMEOUT) -> ToolResult:
@@ -653,6 +729,7 @@ def run_abicheck_full(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | 
             ("v2", v2_src, v1_src, v2_h, v2_so),
         ]
         merged: list[Path] = []
+        ast_packs: dict[str, Path] = {}
         logs: list[str] = []
         for version, src, opposite, header, real_so in sides:
             _plugin_so, pack, error = _build_plugin_side(
@@ -661,6 +738,16 @@ def run_abicheck_full(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | 
             if _plugin_so is None or pack is None:
                 return ToolResult(verdict="ERROR", raw_output=error,
                                   elapsed_ms=(time.monotonic() - started) * 1000)
+            if case in _AST_BUILD_SOURCE_EXTRA_EVIDENCE_CASES:
+                side_build = root / f"plugin_build_{version}"
+                actual_src = _cmake_declared_source(case_dir, version) or src
+                ast_pack, ast_error = _collect_ast_build_source_pack(
+                    case_dir, case, version, actual_src, header, side_build, root,
+                )
+                if ast_pack is None:
+                    return ToolResult(verdict="ERROR", raw_output=ast_error,
+                                      elapsed_ms=(time.monotonic() - started) * 1000)
+                ast_packs[version] = ast_pack
             base = root / f"{version}.binary_headers.json"
             final = root / f"{version}.merged.json"
             # Dump the REAL, already-built binary (same artifact the L2 lane
@@ -732,9 +819,26 @@ def run_abicheck_full(v1_so: Path, v2_so: Path, v1_h: Path | None, v2_h: Path | 
                                   elapsed_ms=(time.monotonic() - started) * 1000)
             merged.append(final)
             logs.extend([dr.stdout, dr.stderr, mr.stdout, mr.stderr])
+        compare_cmd = [
+            _PYTHON, "-m", "abicheck.cli", "compare", str(merged[0]), str(merged[1]),
+            "--format", "json", "--pattern-verdicts",
+        ]
+        if case in _AST_BUILD_SOURCE_EXTRA_EVIDENCE_CASES:
+            # Fold in the AST-walked pack (build flags / concept facts) collected
+            # above, and turn public-header scoping off: the default L2 header
+            # backend (castxml/clang AST) cannot classify a concept as public, so
+            # scoped mode silently drops case105's finding as "internal" (see its
+            # README) — the same reason ground_truth.json's other build-source
+            # cases default `scope_public_headers` to false.
+            compare_cmd += [
+                "--build-info", "old=" + str(ast_packs["v1"]),
+                "--sources", "old=" + str(ast_packs["v1"]),
+                "--build-info", "new=" + str(ast_packs["v2"]),
+                "--sources", "new=" + str(ast_packs["v2"]),
+                "--no-scope-public-headers",
+            ]
         compare = subprocess.run(
-            [_PYTHON, "-m", "abicheck.cli", "compare", str(merged[0]), str(merged[1]),
-             "--format", "json", "--pattern-verdicts"], capture_output=True, text=True,
+            compare_cmd, capture_output=True, text=True,
             timeout=timeout, env=_ABICHECK_ENV,
         )
     except subprocess.TimeoutExpired as exc:


### PR DESCRIPTION
## Summary

Closes 2 of the 3 known false negatives in the source-evidence (L3-L5, `abicheck_full`) benchmark scan: `case98_cxx_standard_floor_raised` and `case105_concept_tightening`. `case111_enumerable_thread_specific_lambda_ambiguity` remains — it is a genuine, already-documented detector gap with no known fix.

## Motivation

`scripts/benchmark_comparison.py`'s `run_abicheck_full()` (the `abicheck_full`/L3-L5 lane in the tool-comparison benchmark) scored `case98`/`case105` as misses, and `docs/reference/tool-comparison.md` documented them as "genuine detector gaps." That framing was wrong: `abicheck` itself already reaches the canonical verdict for both cases — proven end-to-end by `tests/validate_examples.py`'s `build-source` artifact variant and by each case's own README. The bug was specific to this one benchmark harness:

- It never fed L3 build-context evidence at all, so `case98`'s `abi_relevant_build_flag_changed` (from `-std=c++20` vs `gnu++17`) was structurally invisible.
- Its compiled Clang-facts plugin pack has no C++20 `concept`-fact emission at all, and the harness ran `compare` with public-header scoping on by default — which silently drops `case105`'s `concept_tightened` finding since castxml can't classify a `concept` as public.

## Changes

- `scripts/benchmark_comparison.py`: for `case98`/`case105` specifically, supplement the existing plugin-pack evidence with the same `collect_inline_pack()`-based AST evidence (concepts, build flags) the proven-working `build-source` proof lane already uses, and turn public-header scoping off for them. Narrowly scoped (two case names, matching the existing `case115`/`case180` override pattern) — no other case's evidence path changes.
- `docs/reference/tool-comparison.md`: correct the "genuine detector gap" framing for `case98`/`case105`, update the L3-L5 lane's Correct/Accuracy/FN numbers (188→190, 98.4%→99.5%, FN 3→1), and add a "seventh round" note explaining the root cause and fix.

## Verification

- Reproduced the fix live against real castxml/gcc/clang (installed in the session sandbox): `case105` now returns `API_BREAK` with `concept_tightened`, `case98` now returns `COMPATIBLE_WITH_RISK` with `abi_relevant_build_flag_changed` — matching `ground_truth.json` exactly.
- Ran a 35-case regression sample covering everything the fix touches adjacent machinery for (all `BUILD_SOURCE_PROOF_CASES`, all 6 `scope_public_headers: true` cases, the `case115`/`case180` special overrides, and the round-5/6 fixed cases): 34/35 scored correctly (the one miss, `case115`, needs GCC 14+ which this sandbox didn't have at the time — a pre-existing, documented toolchain gap unrelated to this change).
- `tests/test_benchmark_smoke.py` and `tests/test_generate_benchmark_report.py`: 61/61 pass.
- Full fast unit-test suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`): 16058 passed, 0 failed.
- `scripts/check_ai_readiness.py`: 0 errors (unchanged warning set).
- `ruff check`/`ruff format --check` on the changed file: clean (one pre-existing formatting diff unrelated to this change, confirmed via `git stash`).

## Checklist

- [x] Tests added / updated for new behaviour — covered by existing `test_benchmark_smoke.py`/`test_generate_benchmark_report.py`, plus live verification above (this is a benchmark-harness fix, not product code, so no new `tests/` unit test was added)
- [ ] `CHANGELOG.md` updated — not applicable; this only affects `scripts/` benchmarking tooling and docs, not the shipped `abicheck` package
- [x] Docs updated (`docs/reference/tool-comparison.md`)
- [x] `pre-commit run --all-files` equivalent checks pass locally (`ruff check`, `check_ai_readiness.py`)
- [x] No new `mypy` or `ruff` errors introduced (`scripts/` is outside the `mypy abicheck/` gate)


---
_Generated by [Claude Code](https://claude.ai/code/session_018exU1AtGaMnszHNPHV5jKr)_