### PR TITLE
fix: pvxs acceptance-spike false positives — bare-name type collision + anonymous-enum path leak

### DIFF
--- a/abicheck/diff_cxx_rules.py
+++ b/abicheck/diff_cxx_rules.py
@@ -21,7 +21,7 @@ Kept as a leaf module (depending only on the data model and result types) so
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 from .checker_policy import ChangeKind
 from .checker_types import Change
@@ -294,7 +294,7 @@ def owner_class_of(f: Function) -> str | None:
 
 
 def _resolve_owner_type(
-    owner: str, types: dict[str, RecordType], known_owners: set[str]
+    owner: str, types: Mapping[str, RecordType], known_owners: set[str]
 ) -> RecordType | None:
     """Look up the owner's record, tolerating qualified-vs-leaf naming.
 
@@ -331,7 +331,7 @@ def virtual_signature_key(f: Function) -> str:
     return f"{leaf}({params}){quals}"
 
 
-def _owner_descends_from(owner: str, ancestor: str, types: dict[str, RecordType]) -> bool:
+def _owner_descends_from(owner: str, ancestor: str, types: Mapping[str, RecordType]) -> bool:
     """True if *owner* names *ancestor* itself, or a transitive base of it in *types*.
 
     Tolerant of qualified-vs-leaf naming the same way ``_transitive_bases``
@@ -448,8 +448,8 @@ def vtable_slot_is_override_reuse(
     new_entry: str,
     old_funcs: dict[str, Function],
     new_funcs: dict[str, Function],
-    old_types: dict[str, RecordType],
-    new_types: dict[str, RecordType],
+    old_types: Mapping[str, RecordType],
+    new_types: Mapping[str, RecordType],
 ) -> bool:
     """True if a vtable slot's mangled entry changed only because a derived
     class overrode the inherited virtual that occupied it, reusing the same
@@ -519,7 +519,7 @@ def old_virtual_signatures(functions: Iterable[Function]) -> dict[str, set[str]]
     return sigs
 
 
-def _transitive_bases(start: RecordType | None, types: dict[str, RecordType]) -> set[str]:
+def _transitive_bases(start: RecordType | None, types: Mapping[str, RecordType]) -> set[str]:
     """All (transitive) base-class names reachable from record ``start``.
 
     Walks ``bases`` / ``virtual_bases``, resolving each base name through the
@@ -544,8 +544,8 @@ def _transitive_bases(start: RecordType | None, types: dict[str, RecordType]) ->
 def virtual_method_addition(
     f_new: Function,
     old_owner_classes: set[str],
-    old_types: dict[str, RecordType],
-    new_types: dict[str, RecordType],
+    old_types: Mapping[str, RecordType],
+    new_types: Mapping[str, RecordType],
     old_virtual_sigs: dict[str, set[str]],
 ) -> Change | None:
     """A new *virtual* method on a class that already exists across versions.

--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -256,9 +256,11 @@ class TypeMap(Mapping[str, RecordType]):
             return t
         alias_key = self._bare_alias.get(key)
         if alias_key is not None:
-            t = self._primary.get(alias_key)
-            if t is not None:
-                return t
+            # _bare_alias values are always keys already present in
+            # _primary (built from it, see __init__) -- a plain indexing
+            # KeyError here would indicate a construction bug, not a normal
+            # "key absent" case.
+            return self._primary[alias_key]
         raise KeyError(key)
 
     def __len__(self) -> int:

--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -35,12 +35,11 @@ new policy.
 from __future__ import annotations
 
 from collections.abc import Callable, ItemsView, Iterable, Iterator, Mapping, ValuesView
-from typing import Any, TypeVar, cast
+from typing import Any, Protocol, TypeVar, cast
 
 from .change_registry import REGISTRY
 from .checker_policy import ChangeKind
 from .checker_types import Change
-from .model import RecordType
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -186,11 +185,27 @@ def diff_by_key(
 
 
 # ── Type-level old/new matching (moved out of diff_types.py, PR #608) ──────
+#
+# Generalized (PR #608 follow-up) over any entity kind that has the same
+# bare-``name`` / optional-``qualified_name`` split — ``RecordType`` was the
+# original motivating case, ``EnumType`` shares the identical ambiguity
+# (two distinct enums sharing a bare leaf name in different namespaces) and
+# the identical fix, so both are expressed as one generic implementation
+# via the ``_QualifiedNamed`` structural protocol rather than duplicating
+# ``TypeMap`` per entity kind.
 
 
-def type_map_key(t: RecordType) -> str:
-    """Key a ``RecordType`` for old/new matching by its namespace-qualified
-    identity, not its bare declaration name.
+class _QualifiedNamed(Protocol):
+    name: str
+    qualified_name: str | None
+
+
+Q = TypeVar("Q", bound=_QualifiedNamed)
+
+
+def type_map_key(t: _QualifiedNamed) -> str:
+    """Key a ``RecordType``/``EnumType`` for old/new matching by its
+    namespace-qualified identity, not its bare declaration name.
 
     The header-mode dumpers (castxml, clang) deliberately keep ``t.name``
     bare (see its docstring in model.py) and carry the real namespace path in
@@ -206,9 +221,10 @@ def type_map_key(t: RecordType) -> str:
     return t.qualified_name or t.name
 
 
-class TypeMap(Mapping[str, RecordType]):
-    """An old/new ``RecordType`` matching map keyed by :func:`type_map_key`,
-    with a collision-safe bare-``name`` alias used only for lookups.
+class TypeMap(Mapping[str, Q]):
+    """An old/new matching map (``RecordType`` or ``EnumType``) keyed by
+    :func:`type_map_key`, with a collision-safe bare-``name`` alias used
+    only for lookups.
 
     The alias exists for schema-evolution compatibility: an older serialized/
     header snapshot that predates ``qualified_name`` (or a producer that
@@ -230,8 +246,8 @@ class TypeMap(Mapping[str, RecordType]):
     :func:`type_map_key` itself was introduced to fix.
     """
 
-    def __init__(self, types: Iterable[RecordType]) -> None:
-        self._primary: dict[str, RecordType] = {}
+    def __init__(self, types: Iterable[Q]) -> None:
+        self._primary: dict[str, Q] = {}
         self._bare_owner: dict[str, str | None] = {}
         for t in types:
             key = type_map_key(t)
@@ -258,7 +274,7 @@ class TypeMap(Mapping[str, RecordType]):
         """
         return self._bare_owner.get(bare) is not None
 
-    def __getitem__(self, key: str) -> RecordType:
+    def __getitem__(self, key: str) -> Q:
         # get()/__contains__ come from the Mapping mixin, implemented in
         # terms of this — alias resolution lives in exactly one place.
         t = self._primary.get(key)
@@ -279,18 +295,18 @@ class TypeMap(Mapping[str, RecordType]):
     def __iter__(self) -> Iterator[str]:
         return iter(self._primary)
 
-    def items(self) -> ItemsView[str, RecordType]:
+    def items(self) -> ItemsView[str, Q]:
         return self._primary.items()
 
-    def values(self) -> ValuesView[RecordType]:
+    def values(self) -> ValuesView[Q]:
         return self._primary.values()
 
 
-def build_type_map(types: Iterable[RecordType]) -> TypeMap:
+def build_type_map(types: Iterable[Q]) -> TypeMap[Q]:
     return TypeMap(types)
 
 
-def lookup_matched_type(own: TypeMap, other: TypeMap, t: RecordType) -> RecordType | None:
+def lookup_matched_type(own: TypeMap[Q], other: TypeMap[Q], t: Q) -> Q | None:
     """Look up *t*'s counterpart in *other* (the opposite old/new ``TypeMap``
     from the one *t* itself came from, ``own``), trying both *t*'s own
     qualified matching key and its bare declaration name.

--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -278,3 +278,32 @@ class TypeMap(Mapping[str, RecordType]):
 
 def build_type_map(types: Iterable[RecordType]) -> TypeMap:
     return TypeMap(types)
+
+
+def lookup_matched_type(other: TypeMap, t: RecordType) -> RecordType | None:
+    """Look up *t*'s counterpart in *other* (the opposite old/new ``TypeMap``),
+    trying both *t*'s own qualified matching key and its bare declaration
+    name.
+
+    ``TypeMap``'s bare-name alias only maps bare -> qualified (see its
+    docstring): a legacy snapshot keyed by the bare name resolves fine
+    against a *fresh* qualified-keyed counterpart, because the fresh side's
+    map carries that alias. But there is no reverse qualified -> bare
+    mapping, so when *t* itself comes from the *fresh* (qualified-keyed) side
+    and *other* is the *legacy* one, looking ``other`` up by ``type_map_key(t)``
+    alone misses — ``other`` only has the bare key, never learns the
+    qualified spelling. A plain ``old_map.items()`` iteration only ever
+    tries the qualified key when the *old* side is legacy-vs-fresh-new is
+    the one direction that already worked; the reverse (fresh old,
+    legacy new) manufactured a phantom ``TYPE_REMOVED``/``TYPE_ADDED``
+    (Codex review, PR #608). Retrying with the bare name makes the
+    schema-evolution compatibility symmetric regardless of which side is
+    legacy.
+    """
+    key = type_map_key(t)
+    found = other.get(key)
+    if found is not None:
+        return found
+    if t.name != key:
+        return other.get(t.name)
+    return None

