### PR TITLE
fix(action): fail fast on unsupported mode/input combinations

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -462,6 +462,7 @@ runs:
       env:
         INPUT_MODE: ${{ inputs.mode }}
         INPUT_NEW_LIBRARY: ${{ inputs.new-library }}
+        INPUT_OLD_LIBRARY: ${{ inputs.old-library }}
         INPUT_FORMAT: ${{ inputs.format }}
         INPUT_UPLOAD_SARIF: ${{ inputs.upload-sarif }}
       run: bash "${{ github.action_path }}/action/validate-inputs.sh"

--- a/action.yml
+++ b/action.yml
@@ -34,9 +34,15 @@ inputs:
     required: false
   new-library:
     description: >
-      Path to the new (current) library or binary. Required for compare and
-      dump modes. May also be a directory or package (RPM, Deb, tar, conda,
-      wheel), matching old-library.
+      Path to the new (current) library, binary, or JSON snapshot. Required
+      for compare, dump (unless a source-only sources/build-info/compile-db
+      input is given), scan, and deps-tree/deps-compare modes. May be a
+      directory or package (RPM, Deb, tar, conda, wheel) ONLY in compare
+      mode, matching old-library — compare then fans out to a per-library
+      comparison automatically. dump and scan each analyse exactly one
+      artifact and reject a directory/package with an error (they have no
+      per-library fan-out); for a multi-library release, dump/scan each
+      library individually or use compare instead.
     required: false
 
   # ── Package inputs (compare mode, directory/package operands only) ──────────
@@ -287,10 +293,16 @@ inputs:
   # ── Output & policy ─────────────────────────────────────────────────────────
   format:
     description: >
-      Output format: markdown (default), json, sarif, html.
-      sarif and html are only supported in compare mode; other modes
-      support markdown and json only (unsupported formats fall back
-      to markdown with a warning).
+      Output format: markdown (default), json, sarif, html. sarif and html
+      are only supported in compare mode with a single-pair (non-directory,
+      non-package) operand — a directory/package compare rejects them with
+      an error. scan supports text (its default) and json only.
+      deps-tree/deps-compare support markdown and json only. dump ignores
+      this input; it always writes a JSON snapshot. Requesting an
+      unsupported format for the mode is a hard error raised before any
+      dependency install (it used to silently fall back to a supported
+      format with only a warning, which is unsafe for CI — see
+      upload-sarif).
     required: false
     default: 'markdown'
   output-file:
@@ -323,7 +335,9 @@ inputs:
   upload-sarif:
     description: >
       Upload SARIF results to GitHub Code Scanning (requires security-events: write permission).
-      Only effective when format=sarif.
+      Requires format=sarif and mode=compare — setting this with any other
+      mode or format is a hard error raised before any dependency install
+      (mode=scan/dump/deps-tree/deps-compare never produce a SARIF report).
     required: false
     default: 'false'
   fail-on-breaking:
@@ -431,6 +445,20 @@ outputs:
 runs:
   using: 'composite'
   steps:
+    # ── 0. Validate mode/input combinations ──────────────────────────────────
+    # Fails fast on an unsupported mode/input combination (e.g. a directory
+    # passed to dump/scan, or format: sarif on a non-compare mode) before
+    # Python setup, system-dependency installation, or any build/analysis
+    # work runs — see action/validate-inputs.sh for the rationale.
+    - name: Validate mode/input combination
+      shell: bash
+      env:
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_NEW_LIBRARY: ${{ inputs.new-library }}
+        INPUT_FORMAT: ${{ inputs.format }}
+        INPUT_UPLOAD_SARIF: ${{ inputs.upload-sarif }}
+      run: bash "${{ github.action_path }}/action/validate-inputs.sh"
+
     # ── 1. Python ─────────────────────────────────────────────────────────────
     - name: Set up Python
       uses: actions/setup-python@v6

--- a/action.yml
+++ b/action.yml
@@ -295,12 +295,13 @@ inputs:
     description: >
       Output format: json, sarif, html, or markdown/text (each mode's
       default when this input is left unset — markdown for compare/
-      deps-tree/deps-compare, text for scan). sarif and html are only
-      supported in compare mode with a single-pair (non-directory,
-      non-package) operand — a directory/package compare rejects them with
-      an error. scan supports text (its default) and json only.
-      deps-tree/deps-compare support markdown and json only. dump ignores
-      this input; it always writes a JSON snapshot. Requesting an
+      deps-tree/deps-compare, text for scan). sarif is only supported in
+      compare mode with a single-pair (non-directory, non-package) operand
+      — a directory/package compare rejects it with an error. html is
+      supported by compare (same single-pair restriction as sarif) and by
+      deps-tree/deps-compare (a dependency-stack report). scan supports
+      text (its default) and json only. dump ignores this input; it always
+      writes a JSON snapshot. Requesting an
       unsupported format for the mode is a hard error raised before any
       dependency install (it used to silently fall back to a supported
       format with only a warning, which is unsafe for CI — see

--- a/action.yml
+++ b/action.yml
@@ -293,8 +293,10 @@ inputs:
   # ── Output & policy ─────────────────────────────────────────────────────────
   format:
     description: >
-      Output format: markdown (default), json, sarif, html. sarif and html
-      are only supported in compare mode with a single-pair (non-directory,
+      Output format: json, sarif, html, or markdown/text (each mode's
+      default when this input is left unset — markdown for compare/
+      deps-tree/deps-compare, text for scan). sarif and html are only
+      supported in compare mode with a single-pair (non-directory,
       non-package) operand — a directory/package compare rejects them with
       an error. scan supports text (its default) and json only.
       deps-tree/deps-compare support markdown and json only. dump ignores
@@ -302,9 +304,13 @@ inputs:
       unsupported format for the mode is a hard error raised before any
       dependency install (it used to silently fall back to a supported
       format with only a warning, which is unsafe for CI — see
-      upload-sarif).
+      upload-sarif). Deliberately has no Action-level default (unlike most
+      inputs): a single default here would resolve to the wrong value for
+      scan regardless of mode, since GitHub Actions has no way to tell
+      "left unset" from "explicitly set to the default" apart once a
+      default is declared — each mode branch in action/run.sh supplies its
+      own correct default instead.
     required: false
-    default: 'markdown'
   output-file:
     description: 'Path to write the report file. If not set, output goes to stdout and job summary.'
     required: false

--- a/action/run.sh
+++ b/action/run.sh
@@ -224,6 +224,14 @@ if [[ "$MODE" == "dump" ]]; then
   # (`abicheck dump --sources ./src -o out.json`) needs no binary. Require
   # either a binary OR a source/build-evidence input.
   if [[ -n "${INPUT_NEW_LIBRARY:-}" ]]; then
+    # dump has no per-library fan-out (unlike compare) — a directory/package
+    # is normally caught early by action/validate-inputs.sh, before any
+    # dependency install; re-checked here for anyone invoking run.sh
+    # directly (e.g. tests) without that step.
+    if _is_release_style_operand "${INPUT_NEW_LIBRARY}"; then
+      echo "::error::mode: dump does not accept a directory or package for new-library ('${INPUT_NEW_LIBRARY}') — dump snapshots exactly one library. Dump each library individually, or use mode: compare with a directory/package operand instead."
+      exit 1
+    fi
     CMD+=("${INPUT_NEW_LIBRARY}")
   elif [[ -z "${INPUT_SOURCES:-}${INPUT_BUILD_INFO:-}${INPUT_COMPILE_DB:-}" ]]; then
     echo "::error::dump mode requires new-library, or one of sources/build-info/compile-db for a source-only dump."
@@ -392,11 +400,12 @@ elif [[ "$MODE" == "deps-tree" ]]; then
   add_flag "--search-path" "${INPUT_SEARCH_PATH:-}"
   add_single_flag "--ld-library-path" "${INPUT_LD_LIBRARY_PATH:-}"
 
-  # Format — deps-tree only supports markdown and json
+  # Format — deps-tree only supports markdown and json (hard error, not a
+  # silent fallback — see the scan branch's format check above).
   FORMAT="${INPUT_FORMAT:-markdown}"
   if [[ "$FORMAT" != "markdown" && "$FORMAT" != "json" ]]; then
-    echo "::warning::deps-tree mode only supports 'markdown' and 'json' formats. Falling back to 'markdown'."
-    FORMAT="markdown"
+    echo "::error::mode: deps-tree does not support format: $FORMAT. Only 'markdown' and 'json' are supported."
+    exit 1
   fi
   CMD+=(--format "$FORMAT")
 
@@ -419,11 +428,12 @@ elif [[ "$MODE" == "deps-compare" ]]; then
   add_flag "--search-path" "${INPUT_SEARCH_PATH:-}"
   add_single_flag "--ld-library-path" "${INPUT_LD_LIBRARY_PATH:-}"
 
-  # Format — deps-compare only supports markdown and json
+  # Format — deps-compare only supports markdown and json (hard error, not
+  # a silent fallback — see the scan branch's format check above).
   FORMAT="${INPUT_FORMAT:-markdown}"
   if [[ "$FORMAT" != "markdown" && "$FORMAT" != "json" ]]; then
-    echo "::warning::deps-compare mode only supports 'markdown' and 'json' formats. Falling back to 'markdown'."
-    FORMAT="markdown"
+    echo "::error::mode: deps-compare does not support format: $FORMAT. Only 'markdown' and 'json' are supported."
+    exit 1
   fi
   CMD+=(--format "$FORMAT")
 
@@ -445,7 +455,16 @@ elif [[ "$MODE" == "scan" ]]; then
   # — there is no separate --audit/--mode/--source-method/--estimate flag any
   # more (CLI simplification).
   CMD+=(scan)
-  CMD+=("${INPUT_NEW_LIBRARY:?new-library (the scanned binary or .abi.json) is required for scan mode}")
+  SCAN_ARTIFACT="${INPUT_NEW_LIBRARY:?new-library (the scanned binary or .abi.json) is required for scan mode}"
+  # scan has no per-library fan-out (unlike compare) — a directory/package
+  # is normally caught early by action/validate-inputs.sh, before any
+  # dependency install; re-checked here for anyone invoking run.sh directly
+  # (e.g. tests) without that step.
+  if _is_release_style_operand "$SCAN_ARTIFACT"; then
+    echo "::error::mode: scan does not accept a directory or package for new-library ('$SCAN_ARTIFACT') — scan analyses exactly one artifact. Use mode: compare against a directory/package for a multi-library binary comparison instead."
+    exit 1
+  fi
+  CMD+=("$SCAN_ARTIFACT")
 
   # -H/-I are side-aware on scan: a bare value applies to both ARTIFACT and
   # the --against side; old-header/old-include and new-header/new-include
@@ -490,11 +509,15 @@ elif [[ "$MODE" == "scan" ]]; then
     CMD+=(--allow-build-query)
   fi
 
-  # Format — scan only supports text and json.
+  # Format — scan only supports text and json. Normally caught early by
+  # action/validate-inputs.sh; re-checked here (hard error, not a silent
+  # fallback — a fallback here used to make a misconfigured `format: sarif`
+  # + `upload-sarif: true` scan step silently produce neither an error nor
+  # a SARIF report) for anyone invoking run.sh directly without that step.
   FORMAT="${INPUT_FORMAT:-text}"
   if [[ "$FORMAT" != "text" && "$FORMAT" != "json" ]]; then
-    echo "::warning::scan mode only supports 'text' and 'json' formats. Falling back to 'text'."
-    FORMAT="text"
+    echo "::error::mode: scan does not support format: $FORMAT. Only 'text' and 'json' are supported."
+    exit 1
   fi
   CMD+=(--format "$FORMAT")
 

--- a/action/run.sh
+++ b/action/run.sh
@@ -400,11 +400,13 @@ elif [[ "$MODE" == "deps-tree" ]]; then
   add_flag "--search-path" "${INPUT_SEARCH_PATH:-}"
   add_single_flag "--ld-library-path" "${INPUT_LD_LIBRARY_PATH:-}"
 
-  # Format — deps-tree only supports markdown and json (hard error, not a
-  # silent fallback — see the scan branch's format check above).
+  # Format — deps-tree supports markdown, json, and html (`deps tree
+  # --help`; html renders via cli_stack.py's stack_to_html). Hard error on
+  # anything else (sarif), not a silent fallback — see the scan branch's
+  # format check above.
   FORMAT="${INPUT_FORMAT:-markdown}"
-  if [[ "$FORMAT" != "markdown" && "$FORMAT" != "json" ]]; then
-    echo "::error::mode: deps-tree does not support format: $FORMAT. Only 'markdown' and 'json' are supported."
+  if [[ "$FORMAT" != "markdown" && "$FORMAT" != "json" && "$FORMAT" != "html" ]]; then
+    echo "::error::mode: deps-tree does not support format: $FORMAT. Only 'markdown', 'json', and 'html' are supported."
     exit 1
   fi
   CMD+=(--format "$FORMAT")
@@ -428,11 +430,13 @@ elif [[ "$MODE" == "deps-compare" ]]; then
   add_flag "--search-path" "${INPUT_SEARCH_PATH:-}"
   add_single_flag "--ld-library-path" "${INPUT_LD_LIBRARY_PATH:-}"
 
-  # Format — deps-compare only supports markdown and json (hard error, not
-  # a silent fallback — see the scan branch's format check above).
+  # Format — deps-compare supports markdown, json, and html (`deps compare
+  # --help`; html renders via cli_stack.py's stack_to_html). Hard error on
+  # anything else (sarif), not a silent fallback — see the scan branch's
+  # format check above.
   FORMAT="${INPUT_FORMAT:-markdown}"
-  if [[ "$FORMAT" != "markdown" && "$FORMAT" != "json" ]]; then
-    echo "::error::mode: deps-compare does not support format: $FORMAT. Only 'markdown' and 'json' are supported."
+  if [[ "$FORMAT" != "markdown" && "$FORMAT" != "json" && "$FORMAT" != "html" ]]; then
+    echo "::error::mode: deps-compare does not support format: $FORMAT. Only 'markdown', 'json', and 'html' are supported."
     exit 1
   fi
   CMD+=(--format "$FORMAT")

--- a/action/validate-inputs.sh
+++ b/action/validate-inputs.sh
@@ -106,6 +106,15 @@ case "$MODE" in
       fi
     fi
     ;;
+  *)
+    # An unrecognized mode (e.g. a typo like 'scna') has no arm above, so
+    # without this catch-all the case falls through silently and every
+    # other check in this script is skipped -- Python setup, dependency
+    # install, and pip install would all still run before run.sh's own
+    # "Unknown mode" check finally reports it. Mirrors run.sh's message
+    # verbatim.
+    _fail "Unknown mode '$MODE'. Use 'compare', 'dump', 'scan', 'deps-tree', or 'deps-compare'."
+    ;;
 esac
 
 if [[ "$UPLOAD_SARIF" == "true" && "$MODE" != "compare" ]]; then

--- a/action/validate-inputs.sh
+++ b/action/validate-inputs.sh
@@ -74,8 +74,8 @@ case "$MODE" in
     fi
     ;;
   deps-tree | deps-compare)
-    if [[ "$FORMAT" == "sarif" || "$FORMAT" == "html" ]]; then
-      _fail "mode: $MODE does not support format: $FORMAT — only 'markdown' and 'json' are supported."
+    if [[ "$FORMAT" == "sarif" ]]; then
+      _fail "mode: $MODE does not support format: $FORMAT — only 'markdown', 'json', and 'html' are supported."
     fi
     ;;
 esac

--- a/action/validate-inputs.sh
+++ b/action/validate-inputs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Mode-aware validation of the Action's `mode`/`new-library`/`format`/
-# `upload-sarif` inputs, run as the very first composite-action step —
+# Mode-aware validation of the Action's `mode`/`new-library`/`old-library`/
+# `format`/`upload-sarif` inputs, run as the very first composite-action step —
 # before Python setup, system-dependency installation (castxml/gcc/clang,
 # action/install-deps.sh), or `pip install abicheck`.
 #
@@ -25,6 +25,7 @@ set -uo pipefail
 MODE="${INPUT_MODE:-compare}"
 FORMAT="${INPUT_FORMAT:-}"
 NEW_LIBRARY="${INPUT_NEW_LIBRARY:-}"
+OLD_LIBRARY="${INPUT_OLD_LIBRARY:-}"
 UPLOAD_SARIF="${INPUT_UPLOAD_SARIF:-false}"
 
 # A directory, or a file whose name/magic bytes match a recognized package
@@ -69,13 +70,29 @@ case "$MODE" in
     if [[ -n "$NEW_LIBRARY" ]] && _is_release_style_operand "$NEW_LIBRARY"; then
       _fail "mode: scan does not accept a directory or package for new-library ('$NEW_LIBRARY') — scan analyses exactly one artifact (a binary or a JSON snapshot), it has no per-library fan-out. Point new-library at a single library, or use mode: compare against a directory/package for a multi-library binary comparison."
     fi
-    if [[ "$FORMAT" == "sarif" || "$FORMAT" == "html" ]]; then
-      _fail "mode: scan does not support format: $FORMAT — only 'text' and 'json' are supported. (This used to silently fall back to 'text', which is especially misleading paired with upload-sarif: you would get neither an error nor a SARIF report.) Set format to 'text' or 'json', or switch to mode: compare for SARIF output."
+    # Allowlist, not a denylist: any value other than scan's two real
+    # formats (including a typo like 'xml', not just the known-bad
+    # sarif/html) must be caught here too, not just downstream in the CLI.
+    if [[ -n "$FORMAT" && "$FORMAT" != "text" && "$FORMAT" != "json" ]]; then
+      _fail "mode: scan does not support format: $FORMAT — only 'text' and 'json' are supported. (An unsupported format used to silently fall back to 'text', which is especially misleading paired with upload-sarif: you would get neither an error nor a SARIF report.) Set format to 'text' or 'json', or switch to mode: compare for SARIF output."
     fi
     ;;
   deps-tree | deps-compare)
-    if [[ "$FORMAT" == "sarif" ]]; then
+    if [[ -n "$FORMAT" && "$FORMAT" != "markdown" && "$FORMAT" != "json" && "$FORMAT" != "html" ]]; then
       _fail "mode: $MODE does not support format: $FORMAT — only 'markdown', 'json', and 'html' are supported."
+    fi
+    ;;
+  compare)
+    # sarif/html require a single-pair comparison; the CLI itself already
+    # rejects a directory/package operand for them (a clear UsageError,
+    # surfaced as VERDICT=ERROR by run.sh) but only after Python/deps are
+    # installed. Catch it here too so it's free, like every other check in
+    # this script.
+    if [[ "$FORMAT" == "sarif" || "$FORMAT" == "html" ]]; then
+      if { [[ -n "$NEW_LIBRARY" ]] && _is_release_style_operand "$NEW_LIBRARY"; } \
+         || { [[ -n "$OLD_LIBRARY" ]] && _is_release_style_operand "$OLD_LIBRARY"; }; then
+        _fail "mode: compare does not support format: $FORMAT with a directory/package operand (old-library='$OLD_LIBRARY', new-library='$NEW_LIBRARY') — $FORMAT requires a single-pair comparison. Use format: markdown or json for a directory/package compare."
+      fi
     fi
     ;;
 esac

--- a/action/validate-inputs.sh
+++ b/action/validate-inputs.sh
@@ -83,15 +83,26 @@ case "$MODE" in
     fi
     ;;
   compare)
-    # sarif/html require a single-pair comparison; the CLI itself already
-    # rejects a directory/package operand for them (a clear UsageError,
-    # surfaced as VERDICT=ERROR by run.sh) but only after Python/deps are
-    # installed. Catch it here too so it's free, like every other check in
-    # this script.
-    if [[ "$FORMAT" == "sarif" || "$FORMAT" == "html" ]]; then
+    # compare's full --format choice set is json|markdown|sarif|html|junit|
+    # review (`abicheck compare --help-all`); a directory/package operand
+    # fans out through the release engine, which narrows that to
+    # cli.py's _RELEASE_FORMATS = {json, markdown, junit} (sarif/html/review
+    # rejected — a clear UsageError, surfaced as VERDICT=ERROR by run.sh —
+    # but only after Python/deps are installed). Mirror both allowlists
+    # here so a bad value (a typo, or a release-only-invalid format like
+    # sarif/html/review on a directory/package) is caught before that
+    # install, not just downstream in the CLI.
+    # tests/test_action_validate_inputs.py cross-checks these two sets
+    # against the live CLI to catch drift.
+    if [[ -n "$FORMAT" ]]; then
       if { [[ -n "$NEW_LIBRARY" ]] && _is_release_style_operand "$NEW_LIBRARY"; } \
          || { [[ -n "$OLD_LIBRARY" ]] && _is_release_style_operand "$OLD_LIBRARY"; }; then
-        _fail "mode: compare does not support format: $FORMAT with a directory/package operand (old-library='$OLD_LIBRARY', new-library='$NEW_LIBRARY') — $FORMAT requires a single-pair comparison. Use format: markdown or json for a directory/package compare."
+        if [[ "$FORMAT" != "json" && "$FORMAT" != "markdown" && "$FORMAT" != "junit" ]]; then
+          _fail "mode: compare does not support format: $FORMAT with a directory/package operand (old-library='$OLD_LIBRARY', new-library='$NEW_LIBRARY') — only 'json', 'markdown', and 'junit' are available for a directory/package comparison."
+        fi
+      elif [[ "$FORMAT" != "json" && "$FORMAT" != "markdown" && "$FORMAT" != "sarif" \
+            && "$FORMAT" != "html" && "$FORMAT" != "junit" && "$FORMAT" != "review" ]]; then
+        _fail "mode: compare does not support format: $FORMAT — only 'json', 'markdown', 'sarif', 'html', 'junit', and 'review' are supported."
       fi
     fi
     ;;

--- a/action/validate-inputs.sh
+++ b/action/validate-inputs.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Mode-aware validation of the Action's `mode`/`new-library`/`format`/
+# `upload-sarif` inputs, run as the very first composite-action step —
+# before Python setup, system-dependency installation (castxml/gcc/clang,
+# action/install-deps.sh), or `pip install abicheck`.
+#
+# Why this exists: a real integration passed a multi-library release
+# directory as `new-library` to `mode: scan` (and separately to `mode:
+# dump`), and requested `format: sarif` + `upload-sarif: true` on a scan
+# step. Neither combination is supported — scan/dump analyse exactly one
+# artifact (they have no per-library fan-out the way `compare`'s release
+# engine does), and scan only emits text/json — but previously nothing
+# caught this until well after a multi-minute toolchain install and build,
+# and the unsupported format silently fell back to `text` with only a
+# `::warning::`, so a workflow that thought it was wiring up GitHub Code
+# Scanning via SARIF got neither an error nor a SARIF report. Failing fast
+# here, before any dependency install, surfaces the misconfiguration
+# immediately and for free.
+#
+# action/run.sh independently re-checks the format/upload-sarif rules
+# right before invoking abicheck (defense in depth for anyone invoking
+# run.sh directly, e.g. in tests) — keep both in sync.
+set -uo pipefail
+
+MODE="${INPUT_MODE:-compare}"
+FORMAT="${INPUT_FORMAT:-}"
+NEW_LIBRARY="${INPUT_NEW_LIBRARY:-}"
+UPLOAD_SARIF="${INPUT_UPLOAD_SARIF:-false}"
+
+# A directory, or a file whose name/magic bytes match a recognized package
+# format (RPM, Deb, tar, conda, wheel) — mirrors action/run.sh's
+# `_is_release_style_operand()` (abicheck/package.py's `is_package()`
+# detection, including its magic-byte fallback for extensionless RPM/Deb).
+# Duplicated rather than sourced so this validation step has zero
+# dependency on run.sh's internal layout; tests/test_action_validate_inputs.py
+# runs both copies against the same fixtures to catch drift between them.
+_is_release_style_operand() {
+  local path="$1"
+  [[ -d "$path" ]] && return 0
+  local lower
+  lower=$(printf '%s' "$path" | tr '[:upper:]' '[:lower:]')
+  case "$lower" in
+    *.rpm | *.deb | *.tar | *.tar.gz | *.tar.xz | *.tar.bz2 | *.tar.zst | *.tgz | *.conda | *.whl)
+      return 0
+      ;;
+  esac
+  [[ -f "$path" ]] || return 1
+  local magic
+  magic=$(od -An -tx1 -N 8 "$path" 2>/dev/null | tr -d ' \n')
+  case "$magic" in
+    edabeedb*) return 0 ;;          # RPM lead magic
+    213c617263683e0a) return 0 ;;   # "!<arch>\n" (Deb ar archive)
+  esac
+  return 1
+}
+
+_fail() {
+  echo "::error::$1"
+  exit 1
+}
+
+case "$MODE" in
+  dump)
+    if [[ -n "$NEW_LIBRARY" ]] && _is_release_style_operand "$NEW_LIBRARY"; then
+      _fail "mode: dump does not accept a directory or package for new-library ('$NEW_LIBRARY') — dump snapshots exactly one library, it has no per-library fan-out. Dump each library individually (one step per binary, or a matrix), or switch to mode: compare with a directory/package operand, which fans out to a per-library comparison automatically."
+    fi
+    ;;
+  scan)
+    if [[ -n "$NEW_LIBRARY" ]] && _is_release_style_operand "$NEW_LIBRARY"; then
+      _fail "mode: scan does not accept a directory or package for new-library ('$NEW_LIBRARY') — scan analyses exactly one artifact (a binary or a JSON snapshot), it has no per-library fan-out. Point new-library at a single library, or use mode: compare against a directory/package for a multi-library binary comparison."
+    fi
+    if [[ "$FORMAT" == "sarif" || "$FORMAT" == "html" ]]; then
+      _fail "mode: scan does not support format: $FORMAT — only 'text' and 'json' are supported. (This used to silently fall back to 'text', which is especially misleading paired with upload-sarif: you would get neither an error nor a SARIF report.) Set format to 'text' or 'json', or switch to mode: compare for SARIF output."
+    fi
+    ;;
+  deps-tree | deps-compare)
+    if [[ "$FORMAT" == "sarif" || "$FORMAT" == "html" ]]; then
+      _fail "mode: $MODE does not support format: $FORMAT — only 'markdown' and 'json' are supported."
+    fi
+    ;;
+esac
+
+if [[ "$UPLOAD_SARIF" == "true" && "$MODE" != "compare" ]]; then
+  _fail "upload-sarif is only meaningful with mode: compare (single-pair operands) — mode: $MODE never produces a SARIF report to upload. Remove upload-sarif, or switch to mode: compare."
+fi
+
+if [[ "$UPLOAD_SARIF" == "true" && "$FORMAT" != "sarif" ]]; then
+  _fail "upload-sarif requires format: sarif (got '${FORMAT:-markdown}') — without it there is no SARIF report for the upload-sarif step to find."
+fi

--- a/action/validate-inputs.sh
+++ b/action/validate-inputs.sh
@@ -78,6 +78,13 @@ case "$MODE" in
     fi
     ;;
   deps-tree | deps-compare)
+    # `abicheck deps tree`/`deps compare` both take a single BINARY, not a
+    # directory/package -- the same per-artifact contract dump/scan have,
+    # missing here let an unsupported compare-only operand pass this
+    # fail-fast step and fail later in the CLI instead (Codex review).
+    if [[ -n "$NEW_LIBRARY" ]] && _is_release_style_operand "$NEW_LIBRARY"; then
+      _fail "mode: $MODE does not accept a directory or package for new-library ('$NEW_LIBRARY') — deps tree/deps compare analyse exactly one binary, they have no per-library fan-out. Point new-library at a single binary."
+    fi
     if [[ -n "$FORMAT" && "$FORMAT" != "markdown" && "$FORMAT" != "json" && "$FORMAT" != "html" ]]; then
       _fail "mode: $MODE does not support format: $FORMAT — only 'markdown', 'json', and 'html' are supported."
     fi

