### PR TITLE
fix: cv-neutral callback params and legacy volatile-variable noise

### DIFF
--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -62,6 +62,7 @@ from .diff_symbols_scalar import (  # noqa: F401  (public-surface re-exports)
     _canonical_int_spelling as _canonical_int_spelling,
     _scalar_repr as _scalar_repr,
 )
+from .diff_symbols_variables import _check_variable_alignment, _without_top_level_const
 from .dumper_castxml import is_synthetic_ctor_key, is_synthetic_dtor_key
 from .elf_symbol_filter import (
     FUNCTION_SYMBOL_TYPES,
@@ -1102,90 +1103,17 @@ def _diff_inline_hidden_friends(
     return changes
 
 
-def _check_variable_alignment(
-    mangled: str, v_old: Variable, v_new: Variable
+def _check_variable(
+    mangled: str, v_old: Variable, v_new: Variable, *, cv_facts_reliable: bool = True
 ) -> list[Change]:
-    """Emit a change when a variable's declared alignment changed.
+    """Compare a matched pair of public variables.
 
-    Tri-state: None = not captured (older snapshots / dumpers without
-    alignment support) — skip rather than compare.
+    *cv_facts_reliable* mirrors ``diff_types._field_type_genuinely_changed``:
+    a pre-v9 CastXML snapshot silently dropped ``volatile`` from a variable's
+    type spelling (no dedicated ``is_volatile`` fact to fall back on, unlike
+    ``TypeField``), so an unchanged legacy-vs-fresh pair would otherwise
+    misreport a breaking ``VAR_TYPE_CHANGED`` (Codex review, PR #582).
     """
-    if v_old.alignment_bits is None or v_new.alignment_bits is None:
-        return []
-    if v_old.alignment_bits == v_new.alignment_bits:
-        return []
-    return [
-        make_change(
-            ChangeKind.VAR_ALIGNMENT_CHANGED,
-            symbol=mangled,
-            name=v_old.name,
-            old=str(v_old.alignment_bits),
-            new=str(v_new.alignment_bits),
-        )
-    ]
-
-
-_TRAILING_CONST_RE = re.compile(r"\s*\bconst\b\s*$")
-_LEADING_CONST_TOKEN_RE = re.compile(r"^\s*\bconst\b\s*")
-
-
-def _has_top_level_pointer_or_ref(canonical_type: str) -> bool:
-    """True if *canonical_type* has a ``*``/``&`` outside any ``<...>``
-    template-argument bracket.
-
-    A plain substring search for ``*``/``&`` would also match one nested
-    *inside* a template argument (e.g. ``std::vector<int *>`` — a by-value
-    vector of pointers, not itself a pointer), wrongly routing a pure
-    top-level const flip on that by-value variable into the
-    pointer/reference branch below, which only strips a *trailing* const —
-    but the top-level const here is leading (Codex review).
-    """
-    depth = 0
-    for ch in canonical_type:
-        if ch == "<":
-            depth += 1
-        elif ch == ">":
-            depth = max(0, depth - 1)
-        elif ch in "*&" and depth == 0:
-            return True
-    return False
-
-
-def _without_top_level_const(canonical_type: str) -> str:
-    """Strip the *top-level* ``const`` from an already-canonicalized type name.
-
-    ``canonicalize_type_name`` normalizes a leading ``const T`` to ``T
-    const`` (moving the qualifier immediately after what it qualifies) —
-    but only when the base type has no template args (``"<...>"``); for a
-    templated base it deliberately leaves the spelling untouched, so a
-    top-level const on e.g. ``std::vector<int>`` stays leading
-    (``"const std::vector<int>"``), not trailing.
-
-    So which end is "top-level" depends on whether a pointer/reference
-    sigil is present, not on template-ness:
-
-    - No ``*``/``&`` at all: the *whole object* is what's qualified, so a
-      const at *either* end (leading, for a templated base; trailing, the
-      east-const form for a non-template base) is the top-level qualifier
-      — strip whichever is present.
-    - A ``*``/``&`` present: the top-level (pointer-itself) qualifier is
-      always the trailing token (``"int * const"``, or ``"std::vector<int>
-      * const"``) regardless of template-ness. A *leading* const there
-      (``"int const *"``, ``"const std::vector<int> *"``) qualifies the
-      pointee, not the pointer, and must NOT be stripped — collapsing it
-      would hide a real type change (the pointer itself is still writable;
-      only what it points to changed) behind a misleading "variable became
-      const" (Codex review, x2: the original non-template pointee-const
-      case, and the templated-base variant of the same issue).
-    """
-    if _has_top_level_pointer_or_ref(canonical_type):
-        return _TRAILING_CONST_RE.sub("", canonical_type)
-    stripped = _LEADING_CONST_TOKEN_RE.sub("", canonical_type)
-    return _TRAILING_CONST_RE.sub("", stripped)
-
-
-def _check_variable(mangled: str, v_old: Variable, v_new: Variable) -> list[Change]:
-    """Compare a matched pair of public variables."""
     changes = _check_variable_alignment(mangled, v_old, v_new)
     # RD2-5: a stripped side reports type "?"; unknown is not a type change.
     if _type_unknown(v_old.type) or _type_unknown(v_new.type):
@@ -1204,7 +1132,8 @@ def _check_variable(mangled: str, v_old: Variable, v_new: Variable) -> list[Chan
             v_old.is_const != v_new.is_const
             and _without_top_level_const(canon_old) == _without_top_level_const(canon_new)
         )
-        if not is_pure_const_flip:
+        legacy_cv_noise = not cv_facts_reliable and func_signature_cv_only_differ(canon_old, canon_new)
+        if not is_pure_const_flip and not legacy_cv_noise:
             return changes + [
                 make_change(
                     ChangeKind.VAR_TYPE_CHANGED,
@@ -1254,12 +1183,13 @@ def _var_added(mangled: str, v_new: Variable) -> list[Change]:
 
 @registry.detector("variables")
 def _diff_variables(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
+    cv_facts_reliable = old.header_cv_facts_reliable and new.header_cv_facts_reliable
     return diff_by_key(
         _public_variables(old),
         _public_variables(new),
         on_removed=_var_removed,
         on_added=_var_added,
-        on_common=_check_variable,
+        on_common=lambda m, o, n: _check_variable(m, o, n, cv_facts_reliable=cv_facts_reliable),
     )
 
 

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -1132,8 +1132,16 @@ def _check_variable(
             v_old.is_const != v_new.is_const
             and _without_top_level_const(canon_old) == _without_top_level_const(canon_new)
         )
-        legacy_cv_noise = not cv_facts_reliable and func_signature_cv_only_differ(canon_old, canon_new)
-        if not is_pure_const_flip and not legacy_cv_noise:
+        if not is_pure_const_flip:
+            if not cv_facts_reliable and func_signature_cv_only_differ(canon_old, canon_new):
+                # Legacy-snapshot cv noise: the type-string difference itself
+                # is untrustworthy (see this function's docstring), so don't
+                # fall through to the const-transition check below either —
+                # is_const may be equally unreliable for the same reason,
+                # and falling through would just resurface the same false
+                # positive as VAR_BECAME_CONST/VAR_LOST_CONST instead of
+                # VAR_TYPE_CHANGED (Codex review, PR #589).
+                return changes
             return changes + [
                 make_change(
                     ChangeKind.VAR_TYPE_CHANGED,

--- a/abicheck/diff_symbols_variables.py
+++ b/abicheck/diff_symbols_variables.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Public-variable comparison helpers: alignment changes and top-level
+const/reference-aware type-spelling normalization.
+
+Leaf module (must not import from ``diff_symbols`` to avoid an import
+cycle). ``diff_symbols._check_variable`` is the sole caller.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .checker_policy import ChangeKind
+from .checker_types import Change
+from .diff_helpers import make_change
+from .model import Variable
+
+
+def _check_variable_alignment(
+    mangled: str, v_old: Variable, v_new: Variable
+) -> list[Change]:
+    """Emit a change when a variable's declared alignment changed.
+
+    Tri-state: None = not captured (older snapshots / dumpers without
+    alignment support) — skip rather than compare.
+    """
+    if v_old.alignment_bits is None or v_new.alignment_bits is None:
+        return []
+    if v_old.alignment_bits == v_new.alignment_bits:
+        return []
+    return [
+        make_change(
+            ChangeKind.VAR_ALIGNMENT_CHANGED,
+            symbol=mangled,
+            name=v_old.name,
+            old=str(v_old.alignment_bits),
+            new=str(v_new.alignment_bits),
+        )
+    ]
+
+
+_TRAILING_CONST_RE = re.compile(r"\s*\bconst\b\s*$")
+_LEADING_CONST_TOKEN_RE = re.compile(r"^\s*\bconst\b\s*")
+
+
+def _has_top_level_pointer_or_ref(canonical_type: str) -> bool:
+    """True if *canonical_type* has a ``*``/``&`` outside any ``<...>``
+    template-argument bracket.
+
+    A plain substring search for ``*``/``&`` would also match one nested
+    *inside* a template argument (e.g. ``std::vector<int *>`` — a by-value
+    vector of pointers, not itself a pointer), wrongly routing a pure
+    top-level const flip on that by-value variable into the
+    pointer/reference branch below, which only strips a *trailing* const —
+    but the top-level const here is leading (Codex review).
+    """
+    depth = 0
+    for ch in canonical_type:
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif ch in "*&" and depth == 0:
+            return True
+    return False
+
+
+def _without_top_level_const(canonical_type: str) -> str:
+    """Strip the *top-level* ``const`` from an already-canonicalized type name.
+
+    ``canonicalize_type_name`` normalizes a leading ``const T`` to ``T
+    const`` (moving the qualifier immediately after what it qualifies) —
+    but only when the base type has no template args (``"<...>"``); for a
+    templated base it deliberately leaves the spelling untouched, so a
+    top-level const on e.g. ``std::vector<int>`` stays leading
+    (``"const std::vector<int>"``), not trailing.
+
+    So which end is "top-level" depends on whether a pointer/reference
+    sigil is present, not on template-ness:
+
+    - No ``*``/``&`` at all: the *whole object* is what's qualified, so a
+      const at *either* end (leading, for a templated base; trailing, the
+      east-const form for a non-template base) is the top-level qualifier
+      — strip whichever is present.
+    - A ``*``/``&`` present: the top-level (pointer-itself) qualifier is
+      always the trailing token (``"int * const"``, or ``"std::vector<int>
+      * const"``) regardless of template-ness. A *leading* const there
+      (``"int const *"``, ``"const std::vector<int> *"``) qualifies the
+      pointee, not the pointer, and must NOT be stripped — collapsing it
+      would hide a real type change (the pointer itself is still writable;
+      only what it points to changed) behind a misleading "variable became
+      const" (Codex review, x2: the original non-template pointee-const
+      case, and the templated-base variant of the same issue).
+    """
+    if _has_top_level_pointer_or_ref(canonical_type):
+        return _TRAILING_CONST_RE.sub("", canonical_type)
+    stripped = _LEADING_CONST_TOKEN_RE.sub("", canonical_type)
+    return _TRAILING_CONST_RE.sub("", stripped)

--- a/abicheck/diff_symbols_variables.py
+++ b/abicheck/diff_symbols_variables.py
@@ -28,6 +28,7 @@ from .checker_policy import ChangeKind
 from .checker_types import Change
 from .diff_helpers import make_change
 from .model import Variable
+from .name_classification import _find_matching_close
 
 
 def _check_variable_alignment(
@@ -80,15 +81,16 @@ def _has_top_level_pointer_or_ref(canonical_type: str) -> bool:
     return False
 
 
-def _last_top_level_sigil_pos(canonical_type: str) -> int | None:
-    """Index of the last ``*``/``&`` outside any ``<...>`` bracket, or None.
-
-    Same "top-level" definition as ``_has_top_level_pointer_or_ref``, just
-    reporting the position instead of a boolean.
+def _last_sigil_in_range(canonical_type: str, start: int, end: int) -> int | None:
+    """Index of the last ``*``/``&`` in ``canonical_type[start:end]`` outside
+    any ``<...>`` bracket, or None. Same "top-level" definition as
+    ``_has_top_level_pointer_or_ref``, just reporting a position within a
+    sub-range instead of a whole-string boolean.
     """
     depth = 0
     pos = None
-    for i, ch in enumerate(canonical_type):
+    for i in range(start, end):
+        ch = canonical_type[i]
         if ch == "<":
             depth += 1
         elif ch == ">":
@@ -96,6 +98,47 @@ def _last_top_level_sigil_pos(canonical_type: str) -> int | None:
         elif ch in "*&" and depth == 0:
             pos = i
     return pos
+
+
+def _first_top_level_paren_span(canonical_type: str) -> tuple[int, int] | None:
+    """``(open_idx, close_idx)`` of the first top-level (non-``<...>``-
+    nested) ``(...)`` group, or None if there is none."""
+    depth = 0
+    for i, ch in enumerate(canonical_type):
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif ch == "(" and depth == 0:
+            close = _find_matching_close(canonical_type, i)
+            return i, min(close, len(canonical_type) - 1)
+    return None
+
+
+def _declarator_sigil_pos(canonical_type: str) -> int | None:
+    """Index of the variable's OWN declarator ``*``/``&``, as opposed to one
+    belonging to a parameter or array size nested further in the spelling.
+
+    A function-/array-pointer variable's canonical spelling is always
+    ``BaseType ( *quals)(...)``/``BaseType ( *quals)[...]`` — the FIRST
+    top-level ``(...)`` group is structurally this declarator (the actual
+    parameter list or array dimensions, if present, always comes after it).
+    Searching the whole string for the LAST top-level sigil instead (as an
+    earlier version of this function did) picks up a parameter's own
+    pointer sigil for a callback/function-pointer parameter (``"void (
+    *const)(int *)"`` — the last ``*`` is the parameter's, not the outer
+    declarator's), so its trailing ``const`` never gets recognized as the
+    variable's own (Codex review, PR #589). Falls back to the whole
+    string's last top-level sigil for a bare pointer with no parens at all
+    (``"int * const"``).
+    """
+    span = _first_top_level_paren_span(canonical_type)
+    if span is not None:
+        open_idx, close_idx = span
+        pos = _last_sigil_in_range(canonical_type, open_idx + 1, close_idx)
+        if pos is not None:
+            return pos
+    return _last_sigil_in_range(canonical_type, 0, len(canonical_type))
 
 
 def _strip_trailing_declarator_const(canonical_type: str) -> str:
@@ -112,7 +155,7 @@ def _strip_trailing_declarator_const(canonical_type: str) -> str:
     something that isn't actually this declarator's own qualifier
     (CodeRabbit review, PR #589).
     """
-    pos = _last_top_level_sigil_pos(canonical_type)
+    pos = _declarator_sigil_pos(canonical_type)
     if pos is not None:
         span_end = len(canonical_type)
         for k in range(pos + 1, len(canonical_type)):

--- a/abicheck/diff_symbols_variables.py
+++ b/abicheck/diff_symbols_variables.py
@@ -55,6 +55,7 @@ def _check_variable_alignment(
 
 _TRAILING_CONST_RE = re.compile(r"\s*\bconst\b\s*$")
 _LEADING_CONST_TOKEN_RE = re.compile(r"^\s*\bconst\b\s*")
+_CV_TOKEN_RE = re.compile(r"\b(?:const|volatile)\b")
 
 
 def _has_top_level_pointer_or_ref(canonical_type: str) -> bool:
@@ -79,6 +80,56 @@ def _has_top_level_pointer_or_ref(canonical_type: str) -> bool:
     return False
 
 
+def _last_top_level_sigil_pos(canonical_type: str) -> int | None:
+    """Index of the last ``*``/``&`` outside any ``<...>`` bracket, or None.
+
+    Same "top-level" definition as ``_has_top_level_pointer_or_ref``, just
+    reporting the position instead of a boolean.
+    """
+    depth = 0
+    pos = None
+    for i, ch in enumerate(canonical_type):
+        if ch == "<":
+            depth += 1
+        elif ch == ">":
+            depth = max(0, depth - 1)
+        elif ch in "*&" and depth == 0:
+            pos = i
+    return pos
+
+
+def _strip_trailing_declarator_const(canonical_type: str) -> str:
+    """Strip a top-level pointer/reference declarator's own trailing
+    ``const`` — whether at the absolute end of the string (a bare pointer,
+    ``"int * const"``) or immediately before the closing paren/bracket of a
+    function- or array-pointer declarator (``"void ( *const)()"``, ``"int
+    ( *const)[5]"`` — a variable whose type itself is a function or array
+    pointer, canonicalized with the qualifier directly after the ``*``, not
+    at the string's end). Only a run of pure cv tokens between the sigil and
+    that close counts; anything else there (a real parameter/element type)
+    means this isn't the simple ``"(*quals)"`` declarator shape, so fall
+    back to the plain end-of-string case rather than risk stripping
+    something that isn't actually this declarator's own qualifier
+    (CodeRabbit review, PR #589).
+    """
+    pos = _last_top_level_sigil_pos(canonical_type)
+    if pos is not None:
+        span_end = len(canonical_type)
+        for k in range(pos + 1, len(canonical_type)):
+            if canonical_type[k] in ")]":
+                span_end = k
+                break
+        span = canonical_type[pos + 1 : span_end]
+        if (
+            span_end < len(canonical_type)
+            and re.fullmatch(r"(?:\s|const|volatile)*", span)
+            and _CV_TOKEN_RE.search(span)
+        ):
+            new_span = re.sub(r"\bconst\b", "", span)
+            return canonical_type[: pos + 1] + new_span + canonical_type[span_end:]
+    return _TRAILING_CONST_RE.sub("", canonical_type)
+
+
 def _without_top_level_const(canonical_type: str) -> str:
     """Strip the *top-level* ``const`` from an already-canonicalized type name.
 
@@ -98,7 +149,9 @@ def _without_top_level_const(canonical_type: str) -> str:
       — strip whichever is present.
     - A ``*``/``&`` present: the top-level (pointer-itself) qualifier is
       always the trailing token (``"int * const"``, or ``"std::vector<int>
-      * const"``) regardless of template-ness. A *leading* const there
+      * const"``) regardless of template-ness — see
+      ``_strip_trailing_declarator_const`` for the function-/array-pointer
+      declarator's own variant of "trailing". A *leading* const there
       (``"int const *"``, ``"const std::vector<int> *"``) qualifies the
       pointee, not the pointer, and must NOT be stripped — collapsing it
       would hide a real type change (the pointer itself is still writable;
@@ -107,6 +160,6 @@ def _without_top_level_const(canonical_type: str) -> str:
       case, and the templated-base variant of the same issue).
     """
     if _has_top_level_pointer_or_ref(canonical_type):
-        return _TRAILING_CONST_RE.sub("", canonical_type)
+        return _strip_trailing_declarator_const(canonical_type)
     stripped = _LEADING_CONST_TOKEN_RE.sub("", canonical_type)
     return _TRAILING_CONST_RE.sub("", stripped)

--- a/abicheck/diff_symbols_variables.py
+++ b/abicheck/diff_symbols_variables.py
@@ -141,6 +141,25 @@ def _declarator_sigil_pos(canonical_type: str) -> int | None:
     return _last_sigil_in_range(canonical_type, 0, len(canonical_type))
 
 
+def _has_real_trailing_group(canonical_type: str, after: int) -> bool:
+    """True if a top-level ``(...)``/``[...]`` group (skipping only
+    whitespace) starts at or after index *after*.
+
+    Used to recognize a member-function-POINTER's own trailing cv (``"void
+    (C:: *)(int) const"`` — the pointer points to a const member function):
+    once a REAL parameter list or array-dimension group follows the
+    declarator, anything trailing after IT is that group's own business
+    (member-function cv-qualification, a genuinely different, non-
+    interchangeable type — confirmed against real g++ mangling), never the
+    bare-pointer "trailing own const" case the end-of-string fallback below
+    exists for (CodeRabbit review, PR #589).
+    """
+    k = after
+    while k < len(canonical_type) and canonical_type[k].isspace():
+        k += 1
+    return k < len(canonical_type) and canonical_type[k] in "(["
+
+
 def _strip_trailing_declarator_const(canonical_type: str) -> str:
     """Strip a top-level pointer/reference declarator's own trailing
     ``const`` — whether at the absolute end of the string (a bare pointer,
@@ -151,9 +170,13 @@ def _strip_trailing_declarator_const(canonical_type: str) -> str:
     at the string's end). Only a run of pure cv tokens between the sigil and
     that close counts; anything else there (a real parameter/element type)
     means this isn't the simple ``"(*quals)"`` declarator shape, so fall
-    back to the plain end-of-string case rather than risk stripping
-    something that isn't actually this declarator's own qualifier
-    (CodeRabbit review, PR #589).
+    back to the plain end-of-string case — UNLESS a real parameter list or
+    array-dimension group follows the declarator (see
+    :func:`_has_real_trailing_group`), in which case a trailing end-of-string
+    ``const``/``volatile`` belongs to THAT group, not this declarator, and
+    must be left untouched entirely rather than risk stripping something
+    that isn't actually this declarator's own qualifier (CodeRabbit review,
+    PR #589, x2).
     """
     pos = _declarator_sigil_pos(canonical_type)
     if pos is not None:
@@ -179,6 +202,8 @@ def _strip_trailing_declarator_const(canonical_type: str) -> str:
             # compare unequal (Codex review, PR #589).
             new_span = re.sub(r"\bconst\b", "", span).strip()
             return canonical_type[: pos + 1] + new_span + canonical_type[span_end:]
+        if span_end < len(canonical_type) and _has_real_trailing_group(canonical_type, span_end + 1):
+            return canonical_type
     return _TRAILING_CONST_RE.sub("", canonical_type)
 
 

--- a/abicheck/diff_symbols_variables.py
+++ b/abicheck/diff_symbols_variables.py
@@ -168,7 +168,16 @@ def _strip_trailing_declarator_const(canonical_type: str) -> str:
             and re.fullmatch(r"(?:\s|const|volatile)*", span)
             and _CV_TOKEN_RE.search(span)
         ):
-            new_span = re.sub(r"\bconst\b", "", span)
+            # .strip(): canonicalize_type_name never puts whitespace directly
+            # after the sigil or directly before the declarator's closing
+            # bracket (e.g. an unchanged volatile-only declarator canonicalizes
+            # to "( *volatile)", not "( * volatile)") — removing "const" from
+            # a combined "const volatile"/"volatile const" span leaves a
+            # separator space stranded at whichever end "const" vacated,
+            # which must be trimmed to match that convention or an unrelated,
+            # unchanged volatile qualifier makes the two sides spuriously
+            # compare unequal (Codex review, PR #589).
+            new_span = re.sub(r"\bconst\b", "", span).strip()
             return canonical_type[: pos + 1] + new_span + canonical_type[span_end:]
     return _TRAILING_CONST_RE.sub("", canonical_type)
 

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -456,8 +456,62 @@ def _strip_cv_in_segment(name: str, chars: list[str], start: int, end: int, *, s
             continue
         if ch == "(":
             j = min(_find_matching_close(name, i), end - 1)
+            k = j + 1
+            while k < end and name[k].isspace():
+                k += 1
+            if k < end and name[k] in "([":
+                # A pointer/pointer-to-member DECLARATOR-GROUPING paren --
+                # e.g. the "(*)"/"(*const)"/"(C::*)" in "RetType
+                # (*)(Params)"/"RetType (C::*)(Params)" -- recognized
+                # structurally by being immediately followed by ANOTHER
+                # top-level paren/bracket (the real parameter list or array
+                # dimensions), regardless of what's inside it (a bare
+                # sigil, or a qualified pointer-to-member "Class::*" —
+                # deliberately NOT restricted to "only sigils/cv tokens
+                # inside", since that missed the class-qualified case:
+                # Codex review, PR #589, round 2). It is NOT itself a
+                # nested parameter list, so don't open a fresh strict scope
+                # for it: its "*" is the CURRENT (possibly
+                # nested-callback-parameter's own) declarator's top-level
+                # sigil and must stay visible to it. Recursing here would
+                # hide that "*" inside an isolated call whose own
+                # last_ptr_pos never reaches this scope's tracking, so a
+                # callback parameter that is itself a function pointer with
+                # a cv-qualified return type (``void(*)(int (*)())`` vs.
+                # ``void(*)(const int (*)())`` — confirmed distinct,
+                # non-interchangeable types by real g++ mangling) had its
+                # return-type cv wrongly treated as the callback
+                # parameter's own neutral by-value qualifier instead. Just
+                # step past the "(" and let this same scan process the
+                # interior in place.
+                i += 1
+                continue
             _strip_cv_in_segment(name, chars, i + 1, j, strict=True)
             i = j + 1
+            # A cv qualifier immediately following a REAL parameter list's
+            # closing paren is a member-function-POINTER's own
+            # cv-qualification (e.g. "void (C::*)(int) const" — the pointer
+            # points to a const member function) — a genuinely different,
+            # non-interchangeable type (confirmed against real g++
+            # mangling: two same-named overloads differing only in this
+            # trailing const compile as distinct symbols, matching the
+            # existing FUNC_CV_CHANGED precedent for a member function's
+            # own const/volatile). Never neutral, regardless of strict/
+            # non-strict context or position relative to any pointer
+            # sigil — leave it completely untouched rather than stripping
+            # it (permissive/non-strict mode) or treating it as a
+            # stripping candidate (strict mode) (CodeRabbit review, PR
+            # #589).
+            k = i
+            while k < end and name[k].isspace():
+                k += 1
+            m = _CV_TOKEN_RE.match(name, k)
+            while m and m.end() <= end:
+                k = m.end()
+                while k < end and name[k].isspace():
+                    k += 1
+                m = _CV_TOKEN_RE.match(name, k)
+            i = k
             continue
         if strict and ch == ",":
             _flush()

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -370,8 +370,7 @@ _CV_TOKEN_RE = re.compile(r"\b(?:const|volatile)\b")
 
 def _strip_cv_qualifiers(name: str) -> str:
     """Return *name* with ``const`` / ``volatile`` tokens removed — but only
-    at bracket depth 0 (not nested inside a template argument list,
-    function-parameter list, or array subscript).
+    outside a template-argument list or array subscript.
 
     A cv qualifier nested inside a template argument
     (``Box<const int>`` vs. ``Box<int>``) names a genuinely different,
@@ -384,21 +383,32 @@ def _strip_cv_qualifiers(name: str) -> str:
     parameter changing from ``Box<int, int>`` to ``Box<int, const int>``)
     as a harmless cv-only difference, silently suppressing a real breaking
     ``FUNC_PARAMS_CHANGED``/``FUNC_RETURN_CHANGED`` finding (Codex/
-    CodeRabbit review, PR #582). Depth tracking mirrors
-    :func:`_has_top_level_ptr_or_ref`.
+    CodeRabbit review, PR #582).
 
-    Whitespace introduced by the removal is collapsed, and spaces adjacent to
-    pointer/reference sigils are normalised so that ``const char *`` and
-    ``char *`` reduce to the same string.
+    ``(...)`` is NOT one of the blocking brackets: it spells a function
+    type's parameter list (a plain function-pointer type, or a nested
+    callback parameter of one), and a top-level/by-value cv qualifier
+    there is dropped from the function type for mangling purposes at
+    *every* nesting level, not just the outermost — confirmed against real
+    clang/gcc output (``void f(void (*)(int))`` and ``void g(void (*)(const
+    int))`` mangle identically). An earlier version of this depth tracking
+    also blocked on ``(``/``)``, which made a cv-neutral callback parameter
+    (e.g. ``const`` added to a callback's own by-value ``int`` parameter)
+    misfire the same breaking ``FUNC_PARAMS_CHANGED`` path this function
+    exists to prevent (Codex review, PR #582).
+
+    Whitespace introduced by the removal is collapsed; spaces adjacent to
+    pointer/reference sigils and parentheses are normalised so that
+    ``const char *`` / ``char *`` and ``void (*)(int)`` / ``void (*)( int
+    )`` each reduce to the same string.
     """
-    depth = 0
     chars = list(name)
     for m in _CV_TOKEN_RE.finditer(name):
         depth = 0
         for ch in name[: m.start()]:
-            if ch in "<([":
+            if ch in "<[":
                 depth += 1
-            elif ch in ">)]":
+            elif ch in ">]":
                 depth = max(0, depth - 1)
         if depth == 0:
             for i in range(m.start(), m.end()):
@@ -407,6 +417,11 @@ def _strip_cv_qualifiers(name: str) -> str:
     stripped = _MULTI_SPACE_RE.sub(" ", stripped)
     # Normalise spacing around pointer/reference sigils so "char  *" == "char *".
     stripped = re.sub(r"\s*([*&])\s*", r" \1", stripped)
+    # Normalise spacing around parens so removing a token flush against "("
+    # or ")" doesn't leave a stray space a non-stripped spelling never had.
+    stripped = re.sub(r"\(\s+", "(", stripped)
+    stripped = re.sub(r"\s+\)", ")", stripped)
+    stripped = re.sub(r"\s+,", ",", stripped)
     return _MULTI_SPACE_RE.sub(" ", stripped).strip()
 
 

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -436,7 +436,21 @@ def _strip_cv_in_segment(name: str, chars: list[str], start: int, end: int, *, s
     i = start
     while i < end:
         ch = name[i]
-        if ch in "<[":
+        if ch == "<":
+            j = min(_find_matching_close(name, i), end - 1)
+            i = j + 1
+            continue
+        if ch == "[":
+            # An array-typed function PARAMETER decays to a pointer, so a cv
+            # qualifier before it is pointee-position, not by-value — same
+            # non-strippable treatment as a real pointer sigil (confirmed
+            # against real clang/gcc mangling: void(*)(int[3]) and
+            # void(*)(const int[3]) are different, non-interchangeable
+            # function pointer types, same as the int*/const int* case
+            # above). Only matters in strict mode; harmless otherwise since
+            # non-strict stripping ignores last_ptr_pos entirely (Codex
+            # review, PR #589).
+            last_ptr_pos = i
             j = min(_find_matching_close(name, i), end - 1)
             i = j + 1
             continue

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -368,34 +368,110 @@ def canonicalize_type_name(name: str) -> str:
 _CV_TOKEN_RE = re.compile(r"\b(?:const|volatile)\b")
 
 
+def _find_matching_close(name: str, open_idx: int) -> int:
+    """Index of the bracket matching the opener at *open_idx*.
+
+    Tracks combined ``<([``/``>)]`` depth rather than per-family matching —
+    real compiler-produced type spellings are always well-nested, so this is
+    sufficient and mirrors the depth-counting already used elsewhere in this
+    module (e.g. ``_has_top_level_ptr_or_ref``).
+    """
+    depth = 1
+    i = open_idx + 1
+    while i < len(name):
+        if name[i] in "<([":
+            depth += 1
+        elif name[i] in ">)]":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return len(name) - 1
+
+
+def _strip_cv_in_segment(name: str, chars: list[str], start: int, end: int, *, strict: bool) -> None:
+    """Blank out strippable ``const``/``volatile`` tokens in ``name[start:end]``.
+
+    A ``<...>``/``[...]`` sub-range is always fully skipped (a cv qualifier
+    inside a template-argument list or array subscript names a genuinely
+    different type — ``Box<const int>`` vs. ``Box<int>``, Codex/CodeRabbit
+    review, PR #582). A ``(...)`` sub-range recurses with ``strict=True``.
+
+    When *strict* (i.e. we're inside a function-parameter list, spelling a
+    callback/function-pointer type's own parameters), only a token that is
+    NOT in pointee position is strippable: dropped from a function type for
+    mangling purposes is the parameter's own by-value or pointer-own
+    (trailing, ``"int * const"``) cv, at every nesting level of a function
+    type — confirmed against real clang/gcc output. But a callback
+    parameter's POINTEE cv (``"const int *"`` — leading, before a top-level
+    ``*``/``&``) is NOT mangling-equivalent (``void(*)(int*)`` and
+    ``void(*)(const int*)`` are different, non-interchangeable function
+    pointer types, unlike an ordinary top-level parameter where ``T*``
+    implicitly converts to ``const T*``) — an earlier version of this
+    function stripped indiscriminately inside a paren, wrongly neutralizing
+    that case too (Codex review, PR #589).
+
+    When not strict (the true top level, i.e. not nested in anything), a cv
+    token is strippable regardless of pointee/pointer-own position — this
+    intentionally more permissive rule for a plain top-level parameter/
+    return/field-adjacent type spelling predates this function and is left
+    unchanged (``cv_qualifiers_only_differ``'s own docstring).
+
+    In strict mode, the pointee-vs-pointer-own position is resolved
+    independently PER comma-separated parameter within this paren (a
+    callback can itself take multiple parameters, e.g. ``void
+    (*)(int*, const int)`` — the second parameter's own by-value cv must
+    not be judged against the FIRST parameter's unrelated pointer sigil).
+    """
+    last_ptr_pos: int | None = None
+    candidates: list[tuple[int, int]] = []
+
+    def _flush() -> None:
+        for tok_start, tok_end in candidates:
+            if last_ptr_pos is None or tok_start > last_ptr_pos:
+                for k in range(tok_start, tok_end):
+                    chars[k] = " "
+        candidates.clear()
+
+    i = start
+    while i < end:
+        ch = name[i]
+        if ch in "<[":
+            j = min(_find_matching_close(name, i), end - 1)
+            i = j + 1
+            continue
+        if ch == "(":
+            j = min(_find_matching_close(name, i), end - 1)
+            _strip_cv_in_segment(name, chars, i + 1, j, strict=True)
+            i = j + 1
+            continue
+        if strict and ch == ",":
+            _flush()
+            last_ptr_pos = None
+            i += 1
+            continue
+        if ch in "*&":
+            last_ptr_pos = i
+            i += 1
+            continue
+        m = _CV_TOKEN_RE.match(name, i)
+        if m and m.end() <= end:
+            if strict:
+                candidates.append((m.start(), m.end()))
+            else:
+                for k in range(m.start(), m.end()):
+                    chars[k] = " "
+            i = m.end()
+            continue
+        i += 1
+    _flush()
+
+
 def _strip_cv_qualifiers(name: str) -> str:
     """Return *name* with ``const`` / ``volatile`` tokens removed — but only
-    outside a template-argument list or array subscript.
-
-    A cv qualifier nested inside a template argument
-    (``Box<const int>`` vs. ``Box<int>``) names a genuinely different,
-    unrelated C++ type, not a cv-qualified variant of the same type — two
-    distinct template instantiations, each with its own real mangled
-    identity. Stripping it unconditionally (as an earlier version of this
-    function did) made both of this module's callers —
-    ``cv_qualifiers_only_differ`` and ``func_signature_cv_only_differ`` —
-    misclassify a genuine, ABI-relevant type change (e.g. a function
-    parameter changing from ``Box<int, int>`` to ``Box<int, const int>``)
-    as a harmless cv-only difference, silently suppressing a real breaking
-    ``FUNC_PARAMS_CHANGED``/``FUNC_RETURN_CHANGED`` finding (Codex/
-    CodeRabbit review, PR #582).
-
-    ``(...)`` is NOT one of the blocking brackets: it spells a function
-    type's parameter list (a plain function-pointer type, or a nested
-    callback parameter of one), and a top-level/by-value cv qualifier
-    there is dropped from the function type for mangling purposes at
-    *every* nesting level, not just the outermost — confirmed against real
-    clang/gcc output (``void f(void (*)(int))`` and ``void g(void (*)(const
-    int))`` mangle identically). An earlier version of this depth tracking
-    also blocked on ``(``/``)``, which made a cv-neutral callback parameter
-    (e.g. ``const`` added to a callback's own by-value ``int`` parameter)
-    misfire the same breaking ``FUNC_PARAMS_CHANGED`` path this function
-    exists to prevent (Codex review, PR #582).
+    where doing so can't hide a genuinely different type (see
+    ``_strip_cv_in_segment`` for the exact top-level vs. nested-callback-
+    parameter rules).
 
     Whitespace introduced by the removal is collapsed; spaces adjacent to
     pointer/reference sigils and parentheses are normalised so that
@@ -403,16 +479,7 @@ def _strip_cv_qualifiers(name: str) -> str:
     )`` each reduce to the same string.
     """
     chars = list(name)
-    for m in _CV_TOKEN_RE.finditer(name):
-        depth = 0
-        for ch in name[: m.start()]:
-            if ch in "<[":
-                depth += 1
-            elif ch in ">]":
-                depth = max(0, depth - 1)
-        if depth == 0:
-            for i in range(m.start(), m.end()):
-                chars[i] = " "
+    _strip_cv_in_segment(name, chars, 0, len(name), strict=False)
     stripped = "".join(chars)
     stripped = _MULTI_SPACE_RE.sub(" ", stripped)
     # Normalise spacing around pointer/reference sigils so "char  *" == "char *".
@@ -504,12 +571,19 @@ def func_signature_cv_only_differ(old_type: str, new_type: str) -> bool:
     BY-VALUE difference (``int`` -> ``volatile int``) that
     :func:`cv_qualifiers_only_differ` deliberately excludes.
 
-    DO NOT use this for fields or variables — a top-level by-value cv change
-    on THOSE is intentionally treated as a source-level contract change (see
-    :func:`cv_qualifiers_only_differ`'s own docstring and the
-    ``case30_field_qualifiers`` example; confirmed by
-    ``test_top_level_field_const_is_not_neutralised``). This function exists
-    because that reasoning does NOT extend to a function's own parameter or
+DO NOT use this for an ordinary field/variable comparison — a top-level
+    by-value cv change on THOSE is intentionally treated as a source-level
+    contract change (see :func:`cv_qualifiers_only_differ`'s own docstring
+    and the ``case30_field_qualifiers`` example; confirmed by
+    ``test_top_level_field_const_is_not_neutralised``). The one deliberate
+    exception is a *legacy-snapshot* fallback (``header_cv_facts_reliable``
+    is False): both ``diff_types._field_type_genuinely_changed`` and
+    ``diff_symbols._check_variable`` reuse this function there specifically
+    because a pre-fix CastXML snapshot's spelling may have silently dropped
+    the real qualifier, making a genuine field/variable cv change
+    indistinguishable from tool-upgrade noise — see those callers' own
+    docstrings. This function exists in the first place because the field/
+    variable reasoning does NOT extend to a function's own parameter or
     return type: per the C++ standard, a top-level cv-qualifier on a
     by-value parameter or return type is dropped from the function's type
     for linkage/mangling purposes — ``void f(int)`` and ``void f(const

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -441,17 +441,31 @@ def _strip_cv_in_segment(name: str, chars: list[str], start: int, end: int, *, s
             i = j + 1
             continue
         if ch == "[":
-            # An array-typed function PARAMETER decays to a pointer, so a cv
-            # qualifier before it is pointee-position, not by-value — same
-            # non-strippable treatment as a real pointer sigil (confirmed
-            # against real clang/gcc mangling: void(*)(int[3]) and
-            # void(*)(const int[3]) are different, non-interchangeable
-            # function pointer types, same as the int*/const int* case
-            # above). Only matters in strict mode; harmless otherwise since
-            # non-strict stripping ignores last_ptr_pos entirely (Codex
-            # review, PR #589).
-            last_ptr_pos = i
             j = min(_find_matching_close(name, i), end - 1)
+            if last_ptr_pos is None:
+                # An array-typed function PARAMETER (no preceding pointer
+                # sigil in this segment yet) decays to a pointer, so a cv
+                # qualifier before it is pointee-position, not by-value —
+                # same non-strippable treatment as a real pointer sigil
+                # (confirmed against real clang/gcc mangling: void(*)(int[3])
+                # and void(*)(const int[3]) are different, non-
+                # interchangeable function pointer types, same as the
+                # int*/const int* case above). Only matters in strict mode;
+                # harmless otherwise since non-strict stripping ignores
+                # last_ptr_pos entirely (Codex review, PR #589).
+                last_ptr_pos = i
+            # else: a "[...]" AFTER an already-seen pointer sigil is the
+            # POINTEE's array bound (e.g. "int (*)[3]" — a pointer to an
+            # array, not a decaying array parameter), analogous to a
+            # callback's own parameter list: it doesn't move last_ptr_pos,
+            # so the declarator's own preceding qualifier (e.g. "int (*
+            # const)[3]") stays recognized as its own trailing cv, dropped
+            # for mangling (confirmed identical types by real g++: two
+            # same-named overloads differing only in that const are a
+            # hard redefinition error, not distinct overloads) — treating
+            # this "[" the same as the decay case above wrongly moved the
+            # boundary past the declarator's own const, leaving it
+            # unstrippable (Codex review, PR #589, round 3).
             i = j + 1
             continue
         if ch == "(":

--- a/changelog.d/20260717_190500_claude_castxml-clang-l2-comparison-c56lhi.md
+++ b/changelog.d/20260717_190500_claude_castxml-clang-l2-comparison-c56lhi.md
@@ -70,6 +70,29 @@
     known, deliberately deferred limitation (needs dict-key reconciliation,
     not just a comparison gate) — documented in
     `docs/development/plans/g28-castxml-clang-l2-parity-hardening.md`.
+  - A callback parameter that is itself a function pointer with a
+    cv-qualified RETURN type (`void(*)(int (*)())` vs. `void(*)(const int
+    (*)())` — confirmed distinct, non-interchangeable types by real g++
+    mangling) had that return-type cv wrongly treated as the callback
+    parameter's own neutral by-value qualifier: the recursive paren
+    handling hid the inner declarator's `*` inside an isolated recursive
+    call whose own pointer-position tracking never reached the enclosing
+    scope.
+  - A member-function-POINTER's own trailing cv (`void (C::*)(int) const`
+    — the pointer points to a const member function; `void (* const)()`'s
+    own trailing const is dropped for mangling, but a member function's is
+    NOT, matching the existing `FUNC_CV_CHANGED` precedent — confirmed
+    distinct, non-interchangeable types by real g++ mangling: two
+    same-named overloads differing only in this trailing const compile as
+    distinct symbols) was stripped like an ordinary disposable trailing
+    qualifier, both as a callback parameter and as a variable's own type
+    (`_without_top_level_const`'s end-of-string fallback didn't know a real
+    parameter list preceded the trailing cv). Fixed in both
+    `_strip_cv_qualifiers` and `_without_top_level_const` by recognizing a
+    pointer/pointer-to-member declarator-grouping paren structurally — it's
+    always immediately followed by another top-level paren/bracket (the
+    real parameter list or array dimensions) — regardless of what's inside
+    it (a bare sigil, or a class-qualified `Class::*`).
   - `abicheck/diff_symbols.py` was already at the 2000-line AI-readiness
     hard cap, so the pre-existing variable-alignment/const-normalization
     helpers moved into a new leaf module (`diff_symbols_variables.py`),

--- a/changelog.d/20260717_190500_claude_castxml-clang-l2-comparison-c56lhi.md
+++ b/changelog.d/20260717_190500_claude_castxml-clang-l2-comparison-c56lhi.md
@@ -93,6 +93,14 @@
     always immediately followed by another top-level paren/bracket (the
     real parameter list or array dimensions) — regardless of what's inside
     it (a bare sigil, or a class-qualified `Class::*`).
+  - A pointer-to-array callback parameter's own cv (`int (*)[3]` vs.
+    `int (* const)[3]` — real g++ rejects the two as a redefinition, not
+    distinct overloads, confirming they're the identical type) was wrongly
+    treated as non-neutral: the array-decay handling above also fired for
+    the pointee's array bound after an already-seen pointer sigil, moving
+    the boundary past the declarator's own trailing qualifier. Now only
+    treats a `[...]` as decay when no pointer sigil has been seen yet in
+    the current parameter.
   - `abicheck/diff_symbols.py` was already at the 2000-line AI-readiness
     hard cap, so the pre-existing variable-alignment/const-normalization
     helpers moved into a new leaf module (`diff_symbols_variables.py`),

--- a/changelog.d/20260717_190500_claude_castxml-clang-l2-comparison-c56lhi.md
+++ b/changelog.d/20260717_190500_claude_castxml-clang-l2-comparison-c56lhi.md
@@ -1,0 +1,77 @@
+### Fixed
+
+- **Cv-neutral callback parameters, and legacy-snapshot cv false positives on
+  variables.** Follow-up review findings on the CastXML/Clang L2 parity work
+  in #582:
+  - `_strip_cv_qualifiers`'s template-arg depth tracking (added to stop
+    `Box<const int>` vs. `Box<int>` from misclassifying as cv-only)
+    over-corrected by also blocking on `(`/`)`, so a cv-neutral callback/
+    function-pointer parameter (e.g. `const` added to a callback's own
+    by-value `int` parameter) misfired the breaking `FUNC_PARAMS_CHANGED`
+    path. Confirmed against real clang/gcc mangling: `void(*)(int)` and
+    `void(*)(const int)` are the identical function pointer type — top-level
+    cv on a by-value (or trailing pointer-own `* const`/`* volatile`)
+    parameter is dropped for mangling at every nesting level of a function
+    type, not just the outermost. Now only blocks on `<`/`[` (template args,
+    array subscripts), resolved independently per comma-separated parameter
+    within one callback's own list (a sibling parameter's unrelated pointer
+    sigil must not affect another's verdict).
+  - A callback parameter's POINTEE cv (`void(*)(int*)` vs.
+    `void(*)(const int*)`) IS a genuinely different, non-interchangeable
+    function pointer type (confirmed against real mangling — unlike an
+    ordinary top-level parameter, where `T*` implicitly converts to `const
+    T*`, a caller's existing callback written for one pointee-cv signature
+    can't be passed where the other is expected), so the fix above must NOT
+    neutralize it. An array-typed callback parameter decays to a pointer too
+    (`void(*)(int[3])` vs. `void(*)(const int[3])`), and gets the same
+    treatment.
+  - `_check_variable` didn't consult `header_cv_facts_reliable` the way
+    `diff_types._field_type_genuinely_changed` does for struct fields — a
+    pre-v9 CastXML snapshot's `_type_name()` silently dropped `volatile`
+    from a variable's type spelling, and `Variable` has no dedicated
+    `is_volatile` fact to fall back on (unlike `TypeField`), so an unchanged
+    `volatile` variable compared against a legacy baseline misreported a
+    breaking `VAR_TYPE_CHANGED` purely from the tool upgrade. Gated the same
+    way, reusing `func_signature_cv_only_differ`. The suppression didn't
+    fully suppress on its own, though: it only skipped `VAR_TYPE_CHANGED`,
+    then fell through to an unconditional `is_const`-based const-transition
+    check, so the same false positive resurfaced as the more specific
+    `VAR_BECAME_CONST` instead. Now returns immediately for the legacy-noise
+    case, leaving only the dedicated `is_pure_const_flip` path (a real,
+    structural signal independent of the legacy type-spelling bug) free to
+    report a genuine const transition.
+  - The clang backend's typedef-desugaring fix for a field's hidden
+    `const`/`volatile` (`typedef const int T;` renders as the bare alias
+    `"T"` in `qualType`, only visible via `desugaredQualType`) scanned the
+    WHOLE desugared spelling for a pointer typedef too — but `typedef const
+    int *P;` desugars to `"const int *"`, where the `const` qualifies the
+    POINTEE, not `P` itself (a plain, non-const pointer). Now scans only the
+    substring after the last top-level `*`.
+  - `_without_top_level_const` (a variable's own top-level const, as opposed
+    to its pointee's) only recognized a bare pointer's trailing own-const at
+    the absolute end of the string, so a variable whose type is itself a
+    function or array pointer (`void (* const)()`, `int (* const)[5]` —
+    canonicalized with the qualifier directly after the `*`, before the
+    declarator's closing `)`/`]`, not at the string's end) misreported
+    becoming const as `VAR_TYPE_CHANGED` instead of `VAR_BECAME_CONST`. Two
+    further fixes on top of that: the sigil search picked the LAST
+    top-level `*`/`&` in the whole string, which for a function-pointer
+    variable whose own PARAMETER is itself a pointer (`void (* const)(int
+    *)`) picks up the parameter's `*` instead of the outer declarator's —
+    now scoped to the first top-level `(...)` group specifically (always
+    the outer declarator); and removing `const` from a combined
+    `"const volatile"`/`"volatile const"` span (when volatile is unchanged
+    and only const is newly added — still a pure const-only flip) left a
+    stray separator space that made the two sides compare spuriously
+    unequal — now trimmed to match `canonicalize_type_name`'s own
+    no-whitespace-adjacent-to-sigil convention.
+  - Legacy CastXML C-linkage variable mangled-key identity across the fix
+    that normalizes bogus `_Z`-prefixed keys to bare export names is a
+    known, deliberately deferred limitation (needs dict-key reconciliation,
+    not just a comparison gate) — documented in
+    `docs/development/plans/g28-castxml-clang-l2-parity-hardening.md`.
+  - `abicheck/diff_symbols.py` was already at the 2000-line AI-readiness
+    hard cap, so the pre-existing variable-alignment/const-normalization
+    helpers moved into a new leaf module (`diff_symbols_variables.py`),
+    mirroring the existing `diff_symbols_scalar.py`/`diff_symbols_renames.py`
+    split pattern.

--- a/docs/development/plans/g28-castxml-clang-l2-parity-hardening.md
+++ b/docs/development/plans/g28-castxml-clang-l2-parity-hardening.md
@@ -139,6 +139,36 @@ fix folded into an already-large hardening pass.
 
 ---
 
+## Known, deferred limitation: legacy C-variable mangled-key identity across the upgrade boundary
+
+**Confirmed real** (Codex review): `_CastxmlParser.parse_variables` reassigns
+a C-linkage global's bogus castxml-fabricated `_Z<len><name>` "mangled" key
+to the real bare export name — but only when corroborated by real ELF export
+evidence (`mangled not in self._exported_dynamic/static` and `name in`
+either). A snapshot persisted with an abicheck version *before* this
+reassignment existed still keys that same variable by the old bogus `_Z...`
+name. `_diff_variables` matches old/new variable maps by that key
+(`diff_by_key`) with no reconciliation path, so re-running abicheck against
+such a legacy baseline reports an unchanged `extern int g;` as
+`VAR_REMOVED _Z1g` plus `VAR_ADDED g` — a false breaking pair from the tool
+upgrade, not a real header edit.
+
+**Deliberately not fixed here**: unlike the CV-fact case above (gated by the
+schema-versioned `header_cv_facts_reliable` flag, itself narrowly scoped to
+CV comparisons), a safe fix here needs to *reconcile two dict keys* rather
+than just neutralize a comparison. The bogus old key (`_Z1g`) and a
+genuinely, separately-mangled real C++ global that happens to also be a
+simple one-character identifier are textually indistinguishable from the old
+snapshot's side alone — the only real corroborating signal (does the *new*
+snapshot's variable list contain an unmatched bare-name entry that the old
+side's bogus key would explain) requires new pre-pass reconciliation logic in
+or around `_diff_variables`/`diff_by_key`, plus new golden/regression
+coverage proving it can't silently merge two genuinely-different variables
+that happen to share a short name. Scope this as its own follow-up rather
+than bolting an ambiguous heuristic onto an already-large hardening pass.
+
+---
+
 ## Phase 3 — hybrid multi-producer snapshot with per-field provenance
 
 **Problem.** Today a snapshot is parsed by exactly one L2 backend

--- a/tests/test_const_pointer_abi_neutral.py
+++ b/tests/test_const_pointer_abi_neutral.py
@@ -392,6 +392,8 @@ def test_callback_by_value_cv_qualifier_is_neutralised(old_t, new_t):
     ("void (*)(int*)", "void (*)(const int*)"),
     ("void (*)(void (*)(int*))", "void (*)(void (*)(const int*))"),
     ("void (*)(int*, int*)", "void (*)(int*, const int*)"),
+    ("void (*)(int[3])", "void (*)(const int[3])"),
+    ("void (*)(int[3], int)", "void (*)(const int[3], int)"),
 ])
 def test_callback_pointee_cv_qualifier_is_not_neutralised(old_t, new_t):
     """Negative control (Codex review, PR #589): a callback parameter's
@@ -402,8 +404,13 @@ def test_callback_pointee_cv_qualifier_is_not_neutralised(old_t, new_t):
     a callback supplied by the caller with one pointee-cv signature can't be
     passed where the other is expected) — only the callback's own by-value/
     pointer-value cv is neutral, not its pointee's, at any nesting depth or
-    parameter position. An earlier version of the fix above stripped cv
-    indiscriminately inside any paren, wrongly neutralizing this case too."""
+    parameter position. An array-typed parameter decays to a pointer too
+    (``void(*)(int[3])`` and ``void(*)(const int[3])`` are confirmed by real
+    mangling to be equally non-interchangeable, Codex review round 2) — the
+    ``[...]`` handling must treat it the same as a real pointer sigil rather
+    than as an opaque, ptr-blind skip. An earlier version of the fix above
+    stripped cv indiscriminately inside any paren, wrongly neutralizing this
+    case too."""
     assert func_signature_cv_only_differ(old_t, new_t) is False
 
 

--- a/tests/test_const_pointer_abi_neutral.py
+++ b/tests/test_const_pointer_abi_neutral.py
@@ -369,6 +369,7 @@ def test_nested_template_cv_change_still_reported_as_param_change():
     ("void (*)(int*, int)", "void (*)(int*, const int)"),
     ("void (*)(int, int*)", "void (*)(const int, int*)"),
     ("void (*)(int*, int*)", "void (*)(int* const, int*)"),
+    ("void (*)(int (*)[3])", "void (*)(int (* const)[3])"),
 ])
 def test_callback_by_value_cv_qualifier_is_neutralised(old_t, new_t):
     """Regression guard (Codex review, PR #582): the fix for nested TEMPLATE
@@ -383,7 +384,14 @@ def test_callback_by_value_cv_qualifier_is_neutralised(old_t, new_t):
     comma-separated parameter within one callback's own parameter list (a
     later/earlier sibling parameter's unrelated pointer sigil must not affect
     this one's own verdict). Blocking the callback's own cv this way made an
-    ABI-neutral header edit misfire the breaking FUNC_PARAMS_CHANGED path."""
+    ABI-neutral header edit misfire the breaking FUNC_PARAMS_CHANGED path.
+    A further review round (Codex, PR #589) found a pointer-to-array
+    parameter's own cv (``int (*)[3]`` vs. ``int (* const)[3]``) wrongly
+    treated as non-neutral: real g++ rejects the two as a redefinition
+    (not distinct overloads), confirming they're the identical type — the
+    ``[3]`` here is the POINTEE's array bound (after an already-seen
+    pointer sigil), not a decaying array parameter, and must not move the
+    declarator's own trailing-cv boundary past it."""
     assert func_signature_cv_only_differ(old_t, new_t) is True
 
 
@@ -394,9 +402,11 @@ def test_callback_by_value_cv_qualifier_is_neutralised(old_t, new_t):
     ("void (*)(int*, int*)", "void (*)(int*, const int*)"),
     ("void (*)(int[3])", "void (*)(const int[3])"),
     ("void (*)(int[3], int)", "void (*)(const int[3], int)"),
+    ("void (*)(int (*)[3])", "void (*)(const int (*)[3])"),
     ("void (*)(int (*)())", "void (*)(const int (*)())"),
     ("void (C::*)(int)", "void (C::*)(int) const"),
     ("void (C::*)(int)", "void (C::*)(int) volatile"),
+    ("void (C::*)(int)", "void (C::*)(int) const volatile"),
     ("void (*)(void (C::*)())", "void (*)(void (C::*)() const)"),
 ])
 def test_callback_pointee_cv_qualifier_is_not_neutralised(old_t, new_t):

--- a/tests/test_const_pointer_abi_neutral.py
+++ b/tests/test_const_pointer_abi_neutral.py
@@ -394,6 +394,10 @@ def test_callback_by_value_cv_qualifier_is_neutralised(old_t, new_t):
     ("void (*)(int*, int*)", "void (*)(int*, const int*)"),
     ("void (*)(int[3])", "void (*)(const int[3])"),
     ("void (*)(int[3], int)", "void (*)(const int[3], int)"),
+    ("void (*)(int (*)())", "void (*)(const int (*)())"),
+    ("void (C::*)(int)", "void (C::*)(int) const"),
+    ("void (C::*)(int)", "void (C::*)(int) volatile"),
+    ("void (*)(void (C::*)())", "void (*)(void (C::*)() const)"),
 ])
 def test_callback_pointee_cv_qualifier_is_not_neutralised(old_t, new_t):
     """Negative control (Codex review, PR #589): a callback parameter's
@@ -410,7 +414,26 @@ def test_callback_pointee_cv_qualifier_is_not_neutralised(old_t, new_t):
     ``[...]`` handling must treat it the same as a real pointer sigil rather
     than as an opaque, ptr-blind skip. An earlier version of the fix above
     stripped cv indiscriminately inside any paren, wrongly neutralizing this
-    case too."""
+    case too. Two more real bugs from a further review round: a callback
+    parameter that is itself a function pointer with a cv-qualified RETURN
+    type (``void(*)(int (*)())`` vs. ``void(*)(const int (*)())``) had that
+    return-type cv wrongly treated as the callback's own neutral by-value
+    qualifier, because the recursive paren-handling hid the inner
+    declarator's ``*`` from the enclosing scope's own pointer-position
+    tracking; and a member-function-POINTER's own trailing cv (``void
+    (C::*)(int) const`` — the pointer points to a const member function,
+    confirmed by real g++ mangling to be a genuinely different,
+    non-interchangeable type, matching the existing FUNC_CV_CHANGED
+    precedent for a member function's own const/volatile) was stripped like
+    an ordinary disposable trailing qualifier. The fix for the first of
+    those two also had to generalize beyond "this paren contains only
+    sigils/cv tokens" — that heuristic missed a class-qualified
+    pointer-to-member declarator (``(C::*)``, real text besides the sigil)
+    nested as a callback's own parameter (``void(*)(void (C::*)())`` vs.
+    ``void(*)(void (C::*)() const)``); the general, content-independent
+    signal is structural: a declarator-grouping paren is always
+    immediately followed by another top-level paren/bracket (the real
+    parameter list or array dimensions)."""
     assert func_signature_cv_only_differ(old_t, new_t) is False
 
 

--- a/tests/test_const_pointer_abi_neutral.py
+++ b/tests/test_const_pointer_abi_neutral.py
@@ -363,9 +363,12 @@ def test_nested_template_cv_change_still_reported_as_param_change():
 @pytest.mark.parametrize("old_t, new_t", [
     ("void (*)(int)", "void (*)(const int)"),
     ("void (*)(int, int)", "void (*)(int, const int)"),
-    ("void (*)(int*)", "void (*)(const int*)"),
     ("void (*)(int* const)", "void (*)(int*)"),
     ("void (*)(int* volatile)", "void (*)(int*)"),
+    ("void (*)(void (*)(int))", "void (*)(void (*)(const int))"),
+    ("void (*)(int*, int)", "void (*)(int*, const int)"),
+    ("void (*)(int, int*)", "void (*)(const int, int*)"),
+    ("void (*)(int*, int*)", "void (*)(int* const, int*)"),
 ])
 def test_callback_by_value_cv_qualifier_is_neutralised(old_t, new_t):
     """Regression guard (Codex review, PR #582): the fix for nested TEMPLATE
@@ -375,18 +378,33 @@ def test_callback_by_value_cv_qualifier_is_neutralised(old_t, new_t):
     ``void (*)(int)`` and ``void (*)(const int)`` are the identical function
     pointer type: top-level cv on a by-value (or pointer-own, trailing
     ``* const``/``* volatile``) parameter is dropped for mangling purposes at
-    every nesting level of a function type, not just the outermost. Blocking
-    the callback's own cv this way made an ABI-neutral header edit misfire
-    the breaking FUNC_PARAMS_CHANGED path."""
+    every nesting level of a function type, not just the outermost — at
+    every level of nesting (a callback-of-a-callback), and independently per
+    comma-separated parameter within one callback's own parameter list (a
+    later/earlier sibling parameter's unrelated pointer sigil must not affect
+    this one's own verdict). Blocking the callback's own cv this way made an
+    ABI-neutral header edit misfire the breaking FUNC_PARAMS_CHANGED path."""
     assert func_signature_cv_only_differ(old_t, new_t) is True
 
 
-def test_callback_pointee_cv_qualifier_is_not_neutralised():
-    """Negative control: a callback parameter's POINTEE cv IS a genuinely
-    different type (confirmed against real mangling: ``void(*)(int*)`` and
-    ``void(*)(const int*)`` are different overloads) — only the callback's
-    own by-value/pointer-value cv (above) is neutral, not its pointee's."""
-    assert func_signature_cv_only_differ("void (*)(int*)", "void (*)(long*)") is False
+@pytest.mark.parametrize("old_t, new_t", [
+    ("void (*)(int*)", "void (*)(long*)"),
+    ("void (*)(int*)", "void (*)(const int*)"),
+    ("void (*)(void (*)(int*))", "void (*)(void (*)(const int*))"),
+    ("void (*)(int*, int*)", "void (*)(int*, const int*)"),
+])
+def test_callback_pointee_cv_qualifier_is_not_neutralised(old_t, new_t):
+    """Negative control (Codex review, PR #589): a callback parameter's
+    POINTEE cv IS a genuinely different type (confirmed against real
+    mangling: ``void(*)(int*)`` and ``void(*)(const int*)`` are different,
+    non-interchangeable function pointer types — unlike an ordinary
+    top-level parameter, where ``T*`` implicitly converts to ``const T*``,
+    a callback supplied by the caller with one pointee-cv signature can't be
+    passed where the other is expected) — only the callback's own by-value/
+    pointer-value cv is neutral, not its pointee's, at any nesting depth or
+    parameter position. An earlier version of the fix above stripped cv
+    indiscriminately inside any paren, wrongly neutralizing this case too."""
+    assert func_signature_cv_only_differ(old_t, new_t) is False
 
 
 def test_callback_cv_change_still_reported_as_param_change():

--- a/tests/test_const_pointer_abi_neutral.py
+++ b/tests/test_const_pointer_abi_neutral.py
@@ -358,3 +358,55 @@ def test_nested_template_cv_change_still_reported_as_param_change():
     new = _snap("2", functions=[_fn("f", "f", params=[Param(name="x", type="Box<int, const int>")])])
     r = compare(old, new)
     assert ChangeKind.FUNC_PARAMS_CHANGED in _kinds(r)
+
+
+@pytest.mark.parametrize("old_t, new_t", [
+    ("void (*)(int)", "void (*)(const int)"),
+    ("void (*)(int, int)", "void (*)(int, const int)"),
+    ("void (*)(int*)", "void (*)(const int*)"),
+    ("void (*)(int* const)", "void (*)(int*)"),
+    ("void (*)(int* volatile)", "void (*)(int*)"),
+])
+def test_callback_by_value_cv_qualifier_is_neutralised(old_t, new_t):
+    """Regression guard (Codex review, PR #582): the fix for nested TEMPLATE
+    cv (``Box<const int>``, above) over-corrected by also blocking stripping
+    inside a nested PAREN — a callback/function-pointer parameter's own
+    by-value cv qualifier. But confirmed against real clang/gcc mangling,
+    ``void (*)(int)`` and ``void (*)(const int)`` are the identical function
+    pointer type: top-level cv on a by-value (or pointer-own, trailing
+    ``* const``/``* volatile``) parameter is dropped for mangling purposes at
+    every nesting level of a function type, not just the outermost. Blocking
+    the callback's own cv this way made an ABI-neutral header edit misfire
+    the breaking FUNC_PARAMS_CHANGED path."""
+    assert func_signature_cv_only_differ(old_t, new_t) is True
+
+
+def test_callback_pointee_cv_qualifier_is_not_neutralised():
+    """Negative control: a callback parameter's POINTEE cv IS a genuinely
+    different type (confirmed against real mangling: ``void(*)(int*)`` and
+    ``void(*)(const int*)`` are different overloads) — only the callback's
+    own by-value/pointer-value cv (above) is neutral, not its pointee's."""
+    assert func_signature_cv_only_differ("void (*)(int*)", "void (*)(long*)") is False
+
+
+def test_callback_cv_change_still_reported_as_param_change():
+    """End-to-end: an outer function whose callback parameter's own by-value
+    cv changed must NOT report FUNC_PARAMS_CHANGED (ABI-neutral), but a
+    genuine callback signature change must still be reported."""
+    neutral_old = _snap(
+        "1", functions=[_fn("f", "f", params=[Param(name="cb", type="void (*)(int)")])]
+    )
+    neutral_new = _snap(
+        "2", functions=[_fn("f", "f", params=[Param(name="cb", type="void (*)(const int)")])]
+    )
+    r = compare(neutral_old, neutral_new)
+    assert ChangeKind.FUNC_PARAMS_CHANGED not in _kinds(r)
+
+    breaking_old = _snap(
+        "1", functions=[_fn("f", "f", params=[Param(name="cb", type="void (*)(int)")])]
+    )
+    breaking_new = _snap(
+        "2", functions=[_fn("f", "f", params=[Param(name="cb", type="void (*)(long)")])]
+    )
+    r2 = compare(breaking_old, breaking_new)
+    assert ChangeKind.FUNC_PARAMS_CHANGED in _kinds(r2)

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -642,6 +642,29 @@ class TestVarConstChanged:
         assert ChangeKind.VAR_BECAME_CONST in _kinds(r)
         assert ChangeKind.VAR_TYPE_CHANGED not in _kinds(r)
 
+    def test_function_pointer_already_volatile_gaining_const_is_var_became_const(self):
+        """`void (* volatile)()` -> `void (* const volatile)()` (Codex
+        review, PR #589): volatile stays unchanged on both sides, only
+        const is newly added — a pure const-only flip. Removing "const"
+        from the combined "const volatile" span left a stray separator
+        space, so the stripped old/new spellings compared spuriously
+        unequal and misreported VAR_TYPE_CHANGED instead of the correct
+        VAR_BECAME_CONST."""
+        v_v1 = _pub_var("fp", "_Z2fp", "void (* volatile)()", is_const=False)
+        v_v2 = _pub_var("fp", "_Z2fp", "void (* const volatile)()", is_const=True)
+        r = compare(_snap(variables=[v_v1]), _snap(variables=[v_v2]))
+        assert ChangeKind.VAR_BECAME_CONST in _kinds(r)
+        assert ChangeKind.VAR_TYPE_CHANGED not in _kinds(r)
+
+    def test_function_pointer_gaining_both_const_and_volatile_is_type_changed(self):
+        """Negative control: unlike the test above, here volatile is ALSO
+        newly added (not just const) — that's not a pure const-only flip,
+        so it must still report VAR_TYPE_CHANGED."""
+        v_v1 = _pub_var("fp", "_Z2fp", "void (*)()", is_const=False)
+        v_v2 = _pub_var("fp", "_Z2fp", "void (* const volatile)()", is_const=True)
+        r = compare(_snap(variables=[v_v1]), _snap(variables=[v_v2]))
+        assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
+
 
 # ── legacy CastXML volatile-variable noise (Codex review, PR #582) ──────────
 

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -628,6 +628,20 @@ class TestVarConstChanged:
         assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
         assert ChangeKind.VAR_BECAME_CONST not in _kinds(r)
 
+    def test_function_pointer_with_pointer_param_own_const_is_var_became_const(self):
+        """`void (*)(int *)` -> `void (* const)(int *)` (Codex review, PR
+        #589): the OUTER declarator's own sigil must be found even when a
+        PARAMETER is itself a pointer — the last top-level `*` in the whole
+        string belongs to the parameter (`int *`), not the outer `(*
+        const)` declarator, so picking "the last one" alone misses the
+        variable's own trailing const. Must report VAR_BECAME_CONST, not
+        VAR_TYPE_CHANGED."""
+        v_v1 = _pub_var("fp", "_Z2fp", "void (*)(int *)", is_const=False)
+        v_v2 = _pub_var("fp", "_Z2fp", "void (* const)(int *)", is_const=True)
+        r = compare(_snap(variables=[v_v1]), _snap(variables=[v_v2]))
+        assert ChangeKind.VAR_BECAME_CONST in _kinds(r)
+        assert ChangeKind.VAR_TYPE_CHANGED not in _kinds(r)
+
 
 # ── legacy CastXML volatile-variable noise (Codex review, PR #582) ──────────
 

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -597,6 +597,37 @@ class TestVarConstChanged:
         assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
         assert ChangeKind.VAR_BECAME_CONST not in _kinds(r)
 
+    def test_function_pointer_own_const_is_var_became_const(self):
+        """`void (*)()` -> `void (* const)()`: the function-pointer VARIABLE
+        itself became const (CodeRabbit review, PR #589) — the qualifier
+        sits directly before the declarator's closing `)`, not at the
+        string's end, unlike a bare pointer's `"int * const"`. Must still
+        report VAR_BECAME_CONST, not VAR_TYPE_CHANGED."""
+        v_v1 = _pub_var("fp", "_Z2fp", "void (*)()", is_const=False)
+        v_v2 = _pub_var("fp", "_Z2fp", "void (* const)()", is_const=True)
+        r = compare(_snap(variables=[v_v1]), _snap(variables=[v_v2]))
+        assert ChangeKind.VAR_BECAME_CONST in _kinds(r)
+        assert ChangeKind.VAR_TYPE_CHANGED not in _kinds(r)
+
+    def test_array_pointer_own_const_is_var_became_const(self):
+        """`int (*)[5]` -> `int (* const)[5]`: same as the function-pointer
+        case above, but the declarator closes with `]` instead of `)`."""
+        v_v1 = _pub_var("ap", "_Z2ap", "int (*)[5]", is_const=False)
+        v_v2 = _pub_var("ap", "_Z2ap", "int (* const)[5]", is_const=True)
+        r = compare(_snap(variables=[v_v1]), _snap(variables=[v_v2]))
+        assert ChangeKind.VAR_BECAME_CONST in _kinds(r)
+        assert ChangeKind.VAR_TYPE_CHANGED not in _kinds(r)
+
+    def test_function_pointer_return_type_const_is_type_changed(self):
+        """Negative control: `void (*)()` -> `const void (*)()` — the
+        POINTEE (the function's return type) became const, not the pointer
+        variable itself. Must report VAR_TYPE_CHANGED, not VAR_BECAME_CONST."""
+        v_v1 = _pub_var("fp", "_Z2fp", "void (*)()", is_const=False)
+        v_v2 = _pub_var("fp", "_Z2fp", "const void (*)()", is_const=True)
+        r = compare(_snap(variables=[v_v1]), _snap(variables=[v_v2]))
+        assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
+        assert ChangeKind.VAR_BECAME_CONST not in _kinds(r)
+
 
 # ── legacy CastXML volatile-variable noise (Codex review, PR #582) ──────────
 

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -597,6 +597,45 @@ class TestVarConstChanged:
         assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
         assert ChangeKind.VAR_BECAME_CONST not in _kinds(r)
 
+
+# ── legacy CastXML volatile-variable noise (Codex review, PR #582) ──────────
+
+
+class TestVarLegacyVolatileNoise:
+    """A pre-v9 CastXML snapshot's ``_type_name()`` silently dropped
+    ``volatile`` from a variable's type spelling — there is no dedicated
+    ``Variable.is_volatile`` fact (unlike ``TypeField``) to fall back on, so
+    an unchanged ``volatile`` variable compared against a legacy baseline
+    would otherwise misreport a breaking VAR_TYPE_CHANGED purely from an
+    abicheck upgrade, not a real header edit."""
+
+    def test_legacy_snapshot_volatile_drop_is_not_reported(self):
+        v_old = _pub_var("g", "g", "int")
+        v_new = _pub_var("g", "g", "volatile int")
+        old = _snap(variables=[v_old])
+        old.header_cv_facts_reliable = False
+        new = _snap(variables=[v_new])
+        r = compare(old, new)
+        assert ChangeKind.VAR_TYPE_CHANGED not in _kinds(r)
+
+    def test_real_volatile_change_between_reliable_snapshots_is_reported(self):
+        v_old = _pub_var("g", "g", "int")
+        v_new = _pub_var("g", "g", "volatile int")
+        r = compare(_snap(variables=[v_old]), _snap(variables=[v_new]))
+        assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
+
+    def test_genuine_type_change_still_reported_even_when_unreliable(self):
+        """The legacy-noise suppression only neutralizes a cv-only spelling
+        difference — a genuinely different base type must still be caught
+        even when cv facts aren't trustworthy for this pair."""
+        v_old = _pub_var("g", "g", "int")
+        v_new = _pub_var("g", "g", "long")
+        old = _snap(variables=[v_old])
+        old.header_cv_facts_reliable = False
+        new = _snap(variables=[v_new])
+        r = compare(old, new)
+        assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
+
     def test_pointer_inside_template_arg_is_not_top_level(self):
         """`std::vector<int *>` -> `const std::vector<int *>`: the variable
         itself is a by-value templated type (not a pointer) — the `*` lives

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -681,6 +681,32 @@ class TestVarLegacyVolatileNoise:
         r = compare(old, new)
         assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
 
+    def test_legacy_pointee_const_noise_does_not_resurface_as_var_became_const(self):
+        """Codex review, PR #589: suppressing VAR_TYPE_CHANGED for legacy cv
+        noise isn't enough on its own — ``is_const`` (a raw dumper-populated
+        bool, unconditionally checked below the type-string branch) still
+        differs for this same pointee-const-in-a-legacy-snapshot case, so an
+        earlier version of the fix let the SAME false positive resurface as
+        the more specific VAR_BECAME_CONST instead of being genuinely
+        suppressed. Neither should fire when the pair is legacy noise."""
+        v_old = _pub_var("g", "g", "int *", is_const=False)
+        v_new = _pub_var("g", "g", "const int *", is_const=True)
+        old = _snap(variables=[v_old])
+        old.header_cv_facts_reliable = False
+        new = _snap(variables=[v_new])
+        r = compare(old, new)
+        assert ChangeKind.VAR_TYPE_CHANGED not in _kinds(r)
+        assert ChangeKind.VAR_BECAME_CONST not in _kinds(r)
+
+    def test_real_pointee_const_change_between_reliable_snapshots_still_reported(self):
+        """Negative control for the test above: the same pointee-const type
+        change between two fully-reliable (non-legacy) snapshots is a real
+        change and must still report VAR_TYPE_CHANGED."""
+        v_old = _pub_var("g", "g", "int *", is_const=False)
+        v_new = _pub_var("g", "g", "const int *", is_const=True)
+        r = compare(_snap(variables=[v_old]), _snap(variables=[v_new]))
+        assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
+
     def test_pointer_inside_template_arg_is_not_top_level(self):
         """`std::vector<int *>` -> `const std::vector<int *>`: the variable
         itself is a by-value templated type (not a pointer) — the `*` lives

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -665,6 +665,22 @@ class TestVarConstChanged:
         r = compare(_snap(variables=[v_v1]), _snap(variables=[v_v2]))
         assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
 
+    def test_member_function_pointer_own_const_is_type_changed_not_var_became_const(self):
+        """`void (C::*)(int)` -> `void (C::*)(int) const` (CodeRabbit
+        review, PR #589): the trailing `const` here is the member-function-
+        POINTER's own cv-qualification (it points to a const member
+        function) — a genuinely different, non-interchangeable type
+        (confirmed by real g++ mangling: two same-named overloads differing
+        only in this trailing const compile as distinct symbols, matching
+        the existing FUNC_CV_CHANGED precedent for a member function's own
+        const/volatile), NOT a pure top-level pointer-value const flip. Must
+        report VAR_TYPE_CHANGED, not VAR_BECAME_CONST."""
+        v_v1 = _pub_var("mp", "_Z2mp", "void (C::*)(int)", is_const=False)
+        v_v2 = _pub_var("mp", "_Z2mp", "void (C::*)(int) const", is_const=True)
+        r = compare(_snap(variables=[v_v1]), _snap(variables=[v_v2]))
+        assert ChangeKind.VAR_TYPE_CHANGED in _kinds(r)
+        assert ChangeKind.VAR_BECAME_CONST not in _kinds(r)
+
 
 # ── legacy CastXML volatile-variable noise (Codex review, PR #582) ──────────
 


### PR DESCRIPTION
## Summary

Follow-up review fixes on the CastXML/Clang L2 parity work merged in #582. Three more Codex-review findings surfaced after that PR merged; two are fixed here, one is documented as a deliberately-deferred limitation.

## Motivation

Continuing to act as PR steward on the CastXML/Clang L2 parity hardening work — Codex flagged three more real issues after #582 merged, surfaced while re-reviewing the merged diff.

## Changes

- **Cv-neutral callback parameter regression**: `_strip_cv_qualifiers`'s template-arg depth tracking (added in #582 to stop `Box<const int>` vs `Box<int>` from misclassifying as cv-only) over-corrected by also blocking on `(`/`)`, so a cv-neutral callback/function-pointer parameter (e.g. `const` added to a callback's own by-value `int` parameter) misfired the breaking `FUNC_PARAMS_CHANGED` path. Confirmed against real clang/gcc mangling: `void(*)(int)` and `void(*)(const int)` are the identical function pointer type. Fixed by only blocking on `<`/`[` (template args, array subscripts), plus paren-spacing normalization.
- **Legacy volatile-variable false positive**: `_check_variable` didn't consult `header_cv_facts_reliable` the way `diff_types._field_type_genuinely_changed` does for struct fields — a pre-v9 CastXML snapshot's `_type_name()` silently dropped `volatile` from a variable's type spelling, and `Variable` has no dedicated `is_volatile` fact to fall back on. Gated the same way, reusing `func_signature_cv_only_differ`.
- **Clang backend: pointee cv mistaken for a pointer field's own cv**: the typedef-desugaring fix for a clang-parsed field's hidden `const`/`volatile` scanned the whole desugared spelling for a pointer typedef too, but `typedef const int *P;` desugars to `"const int *"` where the `const` qualifies the pointee, not `P` itself. Fixed by scanning only the substring after the last top-level `*`.
- **Known, deferred limitation documented**: legacy CastXML C-variable mangled-key identity across the fix that normalizes bogus `_Z`-prefixed keys to bare export names — needs dict-key reconciliation logic, not just a comparison gate, so it's documented in the G28 plan doc as its own follow-up rather than a rushed fix.
- `abicheck/diff_symbols.py` was already at the 2000-line AI-readiness hard cap, so extracted the pre-existing variable-alignment/const-normalization helpers into a new leaf module (`diff_symbols_variables.py`), mirroring the existing `diff_symbols_scalar.py`/`diff_symbols_renames.py` split pattern.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] `CHANGELOG.md` updated (under `[Unreleased]`)
- [x] Docs updated (G28 plan doc: new deferred-limitation section)
- [x] `ruff check` / `mypy abicheck/` clean
- [x] `python scripts/check_ai_readiness.py` — 0 errors
- [x] `python scripts/check_fp_rate.py` / `check_tier_accuracy.py` — clean, within baseline
- [x] Full fast test suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`) — 16290 passed


---
_Generated by [Claude Code](https://claude.ai/code/session_011pDcUBJtexJx5Ug1SSyvVa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ABI comparison for pointer, callback, and function-pointer const/volatile qualifiers, including correct detection of the variable’s own qualifier vs nested parameter qualifiers.
  * Suppressed spurious variable type-change reports when qualifier facts are marked unreliable (legacy qualifier noise).
  * Enhanced normalization to avoid miscomparisons from token/spacing differences after qualifier stripping.
  * Tightened alignment-change reporting to only flag real alignment bit differences.
* **Documentation**
  * Added/expanded a known limitation for legacy C-linkage variable identity mismatches across snapshot baselines.
* **Tests**
  * Added regression and negative-control coverage for callback/function-pointer qualifier-neutral cases and clarified variable const/volatile classification for function/array pointers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->