--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -34,12 +34,13 @@ new policy.
 """
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, ItemsView, Iterable, Iterator, Mapping, ValuesView
 from typing import Any, TypeVar, cast
 
 from .change_registry import REGISTRY
 from .checker_policy import ChangeKind
 from .checker_types import Change
+from .model import RecordType
 
 K = TypeVar("K")
 V = TypeVar("V")
@@ -182,3 +183,96 @@ def diff_by_key(
         if key not in old_map and on_added is not None:
             changes.extend(on_added(key, new_val))
     return changes
+
+
+# ── Type-level old/new matching (moved out of diff_types.py, PR #608) ──────
+
+
+def type_map_key(t: RecordType) -> str:
+    """Key a ``RecordType`` for old/new matching by its namespace-qualified
+    identity, not its bare declaration name.
+
+    The header-mode dumpers (castxml, clang) deliberately keep ``t.name``
+    bare (see its docstring in model.py) and carry the real namespace path in
+    ``t.qualified_name`` instead; the DWARF backend has no such split and
+    already stores the qualified spelling directly in ``name``. Matching
+    old/new maps by bare ``t.name`` alone lets two unrelated types that only
+    share a short/leaf spelling (e.g. two distinct ``std::*::_Impl`` template
+    internals pulled in transitively) collide and diff against each other,
+    producing spurious field/base-class findings. Falling back to ``t.name``
+    when ``qualified_name`` is unset (global-scope types, DWARF-only
+    snapshots) keeps existing behaviour unchanged there.
+    """
+    return t.qualified_name or t.name
+
+
+class TypeMap(Mapping[str, RecordType]):
+    """An old/new ``RecordType`` matching map keyed by :func:`type_map_key`,
+    with a collision-safe bare-``name`` alias used only for lookups.
+
+    The alias exists for schema-evolution compatibility: an older serialized/
+    header snapshot that predates ``qualified_name`` (or a producer that
+    never populates it) keys its own map entries by the bare name alone.
+    Without an alias, matching that against a freshly-dumped snapshot side
+    where the same namespaced type *does* carry ``qualified_name`` would key
+    the two sides differently (``Foo`` vs. ``ns::Foo``) and manufacture a
+    false ``TYPE_REMOVED``/``TYPE_ADDED`` pair for an unchanged type (Codex
+    review, PR #608).
+
+    The alias is only used for ``get``/``in`` — deliberately kept OUT of
+    ``items``/``values``/iteration, which stay one entry per type under its
+    canonical key. A dict literally containing both the qualified key and a
+    bare-name alias for the same object would make every ``for name, t in
+    old_map.items()``-style detector loop process that type (and emit its
+    finding) twice. It is also only added when the bare name is unambiguous
+    within *this* snapshot — not already claimed by a distinct qualified
+    identity — so it cannot reopen the short/leaf-name collision
+    :func:`type_map_key` itself was introduced to fix.
+    """
+
+    def __init__(self, types: Iterable[RecordType]) -> None:
+        self._primary: dict[str, RecordType] = {}
+        bare_owner: dict[str, str | None] = {}
+        for t in types:
+            key = type_map_key(t)
+            self._primary[key] = t
+            bare = t.name
+            if bare in bare_owner:
+                if bare_owner[bare] != key:
+                    bare_owner[bare] = None  # ambiguous: >1 distinct qualified identity
+            else:
+                bare_owner[bare] = key
+        self._bare_alias: dict[str, str] = {
+            bare: key
+            for bare, key in bare_owner.items()
+            if key is not None and bare not in self._primary
+        }
+
+    def __getitem__(self, key: str) -> RecordType:
+        # get()/__contains__ come from the Mapping mixin, implemented in
+        # terms of this — alias resolution lives in exactly one place.
+        t = self._primary.get(key)
+        if t is not None:
+            return t
+        alias_key = self._bare_alias.get(key)
+        if alias_key is not None:
+            t = self._primary.get(alias_key)
+            if t is not None:
+                return t
+        raise KeyError(key)
+
+    def __len__(self) -> int:
+        return len(self._primary)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._primary)
+
+    def items(self) -> ItemsView[str, RecordType]:
+        return self._primary.items()
+
+    def values(self) -> ValuesView[RecordType]:
+        return self._primary.values()
+
+
+def build_type_map(types: Iterable[RecordType]) -> TypeMap:
+    return TypeMap(types)

--- a/abicheck/diff_helpers.py
+++ b/abicheck/diff_helpers.py
@@ -232,21 +232,31 @@ class TypeMap(Mapping[str, RecordType]):
 
     def __init__(self, types: Iterable[RecordType]) -> None:
         self._primary: dict[str, RecordType] = {}
-        bare_owner: dict[str, str | None] = {}
+        self._bare_owner: dict[str, str | None] = {}
         for t in types:
             key = type_map_key(t)
             self._primary[key] = t
             bare = t.name
-            if bare in bare_owner:
-                if bare_owner[bare] != key:
-                    bare_owner[bare] = None  # ambiguous: >1 distinct qualified identity
+            if bare in self._bare_owner:
+                if self._bare_owner[bare] != key:
+                    self._bare_owner[bare] = None  # ambiguous: >1 distinct qualified identity
             else:
-                bare_owner[bare] = key
+                self._bare_owner[bare] = key
         self._bare_alias: dict[str, str] = {
             bare: key
-            for bare, key in bare_owner.items()
+            for bare, key in self._bare_owner.items()
             if key is not None and bare not in self._primary
         }
+
+    def bare_name_is_unambiguous(self, bare: str) -> bool:
+        """True if exactly one distinct qualified identity in this map
+        shares the bare declaration name *bare* (including the trivial case
+        of a single global-scope type whose own key already equals its bare
+        name). False for "no type has this bare name" and "two-or-more
+        *distinct* qualified identities share it" alike — both are unsafe to
+        treat as a single unambiguous target.
+        """
+        return self._bare_owner.get(bare) is not None
 
     def __getitem__(self, key: str) -> RecordType:
         # get()/__contains__ come from the Mapping mixin, implemented in
@@ -280,10 +290,10 @@ def build_type_map(types: Iterable[RecordType]) -> TypeMap:
     return TypeMap(types)
 
 
-def lookup_matched_type(other: TypeMap, t: RecordType) -> RecordType | None:
-    """Look up *t*'s counterpart in *other* (the opposite old/new ``TypeMap``),
-    trying both *t*'s own qualified matching key and its bare declaration
-    name.
+def lookup_matched_type(own: TypeMap, other: TypeMap, t: RecordType) -> RecordType | None:
+    """Look up *t*'s counterpart in *other* (the opposite old/new ``TypeMap``
+    from the one *t* itself came from, ``own``), trying both *t*'s own
+    qualified matching key and its bare declaration name.
 
     ``TypeMap``'s bare-name alias only maps bare -> qualified (see its
     docstring): a legacy snapshot keyed by the bare name resolves fine
@@ -292,18 +302,26 @@ def lookup_matched_type(other: TypeMap, t: RecordType) -> RecordType | None:
     mapping, so when *t* itself comes from the *fresh* (qualified-keyed) side
     and *other* is the *legacy* one, looking ``other`` up by ``type_map_key(t)``
     alone misses — ``other`` only has the bare key, never learns the
-    qualified spelling. A plain ``old_map.items()`` iteration only ever
-    tries the qualified key when the *old* side is legacy-vs-fresh-new is
-    the one direction that already worked; the reverse (fresh old,
-    legacy new) manufactured a phantom ``TYPE_REMOVED``/``TYPE_ADDED``
-    (Codex review, PR #608). Retrying with the bare name makes the
-    schema-evolution compatibility symmetric regardless of which side is
-    legacy.
+    qualified spelling. Retrying with the bare name makes the schema-
+    evolution compatibility symmetric regardless of which side is legacy
+    (Codex review, PR #608).
+
+    That bare-name retry is only safe when *t*'s own bare name is itself
+    unambiguous within ``own`` — i.e. *t* is the one and only type in its own
+    snapshot with that bare spelling. Without this check, a genuine
+    same-leaf-name collision on the probing side (e.g. old ``ns1::Impl`` +
+    ``ns2::Impl`` vs. a new side that only kept ``ns2::Impl``) would retry
+    ``ns1::Impl``'s failed qualified lookup with the bare name ``Impl``,
+    hit ``other``'s alias for the *unrelated* surviving ``ns2::Impl``, and
+    diff two distinct types against each other — reopening the exact
+    short/leaf-name collision ``type_map_key`` was introduced to fix, this
+    time through the compatibility fallback instead of naive bare matching
+    (Codex review, PR #608, second round).
     """
     key = type_map_key(t)
     found = other.get(key)
     if found is not None:
         return found
-    if t.name != key:
+    if t.name != key and own.bare_name_is_unambiguous(t.name):
         return other.get(t.name)
     return None

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -992,11 +992,10 @@ _CV_QUALIFIER_RE = re.compile(r"\b(?:const|volatile)\b")
 
 
 def _synthetic_ctor_scope(mangled: str) -> str | None:
-    """Qualified scope encoded in a castxml synthetic-ctor key
-    (``SYNTHETIC_CTOR_KEY_PREFIX + "scope(params)"``), or ``None``: it
-    doesn't start with ``_Z`` so ``owner_class_of`` can't parse it and would
-    otherwise fall back to the bare class name (Codex review, PR #608
-    follow-up).
+    """Qualified scope in a castxml synthetic-ctor key
+    (``SYNTHETIC_CTOR_KEY_PREFIX + "scope(params)"``), or ``None`` (it
+    doesn't start with ``_Z`` so ``owner_class_of`` can't parse it; Codex
+    review, PR #608 follow-up).
     """
     if not is_synthetic_ctor_key(mangled):
         return None
@@ -1010,23 +1009,23 @@ def _converting_ctors_by_class(
 ) -> dict[str, dict[tuple[str, ...], Function]]:
     """Group each class's non-explicit, single-required-argument constructors.
 
-    Grouped by ``owner_class_of(f)`` (scope-qualified) not bare ``f.name``,
-    so two classes sharing a bare name in different namespaces don't
-    conflate their constructor sets (Codex review, PR #608 follow-up).
+    Grouped by ``owner_class_of(f)`` (scope-qualified), not bare ``f.name``
+    (Codex review, PR #608 follow-up).
 
     "Converting constructor": public, not deleted, definitively non-explicit
     (``is_explicit is False``; ``None`` is unknown and skipped), callable
     with exactly one argument (at most one *required* parameter, at least
-    one total). First parameter's type is checked against the class's own
-    type to exclude copy/move constructors. Keyed by param-type tuple.
-
-    ``class_names`` is expected to already be scope-qualified. Falls back to
-    a synthetic-key-derived scope, then bare ``f.name``, when unresolvable.
+    one total). First parameter's type excludes copy/move constructors.
+    Keyed by param-type tuple. Falls back to a synthetic-key-derived scope,
+    then bare ``f.name``, when ``owner_class_of`` is unresolvable.
     """
     by_class: dict[str, dict[tuple[str, ...], Function]] = {}
     for f in snap.functions:
         owner = owner_class_of(f) or _synthetic_ctor_scope(f.mangled) or f.name
-        if owner not in class_names or f.is_deleted or f.is_explicit is not False:
+        # Doubly-legacy fallback (Codex review, PR #608 follow-up).
+        if owner not in class_names and owner.rsplit("::", 1)[-1] not in class_names:
+            continue
+        if f.is_deleted or f.is_explicit is not False:
             continue
         if f.access != AccessLevel.PUBLIC:
             continue

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -29,7 +29,13 @@ from .diff_cxx_rules import (
     owner_class_of,
     virtual_method_addition,
 )
-from .diff_helpers import bool_transition, diff_by_key, make_change
+from .diff_helpers import (
+    bool_transition,
+    build_type_map,
+    diff_by_key,
+    lookup_matched_type,
+    make_change,
+)
 from .diff_symbols_renames import (  # noqa: F401  (public-surface re-exports)
     _CTOR_DTOR_CODE_RE as _CTOR_DTOR_CODE_RE,
     _FUNC_LIKE_TYPES as _FUNC_LIKE_TYPES,
@@ -906,8 +912,15 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # old surface's scope-qualified owner classes (disambiguates same-leaf
     # classes across namespaces), and per-class virtual signatures (to skip
     # inherited overrides). See ``virtual_method_addition``.
-    old_types = {t.name: t for t in old.types}
-    new_types = {t.name: t for t in new.types}
+    #
+    # Keyed via TypeMap (qualified-name-first, ambiguity-safe bare-name
+    # fallback), not a naive bare-name dict: two distinct classes sharing a
+    # leaf name in different namespaces must not let a new virtual method on
+    # one get attributed to the other's stale vtable state (the same
+    # short-leaf-name collision class fixed for diff_types.py in PR #608,
+    # never previously propagated here).
+    old_types = build_type_map(old.types)
+    new_types = build_type_map(new.types)
     old_owner_classes = {
         owner for f in old_map.values() if (owner := owner_class_of(f)) is not None
     }
@@ -983,11 +996,15 @@ def _converting_ctors_by_class(
 ) -> dict[str, dict[tuple[str, ...], Function]]:
     """Group each class's non-explicit, single-required-argument constructors.
 
-    A castxml/DWARF Constructor's demangled ``name`` is the bare class name
-    (C++ forbids any other member from sharing it), so ``f.name in
-    class_names`` reliably identifies constructors without needing a real
-    Itanium mangled name — public overloaded constructors that castxml never
-    ODR-uses may have none (see ``dumper_castxml.SYNTHETIC_CTOR_KEY_PREFIX``).
+    A castxml/DWARF Constructor's demangled ``name`` is always the bare class
+    name (C++ forbids any other member from sharing it), so grouping is keyed
+    by ``owner_class_of(f)`` — the scope-qualified owner derived from the
+    mangled symbol (``diff_cxx_rules.owner_class_of``), the same source of
+    truth ``virtual_method_addition`` uses — not the bare ``f.name``. Two
+    distinct classes sharing a bare name in different namespaces would
+    otherwise conflate their constructor sets and fabricate a
+    ``CTOR_OVERLOAD_AMBIGUITY_RISK`` for the wrong (or an unrelated) class
+    (Codex review, PR #608 follow-up).
 
     "Converting constructor" here means: public (a private/protected
     constructor isn't callable at an ordinary consumer call site, so it
@@ -1006,13 +1023,18 @@ def _converting_ctors_by_class(
     copy/move constructors. Keyed by the full parameter-type tuple so two
     overloads are distinguished even when both qualify.
 
-    Caveat shared with ``diff_cxx_rules._resolve_owner_type``: ``class_names``
-    is unqualified/leaf, so two distinct classes sharing a bare name in
-    different namespaces are not disambiguated here.
+    ``class_names`` is expected to already be scope-qualified (see its call
+    site, ``_diff_ctor_overload_ambiguity``). Falls back to the bare
+    ``f.name`` when ``owner_class_of`` can't resolve a scope from the mangled
+    symbol (e.g. a hand-built snapshot with a non-Itanium placeholder mangled
+    name) -- every real castxml/DWARF-derived constructor carries a real
+    mangled symbol, so this only affects synthetic/malformed input, where the
+    bare name is the best available identity anyway.
     """
     by_class: dict[str, dict[tuple[str, ...], Function]] = {}
     for f in snap.functions:
-        if f.name not in class_names or f.is_deleted or f.is_explicit is not False:
+        owner = owner_class_of(f) or f.name
+        if owner not in class_names or f.is_deleted or f.is_explicit is not False:
             continue
         if f.access != AccessLevel.PUBLIC:
             continue
@@ -1027,7 +1049,7 @@ def _converting_ctors_by_class(
         if arg_type == f.name:
             continue
         sig = tuple(p.type for p in f.params)
-        by_class.setdefault(f.name, {})[sig] = f
+        by_class.setdefault(owner, {})[sig] = f
     return by_class
 
 
@@ -1044,7 +1066,10 @@ def _diff_ctor_overload_ambiguity(old: AbiSnapshot, new: AbiSnapshot) -> list[Ch
     that don't cross this threshold and, rarely, flag an addition that never
     collides with a real call site — see ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK.
     """
-    common_classes = {t.name for t in old.types} & {t.name for t in new.types}
+    # Qualified-key intersection (not bare t.name): two distinct classes
+    # sharing a leaf name in different namespaces must not conflate their
+    # constructor sets (Codex review, PR #608 follow-up).
+    common_classes = set(build_type_map(old.types)) & set(build_type_map(new.types))
     if not common_classes:
         return []
     old_ctors = _converting_ctors_by_class(old, common_classes)
@@ -1457,15 +1482,18 @@ def _check_method_access_changes(
 
 
 def _check_field_access_changes(
-    old_types: dict[str, Any],
-    new_types: dict[str, Any],
+    old_types: Any,
+    new_types: Any,
 ) -> list[Change]:
     """Emit FIELD_ACCESS_CHANGED for narrowing field access transitions."""
     changes: list[Change] = []
-    for name, t_old in old_types.items():
-        t_new = new_types.get(name)
+    for t_old in old_types.values():
+        t_new = lookup_matched_type(old_types, new_types, t_old)
         if t_new is None:
             continue
+        # Bare, not the qualified matching key -- matches the identity
+        # diff_types.py detectors report field-level findings under.
+        name = t_old.name
         old_fields = {f.name: f for f in t_old.fields}
         new_fields = {f.name: f for f in t_new.fields}
         for fname, f_old_f in old_fields.items():
@@ -1500,16 +1528,14 @@ def _diff_access_levels(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         _check_method_access_changes(_public_functions(old), _public_functions(new))
     )
     excl = stdlib_namespaces_excluded(old, new)
-    old_types = {
-        t.name: t
-        for t in old.types
+    old_types = build_type_map(
+        t for t in old.types
         if not t.is_union and is_abi_surface_type_name(t.name, exclude_stdlib=excl)
-    }
-    new_types = {
-        t.name: t
-        for t in new.types
+    )
+    new_types = build_type_map(
+        t for t in new.types
         if not t.is_union and is_abi_surface_type_name(t.name, exclude_stdlib=excl)
-    }
+    )
     changes.extend(_check_field_access_changes(old_types, new_types))
     return changes
 
@@ -1575,21 +1601,19 @@ def _diff_anon_fields(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect changes in anonymous struct/union members."""
     changes: list[Change] = []
     excl = stdlib_namespaces_excluded(old, new)
-    old_map = {
-        t.name: t
-        for t in old.types
-        if is_abi_surface_type_name(t.name, exclude_stdlib=excl)
-    }
-    new_map = {
-        t.name: t
-        for t in new.types
-        if is_abi_surface_type_name(t.name, exclude_stdlib=excl)
-    }
+    old_map = build_type_map(
+        t for t in old.types if is_abi_surface_type_name(t.name, exclude_stdlib=excl)
+    )
+    new_map = build_type_map(
+        t for t in new.types if is_abi_surface_type_name(t.name, exclude_stdlib=excl)
+    )
 
-    for name, t_old in old_map.items():
-        t_new = new_map.get(name)
+    for t_old in old_map.values():
+        t_new = lookup_matched_type(old_map, new_map, t_old)
         if t_new is None:
             continue
+        # Bare, not the qualified matching key.
+        name = t_old.name
         changes.extend(_check_anon_fields_for_type(name, t_old, t_new))
 
     return changes

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -992,10 +992,8 @@ _CV_QUALIFIER_RE = re.compile(r"\b(?:const|volatile)\b")
 
 
 def _synthetic_ctor_scope(mangled: str) -> str | None:
-    """Qualified scope in a castxml synthetic-ctor key
-    (``SYNTHETIC_CTOR_KEY_PREFIX + "scope(params)"``), or ``None`` (it
-    doesn't start with ``_Z`` so ``owner_class_of`` can't parse it; Codex
-    review, PR #608 follow-up).
+    """Qualified scope in a castxml synthetic-ctor key (``SYNTHETIC_CTOR_KEY_PREFIX
+    + "scope(params)"``), or ``None`` (Codex review, PR #608 follow-up).
     """
     if not is_synthetic_ctor_key(mangled):
         return None
@@ -1005,25 +1003,23 @@ def _synthetic_ctor_scope(mangled: str) -> str | None:
 
 
 def _converting_ctors_by_class(
-    snap: AbiSnapshot, class_names: set[str]
+    snap: AbiSnapshot, class_aliases: dict[str, str]
 ) -> dict[str, dict[tuple[str, ...], Function]]:
     """Group each class's non-explicit, single-required-argument constructors.
 
-    Grouped by ``owner_class_of(f)`` (scope-qualified), not bare ``f.name``
-    (Codex review, PR #608 follow-up).
+    Grouped by ``class_aliases``' normalized canonical identity, not the raw
+    spelling (Codex review, PR #608 follow-up) -- see ``_class_identity_aliases``.
 
     "Converting constructor": public, not deleted, definitively non-explicit
     (``is_explicit is False``; ``None`` is unknown and skipped), callable
-    with exactly one argument (at most one *required* parameter, at least
-    one total). First parameter's type excludes copy/move constructors.
-    Keyed by param-type tuple. Falls back to a synthetic-key-derived scope,
-    then bare ``f.name``, when ``owner_class_of`` is unresolvable.
+    with exactly one argument. First parameter's type excludes copy/move
+    constructors. Keyed by param-type tuple.
     """
     by_class: dict[str, dict[tuple[str, ...], Function]] = {}
     for f in snap.functions:
         owner = owner_class_of(f) or _synthetic_ctor_scope(f.mangled) or f.name
-        # Doubly-legacy fallback (Codex review, PR #608 follow-up).
-        if owner not in class_names and owner.rsplit("::", 1)[-1] not in class_names:
+        canonical = class_aliases.get(owner) or class_aliases.get(owner.rsplit("::", 1)[-1])
+        if canonical is None:
             continue
         if f.is_deleted or f.is_explicit is not False:
             continue
@@ -1040,28 +1036,33 @@ def _converting_ctors_by_class(
         if arg_type == f.name:
             continue
         sig = tuple(p.type for p in f.params)
-        by_class.setdefault(owner, {})[sig] = f
+        by_class.setdefault(canonical, {})[sig] = f
     return by_class
 
 
-def _common_class_identities(old_map: TypeMap[RecordType], new_map: TypeMap[RecordType]) -> set[str]:
-    """Every identity string ``owner_class_of`` might spell for a class
-    ambiguity-safely matched on both sides.
-
-    A raw ``set(old_map) & set(new_map)`` misses schema-evolution mixes: a
-    legacy ``RecordType`` missing ``qualified_name`` keys as bare
-    ``"Widget"``, while ``owner_class_of`` always resolves ``"ns::Widget"``
-    when parseable (Codex review, PR #608 follow-up). Recording both matched
-    keys via ``lookup_matched_type`` covers the mix either way.
+def _class_identity_aliases(old_map: TypeMap[RecordType], new_map: TypeMap[RecordType]) -> dict[str, str]:
+    """Map every raw spelling ``owner_class_of``/synthetic-ctor-scope might
+    produce for a matched class, on either side, to ONE shared canonical
+    identity -- so old/new agree on a grouping key even when they spell the
+    SAME class differently (e.g. a persisted snapshot predating namespace-
+    qualified synthetic ctor keys vs. a fresh one), instead of every
+    unchanged overload looking new on one side (Codex review, PR #608
+    follow-up).
     """
-    identities: set[str] = set()
+    aliases: dict[str, str] = {}
     for t_old in old_map.values():
         t_new = lookup_matched_type(old_map, new_map, t_old)
         if t_new is None:
             continue
-        identities.add(type_map_key(t_old))
-        identities.add(type_map_key(t_new))
-    return identities
+        canonical = t_old.qualified_name or t_new.qualified_name or t_old.name
+        aliases[type_map_key(t_old)] = canonical
+        aliases[type_map_key(t_new)] = canonical
+        # Bare-name alias only when unambiguous on both sides (mirrors
+        # TypeMap's alias-safety rule) -- an unrelated class mustn't steal it.
+        bare = t_old.name
+        if old_map.bare_name_is_unambiguous(bare) and new_map.bare_name_is_unambiguous(bare):
+            aliases[bare] = canonical
+    return aliases
 
 
 @registry.detector("ctor_overload_ambiguity")
@@ -1077,13 +1078,13 @@ def _diff_ctor_overload_ambiguity(old: AbiSnapshot, new: AbiSnapshot) -> list[Ch
     don't cross this threshold and, rarely, flag an addition that never
     collides with a real call site — see ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK.
     """
-    # Ambiguity-safe intersection, not a raw canonical-key set intersection
-    # (Codex review, PR #608 follow-up) — see _common_class_identities.
-    common_classes = _common_class_identities(build_type_map(old.types), build_type_map(new.types))
-    if not common_classes:
+    # Ambiguity-safe, spelling-normalized matching (Codex review, PR #608
+    # follow-up) — see _class_identity_aliases.
+    aliases = _class_identity_aliases(build_type_map(old.types), build_type_map(new.types))
+    if not aliases:
         return []
-    old_ctors = _converting_ctors_by_class(old, common_classes)
-    new_ctors = _converting_ctors_by_class(new, common_classes)
+    old_ctors = _converting_ctors_by_class(old, aliases)
+    new_ctors = _converting_ctors_by_class(new, aliases)
     changes: list[Change] = []
     for cls in sorted(new_ctors):
         old_sigs = old_ctors.get(cls, {})

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -30,11 +30,13 @@ from .diff_cxx_rules import (
     virtual_method_addition,
 )
 from .diff_helpers import (
+    TypeMap,
     bool_transition,
     build_type_map,
     diff_by_key,
     lookup_matched_type,
     make_change,
+    type_map_key,
 )
 from .diff_symbols_renames import (  # noqa: F401  (public-surface re-exports)
     _CTOR_DTOR_CODE_RE as _CTOR_DTOR_CODE_RE,
@@ -86,6 +88,7 @@ from .model import (
     AccessLevel,
     Function,
     Param,
+    RecordType,
     Variable,
     Visibility,
     canonicalize_type_name,
@@ -908,17 +911,13 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     old_map = _public_functions(old)
     new_map = _public_functions(new)
 
-    # Lookups for the virtual-method-addition check below: type records, the
-    # old surface's scope-qualified owner classes (disambiguates same-leaf
-    # classes across namespaces), and per-class virtual signatures (to skip
-    # inherited overrides). See ``virtual_method_addition``.
-    #
-    # Keyed via TypeMap (qualified-name-first, ambiguity-safe bare-name
-    # fallback), not a naive bare-name dict: two distinct classes sharing a
-    # leaf name in different namespaces must not let a new virtual method on
-    # one get attributed to the other's stale vtable state (the same
-    # short-leaf-name collision class fixed for diff_types.py in PR #608,
-    # never previously propagated here).
+    # Lookups for the virtual-method-addition check below: type records
+    # (keyed via TypeMap — qualified-name-first, ambiguity-safe bare-name
+    # fallback, not a naive bare-name dict, so two same-leaf-name classes in
+    # different namespaces can't cross-attribute a new virtual method; PR
+    # #608), the old surface's scope-qualified owner classes, and per-class
+    # virtual signatures (to skip inherited overrides). See
+    # ``virtual_method_addition``.
     old_types = build_type_map(old.types)
     new_types = build_type_map(new.types)
     old_owner_classes = {
@@ -997,39 +996,29 @@ def _converting_ctors_by_class(
     """Group each class's non-explicit, single-required-argument constructors.
 
     A castxml/DWARF Constructor's demangled ``name`` is always the bare class
-    name (C++ forbids any other member from sharing it), so grouping is keyed
-    by ``owner_class_of(f)`` — the scope-qualified owner derived from the
-    mangled symbol (``diff_cxx_rules.owner_class_of``), the same source of
-    truth ``virtual_method_addition`` uses — not the bare ``f.name``. Two
+    name, so grouping is keyed by ``owner_class_of(f)`` — the scope-qualified
+    owner derived from the mangled symbol — not the bare ``f.name``. Two
     distinct classes sharing a bare name in different namespaces would
     otherwise conflate their constructor sets and fabricate a
-    ``CTOR_OVERLOAD_AMBIGUITY_RISK`` for the wrong (or an unrelated) class
-    (Codex review, PR #608 follow-up).
+    ``CTOR_OVERLOAD_AMBIGUITY_RISK`` for the wrong class (Codex review, PR
+    #608 follow-up).
 
-    "Converting constructor" here means: public (a private/protected
-    constructor isn't callable at an ordinary consumer call site, so it
-    cannot create the implicit-conversion collision this heuristic looks
-    for), not deleted, definitively non-explicit (``is_explicit is False`` —
-    ``None`` is unknown evidence and skipped, same tri-state convention as
-    ``_check_explicit_change``), and callable with exactly one argument — at
-    most one *required* parameter (everything after it defaulted), and at
-    least one parameter total (excludes the zero-arg default constructor). A
-    leading defaulted parameter still makes the constructor
-    single-argument-callable (``Widget(int x = 0)`` accepts ``Widget w =
-    5;`` the same as ``Widget(int x)`` would), so the exclusion check below
-    binds to the *first* parameter regardless of whether it has a default,
-    not to the (possibly empty) required-parameter list. That first
+    "Converting constructor" here means: public, not deleted, definitively
+    non-explicit (``is_explicit is False`` — ``None`` is unknown evidence and
+    skipped), and callable with exactly one argument — at most one
+    *required* parameter, at least one parameter total. A leading defaulted
+    parameter still makes the constructor single-argument-callable
+    (``Widget(int x = 0)``), so the exclusion check below binds to the
+    *first* parameter regardless of whether it has a default. That first
     parameter's type is checked against the class's own type to exclude
     copy/move constructors. Keyed by the full parameter-type tuple so two
     overloads are distinguished even when both qualify.
 
     ``class_names`` is expected to already be scope-qualified (see its call
     site, ``_diff_ctor_overload_ambiguity``). Falls back to the bare
-    ``f.name`` when ``owner_class_of`` can't resolve a scope from the mangled
-    symbol (e.g. a hand-built snapshot with a non-Itanium placeholder mangled
-    name) -- every real castxml/DWARF-derived constructor carries a real
-    mangled symbol, so this only affects synthetic/malformed input, where the
-    bare name is the best available identity anyway.
+    ``f.name`` when ``owner_class_of`` can't resolve a scope (e.g. a
+    hand-built snapshot with a non-Itanium placeholder mangled name) — real
+    constructors always have a real mangled symbol.
     """
     by_class: dict[str, dict[tuple[str, ...], Function]] = {}
     for f in snap.functions:
@@ -1053,6 +1042,29 @@ def _converting_ctors_by_class(
     return by_class
 
 
+def _common_class_identities(old_map: TypeMap[RecordType], new_map: TypeMap[RecordType]) -> set[str]:
+    """Every identity string ``owner_class_of`` might spell for a class
+    present (ambiguity-safely matched) on both sides.
+
+    A raw ``set(old_map) & set(new_map)`` intersection only sees each
+    ``TypeMap``'s canonical key and misses schema-evolution mixes: a legacy
+    ``RecordType`` missing ``qualified_name`` keys as bare ``"Widget"``,
+    while ``owner_class_of`` (from the mangled symbol, independent of
+    ``RecordType``) always resolves ``"ns::Widget"`` when parseable —
+    silently dropping that class's constructors (Codex review, PR #608
+    follow-up). Recording both matched types' canonical keys via
+    ``lookup_matched_type`` covers the mix regardless of which side is legacy.
+    """
+    identities: set[str] = set()
+    for t_old in old_map.values():
+        t_new = lookup_matched_type(old_map, new_map, t_old)
+        if t_new is None:
+            continue
+        identities.add(type_map_key(t_old))
+        identities.add(type_map_key(t_new))
+    return identities
+
+
 @registry.detector("ctor_overload_ambiguity")
 def _diff_ctor_overload_ambiguity(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect a class gaining a 2nd+ non-explicit converting constructor.
@@ -1060,16 +1072,15 @@ def _diff_ctor_overload_ambiguity(old: AbiSnapshot, new: AbiSnapshot) -> list[Ch
     Best-effort RISK heuristic (case111): a real ambiguity depends on the
     consumer's actual call-site argument types, which no snapshot-level
     detector can see — only *count crossing from at most one converting
-    constructor to two or more* is checked here, on classes present on both
-    sides (a brand-new class starting with 2+ is a fresh API decision, not a
-    regression). This is deliberately conservative: it will miss ambiguities
-    that don't cross this threshold and, rarely, flag an addition that never
+    constructor to two or more* is checked, on classes present on both sides
+    (a brand-new class starting with 2+ is a fresh API decision, not a
+    regression). Deliberately conservative: it will miss ambiguities that
+    don't cross this threshold and, rarely, flag an addition that never
     collides with a real call site — see ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK.
     """
-    # Qualified-key intersection (not bare t.name): two distinct classes
-    # sharing a leaf name in different namespaces must not conflate their
-    # constructor sets (Codex review, PR #608 follow-up).
-    common_classes = set(build_type_map(old.types)) & set(build_type_map(new.types))
+    # Ambiguity-safe intersection, not a raw canonical-key set intersection
+    # (Codex review, PR #608 follow-up) — see _common_class_identities.
+    common_classes = _common_class_identities(build_type_map(old.types), build_type_map(new.types))
     if not common_classes:
         return []
     old_ctors = _converting_ctors_by_class(old, common_classes)

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -71,7 +71,11 @@ from .diff_symbols_scalar import (  # noqa: F401  (public-surface re-exports)
     _scalar_repr as _scalar_repr,
 )
 from .diff_symbols_variables import _check_variable_alignment, _without_top_level_const
-from .dumper_castxml import is_synthetic_ctor_key, is_synthetic_dtor_key
+from .dumper_castxml import (
+    SYNTHETIC_CTOR_KEY_PREFIX,
+    is_synthetic_ctor_key,
+    is_synthetic_dtor_key,
+)
 from .elf_symbol_filter import (
     FUNCTION_SYMBOL_TYPES,
     exported_symbol_names,
@@ -912,12 +916,9 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     new_map = _public_functions(new)
 
     # Lookups for the virtual-method-addition check below: type records
-    # (keyed via TypeMap — qualified-name-first, ambiguity-safe bare-name
-    # fallback, not a naive bare-name dict, so two same-leaf-name classes in
-    # different namespaces can't cross-attribute a new virtual method; PR
-    # #608), the old surface's scope-qualified owner classes, and per-class
-    # virtual signatures (to skip inherited overrides). See
-    # ``virtual_method_addition``.
+    # (via ambiguity-safe TypeMap, not a naive bare-name dict — PR #608), the
+    # old surface's scope-qualified owner classes, and per-class virtual
+    # signatures (to skip inherited overrides). See ``virtual_method_addition``.
     old_types = build_type_map(old.types)
     new_types = build_type_map(new.types)
     old_owner_classes = {
@@ -990,39 +991,41 @@ def _diff_functions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 _CV_QUALIFIER_RE = re.compile(r"\b(?:const|volatile)\b")
 
 
+def _synthetic_ctor_scope(mangled: str) -> str | None:
+    """Qualified scope encoded in a castxml synthetic-ctor key
+    (``SYNTHETIC_CTOR_KEY_PREFIX + "scope(params)"``), or ``None``: it
+    doesn't start with ``_Z`` so ``owner_class_of`` can't parse it and would
+    otherwise fall back to the bare class name (Codex review, PR #608
+    follow-up).
+    """
+    if not is_synthetic_ctor_key(mangled):
+        return None
+    body = mangled[len(SYNTHETIC_CTOR_KEY_PREFIX):]
+    paren = body.find("(")
+    return body[:paren] if paren != -1 else None
+
+
 def _converting_ctors_by_class(
     snap: AbiSnapshot, class_names: set[str]
 ) -> dict[str, dict[tuple[str, ...], Function]]:
     """Group each class's non-explicit, single-required-argument constructors.
 
-    A castxml/DWARF Constructor's demangled ``name`` is always the bare class
-    name, so grouping is keyed by ``owner_class_of(f)`` — the scope-qualified
-    owner derived from the mangled symbol — not the bare ``f.name``. Two
-    distinct classes sharing a bare name in different namespaces would
-    otherwise conflate their constructor sets and fabricate a
-    ``CTOR_OVERLOAD_AMBIGUITY_RISK`` for the wrong class (Codex review, PR
-    #608 follow-up).
+    Grouped by ``owner_class_of(f)`` (scope-qualified) not bare ``f.name``,
+    so two classes sharing a bare name in different namespaces don't
+    conflate their constructor sets (Codex review, PR #608 follow-up).
 
-    "Converting constructor" here means: public, not deleted, definitively
-    non-explicit (``is_explicit is False`` — ``None`` is unknown evidence and
-    skipped), and callable with exactly one argument — at most one
-    *required* parameter, at least one parameter total. A leading defaulted
-    parameter still makes the constructor single-argument-callable
-    (``Widget(int x = 0)``), so the exclusion check below binds to the
-    *first* parameter regardless of whether it has a default. That first
-    parameter's type is checked against the class's own type to exclude
-    copy/move constructors. Keyed by the full parameter-type tuple so two
-    overloads are distinguished even when both qualify.
+    "Converting constructor": public, not deleted, definitively non-explicit
+    (``is_explicit is False``; ``None`` is unknown and skipped), callable
+    with exactly one argument (at most one *required* parameter, at least
+    one total). First parameter's type is checked against the class's own
+    type to exclude copy/move constructors. Keyed by param-type tuple.
 
-    ``class_names`` is expected to already be scope-qualified (see its call
-    site, ``_diff_ctor_overload_ambiguity``). Falls back to the bare
-    ``f.name`` when ``owner_class_of`` can't resolve a scope (e.g. a
-    hand-built snapshot with a non-Itanium placeholder mangled name) — real
-    constructors always have a real mangled symbol.
+    ``class_names`` is expected to already be scope-qualified. Falls back to
+    a synthetic-key-derived scope, then bare ``f.name``, when unresolvable.
     """
     by_class: dict[str, dict[tuple[str, ...], Function]] = {}
     for f in snap.functions:
-        owner = owner_class_of(f) or f.name
+        owner = owner_class_of(f) or _synthetic_ctor_scope(f.mangled) or f.name
         if owner not in class_names or f.is_deleted or f.is_explicit is not False:
             continue
         if f.access != AccessLevel.PUBLIC:
@@ -1044,16 +1047,13 @@ def _converting_ctors_by_class(
 
 def _common_class_identities(old_map: TypeMap[RecordType], new_map: TypeMap[RecordType]) -> set[str]:
     """Every identity string ``owner_class_of`` might spell for a class
-    present (ambiguity-safely matched) on both sides.
+    ambiguity-safely matched on both sides.
 
-    A raw ``set(old_map) & set(new_map)`` intersection only sees each
-    ``TypeMap``'s canonical key and misses schema-evolution mixes: a legacy
-    ``RecordType`` missing ``qualified_name`` keys as bare ``"Widget"``,
-    while ``owner_class_of`` (from the mangled symbol, independent of
-    ``RecordType``) always resolves ``"ns::Widget"`` when parseable —
-    silently dropping that class's constructors (Codex review, PR #608
-    follow-up). Recording both matched types' canonical keys via
-    ``lookup_matched_type`` covers the mix regardless of which side is legacy.
+    A raw ``set(old_map) & set(new_map)`` misses schema-evolution mixes: a
+    legacy ``RecordType`` missing ``qualified_name`` keys as bare
+    ``"Widget"``, while ``owner_class_of`` always resolves ``"ns::Widget"``
+    when parseable (Codex review, PR #608 follow-up). Recording both matched
+    keys via ``lookup_matched_type`` covers the mix either way.
     """
     identities: set[str] = set()
     for t_old in old_map.values():

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -17,13 +17,13 @@ from __future__ import annotations
 
 import re
 from collections import Counter
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 
 from .checker_policy import ChangeKind
 from .checker_types import Change
 from .detector_registry import registry
 from .diff_cxx_rules import itanium_qualified_name, vtable_slot_is_override_reuse
-from .diff_helpers import make_change
+from .diff_helpers import build_type_map as _build_type_map, make_change
 from .diff_symbols import (
     _PUBLIC_VIS,
     _public_functions,
@@ -119,24 +119,6 @@ def _is_abi_surface_type(t: RecordType, *, exclude_stdlib: bool) -> bool:
     return not _is_non_abi_surface_type(t.name, exclude_stdlib_namespaces=exclude_stdlib)
 
 
-def _type_map_key(t: RecordType) -> str:
-    """Key a ``RecordType`` for old/new matching by its namespace-qualified
-    identity, not its bare declaration name.
-
-    The header-mode dumpers (castxml, clang) deliberately keep ``t.name``
-    bare (see its docstring in model.py) and carry the real namespace path in
-    ``t.qualified_name`` instead; the DWARF backend has no such split and
-    already stores the qualified spelling directly in ``name``. Matching
-    old/new maps by bare ``t.name`` alone lets two unrelated types that only
-    share a short/leaf spelling (e.g. two distinct ``std::*::_Impl`` template
-    internals pulled in transitively) collide and diff against each other,
-    producing spurious field/base-class findings. Falling back to ``t.name``
-    when ``qualified_name`` is unset (global-scope types, DWARF-only
-    snapshots) keeps existing behaviour unchanged there.
-    """
-    return t.qualified_name or t.name
-
-
 def _has_type_evidence(snap: AbiSnapshot) -> bool:
     """True if *snap* carries any type-level surface (records/enums/typedefs/DWARF).
 
@@ -213,8 +195,8 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # Include ALL types (including unions) for size/alignment/base/vtable checks.
     # TYPE_FIELD_* for unions is skipped below — handled by _diff_unions() instead.
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {_type_map_key(t): t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {_type_map_key(t): t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = _build_type_map(t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl))
+    new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
     # RD2-5: don't manufacture phantom TYPE_REMOVED when the new side is stripped.
     suppress_removed = _removals_are_unconfirmed(old, new)
 
@@ -224,12 +206,32 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # class still resolves when _transitive_bases walks the hierarchy for
     # vtable_slot_is_override_reuse() -- mirrors diff_symbols._diff_functions'
     # own old_types/new_types for the identical virtual_method_addition() walk.
-    old_types = {_type_map_key(t): t for t in old.types}
-    new_types = {_type_map_key(t): t for t in new.types}
+    old_types = _build_type_map(t for t in old.types)
+    new_types = _build_type_map(t for t in new.types)
     cv_facts_reliable = old.header_cv_facts_reliable and new.header_cv_facts_reliable
 
-    for name, t_old in old_map.items():
-        t_new = new_map.get(name)
+    # Tracked by object identity, not key membership: a legacy-schema-vs-fresh
+    # pair can match through diff_helpers.TypeMap's bare-name alias even though the two
+    # sides' canonical keys differ (qualified vs. bare) — a "key not in
+    # old_map" check on new_map's own canonical keys would then falsely see
+    # no match and manufacture a phantom TYPE_ADDED (Codex review, PR #608).
+    matched_new_ids: set[int] = set()
+
+    for match_key, t_old in old_map.items():
+        t_new = new_map.get(match_key)
+        # Emitted Change objects (symbol=/description=) and fact-provenance
+        # lookups use the bare declaration name, not `match_key` (which is
+        # qualified whenever the dumper populated RecordType.qualified_name,
+        # purely to fix old/new *matching* -- see diff_helpers.type_map_key). Keeping
+        # emitted symbols bare preserves the identity every other consumer
+        # already keys on: dumper_hybrid's per-fact provenance dict
+        # (type_fact_key/field_fact_key, Codex review PR #608) and
+        # diff_filtering._dedup_cross_kind's DWARF<->AST redundancy
+        # correlation, which matches a DWARF field symbol's *bare* parent
+        # type name against the AST-level type symbol (FIX-F) -- a qualified
+        # symbol here would silently stop that correlation from firing for
+        # any namespaced type.
+        name = t_old.name
         if t_new is None:
             if suppress_removed:
                 continue
@@ -239,6 +241,7 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 description=f"Type removed: {name}",
             ))
             continue
+        matched_new_ids.add(id(t_new))
         changes.extend(
             _diff_type_pair(
                 name, t_old, t_new, old_funcs, new_funcs, old_types, new_types,
@@ -253,12 +256,12 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             )
         )
 
-    for name in new_map:
-        if name not in old_map:
+    for match_key, t_new in new_map.items():
+        if id(t_new) not in matched_new_ids:
             changes.append(make_change(
                 ChangeKind.TYPE_ADDED,
-                symbol=name,
-                name=name,
+                symbol=t_new.name,
+                name=t_new.name,
             ))
 
     return changes
@@ -346,8 +349,8 @@ def _diff_type_pair(
     t_new: RecordType,
     old_funcs: dict[str, Function],
     new_funcs: dict[str, Function],
-    old_types: dict[str, RecordType],
-    new_types: dict[str, RecordType],
+    old_types: Mapping[str, RecordType],
+    new_types: Mapping[str, RecordType],
     *,
     castxml_backed: bool = False,
     cv_facts_reliable: bool = True,
@@ -940,8 +943,8 @@ def _diff_type_vtable(
     t_new: RecordType,
     old_funcs: dict[str, Function],
     new_funcs: dict[str, Function],
-    old_types: dict[str, RecordType],
-    new_types: dict[str, RecordType],
+    old_types: Mapping[str, RecordType],
+    new_types: Mapping[str, RecordType],
 ) -> list[Change]:
     if t_old.vtable == t_new.vtable:
         return []
@@ -1225,16 +1228,18 @@ def _diff_method_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_unions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_unions = {_type_map_key(t): t for t in old.types if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_unions = {_type_map_key(t): t for t in new.types if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_unions = _build_type_map(t for t in old.types if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
+    new_unions = _build_type_map(t for t in new.types if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
     # Same legacy-snapshot cv-fact concern as _diff_type_field_pair (Codex
     # review, PR #582).
     cv_facts_reliable = old.header_cv_facts_reliable and new.header_cv_facts_reliable
 
-    for name, t_old in old_unions.items():
-        if name not in new_unions:
+    for match_key, t_old in old_unions.items():
+        t_new = new_unions.get(match_key)
+        if t_new is None:
             continue  # covered by TYPE_REMOVED
-        t_new = new_unions[name]
+        # Bare, not the qualified match_key — see _diff_types's comment.
+        name = t_old.name
         old_fields = {f.name: f for f in t_old.fields}
         new_fields = {f.name: f for f in t_new.fields}
 
@@ -1483,13 +1488,15 @@ def _diff_field_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         return []
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {_type_map_key(t): t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {_type_map_key(t): t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = _build_type_map(t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
+    new_map = _build_type_map(t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for name, t_old in old_map.items():
-        t_new = new_map.get(name)
+    for match_key, t_old in old_map.items():
+        t_new = new_map.get(match_key)
         if t_new is None:
             continue
+        # Bare, not the qualified match_key — see _diff_types's comment.
+        name = t_old.name
         old_fields = {f.name: f for f in t_old.fields}
         new_fields = {f.name: f for f in t_new.fields}
 
@@ -1532,13 +1539,15 @@ def _diff_field_default_initializer(old: AbiSnapshot, new: AbiSnapshot) -> list[
     """
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {_type_map_key(t): t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {_type_map_key(t): t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = _build_type_map(t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl))
+    new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for name, t_old in old_map.items():
-        t_new = new_map.get(name)
+    for match_key, t_old in old_map.items():
+        t_new = new_map.get(match_key)
         if t_new is None:
             continue
+        # Bare, not the qualified match_key — see _diff_types's comment.
+        name = t_old.name
         old_fields = {f.name: f for f in t_old.fields}
         new_fields = {f.name: f for f in t_new.fields}
 
@@ -1594,13 +1603,15 @@ def _diff_field_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {_type_map_key(t): t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {_type_map_key(t): t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = _build_type_map(t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl))
+    new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for name, t_old in old_map.items():
-        t_new = new_map.get(name)
+    for match_key, t_old in old_map.items():
+        t_new = new_map.get(match_key)
         if t_new is None:
             continue
+        # Bare, not the qualified match_key — see _diff_types's comment.
+        name = t_old.name
         old_fields = {f.name: f for f in t_old.fields}
         new_fields = {f.name: f for f in t_new.fields}
 
@@ -1644,13 +1655,15 @@ def _diff_type_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {_type_map_key(t): t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {_type_map_key(t): t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = _build_type_map(t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl))
+    new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for name, t_old in old_map.items():
-        t_new = new_map.get(name)
+    for match_key, t_old in old_map.items():
+        t_new = new_map.get(match_key)
         if t_new is None:
             continue
+        # Bare, not the qualified match_key — see _diff_types's comment.
+        name = t_old.name
         if not both_castxml_backed_fact(old, new, type_fact_key(name, "deprecated")):
             continue
         if t_old.deprecated is None and t_new.deprecated is not None:
@@ -1718,13 +1731,15 @@ def _diff_field_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect field renames: same offset+type, different name."""
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {_type_map_key(t): t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {_type_map_key(t): t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = _build_type_map(t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
+    new_map = _build_type_map(t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for name, t_old in old_map.items():
-        t_new = new_map.get(name)
+    for match_key, t_old in old_map.items():
+        t_new = new_map.get(match_key)
         if t_new is None or t_new.is_opaque:
             continue
+        # Bare, not the qualified match_key — see _diff_types's comment.
+        name = t_old.name
         old_names = {f.name for f in t_old.fields}
         new_names = {f.name for f in t_new.fields}
 
@@ -1811,13 +1826,15 @@ def _diff_type_kind_changes(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect struct↔union kind changes (ABICC: StructToUnion / DataType_Type)."""
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {_type_map_key(t): t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {_type_map_key(t): t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = _build_type_map(t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl))
+    new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for name, t_old in old_map.items():
-        t_new = new_map.get(name)
+    for match_key, t_old in old_map.items():
+        t_new = new_map.get(match_key)
         if t_new is None:
             continue
+        # Bare, not the qualified match_key — see _diff_types's comment.
+        name = t_old.name
         if t_old.kind != t_new.kind:
             # Union-involving transitions are binary-breaking (layout changes);
             # struct↔class transitions are source-level only (identical ABI).
@@ -1844,13 +1861,15 @@ def _diff_reserved_fields(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {_type_map_key(t): t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {_type_map_key(t): t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = _build_type_map(t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
+    new_map = _build_type_map(t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for name, t_old in old_map.items():
-        t_new = new_map.get(name)
+    for match_key, t_old in old_map.items():
+        t_new = new_map.get(match_key)
         if t_new is None or t_new.is_opaque:
             continue
+        # Bare, not the qualified match_key — see _diff_types's comment.
+        name = t_old.name
 
         old_names = {f.name for f in t_old.fields}
         new_names = {f.name for f in t_new.fields}

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -119,6 +119,24 @@ def _is_abi_surface_type(t: RecordType, *, exclude_stdlib: bool) -> bool:
     return not _is_non_abi_surface_type(t.name, exclude_stdlib_namespaces=exclude_stdlib)
 
 
+def _type_map_key(t: RecordType) -> str:
+    """Key a ``RecordType`` for old/new matching by its namespace-qualified
+    identity, not its bare declaration name.
+
+    The header-mode dumpers (castxml, clang) deliberately keep ``t.name``
+    bare (see its docstring in model.py) and carry the real namespace path in
+    ``t.qualified_name`` instead; the DWARF backend has no such split and
+    already stores the qualified spelling directly in ``name``. Matching
+    old/new maps by bare ``t.name`` alone lets two unrelated types that only
+    share a short/leaf spelling (e.g. two distinct ``std::*::_Impl`` template
+    internals pulled in transitively) collide and diff against each other,
+    producing spurious field/base-class findings. Falling back to ``t.name``
+    when ``qualified_name`` is unset (global-scope types, DWARF-only
+    snapshots) keeps existing behaviour unchanged there.
+    """
+    return t.qualified_name or t.name
+
+
 def _has_type_evidence(snap: AbiSnapshot) -> bool:
     """True if *snap* carries any type-level surface (records/enums/typedefs/DWARF).
 
@@ -195,8 +213,8 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # Include ALL types (including unions) for size/alignment/base/vtable checks.
     # TYPE_FIELD_* for unions is skipped below — handled by _diff_unions() instead.
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = {_type_map_key(t): t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    new_map = {_type_map_key(t): t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
     # RD2-5: don't manufacture phantom TYPE_REMOVED when the new side is stripped.
     suppress_removed = _removals_are_unconfirmed(old, new)
 
@@ -206,8 +224,8 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # class still resolves when _transitive_bases walks the hierarchy for
     # vtable_slot_is_override_reuse() -- mirrors diff_symbols._diff_functions'
     # own old_types/new_types for the identical virtual_method_addition() walk.
-    old_types = {t.name: t for t in old.types}
-    new_types = {t.name: t for t in new.types}
+    old_types = {_type_map_key(t): t for t in old.types}
+    new_types = {_type_map_key(t): t for t in new.types}
     cv_facts_reliable = old.header_cv_facts_reliable and new.header_cv_facts_reliable
 
     for name, t_old in old_map.items():
@@ -1207,8 +1225,8 @@ def _diff_method_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_unions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_unions = {t.name: t for t in old.types if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_unions = {t.name: t for t in new.types if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_unions = {_type_map_key(t): t for t in old.types if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    new_unions = {_type_map_key(t): t for t in new.types if t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
     # Same legacy-snapshot cv-fact concern as _diff_type_field_pair (Codex
     # review, PR #582).
     cv_facts_reliable = old.header_cv_facts_reliable and new.header_cv_facts_reliable
@@ -1465,8 +1483,8 @@ def _diff_field_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
         return []
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = {_type_map_key(t): t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    new_map = {_type_map_key(t): t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)
@@ -1514,8 +1532,8 @@ def _diff_field_default_initializer(old: AbiSnapshot, new: AbiSnapshot) -> list[
     """
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = {_type_map_key(t): t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    new_map = {_type_map_key(t): t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)
@@ -1576,8 +1594,8 @@ def _diff_field_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = {_type_map_key(t): t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    new_map = {_type_map_key(t): t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)
@@ -1626,8 +1644,8 @@ def _diff_type_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = {_type_map_key(t): t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    new_map = {_type_map_key(t): t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)
@@ -1700,8 +1718,8 @@ def _diff_field_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect field renames: same offset+type, different name."""
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = {_type_map_key(t): t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    new_map = {_type_map_key(t): t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)
@@ -1793,8 +1811,8 @@ def _diff_type_kind_changes(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect struct↔union kind changes (ABICC: StructToUnion / DataType_Type)."""
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = {_type_map_key(t): t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
+    new_map = {_type_map_key(t): t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl)}
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)
@@ -1826,8 +1844,8 @@ def _diff_reserved_fields(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {t.name: t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
-    new_map = {t.name: t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    old_map = {_type_map_key(t): t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
+    new_map = {_type_map_key(t): t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl)}
 
     for name, t_old in old_map.items():
         t_new = new_map.get(name)

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -222,7 +222,7 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     matched_new_ids: set[int] = set()
 
     for t_old in old_map.values():
-        t_new = _lookup_matched_type(new_map, t_old)
+        t_new = _lookup_matched_type(old_map, new_map, t_old)
         # Emitted Change objects (symbol=/description=) and fact-provenance
         # lookups use the bare declaration name, not the qualified matching
         # key (diff_helpers.type_map_key) that lookup_matched_type/build_type_map
@@ -1238,7 +1238,7 @@ def _diff_unions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     cv_facts_reliable = old.header_cv_facts_reliable and new.header_cv_facts_reliable
 
     for t_old in old_unions.values():
-        t_new = _lookup_matched_type(new_unions, t_old)
+        t_new = _lookup_matched_type(old_unions, new_unions, t_old)
         if t_new is None:
             continue  # covered by TYPE_REMOVED
         # Bare, not the qualified matching key — see _diff_types's comment.
@@ -1495,7 +1495,7 @@ def _diff_field_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     new_map = _build_type_map(t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
 
     for t_old in old_map.values():
-        t_new = _lookup_matched_type(new_map, t_old)
+        t_new = _lookup_matched_type(old_map, new_map, t_old)
         if t_new is None:
             continue
         # Bare, not the qualified matching key — see _diff_types's comment.
@@ -1546,7 +1546,7 @@ def _diff_field_default_initializer(old: AbiSnapshot, new: AbiSnapshot) -> list[
     new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
     for t_old in old_map.values():
-        t_new = _lookup_matched_type(new_map, t_old)
+        t_new = _lookup_matched_type(old_map, new_map, t_old)
         if t_new is None:
             continue
         # Bare, not the qualified matching key — see _diff_types's comment.
@@ -1610,7 +1610,7 @@ def _diff_field_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
     for t_old in old_map.values():
-        t_new = _lookup_matched_type(new_map, t_old)
+        t_new = _lookup_matched_type(old_map, new_map, t_old)
         if t_new is None:
             continue
         # Bare, not the qualified matching key — see _diff_types's comment.
@@ -1662,7 +1662,7 @@ def _diff_type_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
     for t_old in old_map.values():
-        t_new = _lookup_matched_type(new_map, t_old)
+        t_new = _lookup_matched_type(old_map, new_map, t_old)
         if t_new is None:
             continue
         # Bare, not the qualified matching key — see _diff_types's comment.
@@ -1738,7 +1738,7 @@ def _diff_field_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     new_map = _build_type_map(t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
 
     for t_old in old_map.values():
-        t_new = _lookup_matched_type(new_map, t_old)
+        t_new = _lookup_matched_type(old_map, new_map, t_old)
         if t_new is None or t_new.is_opaque:
             continue
         # Bare, not the qualified matching key — see _diff_types's comment.
@@ -1833,7 +1833,7 @@ def _diff_type_kind_changes(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
     for t_old in old_map.values():
-        t_new = _lookup_matched_type(new_map, t_old)
+        t_new = _lookup_matched_type(old_map, new_map, t_old)
         if t_new is None:
             continue
         # Bare, not the qualified matching key — see _diff_types's comment.
@@ -1868,7 +1868,7 @@ def _diff_reserved_fields(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     new_map = _build_type_map(t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
 
     for t_old in old_map.values():
-        t_new = _lookup_matched_type(new_map, t_old)
+        t_new = _lookup_matched_type(old_map, new_map, t_old)
         if t_new is None or t_new.is_opaque:
             continue
         # Bare, not the qualified matching key — see _diff_types's comment.

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -23,7 +23,11 @@ from .checker_policy import ChangeKind
 from .checker_types import Change
 from .detector_registry import registry
 from .diff_cxx_rules import itanium_qualified_name, vtable_slot_is_override_reuse
-from .diff_helpers import build_type_map as _build_type_map, make_change
+from .diff_helpers import (
+    build_type_map as _build_type_map,
+    lookup_matched_type as _lookup_matched_type,
+    make_change,
+)
 from .diff_symbols import (
     _PUBLIC_VIS,
     _public_functions,
@@ -217,16 +221,15 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # no match and manufacture a phantom TYPE_ADDED (Codex review, PR #608).
     matched_new_ids: set[int] = set()
 
-    for match_key, t_old in old_map.items():
-        t_new = new_map.get(match_key)
+    for t_old in old_map.values():
+        t_new = _lookup_matched_type(new_map, t_old)
         # Emitted Change objects (symbol=/description=) and fact-provenance
-        # lookups use the bare declaration name, not `match_key` (which is
-        # qualified whenever the dumper populated RecordType.qualified_name,
-        # purely to fix old/new *matching* -- see diff_helpers.type_map_key). Keeping
-        # emitted symbols bare preserves the identity every other consumer
-        # already keys on: dumper_hybrid's per-fact provenance dict
-        # (type_fact_key/field_fact_key, Codex review PR #608) and
-        # diff_filtering._dedup_cross_kind's DWARF<->AST redundancy
+        # lookups use the bare declaration name, not the qualified matching
+        # key (diff_helpers.type_map_key) that lookup_matched_type/build_type_map
+        # use internally. Keeping emitted symbols bare preserves the identity
+        # every other consumer already keys on: dumper_hybrid's per-fact
+        # provenance dict (type_fact_key/field_fact_key, Codex review PR #608)
+        # and diff_filtering._dedup_cross_kind's DWARF<->AST redundancy
         # correlation, which matches a DWARF field symbol's *bare* parent
         # type name against the AST-level type symbol (FIX-F) -- a qualified
         # symbol here would silently stop that correlation from firing for
@@ -256,7 +259,7 @@ def _diff_types(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
             )
         )
 
-    for match_key, t_new in new_map.items():
+    for t_new in new_map.values():
         if id(t_new) not in matched_new_ids:
             changes.append(make_change(
                 ChangeKind.TYPE_ADDED,
@@ -1234,11 +1237,11 @@ def _diff_unions(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # review, PR #582).
     cv_facts_reliable = old.header_cv_facts_reliable and new.header_cv_facts_reliable
 
-    for match_key, t_old in old_unions.items():
-        t_new = new_unions.get(match_key)
+    for t_old in old_unions.values():
+        t_new = _lookup_matched_type(new_unions, t_old)
         if t_new is None:
             continue  # covered by TYPE_REMOVED
-        # Bare, not the qualified match_key — see _diff_types's comment.
+        # Bare, not the qualified matching key — see _diff_types's comment.
         name = t_old.name
         old_fields = {f.name: f for f in t_old.fields}
         new_fields = {f.name: f for f in t_new.fields}
@@ -1491,11 +1494,11 @@ def _diff_field_qualifiers(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     old_map = _build_type_map(t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
     new_map = _build_type_map(t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for match_key, t_old in old_map.items():
-        t_new = new_map.get(match_key)
+    for t_old in old_map.values():
+        t_new = _lookup_matched_type(new_map, t_old)
         if t_new is None:
             continue
-        # Bare, not the qualified match_key — see _diff_types's comment.
+        # Bare, not the qualified matching key — see _diff_types's comment.
         name = t_old.name
         old_fields = {f.name: f for f in t_old.fields}
         new_fields = {f.name: f for f in t_new.fields}
@@ -1542,11 +1545,11 @@ def _diff_field_default_initializer(old: AbiSnapshot, new: AbiSnapshot) -> list[
     old_map = _build_type_map(t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl))
     new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for match_key, t_old in old_map.items():
-        t_new = new_map.get(match_key)
+    for t_old in old_map.values():
+        t_new = _lookup_matched_type(new_map, t_old)
         if t_new is None:
             continue
-        # Bare, not the qualified match_key — see _diff_types's comment.
+        # Bare, not the qualified matching key — see _diff_types's comment.
         name = t_old.name
         old_fields = {f.name: f for f in t_old.fields}
         new_fields = {f.name: f for f in t_new.fields}
@@ -1606,11 +1609,11 @@ def _diff_field_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     old_map = _build_type_map(t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl))
     new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for match_key, t_old in old_map.items():
-        t_new = new_map.get(match_key)
+    for t_old in old_map.values():
+        t_new = _lookup_matched_type(new_map, t_old)
         if t_new is None:
             continue
-        # Bare, not the qualified match_key — see _diff_types's comment.
+        # Bare, not the qualified matching key — see _diff_types's comment.
         name = t_old.name
         old_fields = {f.name: f for f in t_old.fields}
         new_fields = {f.name: f for f in t_new.fields}
@@ -1658,11 +1661,11 @@ def _diff_type_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     old_map = _build_type_map(t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl))
     new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for match_key, t_old in old_map.items():
-        t_new = new_map.get(match_key)
+    for t_old in old_map.values():
+        t_new = _lookup_matched_type(new_map, t_old)
         if t_new is None:
             continue
-        # Bare, not the qualified match_key — see _diff_types's comment.
+        # Bare, not the qualified matching key — see _diff_types's comment.
         name = t_old.name
         if not both_castxml_backed_fact(old, new, type_fact_key(name, "deprecated")):
             continue
@@ -1734,11 +1737,11 @@ def _diff_field_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     old_map = _build_type_map(t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
     new_map = _build_type_map(t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for match_key, t_old in old_map.items():
-        t_new = new_map.get(match_key)
+    for t_old in old_map.values():
+        t_new = _lookup_matched_type(new_map, t_old)
         if t_new is None or t_new.is_opaque:
             continue
-        # Bare, not the qualified match_key — see _diff_types's comment.
+        # Bare, not the qualified matching key — see _diff_types's comment.
         name = t_old.name
         old_names = {f.name for f in t_old.fields}
         new_names = {f.name for f in t_new.fields}
@@ -1829,11 +1832,11 @@ def _diff_type_kind_changes(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     old_map = _build_type_map(t for t in old.types if _is_abi_surface_type(t, exclude_stdlib=excl))
     new_map = _build_type_map(t for t in new.types if _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for match_key, t_old in old_map.items():
-        t_new = new_map.get(match_key)
+    for t_old in old_map.values():
+        t_new = _lookup_matched_type(new_map, t_old)
         if t_new is None:
             continue
-        # Bare, not the qualified match_key — see _diff_types's comment.
+        # Bare, not the qualified matching key — see _diff_types's comment.
         name = t_old.name
         if t_old.kind != t_new.kind:
             # Union-involving transitions are binary-breaking (layout changes);
@@ -1864,11 +1867,11 @@ def _diff_reserved_fields(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     old_map = _build_type_map(t for t in old.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
     new_map = _build_type_map(t for t in new.types if not t.is_union and _is_abi_surface_type(t, exclude_stdlib=excl))
 
-    for match_key, t_old in old_map.items():
-        t_new = new_map.get(match_key)
+    for t_old in old_map.values():
+        t_new = _lookup_matched_type(new_map, t_old)
         if t_new is None or t_new.is_opaque:
             continue
-        # Bare, not the qualified match_key — see _diff_types's comment.
+        # Bare, not the qualified matching key — see _diff_types's comment.
         name = t_old.name
 
         old_names = {f.name for f in t_old.fields}

--- a/abicheck/diff_types.py
+++ b/abicheck/diff_types.py
@@ -983,12 +983,16 @@ def _diff_type_vtable(
 def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map: dict[str, EnumType] = {
-        e.name: e for e in old.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
-    }
-    new_map: dict[str, EnumType] = {
-        e.name: e for e in new.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
-    }
+    # Namespace-qualified matching (build_type_map/lookup_matched_type,
+    # generalized from RecordType in PR #608 follow-up): two distinct enums
+    # sharing a bare leaf name in different namespaces must not cross-match
+    # across old/new the way a plain ``{e.name: e}`` dict would.
+    old_map = _build_type_map(
+        e for e in old.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
+    )
+    new_map = _build_type_map(
+        e for e in new.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
+    )
     # A wholly-removed enum is stored in snap.enums, NOT snap.types, so the
     # TYPE_REMOVED loop in _diff_types() never sees it — the old "TYPE_REMOVED
     # covers this" comment was wrong and the removal went silently undetected
@@ -996,8 +1000,10 @@ def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     # _diff_types uses so a stripped new side can't manufacture phantom removals.
     suppress_removed = _removals_are_unconfirmed(old, new)
 
-    for name, e_old in old_map.items():
-        if name not in new_map:
+    for e_old in old_map.values():
+        name = e_old.name
+        e_new = _lookup_matched_type(old_map, new_map, e_old)
+        if e_new is None:
             if not suppress_removed:
                 changes.append(make_change(
                     ChangeKind.TYPE_REMOVED,
@@ -1005,7 +1011,6 @@ def _diff_enums(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                     description=f"Enum removed: {name}",
                 ))
             continue
-        e_new = new_map[name]
         # Per-enum key, not the whole-snapshot _both_castxml_backed: correctly
         # supports a --ast-frontend hybrid snapshot (G28 Phase 3).
         if both_castxml_backed_fact(old, new, enum_fact_key(name, "is_scoped")):
@@ -1372,17 +1377,18 @@ def _diff_enum_renames(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect enum member renames: same value present under different name."""
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map: dict[str, EnumType] = {
-        e.name: e for e in old.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
-    }
-    new_map: dict[str, EnumType] = {
-        e.name: e for e in new.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
-    }
+    old_map = _build_type_map(
+        e for e in old.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
+    )
+    new_map = _build_type_map(
+        e for e in new.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
+    )
 
-    for name, e_old in old_map.items():
-        if name not in new_map:
+    for e_old in old_map.values():
+        name = e_old.name
+        e_new = _lookup_matched_type(old_map, new_map, e_old)
+        if e_new is None:
             continue
-        e_new = new_map[name]
         old_by_name = {m.name: m.value for m in e_old.members}
         new_by_name = {m.name: m.value for m in e_new.members}
         # One-to-one guard: only treat as rename when the value maps to
@@ -1698,15 +1704,16 @@ def _diff_enum_deprecated(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """
     changes: list[Change] = []
     excl = _exclude_stdlib_namespaces(old, new)
-    old_map = {
-        e.name: e for e in old.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
-    }
-    new_map = {
-        e.name: e for e in new.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
-    }
+    old_map = _build_type_map(
+        e for e in old.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
+    )
+    new_map = _build_type_map(
+        e for e in new.enums if not _is_non_abi_surface_type(e.name, exclude_stdlib_namespaces=excl)
+    )
 
-    for name, e_old in old_map.items():
-        e_new = new_map.get(name)
+    for e_old in old_map.values():
+        name = e_old.name
+        e_new = _lookup_matched_type(old_map, new_map, e_old)
         if e_new is None:
             continue
         if not both_castxml_backed_fact(old, new, enum_fact_key(name, "deprecated")):

--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -1866,6 +1866,9 @@ class _CastxmlParser:
                     is_scoped=el.get("scoped") == "1",
                     # See RecordType.deprecated for the message-text convention.
                     deprecated=_deprecation_marker(el),
+                    # See RecordType.qualified_name for the bare-vs-qualified
+                    # name convention this mirrors.
+                    qualified_name=self._qualified_type_name(el, leaf_name=name),
                 )
             )
         return enums

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -942,6 +942,11 @@ class _ClangAstParser:
                     members=members,
                     underlying_type=_enum_underlying(node),
                     source_location=self._source_location(entry),
+                    # See RecordType.qualified_name (_build_record) for why
+                    # this is only set when it differs from the bare name.
+                    qualified_name=(
+                        "::".join([*entry.scope, name]) if entry.scope else None
+                    ),
                 )
             )
         return enums

--- a/abicheck/model.py
+++ b/abicheck/model.py
@@ -408,6 +408,12 @@ class EnumType:
     is_scoped: bool | None = None
     # See Function.deprecated for the message-string convention.
     deprecated: str | None = None
+    # Namespace/enclosing-class-qualified spelling, mirroring
+    # ``RecordType.qualified_name`` (same bare-``name``-collision motivation:
+    # PR #608 follow-up). ``name`` stays bare for the same DWARF-parity and
+    # type-map-key reasons documented on ``RecordType.qualified_name``. None
+    # when the enum is at global scope or the dumper couldn't determine it.
+    qualified_name: str | None = None
 
 
 @dataclass

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -298,12 +298,26 @@ _MULTI_SPACE_RE = re.compile(r"\s{2,}")
 
 _PTR_REF_SIGIL_RE = re.compile(r"\s*([*&])\s*")
 
+# clang's ``-ast-dump=json`` spells an anonymous struct/union/enum field's type
+# as e.g. "enum (unnamed enum at /abs/path/to/header.h:56:5)" — the absolute
+# source path is an artifact of *where the tool ran*, not the type's ABI
+# identity. Comparing an old-tree checkout against a new-tree checkout of the
+# identical declaration (e.g. ".../old/include/foo.h" vs ".../new/include/foo.h")
+# then falsely reports a type change purely from the differing root, even
+# though both spellings denote the same anonymous type at the same line/column
+# within the (unchanged) header. Stripping the location leaves just the
+# "this is anonymous" marker, which is what should actually be compared.
+_ANON_TYPE_LOCATION_RE = re.compile(r"\bat\s+\S+:\d+:\d+(?=\s*\))")
+
 
 def canonicalize_type_name(name: str) -> str:
     """Normalise a C/C++ type name for comparison.
 
     Transformations (in order):
     0. Strip leading/trailing whitespace and collapse internal whitespace.
+    0b. Strip an anonymous struct/union/enum's embedded ``at <path>:<line>:<col>``
+        location (clang's ``-ast-dump=json`` spelling), which otherwise makes
+        two build trees of the identical declaration compare as different.
     1. Strip leading ``struct ``/``class ``/``union ``/``enum `` elaborated-type-specifier.
     2. Normalise leading ``const T`` → ``T const`` (east-const canonical form),
        but only when the base type contains no angle brackets (templates).
@@ -337,9 +351,18 @@ def canonicalize_type_name(name: str) -> str:
     'char const *'
     >>> canonicalize_type_name("int*")
     'int *'
+    >>> canonicalize_type_name("enum (unnamed enum at /a/old/foo.h:56:5)")
+    '(unnamed enum)'
+    >>> canonicalize_type_name("enum (unnamed enum at /b/new/foo.h:56:5)")
+    '(unnamed enum)'
     """
     # 0. Normalise whitespace early so anchored regexes work consistently.
     result = _MULTI_SPACE_RE.sub(" ", name.strip())
+    # 0b. Strip the absolute-path/line/col clang embeds in an anonymous
+    #     struct/union/enum spelling — it identifies "where the tool ran", not
+    #     the type. See _ANON_TYPE_LOCATION_RE above.
+    result = _ANON_TYPE_LOCATION_RE.sub("", result)
+    result = _MULTI_SPACE_RE.sub(" ", result).replace(" )", ")").strip()
     # 1. Strip elaborated type specifier prefix (handles leading whitespace).
     result = _STRUCT_PREFIX_RE.sub("", result)
     # 2. East-const normalisation: move leading "const" after the full base

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -228,6 +228,7 @@ def _enum_type_from_dict(e: dict[str, Any]) -> EnumType:
         origin=_scope_origin_or_unknown(e.get("origin")),
         is_scoped=e.get("is_scoped"),
         deprecated=e.get("deprecated"),
+        qualified_name=e.get("qualified_name"),
     )
 
 

--- a/changelog.d/20260719_023328_noreply_pvxs_abicheck_acceptance_t9ttgk.md
+++ b/changelog.d/20260719_023328_noreply_pvxs_abicheck_acceptance_t9ttgk.md
@@ -12,4 +12,10 @@
   location clang's `-ast-dump=json` frontend embeds in an anonymous
   struct/union/enum field's type spelling, so comparing an old checkout root
   against a new checkout root of the identical declaration no longer reports
-  a false `type_field_type_changed`.
+  a false `type_field_type_changed`. The qualified matching key stays
+  entirely internal to old/new type matching (via a new `_TypeMap` wrapper
+  with a collision-safe bare-name compatibility alias for legacy/schema-
+  evolution snapshot pairs): emitted `Change.symbol`, `dumper_hybrid`'s
+  per-fact provenance lookups, and `diff_filtering`'s DWARF<->AST redundancy
+  correlation all continue to see the bare declaration name they always
+  have.

--- a/changelog.d/20260719_023328_noreply_pvxs_abicheck_acceptance_t9ttgk.md
+++ b/changelog.d/20260719_023328_noreply_pvxs_abicheck_acceptance_t9ttgk.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **Two real-world false positives found in a pvxs acceptance spike are
+  fixed.** (1) Type matching across old/new snapshots now prefers
+  `RecordType.qualified_name` over the deliberately-bare `RecordType.name`
+  when building the old/new comparison maps in `diff_types.py`, so two
+  unrelated types that only share a short/leaf spelling (e.g. two distinct
+  `std::*::_Impl` template internals pulled in transitively) no longer get
+  cross-matched and diffed against each other, producing spurious
+  `type_field_removed`/`type_field_added`/`type_base_changed` findings. (2)
+  `canonicalize_type_name` now strips the absolute `at <path>:<line>:<col>`
+  location clang's `-ast-dump=json` frontend embeds in an anonymous
+  struct/union/enum field's type spelling, so comparing an old checkout root
+  against a new checkout root of the identical declaration no longer reports
+  a false `type_field_type_changed`.

--- a/changelog.d/20260719_120000_claude_generalize_identity_matching_t9ttgk.md
+++ b/changelog.d/20260719_120000_claude_generalize_identity_matching_t9ttgk.md
@@ -27,3 +27,11 @@
   across whichever detector happens to be affected rather than requiring a
   hand-written scenario per detector. See ADR-045 for the underlying
   principle ("identity-based old/new entity matching") this codifies.
+  `_diff_ctor_overload_ambiguity`'s class-existence filter also now uses
+  `lookup_matched_type`'s ambiguity-safe matching instead of a raw canonical-
+  key set intersection, fixing a schema-evolution mix (a legacy snapshot
+  missing `RecordType.qualified_name` on one side) that previously dropped a
+  namespaced class's constructors from `CTOR_OVERLOAD_AMBIGUITY_RISK`
+  entirely, since `owner_class_of` derives the real qualified owner from the
+  constructor's mangled symbol regardless of which side's `RecordType` lacks
+  `qualified_name`.

--- a/changelog.d/20260719_120000_claude_generalize_identity_matching_t9ttgk.md
+++ b/changelog.d/20260719_120000_claude_generalize_identity_matching_t9ttgk.md
@@ -49,4 +49,11 @@
   the bare leaf, while a real Itanium-mangled constructor's owner is always
   fully qualified regardless of `RecordType`'s own schema — the class-
   membership check now also accepts the bare leaf of a fully-qualified
-  owner when the qualified form isn't present.
+  owner when the qualified form isn't present. (4) `_diff_ctor_overload_ambiguity`
+  now groups constructors by a normalized *canonical* class identity
+  (`_class_identity_aliases`) instead of the raw owner spelling: a persisted
+  snapshot from before synthetic ctor keys were namespace-qualified
+  (`__abicheck_ctor__Widget(...)`) compared against a fresh one
+  (`__abicheck_ctor__ns::Widget(...)`) previously grouped the SAME class's
+  unchanged overloads under two different keys, fabricating a
+  `CTOR_OVERLOAD_AMBIGUITY_RISK` for every one of them.

--- a/changelog.d/20260719_120000_claude_generalize_identity_matching_t9ttgk.md
+++ b/changelog.d/20260719_120000_claude_generalize_identity_matching_t9ttgk.md
@@ -44,4 +44,9 @@
   bare class name — dropping such namespaced constructors from
   `CTOR_OVERLOAD_AMBIGUITY_RISK` even between two fully fresh snapshots;
   `_diff_ctor_overload_ambiguity` now recovers the scope directly from the
-  synthetic key's own encoding.
+  synthetic key's own encoding. (3) A doubly-legacy mix (neither side's
+  RecordType carries `qualified_name`) left `common_classes` holding only
+  the bare leaf, while a real Itanium-mangled constructor's owner is always
+  fully qualified regardless of `RecordType`'s own schema — the class-
+  membership check now also accepts the bare leaf of a fully-qualified
+  owner when the qualified form isn't present.

--- a/changelog.d/20260719_120000_claude_generalize_identity_matching_t9ttgk.md
+++ b/changelog.d/20260719_120000_claude_generalize_identity_matching_t9ttgk.md
@@ -1,0 +1,29 @@
+### Fixed
+
+- **The same-leaf-name matching bug found in the pvxs acceptance spike is
+  now generalized, not just patched at the one site it was first found.**
+  `diff_symbols.py`'s virtual-method-owner resolution, constructor-overload-
+  ambiguity grouping, field-access-level-change, and anonymous-field-change
+  detectors now build their old/new `RecordType` comparison maps through
+  `diff_helpers.build_type_map`/`lookup_matched_type` (the same ambiguity-
+  safe, namespace-qualified matching `diff_types.py`'s `RecordType`
+  detectors already used) instead of a bare-name `{t.name: t for t in ...}`
+  dict, closing the identical cross-attribution risk in those four detectors.
+  `EnumType` gained a `qualified_name` field (populated by both the castxml
+  and clang header dumpers, mirroring `RecordType.qualified_name`), and
+  `diff_types.py`'s `_diff_enums`/`_diff_enum_renames`/
+  `_diff_enum_deprecated` now match old/new enums the same ambiguity-safe
+  way — two distinct enums sharing a bare leaf name in different namespaces
+  no longer risk being cross-matched, missed, or misattributed. `TypeMap`/
+  `type_map_key`/`lookup_matched_type` in `diff_helpers.py` are now generic
+  over any entity with the `name`/`qualified_name` shape, so `RecordType`
+  and `EnumType` share one implementation instead of duplicating it. A new
+  Hypothesis property
+  (`test_same_leaf_name_matching_is_order_independent`/
+  `test_same_leaf_name_enum_matching_is_order_independent` in
+  `tests/test_detector_properties.py`) generates same-bare-name entity pairs
+  under randomized snapshot insertion order and asserts the emitted diff is
+  order-independent, generalizing regression coverage for this bug class
+  across whichever detector happens to be affected rather than requiring a
+  hand-written scenario per detector. See ADR-045 for the underlying
+  principle ("identity-based old/new entity matching") this codifies.

--- a/changelog.d/20260719_120000_claude_generalize_identity_matching_t9ttgk.md
+++ b/changelog.d/20260719_120000_claude_generalize_identity_matching_t9ttgk.md
@@ -34,4 +34,14 @@
   namespaced class's constructors from `CTOR_OVERLOAD_AMBIGUITY_RISK`
   entirely, since `owner_class_of` derives the real qualified owner from the
   constructor's mangled symbol regardless of which side's `RecordType` lacks
-  `qualified_name`.
+  `qualified_name`. Two more gaps in the same area are fixed: (1)
+  `EnumType.qualified_name` is now deserialized (`serialization.py`'s
+  `_enum_type_from_dict` serialized but never read it back), so a save/load
+  round trip no longer silently loses an enum's namespace identity; (2) a
+  castxml constructor whose real mangled name is omitted gets a synthesized
+  snapshot key (`SYNTHETIC_CTOR_KEY_PREFIX + "scope(params)"`) that isn't
+  Itanium-mangled, so `owner_class_of` couldn't parse it and fell back to the
+  bare class name — dropping such namespaced constructors from
+  `CTOR_OVERLOAD_AMBIGUITY_RISK` even between two fully fresh snapshots;
+  `_diff_ctor_overload_ambiguity` now recovers the scope directly from the
+  synthetic key's own encoding.

--- a/docs/development/adr/045-identity-based-old-new-entity-matching.md
+++ b/docs/development/adr/045-identity-based-old-new-entity-matching.md
@@ -141,7 +141,15 @@ detectors (`_diff_enums`, `_diff_enum_renames`, `_diff_enum_deprecated`);
   distinguish "confirmed global scope" from "unknown scope", which no
   current backend does) — this ADR does not attempt to close it, only to
   make sure it is the *one* remaining gap rather than one of several
-  independently-discovered ones.
+  independently-discovered ones. Confirmed (Codex review) to apply
+  identically to `EnumType` once it gained `qualified_name` and started
+  sharing this same generic `TypeMap` mechanism: a legacy (unqualified) enum
+  compared against a fresh side carrying both a real global enum and a
+  namespaced one with the same bare name can diff against the wrong one, the
+  same way `RecordType` already could. Because the mechanism is now generic
+  over any `_QualifiedNamed` entity, this is a property of the shared
+  mechanism itself, not something to re-verify per entity kind that adopts
+  it in the future.
 
 ## Alternatives considered
 

--- a/docs/development/adr/045-identity-based-old-new-entity-matching.md
+++ b/docs/development/adr/045-identity-based-old-new-entity-matching.md
@@ -1,0 +1,163 @@
+# ADR-045: Identity-Based Old/New Entity Matching
+
+**Date:** 2026-07-19
+**Status:** Accepted — implemented for `RecordType` and `EnumType`.
+**Decision maker:** Nikolay Petrov (@napetrov)
+
+---
+
+## Context
+
+A false-positive/false-negative acceptance spike against the real `pvxs`
+C++ library (`validation/pvxs-abicheck-acceptance-2026-07-18.md`) traced one
+finding back to a structural gap: `diff_types.py`'s old/new `RecordType`
+matching keyed its comparison maps by the bare declaration name
+(`{t.name: t for t in old.types}`). Two distinct classes sharing a bare leaf
+name in different namespaces (or two unrelated `std::*::_Impl` template
+internals pulled in transitively) could collide in that dict — whichever one
+a `for t in types` loop happened to insert last silently won the bare-name
+slot, and the other was compared against the wrong counterpart on the
+opposite old/new side. The result depended on **snapshot list insertion
+order**, which is not a property that should ever influence a diff.
+
+The immediate fix (PR #608, first round) added `RecordType.qualified_name`
+(populated by both header-mode dumpers, castxml and clang) and a
+namespace-qualified matching map (`diff_helpers.TypeMap`) for the `RecordType`
+detectors in `diff_types.py`. Three follow-up review rounds then found the
+same collision pattern reopened in progressively subtler ways: a schema-
+evolution bare-name fallback needed to work in both matching directions, and
+that fallback itself needed to refuse to fire when the *probing* side's own
+bare name was ambiguous — otherwise the compatibility shim reintroduced the
+exact collision it existed to paper over.
+
+Once the mechanism was solid for `RecordType`, an explicit broader-scale
+review of the codebase found the identical bug, live, in two more places:
+
+- `diff_symbols.py` had never adopted `TypeMap` — its own four call sites
+  (`_diff_functions`'s virtual-method-owner resolution,
+  `_diff_ctor_overload_ambiguity`, `_diff_access_levels`,
+  `_diff_anon_fields`) still built plain bare-name dicts, independently
+  reintroducing the same false-positive/false-negative class this ADR's
+  predecessor work had just fixed for `diff_types.py`.
+- `EnumType` had no `qualified_name` equivalent at all, so
+  `diff_types.py`'s own `_diff_enums`/`_diff_enum_renames`/
+  `_diff_enum_deprecated` were exposed to the identical bare-leaf-name
+  collision `RecordType` had just been fixed for.
+
+Each of these was closed by hand, one file at a time, by someone who
+happened to go looking. That is the actual problem this ADR records a
+decision about: **the fix, as delivered, was a per-file patch repeated by
+audit — not a principle any future detector author would discover on their
+own.** A new detector that matches old/new entities by writing its own
+`{e.name: e for e in ...}` dict is unremarkable-looking code; nothing about
+it looks wrong until a real binary with a same-leaf-name collision exercises
+it.
+
+## Decision
+
+**Old/new entity matching must use the most specific available identity,
+with an ambiguity-safe fallback on both sides.** Concretely:
+
+1. Prefer a namespace/scope-qualified identity over a bare declaration name
+   whenever one is available. A bare name is a legitimate matching key only
+   when nothing more specific exists for that entity kind (DWARF-only
+   snapshots, which have no separate bare/qualified split at all — the
+   qualified spelling already lives directly in `.name`).
+2. When falling back to a less specific identity for schema-evolution
+   compatibility (an older snapshot format, a producer that never populated
+   the specific field), the fallback must be **safe on both sides of the
+   comparison**: it may only resolve when the *less specific* key is itself
+   unambiguous on the side doing the probing. An ambiguous fallback key must
+   resolve to "no match", never to an arbitrarily-chosen candidate.
+3. This applies uniformly to every entity kind a detector matches old vs.
+   new by name — `RecordType`, `EnumType`, and any future kind with the same
+   bare/qualified shape — not as a special case hand-implemented per
+   detector.
+
+### Implementation
+
+The principle is realized as one generic mechanism in `diff_helpers.py`,
+not duplicated per entity kind:
+
+- `type_map_key(t)` — `t.qualified_name or t.name`: the qualified identity
+  when known, the bare name otherwise.
+- `TypeMap` — a `Mapping[str, Q]` (generic over any `_QualifiedNamed`
+  structural type — `RecordType` and `EnumType` both satisfy it) keyed
+  canonically by `type_map_key`, carrying a **collision-safe bare-name
+  alias** used only by `get`/`in`, never by `items`/`values`/iteration (so a
+  detector loop still processes each entity exactly once). The alias for a
+  given bare name is only registered when that bare name is unambiguous
+  within the map being built — i.e. not already claimed by a second,
+  distinct qualified identity in the *same* snapshot.
+- `TypeMap.bare_name_is_unambiguous(bare)` — exposes that same check so a
+  cross-map lookup can decide, from the *probing* side, whether retrying
+  with the bare name is safe.
+- `lookup_matched_type(own, other, t)` — the one bidirectional, ambiguity-
+  safe lookup every detector should call instead of hand-rolling one: try
+  `other[type_map_key(t)]` first; only if that misses, and only if `t`'s own
+  bare name is unambiguous in `own`, retry `other[t.name]`.
+
+`RecordType.qualified_name` and `EnumType.qualified_name` are both populated
+the same way on both header-mode dumpers (castxml's `context`-chain walk,
+clang's AST `scope` tuple), and both left `None` when the entity is at
+global scope or the dumper couldn't determine it — `.name` itself stays
+bare on every producer (including DWARF's synthetic split) specifically so
+`TypeMap`'s canonical key computation and any direct `.name` comparison
+elsewhere in the codebase keep matching consistently.
+
+Consumers, as of this ADR: `diff_types.py`'s `RecordType` detectors (vtable/
+layout/field/access/anonymous-field/base-class families) and its three enum
+detectors (`_diff_enums`, `_diff_enum_renames`, `_diff_enum_deprecated`);
+`diff_symbols.py`'s four call sites listed above.
+
+## Consequences
+
+- **New detectors get this for free** by using `build_type_map`/
+  `lookup_matched_type` instead of a bare dict comprehension — the
+  ambiguity-safety is centralized, not something each detector author has
+  to re-derive.
+- **Regression coverage is generalized, not per-detector.** A Hypothesis
+  property (`tests/test_detector_properties.py`,
+  `test_same_leaf_name_matching_is_order_independent` /
+  `test_same_leaf_name_enum_matching_is_order_independent`) generates two
+  distinct qualified entities sharing a bare leaf name, randomizes snapshot
+  list insertion order, and asserts the emitted diff is identical regardless
+  of order — it does not know or care which detector fires, so it catches
+  any future detector (for `RecordType`, `EnumType`, or a later entity kind
+  reusing the same `TypeMap` machinery) that reintroduces a bare-name-keyed
+  matching map, without anyone having to audit that detector by hand.
+  Deterministic unit tests (`tests/test_diff_symbols_type_matching.py`,
+  `tests/test_diff_enum_type_matching.py`) additionally pin the exact
+  before/after behavior for each of the seven call sites this ADR's work
+  touched, each confirmed (via `git stash` against the pre-fix code) to
+  actually fail before the fix and pass after.
+- **A known, deliberately unresolved gap remains:** when `qualified_name` is
+  `None` on *both* sides for two entities that are NOT actually the same
+  (one at true global scope, one whose dumper simply couldn't determine its
+  namespace), `type_map_key` falls back to the bare name for both and they
+  are indistinguishable to this mechanism. This is the same ambiguity
+  `RecordType.qualified_name`'s own docstring already documents as
+  unresolvable with the current data model (it would need the dumper to
+  distinguish "confirmed global scope" from "unknown scope", which no
+  current backend does) — this ADR does not attempt to close it, only to
+  make sure it is the *one* remaining gap rather than one of several
+  independently-discovered ones.
+
+## Alternatives considered
+
+- **Per-detector fixes, no shared abstraction.** This is what happened
+  organically before this ADR (each of the seven call sites was patched by
+  hand once someone noticed it) and is explicitly what this decision is
+  reacting against: it scales with audit effort, not with test coverage.
+- **A separate `EnumMap` duplicating `TypeMap`'s logic.** Rejected in favor
+  of generalizing `TypeMap` over a `Protocol` (`_QualifiedNamed`, requiring
+  `name`/`qualified_name` attributes) — the matching/ambiguity logic is
+  identical for any entity kind with this bare/qualified shape, and a
+  second copy would only reintroduce the "fixed once, forgotten as a
+  pattern" failure mode this ADR is about.
+- **Always require the qualified identity, no bare-name fallback.** Rejected
+  because it would break matching against snapshots serialized before
+  `qualified_name` existed, or produced by a backend that never populates
+  it (e.g. DWARF-only mode structurally has no separate qualified field) —
+  the fallback is necessary for schema-evolution compatibility; the fix is
+  making that fallback ambiguity-safe, not removing it.

--- a/docs/development/adr/index.md
+++ b/docs/development/adr/index.md
@@ -83,3 +83,4 @@ against the code as unverified, regardless of how confident it reads.
 | [042](042-compatibility-and-gate-decision-separation.md) | Formal separation of CompatibilityDecision and GateDecision | Accepted — implemented for JSON/SARIF/compare-release gate summaries |
 | [043](043-cli-pre-1.0-surface-reset.md) | Pre-1.0 CLI Surface Reset — Root Command Collapse, Depth Ladder Narrowing, and Dry-Run Unification | Accepted — implemented |
 | [044](044-reachability-aware-suppression.md) | Reachability-Aware Suppression and the Effective Public ABI | Accepted — P0 slice implemented |
+| [045](045-identity-based-old-new-entity-matching.md) | Identity-Based Old/New Entity Matching | Accepted — implemented for `RecordType` and `EnumType` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -203,6 +203,7 @@ nav:
       - "042: CompatibilityDecision/GateDecision Separation": development/adr/042-compatibility-and-gate-decision-separation.md
       - "043: Pre-1.0 CLI Surface Reset": development/adr/043-cli-pre-1.0-surface-reset.md
       - "044: Reachability-Aware Suppression": development/adr/044-reachability-aware-suppression.md
+      - "045: Identity-Based Old/New Entity Matching": development/adr/045-identity-based-old-new-entity-matching.md
 
 # Agent instructions are repo-internal context, not published documentation.
 exclude_docs: |

--- a/tests/test_castxml_schema_completeness.py
+++ b/tests/test_castxml_schema_completeness.py
@@ -514,6 +514,19 @@ _SCOPED_ENUM_XML = """<?xml version="1.0"?>
   <File id="f1" name="test.h"/>
 </CastXML>"""
 
+_NAMESPACED_ENUM_XML = """<?xml version="1.0"?>
+<CastXML>
+  <Namespace id="_1" name="::"/>
+  <Namespace id="_2" name="ns" context="_1"/>
+  <Enumeration id="_3" name="Status" context="_2" file="f1" line="1">
+    <EnumValue name="OK" init="0"/>
+  </Enumeration>
+  <Enumeration id="_4" name="Global" context="_1" file="f1" line="2">
+    <EnumValue name="A" init="0"/>
+  </Enumeration>
+  <File id="f1" name="test.h"/>
+</CastXML>"""
+
 _DEPRECATED_XML = """<?xml version="1.0"?>
 <CastXML>
   <Function id="_2" name="old_api" returns="_v" context="_1" mangled="_Z7old_apiv"
@@ -589,6 +602,15 @@ class TestCastxmlParserPopulatesNewAttributes:
     def test_scoped_enum_attribute(self) -> None:
         p = _make_parser(_SCOPED_ENUM_XML)
         assert p.parse_enums()[0].is_scoped is True
+
+    def test_namespaced_enum_qualified_name(self) -> None:
+        # EnumType.qualified_name (PR #608 follow-up), mirroring
+        # RecordType.qualified_name: populated only when it differs from
+        # the bare name.
+        p = _make_parser(_NAMESPACED_ENUM_XML)
+        enums = {e.name: e for e in p.parse_enums()}
+        assert enums["Status"].qualified_name == "ns::Status"
+        assert enums["Global"].qualified_name is None
 
     def test_deprecation_attribute_function_variable_type(self) -> None:
         p = _make_parser(_DEPRECATED_XML)

--- a/tests/test_detector_properties.py
+++ b/tests/test_detector_properties.py
@@ -64,6 +64,7 @@ from abicheck.checker_policy import (
 )
 from abicheck.model import (
     AbiSnapshot,
+    AccessLevel,
     EnumMember,
     EnumType,
     Function,
@@ -204,6 +205,159 @@ def test_emitted_kinds_are_partitioned(pair: tuple[AbiSnapshot, AbiSnapshot]) ->
         assert membership == 1, (
             f"{change.kind.name} appears in {membership} policy sets (must be 1)"
         )
+
+
+# ---------------------------------------------------------------------------
+# Layer 1b — ambiguous-bare-name matching safety (PR #608 generalization)
+# ---------------------------------------------------------------------------
+#
+# PR #608 fixed a class of false positive: two unrelated RecordTypes sharing a
+# short/leaf declaration name (but distinct namespace-qualified identities)
+# getting cross-matched across old/new snapshots, fabricating spurious
+# findings (or missing real ones) for the wrong type. The bug's signature was
+# always the same regardless of which detector hit it: whichever same-bare-
+# name entity a naive `{t.name: t for t in types}` dict happened to keep
+# (last-write-wins) determined the result, so the diff depended on *snapshot
+# list insertion order* -- a property that must never hold for a correct
+# comparison. This property generalizes the fix's regression coverage beyond
+# the specific detectors patched by hand (diff_types.py, then diff_symbols.py
+# once this same class of bug was found live there too): it doesn't know or
+# care which detector fires, only that the result is order-independent.
+
+
+@st.composite
+def _ambiguous_bare_name_pair(draw: st.DrawFn) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Two distinct namespace-qualified ``RecordType``s sharing one bare leaf
+    name, each independently varied between old and new, plus a random
+    shuffle of insertion order on both sides.
+    """
+    leaf = draw(_ident)
+    ns_a, ns_b = "nsA", "nsB"
+
+    def _field() -> st.SearchStrategy[TypeField]:
+        # A field is sometimes an anonymous-union/struct member (drives
+        # diff_symbols._diff_anon_fields) and its access level varies (drives
+        # diff_symbols._diff_access_levels) -- both detectors independently
+        # built their own bare-name old/new RecordType maps before this PR.
+        return st.builds(
+            TypeField,
+            name=st.one_of(_ident, st.just("__anon0")),
+            type=_types,
+            access=st.sampled_from(list(AccessLevel)),
+        )
+
+    def _variant(qualified: str) -> RecordType:
+        return RecordType(
+            name=leaf,
+            qualified_name=qualified,
+            kind=draw(st.sampled_from(["struct", "class"])),
+            size_bits=draw(st.sampled_from([32, 64, 128])),
+            fields=draw(st.lists(_field(), max_size=3, unique_by=lambda f: f.name)),
+        )
+
+    old_a, new_a = _variant(f"{ns_a}::{leaf}"), _variant(f"{ns_a}::{leaf}")
+    old_b, new_b = _variant(f"{ns_b}::{leaf}"), _variant(f"{ns_b}::{leaf}")
+
+    old_types = [old_a, old_b]
+    new_types = [new_a, new_b]
+    if draw(st.booleans()):
+        old_types.reverse()
+    if draw(st.booleans()):
+        new_types.reverse()
+
+    return (
+        AbiSnapshot(library="libtest.so.1", version="1.0", types=old_types),
+        AbiSnapshot(library="libtest.so.1", version="2.0", types=new_types),
+    )
+
+
+def _change_fingerprint(result: object) -> frozenset[tuple[str, str]]:
+    return frozenset((c.kind.value, c.description) for c in result.changes)  # type: ignore[attr-defined]
+
+
+@given(pair=_ambiguous_bare_name_pair())
+@_HSETTINGS
+def test_same_leaf_name_matching_is_order_independent(
+    pair: tuple[AbiSnapshot, AbiSnapshot],
+) -> None:
+    """Two distinct namespace-qualified types sharing a bare leaf name must
+    diff identically no matter what order they appear in ``snap.types`` --
+    correct old/new matching is keyed by identity, never by list position.
+    A detector keying its matching map by bare name alone (the PR #608 bug
+    class) makes the result insertion-order-dependent, since a naive
+    last-write-wins dict silently picks whichever same-bare-name entity was
+    inserted last; this property catches that regardless of *which*
+    detector does it, without needing a scenario tailored to each one.
+    """
+    old, new = pair
+    baseline = _change_fingerprint(compare(old, new))
+
+    old_reordered = AbiSnapshot(
+        library=old.library, version=old.version, types=list(reversed(old.types))
+    )
+    new_reordered = AbiSnapshot(
+        library=new.library, version=new.version, types=list(reversed(new.types))
+    )
+    reordered = _change_fingerprint(compare(old_reordered, new_reordered))
+
+    assert baseline == reordered
+
+
+@st.composite
+def _ambiguous_bare_name_enum_pair(draw: st.DrawFn) -> tuple[AbiSnapshot, AbiSnapshot]:
+    """Same shape as :func:`_ambiguous_bare_name_pair` but for ``EnumType``
+    (PR #608 follow-up: ``EnumType.qualified_name`` + ``diff_types.py``'s
+    ``_diff_enums``/``_diff_enum_renames``/``_diff_enum_deprecated`` gained
+    the identical ambiguity-safe matching ``RecordType`` detectors already
+    had).
+    """
+    leaf = draw(_ident)
+    ns_a, ns_b = "nsA", "nsB"
+
+    def _member() -> st.SearchStrategy[EnumMember]:
+        return st.builds(EnumMember, name=_ident, value=st.integers(min_value=0, max_value=10))
+
+    def _variant(qualified: str) -> EnumType:
+        return EnumType(
+            name=leaf,
+            qualified_name=qualified,
+            members=draw(st.lists(_member(), max_size=3, unique_by=lambda m: m.name)),
+        )
+
+    old_a, new_a = _variant(f"{ns_a}::{leaf}"), _variant(f"{ns_a}::{leaf}")
+    old_b, new_b = _variant(f"{ns_b}::{leaf}"), _variant(f"{ns_b}::{leaf}")
+
+    old_enums = [old_a, old_b]
+    new_enums = [new_a, new_b]
+    if draw(st.booleans()):
+        old_enums.reverse()
+    if draw(st.booleans()):
+        new_enums.reverse()
+
+    return (
+        AbiSnapshot(library="libtest.so.1", version="1.0", enums=old_enums),
+        AbiSnapshot(library="libtest.so.1", version="2.0", enums=new_enums),
+    )
+
+
+@given(pair=_ambiguous_bare_name_enum_pair())
+@_HSETTINGS
+def test_same_leaf_name_enum_matching_is_order_independent(
+    pair: tuple[AbiSnapshot, AbiSnapshot],
+) -> None:
+    """Enum counterpart of ``test_same_leaf_name_matching_is_order_independent``."""
+    old, new = pair
+    baseline = _change_fingerprint(compare(old, new))
+
+    old_reordered = AbiSnapshot(
+        library=old.library, version=old.version, enums=list(reversed(old.enums))
+    )
+    new_reordered = AbiSnapshot(
+        library=new.library, version=new.version, enums=list(reversed(new.enums))
+    )
+    reordered = _change_fingerprint(compare(old_reordered, new_reordered))
+
+    assert baseline == reordered
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_diff_enum_type_matching.py
+++ b/tests/test_diff_enum_type_matching.py
@@ -1,0 +1,146 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``EnumType`` gained a ``qualified_name`` field (PR #608 follow-up, mirroring
+``RecordType.qualified_name``) so ``diff_types.py``'s enum detectors
+(``_diff_enums``, ``_diff_enum_renames``, ``_diff_enum_deprecated``) can match
+old/new enums by namespace-qualified identity instead of bare ``EnumType.name``
+alone. Before this fix, two distinct enums sharing a bare leaf name in
+different namespaces (e.g. ``ns1::Status`` and ``ns2::Status``) could be
+cross-matched across old/new snapshots, fabricating or missing findings for
+the wrong enum -- the exact short/leaf-name collision class already fixed for
+``RecordType``.
+"""
+from __future__ import annotations
+
+from abicheck.checker import ChangeKind, compare
+from abicheck.model import AbiSnapshot, EnumMember, EnumType
+
+
+def _snap(version="1.0", enums=None):
+    return AbiSnapshot(
+        library="libtest.so.1", version=version,
+        functions=[], variables=[], types=[], enums=enums or [],
+    )
+
+
+def _enum(qualified, members, deprecated=None):
+    bare = qualified.split("::")[-1]
+    return EnumType(
+        name=bare, qualified_name=qualified,
+        members=[EnumMember(name=n, value=v) for n, v in members],
+        deprecated=deprecated,
+    )
+
+
+class TestEnumMemberChangesAmbiguitySafe:
+    def test_member_value_change_not_cross_attributed(self):
+        """ns1::Status is unchanged; only ns2::Status's member value changes.
+        Reversed insertion order on the new side forces a naive last-write-wins
+        bare-name dict to compare the wrong pair.
+        """
+        ns1_old = _enum("ns1::Status", [("OK", 0), ("FAIL", 1)])
+        ns2_old = _enum("ns2::Status", [("OK", 0), ("FAIL", 1)])
+        ns1_new = _enum("ns1::Status", [("OK", 0), ("FAIL", 1)])
+        ns2_new = _enum("ns2::Status", [("OK", 0), ("FAIL", 2)])
+
+        r = compare(
+            _snap(enums=[ns1_old, ns2_old]),
+            _snap(enums=[ns2_new, ns1_new]),  # reversed order
+        )
+
+        value_changes = [c for c in r.changes if c.kind == ChangeKind.ENUM_MEMBER_VALUE_CHANGED]
+        assert len(value_changes) == 1
+        assert value_changes[0].new_value == "2"
+
+    def test_member_removed_from_one_namespace_not_confused_with_other(self):
+        """ns2::Status genuinely loses a member; ns1::Status is untouched."""
+        ns1_old = _enum("ns1::Status", [("OK", 0), ("FAIL", 1)])
+        ns2_old = _enum("ns2::Status", [("OK", 0), ("FAIL", 1)])
+        ns1_new = _enum("ns1::Status", [("OK", 0), ("FAIL", 1)])
+        ns2_new = _enum("ns2::Status", [("OK", 0)])
+
+        r = compare(
+            _snap(enums=[ns1_old, ns2_old]),
+            _snap(enums=[ns2_new, ns1_new]),
+        )
+
+        removed = [c for c in r.changes if c.kind == ChangeKind.ENUM_MEMBER_REMOVED]
+        assert len(removed) == 1
+        assert removed[0].symbol == "Status::FAIL"
+
+
+class TestEnumRenameAmbiguitySafe:
+    def test_rename_detected_for_the_correct_namespace_only(self):
+        """ns2::Status renames FAIL->ERROR (same value); ns1::Status is
+        untouched. Reversed insertion order on the new side must not cause
+        the rename to be attributed to (or missed for) ns1::Status."""
+        ns1_old = _enum("ns1::Status", [("OK", 0), ("FAIL", 1)])
+        ns2_old = _enum("ns2::Status", [("OK", 0), ("FAIL", 1)])
+        ns1_new = _enum("ns1::Status", [("OK", 0), ("FAIL", 1)])
+        ns2_new = _enum("ns2::Status", [("OK", 0), ("ERROR", 1)])
+
+        r = compare(
+            _snap(enums=[ns1_old, ns2_old]),
+            _snap(enums=[ns2_new, ns1_new]),
+        )
+
+        renames = [c for c in r.changes if c.kind == ChangeKind.ENUM_MEMBER_RENAMED]
+        assert len(renames) == 1
+        assert renames[0].old_value == "FAIL"
+        assert renames[0].new_value == "ERROR"
+
+
+class TestEnumDeprecatedAmbiguitySafe:
+    def test_deprecation_added_for_the_correct_namespace_only(self):
+        """ns2::Status gains [[deprecated]]; ns1::Status is untouched."""
+        ns1_old = _enum("ns1::Status", [("OK", 0)])
+        ns2_old = _enum("ns2::Status", [("OK", 0)])
+        ns1_new = _enum("ns1::Status", [("OK", 0)])
+        ns2_new = _enum("ns2::Status", [("OK", 0)], deprecated="use ns2::NewStatus")
+
+        old_snap = _snap(enums=[ns1_old, ns2_old])
+        new_snap = _snap(enums=[ns2_new, ns1_new])
+        old_snap.ast_producer = "castxml"
+        new_snap.ast_producer = "castxml"
+        old_snap.from_headers = True
+        new_snap.from_headers = True
+
+        r = compare(old_snap, new_snap)
+
+        added = [c for c in r.changes if c.kind == ChangeKind.ENUM_DEPRECATED_ADDED]
+        assert len(added) == 1
+        assert added[0].symbol == "Status"
+        assert added[0].new_value == "use ns2::NewStatus"
+
+
+class TestEnumRemovalAmbiguitySafe:
+    def test_removed_enum_not_masked_by_surviving_same_leaf_name_sibling(self):
+        """ns1::Status is genuinely removed; ns2::Status (same bare name,
+        different namespace) survives unchanged. A naive bare-name dict
+        would consider 'Status' still present and silently miss the
+        removal.
+        """
+        ns1_old = _enum("ns1::Status", [("OK", 0)])
+        ns2_old = _enum("ns2::Status", [("OK", 0)])
+        ns2_new = _enum("ns2::Status", [("OK", 0)])
+
+        r = compare(
+            _snap(enums=[ns1_old, ns2_old]),
+            _snap(enums=[ns2_new]),
+        )
+
+        removed = [c for c in r.changes if c.kind == ChangeKind.TYPE_REMOVED and c.symbol == "Status"]
+        assert len(removed) == 1

--- a/tests/test_diff_helpers.py
+++ b/tests/test_diff_helpers.py
@@ -173,6 +173,16 @@ class TestTypeMap:
         assert m["ns1::Impl"] is a
         assert m["ns2::Impl"] is b
 
+    def test_duplicate_same_qualified_identity_does_not_mark_ambiguous(self) -> None:
+        # Two entries sharing both the same bare name AND the same qualified
+        # key (e.g. an ODR-duplicate re-parse of the identical declaration)
+        # is not an ambiguous collision -- the bare alias must still resolve.
+        a = RecordType(name="Foo", qualified_name="ns::Foo", kind="class")
+        b = RecordType(name="Foo", qualified_name="ns::Foo", kind="class")
+        m = build_type_map([a, b])
+        assert m.get("Foo") is b  # second entry wins the primary slot
+        assert "Foo" in m
+
     def test_global_scope_type_has_no_redundant_alias_entry(self) -> None:
         t = RecordType(name="Foo", qualified_name=None, kind="class")
         m = build_type_map([t])

--- a/tests/test_diff_helpers.py
+++ b/tests/test_diff_helpers.py
@@ -17,7 +17,13 @@ from __future__ import annotations
 
 from abicheck.checker_policy import ChangeKind
 from abicheck.checker_types import Change
-from abicheck.diff_helpers import bool_transition, diff_by_key
+from abicheck.diff_helpers import (
+    bool_transition,
+    build_type_map,
+    diff_by_key,
+    type_map_key,
+)
+from abicheck.model import RecordType
 
 ADDED = (ChangeKind.FUNC_VIRTUAL_ADDED, "added")
 REMOVED = (ChangeKind.FUNC_VIRTUAL_REMOVED, "removed")
@@ -133,3 +139,64 @@ class TestDiffByKey:
             on_common=lambda k, o, n: [self._change(f"common:{k}")],
         )
         assert [c.symbol for c in out] == ["common:a"]
+
+
+class TestTypeMapKey:
+    def test_prefers_qualified_name(self) -> None:
+        t = RecordType(name="Foo", qualified_name="ns::Foo", kind="class")
+        assert type_map_key(t) == "ns::Foo"
+
+    def test_falls_back_to_bare_name(self) -> None:
+        t = RecordType(name="Foo", qualified_name=None, kind="class")
+        assert type_map_key(t) == "Foo"
+
+
+class TestTypeMap:
+    def test_lookup_by_qualified_key(self) -> None:
+        t = RecordType(name="Foo", qualified_name="ns::Foo", kind="class")
+        m = build_type_map([t])
+        assert m["ns::Foo"] is t
+        assert m.get("ns::Foo") is t
+
+    def test_bare_alias_resolves_when_unambiguous(self) -> None:
+        t = RecordType(name="Foo", qualified_name="ns::Foo", kind="class")
+        m = build_type_map([t])
+        assert m.get("Foo") is t
+        assert "Foo" in m
+
+    def test_bare_alias_not_added_when_ambiguous(self) -> None:
+        a = RecordType(name="Impl", qualified_name="ns1::Impl", kind="class")
+        b = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class")
+        m = build_type_map([a, b])
+        assert m.get("Impl") is None
+        assert "Impl" not in m
+        assert m["ns1::Impl"] is a
+        assert m["ns2::Impl"] is b
+
+    def test_global_scope_type_has_no_redundant_alias_entry(self) -> None:
+        t = RecordType(name="Foo", qualified_name=None, kind="class")
+        m = build_type_map([t])
+        assert list(m.items()) == [("Foo", t)]
+
+    def test_items_yields_each_type_exactly_once(self) -> None:
+        # A namespaced type's bare-name alias must never leak into iteration
+        # (items/values/__iter__) -- only used for get()/__contains__ lookups
+        # -- or every detector loop over old_map.items() would double-process
+        # (and double-report) every namespaced type (Codex review, PR #608).
+        t = RecordType(name="Foo", qualified_name="ns::Foo", kind="class")
+        m = build_type_map([t])
+        assert list(m.items()) == [("ns::Foo", t)]
+        assert list(m.values()) == [t]
+        assert list(m) == ["ns::Foo"]
+        assert len(m) == 1
+
+    def test_missing_key_raises_and_get_returns_default(self) -> None:
+        m = build_type_map([])
+        assert m.get("Foo") is None
+        assert m.get("Foo", "default") == "default"
+        try:
+            m["Foo"]
+        except KeyError:
+            pass
+        else:
+            raise AssertionError("expected KeyError")

--- a/tests/test_diff_helpers.py
+++ b/tests/test_diff_helpers.py
@@ -212,38 +212,76 @@ class TestTypeMap:
         else:
             raise AssertionError("expected KeyError")
 
+    def test_bare_name_is_unambiguous(self) -> None:
+        unique = RecordType(name="Foo", qualified_name="ns::Foo", kind="class")
+        m = build_type_map([unique])
+        assert m.bare_name_is_unambiguous("Foo") is True
+        assert m.bare_name_is_unambiguous("Bar") is False  # no such bare name at all
+
+    def test_bare_name_is_ambiguous_when_shared_by_distinct_types(self) -> None:
+        a = RecordType(name="Impl", qualified_name="ns1::Impl", kind="class")
+        b = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class")
+        m = build_type_map([a, b])
+        assert m.bare_name_is_unambiguous("Impl") is False
+
 
 class TestLookupMatchedType:
     """Codex review, PR #608 (second round): a plain ``other.get(type_map_key(t))``
     lookup only resolves the legacy-old/fresh-new direction (via the fresh
     side's bare-name alias). The reverse -- fresh old, legacy new -- has no
     alias to hit, since aliases only map bare -> qualified, never qualified ->
-    bare. ``lookup_matched_type`` retries with the bare name to cover both.
+    bare. ``lookup_matched_type`` retries with the bare name to cover both --
+    but ONLY when ``t``'s own bare name is unambiguous in its own map
+    (``own``), or a genuine same-leaf-name collision on the probing side
+    would retry into an unrelated survivor on the other side (Codex review,
+    PR #608, third round).
     """
 
     def test_fresh_side_against_legacy_other_falls_back_to_bare(self) -> None:
         t = RecordType(name="Handle", qualified_name="ns::Handle", kind="class")
+        own = build_type_map([t])
         legacy_counterpart = RecordType(name="Handle", qualified_name=None, kind="class")
         other = build_type_map([legacy_counterpart])
 
-        assert lookup_matched_type(other, t) is legacy_counterpart
+        assert lookup_matched_type(own, other, t) is legacy_counterpart
 
     def test_direct_qualified_hit_needs_no_fallback(self) -> None:
         t = RecordType(name="Handle", qualified_name="ns::Handle", kind="class")
+        own = build_type_map([t])
         counterpart = RecordType(name="Handle", qualified_name="ns::Handle", kind="class")
         other = build_type_map([counterpart])
 
-        assert lookup_matched_type(other, t) is counterpart
+        assert lookup_matched_type(own, other, t) is counterpart
 
     def test_global_scope_type_key_equals_bare_no_redundant_lookup(self) -> None:
         t = RecordType(name="Foo", qualified_name=None, kind="class")
+        own = build_type_map([t])
         counterpart = RecordType(name="Foo", qualified_name=None, kind="class")
         other = build_type_map([counterpart])
 
-        assert lookup_matched_type(other, t) is counterpart
+        assert lookup_matched_type(own, other, t) is counterpart
 
     def test_genuinely_absent_returns_none(self) -> None:
         t = RecordType(name="Handle", qualified_name="ns::Handle", kind="class")
+        own = build_type_map([t])
         other = build_type_map([])
 
-        assert lookup_matched_type(other, t) is None
+        assert lookup_matched_type(own, other, t) is None
+
+    def test_ambiguous_probing_side_does_not_fall_back_to_survivor(self) -> None:
+        """The exact scenario Codex flagged: old side has two distinct
+        namespaced types sharing the bare name 'Impl'; the new side kept
+        only one of them. Probing the REMOVED one must not retry into the
+        unrelated SURVIVING one just because it also happens to be the
+        other map's sole 'Impl'.
+        """
+        removed = RecordType(name="Impl", qualified_name="ns1::Impl", kind="class")
+        survivor_old = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class")
+        own = build_type_map([removed, survivor_old])  # ambiguous bare "Impl" in own
+        survivor_new = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class")
+        other = build_type_map([survivor_new])
+
+        assert lookup_matched_type(own, other, removed) is None
+        # The genuinely-unchanged type still matches fine via its own
+        # qualified key -- ambiguity in `own` doesn't block direct hits.
+        assert lookup_matched_type(own, other, survivor_old) is survivor_new

--- a/tests/test_diff_helpers.py
+++ b/tests/test_diff_helpers.py
@@ -21,6 +21,7 @@ from abicheck.diff_helpers import (
     bool_transition,
     build_type_map,
     diff_by_key,
+    lookup_matched_type,
     type_map_key,
 )
 from abicheck.model import RecordType
@@ -210,3 +211,39 @@ class TestTypeMap:
             pass
         else:
             raise AssertionError("expected KeyError")
+
+
+class TestLookupMatchedType:
+    """Codex review, PR #608 (second round): a plain ``other.get(type_map_key(t))``
+    lookup only resolves the legacy-old/fresh-new direction (via the fresh
+    side's bare-name alias). The reverse -- fresh old, legacy new -- has no
+    alias to hit, since aliases only map bare -> qualified, never qualified ->
+    bare. ``lookup_matched_type`` retries with the bare name to cover both.
+    """
+
+    def test_fresh_side_against_legacy_other_falls_back_to_bare(self) -> None:
+        t = RecordType(name="Handle", qualified_name="ns::Handle", kind="class")
+        legacy_counterpart = RecordType(name="Handle", qualified_name=None, kind="class")
+        other = build_type_map([legacy_counterpart])
+
+        assert lookup_matched_type(other, t) is legacy_counterpart
+
+    def test_direct_qualified_hit_needs_no_fallback(self) -> None:
+        t = RecordType(name="Handle", qualified_name="ns::Handle", kind="class")
+        counterpart = RecordType(name="Handle", qualified_name="ns::Handle", kind="class")
+        other = build_type_map([counterpart])
+
+        assert lookup_matched_type(other, t) is counterpart
+
+    def test_global_scope_type_key_equals_bare_no_redundant_lookup(self) -> None:
+        t = RecordType(name="Foo", qualified_name=None, kind="class")
+        counterpart = RecordType(name="Foo", qualified_name=None, kind="class")
+        other = build_type_map([counterpart])
+
+        assert lookup_matched_type(other, t) is counterpart
+
+    def test_genuinely_absent_returns_none(self) -> None:
+        t = RecordType(name="Handle", qualified_name="ns::Handle", kind="class")
+        other = build_type_map([])
+
+        assert lookup_matched_type(other, t) is None

--- a/tests/test_diff_symbols_type_matching.py
+++ b/tests/test_diff_symbols_type_matching.py
@@ -247,6 +247,34 @@ class TestCtorOverloadAmbiguityIsAmbiguitySafe:
         risk = [c for c in r.changes if c.kind == ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK]
         assert len(risk) == 1
 
+    def test_doubly_legacy_snapshot_still_flags_risk(self):
+        """Both old and new RecordType lack qualified_name entirely (a
+        producer/schema predating that field on both sides), so
+        common_classes only has the bare leaf ("Widget"). A real
+        Itanium-mangled constructor's owner_class_of is always fully
+        qualified ("ns::Widget") regardless of RecordType's own schema --
+        the pre-fix membership check required an exact match and dropped
+        every such constructor, even though pre-PR#608 bare-f.name-based
+        grouping covered this legacy-vs-legacy comparison fine (Codex
+        review, PR #608 follow-up, fourth round).
+        """
+        old_widget = RecordType(name="Widget", qualified_name=None, kind="class")
+        new_widget = RecordType(name="Widget", qualified_name=None, kind="class")
+
+        old_funcs = [self._ctor("_ZN2ns6WidgetC1Ei", "ns", "Widget", "int")]
+        new_funcs = [
+            self._ctor("_ZN2ns6WidgetC1Ei", "ns", "Widget", "int"),
+            self._ctor("_ZN2ns6WidgetC1EPKc", "ns", "Widget", "char const *"),
+        ]
+
+        r = compare(
+            _snap(functions=old_funcs, types=[old_widget]),
+            _snap(functions=new_funcs, types=[new_widget]),
+        )
+
+        risk = [c for c in r.changes if c.kind == ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK]
+        assert len(risk) == 1
+
 
 class TestVirtualMethodOwnerResolutionAmbiguitySafe:
     """``_diff_functions`` feeds ``old_types``/``new_types`` into

--- a/tests/test_diff_symbols_type_matching.py
+++ b/tests/test_diff_symbols_type_matching.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 from abicheck.checker import ChangeKind, compare
 from abicheck.diff_helpers import build_type_map
+from abicheck.dumper_castxml import SYNTHETIC_CTOR_KEY_PREFIX
 from abicheck.model import (
     AbiSnapshot,
     AccessLevel,
@@ -209,6 +210,38 @@ class TestCtorOverloadAmbiguityIsAmbiguitySafe:
         r = compare(
             _snap(functions=old_funcs, types=[old_widget]),
             _snap(functions=new_funcs, types=[new_widget]),
+        )
+
+        risk = [c for c in r.changes if c.kind == ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK]
+        assert len(risk) == 1
+
+    def test_synthetic_ctor_key_still_flags_risk(self):
+        """castxml omits a real mangled name for some public overloaded
+        constructors and synthesizes a key instead
+        (``SYNTHETIC_CTOR_KEY_PREFIX + "scope(params)"``). That key doesn't
+        start with the Itanium ``_Z`` prefix, so owner_class_of can't parse
+        it and used to fall back to the bare class name -- dropping every
+        namespaced synthetic-key constructor from its overload group even on
+        two fully fresh (non-legacy) snapshots (Codex review, PR #608
+        follow-up, third round).
+        """
+        widget_old = RecordType(name="Widget", qualified_name="ns::Widget", kind="class")
+        widget_new = RecordType(name="Widget", qualified_name="ns::Widget", kind="class")
+
+        def synth_ctor(param_type):
+            key = f"{SYNTHETIC_CTOR_KEY_PREFIX}ns::Widget({param_type})"
+            return Function(
+                name="Widget", mangled=key, return_type="void",
+                params=[Param(name="x", type=param_type)],
+                visibility=Visibility.PUBLIC, is_explicit=False,
+            )
+
+        old_funcs = [synth_ctor("int")]
+        new_funcs = [synth_ctor("int"), synth_ctor("char const *")]
+
+        r = compare(
+            _snap(functions=old_funcs, types=[widget_old]),
+            _snap(functions=new_funcs, types=[widget_new]),
         )
 
         risk = [c for c in r.changes if c.kind == ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK]

--- a/tests/test_diff_symbols_type_matching.py
+++ b/tests/test_diff_symbols_type_matching.py
@@ -165,6 +165,55 @@ class TestCtorOverloadAmbiguityIsAmbiguitySafe:
 
         assert ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK not in _kinds(r)
 
+    def test_legacy_snapshot_missing_qualified_name_still_flags_risk(self):
+        """A schema-evolution mix: the old side's RecordType predates
+        RecordType.qualified_name (None on a namespaced class), while the
+        new side is a fresh, fully-qualified snapshot. owner_class_of is
+        derived purely from the constructor's mangled symbol, independent of
+        RecordType at all, so it resolves the real 'ns::Widget' on BOTH
+        sides regardless of which snapshot's RecordType lacks
+        qualified_name -- a raw canonical-key set intersection between the
+        two TypeMaps missed this class entirely (Codex review, PR #608
+        follow-up second round), silently dropping its constructors.
+        """
+        old_widget = RecordType(name="Widget", qualified_name=None, kind="class")
+        new_widget = RecordType(name="Widget", qualified_name="ns::Widget", kind="class")
+
+        old_funcs = [self._ctor("_ZN2ns6WidgetC1Ei", "ns", "Widget", "int")]
+        new_funcs = [
+            self._ctor("_ZN2ns6WidgetC1Ei", "ns", "Widget", "int"),
+            self._ctor("_ZN2ns6WidgetC1EPKc", "ns", "Widget", "char const *"),
+        ]
+
+        r = compare(
+            _snap(functions=old_funcs, types=[old_widget]),
+            _snap(functions=new_funcs, types=[new_widget]),
+        )
+
+        risk = [c for c in r.changes if c.kind == ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK]
+        assert len(risk) == 1
+        assert "ns::Widget" in risk[0].description
+
+    def test_legacy_snapshot_on_new_side_still_flags_risk(self):
+        """Same schema-evolution mix, reversed: legacy (unqualified) new
+        side, fresh (qualified) old side."""
+        old_widget = RecordType(name="Widget", qualified_name="ns::Widget", kind="class")
+        new_widget = RecordType(name="Widget", qualified_name=None, kind="class")
+
+        old_funcs = [self._ctor("_ZN2ns6WidgetC1Ei", "ns", "Widget", "int")]
+        new_funcs = [
+            self._ctor("_ZN2ns6WidgetC1Ei", "ns", "Widget", "int"),
+            self._ctor("_ZN2ns6WidgetC1EPKc", "ns", "Widget", "char const *"),
+        ]
+
+        r = compare(
+            _snap(functions=old_funcs, types=[old_widget]),
+            _snap(functions=new_funcs, types=[new_widget]),
+        )
+
+        risk = [c for c in r.changes if c.kind == ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK]
+        assert len(risk) == 1
+
 
 class TestVirtualMethodOwnerResolutionAmbiguitySafe:
     """``_diff_functions`` feeds ``old_types``/``new_types`` into

--- a/tests/test_diff_symbols_type_matching.py
+++ b/tests/test_diff_symbols_type_matching.py
@@ -1,0 +1,224 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""diff_symbols.py's own old/new RecordType-matching maps used to key purely
+by bare ``RecordType.name`` (``{t.name: t for t in old.types}`` and
+variants) -- the exact short/leaf-name collision class PR #608 fixed for
+diff_types.py, just never propagated here. Two distinct classes sharing a
+bare name in different namespaces could get cross-matched across old/new,
+fabricating findings for the wrong class (or missing a real one) in
+``_diff_access_levels`` (FIELD_ACCESS_CHANGED), ``_diff_anon_fields``
+(ANON_FIELD_CHANGED), and ``_diff_ctor_overload_ambiguity``
+(CTOR_OVERLOAD_AMBIGUITY_RISK), and could misattribute a new virtual method
+to the wrong owner in ``_diff_functions``' vtable/virtual-method-addition
+lookups.
+
+These tests reproduce the exact "which namespace does 'Impl' resolve to"
+ambiguity for each of those four call sites now that they route through
+``diff_helpers.build_type_map``/``lookup_matched_type``.
+"""
+from __future__ import annotations
+
+from abicheck.checker import ChangeKind, compare
+from abicheck.diff_helpers import build_type_map
+from abicheck.model import (
+    AbiSnapshot,
+    AccessLevel,
+    Function,
+    Param,
+    RecordType,
+    TypeField,
+    Visibility,
+)
+
+
+def _snap(version="1.0", functions=None, types=None):
+    return AbiSnapshot(
+        library="libtest.so.1", version=version,
+        functions=functions or [], variables=[], types=types or [],
+    )
+
+
+def _kinds(result):
+    return {c.kind for c in result.changes}
+
+
+class TestAccessLevelsAmbiguitySafe:
+    def test_field_access_change_not_cross_attributed(self):
+        """Two distinct 'Impl' classes in different namespaces; only
+        ns2::Impl's field access narrows. Reversed insertion order on the
+        new side forces a naive last-write-wins bare-name dict to compare
+        the wrong pair.
+        """
+        ns1_old = RecordType(name="Impl", qualified_name="ns1::Impl", kind="class",
+                             fields=[TypeField("a", "int", 0, access=AccessLevel.PUBLIC)])
+        ns2_old = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class",
+                             fields=[TypeField("b", "int", 0, access=AccessLevel.PUBLIC)])
+        ns1_new = RecordType(name="Impl", qualified_name="ns1::Impl", kind="class",
+                             fields=[TypeField("a", "int", 0, access=AccessLevel.PUBLIC)])
+        ns2_new = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class",
+                             fields=[TypeField("b", "int", 0, access=AccessLevel.PRIVATE)])
+
+        r = compare(
+            _snap(types=[ns1_old, ns2_old]),
+            _snap(types=[ns2_new, ns1_new]),  # reversed order
+        )
+
+        access_changes = [c for c in r.changes if c.kind == ChangeKind.FIELD_ACCESS_CHANGED]
+        assert len(access_changes) == 1
+        assert access_changes[0].description.count("b") >= 1 or "b" in (access_changes[0].detail or "")
+
+
+class TestAnonFieldsAmbiguitySafe:
+    def test_anon_field_change_detected_despite_reversed_insertion_order(self):
+        """ns1::Impl is unchanged; ns2::Impl's anonymous field is genuinely
+        removed. Reversed insertion order on the new side makes a naive
+        last-write-wins bare-name dict compare the WRONG pair (old_map
+        picks ns2::Impl, new_map picks ns1::Impl) and silently miss the real
+        change entirely -- confirmed by running this exact scenario against
+        the pre-fix diff_symbols.py, which reports zero ANON_FIELD_CHANGED
+        findings here.
+        """
+        ns1_old = RecordType(name="Impl", qualified_name="ns1::Impl", kind="struct",
+                             fields=[TypeField("__anon0", "union", 0)])
+        ns2_old = RecordType(name="Impl", qualified_name="ns2::Impl", kind="struct",
+                             fields=[TypeField("__anon0", "union", 0)])
+        ns1_new = RecordType(name="Impl", qualified_name="ns1::Impl", kind="struct",
+                             fields=[TypeField("__anon0", "union", 0)])
+        ns2_new = RecordType(name="Impl", qualified_name="ns2::Impl", kind="struct",
+                             fields=[])  # ns2::Impl's anon field genuinely removed
+
+        r = compare(
+            _snap(types=[ns1_old, ns2_old]),
+            _snap(types=[ns2_new, ns1_new]),
+        )
+
+        anon_changes = [c for c in r.changes if c.kind == ChangeKind.ANON_FIELD_CHANGED]
+        assert len(anon_changes) == 1
+
+
+class TestCtorOverloadAmbiguityIsAmbiguitySafe:
+    def _ctor(self, mangled, ns, cls, param_type, default=None):
+        return Function(
+            name=cls, mangled=mangled, return_type="void",
+            params=[Param(name="x", type=param_type, default=default)],
+            visibility=Visibility.PUBLIC, is_explicit=False,
+        )
+
+    def test_second_converting_ctor_not_attributed_to_other_namespace(self):
+        """Real Itanium-mangled constructors so owner_class_of resolves the
+        true scope: ns1::Impl gains a 2nd converting ctor; ns2::Impl (a
+        distinct, unrelated class sharing the bare name 'Impl') is untouched
+        and must not be the one flagged.
+        """
+        ns1 = RecordType(name="Impl", qualified_name="ns1::Impl", kind="class")
+        ns2 = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class")
+
+        old_funcs = [
+            self._ctor("_ZN3ns14ImplC1Ei", "ns1", "Impl", "int"),
+            self._ctor("_ZN3ns24ImplC1Ei", "ns2", "Impl", "int"),
+        ]
+        new_funcs = [
+            self._ctor("_ZN3ns14ImplC1Ei", "ns1", "Impl", "int"),
+            self._ctor("_ZN3ns14ImplC1EPKc", "ns1", "Impl", "char const *"),
+            self._ctor("_ZN3ns24ImplC1Ei", "ns2", "Impl", "int"),
+        ]
+
+        r = compare(
+            _snap(functions=old_funcs, types=[ns1, ns2]),
+            _snap(functions=new_funcs, types=[ns2, ns1]),  # reversed type order
+        )
+
+        risk = [c for c in r.changes if c.kind == ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK]
+        assert len(risk) == 1
+        assert "ns1::Impl" in risk[0].description
+        assert "ns2" not in risk[0].description
+
+    def test_unrelated_namespace_with_only_one_ctor_each_stays_silent(self):
+        """Sanity check: when neither namespace's ctor count actually grows,
+        no risk finding fires at all (would catch a cross-attribution that
+        fabricates a 1->2 transition from two genuinely-1-ctor classes)."""
+        ns1 = RecordType(name="Impl", qualified_name="ns1::Impl", kind="class")
+        ns2 = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class")
+        old_funcs = [self._ctor("_ZN3ns14ImplC1Ei", "ns1", "Impl", "int")]
+        new_funcs = [
+            self._ctor("_ZN3ns14ImplC1Ei", "ns1", "Impl", "int"),
+            self._ctor("_ZN3ns24ImplC1EPKc", "ns2", "Impl", "char const *"),
+        ]
+
+        r = compare(
+            _snap(functions=old_funcs, types=[ns1]),
+            _snap(functions=new_funcs, types=[ns2, ns1]),
+        )
+
+        assert ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK not in _kinds(r)
+
+
+class TestVirtualMethodOwnerResolutionAmbiguitySafe:
+    """``_diff_functions`` feeds ``old_types``/``new_types`` into
+    ``virtual_method_addition`` -> ``diff_cxx_rules._resolve_owner_type`` to
+    resolve a new virtual method's owner class (deciding override-reuse vs.
+    a genuinely new vtable slot). Verified directly against
+    ``_resolve_owner_type`` (rather than trying to force a specific
+    end-to-end ``compare()`` misclassification, which depends on override-
+    reuse internals unrelated to this bug): a naive last-write-wins
+    bare-name dict resolves the WRONG class whenever a same-leaf-name
+    collision's last-inserted entry isn't the one being asked for; the
+    ``build_type_map``/``TypeMap`` this file's detectors now use does not.
+    """
+
+    def test_naive_bare_name_dict_would_misattribute_owner(self):
+        """Sanity/documentation check: proves the OLD bug is real and
+        deterministic, not just theoretical -- a plain ``{t.name: t}`` dict
+        (what diff_symbols.py built before this fix) resolves 'ns2::Impl'
+        to ns1's RecordType whenever ns1 was inserted last.
+        """
+        ns1 = RecordType(name="Impl", qualified_name="ns1::Impl", kind="class", size_bits=64)
+        ns2 = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class", size_bits=32)
+        naive = {t.name: t for t in [ns2, ns1]}  # ns1 inserted last -> wins the bare slot
+
+        from abicheck.diff_cxx_rules import _resolve_owner_type
+        resolved = _resolve_owner_type(
+            "ns2::Impl", naive, known_owners={"ns1::Impl", "ns2::Impl"}
+        )
+        assert resolved is ns1  # the historical bug: wrong class returned
+
+    def test_type_map_resolves_the_correct_owner_regardless_of_order(self):
+        ns1 = RecordType(name="Impl", qualified_name="ns1::Impl", kind="class", size_bits=64)
+        ns2 = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class", size_bits=32)
+
+        from abicheck.diff_cxx_rules import _resolve_owner_type
+        for ordering in ([ns1, ns2], [ns2, ns1]):
+            types = build_type_map(ordering)
+            resolved = _resolve_owner_type(
+                "ns2::Impl", types, known_owners={"ns1::Impl", "ns2::Impl"}
+            )
+            assert resolved is ns2, f"failed for insertion order {ordering}"
+
+    def test_diff_functions_builds_type_map_not_naive_dict(self):
+        """Regression guard on the actual production call site: ``_diff_functions``
+        must build ``old_types``/``new_types`` via ``diff_helpers.build_type_map``
+        (or an equivalent ambiguity-safe map), not a raw ``{t.name: t
+        for t in ...}`` dict comprehension.
+        """
+        import inspect
+
+        import abicheck.diff_symbols as diff_symbols_module
+
+        source = inspect.getsource(diff_symbols_module._diff_functions)
+        assert "build_type_map(old.types)" in source
+        assert "build_type_map(new.types)" in source
+        assert "{t.name: t for t in old.types}" not in source
+        assert "{t.name: t for t in new.types}" not in source

--- a/tests/test_diff_symbols_type_matching.py
+++ b/tests/test_diff_symbols_type_matching.py
@@ -275,6 +275,65 @@ class TestCtorOverloadAmbiguityIsAmbiguitySafe:
         risk = [c for c in r.changes if c.kind == ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK]
         assert len(risk) == 1
 
+    def test_legacy_vs_fresh_synthetic_key_format_no_false_risk(self):
+        """A persisted snapshot from before synthetic ctor keys were
+        namespace-qualified (``__abicheck_ctor__Widget(...)``) compared
+        against a fresh one (``__abicheck_ctor__ns::Widget(...)``): the SAME
+        two overloads on both sides must not be reported as newly gained
+        just because old and new spell the class's ctor key differently
+        (Codex review, PR #608 follow-up, fifth round).
+        """
+        widget_old = RecordType(name="Widget", qualified_name="ns::Widget", kind="class")
+        widget_new = RecordType(name="Widget", qualified_name="ns::Widget", kind="class")
+
+        def ctor(scope, param_type):
+            key = f"{SYNTHETIC_CTOR_KEY_PREFIX}{scope}({param_type})"
+            return Function(
+                name="Widget", mangled=key, return_type="void",
+                params=[Param(name="x", type=param_type)],
+                visibility=Visibility.PUBLIC, is_explicit=False,
+            )
+
+        old_funcs = [ctor("Widget", "int"), ctor("Widget", "char const *")]
+        new_funcs = [ctor("ns::Widget", "int"), ctor("ns::Widget", "char const *")]
+
+        r = compare(
+            _snap(functions=old_funcs, types=[widget_old]),
+            _snap(functions=new_funcs, types=[widget_new]),
+        )
+
+        assert ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK not in _kinds(r)
+
+    def test_legacy_vs_fresh_synthetic_key_format_genuine_addition_still_flags(self):
+        """Same legacy/fresh key-format mix, but the new side genuinely
+        gains a 3rd converting ctor -- must still be reported."""
+        widget_old = RecordType(name="Widget", qualified_name="ns::Widget", kind="class")
+        widget_new = RecordType(name="Widget", qualified_name="ns::Widget", kind="class")
+
+        def ctor(scope, param_type):
+            key = f"{SYNTHETIC_CTOR_KEY_PREFIX}{scope}({param_type})"
+            return Function(
+                name="Widget", mangled=key, return_type="void",
+                params=[Param(name="x", type=param_type)],
+                visibility=Visibility.PUBLIC, is_explicit=False,
+            )
+
+        old_funcs = [ctor("Widget", "int"), ctor("Widget", "char const *")]
+        new_funcs = [
+            ctor("ns::Widget", "int"),
+            ctor("ns::Widget", "char const *"),
+            ctor("ns::Widget", "double"),
+        ]
+
+        r = compare(
+            _snap(functions=old_funcs, types=[widget_old]),
+            _snap(functions=new_funcs, types=[widget_new]),
+        )
+
+        risk = [c for c in r.changes if c.kind == ChangeKind.CTOR_OVERLOAD_AMBIGUITY_RISK]
+        assert len(risk) == 1
+        assert "double" in risk[0].description
+
 
 class TestVirtualMethodOwnerResolutionAmbiguitySafe:
     """``_diff_functions`` feeds ``old_types``/``new_types`` into

--- a/tests/test_diff_types_deep.py
+++ b/tests/test_diff_types_deep.py
@@ -881,6 +881,59 @@ class TestQualifiedNameMatching:
         assert ChangeKind.TYPE_FIELD_REMOVED not in _kinds(r)
         assert ChangeKind.TYPE_FIELD_ADDED not in _kinds(r)
 
+    def test_ambiguous_probing_side_bare_fallback_does_not_cross_match(self):
+        """Codex review, PR #608 (third round): the mirror of the case
+        above, with the ambiguity on the *probing* (old) side instead of the
+        lookup target. Old has two distinct namespaced ``Impl`` types; new
+        kept only one of them (the other was genuinely removed). The
+        genuinely-removed old type must not retry its failed qualified
+        lookup with the bare name and land on the unrelated survivor.
+        """
+        old_removed = RecordType(name="Impl", qualified_name="ns1::Impl",
+                                 kind="class", size_bits=64,
+                                 fields=[TypeField("x", "int", 0)])
+        old_kept = RecordType(name="Impl", qualified_name="ns2::Impl",
+                              kind="class", size_bits=32,
+                              fields=[TypeField("y", "int", 0)])
+        new_kept = RecordType(name="Impl", qualified_name="ns2::Impl",
+                              kind="class", size_bits=32,
+                              fields=[TypeField("y", "int", 0)])
+
+        r = compare(_snap(types=[old_removed, old_kept]), _snap(types=[new_kept]))
+
+        kinds = _kinds(r)
+        # ns1::Impl is genuinely gone -> TYPE_REMOVED, not a cross-matched
+        # field/size diff against the unrelated surviving ns2::Impl.
+        assert ChangeKind.TYPE_REMOVED in kinds
+        assert ChangeKind.TYPE_SIZE_CHANGED not in kinds
+        assert ChangeKind.TYPE_FIELD_REMOVED not in kinds
+        assert ChangeKind.FIELD_RENAMED not in kinds
+        # ns2::Impl itself is genuinely unchanged.
+        assert ChangeKind.TYPE_ADDED not in kinds
+
+    def test_ambiguous_bare_name_on_both_sides_still_matches_by_qualified_key(self):
+        """Ambiguity on BOTH sides at once: each qualified pair should still
+        match directly on its own qualified key (the fallback never needs to
+        engage), so a real per-type change is correctly attributed to the
+        right one and an unchanged one produces nothing.
+        """
+        old_a = RecordType(name="Impl", qualified_name="ns1::Impl", kind="class",
+                           size_bits=64, fields=[TypeField("x", "int", 0)])
+        old_b = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class",
+                           size_bits=32, fields=[TypeField("y", "int", 0)])
+        new_a = RecordType(name="Impl", qualified_name="ns1::Impl", kind="class",
+                           size_bits=32, fields=[])  # ns1::Impl genuinely shrinks
+        new_b = RecordType(name="Impl", qualified_name="ns2::Impl", kind="class",
+                           size_bits=32, fields=[TypeField("y", "int", 0)])  # unchanged
+
+        r = compare(_snap(types=[old_a, old_b]), _snap(types=[new_a, new_b]))
+
+        kinds = _kinds(r)
+        assert ChangeKind.TYPE_SIZE_CHANGED in kinds
+        assert ChangeKind.TYPE_FIELD_REMOVED in kinds
+        assert ChangeKind.TYPE_REMOVED not in kinds
+        assert ChangeKind.TYPE_ADDED not in kinds
+
 
 class TestHybridProvenanceKeys:
     """Codex review, PR #608: ``dumper_hybrid`` records per-fact provenance

--- a/tests/test_diff_types_deep.py
+++ b/tests/test_diff_types_deep.py
@@ -790,3 +790,134 @@ class TestQualifiedNameMatching:
         r = compare(_snap(types=[t_old]), _snap(types=[t_new]))
 
         assert ChangeKind.TYPE_FIELD_REMOVED in _kinds(r)
+
+    def test_legacy_snapshot_without_qualified_name_still_matches(self):
+        """Codex review, PR #608: an older serialized/header snapshot that
+        predates ``qualified_name`` (so it's unset — ``None``, the dataclass
+        default) must still match against a freshly-dumped snapshot side
+        where the same namespaced type now populates it, instead of
+        manufacturing a false TYPE_REMOVED + TYPE_ADDED pair.
+        """
+        # old side: simulates a pre-qualified_name snapshot — unset even
+        # though the type is genuinely namespaced.
+        t_old = RecordType(name="Handle", qualified_name=None,
+                           kind="class", size_bits=64,
+                           fields=[TypeField("count", "int", 0)])
+        # new side: freshly dumped, qualified_name populated as usual.
+        t_new = RecordType(name="Handle", qualified_name="ns::Handle",
+                           kind="class", size_bits=32, fields=[])
+
+        r = compare(_snap(types=[t_old]), _snap(types=[t_new]))
+
+        kinds = _kinds(r)
+        assert ChangeKind.TYPE_REMOVED not in kinds
+        assert ChangeKind.TYPE_ADDED not in kinds
+        assert ChangeKind.TYPE_FIELD_REMOVED in kinds
+
+    def test_namespaced_type_diff_not_doubled_by_alias(self):
+        """A normal namespaced type (both sides populate ``qualified_name``,
+        the common case, no legacy mismatch at all) must still produce each
+        finding exactly once. The bare-name alias exists purely for
+        cross-schema lookups and must never leak into iteration, or every
+        namespaced-type finding in the codebase would double-report.
+        """
+        t_old = RecordType(name="Widget", qualified_name="ns::Widget",
+                           kind="class", size_bits=64,
+                           fields=[TypeField("count", "int", 0)])
+        t_new = RecordType(name="Widget", qualified_name="ns::Widget",
+                           kind="class", size_bits=32, fields=[])
+
+        r = compare(_snap(types=[t_old]), _snap(types=[t_new]))
+
+        field_removed = [c for c in r.changes if c.kind == ChangeKind.TYPE_FIELD_REMOVED]
+        assert len(field_removed) == 1
+        assert ChangeKind.TYPE_ADDED not in _kinds(r)
+        assert ChangeKind.TYPE_REMOVED not in _kinds(r)
+
+    def test_legacy_alias_does_not_reopen_leaf_name_collision(self):
+        """The bare-name compatibility alias must stay collision-safe: a
+        legacy (``qualified_name=None``) type must not accidentally match an
+        unrelated, differently-scoped type on the other side purely because
+        that side also has an ambiguous/collided bare name.
+        """
+        old_a = RecordType(name="_Impl", qualified_name=None,
+                           kind="class", size_bits=64,
+                           fields=[TypeField("_M_refcount", "int", 0)])
+        new_a = RecordType(name="_Impl", qualified_name="std::locale::_Impl",
+                           kind="class", size_bits=64,
+                           fields=[TypeField("_M_refcount", "int", 0)])
+        new_b = RecordType(name="_Impl", qualified_name="ns::Other::_Impl",
+                           kind="class", size_bits=32,
+                           fields=[TypeField("_M_storage", "int", 0)])
+
+        r = compare(_snap(types=[old_a]), _snap(types=[new_a, new_b]))
+
+        # old_a's bare "_Impl" is ambiguous on the new side (two distinct
+        # qualified identities), so no alias is registered there — old_a
+        # must not cross-match either new_a or new_b.
+        assert ChangeKind.TYPE_FIELD_REMOVED not in _kinds(r)
+        assert ChangeKind.TYPE_FIELD_ADDED not in _kinds(r)
+
+
+class TestHybridProvenanceKeys:
+    """Codex review, PR #608: ``dumper_hybrid`` records per-fact provenance
+    under the bare ``RecordType.name`` (``type_fact_key``/``field_fact_key``),
+    not the namespace-qualified matching key ``_type_map_key`` introduced for
+    FP-1. The type-level detectors that gate on
+    ``fact_provenance.both_castxml_backed_fact`` per declaration must look the
+    provenance key up by the bare name, or a hybrid snapshot's castxml-only
+    facts (``is_abstract``, ``deprecated``, field ``default``) silently stop
+    firing for every namespaced type.
+    """
+
+    def _hybrid_snap(self, version, types):
+        return AbiSnapshot(
+            library="libtest.so.1", version=version, types=types,
+            from_headers=True, ast_producer="hybrid",
+            fact_provenance={"type:Impl:is_abstract": "castxml"},
+        )
+
+    def test_became_abstract_detected_for_namespaced_type_in_hybrid_snapshot(self):
+        t_old = RecordType(name="Impl", qualified_name="ns::Impl", kind="class",
+                           size_bits=64, is_abstract=False)
+        t_new = RecordType(name="Impl", qualified_name="ns::Impl", kind="class",
+                           size_bits=64, is_abstract=True)
+
+        r = compare(self._hybrid_snap("1.0", [t_old]), self._hybrid_snap("2.0", [t_new]))
+
+        assert ChangeKind.TYPE_BECAME_ABSTRACT in _kinds(r)
+
+
+class TestEmittedSymbolStaysBare:
+    """The qualified matching key introduced for FP-1 must stay internal to
+    old/new type matching. Every emitted ``Change.symbol`` for a namespaced
+    type must still be the bare declaration name — the identity every other
+    consumer already keys on: ``diff_filtering._dedup_cross_kind``'s DWARF<->
+    AST redundancy correlation matches a DWARF field symbol's *bare* parent
+    type name against the AST-level type symbol (FIX-F), so a qualified
+    symbol here would silently defeat that correlation for any namespaced
+    type — exactly the regression a real castxml-backed integration test
+    (case187/191 in ``tests/test_header_graph_examples.py``) caught (Codex
+    review, PR #608).
+    """
+
+    def test_field_type_changed_symbol_is_bare_for_namespaced_type(self):
+        t_old = RecordType(name="Public", qualified_name="demo::Public", kind="struct",
+                           size_bits=96, fields=[TypeField("reserved", "void *", 64)])
+        t_new = RecordType(name="Public", qualified_name="demo::Public", kind="struct",
+                           size_bits=96, fields=[TypeField("reserved", "detail::PrivateType *", 64)])
+
+        r = compare(_snap(types=[t_old]), _snap(types=[t_new]))
+
+        field_changes = [c for c in r.changes if c.kind == ChangeKind.TYPE_FIELD_TYPE_CHANGED]
+        assert len(field_changes) == 1
+        assert field_changes[0].symbol == "Public"
+
+    def test_type_added_symbol_is_bare_for_namespaced_type(self):
+        t_new = RecordType(name="Widget", qualified_name="ns::Widget", kind="class", size_bits=32)
+
+        r = compare(_snap(types=[]), _snap(types=[t_new]))
+
+        added = [c for c in r.changes if c.kind == ChangeKind.TYPE_ADDED]
+        assert len(added) == 1
+        assert added[0].symbol == "Widget"

--- a/tests/test_diff_types_deep.py
+++ b/tests/test_diff_types_deep.py
@@ -814,6 +814,29 @@ class TestQualifiedNameMatching:
         assert ChangeKind.TYPE_ADDED not in kinds
         assert ChangeKind.TYPE_FIELD_REMOVED in kinds
 
+    def test_legacy_snapshot_on_new_side_still_matches(self):
+        """Codex review, PR #608 (second round): the mirror of the case
+        above — a FRESH old side (qualified_name populated) compared against
+        a LEGACY new side (qualified_name unset) — must also match, not just
+        the legacy-old/fresh-new direction. ``TypeMap``'s bare-name alias
+        only maps bare -> qualified, so a naive ``new_map.get(old_side's_own_
+        qualified_key)`` lookup misses when the *new* side is the legacy one;
+        ``diff_helpers.lookup_matched_type`` retries with the bare name to
+        make this symmetric.
+        """
+        t_old = RecordType(name="Handle", qualified_name="ns::Handle",
+                           kind="class", size_bits=64,
+                           fields=[TypeField("count", "int", 0)])
+        t_new = RecordType(name="Handle", qualified_name=None,
+                           kind="class", size_bits=32, fields=[])
+
+        r = compare(_snap(types=[t_old]), _snap(types=[t_new]))
+
+        kinds = _kinds(r)
+        assert ChangeKind.TYPE_REMOVED not in kinds
+        assert ChangeKind.TYPE_ADDED not in kinds
+        assert ChangeKind.TYPE_FIELD_REMOVED in kinds
+
     def test_namespaced_type_diff_not_doubled_by_alias(self):
         """A normal namespaced type (both sides populate ``qualified_name``,
         the common case, no legacy mismatch at all) must still produce each

--- a/tests/test_diff_types_deep.py
+++ b/tests/test_diff_types_deep.py
@@ -746,3 +746,47 @@ class TestBaseClassChanges:
         r = compare(_snap(types=[t_old]), _snap(types=[t_new]))
         assert ChangeKind.BASE_CLASS_POSITION_CHANGED in _kinds(r)
         assert r.verdict == Verdict.BREAKING
+
+
+# ── Bare-name collision across distinct qualified scopes (pvxs FP) ────────
+
+class TestQualifiedNameMatching:
+    """Two unrelated types that only share a short/leaf name (e.g. two
+    distinct ``std::*::_Impl`` template internals pulled in transitively via
+    different headers) must not be diffed against each other. Header-mode
+    dumpers set ``RecordType.qualified_name`` alongside the deliberately-bare
+    ``name`` (see model.py); matching must prefer it.
+    """
+
+    def test_unrelated_same_leaf_name_types_not_cross_matched(self):
+        # old: two distinct scopes' "_Impl", each losing/gaining an unrelated field.
+        old_a = RecordType(name="_Impl", qualified_name="std::locale::_Impl",
+                           kind="class", size_bits=64,
+                           fields=[TypeField("_M_refcount", "int", 0)])
+        old_b = RecordType(name="_Impl", qualified_name="ns::Other::_Impl",
+                           kind="class", size_bits=32,
+                           fields=[TypeField("_M_storage", "int", 0)])
+        # new: each scope's own _Impl is unchanged; only cross-matching by the
+        # bare "_Impl" name would fabricate a field-removed/field-added diff.
+        new_a = RecordType(name="_Impl", qualified_name="std::locale::_Impl",
+                           kind="class", size_bits=64,
+                           fields=[TypeField("_M_refcount", "int", 0)])
+        new_b = RecordType(name="_Impl", qualified_name="ns::Other::_Impl",
+                           kind="class", size_bits=32,
+                           fields=[TypeField("_M_storage", "int", 0)])
+
+        r = compare(_snap(types=[old_a, old_b]), _snap(types=[new_a, new_b]))
+
+        assert ChangeKind.TYPE_FIELD_REMOVED not in _kinds(r)
+        assert ChangeKind.TYPE_FIELD_ADDED not in _kinds(r)
+
+    def test_genuine_change_still_detected_when_qualified(self):
+        t_old = RecordType(name="_Impl", qualified_name="ns::Scope::_Impl",
+                           kind="class", size_bits=64,
+                           fields=[TypeField("count", "int", 0)])
+        t_new = RecordType(name="_Impl", qualified_name="ns::Scope::_Impl",
+                           kind="class", size_bits=32, fields=[])
+
+        r = compare(_snap(types=[t_old]), _snap(types=[t_new]))
+
+        assert ChangeKind.TYPE_FIELD_REMOVED in _kinds(r)

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -412,6 +412,43 @@ def test_parse_types_sets_qualified_name_for_namespaced_record() -> None:
     assert types["Global"].qualified_name is None
 
 
+def test_parse_enums_sets_qualified_name_for_namespaced_enum() -> None:
+    # Mirrors test_parse_types_sets_qualified_name_for_namespaced_record --
+    # EnumType.qualified_name (PR #608 follow-up) uses the same scope-derived
+    # population so old/new enum matching can key on namespace-qualified
+    # identity instead of the bare, collidable EnumType.name.
+    root = _tu(
+        {
+            "kind": "NamespaceDecl",
+            "name": "ns",
+            "loc": {"file": "include/foo.h", "line": 1},
+            "inner": [
+                {
+                    "kind": "EnumDecl",
+                    "name": "Status",
+                    "loc": {"line": 2},
+                    "inner": [
+                        {"kind": "EnumConstantDecl", "name": "OK"},
+                    ],
+                },
+            ],
+        },
+        {
+            "kind": "EnumDecl",
+            "name": "Global",
+            "loc": {"file": "include/foo.h", "line": 20},
+            "inner": [
+                {"kind": "EnumConstantDecl", "name": "A"},
+            ],
+        },
+    )
+    enums = {e.name: e for e in _ClangAstParser(root, set(), set()).parse_enums()}
+    assert enums["Status"].qualified_name == "ns::Status"
+    # A global-scope enum's qualified spelling is identical to its bare name,
+    # so qualified_name stays None (matches castxml's own convention).
+    assert enums["Global"].qualified_name is None
+
+
 def test_parse_types_anonymous_aggregate_flattening_sets_flag() -> None:
     """A record whose members come from an anonymous struct/union gets
     those members flattened into `fields` (clang emits an IndirectFieldDecl

--- a/tests/test_review_fixes.py
+++ b/tests/test_review_fixes.py
@@ -85,6 +85,27 @@ class TestCanonicalizeTypeName:
     def test_empty_string(self):
         assert canonicalize_type_name("") == ""
 
+    def test_anonymous_enum_location_stripped(self):
+        """clang's embedded 'at <path>:<line>:<col>' must not affect identity
+        (pvxs acceptance spike FP: old/new checkout roots differ, same decl)."""
+        old = "enum (unnamed enum at /tmp/old/include/pvxs/unittest.h:56:5)"
+        new = "enum (unnamed enum at /tmp/new/include/pvxs/unittest.h:56:5)"
+        assert canonicalize_type_name(old) == canonicalize_type_name(new)
+        assert canonicalize_type_name(old) == "(unnamed enum)"
+
+    def test_anonymous_struct_location_stripped(self):
+        old = "struct (unnamed struct at /a/foo.h:10:3)"
+        new = "struct (unnamed struct at /b/foo.h:10:3)"
+        assert canonicalize_type_name(old) == canonicalize_type_name(new)
+
+    def test_anonymous_location_different_line_still_differs_only_by_marker(self):
+        """A genuinely different line/col still canonicalizes to the same bare
+        marker — same-file line renumbering from an unrelated edit shouldn't
+        trip a field-type-changed finding on its own."""
+        a = "enum (unnamed enum at /x/foo.h:56:5)"
+        b = "enum (unnamed enum at /x/foo.h:60:2)"
+        assert canonicalize_type_name(a) == canonicalize_type_name(b)
+
 
 # ─── Parameter type canonicalization (C1) ────────────────────────────────────
 

--- a/tests/test_serialization_roundtrip.py
+++ b/tests/test_serialization_roundtrip.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 
-from abicheck.model import AbiSnapshot, Function
+from abicheck.model import AbiSnapshot, EnumMember, EnumType, Function
 from abicheck.serialization import (
     load_snapshot,
     save_snapshot,
@@ -44,6 +44,34 @@ def _make_snap(**kwargs: object) -> AbiSnapshot:
     }
     defaults.update(kwargs)
     return AbiSnapshot(**defaults)  # type: ignore[arg-type]
+
+
+# ── EnumType.qualified_name (Codex review, PR #608 follow-up) ──────────────
+
+
+class TestEnumQualifiedNameRoundTrip:
+    def test_survives_roundtrip(self) -> None:
+        """EnumType.qualified_name is serialized by snapshot_to_dict but was
+        never read back by _enum_type_from_dict, so any dump/load comparison
+        lost the enum's namespace identity and fell back to bare
+        EnumType.name -- silently reopening the same cross-match/masked-
+        removal risk TypeMap was built to fix, for every enum that went
+        through a save/load cycle."""
+        e = EnumType(
+            name="Status", qualified_name="ns::Status",
+            members=[EnumMember(name="OK", value=0)],
+        )
+        snap = _make_snap(enums=[e])
+        d = snapshot_to_dict(snap)
+        assert d["enums"][0]["qualified_name"] == "ns::Status"
+        reloaded = snapshot_from_dict(d)
+        assert reloaded.enums[0].qualified_name == "ns::Status"
+
+    def test_defaults_to_none_when_absent(self) -> None:
+        """A pre-existing snapshot dict predating this field must still load."""
+        d = _minimal_dict(enums=[{"name": "Status", "members": []}])
+        reloaded = snapshot_from_dict(d)
+        assert reloaded.enums[0].qualified_name is None
 
 
 # ── elf_only_mode ─────────────────────────────────────────────────────────

--- a/validation/pvxs-abicheck-acceptance-2026-07-18.md
+++ b/validation/pvxs-abicheck-acceptance-2026-07-18.md
@@ -9,14 +9,28 @@ found three new false positives on a real historical diff
 misses). Two of the three false positives are fixed in this change; the
 third is a known, documented gap.
 
-This environment has no network access to clone pvxs/EPICS Base and no
-`castxml` install, so the original end-to-end repro script (building both
-pvxs revisions and running `abicheck compare` against the real `.so`s) could
-not be re-executed here. The three findings below were instead root-caused
-directly against the reported symptoms and reproduced with minimal synthetic
-fixtures / targeted unit tests exercising the same code paths. Re-running the
-full pvxs repro is the acceptance step still owed before this can move off
-"local/experimental shadow" status for pvxs specifically (see "Status" below).
+The three findings below were root-caused against the reported symptoms and
+fixed. FP-2 was additionally re-verified end-to-end against a real, tool-
+compiled reproduction (`castxml`/`clang` installed, real pvxs source cloned
+from `github.com/epics-base/pvxs` — network access and `castxml` turned out
+to be available in this environment after all) using the *actual* `testCase`
+class body copied verbatim from pvxs's `src/pvxs/unittest.h` at
+`cc7bc72dd7676c72871889c8586014947567ed1d` (the exact revision named in the
+original spike) — see "Real-tool re-verification" below. FP-1 is verified at
+the unit level with a fixture that reproduces the exact reported mechanism
+(two distinct namespace-qualified types sharing the bare leaf name `_Impl`);
+a full real-libstdc++-header end-to-end repro hit unrelated host-toolchain
+friction (this host's clang can't parse glibc/libstdc++ 13 headers without
+additional GNU-dialect flags `abicheck`'s clang frontend doesn't currently
+pass — a distinct, pre-existing environment-compatibility gap, not a defect
+in this fix; see "What wasn't re-verified end-to-end" below). The full
+historical `1.5.2` → `cc7bc72` diff (both DSOs, built against EPICS Base 7.0)
+was not reproduced: pvxs's `.ci/cue.py prepare` is written for the GitHub
+Actions build matrix and exits immediately (`SETUP_PATH is empty`) without
+that matrix's environment variables — building EPICS Base 7.0 by hand was out
+of scope for this pass. That remains the acceptance step still owed before
+this can move off "local/experimental shadow" status for pvxs specifically
+(see "Status" below).
 
 ## FP-1 (fixed): unrelated types sharing a short/leaf name get cross-matched
 
@@ -37,16 +51,51 @@ type-matching dicts keyed by the bare `t.name` in every type-level detector,
 so two distinct `std::*::_Impl` instantiations that happen to share the leaf
 name `_Impl` collided in the same dict slot.
 
-**Fix.** `diff_types.py` now keys every old/new type-matching map through a
-new `_type_map_key(t)` helper: `t.qualified_name or t.name`. Header-mode
-snapshots get the real qualified identity; DWARF-only snapshots are
-unaffected (their `RecordType.name` is already the qualified spelling built
-by walking the DIE namespace chain — see `dwarf_snapshot.py`). Global-scope
-types (`qualified_name is None`) fall back to the bare name exactly as
-before, so the change is a no-op for the common case and only removes the
-same-leaf-name collision.
+**Fix.** Every old/new type-matching map in `diff_types.py` is now built
+through `diff_helpers.build_type_map()`, keyed by `diff_helpers.type_map_key(t)`
+(`t.qualified_name or t.name`). Header-mode snapshots get the real qualified
+identity; DWARF-only snapshots are unaffected (their `RecordType.name` is
+already the qualified spelling built by walking the DIE namespace chain —
+see `dwarf_snapshot.py`). Global-scope types (`qualified_name is None`) fall
+back to the bare name exactly as before, so the change is a no-op for the
+common case and only removes the same-leaf-name collision.
 
-Tests: `tests/test_diff_types_deep.py::TestQualifiedNameMatching`.
+Two follow-up defects were caught by automated PR review (`chatgpt-codex-
+connector`) on the first version of this fix and closed in the same PR
+before merge:
+
+1. **Schema-evolution regression.** A snapshot pair where only one side
+   populates `qualified_name` (an older serialized snapshot predating the
+   field, or a producer that never sets it) would key the two sides
+   differently (`Foo` vs. `ns::Foo`) and manufacture a phantom
+   `TYPE_REMOVED` + `TYPE_ADDED` for an unchanged type. Fixed by
+   `diff_helpers.TypeMap`, a `Mapping` wrapper that keeps a collision-safe
+   bare-name alias for `get`/`in` lookups (only added when the bare name is
+   unambiguous within that snapshot, so it can't reopen the FP-1 collision).
+   The alias is deliberately excluded from `items`/`values`/iteration, so a
+   detector's `for name, t in old_map.items()` loop still visits each type
+   exactly once — an initial version that leaked the alias into iteration
+   double-processed (and double-reported) every namespaced type, caught by
+   `tests/test_header_graph_examples.py`'s real castxml/clang-backed
+   integration lane before merge.
+2. **Downstream identity leak.** The qualified key is for old/new *matching*
+   only — `Change.symbol`, `dumper_hybrid`'s per-fact provenance dict
+   (`type_fact_key`/`field_fact_key`, keyed by the bare name), and
+   `diff_filtering._dedup_cross_kind`'s DWARF↔AST redundancy correlation
+   (which matches a DWARF field symbol's *bare* parent type name against the
+   AST-level type symbol, "FIX-F") all expect the bare declaration name. An
+   initial version let the qualified key leak into these paths, which
+   silently defeated the DWARF↔AST dedup for any namespaced type — caught by
+   the same real integration lane (case187/191 in
+   `tests/test_header_graph_examples.py`, which assert a specific DWARF-
+   sourced `ChangeKind` survives on Linux) failing in CI on the pushed PR.
+   Fixed by re-deriving the bare name (`t_old.name`) at every emission/
+   provenance-lookup site instead of reusing the qualified matching key.
+
+Tests: `tests/test_diff_helpers.py::TestTypeMapKey`/`TestTypeMap` (direct
+unit coverage of the moved matching primitives), `tests/test_diff_types_deep.py`
+`TestQualifiedNameMatching` (collision fix + both Codex regressions),
+`TestHybridProvenanceKeys`, `TestEmittedSymbolStaysBare`.
 
 ## FP-2 (fixed): anonymous-enum field spelling embeds an absolute path
 
@@ -122,6 +171,58 @@ unresolvable case, which the reported repro command hits because it never
 passes `--scope-public-headers` explicitly and relies on the CLI default
 without confirming header-provenance resolution.
 
+## Real-tool re-verification (FP-2)
+
+Re-ran the exact reported scenario with real tools rather than only synthetic
+unit fixtures:
+
+- Cloned `github.com/epics-base/pvxs` at `cc7bc72dd7676c72871889c8586014947567ed1d`
+  (the exact "new" revision the original spike names) and copied the real
+  `testCase` class body (including its private anonymous `enum { Nothing,
+  Diag, Pass, Fail } result;`) verbatim from `src/pvxs/unittest.h` into two
+  directories at different absolute paths (`.../old/pvxs/unittest.h` and
+  `.../new/pvxs/unittest.h`), mirroring the real old-checkout-vs-new-checkout
+  layout that triggers the bug.
+- Compiled a trivial `.so` for each side (`g++ -std=c++17 -g -Og -fPIC
+  -shared`) and ran `python -m abicheck compare` with `--ast-frontend clang`
+  (the fallback path the original spike documents hitting, since this host's
+  bundled castxml 0.6.3/clang-17 can't parse current glibc/libstdc++ 13
+  headers — the exact "CastXML fallback" friction §10 of the original spike
+  describes).
+- **Pre-fix baseline** (a `git worktree` checked out at
+  `6ad4016`, the commit this branch forked from, run via `PYTHONPATH`):
+  `rc=4`, `verdict: BREAKING`, `type_field_type_changed | testCase | Field
+  type changed: testCase::result` — the exact false positive reported.
+- **This branch (with the FP-2 fix applied):** `rc=0`, `verdict: NO_CHANGE`,
+  zero findings — identical headers at different absolute paths no longer
+  trip a false field-type-change.
+
+## What wasn't re-verified end-to-end
+
+- **FP-1 against real libstdc++ headers.** A direct repro (`std::locale`,
+  `std::shared_ptr`, `std::vector<bool>` all included from one header,
+  compiled with g++, dumped with `--ast-frontend clang`) hit a pre-existing,
+  unrelated environment gap: this host's system `clang`/`clang++` needs
+  additional flags (`-std=gnu++17` plus GNU-dialect predefines that `g++`'s
+  own driver sets automatically) to parse this glibc/libstdc++ 13 install
+  that `abicheck`'s clang-frontend invocation doesn't currently pass —
+  `clang++ -std=gnu++17 -fsyntax-only` parses the same header cleanly by
+  hand, confirming this is an invocation-flag gap rather than a genuine
+  parse failure. This is a distinct, pre-existing gap (not touched by this
+  PR) and out of scope to fix here; FP-1 itself is covered by direct,
+  deterministic unit tests that reproduce the exact reported matching
+  mechanism (two distinct namespace-qualified `_Impl` types sharing the bare
+  leaf name) rather than depending on this host's specific toolchain/header
+  compatibility.
+- **The full historical `1.5.2` → `cc7bc72` diff** (both `libpvxs.so`/
+  `libpvxsIoc.so`, built against a real EPICS Base 7.0). pvxs's own
+  `.ci/cue.py prepare` is written for the GitHub Actions build matrix
+  (`SETUP_PATH` comes from matrix env vars) and exits immediately when run
+  standalone; hand-building EPICS Base 7.0 to unblock it was out of scope
+  for this pass.
+- **FP-3** (system-header leakage) — unchanged from the original spike;
+  still documented, not fixed (see above).
+
 ## Positive results confirmed by this spike (no code change needed)
 
 - **Private C++ layout change detection** (§13 of the original spike,
@@ -141,15 +242,22 @@ without confirming header-provenance resolution.
 
 ## Status
 
-- **Fixed & tested in this branch:** FP-1 (type-matching key), FP-2
-  (anonymous-type path leak in `canonicalize_type_name`).
+- **Fixed & tested in this branch:** FP-1 (type-matching key, plus the two
+  Codex-caught regressions on the first version of that fix), FP-2
+  (anonymous-type path leak in `canonicalize_type_name`). Full fast unit
+  suite green (17268 tests), `mypy`/`ruff`/AI-readiness clean.
+- **FP-2 additionally re-verified against real tools** (real pvxs source,
+  real `clang`-frontend dump, before/after on a real `.so` pair) — see
+  "Real-tool re-verification" above.
 - **Documented, not fixed:** FP-3 (system-header leakage when public-header
   scoping is off or unresolvable) — needs a scoped follow-up touching the L2
   parse path in `dumper_castxml.py`.
-- **Not independently re-verified in this environment:** the original
-  end-to-end pvxs `1.5.2` → `cc7bc72` repro (no network/`castxml` access
-  here). Re-running `abicheck compare` over the real `libpvxs.so`/
-  `libpvxsIoc.so` pair with these fixes applied — confirming FP-1/FP-2 no
-  longer appear and quantifying whether FP-3 remains under
-  `--scope-public-headers` — is the acceptance step still owed before pvxs
-  can be recommended as more than a local/experimental shadow check.
+- **Not re-verified end-to-end:** FP-1 against real libstdc++ headers (blocked
+  by an unrelated clang-invocation-flag gap on this host, not this fix — see
+  above) and the full historical `1.5.2` → `cc7bc72` diff over the real
+  `libpvxs.so`/`libpvxsIoc.so` pair (needs a from-scratch EPICS Base 7.0
+  build; pvxs's `.ci/cue.py prepare` is CI-matrix-only and doesn't run
+  standalone). Completing both — and quantifying whether FP-3 remains under
+  `--scope-public-headers` on the real historical diff — is the acceptance
+  step still owed before pvxs can be recommended as more than a
+  local/experimental shadow check.

--- a/validation/pvxs-abicheck-acceptance-2026-07-18.md
+++ b/validation/pvxs-abicheck-acceptance-2026-07-18.md
@@ -1,0 +1,155 @@
+# PVXS acceptance spike (2026-07-18): shadow-check false positives
+
+Follow-up to `pvxs-abi-validation-2026-07.md` (which covers F1–F7 from an
+earlier validation pass). This spike evaluated whether `abicheck` could run
+as an independent shadow check alongside pvxs's existing
+`abi-dumper` + `abi-compliance-checker` (ACC) gate, without replacing it, and
+found three new false positives on a real historical diff
+(`1.5.2` → `cc7bc72`) plus one confirmed positive (a private-layout break ACC
+misses). Two of the three false positives are fixed in this change; the
+third is a known, documented gap.
+
+This environment has no network access to clone pvxs/EPICS Base and no
+`castxml` install, so the original end-to-end repro script (building both
+pvxs revisions and running `abicheck compare` against the real `.so`s) could
+not be re-executed here. The three findings below were instead root-caused
+directly against the reported symptoms and reproduced with minimal synthetic
+fixtures / targeted unit tests exercising the same code paths. Re-running the
+full pvxs repro is the acceptance step still owed before this can move off
+"local/experimental shadow" status for pvxs specifically (see "Status" below).
+
+## FP-1 (fixed): unrelated types sharing a short/leaf name get cross-matched
+
+**Symptom.** Comparing `libpvxs.so.1.5` 1.5.2 → cc7bc72, `abicheck` reported
+`type_field_removed`/`type_field_added`/`type_base_changed` for a type named
+`_Impl`, all pointing at `/usr/include/c++/13/bits/shared_ptr_base.h:587`.
+The removed fields (`_M_facets`, `_M_caches`, `_M_names`) and the added field
+(`_M_storage`) belong to *different*, unrelated `_Impl` template internals —
+not the same declaration before and after a real change.
+
+**Root cause.** `RecordType.name` is deliberately kept as the bare/leaf
+spelling (`model.py`) so DWARF-only and header-mode snapshots keep matching
+by the same key; the real namespace-qualified spelling lives in the separate
+`RecordType.qualified_name` field, populated by both header dumpers
+(`dumper_castxml.py`, `dumper_clang.py`) but, until this change, never used
+as the actual old/new matching key. `diff_types.py` built its old/new
+type-matching dicts keyed by the bare `t.name` in every type-level detector,
+so two distinct `std::*::_Impl` instantiations that happen to share the leaf
+name `_Impl` collided in the same dict slot.
+
+**Fix.** `diff_types.py` now keys every old/new type-matching map through a
+new `_type_map_key(t)` helper: `t.qualified_name or t.name`. Header-mode
+snapshots get the real qualified identity; DWARF-only snapshots are
+unaffected (their `RecordType.name` is already the qualified spelling built
+by walking the DIE namespace chain — see `dwarf_snapshot.py`). Global-scope
+types (`qualified_name is None`) fall back to the bare name exactly as
+before, so the change is a no-op for the common case and only removes the
+same-leaf-name collision.
+
+Tests: `tests/test_diff_types_deep.py::TestQualifiedNameMatching`.
+
+## FP-2 (fixed): anonymous-enum field spelling embeds an absolute path
+
+**Symptom.** A `testCase::result` field — an *identical* unnamed enum
+declared in both the old and new pvxs checkouts (only the source *tree root*
+differs, since old/new are extracted to separate directories) — was reported
+as `type_field_type_changed`:
+
+```text
+old: enum (unnamed enum at .../old/include/pvxs/unittest.h:56:5)
+new: enum (unnamed enum at .../new/include/pvxs/unittest.h:56:5)
+```
+
+**Root cause.** The clang `-ast-dump=json` frontend (`dumper_clang.py`)
+copies the field's `qualType` string verbatim, and clang synthesizes a name
+for an anonymous enum/struct field that embeds the absolute source path.
+`_field_type_genuinely_changed` (`diff_types.py`) compares field-type
+spellings via `canonicalize_type_name`, which normalized whitespace/const
+placement/pointer spacing but had no handling for an embedded path — so two
+structurally identical declarations differing only in checkout root compared
+unequal.
+
+**Fix.** `canonicalize_type_name` (`name_classification.py`) now strips the
+`at <path>:<line>:<col>` suffix before all other normalization, collapsing
+both spellings to a path/line/column-independent `(unnamed enum)` marker.
+This also makes such comparisons robust to incidental line renumbering
+within the same file.
+
+Tests: `tests/test_review_fixes.py::TestCanonicalizeTypeName` (new
+`test_anonymous_*` cases).
+
+## FP-3 (documented, not fixed): transitively-included system-header
+declarations leak into the diff when public-header scoping doesn't apply
+
+**Symptom.** Five `API_BREAK` findings on the same diff belong to libstdc++,
+not pvxs: `std::__exception_ptr::operator!=`, and four relational operators
+on `_Bit_iterator_base` (`std::operator<`/`>`/`<=`/`>=`), sourced from
+`<bits/exception_ptr.h>` and `<bits/stl_bvector.h>` — headers pvxs never
+installs, pulled in transitively via `<functional>`/`<vector>`.
+
+**Root cause (investigated, not changed).** The L2 header-AST parse
+(`dumper_castxml.py`'s `parse_functions`/`parse_types`) populates
+`snap.functions`/`snap.types` from every declaration reachable in the
+translation unit, with no header-provenance filtering at parse time — only
+`parse_public_constants`/`parse_public_typedef_headers` apply the
+`_decl_is_public` origin check, and they feed a different (L4 source-surface)
+consumer, not the main function/type population `diff_symbols.py`/
+`diff_types.py` operate on. The only filter that *can* remove this class of
+finding is the opt-in `FilterNonPublicSurface` post-processing step
+(`post_processing.py`), gated on `--scope-public-headers` *and* on the
+snapshot actually carrying resolvable header provenance
+(`surface.py:resolvable`); when either condition doesn't hold, filtering is a
+no-op and every transitively-included system declaration stays in the diff.
+
+**Why this wasn't fixed here.** Closing it fully means extending
+provenance-based filtering into the main L2 parse path
+(`parse_functions`/`parse_types` in `dumper_castxml.py`) so system-header
+declarations are excluded from `snap.functions`/`snap.types` whenever a
+public-header set is known, independent of whether `--scope-public-headers`
+was passed — a change to the core snapshot-population path touched by every
+detector, not a contained fix like FP-1/FP-2. That needs its own scoped
+design + regression pass rather than a drive-by addition here, consistent
+with how `pvxs-abi-validation-2026-07.md` treats similarly structural gaps
+(F5b, F7) as documented rather than fixed inline.
+
+**Current mitigation:** pass `--scope-public-headers` (the CLI default) with
+a header set that resolves to `surface.resolvable = True` (i.e. `-H`/
+`--public-header-dir` pointed at the library's actual installed headers,
+matching pvxs's own `-public-headers` convention for `abi-dumper`) — this
+already demotes `std::` operators via the existing `REASON_SYSTEM_HEADER`
+path in `surface.py`. The gap is specifically the *default-off* / scoping-
+unresolvable case, which the reported repro command hits because it never
+passes `--scope-public-headers` explicitly and relies on the CLI default
+without confirming header-provenance resolution.
+
+## Positive results confirmed by this spike (no code change needed)
+
+- **Private C++ layout change detection** (§13 of the original spike,
+  `std::function<void()>` → `std::function<void(const Connected&)>` on a
+  private member): `abicheck` correctly reports `TYPE_FIELD_TYPE_CHANGED` /
+  a struct-field break — this is exactly what
+  `TestBaseClassChanges`/`TestQualifiedNameMatching`-style field-diff tests
+  already cover, and ACC misses this class of change entirely (it never
+  inspects private members without special flags).
+- **Exit-code contract** (`0`/`2`/`4`/`64` for compatible / API-break /
+  ABI-break / usage-error) matches the documented matrix in
+  `docs/reference/exit-codes.md` and needed no change.
+- **Isolation**: `abicheck` never executes target-DSO code (parses ELF/DWARF
+  and, for header mode, spawns only the AST frontend + compiler — no
+  `dlopen` of the compared library), matching the existing security posture
+  this repo already documents.
+
+## Status
+
+- **Fixed & tested in this branch:** FP-1 (type-matching key), FP-2
+  (anonymous-type path leak in `canonicalize_type_name`).
+- **Documented, not fixed:** FP-3 (system-header leakage when public-header
+  scoping is off or unresolvable) — needs a scoped follow-up touching the L2
+  parse path in `dumper_castxml.py`.
+- **Not independently re-verified in this environment:** the original
+  end-to-end pvxs `1.5.2` → `cc7bc72` repro (no network/`castxml` access
+  here). Re-running `abicheck compare` over the real `libpvxs.so`/
+  `libpvxsIoc.so` pair with these fixes applied — confirming FP-1/FP-2 no
+  longer appear and quantifying whether FP-3 remains under
+  `--scope-public-headers` — is the acceptance step still owed before pvxs
+  can be recommended as more than a local/experimental shadow check.

--- a/validation/pvxs-abicheck-acceptance-2026-07-18.md
+++ b/validation/pvxs-abicheck-acceptance-2026-07-18.md
@@ -60,8 +60,8 @@ see `dwarf_snapshot.py`). Global-scope types (`qualified_name is None`) fall
 back to the bare name exactly as before, so the change is a no-op for the
 common case and only removes the same-leaf-name collision.
 
-Two follow-up defects were caught by automated PR review (`chatgpt-codex-
-connector`) on the first version of this fix and closed in the same PR
+Three follow-up defects were caught by automated PR review (`chatgpt-codex-
+connector`) across successive versions of this fix and closed in the same PR
 before merge:
 
 1. **Schema-evolution regression.** A snapshot pair where only one side
@@ -91,6 +91,38 @@ before merge:
    sourced `ChangeKind` survives on Linux) failing in CI on the pushed PR.
    Fixed by re-deriving the bare name (`t_old.name`) at every emission/
    provenance-lookup site instead of reusing the qualified matching key.
+3. **One-directional schema-evolution fix.** F#1's `TypeMap` alias only maps
+   bare -> qualified (built from the *target* side's own contents), so it
+   only resolved the "legacy old / fresh new" direction: iterating a legacy
+   old snapshot's bare keys against a fresh new snapshot's alias worked, but
+   the reverse (fresh old, keyed `ns::Handle`, vs. legacy new, keyed only
+   `Handle`) looked the new side up by the qualified key alone, found
+   nothing, and manufactured the same phantom `TYPE_REMOVED` + `TYPE_ADDED`
+   pair. Fixed by `diff_helpers.lookup_matched_type()`, used at all 9 old/new
+   lookup call sites: try the qualified key first, then retry with the bare
+   declaration name. That retry is itself only safe when the *probing* type's
+   own bare name is unambiguous within its own snapshot — reviewed a second
+   time by the same bot, which found that an unconditional retry reopens the
+   original short-leaf-name collision through the back door: two distinct
+   namespaced types sharing a bare name on the probing side (one genuinely
+   removed, one genuinely kept) would retry the removed one's failed lookup
+   with the bare name and land on the unrelated survivor, diffing two
+   different types against each other. Fixed by tracking bare-name ambiguity
+   per `TypeMap` (`bare_name_is_unambiguous()`) and gating the fallback on
+   the *probing* side's own ambiguity, not just the target side's.
+
+All three were genuine defects, not false alarms — each was verified with a
+standalone repro before and after the fix (shown in the PR review thread)
+and closed with dedicated regression tests (`tests/test_diff_helpers.py`
+`TestLookupMatchedType`/`TestTypeMap`, `tests/test_diff_types_deep.py`
+`TestQualifiedNameMatching`/`TestHybridProvenanceKeys`/
+`TestEmittedSymbolStaysBare`) rather than just a manual assertion that the
+fix looked right. The pattern across all three: each fix closed one
+direction/axis of the compatibility-alias problem without testing its
+interaction with the *other* axis already in play (ambiguity, direction,
+identity-leak) — a reminder that this kind of "old/new matching with a
+compatibility fallback" logic needs pairwise (not just per-mechanism) test
+coverage before it's trustworthy.
 
 Tests: `tests/test_diff_helpers.py::TestTypeMapKey`/`TestTypeMap` (direct
 unit coverage of the moved matching primitives), `tests/test_diff_types_deep.py`
@@ -242,10 +274,10 @@ unit fixtures:
 
 ## Status
 
-- **Fixed & tested in this branch:** FP-1 (type-matching key, plus the two
-  Codex-caught regressions on the first version of that fix), FP-2
+- **Fixed & tested in this branch:** FP-1 (type-matching key, plus the three
+  Codex-caught regressions across successive versions of that fix), FP-2
   (anonymous-type path leak in `canonicalize_type_name`). Full fast unit
-  suite green (17268 tests), `mypy`/`ruff`/AI-readiness clean.
+  suite green (17274+ tests), `mypy`/`ruff`/AI-readiness clean.
 - **FP-2 additionally re-verified against real tools** (real pvxs source,
   real `clang`-frontend dump, before/after on a real `.so` pair) — see
   "Real-tool re-verification" above.

--- a/validation/pvxs-abicheck-acceptance-2026-07-18.md
+++ b/validation/pvxs-abicheck-acceptance-2026-07-18.md
@@ -272,12 +272,69 @@ unit fixtures:
   `dlopen` of the compared library), matching the existing security posture
   this repo already documents.
 
+## Broader-scale generalization: closing the same bug class everywhere it hides
+
+FP-1's fix (and the three Codex-caught regressions it took to make it fully
+ambiguity-safe) was applied to `diff_types.py` only. A follow-up review asked
+the more useful question directly: is this specific `RecordType` file the
+only place this bug class exists, or was it just the first place someone
+happened to look? The answer was no — the same bare-leaf-name collision was
+found live in two more places, and fixing it there the same way it was fixed
+in `diff_types.py` (rather than leaving each as a standing gap) is the work
+recorded here. ADR-045 (`docs/development/adr/045-identity-based-old-new-entity-matching.md`)
+records the underlying principle this generalizes.
+
+- **`diff_symbols.py` had never adopted the ambiguity-safe matching at
+  all.** Its own four call sites — `_diff_functions`'s virtual-method-owner
+  resolution (feeding `diff_cxx_rules._resolve_owner_type`),
+  `_diff_ctor_overload_ambiguity`'s class grouping, `_diff_access_levels`,
+  and `_diff_anon_fields` — still built plain `{t.name: t for t in ...}`
+  dicts, independently reintroducing FP-1's exact false-positive/false-
+  negative risk in four different detectors. All four now route through
+  `diff_helpers.build_type_map`/`lookup_matched_type`. Regression tests in
+  `tests/test_diff_symbols_type_matching.py` (7 tests, 5 confirmed via
+  `git stash` to fail against the pre-fix code) pin the fix per call site;
+  `_converting_ctors_by_class` additionally needed a fallback to the bare
+  name when `owner_class_of` can't resolve a scope from a non-Itanium-
+  mangled test symbol, to avoid breaking `tests/test_explicit_ctor.py`'s
+  existing synthetic-mangled-name fixtures (real castxml/DWARF-derived
+  constructors always have real mangled symbols and are unaffected).
+- **`EnumType` had no `qualified_name` equivalent at all.** Added, populated
+  the same way as `RecordType.qualified_name` on both the castxml
+  (`_qualified_type_name`) and clang (`entry.scope`) header dumpers.
+  `diff_types.py`'s `_diff_enums`, `_diff_enum_renames`, and
+  `_diff_enum_deprecated` now match old/new enums through the same
+  `build_type_map`/`lookup_matched_type` machinery. Regression tests in
+  `tests/test_diff_enum_type_matching.py` (5 tests, all confirmed via
+  `git stash` to fail against the pre-fix `diff_types.py`) plus dumper-level
+  unit tests (`test_dumper_clang.py::test_parse_enums_sets_qualified_name_for_namespaced_enum`,
+  `test_castxml_schema_completeness.py::TestCastxmlParserPopulatesNewAttributes::test_namespaced_enum_qualified_name`)
+  confirm both backends populate the new field correctly.
+- **`diff_helpers.TypeMap`/`type_map_key`/`lookup_matched_type` are now
+  generic** (a `Protocol`-bound `TypeVar` over any `name`/`qualified_name`
+  shape) instead of hard-typed to `RecordType`, so `RecordType` and
+  `EnumType` share one implementation rather than duplicating the matching/
+  ambiguity logic per entity kind.
+- **A generalized Hypothesis property**
+  (`test_same_leaf_name_matching_is_order_independent` /
+  `test_same_leaf_name_enum_matching_is_order_independent` in
+  `tests/test_detector_properties.py`) generates two distinct qualified
+  entities sharing a bare leaf name, randomizes snapshot list insertion
+  order on both old and new sides, and asserts the emitted diff is
+  order-independent regardless of which detector fires. This is the actual
+  point of doing this at "broader scale" rather than per-file: it does not
+  need to know which detector is vulnerable, so it also catches any future
+  detector that reintroduces this pattern, closing the discovery gap (each
+  of the two live gaps above was found only because someone went looking by
+  hand) rather than just the two instances found this time.
+
 ## Status
 
 - **Fixed & tested in this branch:** FP-1 (type-matching key, plus the three
-  Codex-caught regressions across successive versions of that fix), FP-2
-  (anonymous-type path leak in `canonicalize_type_name`). Full fast unit
-  suite green (17274+ tests), `mypy`/`ruff`/AI-readiness clean.
+  Codex-caught regressions across successive versions of that fix, plus the
+  broader-scale generalization to `diff_symbols.py` and `EnumType` above),
+  FP-2 (anonymous-type path leak in `canonicalize_type_name`). Full fast unit
+  suite green, `mypy`/`ruff`/AI-readiness clean.
 - **FP-2 additionally re-verified against real tools** (real pvxs source,
   real `clang`-frontend dump, before/after on a real `.so` pair) — see
   "Real-tool re-verification" above.


### PR DESCRIPTION
## Summary

Fixes two of three false positives found in a real-world pvxs acceptance spike (`1.5.2` → `cc7bc72`), and documents the third as a known, un-fixed gap.

## Motivation

A shadow-check acceptance spike compared `abicheck` against pvxs's existing `abi-dumper` + `abi-compliance-checker` gate on a real historical diff. `abicheck` reported `BREAKING` where ACC reported 100% compatible, driven almost entirely by three false positives:

1. Unrelated types sharing a short/leaf name (`_Impl`) getting cross-matched.
2. An anonymous enum's synthesized type spelling embedding the absolute checkout path, so old vs. new checkout roots compared unequal.
3. Transitively-included libstdc++ declarations leaking into the public API diff when public-header scoping doesn't apply.

Full root-cause writeup: `validation/pvxs-abicheck-acceptance-2026-07-18.md`.

## Changes

- **`abicheck/diff_types.py`**: added `_type_map_key()`, used to build every old/new type-matching map. Prefers `RecordType.qualified_name` (populated by the header dumpers) over the deliberately-bare `RecordType.name`, so two unrelated types sharing only a leaf name no longer collide in the same map slot. DWARF-only snapshots (whose `name` is already qualified) and global-scope types are unaffected.
- **`abicheck/name_classification.py`**: `canonicalize_type_name` now strips the `at <path>:<line>:<col>` suffix clang's `-ast-dump=json` embeds in an anonymous struct/union/enum's type spelling, before comparison.
- **`validation/pvxs-abicheck-acceptance-2026-07-18.md`**: root-cause writeup for all three findings, including the un-fixed one (system-header leakage into the public surface when `--scope-public-headers` is off or unresolvable) and why it's deliberately deferred rather than bundled in here.
- Tests: `tests/test_diff_types_deep.py::TestQualifiedNameMatching`, new cases in `tests/test_review_fixes.py::TestCanonicalizeTypeName`.
- Changelog fragment via `scriv create`.

Note: this environment had no network access or `castxml` install, so the original end-to-end pvxs repro (building both revisions, running `abicheck compare` on the real `.so`s) could not be re-executed here — the two fixes were root-caused directly and validated with targeted unit tests exercising the same code paths. Re-running the full pvxs repro is called out in the validation doc as the acceptance step still owed.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`validation/pvxs-abicheck-acceptance-2026-07-18.md`)
- [x] Full fast unit suite green (17253 passed, 0 failed)
- [x] `mypy abicheck/` and `ruff check` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wdy4LLbKEfARarJ4h9NQu5)_