### PR TITLE
fix(buildsource): stabilize content_hash further, guard empty gh -R array

### DIFF
--- a/abicheck/buildsource/merge_support.py
+++ b/abicheck/buildsource/merge_support.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .model import CoverageStatus, DataLayer, ExtractorRecord, LayerCoverage
-from .pack import BuildSourcePack, _payload_sha256
+from .pack import BuildSourcePack, _normalize_source_abi_payload, _payload_sha256
 
 if TYPE_CHECKING:
     from ..model import AbiSnapshot
@@ -198,7 +198,19 @@ def _append_chosen_payload_digests(
     for payload in chosen:
         if payload is None:
             continue
-        digest = "sha256:" + _payload_sha256(payload.to_dict())  # type: ignore[attr-defined]
+        # _normalize_source_abi_payload strips the same replay wall-clock/
+        # cache-hit fields BuildSourcePack._artifact_digests() already
+        # strips from an on-disk/self-contained pack's source_abi.json --
+        # without it here, a combined/embedded pack (this function's own
+        # docstring: an inline-collected --sources contributor that was
+        # never written to disk) hashed the chosen SourceAbiSurface's raw
+        # payload, bypassing that fix for the --sources/--build-info
+        # combine path (Codex review). A no-op for build_evidence/
+        # source_graph payloads, neither of which carries these keys under
+        # a top-level "coverage" dict.
+        digest = "sha256:" + _payload_sha256(
+            _normalize_source_abi_payload(payload.to_dict())  # type: ignore[attr-defined]
+        )
         if digest not in artifacts:
             artifacts.append(digest)
 

--- a/abicheck/buildsource/pack.py
+++ b/abicheck/buildsource/pack.py
@@ -180,11 +180,27 @@ class BuildSourcePack:
             digests.append("sha256:" + _file_sha256(be_path))
         elif self.build_evidence is not None:
             digests.append("sha256:" + _payload_sha256(self.build_evidence.to_dict()))
+        # source_abi.json's own top-level "coverage" dict (SourceAbiSurface.
+        # coverage) is stamped by source_replay.py's replay producer (cache_
+        # lookup_s/extract_s/link_s/elapsed_s/extractor_jobs/cache_misses)
+        # and inline.py's cache bookkeeping (cache_hits) -- the same
+        # volatile-field shape actions/baseline/build_manifest.py already
+        # strips from the *embedded* snapshot's build_source.source_abi.
+        # coverage, but this method hashed the raw file/payload directly, so
+        # content_hash() was still unstable across runs with different
+        # cache warmth or runner load even after normalizing the manifest
+        # coverage rows (Codex review). Read+normalize+rehash instead of
+        # _file_sha256's raw-bytes shortcut so the strip applies uniformly.
         sa_path = self.root / SOURCE_ABI_REL
         if sa_path.is_file():
-            digests.append("sha256:" + _file_sha256(sa_path))
+            digests.append(
+                "sha256:" + _payload_sha256(_normalize_source_abi_payload(_read_json(sa_path)))
+            )
         elif self.source_abi is not None:
-            digests.append("sha256:" + _payload_sha256(self.source_abi.to_dict()))
+            digests.append(
+                "sha256:"
+                + _payload_sha256(_normalize_source_abi_payload(self.source_abi.to_dict()))
+            )
         sg_path = self.root / SOURCE_GRAPH_REL
         if sg_path.is_file():
             digests.append("sha256:" + _file_sha256(sg_path))
@@ -293,6 +309,33 @@ class BuildSourcePack:
                 for c in self.manifest.coverage
             },
         )
