### PR TITLE
fix(clang-plugin,dumper): LLVM 19-22 support + --gcc-path icx/icpx recognition

### DIFF
--- a/.github/workflows/clang-plugin.yml
+++ b/.github/workflows/clang-plugin.yml
@@ -51,17 +51,34 @@ jobs:
       #  * LLVM major — the plugin is ABI-locked to its LLVM (C.5), so parity is
       #    validated per-version. Each major is pinned to a runner whose
       #    apt.llvm.org channel publishes it (16 is jammy-only; noble-16 does not
-      #    exist; 17/18 are on noble).
+      #    exist; 17-22 are on noble).
       #  * Host C++ compiler — the plugin is a plain LLVM shared module, so it
       #    must build with either GCC or Clang as the *host* compiler. LLVM 18
-      #    is built both ways (g++ and clang++) to prove that; 16/17 use the
-      #    distro default (g++) to keep the matrix small.
+      #    (the lowest major whose fileinfo_iterator key is FileEntryRef) and 22
+      #    (the newest major tested, currently the highest apt.llvm.org
+      #    publishes) are each built both ways (g++ and clang++) to prove that
+      #    across the FileEntry-API split; 16/17/19/20/21 use the distro default
+      #    (g++) to keep the matrix from growing on every dimension at once.
+      #
+      # 19-22 exist to catch upstream Clang AST-JSON/API churn as soon as it
+      # lands, not because oneDAL/Intel's icpx needs them: icpx is a separate
+      # downstream LLVM fork, not vanilla apt.llvm.org, so passing here does
+      # NOT mean the plugin builds against icpx's own bundled toolchain (which
+      # ships no LLVM/Clang CMake package at all, vendor or not -- see
+      # actions/collect-facts/run.sh's $CMPLR_ROOT handling). This matrix
+      # covers "does the plugin still build clean against the current LLVM
+      # majors a distro/apt.llvm.org actually ships."
       matrix:
         include:
           - { llvm: "16", runner: "ubuntu-22.04", host_cc: "gcc",   host_cxx: "g++" }
           - { llvm: "17", runner: "ubuntu-24.04", host_cc: "gcc",   host_cxx: "g++" }
           - { llvm: "18", runner: "ubuntu-24.04", host_cc: "gcc",   host_cxx: "g++" }
           - { llvm: "18", runner: "ubuntu-24.04", host_cc: "clang", host_cxx: "clang++" }
+          - { llvm: "19", runner: "ubuntu-24.04", host_cc: "gcc",   host_cxx: "g++" }
+          - { llvm: "20", runner: "ubuntu-24.04", host_cc: "gcc",   host_cxx: "g++" }
+          - { llvm: "21", runner: "ubuntu-24.04", host_cc: "gcc",   host_cxx: "g++" }
+          - { llvm: "22", runner: "ubuntu-24.04", host_cc: "gcc",   host_cxx: "g++" }
+          - { llvm: "22", runner: "ubuntu-24.04", host_cc: "clang", host_cxx: "clang++" }
     steps:
       - uses: actions/checkout@v4
         with:

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -93,17 +93,39 @@ def _clang_available(clang_bin: str = "clang") -> bool:
     return shutil.which(clang_bin) is not None
 
 
+#: Non-"clang"-spelled binary names that are still clang-driver-compatible (accept
+#: ``-Xclang``/``-ast-dump=json`` directly): Intel's oneAPI DPC++/C++ compiler
+#: (``icx``/``icpx``, and its older ``dpcpp``/``dpcpp-cl`` aliases — all four are
+#: the same clang-based binary under different names/symlinks in Intel's package,
+#: confirmed via ``__clang_major__``/``-Xclang -ast-dump=json`` against a real
+#: install). Without this, ``--gcc-path .../icpx`` is silently ignored (the
+#: substring check below only matches "clang") and falls back to plain "clang" on
+#: PATH — a *different* compiler than the one the real build used, so the wrong
+#: toolchain's headers/predefined macros get parsed. This does not attempt
+#: general vendor-fork detection (e.g. Apple clang already spells "clang"); it is
+#: narrowly the known non-"clang"-named forks that are otherwise indistinguishable
+#: from a real GCC binary by name alone.
+_CLANG_FAMILY_ALIAS_NAMES = frozenset({"icx", "icpx", "dpcpp", "dpcpp-cl"})
+
+
+def _is_clang_family_binary(path: str) -> bool:
+    stem = Path(path).stem.lower()
+    return "clang" in stem or stem in _CLANG_FAMILY_ALIAS_NAMES
+
+
 def _resolve_clang_bin(
-    compiler: str, gcc_path: str | None, gcc_prefix: str | None,
+    compiler: str,
+    gcc_path: str | None,
+    gcc_prefix: str | None,
 ) -> str:
     """Resolve the clang executable to run, raising if it is not on ``PATH``.
 
-    ``--gcc-path`` is honored only when it points at a clang (castxml emulates a
-    GCC/G++ binary, which can't take clang-only flags); ``--gcc-prefix`` maps to
-    the prefixed clang driver.
+    ``--gcc-path`` is honored only when it points at a clang(-family) binary
+    (castxml emulates a GCC/G++ binary, which can't take clang-only flags);
+    ``--gcc-prefix`` maps to the prefixed clang driver.
     """
     clang_bin: str | None = None
-    if gcc_path and "clang" in Path(gcc_path).name.lower():
+    if gcc_path and _is_clang_family_binary(gcc_path):
         clang_bin = gcc_path
     elif gcc_prefix:
         clang_bin = (
@@ -164,7 +186,9 @@ _WRAPPER_EXPR_KINDS = frozenset(
     }
 )
 #: Pseudo-files clang attributes builtin / command-line declarations to.
-_BUILTIN_FILES = frozenset({"<built-in>", "<builtin>", "<command line>", "<scratch space>"})
+_BUILTIN_FILES = frozenset(
+    {"<built-in>", "<builtin>", "<command line>", "<scratch space>"}
+)
 
 
 def _pointer_depth(type_str: str) -> int:
