### PR TITLE
fix(pr-comment): stop reporting policy-gated additions as ABI BREAKING

### DIFF
--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -791,6 +791,13 @@ def generate_html_report(
         scoped_exit_code = getattr(result, "scoped_exit_code", None)
         scoped_exit_code_scheme = getattr(result, "scoped_exit_code_scheme", None)
         gate_exit_code: int
+        # blocking_categories only corresponds 1:1 to full_gate in the
+        # non-scoped branch below (gate_passed derives directly from
+        # full_gate.blocking there); the scoped exit code can fail for a
+        # reason full_gate's categories don't describe at all (e.g. a
+        # missing --required-symbol entrypoint), so it's left blank there
+        # rather than risk naming the wrong cause.
+        gate_blocking_categories: tuple[str, ...] = ()
         if scoped_exit_code is not None and scoped_exit_code_scheme == "severity":
             gate_passed = scoped_exit_code == 0
             gate_exit_code = scoped_exit_code
@@ -812,11 +819,26 @@ def generate_html_report(
                 "Compatibility verdict above (e.g. an addition promoted to "
                 "<code>error</code> still fails CI)."
             )
+            gate_blocking_categories = full_gate.blocking_categories
         gate_fg, gate_bg = (
             ("#1b5e20", "#e8f5e9") if gate_passed else ("#b71c1c", "#ffebee")
         )
         gate_label = "PASS" if gate_passed else f"FAIL (exit {gate_exit_code})"
         gate_icon = "✅" if gate_passed else "🛑"
+        # Names which severity category(ies) actually gated CI — without
+        # this, "FAIL" reads as an undifferentiated red box even when the
+        # cause is a policy-blocked COMPATIBLE addition rather than a
+        # genuine ABI/API break (same category-naming this PR already
+        # added to the sticky PR comment and the Action's Job Summary).
+        gate_categories_html = ""
+        if not gate_passed and gate_blocking_categories:
+            cats = ", ".join(
+                f"<code>{h(c)}</code>" for c in sorted(gate_blocking_categories)
+            )
+            gate_categories_html = (
+                f"<div class='bc-metric' style='font-size:0.85em; opacity:0.85;'>"
+                f"Blocked by: {cats}</div>"
+            )
         gate_html = (
             f"<div class='verdict-box' "
             f"style='background:{gate_bg}; color:{gate_fg}; "
@@ -824,7 +846,9 @@ def generate_html_report(
             f"<h2>{gate_icon} {h(gate_title)}: {h(gate_label)}</h2>"
             f"<div class='bc-metric' style='font-size:0.85em; opacity:0.85;'>"
             f"{gate_note}"
-            f"</div></div>"
+            f"</div>"
+            f"{gate_categories_html}"
+            f"</div>"
         )
 
     scoped_verdict = getattr(result, "scoped_verdict", None)

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -714,7 +714,8 @@ def abi_compare(
     Returns a structured JSON result with verdict, change summary, and the
     full list of changes. The verdict indicates binary ABI compatibility:
     - NO_CHANGE: identical ABI
-    - COMPATIBLE: only additions (backward compatible)
+    - COMPATIBLE: no incompatible ABI/API changes (may include additions
+      and quality findings; backward compatible)
     - COMPATIBLE_WITH_RISK: binary-compatible but deployment risk present
     - API_BREAK: source-level break (recompilation needed)
     - BREAKING: binary ABI break (old binaries will crash)

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -125,6 +125,13 @@ class Finding:
     # the renderer *why* a finding landed in Breaking, so a policy-gated
     # COMPATIBLE addition doesn't get reported as "ABI BREAKING".
     category: str = ""
+    # Raw severity label ("breaking" / "api_break" / "risk" / "compatible" /
+    # "unknown"), or "" when not tracked. `category` alone conflates
+    # "api_break" and "risk" into one "potential_breaking" bucket (they share
+    # a severity-config knob), which isn't enough to word the headline
+    # correctly: a risk finding promoted by `potential_breaking: error` is
+    # not a "source API break" (Codex review, PR #595).
+    severity: str = ""
 
 
 @dataclass
@@ -151,6 +158,12 @@ class CommentModel:
     # tell a genuine ABI/API break apart from a policy-gated COMPATIBLE
     # finding without re-deriving it from bucket membership alone.
     breaking_categories: frozenset[str] = field(default_factory=frozenset)
+    # Raw severities ("breaking" / "api_break" / "risk") behind a non-empty
+    # Breaking bucket — same purpose as `breaking_categories`, but resolves
+    # the "potential_breaking" category into which severity actually caused
+    # it, since "api_break" (a real source break) and "risk" (a risk
+    # promoted to blocking) need different headline wording.
+    breaking_severities: frozenset[str] = field(default_factory=frozenset)
     # release mode only: (library, verdict, n_breaking, n_review, n_safe)
     library_rows: list[tuple[str, str, int, int, int]] = field(default_factory=list)
     removed_libraries: list[str] = field(default_factory=list)
@@ -262,6 +275,7 @@ def _bucket_changes(
                     detail=_detail_text(c),
                     location=str(loc) if loc else None,
                     category=category,
+                    severity=sev,
                 )
             )
     return breaking, review, safe
@@ -270,6 +284,17 @@ def _bucket_changes(
 def _breaking_categories(findings: list[Finding]) -> frozenset[str]:
     """The set of severity-config categories present in a Breaking bucket."""
     return frozenset(f.category for f in findings if f.category)
+
+
+def _breaking_severities(findings: list[Finding]) -> frozenset[str]:
+    """The set of raw severities present in a Breaking bucket.
+
+    Resolves the "potential_breaking" category (which "api_break" and "risk"
+    both map to) back to which severity is actually responsible, so the
+    headline can tell a real source break apart from a risk promoted to
+    blocking.
+    """
+    return frozenset(f.severity for f in findings if f.severity)
 
 
 def _from_compare(
@@ -299,6 +324,7 @@ def _from_compare(
         review=review,
         safe=safe,
         breaking_categories=_breaking_categories(breaking),
+        breaking_severities=_breaking_severities(breaking),
         scoped_verdict=scoped_verdict,
         full_verdict=(
             str(report["full_verdict"]) if "full_verdict" in report else None
@@ -329,6 +355,7 @@ def _from_appcompat(
                     symbol=str(sym),
                     detail="required symbol not provided by new library",
                     category="abi_breaking",
+                    severity="breaking",
                 )
             )
     # A missing required version tag is breaking for the app too (appcompat
@@ -342,6 +369,7 @@ def _from_appcompat(
                     symbol=str(ver),
                     detail="required symbol version not provided by new library",
                     category="abi_breaking",
+                    severity="breaking",
                 )
             )
     return CommentModel(
@@ -354,6 +382,7 @@ def _from_appcompat(
         review=review,
         safe=safe,
         breaking_categories=_breaking_categories(breaking),
+        breaking_severities=_breaking_severities(breaking),
     )
 
 
@@ -362,9 +391,10 @@ def _append_release_global_row(
     name: str,
     verdict: object,
     findings: object,
-    gate_api_break: bool = False,
-    levels: dict[str, str] | None = None,
-    categories: set[str] | None = None,
+    gate_api_break: bool,
+    levels: dict[str, str],
+    categories: set[str],
+    severities: set[str],
 ) -> None:
     """Fold a release-global check (bundle / probe-matrix) into the rows.
 
@@ -376,15 +406,19 @@ def _append_release_global_row(
     issues are classified per finding and only the gated category is promoted to
     Breaking, matching what ``_fold_release_global_severity`` actually computes.
 
-    *categories* (when given) accumulates the severity-config category
-    responsible each time this call pushes a count into the Breaking column,
-    so the headline can tell a genuine break from a policy-gated COMPATIBLE
-    section (see ``CommentModel.breaking_categories``).
+    *categories* accumulates the severity-config category responsible each
+    time this call pushes a count into the Breaking column, so the headline
+    can tell a genuine break from a policy-gated COMPATIBLE section (see
+    ``CommentModel.breaking_categories``). *severities* similarly accumulates
+    "breaking"/"api_break"/"risk" — needed because "api_break" and "risk"
+    share the same "potential_breaking" category but need different headline
+    wording (a risk is not a "source API break"). Both are caller-owned
+    accumulators (the sole caller, ``_from_release``, shares one set across
+    all rows) rather than defaulted here, since an empty-per-call set would
+    silently lose that aggregation.
     """
     if not isinstance(findings, list) or not findings:
         return
-    if categories is None:
-        categories = set()
     verdict_map = (
         {**_VERDICT_BUCKET, "API_BREAK": "breaking"}
         if gate_api_break
@@ -393,10 +427,26 @@ def _append_release_global_row(
     bucket = verdict_map.get(str(verdict or ""), "review")
     levels = levels or {}
     n = len(findings)
-    # A risk section under potential_breaking=error turns the check red.
-    if bucket == "review" and levels.get("potential_breaking") == "error":
+    # Classify *why* the section is Breaking exactly once: either it started
+    # there (an intrinsically BREAKING verdict — a genuine break — or, under
+    # fail-on-api-break, a gated API_BREAK promotion, a source break), or it
+    # got promoted from "review" by potential_breaking=error (elif, not a
+    # second independent `if`: reusing `if bucket == "breaking"` here would
+    # re-fire on the just-promoted bucket and mis-tag a risk as "breaking").
+    if bucket == "breaking":
+        if str(verdict) == "API_BREAK":
+            categories.add("potential_breaking")
+            severities.add("api_break")
+        else:
+            categories.add("abi_breaking")
+            severities.add("breaking")
+    elif bucket == "review" and levels.get("potential_breaking") == "error":
+        # A risk (or, without fail-on-api-break, a plain API_BREAK) section
+        # promoted this way — COMPATIBLE_WITH_RISK is a risk, API_BREAK is a
+        # real source break; only the latter is a "source API break".
         bucket = "breaking"
         categories.add("potential_breaking")
+        severities.add("api_break" if str(verdict) == "API_BREAK" else "risk")
     # A compatible section is additions + quality; classify each finding by its
     # kind and promote only the gated category to Breaking (addition and quality
     # gates are not interchangeable).
@@ -417,10 +467,6 @@ def _append_release_global_row(
                 categories.add("quality_issues")
             rows.append((name, str(verdict or "?"), nb, 0, n - nb))
             return
-    if bucket == "breaking":
-        # An intrinsically BREAKING verdict is a genuine break; API_BREAK only
-        # lands here under fail-on-api-break gating, so it's a source break.
-        categories.add("potential_breaking" if str(verdict) == "API_BREAK" else "abi_breaking")
     rows.append(
         (
             name,
@@ -437,6 +483,7 @@ def _release_lib_row(
     gate_api_break: bool,
     levels: dict[str, str],
     categories: set[str],
+    severities: set[str],
 ) -> tuple[str, str, int, int, int]:
     """Per-library (name, verdict, breaking, review, safe) counts.
 
@@ -449,11 +496,15 @@ def _release_lib_row(
 
     *categories* accumulates the severity-config category responsible each
     time a count is pushed into ``nb`` (see ``CommentModel.breaking_categories``).
+    *severities* similarly accumulates "breaking"/"api_break"/"risk" — needed
+    because source_breaks (api_break) and risk_changes (risk) both feed the
+    same "potential_breaking" category but need different headline wording.
     """
     name = str(lib.get("library", "?"))
     verdict = str(lib.get("verdict", "?"))
     if verdict == "ERROR":
         categories.add("abi_breaking")
+        severities.add("breaking")
         return name, verdict, 1, 0, 0
     src = _as_int(lib.get("source_breaks"))
     risk = _as_int(lib.get("risk_changes"))
@@ -469,17 +520,20 @@ def _release_lib_row(
     nb = _as_int(lib.get("breaking"))
     if nb:
         categories.add("abi_breaking")
+        severities.add("breaking")
     nr = 0
     ns = 0
     if gate_api_break or pot_err:
         if src:
             categories.add("potential_breaking")
+            severities.add("api_break")
         nb, nr = nb + src, nr
     else:
         nb, nr = nb, nr + src
     if pot_err:
         if risk:
             categories.add("potential_breaking")
+            severities.add("risk")
         nb, nr = nb + risk, nr
     else:
         nb, nr = nb, nr + risk
@@ -504,12 +558,15 @@ def _from_release(
     rows: list[tuple[str, str, int, int, int]] = []
     levels = _severity_levels(report)
     categories: set[str] = set()
+    severities: set[str] = set()
     libraries = report.get("libraries")
     if isinstance(libraries, list):
         for lib in libraries:
             if not isinstance(lib, dict):
                 continue
-            rows.append(_release_lib_row(lib, gate_api_break, levels, categories))
+            rows.append(
+                _release_lib_row(lib, gate_api_break, levels, categories, severities)
+            )
     n_libs = len(rows)
     _append_release_global_row(
         rows,
@@ -519,6 +576,7 @@ def _from_release(
         gate_api_break,
         levels,
         categories,
+        severities,
     )
     _append_release_global_row(
         rows,
@@ -528,6 +586,7 @@ def _from_release(
         gate_api_break,
         levels,
         categories,
+        severities,
     )
     removed = report.get("unmatched_old")
     added = report.get("unmatched_new")
@@ -539,6 +598,7 @@ def _from_release(
         policy="strict_abi",
         library_rows=rows,
         breaking_categories=frozenset(categories),
+        breaking_severities=frozenset(severities),
         removed_libraries=[str(x) for x in removed]
         if isinstance(removed, list)
         else [],
@@ -654,6 +714,16 @@ def _header(model: CommentModel) -> tuple[str, str]:
         if "abi_breaking" in cats:
             return "❌", "ABI BREAKING"
         if "potential_breaking" in cats:
+            # "potential_breaking" covers both "api_break" (a real source
+            # break) and "risk" (a risk promoted to blocking) — they share a
+            # severity-config knob but are not the same claim, so resolve
+            # via the raw severities rather than wording every gated risk as
+            # a "source API break" (Codex review, PR #595).
+            sevs = model.breaking_severities
+            if "api_break" in sevs:
+                return "⛔", "Source API break blocks this PR"
+            if "risk" in sevs:
+                return "⛔", "Compatibility risk blocks this PR"
             return "⛔", "Source API break blocks this PR"
         policy_header = _POLICY_ONLY_HEADER.get(cats)
         if policy_header is not None:

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -971,11 +971,23 @@ def _gate_note(model: CommentModel) -> list[str]:
     """
     if model.removed_libraries or model.scoped_verdict is not None:
         return []
-    b, _, _ = model.counts
+    b, r, _ = model.counts
     cats = model.breaking_categories
     if not b or "abi_breaking" in cats or "potential_breaking" in cats or not cats:
         return []
     names = ", ".join(f"`{_CATEGORY_LABEL.get(c, c)}`" for c in sorted(cats))
+    if r:
+        # A separate, ungated api_break/risk finding sits in "Needs review" —
+        # asserting whole-report "Compatibility: COMPATIBLE" here would
+        # overstate it (Codex review, PR #595), so scope the claim to just
+        # the Breaking bucket's own entries and point at the other section.
+        return [
+            f"> ℹ️ **Gate: BLOCKED** by severity policy — {names} is "
+            f"configured as `error`. These entries are themselves COMPATIBLE "
+            f"(not an ABI/API break) — see \"Needs review\" below for other "
+            f"findings that may affect compatibility.",
+            "",
+        ]
     return [
         f"> ℹ️ **Compatibility: COMPATIBLE** — existing binaries/consumers are "
         f"unaffected; this is not an ABI/API break. **Gate: BLOCKED** by "

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -23,11 +23,17 @@ place:
 
 * **Breaking** — clear ABI breaks (and gated source breaks);
 * **Needs review** — source breaks / risk a human should sign off on;
-* **Safe** — additions and policy/surface-scoped compatible removals.
+* **Safe** — compatible changes: new public-API surface and quality findings.
 
 "Safe" here is a pure mirror of the severity the checker already assigned
 (``severity`` field in the JSON, which honours public-surface scoping and the
-active policy) — this module never re-classifies anything.
+active policy) — this module never re-classifies anything. Within Safe, new
+public-API surface (the ``ADDITION_KINDS`` registry — ``func_added``,
+``type_added``, ``enum_member_added``, etc.) renders as its own "➕ Public API
+additions" table with per-symbol kind/detail/location, separate from the
+generic "✅ Safe" list of quality findings — a reviewer approving a new export
+wants to see what was added, not just a bare count folded in with unrelated
+quality notes.
 
 A severity-config category set to ``error`` (e.g. ``severity-addition:
 error``) moves its findings into the Breaking bucket too, since that is what
@@ -1014,7 +1020,17 @@ def _body_sections(model: CommentModel, detail: str) -> list[str]:
         detail,
         open_default=(not model.breaking and bool(model.review)),
     )
-    out += _safe_section(model.safe, detail)
+    # New public-API surface gets its own section — a per-symbol table with
+    # kind/detail/location, the same treatment Breaking/Needs review get —
+    # rather than being folded anonymously into the generic quality-findings
+    # "Safe" list below. A reviewer approving new exports wants to see what
+    # was added, not just a bare symbol count.
+    additions = [f for f in model.safe if f.category == "addition"]
+    quality = [f for f in model.safe if f.category != "addition"]
+    out += _findings_table(
+        "➕ Public API additions", additions, detail, open_default=False
+    )
+    out += _safe_section(quality, detail)
     return out
 
 

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -29,6 +29,15 @@ place:
 (``severity`` field in the JSON, which honours public-surface scoping and the
 active policy) — this module never re-classifies anything.
 
+A severity-config category set to ``error`` (e.g. ``severity-addition:
+error``) moves its findings into the Breaking bucket too, since that is what
+turns the check red — but a COMPATIBLE addition/quality finding promoted this
+way is still not an ABI/API break (ADR-042: compatibility and gate decisions
+are separate axes). The headline and the Breaking section title reflect this:
+they only say "ABI BREAKING" when the bucket actually holds a genuine
+``abi_breaking``/``potential_breaking`` finding, and say "blocked by policy"
+instead when every member is a gate-promoted COMPATIBLE finding.
+
 The body carries a hidden HTML :data:`MARKER` so the action can find and
 update the same comment across runs, and surfaces the scanned commit SHA in
 both the header and the footer.
@@ -109,6 +118,13 @@ class Finding:
     symbol: str
     detail: str = ""
     location: str | None = None
+    # Severity-config category this finding belongs to ("abi_breaking" /
+    # "potential_breaking" / "addition" / "quality_issues"), or "" when not
+    # tracked (e.g. release-mode global rows, which stay aggregate counts).
+    # Drives the Breaking-bucket headline (see module docstring): it tells
+    # the renderer *why* a finding landed in Breaking, so a policy-gated
+    # COMPATIBLE addition doesn't get reported as "ABI BREAKING".
+    category: str = ""
 
 
 @dataclass
@@ -127,6 +143,14 @@ class CommentModel:
     breaking: list[Finding] = field(default_factory=list)
     review: list[Finding] = field(default_factory=list)
     safe: list[Finding] = field(default_factory=list)
+    # Severity-config categories ("abi_breaking" / "potential_breaking" /
+    # "addition" / "quality_issues") responsible for a non-empty Breaking
+    # bucket. Populated alongside `breaking` in every mode (see
+    # `_breaking_categories` and the release-mode `categories` accumulator in
+    # `_release_lib_row`/`_append_release_global_row`) so the headline can
+    # tell a genuine ABI/API break apart from a policy-gated COMPATIBLE
+    # finding without re-deriving it from bucket membership alone.
+    breaking_categories: frozenset[str] = field(default_factory=frozenset)
     # release mode only: (library, verdict, n_breaking, n_review, n_safe)
     library_rows: list[tuple[str, str, int, int, int]] = field(default_factory=list)
     removed_libraries: list[str] = field(default_factory=list)
@@ -227,7 +251,8 @@ def _bucket_changes(
             if gate_api_break and sev == "api_break":
                 bucket = "breaking"
             # … and a severity category set to error turns it red too.
-            if levels.get(_finding_category(sev, kind)) == "error":
+            category = _finding_category(sev, kind)
+            if levels.get(category) == "error":
                 bucket = "breaking"
             loc = c.get("source_location")
             target[bucket].append(
@@ -236,9 +261,15 @@ def _bucket_changes(
                     symbol=str(c.get("symbol", "")),
                     detail=_detail_text(c),
                     location=str(loc) if loc else None,
+                    category=category,
                 )
             )
     return breaking, review, safe
+
+
+def _breaking_categories(findings: list[Finding]) -> frozenset[str]:
+    """The set of severity-config categories present in a Breaking bucket."""
+    return frozenset(f.category for f in findings if f.category)
 
 
 def _from_compare(
@@ -267,6 +298,7 @@ def _from_compare(
         breaking=breaking,
         review=review,
         safe=safe,
+        breaking_categories=_breaking_categories(breaking),
         scoped_verdict=scoped_verdict,
         full_verdict=(
             str(report["full_verdict"]) if "full_verdict" in report else None
@@ -296,6 +328,7 @@ def _from_appcompat(
                     kind="symbol_missing",
                     symbol=str(sym),
                     detail="required symbol not provided by new library",
+                    category="abi_breaking",
                 )
             )
     # A missing required version tag is breaking for the app too (appcompat
@@ -308,6 +341,7 @@ def _from_appcompat(
                     kind="version_missing",
                     symbol=str(ver),
                     detail="required symbol version not provided by new library",
+                    category="abi_breaking",
                 )
             )
     return CommentModel(
@@ -319,6 +353,7 @@ def _from_appcompat(
         breaking=breaking,
         review=review,
         safe=safe,
+        breaking_categories=_breaking_categories(breaking),
     )
 
 
@@ -329,6 +364,7 @@ def _append_release_global_row(
     findings: object,
     gate_api_break: bool = False,
     levels: dict[str, str] | None = None,
+    categories: set[str] | None = None,
 ) -> None:
     """Fold a release-global check (bundle / probe-matrix) into the rows.
 
@@ -339,9 +375,16 @@ def _append_release_global_row(
     ``kind`` — so when a compatible section is gated, the additions and quality
     issues are classified per finding and only the gated category is promoted to
     Breaking, matching what ``_fold_release_global_severity`` actually computes.
+
+    *categories* (when given) accumulates the severity-config category
+    responsible each time this call pushes a count into the Breaking column,
+    so the headline can tell a genuine break from a policy-gated COMPATIBLE
+    section (see ``CommentModel.breaking_categories``).
     """
     if not isinstance(findings, list) or not findings:
         return
+    if categories is None:
+        categories = set()
     verdict_map = (
         {**_VERDICT_BUCKET, "API_BREAK": "breaking"}
         if gate_api_break
@@ -353,6 +396,7 @@ def _append_release_global_row(
     # A risk section under potential_breaking=error turns the check red.
     if bucket == "review" and levels.get("potential_breaking") == "error":
         bucket = "breaking"
+        categories.add("potential_breaking")
     # A compatible section is additions + quality; classify each finding by its
     # kind and promote only the gated category to Breaking (addition and quality
     # gates are not interchangeable).
@@ -360,18 +404,23 @@ def _append_release_global_row(
         add_err = levels.get("addition") == "error"
         qual_err = levels.get("quality_issues") == "error"
         if add_err or qual_err:
-            nb = sum(
+            n_add = sum(
                 1
                 for f in findings
-                if isinstance(f, dict)
-                and (
-                    add_err
-                    if str(f.get("kind", "")) in _ADDITION_KIND_VALUES
-                    else qual_err
-                )
+                if isinstance(f, dict) and str(f.get("kind", "")) in _ADDITION_KIND_VALUES
             )
+            n_qual = n - n_add
+            nb = (n_add if add_err else 0) + (n_qual if qual_err else 0)
+            if add_err and n_add:
+                categories.add("addition")
+            if qual_err and n_qual:
+                categories.add("quality_issues")
             rows.append((name, str(verdict or "?"), nb, 0, n - nb))
             return
+    if bucket == "breaking":
+        # An intrinsically BREAKING verdict is a genuine break; API_BREAK only
+        # lands here under fail-on-api-break gating, so it's a source break.
+        categories.add("potential_breaking" if str(verdict) == "API_BREAK" else "abi_breaking")
     rows.append(
         (
             name,
@@ -384,7 +433,10 @@ def _append_release_global_row(
 
 
 def _release_lib_row(
-    lib: dict[str, object], gate_api_break: bool, levels: dict[str, str]
+    lib: dict[str, object],
+    gate_api_break: bool,
+    levels: dict[str, str],
+    categories: set[str],
 ) -> tuple[str, str, int, int, int]:
     """Per-library (name, verdict, breaking, review, safe) counts.
 
@@ -394,10 +446,14 @@ def _release_lib_row(
     error. Otherwise source breaks + risk are review and additions + quality are
     safe. A library whose comparison errored carries no count fields, so it is
     counted as one breaking finding to reflect the failed comparison.
+
+    *categories* accumulates the severity-config category responsible each
+    time a count is pushed into ``nb`` (see ``CommentModel.breaking_categories``).
     """
     name = str(lib.get("library", "?"))
     verdict = str(lib.get("verdict", "?"))
     if verdict == "ERROR":
+        categories.add("abi_breaking")
         return name, verdict, 1, 0, 0
     src = _as_int(lib.get("source_breaks"))
     risk = _as_int(lib.get("risk_changes"))
@@ -411,12 +467,34 @@ def _release_lib_row(
     qual_err = levels.get("quality_issues") == "error"
 
     nb = _as_int(lib.get("breaking"))
+    if nb:
+        categories.add("abi_breaking")
     nr = 0
     ns = 0
-    nb, nr = (nb + src, nr) if (gate_api_break or pot_err) else (nb, nr + src)
-    nb, nr = (nb + risk, nr) if pot_err else (nb, nr + risk)
-    nb, ns = (nb + additions, ns) if add_err else (nb, ns + additions)
-    nb, ns = (nb + quality, ns) if qual_err else (nb, ns + quality)
+    if gate_api_break or pot_err:
+        if src:
+            categories.add("potential_breaking")
+        nb, nr = nb + src, nr
+    else:
+        nb, nr = nb, nr + src
+    if pot_err:
+        if risk:
+            categories.add("potential_breaking")
+        nb, nr = nb + risk, nr
+    else:
+        nb, nr = nb, nr + risk
+    if add_err:
+        if additions:
+            categories.add("addition")
+        nb, ns = nb + additions, ns
+    else:
+        nb, ns = nb, ns + additions
+    if qual_err:
+        if quality:
+            categories.add("quality_issues")
+        nb, ns = nb + quality, ns
+    else:
+        nb, ns = nb, ns + quality
     return name, verdict, nb, nr, ns
 
 
@@ -425,12 +503,13 @@ def _from_release(
 ) -> CommentModel:
     rows: list[tuple[str, str, int, int, int]] = []
     levels = _severity_levels(report)
+    categories: set[str] = set()
     libraries = report.get("libraries")
     if isinstance(libraries, list):
         for lib in libraries:
             if not isinstance(lib, dict):
                 continue
-            rows.append(_release_lib_row(lib, gate_api_break, levels))
+            rows.append(_release_lib_row(lib, gate_api_break, levels, categories))
     n_libs = len(rows)
     _append_release_global_row(
         rows,
@@ -439,6 +518,7 @@ def _from_release(
         report.get("bundle_findings"),
         gate_api_break,
         levels,
+        categories,
     )
     _append_release_global_row(
         rows,
@@ -447,6 +527,7 @@ def _from_release(
         report.get("matrix_findings"),
         gate_api_break,
         levels,
+        categories,
     )
     removed = report.get("unmatched_old")
     added = report.get("unmatched_new")
@@ -457,6 +538,7 @@ def _from_release(
         new_label=_basename(report.get("new_dir", "new")),
         policy="strict_abi",
         library_rows=rows,
+        breaking_categories=frozenset(categories),
         removed_libraries=[str(x) for x in removed]
         if isinstance(removed, list)
         else [],
@@ -539,6 +621,19 @@ _SCOPED_HEADER: dict[str, tuple[str, str]] = {
 }
 
 
+#: Reviewer-facing headline for a Breaking bucket whose members are *only*
+#: policy-gated COMPATIBLE findings (a severity-config category promoted to
+#: ``error``) — not a genuine ABI/API incompatibility. Keyed by the exact
+#: frozenset of categories responsible; a bucket that also holds a genuine
+#: ``abi_breaking``/``potential_breaking`` finding never reaches this table
+#: (see ``_header``), since that finding *is* accurately a break.
+_POLICY_ONLY_HEADER: dict[frozenset[str], tuple[str, str]] = {
+    frozenset({"addition"}): ("⛔", "Public API expansion requires approval"),
+    frozenset({"quality_issues"}): ("⛔", "Quality policy violation"),
+    frozenset({"addition", "quality_issues"}): ("⛔", "Policy violation blocks this PR"),
+}
+
+
 def _header(model: CommentModel) -> tuple[str, str]:
     if model.scoped_verdict is not None:
         header = _SCOPED_HEADER.get(model.scoped_verdict)
@@ -548,6 +643,24 @@ def _header(model: CommentModel) -> tuple[str, str]:
     if model.removed_libraries:
         return "❌", "LIBRARY REMOVED"
     if b:
+        # A finding is only accurately reported as "ABI BREAKING" when the
+        # Breaking bucket holds a genuine abi_breaking/potential_breaking
+        # finding — never infer that wording from bucket membership alone.
+        # Severity-config promotion (ADR-042: compatibility and gate
+        # decisions are separate axes) can populate Breaking with a
+        # COMPATIBLE addition/quality finding that policy chose to block;
+        # that is a policy violation, not an ABI/API break.
+        cats = model.breaking_categories
+        if "abi_breaking" in cats:
+            return "❌", "ABI BREAKING"
+        if "potential_breaking" in cats:
+            return "⛔", "Source API break blocks this PR"
+        policy_header = _POLICY_ONLY_HEADER.get(cats)
+        if policy_header is not None:
+            return policy_header
+        # No per-category tracking for this bucket (shouldn't normally
+        # happen — every mode populates breaking_categories) — fall back to
+        # the conservative default rather than under-stating a red check.
         return "❌", "ABI BREAKING"
     if r:
         return "⚠️", "Review recommended"
@@ -773,11 +886,45 @@ def _scoped_notes(model: CommentModel) -> list[str]:
     return out
 
 
+#: Human-readable label for a severity-config category, used in policy-block
+#: messaging ("addition"/"quality_issues" are the only categories that can
+#: populate a *policy-only* Breaking bucket — see `_POLICY_ONLY_HEADER`).
+_CATEGORY_LABEL = {"addition": "addition", "quality_issues": "quality"}
+
+
+def _gate_note(model: CommentModel) -> list[str]:
+    """Explain a policy-only block (ADR-042): compatibility and gate
+    decisions are separate axes, so a COMPATIBLE addition/quality finding
+    can still fail the check under a strict severity config. Rendered only
+    when the Breaking bucket holds no genuine incompatibility, so a
+    reviewer isn't left thinking ABI/API compatibility itself is broken.
+    """
+    if model.removed_libraries or model.scoped_verdict is not None:
+        return []
+    b, _, _ = model.counts
+    cats = model.breaking_categories
+    if not b or "abi_breaking" in cats or "potential_breaking" in cats or not cats:
+        return []
+    names = ", ".join(f"`{_CATEGORY_LABEL.get(c, c)}`" for c in sorted(cats))
+    return [
+        f"> ℹ️ **Compatibility: COMPATIBLE** — existing binaries/consumers are "
+        f"unaffected; this is not an ABI/API break. **Gate: BLOCKED** by "
+        f"severity policy — {names} is configured as `error`.",
+        "",
+    ]
+
+
 def _body_sections(model: CommentModel, detail: str) -> list[str]:
     if model.mode == "release":
         return _release_table(model, detail)
+    cats = model.breaking_categories
+    breaking_title = (
+        "❌ Breaking"
+        if (not cats or "abi_breaking" in cats or "potential_breaking" in cats)
+        else "⛔ Blocked by policy (compatible)"
+    )
     out = _findings_table(
-        "❌ Breaking", model.breaking, detail, open_default=bool(model.breaking)
+        breaking_title, model.breaking, detail, open_default=bool(model.breaking)
     )
     out += _findings_table(
         "⚠️ Needs review",
@@ -820,6 +967,7 @@ def _render_body(
         note += f" — see the [full report]({_md_url(report_url)})._" if report_url else "._"
         lines += [note, ""]
     lines += _library_notes(model)
+    lines += _gate_note(model)
     lines += _scoped_notes(model)
     if detail != "summary":
         lines += _body_sections(model, detail)

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -296,6 +296,11 @@ def _to_json_leaf(
             "old_value": getattr(c, "old_value", None),
             "new_value": getattr(c, "new_value", None),
         }
+        reviewer_action = _reviewer_action_for_change(
+            c, policy=result.policy, kind_sets=eff_sets, policy_file=result.policy_file,
+        )
+        if reviewer_action is not None:
+            entry["reviewer_action"] = reviewer_action
         evidence_status = evidence_status_for_change(cast(HasKind, c))
         if evidence_status is not None:
             entry["evidence_status"] = evidence_status.value
@@ -722,6 +727,52 @@ def _recommended_action_for_change(
     return "no_action_required" if category == IssueCategory.ADDITION else "review_recommended"
 
 
+#: Per-kind reviewer guidance for a COMPATIBLE addition, keyed by
+#: ``ChangeKind.value``. Falls back to ``_DEFAULT_ADDITION_REVIEWER_ACTION``
+#: for any addition kind not listed here.
+_ADDITION_REVIEWER_ACTION: dict[str, str] = {
+    # Old binaries are unaffected, but exhaustive `switch`/sentinel-value
+    # patterns in *source* consumers can miss the new case silently.
+    "enum_member_added": "review_exhaustive_switches",
+    # A semantic addition with no new symbol: the API existed but was
+    # unstable; graduating it is a documentation/support-contract change,
+    # not a binary one.
+    "experimental_graduated": "document_stable_replacement",
+}
+_DEFAULT_ADDITION_REVIEWER_ACTION = "confirm_public_api_intent"
+
+
+def _reviewer_action_for_change(
+    c: object,
+    *,
+    policy: str | None,
+    kind_sets: KindSets | None,
+    policy_file: object | None,
+) -> str | None:
+    """Finer-grained reviewer guidance for a COMPATIBLE addition (additive).
+
+    ``recommended_action`` collapses every addition to one value,
+    ``no_action_required`` — accurate for the *old binary consumer*
+    (nothing to recompile, nothing to relink), but a reviewer approving a
+    new public export almost always has something to check: was it
+    intentional, does it need a release note, do exhaustive switches need
+    the new case. This field carries that reviewer-facing nuance without
+    changing ``recommended_action``'s existing meaning or schema enum.
+    Returns ``None`` for every non-addition finding, since those already
+    have reviewer-actionable guidance via ``recommended_action`` itself.
+    """
+    from .severity import IssueCategory, classify_effective_change
+
+    category = classify_effective_change(
+        cast(HasKind, c), policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+    )
+    if category != IssueCategory.ADDITION:
+        return None
+    kind = getattr(c, "kind", None)
+    kind_val = kind.value if kind else ""
+    return _ADDITION_REVIEWER_ACTION.get(kind_val, _DEFAULT_ADDITION_REVIEWER_ACTION)
+
+
 def _change_to_dict(
     c: object,
     *,
@@ -776,6 +827,11 @@ def _change_to_dict(
         d["recommended_action"] = _recommended_action_for_change(
             c, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
         )
+        reviewer_action = _reviewer_action_for_change(
+            c, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+        )
+        if reviewer_action is not None:
+            d["reviewer_action"] = reviewer_action
     if evidence_status is not None:
         d["evidence_status"] = evidence_status.value
     # Impact explanation

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -787,7 +787,7 @@ def _footer_lines() -> list[str]:
         "| Verdict | Meaning |",
         "|---------|---------|",
         "| ✅ NO_CHANGE | Identical ABI |",
-        "| ✅ COMPATIBLE | Only additions (backward compatible) |",
+        "| ✅ COMPATIBLE | No incompatible ABI/API changes — may include additions and quality findings (backward compatible) |",
         "| ⚠️ COMPATIBLE_WITH_RISK | Binary-compatible; verify target environment |",
         "| ⚠️ API_BREAK | Source-level API change — recompilation required |",
         "| ❌ BREAKING | Binary ABI break — recompilation required |",
@@ -869,7 +869,13 @@ def _build_severity_sections(
             sev_label = _section_severity_label(severity_config, "addition")
             lines += [f"## {_ADDITION_ICON} Additions{sev_label}", ""]
             for c in additions_list:
-                lines.append(f"- {c.description}")
+                # Same per-change detail as Breaking/Source-Level Breaks
+                # (kind, location, impact) — a bare description dropped the
+                # kind and any per-kind caveat (e.g. enum_member_added's
+                # "may shift subsequent values" note), silently losing
+                # information a reviewer needs to approve new public API
+                # surface.
+                lines.append(_format_change_md(c))
             lines.append("")
 
     return lines

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -82,7 +82,19 @@ from typing import Any
 #:       (e.g. ``"inline_body_changed"``) — the structured sibling to the
 #:       correlation ``description`` already carried in prose. Additive
 #:       optional key.
-REPORT_SCHEMA_VERSION = "2.5"
+#: 2.6 — added the optional per-finding ``reviewer_action`` key, present only
+#:       on a COMPATIBLE addition (``recommended_action == "no_action_required"``):
+#:       finer-grained reviewer guidance that field alone couldn't carry, since
+#:       it only answers "does the old binary consumer need to do anything?"
+#:       (no) and not "does a human reviewing this PR have anything to check?"
+#:       (usually yes — was the export intentional, do exhaustive switches
+#:       need the new case, does a stable-API doc need updating). One of
+#:       ``review_exhaustive_switches`` (``enum_member_added``),
+#:       ``document_stable_replacement`` (``experimental_graduated``), or the
+#:       default ``confirm_public_api_intent`` for every other addition kind.
+#:       Additive optional key; does not change ``recommended_action``'s
+#:       existing values or meaning.
+REPORT_SCHEMA_VERSION = "2.6"
 
 #: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as
 #: ``scan_schema_version`` at the top level of both public scan dict shapes:

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -290,6 +290,15 @@
         "correlated_change_kind": {
           "type": "string",
           "description": "ADR-041 P0 roadmap item 2: for a public_api_internal_dependency_added finding correlated with the same public entry's own body/type-hash change this version, the correlated finding's ChangeKind value (e.g. 'inline_body_changed') — the structured sibling to the correlation already carried in the description prose."
+        },
+        "reviewer_action": {
+          "type": "string",
+          "description": "Finer-grained reviewer guidance, present only when recommended_action is 'no_action_required' (a COMPATIBLE addition). recommended_action alone only answers whether the old binary consumer needs to do anything (no); this answers whether a human reviewing the change has anything to check.",
+          "enum": [
+            "review_exhaustive_switches",
+            "document_stable_replacement",
+            "confirm_public_api_intent"
+          ]
         }
       }
     }

--- a/action/run.sh
+++ b/action/run.sh
@@ -691,7 +691,26 @@ if [[ "${INPUT_ADD_JOB_SUMMARY:-true}" == "true" && "$MODE" != "dump" ]]; then
         echo "> **Verdict: COMPATIBLE** — No binary ABI break detected."
         ;;
       SEVERITY_ERROR)
-        echo "> **Verdict: SEVERITY_ERROR** ⚠️ — Severity-level issue detected (see severity configuration)."
+        # SEVERITY_ERROR (exit code 1) means a severity-config category is
+        # gating the check — it does NOT mean the checker found an ABI/API
+        # break (that's BREAKING/API_BREAK above, different exit codes).
+        # e.g. `severity-addition: error` blocks CI on a COMPATIBLE new
+        # public API entry; naming the category here (via the JSON report's
+        # `severity.blocking_categories`, ADR-042) tells the reader that up
+        # front instead of leaving a bare "severity-level issue" that reads
+        # like an unspecified break. Best-effort: only available when a JSON
+        # report was produced (FORMAT=json) and jq is on PATH; falls back to
+        # the generic message otherwise.
+        _blocking_categories=""
+        if [[ "${FORMAT:-}" == "json" && -n "${OUTPUT_FILE:-}" && -s "${OUTPUT_FILE:-}" ]] \
+          && command -v jq >/dev/null 2>&1; then
+          _blocking_categories=$(jq -r '(.severity.blocking_categories // []) | join(", ")' "$OUTPUT_FILE" 2>/dev/null)
+        fi
+        if [[ -n "$_blocking_categories" ]]; then
+          echo "> **Verdict: SEVERITY_ERROR** ⚠️ — Blocked by severity policy: \`$_blocking_categories\` configured as \`error\`. This is a policy gate, not necessarily an ABI/API break — see the report below for each finding's actual compatibility."
+        else
+          echo "> **Verdict: SEVERITY_ERROR** ⚠️ — Severity-level issue detected (see severity configuration)."
+        fi
         ;;
       API_BREAK)
         echo "> **Verdict: API_BREAK** — Source-level API break detected. Recompilation required."

--- a/action/run.sh
+++ b/action/run.sh
@@ -698,13 +698,23 @@ if [[ "${INPUT_ADD_JOB_SUMMARY:-true}" == "true" && "$MODE" != "dump" ]]; then
         # public API entry; naming the category here (via the JSON report's
         # `severity.blocking_categories`, ADR-042) tells the reader that up
         # front instead of leaving a bare "severity-level issue" that reads
-        # like an unspecified break. Best-effort: only available when a JSON
-        # report was produced (FORMAT=json) and jq is on PATH; falls back to
-        # the generic message otherwise.
+        # like an unspecified break. Best-effort, and checks two possible
+        # JSON sources: the primary output when FORMAT=json, or (the common
+        # case: default FORMAT=markdown with PR comments on) $PR_JSON — the
+        # always-unfiltered secondary JSON report the compare-mode command
+        # setup above already asks the same abicheck invocation to write via
+        # --secondary-format/--secondary-output, so it's already populated
+        # by this point without a second run (Codex review). Falls back to
+        # the generic message when neither is available or jq is missing.
         _blocking_categories=""
-        if [[ "${FORMAT:-}" == "json" && -n "${OUTPUT_FILE:-}" && -s "${OUTPUT_FILE:-}" ]] \
-          && command -v jq >/dev/null 2>&1; then
-          _blocking_categories=$(jq -r '(.severity.blocking_categories // []) | join(", ")' "$OUTPUT_FILE" 2>/dev/null)
+        _json_src=""
+        if [[ "${FORMAT:-}" == "json" && -n "${OUTPUT_FILE:-}" && -s "${OUTPUT_FILE:-}" ]]; then
+          _json_src="${OUTPUT_FILE}"
+        elif [[ -n "${PR_JSON:-}" && -s "${PR_JSON:-}" ]]; then
+          _json_src="${PR_JSON}"
+        fi
+        if [[ -n "$_json_src" ]] && command -v jq >/dev/null 2>&1; then
+          _blocking_categories=$(jq -r '(.severity.blocking_categories // []) | join(", ")' "$_json_src" 2>/dev/null)
         fi
         if [[ -n "$_blocking_categories" ]]; then
           echo "> **Verdict: SEVERITY_ERROR** ⚠️ — Blocked by severity policy: \`$_blocking_categories\` configured as \`error\`. This is a policy gate, not necessarily an ABI/API break — see the report below for each finding's actual compatibility."

--- a/changelog.d/20260717_194300_noreply_additions_presentation_model_lpf498.md
+++ b/changelog.d/20260717_194300_noreply_additions_presentation_model_lpf498.md
@@ -1,0 +1,81 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Fixed
+
+- **Sticky PR comment no longer reports a policy-gated COMPATIBLE finding as
+  "ABI BREAKING"** — with a severity category (e.g. `severity-addition:
+  error`) promoting a COMPATIBLE addition or quality finding into the
+  Breaking bucket to match the now-red check, the comment headline
+  previously read "ABI BREAKING" regardless of *why* the bucket was
+  non-empty. `pr_comment.py` now tracks each finding's severity-config
+  category and only shows "ABI BREAKING" when the bucket holds a genuine
+  `abi_breaking`/`potential_breaking` finding; a policy-only block now reads
+  "Public API expansion requires approval" / "Quality policy violation" /
+  "Source API break blocks this PR", with an added note explaining that
+  compatibility and the CI gate are separate axes (ADR-042). The GitHub
+  Action's Job Summary similarly names the blocking `severity.category`
+  (from the JSON report) instead of a generic "Severity-level issue
+  detected" for the `SEVERITY_ERROR` verdict.
+
+<!--
+### Added
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Changed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Deprecated
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Removed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Performance
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Security
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Documentation
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->

--- a/changelog.d/20260717_210925_noreply_additions_presentation_model_lpf498.md
+++ b/changelog.d/20260717_210925_noreply_additions_presentation_model_lpf498.md
@@ -1,0 +1,82 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Added
+
+- **New public-API additions get their own reporting sections and reviewer
+  guidance** — the sticky PR comment now renders new public-API surface
+  (`func_added`, `type_added`, `enum_member_added`, etc.) as its own "➕
+  Public API additions" table (kind/symbol/detail/location), separate from
+  the generic "✅ Safe" quality-findings list. The full Markdown report's
+  Additions section now shows the same per-finding detail (kind, location,
+  impact) that Breaking findings already get, instead of a bare description.
+  Each finding with `recommended_action: "no_action_required"` now also
+  carries a new, additive `reviewer_action` JSON field
+  (`review_exhaustive_switches` / `document_stable_replacement` /
+  `confirm_public_api_intent`) distinguishing "nothing for the old binary
+  consumer to do" from "here's what a human reviewing this PR should check"
+  (report schema bumped to `2.6`, additive). The "`COMPATIBLE` = only
+  additions" legend text (Markdown report, MCP server docstring, and docs)
+  is corrected to note that COMPATIBLE also covers quality findings.
+
+<!--
+### Changed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Deprecated
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Removed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Fixed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Performance
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Security
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Documentation
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->

--- a/changelog.d/20260717_231232_noreply_additions_presentation_model_lpf498.md
+++ b/changelog.d/20260717_231232_noreply_additions_presentation_model_lpf498.md
@@ -1,0 +1,75 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Added
+
+- **HTML report's CI Gate card names the blocking severity category** —
+  when a severity config blocks CI (e.g. `severity-addition: error`), the
+  card now shows "Blocked by: `addition`" instead of an undifferentiated
+  FAIL, mirroring the category-naming already added to the sticky PR
+  comment and the GitHub Action's Job Summary. `docs/development/adr/042-...md`
+  is corrected to reflect that the CI Gate card already routes through
+  `GateDecision`/`compute_gate_decision` (it did from the ADR's own
+  originating commit; the "candidate to adopt" listing was stale).
+
+<!--
+### Changed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Deprecated
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Removed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Fixed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Performance
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Security
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Documentation
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->

--- a/changelog.d/20260717_232400_noreply_additions_presentation_model_lpf498.md
+++ b/changelog.d/20260717_232400_noreply_additions_presentation_model_lpf498.md
@@ -1,0 +1,78 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+<!--
+### Added
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Changed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Deprecated
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Removed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+### Fixed
+
+- **The GitHub Action's Job Summary now names the blocking severity
+  category in the common default-format case** — the category-aware
+  `SEVERITY_ERROR` message (e.g. "Blocked by severity policy: `addition`
+  configured as `error`") previously only read the JSON report when the
+  primary `format` input was `json`. With the action's default
+  `format: markdown` and PR comments enabled, the compare-mode command
+  already asks the same `abicheck` invocation to write an always-unfiltered
+  secondary JSON report (`--secondary-format`/`--secondary-output`) before
+  the Job Summary is rendered — that report is now read too, so the
+  category-aware message applies to the default configuration, not just
+  `format: json`.
+
+<!--
+### Performance
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Security
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Documentation
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->

--- a/docs/development/adr/042-compatibility-and-gate-decision-separation.md
+++ b/docs/development/adr/042-compatibility-and-gate-decision-separation.md
@@ -3,9 +3,10 @@
 ## Status
 
 Accepted — implemented for the JSON/SARIF/`compare-release` gate summaries
-(`abicheck.severity.GateDecision`/`compute_gate_decision`). Other renderers
-(HTML's CI Gate card, the MCP server, JUnit) still compute an exit code
-inline via `compute_exit_code` — see "Rollout" below.
+and `html_report.py`'s CI Gate card (`abicheck.severity.GateDecision`/
+`compute_gate_decision`). `mcp_server.py` and `junit_report.py` still
+compute an exit code inline via `compute_exit_code` at some call sites —
+see "Rollout" below.
 
 ## Context
 
@@ -89,14 +90,18 @@ top of it once severity configuration is in play.
   category list computed from different inputs) is now structurally
   prevented at the three sites that were actually affected, rather than
   fixed one-off each time a new renderer reimplements the pattern.
-- `html_report.py`'s CI Gate card, `mcp_server.py`'s exit-code computation,
-  and `junit_report.py`'s per-change `_is_failure` still call
-  `compute_exit_code`/`classify_effective_change` directly rather than
-  `compute_gate_decision` — they only ever needed the exit code (or a
-  per-change category, not a whole-report `blocking_categories` list), so
-  there was no duplicated-computation bug to fix there. They are candidates
-  to adopt `GateDecision` for API consistency in a future pass, not because
-  they are currently wrong.
+- `html_report.py`'s CI Gate card already routes through
+  `compute_gate_decision` (from the same commit that introduced this ADR) —
+  an earlier draft of this document listed it as a remaining candidate,
+  which was corrected once the discrepancy was noticed. `mcp_server.py`
+  still has two exit-code call sites using `compute_exit_code` directly
+  (its severity-aware HTML/JSON tool path already uses
+  `compute_gate_decision`), and `junit_report.py`'s per-change
+  `_is_failure` still calls `classify_effective_change` directly — the
+  latter only ever needed a per-change category, not a whole-report
+  `blocking_categories` list, so there was no duplicated-computation bug to
+  fix there. They are candidates to adopt `GateDecision` for API
+  consistency in a future pass, not because they are currently wrong.
 - `compare-release`'s per-library `findings` projection
   (`_release_gating_buckets`) needs the actual `Change` objects per blocking
   category, not just `GateDecision`'s category names, so it calls
@@ -112,8 +117,9 @@ Not a phased rollout in the ADR-036 sense (no golden-snapshot risk — the
 JSON/SARIF/release-JSON shapes are unchanged). Remaining candidates to adopt
 `GateDecision` are opportunistic follow-ups, not required work:
 
-- `html_report.py`'s CI Gate card could expose `GateDecision.blocking`
-  instead of comparing `exit_code != 0` inline.
-- `mcp_server.py`'s severity-aware exit-code computation could return a
-  `GateDecision` instead of a bare int, if a future MCP tool surface wants
+- `mcp_server.py`'s two remaining `compute_exit_code` call sites could
+  switch to `compute_gate_decision`, matching its already-converted
+  severity-aware HTML/JSON path, if a future MCP tool surface wants
   `blocking_categories` too.
+- `junit_report.py`'s `_is_failure` could adopt `GateDecision` for API
+  consistency, though it only ever needed a per-change category.

--- a/docs/examples/case16_inline_to_non_inline.md
+++ b/docs/examples/case16_inline_to_non_inline.md
@@ -93,7 +93,14 @@ abi-compliance-checker -lib fast_hash -v1 1.0 -v2 2.0 \
 
 ## Real Failure Demo
 
-**Severity: CRITICAL**
+**Severity: ⚠️ Requires coordinated deployment — not an ABI break**
+
+Existing binaries are unaffected (see "Why runtime result may differ from
+verdict" below) — the risk here is a *specific build-mismatch* scenario,
+not a break in any already-compiled consumer. See case47
+(`inline_to_outlined`) for the same mechanism on a class method, framed at
+the same severity, plus the compatibility matrix below spelling out
+exactly which of the four header/library combinations fails.
 
 **Scenario B — linker error:** compile app with v2.hpp (no inline), link against v1.so (no symbol).
 
@@ -113,11 +120,27 @@ g++ -std=c++17 -g app.cpp -I. -L. -lhash -Wl,-rpath,. -o app  # links OK
 # → fast_hash(42) = ...
 ```
 
-**Why CRITICAL:** Existing binaries compiled against v1 (inline) are unaffected —
-they have the inline body baked in. The break hits **new consumers**: any code compiled
-against v2.hpp (declaration only) that links against v1.so gets a hard linker error
-because the symbol doesn't exist in v1.so. This forces a coordinated upgrade:
-v2.hpp and v2.so must ship together.
+**Why this needs coordinated deployment (not a binary ABI break):**
+Existing binaries compiled against v1 (inline) are unaffected — they have
+the inline body baked in, and abicheck's COMPATIBLE verdict is correct
+for them. The failure hits **new consumers**: any code compiled against
+v2.hpp (declaration only) that links against v1.so gets a hard linker
+error because the symbol doesn't exist in v1.so. This forces v2.hpp and
+v2.so to ship together — a packaging/release-coordination requirement, not
+an ABI incompatibility abicheck's binary-vs-binary comparison would (or
+should) flag.
+
+## Compatibility matrix (consumer headers × runtime library)
+
+| Consumer built against | Runtime library | Result |
+|---|---|---|
+| v1 header (inline, no symbol) | v1.so | ✅ works — caller uses its own inlined copy |
+| v1 header (inline, no symbol) | v2.so (symbol exported) | ✅ works — caller's inlined copy is used; the new export is simply unused |
+| v2 header (declaration only) | v2.so (symbol exported) | ✅ works — caller resolves the exported symbol |
+| v2 header (declaration only) | v1.so (no symbol) | ❌ **link failure** — `fast_hash` was never exported by v1 |
+
+Only the last row fails, and it requires a specific build mismatch (new
+headers, old library) that a coordinated release naturally avoids.
 
 ## Why runtime result may differ from verdict
 Inline→non-inline: old binary uses inlined copy, runtime unaffected

--- a/docs/examples/case47_inline_to_outlined.md
+++ b/docs/examples/case47_inline_to_outlined.md
@@ -64,6 +64,30 @@ While ABI-compatible, moving inline→outlined is a **source-level change**: any
 consumer that relied on the inlined body being optimized away (e.g. in `constexpr`
 contexts or LTO-heavy builds) may see different behavior. Document the change.
 
+There is also a build-coordination risk that abicheck's binary-vs-binary
+COMPATIBLE verdict does not itself flag, since it compares two libraries,
+not a specific consumer's header/library pairing: a consumer compiled
+against **v2's** header (declaration only, no inline body) but linked
+against **v1's** `.so` (which never exported `add` — it was inline) gets a
+hard linker error, `undefined reference to Calculator::add(int, int)`.
+That's not an ABI break in the usual sense (no *existing* binary stops
+working), but it does mean v2's header and v2's `.so` must ship together —
+see the compatibility matrix below and case16 (`inline_to_non_inline`),
+which demonstrates the same mechanism with a free function and spells out
+that failure mode end to end.
+
+## Compatibility matrix (consumer headers × runtime library)
+
+| Consumer built against | Runtime `.so` | Result |
+|---|---|---|
+| v1 header (inline, no symbol) | v1 `.so` | ✅ works — caller uses its own inlined copy |
+| v1 header (inline, no symbol) | v2 `.so` (symbol exported) | ✅ works — caller's inlined copy is used; the new export is simply unused |
+| v2 header (declaration only) | v2 `.so` (symbol exported) | ✅ works — caller resolves the exported symbol |
+| v2 header (declaration only) | v1 `.so` (no symbol) | ❌ **link failure** — `add` was never exported by v1 |
+
+Only the last row fails, and it requires a specific build mismatch (new
+headers, old library) that a coordinated release naturally avoids.
+
 ---
 
 ## Source files

--- a/docs/examples/case62_type_field_added_compatible.md
+++ b/docs/examples/case62_type_field_added_compatible.md
@@ -54,8 +54,19 @@ embed — that's breaking. This case demonstrates the safe pattern.
 
 ## What abicheck detects
 
-- **`TYPE_FIELD_ADDED`**: A new field was added to the struct.
 - **`FUNC_ADDED`**: `session_get_priority()` is a new symbol.
+
+`Session` is forward-declared only in the public header — its definition
+never appears in header-based diffing at all, so no type-level finding
+fires for it (not `TYPE_FIELD_ADDED`, not `TYPE_FIELD_ADDED_COMPATIBLE`).
+That's the point of the pattern: the struct's layout isn't part of the
+diffed public surface to begin with, so there's nothing to classify as
+"added" or "compatible" — it's simply invisible to the checker, which is
+exactly what makes it safe to change. (For an example where `TYPE_FIELD_ADDED_COMPATIBLE`
+actually fires on a *visible* struct's appended field, see case94 — there
+it's paired with a breaking `TYPE_SIZE_CHANGED` on the same struct, since
+the catalog does not yet have a case isolating a clean, standalone
+COMPATIBLE verdict driven by `TYPE_FIELD_ADDED_COMPATIBLE` alone.)
 
 **Overall verdict: COMPATIBLE**
 
@@ -68,7 +79,7 @@ gcc -shared -fPIC -g good.c -include good.h -o libgood.so
 python3 -m abicheck.cli dump libbad.so  -o /tmp/v1.json
 python3 -m abicheck.cli dump libgood.so -o /tmp/v2.json
 python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
-# → COMPATIBLE: TYPE_FIELD_ADDED, FUNC_ADDED
+# → COMPATIBLE: FUNC_ADDED
 ```
 
 ## Design pattern
@@ -97,7 +108,15 @@ struct Widget {
 - [How to Write Shared Libraries — Opaque Types](https://www.akkadia.org/drepper/dsohowto.pdf)
 
 
-Implementation note: v1 keeps reserved private storage in the opaque `Session` object; v2 consumes part of that storage for the new private `priority` field while preserving the public handle ABI. This keeps the case focused on a compatible private field addition rather than a public layout change.
+Implementation note: v1's private `Session` definition keeps a reserved
+`_reserved0` slot; v2 renames it to `priority` at the same offset and size.
+This keeps `sizeof(Session)` identical between versions — deliberately, so
+the case isolates *only* the opacity argument (the struct is invisible to
+header-based diffing either way) rather than also depending on
+`_filter_opaque_size_changes`' pointer-only-usage suppression of a growing
+`sizeof`. Since `Session` is never in the public header, none of this is
+visible to abicheck regardless — the private struct could have changed
+size too and the verdict would be identical.
 
 ---
 

--- a/docs/schemas/v1/compare_report.schema.json
+++ b/docs/schemas/v1/compare_report.schema.json
@@ -290,6 +290,15 @@
         "correlated_change_kind": {
           "type": "string",
           "description": "ADR-041 P0 roadmap item 2: for a public_api_internal_dependency_added finding correlated with the same public entry's own body/type-hash change this version, the correlated finding's ChangeKind value (e.g. 'inline_body_changed') — the structured sibling to the correlation already carried in the description prose."
+        },
+        "reviewer_action": {
+          "type": "string",
+          "description": "Finer-grained reviewer guidance, present only when recommended_action is 'no_action_required' (a COMPATIBLE addition). recommended_action alone only answers whether the old binary consumer needs to do anything (no); this answers whether a human reviewing the change has anything to check.",
+          "enum": [
+            "review_exhaustive_switches",
+            "document_stable_replacement",
+            "confirm_public_api_intent"
+          ]
         }
       }
     }

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -394,6 +394,32 @@ already use — so it can never disagree with them for the same finding:
 }
 ```
 
+### Reviewer guidance for additions (`reviewer_action`)
+
+`recommended_action: "no_action_required"` is accurate for the *old binary
+consumer* — nothing to recompile, nothing to relink — but collapses every
+addition to the same value even though a reviewer approving new public API
+surface almost always has something to check. Findings with
+`recommended_action: "no_action_required"` also carry a `reviewer_action`
+key with that finer-grained guidance; every other finding omits the key,
+since `recommended_action` itself is already reviewer-actionable there.
+
+| `reviewer_action` | When | Meaning |
+|---|---|---|
+| `review_exhaustive_switches` | kind `enum_member_added` | Old binaries are unaffected, but a source consumer's exhaustive `switch`/sentinel-value pattern may silently miss the new value. |
+| `document_stable_replacement` | kind `experimental_graduated` | An unstable API just became part of the stable support contract — document the change, don't just ship it. |
+| `confirm_public_api_intent` | every other addition | Confirm the new export was intentional (not an accidental symbol leak) and consider a release note. |
+
+```json
+{
+  "kind": "enum_member_added",
+  "symbol": "Color::PURPLE",
+  "severity": "compatible",
+  "recommended_action": "no_action_required",
+  "reviewer_action": "review_exhaustive_switches"
+}
+```
+
 ### Typed gate summary (`severity.blocking`, `severity.blocking_categories`)
 
 When `--severity-*` configuration is active, the top-level `severity` object

--- a/docs/user-guide/real-world-example.md
+++ b/docs/user-guide/real-world-example.md
@@ -267,7 +267,7 @@ are for the hypothetical `libfoo`:
 | Verdict | Meaning |
 |---------|---------|
 | ✅ NO_CHANGE | Identical ABI |
-| ✅ COMPATIBLE | Only additions (backward compatible) |
+| ✅ COMPATIBLE | No incompatible ABI/API changes — may include additions and quality findings (backward compatible) |
 | ⚠️ COMPATIBLE_WITH_RISK | Binary-compatible; verify target environment |
 | ⚠️ API_BREAK | Source-level API change — recompilation required |
 | ❌ BREAKING | Binary ABI break — recompilation required |

--- a/examples/case16_inline_to_non_inline/README.md
+++ b/examples/case16_inline_to_non_inline/README.md
@@ -84,7 +84,14 @@ abi-compliance-checker -lib fast_hash -v1 1.0 -v2 2.0 \
 
 ## Real Failure Demo
 
-**Severity: CRITICAL**
+**Severity: ⚠️ Requires coordinated deployment — not an ABI break**
+
+Existing binaries are unaffected (see "Why runtime result may differ from
+verdict" below) — the risk here is a *specific build-mismatch* scenario,
+not a break in any already-compiled consumer. See case47
+(`inline_to_outlined`) for the same mechanism on a class method, framed at
+the same severity, plus the compatibility matrix below spelling out
+exactly which of the four header/library combinations fails.
 
 **Scenario B — linker error:** compile app with v2.hpp (no inline), link against v1.so (no symbol).
 
@@ -104,11 +111,27 @@ g++ -std=c++17 -g app.cpp -I. -L. -lhash -Wl,-rpath,. -o app  # links OK
 # → fast_hash(42) = ...
 ```
 
-**Why CRITICAL:** Existing binaries compiled against v1 (inline) are unaffected —
-they have the inline body baked in. The break hits **new consumers**: any code compiled
-against v2.hpp (declaration only) that links against v1.so gets a hard linker error
-because the symbol doesn't exist in v1.so. This forces a coordinated upgrade:
-v2.hpp and v2.so must ship together.
+**Why this needs coordinated deployment (not a binary ABI break):**
+Existing binaries compiled against v1 (inline) are unaffected — they have
+the inline body baked in, and abicheck's COMPATIBLE verdict is correct
+for them. The failure hits **new consumers**: any code compiled against
+v2.hpp (declaration only) that links against v1.so gets a hard linker
+error because the symbol doesn't exist in v1.so. This forces v2.hpp and
+v2.so to ship together — a packaging/release-coordination requirement, not
+an ABI incompatibility abicheck's binary-vs-binary comparison would (or
+should) flag.
+
+## Compatibility matrix (consumer headers × runtime library)
+
+| Consumer built against | Runtime library | Result |
+|---|---|---|
+| v1 header (inline, no symbol) | v1.so | ✅ works — caller uses its own inlined copy |
+| v1 header (inline, no symbol) | v2.so (symbol exported) | ✅ works — caller's inlined copy is used; the new export is simply unused |
+| v2 header (declaration only) | v2.so (symbol exported) | ✅ works — caller resolves the exported symbol |
+| v2 header (declaration only) | v1.so (no symbol) | ❌ **link failure** — `fast_hash` was never exported by v1 |
+
+Only the last row fails, and it requires a specific build mismatch (new
+headers, old library) that a coordinated release naturally avoids.
 
 ## Why runtime result may differ from verdict
 Inline→non-inline: old binary uses inlined copy, runtime unaffected

--- a/examples/case47_inline_to_outlined/README.md
+++ b/examples/case47_inline_to_outlined/README.md
@@ -53,3 +53,27 @@ abidiff v1.abi v2.abi
 While ABI-compatible, moving inline→outlined is a **source-level change**: any
 consumer that relied on the inlined body being optimized away (e.g. in `constexpr`
 contexts or LTO-heavy builds) may see different behavior. Document the change.
+
+There is also a build-coordination risk that abicheck's binary-vs-binary
+COMPATIBLE verdict does not itself flag, since it compares two libraries,
+not a specific consumer's header/library pairing: a consumer compiled
+against **v2's** header (declaration only, no inline body) but linked
+against **v1's** `.so` (which never exported `add` — it was inline) gets a
+hard linker error, `undefined reference to Calculator::add(int, int)`.
+That's not an ABI break in the usual sense (no *existing* binary stops
+working), but it does mean v2's header and v2's `.so` must ship together —
+see the compatibility matrix below and case16 (`inline_to_non_inline`),
+which demonstrates the same mechanism with a free function and spells out
+that failure mode end to end.
+
+## Compatibility matrix (consumer headers × runtime library)
+
+| Consumer built against | Runtime `.so` | Result |
+|---|---|---|
+| v1 header (inline, no symbol) | v1 `.so` | ✅ works — caller uses its own inlined copy |
+| v1 header (inline, no symbol) | v2 `.so` (symbol exported) | ✅ works — caller's inlined copy is used; the new export is simply unused |
+| v2 header (declaration only) | v2 `.so` (symbol exported) | ✅ works — caller resolves the exported symbol |
+| v2 header (declaration only) | v1 `.so` (no symbol) | ❌ **link failure** — `add` was never exported by v1 |
+
+Only the last row fails, and it requires a specific build mismatch (new
+headers, old library) that a coordinated release naturally avoids.

--- a/examples/case62_type_field_added_compatible/README.md
+++ b/examples/case62_type_field_added_compatible/README.md
@@ -44,8 +44,19 @@ embed — that's breaking. This case demonstrates the safe pattern.
 
 ## What abicheck detects
 
-- **`TYPE_FIELD_ADDED`**: A new field was added to the struct.
 - **`FUNC_ADDED`**: `session_get_priority()` is a new symbol.
+
+`Session` is forward-declared only in the public header — its definition
+never appears in header-based diffing at all, so no type-level finding
+fires for it (not `TYPE_FIELD_ADDED`, not `TYPE_FIELD_ADDED_COMPATIBLE`).
+That's the point of the pattern: the struct's layout isn't part of the
+diffed public surface to begin with, so there's nothing to classify as
+"added" or "compatible" — it's simply invisible to the checker, which is
+exactly what makes it safe to change. (For an example where `TYPE_FIELD_ADDED_COMPATIBLE`
+actually fires on a *visible* struct's appended field, see case94 — there
+it's paired with a breaking `TYPE_SIZE_CHANGED` on the same struct, since
+the catalog does not yet have a case isolating a clean, standalone
+COMPATIBLE verdict driven by `TYPE_FIELD_ADDED_COMPATIBLE` alone.)
 
 **Overall verdict: COMPATIBLE**
 
@@ -58,7 +69,7 @@ gcc -shared -fPIC -g good.c -include good.h -o libgood.so
 python3 -m abicheck.cli dump libbad.so  -o /tmp/v1.json
 python3 -m abicheck.cli dump libgood.so -o /tmp/v2.json
 python3 -m abicheck.cli compare /tmp/v1.json /tmp/v2.json
-# → COMPATIBLE: TYPE_FIELD_ADDED, FUNC_ADDED
+# → COMPATIBLE: FUNC_ADDED
 ```
 
 ## Design pattern
@@ -87,4 +98,12 @@ struct Widget {
 - [How to Write Shared Libraries — Opaque Types](https://www.akkadia.org/drepper/dsohowto.pdf)
 
 
-Implementation note: v1 keeps reserved private storage in the opaque `Session` object; v2 consumes part of that storage for the new private `priority` field while preserving the public handle ABI. This keeps the case focused on a compatible private field addition rather than a public layout change.
+Implementation note: v1's private `Session` definition keeps a reserved
+`_reserved0` slot; v2 renames it to `priority` at the same offset and size.
+This keeps `sizeof(Session)` identical between versions — deliberately, so
+the case isolates *only* the opacity argument (the struct is invisible to
+header-based diffing either way) rather than also depending on
+`_filter_opaque_size_changes`' pointer-only-usage suppression of a growing
+`sizeof`. Since `Session` is never in the public header, none of this is
+visible to abicheck regardless — the private struct could have changed
+size too and the verdict would be identical.

--- a/tests/golden/compatible_addition.md
+++ b/tests/golden/compatible_addition.md
@@ -35,7 +35,8 @@
 
 ## ✅ Additions
 
-- New public function: helper
+- **func_added**: New public function: helper (`helper`)
+  > New function available; existing binaries are unaffected.
 
 ---
 ## Legend
@@ -43,7 +44,7 @@
 | Verdict | Meaning |
 |---------|---------|
 | ✅ NO_CHANGE | Identical ABI |
-| ✅ COMPATIBLE | Only additions (backward compatible) |
+| ✅ COMPATIBLE | No incompatible ABI/API changes — may include additions and quality findings (backward compatible) |
 | ⚠️ COMPATIBLE_WITH_RISK | Binary-compatible; verify target environment |
 | ⚠️ API_BREAK | Source-level API change — recompilation required |
 | ❌ BREAKING | Binary ABI break — recompilation required |

--- a/tests/golden/compatible_with_risk.md
+++ b/tests/golden/compatible_with_risk.md
@@ -57,7 +57,7 @@
 | Verdict | Meaning |
 |---------|---------|
 | ✅ NO_CHANGE | Identical ABI |
-| ✅ COMPATIBLE | Only additions (backward compatible) |
+| ✅ COMPATIBLE | No incompatible ABI/API changes — may include additions and quality findings (backward compatible) |
 | ⚠️ COMPATIBLE_WITH_RISK | Binary-compatible; verify target environment |
 | ⚠️ API_BREAK | Source-level API change — recompilation required |
 | ❌ BREAKING | Binary ABI break — recompilation required |

--- a/tests/golden/enum_change.md
+++ b/tests/golden/enum_change.md
@@ -44,7 +44,7 @@
 | Verdict | Meaning |
 |---------|---------|
 | ✅ NO_CHANGE | Identical ABI |
-| ✅ COMPATIBLE | Only additions (backward compatible) |
+| ✅ COMPATIBLE | No incompatible ABI/API changes — may include additions and quality findings (backward compatible) |
 | ⚠️ COMPATIBLE_WITH_RISK | Binary-compatible; verify target environment |
 | ⚠️ API_BREAK | Source-level API change — recompilation required |
 | ❌ BREAKING | Binary ABI break — recompilation required |

--- a/tests/golden/func_removed.md
+++ b/tests/golden/func_removed.md
@@ -44,7 +44,7 @@
 | Verdict | Meaning |
 |---------|---------|
 | ✅ NO_CHANGE | Identical ABI |
-| ✅ COMPATIBLE | Only additions (backward compatible) |
+| ✅ COMPATIBLE | No incompatible ABI/API changes — may include additions and quality findings (backward compatible) |
 | ⚠️ COMPATIBLE_WITH_RISK | Binary-compatible; verify target environment |
 | ⚠️ API_BREAK | Source-level API change — recompilation required |
 | ❌ BREAKING | Binary ABI break — recompilation required |

--- a/tests/golden/leaked_dependency_symbol.md
+++ b/tests/golden/leaked_dependency_symbol.md
@@ -43,7 +43,7 @@
 | Verdict | Meaning |
 |---------|---------|
 | ✅ NO_CHANGE | Identical ABI |
-| ✅ COMPATIBLE | Only additions (backward compatible) |
+| ✅ COMPATIBLE | No incompatible ABI/API changes — may include additions and quality findings (backward compatible) |
 | ⚠️ COMPATIBLE_WITH_RISK | Binary-compatible; verify target environment |
 | ⚠️ API_BREAK | Source-level API change — recompilation required |
 | ❌ BREAKING | Binary ABI break — recompilation required |

--- a/tests/golden/no_change.md
+++ b/tests/golden/no_change.md
@@ -40,7 +40,7 @@ _No ABI changes detected._
 | Verdict | Meaning |
 |---------|---------|
 | ✅ NO_CHANGE | Identical ABI |
-| ✅ COMPATIBLE | Only additions (backward compatible) |
+| ✅ COMPATIBLE | No incompatible ABI/API changes — may include additions and quality findings (backward compatible) |
 | ⚠️ COMPATIBLE_WITH_RISK | Binary-compatible; verify target environment |
 | ⚠️ API_BREAK | Source-level API change — recompilation required |
 | ❌ BREAKING | Binary ABI break — recompilation required |

--- a/tests/golden/struct_size_change.md
+++ b/tests/golden/struct_size_change.md
@@ -39,7 +39,8 @@
 
 ## ✅ Additions
 
-- Field added: Point::z
+- **type_field_added_compatible**: Field added: Point::z
+  > Field appended without changing existing offsets; old code works but won't initialize the new field.
 
 ---
 ## Legend
@@ -47,7 +48,7 @@
 | Verdict | Meaning |
 |---------|---------|
 | ✅ NO_CHANGE | Identical ABI |
-| ✅ COMPATIBLE | Only additions (backward compatible) |
+| ✅ COMPATIBLE | No incompatible ABI/API changes — may include additions and quality findings (backward compatible) |
 | ⚠️ COMPATIBLE_WITH_RISK | Binary-compatible; verify target environment |
 | ⚠️ API_BREAK | Source-level API change — recompilation required |
 | ❌ BREAKING | Binary ABI break — recompilation required |

--- a/tests/test_action_run_sh_severity_summary.py
+++ b/tests/test_action_run_sh_severity_summary.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for ``action/run.sh``'s SEVERITY_ERROR Job Summary line.
+
+Verified defect (companion to the ``pr_comment.py`` "ABI BREAKING" fix): the
+Job Summary previously wrote a bare "Severity-level issue detected" for exit
+code 1, which does not tell the reader *which* severity-config category
+gated the check — in particular it looks identical whether a real risk was
+promoted or a COMPATIBLE addition/quality finding was blocked by policy
+(``severity-addition: error`` et al.). This extracts the real ``case
+$VERDICT in ... esac`` block from ``run.sh`` (the same "parse the real file,
+don't hand-copy it" discipline as ``test_action_run_sh_summary.py``) so a
+future edit to the real logic is exercised here too.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+
+RUN_SH = Path(__file__).resolve().parents[1] / "action" / "run.sh"
+_START_MARKER = "case $VERDICT in"
+_END_MARKER = "    esac"
+
+
+def _verdict_case_region() -> str:
+    """The Job Summary's ``case $VERDICT in ... esac`` block, verbatim."""
+    text = RUN_SH.read_text(encoding="utf-8")
+    start = text.index(_START_MARKER)
+    end = text.index(_END_MARKER, start) + len(_END_MARKER)
+    return text[start:end]
+
+
+def _bash_executable() -> str:
+    """Resolve a real bash, bypassing Windows' WSL-launcher stub.
+
+    See ``test_action_run_sh_helpers._bash_executable`` for the full
+    rationale (GitHub windows-latest runners resolve a bare "bash" to a
+    non-functional WSL stub ahead of Git for Windows' real bash).
+    """
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
+def _run(env_overrides: dict[str, str]) -> str:
+    """Run the extracted VERDICT-case snippet, return its stdout."""
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".sh", delete=False, encoding="utf-8", newline="\n",
+    ) as f:
+        f.write(_verdict_case_region())
+        script_path = f.name
+    env = dict(os.environ)
+    env.update(env_overrides)
+    try:
+        result = subprocess.run(
+            [_bash_executable(), script_path],
+            capture_output=True, text=True, encoding="utf-8", env=env,
+        )
+    finally:
+        os.unlink(script_path)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"harness script failed (exit {result.returncode})\n"
+            f"--- stdout ---\n{result.stdout}\n"
+            f"--- stderr ---\n{result.stderr}"
+        )
+    return result.stdout
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="action/run.sh not found")
+@pytest.mark.skipif(shutil.which("jq") is None, reason="jq not on PATH")
+class TestSeverityErrorSummaryLine:
+    def test_names_blocking_category_from_json_report(self, tmp_path) -> None:
+        report = tmp_path / "report.json"
+        report.write_text(
+            json.dumps({"severity": {"blocking_categories": ["addition"]}}),
+            encoding="utf-8",
+        )
+        out = _run(
+            {
+                "VERDICT": "SEVERITY_ERROR",
+                "FORMAT": "json",
+                "OUTPUT_FILE": str(report),
+                "ABICHECK_EXIT": "1",
+            }
+        )
+        assert "`addition` configured as `error`" in out
+        # Must not read as an ABI/API break when it's only a policy gate.
+        assert "ABI BREAKING" not in out
+        assert "policy gate, not necessarily an ABI/API break" in out
+
+    def test_joins_multiple_blocking_categories(self, tmp_path) -> None:
+        report = tmp_path / "report.json"
+        report.write_text(
+            json.dumps(
+                {"severity": {"blocking_categories": ["addition", "quality_issues"]}}
+            ),
+            encoding="utf-8",
+        )
+        out = _run(
+            {
+                "VERDICT": "SEVERITY_ERROR",
+                "FORMAT": "json",
+                "OUTPUT_FILE": str(report),
+                "ABICHECK_EXIT": "1",
+            }
+        )
+        assert "addition, quality_issues" in out
+
+    def test_falls_back_to_generic_message_without_json(self, tmp_path) -> None:
+        # FORMAT is markdown (the action default) -- no JSON report to read
+        # `blocking_categories` from, so the generic message is kept.
+        out = _run(
+            {
+                "VERDICT": "SEVERITY_ERROR",
+                "FORMAT": "markdown",
+                "OUTPUT_FILE": "",
+                "ABICHECK_EXIT": "1",
+            }
+        )
+        assert "Severity-level issue detected" in out
+        assert "configured as `error`" not in out
+
+    def test_falls_back_when_blocking_categories_empty(self, tmp_path) -> None:
+        report = tmp_path / "report.json"
+        report.write_text(json.dumps({"severity": {"blocking_categories": []}}), encoding="utf-8")
+        out = _run(
+            {
+                "VERDICT": "SEVERITY_ERROR",
+                "FORMAT": "json",
+                "OUTPUT_FILE": str(report),
+                "ABICHECK_EXIT": "1",
+            }
+        )
+        assert "Severity-level issue detected" in out
+
+    def test_other_verdicts_unaffected(self) -> None:
+        out = _run({"VERDICT": "COMPATIBLE", "FORMAT": "markdown", "ABICHECK_EXIT": "0"})
+        assert "No binary ABI break detected" in out

--- a/tests/test_action_run_sh_severity_summary.py
+++ b/tests/test_action_run_sh_severity_summary.py
@@ -135,17 +135,73 @@ class TestSeverityErrorSummaryLine:
 
     def test_falls_back_to_generic_message_without_json(self, tmp_path) -> None:
         # FORMAT is markdown (the action default) -- no JSON report to read
-        # `blocking_categories` from, so the generic message is kept.
+        # `blocking_categories` from (PR_JSON explicitly unset too, so this
+        # doesn't depend on there being no ambient PR_JSON in the test
+        # runner's own environment), so the generic message is kept.
         out = _run(
             {
                 "VERDICT": "SEVERITY_ERROR",
                 "FORMAT": "markdown",
                 "OUTPUT_FILE": "",
+                "PR_JSON": "",
                 "ABICHECK_EXIT": "1",
             }
         )
         assert "Severity-level issue detected" in out
         assert "configured as `error`" not in out
+
+    def test_names_blocking_category_from_pr_json_when_format_is_markdown(
+        self, tmp_path
+    ) -> None:
+        # Codex review, PR #595: the common case is FORMAT=markdown (the
+        # action default) with PR comments on, where the compare-mode
+        # command setup already asks the same abicheck invocation to write
+        # an always-unfiltered secondary JSON report to $PR_JSON (via
+        # --secondary-format/--secondary-output) before this Job Summary
+        # code runs -- that must be read too, not just a FORMAT=json
+        # primary output, or the common default-config case never gets the
+        # category-aware message.
+        report = tmp_path / "pr.json"
+        report.write_text(
+            json.dumps({"severity": {"blocking_categories": ["addition"]}}),
+            encoding="utf-8",
+        )
+        out = _run(
+            {
+                "VERDICT": "SEVERITY_ERROR",
+                "FORMAT": "markdown",
+                "OUTPUT_FILE": "",
+                "PR_JSON": str(report),
+                "ABICHECK_EXIT": "1",
+            }
+        )
+        assert "`addition` configured as `error`" in out
+        assert "Severity-level issue detected" not in out
+
+    def test_prefers_primary_json_output_over_pr_json(self, tmp_path) -> None:
+        # When FORMAT=json, OUTPUT_FILE is the primary (unfiltered) report
+        # and should win over a stale/mismatched $PR_JSON if both are set.
+        primary = tmp_path / "primary.json"
+        primary.write_text(
+            json.dumps({"severity": {"blocking_categories": ["quality_issues"]}}),
+            encoding="utf-8",
+        )
+        pr_json = tmp_path / "pr.json"
+        pr_json.write_text(
+            json.dumps({"severity": {"blocking_categories": ["addition"]}}),
+            encoding="utf-8",
+        )
+        out = _run(
+            {
+                "VERDICT": "SEVERITY_ERROR",
+                "FORMAT": "json",
+                "OUTPUT_FILE": str(primary),
+                "PR_JSON": str(pr_json),
+                "ABICHECK_EXIT": "1",
+            }
+        )
+        assert "`quality_issues` configured as `error`" in out
+        assert "addition" not in out
 
     def test_falls_back_when_blocking_categories_empty(self, tmp_path) -> None:
         report = tmp_path / "report.json"

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -938,6 +938,26 @@ def test_full_detail_expands_all_sections():
     assert body.count("<details open>") == 3
 
 
+def test_safe_quality_section_full_detail_table_with_rows():
+    # Quality-only compatible findings keep their own per-symbol table in
+    # full detail — the fixture above is all-additions, so this exercises
+    # the "✅ Safe" section's full-detail path specifically.
+    report = _compare_report(
+        [
+            {
+                "kind": "soname_bump_unnecessary",
+                "symbol": "libfoo",
+                "description": "unnecessary bump",
+                "severity": "compatible",
+            },
+        ]
+    )
+    body = render_comment(build_model(report), sha="x", detail="full")
+    assert "✅ Safe (1)" in body
+    assert "soname_bump_unnecessary" in body
+    assert "unnecessary bump" in body
+
+
 def test_standard_truncates_large_breaking_table():
     changes = [
         {
@@ -1112,7 +1132,64 @@ def test_finding_with_only_location_renders_location_cell():
     assert "foo.h:9" in body
 
 
-def test_safe_section_caps_symbols_per_kind():
+def test_safe_quality_section_caps_symbols_per_kind():
+    # Quality (non-addition) compatible findings keep the terse
+    # kind:symbols-with-cap rendering in the "✅ Safe" section — additions
+    # are split out into their own section (see tests below) and use a
+    # different (per-symbol table) rendering, so this cap only applies here.
+    changes = [
+        {
+            "kind": "soname_bump_unnecessary",
+            "symbol": f"lib_{i}",
+            "description": "unnecessary bump",
+            "severity": "compatible",
+        }
+        for i in range(20)
+    ]
+    body = render_comment(build_model(_compare_report(changes)), sha="x")
+    assert "(+8)" in body  # 20 symbols, cap 12 → "+8" more
+    assert "➕ Public API additions" not in body
+
+
+def test_additions_render_as_own_section_with_detail():
+    # New public-API surface gets its own "➕ Public API additions" table
+    # with kind/symbol/detail/location — not folded into the generic quality
+    # "Safe" list (a reviewer approving a new export wants to see what was
+    # added, not just a bare count mixed in with unrelated quality notes).
+    report = _compare_report(
+        [
+            {
+                "kind": "func_added",
+                "symbol": "foo_v2",
+                "description": "new exported function",
+                "severity": "compatible",
+                "source_location": "foo.h:42",
+            },
+            {
+                "kind": "soname_bump_unnecessary",
+                "symbol": "libfoo",
+                "description": "SONAME bumped without a break",
+                "severity": "compatible",
+            },
+        ]
+    )
+    body = render_comment(build_model(report), sha="x")
+    assert "➕ Public API additions (1)" in body
+    assert "✅ Safe (1)" in body
+    # the addition shows the same per-symbol detail as Breaking/Needs review
+    assert "new exported function" in body
+    assert "foo.h:42" in body
+    # the addition doesn't leak into the quality-only Safe section
+    additions_block = body.split("➕ Public API additions")[1].split("✅ Safe")[0]
+    assert "foo_v2" in additions_block
+    assert "libfoo" not in additions_block
+
+
+def test_additions_section_lists_all_distinct_symbols_under_row_cap():
+    # 20 distinct addition symbols (no natural API grouping) all render as
+    # their own row — additions go through the same per-symbol table/rollup
+    # as Breaking/Needs review, not the terse kind:symbols-list-with-cap
+    # format the quality-only Safe section still uses.
     changes = [
         {
             "kind": "func_added",
@@ -1123,7 +1200,56 @@ def test_safe_section_caps_symbols_per_kind():
         for i in range(20)
     ]
     body = render_comment(build_model(_compare_report(changes)), sha="x")
-    assert "(+8)" in body  # 20 symbols, cap 12 → "+8" more
+    assert "➕ Public API additions (20)" in body
+    assert "add_0" in body and "add_19" in body
+    assert "more_" not in body  # 20 < the 25-row standard cap
+
+
+def test_additions_section_truncates_past_standard_row_cap():
+    changes = [
+        {
+            "kind": "func_added",
+            "symbol": f"add_{i}",
+            "description": "new",
+            "severity": "compatible",
+        }
+        for i in range(30)
+    ]
+    body = render_comment(build_model(_compare_report(changes)), sha="x")
+    assert "➕ Public API additions (30)" in body
+    assert "more_" in body  # 30 > the 25-row standard cap
+
+
+def test_additions_section_absent_when_only_quality_findings():
+    report = _compare_report(
+        [
+            {
+                "kind": "soname_bump_unnecessary",
+                "symbol": "libfoo",
+                "description": "unnecessary bump",
+                "severity": "compatible",
+            },
+        ]
+    )
+    body = render_comment(build_model(report), sha="x")
+    assert "➕ Public API additions" not in body
+    assert "✅ Safe (1)" in body
+
+
+def test_additions_section_full_detail_flat_rows():
+    changes = [
+        {
+            "kind": "func_added",
+            "symbol": f"Widget::method{i}(int)",
+            "description": "new overload",
+            "severity": "compatible",
+        }
+        for i in range(3)
+    ]
+    body = render_comment(build_model(_compare_report(changes)), sha="x", detail="full")
+    # full detail keeps every addition as its own per-symbol row (no rollup)
+    assert "Widget::method0(int)" in body
+    assert "`Widget` (3)" not in body
 
 
 def test_release_full_detail_table_with_rows():

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -23,6 +23,7 @@ import pytest
 from abicheck.pr_comment import (
     MARKER,
     CommentModel,
+    Finding,
     build_model,
     render_comment,
     should_post,
@@ -395,6 +396,189 @@ def test_gate_api_break_files_api_break_as_breaking():
     # default (ungated) keeps api_break in review
     ungated = build_model(report)
     assert ungated.counts == (0, 2, 0)
+
+
+def test_severity_potential_breaking_error_risk_only_not_worded_as_source_break():
+    # "api_break" and "risk" share the "potential_breaking" severity-config
+    # category, but a risk-only gate is not a source API break — the
+    # headline must say so distinctly (Codex review, PR #595).
+    report = _compare_report(
+        [
+            {
+                "kind": "type_field_added",
+                "symbol": "S",
+                "description": "d",
+                "severity": "risk",
+            },
+        ]
+    )
+    report["severity"] = {"config": {"potential_breaking": "error"}, "exit_code": 1}
+    model = build_model(report)
+    assert model.counts == (1, 0, 0)
+    assert model.breaking_categories == frozenset({"potential_breaking"})
+    assert model.breaking_severities == frozenset({"risk"})
+    body = render_comment(model, sha="x")
+    assert "ABI BREAKING" not in body
+    assert "Source API break" not in body
+    assert "Compatibility risk blocks this PR" in body
+
+
+def test_severity_potential_breaking_error_api_break_worded_as_source_break():
+    # The api_break sibling of the case above: this one genuinely is a
+    # source-level API break, so it keeps the "Source API break" wording.
+    report = _compare_report(
+        [
+            {
+                "kind": "enum_member_added",
+                "symbol": "E::X",
+                "description": "d",
+                "severity": "api_break",
+            },
+        ]
+    )
+    report["severity"] = {"config": {"potential_breaking": "error"}, "exit_code": 1}
+    model = build_model(report)
+    assert model.breaking_severities == frozenset({"api_break"})
+    body = render_comment(model, sha="x")
+    assert "Source API break blocks this PR" in body
+
+
+def test_severity_potential_breaking_error_release_risk_only_not_source_break():
+    # Release-mode twin: risk_changes (not source_breaks) promoted by
+    # potential_breaking=error must not read as a "source API break" either.
+    report = {
+        "verdict": "COMPATIBLE_WITH_RISK",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [
+            {
+                "library": "lib.so",
+                "verdict": "COMPATIBLE_WITH_RISK",
+                "breaking": 0,
+                "source_breaks": 0,
+                "risk_changes": 3,
+                "compatible_additions": 0,
+            },
+        ],
+        "severity": {"config": {"potential_breaking": "error"}, "exit_code": 1},
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    model = build_model(report)
+    assert model.counts == (3, 0, 0)
+    assert model.breaking_severities == frozenset({"risk"})
+    body = render_comment(model, sha="x")
+    assert "Source API break" not in body
+    assert "Compatibility risk blocks this PR" in body
+
+
+def test_severity_potential_breaking_error_release_api_break_source_break():
+    # Release-mode twin: source_breaks promoted by potential_breaking=error
+    # (without fail-on-api-break) is a genuine source API break.
+    report = {
+        "verdict": "API_BREAK",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [
+            {
+                "library": "lib.so",
+                "verdict": "API_BREAK",
+                "breaking": 0,
+                "source_breaks": 2,
+                "risk_changes": 0,
+                "compatible_additions": 0,
+            },
+        ],
+        "severity": {"config": {"potential_breaking": "error"}, "exit_code": 1},
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    model = build_model(report)
+    assert model.counts == (2, 0, 0)
+    assert model.breaking_severities == frozenset({"api_break"})
+    body = render_comment(model, sha="x")
+    assert "Source API break blocks this PR" in body
+
+
+def test_severity_potential_breaking_error_release_global_risk_section():
+    # A release-global (bundle/matrix) COMPATIBLE_WITH_RISK section promoted
+    # by potential_breaking=error is a risk, not a source API break.
+    report = {
+        "verdict": "COMPATIBLE_WITH_RISK",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [],
+        "matrix_verdict": "COMPATIBLE_WITH_RISK",
+        "matrix_findings": [
+            {"kind": "macro_guarded", "symbol": "FOO", "description": "z"},
+        ],
+        "severity": {"config": {"potential_breaking": "error"}, "exit_code": 1},
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    model = build_model(report)
+    assert model.counts == (1, 0, 0)
+    assert model.breaking_severities == frozenset({"risk"})
+    body = render_comment(model, sha="x")
+    assert "Source API break" not in body
+    assert "Compatibility risk blocks this PR" in body
+
+
+def test_gate_api_break_release_global_api_break_worded_as_source_break():
+    # A release-global section whose own verdict IS API_BREAK, promoted to
+    # Breaking directly via fail-on-api-break's verdict_map override (not via
+    # the potential_breaking=error "review"→"breaking" promotion path) — the
+    # `if bucket == "breaking":` branch must still classify it as a source
+    # break, not silently mis-tag it as a binary ABI break.
+    report = {
+        "verdict": "API_BREAK",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [],
+        "matrix_verdict": "API_BREAK",
+        "matrix_findings": [
+            {"kind": "macro_guarded", "symbol": "FOO", "description": "z"},
+        ],
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    model = build_model(report, gate_api_break=True)
+    assert model.breaking_categories == frozenset({"potential_breaking"})
+    assert model.breaking_severities == frozenset({"api_break"})
+    body = render_comment(model, sha="x")
+    assert "ABI BREAKING" not in body
+    assert "Source API break blocks this PR" in body
+
+
+def test_release_lib_row_zero_gated_additions_and_quality_add_no_category():
+    # add_err/qual_err gate a library with zero additions/quality findings —
+    # the count contribution is (correctly) zero, and it must not spuriously
+    # add "addition"/"quality_issues" to breaking_categories for an empty set.
+    report = {
+        "verdict": "BREAKING",
+        "old_dir": "/o",
+        "new_dir": "/n",
+        "libraries": [
+            {
+                "library": "lib.so",
+                "verdict": "BREAKING",
+                "breaking": 2,
+                "source_breaks": 0,
+                "risk_changes": 0,
+                "compatible_additions": 0,
+                "quality_issues": 0,
+            },
+        ],
+        "severity": {
+            "config": {"addition": "error", "quality_issues": "error"},
+            "exit_code": 1,
+        },
+        "unmatched_old": [],
+        "unmatched_new": [],
+    }
+    model = build_model(report)
+    assert model.counts == (2, 0, 0)
+    assert model.breaking_categories == frozenset({"abi_breaking"})
 
 
 def test_gate_api_break_release_source_breaks_count_as_breaking():
@@ -952,6 +1136,43 @@ def test_empty_model_renders_clean_verdict():
     body = render_comment(model, sha="")
     assert "No ABI changes" in body
     assert MARKER in body
+
+
+def test_header_potential_breaking_with_no_severity_falls_back_to_source_break():
+    # Defensive fallback: a "potential_breaking" bucket should always carry
+    # an "api_break" or "risk" severity in practice (every code path that
+    # sets the category sets the severity alongside it) — but if it somehow
+    # didn't, the header must still say something, not crash or go silent.
+    model = CommentModel(
+        mode="compare",
+        subject="lib",
+        old_label="o",
+        new_label="n",
+        policy="strict_abi",
+        breaking=[Finding(kind="k", symbol="s", category="potential_breaking")],
+        breaking_categories=frozenset({"potential_breaking"}),
+    )
+    body = render_comment(model, sha="x")
+    assert "Source API break blocks this PR" in body
+
+
+def test_header_untracked_category_falls_back_to_abi_breaking():
+    # Defensive fallback: every mode is supposed to populate
+    # breaking_categories from a known set ("abi_breaking" /
+    # "potential_breaking" / "addition" / "quality_issues") — if a bucket is
+    # non-empty with an unrecognised category, err conservative rather than
+    # silently rendering no headline at all.
+    model = CommentModel(
+        mode="compare",
+        subject="lib",
+        old_label="o",
+        new_label="n",
+        policy="strict_abi",
+        breaking=[Finding(kind="k", symbol="s")],
+        breaking_categories=frozenset({"unrecognised_category"}),
+    )
+    body = render_comment(model, sha="x")
+    assert "## ❌ abicheck — ABI BREAKING" in body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -656,6 +656,38 @@ def test_severity_addition_error_files_additions_as_breaking():
     assert build_model(plain).counts == (0, 0, 1)
 
 
+def test_severity_addition_error_with_ungated_review_finding_scopes_gate_note():
+    # A gated addition (policy-only Breaking bucket) alongside a separate,
+    # *ungated* api_break sitting in "Needs review" must not claim whole-
+    # report "Compatibility: COMPATIBLE" — that overstates it, since the
+    # review finding may itself be an incompatibility (Codex review, #595).
+    report = _compare_report(
+        [
+            {
+                "kind": "func_added",
+                "symbol": "foo_new",
+                "description": "new",
+                "severity": "compatible",
+            },
+            {
+                "kind": "enum_member_added",
+                "symbol": "E::X",
+                "description": "d",
+                "severity": "api_break",
+            },
+        ]
+    )
+    report["severity"] = {"config": {"addition": "error"}, "exit_code": 1}
+    model = build_model(report)
+    assert model.counts == (1, 1, 0)  # addition → breaking, api_break → review
+    body = render_comment(model, sha="x")
+    assert "Public API expansion requires approval" in body
+    assert "Compatibility: COMPATIBLE" not in body
+    assert "Gate: BLOCKED" in body
+    assert "`addition` is configured as `error`" in body
+    assert "Needs review" in body
+
+
 def test_severity_addition_error_classifies_non_added_kinds():
     # Addition kinds that don't end in "_added" must still be treated as
     # additions (sourced from ADDITION_KINDS), so severity-addition: error files

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -387,7 +387,11 @@ def test_gate_api_break_files_api_break_as_breaking():
     gated = build_model(report, gate_api_break=True)
     assert gated.counts == (1, 1, 0)  # api_break → breaking, risk stays review
     body = render_comment(gated, sha="x")
-    assert "ABI BREAKING" in body
+    # A gated *source* API break is not a binary ABI break — it gets its own
+    # headline rather than being folded into "ABI BREAKING" (ADR-042: the
+    # compatibility and gate axes are independent).
+    assert "ABI BREAKING" not in body
+    assert "Source API break blocks this PR" in body
     # default (ungated) keeps api_break in review
     ungated = build_model(report)
     assert ungated.counts == (0, 2, 0)
@@ -443,7 +447,17 @@ def test_severity_addition_error_files_additions_as_breaking():
     }
     gated = build_model(report)
     assert gated.counts == (1, 0, 0)  # addition → breaking
-    assert "ABI BREAKING" in render_comment(gated, sha="x")
+    assert gated.breaking_categories == frozenset({"addition"})
+    body = render_comment(gated, sha="x")
+    # A policy-gated COMPATIBLE addition is not an ABI break: the checker
+    # still reports COMPATIBLE, only the CI *gate* is blocked (ADR-042).
+    # "ABI BREAKING" would tell the reviewer the wrong thing.
+    assert "ABI BREAKING" not in body
+    assert "Public API expansion requires approval" in body
+    assert "Compatibility: COMPATIBLE" in body
+    assert "Gate: BLOCKED" in body
+    assert "`addition` is configured as `error`" in body
+    assert "foo_new" in body
     # without the severity config, the same addition stays safe
     plain = _compare_report(
         [
@@ -503,7 +517,12 @@ def test_severity_quality_error_release_quality_breaking():
         "unmatched_new": [],
     }
     # quality (2) → breaking, additions (5-2=3) → safe
-    assert build_model(report).counts == (2, 0, 3)
+    model = build_model(report)
+    assert model.counts == (2, 0, 3)
+    assert model.breaking_categories == frozenset({"quality_issues"})
+    body = render_comment(model, sha="x")
+    assert "ABI BREAKING" not in body
+    assert "Quality policy violation" in body
 
 
 def test_severity_addition_error_release_additions_breaking():
@@ -525,7 +544,74 @@ def test_severity_addition_error_release_additions_breaking():
         "unmatched_old": [],
         "unmatched_new": [],
     }
-    assert build_model(report).counts == (4, 0, 0)
+    model = build_model(report)
+    assert model.counts == (4, 0, 0)
+    assert model.breaking_categories == frozenset({"addition"})
+    body = render_comment(model, sha="x")
+    # Release-mode rows don't carry per-finding detail, but the headline must
+    # still avoid "ABI BREAKING" for a policy-gated COMPATIBLE release.
+    assert "ABI BREAKING" not in body
+    assert "Public API expansion requires approval" in body
+
+
+def test_severity_addition_and_quality_both_gated_mixed_headline():
+    # Both categories gated and both contribute findings → neither
+    # single-category headline fits; use the generic policy-violation one
+    # (still never "ABI BREAKING").
+    report = _compare_report(
+        [
+            {
+                "kind": "func_added",
+                "symbol": "foo_new",
+                "description": "new",
+                "severity": "compatible",
+            },
+            {
+                "kind": "soname_bump_unnecessary",
+                "symbol": "libfoo",
+                "description": "unnecessary bump",
+                "severity": "compatible",
+            },
+        ]
+    )
+    report["severity"] = {
+        "config": {"addition": "error", "quality_issues": "error"},
+        "exit_code": 1,
+    }
+    model = build_model(report)
+    assert model.breaking_categories == frozenset({"addition", "quality_issues"})
+    body = render_comment(model, sha="x")
+    assert "ABI BREAKING" not in body
+    assert "Policy violation blocks this PR" in body
+
+
+def test_severity_addition_error_mixed_with_real_break_stays_abi_breaking():
+    # A real ABI break alongside a gated addition must still headline as
+    # "ABI BREAKING" — the addition doesn't dilute a genuine incompatibility.
+    report = _compare_report(
+        [
+            {
+                "kind": "func_removed",
+                "symbol": "foo_gone",
+                "description": "removed",
+                "severity": "breaking",
+            },
+            {
+                "kind": "func_added",
+                "symbol": "foo_new",
+                "description": "new",
+                "severity": "compatible",
+            },
+        ]
+    )
+    report["severity"] = {"config": {"addition": "error"}, "exit_code": 1}
+    model = build_model(report)
+    assert model.breaking_categories == frozenset({"abi_breaking", "addition"})
+    body = render_comment(model, sha="x")
+    assert "ABI BREAKING" in body
+    # The genuine break takes priority; no policy-only gate note is shown
+    # since the bucket isn't policy-only.
+    assert "Gate: BLOCKED" not in body
 
 
 def test_malformed_changes_are_skipped():

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -149,6 +149,27 @@ class TestReportValidatesAgainstSchema:
         )
         self._validate(payload)
 
+    def test_addition_reviewer_action_validates_against_packaged_schema(self):
+        # Regression guard (Codex review, PR #595): reviewer_action was added
+        # to reporter.py and the *docs* schema copy, but the packaged schema
+        # abicheck/schemas/compare_report.schema.json -- what
+        # load_compare_report_schema() actually reads at runtime -- was left
+        # stale. jsonschema.validate would still pass a stale schema (its
+        # "change" object has additionalProperties: true), so this doesn't
+        # just check "no error" -- it asserts the field the real payload
+        # carries is the one actually declared in the packaged schema's enum.
+        old, new = _breaking_pair()
+        payload = json.loads(reporter.to_json(compare(old, new)))
+        self._validate(payload)
+        additions = [
+            c for c in payload["changes"] if c.get("recommended_action") == "no_action_required"
+        ]
+        assert additions, "fixture must produce at least one addition finding"
+        schema = load_compare_report_schema()
+        declared_enum = schema["$defs"]["change"]["properties"]["reviewer_action"]["enum"]
+        for c in additions:
+            assert c["reviewer_action"] in declared_enum
+
 
 class TestSchemaVersion:
     def test_emitted_version_matches_constant(self):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -167,9 +167,9 @@ class TestEvidenceStatusInJson:
         d = json.loads(to_json(r))
         assert d["changes"][0]["evidence_status"] == "not_checkable"
 
-    def test_report_schema_version_is_2_5(self):
+    def test_report_schema_version_is_2_6(self):
         d = json.loads(to_json(_result(Verdict.NO_CHANGE)))
-        assert d["report_schema_version"] == "2.5"
+        assert d["report_schema_version"] == "2.6"
 
     def test_change_operation_field(self):
         added = Change(ChangeKind.FUNC_ADDED, "s1", "added")
@@ -225,6 +225,52 @@ class TestEvidenceStatusInJson:
         # func_removed is not itself an addition kind -> quality issue, not
         # "no action required".
         assert d["changes"][0]["recommended_action"] == "review_recommended"
+
+    def test_reviewer_action_present_only_for_additions(self):
+        # reviewer_action refines the ambiguous "no_action_required" bucket
+        # with what a *reviewer* (not the old binary consumer) should check;
+        # every other verdict already has reviewer-actionable guidance via
+        # recommended_action itself, so the key is omitted there.
+        breaking = Change(ChangeKind.FUNC_REMOVED, "s1", "removed")
+        api_break = Change(ChangeKind.FIELD_RENAMED, "s2", "renamed")
+        risk = Change(ChangeKind.SYMBOL_VERSION_REQUIRED_ADDED, "s3", "version req added")
+        quality = Change(ChangeKind.VISIBILITY_LEAK, "s4", "visibility leak")
+        addition = Change(ChangeKind.FUNC_ADDED, "s5", "added")
+        r = _result(
+            Verdict.BREAKING,
+            changes=[breaking, api_break, risk, quality, addition],
+        )
+        d = json.loads(to_json(r))
+        by_symbol = {c["symbol"]: c for c in d["changes"]}
+        for sym in ("s1", "s2", "s3", "s4"):
+            assert "reviewer_action" not in by_symbol[sym]
+        assert by_symbol["s5"]["reviewer_action"] == "confirm_public_api_intent"
+
+    def test_reviewer_action_per_kind_overrides(self):
+        enum_member = Change(ChangeKind.ENUM_MEMBER_ADDED, "E::X", "added")
+        graduated = Change(ChangeKind.EXPERIMENTAL_GRADUATED, "foo_v2", "graduated")
+        r = _result(Verdict.COMPATIBLE, changes=[enum_member, graduated])
+        d = json.loads(to_json(r))
+        by_symbol = {c["symbol"]: c["reviewer_action"] for c in d["changes"]}
+        assert by_symbol == {
+            "E::X": "review_exhaustive_switches",
+            "foo_v2": "document_stable_replacement",
+        }
+
+    def test_reviewer_action_honours_policy_file_override(self):
+        """A kind demoted to COMPATIBLE by a policy override, and classified
+        as an addition, must still get reviewer_action — same effective-
+        verdict/category resolver recommended_action uses."""
+        from abicheck.policy_file import PolicyFile
+
+        c = Change(ChangeKind.FUNC_ADDED, "s", "added")
+        pf = PolicyFile(overrides={ChangeKind.FUNC_ADDED: Verdict.COMPATIBLE})
+        r = DiffResult(
+            old_version="1.0", new_version="2.0", library="libtest.so",
+            changes=[c], verdict=Verdict.COMPATIBLE, policy_file=pf,
+        )
+        d = json.loads(to_json(r))
+        assert d["changes"][0]["reviewer_action"] == "confirm_public_api_intent"
 
     def test_finding_id_is_stable_and_deterministic(self):
         """Same underlying finding -> same finding_id across independent runs."""
@@ -369,6 +415,17 @@ class TestEvidenceStatusInJson:
         d = json.loads(to_json(r, report_mode="leaf"))
         assert d["leaf_changes"][0]["recommended_action"] == "recompile_and_relink_required"
         assert d["changes"][0]["recommended_action"] == "recompile_and_relink_required"
+
+    def test_leaf_mode_root_type_change_carries_reviewer_action(self):
+        # enum_member_added is both a root-type-change kind (routed through
+        # _leaf_entry, which builds its own dict rather than reusing
+        # _change_to_dict) and an addition -- must carry reviewer_action in
+        # both leaf_changes[] and changes[], matching full-mode entries.
+        c = Change(ChangeKind.ENUM_MEMBER_ADDED, "E::X", "added")
+        r = _result(Verdict.COMPATIBLE, changes=[c])
+        d = json.loads(to_json(r, report_mode="leaf"))
+        assert d["leaf_changes"][0]["reviewer_action"] == "review_exhaustive_switches"
+        assert d["changes"][0]["reviewer_action"] == "review_exhaustive_switches"
 
     def test_leaf_mode_root_type_change_honours_frozen_namespace_floor(self):
         """Codex review on #549: a policy-file override that demotes a root

--- a/tests/test_sprint9_html.py
+++ b/tests/test_sprint9_html.py
@@ -520,6 +520,61 @@ def test_gate_card_fails_for_addition_promoted_to_error() -> None:
     assert "FAIL (exit 1)" in out
 
 
+def test_gate_card_names_blocking_category_for_addition() -> None:
+    """The CI Gate card must name *which* category gated CI (`addition`
+    here), not just show an undifferentiated FAIL — same category-naming
+    already added to the sticky PR comment and the Action's Job Summary."""
+    from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+    from abicheck.severity import resolve_severity_config
+
+    c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+    result = DiffResult(
+        old_version="1.0", new_version="2.0", library="libtest.so",
+        changes=[c], verdict=Verdict.COMPATIBLE,
+    )
+    cfg = resolve_severity_config("default", addition="error")
+    out = generate_html_report(result, severity_config=cfg)
+    assert "Blocked by:" in out
+    assert "<code>addition</code>" in out
+
+
+def test_gate_card_omits_blocking_categories_when_passing() -> None:
+    from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+    from abicheck.severity import resolve_severity_config
+
+    c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+    result = DiffResult(
+        old_version="1.0", new_version="2.0", library="libtest.so",
+        changes=[c], verdict=Verdict.COMPATIBLE,
+    )
+    cfg = resolve_severity_config("default")
+    out = generate_html_report(result, severity_config=cfg)
+    assert "PASS" in out
+    assert "Blocked by:" not in out
+
+
+def test_gate_card_scoped_gate_omits_full_library_blocking_categories() -> None:
+    """Regression guard: the scoped gate's exit code can fail for a reason
+    unrelated to full_gate's categories (e.g. a missing --required-symbol
+    entrypoint), so the card must not name full-library categories next to
+    the scoped FAIL -- that would misattribute the cause."""
+    from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
+    from abicheck.severity import resolve_severity_config
+
+    c = Change(ChangeKind.FUNC_ADDED, "_Z3newv", "new public function")
+    result = DiffResult(
+        old_version="1.0", new_version="2.0", library="libtest.so",
+        changes=[c], verdict=Verdict.COMPATIBLE,
+    )
+    result.scoped_verdict = Verdict.BREAKING  # type: ignore[attr-defined]
+    result.scoped_exit_code = 4  # type: ignore[attr-defined]
+    result.scoped_exit_code_scheme = "severity"  # type: ignore[attr-defined]
+    cfg = resolve_severity_config("default", addition="error")
+    out = generate_html_report(result, severity_config=cfg)
+    assert "CI Gate (scoped)" in out
+    assert "Blocked by:" not in out
+
+
 def test_gate_card_passes_when_no_error_level_findings() -> None:
     from abicheck.checker import Change, ChangeKind, DiffResult, Verdict
     from abicheck.severity import resolve_severity_config


### PR DESCRIPTION
## Summary

The sticky PR comment reported a policy-gated but ABI/API-**compatible** addition (e.g. under `severity-addition: error`) with the headline "ABI BREAKING" — conflating "does this block CI?" (the gate axis) with "is this ABI/API-compatible?" (the compatibility axis), which ADR-042 explicitly established as independent.

## Motivation

With `severity-addition: error`, a new public function is correctly:
1. Still `COMPATIBLE` in the JSON report's `verdict`.
2. Correctly blocking CI with exit code 1.
3. But the sticky PR comment moved it into the "Breaking" bucket to match the red check, and the headline logic then said "❌ abicheck — ABI BREAKING" purely because that bucket was non-empty — regardless of whether it held a genuine incompatibility or a compatible finding promoted by policy.

This tells the reviewer "you broke the ABI" when the actual message should be "this compatible API expansion needs sign-off per your policy." The bug was locked in by an existing unit test asserting the old headline.

## Changes

- `abicheck/pr_comment.py`:
  - `Finding` and `CommentModel` now track the severity-config category (`abi_breaking` / `potential_breaking` / `addition` / `quality_issues`) responsible for each Breaking-bucket entry, threaded through `compare`, `appcompat`, and `compare-release` (release-mode `library_rows` + bundle/matrix global rows) modes.
  - The headline only reads **"ABI BREAKING"** when the bucket holds a genuine `abi_breaking` finding; a gated *source* break reads **"Source API break blocks this PR"**; a policy-only compatible block reads **"Public API expansion requires approval"** / **"Quality policy violation"** / a generic mixed variant — never "ABI BREAKING".
  - A new note block distinguishes the two axes explicitly for a policy-only block: `**Compatibility: COMPATIBLE** ... **Gate: BLOCKED** by severity policy — \`addition\` is configured as \`error\`.`
  - The Breaking section's own table title switches to "⛔ Blocked by policy (compatible)" in the same policy-only case.
- `action/run.sh`: the Job Summary's `SEVERITY_ERROR` line now names the actual blocking `severity.blocking_categories` from the JSON report (ADR-042) instead of a generic "Severity-level issue detected", when a JSON report is available (`FORMAT=json` + `jq`); falls back to the generic message otherwise.
- Tests: updated the existing tests that locked in the old "ABI BREAKING" wording, added coverage for addition-only / quality-only / mixed-category / real-break-plus-addition scenarios in `test_pr_comment.py`, and a new `test_action_run_sh_severity_summary.py` exercising the real `run.sh` snippet end to end.
- Changelog fragment added via `scriv create`.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed — the sticky-comment/Job-Summary wording change is documented in the changelog fragment and inline docstrings; no separate user-guide page describes the exact headline strings today
- [x] `ruff check abicheck/ tests/` and `mypy abicheck/` pass locally, plus the full fast unit suite (16,376 passed)
- [x] No new `mypy` or `ruff` errors introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1VYCD2fKdGensNCLjEjAh)_