+
+
+# SourceAbiSurface.coverage keys populated by source_replay.py's replay
+# producer (wall-clock durations, its own parallelism setting) and
+# inline.py's per-TU cache bookkeeping -- runner/cache-warmth state, not a
+# property of the extracted source facts themselves.
+_VOLATILE_SOURCE_ABI_COVERAGE_KEYS = (
+    "cache_lookup_s",
+    "extract_s",
+    "link_s",
+    "elapsed_s",
+    "extractor_jobs",
+    "cache_misses",
+    "cache_hits",
+)
+
+
+def _normalize_source_abi_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Strip volatile coverage timing/cache fields before hashing a source_abi payload."""
+    coverage = payload.get("coverage")
+    if not isinstance(coverage, dict):
+        return payload
+    normalized = dict(payload)
+    normalized["coverage"] = {
+        k: v for k, v in coverage.items() if k not in _VOLATILE_SOURCE_ABI_COVERAGE_KEYS
+    }
+    return normalized
 
 
 def _read_json(path: Path) -> dict[str, Any]:

--- a/action/run.sh
+++ b/action/run.sh
@@ -172,14 +172,20 @@ if [[ -n "$ABI_BASELINE" \
     [[ -n "${GITHUB_REPOSITORY:-}" ]] && _GH_REPO_FLAG=(-R "$GITHUB_REPOSITORY")
     if [[ "$ABI_BASELINE" == "latest-release" ]]; then
       echo "::group::Fetch ABI baseline from latest release"
-      if ! gh release download "${_GH_REPO_FLAG[@]}" --pattern '*.abicheck.json' -D "$BASELINE_DIR"; then
+      # ${arr[@]+"${arr[@]}"}, not a bare "${arr[@]}": under macOS's stock
+      # (GPLv2-frozen) bash 3.2's set -u, expanding an *empty* array as
+      # "${arr[@]}" is itself treated as an unbound-variable reference (bash
+      # 4.4+ special-cased this away) -- the same portability trap
+      # add_flag()'s callers already guard against elsewhere in this file
+      # (Codex review).
+      if ! gh release download ${_GH_REPO_FLAG[@]+"${_GH_REPO_FLAG[@]}"} --pattern '*.abicheck.json' -D "$BASELINE_DIR"; then
         _baseline_unavailable "No ABI baseline found in latest release. Run 'abicheck dump path/to/libfoo.so -o libfoo.abicheck.json' in your release workflow and upload the resulting *.abicheck.json file as a release asset."
       fi
       echo "::endgroup::"
     else
       # Treat as a tag name
       echo "::group::Fetch ABI baseline from release $ABI_BASELINE"
-      if ! gh release download "$ABI_BASELINE" "${_GH_REPO_FLAG[@]}" --pattern '*.abicheck.json' -D "$BASELINE_DIR"; then
+      if ! gh release download "$ABI_BASELINE" ${_GH_REPO_FLAG[@]+"${_GH_REPO_FLAG[@]}"} --pattern '*.abicheck.json' -D "$BASELINE_DIR"; then
         _baseline_unavailable "No ABI baseline found in release '$ABI_BASELINE'. Ensure the release has a *.abicheck.json asset."
       fi
       echo "::endgroup::"

--- a/changelog.d/20260718_032644_claude_abicheck_onedal_integration_followup2.md
+++ b/changelog.d/20260718_032644_claude_abicheck_onedal_integration_followup2.md
@@ -9,13 +9,16 @@ it should read in CHANGELOG.md. Delete the other sections.
 ### Fixed
 
 - **`BuildSourcePack.content_hash()` is now stable across replay runner
-  cache warmth/wall time for the on-disk `source_abi.json` artifact too.**
-  Its coverage dict carries the same replay timing/cache-hit fields
+  cache warmth/wall time for the on-disk `source_abi.json` artifact, and
+  for a combined `--build-info`/`--sources` pack too.** The surface's
+  coverage dict carries the same replay timing/cache-hit fields
   (`cache_lookup_s`, `extract_s`, `link_s`, `elapsed_s`, `extractor_jobs`,
   `cache_misses`, `cache_hits`) as the manifest coverage rows fixed
   previously, so two packs with identical source facts collected under
   different cache/timing conditions still produced different artifact
-  digests. **The GitHub Action's `abi-baseline` auto-fetch no longer
+  digests — including via the merge/combine path that hashes an
+  inline-collected `--sources` contributor's payload directly.
+  **The GitHub Action's `abi-baseline` auto-fetch no longer
   crashes under macOS's stock bash 3.2** when `GITHUB_REPOSITORY` is
   unset — expanding an empty array as `"${arr[@]}"` is itself an
   unbound-variable reference on bash < 4.4, so the `-R` flag array now

--- a/changelog.d/20260718_032644_claude_abicheck_onedal_integration_followup2.md
+++ b/changelog.d/20260718_032644_claude_abicheck_onedal_integration_followup2.md
@@ -1,0 +1,72 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Fixed
+
+- **`BuildSourcePack.content_hash()` is now stable across replay runner
+  cache warmth/wall time for the on-disk `source_abi.json` artifact too.**
+  Its coverage dict carries the same replay timing/cache-hit fields
+  (`cache_lookup_s`, `extract_s`, `link_s`, `elapsed_s`, `extractor_jobs`,
+  `cache_misses`, `cache_hits`) as the manifest coverage rows fixed
+  previously, so two packs with identical source facts collected under
+  different cache/timing conditions still produced different artifact
+  digests. **The GitHub Action's `abi-baseline` auto-fetch no longer
+  crashes under macOS's stock bash 3.2** when `GITHUB_REPOSITORY` is
+  unset — expanding an empty array as `"${arr[@]}"` is itself an
+  unbound-variable reference on bash < 4.4, so the `-R` flag array now
+  uses the same `${arr[@]+"${arr[@]}"}` guard the file already relies on
+  elsewhere.
+
+<!--
+### Changed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Deprecated
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Removed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Performance
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Security
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Documentation
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -2268,6 +2268,70 @@ def test_mixed_build_pack_and_raw_sources_hash_distinguishes_trees(tmp_path):
     assert a.content_hash() == same.content_hash()
 
 
+def test_combined_pack_content_hash_stable_across_source_abi_coverage_timing(
+    tmp_path,
+):
+    # Regression (Codex review): _append_chosen_payload_digests() (merge_
+    # support.py), used for an inline-collected --sources contributor that
+    # was never written to disk, hashed the chosen SourceAbiSurface's raw
+    # payload directly -- bypassing the same replay wall-clock/cache-hit
+    # normalization BuildSourcePack._artifact_digests() already applies to
+    # an on-disk/self-contained pack's source_abi.json. A --build-info +
+    # --sources combine of identical source facts collected under
+    # different cache warmth or runner load therefore still produced a
+    # different content_hash().
+    from pathlib import Path
+
+    from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
+    from abicheck.buildsource.pack import BuildSourcePack
+    from abicheck.buildsource.source_abi import SourceAbiSurface
+    from abicheck.cli_buildsource import _combine_packs
+
+    bi = BuildSourcePack.empty(tmp_path / "bi")
+    ev = BuildEvidence()
+    ev.compile_units.append(CompileUnit(id="cu://x", source="x.cpp"))
+    bi.build_evidence = ev
+    bi.write()
+    bi = BuildSourcePack.load(tmp_path / "bi")
+
+    def _inline_with(coverage: dict) -> BuildSourcePack:
+        return BuildSourcePack(
+            root=Path(""),
+            source_abi=SourceAbiSurface(library="libfoo.so", coverage=coverage),
+        )
+
+    a = _combine_packs(
+        bi,
+        None,
+        _inline_with(
+            {
+                "compile_units_parsed": 3,
+                "cache_lookup_s": 0.01,
+                "extract_s": 1.79,
+                "elapsed_s": 1.85,
+                "cache_misses": 3,
+                "cache_hits": 0,
+            }
+        ),
+    )
+    b = _combine_packs(
+        bi,
+        None,
+        _inline_with(
+            {
+                "compile_units_parsed": 3,
+                "cache_lookup_s": 0.02,
+                "extract_s": 0.11,
+                "elapsed_s": 0.17,
+                "cache_misses": 0,
+                "cache_hits": 3,
+            }
+        ),
+    )
+    assert a is not None and b is not None
+    assert a.content_hash() == b.content_hash()
+
+
 def test_inline_source_changed_falls_back_to_headers_only_scope(tmp_path, monkeypatch):
     """ADR-035 P3: inline dump has no PR diff, so a 'changed' scope falls back to
     'headers-only' (the public-API surface) — non-empty, but NOT the full-target