--- a/actions/baseline/action.yml
+++ b/actions/baseline/action.yml
@@ -1,0 +1,130 @@
+name: 'abicheck baseline'
+description: >-
+  Dump a set of libraries into a baseline-set (one snapshot file per
+  library plus a manifest.json recording fact-set identity, profile, and
+  per-library content digests), instead of a single `*.abicheck.json` that
+  a multi-library release has no honest way to fit into. Read-only: this
+  Action never commits or pushes -- publishing the result is the calling
+  workflow's job (see docs/user-guide/baseline-management.md).
+
+branding:
+  icon: 'archive'
+  color: 'blue'
+
+inputs:
+  libraries:
+    description: >
+      JSON array of libraries to dump, one object per library:
+      `[{"name": "libfoo", "artifact": "build/libfoo.so", "header":
+      "include/foo.h", "include": "include"}, ...]`. `name` and `artifact`
+      are required per entry; `header`/`include` are optional (space-
+      separated for multiple paths, matching the main Action's `header`/
+      `include` inputs).
+    required: true
+  output-dir:
+    description: 'Directory to write the per-library snapshots and manifest.json into.'
+    required: false
+    default: '.abicheck-baseline'
+  project-ref:
+    description: 'Release/version label recorded in the manifest and passed as each dump''s --version (e.g. github.ref_name).'
+    required: false
+    default: ''
+  profile:
+    description: >
+      Build-profile identifier recorded in the manifest (platform/
+      architecture/compiler/ISA/debug-or-release, e.g.
+      "linux-x86_64-icx-avx2-debug") -- see baseline-management.md#baseline-identity-is-more-than-a-version-number
+      for why a version number alone is not a safe baseline identity for a
+      project with more than one build profile.
+    required: false
+    default: ''
+  build-info:
+    description: >
+      Shared build/source facts pack (e.g. from the collect-facts Action)
+      passed as --build-info to every library's dump call. Omit for a
+      binary/header-only (L0-L2) baseline-set.
+    required: false
+  depth:
+    description: 'Evidence depth passed to every dump call (binary, headers, build, or source). Omit for the CLI default.'
+    required: false
+  previous-manifest:
+    description: >
+      Path to a previous manifest.json to diff against for the
+      refresh-required/refresh-reasons outputs. Omit to skip the freshness
+      comparison (refresh-required is always 'false' without one -- there
+      is nothing to compare against, not a claim that no refresh is
+      needed).
+    required: false
+  validation:
+    description: >
+      'strict' (default) round-trips each freshly-dumped snapshot through
+      a self-compare (compare a.json against itself) as a sanity check
+      that the file it just wrote is loadable and internally consistent;
+      'none' skips it.
+    required: false
+    default: 'strict'
+  python-version:
+    description: 'Python version for setup-python.'
+    required: false
+    default: '3.13'
+  install-deps:
+    description: 'Install system dependencies (castxml, gcc). Set to false if pre-installed.'
+    required: false
+    default: 'true'
+
+outputs:
+  baseline-path:
+    description: 'The output-dir this run wrote into.'
+    value: ${{ steps.run-baseline.outputs.baseline-path }}
+  manifest-path:
+    description: 'Path to the generated manifest.json.'
+    value: ${{ steps.run-baseline.outputs.manifest-path }}
+  library-count:
+    description: 'Number of libraries successfully dumped into this baseline-set.'
+    value: ${{ steps.run-baseline.outputs.library-count }}
+  content-digest:
+    description: 'SHA-256 over the manifest''s artifact list (library names + per-file digests) -- changes whenever any library''s snapshot content changes.'
+    value: ${{ steps.run-baseline.outputs.content-digest }}
+  refresh-required:
+    description: >
+      'true' when previous-manifest was given and this run's manifest
+      differs from it in a way that means old comparisons against it are
+      no longer trustworthy (snapshot_schema, fact_set identity, or the
+      library set changed). 'false' when no previous-manifest was given,
+      or none of those changed.
+    value: ${{ steps.run-baseline.outputs.refresh-required }}
+  refresh-reasons:
+    description: 'Semicolon-separated human-readable reasons refresh-required is true. Empty otherwise.'
+    value: ${{ steps.run-baseline.outputs.refresh-reasons }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install system dependencies
+      if: inputs.install-deps == 'true'
+      shell: bash
+      run: bash "${{ github.action_path }}/../../action/install-deps.sh"
+
+    - name: Install abicheck
+      shell: bash
+      run: pip install "${{ github.action_path }}/../.."
+
+    - name: Dump baseline-set
+      id: run-baseline
+      shell: bash
+      env:
+        INPUT_LIBRARIES: ${{ inputs.libraries }}
+        INPUT_OUTPUT_DIR: ${{ inputs.output-dir }}
+        INPUT_PROJECT_REF: ${{ inputs.project-ref }}
+        INPUT_PROFILE: ${{ inputs.profile }}
+        INPUT_BUILD_INFO: ${{ inputs.build-info }}
+        INPUT_DEPTH: ${{ inputs.depth }}
+        INPUT_PREVIOUS_MANIFEST: ${{ inputs.previous-manifest }}
+        INPUT_VALIDATION: ${{ inputs.validation }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: bash "${{ github.action_path }}/run.sh"

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -48,8 +48,25 @@ def _read_snapshot_meta(path: Path) -> dict[str, Any]:
     # therefore content-digest, which is built from these per-artifact
     # digests -- changed on every single run even when the actual ABI
     # content was byte-identical (Codex review).
+    #
+    # A snapshot dumped with --build-info/--sources also embeds a *second*,
+    # independently-stamped timestamp at build_source.manifest.created_at
+    # (BuildSourceManifest.created_at, written fresh by every collect-facts
+    # run -- see abicheck/buildsource/pack.py's own content_hash(), which
+    # excludes it for the same reason). Leaving it in place kept the digest
+    # unstable for any baseline with embedded source facts even after the
+    # top-level created_at was stripped (Codex review).
     stable = dict(raw)
     stable.pop("created_at", None)
+    build_source = stable.get("build_source")
+    if isinstance(build_source, dict):
+        manifest = build_source.get("manifest")
+        if isinstance(manifest, dict) and "created_at" in manifest:
+            build_source = dict(build_source)
+            manifest = dict(manifest)
+            manifest.pop("created_at", None)
+            build_source["manifest"] = manifest
+            stable["build_source"] = build_source
     sha256 = hashlib.sha256(
         json.dumps(stable, sort_keys=True).encode("utf-8")
     ).hexdigest()

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -91,6 +91,8 @@ def build_manifest(
     # compiler_version comparability rules, which this mirrors so a refresh
     # is flagged for the same reasons.
     fact_set_ids: set[tuple[str, int, str, str, str, str]] = set()
+    fact_set_present = 0
+    fact_set_absent = 0
     for entry in entries:
         name = entry["name"]
         snap_path = output_dir / f"{name}.abicheck.json"
@@ -109,6 +111,7 @@ def build_manifest(
             and fact_set.get("name")
             and fact_set.get("version") is not None
         ):
+            fact_set_present += 1
             fact_set_ids.add(
                 (
                     str(fact_set["name"]),
@@ -119,6 +122,8 @@ def build_manifest(
                     str(fact_set.get("compiler_version") or ""),
                 )
             )
+        else:
+            fact_set_absent += 1
         artifacts.append(
             {
                 "library": name,
@@ -132,19 +137,33 @@ def build_manifest(
             }
         )
 
+    # Every check below is a self-consistency invariant of one baseline-set
+    # run (all libraries dumped in the same job, by the same installed
+    # abicheck, against the same shared --build-info pack per action.yml's
+    # contract) -- a violation means the invariant broke, not that there is
+    # a legitimate "mixed" state to represent, so this fails loudly rather
+    # than publishing a manifest whose identity silently dropped information
+    # a later comparison could have used to detect drift (CodeRabbit review).
     if len(schema_versions) > 1:
-        print(
-            f"::warning::baseline-set snapshots disagree on schema_version "
+        raise SystemExit(
+            f"baseline-set snapshots disagree on schema_version "
             f"{sorted(schema_versions)} -- they were dumped by different "
-            f"abicheck versions in the same run, which should not happen.",
-            file=sys.stderr,
+            f"abicheck versions in the same run, which should never happen."
+        )
+    if fact_set_present and fact_set_absent:
+        raise SystemExit(
+            f"baseline-set snapshots disagree on whether source-fact "
+            f"evidence is present: {fact_set_present} carry a fact_set "
+            f"identity, {fact_set_absent} do not -- each library should "
+            f"share the one build-info pack passed to every dump call "
+            f"(pass the same --build-info/--sources to every library, or "
+            f"none)."
         )
     if len(fact_set_ids) > 1:
-        print(
-            f"::warning::baseline-set snapshots disagree on fact_set "
-            f"identity {sorted(fact_set_ids)} -- each library should share "
-            f"the one build-info pack passed to every dump call.",
-            file=sys.stderr,
+        raise SystemExit(
+            f"baseline-set snapshots disagree on fact_set identity "
+            f"{sorted(fact_set_ids)} -- each library should share the one "
+            f"build-info pack passed to every dump call."
         )
 
     fact_set_out = None
@@ -188,8 +207,21 @@ def _compute_freshness(
     """Compare against a previous manifest (if given) and report what
     changed -- the structured input to an Action's refresh-required output.
     Absent a previous manifest, freshness cannot be assessed either way."""
-    if previous_manifest_path is None or not previous_manifest_path.is_file():
+    if previous_manifest_path is None:
         return {"refresh_required": False, "reasons": []}
+    if not previous_manifest_path.is_file():
+        # Omitting --previous-manifest entirely is the documented way to say
+        # "no previous baseline" (action.yml); a caller that *did* pass one
+        # pointing at a path that doesn't exist is a broken workflow (a typo,
+        # or an artifact download that silently failed) -- silently treating
+        # it the same as "omitted" would report refresh-required=false as if
+        # the comparison had actually run and found nothing stale (CodeRabbit
+        # review).
+        raise SystemExit(
+            f"--previous-manifest was given as {previous_manifest_path} but "
+            "that file does not exist -- omit the flag entirely for 'no "
+            "previous baseline', don't point it at a missing path."
+        )
 
     with previous_manifest_path.open(encoding="utf-8") as f:
         previous = json.load(f)
@@ -246,8 +278,25 @@ def main(argv: list[str] | None = None) -> int:
         json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
     )
 
+    # Only library name + snapshot sha256, sorted by library -- matches
+    # action.yml's documented contract ("library names + per-file digests").
+    # Hashing the full artifact list (as before) pulled in created_at, which
+    # dumper.py auto-stamps fresh on every dump call, so the digest changed
+    # on every run even when every snapshot's actual content was identical,
+    # defeating its purpose as a "did anything really change" signal
+    # (CodeRabbit review). Sorted by library so digest is independent of
+    # entry/matrix order too.
     content_digest = hashlib.sha256(
-        json.dumps(manifest["artifacts"], sort_keys=True).encode("utf-8")
+        json.dumps(
+            sorted(
+                (
+                    {"library": a["library"], "sha256": a["sha256"]}
+                    for a in manifest["artifacts"]
+                ),
+                key=lambda a: a["library"],
+            ),
+            sort_keys=True,
+        ).encode("utf-8")
     ).hexdigest()
 
     # key=value lines on stdout -- the caller (run.sh) forwards these to

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -51,7 +51,17 @@ def _read_snapshot_meta(path: Path) -> dict[str, Any]:
     if isinstance(build_source, dict):
         source_abi = build_source.get("source_abi")
         if isinstance(source_abi, dict):
-            fact_set = source_abi.get("fact_set")
+            # SourceAbiSurface.to_dict() (abicheck/buildsource/source_abi.py)
+            # has no top-level "fact_set" key -- the rolled-up identity is
+            # written to surface.coverage["fact_set"] by
+            # source_link.link_source_abi() (abicheck/buildsource/
+            # source_link.py). Reading source_abi["fact_set"] directly always
+            # returned None for a real dump --sources/--build-info baseline,
+            # silently disabling the freshness recipe-identity check this
+            # manifest exists to provide (Codex review).
+            coverage = source_abi.get("coverage")
+            if isinstance(coverage, dict):
+                fact_set = coverage.get("fact_set")
     return {
         "schema_version": raw.get("schema_version"),
         "library": raw.get("library"),

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Build a baseline-set manifest.json from a directory of per-library
+.abicheck.json snapshots that actions/baseline/run.sh just dumped.
+
+Reads each snapshot's raw JSON directly (not through abicheck's AbiSnapshot
+model) so this script has no dependency on abicheck's internal schema beyond
+a handful of top-level, long-stable keys -- the same defensive-.get()
+philosophy abicheck/buildsource/CLAUDE.md documents for its own dataclasses.
+
+A baseline-set is *not* self-describing from a version number alone (see
+docs/user-guide/baseline-management.md#baseline-identity-is-more-than-a-version-number):
+this manifest records the profile string the caller supplies, plus each
+snapshot's own schema_version and (when build-source evidence is embedded)
+fact_set identity, so a mismatch against a previous manifest is a structured
+comparison instead of a human guessing from a filename.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _read_snapshot_meta(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as f:
+        raw = json.load(f)
+    fact_set = None
+    build_source = raw.get("build_source")
+    if isinstance(build_source, dict):
+        source_abi = build_source.get("source_abi")
+        if isinstance(source_abi, dict):
+            fact_set = source_abi.get("fact_set")
+    return {
+        "schema_version": raw.get("schema_version"),
+        "library": raw.get("library"),
+        "version": raw.get("version"),
+        "git_commit": raw.get("git_commit"),
+        "git_tag": raw.get("git_tag"),
+        "created_at": raw.get("created_at"),
+        "build_id": raw.get("build_id"),
+        "fact_set": fact_set,
+    }
+
+
+def build_manifest(
+    output_dir: Path,
+    project_ref: str,
+    profile: str,
+    entries: list[dict[str, str]],
+    previous_manifest_path: Path | None,
+) -> dict[str, Any]:
+    artifacts = []
+    schema_versions: set[int] = set()
+    fact_set_ids: set[tuple[str, int]] = set()
+    for entry in entries:
+        name = entry["name"]
+        snap_path = output_dir / f"{name}.abicheck.json"
+        if not snap_path.is_file():
+            raise SystemExit(
+                f"expected a dumped snapshot for library '{name}' at "
+                f"{snap_path}, but it does not exist -- the dump step for "
+                f"this library must have failed silently."
+            )
+        meta = _read_snapshot_meta(snap_path)
+        if meta["schema_version"] is not None:
+            schema_versions.add(int(meta["schema_version"]))
+        fact_set = meta["fact_set"]
+        if (
+            isinstance(fact_set, dict)
+            and fact_set.get("name")
+            and fact_set.get("version") is not None
+        ):
+            fact_set_ids.add((str(fact_set["name"]), int(fact_set["version"])))
+        artifacts.append(
+            {
+                "library": name,
+                "artifact": entry.get("artifact", ""),
+                "snapshot": snap_path.name,
+                "sha256": _sha256(snap_path),
+                "git_commit": meta["git_commit"],
+                "git_tag": meta["git_tag"],
+                "created_at": meta["created_at"],
+                "build_id": meta["build_id"],
+            }
+        )
+
+    if len(schema_versions) > 1:
+        print(
+            f"::warning::baseline-set snapshots disagree on schema_version "
+            f"{sorted(schema_versions)} -- they were dumped by different "
+            f"abicheck versions in the same run, which should not happen.",
+            file=sys.stderr,
+        )
+    if len(fact_set_ids) > 1:
+        print(
+            f"::warning::baseline-set snapshots disagree on fact_set "
+            f"identity {sorted(fact_set_ids)} -- each library should share "
+            f"the one build-info pack passed to every dump call.",
+            file=sys.stderr,
+        )
+
+    fact_set_out = None
+    if len(fact_set_ids) == 1:
+        name, version = next(iter(fact_set_ids))
+        fact_set_out = {"name": name, "version": version}
+
+    manifest: dict[str, Any] = {
+        "manifest_version": 1,
+        "project_ref": project_ref,
+        "profile": profile,
+        "snapshot_schema": max(schema_versions) if schema_versions else None,
+        "fact_set": fact_set_out,
+        "artifacts": artifacts,
+    }
+    manifest["freshness"] = _compute_freshness(manifest, previous_manifest_path)
+    return manifest
+
+
+def _compute_freshness(
+    manifest: dict[str, Any], previous_manifest_path: Path | None
+) -> dict[str, Any]:
+    """Compare against a previous manifest (if given) and report what
+    changed -- the structured input to an Action's refresh-required output.
+    Absent a previous manifest, freshness cannot be assessed either way."""
+    if previous_manifest_path is None or not previous_manifest_path.is_file():
+        return {"refresh_required": False, "reasons": []}
+
+    with previous_manifest_path.open(encoding="utf-8") as f:
+        previous = json.load(f)
+
+    reasons = []
+    if previous.get("snapshot_schema") != manifest["snapshot_schema"]:
+        reasons.append(
+            f"snapshot_schema {previous.get('snapshot_schema')} -> {manifest['snapshot_schema']}"
+        )
+    if previous.get("fact_set") != manifest["fact_set"]:
+        reasons.append(f"fact_set {previous.get('fact_set')} -> {manifest['fact_set']}")
+
+    prev_libs = {a["library"] for a in previous.get("artifacts", [])}
+    cur_libs = {a["library"] for a in manifest["artifacts"]}
+    removed = prev_libs - cur_libs
+    added = cur_libs - prev_libs
+    if removed:
+        reasons.append(f"libraries removed: {sorted(removed)}")
+    if added:
+        reasons.append(f"libraries added: {sorted(added)}")
+
+    return {"refresh_required": bool(reasons), "reasons": reasons}
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", required=True, type=Path)
+    parser.add_argument("--project-ref", default="")
+    parser.add_argument("--profile", default="")
+    parser.add_argument(
+        "--libraries",
+        required=True,
+        help='JSON array of {"name": ..., "artifact": ...} entries, one per library.',
+    )
+    parser.add_argument("--previous-manifest", default=None, type=Path)
+    parser.add_argument("--manifest-out", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    entries = json.loads(args.libraries)
+    manifest = build_manifest(
+        args.output_dir, args.project_ref, args.profile, entries, args.previous_manifest
+    )
+    args.manifest_out.write_text(
+        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
+    )
+
+    content_digest = hashlib.sha256(
+        json.dumps(manifest["artifacts"], sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+    # key=value lines on stdout -- the caller (run.sh) forwards these to
+    # GITHUB_OUTPUT rather than this script writing there directly, so it
+    # stays testable as a plain function/CLI with no Action-runner dependency.
+    print(f"library-count={len(manifest['artifacts'])}")
+    print(f"content-digest={content_digest}")
+    print(
+        f"refresh-required={'true' if manifest['freshness']['refresh_required'] else 'false'}"
+    )
+    print(f"refresh-reasons={'; '.join(manifest['freshness']['reasons'])}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -48,6 +48,16 @@ from typing import Any
 # one-off pop so the next volatile field lands here too (Codex review).
 _VOLATILE_TOP_LEVEL_KEYS = ("created_at", "source_mtime", "source_mtime_epoch")
 _VOLATILE_BUILD_SOURCE_MANIFEST_KEYS = ("created_at",)
+# BuildSourceRef.path_hint (abicheck/buildsource/model.py) -- the out-of-band
+# pack's on-disk location, documented on the field itself as "advisory only".
+# cli_buildsource.py's embed_build_source() defaults it to the --sources/
+# --build-info operand path when the caller doesn't pass a name hint, so the
+# same ABI/source facts dumped from a relative abicheck_inputs/ vs an
+# absolute restored pack path get a different path_hint and therefore a
+# different per-artifact sha256/content-digest, even though nothing semantic
+# changed (Codex review). content_hash/coverage_summary, the ref's other two
+# fields, are real content identity and stay.
+_VOLATILE_BUILD_SOURCE_PACK_KEYS = ("path_hint",)
 # Populated by abicheck/buildsource/source_replay.py's replay producer (and
 # inline.py's cache bookkeeping) -- wall-clock durations and cache hit/miss
 # counts that depend on the runner's cache warmth and load, not on the
@@ -100,6 +110,13 @@ def _strip_volatile_fields(raw: dict[str, Any]) -> dict[str, Any]:
     stable = dict(raw)
     for key in _VOLATILE_TOP_LEVEL_KEYS:
         stable.pop(key, None)
+
+    build_source_pack = stable.get("build_source_pack")
+    if isinstance(build_source_pack, dict):
+        build_source_pack = dict(build_source_pack)
+        for key in _VOLATILE_BUILD_SOURCE_PACK_KEYS:
+            build_source_pack.pop(key, None)
+        stable["build_source_pack"] = build_source_pack
 
     build_source = stable.get("build_source")
     if isinstance(build_source, dict):

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -59,6 +59,11 @@ _VOLATILE_COVERAGE_KEYS = (
     "elapsed_s",
     "cache_misses",
     "cache_hits",
+    # The replay producer's own parallelism setting (CPU count or
+    # ABICHECK_L4_JOBS), not a property of the extracted content -- the
+    # same ABI/source facts replayed on a differently-sized runner would
+    # otherwise still churn the digest (Codex review).
+    "extractor_jobs",
 )
 # LayerCoverage rows (abicheck/buildsource/model.py) embedded at
 # build_source.manifest.coverage: build_inline_coverage() (buildsource/

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -185,6 +185,16 @@ def _compute_freshness(
         previous = json.load(f)
 
     reasons = []
+    if previous.get("profile") != manifest["profile"]:
+        # profile is the platform/compiler build-profile identity the action
+        # itself records (e.g. linux-x86_64-gcc vs linux-x86_64-clang) -- a
+        # previous-manifest from a different profile is not a stale copy of
+        # this one, it is a baseline for a different target entirely, and
+        # comparing schema/fact_set/library-set alone can't tell the two
+        # apart (Codex review).
+        reasons.append(
+            f"profile {previous.get('profile')!r} -> {manifest['profile']!r}"
+        )
     if previous.get("snapshot_schema") != manifest["snapshot_schema"]:
         reasons.append(
             f"snapshot_schema {previous.get('snapshot_schema')} -> {manifest['snapshot_schema']}"

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -69,6 +69,26 @@ _VOLATILE_COVERAGE_KEYS = (
 # "layer"/"status"/"confidence" are the semantic identity; "detail" is by
 # its own docstring presentational, so both are dropped rather than parsed.
 _VOLATILE_MANIFEST_COVERAGE_ROW_KEYS = ("detail", "elapsed_s")
+# ExtractorRecord rows (abicheck/buildsource/model.py) embedded at
+# build_source.manifest.extractors: inline_graph_fold.py appends
+# "N.NNs, jobs=M" (last_elapsed_s/last_jobs) to a row's "detail", and
+# started_at/finished_at are ISO 8601 wall-clock bounds -- runner
+# load/CPU count and collection time, not source-fact content, so a
+# fourth leak of the same volatile-info-in-a-row-field shape. name/
+# version/status/inputs/artifacts/command/command_hash/capabilities/
+# diagnostics are the semantic identity and stay.
+_VOLATILE_MANIFEST_EXTRACTOR_ROW_KEYS = ("detail", "started_at", "finished_at")
+
+
+def _strip_row_keys(rows: Any, volatile_keys: tuple[str, ...]) -> Any:
+    if not isinstance(rows, list):
+        return rows
+    return [
+        {k: v for k, v in row.items() if k not in volatile_keys}
+        if isinstance(row, dict)
+        else row
+        for row in rows
+    ]
 
 
 def _strip_volatile_fields(raw: dict[str, Any]) -> dict[str, Any]:
@@ -85,18 +105,14 @@ def _strip_volatile_fields(raw: dict[str, Any]) -> dict[str, Any]:
             manifest = dict(manifest)
             for key in _VOLATILE_BUILD_SOURCE_MANIFEST_KEYS:
                 manifest.pop(key, None)
-            coverage_rows = manifest.get("coverage")
-            if isinstance(coverage_rows, list):
-                manifest["coverage"] = [
-                    {
-                        k: v
-                        for k, v in row.items()
-                        if k not in _VOLATILE_MANIFEST_COVERAGE_ROW_KEYS
-                    }
-                    if isinstance(row, dict)
-                    else row
-                    for row in coverage_rows
-                ]
+            if "coverage" in manifest:
+                manifest["coverage"] = _strip_row_keys(
+                    manifest["coverage"], _VOLATILE_MANIFEST_COVERAGE_ROW_KEYS
+                )
+            if "extractors" in manifest:
+                manifest["extractors"] = _strip_row_keys(
+                    manifest["extractors"], _VOLATILE_MANIFEST_EXTRACTOR_ROW_KEYS
+                )
             build_source["manifest"] = manifest
 
         source_abi = build_source.get("source_abi")

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -38,35 +38,70 @@ import sys
 from pathlib import Path
 from typing import Any
 
+# Keys that vary between two dumps/replays of otherwise ABI-identical
+# content -- timestamps, source-file mtimes, and wall-clock/cache-state
+# counters -- so a stable content hash must strip all of them, not hash raw
+# file bytes. This started as a single `created_at` pop and grew by three
+# separate review rounds (top-level created_at, then the nested
+# build_source.manifest.created_at, then this fuller set) as each left
+# something volatile behind; kept as one explicit list instead of another
+# one-off pop so the next volatile field lands here too (Codex review).
+_VOLATILE_TOP_LEVEL_KEYS = ("created_at", "source_mtime", "source_mtime_epoch")
+_VOLATILE_BUILD_SOURCE_MANIFEST_KEYS = ("created_at",)
+# Populated by abicheck/buildsource/source_replay.py's replay producer (and
+# inline.py's cache bookkeeping) -- wall-clock durations and cache hit/miss
+# counts that depend on the runner's cache warmth and load, not on the
+# semantic source-fact content itself.
+_VOLATILE_COVERAGE_KEYS = (
+    "cache_lookup_s",
+    "extract_s",
+    "link_s",
+    "elapsed_s",
+    "cache_misses",
+    "cache_hits",
+)
+
+
+def _strip_volatile_fields(raw: dict[str, Any]) -> dict[str, Any]:
+    stable = dict(raw)
+    for key in _VOLATILE_TOP_LEVEL_KEYS:
+        stable.pop(key, None)
+
+    build_source = stable.get("build_source")
+    if isinstance(build_source, dict):
+        build_source = dict(build_source)
+
+        manifest = build_source.get("manifest")
+        if isinstance(manifest, dict):
+            manifest = dict(manifest)
+            for key in _VOLATILE_BUILD_SOURCE_MANIFEST_KEYS:
+                manifest.pop(key, None)
+            build_source["manifest"] = manifest
+
+        source_abi = build_source.get("source_abi")
+        if isinstance(source_abi, dict):
+            source_abi = dict(source_abi)
+            coverage = source_abi.get("coverage")
+            if isinstance(coverage, dict):
+                coverage = dict(coverage)
+                for key in _VOLATILE_COVERAGE_KEYS:
+                    coverage.pop(key, None)
+                source_abi["coverage"] = coverage
+            build_source["source_abi"] = source_abi
+
+        stable["build_source"] = build_source
+
+    return stable
+
 
 def _read_snapshot_meta(path: Path) -> dict[str, Any]:
     with path.open(encoding="utf-8") as f:
         raw = json.load(f)
-    # Hash the snapshot with created_at removed, not the raw file bytes:
-    # dumper.py auto-stamps created_at fresh on every dump call (absent
-    # SOURCE_DATE_EPOCH, the normal CI case), so a raw-bytes hash -- and
-    # therefore content-digest, which is built from these per-artifact
-    # digests -- changed on every single run even when the actual ABI
-    # content was byte-identical (Codex review).
-    #
-    # A snapshot dumped with --build-info/--sources also embeds a *second*,
-    # independently-stamped timestamp at build_source.manifest.created_at
-    # (BuildSourceManifest.created_at, written fresh by every collect-facts
-    # run -- see abicheck/buildsource/pack.py's own content_hash(), which
-    # excludes it for the same reason). Leaving it in place kept the digest
-    # unstable for any baseline with embedded source facts even after the
-    # top-level created_at was stripped (Codex review).
-    stable = dict(raw)
-    stable.pop("created_at", None)
-    build_source = stable.get("build_source")
-    if isinstance(build_source, dict):
-        manifest = build_source.get("manifest")
-        if isinstance(manifest, dict) and "created_at" in manifest:
-            build_source = dict(build_source)
-            manifest = dict(manifest)
-            manifest.pop("created_at", None)
-            build_source["manifest"] = manifest
-            stable["build_source"] = build_source
+    # Hash the snapshot with volatile fields removed, not the raw file
+    # bytes: dumper.py/collect-facts stamp several fields fresh on every run
+    # (absent SOURCE_DATE_EPOCH) even when the actual ABI/source-fact
+    # content is identical -- see _strip_volatile_fields above.
+    stable = _strip_volatile_fields(raw)
     sha256 = hashlib.sha256(
         json.dumps(stable, sort_keys=True).encode("utf-8")
     ).hexdigest()

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -73,7 +73,14 @@ def build_manifest(
 ) -> dict[str, Any]:
     artifacts = []
     schema_versions: set[int] = set()
-    fact_set_ids: set[tuple[str, int]] = set()
+    # The full source-fact recipe identity, not just (name, version): two
+    # snapshots can share fact_set.version while a producer/compiler upgrade
+    # (e.g. a new Clang plugin build, or a different loading Clang) silently
+    # changed the opaque body/template hash recipe underneath it -- see
+    # abicheck/buildsource/fact_set.py's own producer/producer_version/
+    # compiler_version comparability rules, which this mirrors so a refresh
+    # is flagged for the same reasons.
+    fact_set_ids: set[tuple[str, int, str, str, str, str]] = set()
     for entry in entries:
         name = entry["name"]
         snap_path = output_dir / f"{name}.abicheck.json"
@@ -92,7 +99,16 @@ def build_manifest(
             and fact_set.get("name")
             and fact_set.get("version") is not None
         ):
-            fact_set_ids.add((str(fact_set["name"]), int(fact_set["version"])))
+            fact_set_ids.add(
+                (
+                    str(fact_set["name"]),
+                    int(fact_set["version"]),
+                    str(fact_set.get("compiler_family") or ""),
+                    str(fact_set.get("producer") or ""),
+                    str(fact_set.get("producer_version") or ""),
+                    str(fact_set.get("compiler_version") or ""),
+                )
+            )
         artifacts.append(
             {
                 "library": name,
@@ -123,8 +139,26 @@ def build_manifest(
 
     fact_set_out = None
     if len(fact_set_ids) == 1:
-        name, version = next(iter(fact_set_ids))
+        (
+            name,
+            version,
+            compiler_family,
+            producer,
+            producer_version,
+            compiler_version,
+        ) = next(iter(fact_set_ids))
         fact_set_out = {"name": name, "version": version}
+        # Only recorded when present, so a fact_set with no producer identity
+        # (a pre-C.8 producer, or a hand-written one) keeps the same
+        # {"name", "version"}-only shape as before.
+        if compiler_family:
+            fact_set_out["compiler_family"] = compiler_family
+        if producer:
+            fact_set_out["producer"] = producer
+        if producer_version:
+            fact_set_out["producer_version"] = producer_version
+        if compiler_version:
+            fact_set_out["compiler_version"] = compiler_version
 
     manifest: dict[str, Any] = {
         "manifest_version": 1,

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -128,10 +128,24 @@ def build_manifest(
                 f"this library must have failed silently."
             )
         meta = _read_snapshot_meta(snap_path)
-        if meta["schema_version"] is not None:
-            schema_versions.add(int(meta["schema_version"]))
+        # A missing schema_version is not a legitimate "unknown" state to
+        # silently tolerate -- every real `abicheck dump` snapshot carries
+        # one, so its absence means this snapshot is malformed/truncated,
+        # and letting it through would publish a manifest whose
+        # snapshot_schema silently lost that information (CodeRabbit review).
+        if meta["schema_version"] is None:
+            raise SystemExit(
+                f"snapshot for library {name!r} is missing schema_version "
+                f"-- the dump step for this library must have produced a "
+                f"malformed snapshot."
+            )
+        schema_versions.add(int(meta["schema_version"]))
         fact_set = meta["fact_set"]
-        if (
+        if fact_set is None:
+            # No build_source/source_abi/coverage.fact_set at all -- this
+            # library was legitimately dumped without --build-info/--sources.
+            fact_set_absent += 1
+        elif (
             isinstance(fact_set, dict)
             and fact_set.get("name")
             and fact_set.get("version") is not None
@@ -148,7 +162,16 @@ def build_manifest(
                 )
             )
         else:
-            fact_set_absent += 1
+            # A non-None fact_set that isn't a well-formed identity is
+            # corrupted evidence, not "no evidence" -- collapsing it into
+            # fact_set_absent (as before) silently published a lossy
+            # baseline identity instead of surfacing the corruption
+            # (CodeRabbit review).
+            raise SystemExit(
+                f"snapshot for library {name!r} has a malformed fact_set "
+                f"identity {fact_set!r} -- expected a dict with at least "
+                f"'name' and 'version' keys."
+            )
         artifacts.append(
             {
                 "library": name,

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -39,13 +39,20 @@ from pathlib import Path
 from typing import Any
 
 
-def _sha256(path: Path) -> str:
-    return hashlib.sha256(path.read_bytes()).hexdigest()
-
-
 def _read_snapshot_meta(path: Path) -> dict[str, Any]:
     with path.open(encoding="utf-8") as f:
         raw = json.load(f)
+    # Hash the snapshot with created_at removed, not the raw file bytes:
+    # dumper.py auto-stamps created_at fresh on every dump call (absent
+    # SOURCE_DATE_EPOCH, the normal CI case), so a raw-bytes hash -- and
+    # therefore content-digest, which is built from these per-artifact
+    # digests -- changed on every single run even when the actual ABI
+    # content was byte-identical (Codex review).
+    stable = dict(raw)
+    stable.pop("created_at", None)
+    sha256 = hashlib.sha256(
+        json.dumps(stable, sort_keys=True).encode("utf-8")
+    ).hexdigest()
     fact_set = None
     build_source = raw.get("build_source")
     if isinstance(build_source, dict):
@@ -71,6 +78,7 @@ def _read_snapshot_meta(path: Path) -> dict[str, Any]:
         "created_at": raw.get("created_at"),
         "build_id": raw.get("build_id"),
         "fact_set": fact_set,
+        "sha256": sha256,
     }
 
 
@@ -129,7 +137,7 @@ def build_manifest(
                 "library": name,
                 "artifact": entry.get("artifact", ""),
                 "snapshot": snap_path.name,
-                "sha256": _sha256(snap_path),
+                "sha256": meta["sha256"],
                 "git_commit": meta["git_commit"],
                 "git_tag": meta["git_tag"],
                 "created_at": meta["created_at"],

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -60,6 +60,15 @@ _VOLATILE_COVERAGE_KEYS = (
     "cache_misses",
     "cache_hits",
 )
+# LayerCoverage rows (abicheck/buildsource/model.py) embedded at
+# build_source.manifest.coverage: build_inline_coverage() (buildsource/
+# inline.py) copies the same cache/timing state into each row's "detail"
+# (a free-form human string that can embed "cache X/Y hit (Z%)" and
+# "N.NNs") and "elapsed_s" -- a *third* place the same volatile info
+# leaks into, after source_abi.coverage and build_source.manifest itself.
+# "layer"/"status"/"confidence" are the semantic identity; "detail" is by
+# its own docstring presentational, so both are dropped rather than parsed.
+_VOLATILE_MANIFEST_COVERAGE_ROW_KEYS = ("detail", "elapsed_s")
 
 
 def _strip_volatile_fields(raw: dict[str, Any]) -> dict[str, Any]:
@@ -76,6 +85,18 @@ def _strip_volatile_fields(raw: dict[str, Any]) -> dict[str, Any]:
             manifest = dict(manifest)
             for key in _VOLATILE_BUILD_SOURCE_MANIFEST_KEYS:
                 manifest.pop(key, None)
+            coverage_rows = manifest.get("coverage")
+            if isinstance(coverage_rows, list):
+                manifest["coverage"] = [
+                    {
+                        k: v
+                        for k, v in row.items()
+                        if k not in _VOLATILE_MANIFEST_COVERAGE_ROW_KEYS
+                    }
+                    if isinstance(row, dict)
+                    else row
+                    for row in coverage_rows
+                ]
             build_source["manifest"] = manifest
 
         source_abi = build_source.get("source_abi")

--- a/actions/baseline/run.sh
+++ b/actions/baseline/run.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Dumps a set of libraries into a baseline-set: one .abicheck.json per
+# library plus a manifest.json (actions/baseline/build_manifest.py) --
+# see actions/baseline/action.yml for the rationale. Read-only: never
+# commits or pushes; publishing the result is the calling workflow's job.
+set -uo pipefail
+
+# NOTE: the ${VAR:?message} message must not contain a literal '{' or '}' --
+# bash's ${...} parser is not brace-depth-aware for the message text, so it
+# closes the expansion at the FIRST literal '}' it sees and treats anything
+# after that as trailing text appended to the assignment (a real bug this
+# script hit during testing: the JSON example below silently corrupted
+# LIBRARIES_JSON). Keep this message brace-free; the JSON shape is
+# documented in action.yml instead.
+LIBRARIES_JSON="${INPUT_LIBRARIES:?libraries input is required -- a JSON array of library entries, see action.yml}"
+OUTPUT_DIR="${INPUT_OUTPUT_DIR:-.abicheck-baseline}"
+PROJECT_REF="${INPUT_PROJECT_REF:-}"
+PROFILE="${INPUT_PROFILE:-}"
+BUILD_INFO="${INPUT_BUILD_INFO:-}"
+DEPTH="${INPUT_DEPTH:-}"
+PREVIOUS_MANIFEST="${INPUT_PREVIOUS_MANIFEST:-}"
+VALIDATION="${INPUT_VALIDATION:-strict}"
+ACTION_PATH="${ACTION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+_fail() {
+  echo "::error::$1"
+  exit 1
+}
+
+case "$VALIDATION" in
+  strict | none) ;;
+  *) _fail "validation '$VALIDATION' is not recognized. Use 'strict' or 'none'." ;;
+esac
+
+# Validate the libraries JSON up front (name/artifact required per entry) --
+# fail before any dump runs, not after the Nth one.
+LIBRARIES_ERROR=$(python3 -c '
+import json, sys
+try:
+    entries = json.loads(sys.argv[1])
+except json.JSONDecodeError as exc:
+    sys.exit(f"not valid JSON: {exc}")
+if not isinstance(entries, list) or not entries:
+    sys.exit("must be a non-empty JSON array")
+for i, e in enumerate(entries):
+    if not isinstance(e, dict) or "name" not in e or "artifact" not in e:
+        sys.exit(f"entry {i} must be an object with at least \"name\" and \"artifact\"")
+' "$LIBRARIES_JSON" 2>&1) || _fail "invalid libraries input: $LIBRARIES_ERROR"
+
+mkdir -p "$OUTPUT_DIR"
+
+echo "::group::Dump baseline-set into $OUTPUT_DIR"
+# Emit one TSV row per library (name, artifact, header, include -- header/
+# include default to empty, never absent, so the bash read below always
+# gets four fields). Python does the JSON parsing; bash just loops.
+while IFS=$'\t' read -r name artifact header include; do
+  [[ -z "$name" ]] && continue
+  echo "-- $name ($artifact)"
+  CMD=(abicheck dump "$artifact")
+  if [[ -n "$header" ]]; then
+    for h in $header; do CMD+=(-H "$h"); done
+  fi
+  if [[ -n "$include" ]]; then
+    for i in $include; do CMD+=(-I "$i"); done
+  fi
+  [[ -n "$BUILD_INFO" ]] && CMD+=(--build-info "$BUILD_INFO")
+  [[ -n "$DEPTH" ]] && CMD+=(--depth "$DEPTH")
+  [[ -n "$PROJECT_REF" ]] && CMD+=(--version "$PROJECT_REF")
+  CMD+=(-o "$OUTPUT_DIR/$name.abicheck.json")
+  if ! "${CMD[@]}"; then
+    _fail "dump failed for library '$name' ($artifact) -- see the command output above."
+  fi
+done < <(python3 -c '
+import json, sys
+for e in json.loads(sys.argv[1]):
+    print("\t".join([
+        e["name"],
+        e["artifact"],
+        e.get("header", ""),
+        e.get("include", ""),
+    ]))
+' "$LIBRARIES_JSON")
+echo "::endgroup::"
+
+if [[ "$VALIDATION" == "strict" ]]; then
+  echo "::group::Self-compare validation (each snapshot against itself)"
+  while IFS=$'\t' read -r name _artifact _header _include; do
+    [[ -z "$name" ]] && continue
+    snap="$OUTPUT_DIR/$name.abicheck.json"
+    if ! abicheck compare "$snap" "$snap" --format json > /dev/null; then
+      _fail "self-compare failed for '$snap' -- the snapshot this run just wrote is not loadable/self-consistent. This should never happen; please report it."
+    fi
+  done < <(python3 -c '
+import json, sys
+for e in json.loads(sys.argv[1]):
+    print(e["name"])
+' "$LIBRARIES_JSON")
+  echo "all snapshots round-tripped cleanly."
+  echo "::endgroup::"
+fi
+
+MANIFEST_PATH="$OUTPUT_DIR/manifest.json"
+MANIFEST_ARGS=(
+  --output-dir "$OUTPUT_DIR"
+  --project-ref "$PROJECT_REF"
+  --profile "$PROFILE"
+  --libraries "$LIBRARIES_JSON"
+  --manifest-out "$MANIFEST_PATH"
+)
+[[ -n "$PREVIOUS_MANIFEST" ]] && MANIFEST_ARGS+=(--previous-manifest "$PREVIOUS_MANIFEST")
+
+MANIFEST_STDOUT=$(python3 "$ACTION_PATH/build_manifest.py" "${MANIFEST_ARGS[@]}") \
+  || _fail "manifest generation failed -- see output above."
+echo "$MANIFEST_STDOUT"
+
+{
+  echo "baseline-path=$OUTPUT_DIR"
+  echo "manifest-path=$MANIFEST_PATH"
+  echo "$MANIFEST_STDOUT"
+} >> "${GITHUB_OUTPUT:-/dev/null}"
+
+echo "baseline-set written: $OUTPUT_DIR ($MANIFEST_PATH)"

--- a/actions/baseline/run.sh
+++ b/actions/baseline/run.sh
@@ -66,7 +66,18 @@ if [[ -d "$OUTPUT_DIR" ]]; then
   # output-dir that happens to already exist for an unrelated reason isn't
   # blown away.
   find "$OUTPUT_DIR" -maxdepth 1 -name '*.abicheck.json' -delete
-  rm -f "$OUTPUT_DIR/manifest.json"
+  # Don't delete manifest.json if it IS the caller's previous-manifest -- a
+  # workflow that restores the previous baseline set into output-dir before
+  # regenerating (an in-place refresh) points previous-manifest at that same
+  # file; deleting it here would make build_manifest.py unable to read it,
+  # and since a provided-but-missing previous-manifest is now a hard failure,
+  # that valid workflow would break instead of just losing freshness
+  # detection like before (Codex review). `-ef` compares by inode, so it
+  # works regardless of relative/absolute paths or symlinks, and is false
+  # (safe to delete) whenever either side doesn't exist yet.
+  if [[ -z "$PREVIOUS_MANIFEST" ]] || ! [[ "$OUTPUT_DIR/manifest.json" -ef "$PREVIOUS_MANIFEST" ]]; then
+    rm -f "$OUTPUT_DIR/manifest.json"
+  fi
 fi
 mkdir -p "$OUTPUT_DIR"
 

--- a/actions/baseline/run.sh
+++ b/actions/baseline/run.sh
@@ -42,9 +42,17 @@ except json.JSONDecodeError as exc:
     sys.exit(f"not valid JSON: {exc}")
 if not isinstance(entries, list) or not entries:
     sys.exit("must be a non-empty JSON array")
+seen_names = set()
 for i, e in enumerate(entries):
     if not isinstance(e, dict) or "name" not in e or "artifact" not in e:
         sys.exit(f"entry {i} must be an object with at least \"name\" and \"artifact\"")
+    name = e["name"]
+    if name in seen_names:
+        # A repeated name would otherwise have its dump silently overwrite
+        # the first entry at $OUTPUT_DIR/$name.abicheck.json while the
+        # manifest still lists two artifact rows for it (Codex review).
+        sys.exit(f"duplicate library name {name!r} (entry {i}) -- each entry needs a unique \"name\"")
+    seen_names.add(name)
 ' "$LIBRARIES_JSON" 2>&1) || _fail "invalid libraries input: $LIBRARIES_ERROR"
 
 mkdir -p "$OUTPUT_DIR"

--- a/actions/baseline/run.sh
+++ b/actions/baseline/run.sh
@@ -50,10 +50,16 @@ for i, e in enumerate(entries):
 mkdir -p "$OUTPUT_DIR"
 
 echo "::group::Dump baseline-set into $OUTPUT_DIR"
-# Emit one TSV row per library (name, artifact, header, include -- header/
+# Emit one row per library (name, artifact, header, include -- header/
 # include default to empty, never absent, so the bash read below always
-# gets four fields). Python does the JSON parsing; bash just loops.
-while IFS=$'\t' read -r name artifact header include; do
+# gets four fields), delimited by ASCII Unit Separator (\x1f) rather than a
+# tab: bash's word-splitting always treats a literal tab in IFS as "IFS
+# whitespace" and collapses adjacent/empty fields regardless of what IFS is
+# set to, so a library with `include` set but `header` omitted (an adjacent
+# empty field) would silently shift include's value into header. \x1f is not
+# whitespace to bash, so empty fields between delimiters are preserved.
+# Python does the JSON parsing; bash just loops.
+while IFS=$'\x1f' read -r name artifact header include; do
   [[ -z "$name" ]] && continue
   echo "-- $name ($artifact)"
   CMD=(abicheck dump "$artifact")
@@ -73,7 +79,7 @@ while IFS=$'\t' read -r name artifact header include; do
 done < <(python3 -c '
 import json, sys
 for e in json.loads(sys.argv[1]):
-    print("\t".join([
+    print("\x1f".join([
         e["name"],
         e["artifact"],
         e.get("header", ""),
@@ -84,7 +90,7 @@ echo "::endgroup::"
 
 if [[ "$VALIDATION" == "strict" ]]; then
   echo "::group::Self-compare validation (each snapshot against itself)"
-  while IFS=$'\t' read -r name _artifact _header _include; do
+  while IFS=$'\x1f' read -r name _artifact _header _include; do
     [[ -z "$name" ]] && continue
     snap="$OUTPUT_DIR/$name.abicheck.json"
     if ! abicheck compare "$snap" "$snap" --format json > /dev/null; then

--- a/actions/baseline/run.sh
+++ b/actions/baseline/run.sh
@@ -55,6 +55,19 @@ for i, e in enumerate(entries):
     seen_names.add(name)
 ' "$LIBRARIES_JSON" 2>&1) || _fail "invalid libraries input: $LIBRARIES_ERROR"
 
+if [[ -d "$OUTPUT_DIR" ]]; then
+  # Clear stale per-library snapshots/manifest left by an earlier run at
+  # this same output-dir -- a library removed/renamed since that run would
+  # otherwise leave its old *.abicheck.json sitting here: invisible to this
+  # run's manifest.json/content-digest, but still physically present for a
+  # caller that publishes/uploads the whole directory rather than iterating
+  # manifest.json's artifact list (CodeRabbit review). Only removes the
+  # files this script itself writes, never the whole directory, so an
+  # output-dir that happens to already exist for an unrelated reason isn't
+  # blown away.
+  find "$OUTPUT_DIR" -maxdepth 1 -name '*.abicheck.json' -delete
+  rm -f "$OUTPUT_DIR/manifest.json"
+fi
 mkdir -p "$OUTPUT_DIR"
 
 echo "::group::Dump baseline-set into $OUTPUT_DIR"
@@ -93,7 +106,13 @@ for e in json.loads(sys.argv[1]):
         e.get("header", ""),
         e.get("include", ""),
     ]))
-' "$LIBRARIES_JSON")
+' "$LIBRARIES_JSON" | tr -d '\r')
+# ^ Windows CPython opens stdout in text mode, so `print()` translates \n to
+# \r\n there; bash `read` only strips the trailing \n, leaving a stray \r
+# glued onto the last field of every row. For a row whose last field is
+# meant to be empty (include omitted), that \r makes `[[ -n "$include" ]]`
+# true, so an empty -I flag was silently added on Windows runners even
+# though include was never set (caught by the windows-latest CI lane).
 echo "::endgroup::"
 
 if [[ "$VALIDATION" == "strict" ]]; then
@@ -108,7 +127,7 @@ if [[ "$VALIDATION" == "strict" ]]; then
 import json, sys
 for e in json.loads(sys.argv[1]):
     print(e["name"])
-' "$LIBRARIES_JSON")
+' "$LIBRARIES_JSON" | tr -d '\r')
   echo "all snapshots round-tripped cleanly."
   echo "::endgroup::"
 fi

--- a/actions/baseline/run.sh
+++ b/actions/baseline/run.sh
@@ -47,6 +47,22 @@ for i, e in enumerate(entries):
     if not isinstance(e, dict) or "name" not in e or "artifact" not in e:
         sys.exit(f"entry {i} must be an object with at least \"name\" and \"artifact\"")
     name = e["name"]
+    if not isinstance(name, str) or not name:
+        sys.exit(f"entry {i} has an invalid \"name\" {name!r} -- must be a non-empty string")
+    # Both run.sh ("$OUTPUT_DIR/$name.abicheck.json", bash string concat)
+    # and build_manifest.py (output_dir / f"{name}.abicheck.json", pathlib)
+    # build the per-library snapshot path directly from this string, so a
+    # name containing a path separator or ".."/"." traversal segment -- or
+    # an absolute path, which pathlib silently lets override the left-hand
+    # side of the / operator entirely -- would write outside output_dir
+    # instead of a same-directory snapshot (Codex review).
+    if (
+        "/" in name
+        or "\\" in name
+        or name in (".", "..")
+        or any(ord(c) < 0x20 for c in name)
+    ):
+        sys.exit(f"entry {i} has an invalid \"name\" {name!r} -- must not contain a path separator, be \".\"/\"..\", or contain control characters")
     if name in seen_names:
         # A repeated name would otherwise have its dump silently overwrite
         # the first entry at $OUTPUT_DIR/$name.abicheck.json while the

--- a/actions/collect-facts/action.yml
+++ b/actions/collect-facts/action.yml
@@ -1,0 +1,147 @@
+name: 'abicheck collect-facts'
+description: >-
+  Collect L3/L4/L5 build/source facts for abicheck using the right producer
+  for your build (replay from a compile database, the abicheck-cc wrapper,
+  or the optional Clang plugin), so integrators stop hand-rolling shell
+  scripts and separately pinning a producer version.
+
+branding:
+  icon: 'database'
+  color: 'blue'
+
+inputs:
+  phase:
+    description: >
+      'prepare' (default for producer: replay, since nothing else is needed),
+      'verify', or 'auto'. Wrapper and clang-plugin producers need your own
+      build command to run *between* collection and verification (this
+      Action cannot run your build for you), so a workflow using either of
+      those two producers needs two separate steps: this Action with
+      `phase: prepare`, then your build step, then this Action again with
+      `phase: verify`. 'auto' runs both phases in one step, which only works
+      for producer: replay (a bare `sources:` pointer, no build step needed);
+      auto with wrapper/clang-plugin runs prepare only and prints a notice
+      to add a verify step after the build.
+    required: false
+    default: 'auto'
+  producer:
+    description: >
+      'auto' picks between replay and wrapper by inspecting `sources` for an
+      existing compile database or build-system files (never auto-selects
+      clang-plugin — see below); 'replay' (`dump --sources`, the portable
+      default); 'wrapper' (the abicheck-cc compiler wrapper, portable, needs
+      you to front your build command); 'clang-plugin' (zero extra parse,
+      but ABI-locked to the loading Clang's LLVM major — opt-in only, never
+      auto-selected, since owning the toolchain image can't be inferred).
+      See docs/user-guide/producing-source-facts.md for the full decision
+      tree this mirrors.
+    required: false
+    default: 'auto'
+  sources:
+    description: >
+      Source tree to collect facts from. Used directly by the replay
+      producer, and to auto-detect an existing compile database/build
+      system for producer: auto.
+    required: false
+    default: '.'
+  output:
+    description: >
+      Output directory for the collected abicheck_inputs/ pack (wrapper and
+      clang-plugin producers only — replay collects inline at dump/scan/
+      compare time, there is no separate pack directory).
+    required: false
+    default: 'abicheck_inputs'
+  public-roots:
+    description: >
+      Public header root(s), one per line, as the compiler *resolves* them
+      (not necessarily the install path — see the producing-source-facts.md
+      "one trap"). Feeds the wrapper's ABICHECK_CC_HEADERS / the plugin's
+      public-roots=. Omit to let the wrapper/plugin auto-derive roots from
+      the compile's own -I/-iquote dirs (broader surface, but never an
+      empty pack from a forgotten flag).
+    required: false
+  library:
+    description: 'Library name hint recorded in the pack manifest (wrapper ABICHECK_CC_LIBRARY / plugin library=).'
+    required: false
+  extractor:
+    description: >
+      Wrapper-producer only: which front-end extracts facts per TU -- 'auto'
+      (clang if present, else castxml), 'castxml', or 'clang'. Maps to
+      ABICHECK_CC_EXTRACTOR. Not used by producer: clang-plugin (the plugin
+      always reads the loading Clang's own AST) or producer: replay (dump's
+      --ast-frontend selects that side's frontend separately).
+    required: false
+    default: 'auto'
+  compiler:
+    description: >
+      Compiler used for the build (informational for replay/wrapper; for
+      clang-plugin this selects which clang the plugin is built against and
+      must match the clang that later loads it via -fplugin=).
+    required: false
+    default: 'clang++'
+  install-deps:
+    description: >
+      Install system dependencies needed by the selected producer (clang/
+      castxml for replay and wrapper; the matching libclang-<N>-dev package
+      for clang-plugin). Set to false if pre-installed.
+    required: false
+    default: 'true'
+  python-version:
+    description: 'Python version for setup-python.'
+    required: false
+    default: '3.13'
+
+outputs:
+  producer:
+    description: 'The producer actually used (replay, wrapper, or clang-plugin) after auto-resolution.'
+    value: ${{ steps.run-collect-facts.outputs.producer }}
+  mode:
+    description: >
+      'inline' (replay -- pass `sources` straight to dump/scan/compare, no
+      pack was collected) or 'pack' (wrapper/clang-plugin -- a pack
+      directory was collected at `pack-path`).
+    value: ${{ steps.run-collect-facts.outputs.mode }}
+  pack-path:
+    description: 'Path to the collected abicheck_inputs/ pack. Empty when mode is inline.'
+    value: ${{ steps.run-collect-facts.outputs.pack-path }}
+  ready:
+    description: >
+      'true' when the pack is ready to consume (replay always; wrapper/
+      clang-plugin only after phase: verify has run following your build
+      step). 'false' after phase: prepare for wrapper/clang-plugin -- your
+      build step must run next, then a phase: verify step.
+    value: ${{ steps.run-collect-facts.outputs.ready }}
+  producer-version:
+    description: >
+      Version identity of the producer used -- the compiler version for
+      replay/wrapper, or the plugin build's content digest + loading
+      Clang's version for clang-plugin. Empty until phase: verify.
+    value: ${{ steps.run-collect-facts.outputs.producer-version }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install abicheck
+      shell: bash
+      run: pip install "${{ github.action_path }}/../.."
+
+    - name: Collect source facts
+      id: run-collect-facts
+      shell: bash
+      env:
+        INPUT_PHASE: ${{ inputs.phase }}
+        INPUT_PRODUCER: ${{ inputs.producer }}
+        INPUT_SOURCES: ${{ inputs.sources }}
+        INPUT_OUTPUT: ${{ inputs.output }}
+        INPUT_PUBLIC_ROOTS: ${{ inputs.public-roots }}
+        INPUT_LIBRARY: ${{ inputs.library }}
+        INPUT_EXTRACTOR: ${{ inputs.extractor }}
+        INPUT_COMPILER: ${{ inputs.compiler }}
+        INPUT_INSTALL_DEPS: ${{ inputs.install-deps }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: bash "${{ github.action_path }}/run.sh"

--- a/actions/collect-facts/action.yml
+++ b/actions/collect-facts/action.yml
@@ -56,9 +56,13 @@ inputs:
       Public header root(s), one per line, as the compiler *resolves* them
       (not necessarily the install path — see the producing-source-facts.md
       "one trap"). Feeds the wrapper's ABICHECK_CC_HEADERS / the plugin's
-      public-roots=. Omit to let the wrapper/plugin auto-derive roots from
-      the compile's own -I/-iquote dirs (broader surface, but never an
-      empty pack from a forgotten flag).
+      public-roots=. Only the clang-plugin producer auto-derives roots from
+      the compile's own -I/-iquote dirs when this is omitted -- the wrapper
+      producer has no such fallback: an empty ABICHECK_CC_HEADERS makes
+      cc_wrapper.py's extractors classify every declaration as UNKNOWN/
+      non-public (provenance.classify_origin() is opt-in), so a pack still
+      collects TU records and passes phase: verify but carries no public
+      source facts. Set this explicitly for producer: wrapper.
     required: false
   library:
     description: 'Library name hint recorded in the pack manifest (wrapper ABICHECK_CC_LIBRARY / plugin library=).'

--- a/actions/collect-facts/action.yml
+++ b/actions/collect-facts/action.yml
@@ -113,9 +113,12 @@ outputs:
     value: ${{ steps.run-collect-facts.outputs.ready }}
   producer-version:
     description: >
-      Version identity of the producer used -- the compiler version for
-      replay/wrapper, or the plugin build's content digest + loading
-      Clang's version for clang-plugin. Empty until phase: verify.
+      Version identity of the producer used. Always empty for replay and
+      wrapper (this Action cannot know which compiler the caller's build
+      will actually invoke). For clang-plugin: the LLVM major plus a short
+      content digest of the built plugin binary, set at phase: prepare
+      (the plugin's identity is fixed the moment it's built, before your
+      build even runs) and re-emitted unchanged at phase: verify.
     value: ${{ steps.run-collect-facts.outputs.producer-version }}
 
 runs:

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -28,6 +28,28 @@ _is_absolute_path() {
   esac
 }
 
+# Git Bash/MSYS's own `pwd` reports its POSIX-style view of the filesystem
+# (e.g. /d/a/repo/repo), not a Windows path. That is fine as long as
+# everything downstream stays inside Git Bash, but ABICHECK_INPUTS_DIR/the
+# plugin out=/public-roots= flags are read by the native Windows Python and
+# Clang toolchain the Action installs, which has no notion of an MSYS root
+# and resolves /d/... as a relative path (a literal "d" directory) under
+# whatever the current drive happens to be -- silently writing the pack
+# somewhere other than where phase: verify or the caller's build looks for
+# it. cygpath -m converts to the mixed form (drive letter + forward
+# slashes) both Git Bash and native Windows tools accept (Codex review).
+_native_pwd() {
+  case "$(uname -s)" in
+    MINGW* | MSYS* | CYGWIN*)
+      if command -v cygpath >/dev/null 2>&1; then
+        cygpath -m "$(pwd)"
+        return
+      fi
+      ;;
+  esac
+  pwd
+}
+
 PHASE="${INPUT_PHASE:-auto}"
 PRODUCER_IN="${INPUT_PRODUCER:-auto}"
 SOURCES="${INPUT_SOURCES:-.}"
@@ -40,7 +62,7 @@ OUTPUT="${INPUT_OUTPUT:-abicheck_inputs}"
 # pack-path all reference, so verification would report an empty pack even
 # though the build was actually instrumented (Codex review).
 if ! _is_absolute_path "$OUTPUT"; then
-  OUTPUT="$(pwd)/$OUTPUT"
+  OUTPUT="$(_native_pwd)/$OUTPUT"
 fi
 PUBLIC_ROOTS="${INPUT_PUBLIC_ROOTS:-}"
 LIBRARY="${INPUT_LIBRARY:-}"
@@ -189,7 +211,7 @@ _resolve_public_root() {
   if _is_absolute_path "$root"; then
     printf '%s' "$root"
   else
-    printf '%s' "$(pwd)/$root"
+    printf '%s' "$(_native_pwd)/$root"
   fi
 }
 

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -13,6 +13,21 @@
 # build itself. See the `phase` input in action.yml.
 set -uo pipefail
 
+# Recognizes a leading /, a Windows drive letter (C:\ or C:/), or a UNC
+# path (\\server\share) as already-absolute. This script runs via Git
+# Bash/MSYS on windows-latest, where most GITHUB_*-derived paths are
+# already POSIX-style, but a workflow can still supply a native Windows
+# absolute path (e.g. output: ${{ runner.temp }}\abicheck_inputs, since
+# RUNNER_TEMP itself is Windows-style there) -- matching only `/*` treated
+# that as relative and produced a nonsensical mixed path like
+# /d/a/repo/C:\... when $(pwd)/ was prepended (Codex review).
+_is_absolute_path() {
+  case "$1" in
+    /* | [A-Za-z]:[/\\]* | \\\\*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 PHASE="${INPUT_PHASE:-auto}"
 PRODUCER_IN="${INPUT_PRODUCER:-auto}"
 SOURCES="${INPUT_SOURCES:-.}"
@@ -24,10 +39,9 @@ OUTPUT="${INPUT_OUTPUT:-abicheck_inputs}"
 # under build/ instead of the top-level pack _reset_output_dir/phase: verify/
 # pack-path all reference, so verification would report an empty pack even
 # though the build was actually instrumented (Codex review).
-case "$OUTPUT" in
-  /*) ;;
-  *) OUTPUT="$(pwd)/$OUTPUT" ;;
-esac
+if ! _is_absolute_path "$OUTPUT"; then
+  OUTPUT="$(pwd)/$OUTPUT"
+fi
 PUBLIC_ROOTS="${INPUT_PUBLIC_ROOTS:-}"
 LIBRARY="${INPUT_LIBRARY:-}"
 EXTRACTOR="${INPUT_EXTRACTOR:-auto}"
@@ -172,10 +186,11 @@ _reset_output_dir() {
 # doesn't exist yet), is passed through unchanged (Codex review).
 _resolve_public_root() {
   local root="$1"
-  case "$root" in
-    /*) printf '%s' "$root" ;;
-    *) printf '%s' "$(pwd)/$root" ;;
-  esac
+  if _is_absolute_path "$root"; then
+    printf '%s' "$root"
+  else
+    printf '%s' "$(pwd)/$root"
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -253,7 +253,43 @@ _verify_pack() {
   if [[ "$file_count" -eq 0 ]]; then
     _fail "phase: verify found pack directory '$OUTPUT' but it is empty -- see the producing-source-facts.md 'public-roots must match how headers resolve' trap: a wrong ABICHECK_CC_HEADERS/public-roots= silently yields nothing to collect from, even though the build otherwise looked fine."
   fi
-  echo "pack at '$OUTPUT' contains $file_count file(s)."
+  # A nonzero file count alone is not proof of real facts: init_inputs_pack()
+  # writes manifest.json up front, before any TU is ever appended, so a build
+  # that never actually routed through the wrapper/plugin (or whose every
+  # extraction failed) still leaves a nonempty directory here -- only
+  # source_facts/*.jsonl proves a TU was collected (Codex review). Run the
+  # same validator dump --build-info uses downstream, so this is a real
+  # pre-flight check instead of a bash reimplementation of it, and fail hard
+  # on zero TU records instead of the silent warning the downstream consumer
+  # gives a mis-instrumented build.
+  local validate_out
+  if ! validate_out=$(python3 -c '
+import sys
+from abicheck.buildsource.inputs_validate import validate_inputs_pack
+
+try:
+    report = validate_inputs_pack(sys.argv[1])
+except (FileNotFoundError, ValueError) as exc:
+    print(f"not a readable abicheck_inputs pack: {exc}")
+    sys.exit(1)
+if report.errors:
+    print("pack validation error(s): " + "; ".join(report.errors))
+    sys.exit(1)
+if report.tu_count == 0:
+    print(
+        "pack directory exists (manifest.json present) but contains zero "
+        "readable TU records under source_facts/ -- no translation unit "
+        "ever appended facts to it (wrong extractor, the build never "
+        "actually invoked the wrapper/plugin, or every extraction failed)."
+    )
+    sys.exit(1)
+for w in report.warnings:
+    print(f"::warning::{w}")
+print(f"pack at {sys.argv[1]!r} contains {report.tu_count} TU record(s).")
+' "$OUTPUT"); then
+    _fail "$validate_out"
+  fi
+  echo "pack at '$OUTPUT' contains $file_count file(s). $validate_out"
   _write_output "producer" "$PRODUCER"
   _write_output "mode" "pack"
   _write_output "pack-path" "$OUTPUT"

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -172,10 +172,16 @@ _prepare_wrapper() {
   [[ -n "$LIBRARY" ]] && _write_env "ABICHECK_CC_LIBRARY" "$LIBRARY"
   if [[ -n "$PUBLIC_ROOTS" ]]; then
     # ABICHECK_CC_HEADERS takes one root; the wrapper docs show a single
-    # value -- join multiple lines with ':' (PATH-style), the wrapper's own
-    # documented convention for multi-root scoping.
+    # value -- join multiple lines PATH-style. cc_wrapper.py splits this
+    # with Python's os.pathsep, which is ';' on Windows and ':' everywhere
+    # else -- a hardcoded ':' glued every root into one unsplit string on a
+    # Windows runner instead of scoping to each of them (Codex review).
+    local sep=':'
+    case "$(uname -s)" in
+      MINGW* | MSYS* | CYGWIN*) sep=';' ;;
+    esac
     local roots_joined
-    roots_joined=$(printf '%s' "$PUBLIC_ROOTS" | tr '\n' ':' | sed 's/:$//')
+    roots_joined=$(printf '%s' "$PUBLIC_ROOTS" | tr '\n' "$sep" | sed "s/${sep}\$//")
     _write_env "ABICHECK_CC_HEADERS" "$roots_joined"
   fi
   echo "::notice::producer: wrapper prepared -- front your build command with 'abicheck-cc' (e.g. CC=\"abicheck-cc gcc\" CXX=\"abicheck-cc g++\", or CMAKE_CXX_COMPILER_LAUNCHER=abicheck-cc), run your build next, then call this Action again with phase: verify to check the collected pack at '$OUTPUT'."

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -79,6 +79,20 @@ _detect_producer() {
     echo "replay"
     return
   fi
+  # Checked last, after cmake/bazel (same priority order as
+  # abicheck/buildsource/build_query.py's own _MARKERS -- a cmake project
+  # often ships a convenience Makefile that just drives cmake, so cmake/
+  # bazel take precedence when both are present). A bare Make/EPICS-style
+  # tree with no compile_commands.json is still replay-capable: the inline
+  # replay path auto-runs `make -B -n -k -w` and scrapes compile commands
+  # from the transcript -- this bash heuristic used to assume Make couldn't
+  # be replayed and fell through to wrapper, unnecessarily requiring
+  # wrapper instrumentation for a build build_query.py already knows how to
+  # query (Codex review).
+  if [[ -f "$src/GNUmakefile" || -f "$src/makefile" || -f "$src/Makefile" ]]; then
+    echo "replay"
+    return
+  fi
   echo "wrapper"
 }
 

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -86,6 +86,22 @@ _write_output() {
   fi
 }
 
+# Start each pack from a genuinely empty directory. init_inputs_pack()
+# (abicheck/buildsource/inputs_emit.py) is deliberately idempotent across
+# repeated per-TU calls *within one build* -- it loads and preserves an
+# existing manifest.json rather than resetting it -- but that means a stale
+# pack left over from an earlier prepare/build/verify cycle (a reused
+# workspace, or two cycles sharing the default abicheck_inputs path) is
+# silently adopted here too: `mkdir -p` alone is a no-op on an already-
+# existing directory, so old source_facts/*.jsonl TU records survive into
+# this run. _verify_pack's TU-count check would then see the STALE nonzero
+# count and report ready=true even if this run's build never actually
+# invoked abicheck-cc/the plugin (Codex review).
+_reset_output_dir() {
+  rm -rf "$OUTPUT"
+  mkdir -p "$OUTPUT"
+}
+
 # ---------------------------------------------------------------------------
 # Resolve producer
 # ---------------------------------------------------------------------------
@@ -173,7 +189,7 @@ _prepare_wrapper() {
     bash "$(dirname "${BASH_SOURCE[0]}")/../../action/install-deps.sh" \
       || _fail "failed to install dependencies required by producer: wrapper -- see the output above."
   fi
-  mkdir -p "$OUTPUT"
+  _reset_output_dir
   _write_env "ABICHECK_INPUTS_DIR" "$OUTPUT"
   _write_env "ABICHECK_CC_EXTRACTOR" "$EXTRACTOR"
   [[ -n "$LIBRARY" ]] && _write_env "ABICHECK_CC_LIBRARY" "$LIBRARY"
@@ -267,7 +283,7 @@ $version_output"
     _fail "the built Clang plugin failed to load on a smoke-test translation unit -- see the compiler output above. This usually means '$COMPILER' is not the same LLVM major ($major) the plugin was built against."
   fi
   echo "Clang plugin smoke test passed ($plugin_so loads into $COMPILER)."
-  mkdir -p "$OUTPUT"
+  _reset_output_dir
 
   # Assemble the exact flags the caller's build needs to add, one -Xclang
   # pair per public root (public-roots= is repeatable per the plugin docs).

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# Collects L3/L4/L5 build/source facts using the right producer for the
+# caller's build, replacing the hand-rolled shell scripts + separately
+# pinned producer version that real integrations were writing on their own.
+#
+# Producer decision tree (mirrors docs/user-guide/producing-source-facts.md):
+#   own the toolchain image and second-parse cost hurts?  -> clang-plugin (opt-in only)
+#   have/can-generate a compile database?                  -> replay
+#   otherwise                                               -> wrapper
+#
+# Wrapper and clang-plugin need the *caller's own build command* to run
+# between collection and verification -- this script cannot invoke that
+# build itself. See the `phase` input in action.yml.
+set -uo pipefail
+
+PHASE="${INPUT_PHASE:-auto}"
+PRODUCER_IN="${INPUT_PRODUCER:-auto}"
+SOURCES="${INPUT_SOURCES:-.}"
+OUTPUT="${INPUT_OUTPUT:-abicheck_inputs}"
+PUBLIC_ROOTS="${INPUT_PUBLIC_ROOTS:-}"
+LIBRARY="${INPUT_LIBRARY:-}"
+EXTRACTOR="${INPUT_EXTRACTOR:-auto}"
+COMPILER="${INPUT_COMPILER:-clang++}"
+INSTALL_DEPS="${INPUT_INSTALL_DEPS:-true}"
+ACTION_PATH="${ACTION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+_fail() {
+  echo "::error::$1"
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no side effects -- tests/test_action_collect_facts.py sources
+# this region directly, the same "parse the real file" discipline as
+# action/run.sh's helper functions).
+# ---------------------------------------------------------------------------
+
+# Auto-detect replay vs wrapper by inspecting SOURCES for an existing compile
+# database or a build system that can emit one. Never returns clang-plugin --
+# "own the toolchain image" cannot be inferred, it is opt-in only.
+_detect_producer() {
+  local src="$1"
+  if [[ -f "$src/compile_commands.json" ]]; then
+    echo "replay"
+    return
+  fi
+  if find "$src" -maxdepth 3 -name compile_commands.json 2>/dev/null | grep -q .; then
+    echo "replay"
+    return
+  fi
+  if [[ -f "$src/CMakeLists.txt" || -f "$src/WORKSPACE" || -f "$src/WORKSPACE.bazel" ]]; then
+    # cmake/bazel can emit a compile DB on request -- replay's own
+    # build-system query (documented in producing-source-facts.md) handles
+    # generating it, no wrapper needed.
+    echo "replay"
+    return
+  fi
+  echo "wrapper"
+}
+
+# Extract the LLVM/Clang major version number from a `clang --version`-style
+# string (e.g. "clang version 18.1.3" -> "18"). Empty output means unparsable.
+_llvm_major_from_version_string() {
+  local version_output="$1"
+  printf '%s' "$version_output" | grep -oE 'clang version [0-9]+' | grep -oE '[0-9]+' | head -1
+}
+
+# Validate the phase/producer combination the way action.yml documents it:
+# phase=auto only completes standalone for producer=replay.
+_phase_needs_external_build_step() {
+  local phase="$1" producer="$2"
+  [[ "$phase" == "prepare" || "$phase" == "auto" ]] && [[ "$producer" == "wrapper" || "$producer" == "clang-plugin" ]]
+}
+
+_write_env() {
+  local name="$1" value="$2"
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    echo "${name}=${value}" >> "$GITHUB_ENV"
+  fi
+}
+
+_write_output() {
+  local name="$1" value="$2"
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    echo "${name}=${value}" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Resolve producer
+# ---------------------------------------------------------------------------
+case "$PRODUCER_IN" in
+  auto)
+    PRODUCER=$(_detect_producer "$SOURCES")
+    echo "producer: auto -> $PRODUCER (no compile database/build system found under '$SOURCES' means wrapper; found one means replay)"
+    ;;
+  replay | wrapper | clang-plugin)
+    PRODUCER="$PRODUCER_IN"
+    ;;
+  *)
+    _fail "producer '$PRODUCER_IN' is not recognized. Use 'auto', 'replay', 'wrapper', or 'clang-plugin'."
+    ;;
+esac
+
+case "$PHASE" in
+  auto | prepare | verify) ;;
+  *) _fail "phase '$PHASE' is not recognized. Use 'auto', 'prepare', or 'verify'." ;;
+esac
+
+if [[ "$PHASE" == "verify" && "$PRODUCER" == "replay" ]]; then
+  echo "::notice::producer: replay collects inline at dump/scan/compare time -- there is nothing for phase: verify to check here. Pass sources: $SOURCES directly to the next abicheck step."
+fi
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+_prepare_replay() {
+  [[ -d "$SOURCES" ]] || _fail "sources '$SOURCES' does not exist."
+  local has_db=""
+  if [[ -f "$SOURCES/compile_commands.json" ]] || find "$SOURCES" -maxdepth 3 -name compile_commands.json 2>/dev/null | grep -q .; then
+    has_db="yes"
+  fi
+  if [[ -z "$has_db" ]]; then
+    echo "::notice::No compile_commands.json found under '$SOURCES'. abicheck infers and runs the build-system query itself (cmake/bazel/make) at dump/scan/compare time when it sees --sources -- no separate collection step is needed here."
+  fi
+  echo "producer: replay needs no separate collection step -- pass sources: $SOURCES directly to dump/scan/compare (--depth build/source selects how much of it is used)."
+  _write_output "producer" "replay"
+  _write_output "mode" "inline"
+  _write_output "pack-path" ""
+  _write_output "ready" "true"
+  _write_output "producer-version" ""
+}
+
+_prepare_wrapper() {
+  if [[ "$INSTALL_DEPS" == "true" ]]; then
+    bash "$(dirname "${BASH_SOURCE[0]}")/../../action/install-deps.sh" || true
+  fi
+  mkdir -p "$OUTPUT"
+  _write_env "ABICHECK_INPUTS_DIR" "$OUTPUT"
+  _write_env "ABICHECK_CC_EXTRACTOR" "$EXTRACTOR"
+  [[ -n "$LIBRARY" ]] && _write_env "ABICHECK_CC_LIBRARY" "$LIBRARY"
+  if [[ -n "$PUBLIC_ROOTS" ]]; then
+    # ABICHECK_CC_HEADERS takes one root; the wrapper docs show a single
+    # value -- join multiple lines with ':' (PATH-style), the wrapper's own
+    # documented convention for multi-root scoping.
+    local roots_joined
+    roots_joined=$(printf '%s' "$PUBLIC_ROOTS" | tr '\n' ':' | sed 's/:$//')
+    _write_env "ABICHECK_CC_HEADERS" "$roots_joined"
+  fi
+  echo "::notice::producer: wrapper prepared -- front your build command with 'abicheck-cc' (e.g. CC=\"abicheck-cc gcc\" CXX=\"abicheck-cc g++\", or CMAKE_CXX_COMPILER_LAUNCHER=abicheck-cc), run your build next, then call this Action again with phase: verify to check the collected pack at '$OUTPUT'."
+  _write_output "producer" "wrapper"
+  _write_output "mode" "pack"
+  _write_output "pack-path" "$OUTPUT"
+  _write_output "ready" "false"
+  _write_output "producer-version" ""
+}
+
+_prepare_clang_plugin() {
+  command -v "$COMPILER" >/dev/null 2>&1 || _fail "compiler '$COMPILER' not found on PATH -- producer: clang-plugin needs the loading Clang available to detect and match its LLVM major."
+  local version_output major
+  version_output=$("$COMPILER" --version 2>&1)
+  major=$(_llvm_major_from_version_string "$version_output")
+  [[ -n "$major" ]] || _fail "could not parse an LLVM major version from '$COMPILER --version':
+$version_output"
+  echo "detected LLVM major $major from $COMPILER"
+
+  if [[ "$INSTALL_DEPS" == "true" ]]; then
+    if [[ "$(uname -s)" == "Linux" ]] && command -v apt-get >/dev/null 2>&1 && command -v sudo >/dev/null 2>&1; then
+      echo "::group::Install clang-$major dev packages for the plugin build"
+      sudo apt-get update -qq
+      sudo apt-get install -y -qq "clang-$major" "llvm-$major-dev" "libclang-$major-dev" > /dev/null \
+        || _fail "failed to install clang-$major/llvm-$major-dev/libclang-$major-dev -- producer: clang-plugin needs the exact-major Clang development package (see contrib/abicheck-clang-plugin/README.md#build)."
+      echo "::endgroup::"
+    else
+      echo "::warning::install-deps: true but this OS/environment cannot apt-get install the Clang dev package automatically. Ensure the libclang-$major-dev equivalent is already installed."
+    fi
+  fi
+
+  # Build FROM the already-checked-out copy of this same commit (ACTION_PATH
+  # is inside the abicheck/abicheck checkout GitHub Actions made for THIS
+  # step) -- not a separately pinned plugin_ref. One `uses: .../collect-facts
+  # @<sha>` pin covers both the scanner and the plugin it builds, closing the
+  # "version pinned in two places" gap a hand-rolled integration hits.
+  local plugin_src="$ACTION_PATH/../../contrib/abicheck-clang-plugin"
+  [[ -d "$plugin_src" ]] || _fail "expected the Clang plugin source at '$plugin_src' (relative to this Action's own checkout) -- the abicheck/abicheck checkout this Action runs from looks incomplete."
+  local build_dir
+  build_dir=$(mktemp -d)
+  echo "::group::Build the Clang facts plugin (LLVM $major)"
+  if ! command -v cmake >/dev/null 2>&1; then
+    _fail "cmake not found -- required to build the Clang plugin (contrib/abicheck-clang-plugin)."
+  fi
+  local llvm_cmake_dir
+  llvm_cmake_dir=$(llvm-config-"$major" --cmakedir 2>/dev/null || llvm-config --cmakedir 2>/dev/null || true)
+  cmake -S "$plugin_src" -B "$build_dir" \
+    ${llvm_cmake_dir:+-DCMAKE_PREFIX_PATH="$llvm_cmake_dir/.."} \
+    || _fail "cmake configure failed for the Clang plugin -- see contrib/abicheck-clang-plugin/README.md#build (needs the full libclang-$major-dev package, not just clang-$major)."
+  cmake --build "$build_dir" || _fail "cmake build failed for the Clang plugin."
+  echo "::endgroup::"
+
+  local plugin_so
+  plugin_so=$(find "$build_dir" -maxdepth 2 -name 'libabicheck-facts.*' | head -1)
+  [[ -n "$plugin_so" ]] || _fail "Clang plugin build did not produce libabicheck-facts.* under '$build_dir'."
+
+  # Smoke-test: the plugin must at least load into the compiler without
+  # crashing, on a trivial translation unit, before we hand its path to the
+  # caller's real build.
+  local smoke_dir smoke_src
+  smoke_dir=$(mktemp -d)
+  smoke_src="$smoke_dir/smoke.cpp"
+  printf 'int abicheck_smoke_test() { return 0; }\n' > "$smoke_src"
+  mkdir -p "$OUTPUT"
+  if ! "$COMPILER" -std=c++17 \
+      -fplugin="$plugin_so" \
+      -Xclang -plugin-arg-abicheck-facts -Xclang "out=$OUTPUT" \
+      -fsyntax-only "$smoke_src" 2>"$smoke_dir/stderr.log"; then
+    cat "$smoke_dir/stderr.log" >&2
+    _fail "the built Clang plugin failed to load on a smoke-test translation unit -- see the compiler output above. This usually means '$COMPILER' is not the same LLVM major ($major) the plugin was built against."
+  fi
+  echo "Clang plugin smoke test passed ($plugin_so loads into $COMPILER)."
+
+  # Assemble the exact flags the caller's build needs to add, one -Xclang
+  # pair per public root (public-roots= is repeatable per the plugin docs).
+  local plugin_flags="-fplugin=$plugin_so -Xclang -plugin-arg-abicheck-facts -Xclang out=$OUTPUT"
+  if [[ -n "$PUBLIC_ROOTS" ]]; then
+    local root
+    while IFS= read -r root; do
+      [[ -n "$root" ]] && plugin_flags="$plugin_flags -Xclang -plugin-arg-abicheck-facts -Xclang public-roots=$root"
+    done <<< "$PUBLIC_ROOTS"
+  fi
+  [[ -n "$LIBRARY" ]] && plugin_flags="$plugin_flags -Xclang -plugin-arg-abicheck-facts -Xclang library=$LIBRARY"
+
+  _write_env "ABICHECK_PLUGIN_SO" "$plugin_so"
+  _write_env "ABICHECK_PLUGIN_FLAGS" "$plugin_flags"
+  echo "::notice::producer: clang-plugin ready at $plugin_so. Add these flags to your compile command (also exported as \$ABICHECK_PLUGIN_FLAGS): $plugin_flags -- run your build next, then call this Action again with phase: verify to check the collected pack at '$OUTPUT'."
+  _write_output "producer" "clang-plugin"
+  _write_output "mode" "pack"
+  _write_output "pack-path" "$OUTPUT"
+  _write_output "ready" "false"
+  _write_output "producer-version" "llvm-$major"
+}
+
+_verify_pack() {
+  [[ -d "$OUTPUT" ]] || _fail "phase: verify found no pack directory at '$OUTPUT' -- did the build step between phase: prepare and phase: verify actually run (and write ABICHECK_INPUTS_DIR/-fplugin's out= there)?"
+  local file_count
+  file_count=$(find "$OUTPUT" -type f | wc -l | tr -d ' ')
+  if [[ "$file_count" -eq 0 ]]; then
+    _fail "phase: verify found pack directory '$OUTPUT' but it is empty -- see the producing-source-facts.md 'public-roots must match how headers resolve' trap: a wrong ABICHECK_CC_HEADERS/public-roots= silently yields nothing to collect from, even though the build otherwise looked fine."
+  fi
+  echo "pack at '$OUTPUT' contains $file_count file(s)."
+  _write_output "producer" "$PRODUCER"
+  _write_output "mode" "pack"
+  _write_output "pack-path" "$OUTPUT"
+  _write_output "ready" "true"
+  _write_output "producer-version" ""
+}
+
+if [[ "$PHASE" == "verify" ]]; then
+  if [[ "$PRODUCER" == "replay" ]]; then
+    _write_output "producer" "replay"
+    _write_output "mode" "inline"
+    _write_output "pack-path" ""
+    _write_output "ready" "true"
+    _write_output "producer-version" ""
+  else
+    _verify_pack
+  fi
+else
+  case "$PRODUCER" in
+    replay) _prepare_replay ;;
+    wrapper) _prepare_wrapper ;;
+    clang-plugin) _prepare_clang_plugin ;;
+  esac
+  if [[ "$PHASE" == "auto" ]] && _phase_needs_external_build_step "$PHASE" "$PRODUCER"; then
+    echo "::notice::phase: auto only completes both phases for producer: replay. For producer: $PRODUCER, add a build step here, then a second 'uses: .../collect-facts' step with phase: verify."
+  fi
+fi

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -102,6 +102,13 @@ case "$PRODUCER_IN" in
       # explicitly -- enforce that instead of trusting it.
       _fail "phase: verify needs the exact producer phase: prepare resolved, not producer: auto -- pass producer: \${{ steps.<prepare-step-id>.outputs.producer }}."
     fi
+    # A misspelled/missing sources: path looks identical to "no compile
+    # database found here" to _detect_producer, which silently resolves to
+    # wrapper instead of erroring -- a workflow expecting replay from a real
+    # compile-DB tree would silently get wrapper's very different setup
+    # instead (Codex review). Same check _prepare_replay already does, run
+    # up front so auto-detection can't paper over it.
+    [[ -d "$SOURCES" ]] || _fail "sources '$SOURCES' does not exist."
     PRODUCER=$(_detect_producer "$SOURCES")
     echo "producer: auto -> $PRODUCER (no compile database/build system found under '$SOURCES' means wrapper; found one means replay)"
     ;;

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -44,7 +44,15 @@ _detect_producer() {
     echo "replay"
     return
   fi
-  if find "$src" -maxdepth 3 -name compile_commands.json 2>/dev/null | grep -q .; then
+  # -print -quit (not `| grep -q .`): under this script's `set -o pipefail`,
+  # a nested tree with multiple compile_commands.json matches can make grep
+  # exit right after the first line while find still has output queued --
+  # find's next write() then gets SIGPIPE (exit 141), pipefail treats that
+  # as the pipeline's failure even though grep itself matched, and this
+  # `if` silently takes the false branch instead. `-quit` makes find stop
+  # itself after the first match, so there is no pipe to race (Codex
+  # review; reproduced locally with a 5000-entry tree).
+  if [[ -n "$(find "$src" -maxdepth 3 -name compile_commands.json -print -quit 2>/dev/null)" ]]; then
     echo "replay"
     return
   fi
@@ -165,7 +173,10 @@ fi
 _prepare_replay() {
   [[ -d "$SOURCES" ]] || _fail "sources '$SOURCES' does not exist."
   local has_db=""
-  if [[ -f "$SOURCES/compile_commands.json" ]] || find "$SOURCES" -maxdepth 3 -name compile_commands.json 2>/dev/null | grep -q .; then
+  # -print -quit, not `| grep -q .` -- same pipefail/SIGPIPE race as
+  # _detect_producer above (Codex review).
+  if [[ -f "$SOURCES/compile_commands.json" ]] \
+    || [[ -n "$(find "$SOURCES" -maxdepth 3 -name compile_commands.json -print -quit 2>/dev/null)" ]]; then
     has_db="yes"
   fi
   if [[ -z "$has_db" ]]; then

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -17,6 +17,17 @@ PHASE="${INPUT_PHASE:-auto}"
 PRODUCER_IN="${INPUT_PRODUCER:-auto}"
 SOURCES="${INPUT_SOURCES:-.}"
 OUTPUT="${INPUT_OUTPUT:-abicheck_inputs}"
+# Resolve to an absolute path up front: the CMake compiler-launcher recipe
+# this Action documents invokes abicheck-cc (and the Clang plugin's out=
+# flag) with cwd set to the *build* directory, not this script's own cwd
+# (the repo root) -- a relative ABICHECK_INPUTS_DIR/out= would then resolve
+# under build/ instead of the top-level pack _reset_output_dir/phase: verify/
+# pack-path all reference, so verification would report an empty pack even
+# though the build was actually instrumented (Codex review).
+case "$OUTPUT" in
+  /*) ;;
+  *) OUTPUT="$(pwd)/$OUTPUT" ;;
+esac
 PUBLIC_ROOTS="${INPUT_PUBLIC_ROOTS:-}"
 LIBRARY="${INPUT_LIBRARY:-}"
 EXTRACTOR="${INPUT_EXTRACTOR:-auto}"
@@ -56,7 +67,12 @@ _detect_producer() {
     echo "replay"
     return
   fi
-  if [[ -f "$src/CMakeLists.txt" || -f "$src/WORKSPACE" || -f "$src/WORKSPACE.bazel" ]]; then
+  # MODULE.bazel: the bzlmod-only layout Bazel 6+ projects use has no
+  # WORKSPACE file at all -- omitting it here left auto-detection silently
+  # inconsistent with abicheck/buildsource/build_query.py's own Bazel
+  # marker set (WORKSPACE.bazel, WORKSPACE, and MODULE.bazel), which the
+  # replay path actually queries (Codex review).
+  if [[ -f "$src/CMakeLists.txt" || -f "$src/WORKSPACE" || -f "$src/WORKSPACE.bazel" || -f "$src/MODULE.bazel" ]]; then
     # cmake/bazel can emit a compile DB on request -- replay's own
     # build-system query (documented in producing-source-facts.md) handles
     # generating it, no wrapper needed.

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -144,9 +144,38 @@ _write_output() {
 # this run. _verify_pack's TU-count check would then see the STALE nonzero
 # count and report ready=true even if this run's build never actually
 # invoked abicheck-cc/the plugin (Codex review).
+#
+# Removes only the two known pack-content items (abicheck/buildsource/
+# inputs_pack.py's INPUTS_MANIFEST_NAME/SOURCE_FACTS_DIR), never the whole
+# $OUTPUT tree: output is a user-controlled Action input, and a workflow
+# that accidentally points it at an existing non-pack directory (the
+# workspace root, a shared build/source directory) must not have this step
+# recursively delete whatever is there (Codex review).
 _reset_output_dir() {
-  rm -rf "$OUTPUT"
+  rm -f "$OUTPUT/manifest.json"
+  rm -rf "$OUTPUT/source_facts"
   mkdir -p "$OUTPUT"
+}
+
+# Resolve a public-roots line to an absolute path, same rationale as
+# OUTPUT above: ABICHECK_CC_HEADERS/the plugin's public-roots= flag are
+# read by abicheck-cc/the plugin while they run with cwd set to the
+# *build* directory (the documented CMake compiler-launcher recipe), not
+# this script's own cwd. A relative root like the documented
+# public-roots: "include" would then resolve against the wrong
+# directory -- split_public_roots() (abicheck/buildsource/
+# source_extractors/_argv.py) checks os.path.isdir() there and, finding
+# nothing, misclassifies it as a file root instead of a directory root,
+# so declarations under the real source-tree include/ never match. An
+# already-absolute root, or one already ending in a path separator (a
+# directory marker split_public_roots() honours even when the path
+# doesn't exist yet), is passed through unchanged (Codex review).
+_resolve_public_root() {
+  local root="$1"
+  case "$root" in
+    /*) printf '%s' "$root" ;;
+    *) printf '%s' "$(pwd)/$root" ;;
+  esac
 }
 
 # ---------------------------------------------------------------------------
@@ -255,8 +284,12 @@ _prepare_wrapper() {
     case "$(uname -s)" in
       MINGW* | MSYS* | CYGWIN*) sep=';' ;;
     esac
-    local roots_joined
-    roots_joined=$(printf '%s' "$PUBLIC_ROOTS" | tr '\n' "$sep" | sed "s/${sep}\$//")
+    local roots_joined="" root resolved
+    while IFS= read -r root; do
+      [[ -z "$root" ]] && continue
+      resolved=$(_resolve_public_root "$root")
+      roots_joined="${roots_joined:+$roots_joined$sep}$resolved"
+    done <<< "$PUBLIC_ROOTS"
     _write_env "ABICHECK_CC_HEADERS" "$roots_joined"
   fi
   echo "::notice::producer: wrapper prepared -- front your build command with 'abicheck-cc' (e.g. CC=\"abicheck-cc gcc\" CXX=\"abicheck-cc g++\", or CMAKE_CXX_COMPILER_LAUNCHER=abicheck-cc), run your build next, then call this Action again with phase: verify to check the collected pack at '$OUTPUT'."
@@ -341,9 +374,12 @@ $version_output"
   # pair per public root (public-roots= is repeatable per the plugin docs).
   local plugin_flags="-fplugin=$plugin_so -Xclang -plugin-arg-abicheck-facts -Xclang out=$OUTPUT"
   if [[ -n "$PUBLIC_ROOTS" ]]; then
-    local root
+    local root resolved
     while IFS= read -r root; do
-      [[ -n "$root" ]] && plugin_flags="$plugin_flags -Xclang -plugin-arg-abicheck-facts -Xclang public-roots=$root"
+      if [[ -n "$root" ]]; then
+        resolved=$(_resolve_public_root "$root")
+        plugin_flags="$plugin_flags -Xclang -plugin-arg-abicheck-facts -Xclang public-roots=$resolved"
+      fi
     done <<< "$PUBLIC_ROOTS"
   fi
   [[ -n "$LIBRARY" ]] && plugin_flags="$plugin_flags -Xclang -plugin-arg-abicheck-facts -Xclang library=$LIBRARY"

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -91,6 +91,17 @@ _write_output() {
 # ---------------------------------------------------------------------------
 case "$PRODUCER_IN" in
   auto)
+    if [[ "$PHASE" == "verify" ]]; then
+      # Re-running auto-detection here can silently resolve to a different
+      # producer than the one your build was actually instrumented for --
+      # e.g. a wrapper prepare followed by a build step that (as a side
+      # effect) generates compile_commands.json would flip auto to replay,
+      # and phase: verify would report ready=true having never checked the
+      # wrapper's pack at all (CodeRabbit review). Every documented recipe
+      # already threads the prepare step's resolved producer through
+      # explicitly -- enforce that instead of trusting it.
+      _fail "phase: verify needs the exact producer phase: prepare resolved, not producer: auto -- pass producer: \${{ steps.<prepare-step-id>.outputs.producer }}."
+    fi
     PRODUCER=$(_detect_producer "$SOURCES")
     echo "producer: auto -> $PRODUCER (no compile database/build system found under '$SOURCES' means wrapper; found one means replay)"
     ;;
@@ -105,6 +116,20 @@ esac
 case "$PHASE" in
   auto | prepare | verify) ;;
   *) _fail "phase '$PHASE' is not recognized. Use 'auto', 'prepare', or 'verify'." ;;
+esac
+
+# Validate before any preparation/build work starts -- an unrecognized
+# extractor used to reach the wrapper env vars uncaught, and a misspelled
+# install-deps value (e.g. "True", "yes") silently behaved as false since
+# every check below is a literal `== "true"` string comparison
+# (CodeRabbit review).
+case "$EXTRACTOR" in
+  auto | castxml | clang) ;;
+  *) _fail "extractor '$EXTRACTOR' is not recognized. Use 'auto', 'castxml', or 'clang'." ;;
+esac
+case "$INSTALL_DEPS" in
+  true | false) ;;
+  *) _fail "install-deps '$INSTALL_DEPS' is not recognized. Use 'true' or 'false'." ;;
 esac
 
 if [[ "$PHASE" == "verify" && "$PRODUCER" == "replay" ]]; then
@@ -133,7 +158,13 @@ _prepare_replay() {
 
 _prepare_wrapper() {
   if [[ "$INSTALL_DEPS" == "true" ]]; then
-    bash "$(dirname "${BASH_SOURCE[0]}")/../../action/install-deps.sh" || true
+    # A failed installer used to still report preparation success here
+    # (a trailing "or true" swallowed it entirely), leaving the caller's
+    # build to fail later with a confusing "abicheck-cc: command not
+    # found", or -- worse -- to run uninstrumented and quietly produce an
+    # empty pack (CodeRabbit review).
+    bash "$(dirname "${BASH_SOURCE[0]}")/../../action/install-deps.sh" \
+      || _fail "failed to install dependencies required by producer: wrapper -- see the output above."
   fi
   mkdir -p "$OUTPUT"
   _write_env "ABICHECK_INPUTS_DIR" "$OUTPUT"
@@ -236,14 +267,30 @@ $version_output"
   fi
   [[ -n "$LIBRARY" ]] && plugin_flags="$plugin_flags -Xclang -plugin-arg-abicheck-facts -Xclang library=$LIBRARY"
 
+  # The plugin's identity is fully fixed the moment it's built here -- the
+  # caller's later build populates the *pack*, it never changes the plugin
+  # binary itself -- so compute the complete documented identity (LLVM major
+  # + a content digest of the built plugin) now rather than emitting a
+  # partial value at prepare and clearing it at verify (CodeRabbit review).
+  # Persisted via GITHUB_ENV so the separate phase: verify invocation of
+  # this script (a fresh process) can re-emit the same value instead of
+  # re-deriving or losing it.
+  local plugin_digest
+  plugin_digest=$(python3 -c '
+import hashlib, sys
+print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest()[:12])
+' "$plugin_so")
+  local producer_version="llvm-$major+plugin-sha256-$plugin_digest"
+
   _write_env "ABICHECK_PLUGIN_SO" "$plugin_so"
   _write_env "ABICHECK_PLUGIN_FLAGS" "$plugin_flags"
+  _write_env "ABICHECK_PRODUCER_VERSION" "$producer_version"
   echo "::notice::producer: clang-plugin ready at $plugin_so. Add these flags to your compile command (also exported as \$ABICHECK_PLUGIN_FLAGS): $plugin_flags -- run your build next, then call this Action again with phase: verify to check the collected pack at '$OUTPUT'."
   _write_output "producer" "clang-plugin"
   _write_output "mode" "pack"
   _write_output "pack-path" "$OUTPUT"
   _write_output "ready" "false"
-  _write_output "producer-version" "llvm-$major"
+  _write_output "producer-version" "$producer_version"
 }
 
 _verify_pack() {
@@ -294,7 +341,12 @@ print(f"pack at {sys.argv[1]!r} contains {report.tu_count} TU record(s).")
   _write_output "mode" "pack"
   _write_output "pack-path" "$OUTPUT"
   _write_output "ready" "true"
-  _write_output "producer-version" ""
+  # Re-emit whatever phase: prepare computed and persisted via GITHUB_ENV
+  # (clang-plugin only -- its identity is fixed at build time) instead of
+  # unconditionally clearing it here. Empty for wrapper: nothing about
+  # *which compiler* the caller's build actually invoked is knowable from
+  # this side (CodeRabbit review).
+  _write_output "producer-version" "${ABICHECK_PRODUCER_VERSION:-}"
 }
 
 if [[ "$PHASE" == "verify" ]]; then

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -63,7 +63,16 @@ _detect_producer() {
   # `if` silently takes the false branch instead. `-quit` makes find stop
   # itself after the first match, so there is no pipe to race (Codex
   # review; reproduced locally with a 5000-entry tree).
-  if [[ -n "$(find "$src" -maxdepth 3 -name compile_commands.json -print -quit 2>/dev/null)" ]]; then
+  #
+  # -maxdepth 2 (root or one immediate subdirectory below $src), not 3: the
+  # inline replay path this producer: replay hands off to
+  # (abicheck/buildsource/inline.py::_find_compile_db_in_dir) only ever
+  # looks at $src/compile_commands.json or $src/<one-subdir>/
+  # compile_commands.json -- a DB two levels deep would make this report
+  # producer=replay/ready=true, but the actual replay collection step
+  # would never find it and silently collect zero source facts (Codex
+  # review).
+  if [[ -n "$(find "$src" -maxdepth 2 -name compile_commands.json -print -quit 2>/dev/null)" ]]; then
     echo "replay"
     return
   fi
@@ -204,9 +213,11 @@ _prepare_replay() {
   [[ -d "$SOURCES" ]] || _fail "sources '$SOURCES' does not exist."
   local has_db=""
   # -print -quit, not `| grep -q .` -- same pipefail/SIGPIPE race as
-  # _detect_producer above (Codex review).
+  # _detect_producer above. -maxdepth 2, not 3 -- same discoverable-depth
+  # mismatch with inline.py::_find_compile_db_in_dir as _detect_producer
+  # above (Codex review).
   if [[ -f "$SOURCES/compile_commands.json" ]] \
-    || [[ -n "$(find "$SOURCES" -maxdepth 3 -name compile_commands.json -print -quit 2>/dev/null)" ]]; then
+    || [[ -n "$(find "$SOURCES" -maxdepth 2 -name compile_commands.json -print -quit 2>/dev/null)" ]]; then
     has_db="yes"
   fi
   if [[ -z "$has_db" ]]; then

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -203,20 +203,27 @@ $version_output"
 
   # Smoke-test: the plugin must at least load into the compiler without
   # crashing, on a trivial translation unit, before we hand its path to the
-  # caller's real build.
-  local smoke_dir smoke_src
+  # caller's real build. Writes its facts to an isolated scratch directory,
+  # NOT $OUTPUT -- that is the real pack the caller's build populates next,
+  # and phase: verify only checks "the pack has at least one file", so a
+  # smoke-test record left sitting in $OUTPUT would make a pack that never
+  # received real facts (build step skipped, wrong flags, wrong TU) look
+  # ready anyway.
+  local smoke_dir smoke_src smoke_out
   smoke_dir=$(mktemp -d)
   smoke_src="$smoke_dir/smoke.cpp"
+  smoke_out="$smoke_dir/out"
   printf 'int abicheck_smoke_test() { return 0; }\n' > "$smoke_src"
-  mkdir -p "$OUTPUT"
+  mkdir -p "$smoke_out"
   if ! "$COMPILER" -std=c++17 \
       -fplugin="$plugin_so" \
-      -Xclang -plugin-arg-abicheck-facts -Xclang "out=$OUTPUT" \
+      -Xclang -plugin-arg-abicheck-facts -Xclang "out=$smoke_out" \
       -fsyntax-only "$smoke_src" 2>"$smoke_dir/stderr.log"; then
     cat "$smoke_dir/stderr.log" >&2
     _fail "the built Clang plugin failed to load on a smoke-test translation unit -- see the compiler output above. This usually means '$COMPILER' is not the same LLVM major ($major) the plugin was built against."
   fi
   echo "Clang plugin smoke test passed ($plugin_so loads into $COMPILER)."
+  mkdir -p "$OUTPUT"
 
   # Assemble the exact flags the caller's build needs to add, one -Xclang
   # pair per public root (public-roots= is repeatable per the plugin docs).

--- a/changelog.d/20260717_194428_noreply_abicheck_onedal_integration_apg6c9.md
+++ b/changelog.d/20260717_194428_noreply_abicheck_onedal_integration_apg6c9.md
@@ -1,0 +1,71 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Fixed
+
+- **The GitHub Action now fails fast on unsupported mode/input combinations
+  instead of failing late or silently doing the wrong thing.** A new
+  `Validate mode/input combination` step runs before Python setup, system
+  dependency installation, and `pip install abicheck`, and rejects: a
+  directory/package passed to `dump`/`scan`'s `new-library` (neither mode
+  has `compare`'s per-library fan-out — this previously surfaced as a
+  confusing failure deep inside the tool, after a full toolchain install);
+  `format: sarif`/`html` on `scan`/`deps-tree`/`deps-compare` (previously a
+  silent fallback to a supported format with only a `::warning::`, which
+  combined with `upload-sarif: true` produced neither an error nor a SARIF
+  report); and `upload-sarif: true` without `mode: compare` + `format:
+  sarif`. `action/run.sh` re-checks the same rules as defense in depth.
+
+<!--
+### Changed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Deprecated
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Removed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Performance
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Security
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Documentation
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->

--- a/docs/user-guide/baseline-management.md
+++ b/docs/user-guide/baseline-management.md
@@ -276,3 +276,77 @@ abicheck scan new/libfoo.so --against old/libfoo.so \
   time.
 
 See [Source-Scan Depth](scan-levels.md) for the full `scan` flag reference.
+
+## Two kinds of baseline: release contract vs. accepted-main
+
+A single fixed baseline answers only one question well. Most projects
+actually need *two* baselines, because they answer different questions and
+should behave differently when a PR is labeled as an intentional break:
+
+| Baseline | Question it answers | Where it comes from | What advances it |
+|---|---|---|---|
+| **Release / contract baseline** | Is the current code still compatible with what we already shipped? | A dump of the last **released** version (a release tag/asset — [Recipe A](#recipe-a-github-releases-recommended) above) | Only a new project release |
+| **Accepted-main baseline** | Did *this PR* introduce a new break (as opposed to one already merged)? | A dump of the last build that passed CI on the default branch | Every PR merged to the default branch |
+
+Conflating them causes a specific, recurring failure: if CI only keeps a
+*fixed* release baseline and skips the whole check whenever a PR carries an
+"intentional API/ABI break" label, the break lands on the default branch
+still relative to the old release. Every subsequent, unrelated PR then
+diffs against that same stale release baseline, sees the same break again,
+and fails too — even though the break was already reviewed and accepted.
+The label suppressed the *check*, not just the *gate*, so nothing ever
+re-baselines.
+
+**The fix is to keep both baselines running, and let the label only relax
+which one gates the build:**
+
+- Always run and publish **both** comparisons — the release-contract report
+  stays visible even when its gate is relaxed, so "compatible with the last
+  release" doesn't silently go unreported.
+- The label affects only the **gate** for that specific PR (e.g. downgrade
+  `fail-on-breaking`/`fail-on-api-break` for the release-contract job), never
+  whether the comparison **runs**.
+- The accepted-main baseline is what should ordinarily gate merges: refresh
+  it from the default branch after every merge (a lightweight `dump` step on
+  a `push` trigger, [Recipe C](#recipe-c-github-actions-cache) or a
+  git-committed file work well for this since it churns on every merge).
+- The release-contract baseline advances deliberately, only when you cut a
+  new release — treat that refresh as part of the release process, not
+  something a regular PR should touch.
+
+```yaml
+# PR workflow — both baselines compared, only one gates by default
+jobs:
+  release-contract:
+    steps:
+      - uses: abicheck/abicheck@v0.3.0
+        with:
+          abi-baseline: latest-release       # fixed until the next release
+          new-library: build/libfoo.so
+          new-header: include/foo.h
+          fail-on-breaking: ${{ !contains(github.event.pull_request.labels.*.name, 'intentional-api-break') }}
+
+  accepted-main:
+    steps:
+      - uses: abicheck/abicheck@v0.3.0
+        with:
+          old-library: main-baseline.json     # refreshed on every merge to main
+          new-library: build/libfoo.so
+          new-header: include/foo.h
+          fail-on-breaking: true               # never relaxed by a label
+```
+
+### Baseline identity is more than a version number
+
+A baseline file name like `2.0.0.abicheck.json` is not self-describing
+enough on its own to guarantee two dumps are comparable — a meaningful
+identity also includes the platform/architecture, build profile (compiler,
+ISA, debug/release), the public-header/source configuration used to dump it,
+and (for build-source evidence) the producer and toolchain that collected it
+(replay vs. `abicheck-cc` vs. the Clang plugin — see [Producing Source
+Facts](producing-source-facts.md) for how each is versioned). If your project ships more
+than one platform/architecture/build-profile combination, encode that in the
+baseline's path or filename (e.g.
+`linux-x86_64-icx-avx2-debug/2.0.0.abicheck.json`), not just the version —
+otherwise a baseline dumped on one profile can silently get compared against
+a candidate built on another.

--- a/docs/user-guide/baseline-management.md
+++ b/docs/user-guide/baseline-management.md
@@ -290,7 +290,7 @@ should behave differently when a PR is labeled as an intentional break:
 
 Conflating them causes a specific, recurring failure: if CI only keeps a
 *fixed* release baseline and skips the whole check whenever a PR carries an
-"intentional API/ABI break" label, the break lands on the default branch
+`intentional-breaking-change` label, the break lands on the default branch
 still relative to the old release. Every subsequent, unrelated PR then
 diffs against that same stale release baseline, sees the same break again,
 and fails too — even though the break was already reviewed and accepted.
@@ -298,24 +298,28 @@ The label suppressed the *check*, not just the *gate*, so nothing ever
 re-baselines.
 
 **The fix is to keep both baselines running, and let the label only relax
-which one gates the build:**
+their gates — never whether either comparison runs:**
 
 - Always run and publish **both** comparisons — the release-contract report
   stays visible even when its gate is relaxed, so "compatible with the last
   release" doesn't silently go unreported.
-- The label affects only the **gate** for that specific PR (e.g. downgrade
-  `fail-on-breaking`/`fail-on-api-break` for the release-contract job), never
-  whether the comparison **runs**.
-- The accepted-main baseline is what should ordinarily gate merges: refresh
-  it from the default branch after every merge (a lightweight `dump` step on
-  a `push` trigger, [Recipe C](#recipe-c-github-actions-cache) or a
+- On the PR that introduces the break, the label relaxes **both** jobs'
+  `fail-on-breaking` — that PR is, by construction, the one case where the
+  accepted-main comparison is *expected* to report a break (that's what it's
+  for), and the label plus its review is what makes the break "accepted."
+  Neither job's *comparison* is skipped, only its gate, for that one PR.
+- The accepted-main baseline is what ordinarily gates every other PR:
+  refresh it from the default branch after every merge (a lightweight `dump`
+  step on a `push` trigger, [Recipe C](#recipe-c-github-actions-cache) or a
   git-committed file work well for this since it churns on every merge).
+  Once refreshed, the gate is strict again for the *next* PR — the label
+  only ever excuses the PR that carries it, not the ones that follow.
 - The release-contract baseline advances deliberately, only when you cut a
   new release — treat that refresh as part of the release process, not
   something a regular PR should touch.
 
 ```yaml
-# PR workflow — both baselines compared, only one gates by default
+# PR workflow — both baselines compared, both share the same label-relaxed gate
 jobs:
   release-contract:
     steps:
@@ -324,7 +328,7 @@ jobs:
           abi-baseline: latest-release       # fixed until the next release
           new-library: build/libfoo.so
           new-header: include/foo.h
-          fail-on-breaking: ${{ !contains(github.event.pull_request.labels.*.name, 'intentional-api-break') }}
+          fail-on-breaking: ${{ !contains(github.event.pull_request.labels.*.name, 'intentional-breaking-change') }}
 
   accepted-main:
     steps:
@@ -333,7 +337,11 @@ jobs:
           old-library: main-baseline.json     # refreshed on every merge to main
           new-library: build/libfoo.so
           new-header: include/foo.h
-          fail-on-breaking: true               # never relaxed by a label
+          # Same label relaxes this gate too — this comparison is *expected*
+          # to report a break for the one PR that introduces it. Once merged
+          # and main-baseline.json is refreshed, every subsequent PR is
+          # gated strictly again (the label doesn't carry over).
+          fail-on-breaking: ${{ !contains(github.event.pull_request.labels.*.name, 'intentional-breaking-change') }}
 ```
 
 ### Baseline identity is more than a version number

--- a/docs/user-guide/baseline-management.md
+++ b/docs/user-guide/baseline-management.md
@@ -358,3 +358,11 @@ baseline's path or filename (e.g.
 `linux-x86_64-icx-avx2-debug/2.0.0.abicheck.json`), not just the version —
 otherwise a baseline dumped on one profile can silently get compared against
 a candidate built on another.
+
+For a project that ships several libraries from one build, apply this per
+library rather than trying to fold them into a single baseline file — see
+[Source Scans → Recommended flow: a multi-library release with one shared
+facts
+pack](github-action-source-scans.md#recommended-flow-a-multi-library-release-with-one-shared-facts-pack)
+for a concrete per-library baseline-set walkthrough (build once, one facts
+pack, one baseline file per library).

--- a/docs/user-guide/ci-gating.md
+++ b/docs/user-guide/ci-gating.md
@@ -146,13 +146,16 @@ and the policy recipes in [Getting Started](../getting-started.md).
 
 !!! warning "A label should relax the gate, not skip the check"
     A common mistake: skipping the whole comparison job whenever a PR
-    carries an "intentional breaking change" label. That only defers the
+    carries an `intentional-breaking-change` label. That only defers the
     problem — every subsequent, unrelated PR still diffs against the old
     (pre-break) baseline, sees the same accepted break again, and fails.
     Keep the comparison running unconditionally; use the label only to
-    relax that PR's own gate (e.g. lower `fail-on-breaking`), and refresh
-    the baseline that other PRs compare against once the break lands on the
-    default branch. See [Baseline Management → Two kinds of
+    relax **every** baseline's gate for that one PR (e.g. lower
+    `fail-on-breaking` on both the release-contract and accepted-main jobs —
+    that PR is expected to report a break against both), and refresh the
+    baseline other PRs compare against once the break lands on the default
+    branch, so the label doesn't carry over to unrelated PRs. See [Baseline
+    Management → Two kinds of
     baseline](baseline-management.md#two-kinds-of-baseline-release-contract-vs-accepted-main)
     for the release-contract vs. accepted-main split this implies.
 

--- a/docs/user-guide/ci-gating.md
+++ b/docs/user-guide/ci-gating.md
@@ -144,6 +144,18 @@ and the policy recipes in [Getting Started](../getting-started.md).
     user-facing flag or command changes — a repo-internal mechanic for
     abicheck contributors, not something you configure for your own project.
 
+!!! warning "A label should relax the gate, not skip the check"
+    A common mistake: skipping the whole comparison job whenever a PR
+    carries an "intentional breaking change" label. That only defers the
+    problem — every subsequent, unrelated PR still diffs against the old
+    (pre-break) baseline, sees the same accepted break again, and fails.
+    Keep the comparison running unconditionally; use the label only to
+    relax that PR's own gate (e.g. lower `fail-on-breaking`), and refresh
+    the baseline that other PRs compare against once the break lands on the
+    default branch. See [Baseline Management → Two kinds of
+    baseline](baseline-management.md#two-kinds-of-baseline-release-contract-vs-accepted-main)
+    for the release-contract vs. accepted-main split this implies.
+
 ## Related pages
 
 - [Baseline Management](baseline-management.md) — producing, storing, and

--- a/docs/user-guide/github-action-recipes.md
+++ b/docs/user-guide/github-action-recipes.md
@@ -91,6 +91,14 @@ then compare with a separate step.
           new-header: ${{ matrix.lib.header }}
 ```
 
+If the release also carries build-emitted source facts from one shared
+`abicheck_inputs/` pack, see [Source Scans → Recommended flow: a
+multi-library release with one shared facts
+pack](github-action-source-scans.md#recommended-flow-a-multi-library-release-with-one-shared-facts-pack)
+for the full walkthrough — it chains this recipe with inline `build-info`
+embedding and the [post-matrix ABI gate](#post-matrix-abi-gate-unified-verdict)
+below.
+
 ## Matrix: multiple platforms (native scan per OS)
 
 Use native runners to get the best platform-specific signal (Linux/ELF, macOS/Mach-O, Windows/PE):

--- a/docs/user-guide/github-action-source-scans.md
+++ b/docs/user-guide/github-action-source-scans.md
@@ -381,10 +381,16 @@ jobs:
           output-file: report-${{ matrix.lib.name }}.json
           fail-on-breaking: false   # let the post-matrix gate job decide
           fail-on-api-break: false
+      - name: Upload this library's report
+        uses: actions/upload-artifact@v4
+        with:
+          name: report-${{ matrix.lib.name }}
+          path: report-${{ matrix.lib.name }}.json
 
   abi-gate:
     needs: scan-candidates
-    # same aggregation job as "Post-matrix ABI gate (unified verdict)"
+    # same aggregation job as "Post-matrix ABI gate (unified verdict)" --
+    # downloads with `pattern: report-*`, `merge-multiple: true`
 ```
 
 **Layering onto an existing binary-ABI tool** (the common reason to reach for

--- a/docs/user-guide/github-action-source-scans.md
+++ b/docs/user-guide/github-action-source-scans.md
@@ -315,13 +315,38 @@ jobs:
 # at compare time — both sides already have their facts embedded).
 jobs:
   build:
-    # same as above, no publish step
+    # Identical to the release workflow's `build` job above, just without
+    # its `publish-baselines` job at the end -- repeated in full here (not
+    # abbreviated) so this block is copy-pasteable on its own.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: abicheck/abicheck/actions/collect-facts@v0.3.0
+        id: facts
+        with: { phase: prepare, producer: wrapper, public-roots: "include" }
+      - name: Build
+        run: |
+          cmake -DCMAKE_CXX_COMPILER_LAUNCHER=abicheck-cc \
+                -DCMAKE_C_COMPILER_LAUNCHER=abicheck-cc -S . -B build
+          cmake --build build
+      - uses: abicheck/abicheck/actions/collect-facts@v0.3.0
+        id: facts-verify
+        with: { phase: verify, producer: ${{ steps.facts.outputs.producer }} }
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-build
+          path: |
+            build/lib*.so
+            include/
+            abicheck_inputs/
 
   scan-candidates:
     needs: build
     strategy:
       matrix:
-        lib: [ ... same list as above ... ]
+        lib:
+          - { name: libfoo, so: build/libfoo.so, header: include/foo.h }
+          - { name: libbar, so: build/libbar.so, header: include/bar.h }
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/docs/user-guide/github-action-source-scans.md
+++ b/docs/user-guide/github-action-source-scans.md
@@ -248,7 +248,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: abicheck/abicheck/actions/collect-facts@v0.3.0
+      # collect-facts pinned to a commit SHA, not a tag: see "Pin both uses:
+      # lines" in producing-source-facts.md -- a version tag old enough to
+      # predate this sub-action's own introduction can't resolve it at all.
+      - uses: abicheck/abicheck/actions/collect-facts@<same-sha-as-below>
         id: facts
         with: { phase: prepare, producer: wrapper, public-roots: "include" }
       - name: Build
@@ -262,7 +265,7 @@ jobs:
           cmake -DCMAKE_CXX_COMPILER_LAUNCHER=abicheck-cc \
                 -DCMAKE_C_COMPILER_LAUNCHER=abicheck-cc -S . -B build
           cmake --build build
-      - uses: abicheck/abicheck/actions/collect-facts@v0.3.0
+      - uses: abicheck/abicheck/actions/collect-facts@<same-sha-as-below>
         id: facts-verify
         with: { phase: verify, producer: ${{ steps.facts.outputs.producer }} }
       - uses: actions/upload-artifact@v4
@@ -305,7 +308,10 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with: { pattern: baseline-*, merge-multiple: true, path: baselines/ }
-      - run: gh release upload ${{ github.ref_name }} baselines/*.abicheck.json --clobber
+      # -R is required here: gh normally infers the repo from a local git
+      # checkout, but this job only downloads artifacts, never checks out
+      # the repo, so gh has no repository context to infer from.
+      - run: gh release upload ${{ github.ref_name }} baselines/*.abicheck.json --clobber -R ${{ github.repository }}
         env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
 ```
 
@@ -321,7 +327,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: abicheck/abicheck/actions/collect-facts@v0.3.0
+      - uses: abicheck/abicheck/actions/collect-facts@<same-sha-as-below>
         id: facts
         with: { phase: prepare, producer: wrapper, public-roots: "include" }
       - name: Build
@@ -329,7 +335,7 @@ jobs:
           cmake -DCMAKE_CXX_COMPILER_LAUNCHER=abicheck-cc \
                 -DCMAKE_C_COMPILER_LAUNCHER=abicheck-cc -S . -B build
           cmake --build build
-      - uses: abicheck/abicheck/actions/collect-facts@v0.3.0
+      - uses: abicheck/abicheck/actions/collect-facts@<same-sha-as-below>
         id: facts-verify
         with: { phase: verify, producer: ${{ steps.facts.outputs.producer }} }
       - uses: actions/upload-artifact@v4
@@ -361,7 +367,10 @@ jobs:
           depth: source
           output-file: candidate.json
       - name: Download this library's baseline
-        run: gh release download --pattern '${{ matrix.lib.name }}.abicheck.json' -D baselines/
+        # -R is required: this job never checks out the repo either, so gh
+        # has no local repository context to infer from (same reason as the
+        # release-workflow's gh release upload above).
+        run: gh release download --pattern '${{ matrix.lib.name }}.abicheck.json' -D baselines/ -R ${{ github.repository }}
         env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
       - name: Compare two snapshots (source/API + binary evidence together)
         uses: abicheck/abicheck@v0.3.0

--- a/docs/user-guide/github-action-source-scans.md
+++ b/docs/user-guide/github-action-source-scans.md
@@ -287,7 +287,13 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
         with: { name: release-build }
-      - uses: abicheck/abicheck@v0.3.0
+      # Same SHA as the build job's collect-facts calls above -- this step
+      # consumes the abicheck_inputs/ pack that produced, and a version tag
+      # here could disagree with collect-facts' pinned SHA on the pack
+      # schema/fact-set recipe, risking a mismatch or missing source facts
+      # the same "pin both uses: lines" rule in producing-source-facts.md
+      # exists to prevent (Codex review).
+      - uses: abicheck/abicheck@<same-sha-as-above>
         with:
           mode: dump
           new-library: ${{ matrix.lib.so }}
@@ -358,7 +364,9 @@ jobs:
       - uses: actions/download-artifact@v4
         with: { name: release-build }
       - name: Dump candidate with build/source evidence
-        uses: abicheck/abicheck@v0.3.0
+        # Same SHA as the build job's collect-facts calls above (Codex
+        # review) -- see the note on the release workflow's equivalent step.
+        uses: abicheck/abicheck@<same-sha-as-above>
         with:
           mode: dump
           new-library: ${{ matrix.lib.so }}
@@ -373,7 +381,7 @@ jobs:
         run: gh release download --pattern '${{ matrix.lib.name }}.abicheck.json' -D baselines/ -R ${{ github.repository }}
         env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
       - name: Compare two snapshots (source/API + binary evidence together)
-        uses: abicheck/abicheck@v0.3.0
+        uses: abicheck/abicheck@<same-sha-as-above>
         with:
           old-library: baselines/${{ matrix.lib.name }}.abicheck.json
           new-library: candidate.json

--- a/docs/user-guide/github-action-source-scans.md
+++ b/docs/user-guide/github-action-source-scans.md
@@ -222,6 +222,11 @@ which is easy to miss without seeing them chained together:
    single combined verdict from a fan-out this page's `dump`/`scan` don't do
    natively.
 
+The `abicheck_inputs/` pack itself is produced by whichever [producer](producing-source-facts.md#which-producer-pick-one)
+fits your build; the [`collect-facts` Action](producing-source-facts.md#github-actions-the-collect-facts-action)
+wires that up (`phase: prepare` before the build, `phase: verify` after)
+instead of a hand-rolled build script:
+
 ```yaml
 # Release workflow — build once, produce a per-library baseline set from the
 # one shared facts pack (matches "Recipe A" in Baseline Management, but with a
@@ -231,8 +236,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Build (source-fact collection wired into this step)
-        run: ./ci/build.sh --with-source-facts   # emits abicheck_inputs/ once
+      - uses: abicheck/abicheck/actions/collect-facts@v0.3.0
+        id: facts
+        with: { phase: prepare, producer: auto, public-roots: "include" }
+      - name: Build
+        run: cmake -B build -S . && cmake --build build   # picks up the wrapper/plugin env vars collect-facts exported
+      - uses: abicheck/abicheck/actions/collect-facts@v0.3.0
+        id: facts-verify
+        with: { phase: verify, producer: ${{ steps.facts.outputs.producer }} }
       - uses: actions/upload-artifact@v4
         with:
           name: release-build

--- a/docs/user-guide/github-action-source-scans.md
+++ b/docs/user-guide/github-action-source-scans.md
@@ -252,7 +252,16 @@ jobs:
         id: facts
         with: { phase: prepare, producer: wrapper, public-roots: "include" }
       - name: Build
-        run: cmake -B build -S . && cmake --build build   # picks up the wrapper/plugin env vars collect-facts exported
+        # phase: prepare only *exports* the ABICHECK_CC_* env vars
+        # abicheck-cc reads (see its own ::notice::) -- nothing invokes
+        # abicheck-cc for you, so front every compile with it explicitly via
+        # CMake's compiler-launcher hooks. Swap this line for
+        # `-DCMAKE_CXX_FLAGS="$ABICHECK_PLUGIN_FLAGS"` if you pin
+        # `producer: clang-plugin` instead.
+        run: |
+          cmake -DCMAKE_CXX_COMPILER_LAUNCHER=abicheck-cc \
+                -DCMAKE_C_COMPILER_LAUNCHER=abicheck-cc -S . -B build
+          cmake --build build
       - uses: abicheck/abicheck/actions/collect-facts@v0.3.0
         id: facts-verify
         with: { phase: verify, producer: ${{ steps.facts.outputs.producer }} }
@@ -261,6 +270,7 @@ jobs:
           name: release-build
           path: |
             build/lib*.so
+            include/
             abicheck_inputs/
 
   dump-baselines:

--- a/docs/user-guide/github-action-source-scans.md
+++ b/docs/user-guide/github-action-source-scans.md
@@ -225,7 +225,19 @@ which is easy to miss without seeing them chained together:
 The `abicheck_inputs/` pack itself is produced by whichever [producer](producing-source-facts.md#which-producer-pick-one)
 fits your build; the [`collect-facts` Action](producing-source-facts.md#github-actions-the-collect-facts-action)
 wires that up (`phase: prepare` before the build, `phase: verify` after)
-instead of a hand-rolled build script:
+instead of a hand-rolled build script.
+
+This recipe specifically needs a pack it can `upload-artifact` from the
+`build` job and `download-artifact` into separate `dump-baselines` matrix
+jobs, so pin `producer` to `wrapper` or `clang-plugin` rather than `auto`:
+for a CMake/Bazel/compile-DB project, `auto` resolves to `replay`, whose
+`phase: prepare` returns `mode: inline` with an empty `pack-path` and never
+creates an `abicheck_inputs/` directory at all — there is nothing to upload,
+and every matrix row's `build-info: abicheck_inputs/` would point at a
+directory that doesn't exist. (Replay's inline mode is for the single-job
+case in [Section A](#a-inline-at-dump-time-simplest), where `dump` runs
+right after the build with the checked-out `sources:` tree still on disk —
+not for reuse across separate jobs.)
 
 ```yaml
 # Release workflow — build once, produce a per-library baseline set from the
@@ -238,7 +250,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: abicheck/abicheck/actions/collect-facts@v0.3.0
         id: facts
-        with: { phase: prepare, producer: auto, public-roots: "include" }
+        with: { phase: prepare, producer: wrapper, public-roots: "include" }
       - name: Build
         run: cmake -B build -S . && cmake --build build   # picks up the wrapper/plugin env vars collect-facts exported
       - uses: abicheck/abicheck/actions/collect-facts@v0.3.0

--- a/docs/user-guide/github-action-source-scans.md
+++ b/docs/user-guide/github-action-source-scans.md
@@ -192,3 +192,145 @@ directly with the CLI (`pip install abicheck`) instead of through this Action,
 or embed inline at dump time as in Section A. See
 [Build Info & Sources](../concepts/build-source-data.md) for the underlying
 CLI-level flows.
+
+## Recommended flow: a multi-library release with one shared facts pack
+
+This is the concrete, Action-supported answer to a specific, recurring shape
+of project: several libraries built from one source tree, one facts pack
+collected **once** for the whole build (via [source
+replay](producing-source-facts.md#full-source-scan--replay-from-a-compile-database),
+the [`abicheck-cc` wrapper](producing-source-facts.md#wrapper-injection--the-abicheck-cc-compiler-wrapper),
+or the [Clang plugin](producing-source-facts.md#plugin-injection--the-clang-facts-plugin)),
+and no single ".so that represents the release" to hand `scan`/`dump` — which,
+per [Mode/input compatibility](github-action.md#modeinput-compatibility), only
+accept **one** artifact each; there is no `scan`/`dump` equivalent of
+`compare`'s directory/package fan-out.
+
+The fix is not a new Action feature — it's composing three recipes this page
+and [More Recipes](github-action-recipes.md) already document individually,
+which is easy to miss without seeing them chained together:
+
+1. **[Matrix over libraries](github-action-recipes.md#matrix-multiple-libraries)** —
+   one matrix row per library, not per platform.
+2. **[Inline embedding at dump time](#a-inline-at-dump-time-simplest)** — each
+   matrix row's `dump` step points `build-info` at the *same* shared facts
+   pack; `-H`/`header` scopes the L2 declared surface to that row's own public
+   headers, and the embedded L3/L4/L5 facts are matched against it — the pack
+   is collected once per build, not once per library.
+3. **[Post-matrix ABI gate](github-action-recipes.md#post-matrix-abi-gate-unified-verdict)** —
+   aggregates the per-library verdicts into one exit code, since there is no
+   single combined verdict from a fan-out this page's `dump`/`scan` don't do
+   natively.
+
+```yaml
+# Release workflow — build once, produce a per-library baseline set from the
+# one shared facts pack (matches "Recipe A" in Baseline Management, but with a
+# manifest row per library instead of a single baseline file).
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build (source-fact collection wired into this step)
+        run: ./ci/build.sh --with-source-facts   # emits abicheck_inputs/ once
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-build
+          path: |
+            build/lib*.so
+            abicheck_inputs/
+
+  dump-baselines:
+    needs: build
+    strategy:
+      matrix:
+        lib:
+          - { name: libfoo, so: build/libfoo.so, header: include/foo.h }
+          - { name: libbar, so: build/libbar.so, header: include/bar.h }
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { name: release-build }
+      - uses: abicheck/abicheck@v0.3.0
+        with:
+          mode: dump
+          new-library: ${{ matrix.lib.so }}
+          header: ${{ matrix.lib.header }}
+          build-info: abicheck_inputs/       # the one shared pack, every row
+          depth: source
+          new-version: ${{ github.ref_name }}
+          output-file: ${{ matrix.lib.name }}.abicheck.json
+      - uses: actions/upload-artifact@v4
+        with:
+          name: baseline-${{ matrix.lib.name }}
+          path: ${{ matrix.lib.name }}.abicheck.json
+
+  publish-baselines:
+    needs: dump-baselines
+    runs-on: ubuntu-latest
+    permissions: { contents: write }
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { pattern: baseline-*, merge-multiple: true, path: baselines/ }
+      - run: gh release upload ${{ github.ref_name }} baselines/*.abicheck.json --clobber
+        env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
+```
+
+```yaml
+# PR workflow — same matrix, dumping the candidate build instead of publishing,
+# then comparing two JSON snapshots per library (no headers/build-info needed
+# at compare time — both sides already have their facts embedded).
+jobs:
+  build:
+    # same as above, no publish step
+
+  scan-candidates:
+    needs: build
+    strategy:
+      matrix:
+        lib: [ ... same list as above ... ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with: { name: release-build }
+      - name: Dump candidate with build/source evidence
+        uses: abicheck/abicheck@v0.3.0
+        with:
+          mode: dump
+          new-library: ${{ matrix.lib.so }}
+          header: ${{ matrix.lib.header }}
+          build-info: abicheck_inputs/
+          depth: source
+          output-file: candidate.json
+      - name: Download this library's baseline
+        run: gh release download --pattern '${{ matrix.lib.name }}.abicheck.json' -D baselines/
+        env: { GH_TOKEN: ${{ secrets.GITHUB_TOKEN }} }
+      - name: Compare two snapshots (source/API + binary evidence together)
+        uses: abicheck/abicheck@v0.3.0
+        with:
+          old-library: baselines/${{ matrix.lib.name }}.abicheck.json
+          new-library: candidate.json
+          format: json
+          output-file: report-${{ matrix.lib.name }}.json
+          fail-on-breaking: false   # let the post-matrix gate job decide
+          fail-on-api-break: false
+
+  abi-gate:
+    needs: scan-candidates
+    # same aggregation job as "Post-matrix ABI gate (unified verdict)"
+```
+
+**Layering onto an existing binary-ABI tool** (the common reason to reach for
+this pattern at all): keep that tool's job exactly as-is for the binary ABI
+gate, and add the above as a second, independent job for the source/API
+surface — don't try to make one job do both. Start the second job **advisory**
+(`fail-on-breaking: false`, `fail-on-api-break: false`, report only) while you
+build confidence in the new source/API signal on real history; flip on
+`fail-on-api-break: true` once it's been quiet for a burn-in period. This
+mirrors [Choose Your Workflow](choose-your-workflow.md)'s guidance to not make
+one step prove more than its evidence actually supports.
+
+This pattern produces one baseline *file* per library, which is a per-library
+instance of the [release-contract baseline](baseline-management.md#two-kinds-of-baseline-release-contract-vs-accepted-main) —
+apply that page's release-vs-accepted-main split and refresh discipline to
+each file the same way you would to a single-library baseline.

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -18,6 +18,37 @@ automatically, then runs ABI comparison and reports results.
     new-header: include/foo.h
 ```
 
+## Mode/input compatibility
+
+Not every input is meaningful in every `mode`. The Action's first step
+(`Validate mode/input combination`) checks the combinations below **before**
+Python setup, system-dependency installation, or `pip install abicheck` —
+an unsupported combination fails immediately with a clear error instead of
+after a multi-minute toolchain install, and instead of silently falling
+back to a different, unrequested behavior.
+
+| Capability | `compare` | `dump` | `scan` | `deps-tree` / `deps-compare` |
+|---|:--:|:--:|:--:|:--:|
+| Single binary/snapshot | yes | yes | yes | yes |
+| Directory/package (`new-library`/`old-library`) | yes (fans out per-library) | **error** | **error** | — |
+| Source-only (no `new-library`, via `sources`/`build-info`/`compile-db`) | — | yes | — | — |
+| `format: sarif` / `html` | yes (single pair only) | n/a (always JSON) | **error** | **error** |
+| `format: json` | yes | n/a (always JSON) | yes | yes |
+| `format: markdown` / `text` | yes | n/a (always JSON) | `text` only | `markdown` only |
+| `upload-sarif: true` | yes (needs `format: sarif`) | **error** | **error** | **error** |
+| `pr-comment` | yes | no-op | no-op | no-op |
+
+For a multi-library release directory (several `.so`/`.dll`/`.dylib` files),
+use `mode: compare` with a directory/package operand — it fans out to a
+per-library comparison automatically (see [Package comparison
+inputs](#package-comparison-inputs-compare-mode-directorypackage-operands-only)
+below). `dump` and `scan` have no such fan-out: dump each library
+individually (one step per binary, or a matrix), and scan one representative
+artifact at a time, or run `compare` for the binary side and `scan --sources`
+separately for the source/API side (see [Choose Your
+Workflow](choose-your-workflow.md) for weighing that split against a single
+combined step).
+
 ## Inputs
 
 ### Library inputs
@@ -26,7 +57,7 @@ automatically, then runs ABI comparison and reports results.
 |-------|----------|-------------|
 | `mode` | no | `compare` (default), `dump`, `scan`, `deps-tree`, or `deps-compare` |
 | `old-library` | yes (compare) | Path to old library, JSON snapshot, ABICC dump, directory, or package (a directory/package fans out to a per-library comparison automatically — no separate mode) |
-| `new-library` | yes (compare, dump, scan, …) | Path to new library, binary, directory, or package. In `scan` mode this is the scanned binary or `.abi.json` snapshot. |
+| `new-library` | yes (compare, dump\*, scan, deps-tree, deps-compare) | Path to new library, binary, or JSON snapshot. **Directory/package is `compare`-only** — `dump` and `scan` each analyse exactly one artifact and reject a directory/package with a fail-fast error, before any dependency install. \*`dump` may omit `new-library` entirely for a source-only dump (`sources`/`build-info`/`compile-db` given instead). See [Mode/input compatibility](#modeinput-compatibility) below. |
 
 ### Header inputs
 
@@ -143,7 +174,7 @@ scan degrades gracefully and L0–L2 stay authoritative.
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `format` | `markdown` (`text` for scan) | Output format: `markdown`, `json`, `sarif`, `html`. `sarif`/`html` are only available in `compare` mode when `old-library`/`new-library` are a single pair — a directory/package comparison rejects them with a clear error (choose `markdown` or `json` instead). `deps-tree`/`deps-compare` support only `markdown`/`json` and fall back to `markdown`; `scan` supports only `text`/`json` and falls back to `text`. |
+| `format` | `markdown` (`text` for scan) | Output format: `markdown`, `json`, `sarif`, `html`. `sarif`/`html` are only available in `compare` mode when `old-library`/`new-library` are a single pair — a directory/package comparison rejects them with a clear error (choose `markdown` or `json` instead). `deps-tree`/`deps-compare` support only `markdown`/`json`; `scan` supports only `text`/`json`. Requesting an unsupported format for the mode is a **hard error**, raised before any dependency install — it used to silently fall back to a supported format with only a warning, which is unsafe for CI (see [Mode/input compatibility](#modeinput-compatibility)). |
 | `output-file` | — | Path to write report (auto-set for SARIF) |
 | `dry-run` | `false` | Resolve inputs/config and print what the run would do, without analyzing anything or writing output (always exits 0). Maps to `--dry-run`; supported by every mode. In scan mode this also prints the projected per-layer cost. |
 | `estimate` | `false` | **Deprecated.** scan mode only. Functional alias for `dry-run: 'true'` — prefer `dry-run` directly, which applies to every mode. |
@@ -165,7 +196,7 @@ extra-args: '--strict-suppressions --require-justification'
 |-------|---------|-------------|
 | `python-version` | `3.13` | Python version for setup-python |
 | `install-deps` | `true` | Install castxml + gcc automatically |
-| `upload-sarif` | `false` | Upload SARIF to GitHub Code Scanning |
+| `upload-sarif` | `false` | Upload SARIF to GitHub Code Scanning. Requires `format: sarif` and `mode: compare`; any other combination is a hard error raised before any dependency install. |
 | `fail-on-breaking` | `true` | Fail step on binary ABI break |
 | `fail-on-api-break` | `false` | Fail step on source-level API break |
 | `severity-preset` | — | Severity preset: `default`, `strict`, or `info-only` (compare mode only) |

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -48,7 +48,11 @@ individually (one step per binary, or a matrix), and scan one representative
 artifact at a time, or run `compare` for the binary side and `scan --sources`
 separately for the source/API side (see [Choose Your
 Workflow](choose-your-workflow.md) for weighing that split against a single
-combined step).
+combined step). If the release also carries build-emitted source facts (a
+shared `abicheck_inputs/` pack from one build), see [Source Scans →
+Recommended flow: a multi-library release with one shared facts
+pack](github-action-source-scans.md#recommended-flow-a-multi-library-release-with-one-shared-facts-pack)
+for the full matrix-dump-then-compare walkthrough.
 
 ## Inputs
 

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -32,7 +32,8 @@ back to a different, unrequested behavior.
 | Single binary/snapshot | yes | yes | yes | yes |
 | Directory/package (`new-library`/`old-library`) | yes (fans out per-library) | **error** | **error** | — |
 | Source-only (no `new-library`, via `sources`/`build-info`/`compile-db`) | — | yes | — | — |
-| `format: sarif` / `html` | yes (single pair only) | n/a (always JSON) | **error** | **error** |
+| `format: sarif` | yes (single pair only) | n/a (always JSON) | **error** | **error** |
+| `format: html` | yes (single pair only) | n/a (always JSON) | **error** | yes (dependency-stack report) |
 | `format: json` | yes | n/a (always JSON) | yes | yes |
 | `format: markdown` / `text` | yes | n/a (always JSON) | `text` only | `markdown` only |
 | `upload-sarif: true` | yes (needs `format: sarif`) | **error** | **error** | **error** |
@@ -174,7 +175,7 @@ scan degrades gracefully and L0–L2 stay authoritative.
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `format` | `markdown` (`text` for scan) | Output format: `markdown`, `json`, `sarif`, `html`. `sarif`/`html` are only available in `compare` mode when `old-library`/`new-library` are a single pair — a directory/package comparison rejects them with a clear error (choose `markdown` or `json` instead). `deps-tree`/`deps-compare` support only `markdown`/`json`; `scan` supports only `text`/`json`. Requesting an unsupported format for the mode is a **hard error**, raised before any dependency install — it used to silently fall back to a supported format with only a warning, which is unsafe for CI (see [Mode/input compatibility](#modeinput-compatibility)). |
+| `format` | `markdown` (`text` for scan) | Output format: `markdown`, `json`, `sarif`, `html`. `sarif` is only available in `compare` mode when `old-library`/`new-library` are a single pair — a directory/package comparison rejects it with a clear error (choose `markdown` or `json` instead). `html` is available in `compare` (same single-pair restriction) and in `deps-tree`/`deps-compare` (a dependency-stack report); `scan` supports only `text`/`json`. Requesting an unsupported format for the mode is a **hard error**, raised before any dependency install — it used to silently fall back to a supported format with only a warning, which is unsafe for CI (see [Mode/input compatibility](#modeinput-compatibility)). |
 | `output-file` | — | Path to write report (auto-set for SARIF) |
 | `dry-run` | `false` | Resolve inputs/config and print what the run would do, without analyzing anything or writing output (always exits 0). Maps to `--dry-run`; supported by every mode. In scan mode this also prints the projected per-layer cost. |
 | `estimate` | `false` | **Deprecated.** scan mode only. Functional alias for `dry-run: 'true'` — prefer `dry-run` directly, which applies to every mode. |

--- a/docs/user-guide/github-action.md
+++ b/docs/user-guide/github-action.md
@@ -157,8 +157,9 @@ scan degrades gracefully and L0–L2 stay authoritative.
 | `risk-rules` | scan | Path to a YAML file overriding the `risk_rules` profile. |
 
 !!! note "format in scan mode"
-    `scan` supports `format: text` (default) or `json`; other values fall back
-    to `text` with a warning.
+    `scan` supports `format: text` (default) or `json`; any other value is a
+    hard error raised before any dependency install (see [Mode/input
+    compatibility](#modeinput-compatibility)).
 
 !!! tip "Consuming build-emitted source facts (wrapper / Clang plugin)"
     If your **product build** emits its own `abicheck_inputs/` pack — via the

--- a/docs/user-guide/producing-source-facts.md
+++ b/docs/user-guide/producing-source-facts.md
@@ -183,6 +183,16 @@ variables before your build runs. `abicheck/abicheck/actions/collect-facts`
 does that wiring once, so an integration doesn't need its own shell scripts
 or a separately pinned plugin version:
 
+Branch on `steps.facts.outputs.mode` rather than hard-coding a producer:
+`replay` needs nothing further (pass `sources:` straight to `dump`/`scan`),
+while `wrapper`/`clang-plugin` need the `phase: verify` step and
+`build-info: <pack-path>`. Skipping the branch and always wiring
+`build-info: ${{ steps.facts.outputs.pack-path }}` is a trap — for
+`producer: auto` resolving to `replay` (the common case on a project with a
+`compile_commands.json` or a CMake/Bazel build), `pack-path` is empty, so
+`build-info` silently receives nothing and the dump proceeds with **no**
+source facts at all, not an error:
+
 ```yaml
 - uses: abicheck/abicheck/actions/collect-facts@<same-sha-as-below>
   id: facts
@@ -195,10 +205,14 @@ or a separately pinned plugin version:
     output: abicheck_inputs
 
 - name: Build (wrapper/clang-plugin producers pick this up via env vars)
+  if: steps.facts.outputs.mode == 'pack'
   run: cmake -B build -S . && cmake --build build
+# producer: replay needs no build step here at all -- it collects inline at
+# dump/scan time below, from `sources:` directly.
 
 - uses: abicheck/abicheck/actions/collect-facts@<same-sha-as-below>
   id: facts-verify
+  if: steps.facts.outputs.mode == 'pack'
   with:
     phase: verify
     producer: ${{ steps.facts.outputs.producer }}
@@ -209,6 +223,10 @@ or a separately pinned plugin version:
     mode: dump
     new-library: build/libfoo.so
     header: include/
+    # mode: inline (replay) -> pass sources directly; mode: pack (wrapper/
+    # clang-plugin) -> pass the verified pack path. Never pass an empty
+    # build-info -- that's the silent-no-facts trap above.
+    sources: ${{ steps.facts.outputs.mode == 'inline' && '.' || '' }}
     build-info: ${{ steps.facts-verify.outputs.pack-path }}
 ```
 

--- a/docs/user-guide/producing-source-facts.md
+++ b/docs/user-guide/producing-source-facts.md
@@ -204,11 +204,34 @@ source facts at all, not an error:
       include
     output: abicheck_inputs
 
-- name: Build (wrapper/clang-plugin producers pick this up via env vars)
-  if: steps.facts.outputs.mode == 'pack'
-  run: cmake -B build -S . && cmake --build build
-# producer: replay needs no build step here at all -- it collects inline at
-# dump/scan time below, from `sources:` directly.
+- name: Build
+  # Always runs -- this produces build/libfoo.so itself, which the dump step
+  # below needs regardless of producer. Do NOT gate this on
+  # `steps.facts.outputs.mode == 'pack'`: `phase: prepare` only *exports* the
+  # env vars/flags wrapper and clang-plugin need (see the notices it prints);
+  # nothing invokes them for you, so the configure step below has to wire
+  # them in explicitly per producer. producer: replay needs neither -- it
+  # collects its facts separately, inline, from `sources:` at dump time
+  # below -- but the binary still has to actually get built either way.
+  run: |
+    case "${{ steps.facts.outputs.producer }}" in
+      wrapper)
+        # abicheck-cc reads ABICHECK_CC_* (exported by phase: prepare above)
+        # but only compiles anything it's actually invoked for -- CMake's
+        # compiler-launcher hooks are what puts it in front of every call.
+        cmake -DCMAKE_CXX_COMPILER_LAUNCHER=abicheck-cc \
+              -DCMAKE_C_COMPILER_LAUNCHER=abicheck-cc -S . -B build
+        ;;
+      clang-plugin)
+        # $ABICHECK_PLUGIN_FLAGS (exported by phase: prepare above) loads the
+        # plugin into the real compiler; nothing does this automatically.
+        cmake -DCMAKE_CXX_FLAGS="$ABICHECK_PLUGIN_FLAGS" -S . -B build
+        ;;
+      *)
+        cmake -S . -B build
+        ;;
+    esac
+    cmake --build build
 
 - uses: abicheck/abicheck/actions/collect-facts@<same-sha-as-below>
   id: facts-verify

--- a/docs/user-guide/producing-source-facts.md
+++ b/docs/user-guide/producing-source-facts.md
@@ -173,6 +173,72 @@ the portable defaults.
     explicit `public-roots=` when you want the surface scoped precisely to your
     installed public headers.
 
+## GitHub Actions: the `collect-facts` Action
+
+The three producers above are CLI-level (`dump --sources`, the `abicheck-cc`
+wrapper's environment variables, the plugin's `-fplugin=` flags) — wiring any
+of them into CI by hand means writing shell to pick a producer, install its
+dependencies, and (for the wrapper/plugin) export the right environment
+variables before your build runs. `abicheck/abicheck/actions/collect-facts`
+does that wiring once, so an integration doesn't need its own shell scripts
+or a separately pinned plugin version:
+
+```yaml
+- uses: abicheck/abicheck/actions/collect-facts@<same-sha-as-below>
+  id: facts
+  with:
+    phase: prepare
+    producer: auto            # or: replay | wrapper | clang-plugin
+    sources: .
+    public-roots: |
+      include
+    output: abicheck_inputs
+
+- name: Build (wrapper/clang-plugin producers pick this up via env vars)
+  run: cmake -B build -S . && cmake --build build
+
+- uses: abicheck/abicheck/actions/collect-facts@<same-sha-as-below>
+  id: facts-verify
+  with:
+    phase: verify
+    producer: ${{ steps.facts.outputs.producer }}
+    output: abicheck_inputs
+
+- uses: abicheck/abicheck@<same-sha-as-above>
+  with:
+    mode: dump
+    new-library: build/libfoo.so
+    header: include/
+    build-info: ${{ steps.facts-verify.outputs.pack-path }}
+```
+
+Pin both `uses:` lines to the **same commit SHA** and there is exactly one
+version to track: the Action builds the Clang plugin (when
+`producer: clang-plugin`) from its own checked-out copy of
+`contrib/abicheck-clang-plugin` at that SHA, not a separately versioned
+`plugin_ref` — the scanner and the producer can never drift apart the way a
+hand-rolled `plugin_ref: v0.5.0` variable next to a differently-pinned
+`uses: abicheck/abicheck@v0.5.0` line can.
+
+**`phase: prepare` / `phase: verify`, and why there are two steps.** Wrapper
+and Clang-plugin injection both need *your* build command to run in between —
+this Action cannot invoke it for you. `phase: prepare` resolves the producer,
+installs what it needs (the matching `libclang-<N>-dev` for `clang-plugin`,
+`castxml`/`clang` for `wrapper`), and exports the environment variables/flags
+your build step reads; `phase: verify` (run after your build) checks the
+resulting pack is non-empty and reports its path. `producer: replay` needs
+neither — `phase: auto` (the default) completes it in one step, since replay
+collects inline at `dump`/`scan`/`compare` time rather than producing a pack
+ahead of time; pass `sources:` straight to the next abicheck step and skip
+`collect-facts` for that producer entirely if you already know you're on the
+replay path.
+
+**`producer: auto`** inspects `sources` for an existing compile database or a
+CMake/Bazel project (→ `replay`) and falls back to `wrapper` otherwise. It
+never auto-selects `clang-plugin` — "you own the toolchain image and the
+second-parse cost is worth removing" is an operator decision the Action can't
+infer, matching the [decision tree](#which-producer-pick-one) above.
+
 ## Then: fold the facts onto the binary
 
 However you produced them, ingest is a single `dump` call — pass the

--- a/tests/test_action_baseline.py
+++ b/tests/test_action_baseline.py
@@ -192,6 +192,34 @@ class TestLibrariesJsonValidation:
         assert "duplicate library name" in result.stdout
         assert "libfoo" in result.stdout
 
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "../evil",
+            "a/b",
+            "a\\b",
+            "/etc/cron.d/evil",
+            ".",
+            "..",
+            "",
+            "a\nb",
+        ],
+    )
+    def test_invalid_library_name_rejected(self, tmp_path: Path, name: str) -> None:
+        # Regression (Codex review): run.sh writes the dump to
+        # "$OUTPUT_DIR/$name.abicheck.json" (bash string concat) and
+        # build_manifest.py builds output_dir / f"{name}.abicheck.json"
+        # (pathlib, which lets an absolute right-hand side override the
+        # left-hand side entirely) -- neither previously rejected a name
+        # containing a path separator or a ".."/"." traversal segment, so a
+        # crafted libraries input could write a snapshot outside output_dir.
+        result, _ = _run_action(
+            {"INPUT_LIBRARIES": json.dumps([{"name": name, "artifact": "a.so"}])},
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "invalid" in result.stdout
+
 
 @pytest.mark.skipif(not RUN_SH.is_file(), reason="actions/baseline/run.sh not found")
 class TestStaleOutputCleared:

--- a/tests/test_action_baseline.py
+++ b/tests/test_action_baseline.py
@@ -1,0 +1,315 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for ``actions/baseline/run.sh``.
+
+This script backs the ``abicheck baseline`` composite Action: it dumps a
+JSON-described set of libraries into a baseline-set (one ``.abicheck.json``
+per library plus a ``manifest.json`` -- see
+``actions/baseline/build_manifest.py`` and
+``tests/test_baseline_manifest.py`` for the pure-Python manifest logic this
+script's ``build_manifest.py`` call feeds). This file covers the bash
+orchestration layer: input validation, per-library dump invocation, the
+optional self-compare validation pass, and one end-to-end run against real
+compiled shared libraries.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ACTION_DIR = Path(__file__).resolve().parents[1] / "actions" / "baseline"
+RUN_SH = ACTION_DIR / "run.sh"
+
+_GCC = shutil.which("gcc")
+_ABICHECK = shutil.which("abicheck")
+
+
+def _bash_executable() -> str:
+    """Resolve a real bash, bypassing Windows' WSL-launcher stub.
+
+    See ``test_action_run_sh_helpers._bash_executable`` for the full
+    rationale.
+    """
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
+def _run_action(
+    env_extra: dict[str, str], cwd: Path
+) -> tuple[subprocess.CompletedProcess[str], Path]:
+    """Invoke the real script end-to-end with a GITHUB_OUTPUT file."""
+    github_output = cwd / "github_output"
+    github_output.write_text("")
+    env = {
+        **os.environ,
+        "GITHUB_OUTPUT": str(github_output),
+        "ACTION_PATH": str(ACTION_DIR),
+        **env_extra,
+    }
+    result = subprocess.run(
+        [_bash_executable(), str(RUN_SH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd,
+        check=False,
+    )
+    return result, github_output
+
+
+def _parse_kv_file(path: Path) -> dict[str, str]:
+    out = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            out[k] = v
+    return out
+
+
+def _compile_shared_lib(src_text: str, out: Path) -> None:
+    src = out.with_suffix(".c")
+    src.write_text(src_text, encoding="utf-8")
+    subprocess.run(
+        [_GCC, "-shared", "-fPIC", "-g", str(src), "-o", str(out)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="actions/baseline/run.sh not found")
+class TestValidationInputRejected:
+    def test_unknown_validation_value_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {
+                "INPUT_LIBRARIES": json.dumps([{"name": "foo", "artifact": "a.so"}]),
+                "INPUT_VALIDATION": "bogus",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "not recognized" in result.stdout
+
+    def test_missing_libraries_input_fails(self, tmp_path: Path) -> None:
+        # No INPUT_LIBRARIES at all -- the ${VAR:?message} guard should
+        # reject this before any JSON parsing is attempted.
+        result, _ = _run_action({}, tmp_path)
+        assert result.returncode != 0
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="actions/baseline/run.sh not found")
+class TestLibrariesJsonValidation:
+    def test_invalid_json_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action({"INPUT_LIBRARIES": "not json"}, tmp_path)
+        assert result.returncode == 1
+        assert "not valid JSON" in result.stdout
+
+    def test_non_array_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {"INPUT_LIBRARIES": json.dumps({"name": "foo", "artifact": "a.so"})},
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "non-empty JSON array" in result.stdout
+
+    def test_empty_array_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action({"INPUT_LIBRARIES": "[]"}, tmp_path)
+        assert result.returncode == 1
+        assert "non-empty JSON array" in result.stdout
+
+    def test_entry_missing_name_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {"INPUT_LIBRARIES": json.dumps([{"artifact": "a.so"}])}, tmp_path
+        )
+        assert result.returncode == 1
+        assert "entry 0" in result.stdout
+
+    def test_entry_missing_artifact_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {"INPUT_LIBRARIES": json.dumps([{"name": "foo"}])}, tmp_path
+        )
+        assert result.returncode == 1
+        assert "entry 0" in result.stdout
+
+    def test_second_entry_missing_key_is_still_caught(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {
+                "INPUT_LIBRARIES": json.dumps(
+                    [{"name": "foo", "artifact": "a.so"}, {"name": "bar"}]
+                )
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "entry 1" in result.stdout
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="actions/baseline/run.sh not found")
+@pytest.mark.skipif(not _ABICHECK, reason="needs abicheck on PATH")
+class TestDumpFailurePaths:
+    def test_nonexistent_artifact_fails_with_library_name(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {
+                "INPUT_LIBRARIES": json.dumps(
+                    [{"name": "libfoo", "artifact": str(tmp_path / "no-such.so")}]
+                ),
+                "INPUT_OUTPUT_DIR": str(tmp_path / "out"),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "dump failed for library 'libfoo'" in result.stdout
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="actions/baseline/run.sh not found")
+@pytest.mark.skipif(
+    not (sys.platform.startswith("linux") and _GCC and _ABICHECK),
+    reason="needs an ELF host with gcc and abicheck on PATH",
+)
+class TestEndToEndBaselineSet:
+    pytestmark = pytest.mark.integration
+
+    def test_two_libraries_produce_a_manifest_with_freshness(
+        self, tmp_path: Path
+    ) -> None:
+        libfoo = tmp_path / "libfoo.so"
+        libbar = tmp_path / "libbar.so"
+        _compile_shared_lib(
+            "int abicheck_foo_add(int a, int b) { return a + b; }\n", libfoo
+        )
+        _compile_shared_lib(
+            "int abicheck_bar_sub(int a, int b) { return a - b; }\n", libbar
+        )
+        output_dir = tmp_path / "baseline-out"
+        libraries = json.dumps(
+            [
+                {"name": "libfoo", "artifact": str(libfoo)},
+                {"name": "libbar", "artifact": str(libbar)},
+            ]
+        )
+
+        result, github_output = _run_action(
+            {
+                "INPUT_LIBRARIES": libraries,
+                "INPUT_OUTPUT_DIR": str(output_dir),
+                "INPUT_PROJECT_REF": "v1.0.0",
+                "INPUT_PROFILE": "linux-x86_64-gcc",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+        assert (output_dir / "libfoo.abicheck.json").is_file()
+        assert (output_dir / "libbar.abicheck.json").is_file()
+        manifest_path = output_dir / "manifest.json"
+        assert manifest_path.is_file()
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["project_ref"] == "v1.0.0"
+        assert manifest["profile"] == "linux-x86_64-gcc"
+        assert sorted(a["library"] for a in manifest["artifacts"]) == [
+            "libbar",
+            "libfoo",
+        ]
+        assert manifest["snapshot_schema"] is not None
+        assert manifest["freshness"] == {"refresh_required": False, "reasons": []}
+
+        outputs = _parse_kv_file(github_output)
+        assert outputs["baseline-path"] == str(output_dir)
+        assert outputs["manifest-path"] == str(manifest_path)
+        assert outputs["library-count"] == "2"
+        assert outputs["refresh-required"] == "false"
+        assert "content-digest" in outputs
+
+        # "all snapshots round-tripped cleanly" only prints when the
+        # strict-validation self-compare pass actually ran.
+        assert "all snapshots round-tripped cleanly" in result.stdout
+
+    def test_added_library_against_previous_manifest_requires_refresh(
+        self, tmp_path: Path
+    ) -> None:
+        libfoo = tmp_path / "libfoo.so"
+        _compile_shared_lib(
+            "int abicheck_foo_add(int a, int b) { return a + b; }\n", libfoo
+        )
+        output_dir = tmp_path / "baseline-out"
+        first_result, first_output = _run_action(
+            {
+                "INPUT_LIBRARIES": json.dumps(
+                    [{"name": "libfoo", "artifact": str(libfoo)}]
+                ),
+                "INPUT_OUTPUT_DIR": str(output_dir),
+            },
+            tmp_path,
+        )
+        assert first_result.returncode == 0, first_result.stdout + first_result.stderr
+        previous_manifest = output_dir / "manifest.json"
+
+        libbar = tmp_path / "libbar.so"
+        _compile_shared_lib(
+            "int abicheck_bar_sub(int a, int b) { return a - b; }\n", libbar
+        )
+        second_output_dir = tmp_path / "baseline-out-2"
+        result, github_output = _run_action(
+            {
+                "INPUT_LIBRARIES": json.dumps(
+                    [
+                        {"name": "libfoo", "artifact": str(libfoo)},
+                        {"name": "libbar", "artifact": str(libbar)},
+                    ]
+                ),
+                "INPUT_OUTPUT_DIR": str(second_output_dir),
+                "INPUT_PREVIOUS_MANIFEST": str(previous_manifest),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        outputs = _parse_kv_file(github_output)
+        assert outputs["refresh-required"] == "true"
+        assert "libbar" in outputs["refresh-reasons"]
+
+    def test_validation_none_skips_self_compare(self, tmp_path: Path) -> None:
+        libfoo = tmp_path / "libfoo.so"
+        _compile_shared_lib(
+            "int abicheck_foo_add(int a, int b) { return a + b; }\n", libfoo
+        )
+        result, _ = _run_action(
+            {
+                "INPUT_LIBRARIES": json.dumps(
+                    [{"name": "libfoo", "artifact": str(libfoo)}]
+                ),
+                "INPUT_OUTPUT_DIR": str(tmp_path / "baseline-out"),
+                "INPUT_VALIDATION": "none",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "Self-compare validation" not in result.stdout

--- a/tests/test_action_baseline.py
+++ b/tests/test_action_baseline.py
@@ -172,6 +172,26 @@ class TestLibrariesJsonValidation:
         assert result.returncode == 1
         assert "entry 1" in result.stdout
 
+    def test_duplicate_library_name_fails(self, tmp_path: Path) -> None:
+        # A generated matrix producing two entries with the same name would
+        # otherwise have the second dump silently overwrite the first's
+        # $OUTPUT_DIR/$name.abicheck.json while the manifest still lists two
+        # artifact rows for it (Codex review).
+        result, _ = _run_action(
+            {
+                "INPUT_LIBRARIES": json.dumps(
+                    [
+                        {"name": "libfoo", "artifact": "a.so"},
+                        {"name": "libfoo", "artifact": "b.so"},
+                    ]
+                )
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "duplicate library name" in result.stdout
+        assert "libfoo" in result.stdout
+
 
 @pytest.mark.skipif(not RUN_SH.is_file(), reason="actions/baseline/run.sh not found")
 @pytest.mark.skipif(not _ABICHECK, reason="needs abicheck on PATH")

--- a/tests/test_action_baseline.py
+++ b/tests/test_action_baseline.py
@@ -220,6 +220,32 @@ class TestStaleOutputCleared:
         assert not (output_dir / "stale-lib.abicheck.json").exists()
         assert not (output_dir / "manifest.json").exists()
 
+    def test_previous_manifest_pointing_at_output_dir_survives_cleanup(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): a workflow that restores the previous
+        # baseline set into output-dir before regenerating (an in-place
+        # refresh) points previous-manifest at output-dir/manifest.json --
+        # the stale-snapshot cleanup must not delete that same file out from
+        # under build_manifest.py before it gets a chance to read it.
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        previous_manifest = output_dir / "manifest.json"
+        previous_manifest.write_text('{"sentinel": "keep-me"}')
+
+        _run_action(
+            {
+                "INPUT_LIBRARIES": json.dumps(
+                    [{"name": "libfoo", "artifact": str(tmp_path / "no-such.so")}]
+                ),
+                "INPUT_OUTPUT_DIR": str(output_dir),
+                "INPUT_PREVIOUS_MANIFEST": str(previous_manifest),
+            },
+            tmp_path,
+        )
+        assert previous_manifest.is_file()
+        assert previous_manifest.read_text() == '{"sentinel": "keep-me"}'
+
 
 @pytest.mark.skipif(not RUN_SH.is_file(), reason="actions/baseline/run.sh not found")
 @pytest.mark.skipif(not _ABICHECK, reason="needs abicheck on PATH")

--- a/tests/test_action_baseline.py
+++ b/tests/test_action_baseline.py
@@ -313,3 +313,83 @@ class TestEndToEndBaselineSet:
         )
         assert result.returncode == 0, result.stdout + result.stderr
         assert "Self-compare validation" not in result.stdout
+
+
+_DUMP_LOOP_START = 'echo "::group::Dump baseline-set into $OUTPUT_DIR"'
+_DUMP_LOOP_END = 'echo "::endgroup::"'
+
+
+def _dump_loop_region() -> str:
+    """The per-library dump loop, extracted verbatim from run.sh -- the same
+    "parse the real file, don't hand-copy it" discipline as
+    ``test_action_run_sh_legacy_aliases.py`` / ``..._dry_run_baseline.py``."""
+    text = RUN_SH.read_text(encoding="utf-8")
+    start = text.index(_DUMP_LOOP_START)
+    end = text.index(_DUMP_LOOP_END, start) + len(_DUMP_LOOP_END)
+    return text[start:end]
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="actions/baseline/run.sh not found")
+class TestDumpLoopFieldSplitting:
+    """Regression: a library entry with `include` set but `header` omitted
+    (an empty field between two non-empty ones) used to have its `include`
+    value shift into `header` -- bash's word-splitting always treats a
+    literal tab in IFS as whitespace and collapses the adjacent empty field,
+    no matter what IFS is set to. run.sh now delimits with ASCII Unit
+    Separator (\\x1f) instead, which bash does not treat as whitespace."""
+
+    def _run_dump_loop(self, libraries: list[dict[str, str]]) -> str:
+        script = (
+            '_fail() { echo "::error::$1"; exit 1; }\n'
+            'abicheck() { echo "CMD_ARGS:$*"; return 0; }\n'
+            f"LIBRARIES_JSON='{json.dumps(libraries)}'\n"
+            'OUTPUT_DIR="$PWD"\n'
+            'BUILD_INFO=""\n'
+            'DEPTH=""\n'
+            'PROJECT_REF=""\n' + _dump_loop_region()
+        )
+        result = subprocess.run(
+            [_bash_executable(), "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        return result.stdout
+
+    def test_include_without_header_stays_include(self) -> None:
+        stdout = self._run_dump_loop(
+            [{"name": "libfoo", "artifact": "a.so", "include": "include"}]
+        )
+        [cmd_line] = [
+            line for line in stdout.splitlines() if line.startswith("CMD_ARGS:")
+        ]
+        assert "-I include" in cmd_line
+        assert "-H" not in cmd_line.split()
+
+    def test_header_without_include_stays_header(self) -> None:
+        stdout = self._run_dump_loop(
+            [{"name": "libfoo", "artifact": "a.so", "header": "include/foo.h"}]
+        )
+        [cmd_line] = [
+            line for line in stdout.splitlines() if line.startswith("CMD_ARGS:")
+        ]
+        assert "-H include/foo.h" in cmd_line
+        assert "-I" not in cmd_line.split()
+
+    def test_both_header_and_include_are_kept_separate(self) -> None:
+        stdout = self._run_dump_loop(
+            [
+                {
+                    "name": "libfoo",
+                    "artifact": "a.so",
+                    "header": "include/foo.h",
+                    "include": "include",
+                }
+            ]
+        )
+        [cmd_line] = [
+            line for line in stdout.splitlines() if line.startswith("CMD_ARGS:")
+        ]
+        assert "-H include/foo.h" in cmd_line
+        assert "-I include" in cmd_line

--- a/tests/test_action_baseline.py
+++ b/tests/test_action_baseline.py
@@ -194,8 +194,41 @@ class TestLibrariesJsonValidation:
 
 
 @pytest.mark.skipif(not RUN_SH.is_file(), reason="actions/baseline/run.sh not found")
+class TestStaleOutputCleared:
+    def test_stale_snapshot_removed_before_dump(self, tmp_path: Path) -> None:
+        # Regression (Codex review): a library removed/renamed since an
+        # earlier run at this same output-dir used to leave its old
+        # *.abicheck.json sitting there -- invisible to the new run's
+        # manifest.json/content-digest, but still physically present for a
+        # caller that publishes/uploads the whole directory. Runs
+        # regardless of whether the dump itself succeeds (no abicheck
+        # needed on PATH): the cleanup happens before the dump loop starts.
+        output_dir = tmp_path / "out"
+        output_dir.mkdir()
+        (output_dir / "stale-lib.abicheck.json").write_text("{}")
+        (output_dir / "manifest.json").write_text("{}")
+
+        _run_action(
+            {
+                "INPUT_LIBRARIES": json.dumps(
+                    [{"name": "libfoo", "artifact": str(tmp_path / "no-such.so")}]
+                ),
+                "INPUT_OUTPUT_DIR": str(output_dir),
+            },
+            tmp_path,
+        )
+        assert not (output_dir / "stale-lib.abicheck.json").exists()
+        assert not (output_dir / "manifest.json").exists()
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="actions/baseline/run.sh not found")
 @pytest.mark.skipif(not _ABICHECK, reason="needs abicheck on PATH")
 class TestDumpFailurePaths:
+    # Shells out to the real abicheck CLI -- excluded from the default fast
+    # lane so it doesn't silently run just because abicheck happens to be
+    # installed in a dev environment (CodeRabbit review).
+    pytestmark = pytest.mark.integration
+
     def test_nonexistent_artifact_fails_with_library_name(self, tmp_path: Path) -> None:
         result, _ = _run_action(
             {

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -38,7 +38,8 @@ from pathlib import Path
 
 import pytest
 
-ACTION_DIR = Path(__file__).resolve().parents[1] / "actions" / "collect-facts"
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ACTION_DIR = REPO_ROOT / "actions" / "collect-facts"
 RUN_SH = ACTION_DIR / "run.sh"
 _HELPERS_MARKER = "# ---------------------------------------------------------------------------\n# Resolve producer"
 
@@ -96,6 +97,20 @@ def _run_action(
         "GITHUB_ENV": str(github_env),
         "GITHUB_OUTPUT": str(github_output),
         "ACTION_PATH": str(ACTION_DIR),
+        # run.sh's _verify_pack invokes a bare `python3 -c` with cwd=tmp_path
+        # (not this pytest process's own sys.path) to import
+        # abicheck.buildsource.inputs_validate. pytest itself can always
+        # import abicheck via pyproject.toml's `pythonpath = ["."]`, but that
+        # only extends the pytest process's own sys.path -- if whichever
+        # `python3` resolves on PATH inside the subprocess has no site-
+        # packages entry for abicheck (e.g. it isn't the same interpreter
+        # pytest was invoked from), the subprocess fails with
+        # ModuleNotFoundError before ever reaching pack validation (Codex
+        # review). Mirror pytest's own mechanism explicitly instead of
+        # depending on ambient python3 resolution.
+        "PYTHONPATH": os.pathsep.join(
+            filter(None, [str(REPO_ROOT), os.environ.get("PYTHONPATH")])
+        ),
         **env_extra,
     }
     result = subprocess.run(
@@ -756,6 +771,39 @@ class TestWrapperProducer:
         assert outputs["ready"] == "true"
         assert outputs["mode"] == "pack"
         assert outputs["pack-path"] == str(pack)
+
+    def test_subprocess_env_includes_repo_root_on_pythonpath(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Regression (Codex review): _verify_pack's `python3 -c` does a
+        # fresh PATH lookup for python3, independent of whichever
+        # interpreter this pytest process itself runs under -- pytest can
+        # always import abicheck via pyproject.toml's `pythonpath = ["."]`,
+        # but that only extends the pytest process's own sys.path. If the
+        # subprocess's python3 resolves to a different interpreter (or one
+        # with no editable abicheck install at all), it fails with
+        # ModuleNotFoundError before ever reaching pack validation. Verify
+        # _run_action's env directly (intercepting subprocess.run rather
+        # than spinning up a real second interpreter, since abicheck's
+        # required pyyaml/click/pyelftools dependencies would still need
+        # to be independently present in any such interpreter regardless
+        # of PYTHONPATH -- this test isolates the one thing this specific
+        # fix controls: whether REPO_ROOT reaches the subprocess env).
+        captured: dict[str, dict[str, str]] = {}
+
+        def _fake_run(
+            *args: object, **kwargs: object
+        ) -> subprocess.CompletedProcess[str]:
+            captured["env"] = kwargs["env"]  # type: ignore[assignment]
+            return subprocess.CompletedProcess(
+                args=(), returncode=0, stdout="", stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "run", _fake_run)
+        _run_action({"INPUT_PHASE": "verify", "INPUT_PRODUCER": "wrapper"}, tmp_path)
+
+        pythonpath_entries = captured["env"]["PYTHONPATH"].split(os.pathsep)
+        assert str(REPO_ROOT) in pythonpath_entries
 
     def test_verify_reemits_producer_version_persisted_by_prepare(
         self, tmp_path: Path

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -373,6 +373,14 @@ class TestWrapperProducer:
         # nothing here should claim readiness prematurely.
 
     def test_multiple_public_roots_joined_for_env_var(self, tmp_path: Path) -> None:
+        # Regression: this runs the real system uname (no stub, unlike the
+        # Windows-simulation test below), so on an actual windows-latest CI
+        # runner (Git Bash reports uname -s as MINGW64_NT-...) run.sh's own
+        # platform detection correctly joins with ';', not ':' -- a
+        # hardcoded ':' expectation here failed the real Windows CI lane
+        # even though the separator was correct for that platform. Expect
+        # whatever the real OS's separator is, same as cc_wrapper.py's own
+        # os.pathsep-based split.
         result, github_env, _ = _run_action(
             {
                 "INPUT_PHASE": "prepare",
@@ -383,9 +391,8 @@ class TestWrapperProducer:
             tmp_path,
         )
         assert result.returncode == 0, result.stdout + result.stderr
-        assert (
-            _parse_kv_file(github_env)["ABICHECK_CC_HEADERS"] == "include:gen/include"
-        )
+        expected = os.pathsep.join(["include", "gen/include"])
+        assert _parse_kv_file(github_env)["ABICHECK_CC_HEADERS"] == expected
 
     def test_multiple_public_roots_joined_with_semicolon_on_windows(
         self, tmp_path: Path

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -369,6 +369,35 @@ class TestWrapperProducer:
             _parse_kv_file(github_env)["ABICHECK_CC_HEADERS"] == "include:gen/include"
         )
 
+    def test_multiple_public_roots_joined_with_semicolon_on_windows(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): cc_wrapper.py splits ABICHECK_CC_HEADERS
+        # with Python's os.pathsep, which is ';' on Windows and ':'
+        # everywhere else -- a hardcoded ':' join glued every root into one
+        # unsplit string on a Windows runner instead of scoping to each of
+        # them. Stubs `uname` (via a PATH-prepended fake binary) to report a
+        # Windows-style value, since this test environment is Linux.
+        fake_bin = tmp_path / "fakebin"
+        fake_bin.mkdir()
+        uname_stub = fake_bin / "uname"
+        uname_stub.write_text('#!/bin/sh\necho "MINGW64_NT-10.0-x86_64"\n')
+        uname_stub.chmod(0o755)
+        result, github_env, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_PUBLIC_ROOTS": "include\ngen/include",
+                "INPUT_INSTALL_DEPS": "false",
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert (
+            _parse_kv_file(github_env)["ABICHECK_CC_HEADERS"] == "include;gen/include"
+        )
+
     def test_verify_fails_on_missing_pack_dir(self, tmp_path: Path) -> None:
         result, _, _ = _run_action(
             {

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -421,7 +421,10 @@ class TestWrapperProducer:
         assert env["ABICHECK_INPUTS_DIR"] == str(tmp_path / "abicheck_inputs")
         assert env["ABICHECK_CC_EXTRACTOR"] == "clang"
         assert env["ABICHECK_CC_LIBRARY"] == "foo"
-        assert env["ABICHECK_CC_HEADERS"] == "include"
+        # Resolved to absolute (Codex review): abicheck-cc runs with cwd set
+        # to the build directory in the documented recipe, not this
+        # script's cwd, so a relative root must be resolved here first.
+        assert env["ABICHECK_CC_HEADERS"] == str(tmp_path / "include")
         outputs = _parse_kv_file(github_output)
         assert outputs["producer"] == "wrapper"
         assert outputs["mode"] == "pack"
@@ -481,6 +484,37 @@ class TestWrapperProducer:
         assert result.returncode == 0, result.stdout + result.stderr
         assert not stale_record.exists()
 
+    def test_prepare_does_not_recursively_delete_unrelated_output_dir(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): output is a user-controlled Action
+        # input -- the earlier stale-pack-clearing fix (test above) used a
+        # blind `rm -rf "$OUTPUT"`, so a workflow that accidentally pointed
+        # output: at an existing non-pack directory (the workspace root, a
+        # shared build/source directory) would have this step recursively
+        # delete whatever was there. Only the two known pack-content items
+        # (manifest.json, source_facts/) should ever be removed.
+        output = tmp_path / "abicheck_inputs"
+        output.mkdir()
+        unrelated_file = output / "important.txt"
+        unrelated_file.write_text("do not delete me\n")
+        unrelated_dir = output / "unrelated_dir"
+        unrelated_dir.mkdir()
+        (unrelated_dir / "also_important.txt").write_text("keep\n")
+
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_OUTPUT": str(output),
+                "INPUT_INSTALL_DEPS": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert unrelated_file.read_text() == "do not delete me\n"
+        assert (unrelated_dir / "also_important.txt").read_text() == "keep\n"
+
     def test_multiple_public_roots_joined_for_env_var(self, tmp_path: Path) -> None:
         # Regression: this runs the real system uname (no stub, unlike the
         # Windows-simulation test below), so on an actual windows-latest CI
@@ -500,7 +534,11 @@ class TestWrapperProducer:
             tmp_path,
         )
         assert result.returncode == 0, result.stdout + result.stderr
-        expected = os.pathsep.join(["include", "gen/include"])
+        # Each root resolved to absolute (Codex review) before joining --
+        # see test_prepare_writes_env_vars for why.
+        expected = os.pathsep.join(
+            [str(tmp_path / "include"), str(tmp_path / "gen/include")]
+        )
         assert _parse_kv_file(github_env)["ABICHECK_CC_HEADERS"] == expected
 
     def test_multiple_public_roots_joined_with_semicolon_on_windows(
@@ -528,9 +566,8 @@ class TestWrapperProducer:
             tmp_path,
         )
         assert result.returncode == 0, result.stdout + result.stderr
-        assert (
-            _parse_kv_file(github_env)["ABICHECK_CC_HEADERS"] == "include;gen/include"
-        )
+        expected = f"{tmp_path / 'include'};{tmp_path / 'gen/include'}"
+        assert _parse_kv_file(github_env)["ABICHECK_CC_HEADERS"] == expected
 
     def test_verify_fails_on_missing_pack_dir(self, tmp_path: Path) -> None:
         result, _, _ = _run_action(

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -614,6 +614,65 @@ class TestWrapperProducer:
         expected = f"{tmp_path / 'include'};{tmp_path / 'gen/include'}"
         assert _parse_kv_file(github_env)["ABICHECK_CC_HEADERS"] == expected
 
+    def test_output_dir_converted_from_msys_path_on_windows(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): Git Bash/MSYS's own `pwd` reports its
+        # POSIX-style view of the filesystem (e.g. /d/a/repo/repo), not a
+        # Windows path. ABICHECK_INPUTS_DIR is read by the native Windows
+        # Python/Clang toolchain the Action installs, which has no notion of
+        # an MSYS root and would resolve /d/... as a relative path (a
+        # literal "d" directory) under the current drive instead of the
+        # intended location -- run.sh must convert through `cygpath -m`
+        # rather than joining `$(pwd)` directly on MINGW/MSYS/CYGWIN. Stubs
+        # both `uname` and `cygpath` (via a PATH-prepended fake bin dir),
+        # since this test environment is Linux; the stub `cygpath` prefixes
+        # its output so the test can tell it was actually invoked rather
+        # than silently falling back to raw `pwd`.
+        fake_bin = tmp_path / "fakebin"
+        fake_bin.mkdir()
+        (fake_bin / "uname").write_text('#!/bin/sh\necho "MINGW64_NT-10.0-x86_64"\n')
+        (fake_bin / "uname").chmod(0o755)
+        (fake_bin / "cygpath").write_text('#!/bin/sh\necho "WINCONV:$2"\n')
+        (fake_bin / "cygpath").chmod(0o755)
+
+        result, github_env, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_INSTALL_DEPS": "false",
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        expected = f"WINCONV:{tmp_path / 'abicheck_inputs'}"
+        assert _parse_kv_file(github_env)["ABICHECK_INPUTS_DIR"] == expected
+
+    def test_output_dir_uses_raw_pwd_when_cygpath_unavailable(
+        self, tmp_path: Path
+    ) -> None:
+        # cygpath is normally always present alongside Git Bash, but must
+        # not be a hard requirement -- fall back to plain `pwd` rather than
+        # failing the whole step if it's missing for some reason.
+        fake_bin = tmp_path / "fakebin"
+        fake_bin.mkdir()
+        (fake_bin / "uname").write_text('#!/bin/sh\necho "MINGW64_NT-10.0-x86_64"\n')
+        (fake_bin / "uname").chmod(0o755)
+
+        result, github_env, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_INSTALL_DEPS": "false",
+                "PATH": f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        expected = str(tmp_path / "abicheck_inputs")
+        assert _parse_kv_file(github_env)["ABICHECK_INPUTS_DIR"] == expected
+
     def test_verify_fails_on_missing_pack_dir(self, tmp_path: Path) -> None:
         result, _, _ = _run_action(
             {

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -144,6 +144,16 @@ class TestDetectProducer:
         result = _run_predicate(f'_detect_producer "{tmp_path}"')
         assert result.stdout.strip() == "replay"
 
+    def test_bazel_bzlmod_module_file_means_replay(self, tmp_path: Path) -> None:
+        # Regression (Codex review): bzlmod-only Bazel 6+ projects have no
+        # WORKSPACE file at all, only MODULE.bazel -- omitting it here left
+        # auto-detection inconsistent with abicheck/buildsource/
+        # build_query.py's own Bazel marker set, which the replay path
+        # actually queries.
+        (tmp_path / "MODULE.bazel").write_text("")
+        result = _run_predicate(f'_detect_producer "{tmp_path}"')
+        assert result.stdout.strip() == "replay"
+
     def test_empty_tree_means_wrapper(self, tmp_path: Path) -> None:
         result = _run_predicate(f'_detect_producer "{tmp_path}"')
         assert result.stdout.strip() == "wrapper"
@@ -389,6 +399,29 @@ class TestWrapperProducer:
         assert outputs["ready"] == "false"
         # phase: prepare's job is done before the caller's own build step --
         # nothing here should claim readiness prematurely.
+
+    def test_prepare_exports_absolute_inputs_dir(self, tmp_path: Path) -> None:
+        # Regression (Codex review): the documented CMake compiler-launcher
+        # recipe invokes abicheck-cc with cwd set to the *build* directory,
+        # not this script's own cwd -- a relative ABICHECK_INPUTS_DIR/out=
+        # (e.g. the documented default "abicheck_inputs") would then resolve
+        # under build/ instead of the top-level pack _reset_output_dir/
+        # phase: verify/pack-path all reference, so verification would
+        # report an empty pack even though the build was instrumented.
+        result, github_env, github_output = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_OUTPUT": "abicheck_inputs",  # relative, the documented default
+                "INPUT_INSTALL_DEPS": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        env = _parse_kv_file(github_env)
+        assert env["ABICHECK_INPUTS_DIR"] == str(tmp_path / "abicheck_inputs")
+        outputs = _parse_kv_file(github_output)
+        assert outputs["pack-path"] == str(tmp_path / "abicheck_inputs")
 
     def test_prepare_clears_stale_output_dir(self, tmp_path: Path) -> None:
         # Regression (Codex review): init_inputs_pack() is idempotent across

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -372,6 +372,35 @@ class TestWrapperProducer:
         # phase: prepare's job is done before the caller's own build step --
         # nothing here should claim readiness prematurely.
 
+    def test_prepare_clears_stale_output_dir(self, tmp_path: Path) -> None:
+        # Regression (Codex review): init_inputs_pack() is idempotent across
+        # repeated per-TU calls *within one build*, so a stale pack left
+        # over from an earlier prepare/build/verify cycle (a reused
+        # workspace, or two cycles sharing the default abicheck_inputs
+        # path) used to survive a bare `mkdir -p` -- its old
+        # source_facts/*.jsonl TU records would make a later verify see a
+        # nonzero TU count and report ready=true even if this run's build
+        # never actually invoked abicheck-cc.
+        output = tmp_path / "abicheck_inputs"
+        output.mkdir()
+        (output / "manifest.json").write_text('{"kind": "abicheck_inputs"}')
+        stale_facts = output / "source_facts"
+        stale_facts.mkdir()
+        stale_record = stale_facts / "stale.jsonl"
+        stale_record.write_text('{"stale": true}\n')
+
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_OUTPUT": str(output),
+                "INPUT_INSTALL_DEPS": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert not stale_record.exists()
+
     def test_multiple_public_roots_joined_for_env_var(self, tmp_path: Path) -> None:
         # Regression: this runs the real system uname (no stub, unlike the
         # Windows-simulation test below), so on an actual windows-latest CI
@@ -618,6 +647,23 @@ class TestClangPluginSmokeTestIsolation:
             "smoke-test compile must not write into $OUTPUT -- the real pack "
             "directory -- or a smoke record could mask a real collection "
             "failure at phase: verify"
+        )
+
+    def test_prepare_resets_output_dir_before_use(self) -> None:
+        # Regression (Codex review): same stale-pack-survives-mkdir-p issue
+        # as the wrapper producer's end-to-end test above, but
+        # _prepare_clang_plugin needs a real matching libclang-<N>-dev
+        # toolchain to run at all, so assert the invariant statically
+        # against the source instead (same technique as
+        # test_smoke_compile_never_targets_output_dir above).
+        text = RUN_SH.read_text(encoding="utf-8")
+        start = text.index("_prepare_clang_plugin() {")
+        end = text.index("\n_verify_pack() {", start)
+        plugin_block = text[start:end]
+        assert "_reset_output_dir\n" in plugin_block, (
+            "_prepare_clang_plugin must clear any stale pack at $OUTPUT "
+            "(via _reset_output_dir) before use, not a bare mkdir -p that "
+            "leaves old source_facts/*.jsonl in place"
         )
 
 

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -239,6 +239,32 @@ class TestInvalidInputsRejected:
         assert result.returncode == 1
         assert "not found on PATH" in result.stdout
 
+    def test_unknown_extractor_fails(self, tmp_path: Path) -> None:
+        result, _, _ = _run_action({"INPUT_EXTRACTOR": "bogus"}, tmp_path)
+        assert result.returncode == 1
+        assert "not recognized" in result.stdout
+
+    def test_unknown_install_deps_value_fails(self, tmp_path: Path) -> None:
+        # Regression (CodeRabbit review): a misspelled value like "True" or
+        # "yes" used to silently behave as false (every check is a literal
+        # `== "true"` string comparison) instead of being rejected.
+        result, _, _ = _run_action({"INPUT_INSTALL_DEPS": "yes"}, tmp_path)
+        assert result.returncode == 1
+        assert "not recognized" in result.stdout
+
+    def test_verify_with_producer_auto_fails(self, tmp_path: Path) -> None:
+        # Regression (CodeRabbit review): re-running auto-detection at
+        # phase: verify can silently resolve to a different producer than
+        # what phase: prepare resolved (e.g. the build step generated a
+        # compile_commands.json as a side effect, flipping auto from
+        # wrapper to replay) -- verify must be given the exact
+        # prepare-resolved producer, never producer: auto.
+        result, _, _ = _run_action(
+            {"INPUT_PHASE": "verify", "INPUT_PRODUCER": "auto"}, tmp_path
+        )
+        assert result.returncode == 1
+        assert "producer: auto" in result.stdout
+
 
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
@@ -427,6 +453,86 @@ class TestWrapperProducer:
         assert outputs["mode"] == "pack"
         assert outputs["pack-path"] == str(pack)
 
+    def test_verify_reemits_producer_version_persisted_by_prepare(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (CodeRabbit review): phase: verify used to
+        # unconditionally emit producer-version="" regardless of producer,
+        # clearing the clang-plugin identity phase: prepare had already
+        # computed and persisted via GITHUB_ENV (ABICHECK_PRODUCER_VERSION
+        # -- the same env-var persistence mechanism ABICHECK_PLUGIN_SO/
+        # FLAGS already rely on to cross the prepare -> build -> verify
+        # step boundary in a real workflow). A real clang-plugin build
+        # needs a matching libclang-<N>-dev toolchain not guaranteed here,
+        # so this simulates the persisted env var directly rather than
+        # exercising phase: prepare, producer: clang-plugin end-to-end.
+        pytest.importorskip("abicheck")
+        from abicheck.buildsource.inputs_emit import (
+            append_source_facts,
+            init_inputs_pack,
+        )
+        from abicheck.buildsource.source_abi import SourceAbiTu
+
+        pack = tmp_path / "abicheck_inputs"
+        init_inputs_pack(pack, library="libfoo")
+        append_source_facts(
+            pack,
+            [
+                SourceAbiTu(
+                    tu_id="cu://src/foo.cpp",
+                    target_id="target://libfoo",
+                    source="src/foo.cpp",
+                )
+            ],
+        )
+        result, _, github_output = _run_action(
+            {
+                "INPUT_PHASE": "verify",
+                "INPUT_PRODUCER": "clang-plugin",
+                "INPUT_OUTPUT": str(pack),
+                "ABICHECK_PRODUCER_VERSION": "llvm-18+plugin-sha256-abc123def456",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        outputs = _parse_kv_file(github_output)
+        assert outputs["producer-version"] == "llvm-18+plugin-sha256-abc123def456"
+
+    def test_verify_producer_version_empty_for_wrapper(self, tmp_path: Path) -> None:
+        # The wrapper producer has no ABICHECK_PRODUCER_VERSION to persist
+        # (nothing about which compiler the caller's build actually
+        # invoked is knowable from this side) -- verify must not invent one.
+        pytest.importorskip("abicheck")
+        from abicheck.buildsource.inputs_emit import (
+            append_source_facts,
+            init_inputs_pack,
+        )
+        from abicheck.buildsource.source_abi import SourceAbiTu
+
+        pack = tmp_path / "abicheck_inputs"
+        init_inputs_pack(pack, library="libfoo")
+        append_source_facts(
+            pack,
+            [
+                SourceAbiTu(
+                    tu_id="cu://src/foo.cpp",
+                    target_id="target://libfoo",
+                    source="src/foo.cpp",
+                )
+            ],
+        )
+        result, _, github_output = _run_action(
+            {
+                "INPUT_PHASE": "verify",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_OUTPUT": str(pack),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        outputs = _parse_kv_file(github_output)
+        assert outputs["producer-version"] == ""
+
 
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
@@ -458,4 +564,32 @@ class TestClangPluginSmokeTestIsolation:
             "smoke-test compile must not write into $OUTPUT -- the real pack "
             "directory -- or a smoke record could mask a real collection "
             "failure at phase: verify"
+        )
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
+class TestWrapperInstallDepsFailurePropagates:
+    """Regression guard (CodeRabbit review): _prepare_wrapper's
+    install-deps.sh call used to swallow a real installer failure with
+    `|| true`, reporting preparation success even though dependencies never
+    installed -- the caller's build would then fail later with a confusing
+    "command not found", or run uninstrumented and quietly produce an empty
+    pack. Can't force the real install-deps.sh (which shells out to
+    apt-get) to fail deterministically in a test environment, so assert the
+    invariant statically against the actual _prepare_wrapper source instead,
+    the same approach TestClangPluginSmokeTestIsolation uses."""
+
+    def test_install_deps_failure_is_not_swallowed(self) -> None:
+        text = RUN_SH.read_text(encoding="utf-8")
+        start = text.index("_prepare_wrapper() {")
+        end = text.index("_prepare_clang_plugin() {", start)
+        wrapper_block = text[start:end]
+        assert "install-deps.sh" in wrapper_block
+        assert "|| true" not in wrapper_block, (
+            "a failed install-deps.sh must not be silently treated as success"
+        )
+        assert "|| _fail" in wrapper_block, (
+            "install-deps.sh's failure must propagate via _fail"
         )

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -386,3 +386,36 @@ class TestWrapperProducer:
         assert outputs["ready"] == "true"
         assert outputs["mode"] == "pack"
         assert outputs["pack-path"] == str(pack)
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
+class TestClangPluginSmokeTestIsolation:
+    """Regression guard (Codex review): the plugin smoke-test compile used
+    to pass `out=$OUTPUT` -- the real pack directory the caller's build
+    populates next -- so a smoke-test record could sit in the pack and mask
+    a real collection failure (phase: verify only checks "the pack has at
+    least one file"). The smoke compile must target an isolated scratch
+    directory instead. This can't be exercised end-to-end without a real
+    matching libclang-<N>-dev toolchain, so assert the invariant statically
+    against the actual _prepare_clang_plugin source instead."""
+
+    def test_smoke_compile_never_targets_output_dir(self) -> None:
+        text = RUN_SH.read_text(encoding="utf-8")
+        # Isolate just the smoke-test compiler invocation (between the
+        # smoke.cpp printf and its own "smoke test passed" echo) -- the
+        # *real* plugin_flags built further down legitimately reference
+        # $OUTPUT for the caller's actual build, so a whole-function check
+        # would false-positive on that unrelated, correct line.
+        start = text.index("printf 'int abicheck_smoke_test")
+        end = text.index("smoke test passed", start)
+        smoke_block = text[start:end]
+        assert "out=$smoke_out" in smoke_block, (
+            "smoke-test compile must target the isolated $smoke_out scratch dir"
+        )
+        assert "out=$OUTPUT" not in smoke_block, (
+            "smoke-test compile must not write into $OUTPUT -- the real pack "
+            "directory -- or a smoke record could mask a real collection "
+            "failure at phase: verify"
+        )

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -1,0 +1,388 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for ``actions/collect-facts/run.sh``.
+
+This script backs the ``abicheck collect-facts`` composite Action: it
+resolves which source-facts producer to use (replay / wrapper / clang-
+plugin -- see ``docs/user-guide/producing-source-facts.md`` for the
+decision tree it mirrors), runs that producer's collection step, and
+verifies the resulting pack. Wrapper and clang-plugin need the caller's own
+build command to run *between* collection and verification, hence the
+``phase: prepare`` / ``phase: verify`` split this file exercises.
+
+Tests avoid actually building the Clang plugin (needs a matching
+libclang-<N>-dev toolchain not guaranteed in every test environment) --
+those paths are exercised only up to their first fast-failing precondition
+(missing compiler, bad producer/phase value).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ACTION_DIR = Path(__file__).resolve().parents[1] / "actions" / "collect-facts"
+RUN_SH = ACTION_DIR / "run.sh"
+_HELPERS_MARKER = "# ---------------------------------------------------------------------------\n# Resolve producer"
+
+
+def _bash_executable() -> str:
+    """Resolve a real bash, bypassing Windows' WSL-launcher stub.
+
+    See ``test_action_run_sh_helpers._bash_executable`` for the full
+    rationale.
+    """
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
+def _helpers_region() -> str:
+    text = RUN_SH.read_text(encoding="utf-8")
+    idx = text.index(_HELPERS_MARKER)
+    return text[:idx]
+
+
+def _run_predicate(call: str) -> subprocess.CompletedProcess[str]:
+    """Source the pure-helper region and evaluate a call, capturing stdout."""
+    script = _helpers_region() + f"\n{call}\n"
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".sh", delete=False, encoding="utf-8", newline="\n"
+    ) as f:
+        f.write(script)
+        script_path = f.name
+    try:
+        return subprocess.run(
+            [_bash_executable(), script_path], capture_output=True, text=True
+        )
+    finally:
+        os.unlink(script_path)
+
+
+def _run_action(
+    env_extra: dict[str, str], cwd: Path
+) -> tuple[subprocess.CompletedProcess[str], Path, Path]:
+    """Invoke the real script end-to-end with GITHUB_ENV/GITHUB_OUTPUT files."""
+    github_env = cwd / "github_env"
+    github_output = cwd / "github_output"
+    github_env.write_text("")
+    github_output.write_text("")
+    env = {
+        **os.environ,
+        "GITHUB_ENV": str(github_env),
+        "GITHUB_OUTPUT": str(github_output),
+        "ACTION_PATH": str(ACTION_DIR),
+        **env_extra,
+    }
+    result = subprocess.run(
+        [_bash_executable(), str(RUN_SH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd,
+        check=False,
+    )
+    return result, github_env, github_output
+
+
+def _parse_kv_file(path: Path) -> dict[str, str]:
+    out = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            out[k] = v
+    return out
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
+class TestDetectProducer:
+    def test_compile_commands_json_at_root_means_replay(self, tmp_path: Path) -> None:
+        (tmp_path / "compile_commands.json").write_text("[]")
+        result = _run_predicate(f'_detect_producer "{tmp_path}"')
+        assert result.stdout.strip() == "replay"
+
+    def test_compile_commands_json_nested_means_replay(self, tmp_path: Path) -> None:
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+        (build_dir / "compile_commands.json").write_text("[]")
+        result = _run_predicate(f'_detect_producer "{tmp_path}"')
+        assert result.stdout.strip() == "replay"
+
+    def test_cmakelists_means_replay(self, tmp_path: Path) -> None:
+        (tmp_path / "CMakeLists.txt").write_text("")
+        result = _run_predicate(f'_detect_producer "{tmp_path}"')
+        assert result.stdout.strip() == "replay"
+
+    def test_bazel_workspace_means_replay(self, tmp_path: Path) -> None:
+        (tmp_path / "WORKSPACE").write_text("")
+        result = _run_predicate(f'_detect_producer "{tmp_path}"')
+        assert result.stdout.strip() == "replay"
+
+    def test_empty_tree_means_wrapper(self, tmp_path: Path) -> None:
+        result = _run_predicate(f'_detect_producer "{tmp_path}"')
+        assert result.stdout.strip() == "wrapper"
+
+    def test_plain_makefile_means_wrapper(self, tmp_path: Path) -> None:
+        # A bare Makefile with no compile DB and no cmake/bazel project file
+        # cannot be replayed without generating one first -- wrapper is the
+        # safer default (never silently picks clang-plugin).
+        (tmp_path / "Makefile").write_text("")
+        result = _run_predicate(f'_detect_producer "{tmp_path}"')
+        assert result.stdout.strip() == "wrapper"
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
+class TestLlvmMajorParsing:
+    @pytest.mark.parametrize(
+        ("version_output", "expected"),
+        [
+            ("clang version 18.1.3", "18"),
+            ("Ubuntu clang version 18.1.3-1ubuntu1", "18"),
+            ("Debian clang version 16.0.6 (25)", "16"),
+            ("Apple clang version 15.0.0 (clang-1500.3.9.4)", "15"),
+            ("gcc (Ubuntu 13.2.0-4ubuntu3) 13.2.0", ""),
+            ("", ""),
+        ],
+    )
+    def test_parses_major(self, version_output: str, expected: str) -> None:
+        result = _run_predicate(f'_llvm_major_from_version_string "{version_output}"')
+        assert result.stdout.strip() == expected
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
+class TestPhaseNeedsExternalBuildStep:
+    @pytest.mark.parametrize(
+        ("phase", "producer", "expected"),
+        [
+            ("prepare", "wrapper", True),
+            ("prepare", "clang-plugin", True),
+            ("auto", "wrapper", True),
+            ("prepare", "replay", False),
+            ("auto", "replay", False),
+            ("verify", "wrapper", False),
+        ],
+    )
+    def test_matrix(self, phase: str, producer: str, expected: bool) -> None:
+        result = _run_predicate(
+            f'if _phase_needs_external_build_step "{phase}" "{producer}"; '
+            "then echo true; else echo false; fi"
+        )
+        assert result.stdout.strip() == str(expected).lower()
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
+class TestInvalidInputsRejected:
+    def test_unknown_producer_fails(self, tmp_path: Path) -> None:
+        result, _, _ = _run_action({"INPUT_PRODUCER": "bogus"}, tmp_path)
+        assert result.returncode == 1
+        assert "not recognized" in result.stdout
+
+    def test_unknown_phase_fails(self, tmp_path: Path) -> None:
+        result, _, _ = _run_action({"INPUT_PHASE": "bogus"}, tmp_path)
+        assert result.returncode == 1
+        assert "not recognized" in result.stdout
+
+    def test_missing_sources_dir_fails(self, tmp_path: Path) -> None:
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "replay",
+                "INPUT_SOURCES": "/no/such/dir",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "does not exist" in result.stdout
+
+    def test_clang_plugin_missing_compiler_fails_fast(self, tmp_path: Path) -> None:
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "clang-plugin",
+                "INPUT_COMPILER": "no-such-compiler-binary-xyz",
+                "INPUT_INSTALL_DEPS": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "not found on PATH" in result.stdout
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
+class TestReplayProducer:
+    def test_prepare_needs_no_collection_step(self, tmp_path: Path) -> None:
+        sources = tmp_path / "src"
+        sources.mkdir()
+        (sources / "compile_commands.json").write_text("[]")
+        result, _, github_output = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "replay",
+                "INPUT_SOURCES": str(sources),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        outputs = _parse_kv_file(github_output)
+        assert outputs["producer"] == "replay"
+        assert outputs["mode"] == "inline"
+        assert outputs["pack-path"] == ""
+        assert outputs["ready"] == "true"
+
+    def test_auto_producer_with_compile_db_resolves_to_replay(
+        self, tmp_path: Path
+    ) -> None:
+        sources = tmp_path / "src"
+        sources.mkdir()
+        (sources / "compile_commands.json").write_text("[]")
+        result, _, github_output = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "auto",
+                "INPUT_SOURCES": str(sources),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert _parse_kv_file(github_output)["producer"] == "replay"
+
+    def test_verify_on_replay_is_a_no_op_success(self, tmp_path: Path) -> None:
+        sources = tmp_path / "src"
+        sources.mkdir()
+        result, _, github_output = _run_action(
+            {
+                "INPUT_PHASE": "verify",
+                "INPUT_PRODUCER": "replay",
+                "INPUT_SOURCES": str(sources),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert _parse_kv_file(github_output)["ready"] == "true"
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
+class TestWrapperProducer:
+    def test_prepare_writes_env_vars(self, tmp_path: Path) -> None:
+        sources = tmp_path / "src"
+        sources.mkdir()
+        result, github_env, github_output = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_SOURCES": str(sources),
+                "INPUT_OUTPUT": str(tmp_path / "abicheck_inputs"),
+                "INPUT_LIBRARY": "foo",
+                "INPUT_PUBLIC_ROOTS": "include",
+                "INPUT_EXTRACTOR": "clang",
+                "INPUT_INSTALL_DEPS": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        env = _parse_kv_file(github_env)
+        assert env["ABICHECK_INPUTS_DIR"] == str(tmp_path / "abicheck_inputs")
+        assert env["ABICHECK_CC_EXTRACTOR"] == "clang"
+        assert env["ABICHECK_CC_LIBRARY"] == "foo"
+        assert env["ABICHECK_CC_HEADERS"] == "include"
+        outputs = _parse_kv_file(github_output)
+        assert outputs["producer"] == "wrapper"
+        assert outputs["mode"] == "pack"
+        assert outputs["ready"] == "false"
+        # phase: prepare's job is done before the caller's own build step --
+        # nothing here should claim readiness prematurely.
+
+    def test_multiple_public_roots_joined_for_env_var(self, tmp_path: Path) -> None:
+        result, github_env, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_PUBLIC_ROOTS": "include\ngen/include",
+                "INPUT_INSTALL_DEPS": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert (
+            _parse_kv_file(github_env)["ABICHECK_CC_HEADERS"] == "include:gen/include"
+        )
+
+    def test_verify_fails_on_missing_pack_dir(self, tmp_path: Path) -> None:
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "verify",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_OUTPUT": str(tmp_path / "never-created"),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "no pack directory" in result.stdout
+
+    def test_verify_fails_on_empty_pack_dir(self, tmp_path: Path) -> None:
+        pack = tmp_path / "abicheck_inputs"
+        pack.mkdir()
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "verify",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_OUTPUT": str(pack),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "empty" in result.stdout
+
+    def test_verify_succeeds_on_populated_pack_dir(self, tmp_path: Path) -> None:
+        pack = tmp_path / "abicheck_inputs"
+        pack.mkdir()
+        (pack / "foo.jsonl").write_text('{"kind": "function"}\n')
+        result, _, github_output = _run_action(
+            {
+                "INPUT_PHASE": "verify",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_OUTPUT": str(pack),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        outputs = _parse_kv_file(github_output)
+        assert outputs["ready"] == "true"
+        assert outputs["mode"] == "pack"
+        assert outputs["pack-path"] == str(pack)

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -134,6 +134,23 @@ class TestDetectProducer:
         result = _run_predicate(f'_detect_producer "{tmp_path}"')
         assert result.stdout.strip() == "replay"
 
+    def test_compile_commands_json_two_levels_deep_means_wrapper(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): a compile_commands.json two levels
+        # below sources (e.g. sub/build/compile_commands.json) used to
+        # still report producer=replay/ready=true here, but the inline
+        # replay path this producer hands off to
+        # (abicheck/buildsource/inline.py::_find_compile_db_in_dir) only
+        # ever looks at the root or one immediate subdirectory -- it would
+        # never find this DB, so the actual collection step would silently
+        # collect zero source facts despite the false ready=true.
+        deep_dir = tmp_path / "sub" / "build"
+        deep_dir.mkdir(parents=True)
+        (deep_dir / "compile_commands.json").write_text("[]")
+        result = _run_predicate(f'_detect_producer "{tmp_path}"')
+        assert result.stdout.strip() == "wrapper"
+
     def test_cmakelists_means_replay(self, tmp_path: Path) -> None:
         (tmp_path / "CMakeLists.txt").write_text("")
         result = _run_predicate(f'_detect_producer "{tmp_path}"')

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -226,6 +226,24 @@ class TestInvalidInputsRejected:
         assert result.returncode == 1
         assert "does not exist" in result.stdout
 
+    def test_auto_producer_with_missing_sources_dir_fails(self, tmp_path: Path) -> None:
+        # Regression (Codex review): with producer: auto, a misspelled/
+        # missing sources path looked identical to "no compile database
+        # found here" to _detect_producer, which silently resolved to
+        # wrapper instead of erroring -- a workflow expecting replay from a
+        # real compile-DB tree would silently get wrapper's very different
+        # setup instead of a loud failure about the bad path.
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "auto",
+                "INPUT_SOURCES": "/no/such/dir",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "does not exist" in result.stdout
+
     def test_clang_plugin_missing_compiler_fails_fast(self, tmp_path: Path) -> None:
         result, _, _ = _run_action(
             {

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -369,10 +369,50 @@ class TestWrapperProducer:
         assert result.returncode == 1
         assert "empty" in result.stdout
 
-    def test_verify_succeeds_on_populated_pack_dir(self, tmp_path: Path) -> None:
+    def test_verify_fails_on_manifest_only_pack_with_no_tu_records(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression (Codex review): init_inputs_pack() writes manifest.json
+        up front, before any TU is appended, so a build that never actually
+        routed through the wrapper/plugin (or whose every extraction failed)
+        still leaves a nonempty pack directory -- the old file-count check
+        alone would have called this pack "ready"."""
+        pytest.importorskip("abicheck")
+        from abicheck.buildsource.inputs_emit import init_inputs_pack
+
         pack = tmp_path / "abicheck_inputs"
-        pack.mkdir()
-        (pack / "foo.jsonl").write_text('{"kind": "function"}\n')
+        init_inputs_pack(pack, library="libfoo")
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "verify",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_OUTPUT": str(pack),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "zero" in result.stdout and "TU record" in result.stdout
+
+    def test_verify_succeeds_on_populated_pack_dir(self, tmp_path: Path) -> None:
+        pytest.importorskip("abicheck")
+        from abicheck.buildsource.inputs_emit import (
+            append_source_facts,
+            init_inputs_pack,
+        )
+        from abicheck.buildsource.source_abi import SourceAbiTu
+
+        pack = tmp_path / "abicheck_inputs"
+        init_inputs_pack(pack, library="libfoo")
+        append_source_facts(
+            pack,
+            [
+                SourceAbiTu(
+                    tu_id="cu://src/foo.cpp",
+                    target_id="target://libfoo",
+                    source="src/foo.cpp",
+                )
+            ],
+        )
         result, _, github_output = _run_action(
             {
                 "INPUT_PHASE": "verify",

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -217,6 +217,51 @@ class TestDetectProducer:
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
 )
+class TestIsAbsolutePath:
+    """Regression guard (Codex review): OUTPUT/public-roots absolute-path
+    resolution only recognized a leading '/', so an already-absolute
+    Windows-style path (a drive letter, or a UNC share) was treated as
+    relative and got $(pwd)/ nonsensically prepended -- e.g. output:
+    'C:\\Users\\foo\\abicheck_inputs' became
+    '/d/a/repo/C:\\Users\\foo\\abicheck_inputs'. This can be reproduced with
+    Windows-style strings on a Linux test runner since it is pure string
+    matching, no real Windows filesystem semantics involved."""
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/tmp/abicheck_inputs",
+            r"C:\Users\foo\abicheck_inputs",
+            "D:/a/repo/abicheck_inputs",
+            r"\\server\share\abicheck_inputs",
+        ],
+    )
+    def test_recognizes_absolute_paths(self, path: str) -> None:
+        # Single-quoted in the generated bash source (not double-quoted):
+        # double quotes would collapse a UNC path's leading \\ to a single
+        # \ before the argument even reaches _is_absolute_path, corrupting
+        # the very prefix this test means to check. None of these fixture
+        # paths contain a single quote.
+        result = _run_predicate(
+            f"if _is_absolute_path '{path}'; then echo true; else echo false; fi"
+        )
+        assert result.stdout.strip() == "true"
+
+    @pytest.mark.parametrize("path", ["abicheck_inputs", "gen/include", "include"])
+    def test_rejects_relative_paths(self, path: str) -> None:
+        result = _run_predicate(
+            f"if _is_absolute_path '{path}'; then echo true; else echo false; fi"
+        )
+        assert result.stdout.strip() == "false"
+
+    def test_resolve_public_root_passes_through_windows_absolute_path(self) -> None:
+        result = _run_predicate(r"_resolve_public_root 'C:\Users\foo\include'")
+        assert result.stdout.strip() == r"C:\Users\foo\include"
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
 class TestLlvmMajorParsing:
     @pytest.mark.parametrize(
         ("version_output", "expected"),

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -156,6 +156,24 @@ class TestDetectProducer:
         result = _run_predicate(f'_detect_producer "{tmp_path}"')
         assert result.stdout.strip() == "wrapper"
 
+    def test_many_nested_compile_dbs_still_means_replay(self, tmp_path: Path) -> None:
+        # Regression (Codex review): the nested-compile-DB check used to be
+        # `find ... | grep -q .`. Under this script's `set -o pipefail`, a
+        # tree with enough matches/entries that find is still writing when
+        # grep exits right after its first match gets find killed with
+        # SIGPIPE (exit 141) -- pipefail turns that into the pipeline's
+        # exit status even though grep itself matched, so the `if` silently
+        # took the false branch and fell through to "wrapper" instead of
+        # "replay". A small tree (like the sibling test above) essentially
+        # never triggers the race; this needs enough entries that find's
+        # write volume actually exceeds a pipe buffer while it is walking.
+        for i in range(2000):
+            d = tmp_path / f"dir{i}"
+            d.mkdir()
+            (d / "compile_commands.json").write_text("[]")
+        result = _run_predicate(f'_detect_producer "{tmp_path}"')
+        assert result.stdout.strip() == "replay"
+
 
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -158,13 +158,25 @@ class TestDetectProducer:
         result = _run_predicate(f'_detect_producer "{tmp_path}"')
         assert result.stdout.strip() == "wrapper"
 
-    def test_plain_makefile_means_wrapper(self, tmp_path: Path) -> None:
-        # A bare Makefile with no compile DB and no cmake/bazel project file
-        # cannot be replayed without generating one first -- wrapper is the
-        # safer default (never silently picks clang-plugin).
+    def test_plain_makefile_means_replay(self, tmp_path: Path) -> None:
+        # Regression (Codex review): this used to assert "wrapper" here, on
+        # the assumption a bare Make/EPICS-style tree with no
+        # compile_commands.json couldn't be replayed. But
+        # abicheck/buildsource/build_query.py's inline replay path
+        # auto-runs `make -B -n -k -w` and scrapes compile commands from
+        # the transcript, so Make projects are replay-capable the same way
+        # cmake/bazel ones are -- the bash heuristic was stale and
+        # unnecessarily required wrapper instrumentation for these builds.
         (tmp_path / "Makefile").write_text("")
         result = _run_predicate(f'_detect_producer "{tmp_path}"')
-        assert result.stdout.strip() == "wrapper"
+        assert result.stdout.strip() == "replay"
+
+    def test_makefile_variant_names_mean_replay(self, tmp_path: Path) -> None:
+        # GNUmakefile and lowercase makefile are the other two names
+        # build_query.py's marker set recognizes alongside Makefile.
+        (tmp_path / "GNUmakefile").write_text("")
+        result = _run_predicate(f'_detect_producer "{tmp_path}"')
+        assert result.stdout.strip() == "replay"
 
     def test_many_nested_compile_dbs_still_means_replay(self, tmp_path: Path) -> None:
         # Regression (Codex review): the nested-compile-DB check used to be

--- a/tests/test_action_validate_inputs.py
+++ b/tests/test_action_validate_inputs.py
@@ -228,6 +228,29 @@ class TestFormatIsHardErrorNotSilentFallback:
         result = _run_validate({"INPUT_MODE": "compare", "INPUT_FORMAT": "sarif"})
         assert result.returncode == 0, result.stdout + result.stderr
 
+    @pytest.mark.parametrize("mode", ["deps-tree", "deps-compare"])
+    def test_deps_modes_reject_directory_or_package(
+        self, mode: str, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): `abicheck deps tree`/`deps compare`
+        # both take a single BINARY, the same per-artifact contract dump/
+        # scan have -- this branch only validated format, so an
+        # unsupported directory/package operand passed this fail-fast step
+        # and would only fail later in the CLI, after setup/dependency
+        # installation.
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        result = _run_validate({"INPUT_MODE": mode, "INPUT_NEW_LIBRARY": str(lib_dir)})
+        assert result.returncode == 1
+        assert "does not accept a directory or package" in result.stdout
+
+    @pytest.mark.parametrize("mode", ["deps-tree", "deps-compare"])
+    def test_deps_modes_accept_plain_binary(self, mode: str, tmp_path: Path) -> None:
+        lib = tmp_path / "libfoo.so.1"
+        lib.write_text("")
+        result = _run_validate({"INPUT_MODE": mode, "INPUT_NEW_LIBRARY": str(lib)})
+        assert result.returncode == 0, result.stdout + result.stderr
+
 
 @pytest.mark.skipif(
     not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"

--- a/tests/test_action_validate_inputs.py
+++ b/tests/test_action_validate_inputs.py
@@ -61,8 +61,25 @@ def _bash_executable() -> str:
     return "bash"
 
 
+_VALIDATOR_INPUT_VARS = (
+    "INPUT_MODE",
+    "INPUT_NEW_LIBRARY",
+    "INPUT_OLD_LIBRARY",
+    "INPUT_FORMAT",
+    "INPUT_UPLOAD_SARIF",
+)
+
+
 def _run_validate(env_extra: dict[str, str]) -> subprocess.CompletedProcess[str]:
-    env = {**os.environ, **env_extra}
+    # Strip any of validate-inputs.sh's own INPUT_* vars the *test process*
+    # inherited (e.g. if pytest itself ran inside a composite-action step)
+    # before layering env_extra back on top -- otherwise a test that
+    # deliberately omits an input (e.g. test_no_inputs_at_all_passes) could
+    # pick up an ambient value instead of a true unset.
+    env = os.environ.copy()
+    for name in _VALIDATOR_INPUT_VARS:
+        env.pop(name, None)
+    env.update(env_extra)
     return subprocess.run(
         [_bash_executable(), str(VALIDATE_SH)],
         capture_output=True,
@@ -150,8 +167,11 @@ class TestScanRejectsDirectoryOrPackage:
     not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
 )
 class TestFormatIsHardErrorNotSilentFallback:
-    @pytest.mark.parametrize("fmt", ["sarif", "html"])
+    @pytest.mark.parametrize("fmt", ["sarif", "html", "xml", "csv"])
     def test_scan_rejects_unsupported_format(self, fmt: str) -> None:
+        # An allowlist, not a denylist of known-bad values (CodeRabbit
+        # review, PR #594): a typo/garbage value like 'xml' must be caught
+        # here too, not just sarif/html specifically.
         result = _run_validate({"INPUT_MODE": "scan", "INPUT_FORMAT": fmt})
         assert result.returncode == 1
         assert "does not support format" in result.stdout
@@ -163,8 +183,9 @@ class TestFormatIsHardErrorNotSilentFallback:
         assert result.returncode == 0, result.stdout + result.stderr
 
     @pytest.mark.parametrize("mode", ["deps-tree", "deps-compare"])
-    def test_deps_modes_reject_sarif(self, mode: str) -> None:
-        result = _run_validate({"INPUT_MODE": mode, "INPUT_FORMAT": "sarif"})
+    @pytest.mark.parametrize("fmt", ["sarif", "xml"])
+    def test_deps_modes_reject_unsupported_format(self, mode: str, fmt: str) -> None:
+        result = _run_validate({"INPUT_MODE": mode, "INPUT_FORMAT": fmt})
         assert result.returncode == 1
         assert "does not support format" in result.stdout
 
@@ -180,6 +201,72 @@ class TestFormatIsHardErrorNotSilentFallback:
 
     def test_compare_still_allows_sarif(self) -> None:
         result = _run_validate({"INPUT_MODE": "compare", "INPUT_FORMAT": "sarif"})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
+)
+class TestCompareRejectsSarifHtmlWithDirectoryOperand:
+    """compare's sarif/html require a single-pair operand; the CLI itself
+    already rejects a directory/package operand for them (surfaced as
+    VERDICT=ERROR), but only after Python/deps are installed. CodeRabbit
+    review, PR #594: catch it here too, checking BOTH old-library and
+    new-library, not just new-library."""
+
+    @pytest.mark.parametrize("fmt", ["sarif", "html"])
+    def test_directory_new_library_is_rejected(self, tmp_path: Path, fmt: str) -> None:
+        lib_dir = tmp_path / "release"
+        lib_dir.mkdir()
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_OLD_LIBRARY": "old.so",
+                "INPUT_NEW_LIBRARY": str(lib_dir),
+                "INPUT_FORMAT": fmt,
+            }
+        )
+        assert result.returncode == 1
+        assert "single-pair comparison" in result.stdout
+
+    @pytest.mark.parametrize("fmt", ["sarif", "html"])
+    def test_directory_old_library_is_rejected(self, tmp_path: Path, fmt: str) -> None:
+        lib_dir = tmp_path / "release"
+        lib_dir.mkdir()
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_OLD_LIBRARY": str(lib_dir),
+                "INPUT_NEW_LIBRARY": "new.so",
+                "INPUT_FORMAT": fmt,
+            }
+        )
+        assert result.returncode == 1
+        assert "single-pair comparison" in result.stdout
+
+    def test_directory_operand_with_markdown_still_passes(self, tmp_path: Path) -> None:
+        lib_dir = tmp_path / "release"
+        lib_dir.mkdir()
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_OLD_LIBRARY": str(lib_dir),
+                "INPUT_NEW_LIBRARY": "new.so",
+                "INPUT_FORMAT": "markdown",
+            }
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    @pytest.mark.parametrize("fmt", ["sarif", "html"])
+    def test_single_pair_operands_still_pass(self, fmt: str) -> None:
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_OLD_LIBRARY": "old.so",
+                "INPUT_NEW_LIBRARY": "new.so",
+                "INPUT_FORMAT": fmt,
+            }
+        )
         assert result.returncode == 0, result.stdout + result.stderr
 
 

--- a/tests/test_action_validate_inputs.py
+++ b/tests/test_action_validate_inputs.py
@@ -1,0 +1,301 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for ``action/validate-inputs.sh``.
+
+This script runs as the composite Action's very first step (action.yml),
+before Python setup, system-dependency installation, or `pip install
+abicheck` -- it exists to fail fast on a mode/input combination that can
+never work (a directory/package handed to ``dump``/``scan``, which have no
+per-library fan-out) or that used to silently do the wrong thing (an
+unsupported ``format`` for the mode used to warn and fall back instead of
+erroring, which is unsafe paired with ``upload-sarif``).
+
+These tests invoke the real script as a subprocess (not an extracted
+fragment) since it is small and fully self-contained. A separate drift-guard
+class checks its duplicated ``_is_release_style_operand`` copy against
+``action/run.sh``'s original on the same fixture set.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ACTION_DIR = Path(__file__).resolve().parents[1] / "action"
+VALIDATE_SH = ACTION_DIR / "validate-inputs.sh"
+RUN_SH = ACTION_DIR / "run.sh"
+
+
+def _bash_executable() -> str:
+    """Resolve a real bash, bypassing Windows' WSL-launcher stub.
+
+    See ``test_action_run_sh_helpers._bash_executable`` for the full
+    rationale.
+    """
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
+def _run_validate(env_extra: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, **env_extra}
+    return subprocess.run(
+        [_bash_executable(), str(VALIDATE_SH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
+)
+class TestDefaultsPassValidation:
+    def test_no_inputs_at_all_passes(self) -> None:
+        result = _run_validate({})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_plain_compare_passes(self) -> None:
+        result = _run_validate({"INPUT_MODE": "compare", "INPUT_FORMAT": "sarif"})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
+)
+class TestDumpRejectsDirectoryOrPackage:
+    def test_directory_is_rejected(self, tmp_path: Path) -> None:
+        lib_dir = tmp_path / "lib"
+        lib_dir.mkdir()
+        result = _run_validate(
+            {"INPUT_MODE": "dump", "INPUT_NEW_LIBRARY": str(lib_dir)}
+        )
+        assert result.returncode == 1
+        assert "does not accept a directory or package" in result.stdout
+        assert "dump" in result.stdout
+
+    def test_package_extension_is_rejected(self, tmp_path: Path) -> None:
+        pkg = tmp_path / "libfoo.rpm"
+        pkg.write_text("")
+        result = _run_validate({"INPUT_MODE": "dump", "INPUT_NEW_LIBRARY": str(pkg)})
+        assert result.returncode == 1
+        assert "does not accept a directory or package" in result.stdout
+
+    def test_plain_binary_passes(self, tmp_path: Path) -> None:
+        lib = tmp_path / "libfoo.so.1"
+        lib.write_text("")
+        result = _run_validate({"INPUT_MODE": "dump", "INPUT_NEW_LIBRARY": str(lib)})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_source_only_dump_with_no_new_library_passes(self) -> None:
+        # dump's new-library is optional (source-only dump); the required-
+        # ness check lives in run.sh, not this validator.
+        result = _run_validate({"INPUT_MODE": "dump"})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
+)
+class TestScanRejectsDirectoryOrPackage:
+    def test_directory_is_rejected(self, tmp_path: Path) -> None:
+        lib_dir = tmp_path / "release" / "lib" / "intel64"
+        lib_dir.mkdir(parents=True)
+        result = _run_validate(
+            {"INPUT_MODE": "scan", "INPUT_NEW_LIBRARY": str(lib_dir)}
+        )
+        assert result.returncode == 1
+        assert "does not accept a directory or package" in result.stdout
+        assert "scan" in result.stdout
+
+    def test_plain_binary_passes(self, tmp_path: Path) -> None:
+        lib = tmp_path / "libfoo.so.1"
+        lib.write_text("")
+        result = _run_validate({"INPUT_MODE": "scan", "INPUT_NEW_LIBRARY": str(lib)})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_json_snapshot_passes(self, tmp_path: Path) -> None:
+        snap = tmp_path / "baseline.json"
+        snap.write_text("{}")
+        result = _run_validate({"INPUT_MODE": "scan", "INPUT_NEW_LIBRARY": str(snap)})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
+)
+class TestFormatIsHardErrorNotSilentFallback:
+    @pytest.mark.parametrize("fmt", ["sarif", "html"])
+    def test_scan_rejects_unsupported_format(self, fmt: str) -> None:
+        result = _run_validate({"INPUT_MODE": "scan", "INPUT_FORMAT": fmt})
+        assert result.returncode == 1
+        assert "does not support format" in result.stdout
+        assert "warning" not in result.stdout.lower()
+
+    @pytest.mark.parametrize("fmt", ["text", "json"])
+    def test_scan_accepts_supported_format(self, fmt: str) -> None:
+        result = _run_validate({"INPUT_MODE": "scan", "INPUT_FORMAT": fmt})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    @pytest.mark.parametrize("mode", ["deps-tree", "deps-compare"])
+    @pytest.mark.parametrize("fmt", ["sarif", "html"])
+    def test_deps_modes_reject_unsupported_format(self, mode: str, fmt: str) -> None:
+        result = _run_validate({"INPUT_MODE": mode, "INPUT_FORMAT": fmt})
+        assert result.returncode == 1
+        assert "does not support format" in result.stdout
+
+    @pytest.mark.parametrize("mode", ["deps-tree", "deps-compare"])
+    @pytest.mark.parametrize("fmt", ["markdown", "json"])
+    def test_deps_modes_accept_supported_format(self, mode: str, fmt: str) -> None:
+        result = _run_validate({"INPUT_MODE": mode, "INPUT_FORMAT": fmt})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_compare_still_allows_sarif(self) -> None:
+        result = _run_validate({"INPUT_MODE": "compare", "INPUT_FORMAT": "sarif"})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
+)
+class TestUploadSarif:
+    def test_upload_sarif_with_compare_and_sarif_format_passes(self) -> None:
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_FORMAT": "sarif",
+                "INPUT_UPLOAD_SARIF": "true",
+            }
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_upload_sarif_with_non_compare_mode_is_rejected(self) -> None:
+        result = _run_validate(
+            {
+                "INPUT_MODE": "scan",
+                "INPUT_FORMAT": "json",
+                "INPUT_UPLOAD_SARIF": "true",
+            }
+        )
+        assert result.returncode == 1
+        assert "upload-sarif is only meaningful with mode: compare" in result.stdout
+
+    def test_upload_sarif_with_non_sarif_format_is_rejected(self) -> None:
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_FORMAT": "json",
+                "INPUT_UPLOAD_SARIF": "true",
+            }
+        )
+        assert result.returncode == 1
+        assert "upload-sarif requires format: sarif" in result.stdout
+
+    def test_upload_sarif_false_default_never_triggers_the_check(self) -> None:
+        result = _run_validate({"INPUT_MODE": "scan", "INPUT_FORMAT": "json"})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Drift guard: validate-inputs.sh intentionally duplicates run.sh's
+# `_is_release_style_operand()` (documented at the top of validate-inputs.sh
+# as to why: this step must have zero dependency on run.sh's layout). Run
+# both copies against the same fixtures and assert identical verdicts so a
+# future edit to one classifier that isn't mirrored in the other is caught
+# here instead of shipping a validator that disagrees with run.sh itself.
+# ─────────────────────────────────────────────────────────────────────────
+
+_RUN_SH_MARKER = "# Build the abicheck command"
+_VALIDATE_SH_MARKER = "_fail() {"
+
+
+def _run_sh_operand_fn() -> str:
+    text = RUN_SH.read_text(encoding="utf-8")
+    idx = text.index(_RUN_SH_MARKER)
+    return text[:idx]
+
+
+def _validate_sh_operand_fn() -> str:
+    text = VALIDATE_SH.read_text(encoding="utf-8")
+    idx = text.index(_VALIDATE_SH_MARKER)
+    return text[:idx]
+
+
+def _classify(fn_region: str, path: str) -> bool:
+    script = (
+        fn_region
+        + f'\nif _is_release_style_operand "{path}"; then exit 0; else exit 1; fi\n'
+    )
+    with tempfile.NamedTemporaryFile(
+        "w",
+        suffix=".sh",
+        delete=False,
+        encoding="utf-8",
+        newline="\n",
+    ) as f:
+        f.write(script)
+        script_path = f.name
+    try:
+        result = subprocess.run(
+            [_bash_executable(), script_path],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.unlink(script_path)
+    return result.returncode == 0
+
+
+@pytest.mark.skipif(
+    not (VALIDATE_SH.is_file() and RUN_SH.is_file()),
+    reason="action scripts not found",
+)
+class TestClassifierParityWithRunSh:
+    @pytest.mark.parametrize(
+        "kind", ["directory", "plain_file", "json_snapshot", "rpm_extension"]
+    )
+    def test_both_copies_agree(self, tmp_path: Path, kind: str) -> None:
+        if kind == "directory":
+            path = tmp_path / "dir"
+            path.mkdir()
+        elif kind == "plain_file":
+            path = tmp_path / "libfoo.so.1"
+            path.write_text("")
+        elif kind == "json_snapshot":
+            path = tmp_path / "snap.json"
+            path.write_text("{}")
+        else:
+            path = tmp_path / "libfoo.rpm"
+            path.write_text("")
+
+        run_sh_verdict = _classify(_run_sh_operand_fn(), str(path))
+        validate_sh_verdict = _classify(_validate_sh_operand_fn(), str(path))
+        assert run_sh_verdict == validate_sh_verdict, (
+            f"run.sh and validate-inputs.sh disagree on {kind} ({path}): "
+            f"run.sh={run_sh_verdict} validate-inputs.sh={validate_sh_verdict}"
+        )

--- a/tests/test_action_validate_inputs.py
+++ b/tests/test_action_validate_inputs.py
@@ -32,6 +32,7 @@ class checks its duplicated ``_is_release_style_operand`` copy against
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 import tempfile
 from pathlib import Path
@@ -207,15 +208,22 @@ class TestFormatIsHardErrorNotSilentFallback:
 @pytest.mark.skipif(
     not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
 )
-class TestCompareRejectsSarifHtmlWithDirectoryOperand:
-    """compare's sarif/html require a single-pair operand; the CLI itself
-    already rejects a directory/package operand for them (surfaced as
-    VERDICT=ERROR), but only after Python/deps are installed. CodeRabbit
-    review, PR #594: catch it here too, checking BOTH old-library and
-    new-library, not just new-library."""
+class TestCompareFormatAllowlists:
+    """compare's full --format choice set (`abicheck compare --help-all`) is
+    json|markdown|sarif|html|junit|review; a directory/package operand fans
+    out through the release engine, which narrows that to cli.py's
+    _RELEASE_FORMATS = {json, markdown, junit} (sarif/html/review rejected
+    -- a clear UsageError, surfaced as VERDICT=ERROR by run.sh -- but only
+    after Python/deps are installed). Codex + CodeRabbit review, PR #594:
+    catch both restrictions here too, checking BOTH old-library and
+    new-library for the release-style case, and any garbage value (not
+    just sarif/html) for both cases. See TestCompareFormatAllowlistMatchesCli
+    for the drift guard against the live CLI."""
 
-    @pytest.mark.parametrize("fmt", ["sarif", "html"])
-    def test_directory_new_library_is_rejected(self, tmp_path: Path, fmt: str) -> None:
+    @pytest.mark.parametrize("fmt", ["sarif", "html", "review", "xml"])
+    def test_directory_new_library_rejects_non_release_format(
+        self, tmp_path: Path, fmt: str
+    ) -> None:
         lib_dir = tmp_path / "release"
         lib_dir.mkdir()
         result = _run_validate(
@@ -227,10 +235,12 @@ class TestCompareRejectsSarifHtmlWithDirectoryOperand:
             }
         )
         assert result.returncode == 1
-        assert "single-pair comparison" in result.stdout
+        assert "directory/package comparison" in result.stdout
 
-    @pytest.mark.parametrize("fmt", ["sarif", "html"])
-    def test_directory_old_library_is_rejected(self, tmp_path: Path, fmt: str) -> None:
+    @pytest.mark.parametrize("fmt", ["sarif", "html", "review", "xml"])
+    def test_directory_old_library_rejects_non_release_format(
+        self, tmp_path: Path, fmt: str
+    ) -> None:
         lib_dir = tmp_path / "release"
         lib_dir.mkdir()
         result = _run_validate(
@@ -242,9 +252,12 @@ class TestCompareRejectsSarifHtmlWithDirectoryOperand:
             }
         )
         assert result.returncode == 1
-        assert "single-pair comparison" in result.stdout
+        assert "directory/package comparison" in result.stdout
 
-    def test_directory_operand_with_markdown_still_passes(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("fmt", ["json", "markdown", "junit"])
+    def test_directory_operand_accepts_release_formats(
+        self, tmp_path: Path, fmt: str
+    ) -> None:
         lib_dir = tmp_path / "release"
         lib_dir.mkdir()
         result = _run_validate(
@@ -252,13 +265,15 @@ class TestCompareRejectsSarifHtmlWithDirectoryOperand:
                 "INPUT_MODE": "compare",
                 "INPUT_OLD_LIBRARY": str(lib_dir),
                 "INPUT_NEW_LIBRARY": "new.so",
-                "INPUT_FORMAT": "markdown",
+                "INPUT_FORMAT": fmt,
             }
         )
         assert result.returncode == 0, result.stdout + result.stderr
 
-    @pytest.mark.parametrize("fmt", ["sarif", "html"])
-    def test_single_pair_operands_still_pass(self, fmt: str) -> None:
+    @pytest.mark.parametrize(
+        "fmt", ["json", "markdown", "sarif", "html", "junit", "review"]
+    )
+    def test_single_pair_operands_accept_full_format_set(self, fmt: str) -> None:
         result = _run_validate(
             {
                 "INPUT_MODE": "compare",
@@ -268,6 +283,76 @@ class TestCompareRejectsSarifHtmlWithDirectoryOperand:
             }
         )
         assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_single_pair_operands_reject_garbage_format(self) -> None:
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_OLD_LIBRARY": "old.so",
+                "INPUT_NEW_LIBRARY": "new.so",
+                "INPUT_FORMAT": "xml",
+            }
+        )
+        assert result.returncode == 1
+        assert "does not support format" in result.stdout
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
+)
+class TestCompareFormatAllowlistMatchesCli:
+    """Drift guard: validate-inputs.sh hardcodes two format allowlists for
+    compare (single-pair, and directory/package). Parse them out of the
+    script and cross-check against the live CLI's actual choices -- click's
+    own Choice.choices for the single-pair set (introspected directly rather
+    than scraped from --help-all's output, which rich-click hard-wraps
+    mid-word inside its option table at this terminal width) and
+    abicheck/cli.py's _RELEASE_FORMATS constant for the release-style set --
+    so a future CLI format addition/removal doesn't silently desync the
+    Action's fail-fast validator from what the CLI really accepts."""
+
+    def _extract_allowlist(self, fail_marker: str) -> set[str]:
+        """The `"$FORMAT" != "x"` chain in the `if`/`elif [[ ... ]]` block
+        that guards the `_fail` call containing *fail_marker* -- scanned
+        backward from that line to its nearest preceding `if`/`elif` line so
+        two adjacent blocks (release-style vs. single-pair) aren't conflated."""
+        lines = VALIDATE_SH.read_text(encoding="utf-8").splitlines()
+        fail_idx = next(i for i, line in enumerate(lines) if fail_marker in line)
+        start = fail_idx
+        while start > 0 and not re.search(r"\b(if|elif)\s*\[\[", lines[start]):
+            start -= 1
+        condition_text = " ".join(lines[start : fail_idx + 1])
+        return set(re.findall(r'"\$FORMAT" != "([a-z]+)"', condition_text))
+
+    def test_single_pair_allowlist_matches_cli(self) -> None:
+        validator_formats = self._extract_allowlist(
+            "only 'json', 'markdown', 'sarif', 'html', 'junit', and 'review'"
+        )
+        from abicheck.cli import main as abicheck_main
+
+        fmt_param = next(
+            p for p in abicheck_main.commands["compare"].params if p.name == "fmt"
+        )
+        cli_formats = set(fmt_param.type.choices)
+        assert validator_formats == cli_formats, (
+            f"validate-inputs.sh's single-pair compare allowlist {sorted(validator_formats)} "
+            f"has drifted from the live CLI's {sorted(cli_formats)}"
+        )
+
+    def test_release_style_allowlist_matches_cli_constant(self) -> None:
+        validator_formats = self._extract_allowlist(
+            "only 'json', 'markdown', and 'junit' are available"
+        )
+        cli_source = (
+            Path(__file__).resolve().parents[1] / "abicheck" / "cli.py"
+        ).read_text(encoding="utf-8")
+        m = re.search(r"_RELEASE_FORMATS = frozenset\(\{([^}]+)\}\)", cli_source)
+        assert m, "could not find _RELEASE_FORMATS in abicheck/cli.py"
+        cli_formats = {f.strip().strip('"') for f in m.group(1).split(",")}
+        assert validator_formats == cli_formats, (
+            f"validate-inputs.sh's release-style compare allowlist {sorted(validator_formats)} "
+            f"has drifted from abicheck/cli.py's _RELEASE_FORMATS {sorted(cli_formats)}"
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/test_action_validate_inputs.py
+++ b/tests/test_action_validate_inputs.py
@@ -183,6 +183,45 @@ class TestFormatIsHardErrorNotSilentFallback:
 @pytest.mark.skipif(
     not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
 )
+class TestUnsetFormatUsesEachModesOwnDefault:
+    """Regression (Codex review, PR #594): action.yml's `format` input must
+    NOT declare a static top-level default. GitHub Actions applies a
+    declared default to `inputs.format` even when the caller's workflow
+    never sets `format:` at all, so a single 'markdown' default would reach
+    run.sh as INPUT_FORMAT=markdown for every mode -- including scan, whose
+    own default is 'text' -- and this validator would then hard-reject the
+    ordinary, most common scan invocation that never touches `format`.
+    Leaving the input's default unset means an un-set `format:` reaches
+    here as an empty string, and each run.sh mode branch already supplies
+    its own correct per-mode default (`${INPUT_FORMAT:-text}` for scan,
+    `${INPUT_FORMAT:-markdown}` elsewhere)."""
+
+    @pytest.mark.parametrize(
+        "mode", ["scan", "compare", "dump", "deps-tree", "deps-compare"]
+    )
+    def test_format_left_completely_unset_passes(self, mode: str) -> None:
+        result = _run_validate({"INPUT_MODE": mode})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_action_yml_format_input_has_no_static_default(self) -> None:
+        """The actual regression: action.yml declaring `default: 'markdown'`
+        on `format` would silently populate INPUT_FORMAT=markdown for scan
+        runs that never set it, defeating the empty-string sentinel every
+        mode branch's `${INPUT_FORMAT:-...}` relies on."""
+        import yaml
+
+        action_yml = ACTION_DIR.parent / "action.yml"
+        data = yaml.safe_load(action_yml.read_text(encoding="utf-8"))
+        assert "default" not in data["inputs"]["format"], (
+            "action.yml's `format` input must not declare a default — see "
+            "this class's docstring for why a single default breaks scan's "
+            "own 'text' default."
+        )
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
+)
 class TestUploadSarif:
     def test_upload_sarif_with_compare_and_sarif_format_passes(self) -> None:
         result = _run_validate(

--- a/tests/test_action_validate_inputs.py
+++ b/tests/test_action_validate_inputs.py
@@ -163,15 +163,18 @@ class TestFormatIsHardErrorNotSilentFallback:
         assert result.returncode == 0, result.stdout + result.stderr
 
     @pytest.mark.parametrize("mode", ["deps-tree", "deps-compare"])
-    @pytest.mark.parametrize("fmt", ["sarif", "html"])
-    def test_deps_modes_reject_unsupported_format(self, mode: str, fmt: str) -> None:
-        result = _run_validate({"INPUT_MODE": mode, "INPUT_FORMAT": fmt})
+    def test_deps_modes_reject_sarif(self, mode: str) -> None:
+        result = _run_validate({"INPUT_MODE": mode, "INPUT_FORMAT": "sarif"})
         assert result.returncode == 1
         assert "does not support format" in result.stdout
 
     @pytest.mark.parametrize("mode", ["deps-tree", "deps-compare"])
-    @pytest.mark.parametrize("fmt", ["markdown", "json"])
+    @pytest.mark.parametrize("fmt", ["markdown", "json", "html"])
     def test_deps_modes_accept_supported_format(self, mode: str, fmt: str) -> None:
+        # deps-tree/deps-compare's CLI supports markdown|json|html (`deps
+        # tree --help`; html renders via cli_stack.py's stack_to_html) —
+        # Codex review, PR #594: this validator originally rejected html
+        # here too, which would have blocked a real, supported CLI format.
         result = _run_validate({"INPUT_MODE": mode, "INPUT_FORMAT": fmt})
         assert result.returncode == 0, result.stdout + result.stderr
 

--- a/tests/test_action_validate_inputs.py
+++ b/tests/test_action_validate_inputs.py
@@ -106,6 +106,30 @@ class TestDefaultsPassValidation:
 @pytest.mark.skipif(
     not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
 )
+class TestUnknownModeIsRejected:
+    """The `case "$MODE" in ...` has no arm for an unrecognized value, so
+    without an explicit catch-all a typo like 'scna' falls through silently
+    and every other check in the script is skipped -- Python setup,
+    dependency install, and pip install would all still run before run.sh's
+    own "Unknown mode" check finally reports it (Codex review, PR #594)."""
+
+    def test_typo_mode_is_rejected(self) -> None:
+        result = _run_validate({"INPUT_MODE": "scna"})
+        assert result.returncode == 1
+        assert "Unknown mode" in result.stdout
+        assert "scna" in result.stdout
+
+    @pytest.mark.parametrize(
+        "mode", ["compare", "dump", "scan", "deps-tree", "deps-compare"]
+    )
+    def test_every_real_mode_is_accepted(self, mode: str) -> None:
+        result = _run_validate({"INPUT_MODE": mode})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
+)
 class TestDumpRejectsDirectoryOrPackage:
     def test_directory_is_rejected(self, tmp_path: Path) -> None:
         lib_dir = tmp_path / "lib"

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -71,7 +71,11 @@ def _write_snapshot(
         "build_id": None,
     }
     if fact_set is not None:
-        data["build_source"] = {"source_abi": {"fact_set": fact_set}}
+        # Matches the real SourceAbiSurface.to_dict() shape
+        # (abicheck/buildsource/source_abi.py): there is no top-level
+        # "fact_set" key, only "coverage": {"fact_set": ...}, written by
+        # source_link.link_source_abi() (Codex review).
+        data["build_source"] = {"source_abi": {"coverage": {"fact_set": fact_set}}}
     path.write_text(json.dumps(data), encoding="utf-8")
 
 
@@ -105,6 +109,46 @@ class TestBuildManifestBasics:
         entries = [{"name": "libfoo", "artifact": "build/libfoo.so"}]
         manifest = build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
         assert manifest["snapshot_schema"] == 9
+
+    def test_fact_set_read_from_real_snapshot_shape(self, tmp_path: Path) -> None:
+        # Regression (Codex review): SourceAbiSurface.to_dict() has no
+        # top-level "fact_set" key -- link_source_abi() writes the rolled-up
+        # identity to surface.coverage["fact_set"]. Written directly (not via
+        # the _write_snapshot helper) to pin the exact real production
+        # schema, so this can't pass merely because the helper and the reader
+        # drifted together.
+        snap_path = tmp_path / "libfoo.abicheck.json"
+        snap_path.write_text(
+            json.dumps(
+                {
+                    "library": "libfoo",
+                    "version": "1.0.0",
+                    "schema_version": 9,
+                    "git_commit": None,
+                    "git_tag": None,
+                    "created_at": None,
+                    "build_id": None,
+                    "build_source": {
+                        "source_abi": {
+                            "coverage": {
+                                "fact_set": {
+                                    "name": "abicheck-clang-canonical",
+                                    "version": 1,
+                                },
+                                "exported_symbols": 3,
+                            }
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        manifest = build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
+        assert manifest["fact_set"] == {
+            "name": "abicheck-clang-canonical",
+            "version": 1,
+        }
 
     def test_fact_set_recorded_when_consistent(self, tmp_path: Path) -> None:
         fact_set = {"name": "abicheck-clang-canonical", "version": 1}

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -699,6 +699,59 @@ class TestMainCli:
             manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
         )
 
+    def test_sha256_stable_when_only_manifest_coverage_row_changes(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): build_inline_coverage()
+        # (abicheck/buildsource/inline.py) copies the same cache/timing
+        # state that source_abi.coverage carries into each
+        # build_source.manifest.coverage row's "detail" (a free-form string
+        # like "cache 2/3 hit (67%), 1.80s") and "elapsed_s" -- a third
+        # place the same volatile info leaks into, so stripping only
+        # source_abi.coverage's volatile keys still left the digest
+        # unstable.
+        snap_path = tmp_path / "libfoo.abicheck.json"
+
+        def _write(detail: str, elapsed_s: float) -> None:
+            data = {
+                "library": "libfoo",
+                "version": "1.0.0",
+                "schema_version": 9,
+                "git_commit": "aaa",
+                "git_tag": None,
+                "created_at": "2026-07-17T00:00:00+00:00",
+                "build_id": None,
+                "build_source": {
+                    "manifest": {
+                        "build_source_pack_version": 1,
+                        "coverage": [
+                            {
+                                "layer": "L4_source_abi",
+                                "status": "present",
+                                "confidence": "high",
+                                "detail": detail,
+                                "elapsed_s": elapsed_s,
+                            }
+                        ],
+                    },
+                    "source_abi": {"coverage": {}},
+                },
+            }
+            snap_path.write_text(json.dumps(data), encoding="utf-8")
+
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        _write("cache 2/3 hit (67%), 1.80s", 1.8)
+        manifest1 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+        _write("cache 0/3 hit (0%), 3.40s", 3.4)
+        manifest2 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+        assert (
+            manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
+        )
+
     def test_content_digest_changes_when_snapshot_content_changes(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -281,6 +281,51 @@ class TestFreshness:
         assert manifest["freshness"]["refresh_required"] is True
         assert any("fact_set" in r for r in manifest["freshness"]["reasons"])
 
+    def test_fact_set_producer_change_requires_refresh(self, tmp_path: Path) -> None:
+        # Same fact_set name/version, but a different producer_version (e.g.
+        # a rebuilt Clang plugin) -- the recipe identity changed even though
+        # the two-field identity alone would look unchanged.
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json",
+            library="libfoo",
+            schema_version=9,
+            fact_set={
+                "name": "abicheck-clang-canonical",
+                "version": 1,
+                "compiler_family": "clang",
+                "producer": "clang-plugin",
+                "producer_version": "2.0",
+                "compiler_version": "18.1.0",
+            },
+        )
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        previous_path = tmp_path / "previous.json"
+        previous_path.write_text(
+            json.dumps(
+                {
+                    "manifest_version": 1,
+                    "project_ref": "",
+                    "profile": "",
+                    "snapshot_schema": 9,
+                    "fact_set": {
+                        "name": "abicheck-clang-canonical",
+                        "version": 1,
+                        "compiler_family": "clang",
+                        "producer": "clang-plugin",
+                        "producer_version": "1.0",
+                        "compiler_version": "18.1.0",
+                    },
+                    "artifacts": [{"library": "libfoo"}],
+                }
+            )
+        )
+        manifest = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, previous_path
+        )
+        assert manifest["fact_set"]["producer_version"] == "2.0"
+        assert manifest["freshness"]["refresh_required"] is True
+        assert any("fact_set" in r for r in manifest["freshness"]["reasons"])
+
 
 class TestMainCli:
     def test_main_writes_manifest_and_prints_outputs(

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -110,6 +110,27 @@ class TestBuildManifestBasics:
         manifest = build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
         assert manifest["snapshot_schema"] == 9
 
+    def test_fails_when_schema_version_inconsistent_across_libraries(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (CodeRabbit review): every dump in one baseline-set run
+        # goes through the same installed abicheck, so disagreeing
+        # schema_versions means something is structurally broken -- silently
+        # taking max() published a manifest whose declared schema didn't
+        # match what one of its own snapshots actually used.
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", schema_version=9
+        )
+        _write_snapshot(
+            tmp_path / "libbar.abicheck.json", library="libbar", schema_version=10
+        )
+        entries = [
+            {"name": "libfoo", "artifact": "a.so"},
+            {"name": "libbar", "artifact": "b.so"},
+        ]
+        with pytest.raises(SystemExit, match="disagree on schema_version"):
+            build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
+
     def test_fact_set_read_from_real_snapshot_shape(self, tmp_path: Path) -> None:
         # Regression (Codex review): SourceAbiSurface.to_dict() has no
         # top-level "fact_set" key -- link_source_abi() writes the rolled-up
@@ -171,7 +192,7 @@ class TestBuildManifestBasics:
         manifest = build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
         assert manifest["fact_set"] is None
 
-    def test_fact_set_none_when_inconsistent_across_libraries(
+    def test_fails_when_fact_set_inconsistent_across_libraries(
         self, tmp_path: Path
     ) -> None:
         _write_snapshot(
@@ -188,10 +209,32 @@ class TestBuildManifestBasics:
             {"name": "libfoo", "artifact": "a.so"},
             {"name": "libbar", "artifact": "b.so"},
         ]
-        manifest = build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
-        # Disagreement is reported (::warning:: to stderr) rather than
-        # silently picking one side's identity as if it applied to both.
-        assert manifest["fact_set"] is None
+        # Disagreement is a hard failure (CodeRabbit review) -- silently
+        # picking one side's identity, or discarding it to None, would let a
+        # later manifest with the *same* silently-discarded state compare
+        # equal and report no refresh, hiding a real recipe-identity drift.
+        with pytest.raises(SystemExit, match="disagree on fact_set identity"):
+            build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
+
+    def test_fails_when_fact_set_present_on_only_some_libraries(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (CodeRabbit review): libfoo carries a fact_set, libbar
+        # carries none -- fact_set_ids only ever gets libfoo's one entry, so
+        # len(fact_set_ids) == 1 looked "consistent" even though libbar has
+        # no source-fact evidence at all.
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json",
+            library="libfoo",
+            fact_set={"name": "abicheck-clang-canonical", "version": 1},
+        )
+        _write_snapshot(tmp_path / "libbar.abicheck.json", library="libbar")
+        entries = [
+            {"name": "libfoo", "artifact": "a.so"},
+            {"name": "libbar", "artifact": "b.so"},
+        ]
+        with pytest.raises(SystemExit, match="whether source-fact evidence is present"):
+            build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
 
 
 class TestFreshness:
@@ -200,6 +243,21 @@ class TestFreshness:
         entries = [{"name": "libfoo", "artifact": "a.so"}]
         manifest = build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
         assert manifest["freshness"] == {"refresh_required": False, "reasons": []}
+
+    def test_fails_when_previous_manifest_path_given_but_missing(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (CodeRabbit review): omitting --previous-manifest
+        # entirely is the documented way to say "no previous baseline"
+        # (action.yml). A caller that passes one pointing at a path that
+        # doesn't exist has a broken workflow (typo, failed artifact
+        # download) -- silently returning refresh_required=False as if the
+        # comparison ran and found nothing stale would hide that.
+        _write_snapshot(tmp_path / "libfoo.abicheck.json", library="libfoo")
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        missing = tmp_path / "does-not-exist.json"
+        with pytest.raises(SystemExit, match="does not exist"):
+            build_manifest_module.build_manifest(tmp_path, "", "", entries, missing)
 
     def test_identical_manifest_is_not_stale(self, tmp_path: Path) -> None:
         _write_snapshot(
@@ -450,4 +508,68 @@ class TestMainCli:
 
         digest1 = manifest1["artifacts"][0]["sha256"]
         digest2 = manifest2["artifacts"][0]["sha256"]
+        assert digest1 != digest2
+
+    def _run_main_and_get_content_digest(
+        self, tmp_path: Path, libraries: list[dict[str, str]], capsys
+    ) -> str:
+        # Overwritten on every call -- only the printed content-digest= line
+        # matters to these tests, not the manifest file's own path/identity.
+        manifest_out = tmp_path / "manifest-out.json"
+        rc = build_manifest_module.main(
+            [
+                "--output-dir",
+                str(tmp_path),
+                "--libraries",
+                json.dumps(libraries),
+                "--manifest-out",
+                str(manifest_out),
+            ]
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        (line,) = [ln for ln in out.splitlines() if ln.startswith("content-digest=")]
+        return line.removeprefix("content-digest=")
+
+    def test_content_digest_via_cli_stable_across_artifact_path_and_order(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        # CodeRabbit review: the aggregate content-digest output is
+        # documented as "library names + per-file digests" -- it must not
+        # move just because a matrix reordered entries or an artifact was
+        # built at a different path this run.
+        _write_snapshot(tmp_path / "libfoo.abicheck.json", library="libfoo")
+        _write_snapshot(tmp_path / "libbar.abicheck.json", library="libbar")
+
+        digest1 = self._run_main_and_get_content_digest(
+            tmp_path,
+            [
+                {"name": "libfoo", "artifact": "build/libfoo.so"},
+                {"name": "libbar", "artifact": "build/libbar.so"},
+            ],
+            capsys,
+        )
+        digest2 = self._run_main_and_get_content_digest(
+            tmp_path,
+            [
+                {"name": "libbar", "artifact": "elsewhere/libbar.so"},
+                {"name": "libfoo", "artifact": "elsewhere/libfoo.so"},
+            ],
+            capsys,
+        )
+        assert digest1 == digest2
+
+    def test_content_digest_via_cli_changes_when_snapshot_content_changes(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", git_commit="aaa"
+        )
+        libraries = [{"name": "libfoo", "artifact": "a.so"}]
+        digest1 = self._run_main_and_get_content_digest(tmp_path, libraries, capsys)
+
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", git_commit="bbb"
+        )
+        digest2 = self._run_main_and_get_content_digest(tmp_path, libraries, capsys)
         assert digest1 != digest2

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -237,6 +237,52 @@ class TestBuildManifestBasics:
         with pytest.raises(SystemExit, match="whether source-fact evidence is present"):
             build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
 
+    def test_fails_when_schema_version_missing(self, tmp_path: Path) -> None:
+        # Regression (CodeRabbit review): a snapshot with schema_version
+        # omitted entirely was silently skipped (never added to
+        # schema_versions), so a single library -- or every library -- with
+        # a missing schema_version passed with no error, publishing a
+        # manifest whose snapshot_schema silently lost that information.
+        path = tmp_path / "libfoo.abicheck.json"
+        data = {
+            "library": "libfoo",
+            "version": "1.0.0",
+            "schema_version": None,
+            "git_commit": None,
+            "git_tag": None,
+            "created_at": "2026-07-17T00:00:00+00:00",
+            "build_id": None,
+        }
+        path.write_text(json.dumps(data), encoding="utf-8")
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        with pytest.raises(SystemExit, match="missing schema_version"):
+            build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
+
+    def test_fails_when_fact_set_is_malformed(self, tmp_path: Path) -> None:
+        # Regression (CodeRabbit review): a present-but-malformed fact_set
+        # (e.g. missing "version") used to be silently reclassified as
+        # fact_set_absent -- collapsing corrupted evidence into "no
+        # evidence" instead of surfacing the corruption.
+        path = tmp_path / "libfoo.abicheck.json"
+        data = {
+            "library": "libfoo",
+            "version": "1.0.0",
+            "schema_version": 9,
+            "git_commit": None,
+            "git_tag": None,
+            "created_at": "2026-07-17T00:00:00+00:00",
+            "build_id": None,
+            "build_source": {
+                "source_abi": {
+                    "coverage": {"fact_set": {"name": "abicheck-clang-canonical"}}
+                }
+            },
+        }
+        path.write_text(json.dumps(data), encoding="utf-8")
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        with pytest.raises(SystemExit, match="malformed fact_set identity"):
+            build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
+
 
 class TestFreshness:
     def test_no_previous_manifest_means_not_required(self, tmp_path: Path) -> None:

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -60,6 +60,7 @@ def _write_snapshot(
     schema_version: int = 9,
     git_commit: str | None = None,
     fact_set: dict | None = None,
+    created_at: str = "2026-07-17T00:00:00+00:00",
 ) -> None:
     data = {
         "library": library,
@@ -67,7 +68,7 @@ def _write_snapshot(
         "schema_version": schema_version,
         "git_commit": git_commit,
         "git_tag": None,
-        "created_at": "2026-07-17T00:00:00+00:00",
+        "created_at": created_at,
         "build_id": None,
     }
     if fact_set is not None:
@@ -487,6 +488,39 @@ class TestMainCli:
         assert "library-count=1" in out
         assert "refresh-required=false" in out
         assert "content-digest=" in out
+
+    def test_sha256_stable_when_only_created_at_changes(self, tmp_path: Path) -> None:
+        # Regression (Codex review): the per-artifact sha256 used to be a raw
+        # file hash, so it changed on every dump call even when the actual
+        # ABI content was identical -- dumper.py auto-stamps created_at fresh
+        # each time (absent SOURCE_DATE_EPOCH, the normal CI case). This
+        # rippled into content-digest too, since that's built from these
+        # per-artifact digests.
+        snap_path = tmp_path / "libfoo.abicheck.json"
+        _write_snapshot(
+            snap_path,
+            library="libfoo",
+            git_commit="aaa",
+            created_at="2026-07-17T00:00:00+00:00",
+        )
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        manifest1 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+
+        _write_snapshot(
+            snap_path,
+            library="libfoo",
+            git_commit="aaa",
+            created_at="2026-07-17T01:23:45+00:00",
+        )
+        manifest2 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+
+        assert (
+            manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
+        )
 
     def test_content_digest_changes_when_snapshot_content_changes(
         self, tmp_path: Path

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -614,6 +614,50 @@ class TestMainCli:
             manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
         )
 
+    def test_sha256_stable_when_only_build_source_pack_path_hint_changes(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): BuildSourceRef.path_hint (abicheck/
+        # buildsource/model.py) is documented as "advisory only" -- it's the
+        # out-of-band pack's on-disk location, defaulted by
+        # cli_buildsource.embed_build_source() to the --sources/--build-info
+        # operand path. The same ABI/source facts dumped from a relative
+        # abicheck_inputs/ vs an absolute restored pack path therefore got a
+        # different top-level build_source_pack.path_hint and a different
+        # digest, even though nothing semantic changed.
+        snap_path = tmp_path / "libfoo.abicheck.json"
+
+        def _write(path_hint: str) -> None:
+            data = {
+                "library": "libfoo",
+                "version": "1.0.0",
+                "schema_version": 9,
+                "git_commit": "aaa",
+                "git_tag": None,
+                "created_at": "2026-07-17T00:00:00+00:00",
+                "build_id": None,
+                "build_source_pack": {
+                    "schema_version": 1,
+                    "content_hash": "sha256:same",
+                    "path_hint": path_hint,
+                    "coverage_summary": {},
+                },
+            }
+            snap_path.write_text(json.dumps(data), encoding="utf-8")
+
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        _write("abicheck_inputs")
+        manifest1 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+        _write("/restored/path/abicheck_inputs")
+        manifest2 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+        assert (
+            manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
+        )
+
     def test_sha256_stable_when_only_source_mtime_changes(self, tmp_path: Path) -> None:
         # Regression (Codex review): AbiSnapshot.source_mtime/source_mtime_epoch
         # (abicheck/model.py) reflect the dumped binary's filesystem mtime at

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -752,6 +752,65 @@ class TestMainCli:
             manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
         )
 
+    def test_sha256_stable_when_only_manifest_extractor_row_changes(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): inline_graph_fold.py appends
+        # "N.NNs, jobs=M" (last_elapsed_s/last_jobs) to a
+        # build_source.manifest.extractors row's "detail", and
+        # started_at/finished_at are ISO 8601 wall-clock bounds -- runner
+        # load/CPU count and collection time, not source-fact content, so a
+        # fourth place the same volatile-info-in-a-row-field shape leaked
+        # into the digest.
+        snap_path = tmp_path / "libfoo.abicheck.json"
+
+        def _write(detail: str, started_at: str, finished_at: str) -> None:
+            data = {
+                "library": "libfoo",
+                "version": "1.0.0",
+                "schema_version": 9,
+                "git_commit": "aaa",
+                "git_tag": None,
+                "created_at": "2026-07-17T00:00:00+00:00",
+                "build_id": None,
+                "build_source": {
+                    "manifest": {
+                        "build_source_pack_version": 1,
+                        "extractors": [
+                            {
+                                "name": "compile_commands",
+                                "version": "1.0",
+                                "status": "ok",
+                                "inputs": [],
+                                "artifacts": [],
+                                "detail": detail,
+                                "started_at": started_at,
+                                "finished_at": finished_at,
+                            }
+                        ],
+                    },
+                    "source_abi": {"coverage": {}},
+                },
+            }
+            snap_path.write_text(json.dumps(data), encoding="utf-8")
+
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        _write(
+            "1.80s, jobs=4", "2026-07-17T00:00:00+00:00", "2026-07-17T00:00:02+00:00"
+        )
+        manifest1 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+        _write(
+            "3.40s, jobs=8", "2026-07-17T01:00:00+00:00", "2026-07-17T01:00:04+00:00"
+        )
+        manifest2 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+        assert (
+            manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
+        )
+
     def test_content_digest_changes_when_snapshot_content_changes(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -522,6 +522,52 @@ class TestMainCli:
             manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
         )
 
+    def test_sha256_stable_when_only_embedded_build_source_created_at_changes(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): a snapshot dumped with --build-info/
+        # --sources embeds a *second*, independently-stamped timestamp at
+        # build_source.manifest.created_at (BuildSourceManifest.created_at,
+        # written fresh by every collect-facts run). Stripping only the
+        # top-level created_at (the fix above) left this nested one in
+        # place, so the digest was still unstable for any baseline with
+        # embedded source facts.
+        snap_path = tmp_path / "libfoo.abicheck.json"
+
+        def _write(build_source_created_at: str) -> None:
+            data = {
+                "library": "libfoo",
+                "version": "1.0.0",
+                "schema_version": 9,
+                "git_commit": "aaa",
+                "git_tag": None,
+                "created_at": "2026-07-17T00:00:00+00:00",
+                "build_id": None,
+                "build_source": {
+                    "manifest": {
+                        "build_source_pack_version": 1,
+                        "created_at": build_source_created_at,
+                    },
+                    "source_abi": {"coverage": {}},
+                },
+            }
+            snap_path.write_text(json.dumps(data), encoding="utf-8")
+
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        _write("2026-07-17T00:00:00+00:00")
+        manifest1 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+
+        _write("2026-07-17T01:23:45+00:00")
+        manifest2 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+
+        assert (
+            manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
+        )
+
     def test_content_digest_changes_when_snapshot_content_changes(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -1,0 +1,335 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for ``actions/baseline/build_manifest.py``.
+
+Pure-Python tests over synthetic snapshot JSON files (no compiler, no real
+`abicheck dump` needed) -- ``actions/baseline/run.sh`` is what actually
+produces the per-library snapshots this script reads; see
+``tests/test_action_baseline.py`` for the bash-level orchestration
+(including one ``integration``-marked end-to-end test with real compiled
+libraries).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1] / "actions" / "baseline" / "build_manifest.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "baseline_build_manifest", _MODULE_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pytestmark = pytest.mark.skipif(
+    not _MODULE_PATH.is_file(), reason="actions/baseline/build_manifest.py not found"
+)
+build_manifest_module = _load_module() if _MODULE_PATH.is_file() else None
+
+
+def _write_snapshot(
+    path: Path,
+    *,
+    library: str,
+    schema_version: int = 9,
+    git_commit: str | None = None,
+    fact_set: dict | None = None,
+) -> None:
+    data = {
+        "library": library,
+        "version": "1.0.0",
+        "schema_version": schema_version,
+        "git_commit": git_commit,
+        "git_tag": None,
+        "created_at": "2026-07-17T00:00:00+00:00",
+        "build_id": None,
+    }
+    if fact_set is not None:
+        data["build_source"] = {"source_abi": {"fact_set": fact_set}}
+    path.write_text(json.dumps(data), encoding="utf-8")
+
+
+class TestBuildManifestBasics:
+    def test_manifest_lists_every_library(self, tmp_path: Path) -> None:
+        out = tmp_path
+        _write_snapshot(out / "libfoo.abicheck.json", library="libfoo")
+        _write_snapshot(out / "libbar.abicheck.json", library="libbar")
+        entries = [
+            {"name": "libfoo", "artifact": "build/libfoo.so"},
+            {"name": "libbar", "artifact": "build/libbar.so"},
+        ]
+        manifest = build_manifest_module.build_manifest(
+            out, "v1.0.0", "linux-x86_64", entries, None
+        )
+        assert manifest["manifest_version"] == 1
+        assert manifest["project_ref"] == "v1.0.0"
+        assert manifest["profile"] == "linux-x86_64"
+        assert [a["library"] for a in manifest["artifacts"]] == ["libfoo", "libbar"]
+        assert all(a["sha256"] for a in manifest["artifacts"])
+
+    def test_missing_snapshot_raises(self, tmp_path: Path) -> None:
+        entries = [{"name": "libfoo", "artifact": "build/libfoo.so"}]
+        with pytest.raises(SystemExit, match="libfoo"):
+            build_manifest_module.build_manifest(tmp_path, "v1.0.0", "", entries, None)
+
+    def test_snapshot_schema_is_recorded(self, tmp_path: Path) -> None:
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", schema_version=9
+        )
+        entries = [{"name": "libfoo", "artifact": "build/libfoo.so"}]
+        manifest = build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
+        assert manifest["snapshot_schema"] == 9
+
+    def test_fact_set_recorded_when_consistent(self, tmp_path: Path) -> None:
+        fact_set = {"name": "abicheck-clang-canonical", "version": 1}
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", fact_set=fact_set
+        )
+        _write_snapshot(
+            tmp_path / "libbar.abicheck.json", library="libbar", fact_set=fact_set
+        )
+        entries = [
+            {"name": "libfoo", "artifact": "a.so"},
+            {"name": "libbar", "artifact": "b.so"},
+        ]
+        manifest = build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
+        assert manifest["fact_set"] == fact_set
+
+    def test_fact_set_none_when_absent(self, tmp_path: Path) -> None:
+        _write_snapshot(tmp_path / "libfoo.abicheck.json", library="libfoo")
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        manifest = build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
+        assert manifest["fact_set"] is None
+
+    def test_fact_set_none_when_inconsistent_across_libraries(
+        self, tmp_path: Path
+    ) -> None:
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json",
+            library="libfoo",
+            fact_set={"name": "abicheck-clang-canonical", "version": 1},
+        )
+        _write_snapshot(
+            tmp_path / "libbar.abicheck.json",
+            library="libbar",
+            fact_set={"name": "abicheck-clang-canonical", "version": 2},
+        )
+        entries = [
+            {"name": "libfoo", "artifact": "a.so"},
+            {"name": "libbar", "artifact": "b.so"},
+        ]
+        manifest = build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
+        # Disagreement is reported (::warning:: to stderr) rather than
+        # silently picking one side's identity as if it applied to both.
+        assert manifest["fact_set"] is None
+
+
+class TestFreshness:
+    def test_no_previous_manifest_means_not_required(self, tmp_path: Path) -> None:
+        _write_snapshot(tmp_path / "libfoo.abicheck.json", library="libfoo")
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        manifest = build_manifest_module.build_manifest(tmp_path, "", "", entries, None)
+        assert manifest["freshness"] == {"refresh_required": False, "reasons": []}
+
+    def test_identical_manifest_is_not_stale(self, tmp_path: Path) -> None:
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", schema_version=9
+        )
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        first = build_manifest_module.build_manifest(tmp_path, "v1", "p", entries, None)
+        previous_path = tmp_path / "previous.json"
+        previous_path.write_text(json.dumps(first))
+
+        second = build_manifest_module.build_manifest(
+            tmp_path, "v1", "p", entries, previous_path
+        )
+        assert second["freshness"]["refresh_required"] is False
+        assert second["freshness"]["reasons"] == []
+
+    def test_schema_version_bump_requires_refresh(self, tmp_path: Path) -> None:
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", schema_version=9
+        )
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        previous_path = tmp_path / "previous.json"
+        previous_path.write_text(
+            json.dumps(
+                {
+                    "manifest_version": 1,
+                    "project_ref": "",
+                    "profile": "",
+                    "snapshot_schema": 8,
+                    "fact_set": None,
+                    "artifacts": [{"library": "libfoo"}],
+                }
+            )
+        )
+        manifest = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, previous_path
+        )
+        assert manifest["freshness"]["refresh_required"] is True
+        assert any("snapshot_schema" in r for r in manifest["freshness"]["reasons"])
+
+    def test_added_library_requires_refresh(self, tmp_path: Path) -> None:
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", schema_version=9
+        )
+        _write_snapshot(
+            tmp_path / "libbar.abicheck.json", library="libbar", schema_version=9
+        )
+        entries = [
+            {"name": "libfoo", "artifact": "a.so"},
+            {"name": "libbar", "artifact": "b.so"},
+        ]
+        previous_path = tmp_path / "previous.json"
+        previous_path.write_text(
+            json.dumps(
+                {
+                    "manifest_version": 1,
+                    "project_ref": "",
+                    "profile": "",
+                    "snapshot_schema": 9,
+                    "fact_set": None,
+                    "artifacts": [{"library": "libfoo"}],
+                }
+            )
+        )
+        manifest = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, previous_path
+        )
+        assert manifest["freshness"]["refresh_required"] is True
+        assert any(
+            "added" in r and "libbar" in r for r in manifest["freshness"]["reasons"]
+        )
+
+    def test_removed_library_requires_refresh(self, tmp_path: Path) -> None:
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", schema_version=9
+        )
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        previous_path = tmp_path / "previous.json"
+        previous_path.write_text(
+            json.dumps(
+                {
+                    "manifest_version": 1,
+                    "project_ref": "",
+                    "profile": "",
+                    "snapshot_schema": 9,
+                    "fact_set": None,
+                    "artifacts": [{"library": "libfoo"}, {"library": "libbar"}],
+                }
+            )
+        )
+        manifest = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, previous_path
+        )
+        assert manifest["freshness"]["refresh_required"] is True
+        assert any(
+            "removed" in r and "libbar" in r for r in manifest["freshness"]["reasons"]
+        )
+
+    def test_fact_set_change_requires_refresh(self, tmp_path: Path) -> None:
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json",
+            library="libfoo",
+            schema_version=9,
+            fact_set={"name": "abicheck-clang-canonical", "version": 2},
+        )
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        previous_path = tmp_path / "previous.json"
+        previous_path.write_text(
+            json.dumps(
+                {
+                    "manifest_version": 1,
+                    "project_ref": "",
+                    "profile": "",
+                    "snapshot_schema": 9,
+                    "fact_set": {"name": "abicheck-clang-canonical", "version": 1},
+                    "artifacts": [{"library": "libfoo"}],
+                }
+            )
+        )
+        manifest = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, previous_path
+        )
+        assert manifest["freshness"]["refresh_required"] is True
+        assert any("fact_set" in r for r in manifest["freshness"]["reasons"])
+
+
+class TestMainCli:
+    def test_main_writes_manifest_and_prints_outputs(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", schema_version=9
+        )
+        libraries = json.dumps([{"name": "libfoo", "artifact": "a.so"}])
+        manifest_out = tmp_path / "manifest.json"
+        rc = build_manifest_module.main(
+            [
+                "--output-dir",
+                str(tmp_path),
+                "--project-ref",
+                "v1.0.0",
+                "--profile",
+                "linux",
+                "--libraries",
+                libraries,
+                "--manifest-out",
+                str(manifest_out),
+            ]
+        )
+        assert rc == 0
+        assert manifest_out.is_file()
+        out = capsys.readouterr().out
+        assert "library-count=1" in out
+        assert "refresh-required=false" in out
+        assert "content-digest=" in out
+
+    def test_content_digest_changes_when_snapshot_content_changes(
+        self, tmp_path: Path
+    ) -> None:
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", git_commit="aaa"
+        )
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        manifest1 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", git_commit="bbb"
+        )
+        manifest2 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+
+        digest1 = manifest1["artifacts"][0]["sha256"]
+        digest2 = manifest2["artifacts"][0]["sha256"]
+        assert digest1 != digest2

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -653,15 +653,18 @@ class TestMainCli:
         self, tmp_path: Path
     ) -> None:
         # Regression (Codex review): source_replay.py's replay producer
-        # stamps wall-clock durations and cache hit/miss counts into
-        # build_source.source_abi.coverage (cache_lookup_s, extract_s,
-        # link_s, elapsed_s, cache_misses, cache_hits) -- these depend on the
-        # runner's cache warmth/load, not on the source-fact content, so
-        # hashing them made the digest unstable across reruns of identical
-        # source facts.
+        # stamps wall-clock durations, cache hit/miss counts, and its own
+        # parallelism setting into build_source.source_abi.coverage
+        # (cache_lookup_s, extract_s, link_s, elapsed_s, cache_misses,
+        # cache_hits, extractor_jobs) -- these depend on the runner's cache
+        # warmth/load/CPU count, not on the source-fact content, so hashing
+        # them made the digest unstable across reruns of identical source
+        # facts (extractor_jobs was a later addition to this same list, once
+        # replaying the same facts on a differently-sized runner was found
+        # to still churn the digest).
         snap_path = tmp_path / "libfoo.abicheck.json"
 
-        def _write(elapsed_s: float, cache_misses: int) -> None:
+        def _write(elapsed_s: float, cache_misses: int, extractor_jobs: int) -> None:
             data = {
                 "library": "libfoo",
                 "version": "1.0.0",
@@ -679,6 +682,7 @@ class TestMainCli:
                             "elapsed_s": elapsed_s,
                             "cache_misses": cache_misses,
                             "cache_hits": 3,
+                            "extractor_jobs": extractor_jobs,
                             "compile_units_parsed": 12,
                         }
                     }
@@ -687,11 +691,11 @@ class TestMainCli:
             snap_path.write_text(json.dumps(data), encoding="utf-8")
 
         entries = [{"name": "libfoo", "artifact": "a.so"}]
-        _write(1.8, 0)
+        _write(1.8, 0, 4)
         manifest1 = build_manifest_module.build_manifest(
             tmp_path, "", "", entries, None
         )
-        _write(3.4, 5)
+        _write(3.4, 5, 16)
         manifest2 = build_manifest_module.build_manifest(
             tmp_path, "", "", entries, None
         )

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -614,6 +614,91 @@ class TestMainCli:
             manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
         )
 
+    def test_sha256_stable_when_only_source_mtime_changes(self, tmp_path: Path) -> None:
+        # Regression (Codex review): AbiSnapshot.source_mtime/source_mtime_epoch
+        # (abicheck/model.py) reflect the dumped binary's filesystem mtime at
+        # dump time -- a fresh CI checkout of byte-identical source gets a new
+        # mtime every run, so hashing these made the digest unstable even
+        # though the actual ABI content never changed.
+        snap_path = tmp_path / "libfoo.abicheck.json"
+
+        def _write(source_mtime: float) -> None:
+            data = {
+                "library": "libfoo",
+                "version": "1.0.0",
+                "schema_version": 9,
+                "git_commit": "aaa",
+                "git_tag": None,
+                "created_at": "2026-07-17T00:00:00+00:00",
+                "build_id": None,
+                "source_mtime": source_mtime,
+                "source_mtime_epoch": False,
+            }
+            snap_path.write_text(json.dumps(data), encoding="utf-8")
+
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        _write(1000.0)
+        manifest1 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+        _write(2000.0)
+        manifest2 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+        assert (
+            manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
+        )
+
+    def test_sha256_stable_when_only_replay_timing_counters_change(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): source_replay.py's replay producer
+        # stamps wall-clock durations and cache hit/miss counts into
+        # build_source.source_abi.coverage (cache_lookup_s, extract_s,
+        # link_s, elapsed_s, cache_misses, cache_hits) -- these depend on the
+        # runner's cache warmth/load, not on the source-fact content, so
+        # hashing them made the digest unstable across reruns of identical
+        # source facts.
+        snap_path = tmp_path / "libfoo.abicheck.json"
+
+        def _write(elapsed_s: float, cache_misses: int) -> None:
+            data = {
+                "library": "libfoo",
+                "version": "1.0.0",
+                "schema_version": 9,
+                "git_commit": "aaa",
+                "git_tag": None,
+                "created_at": "2026-07-17T00:00:00+00:00",
+                "build_id": None,
+                "build_source": {
+                    "source_abi": {
+                        "coverage": {
+                            "cache_lookup_s": 0.1,
+                            "extract_s": 1.5,
+                            "link_s": 0.2,
+                            "elapsed_s": elapsed_s,
+                            "cache_misses": cache_misses,
+                            "cache_hits": 3,
+                            "compile_units_parsed": 12,
+                        }
+                    }
+                },
+            }
+            snap_path.write_text(json.dumps(data), encoding="utf-8")
+
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        _write(1.8, 0)
+        manifest1 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+        _write(3.4, 5)
+        manifest2 = build_manifest_module.build_manifest(
+            tmp_path, "", "", entries, None
+        )
+        assert (
+            manifest1["artifacts"][0]["sha256"] == manifest2["artifacts"][0]["sha256"]
+        )
+
     def test_content_digest_changes_when_snapshot_content_changes(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_baseline_manifest.py
+++ b/tests/test_baseline_manifest.py
@@ -254,6 +254,35 @@ class TestFreshness:
             "removed" in r and "libbar" in r for r in manifest["freshness"]["reasons"]
         )
 
+    def test_profile_change_requires_refresh(self, tmp_path: Path) -> None:
+        # previous-manifest from a different build profile (e.g.
+        # linux-x86_64-gcc vs linux-x86_64-clang) is a baseline for a
+        # different target entirely, not a stale copy of this one -- even
+        # when schema/fact_set/library-set all otherwise match (Codex
+        # review).
+        _write_snapshot(
+            tmp_path / "libfoo.abicheck.json", library="libfoo", schema_version=9
+        )
+        entries = [{"name": "libfoo", "artifact": "a.so"}]
+        previous_path = tmp_path / "previous.json"
+        previous_path.write_text(
+            json.dumps(
+                {
+                    "manifest_version": 1,
+                    "project_ref": "",
+                    "profile": "linux-x86_64-gcc",
+                    "snapshot_schema": 9,
+                    "fact_set": None,
+                    "artifacts": [{"library": "libfoo"}],
+                }
+            )
+        )
+        manifest = build_manifest_module.build_manifest(
+            tmp_path, "", "linux-x86_64-clang", entries, previous_path
+        )
+        assert manifest["freshness"]["refresh_required"] is True
+        assert any("profile" in r for r in manifest["freshness"]["reasons"])
+
     def test_fact_set_change_requires_refresh(self, tmp_path: Path) -> None:
         _write_snapshot(
             tmp_path / "libfoo.abicheck.json",


### PR DESCRIPTION
## Summary

Add mode-aware, fail-fast validation to the GitHub Action's composite steps, and document the mode/input compatibility matrix and the release-contract-vs-accepted-main baseline distinction.

## Motivation

A review of a real-world integration (an external project wiring abicheck's Action into a multi-library, multi-DSO release with source facts) surfaced two concrete gaps in the Action's contract:

1. **`dump`/`scan` silently accepted a directory** for `new-library`, even though neither mode has `compare`'s per-library fan-out — the failure only surfaced deep inside the tool (a confusing "cannot detect input format" style error), after a full toolchain install (`castxml`/`gcc`/`clang` via `apt-get`) had already run.
2. **`format: sarif`/`html` on `scan`/`deps-tree`/`deps-compare` silently fell back** to a supported format with only a `::warning::`. Combined with `upload-sarif: true`, a misconfigured `scan` step produced **neither an error nor a SARIF report** — a workflow that thought it had wired up GitHub Code Scanning integration got nothing, silently.

Both failure modes are exactly what a CI contract shouldn't do: an unsupported combination should be a loud usage error, not a late failure or a silent no-op.

## Changes

- **New `action/validate-inputs.sh`**, wired as the composite Action's very first step (`Validate mode/input combination`) — runs before Python setup, system-dependency installation, and `pip install abicheck`. Rejects:
  - a directory/package passed to `dump`'s or `scan`'s `new-library`
  - `format: sarif`/`html` on `scan`/`deps-tree`/`deps-compare`
  - `upload-sarif: true` without `mode: compare` + `format: sarif`
- **`action/run.sh` hardened the same way** as defense-in-depth (for anyone invoking it directly, e.g. tests), and its three silent `::warning:: ... falling back to X` format fallbacks are now hard `::error::` + `exit 1`.
- **Fixed misleading `action.yml` input descriptions** (`new-library`, `format`, `upload-sarif`) — the previous wording implied `dump`/`scan` support directories/packages (they don't) and didn't document the fallback-turned-error behavior.
- **Docs**: added a "Mode/input compatibility" matrix to `docs/user-guide/github-action.md`; added a "Two kinds of baseline: release contract vs. accepted-main" section to `docs/user-guide/baseline-management.md` plus a warning in `docs/user-guide/ci-gating.md` about a "breaking change" label relaxing the *gate* rather than skipping the *check* (a fixed release baseline skipped via a label stays stale, so every subsequent unrelated PR re-hits the same already-accepted break).
- **Tests**: new `tests/test_action_validate_inputs.py` (30 cases) covering every validation rule, plus a drift-guard that runs `validate-inputs.sh`'s duplicated directory/package classifier against `run.sh`'s original on the same fixtures.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (mode/input compatibility matrix, baseline lifecycle)
- [x] `ruff check`, `ruff format --check` (new file), `mypy abicheck/`, and `mkdocs build --strict` all pass clean
- [x] No new `mypy` or `ruff` errors introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_018NsUe4JB3jgGwsKwfVGpeW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Composite actions now support baseline-set generation (per-library snapshots + manifest) and reusable source-facts collection across libraries.
  - Added early, fail-fast mode/input validation to catch incompatible inputs before setup work.
- **Bug Fixes**
  - Unsupported mode/format combinations now hard-fail (no warning+fallback).
  - Directory/package operands are rejected in modes requiring single artifacts.
  - `upload-sarif` is enforced only for `mode=compare` with `format=sarif`.
- **Documentation**
  - Updated guidance for mode/input compatibility, baseline identity, and label-based CI gating.
- **Tests**
  - Added end-to-end validation, baseline, and facts-collection coverage, including manifest/digest behavior checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->