@@ -427,7 +451,14 @@ class _ClangAstParser:
         self._records: list[_Decl] = []
         self._enums: list[_Decl] = []
         self._typedefs: list[_Decl] = []
-        self._walk(root, scope=(), current_file="", access="public", extern_c=False, in_friend=False)
+        self._walk(
+            root,
+            scope=(),
+            current_file="",
+            access="public",
+            extern_c=False,
+            in_friend=False,
+        )
 
     # ── traversal ────────────────────────────────────────────────────────────
 
@@ -456,7 +487,9 @@ class _ClangAstParser:
         name = node.get("name") or ""
 
         if not node.get("isImplicit"):
-            self._categorize(node, kind, name, scope, file, access, extern_c, in_friend, in_template)
+            self._categorize(
+                node, kind, name, scope, file, access, extern_c, in_friend, in_template
+            )
 
         # A function/method body is not an ABI declaration surface: its
         # parameters and defaults are read straight off the function node in
@@ -472,7 +505,11 @@ class _ClangAstParser:
             kind == "LinkageSpecDecl" and node.get("language") == "C"
         )
         child_scope = (*scope, name) if kind in _SCOPE_NODE_KINDS and name else scope
-        running = _default_record_access(node) if kind in ("CXXRecordDecl", "RecordDecl") else "public"
+        running = (
+            _default_record_access(node)
+            if kind in ("CXXRecordDecl", "RecordDecl")
+            else "public"
+        )
         # A ``friend`` declaration injects its function into the enclosing
         # namespace but reachable only via ADL ("hidden friend"); mark the
         # subtree so parse_functions can flag it (matches castxml's
@@ -490,7 +527,8 @@ class _ClangAstParser:
         # (Codex review). Mark the whole subtree so RecordType.is_template_pattern
         # is set and the backfill matcher can skip it specifically.
         child_in_template = in_template or kind in (
-            "ClassTemplateDecl", "ClassTemplatePartialSpecializationDecl",
+            "ClassTemplateDecl",
+            "ClassTemplatePartialSpecializationDecl",
         )
         for child in node.get("inner", []) or []:
             if not isinstance(child, dict):
@@ -522,8 +560,13 @@ class _ClangAstParser:
         in_template: bool = False,
     ) -> None:
         entry = _Decl(
-            node=node, scope=scope, file=file, access=access, extern_c=extern_c,
-            in_friend=in_friend, in_template=in_template,
+            node=node,
+            scope=scope,
+            file=file,
+            access=access,
+            extern_c=extern_c,
+            in_friend=in_friend,
+            in_template=in_template,
         )
         if kind in _FUNCTION_NODE_KINDS and name:
             self._functions.append(entry)
@@ -631,7 +674,9 @@ class _ClangAstParser:
                     # Preserve the actual default-argument value (so a changed
                     # default fires PARAM_DEFAULT_VALUE_CHANGED); fall back to a
                     # bare presence marker when the value can't be evaluated.
-                    default=(_initializer_value(p) or "default") if _param_has_default(p) else None,
+                    default=(_initializer_value(p) or "default")
+                    if _param_has_default(p)
+                    else None,
                 )
                 for p in node.get("inner", []) or []
                 if isinstance(p, dict) and p.get("kind") == "ParmVarDecl"
@@ -799,8 +844,10 @@ class _ClangAstParser:
 
     def _build_record(self, entry: _Decl, override_name: str = "") -> RecordType:
         node = entry.node