--- a/tests/test_build_source_pack.py
+++ b/tests/test_build_source_pack.py
@@ -129,6 +129,53 @@ def test_content_hash_stable_across_coverage_detail_and_elapsed_s(tmp_path):
     assert p1.content_hash() == p2.content_hash()
 
 
+def test_content_hash_stable_across_source_abi_coverage_timing(tmp_path):
+    # Regression (Codex review): fresh evidence after the manifest-coverage
+    # fix above -- source_replay.py's replay producer and inline.py's cache
+    # bookkeeping stamp the *same* volatile timing/cache-hit fields
+    # (cache_lookup_s/extract_s/link_s/elapsed_s/extractor_jobs/
+    # cache_misses/cache_hits) directly onto SourceAbiSurface.coverage,
+    # which write() persists at source/source_abi.json. _artifact_digests()
+    # hashed that file's raw bytes (_file_sha256), so two packs with
+    # identical source facts collected under different cache warmth or
+    # runner load still produced different content_hash() values even
+    # after the manifest-row fix above only touched a different coverage
+    # location.
+    from abicheck.buildsource.source_abi import SourceAbiSurface
+
+    p1 = BuildSourcePack.empty(tmp_path / "a")
+    p1.source_abi = SourceAbiSurface(
+        library="libfoo.so",
+        coverage={
+            "compile_units_parsed": 3,
+            "cache_lookup_s": 0.01,
+            "extract_s": 1.79,
+            "link_s": 0.05,
+            "elapsed_s": 1.85,
+            "extractor_jobs": 4,
+            "cache_misses": 3,
+            "cache_hits": 0,
+        },
+    )
+    p1.write()
+    p2 = BuildSourcePack.empty(tmp_path / "b")
+    p2.source_abi = SourceAbiSurface(
+        library="libfoo.so",
+        coverage={
+            "compile_units_parsed": 3,
+            "cache_lookup_s": 0.02,
+            "extract_s": 0.11,
+            "link_s": 0.04,
+            "elapsed_s": 0.17,
+            "extractor_jobs": 16,
+            "cache_misses": 0,
+            "cache_hits": 3,
+        },
+    )
+    p2.write()
+    assert p1.content_hash() == p2.content_hash()
+
+
 def test_to_ref_roundtrip(tmp_path):
     pack = BuildSourcePack.empty(tmp_path / "p")
     pack.manifest.coverage = []


