### PR TITLE
fix(action): stabilize content_hash, pass -R to gh release download

### DIFF
--- a/abicheck/buildsource/pack.py
+++ b/abicheck/buildsource/pack.py
@@ -203,12 +203,22 @@ class BuildSourcePack:
         """Stable ``sha256:<hex>`` over the manifest identity + artifact digests.
 
         Excludes volatile fields (``created_at``) so two packs with identical
-        evidence collected at different times hash the same.
+        evidence collected at different times hash the same. ``coverage``
+        rows drop ``detail``/``elapsed_s`` too: build_inline_coverage()
+        (inline.py) stamps those with the same replay wall-clock/cache-hit
+        text (e.g. "cache 2/3 hit (67%), 1.80s") this hash is otherwise
+        supposed to be stable against, so two identical-evidence packs
+        collected with different cache warmth or runner load still hashed
+        differently (Codex review) -- ``layer``/``status``/``confidence``
+        are the row's actual identity.
         """
         ident = {
             "build_source_pack_version": self.manifest.build_source_pack_version,
             "artifacts": sorted(self.manifest.artifacts or self._artifact_digests()),
-            "coverage": [c.to_dict() for c in self.manifest.coverage],
+            "coverage": [
+                {k: v for k, v in c.to_dict().items() if k not in ("detail", "elapsed_s")}
+                for c in self.manifest.coverage
+            ],
             "extractors": [e.name + "@" + e.version for e in self.manifest.extractors],
         }
         blob = json.dumps(ident, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/action/run.sh
+++ b/action/run.sh
@@ -161,16 +161,25 @@ if [[ -n "$ABI_BASELINE" \
     # normal .json name; the input doc promises a path is used directly).
     BASELINE_FILE="$ABI_BASELINE"
   else
+    # gh release download relies on local git repo context (README: "the
+    # latest release in the project") when no -R/--repo is given -- a job
+    # that never ran actions/checkout (e.g. comparing downloaded release
+    # artifacts only) has none, so the documented auto-fetch would fail
+    # before it even reaches a missing-asset error. Pass -R whenever we
+    # know the repo, same rationale as _gh_pr_comment_fallback above
+    # (Codex review).
+    _GH_REPO_FLAG=()
+    [[ -n "${GITHUB_REPOSITORY:-}" ]] && _GH_REPO_FLAG=(-R "$GITHUB_REPOSITORY")
     if [[ "$ABI_BASELINE" == "latest-release" ]]; then
       echo "::group::Fetch ABI baseline from latest release"
-      if ! gh release download --pattern '*.abicheck.json' -D "$BASELINE_DIR"; then
+      if ! gh release download "${_GH_REPO_FLAG[@]}" --pattern '*.abicheck.json' -D "$BASELINE_DIR"; then
         _baseline_unavailable "No ABI baseline found in latest release. Run 'abicheck dump path/to/libfoo.so -o libfoo.abicheck.json' in your release workflow and upload the resulting *.abicheck.json file as a release asset."
       fi
       echo "::endgroup::"
     else
       # Treat as a tag name
       echo "::group::Fetch ABI baseline from release $ABI_BASELINE"
-      if ! gh release download "$ABI_BASELINE" --pattern '*.abicheck.json' -D "$BASELINE_DIR"; then
+      if ! gh release download "$ABI_BASELINE" "${_GH_REPO_FLAG[@]}" --pattern '*.abicheck.json' -D "$BASELINE_DIR"; then
         _baseline_unavailable "No ABI baseline found in release '$ABI_BASELINE'. Ensure the release has a *.abicheck.json asset."
       fi
       echo "::endgroup::"

--- a/changelog.d/20260718_030538_claude_abicheck_onedal_integration_followup.md
+++ b/changelog.d/20260718_030538_claude_abicheck_onedal_integration_followup.md
@@ -1,0 +1,69 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Fixed
+
+- **`BuildSourcePack.content_hash()` is now stable across replay runner
+  cache warmth/wall time.** Its coverage rows previously hashed the raw
+  `detail`/`elapsed_s` fields (e.g. "cache 2/3 hit (67%), 1.80s"), so two
+  packs with identical evidence collected under different cache/timing
+  conditions produced different content hashes. **The GitHub Action's
+  `abi-baseline: latest-release`/tagged-release auto-fetch now passes
+  `-R "$GITHUB_REPOSITORY"` to `gh release download`**, so it works in a
+  job that never ran `actions/checkout` (e.g. comparing downloaded release
+  artifacts only), matching the `-R`-when-known convention the Action's
+  PR-comment posting already used.
+
+<!--
+### Changed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Deprecated
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Removed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Performance
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Security
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Documentation
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->

--- a/tests/test_action_run_sh_dry_run_baseline.py
+++ b/tests/test_action_run_sh_dry_run_baseline.py
@@ -196,6 +196,101 @@ class TestAuditSkipsBaselineFetch:
         assert result.returncode == 1, result.stderr
 
 
+class TestGhReleaseDownloadRepoFlag:
+    """Regression (Codex review): `gh release download` relies on local git
+    repo context ("the latest release in the project") when no -R/--repo is
+    given, so a job that never ran actions/checkout (e.g. comparing
+    downloaded release artifacts only) would fail before ever reaching a
+    missing-asset error. Stubs `gh` to record its own argv to a file
+    (real gh isn't available/authenticated in the test environment) instead
+    of asserting behavior indirectly through exit codes.
+    """
+
+    def _run(
+        self, env_extra: dict[str, str], argv_file: Path
+    ) -> subprocess.CompletedProcess[str]:
+        script = (
+            'MODE="${INPUT_MODE:-compare}"\n'
+            'FORCE_AUDIT_ONLY="${INPUT_AUDIT:-false}"\n'
+            'gh() {\n'
+            '  printf "%s\\n" "$@" > "$GH_ARGV_FILE"\n'
+            '  local dir=""; while [[ $# -gt 0 ]]; do '
+            '[[ "$1" == "-D" ]] && dir="$2"; shift; done\n'
+            '  touch "$dir/lib.abicheck.json"\n'
+            '}\n'
+            + _baseline_region()
+            + '\necho "REACHED_END"\n'
+        )
+        env = {**os.environ, **env_extra, "GH_ARGV_FILE": str(argv_file)}
+        return subprocess.run(
+            [_bash_executable(), "-c", script],
+            capture_output=True, text=True, env=env, check=False,
+        )
+
+    def test_latest_release_passes_repo_flag(self, tmp_path: Path) -> None:
+        argv_file = tmp_path / "gh_argv"
+        result = self._run(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_ABI_BASELINE": "latest-release",
+                "GITHUB_REPOSITORY": "abicheck/abicheck",
+            },
+            argv_file,
+        )
+        assert result.returncode == 0, result.stderr
+        argv = argv_file.read_text(encoding="utf-8").splitlines()
+        assert "-R" in argv, argv
+        assert argv[argv.index("-R") + 1] == "abicheck/abicheck"
+
+    def test_tagged_release_passes_repo_flag(self, tmp_path: Path) -> None:
+        argv_file = tmp_path / "gh_argv"
+        result = self._run(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_ABI_BASELINE": "v1.2.3",
+                "GITHUB_REPOSITORY": "abicheck/abicheck",
+            },
+            argv_file,
+        )
+        assert result.returncode == 0, result.stderr
+        argv = argv_file.read_text(encoding="utf-8").splitlines()
+        assert "-R" in argv, argv
+        assert argv[argv.index("-R") + 1] == "abicheck/abicheck"
+
+    def test_no_repo_flag_when_github_repository_unset(self, tmp_path: Path) -> None:
+        """Sanity: -R is only added when the repo is actually known -- an
+        empty flag value would be worse than omitting it."""
+        argv_file = tmp_path / "gh_argv"
+        env = {**os.environ}
+        env.pop("GITHUB_REPOSITORY", None)
+        script = (
+            'MODE="${INPUT_MODE:-compare}"\n'
+            'FORCE_AUDIT_ONLY="${INPUT_AUDIT:-false}"\n'
+            'gh() {\n'
+            '  printf "%s\\n" "$@" > "$GH_ARGV_FILE"\n'
+            '  local dir=""; while [[ $# -gt 0 ]]; do '
+            '[[ "$1" == "-D" ]] && dir="$2"; shift; done\n'
+            '  touch "$dir/lib.abicheck.json"\n'
+            '}\n'
+            + _baseline_region()
+            + '\necho "REACHED_END"\n'
+        )
+        env.update(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_ABI_BASELINE": "latest-release",
+                "GH_ARGV_FILE": str(argv_file),
+            }
+        )
+        result = subprocess.run(
+            [_bash_executable(), "-c", script],
+            capture_output=True, text=True, env=env, check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        argv = argv_file.read_text(encoding="utf-8").splitlines()
+        assert "-R" not in argv, argv
+
+
 class TestAmbiguousBaselineAssets:
     def _run(self, gh_body: str) -> subprocess.CompletedProcess[str]:
         script = (

--- a/tests/test_build_source_pack.py
+++ b/tests/test_build_source_pack.py
@@ -94,6 +94,41 @@ def test_content_hash_changes_with_build_evidence(tmp_path):
     assert p1.content_hash() != p2.content_hash()
 
 
+def test_content_hash_stable_across_coverage_detail_and_elapsed_s(tmp_path):
+    # Regression (Codex review): build_inline_coverage() (inline.py) stamps
+    # each LayerCoverage row's "detail" with the same replay wall-clock/
+    # cache-hit text (e.g. "cache 2/3 hit (67%), 1.80s") that
+    # build_manifest.py's own digest already strips elsewhere -- but
+    # content_hash() itself still hashed the raw LayerCoverage.to_dict(),
+    # including "detail"/"elapsed_s", so two packs with identical evidence
+    # collected with different cache warmth or wall time still hashed
+    # differently, contradicting this method's own "identical evidence
+    # collected at different times hash the same" docstring promise.
+    from abicheck.buildsource.model import LayerCoverage
+
+    p1 = BuildSourcePack.empty(tmp_path / "a")
+    p1.manifest.coverage = [
+        LayerCoverage(
+            layer=DataLayer.L4_SOURCE_ABI.value,
+            status=CoverageStatus.PRESENT,
+            detail="cache 2/3 hit (67%), 1.80s",
+            elapsed_s=1.80,
+        )
+    ]
+    p1.write()
+    p2 = BuildSourcePack.empty(tmp_path / "b")
+    p2.manifest.coverage = [
+        LayerCoverage(
+            layer=DataLayer.L4_SOURCE_ABI.value,
+            status=CoverageStatus.PRESENT,
+            detail="cache 0/3 hit (0%), 9.42s",
+            elapsed_s=9.42,
+        )
+    ]
+    p2.write()
+    assert p1.content_hash() == p2.content_hash()
+
+
 def test_to_ref_roundtrip(tmp_path):
     pack = BuildSourcePack.empty(tmp_path / "p")
     pack.manifest.coverage = []


### PR DESCRIPTION
## Summary

Two follow-up fixes from Codex review that landed on PR #594 after it had already merged, so they're carried here as a fresh PR on top of the current `main`.

## Motivation

- `BuildSourcePack.content_hash()` hashed each `LayerCoverage` row's raw `detail`/`elapsed_s` fields, which `build_inline_coverage()` (`inline.py`) stamps with the replay's wall-clock/cache-hit text (e.g. `"cache 2/3 hit (67%), 1.80s"`). Two packs with identical evidence collected under different cache warmth or runner load therefore still hashed differently — contradicting the method's own docstring promise that "two packs with identical evidence collected at different times hash the same."
- `gh release download` (used by `action/run.sh`'s `abi-baseline: latest-release`/tagged-release auto-fetch) relies on local git repo context ("the latest release in the project") when no `-R`/`--repo` is given, so it fails in a job that never ran `actions/checkout` (e.g. one that only compares downloaded release artifacts). `_gh_pr_comment_fallback` in the same file already documents and follows the "pass `-R` when the repo is known" convention for exactly this reason — the baseline fetch was the one place that didn't.

## Changes

- `abicheck/buildsource/pack.py`: `content_hash()` now strips `detail`/`elapsed_s` from each coverage row before hashing, keeping `layer`/`status`/`confidence` (the row's real identity).
- `action/run.sh`: both `gh release download` invocations (latest-release and tag-name branches) now pass `-R "$GITHUB_REPOSITORY"` when that env var is set.
- Tests: `test_content_hash_stable_across_coverage_detail_and_elapsed_s` (`tests/test_build_source_pack.py`) and a new `TestGhReleaseDownloadRepoFlag` class (`tests/test_action_run_sh_dry_run_baseline.py`), both verified to fail pre-fix.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated if user-visible behaviour changed — n/a, no user-visible interface change
- [x] `ruff check`, `ruff format --check` (new/touched lines), `mypy abicheck/` all pass clean
- [x] No new `mypy` or `ruff` errors introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_018NsUe4JB3jgGwsKwfVGpeW)_