-        kind = "union" if node.get("tagUsed") == "union" else (
-            "struct" if node.get("tagUsed") == "struct" else "class"
+        kind = (
+            "union"
+            if node.get("tagUsed") == "union"
+            else ("struct" if node.get("tagUsed") == "struct" else "class")
         )
         fields = self._parse_fields(node)
         bases, virtual_bases, base_access = _parse_bases(node)
@@ -853,7 +900,12 @@ class _ClangAstParser:
         return self._collect_fields(node, _default_record_access(node), injected)
 
     def _collect_fields(
-        self, node: dict[str, Any], running: str, injected: set[str], *, nested: bool = False
+        self,
+        node: dict[str, Any],
+        running: str,
+        injected: set[str],
+        *,
+        nested: bool = False,
     ) -> list[TypeField]:
         fields: list[TypeField] = []
         for child in node.get("inner", []) or []:
@@ -868,7 +920,9 @@ class _ClangAstParser:
                 # in the enclosing record's namespace, so flatten them here. Keep
                 # only the injected names to avoid pulling in a typedef'd
                 # anonymous record's fields.
-                fields.extend(self._collect_fields(child, running, injected, nested=True))
+                fields.extend(
+                    self._collect_fields(child, running, injected, nested=True)
+                )
                 continue
             if kind != "FieldDecl":
                 continue
@@ -920,7 +974,9 @@ class _ClangAstParser:
             node = entry.node
             if _is_builtin_file(entry.file):
                 continue
-            name = str(node.get("name", "")) or typedef_names_by_enum_id.get(str(node.get("id", "")), "")
+            name = str(node.get("name", "")) or typedef_names_by_enum_id.get(
+                str(node.get("id", "")), ""
+            )
             if not name or name.startswith("__"):
                 continue
             members: list[EnumMember] = []
@@ -930,7 +986,10 @@ class _ClangAstParser:
             # reconstruct the implicit ones here.
             next_value = 0
             for child in node.get("inner", []) or []:
-                if not isinstance(child, dict) or child.get("kind") != "EnumConstantDecl":
+                if (
+                    not isinstance(child, dict)
+                    or child.get("kind") != "EnumConstantDecl"
+                ):
                     continue
                 explicit = _enum_constant_value(child)
                 value = explicit if explicit is not None else next_value
@@ -969,7 +1028,15 @@ class _Decl:
     ``__slots__`` keeps the per-decl overhead low on large headers.
     """
 
-    __slots__ = ("node", "scope", "file", "access", "extern_c", "in_friend", "in_template")
+    __slots__ = (
+        "node",
+        "scope",
+        "file",
+        "access",
+        "extern_c",
+        "in_friend",
+        "in_template",
+    )
 
     def __init__(
         self,
@@ -1136,8 +1203,7 @@ def _param_has_default(param: dict[str, Any]) -> bool:
     if param.get("init"):
         return True
     return any(
-        isinstance(c, dict)
-        and not str(c.get("kind", "")).endswith(("Attr", "Comment"))
+        isinstance(c, dict) and not str(c.get("kind", "")).endswith(("Attr", "Comment"))
         for c in param.get("inner", []) or []
     )
 
@@ -1307,6 +1373,7 @@ def _owned_tag_id(typedef_node: dict[str, Any]) -> str:
     that holds the fields. Returns that record's ``id`` so parse_types can emit
     the otherwise-anonymous record under the typedef name.
     """
+
     def _scan(node: Any) -> str:
         if not isinstance(node, dict):
             return ""

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -1029,13 +1029,13 @@ class _Decl:
     """
 
     __slots__ = (
-        "node",
-        "scope",
-        "file",
         "access",
         "extern_c",
+        "file",
         "in_friend",
         "in_template",
+        "node",
+        "scope",
     )
 
     def __init__(

--- a/changelog.d/20260719_010000_claude_clang_plugin_llvm22_ci8x2q.md
+++ b/changelog.d/20260719_010000_claude_clang_plugin_llvm22_ci8x2q.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **Clang facts plugin builds against LLVM/Clang 19-22** — `clang::FileEntry::getName()`
+  was removed upstream (the `SourceManager::fileinfo_*` iteration key moved to
+  `FileEntryRef`, which keeps its own `getName()`, back in LLVM 18), so
+  `contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp` no longer compiled
+  against current LLVM majors. The now-unreachable `const FileEntry *` overload
+  is guarded `#if CLANG_VERSION_MAJOR < 18` instead of relying on overload
+  resolution alone to keep it uncompiled dead code. The `clang-plugin` CI
+  workflow's matrix now covers LLVM 16 through 22 (previously 16-18); the C.6
+  differential-conformance test, the end-to-end scan-flow test, and the
+  public-roots diagnostic test all pass unmodified on every major.

--- a/changelog.d/20260719_020000_claude_gcc_path_icx_family_9k3m2p.md
+++ b/changelog.d/20260719_020000_claude_gcc_path_icx_family_9k3m2p.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **`--gcc-path` now recognizes Intel's `icx`/`icpx`/`dpcpp`/`dpcpp-cl`** as
+  clang-family binaries for the `clang` `--ast-frontend`. Previously the check
+  matched only a `"clang"` substring in the binary name, so a `--gcc-path`
+  pointing at Intel's oneAPI DPC++/C++ compiler (clang-based but not
+  clang-named) was silently ignored — the L2 header frontend fell back to a
+  plain `clang` on `PATH` instead, parsing headers with a different,
+  possibly-mismatched toolchain than the one the real build used.

--- a/contrib/abicheck-clang-plugin/AGENTS.md
+++ b/contrib/abicheck-clang-plugin/AGENTS.md
@@ -24,13 +24,31 @@ A build of this plugin only loads into the exact clang it was built against
 
 - Don't assume a locally-built `.so` from one LLVM version is reusable
   against another — `.github/workflows/clang-plugin.yml` validates a
-  **matrix** of LLVM/Clang majors (16/17/18 as of this writing; check the
+  **matrix** of LLVM/Clang majors (16-22 as of this writing; check the
   workflow for the current set) precisely because there is no single
   portable artifact.
 - If you add code that depends on a Clang/LLVM API that changed shape across
   those majors, either guard it with a version check or confirm the whole
   matrix still builds — a change that only compiles against the newest
-  major silently breaks the older legs.
+  major silently breaks the older legs. `clang::FileEntry::getName()` is one
+  concrete example: it exists on 16/17 (where `SourceManager::fileinfo_*`
+  iterates `const FileEntry *`) but was removed upstream by the time LLVM
+  reached 22 — `AbicheckFactsPlugin.cpp`'s `fileEntryKeyName` overload for
+  that type is now guarded `#if CLANG_VERSION_MAJOR < 18` (18 is where the
+  iteration key itself switched to `FileEntryRef`, which still has
+  `getName()`), instead of relying on overload resolution alone to make the
+  now-uncompilable overload unreachable dead code.
+- **A vendor/downstream LLVM fork (Intel's icpx, Apple's clang, etc.)
+  reporting the same `__clang_major__` as an apt.llvm.org major does not mean
+  the plugin builds or loads against it.** This CI matrix only proves parity
+  against vanilla apt.llvm.org majors; a fork can diverge in API (its own
+  patches) or ABI (struct/vtable layout) independently of that number, and
+  most forks don't ship the LLVM/Clang CMake devel package needed to build
+  against them at all (confirmed for Intel's icpx/icx: its apt packages
+  carry `IntelSYCL`/`IntelDPCPP` CMake helpers, never `LLVMConfig.cmake`/
+  `ClangConfig.cmake`). Building against that fork's *own* source at the
+  matching release commit is the only reliable path if support is ever
+  wanted; a green matrix leg here is not evidence toward that.
 - This asymmetry is *why* the plugin is optional infrastructure: Full source
   scan and the `abicheck-cc` wrapper remain the portable, always-supported
   producers. Don't propose making the plugin required without addressing

--- a/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
+++ b/contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp
@@ -2967,12 +2967,19 @@ private:
   // changed across the LLVM majors this plugin supports (C.5): `FileEntryRef`
   // from LLVM 18, `const FileEntry *` on LLVM 16/17 (confirmed by the C.6 CI
   // matrix — a `FileEntryRef fe = it->first;` here fails to compile on 17).
-  // The two overloads below dispatch on whichever key type the installed
-  // clang headers actually declare, so this file builds unmodified against
-  // every matrix leg without an `#if CLANG_VERSION_MAJOR` guard.
+  // Originally this dispatched via overload resolution alone (no version
+  // guard needed, since only one overload is ever reachable per major) --
+  // but `clang::FileEntry::getName()` was itself removed upstream by LLVM 22
+  // (`FileEntry` is no longer name-bearing at all; only `FileEntryRef`,
+  // which wraps the owning map entry, exposes a name), so the `const
+  // FileEntry *` overload's *body* now fails to compile even though nothing
+  // calls it on 18+. Guard it out by version instead of relying on it being
+  // unreachable dead code.
+#if CLANG_VERSION_MAJOR < 18
   static llvm::StringRef fileEntryKeyName(const FileEntry *fe) {
     return fe->getName();
   }
+#endif
   static llvm::StringRef fileEntryKeyName(FileEntryRef fe) {
     return fe.getName();
   }

--- a/contrib/abicheck-clang-plugin/README.md
+++ b/contrib/abicheck-clang-plugin/README.md
@@ -2,7 +2,7 @@
 
 > Status: **optional optimization**, implemented (ADR-038 Plugin injection).
 > Built and validated by the dedicated `clang-plugin` workflow across
-> LLVM/Clang 16/17/18 (the C.6 differential-conformance test), but **never a
+> LLVM/Clang 16-22 (the C.6 differential-conformance test), but **never a
 > required gate in the main abicheck CI** — it is ABI-locked to the loading
 > clang's LLVM major (ADR-038 C.5). The supported portable producers remain
 > Full source scan (`abicheck dump --sources`/`--build-info` +

--- a/docs/user-guide/dump-compare-flags.md
+++ b/docs/user-guide/dump-compare-flags.md
@@ -46,7 +46,13 @@ abicheck compare libv1.so libv2.so -H include/foo.h \
 ```
 
 Available compile-context flags (on `dump`, `compare`, and `scan`):
-- `--gcc-path` — path to the cross-compiler binary
+- `--gcc-path` — path to the cross-compiler binary. For the `clang`
+  `--ast-frontend`, this is honored only when the binary is clang-family
+  (basename contains `clang`, or is a known non-`clang`-named clang-based
+  fork — currently Intel's `icx`/`icpx`/`dpcpp`/`dpcpp-cl`); a path to a real
+  GCC binary is ignored here and the frontend falls back to plain `clang` on
+  `PATH` instead (castxml can't take clang-only flags, so this guards against
+  a GCC path being misread as a clang toolchain)
 - `--gcc-prefix` — toolchain prefix (e.g. `aarch64-linux-gnu-`)
 - `--gcc-options` — extra compiler flags passed to the header frontend
 - `--sysroot` — alternative system root directory

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -43,6 +43,7 @@ from abicheck.dumper_clang import (
     _ClangAstParser,
     _Decl,
     _function_qualifiers,
+    _is_clang_family_binary,
     _pointer_depth,
     _return_type,
 )
@@ -2100,6 +2101,32 @@ def test_clang_header_dump_nonzero_exit_raises(
     monkeypatch.setattr(dumper.deadline, "run_bounded", lambda *a, **k: _P())
     with pytest.raises(SnapshotError, match="failed to parse"):
         _clang_header_dump([header], [])
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/usr/bin/clang", True),
+        ("/usr/bin/clang++-18", True),
+        ("clang-cl.exe", True),  # extension stripped via .stem, still matches
+        ("/opt/intel/oneapi/compiler/2026.1/bin/icx", True),
+        ("/opt/intel/oneapi/compiler/2026.1/bin/icpx", True),
+        ("/opt/intel/oneapi/compiler/2026.1/bin/dpcpp", True),
+        ("/opt/intel/oneapi/compiler/2026.1/bin/dpcpp-cl", True),
+        ("ICPX", True),  # case-insensitive
+        ("icpx.exe", True),  # extension stripped, still matches the alias set
+        ("/usr/bin/g++-13", False),
+        ("/usr/bin/x86_64-linux-gnu-gcc-13", False),
+        ("cl.exe", False),  # MSVC's own cl.exe is not clang-family
+        ("icc", False),  # Intel's older, non-clang-based Classic compiler
+    ],
+)
+def test_is_clang_family_binary(path: str, expected: bool) -> None:
+    """Pure-function unit test for the --gcc-path clang-family classifier,
+    directly exercising both the "clang" substring branch and the vendor
+    alias-set branch (icx/icpx/dpcpp/dpcpp-cl) in isolation from the larger
+    _clang_header_dump/_resolve_clang_bin call chain the tests below cover."""
+    assert _is_clang_family_binary(path) is expected
 
 
 def test_clang_header_dump_gcc_path_not_used_as_clang(

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -190,7 +190,11 @@ def test_explicit_is_tristate() -> None:
                     "mangledName": "_ZN1CC1Ei",
                     "explicit": True,
                     "inner": [
-                        {"kind": "ParmVarDecl", "name": "n", "type": {"qualType": "int"}}
+                        {
+                            "kind": "ParmVarDecl",
+                            "name": "n",
+                            "type": {"qualType": "int"},
+                        }
                     ],
                 },
                 {
@@ -238,9 +242,7 @@ def test_parse_constants_scoped_to_public_headers() -> None:
             "inner": [{"kind": "IntegerLiteral", "value": "7"}],
         },
     )
-    parser = _ClangAstParser(
-        root, set(), set(), public_header_paths=["include/foo.h"]
-    )
+    parser = _ClangAstParser(root, set(), set(), public_header_paths=["include/foo.h"])
     # Public constant kept and namespace-qualified; private-header one dropped.
     assert parser.parse_constants() == {"ns::kMax": "42"}
 
@@ -434,7 +436,11 @@ def test_parse_types_anonymous_aggregate_flattening_sets_flag() -> None:
                     "completeDefinition": True,
                     "inner": [
                         {"kind": "FieldDecl", "name": "i", "type": {"qualType": "int"}},
-                        {"kind": "FieldDecl", "name": "f", "type": {"qualType": "float"}},
+                        {
+                            "kind": "FieldDecl",
+                            "name": "f",
+                            "type": {"qualType": "float"},
+                        },
                     ],
                 },
                 {"kind": "IndirectFieldDecl", "name": "i"},
@@ -692,7 +698,9 @@ def test_resolve_header_backend_env_override(monkeypatch: pytest.MonkeyPatch) ->
     assert _resolve_header_backend("castxml") == "castxml"
 
 
-def test_resolve_header_backend_ast_frontend_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_resolve_header_backend_ast_frontend_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """ABICHECK_AST_FRONTEND is the canonical env knob."""
     monkeypatch.setenv("ABICHECK_AST_FRONTEND", "clang")
     assert _resolve_header_backend("auto") == "clang"
@@ -760,7 +768,9 @@ def _stub_clang_self_heal(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "abicheck.dumper._resolve_clang_system_includes", lambda *a, **k: ()
     )
-    fail = _sp.CompletedProcess(args=[], returncode=1, stdout="", stderr="fatal error: 'cstddef' file not found")
+    fail = _sp.CompletedProcess(
+        args=[], returncode=1, stdout="", stderr="fatal error: 'cstddef' file not found"
+    )
     ok = _sp.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
     calls = {"n": 0}
 
@@ -936,9 +946,12 @@ def test_constants_private_member_skipped() -> None:
         }
     )
     # The default class access is private → not part of the public constant set.
-    assert _ClangAstParser(
-        root, set(), set(), public_header_paths=["include/foo.h"]
-    ).parse_constants() == {}
+    assert (
+        _ClangAstParser(
+            root, set(), set(), public_header_paths=["include/foo.h"]
+        ).parse_constants()
+        == {}
+    )
 
 
 # ── records: union / C struct / field qualifiers ─────────────────────────────
@@ -1191,11 +1204,20 @@ def test_header_ast_parser_clang_branch(monkeypatch: pytest.MonkeyPatch) -> None
     )
     monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: ast)
     parser = _header_ast_parser(
-        [], [], backend="clang", compiler="c++",
-        gcc_path=None, gcc_prefix=None, gcc_options=None,
-        sysroot=None, nostdinc=False, lang=None,
-        exported_dynamic={"_Z3foov"}, exported_static=set(),
-        public_header_paths=[], public_dir_paths=[],
+        [],
+        [],
+        backend="clang",
+        compiler="c++",
+        gcc_path=None,
+        gcc_prefix=None,
+        gcc_options=None,
+        sysroot=None,
+        nostdinc=False,
+        lang=None,
+        exported_dynamic={"_Z3foov"},
+        exported_static=set(),
+        public_header_paths=[],
+        public_dir_paths=[],
     )
     assert isinstance(parser, _ClangAstParser)
     assert [f.name for f in parser.parse_functions()] == ["foo"]
@@ -1206,11 +1228,20 @@ def test_header_ast_parser_castxml_branch(monkeypatch: pytest.MonkeyPatch) -> No
     monkeypatch.setattr(dumper, "_castxml_dump", lambda *a, **k: sentinel)
     monkeypatch.setattr(dumper, "_CastxmlParser", lambda *a, **k: "castxml-parser")
     parser = _header_ast_parser(
-        [], [], backend="castxml", compiler="c++",
-        gcc_path=None, gcc_prefix=None, gcc_options=None,
-        sysroot=None, nostdinc=False, lang=None,
-        exported_dynamic=set(), exported_static=set(),
-        public_header_paths=[], public_dir_paths=[],
+        [],
+        [],
+        backend="castxml",
+        compiler="c++",
+        gcc_path=None,
+        gcc_prefix=None,
+        gcc_options=None,
+        sysroot=None,
+        nostdinc=False,
+        lang=None,
+        exported_dynamic=set(),
+        exported_static=set(),
+        public_header_paths=[],
+        public_dir_paths=[],
     )
     assert parser == "castxml-parser"
 
@@ -1326,7 +1357,9 @@ def test_parse_clang_ast_result_swallows_cache_write_failure(
     # unwritable cache dir) must not turn a successful parse into an error —
     # the caller already has the parsed root; only the cache population is lost.
     ast_path = tmp_path / "ast.json"
-    ast_path.write_text('{"kind": "TranslationUnitDecl", "inner": []}', encoding="utf-8")
+    ast_path.write_text(
+        '{"kind": "TranslationUnitDecl", "inner": []}', encoding="utf-8"
+    )
     result = _fake_proc(stdout="", stderr="", returncode=0)
 
     def _boom(_src, _dst):
@@ -1346,7 +1379,9 @@ def test_parse_clang_ast_result_rechecks_deadline_after_json_load(
     # streamed cache copy, or an expired budget still completes it and hands
     # back a result for downstream AST walking.
     ast_path = tmp_path / "ast.json"
-    ast_path.write_text('{"kind": "TranslationUnitDecl", "inner": []}', encoding="utf-8")
+    ast_path.write_text(
+        '{"kind": "TranslationUnitDecl", "inner": []}', encoding="utf-8"
+    )
     result = _fake_proc(stdout="", stderr="", returncode=0)
     real_json_load = dumper_clang_errors.json.load
 
@@ -1368,7 +1403,9 @@ def test_parse_clang_ast_result_rechecks_deadline_after_cache_copy(
     # before returning so a budget that expired during the copy doesn't
     # silently hand the result to the (also potentially expensive) caller.
     ast_path = tmp_path / "ast.json"
-    ast_path.write_text('{"kind": "TranslationUnitDecl", "inner": []}', encoding="utf-8")
+    ast_path.write_text(
+        '{"kind": "TranslationUnitDecl", "inner": []}', encoding="utf-8"
+    )
     result = _fake_proc(stdout="", stderr="", returncode=0)
 
     def _slow_copy(_src, _dst):
@@ -1423,7 +1460,8 @@ def test_clang_header_dump_no_output_raises(
     # Exit 0 but empty stdout → the "no AST" path (a nonzero exit is the
     # earlier branch, covered by test_clang_header_dump_nonzero_exit_raises).
     monkeypatch.setattr(
-        dumper.deadline, "run_bounded",
+        dumper.deadline,
+        "run_bounded",
         lambda *a, **k: _fake_proc(stdout="", stderr="boom", returncode=0),
     )
     with pytest.raises(SnapshotError, match="no AST"):
@@ -1527,7 +1565,9 @@ def test_clang_header_dump_retries_cpp_on_missing_cpp_stdlib_header(
     def _run(cmd, **kwargs):
         cmds.append(list(cmd))
         if len(cmds) == 1:
-            return _fake_proc(stderr="fatal error: 'cstddef' file not found", returncode=1)
+            return _fake_proc(
+                stderr="fatal error: 'cstddef' file not found", returncode=1
+            )
         _write_stdout_file(kwargs, ast_json)
         return _fake_proc(returncode=0)
 
@@ -1662,7 +1702,9 @@ def test_typedef_desugared_fallback() -> None:
             "type": {"desugaredQualType": "unsigned long"},
         }
     )
-    assert _ClangAstParser(root, set(), set()).parse_typedefs() == {"t": "unsigned long"}
+    assert _ClangAstParser(root, set(), set()).parse_typedefs() == {
+        "t": "unsigned long"
+    }
 
 
 def test_function_with_no_type_defaults_to_void_return() -> None:
@@ -1905,10 +1947,18 @@ def test_anonymous_union_members_flattened() -> None:
                     "tagUsed": "union",
                     "inner": [
                         {"kind": "FieldDecl", "name": "i", "type": {"qualType": "int"}},
-                        {"kind": "FieldDecl", "name": "f", "type": {"qualType": "float"}},
+                        {
+                            "kind": "FieldDecl",
+                            "name": "f",
+                            "type": {"qualType": "float"},
+                        },
                     ],
                 },
-                {"kind": "FieldDecl", "name": "", "type": {"qualType": "union S::(anonymous)"}},
+                {
+                    "kind": "FieldDecl",
+                    "name": "",
+                    "type": {"qualType": "union S::(anonymous)"},
+                },
                 {"kind": "IndirectFieldDecl", "name": "i"},
                 {"kind": "IndirectFieldDecl", "name": "f"},
                 {"kind": "FieldDecl", "name": "tag", "type": {"qualType": "int"}},
@@ -1916,7 +1966,11 @@ def test_anonymous_union_members_flattened() -> None:
         }
     )
     (s,) = _ClangAstParser(root, set(), set()).parse_types()
-    assert [(f.name, f.type) for f in s.fields] == [("i", "int"), ("f", "float"), ("tag", "int")]
+    assert [(f.name, f.type) for f in s.fields] == [
+        ("i", "int"),
+        ("f", "float"),
+        ("tag", "int"),
+    ]
 
 
 def test_typedef_anonymous_record_inside_struct_not_flattened() -> None:
@@ -1935,7 +1989,9 @@ def test_typedef_anonymous_record_inside_struct_not_flattened() -> None:
                     "kind": "RecordDecl",
                     "name": "",
                     "tagUsed": "struct",
-                    "inner": [{"kind": "FieldDecl", "name": "z", "type": {"qualType": "int"}}],
+                    "inner": [
+                        {"kind": "FieldDecl", "name": "z", "type": {"qualType": "int"}}
+                    ],
                 },
                 {"kind": "TypedefDecl", "name": "T", "type": {"qualType": "struct T"}},
                 {"kind": "FieldDecl", "name": "a", "type": {"qualType": "int"}},
@@ -1968,8 +2024,16 @@ def test_hidden_friend_function_marked() -> None:
                             "mangledName": "_ZeqRK2PtS1_",
                             "type": {"qualType": "bool (Pt, Pt)"},
                             "inner": [
-                                {"kind": "ParmVarDecl", "name": "a", "type": {"qualType": "Pt"}},
-                                {"kind": "ParmVarDecl", "name": "b", "type": {"qualType": "Pt"}},
+                                {
+                                    "kind": "ParmVarDecl",
+                                    "name": "a",
+                                    "type": {"qualType": "Pt"},
+                                },
+                                {
+                                    "kind": "ParmVarDecl",
+                                    "name": "b",
+                                    "type": {"qualType": "Pt"},
+                                },
                             ],
                         }
                     ],
@@ -2073,6 +2137,56 @@ def test_clang_header_dump_explicit_clang_path_honored(
     with pytest.raises(SnapshotError):
         _clang_header_dump([header], [], gcc_path="/opt/llvm/bin/clang-18")
     assert seen["bin"] == "/opt/llvm/bin/clang-18"
+
+
+@pytest.mark.parametrize(
+    "gcc_path",
+    [
+        "/opt/intel/oneapi/compiler/2026.1/bin/icpx",
+        "/opt/intel/oneapi/compiler/2026.1/bin/icx",
+        "/opt/intel/oneapi/compiler/2026.1/bin/dpcpp",
+        "/opt/intel/oneapi/compiler/2026.1/bin/dpcpp-cl",
+        "ICPX",  # case-insensitive
+    ],
+)
+def test_clang_header_dump_gcc_path_recognizes_icx_family(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, gcc_path: str
+) -> None:
+    # Intel's oneAPI DPC++/C++ compiler is clang-based (accepts -Xclang directly)
+    # but is not spelled "clang" -- --gcc-path must still be honored for it
+    # instead of silently falling back to a plain "clang" on PATH (a different,
+    # possibly differently-configured compiler than the one the real build used).
+    header = tmp_path / "foo.h"
+    header.write_text("int foo(void);\n")
+    seen = {}
+
+    def _avail(b="clang"):
+        seen["bin"] = b
+        return False
+
+    monkeypatch.setattr(dumper_clang, "_clang_available", _avail)
+    with pytest.raises(SnapshotError):
+        _clang_header_dump([header], [], gcc_path=gcc_path)
+    assert seen["bin"] == gcc_path
+
+
+def test_clang_header_dump_gcc_path_gcc_binary_not_mistaken_for_icx(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    # A real GCC binary must not accidentally match the icx/icpx alias set.
+    header = tmp_path / "foo.h"
+    header.write_text("int foo(void);\n")
+    seen = {}
+
+    def _avail(b="clang"):
+        seen["bin"] = b
+        return False
+
+    monkeypatch.setattr(dumper_clang, "_clang_available", _avail)
+    with pytest.raises(SnapshotError):
+        _clang_header_dump([header], [], gcc_path="/usr/bin/x86_64-linux-gnu-gcc-13")
+    assert seen["bin"] != "/usr/bin/x86_64-linux-gnu-gcc-13"
+    assert "clang" in seen["bin"]
 
 
 def test_clang_header_dump_gcc_prefix_maps_to_prefixed_clang(
@@ -2309,16 +2423,20 @@ def test_resolve_clang_system_includes_gating(
         "c++", sysroot=None, nostdinc=False, **base
     ) == ("/usr/include/c++/13",)
     # nostdinc, explicit sysroot, or the env toggle each suppress the probe.
-    assert _resolve_clang_system_includes(
-        "c++", sysroot=None, nostdinc=True, **base
-    ) == ()
-    assert _resolve_clang_system_includes(
-        "c++", sysroot=Path("/sysroot"), nostdinc=False, **base
-    ) == ()
+    assert (
+        _resolve_clang_system_includes("c++", sysroot=None, nostdinc=True, **base) == ()
+    )
+    assert (
+        _resolve_clang_system_includes(
+            "c++", sysroot=Path("/sysroot"), nostdinc=False, **base
+        )
+        == ()
+    )
     monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "0")
-    assert _resolve_clang_system_includes(
-        "c++", sysroot=None, nostdinc=False, **base
-    ) == ()
+    assert (
+        _resolve_clang_system_includes("c++", sysroot=None, nostdinc=False, **base)
+        == ()
+    )
 
 
 def test_resolve_clang_system_includes_no_compiler(
@@ -2328,17 +2446,27 @@ def test_resolve_clang_system_includes_no_compiler(
 
     monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "1")
     monkeypatch.setattr(dumper_sysinc, "_resolve_probe_compiler", lambda *a, **k: None)
-    assert _resolve_clang_system_includes(
-        "c++", gcc_path=None, gcc_prefix=None, sysroot=None,
-        nostdinc=False, force_cpp=True,
-    ) == ()
+    assert (
+        _resolve_clang_system_includes(
+            "c++",
+            gcc_path=None,
+            gcc_prefix=None,
+            sysroot=None,
+            nostdinc=False,
+            force_cpp=True,
+        )
+        == ()
+    )
 
 
 def test_build_clang_command_injects_isystem(tmp_path: Path) -> None:
     agg = tmp_path / "agg.hpp"
     agg.write_text("")
     cmd = _build_clang_header_command(
-        "clang++", "gnu", [tmp_path / "inc"], agg,
+        "clang++",
+        "gnu",
+        [tmp_path / "inc"],
+        agg,
         force_cpp=True,
         system_includes=("/usr/include/c++/13", "/usr/include"),
     )
@@ -2357,7 +2485,10 @@ def test_build_clang_command_probed_isystem_after_user_flags(tmp_path: Path) -> 
     agg = tmp_path / "agg.hpp"
     agg.write_text("")
     cmd = _build_clang_header_command(
-        "clang++", "gnu", [], agg,
+        "clang++",
+        "gnu",
+        [],
+        agg,
         force_cpp=True,
         gcc_options="-isystem /sdk/include",
         gcc_option_tokens=("-isystem", "/sdk2"),
@@ -2397,16 +2528,23 @@ def test_resolve_clang_system_includes_respects_passthrough(
     from abicheck import dumper_sysinc
 
     monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "1")
-    monkeypatch.setattr(
-        dumper_sysinc, "_resolve_probe_compiler", lambda *a, **k: "g++"
-    )
+    monkeypatch.setattr(dumper_sysinc, "_resolve_probe_compiler", lambda *a, **k: "g++")
     monkeypatch.setattr(
         dumper_sysinc, "_probe_gnu_system_includes", lambda *a, **k: ["/usr/x"]
     )
-    assert _resolve_clang_system_includes(
-        "c++", gcc_path=None, gcc_prefix=None, sysroot=None, nostdinc=False,
-        force_cpp=True, gcc_options=gcc_options, gcc_option_tokens=gcc_option_tokens,
-    ) == ()
+    assert (
+        _resolve_clang_system_includes(
+            "c++",
+            gcc_path=None,
+            gcc_prefix=None,
+            sysroot=None,
+            nostdinc=False,
+            force_cpp=True,
+            gcc_options=gcc_options,
+            gcc_option_tokens=gcc_option_tokens,
+        )
+        == ()
+    )
 
 
 def test_resolve_clang_system_includes_probes_without_passthrough(
@@ -2416,15 +2554,19 @@ def test_resolve_clang_system_includes_probes_without_passthrough(
     from abicheck import dumper_sysinc
 
     monkeypatch.setenv("ABICHECK_AUTO_SYSTEM_INCLUDES", "1")
-    monkeypatch.setattr(
-        dumper_sysinc, "_resolve_probe_compiler", lambda *a, **k: "g++"
-    )
+    monkeypatch.setattr(dumper_sysinc, "_resolve_probe_compiler", lambda *a, **k: "g++")
     monkeypatch.setattr(
         dumper_sysinc, "_probe_gnu_system_includes", lambda *a, **k: ["/usr/x"]
     )
     assert _resolve_clang_system_includes(
-        "c++", gcc_path=None, gcc_prefix=None, sysroot=None, nostdinc=False,
-        force_cpp=True, gcc_options="-DFOO=1", gcc_option_tokens=("-O2",),
+        "c++",
+        gcc_path=None,
+        gcc_prefix=None,
+        sysroot=None,
+        nostdinc=False,
+        force_cpp=True,
+        gcc_options="-DFOO=1",
+        gcc_option_tokens=("-O2",),
     ) == ("/usr/x",)
 
 


### PR DESCRIPTION
## Summary

Two independent, locally-verified fixes that came out of validating claims from the oneDAL PR's Intel/icpx integration work:

- **Clang facts plugin now builds against LLVM/Clang 19-22** (`contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp`). `clang::FileEntry::getName()` was removed upstream (the `SourceManager::fileinfo_*` iteration key moved to `FileEntryRef`, which keeps its own `getName()`, back in LLVM 18), so the now-unreachable `const FileEntry *` overload of `fileEntryKeyName()` failed to *compile* on current LLVM majors even though nothing calls it there. Guarded `#if CLANG_VERSION_MAJOR < 18` instead of relying on overload resolution alone to keep it dead code.
- **`--gcc-path` now recognizes Intel's `icx`/`icpx`/`dpcpp`/`dpcpp-cl`** as clang-family binaries (`abicheck/dumper_clang.py`). Previously the check only matched a `"clang"` substring in the binary name, so `--gcc-path /path/to/icpx` was silently ignored and the `clang` `--ast-frontend` fell back to a plain `clang` on `PATH` — a different, possibly-mismatched toolchain than the one the real build used. This removes the need for a symlink workaround (e.g. `icpx-clang++ -> icpx`) to get `--gcc-path` honored. As part of this, the match switched from `Path(gcc_path).name.lower()` to `.stem.lower()` — extension-agnostic (e.g. `icpx.exe` on Windows), a minor incidental improvement riding along with the alias-list addition.

## Verification

- Clang plugin fix verified against **real** LLVM/Clang 16, 17, 18, and 22 pulled from apt.llvm.org (not mocked): builds clean on all four, and the C.6 differential-conformance test, the end-to-end scan-flow test, and the public-roots diagnostic test all pass unmodified on every major.
- `.github/workflows/clang-plugin.yml` matrix extended from 16-18 to 16-22 (gcc + clang host legs at the oldest and newest tested majors) so this class of upstream API churn is caught automatically going forward.
- `--gcc-path` fix covered by new unit tests (`tests/test_dumper_clang.py`): a parametrized `test_is_clang_family_binary` exercises the pure classifier directly (both the `"clang"`-substring branch and the vendor alias-set branch, plus negatives like `cl.exe`/`icc`), and the existing `_clang_header_dump`-level tests confirm the end-to-end wiring (icx/icpx/dpcpp/dpcpp-cl honored, a real GCC binary still rejected).
- `ruff check`/`ruff format --check`/`mypy abicheck/dumper_clang.py`/`python scripts/check_ai_readiness.py` all clean (0 errors). CI: all 71 checks green (`codecov/patch` 92.85% patch coverage, target 90%).

## Note on diff size

`abicheck/dumper_clang.py` and `tests/test_dumper_clang.py` carry a lot of `ruff format` reflow beyond the ~25-line functional change — those two files weren't fully `ruff format`-clean on `main` before this PR, and touching them triggered a full-file reformat. That noise is why `changed_files`/`additions` look large relative to the actual fix; the functional diff is the `_is_clang_family_binary` addition in `dumper_clang.py`, the `#if CLANG_VERSION_MAJOR < 18` guard in the plugin, and the CI matrix entries.

## Non-goals / explicitly out of scope

This does **not** add Intel icpx support to the Clang plugin producer. Intel's oneAPI apt packages (confirmed via `dpkg-deb -c` against the real `2026.1.0-235` package) ship no `LLVMConfig.cmake`/`ClangConfig.cmake` at all — only `IntelSYCL`/`IntelDPCPP` CMake helpers — so a green matrix leg here says nothing about building against icpx's own fork. `AGENTS.md` documents this explicitly. The portable path for icpx today is the `wrapper` producer (`abicheck-cc icpx ...`) or `--ast-frontend clang` with `--gcc-path` (now fixed by this PR), neither of which need any vendor CMake package.

## Test plan

- [x] `python contrib/abicheck-clang-plugin/tests/conformance.py --plugin <so> --clangxx clang++` — passes on LLVM 16, 17, 18, 22
- [x] `python contrib/abicheck-clang-plugin/tests/scan_flow.py --plugin <so> --clangxx clang++` — passes on LLVM 22
- [x] `python contrib/abicheck-clang-plugin/tests/test_public_roots_diagnostic.py --plugin <so> --clangxx clang++` — passes on LLVM 22
- [x] `pytest tests/test_dumper_clang.py -q` — 175 passed
- [x] `ruff check` / `ruff format --check` / `mypy abicheck/dumper_clang.py` — clean
- [x] `python scripts/check_ai_readiness.py` — 0 errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and validating the Clang plugin with LLVM/Clang versions 19–22.
  * Added recognition for Intel LLVM-family compiler binaries, including `icx`, `icpx`, `dpcpp`, and `dpcpp-cl`, when configuring compiler paths.

* **Bug Fixes**
  * Resolved compatibility issues with newer LLVM releases.
  * Prevented GCC binaries from being incorrectly treated as Clang-family compilers.

* **Documentation**
  * Updated plugin support coverage and compiler-path behavior documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->