### PR DESCRIPTION
## Summary

Two more follow-up fixes from Codex review that landed on PR #598 after it had already merged, so they're carried here as a fresh PR on top of the current `main`.

## Motivation

- `BuildSourcePack._artifact_digests()` hashed `source_abi.json`'s raw file bytes directly, but `SourceAbiSurface.coverage` carries the same replay wall-clock/cache-hit fields (`cache_lookup_s`, `extract_s`, `link_s`, `elapsed_s`, `extractor_jobs`, `cache_misses`, `cache_hits`) that the manifest-coverage fix in #598 already stripped from a different location (`BuildSourceManifest.coverage` rows). So `content_hash()` was still unstable across runs with different cache warmth or runner load via this path.
- Under macOS's stock (GPLv2-frozen) bash 3.2's `set -u`, expanding an *empty* array as `"${arr[@]}"` is itself treated as an unbound-variable reference (bash 4.4+ fixed this away). The `_GH_REPO_FLAG` array added in #598 hit exactly the portability trap `add_flag()`'s callers already guard against elsewhere in `action/run.sh` (e.g. `${CMD[@]+"${CMD[@]}"}`).

## Changes

- `abicheck/buildsource/pack.py`: `_artifact_digests()` now reads, normalizes (strips the volatile coverage keys), and rehashes `source_abi.json` instead of hashing its raw bytes.
- `action/run.sh`: both `gh release download` invocations now expand `_GH_REPO_FLAG` via `${_GH_REPO_FLAG[@]+"${_GH_REPO_FLAG[@]}"}` instead of a bare `"${_GH_REPO_FLAG[@]}"`.
- Tests: `test_content_hash_stable_across_source_abi_coverage_timing` (`tests/test_build_source_pack.py`), verified to fail pre-fix. The bash-3.2 nounset fix itself isn't independently testable in this environment (only bash 5.2 is available here — the bug doesn't reproduce under it), so it's verified by code inspection against the file's own established `${arr[@]+"${arr[@]}"}` convention rather than a failing regression test.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated if user-visible behaviour changed — n/a, no user-visible interface change
- [x] `ruff check`, `mypy abicheck/` pass clean
- [x] No new `mypy` or `ruff` errors introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_018NsUe4JB3jgGwsKwfVGpeW)_