### PR TITLE
feat(action): G30 P0 backlog + build-output.json validator (P1.1, ADR-047)

### DIFF
--- a/abicheck/buildsource/build_output.py
+++ b/abicheck/buildsource/build_output.py
@@ -1,0 +1,645 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``build-output.json`` schema + validator (ADR-047 §2/§11.1, G30 P1.1).
+
+A standardized, producer-agnostic artifact directory a project's *existing*
+build (or an `install` step) populates once — "build once, scan many" (S3) —
+without abicheck ever owning the build:
+
+.. code-block:: text
+
+    abicheck-build/
+      build-output.json          # this module's schema
+      artifacts/                 # binaries as published by the real build
+      headers/                   # public header roots, as-installed layout
+      generated-headers/         # codegen/configure output, kept separate
+      evidence/
+        compile_commands.json    # if produced
+        abicheck_inputs/         # source-facts pack (inputs_pack.py protocol)
+      provenance/                # toolchain version dumps, build logs digest
+
+This module only defines the contract and validates a hand-authored (or
+build-emitted) ``build-output.json`` -- there is no producer tooling here yet
+(that's G30 P1.2's ``resolve-baseline``/``check-target``, which *consume*
+this artifact) and no ``abicheck build-output emit`` helper either. Pure:
+reads files, never runs a tool.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .inputs_pack import is_inputs_pack, load_inputs_manifest, read_source_facts
+
+#: Schema discriminator stamped into every ``build-output.json`` (ADR-047 §2).
+BUILD_OUTPUT_SCHEMA = "abicheck.build-output/v1"
+
+#: The manifest filename inside an ``abicheck-build/`` directory.
+BUILD_OUTPUT_MANIFEST_NAME = "build-output.json"
+
+#: The only ``evidence.projection`` value P1's validator accepts. ``"inferred"``
+#: is schema-reserved for P2's TU->link-unit->DSO attribution (ADR-047 §2) --
+#: accepting it here today would let an unattributed, build-wide pack validate
+#: as legitimate per-target evidence before the safety mechanism that would
+#: justify trusting it exists.
+DECLARED_PROJECTION = "declared"
+
+#: Every enum value the schema recognizes for ``evidence.projection``, so the
+#: validator can tell "not declared" (fails, but is a known future value) from
+#: "not a real projection value at all" (also fails, but is a different kind
+#: of mistake) -- both produce a validation error today; kept as a named
+#: constant so P2 has one place to extend when ``"inferred"`` is implemented.
+KNOWN_PROJECTIONS = frozenset({"declared", "inferred"})
+
+
+def _opt_str(value: Any, default: str = "") -> str:
+    return str(value) if isinstance(value, str) and value else default
+
+
+def _str_list(d: dict[str, Any], key: str) -> list[str]:
+    raw = d.get(key)
+    return [str(x) for x in raw if x] if isinstance(raw, list) else []
+
+
+@dataclass
+class BuildOutputProfile:
+    """One build's OS/arch/compiler/config identity (ADR-047 §2).
+
+    Singular by design: a single build produces binaries for exactly one
+    profile, never a list — see ADR-047 §2's "one build-output.json = one
+    build profile, always" note. A project matrixing over profiles publishes
+    one uniquely-named ``abicheck-build-<profile.id>/`` artifact per profile
+    (S17), not one artifact holding several.
+    """
+
+    id: str = ""
+    os: str = ""
+    arch: str = ""
+    compiler: dict[str, str] = field(default_factory=dict)
+    cxx_abi: str = ""
+    stdlib: str = ""
+    config: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "os": self.os,
+            "arch": self.arch,
+            "compiler": dict(self.compiler),
+            "cxx_abi": self.cxx_abi,
+            "stdlib": self.stdlib,
+            "config": self.config,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BuildOutputProfile:
+        compiler_raw = d.get("compiler")
+        compiler = (
+            {str(k): str(v) for k, v in compiler_raw.items()}
+            if isinstance(compiler_raw, dict)
+            else {}
+        )
+        return cls(
+            id=_opt_str(d.get("id")),
+            os=_opt_str(d.get("os")),
+            arch=_opt_str(d.get("arch")),
+            compiler=compiler,
+            cxx_abi=_opt_str(d.get("cxx_abi")),
+            stdlib=_opt_str(d.get("stdlib")),
+            config=_opt_str(d.get("config")),
+        )
+
+
+@dataclass
+class BuildOutputEvidence:
+    """A target's L3/L4/L5 evidence pointer (ADR-047 §2).
+
+    ``projection`` is the field the P1.1 validator gates on: ``"declared"``
+    means the build itself asserted this evidence pack belongs to exactly
+    this target (e.g. per-target compile-DB filtering, or a wrapper invoked
+    once per link step); ``"inferred"`` would mean abicheck derived the
+    association from a build-wide pack, which needs P2's attribution work
+    and is rejected by this validator until then.
+    """
+
+    kind: str = ""  # e.g. "source-facts"
+    path: str = ""  # relative to the build-output root
+    projection: str = ""  # "declared" | "inferred" (only "declared" validates)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"kind": self.kind, "path": self.path, "projection": self.projection}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BuildOutputEvidence:
+        return cls(
+            kind=_opt_str(d.get("kind")),
+            path=_opt_str(d.get("path")),
+            projection=_opt_str(d.get("projection")),
+        )
+
+
+@dataclass
+class BuildOutputTarget:
+    """One library/binary this build produced (ADR-047 §2)."""
+
+    id: str = ""
+    binary: str = ""
+    public_header_roots: list[str] = field(default_factory=list)
+    #: Public header roots populated by codegen/configure, kept separate from
+    #: public_header_roots (ADR-047 §2's S10 guard) so an empty codegen step
+    #: can't silently claim an as-installed header root that was never
+    #: actually generated.
+    generated_header_roots: list[str] = field(default_factory=list)
+    compile_context: dict[str, Any] = field(default_factory=dict)
+    bundle: str = ""
+    evidence: BuildOutputEvidence | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "id": self.id,
+            "binary": self.binary,
+            "public_header_roots": list(self.public_header_roots),
+            "generated_header_roots": list(self.generated_header_roots),
+            "compile_context": dict(self.compile_context),
+            "bundle": self.bundle,
+        }
+        if self.evidence is not None:
+            d["evidence"] = self.evidence.to_dict()
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BuildOutputTarget:
+        evidence_raw = d.get("evidence")
+        evidence = (
+            BuildOutputEvidence.from_dict(evidence_raw)
+            if isinstance(evidence_raw, dict)
+            else None
+        )
+        compile_context_raw = d.get("compile_context")
+        compile_context = (
+            dict(compile_context_raw) if isinstance(compile_context_raw, dict) else {}
+        )
+        return cls(
+            id=_opt_str(d.get("id")),
+            binary=_opt_str(d.get("binary")),
+            public_header_roots=_str_list(d, "public_header_roots"),
+            generated_header_roots=_str_list(d, "generated_header_roots"),
+            compile_context=compile_context,
+            bundle=_opt_str(d.get("bundle")),
+            evidence=evidence,
+        )
+
+
+@dataclass
+class BuildOutputBundle:
+    """A named group of targets built/released together (ADR-047 §2)."""
+
+    id: str = ""
+    targets: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"id": self.id, "targets": list(self.targets)}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BuildOutputBundle:
+        return cls(id=_opt_str(d.get("id")), targets=_str_list(d, "targets"))
+
+
+@dataclass
+class BuildOutputEvidenceProducer:
+    """Which tool produced the build's L3/L4/L5 evidence (ADR-047 §2)."""
+
+    kind: str = ""  # "wrapper" | "clang-plugin" | "replay" | ...
+    tool: str = ""
+    version: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"kind": self.kind, "tool": self.tool, "version": self.version}
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BuildOutputEvidenceProducer:
+        return cls(
+            kind=_opt_str(d.get("kind")),
+            tool=_opt_str(d.get("tool")),
+            version=_opt_str(d.get("version")),
+        )
+
+
+@dataclass
+class BuildOutput:
+    """Parsed ``build-output.json`` (ADR-047 §2).
+
+    Every field is optional/defaulted, matching the ``buildsource``-wide
+    convention (see ``abicheck/buildsource/CLAUDE.md`` "Conventions") so a
+    hand-written or forward/backward-mismatched manifest never aborts a load
+    — problems are reported by :func:`validate_build_output`, not raised.
+    """
+
+    schema: str = BUILD_OUTPUT_SCHEMA
+    project: str = ""
+    head_sha: str = ""
+    source_tree_digest: str = ""
+    profile: BuildOutputProfile = field(default_factory=BuildOutputProfile)
+    targets: list[BuildOutputTarget] = field(default_factory=list)
+    bundles: list[BuildOutputBundle] = field(default_factory=list)
+    evidence_producer: BuildOutputEvidenceProducer = field(
+        default_factory=BuildOutputEvidenceProducer
+    )
+    digests: dict[str, str] = field(default_factory=dict)
+    diagnostics: dict[str, list[str]] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": self.schema,
+            "project": self.project,
+            "head_sha": self.head_sha,
+            "source_tree_digest": self.source_tree_digest,
+            "profile": self.profile.to_dict(),
+            "targets": [t.to_dict() for t in self.targets],
+            "bundles": [b.to_dict() for b in self.bundles],
+            "evidence_producer": self.evidence_producer.to_dict(),
+            "digests": dict(self.digests),
+            "diagnostics": {k: list(v) for k, v in self.diagnostics.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BuildOutput:
+        profile_raw = d.get("profile")
+        profile = (
+            BuildOutputProfile.from_dict(profile_raw)
+            if isinstance(profile_raw, dict)
+            else BuildOutputProfile()
+        )
+        targets_raw = d.get("targets")
+        targets = (
+            [BuildOutputTarget.from_dict(t) for t in targets_raw if isinstance(t, dict)]
+            if isinstance(targets_raw, list)
+            else []
+        )
+        bundles_raw = d.get("bundles")
+        bundles = (
+            [BuildOutputBundle.from_dict(b) for b in bundles_raw if isinstance(b, dict)]
+            if isinstance(bundles_raw, list)
+            else []
+        )
+        producer_raw = d.get("evidence_producer")
+        producer = (
+            BuildOutputEvidenceProducer.from_dict(producer_raw)
+            if isinstance(producer_raw, dict)
+            else BuildOutputEvidenceProducer()
+        )
+        digests_raw = d.get("digests")
+        digests = (
+            {str(k): str(v) for k, v in digests_raw.items()}
+            if isinstance(digests_raw, dict)
+            else {}
+        )
+        diagnostics_raw = d.get("diagnostics")
+        diagnostics: dict[str, list[str]] = {}
+        if isinstance(diagnostics_raw, dict):
+            for key, value in diagnostics_raw.items():
+                if isinstance(value, list):
+                    diagnostics[str(key)] = [str(x) for x in value]
+        return cls(
+            schema=_opt_str(d.get("schema"), BUILD_OUTPUT_SCHEMA),
+            project=_opt_str(d.get("project")),
+            head_sha=_opt_str(d.get("head_sha")),
+            source_tree_digest=_opt_str(d.get("source_tree_digest")),
+            profile=profile,
+            targets=targets,
+            bundles=bundles,
+            evidence_producer=producer,
+            digests=digests,
+            diagnostics=diagnostics,
+        )
+
+
+def is_build_output_dir(path: Path | str) -> bool:
+    """Whether *path* is an ``abicheck-build/``-shaped directory.
+
+    A directory whose ``build-output.json`` declares
+    ``schema: abicheck.build-output/v1`` — the explicit discriminator mirrors
+    :func:`~.inputs_pack.is_inputs_pack`'s pattern so a directory input can be
+    routed to the right loader without guessing from its contents alone.
+    """
+    p = Path(path)
+    manifest = p / BUILD_OUTPUT_MANIFEST_NAME
+    if not (p.is_dir() and manifest.is_file()):
+        return False
+    try:
+        with manifest.open(encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and data.get("schema") == BUILD_OUTPUT_SCHEMA
+
+
+def load_build_output(root: Path | str) -> BuildOutput:
+    """Load and parse ``<root>/build-output.json``.
+
+    Raises ``FileNotFoundError`` if absent, ``ValueError`` if *root* carries a
+    ``build-output.json`` that does not declare
+    ``schema: abicheck.build-output/v1`` — matching
+    :func:`~.inputs_pack.load_inputs_manifest`'s same two-exception contract.
+    """
+    root = Path(root)
+    manifest_path = root / BUILD_OUTPUT_MANIFEST_NAME
+    if not manifest_path.is_file():
+        raise FileNotFoundError(
+            f"No build-output manifest at {manifest_path}. Expected an "
+            f"abicheck-build/ directory with a build-output.json declaring "
+            f"schema: {BUILD_OUTPUT_SCHEMA}."
+        )
+    with manifest_path.open(encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"{manifest_path} must contain a JSON object.")
+    if data.get("schema") != BUILD_OUTPUT_SCHEMA:
+        raise ValueError(
+            f"{manifest_path} does not declare schema: {BUILD_OUTPUT_SCHEMA} — "
+            "not a recognized build-output.json."
+        )
+    return BuildOutput.from_dict(data)
+
+
+@dataclass
+class BuildOutputValidationReport:
+    """Result of validating one ``build-output.json`` (ADR-047 §11.1)."""
+
+    root: str = ""
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "root": self.root,
+            "ok": self.ok,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+        }
+
+
+def _file_sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _resolve_under_root(root: Path, rel: str) -> Path | None:
+    """Resolve *rel* under *root*, refusing an absolute path or an escape.
+
+    Mirrors :func:`~.inputs_pack._safe_pack_path`'s same guard — every path a
+    ``build-output.json`` declares is relative-to-root, and this is the one
+    place that needs to hold for a third-party/hand-authored manifest.
+    """
+    if Path(rel).is_absolute():
+        return None
+    candidate = (root / rel).resolve()
+    root_resolved = root.resolve()
+    if candidate != root_resolved and not candidate.is_relative_to(root_resolved):
+        return None
+    return root / rel
+
+
+def _header_root_issues(
+    root: Path, target_id: str, roots: list[str], *, label: str
+) -> list[str]:
+    """A declared header root must exist and contain at least one file.
+
+    Applies to both ``public_header_roots`` and ``generated_header_roots`` —
+    the latter is ADR-047 §2's S10 guard: an empty ``generated-headers/``
+    root declared non-empty is a hard failure, never a warning, so a codegen
+    step that silently didn't run can't pass validation.
+    """
+    issues: list[str] = []
+    for rel in roots:
+        resolved = _resolve_under_root(root, rel)
+        if resolved is None:
+            issues.append(
+                f"target {target_id!r}: {label} root {rel!r} is absolute or "
+                "escapes the build-output directory."
+            )
+            continue
+        if not resolved.is_dir():
+            issues.append(
+                f"target {target_id!r}: {label} root {rel!r} does not exist "
+                f"(expected a directory at {resolved})."
+            )
+            continue
+        if not any(resolved.rglob("*")):
+            issues.append(
+                f"target {target_id!r}: {label} root {rel!r} exists but is "
+                "empty — an empty declared header root is a hard failure, "
+                "not a warning (ADR-047 §2's S10 guard: this usually means a "
+                "codegen/configure step that was supposed to populate it "
+                "never actually ran)."
+            )
+    return issues
+
+
+def _binary_issues(
+    root: Path, target: BuildOutputTarget, digests: dict[str, str]
+) -> list[str]:
+    if not target.binary:
+        return [f"target {target.id!r}: no binary declared."]
+    resolved = _resolve_under_root(root, target.binary)
+    if resolved is None:
+        return [
+            f"target {target.id!r}: binary {target.binary!r} is absolute or "
+            "escapes the build-output directory."
+        ]
+    if not resolved.is_file():
+        return [
+            f"target {target.id!r}: binary {target.binary!r} does not exist "
+            f"(expected a file at {resolved})."
+        ]
+    expected_digest = digests.get(target.binary)
+    if expected_digest is None:
+        return [
+            f"target {target.id!r}: no digests[{target.binary!r}] entry — "
+            "every targets[].binary must have a matching digest so a "
+            "consumer can detect a stale/tampered artifact (ADR-047 §11.1)."
+        ]
+    actual_digest = _file_sha256(resolved)
+    expected_normalized = expected_digest.removeprefix("sha256:")
+    if actual_digest != expected_normalized:
+        return [
+            f"target {target.id!r}: binary {target.binary!r} digest mismatch "
+            f"(declared {expected_digest!r}, actual sha256:{actual_digest})."
+        ]
+    return []
+
+
+def _evidence_projection_issues(target: BuildOutputTarget) -> list[str]:
+    evidence = target.evidence
+    if evidence is None:
+        return []
+    if evidence.projection != DECLARED_PROJECTION:
+        if evidence.projection == "inferred":
+            return [
+                f"target {target.id!r}: evidence.projection is 'inferred', "
+                "which P1's build-output.json validator does not accept — "
+                "the TU->link-unit->DSO attribution needed to trust an "
+                "inferred association is G30 P2, not built yet (ADR-047 §2/"
+                "§9). A build-wide pack may only feed a build-wide source "
+                "audit or a per-target header-depth check until then, never "
+                "a per-target effective_depth: source claim."
+            ]
+        return [
+            f"target {target.id!r}: evidence.projection is "
+            f"{evidence.projection!r}; must be {DECLARED_PROJECTION!r}."
+        ]
+    return []
+
+
+def _declared_evidence_sharing_issues(
+    root: Path, targets: list[BuildOutputTarget]
+) -> list[str]:
+    """The shared-pack-across-targets + manifest/target-mismatch checks.
+
+    ADR-047 §11.1's corrected scope: fail a ``"declared"`` claim only when
+    (a) the evidence pack is referenced by more than one target (shared pack
+    — whether or not its TUs carry ``target_id``), or (b) the pack's
+    ``manifest.library`` (or a tagged TU's ``target_id``) disagrees with the
+    specific target referencing it. A single-target, ``manifest.library``-
+    matched pack with untagged TUs must still pass — this is deliberately
+    narrower than rejecting every untagged-TU pack.
+    """
+    issues: list[str] = []
+    declared_targets = [
+        t
+        for t in targets
+        if t.evidence is not None and t.evidence.projection == DECLARED_PROJECTION
+    ]
+
+    # (a) shared-pack detection: group by the evidence path's resolved,
+    # absolute location so two differently-spelled-but-identical relative
+    # paths still collide.
+    path_to_targets: dict[Path, list[str]] = {}
+    for t in declared_targets:
+        assert t.evidence is not None
+        resolved = _resolve_under_root(root, t.evidence.path)
+        if resolved is None:
+            issues.append(
+                f"target {t.id!r}: evidence.path {t.evidence.path!r} is "
+                "absolute or escapes the build-output directory."
+            )
+            continue
+        path_to_targets.setdefault(resolved.resolve(), []).append(t.id)
+    for shared_path, target_ids in path_to_targets.items():
+        if len(target_ids) > 1:
+            issues.append(
+                "evidence pack at "
+                f"{shared_path} is referenced by more than one target "
+                f"({', '.join(sorted(target_ids))}) with projection: "
+                f"{DECLARED_PROJECTION!r} — a pack shared across targets is "
+                "exactly the unprojected, build-wide evidence ADR-047 §9's "
+                "safe model says must never satisfy a per-target 'declared' "
+                "claim; each target needs its own pack, or the shared build-"
+                "wide claim must be dropped to projection-less/no per-target "
+                "source-depth claim."
+            )
+
+    # (b) manifest.library / TU target_id mismatch against the specific
+    # target that references the pack -- only for packs not already flagged
+    # as shared above (a shared pack's per-target identity is meaningless).
+    for t in declared_targets:
+        assert t.evidence is not None
+        resolved = _resolve_under_root(root, t.evidence.path)
+        if resolved is None or len(path_to_targets.get(resolved.resolve(), [])) > 1:
+            continue
+        if not is_inputs_pack(resolved):
+            issues.append(
+                f"target {t.id!r}: evidence.path {t.evidence.path!r} is not "
+                "a readable abicheck_inputs pack (no manifest.json declaring "
+                "kind: abicheck_inputs)."
+            )
+            continue
+        manifest = load_inputs_manifest(resolved)
+        if manifest.library and manifest.library != t.id:
+            issues.append(
+                f"target {t.id!r}: evidence pack's manifest.library is "
+                f"{manifest.library!r}, not {t.id!r} — this pack's own "
+                "declared identity does not match the target referencing it."
+            )
+            continue
+        diagnostics: list[str] = []
+        tus = read_source_facts(resolved, manifest, diagnostics=diagnostics)
+        expected_tu_target = f"target://{t.id}"
+        mismatched = sorted(
+            {
+                tu.target_id
+                for tu in tus
+                if tu.target_id and tu.target_id != expected_tu_target
+            }
+        )
+        if mismatched:
+            issues.append(
+                f"target {t.id!r}: evidence pack's TU records name a "
+                f"different target_id ({', '.join(mismatched)}) than "
+                f"expected ({expected_tu_target!r}) — this pack's evidence "
+                "does not agree on which target it describes."
+            )
+    return issues
+
+
+def validate_build_output(root: Path | str) -> BuildOutputValidationReport:
+    """Validate one ``build-output.json`` + its referenced artifacts (ADR-047 §11.1).
+
+    Never raises for a structurally-readable ``build-output.json`` — problems
+    are reported, not thrown. Raises ``FileNotFoundError``/``ValueError`` only
+    when *root* is not a readable ``abicheck-build/`` directory at all,
+    matching :func:`load_build_output`.
+    """
+    root = Path(root)
+    report = BuildOutputValidationReport(root=str(root))
+    build_output = load_build_output(root)
+
+    if not build_output.targets:
+        report.warnings.append("build-output.json declares no targets[].")
+
+    for target in build_output.targets:
+        if not target.id:
+            report.errors.append("a targets[] entry has no id.")
+            continue
+        report.errors.extend(
+            _header_root_issues(
+                root, target.id, target.public_header_roots, label="public header"
+            )
+        )
+        report.errors.extend(
+            _header_root_issues(
+                root,
+                target.id,
+                target.generated_header_roots,
+                label="generated header",
+            )
+        )
+        report.errors.extend(_binary_issues(root, target, build_output.digests))
+        report.errors.extend(_evidence_projection_issues(target))
+
+    report.errors.extend(_declared_evidence_sharing_issues(root, build_output.targets))
+
+    return report

--- a/abicheck/buildsource/build_output.py
+++ b/abicheck/buildsource/build_output.py
@@ -448,7 +448,7 @@ def _header_root_issues(
                 f"(expected a directory at {resolved})."
             )
             continue
-        if not any(resolved.rglob("*")):
+        if not any(p.is_file() for p in resolved.rglob("*")):
             issues.append(
                 f"target {target_id!r}: {label} root {rel!r} exists but is "
                 "empty — an empty declared header root is a hard failure, "

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -20,6 +20,7 @@ Extracted from ``checker.py`` to break the circular dependency between
 
 from __future__ import annotations
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
@@ -70,6 +71,32 @@ def validate_evidence_depth(field_name: str, value: str) -> None:
         raise ValueError(
             f"{field_name}: unknown depth {value!r}. "
             f"Valid depths: {sorted(EVIDENCE_DEPTH_VALUES)}"
+        )
+
+
+# A check's full identity (ADR-047 §7): "target@profile#baseline_channel@requested_depth".
+# Each of the four components is constrained to a safe identifier charset (no
+# further '@'/'#' inside a component) so the delimiter-joined form stays
+# unambiguous. Mirrors the ``pattern`` in compare_report.schema.json's
+# ``check_id`` property.
+CHECK_ID_PATTERN = re.compile(
+    r"^[A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*"
+    r"#[A-Za-z0-9][A-Za-z0-9._-]*@(binary|headers|build|source)$"
+)
+
+
+def validate_check_id(value: str) -> None:
+    """Reject a check_id that doesn't match CHECK_ID_PATTERN (G30 P0.3).
+
+    Same rationale as ``validate_evidence_depth``: a future caller (G30 P1.3)
+    setting a malformed ``check_id`` would otherwise only be caught by the
+    JSON Schema, which production code never runs against. Fail fast here
+    instead, at the point ``reporter._add_check_identity`` sets the field.
+    """
+    if not CHECK_ID_PATTERN.match(value):
+        raise ValueError(
+            f"check_id: malformed value {value!r}. Expected shape "
+            "'target@profile#baseline_channel@requested_depth'."
         )
 
 

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -44,6 +44,34 @@ from .policy_file import PolicyFile
 # old alias IS retained the alias-change is compatible and must survive.
 SYMBOL_VERSION_ALIAS_NOT_RETAINED_MARKER = "old version NOT retained as alias"
 
+# The public evidence-depth ladder (ADR-043 D2/ADR-047 §7): exactly the four
+# user-facing rungs, matching the public CLI's ``--depth`` and
+# ``abicheck/mcp_server.py``'s own ``_PUBLIC_DEPTHS`` (kept as a separate,
+# self-contained copy here rather than importing mcp_server — that module
+# sits above this one in the dependency graph). Shared by
+# DiffResult.requested_depth/effective_depth and ScanOutcome's matching
+# fields (G30 P0.3) so both validate against the same set.
+EVIDENCE_DEPTH_VALUES = frozenset({"binary", "headers", "build", "source"})
+
+
+def validate_evidence_depth(field_name: str, value: str) -> None:
+    """Reject a depth spelling outside EVIDENCE_DEPTH_VALUES (G30 P0.3).
+
+    Nothing populates ``requested_depth``/``effective_depth`` yet, but a
+    future caller (G30 P1.3) setting a typo'd value would otherwise only be
+    caught by the JSON Schema — which production code never runs against
+    (only opt-in tests do). Fail fast here instead, at the point the caller
+    actually sets the field, matching
+    ``mcp_server._validate_public_depth``'s same check on the same set.
+    Shared by ``reporter._add_check_identity`` (compare) and
+    ``ScanOutcome.to_dict`` (scan) so both validate identically.
+    """
+    if value not in EVIDENCE_DEPTH_VALUES:
+        raise ValueError(
+            f"{field_name}: unknown depth {value!r}. "
+            f"Valid depths: {sorted(EVIDENCE_DEPTH_VALUES)}"
+        )
+
 
 @dataclass
 class Change:
@@ -268,8 +296,8 @@ class DiffResult:
     # never emitted as a null/empty placeholder.
     check_id: str | None = None  # "target@profile#baseline_channel@requested_depth"
     profile_id: str | None = None  # e.g. "linux-x86_64-gcc13-release"
-    requested_depth: str | None = None  # one of: binary, headers, build, source
-    effective_depth: str | None = None  # one of: binary, headers, build, source
+    requested_depth: str | None = None  # one of EVIDENCE_DEPTH_VALUES
+    effective_depth: str | None = None  # one of EVIDENCE_DEPTH_VALUES
     baseline_channel: str | None = None  # e.g. "accepted-main", a release tag
 
     def _effective_kind_sets(
@@ -319,7 +347,8 @@ class DiffResult:
     def breaking(self) -> list[Change]:
         """Changes classified as BREAKING under the active policy."""
         return [
-            c for c in self.changes
+            c
+            for c in self.changes
             if self._effective_verdict_for_change(c) == Verdict.BREAKING
         ]
 
@@ -327,7 +356,8 @@ class DiffResult:
     def source_breaks(self) -> list[Change]:
         """Changes classified as API_BREAK under the active policy."""
         return [
-            c for c in self.changes
+            c
+            for c in self.changes
             if self._effective_verdict_for_change(c) == Verdict.API_BREAK
         ]
 
@@ -335,7 +365,8 @@ class DiffResult:
     def compatible(self) -> list[Change]:
         """Changes classified as COMPATIBLE under the active policy."""
         return [
-            c for c in self.changes
+            c
+            for c in self.changes
             if self._effective_verdict_for_change(c) == Verdict.COMPATIBLE
         ]
 
@@ -343,7 +374,8 @@ class DiffResult:
     def risk(self) -> list[Change]:
         """Changes classified as COMPATIBLE_WITH_RISK under the active policy."""
         return [
-            c for c in self.changes
+            c
+            for c in self.changes
             if self._effective_verdict_for_change(c) == Verdict.COMPATIBLE_WITH_RISK
         ]
 

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -259,6 +259,18 @@ class DiffResult:
     # ``extractor.duration_seconds``, ``findings.source_only.count``); surfaced
     # in the JSON report so CI can tune mode selection. Empty otherwise.
     evidence_metrics: dict[str, object] = field(default_factory=dict)
+    # ADR-047 §7 report-identity envelope (G30 P0.3) — optional, additive.
+    # Nothing in the CLI/service layer populates these yet; they exist so the
+    # GitHub Actions integration-model primitives planned in G30 P1
+    # (``resolve-baseline``, ``check-target``) have a report-level place to
+    # record a check's identity once they're built. None means "not set by
+    # this caller" and the field is omitted from the JSON report entirely —
+    # never emitted as a null/empty placeholder.
+    check_id: str | None = None  # "target@profile#baseline_channel@requested_depth"
+    profile_id: str | None = None  # e.g. "linux-x86_64-gcc13-release"
+    requested_depth: str | None = None  # one of: binary, headers, build, source
+    effective_depth: str | None = None  # one of: binary, headers, build, source
+    baseline_channel: str | None = None  # e.g. "accepted-main", a release tag
 
     def _effective_kind_sets(
         self,

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1859,6 +1859,7 @@ if __name__ == "__main__":
 
 from . import (  # noqa: E402  — must run after `main` and helpers are defined
     cli_aggregate,  # noqa: F401  — registers aggregate
+    cli_build_output,  # noqa: F401  — registers build-output (validate)
     cli_buildsource,  # noqa: F401  — buildsource internals (no command of its own)
     cli_scan,  # noqa: F401  — registers scan
     cli_stack,  # noqa: F401  — registers deps (tree, compare)

--- a/abicheck/cli_build_output.py
+++ b/abicheck/cli_build_output.py
@@ -1,0 +1,110 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI — the ``build-output`` group (G30 P1.1, ADR-047 §2/§11.1).
+
+``build-output validate`` checks a project-produced ``abicheck-build/``
+directory's ``build-output.json`` against the ADR-047 §11.1 validation rules
+(declared header roots non-empty, binary digests match, evidence projection
+is safely 'declared', no evidence pack shared across targets) before any
+G30 P1 primitive (``resolve-baseline``/``check-target``, not built yet) would
+consume it. Split out of :mod:`abicheck.cli` per the sibling-module pattern;
+imported for side-effect at the bottom of :mod:`abicheck.cli` so
+``@main.group``/``@build_output_group.command`` run.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from .buildsource.build_output import validate_build_output
+from .cli import _safe_write_output, _setup_verbosity, main
+from .cli_options import output_options, verbose_option
+
+
+@main.group("build-output")
+def build_output_group() -> None:
+    """Validate a project-produced ``abicheck-build/`` directory.
+
+    \b
+    Subcommands:
+      validate  Check build-output.json + its referenced artifacts.
+    """
+
+
+@build_output_group.command("validate")
+@click.argument(
+    "directory",
+    type=click.Path(exists=True, file_okay=False, path_type=Path),
+)
+@output_options(
+    ["text", "json"],
+    default="text",
+    format_help="Output format for the validation report.",
+)
+@verbose_option
+def build_output_validate_cmd(
+    directory: Path,
+    fmt: str,
+    output: Path | None,
+    verbose: bool,
+) -> None:
+    """Validate DIRECTORY's build-output.json (ADR-047 §11.1).
+
+    Checks: every declared public/generated header root is non-empty; every
+    target's binary exists and matches its digests[] entry; evidence.projection
+    is 'declared' for every target that has evidence ('inferred' is
+    schema-reserved for a future attribution mechanism and is always
+    rejected); no evidence pack is referenced by more than one target, and a
+    referenced pack's own identity (manifest.library or a tagged TU's
+    target_id) agrees with the specific target using it.
+
+    \b
+    Exit codes:
+      0   Valid — no errors (warnings may still be present).
+      1   One or more validation errors.
+      64  Usage error (DIRECTORY is not a readable build-output.json).
+    """
+    _setup_verbosity(verbose)
+
+    try:
+        report = validate_build_output(directory)
+    except (FileNotFoundError, ValueError) as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    if fmt == "json":
+        text = json.dumps(report.to_dict(), indent=2)
+    else:
+        lines = [f"build-output validation: {directory}"]
+        if report.ok:
+            lines.append("OK — no errors.")
+        else:
+            lines.append(f"FAILED — {len(report.errors)} error(s):")
+            lines.extend(f"  - {e}" for e in report.errors)
+        if report.warnings:
+            lines.append(f"{len(report.warnings)} warning(s):")
+            lines.extend(f"  - {w}" for w in report.warnings)
+        text = "\n".join(lines)
+
+    if output is not None:
+        _safe_write_output(output, text)
+    else:
+        click.echo(text)
+
+    sys.exit(0 if report.ok else 1)

--- a/abicheck/cli_help.py
+++ b/abicheck/cli_help.py
@@ -57,7 +57,10 @@ F = TypeVar("F", bound=Callable[..., object])
 # into a default panel), so a new command never silently vanishes.
 _ROOT_COMMAND_PANELS: list[dict[str, object]] = [
     {"name": "Core analysis", "commands": ["dump", "compare", "scan", "deps"]},
-    {"name": "Workflow composition", "commands": ["aggregate"]},
+    {
+        "name": "Workflow composition",
+        "commands": ["aggregate", "build-output"],
+    },
     {"name": "Legacy compatibility", "commands": ["compat"]},
 ]
 COMMAND_GROUPS: dict[str, list[dict[str, object]]] = {

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -36,6 +36,7 @@ from .checker_policy import (
     impact_for,
     policy_kind_sets as _policy_kind_sets,
 )
+from .checker_types import validate_evidence_depth
 from .report_model import VERDICT_TO_SEVERITY_LABEL as _VERDICT_TO_SEVERITY_LABEL
 from .report_summary import build_summary, surface_breakdown
 
@@ -112,7 +113,10 @@ def _effective_severity_label(
     from .severity import effective_verdict_for_change
 
     verdict = effective_verdict_for_change(
-        cast(HasKind, c), policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+        cast(HasKind, c),
+        policy=policy,
+        kind_sets=kind_sets,
+        policy_file=policy_file,
     )
     return _VERDICT_TO_SEVERITY_LABEL.get(verdict, "unknown")
 
@@ -132,7 +136,10 @@ def _kind_to_severity(kind: ChangeKind, policy: str) -> str:
 
 
 def to_stat_json(
-    result: DiffResult, indent: int = 2, *, severity_config: SeverityConfig | None = None,
+    result: DiffResult,
+    indent: int = 2,
+    *,
+    severity_config: SeverityConfig | None = None,
 ) -> str:
     """JSON output for --stat mode: summary only, no changes array.
 
@@ -277,7 +284,10 @@ def _to_json_leaf(
             "symbol": c.symbol,
             "description": c.description,
             "severity": _effective_severity_label(
-                c, eff_sets, policy=result.policy, policy_file=result.policy_file,
+                c,
+                eff_sets,
+                policy=result.policy,
+                policy_file=result.policy_file,
             ),
             # Schema 2.3/2.4 fields (Codex review on #557): _leaf_entry builds
             # its own dict rather than routing through _change_to_dict, so
@@ -289,7 +299,10 @@ def _to_json_leaf(
             "operation": operation_for_kind(c.kind.value),
             "finding_id": _finding_id(c),
             "recommended_action": _recommended_action_for_change(
-                c, policy=result.policy, kind_sets=eff_sets, policy_file=result.policy_file,
+                c,
+                policy=result.policy,
+                kind_sets=eff_sets,
+                policy_file=result.policy_file,
             ),
             "affected_count": len(c.affected_symbols) if c.affected_symbols else 0,
             "affected_symbols": c.affected_symbols or [],
@@ -298,7 +311,10 @@ def _to_json_leaf(
             "new_value": getattr(c, "new_value", None),
         }
         reviewer_action = _reviewer_action_for_change(
-            c, policy=result.policy, kind_sets=eff_sets, policy_file=result.policy_file,
+            c,
+            policy=result.policy,
+            kind_sets=eff_sets,
+            policy_file=result.policy_file,
         )
         if reviewer_action is not None:
             entry["reviewer_action"] = reviewer_action
@@ -330,7 +346,10 @@ def _to_json_leaf(
     leaf_changes_list = [_leaf_entry(c) for c in type_changes]
     non_type_list = [
         _change_to_dict(
-            c, policy=effective_policy, kind_sets=eff_sets, policy_file=result.policy_file,
+            c,
+            policy=effective_policy,
+            kind_sets=eff_sets,
+            policy_file=result.policy_file,
         )
         for c in non_type_changes
     ]
@@ -354,6 +373,7 @@ def _to_json_leaf(
         # FIX-H: populate changes with union for backward-compat consumers
         "changes": leaf_changes_list + non_type_list,
     }
+    _add_check_identity(d, result)
     if severity_config is not None:
         d["severity"] = _build_severity_json(
             changes,
@@ -436,8 +456,10 @@ def _add_check_identity(d: dict[str, object], result: DiffResult) -> None:
     if result.profile_id is not None:
         d["profile_id"] = result.profile_id
     if result.requested_depth is not None:
+        validate_evidence_depth("requested_depth", result.requested_depth)
         d["requested_depth"] = result.requested_depth
     if result.effective_depth is not None:
+        validate_evidence_depth("effective_depth", result.effective_depth)
         d["effective_depth"] = result.effective_depth
     if result.baseline_channel is not None:
         d["baseline_channel"] = result.baseline_channel
@@ -632,7 +654,10 @@ def to_json(
 
     if report_mode == "leaf":
         return _to_json_leaf(
-            result, indent=indent, show_only=show_only, severity_config=severity_config,
+            result,
+            indent=indent,
+            show_only=show_only,
+            severity_config=severity_config,
         )
 
     changes = list(result.changes)
@@ -746,7 +771,10 @@ def _recommended_action_for_change(
     )
 
     verdict = effective_verdict_for_change(
-        cast(HasKind, c), policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+        cast(HasKind, c),
+        policy=policy,
+        kind_sets=kind_sets,
+        policy_file=policy_file,
     )
     action = _VERDICT_TO_RECOMMENDED_ACTION.get(verdict)
     if action is not None:
@@ -755,9 +783,16 @@ def _recommended_action_for_change(
     # quality issue (compatible, but worth a look) via the same category
     # classification the severity JSON block uses.
     category = classify_effective_change(
-        cast(HasKind, c), policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+        cast(HasKind, c),
+        policy=policy,
+        kind_sets=kind_sets,
+        policy_file=policy_file,
     )
-    return "no_action_required" if category == IssueCategory.ADDITION else "review_recommended"
+    return (
+        "no_action_required"
+        if category == IssueCategory.ADDITION
+        else "review_recommended"
+    )
 
 
 #: Per-kind reviewer guidance for a COMPATIBLE addition, keyed by
@@ -797,7 +832,10 @@ def _reviewer_action_for_change(
     from .severity import IssueCategory, classify_effective_change
 
     category = classify_effective_change(
-        cast(HasKind, c), policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+        cast(HasKind, c),
+        policy=policy,
+        kind_sets=kind_sets,
+        policy_file=policy_file,
     )
     if category != IssueCategory.ADDITION:
         return None
@@ -858,10 +896,16 @@ def _change_to_dict(
         d["operation"] = operation_for_kind(kind.value)
         d["finding_id"] = _finding_id(c)
         d["recommended_action"] = _recommended_action_for_change(
-            c, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+            c,
+            policy=policy,
+            kind_sets=kind_sets,
+            policy_file=policy_file,
         )
         reviewer_action = _reviewer_action_for_change(
-            c, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+            c,
+            policy=policy,
+            kind_sets=kind_sets,
+            policy_file=policy_file,
         )
         if reviewer_action is not None:
             d["reviewer_action"] = reviewer_action

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -36,7 +36,7 @@ from .checker_policy import (
     impact_for,
     policy_kind_sets as _policy_kind_sets,
 )
-from .checker_types import validate_evidence_depth
+from .checker_types import validate_check_id, validate_evidence_depth
 from .report_model import VERDICT_TO_SEVERITY_LABEL as _VERDICT_TO_SEVERITY_LABEL
 from .report_summary import build_summary, surface_breakdown
 
@@ -452,6 +452,7 @@ def _add_check_identity(d: dict[str, object], result: DiffResult) -> None:
     identical to one from before this schema version.
     """
     if result.check_id is not None:
+        validate_check_id(result.check_id)
         d["check_id"] = result.check_id
     if result.profile_id is not None:
         d["profile_id"] = result.profile_id

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -162,6 +162,7 @@ def to_stat_json(
             "affected_pct": round(summary.affected_pct, 1),
         },
     }
+    _add_check_identity(d, result)
     if severity_config is not None:
         d["severity"] = _build_severity_json(
             result.changes,
@@ -422,6 +423,26 @@ def _scope_dict(result: DiffResult) -> dict[str, object] | None:
     }
 
 
+def _add_check_identity(d: dict[str, object], result: DiffResult) -> None:
+    """Add the ADR-047 §7 report-identity envelope fields (G30 P0.3).
+
+    Each field is omitted entirely when unset — additive, and nothing
+    populates these yet (the GitHub Actions integration-model primitives
+    that will are G30 P1 work), so a report with none of them set looks
+    identical to one from before this schema version.
+    """
+    if result.check_id is not None:
+        d["check_id"] = result.check_id
+    if result.profile_id is not None:
+        d["profile_id"] = result.profile_id
+    if result.requested_depth is not None:
+        d["requested_depth"] = result.requested_depth
+    if result.effective_depth is not None:
+        d["effective_depth"] = result.effective_depth
+    if result.baseline_channel is not None:
+        d["baseline_channel"] = result.baseline_channel
+
+
 def _build_json_base(result: DiffResult) -> dict[str, object]:
     """Build the opening header + summary block of the JSON report dict."""
     summary = build_summary(result)
@@ -432,6 +453,7 @@ def _build_json_base(result: DiffResult) -> dict[str, object]:
         "new_version": result.new_version,
         "verdict": result.verdict.value,
     }
+    _add_check_identity(d, result)
     # Library file metadata (path, SHA-256, size) — always present for schema consistency
     d["old_file"] = _metadata_dict(getattr(result, "old_metadata", None))
     d["new_file"] = _metadata_dict(getattr(result, "new_metadata", None))

--- a/abicheck/scan_engine.py
+++ b/abicheck/scan_engine.py
@@ -62,6 +62,7 @@ from .buildsource.preprocessor_scan import run_preprocessor_scan
 from .buildsource.risk import RiskScore
 from .buildsource.scan_levels import EvidenceDepth, ScanMode, SourceMethod
 from .checker_policy import API_BREAK_KINDS, BREAKING_KINDS
+from .checker_types import validate_evidence_depth
 from .cli_scan_baseline import _expand_public_headers, _run_baseline_compare
 from .cli_scan_helpers import (
     _intrinsic_coverage,
@@ -155,8 +156,10 @@ class ScanOutcome:
         if self.profile_id is not None:
             d["profile_id"] = self.profile_id
         if self.requested_depth is not None:
+            validate_evidence_depth("requested_depth", self.requested_depth)
             d["requested_depth"] = self.requested_depth
         if self.effective_depth is not None:
+            validate_evidence_depth("effective_depth", self.effective_depth)
             d["effective_depth"] = self.effective_depth
         if self.baseline_channel is not None:
             d["baseline_channel"] = self.baseline_channel
@@ -274,7 +277,8 @@ def _build_new_snapshot(
             collect_mode=collect_mode,
             changed_paths=changed_paths,
             public_headers=tuple(
-                str(p) for p in _expand_public_headers(
+                str(p)
+                for p in _expand_public_headers(
                     [*list(public_headers or ()), *list(public_header_dirs or ())]
                 )
             ),
@@ -533,7 +537,10 @@ def _build_scan_poi(
 
 
 def _append_replay_scope_advisory(
-    advisories: list[str], seeded: bool, collect_mode: str, sources: Path | None,
+    advisories: list[str],
+    seeded: bool,
+    collect_mode: str,
+    sources: Path | None,
 ) -> None:
     """Advise (ADR-035 P3) when an unseeded run falls back to headers-only replay.
 
@@ -604,7 +611,9 @@ def _remaining_budget_s(start: float, budget_s: float | None) -> float | None:
 
 
 def _check_scan_budget(
-    budget: str | None, budget_s: float | None, elapsed: float,
+    budget: str | None,
+    budget_s: float | None,
+    elapsed: float,
 ) -> None:
     """Budget overflow FAILS, never shrinks scope (ADR-035 D3)."""
     if budget_s is not None and elapsed > budget_s:
@@ -773,8 +782,14 @@ def run_scan_core(
     # A deep depth (build/source/full → collect_mode != "off") needs an L3 compile
     # database; without one the L3/L4/L5 layers cannot be collected.
     _check_scan_evidence_contract(
-        advisories, new_snap, collect_mode, pinned_explicit,
-        sources, effective_build_info, eff_depth_enum, resolved,
+        advisories,
+        new_snap,
+        collect_mode,
+        pinned_explicit,
+        sources,
+        effective_build_info,
+        eff_depth_enum,
+        resolved,
     )
 
     # --- conditional tier: S2 preprocessor pre-scan (D2) ----------------------

--- a/abicheck/scan_engine.py
+++ b/abicheck/scan_engine.py
@@ -110,9 +110,17 @@ class ScanOutcome:
     exit_code: int = 0
     elapsed_s: float = 0.0
     budget_s: float | None = None
+    # ADR-047 §7 report-identity envelope (G30 P0.3) — optional, additive.
+    # Nothing populates these yet; see DiffResult's matching fields in
+    # checker_types.py for the full rationale (shared across compare/scan).
+    check_id: str | None = None
+    profile_id: str | None = None
+    requested_depth: str | None = None
+    effective_depth: str | None = None
+    baseline_channel: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        d: dict[str, Any] = {
             "scan_schema_version": SCAN_SCHEMA_VERSION,
             "mode": self.mode,
             "level": {
@@ -142,6 +150,17 @@ class ScanOutcome:
             "elapsed_s": round(self.elapsed_s, 3),
             "budget_s": self.budget_s,
         }
+        if self.check_id is not None:
+            d["check_id"] = self.check_id
+        if self.profile_id is not None:
+            d["profile_id"] = self.profile_id
+        if self.requested_depth is not None:
+            d["requested_depth"] = self.requested_depth
+        if self.effective_depth is not None:
+            d["effective_depth"] = self.effective_depth
+        if self.baseline_channel is not None:
+            d["baseline_channel"] = self.baseline_channel
+        return d
 
 
 def _build_new_snapshot(

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -135,7 +135,15 @@ from typing import Any
 #:       a single hop). Enrichment on an existing finding, never a
 #:       standalone new finding; present only when the embedded L5 graph
 #:       has relevant reachability data for that finding (Codex review).
-REPORT_SCHEMA_VERSION = "2.11"
+#:   2.12: added five additive optional top-level keys -- ``check_id``,
+#:       ``profile_id``, ``requested_depth``, ``effective_depth``,
+#:       ``baseline_channel`` -- the report-identity envelope subset of
+#:       ADR-047 §7 (G30 P0.3). Nothing in the CLI/service layer populates
+#:       them yet; they exist so the GitHub Actions integration-model
+#:       primitives G30 P1 will add (``resolve-baseline``, ``check-target``)
+#:       have a report-level place to record a check's identity. Omitted
+#:       entirely (never emitted as null) when unset.
+REPORT_SCHEMA_VERSION = "2.12"
 
 #: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as
 #: ``scan_schema_version`` at the top level of both public scan dict shapes:
@@ -147,7 +155,12 @@ REPORT_SCHEMA_VERSION = "2.11"
 #: bump policy as :data:`REPORT_SCHEMA_VERSION` above; independent of it (scan
 #: and compare are separate contracts that evolve on their own schedules).
 #: 1.0 — initial versioned envelope.
-SCAN_SCHEMA_VERSION = "1.0"
+#: 1.1 — added five additive optional top-level keys — ``check_id``,
+#:       ``profile_id``, ``requested_depth``, ``effective_depth``,
+#:       ``baseline_channel`` — mirroring compare's 2.12 report-identity
+#:       envelope (ADR-047 §7, G30 P0.3). Reserved for G30 P1; not yet
+#:       populated. Omitted entirely (never emitted as null) when unset.
+SCAN_SCHEMA_VERSION = "1.1"
 
 _SCHEMA_DIR = Path(__file__).resolve().parent
 COMPARE_REPORT_SCHEMA_PATH = _SCHEMA_DIR / "compare_report.schema.json"

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -42,7 +42,8 @@
     },
     "check_id": {
       "type": "string",
-      "description": "Schema 2.12 (ADR-047 report-identity envelope, G30 P0.3). This check's full identity: \"target@profile#baseline_channel@requested_depth\". Nothing in abicheck's CLI/service layer sets this yet -- reserved for the GitHub Actions integration-model primitives planned in G30 P1 (resolve-baseline, check-target)."
+      "description": "Schema 2.12 (ADR-047 report-identity envelope, G30 P0.3). This check's full identity: \"target@profile#baseline_channel@requested_depth\". Nothing in abicheck's CLI/service layer sets this yet -- reserved for the GitHub Actions integration-model primitives planned in G30 P1 (resolve-baseline, check-target). Each of the four components is constrained to ADR-047 §7's safe identifier charset (no further '@'/'#' inside a component) so the delimiter-joined form stays unambiguous.",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*#[A-Za-z0-9][A-Za-z0-9._-]*@(binary|headers|build|source)$"
     },
     "profile_id": {
       "type": "string",

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -40,6 +40,28 @@
       "description": "Schema 2.9. The full-library verdict, present alongside verdict only when a --used-by/--required-symbol(s) scoped compare's gating verdict differs from the unscoped library-wide result (verdict becomes the scoped, gate-relevant one; full_verdict preserves the original).",
       "enum": ["NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING"]
     },
+    "check_id": {
+      "type": "string",
+      "description": "Schema 2.12 (ADR-047 report-identity envelope, G30 P0.3). This check's full identity: \"target@profile#baseline_channel@requested_depth\". Nothing in abicheck's CLI/service layer sets this yet -- reserved for the GitHub Actions integration-model primitives planned in G30 P1 (resolve-baseline, check-target)."
+    },
+    "profile_id": {
+      "type": "string",
+      "description": "Schema 2.12 (ADR-047 §7). The build/environment profile identifier this check ran under, e.g. \"linux-x86_64-gcc13-release\". Reserved for G30 P1; not yet populated."
+    },
+    "requested_depth": {
+      "type": "string",
+      "description": "Schema 2.12 (ADR-047 §7). The evidence depth the caller asked for. Reserved for G30 P1; not yet populated.",
+      "enum": ["binary", "headers", "build", "source"]
+    },
+    "effective_depth": {
+      "type": "string",
+      "description": "Schema 2.12 (ADR-047 §7). The evidence depth actually achieved -- may be shallower than requested_depth when the requested evidence wasn't available. Reserved for G30 P1; not yet populated.",
+      "enum": ["binary", "headers", "build", "source"]
+    },
+    "baseline_channel": {
+      "type": "string",
+      "description": "Schema 2.12 (ADR-047 §7). Which baseline channel (e.g. \"accepted-main\", a release tag) old_file/old_version was resolved from. Reserved for G30 P1; not yet populated."
+    },
     "old_file": { "$ref": "#/$defs/fileMetadata" },
     "new_file": { "$ref": "#/$defs/fileMetadata" },
     "summary": { "$ref": "#/$defs/summary" },

--- a/action.yml
+++ b/action.yml
@@ -457,7 +457,9 @@ runs:
     # Fails fast on an unsupported mode/input combination (e.g. a directory
     # passed to dump/scan, or format: sarif on a non-compare mode) before
     # Python setup, system-dependency installation, or any build/analysis
-    # work runs — see action/validate-inputs.sh for the rationale.
+    # work runs — see action/validate-inputs.sh for the rationale. It also
+    # warns (not fails) when a mode-scoped input is set on a mode it has no
+    # effect on — a legal-but-inert combination, not an error.
     - name: Validate mode/input combination
       shell: bash
       env:
@@ -466,6 +468,18 @@ runs:
         INPUT_OLD_LIBRARY: ${{ inputs.old-library }}
         INPUT_FORMAT: ${{ inputs.format }}
         INPUT_UPLOAD_SARIF: ${{ inputs.upload-sarif }}
+        INPUT_DEBUG_INFO1: ${{ inputs.debug-info1 }}
+        INPUT_DEBUG_INFO2: ${{ inputs.debug-info2 }}
+        INPUT_DEVEL_PKG1: ${{ inputs.devel-pkg1 }}
+        INPUT_DEVEL_PKG2: ${{ inputs.devel-pkg2 }}
+        INPUT_DSO_ONLY: ${{ inputs.dso-only }}
+        INPUT_INCLUDE_PRIVATE_DSO: ${{ inputs.include-private-dso }}
+        INPUT_KEEP_EXTRACTED: ${{ inputs.keep-extracted }}
+        INPUT_FAIL_ON_REMOVED_LIBRARY: ${{ inputs.fail-on-removed-library }}
+        INPUT_JOBS: ${{ inputs.jobs }}
+        INPUT_ABI_BASELINE: ${{ inputs.abi-baseline }}
+        INPUT_ESTIMATE: ${{ inputs.estimate }}
+        INPUT_AUDIT: ${{ inputs.audit }}
       run: bash "${{ github.action_path }}/action/validate-inputs.sh"
 
     # ── 1. Python ─────────────────────────────────────────────────────────────

--- a/action/validate-inputs.sh
+++ b/action/validate-inputs.sh
@@ -60,6 +60,10 @@ _fail() {
   exit 1
 }
 
+_warn() {
+  echo "::warning::$1"
+}
+
 case "$MODE" in
   dump)
     if [[ -n "$NEW_LIBRARY" ]] && _is_release_style_operand "$NEW_LIBRARY"; then
@@ -123,6 +127,69 @@ case "$MODE" in
     _fail "Unknown mode '$MODE'. Use 'compare', 'dump', 'scan', 'deps-tree', or 'deps-compare'."
     ;;
 esac
+
+# Mode-scoped inputs: each of these is only forwarded/consumed in a subset
+# of modes (per-input scope is already documented inline in action.yml's
+# `description:` text), but setting one on an incompatible mode previously
+# produced no feedback at all -- a silent no-op. These are legal-but-inert
+# combinations, not errors, so warn (job-summary annotation) rather than
+# fail the step outright.
+_RELEASE_STYLE_OPERAND=false
+if { [[ -n "$NEW_LIBRARY" ]] && _is_release_style_operand "$NEW_LIBRARY"; } \
+   || { [[ -n "$OLD_LIBRARY" ]] && _is_release_style_operand "$OLD_LIBRARY"; }; then
+  _RELEASE_STYLE_OPERAND=true
+fi
+
+# debug-info1/2, devel-pkg1/2, dso-only, include-private-dso, keep-extracted,
+# fail-on-removed-library, jobs: compare mode, directory/package operands only
+# (action/run.sh's `_is_release_style_operand()` guard). Name/value kept as
+# separate parallel arrays (not a single colon-joined string) since these
+# values are often paths and may legitimately contain a colon themselves.
+_pkg_input_names=(debug-info1 debug-info2 devel-pkg1 devel-pkg2)
+_pkg_input_values=(
+  "${INPUT_DEBUG_INFO1:-}"
+  "${INPUT_DEBUG_INFO2:-}"
+  "${INPUT_DEVEL_PKG1:-}"
+  "${INPUT_DEVEL_PKG2:-}"
+)
+for _i in "${!_pkg_input_names[@]}"; do
+  if [[ -n "${_pkg_input_values[$_i]}" ]] && { [[ "$MODE" != "compare" ]] || [[ "$_RELEASE_STYLE_OPERAND" != "true" ]]; }; then
+    _warn "${_pkg_input_names[$_i]} is set but has no effect: it only applies to mode: compare with a directory/package old-library/new-library operand (mode is '$MODE')."
+  fi
+done
+
+_bool_input_names=(dso-only include-private-dso keep-extracted fail-on-removed-library)
+_bool_input_values=(
+  "${INPUT_DSO_ONLY:-false}"
+  "${INPUT_INCLUDE_PRIVATE_DSO:-false}"
+  "${INPUT_KEEP_EXTRACTED:-false}"
+  "${INPUT_FAIL_ON_REMOVED_LIBRARY:-false}"
+)
+for _i in "${!_bool_input_names[@]}"; do
+  if [[ "${_bool_input_values[$_i]}" == "true" ]] && { [[ "$MODE" != "compare" ]] || [[ "$_RELEASE_STYLE_OPERAND" != "true" ]]; }; then
+    _warn "${_bool_input_names[$_i]} is set but has no effect: it only applies to mode: compare with a directory/package old-library/new-library operand (mode is '$MODE')."
+  fi
+done
+
+_JOBS="${INPUT_JOBS:-0}"
+if [[ "$_JOBS" != "0" ]] && { [[ "$MODE" != "compare" ]] || [[ "$_RELEASE_STYLE_OPERAND" != "true" ]]; }; then
+  _warn "jobs is set but has no effect: it only applies to mode: compare with a directory/package old-library/new-library operand (mode is '$MODE')."
+fi
+
+# abi-baseline: compare mode (used as old-library) or scan mode (used as the
+# scan baseline) only.
+_ABI_BASELINE="${INPUT_ABI_BASELINE:-}"
+if [[ -n "$_ABI_BASELINE" && "$MODE" != "compare" && "$MODE" != "scan" ]]; then
+  _warn "abi-baseline is set but has no effect: it only applies to mode: compare or mode: scan (mode is '$MODE')."
+fi
+
+# estimate, audit: deprecated scan-mode-only aliases.
+if [[ "${INPUT_ESTIMATE:-false}" == "true" && "$MODE" != "scan" ]]; then
+  _warn "estimate is set but has no effect: it only applies to mode: scan (mode is '$MODE')."
+fi
+if [[ "${INPUT_AUDIT:-false}" == "true" && "$MODE" != "scan" ]]; then
+  _warn "audit is set but has no effect: it only applies to mode: scan (mode is '$MODE')."
+fi
 
 if [[ "$UPLOAD_SARIF" == "true" && "$MODE" != "compare" ]]; then
   _fail "upload-sarif is only meaningful with mode: compare (single-pair operands) — mode: $MODE never produces a SARIF report to upload. Remove upload-sarif, or switch to mode: compare."

--- a/actions/collect-facts/action.yml
+++ b/actions/collect-facts/action.yml
@@ -162,6 +162,20 @@ outputs:
       (the plugin's identity is fixed the moment it's built, before your
       build even runs) and re-emitted unchanged at phase: verify.
     value: ${{ steps.run-collect-facts.outputs.producer-version }}
+  auto-completed:
+    description: >
+      'true' when `phase: auto` collected a ready-to-consume pack in this
+      one step (producer: replay always; producer: wrapper/clang-plugin
+      only ever resolve to 'false' here -- `phase: auto` structurally
+      cannot run your build, so it only completes `prepare` for those two
+      producers and a caller must follow up with your build step, then a
+      second call to this Action with `phase: verify`). Always 'true' for
+      `phase: prepare`/`phase: verify` calls (each already reports its own
+      readiness via the `ready` output; this output exists specifically so
+      a `phase: auto` caller can branch on whether the one-step shortcut
+      actually completed, instead of relying on reading the job-summary
+      notice).
+    value: ${{ steps.run-collect-facts.outputs.auto-completed }}
 
 runs:
   using: 'composite'

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -705,6 +705,9 @@ if [[ "$PHASE" == "verify" ]]; then
   else
     _verify_pack
   fi
+  # phase: verify is itself the second half of a two-step choreography (or
+  # the whole story for producer: replay) -- it always completes.
+  _write_output "auto-completed" "true"
 else
   case "$PRODUCER" in
     replay) _prepare_replay ;;
@@ -712,6 +715,19 @@ else
     clang-plugin) _prepare_clang_plugin ;;
   esac
   if [[ "$PHASE" == "auto" ]] && _phase_needs_external_build_step "$PHASE" "$PRODUCER"; then
-    echo "::notice::phase: auto only completes both phases for producer: replay. For producer: $PRODUCER, add a build step here, then a second 'uses: .../collect-facts' step with phase: verify."
+    # phase: auto structurally cannot run the caller's build, so for
+    # wrapper/clang-plugin it only ever completes `prepare` here -- a
+    # caller relying on phase: auto to mean "one step, done" would
+    # otherwise get an unverified pack with no error (ADR-047 P0.2).
+    # Fail loud with a job-summary notice *and* a machine-readable output
+    # a caller can branch on, instead of a print-only notice.
+    echo "::warning::phase: auto only completes both phases for producer: replay. For producer: $PRODUCER, phase: auto has only run 'prepare' -- add your build step here, then a second 'uses: .../collect-facts' step with phase: verify to check the collected pack. Downstream steps must check this Action's auto-completed output before assuming the pack is ready."
+    _write_output "auto-completed" "false"
+  else
+    # phase: prepare (explicit, non-auto) is always the deliberate first
+    # half of a two-step choreography the caller already knows about; and
+    # phase: auto for producer: replay completes both phases in this one
+    # step (_prepare_replay's own `ready: true` output already says so).
+    _write_output "auto-completed" "true"
   fi
 fi

--- a/changelog.d/20260720_000317_noreply_g30_github_actions_ijvl6d.md
+++ b/changelog.d/20260720_000317_noreply_g30_github_actions_ijvl6d.md
@@ -1,0 +1,19 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Added
+
+- **GitHub Action warns on mode-scoped inputs set on an incompatible mode**
+  — `debug-info1`/`debug-info2`, `devel-pkg1`/`devel-pkg2`, `dso-only`,
+  `include-private-dso`, `keep-extracted`, `fail-on-removed-library`,
+  `jobs`, `abi-baseline`, `estimate`, and `audit` are each only
+  forwarded/consumed by a subset of `mode` values; setting one on an
+  incompatible mode used to be a silent no-op. `action/validate-inputs.sh`
+  now emits a `::warning::` job annotation (the step still succeeds) for
+  these legal-but-inert combinations, as part of G30's onboarding-blocker
+  fixes (ADR-047 P0.1).

--- a/changelog.d/20260720_020500_noreply_g30_github_actions_ijvl6d.md
+++ b/changelog.d/20260720_020500_noreply_g30_github_actions_ijvl6d.md
@@ -1,0 +1,17 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Added
+
+- **`collect-facts` reports whether `phase: auto` actually finished** — a
+  new `auto-completed` output (plus an upgraded `::warning::` job
+  annotation) tells a caller when `phase: auto` only ran `prepare` for
+  `producer: wrapper`/`clang-plugin` (it cannot run your build for you), so
+  a workflow can branch on whether the collected pack is really ready
+  instead of assuming a single `phase: auto` step always is (G30/ADR-047
+  P0.2).

--- a/changelog.d/20260720_021208_noreply_g30_github_actions_ijvl6d.md
+++ b/changelog.d/20260720_021208_noreply_g30_github_actions_ijvl6d.md
@@ -8,7 +8,7 @@ it should read in CHANGELOG.md. Delete the other sections.
 
 ### Added
 
-- **Report identity envelope fields (schema 2.11 / scan schema 1.1)** — the
+- **Report identity envelope fields (schema 2.12 / scan schema 1.1)** — the
   `compare` and `scan` JSON reports can now carry five additive, optional
   identity fields: `check_id`, `profile_id`, `requested_depth`,
   `effective_depth`, `baseline_channel` (ADR-047 §7's report-identity

--- a/changelog.d/20260720_021208_noreply_g30_github_actions_ijvl6d.md
+++ b/changelog.d/20260720_021208_noreply_g30_github_actions_ijvl6d.md
@@ -1,0 +1,19 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Added
+
+- **Report identity envelope fields (schema 2.11 / scan schema 1.1)** — the
+  `compare` and `scan` JSON reports can now carry five additive, optional
+  identity fields: `check_id`, `profile_id`, `requested_depth`,
+  `effective_depth`, `baseline_channel` (ADR-047 §7's report-identity
+  envelope, G30 P0.3). Each is omitted from the JSON entirely (never
+  emitted as `null`) unless a caller explicitly sets it on `DiffResult`/
+  `ScanOutcome`; nothing in the CLI populates them yet — they exist so the
+  upcoming GitHub Actions integration-model primitives (G30 P1) have a
+  report-level place to record a check's identity.

--- a/changelog.d/20260720_021533_noreply_g30_github_actions_ijvl6d.md
+++ b/changelog.d/20260720_021533_noreply_g30_github_actions_ijvl6d.md
@@ -1,0 +1,17 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Documentation
+
+- **Canonical multi-DSO recipe, with a scope caveat** — `github-action-source-scans.md`'s
+  "Recommended flow: a multi-library release with one shared facts pack"
+  section is now explicitly marked as the canonical recipe other pages link
+  to, and states plainly what it does and doesn't prove: it supports a
+  build-wide source audit and per-target header-depth checks, but not an
+  independently-proven per-target *source*-depth claim from one shared
+  `abicheck_inputs/` pack (G30 P0.4).

--- a/changelog.d/20260720_061311_noreply_g30_github_actions_ijvl6d.md
+++ b/changelog.d/20260720_061311_noreply_g30_github_actions_ijvl6d.md
@@ -1,0 +1,25 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Fixed
+
+- **`--report-mode leaf` now carries the report-identity envelope fields
+  too** — `check_id`/`profile_id`/`requested_depth`/`effective_depth`/
+  `baseline_channel` (schema 2.11) were wired into the full and `--stat`
+  JSON paths but not leaf mode's separate code path; code review on the
+  introducing PR caught the gap.
+- **`requested_depth`/`effective_depth` are now validated at the point
+  they're set**, not only by the (opt-in, test-only) JSON Schema — an
+  unknown depth spelling now raises `ValueError` immediately from
+  `compare`'s/`scan`'s JSON builders, matching
+  `mcp_server._validate_public_depth`'s existing check on the same public
+  depth ladder (`abicheck/checker_types.py`'s new
+  `EVIDENCE_DEPTH_VALUES`/`validate_evidence_depth`).
+- **`check_id`'s JSON Schema now enforces its documented
+  `target@profile#baseline_channel@requested_depth` shape** via a
+  `pattern`, instead of describing it in prose only.

--- a/changelog.d/20260720_061311_noreply_g30_github_actions_ijvl6d.md
+++ b/changelog.d/20260720_061311_noreply_g30_github_actions_ijvl6d.md
@@ -10,7 +10,7 @@ it should read in CHANGELOG.md. Delete the other sections.
 
 - **`--report-mode leaf` now carries the report-identity envelope fields
   too** — `check_id`/`profile_id`/`requested_depth`/`effective_depth`/
-  `baseline_channel` (schema 2.11) were wired into the full and `--stat`
+  `baseline_channel` (schema 2.12) were wired into the full and `--stat`
   JSON paths but not leaf mode's separate code path; code review on the
   introducing PR caught the gap.
 - **`requested_depth`/`effective_depth` are now validated at the point

--- a/changelog.d/20260720_062755_noreply_g30_github_actions_ijvl6d.md
+++ b/changelog.d/20260720_062755_noreply_g30_github_actions_ijvl6d.md
@@ -1,0 +1,22 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Added
+
+- **`build-output.json` schema + `abicheck build-output validate`** — a new
+  standardized, producer-agnostic contract (`abicheck.build-output/v1`) a
+  project's existing build can publish once ("build once, scan many"). The
+  new `abicheck build-output validate DIRECTORY` command checks a
+  hand-authored or build-emitted `build-output.json` against ADR-047 §11.1:
+  every declared header root is non-empty, every target's binary matches
+  its digest, `evidence.projection` is safely `"declared"` (never
+  `"inferred"`, reserved for a future attribution mechanism), and no
+  evidence pack is shared across targets or disagrees with the target
+  referencing it. See `docs/reference/build-output-schema.md`. No producer
+  tooling consumes this yet — that's future G30 work (`resolve-baseline`/
+  `check-target`).

--- a/changelog.d/20260720_070000_noreply_g30_github_actions_ijvl6d.md
+++ b/changelog.d/20260720_070000_noreply_g30_github_actions_ijvl6d.md
@@ -1,0 +1,21 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Fixed
+
+- **`build-output validate`'s empty-header-root check now requires an
+  actual file**, not just a directory entry — a declared header root
+  containing only empty subdirectories (e.g. codegen scaffolding that never
+  emitted headers) previously passed the S10 hard-fail guard because
+  `Path.rglob("*")` yields directories too; PR #611 code review caught the
+  gap.
+- **`check_id` is now validated against its documented
+  `target@profile#baseline_channel@requested_depth` shape at the point it's
+  set**, matching `requested_depth`/`effective_depth`'s existing eager
+  validation (`checker_types.validate_check_id`), instead of only being
+  caught by the opt-in JSON Schema.

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -157,8 +157,11 @@ JSON via a shared `_add_check_identity` helper when a caller sets them.
 `abicheck/schemas/compare_report.schema.json` (and its published
 `docs/schemas/v1/` mirror, kept in sync via
 `scripts/publish_schemas.py`) declares the five properties (`report_schema_version`
-bumped `2.10` → `2.11`); `abicheck/schemas/__init__.py` documents both this
-bump and `SCAN_SCHEMA_VERSION`'s matching `1.0` → `1.1` bump for the scan
+bumped `2.10` → `2.11` → `2.12` — `2.11` landed independently via #612's
+G31 Phase B3/ADR-048 `affected_public_roots`/etc. fields while this branch
+was in flight, so this work's own bump moved to `2.12` on rebase);
+`abicheck/schemas/__init__.py` documents both this bump and
+`SCAN_SCHEMA_VERSION`'s matching `1.0` → `1.1` bump for the scan
 side (no packaged JSON Schema file for scan output to update). Nothing
 populates these fields yet — that's still P1.3's job, and the
 `requested_depth`/`effective_depth` CLI-wiring PR remains blocked on PR

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -35,7 +35,7 @@ doc PRs need `mkdocs build --strict` + `check_ai_readiness.py`).
 These fix real defects the audit (ADR-047 §"What the audit found")
 identified in the *existing* surface. None require the new primitives.
 
-### P0.1 — Runtime warning when a mode-scoped input is set on an incompatible mode
+### P0.1 — Runtime warning when a mode-scoped input is set on an incompatible mode — **done**
 
 **Problem:** `debug-info1/2`, `devel-pkg1/2`, `dso-only`,
 `include-private-dso`, `keep-extracted`, `fail-on-removed-library`, `jobs`,
@@ -71,6 +71,16 @@ column.
 
 **PR boundary:** one PR — shell + input descriptions + tests together (small
 enough not to split further).
+
+**Status:** implemented. `action/validate-inputs.sh` now warns
+(`::warning::`, exit 0) when `debug-info1`/`debug-info2`, `devel-pkg1`/
+`devel-pkg2`, `dso-only`, `include-private-dso`, `keep-extracted`,
+`fail-on-removed-library`, or `jobs` are set on a mode/operand combination
+outside "compare mode, directory/package operands only", when `abi-baseline`
+is set outside `compare`/`scan` mode, or when the deprecated `estimate`/
+`audit` scan-only aliases are set outside `scan` mode. `action.yml` forwards
+the new inputs to the validation step; `tests/test_action_validate_inputs.py`
+covers each case (warn and silent) via `TestModeScopedInputWarnings`.
 
 ### P0.2 — `collect-facts` `phase: auto` fail-loud for wrapper/plugin
 

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -164,8 +164,8 @@ was in flight, so this work's own bump moved to `2.12` on rebase);
 `SCAN_SCHEMA_VERSION`'s matching `1.0` → `1.1` bump for the scan
 side (no packaged JSON Schema file for scan output to update). Nothing
 populates these fields yet — that's still P1.3's job, and the
-`requested_depth`/`effective_depth` CLI-wiring PR remains blocked on PR
-#601 per the note above.
+`requested_depth`/`effective_depth` CLI-wiring PR remains blocked on
+PR #601 per the note above.
 `tests/test_report_schema.py`'s new `TestReportIdentityEnvelope`/
 `TestScanReportIdentityEnvelope` classes cover: unset-by-default (omitted,
 not null), round-trip + schema validation when set, `--stat` mode carrying

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -82,7 +82,7 @@ is set outside `compare`/`scan` mode, or when the deprecated `estimate`/
 the new inputs to the validation step; `tests/test_action_validate_inputs.py`
 covers each case (warn and silent) via `TestModeScopedInputWarnings`.
 
-### P0.2 — `collect-facts` `phase: auto` fail-loud for wrapper/plugin
+### P0.2 — `collect-facts` `phase: auto` fail-loud for wrapper/plugin — **done**
 
 **Problem:** `phase: auto` silently only runs `prepare` for
 `producer: wrapper`/`clang-plugin` (`actions/collect-facts/run.sh:714-716`)
@@ -103,6 +103,20 @@ implying `auto` is always one step.
 the new output value per producer.
 
 **PR boundary:** one PR.
+
+**Status:** implemented. `actions/collect-facts/run.sh` now writes a new
+`auto-completed` output (`'true'`/`'false'`) alongside a `::warning::`
+job annotation (upgraded from the print-only `::notice::`) when
+`phase: auto` resolves to `producer: wrapper`/`clang-plugin` and therefore
+only completes `prepare`. `actions/collect-facts/action.yml` documents the
+new output; `docs/user-guide/producing-source-facts.md` spells out the
+two-step choreography explicitly instead of only implying it, with a
+sample `if: steps.facts.outputs.auto-completed != 'true'` guard.
+`tests/test_action_collect_facts.py`'s new `TestAutoCompletedOutput` covers
+replay (`auto-completed: true`, no warning), wrapper under `phase: auto`
+(`auto-completed: false`, warning fires), wrapper under explicit
+`phase: prepare` (`auto-completed: true`, no warning — not flagged like
+`auto` is), and `phase: verify` (`auto-completed: true`).
 
 ### P0.3 — Report identity envelope (subset of ADR-047 §7)
 

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -118,7 +118,7 @@ replay (`auto-completed: true`, no warning), wrapper under `phase: auto`
 `phase: prepare` (`auto-completed: true`, no warning — not flagged like
 `auto` is), and `phase: verify` (`auto-completed: true`).
 
-### P0.3 — Report identity envelope (subset of ADR-047 §7)
+### P0.3 — Report identity envelope (subset of ADR-047 §7) — **done** (schema/model half; CLI-population half still open)
 
 **Problem:** JSON reports don't carry `check_id`/`profile_id`/
 `requested_depth`/`effective_depth`/`baseline_channel` today — a P1
@@ -147,7 +147,29 @@ PR #601's `DumpDepthNotSatisfiedError` work landing first per ADR-047 §11.2
 and the repo's existing Known Gaps entry — do not duplicate that
 enforcement, extend it).
 
-### P0.4 — Canonical single-library and multi-DSO doc pages
+**Status:** the schema/model half is implemented — `DiffResult`
+(`abicheck/checker_types.py`) and `ScanOutcome`
+(`abicheck/scan_engine.py`) each gained five optional fields (`check_id`,
+`profile_id`, `requested_depth`, `effective_depth`, `baseline_channel`,
+all `None` by default and omitted from JSON — never emitted as null — when
+unset). `abicheck/reporter.py` writes them into the full/`--stat`/leaf
+JSON via a shared `_add_check_identity` helper when a caller sets them.
+`abicheck/schemas/compare_report.schema.json` (and its published
+`docs/schemas/v1/` mirror, kept in sync via
+`scripts/publish_schemas.py`) declares the five properties (`report_schema_version`
+bumped `2.10` → `2.11`); `abicheck/schemas/__init__.py` documents both this
+bump and `SCAN_SCHEMA_VERSION`'s matching `1.0` → `1.1` bump for the scan
+side (no packaged JSON Schema file for scan output to update). Nothing
+populates these fields yet — that's still P1.3's job, and the
+`requested_depth`/`effective_depth` CLI-wiring PR remains blocked on PR
+#601 per the note above.
+`tests/test_report_schema.py`'s new `TestReportIdentityEnvelope`/
+`TestScanReportIdentityEnvelope` classes cover: unset-by-default (omitted,
+not null), round-trip + schema validation when set, `--stat` mode carrying
+the fields too, and an invalid `requested_depth` enum value failing schema
+validation.
+
+### P0.4 — Canonical single-library and multi-DSO doc pages — **done**
 
 **Problem:** multi-DSO guidance is split three ways with no single canonical
 page (ADR-047 finding 4).
@@ -183,6 +205,18 @@ pages yet).
 `mkdocs-nav-coverage` and `doc-count-sync` checks.
 
 **PR boundary:** one PR, docs-only.
+
+**Status:** implemented. `github-action.md` and `github-action-recipes.md`
+already linked to `github-action-source-scans.md`'s "Recommended flow: a
+multi-library release with one shared facts pack" section rather than
+restating it — that de-duplication predates this item. What was missing is
+now added: the section is explicitly marked as the canonical multi-DSO
+recipe, and the required scope caveat is in place (shared-pack recipe
+supports build-wide source audits and per-target header-depth checks;
+per-target source-depth coverage needs P1.1's projection validator, not yet
+implemented). `mkdocs build --strict` passes (pre-existing anchor-mismatch
+`INFO` lines in that same section predate this change and are unrelated);
+`check_ai_readiness.py` shows the same warning count as before this item.
 
 ---
 

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -222,7 +222,7 @@ implemented). `mkdocs build --strict` passes (pre-existing anchor-mismatch
 
 ## P1 — Integration model (ADR-047's new primitives)
 
-### P1.1 — `build-output.json` schema + validator
+### P1.1 — `build-output.json` schema + validator — **done**
 
 Implements ADR-047 §2/§11.1. New schema module (e.g.
 `abicheck/buildsource/build_output.py` or a sibling of `inputs_pack.py`,
@@ -265,6 +265,26 @@ specific target referencing it must fail, (3) a single-target,
 `manifest.library`-matched pack with untagged TUs must **pass** (regression
 guard against over-rejecting the legitimate legacy case). (1) and (2) are
 currently unenforced; (3) guards the fix from over-correcting.
+
+**Status:** implemented. `abicheck/buildsource/build_output.py` defines the
+schema (`BuildOutput`/`BuildOutputTarget`/`BuildOutputEvidence`/etc., all
+optional/defaulted per the `buildsource`-wide forward-compat convention) and
+`validate_build_output()`, which implements every §11.1 rule: non-empty
+declared header roots (including the S10 `generated_header_roots` hard-error
+case), binary-exists + digest-matches, `evidence.projection` must be
+`"declared"` (`"inferred"` and any other value hard-fail), and the corrected
+shared-pack/manifest-mismatch scope — implemented as an equivalent
+comparison in the new validator (the second option the plan offered) rather
+than extending `inputs_validate.py`'s existing signature, so no existing
+caller of `validate_inputs_pack` changed. `abicheck/cli_build_output.py`
+registers `abicheck build-output validate DIRECTORY` (`--format text|json`,
+exit `0`/`1`/`64`) — a new top-level command group, since `cli_buildsource.py`
+registers no commands of its own. `docs/reference/build-output-schema.md`
+(new, linked from mkdocs nav) documents the schema + validation rules.
+`tests/test_build_output.py` covers the schema round-trip and the full
+failure taxonomy, including all three of the plan's required shared-pack
+test cases (verified against a hand-authored example directory manually as
+well as in the test suite).
 
 ### P1.2 — `actions/resolve-baseline`
 

--- a/docs/reference/build-output-schema.md
+++ b/docs/reference/build-output-schema.md
@@ -1,0 +1,185 @@
+# `build-output.json` Reference
+
+`build-output.json` is a standardized, producer-agnostic contract for a
+project's *existing* build to publish once — "build once, scan many"
+(G30/ADR-047 §2). abicheck never owns the build: a project's own build
+system, or an `install` step, populates an `abicheck-build/` directory that
+downstream tooling then validates and consumes.
+
+> **Status.** This page documents the schema and the
+> `abicheck build-output validate` command shipped in G30 P1.1. The
+> consumers that read a validated `build-output.json` to resolve a baseline
+> or run a check (`resolve-baseline`, `check-target`) are G30 P1.2/P1.3,
+> not built yet — see the
+> [G30 plan](../development/plans/g30-github-actions-integration-model.md).
+> There is also no `abicheck build-output emit` producer helper yet; author
+> `build-output.json` by hand or from your build's own `install` step.
+
+## Directory layout
+
+```text
+abicheck-build/
+  build-output.json          # this page's schema
+  artifacts/                 # binaries as published by the real build
+  headers/                   # public header roots, as-installed layout
+  generated-headers/         # codegen/configure output, kept separate from headers/
+  evidence/
+    compile_commands.json    # if produced
+    abicheck_inputs/         # source-facts pack (see producing-source-facts.md)
+  provenance/                # toolchain version dumps, build logs digest, etc.
+```
+
+`generated-headers/` is deliberately separate from `headers/` so a codegen/
+configure step that silently didn't run can't be mistaken for an
+as-installed header root — see [Validation rules](#validation-rules) below.
+
+## Schema (`abicheck.build-output/v1`)
+
+```json
+{
+  "schema": "abicheck.build-output/v1",
+  "project": "epics-base/pvxs",
+  "head_sha": "b7e2c1a...",
+  "source_tree_digest": "sha256:...",
+  "profile": {
+    "id": "linux-x86_64-gcc13-release",
+    "os": "linux", "arch": "x86_64",
+    "compiler": {"family": "gcc", "version": "13.2.0"},
+    "cxx_abi": "itanium", "stdlib": "libstdc++",
+    "config": "release"
+  },
+  "targets": [
+    {
+      "id": "libpvxs",
+      "binary": "artifacts/lib/libpvxs.so.1.5",
+      "public_header_roots": ["headers/pvxs"],
+      "generated_header_roots": ["generated-headers/pvxs"],
+      "compile_context": {"include_dirs": ["headers", "generated-headers"], "defines": ["PVXS_ENABLE_EXPERT_API"]},
+      "bundle": "pvxs-release",
+      "evidence": {"kind": "source-facts", "path": "evidence/abicheck_inputs", "projection": "declared"}
+    },
+    {"id": "libpvxsIoc", "binary": "artifacts/lib/libpvxsIoc.so.1.5", "...": "..."}
+  ],
+  "bundles": [{"id": "pvxs-release", "targets": ["libpvxs", "libpvxsIoc"]}],
+  "evidence_producer": {"kind": "wrapper", "tool": "abicheck-cc", "version": "0.x.y"},
+  "digests": {"artifacts/lib/libpvxs.so.1.5": "sha256:..."},
+  "diagnostics": {"warnings": [], "skipped_targets": []}
+}
+```
+
+Every field is optional and defaulted (the `buildsource` package-wide
+forward-compatibility convention) — a hand-written or partially-populated
+manifest never aborts a load. `abicheck build-output validate` is what turns
+missing/inconsistent fields into an actionable report.
+
+### Top-level fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `schema` | string | Must be `"abicheck.build-output/v1"`. |
+| `project` | string | Free-text project identifier, e.g. `"owner/repo"`. |
+| `head_sha` | string | The commit this build was produced from. |
+| `source_tree_digest` | string | Content digest of the source tree at that commit. |
+| `profile` | object | This build's OS/arch/compiler/config identity — see below. |
+| `targets` | array | One entry per library/binary this build produced — see below. |
+| `bundles` | array | Named groups of targets built/released together: `{"id", "targets": [...]}`. |
+| `evidence_producer` | object | Which tool produced L3/L4/L5 evidence: `{"kind", "tool", "version"}`. |
+| `digests` | object | Map of `targets[].binary` path → `"sha256:<hex>"`, checked by the validator. |
+| `diagnostics` | object | Free-form producer diagnostics (warnings, skipped targets); informational only. |
+
+**`profile` is singular by design.** A single build produces binaries for
+exactly one OS/arch/compiler/config combination, so one `build-output.json`
+can only ever describe one profile — never a list. A project matrixing over
+several profiles publishes one uniquely-named
+`abicheck-build-<profile.id>/` artifact per profile (S17 in the ADR-047
+scenario catalog), not one artifact holding several.
+
+### `targets[]` fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `id` | string | The target's identifier — must be unique within this file. |
+| `binary` | string | Path (relative to the `build-output.json` root) to the shipped artifact. |
+| `public_header_roots` | array of string | As-installed public header directories for this target. |
+| `generated_header_roots` | array of string | Public header directories populated by codegen/configure — kept separate from `public_header_roots` so an empty codegen step is a hard validation failure, not a silent gap. |
+| `compile_context` | object | Free-form compile context (`include_dirs`, `defines`, ...), informational. |
+| `bundle` | string | The `bundles[].id` this target belongs to, if any. |
+| `evidence` | object | This target's L3/L4/L5 evidence pointer — see below. |
+
+### `evidence` fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `kind` | string | Evidence kind, e.g. `"source-facts"`. |
+| `path` | string | Path (relative to the `build-output.json` root) to the evidence — typically an `abicheck_inputs/` pack (see [Producing Source Facts](../user-guide/producing-source-facts.md)). |
+| `projection` | string | `"declared"` or `"inferred"` — see below. **Only `"declared"` validates today.** |
+
+**`projection` is the field the P1.1 validator gates on.** `"declared"`
+means the build itself asserted this evidence pack belongs to exactly this
+target (e.g. per-target compile-DB filtering, or a wrapper invoked once per
+link step). `"inferred"` would mean abicheck derived the association from a
+build-wide pack via TU→link-unit→DSO attribution — that attribution
+mechanism is G30 P2, not built yet, so `abicheck build-output validate`
+treats `"inferred"` (and any value other than `"declared"`) as a **hard
+validation failure**, not a lower-confidence warning. Until P2 ships, a
+build-wide evidence pack may only feed a build-wide source audit or a
+per-target header-depth check — never a per-target `effective_depth: source`
+claim (see the [multi-DSO recipe's scope
+caveat](../user-guide/github-action-source-scans.md#recommended-flow-a-multi-library-release-with-one-shared-facts-pack)
+for the practical consequence of this rule).
+
+## Validation rules
+
+`abicheck build-output validate DIRECTORY` checks, per ADR-047 §11.1:
+
+1. **Every declared header root is non-empty.** Each `public_header_roots`/
+   `generated_header_roots` entry must resolve to an existing, non-empty
+   directory under the `build-output.json` root. An empty
+   `generated_header_roots` entry is always a hard error — it almost always
+   means a codegen/configure step that was supposed to populate it never
+   ran. A target that declares no `generated_header_roots` at all makes no
+   claim and is never checked.
+2. **Every `targets[].binary` exists and matches `digests{}`.** The binary
+   file must exist under the `build-output.json` root, and `digests{}` must
+   carry a matching `sha256:<hex>` entry for its exact relative path.
+3. **`evidence.projection` must be `"declared"`.** Any other value —
+   including the schema-reserved `"inferred"` — is a hard failure (see
+   above).
+4. **No evidence pack may be shared across targets when `"declared"`.** Two
+   `targets[]` entries pointing their `evidence.path` at the *same* pack
+   (regardless of whether that pack's translation units carry per-TU
+   `target_id` tags) fails both — a pack shared across targets is exactly
+   the unprojected, build-wide evidence the `"declared"` claim exists to
+   rule out.
+5. **A referenced pack's own identity must agree with the target using it.**
+   If the pack's `manifest.library` is set, it must equal the referencing
+   target's `id`; if any of the pack's translation units carry a
+   `target_id` tag, it must name the referencing target too. A
+   single-target pack whose translation units carry **no** `target_id` tags
+   at all still passes — that's the ordinary output of a legacy Flow-2
+   producer, not an integrity gap (see
+   [Producing Source Facts](../user-guide/producing-source-facts.md)).
+
+None of these ever *downgrade* to a warning — every one is a hard,
+non-zero-exit failure, matching the "fail-loud, no silent shallow success"
+principle ADR-047 §11 states for every G30 validator.
+
+### CLI
+
+```console
+$ abicheck build-output validate abicheck-build/
+build-output validation: abicheck-build/
+OK — no errors.
+
+$ abicheck build-output validate abicheck-build/ --format json
+{
+  "root": "abicheck-build/",
+  "ok": true,
+  "errors": [],
+  "warnings": []
+}
+```
+
+Exit codes: `0` valid (warnings may still be present), `1` one or more
+validation errors, `64` usage error (`DIRECTORY` is not a readable
+`build-output.json`).

--- a/docs/schemas/v1/compare_report.schema.json
+++ b/docs/schemas/v1/compare_report.schema.json
@@ -42,7 +42,8 @@
     },
     "check_id": {
       "type": "string",
-      "description": "Schema 2.12 (ADR-047 report-identity envelope, G30 P0.3). This check's full identity: \"target@profile#baseline_channel@requested_depth\". Nothing in abicheck's CLI/service layer sets this yet -- reserved for the GitHub Actions integration-model primitives planned in G30 P1 (resolve-baseline, check-target)."
+      "description": "Schema 2.12 (ADR-047 report-identity envelope, G30 P0.3). This check's full identity: \"target@profile#baseline_channel@requested_depth\". Nothing in abicheck's CLI/service layer sets this yet -- reserved for the GitHub Actions integration-model primitives planned in G30 P1 (resolve-baseline, check-target). Each of the four components is constrained to ADR-047 §7's safe identifier charset (no further '@'/'#' inside a component) so the delimiter-joined form stays unambiguous.",
+      "pattern": "^[A-Za-z0-9][A-Za-z0-9._-]*@[A-Za-z0-9][A-Za-z0-9._-]*#[A-Za-z0-9][A-Za-z0-9._-]*@(binary|headers|build|source)$"
     },
     "profile_id": {
       "type": "string",

--- a/docs/schemas/v1/compare_report.schema.json
+++ b/docs/schemas/v1/compare_report.schema.json
@@ -40,6 +40,28 @@
       "description": "Schema 2.9. The full-library verdict, present alongside verdict only when a --used-by/--required-symbol(s) scoped compare's gating verdict differs from the unscoped library-wide result (verdict becomes the scoped, gate-relevant one; full_verdict preserves the original).",
       "enum": ["NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING"]
     },
+    "check_id": {
+      "type": "string",
+      "description": "Schema 2.12 (ADR-047 report-identity envelope, G30 P0.3). This check's full identity: \"target@profile#baseline_channel@requested_depth\". Nothing in abicheck's CLI/service layer sets this yet -- reserved for the GitHub Actions integration-model primitives planned in G30 P1 (resolve-baseline, check-target)."
+    },
+    "profile_id": {
+      "type": "string",
+      "description": "Schema 2.12 (ADR-047 §7). The build/environment profile identifier this check ran under, e.g. \"linux-x86_64-gcc13-release\". Reserved for G30 P1; not yet populated."
+    },
+    "requested_depth": {
+      "type": "string",
+      "description": "Schema 2.12 (ADR-047 §7). The evidence depth the caller asked for. Reserved for G30 P1; not yet populated.",
+      "enum": ["binary", "headers", "build", "source"]
+    },
+    "effective_depth": {
+      "type": "string",
+      "description": "Schema 2.12 (ADR-047 §7). The evidence depth actually achieved -- may be shallower than requested_depth when the requested evidence wasn't available. Reserved for G30 P1; not yet populated.",
+      "enum": ["binary", "headers", "build", "source"]
+    },
+    "baseline_channel": {
+      "type": "string",
+      "description": "Schema 2.12 (ADR-047 §7). Which baseline channel (e.g. \"accepted-main\", a release tag) old_file/old_version was resolved from. Reserved for G30 P1; not yet populated."
+    },
     "old_file": { "$ref": "#/$defs/fileMetadata" },
     "new_file": { "$ref": "#/$defs/fileMetadata" },
     "summary": { "$ref": "#/$defs/summary" },

--- a/docs/user-guide/github-action-source-scans.md
+++ b/docs/user-guide/github-action-source-scans.md
@@ -195,6 +195,10 @@ CLI-level flows.
 
 ## Recommended flow: a multi-library release with one shared facts pack
 
+**This is the canonical multi-DSO recipe** — [Action Reference](github-action.md)
+and [More Recipes](github-action-recipes.md) link here rather than restating
+it, so update this section (not a copy) when the recipe changes.
+
 This is the concrete, Action-supported answer to a specific, recurring shape
 of project: several libraries built from one source tree, one facts pack
 collected **once** for the whole build (via [source
@@ -205,6 +209,22 @@ and no single ".so that represents the release" to hand `scan`/`dump` — which,
 per [Mode/input compatibility](github-action.md#modeinput-compatibility), only
 accept **one** artifact each; there is no `scan`/`dump` equivalent of
 `compare`'s directory/package fan-out.
+
+**Scope caveat:** every library in the recipe below points at the *same*
+shared `abicheck_inputs/` pack, with no per-target projection check that the
+pack's facts actually belong to that specific library rather than another
+one built from the same tree. That's fine for what this recipe supports
+today — a build-wide source audit, and a per-target *header*-depth check
+(`-H`/`header` scopes each matrix row's L2 declared surface correctly, which
+is independent of the shared pack). It is **not** enough to claim per-target
+*source*-depth coverage: nothing here proves library A's embedded L3/L4/L5
+facts didn't actually come from library B's translation units. Recording
+that distinction (a `build-output.json` `evidence.projection: "declared"` vs.
+`"inferred"` tag, per [ADR-047 §9](../development/adr/047-github-actions-integration-model.md))
+needs the per-target projection validator tracked as G30 plan item P1.1,
+not yet implemented — until then, treat this recipe's `depth: source` dumps
+as build-wide source evidence applied uniformly, not as independently-proven
+per-library source coverage.
 
 The fix is not a new Action feature — it's composing three recipes this page
 and [More Recipes](github-action-recipes.md) already document individually,

--- a/docs/user-guide/producing-source-facts.md
+++ b/docs/user-guide/producing-source-facts.md
@@ -290,6 +290,33 @@ ahead of time; pass `sources:` straight to the next abicheck step and skip
 `collect-facts` for that producer entirely if you already know you're on the
 replay path.
 
+**`phase: auto` is only ever one step for `producer: replay`.** For
+`producer: wrapper`/`clang-plugin` it cannot run your build for you either,
+so it silently resolves to running `prepare` only — the same two-step
+choreography above still applies, `phase: auto` just doesn't make that
+obvious by itself. Don't assume a single `phase: auto` step is enough
+without checking: the Action sets an `auto-completed` output (`'true'` when
+the pack from this one step is actually ready to consume, `'false'` when
+`phase: auto` only ran `prepare` and a build step + a second `phase: verify`
+call are still needed) and prints a `::warning::` job annotation in the
+`'false'` case. A workflow that always wants an explicit two-step shape for
+wrapper/clang-plugin should just pass `phase: prepare`/`phase: verify`
+directly instead of relying on `auto`'s resolution:
+
+```yaml
+- id: facts
+  uses: abicheck/abicheck/actions/collect-facts@<sha>
+  with:
+    producer: wrapper
+    phase: auto
+    sources: .
+- name: Check the pack is actually ready
+  if: steps.facts.outputs.auto-completed != 'true'
+  run: |
+    echo "phase: auto only ran prepare for producer: ${{ steps.facts.outputs.producer }} -- add your build step, then a phase: verify call." >&2
+    exit 1
+```
+
 **`producer: auto`** inspects `sources` for an existing compile database or a
 CMake/Bazel project (→ `replay`) and falls back to `wrapper` otherwise. It
 never auto-selects `clang-plugin` — "you own the toolchain image and the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,6 +92,7 @@ nav:
     - Detector Spec Matrix: reference/detector-spec.md
     - Exit Codes: reference/exit-codes.md
     - Snapshot Format: reference/snapshot-format.md
+    - Build Output Schema: reference/build-output-schema.md
     - Configuration File: reference/config-file.md
     - Environment Variables: reference/environment.md
     - Platforms: reference/platforms.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ module = [
     "abicheck.cli_resolve",
     "abicheck.cli_aggregate",
     "abicheck.cli_appcompat",
+    "abicheck.cli_build_output",
     "abicheck.cli_compare_release",
     "abicheck.cli_debian_symbols",
     "abicheck.cli_baseline",

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -1037,6 +1037,14 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
                 "cli_aggregate",
                 "cli_appcompat",
                 "cli_baseline",
+                # `cli_build_output` (G30 P1.1) joins this SCC exactly like
+                # `cli_aggregate`: its `build-output validate` command reuses
+                # the shared `-o/--format` pair via `cli_options.output_options`
+                # (module-load import), and `cli_options` is already a member —
+                # so `cli -> cli_build_output -> cli_options -> ... -> cli`
+                # closes through already-member modules, not a new dependency
+                # direction. No init deadlock.
+                "cli_build_output",
                 "cli_buildsource",
                 "cli_buildsource_helpers",
                 "cli_compare_helpers",

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -740,6 +740,82 @@ class TestPhaseNeedsExternalBuildStep:
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
 )
+class TestAutoCompletedOutput:
+    """ADR-047 P0.2: `phase: auto` silently only ran `prepare` for
+    producer: wrapper/clang-plugin, leaving a caller with an unverified pack
+    and no error. The Action now sets a machine-readable `auto-completed`
+    output (plus a `::warning::` job annotation) so a caller can branch on
+    whether the one-step shortcut actually completed."""
+
+    def test_auto_with_replay_completes(self, tmp_path: Path) -> None:
+        sources = tmp_path / "src"
+        sources.mkdir()
+        (sources / "compile_commands.json").write_text("[]")
+        result, _, github_output = _run_action(
+            {
+                "INPUT_PHASE": "auto",
+                "INPUT_PRODUCER": "replay",
+                "INPUT_SOURCES": str(sources),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert _parse_kv_file(github_output)["auto-completed"] == "true"
+        assert "::warning::" not in result.stdout
+
+    def test_auto_with_wrapper_does_not_complete(self, tmp_path: Path) -> None:
+        result, _, github_output = _run_action(
+            {
+                "INPUT_PHASE": "auto",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_OUTPUT": str(tmp_path / "abicheck_inputs"),
+                "INPUT_INSTALL_DEPS": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert _parse_kv_file(github_output)["auto-completed"] == "false"
+        assert "::warning::" in result.stdout
+        assert (
+            "phase: auto only completes both phases for producer: replay"
+            in result.stdout
+        )
+
+    def test_explicit_prepare_with_wrapper_completes(self, tmp_path: Path) -> None:
+        # phase: prepare (not auto) is the deliberate first half of a
+        # two-step choreography the caller already knows about -- it must
+        # not be flagged the same way auto is.
+        result, _, github_output = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "wrapper",
+                "INPUT_OUTPUT": str(tmp_path / "abicheck_inputs"),
+                "INPUT_INSTALL_DEPS": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert _parse_kv_file(github_output)["auto-completed"] == "true"
+        assert "::warning::" not in result.stdout
+
+    def test_verify_completes(self, tmp_path: Path) -> None:
+        sources = tmp_path / "src"
+        sources.mkdir()
+        result, _, github_output = _run_action(
+            {
+                "INPUT_PHASE": "verify",
+                "INPUT_PRODUCER": "replay",
+                "INPUT_SOURCES": str(sources),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert _parse_kv_file(github_output)["auto-completed"] == "true"
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
 class TestInvalidInputsRejected:
     def test_unknown_producer_fails(self, tmp_path: Path) -> None:
         result, _, _ = _run_action({"INPUT_PRODUCER": "bogus"}, tmp_path)

--- a/tests/test_action_validate_inputs.py
+++ b/tests/test_action_validate_inputs.py
@@ -68,6 +68,18 @@ _VALIDATOR_INPUT_VARS = (
     "INPUT_OLD_LIBRARY",
     "INPUT_FORMAT",
     "INPUT_UPLOAD_SARIF",
+    "INPUT_DEBUG_INFO1",
+    "INPUT_DEBUG_INFO2",
+    "INPUT_DEVEL_PKG1",
+    "INPUT_DEVEL_PKG2",
+    "INPUT_DSO_ONLY",
+    "INPUT_INCLUDE_PRIVATE_DSO",
+    "INPUT_KEEP_EXTRACTED",
+    "INPUT_FAIL_ON_REMOVED_LIBRARY",
+    "INPUT_JOBS",
+    "INPUT_ABI_BASELINE",
+    "INPUT_ESTIMATE",
+    "INPUT_AUDIT",
 )
 
 
@@ -480,6 +492,160 @@ class TestUploadSarif:
     def test_upload_sarif_false_default_never_triggers_the_check(self) -> None:
         result = _run_validate({"INPUT_MODE": "scan", "INPUT_FORMAT": "json"})
         assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
+)
+class TestModeScopedInputWarnings:
+    """P0.1: setting a mode-scoped input on an incompatible mode used to be
+    a silent no-op. These inputs are legal-but-inert on the wrong mode, not
+    errors, so the validator warns (exit 0, `::warning::` annotation)
+    instead of failing the step."""
+
+    @pytest.mark.parametrize(
+        "env_name",
+        [
+            "INPUT_DEBUG_INFO1",
+            "INPUT_DEBUG_INFO2",
+            "INPUT_DEVEL_PKG1",
+            "INPUT_DEVEL_PKG2",
+        ],
+    )
+    def test_package_input_warns_on_non_compare_mode(self, env_name: str) -> None:
+        result = _run_validate({"INPUT_MODE": "scan", env_name: "some-package.rpm"})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" in result.stdout
+        assert "has no effect" in result.stdout
+
+    def test_package_input_warns_on_compare_single_pair(self) -> None:
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_OLD_LIBRARY": "old.so",
+                "INPUT_NEW_LIBRARY": "new.so",
+                "INPUT_DEBUG_INFO1": "old-debuginfo.rpm",
+            }
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" in result.stdout
+
+    def test_package_input_silent_on_compare_directory_operand(
+        self, tmp_path: Path
+    ) -> None:
+        lib_dir = tmp_path / "release"
+        lib_dir.mkdir()
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_OLD_LIBRARY": str(lib_dir),
+                "INPUT_NEW_LIBRARY": "new.so",
+                "INPUT_DEBUG_INFO1": "old-debuginfo.rpm",
+            }
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" not in result.stdout
+
+    @pytest.mark.parametrize(
+        "env_name",
+        [
+            "INPUT_DSO_ONLY",
+            "INPUT_INCLUDE_PRIVATE_DSO",
+            "INPUT_KEEP_EXTRACTED",
+            "INPUT_FAIL_ON_REMOVED_LIBRARY",
+        ],
+    )
+    def test_bool_input_warns_when_true_on_non_compare_mode(
+        self, env_name: str
+    ) -> None:
+        result = _run_validate({"INPUT_MODE": "dump", env_name: "true"})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" in result.stdout
+
+    @pytest.mark.parametrize(
+        "env_name",
+        [
+            "INPUT_DSO_ONLY",
+            "INPUT_INCLUDE_PRIVATE_DSO",
+            "INPUT_KEEP_EXTRACTED",
+            "INPUT_FAIL_ON_REMOVED_LIBRARY",
+        ],
+    )
+    def test_bool_input_silent_when_false_default(self, env_name: str) -> None:
+        result = _run_validate({"INPUT_MODE": "dump", env_name: "false"})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" not in result.stdout
+
+    def test_jobs_warns_on_scan_mode(self) -> None:
+        result = _run_validate({"INPUT_MODE": "scan", "INPUT_JOBS": "8"})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" in result.stdout
+        assert "jobs" in result.stdout
+
+    def test_jobs_warns_on_compare_single_pair(self) -> None:
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_OLD_LIBRARY": "old.so",
+                "INPUT_NEW_LIBRARY": "new.so",
+                "INPUT_JOBS": "8",
+            }
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" in result.stdout
+
+    def test_jobs_default_value_never_warns(self) -> None:
+        result = _run_validate({"INPUT_MODE": "scan"})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" not in result.stdout
+
+    def test_jobs_silent_on_compare_directory_operand(self, tmp_path: Path) -> None:
+        lib_dir = tmp_path / "release"
+        lib_dir.mkdir()
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_OLD_LIBRARY": str(lib_dir),
+                "INPUT_NEW_LIBRARY": "new.so",
+                "INPUT_JOBS": "8",
+            }
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" not in result.stdout
+
+    @pytest.mark.parametrize("mode", ["dump", "deps-tree", "deps-compare"])
+    def test_abi_baseline_warns_outside_compare_and_scan(self, mode: str) -> None:
+        result = _run_validate(
+            {"INPUT_MODE": mode, "INPUT_ABI_BASELINE": "latest-release"}
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" in result.stdout
+        assert "abi-baseline" in result.stdout
+
+    @pytest.mark.parametrize("mode", ["compare", "scan"])
+    def test_abi_baseline_silent_on_compare_and_scan(self, mode: str) -> None:
+        result = _run_validate(
+            {"INPUT_MODE": mode, "INPUT_ABI_BASELINE": "latest-release"}
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" not in result.stdout
+
+    @pytest.mark.parametrize("env_name", ["INPUT_ESTIMATE", "INPUT_AUDIT"])
+    def test_deprecated_scan_alias_warns_outside_scan(self, env_name: str) -> None:
+        result = _run_validate({"INPUT_MODE": "compare", env_name: "true"})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" in result.stdout
+
+    @pytest.mark.parametrize("env_name", ["INPUT_ESTIMATE", "INPUT_AUDIT"])
+    def test_deprecated_scan_alias_silent_on_scan(self, env_name: str) -> None:
+        result = _run_validate({"INPUT_MODE": "scan", env_name: "true"})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" not in result.stdout
+
+    def test_no_mode_scoped_inputs_set_produces_no_warnings(self) -> None:
+        result = _run_validate({"INPUT_MODE": "compare"})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" not in result.stdout
 
 
 # ─────────────────────────────────────────────────────────────────────────

--- a/tests/test_build_output.py
+++ b/tests/test_build_output.py
@@ -337,6 +337,33 @@ class TestHeaderRootValidation:
         assert not report.ok
         assert any("empty" in e for e in report.errors)
 
+    def test_header_root_with_only_empty_subdirectory_fails(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        _header_root(root, "headers/foo", populated=False)
+        (root / "headers/foo/nested").mkdir()
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "public_header_roots": ["headers/foo"],
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("empty" in e for e in report.errors)
+
     def test_empty_generated_header_root_is_hard_failure_not_warning(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_build_output.py
+++ b/tests/test_build_output.py
@@ -167,6 +167,27 @@ class TestSchemaRoundTrip:
         assert bo.digests == {}
         assert bo.profile == BuildOutputProfile()
 
+    def test_target_to_dict_omits_evidence_key_when_unset(self) -> None:
+        target = BuildOutputTarget(id="libfoo", binary="artifacts/libfoo.so")
+        assert "evidence" not in target.to_dict()
+
+    def test_diagnostics_round_trip(self) -> None:
+        bo = BuildOutput.from_dict(
+            {
+                "schema": BUILD_OUTPUT_SCHEMA,
+                "diagnostics": {
+                    "warnings": ["w1"],
+                    "skipped_targets": ["libbar"],
+                    "not_a_list": "ignored",
+                },
+            }
+        )
+        assert bo.diagnostics == {
+            "warnings": ["w1"],
+            "skipped_targets": ["libbar"],
+        }
+        assert bo.to_dict()["diagnostics"] == bo.diagnostics
+
 
 class TestIsBuildOutputDir:
     def test_true_for_real_manifest(self, tmp_path: Path) -> None:
@@ -176,6 +197,12 @@ class TestIsBuildOutputDir:
     def test_false_for_plain_dir(self, tmp_path: Path) -> None:
         d = tmp_path / "plain"
         d.mkdir()
+        assert is_build_output_dir(d) is False
+
+    def test_false_for_malformed_json(self, tmp_path: Path) -> None:
+        d = tmp_path / "abicheck-build"
+        d.mkdir()
+        (d / "build-output.json").write_text("{not valid json")
         assert is_build_output_dir(d) is False
 
     def test_false_for_inputs_pack_dir(self, tmp_path: Path) -> None:
@@ -422,6 +449,14 @@ class TestBinaryValidation:
         assert not report.ok
         assert any("does not exist" in e for e in report.errors)
 
+    def test_absolute_binary_path_is_rejected(self, tmp_path: Path) -> None:
+        root = _build_output_dir(
+            tmp_path, targets=[{"id": "libfoo", "binary": "/etc/passwd"}]
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("absolute or escapes" in e for e in report.errors)
+
     def test_digest_mismatch_fails(self, tmp_path: Path) -> None:
         root = tmp_path / "abicheck-build"
         root.mkdir()
@@ -535,6 +570,35 @@ class TestDeclaredEvidenceSharingScope:
     per-TU tags, (2) a manifest/target mismatch must fail, (3) a
     single-target, matched, untagged-TU pack must still pass (regression
     guard against over-rejecting the legitimate legacy case)."""
+
+    def test_absolute_evidence_path_is_rejected(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/liba.so")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "liba",
+                            "binary": "artifacts/lib/liba.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "/etc/passwd",
+                                "projection": "declared",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/liba.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any(
+            "evidence.path" in e and "absolute or escapes" in e for e in report.errors
+        )
 
     def _two_target_setup(
         self,
@@ -735,6 +799,15 @@ class TestBuildOutputCLI:
         res = self._run([str(root)])
         assert res.exit_code == 0, res.output
         assert "OK" in res.output
+
+    def test_text_format_shows_warnings(self, tmp_path: Path) -> None:
+        # No targets[] is valid (ok) but produces a warning -- exercises the
+        # text-format warnings branch, distinct from the errors branch.
+        root = _build_output_dir(tmp_path, targets=[])
+        res = self._run([str(root)])
+        assert res.exit_code == 0, res.output
+        assert "warning(s)" in res.output
+        assert "no targets" in res.output
 
     def test_invalid_dir_exits_1(self, tmp_path: Path) -> None:
         root = _build_output_dir(

--- a/tests/test_build_output.py
+++ b/tests/test_build_output.py
@@ -1,0 +1,771 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``buildsource.build_output`` (ADR-047 §2/§11.1, G30 P1.1).
+
+``build-output.json`` is a standardized, producer-agnostic artifact directory
+a project's existing build populates once. These tests cover the schema
+round-trip and the validator's full ADR-047 §11.1 failure taxonomy: empty
+declared header roots, binary digest mismatches, ``evidence.projection``
+other than ``"declared"``, and the corrected shared-pack /
+manifest-mismatch scope for per-target evidence.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from abicheck.buildsource.build_output import (
+    BUILD_OUTPUT_SCHEMA,
+    BuildOutput,
+    BuildOutputBundle,
+    BuildOutputEvidence,
+    BuildOutputEvidenceProducer,
+    BuildOutputProfile,
+    BuildOutputTarget,
+    is_build_output_dir,
+    load_build_output,
+    validate_build_output,
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_pack(
+    root: Path,
+    rel: str,
+    *,
+    library: str = "",
+    tu_target_ids: list[str | None] | None = None,
+) -> None:
+    """Write a minimal Flow-2 ``abicheck_inputs/`` pack at *root/rel*."""
+    pack_dir = root / rel
+    (pack_dir / "source_facts").mkdir(parents=True)
+    manifest = {"kind": "abicheck_inputs", "abicheck_inputs_version": 1}
+    if library:
+        manifest["library"] = library
+    (pack_dir / "manifest.json").write_text(json.dumps(manifest))
+    for i, target_id in enumerate(tu_target_ids or []):
+        record: dict[str, object] = {"tu_id": f"tu{i}", "declarations": []}
+        if target_id is not None:
+            record["target_id"] = target_id
+        (pack_dir / "source_facts" / f"tu{i}.jsonl").write_text(
+            json.dumps(record) + "\n"
+        )
+
+
+def _build_output_dir(
+    tmp_path: Path,
+    *,
+    targets: list[dict],
+    digests: dict[str, str] | None = None,
+) -> Path:
+    root = tmp_path / "abicheck-build"
+    root.mkdir()
+    manifest = {
+        "schema": BUILD_OUTPUT_SCHEMA,
+        "project": "example/project",
+        "targets": targets,
+        "digests": digests or {},
+    }
+    (root / "build-output.json").write_text(json.dumps(manifest))
+    return root
+
+
+def _binary(root: Path, rel: str, content: bytes = b"binary-content") -> str:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return _sha256(path)
+
+
+def _header_root(root: Path, rel: str, *, populated: bool = True) -> None:
+    d = root / rel
+    d.mkdir(parents=True, exist_ok=True)
+    if populated:
+        (d / "header.h").write_text("#pragma once\n")
+
+
+class TestSchemaRoundTrip:
+    def test_full_round_trip(self) -> None:
+        bo = BuildOutput(
+            schema=BUILD_OUTPUT_SCHEMA,
+            project="epics-base/pvxs",
+            head_sha="b7e2c1a",
+            source_tree_digest="sha256:abc",
+            profile=BuildOutputProfile(
+                id="linux-x86_64-gcc13-release",
+                os="linux",
+                arch="x86_64",
+                compiler={"family": "gcc", "version": "13.2.0"},
+                cxx_abi="itanium",
+                stdlib="libstdc++",
+                config="release",
+            ),
+            targets=[
+                BuildOutputTarget(
+                    id="libpvxs",
+                    binary="artifacts/lib/libpvxs.so.1.5",
+                    public_header_roots=["headers/pvxs"],
+                    generated_header_roots=["generated-headers/pvxs"],
+                    compile_context={"include_dirs": ["headers"]},
+                    bundle="pvxs-release",
+                    evidence=BuildOutputEvidence(
+                        kind="source-facts",
+                        path="evidence/abicheck_inputs",
+                        projection="declared",
+                    ),
+                )
+            ],
+            bundles=[BuildOutputBundle(id="pvxs-release", targets=["libpvxs"])],
+            evidence_producer=BuildOutputEvidenceProducer(
+                kind="wrapper", tool="abicheck-cc", version="0.x.y"
+            ),
+            digests={"artifacts/lib/libpvxs.so.1.5": "sha256:deadbeef"},
+        )
+        round_tripped = BuildOutput.from_dict(json.loads(json.dumps(bo.to_dict())))
+        assert round_tripped == bo
+
+    def test_from_dict_is_forward_compatible(self) -> None:
+        # A hand-written/future manifest missing every optional key must not
+        # raise -- matches the buildsource-wide "every field optional" rule.
+        bo = BuildOutput.from_dict({})
+        assert bo.schema == BUILD_OUTPUT_SCHEMA
+        assert bo.targets == []
+        assert bo.profile == BuildOutputProfile()
+
+    def test_from_dict_ignores_malformed_nested_shapes(self) -> None:
+        bo = BuildOutput.from_dict(
+            {
+                "schema": BUILD_OUTPUT_SCHEMA,
+                "targets": "not-a-list",
+                "bundles": [{"id": "x"}, "not-a-dict"],
+                "digests": "not-a-dict",
+                "profile": "not-a-dict",
+            }
+        )
+        assert bo.targets == []
+        assert len(bo.bundles) == 1
+        assert bo.digests == {}
+        assert bo.profile == BuildOutputProfile()
+
+
+class TestIsBuildOutputDir:
+    def test_true_for_real_manifest(self, tmp_path: Path) -> None:
+        root = _build_output_dir(tmp_path, targets=[])
+        assert is_build_output_dir(root) is True
+
+    def test_false_for_plain_dir(self, tmp_path: Path) -> None:
+        d = tmp_path / "plain"
+        d.mkdir()
+        assert is_build_output_dir(d) is False
+
+    def test_false_for_inputs_pack_dir(self, tmp_path: Path) -> None:
+        # A Flow-2 abicheck_inputs/ pack must not be mistaken for a
+        # build-output dir -- different schema discriminator.
+        d = tmp_path / "abicheck_inputs"
+        d.mkdir()
+        (d / "manifest.json").write_text(json.dumps({"kind": "abicheck_inputs"}))
+        # is_build_output_dir looks for build-output.json specifically, so a
+        # differently-named manifest already returns False; this pins that.
+        assert is_build_output_dir(d) is False
+
+
+class TestLoadBuildOutput:
+    def test_missing_manifest_raises_file_not_found(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            load_build_output(tmp_path)
+
+    def test_wrong_schema_raises_value_error(self, tmp_path: Path) -> None:
+        (tmp_path / "build-output.json").write_text(
+            json.dumps({"schema": "something-else/v1"})
+        )
+        with pytest.raises(ValueError, match="schema"):
+            load_build_output(tmp_path)
+
+    def test_non_object_manifest_raises_value_error(self, tmp_path: Path) -> None:
+        (tmp_path / "build-output.json").write_text(json.dumps(["not", "an", "object"]))
+        with pytest.raises(ValueError):
+            load_build_output(tmp_path)
+
+
+class TestValidateBuildOutputHappyPath:
+    def test_single_target_valid(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        _header_root(root, "headers/foo")
+        _write_pack(root, "evidence/abicheck_inputs", library="libfoo")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "public_header_roots": ["headers/foo"],
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/abicheck_inputs",
+                                "projection": "declared",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert report.ok, report.errors
+
+    def test_no_targets_is_a_warning_not_an_error(self, tmp_path: Path) -> None:
+        root = _build_output_dir(tmp_path, targets=[])
+        report = validate_build_output(root)
+        assert report.ok
+        assert report.warnings
+
+    def test_target_with_no_evidence_never_triggers_projection_checks(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [{"id": "libfoo", "binary": "artifacts/lib/libfoo.so"}],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert report.ok, report.errors
+
+
+class TestHeaderRootValidation:
+    def test_missing_public_header_root_fails(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "public_header_roots": ["headers/does-not-exist"],
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("does not exist" in e for e in report.errors)
+
+    def test_empty_public_header_root_fails(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        _header_root(root, "headers/foo", populated=False)
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "public_header_roots": ["headers/foo"],
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("empty" in e for e in report.errors)
+
+    def test_empty_generated_header_root_is_hard_failure_not_warning(
+        self, tmp_path: Path
+    ) -> None:
+        # ADR-047 §2's S10 guard: an empty generated-headers/ root declared
+        # non-empty is an error, never a warning.
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        _header_root(root, "generated-headers/foo", populated=False)
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "generated_header_roots": ["generated-headers/foo"],
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert not report.warnings
+        assert any("generated header" in e for e in report.errors)
+
+    def test_target_with_empty_generated_header_roots_makes_no_claim(
+        self, tmp_path: Path
+    ) -> None:
+        # An empty generated_header_roots: [] list is simply not a claim --
+        # nothing to check, no failure.
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "generated_header_roots": [],
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert report.ok, report.errors
+
+    def test_absolute_header_root_is_rejected(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "public_header_roots": ["/etc"],
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("absolute or escapes" in e for e in report.errors)
+
+    def test_header_root_escaping_directory_is_rejected(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "public_header_roots": ["../escape"],
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("absolute or escapes" in e for e in report.errors)
+
+
+class TestBinaryValidation:
+    def test_missing_binary_fails(self, tmp_path: Path) -> None:
+        root = _build_output_dir(
+            tmp_path,
+            targets=[{"id": "libfoo", "binary": "artifacts/lib/libfoo.so"}],
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("does not exist" in e for e in report.errors)
+
+    def test_digest_mismatch_fails(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        _binary(root, "artifacts/lib/libfoo.so")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [{"id": "libfoo", "binary": "artifacts/lib/libfoo.so"}],
+                    "digests": {"artifacts/lib/libfoo.so": "sha256:0000"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("digest mismatch" in e for e in report.errors)
+
+    def test_missing_digest_entry_fails(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        _binary(root, "artifacts/lib/libfoo.so")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [{"id": "libfoo", "binary": "artifacts/lib/libfoo.so"}],
+                    "digests": {},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("no digests" in e for e in report.errors)
+
+    def test_no_binary_declared_fails(self, tmp_path: Path) -> None:
+        root = _build_output_dir(tmp_path, targets=[{"id": "libfoo"}])
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("no binary declared" in e for e in report.errors)
+
+    def test_target_with_no_id_is_an_error(self, tmp_path: Path) -> None:
+        root = _build_output_dir(
+            tmp_path, targets=[{"binary": "artifacts/lib/libfoo.so"}]
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("no id" in e for e in report.errors)
+
+
+class TestEvidenceProjection:
+    def test_inferred_projection_is_hard_failure(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        _write_pack(root, "evidence/abicheck_inputs", library="libfoo")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/abicheck_inputs",
+                                "projection": "inferred",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("P2" in e for e in report.errors)
+
+    def test_unknown_projection_value_is_hard_failure(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        _write_pack(root, "evidence/abicheck_inputs", library="libfoo")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/abicheck_inputs",
+                                "projection": "typo",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("must be 'declared'" in e for e in report.errors)
+
+
+class TestDeclaredEvidenceSharingScope:
+    """ADR-047 §11.1's corrected scope, mirrored from the plan's required
+    test matrix: (1) two targets sharing one pack must fail regardless of
+    per-TU tags, (2) a manifest/target mismatch must fail, (3) a
+    single-target, matched, untagged-TU pack must still pass (regression
+    guard against over-rejecting the legitimate legacy case)."""
+
+    def _two_target_setup(
+        self,
+        tmp_path: Path,
+        *,
+        shared: bool,
+        tu_target_ids: list[str | None] | None = None,
+    ) -> Path:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest_a = _binary(root, "artifacts/lib/liba.so", b"a")
+        digest_b = _binary(root, "artifacts/lib/libb.so", b"b")
+        _write_pack(
+            root, "evidence/pack_a", library="liba", tu_target_ids=tu_target_ids
+        )
+        pack_b_rel = "evidence/pack_a" if shared else "evidence/pack_b"
+        if not shared:
+            _write_pack(root, "evidence/pack_b", library="libb")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "liba",
+                            "binary": "artifacts/lib/liba.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/pack_a",
+                                "projection": "declared",
+                            },
+                        },
+                        {
+                            "id": "libb",
+                            "binary": "artifacts/lib/libb.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": pack_b_rel,
+                                "projection": "declared",
+                            },
+                        },
+                    ],
+                    "digests": {
+                        "artifacts/lib/liba.so": f"sha256:{digest_a}",
+                        "artifacts/lib/libb.so": f"sha256:{digest_b}",
+                    },
+                }
+            )
+        )
+        return root
+
+    def test_case1_shared_pack_untagged_tus_fails(self, tmp_path: Path) -> None:
+        root = self._two_target_setup(tmp_path, shared=True)
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("referenced by more than one target" in e for e in report.errors)
+
+    def test_case1_shared_pack_tagged_tus_still_fails(self, tmp_path: Path) -> None:
+        # Even if the shared pack's TUs carry target_id tags, sharing itself
+        # is the failure -- tags don't rescue it.
+        root = self._two_target_setup(
+            tmp_path, shared=True, tu_target_ids=["target://liba"]
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("referenced by more than one target" in e for e in report.errors)
+
+    def test_case2_manifest_library_target_mismatch_fails(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/liba.so")
+        # manifest names a DIFFERENT library than the target referencing it.
+        _write_pack(root, "evidence/pack_a", library="some-other-lib")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "liba",
+                            "binary": "artifacts/lib/liba.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/pack_a",
+                                "projection": "declared",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/liba.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("does not match the target" in e for e in report.errors)
+
+    def test_case2_tu_target_id_mismatch_fails(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/liba.so")
+        # No manifest.library set, but a TU tags a DIFFERENT target.
+        _write_pack(
+            root,
+            "evidence/pack_a",
+            tu_target_ids=["target://some-other-lib"],
+        )
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "liba",
+                            "binary": "artifacts/lib/liba.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/pack_a",
+                                "projection": "declared",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/liba.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("different target_id" in e for e in report.errors)
+
+    def test_case3_single_target_untagged_matched_pack_passes(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression guard: must NOT reject the legitimate legacy-producer
+        # case (untagged TUs, manifest.library correctly names the one
+        # target referencing it, and no other target shares the pack).
+        root = self._two_target_setup(
+            tmp_path, shared=False, tu_target_ids=[None, None]
+        )
+        report = validate_build_output(root)
+        assert report.ok, report.errors
+
+    def test_pack_referenced_but_not_a_readable_inputs_pack_fails(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/liba.so")
+        (root / "evidence" / "not_a_pack").mkdir(parents=True)
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "liba",
+                            "binary": "artifacts/lib/liba.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/not_a_pack",
+                                "projection": "declared",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/liba.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("not a readable abicheck_inputs pack" in e for e in report.errors)
+
+
+class TestBuildOutputCLI:
+    """``abicheck build-output validate DIRECTORY`` (G30 P1.1)."""
+
+    def _run(self, args):
+        from abicheck.cli import main
+
+        return CliRunner().invoke(main, ["build-output", "validate", *args])
+
+    def _valid_dir(self, tmp_path: Path) -> Path:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [{"id": "libfoo", "binary": "artifacts/lib/libfoo.so"}],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        return root
+
+    def test_valid_dir_exits_0(self, tmp_path: Path) -> None:
+        root = self._valid_dir(tmp_path)
+        res = self._run([str(root)])
+        assert res.exit_code == 0, res.output
+        assert "OK" in res.output
+
+    def test_invalid_dir_exits_1(self, tmp_path: Path) -> None:
+        root = _build_output_dir(
+            tmp_path, targets=[{"id": "libfoo", "binary": "does-not-exist"}]
+        )
+        res = self._run([str(root)])
+        assert res.exit_code == 1
+        assert "FAILED" in res.output
+
+    def test_json_format(self, tmp_path: Path) -> None:
+        root = self._valid_dir(tmp_path)
+        res = self._run([str(root), "--format", "json"])
+        assert res.exit_code == 0, res.output
+        payload = json.loads(res.output)
+        assert payload["ok"] is True
+        assert payload["errors"] == []
+
+    def test_not_a_build_output_dir_is_usage_error(self, tmp_path: Path) -> None:
+        plain = tmp_path / "plain"
+        plain.mkdir()
+        res = self._run([str(plain)])
+        assert res.exit_code == 64
+
+    def test_nonexistent_dir_is_usage_error(self, tmp_path: Path) -> None:
+        res = self._run([str(tmp_path / "does-not-exist")])
+        assert res.exit_code != 0
+
+    def test_output_flag_writes_file(self, tmp_path: Path) -> None:
+        root = self._valid_dir(tmp_path)
+        out_file = tmp_path / "report.json"
+        res = self._run([str(root), "--format", "json", "-o", str(out_file)])
+        assert res.exit_code == 0, res.output
+        payload = json.loads(out_file.read_text())
+        assert payload["ok"] is True

--- a/tests/test_cli_root_surface.py
+++ b/tests/test_cli_root_surface.py
@@ -16,15 +16,17 @@
 """Root command-surface behavior tests (ADR-043).
 
 The pre-1.0 CLI reset requires the public root surface to show *exactly*
-``dump``, ``compare``, ``scan``, ``deps``, ``compat`` — plus ``aggregate``, the
-multi-target CI fan-in gate added afterward — with no hidden aliases, and no
-deprecated shims for the deleted commands (``appcompat``, ``plugin-check``,
-``baseline``, ``collect``, ``merge``, ``recommend-collect-mode``,
-``debian-symbols``, ``doctor``, ``config``, ``init``, ``surface-report``,
-``pr-comment``, ``suggest-suppressions``, ``probe``). This module pins that
-contract as an executable behavior test, distinct from
-``test_cli_surface_diff.py`` (which exercises the CLI-surface-dump scripts
-used by the CI gate) and ``test_cli_contract.py`` (the Tier-2 chokepoint gate).
+``dump``, ``compare``, ``scan``, ``deps``, ``compat`` — plus ``aggregate``
+(the multi-target CI fan-in gate) and ``build-output`` (the G30 P1.1
+``build-output.json`` validator group), both added afterward — with no
+hidden aliases, and no deprecated shims for the deleted commands
+(``appcompat``, ``plugin-check``, ``baseline``, ``collect``, ``merge``,
+``recommend-collect-mode``, ``debian-symbols``, ``doctor``, ``config``,
+``init``, ``surface-report``, ``pr-comment``, ``suggest-suppressions``,
+``probe``). This module pins that contract as an executable behavior test,
+distinct from ``test_cli_surface_diff.py`` (which exercises the
+CLI-surface-dump scripts used by the CI gate) and ``test_cli_contract.py``
+(the Tier-2 chokepoint gate).
 """
 
 from __future__ import annotations
@@ -37,7 +39,9 @@ from click.testing import CliRunner
 
 from abicheck.cli import main
 
-_PUBLIC_COMMANDS = frozenset({"dump", "compare", "scan", "deps", "compat", "aggregate"})
+_PUBLIC_COMMANDS = frozenset(
+    {"dump", "compare", "scan", "deps", "compat", "aggregate", "build-output"}
+)
 
 _REMOVED_COMMANDS = (
     "appcompat",

--- a/tests/test_cli_surface_diff.py
+++ b/tests/test_cli_surface_diff.py
@@ -50,7 +50,9 @@ def diff_mod():  # type: ignore[no-untyped-def]
 
 def test_dump_surface_covers_root_commands(dump_mod) -> None:  # type: ignore[no-untyped-def]
     """The dumped surface exposes exactly the public root commands (ADR-043,
-    plus ``aggregate`` — the multi-target CI fan-in gate added afterward).
+    plus ``aggregate`` — the multi-target CI fan-in gate — and
+    ``build-output`` — the G30 P1.1 ``build-output.json`` validator group —
+    both added afterward).
 
     `pr-comment` is deliberately NOT here: it is Action/library-only tooling
     (`python -m abicheck.cli_pr_comment`), never a public `abicheck` subcommand.
@@ -58,6 +60,7 @@ def test_dump_surface_covers_root_commands(dump_mod) -> None:  # type: ignore[no
     surface = dump_mod.dump_surface()
     assert set(surface) == {
         "aggregate",
+        "build-output",
         "compare",
         "compat",
         "deps",
@@ -86,11 +89,21 @@ def test_diff_identical_surface_is_empty(dump_mod, diff_mod) -> None:  # type: i
 def test_diff_detects_removed_and_added_command(diff_mod) -> None:  # type: ignore[no-untyped-def]
     base = {
         "dump": {"path": "dump", "kind": "command", "hidden": False, "params": []},
-        "old-cmd": {"path": "old-cmd", "kind": "command", "hidden": False, "params": []},
+        "old-cmd": {
+            "path": "old-cmd",
+            "kind": "command",
+            "hidden": False,
+            "params": [],
+        },
     }
     head = {
         "dump": {"path": "dump", "kind": "command", "hidden": False, "params": []},
-        "new-cmd": {"path": "new-cmd", "kind": "command", "hidden": False, "params": []},
+        "new-cmd": {
+            "path": "new-cmd",
+            "kind": "command",
+            "hidden": False,
+            "params": [],
+        },
     }
     lines = diff_mod.diff_surfaces(base, head)
     assert any("removed command `old-cmd`" in ln for ln in lines)
@@ -104,9 +117,27 @@ def test_diff_detects_option_added_removed_and_changed(diff_mod) -> None:  # typ
             "kind": "command",
             "hidden": False,
             "params": [
-                {"name": "output", "kind": "option", "opts": ["-o", "--output"], "required": False, "default": None},
-                {"name": "gone", "kind": "option", "opts": ["--gone"], "required": False, "default": None},
-                {"name": "depth", "kind": "option", "opts": ["--depth"], "required": False, "default": "auto"},
+                {
+                    "name": "output",
+                    "kind": "option",
+                    "opts": ["-o", "--output"],
+                    "required": False,
+                    "default": None,
+                },
+                {
+                    "name": "gone",
+                    "kind": "option",
+                    "opts": ["--gone"],
+                    "required": False,
+                    "default": None,
+                },
+                {
+                    "name": "depth",
+                    "kind": "option",
+                    "opts": ["--depth"],
+                    "required": False,
+                    "default": "auto",
+                },
             ],
         },
     }
@@ -116,9 +147,27 @@ def test_diff_detects_option_added_removed_and_changed(diff_mod) -> None:  # typ
             "kind": "command",
             "hidden": False,
             "params": [
-                {"name": "output", "kind": "option", "opts": ["-o", "--output"], "required": False, "default": None},
-                {"name": "new", "kind": "option", "opts": ["--new"], "required": False, "default": None},
-                {"name": "depth", "kind": "option", "opts": ["--depth"], "required": False, "default": "binary"},
+                {
+                    "name": "output",
+                    "kind": "option",
+                    "opts": ["-o", "--output"],
+                    "required": False,
+                    "default": None,
+                },
+                {
+                    "name": "new",
+                    "kind": "option",
+                    "opts": ["--new"],
+                    "required": False,
+                    "default": None,
+                },
+                {
+                    "name": "depth",
+                    "kind": "option",
+                    "opts": ["--depth"],
+                    "required": False,
+                    "default": "binary",
+                },
             ],
         },
     }
@@ -143,4 +192,7 @@ def test_render_report_markdown_header(diff_mod) -> None:  # type: ignore[no-unt
     text = diff_mod.render_report(lines, markdown=True)
     assert "## CLI interface change detected" in text
     assert "- removed command `foo`" in text
-    assert diff_mod.render_report([], markdown=True) == "No user-facing CLI surface changes detected."
+    assert (
+        diff_mod.render_report([], markdown=True)
+        == "No user-facing CLI surface changes detected."
+    )

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -125,6 +125,22 @@ class TestSchemaFile:
         schema = load_compare_report_schema()
         assert "report_schema_version" in schema["required"]
 
+    def test_docs_mirror_matches_packaged_schema(self):
+        # Regression guard (code review, PR #611): the docs/schemas/v1 copy
+        # previously drifted from the packaged schema (PR #595) without any
+        # test catching it, since jsonschema.validate's additionalProperties
+        # tolerance doesn't flag a stale docs copy. scripts/publish_schemas.py
+        # keeps the two byte-identical; assert that invariant directly.
+        docs_copy = (
+            COMPARE_REPORT_SCHEMA_PATH.parent.parent.parent
+            / "docs"
+            / "schemas"
+            / "v1"
+            / "compare_report.schema.json"
+        )
+        assert docs_copy.is_file()
+        assert docs_copy.read_text() == COMPARE_REPORT_SCHEMA_PATH.read_text()
+
 
 @_requires_jsonschema
 class TestReportValidatesAgainstSchema:
@@ -266,13 +282,16 @@ class TestReportIdentityEnvelope:
         # ("target@profile#baseline_channel@requested_depth") is only
         # unambiguous if each component avoids '@'/'#' itself -- a value
         # missing the depth suffix, or with the wrong delimiter order,
-        # must fail the schema's pattern.
+        # must fail the schema's pattern. Code review on PR #611 also added
+        # eager validation at the point check_id is set (matching
+        # requested_depth/effective_depth's validate_evidence_depth), so
+        # to_json now raises ValueError immediately rather than only
+        # failing the opt-in JSON Schema check.
         old, new = _breaking_pair()
         result = compare(old, new)
         result.check_id = "libfoo-missing-the-rest-of-the-shape"
-        payload = json.loads(reporter.to_json(result))
-        with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(instance=payload, schema=load_compare_report_schema())
+        with pytest.raises(ValueError, match="check_id"):
+            reporter.to_json(result)
 
     def test_stat_mode_carries_identity_fields_too(self):
         old, new = _breaking_pair()

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -188,6 +188,42 @@ class TestReportValidatesAgainstSchema:
             assert c["reviewer_action"] in declared_enum
 
 
+class TestEvidenceDepthValidator:
+    """Direct unit coverage for checker_types.validate_evidence_depth/
+    EVIDENCE_DEPTH_VALUES -- the shared depth-spelling guard both
+    reporter._add_check_identity (compare) and ScanOutcome.to_dict (scan)
+    delegate to."""
+
+    def test_accepts_every_public_depth(self):
+        from abicheck.checker_types import (
+            EVIDENCE_DEPTH_VALUES,
+            validate_evidence_depth,
+        )
+
+        for depth in EVIDENCE_DEPTH_VALUES:
+            validate_evidence_depth("requested_depth", depth)  # must not raise
+
+    def test_rejects_unknown_depth_with_field_name_in_message(self):
+        from abicheck.checker_types import validate_evidence_depth
+
+        with pytest.raises(ValueError, match="effective_depth"):
+            validate_evidence_depth("effective_depth", "bogus")
+
+    def test_public_depth_set_matches_mcp_server(self):
+        # Deliberately kept as a separate copy (mcp_server sits above
+        # checker_types in the dependency graph) -- this pins both stay in
+        # sync rather than silently drifting. mcp_server.py raises
+        # ImportError at import time without the optional `mcp` package
+        # (abicheck[mcp]) installed -- skip cleanly rather than failing when
+        # that extra isn't present, matching how the rest of the suite
+        # treats this same optional dependency.
+        pytest.importorskip("mcp")
+        from abicheck.checker_types import EVIDENCE_DEPTH_VALUES
+        from abicheck.mcp_server import _PUBLIC_DEPTHS
+
+        assert EVIDENCE_DEPTH_VALUES == _PUBLIC_DEPTHS
+
+
 @_requires_jsonschema
 class TestReportIdentityEnvelope:
     """ADR-047 §7 report-identity envelope subset (G30 P0.3): check_id,
@@ -225,6 +261,19 @@ class TestReportIdentityEnvelope:
         assert payload["effective_depth"] == "headers"
         assert payload["baseline_channel"] == "accepted-main"
 
+    def test_malformed_check_id_fails_schema_validation(self):
+        # ADR-047 §7's delimiter-joined check_id form
+        # ("target@profile#baseline_channel@requested_depth") is only
+        # unambiguous if each component avoids '@'/'#' itself -- a value
+        # missing the depth suffix, or with the wrong delimiter order,
+        # must fail the schema's pattern.
+        old, new = _breaking_pair()
+        result = compare(old, new)
+        result.check_id = "libfoo-missing-the-rest-of-the-shape"
+        payload = json.loads(reporter.to_json(result))
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=payload, schema=load_compare_report_schema())
+
     def test_stat_mode_carries_identity_fields_too(self):
         old, new = _breaking_pair()
         result = compare(old, new)
@@ -232,13 +281,58 @@ class TestReportIdentityEnvelope:
         payload = json.loads(reporter.to_json(result, stat=True))
         assert payload["check_id"] == "libfoo@profile#channel@binary"
 
-    def test_invalid_depth_enum_fails_schema_validation(self):
+    def test_leaf_mode_carries_identity_fields_too(self):
+        # Regression guard: --report-mode leaf builds its own top-level dict
+        # independently of _build_json_base/to_stat_json (a separate code
+        # path, _to_json_leaf), so it needs its own _add_check_identity call
+        # -- code review on PR #611 caught this gap between the PR's own
+        # description ("full/--stat/leaf JSON via a shared helper") and what
+        # _to_json_leaf actually did (nothing, until this fix).
+        old, new = _breaking_pair()
+        result = compare(old, new)
+        result.check_id = "libfoo@profile#channel@source"
+        result.profile_id = "linux-x86_64-gcc13"
+        result.requested_depth = "source"
+        result.effective_depth = "build"
+        result.baseline_channel = "accepted-main"
+        payload = json.loads(reporter.to_json(result, report_mode="leaf"))
+        assert payload["check_id"] == "libfoo@profile#channel@source"
+        assert payload["profile_id"] == "linux-x86_64-gcc13"
+        assert payload["requested_depth"] == "source"
+        assert payload["effective_depth"] == "build"
+        assert payload["baseline_channel"] == "accepted-main"
+
+    def test_leaf_mode_unset_by_default(self):
+        old, new = _breaking_pair()
+        payload = json.loads(reporter.to_json(compare(old, new), report_mode="leaf"))
+        for key in (
+            "check_id",
+            "profile_id",
+            "requested_depth",
+            "effective_depth",
+            "baseline_channel",
+        ):
+            assert key not in payload
+
+    def test_invalid_requested_depth_rejected_before_json_is_built(self):
+        # reporter.to_json validates requested_depth/effective_depth itself
+        # (matching mcp_server._validate_public_depth's same check) rather
+        # than relying solely on JSON Schema validation, which production
+        # code never runs -- only opt-in tests do. Catches a bad value at
+        # the point it's set, not only when a test happens to schema-check
+        # the output.
         old, new = _breaking_pair()
         result = compare(old, new)
         result.requested_depth = "not-a-real-depth"
-        payload = json.loads(reporter.to_json(result))
-        with pytest.raises(jsonschema.ValidationError):
-            jsonschema.validate(instance=payload, schema=load_compare_report_schema())
+        with pytest.raises(ValueError, match="requested_depth"):
+            reporter.to_json(result)
+
+    def test_invalid_effective_depth_rejected_before_json_is_built(self):
+        old, new = _breaking_pair()
+        result = compare(old, new)
+        result.effective_depth = "not-a-real-depth"
+        with pytest.raises(ValueError, match="effective_depth"):
+            reporter.to_json(result)
 
 
 class TestScanReportIdentityEnvelope:
@@ -293,6 +387,14 @@ class TestScanReportIdentityEnvelope:
         payload = self._outcome().to_dict()
         assert payload["scan_schema_version"] == SCAN_SCHEMA_VERSION
         assert SCAN_SCHEMA_VERSION != "1.0"
+
+    def test_invalid_requested_depth_rejected_before_dict_is_built(self):
+        with pytest.raises(ValueError, match="requested_depth"):
+            self._outcome(requested_depth="not-a-real-depth").to_dict()
+
+    def test_invalid_effective_depth_rejected_before_dict_is_built(self):
+        with pytest.raises(ValueError, match="effective_depth"):
+            self._outcome(effective_depth="not-a-real-depth").to_dict()
 
 
 class TestSchemaVersion:

--- a/tests/test_report_schema.py
+++ b/tests/test_report_schema.py
@@ -62,7 +62,9 @@ _requires_jsonschema = pytest.mark.skipif(
 
 
 def _fn(name: str, mangled: str, ret: str = "int") -> Function:
-    return Function(name=name, mangled=mangled, return_type=ret, visibility=Visibility.PUBLIC)
+    return Function(
+        name=name, mangled=mangled, return_type=ret, visibility=Visibility.PUBLIC
+    )
 
 
 def _breaking_pair() -> tuple[AbiSnapshot, AbiSnapshot]:
@@ -73,7 +75,9 @@ def _breaking_pair() -> tuple[AbiSnapshot, AbiSnapshot]:
         functions=[_fn("api_a", "_Z5api_av"), _fn("api_b", "_Z5api_bv")],
         types=[
             RecordType(
-                name="Cfg", kind="struct", size_bits=32,
+                name="Cfg",
+                kind="struct",
+                size_bits=32,
                 fields=[TypeField(name="x", type="int", offset_bits=0)],
             )
         ],
@@ -85,7 +89,9 @@ def _breaking_pair() -> tuple[AbiSnapshot, AbiSnapshot]:
         functions=[_fn("api_a", "_Z5api_av"), _fn("api_c", "_Z5api_cv")],
         types=[
             RecordType(
-                name="Cfg", kind="struct", size_bits=64,
+                name="Cfg",
+                kind="struct",
+                size_bits=64,
                 fields=[
                     TypeField(name="x", type="int", offset_bits=0),
                     TypeField(name="y", type="int", offset_bits=32),
@@ -95,7 +101,10 @@ def _breaking_pair() -> tuple[AbiSnapshot, AbiSnapshot]:
         enums=[
             EnumType(
                 name="Color",
-                members=[EnumMember(name="RED", value=0), EnumMember(name="BLUE", value=1)],
+                members=[
+                    EnumMember(name="RED", value=0),
+                    EnumMember(name="BLUE", value=1),
+                ],
             )
         ],
     )
@@ -134,7 +143,11 @@ class TestReportValidatesAgainstSchema:
         payload = json.loads(reporter.to_json(compare(old, new)))
         self._validate(payload)
         assert payload["verdict"] in {
-            "NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING",
+            "NO_CHANGE",
+            "COMPATIBLE",
+            "COMPATIBLE_WITH_RISK",
+            "API_BREAK",
+            "BREAKING",
         }
 
     def test_show_only_report_validates(self):
@@ -162,13 +175,124 @@ class TestReportValidatesAgainstSchema:
         payload = json.loads(reporter.to_json(compare(old, new)))
         self._validate(payload)
         additions = [
-            c for c in payload["changes"] if c.get("recommended_action") == "no_action_required"
+            c
+            for c in payload["changes"]
+            if c.get("recommended_action") == "no_action_required"
         ]
         assert additions, "fixture must produce at least one addition finding"
         schema = load_compare_report_schema()
-        declared_enum = schema["$defs"]["change"]["properties"]["reviewer_action"]["enum"]
+        declared_enum = schema["$defs"]["change"]["properties"]["reviewer_action"][
+            "enum"
+        ]
         for c in additions:
             assert c["reviewer_action"] in declared_enum
+
+
+@_requires_jsonschema
+class TestReportIdentityEnvelope:
+    """ADR-047 §7 report-identity envelope subset (G30 P0.3): check_id,
+    profile_id, requested_depth, effective_depth, baseline_channel are
+    additive, optional fields nothing populates yet -- this only pins the
+    schema/round-trip contract so G30 P1's primitives have somewhere to
+    write."""
+
+    def test_unset_by_default(self):
+        f = _fn("api", "_Z3apiv")
+        snap = AbiSnapshot(library="libfoo.so.1", version="1.0", functions=[f])
+        payload = json.loads(reporter.to_json(compare(snap, snap)))
+        for key in (
+            "check_id",
+            "profile_id",
+            "requested_depth",
+            "effective_depth",
+            "baseline_channel",
+        ):
+            assert key not in payload
+
+    def test_set_fields_round_trip_and_validate(self):
+        old, new = _breaking_pair()
+        result = compare(old, new)
+        result.check_id = "libfoo@linux-x86_64-gcc13#accepted-main@source"
+        result.profile_id = "linux-x86_64-gcc13"
+        result.requested_depth = "source"
+        result.effective_depth = "headers"
+        result.baseline_channel = "accepted-main"
+        payload = json.loads(reporter.to_json(result))
+        jsonschema.validate(instance=payload, schema=load_compare_report_schema())
+        assert payload["check_id"] == "libfoo@linux-x86_64-gcc13#accepted-main@source"
+        assert payload["profile_id"] == "linux-x86_64-gcc13"
+        assert payload["requested_depth"] == "source"
+        assert payload["effective_depth"] == "headers"
+        assert payload["baseline_channel"] == "accepted-main"
+
+    def test_stat_mode_carries_identity_fields_too(self):
+        old, new = _breaking_pair()
+        result = compare(old, new)
+        result.check_id = "libfoo@profile#channel@binary"
+        payload = json.loads(reporter.to_json(result, stat=True))
+        assert payload["check_id"] == "libfoo@profile#channel@binary"
+
+    def test_invalid_depth_enum_fails_schema_validation(self):
+        old, new = _breaking_pair()
+        result = compare(old, new)
+        result.requested_depth = "not-a-real-depth"
+        payload = json.loads(reporter.to_json(result))
+        with pytest.raises(jsonschema.ValidationError):
+            jsonschema.validate(instance=payload, schema=load_compare_report_schema())
+
+
+class TestScanReportIdentityEnvelope:
+    """Same ADR-047 §7 fields (G30 P0.3), mirrored on the scan side --
+    ScanOutcome.to_dict() rather than a compare_report.schema.json (scan's
+    JSON output has no packaged JSON Schema to validate against)."""
+
+    def _outcome(self, **identity: str) -> object:
+        from abicheck.buildsource.risk import RiskScore
+        from abicheck.scan_engine import ScanOutcome
+
+        return ScanOutcome(
+            mode="scan",
+            resolved_method="auto",
+            depth="headers",
+            collect_mode="off",
+            risk=RiskScore(total=0),
+            auto=True,
+            changed_path_count=0,
+            changed_path_source="none",
+            **identity,
+        )
+
+    def test_unset_by_default(self):
+        payload = self._outcome().to_dict()
+        for key in (
+            "check_id",
+            "profile_id",
+            "requested_depth",
+            "effective_depth",
+            "baseline_channel",
+        ):
+            assert key not in payload
+
+    def test_set_fields_round_trip(self):
+        payload = self._outcome(
+            check_id="libfoo@profile#channel@source",
+            profile_id="linux-x86_64-gcc13",
+            requested_depth="source",
+            effective_depth="build",
+            baseline_channel="accepted-main",
+        ).to_dict()
+        assert payload["check_id"] == "libfoo@profile#channel@source"
+        assert payload["profile_id"] == "linux-x86_64-gcc13"
+        assert payload["requested_depth"] == "source"
+        assert payload["effective_depth"] == "build"
+        assert payload["baseline_channel"] == "accepted-main"
+
+    def test_scan_schema_version_bumped_for_the_new_fields(self):
+        from abicheck.schemas import SCAN_SCHEMA_VERSION
+
+        payload = self._outcome().to_dict()
+        assert payload["scan_schema_version"] == SCAN_SCHEMA_VERSION
+        assert SCAN_SCHEMA_VERSION != "1.0"
 
 
 class TestSchemaVersion:


### PR DESCRIPTION
## Summary

Implements the full G30/ADR-047 **P0** backlog, addresses code-review feedback on the P0.3 report-identity envelope, and implements **P1.1** (`build-output.json` schema + validator):

- **P0.1** — `action/validate-inputs.sh` warns (job annotation, not a hard failure) when a mode-scoped Action input is set on an incompatible `mode`.
- **P0.2** — `collect-facts`'s `phase: auto` now reports a machine-readable `auto-completed` output (+ upgraded `::warning::`) when it silently only ran `prepare` for `producer: wrapper`/`clang-plugin`.
- **P0.3** — `compare`/`scan` JSON reports gain five additive, optional report-identity fields (`check_id`, `profile_id`, `requested_depth`, `effective_depth`, `baseline_channel`) — schema/model only, nothing populates them yet (that's P1.3).
- **P0.4** — `github-action-source-scans.md`'s multi-library shared-facts-pack recipe is now explicitly marked canonical, with the required scope caveat about per-target source-depth coverage.
- **Review fixes (P0.3)** — `--report-mode leaf` now carries the identity fields too (a gap the code review caught: it's a separate code path from `_build_json_base`/`to_stat_json`); `requested_depth`/`effective_depth` are now validated at the point they're set (`checker_types.validate_evidence_depth`), not only by the opt-in/test-only JSON Schema; `check_id`'s documented `target@profile#baseline_channel@requested_depth` shape is now enforced by a schema `pattern`.
- **P1.1** — `abicheck/buildsource/build_output.py` (schema) + `abicheck build-output validate DIRECTORY` (new CLI command group) implement ADR-047 §2/§11.1: a standardized, producer-agnostic `abicheck-build/` artifact directory a project's existing build can publish once, with a fail-loud validator (empty declared header roots incl. the S10 `generated_header_roots` case, binary digest mismatches, `evidence.projection` must be `"declared"`, and the corrected shared-pack-across-targets / manifest-identity-mismatch scope). See `docs/reference/build-output-schema.md`. No producer/consumer tooling yet — that's P1.2/P1.3.

## Details

### P0.1 — mode-scoped input warnings

`debug-info1`/`debug-info2`, `devel-pkg1`/`devel-pkg2`, `dso-only`, `include-private-dso`, `keep-extracted`, `fail-on-removed-library`, `jobs`, `abi-baseline`, `estimate`, and `audit` are each only forwarded/consumed in a subset of `mode`s, but setting one on an incompatible mode silently did nothing. `action/validate-inputs.sh` now warns via `::warning::` (exit 0); `action.yml` forwards the needed inputs to the validation step.

### P0.2 — collect-facts auto-completed output

`phase: auto` structurally cannot run the caller's build, so for `producer: wrapper`/`clang-plugin` it only ever completes `prepare` — previously a print-only `::notice::`. Now `actions/collect-facts/run.sh` sets a new `auto-completed` output (`'true'`/`'false'`) a caller can branch on, upgraded to a `::warning::` annotation.

### P0.3 — report identity envelope (subset of ADR-047 §7) + review fixes

`DiffResult`/`ScanOutcome` each gain five `None`-by-default optional fields, omitted from JSON entirely when unset. `compare_report.schema.json` declares the new properties (`report_schema_version` 2.10 → 2.11 → **2.12** — 2.11 was independently claimed by #612/ADR-048 while this branch was in flight, so this work's own bump moved to 2.12 on rebase); `SCAN_SCHEMA_VERSION` bumps 1.0 → 1.1. A follow-up commit addresses code-review feedback: leaf-mode JSON now carries the fields too, `requested_depth`/`effective_depth` are validated eagerly (`ValueError` on a bad spelling, matching `mcp_server._validate_public_depth`), and `check_id`'s shape is schema-enforced.

### P0.4 — canonical multi-DSO recipe

`github-action.md`/`github-action-recipes.md` already linked to the multi-library recipe rather than restating it. This PR marks it canonical explicitly and adds the required scope caveat.

### P1.1 — build-output.json schema + validator

New `abicheck/buildsource/build_output.py` (`BuildOutput`/`BuildOutputTarget`/`BuildOutputEvidence`/etc., all optional/defaulted) + `validate_build_output()` implementing every ADR-047 §11.1 rule. New `abicheck build-output validate DIRECTORY` command (`--format text|json`, exit `0`/`1`/`64`) — a new top-level command group, which required updating the ADR-043 pinned public-command-surface contract tests (`test_cli_root_surface.py`, `test_cli_surface_diff.py`) and the root-help command-group panels (`cli_help.py`) accordingly.

## Checklist

- [x] Tests added / updated for new behaviour (`tests/test_action_validate_inputs.py`, `tests/test_action_collect_facts.py`, `tests/test_report_schema.py`, `tests/test_build_output.py`)
- [x] Changelog fragments added (`scriv create`) — one per item
- [x] Docs updated (`docs/development/plans/g30-github-actions-integration-model.md` marks P0.1–P0.4 and P1.1 done; `producing-source-facts.md`, `github-action-source-scans.md`, `docs/reference/build-output-schema.md` new)
- [x] `mypy abicheck/` — no new errors on touched files (pre-existing yaml-stub warnings only, unrelated)
- [x] `ruff check`/`ruff format --check` pass
- [x] `mkdocs build --strict` passes
- [x] `python scripts/check_ai_readiness.py` — 0 errors, same warning count as before
- [x] Full unit suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`) — 17622 passed, 0 failed
- [x] Rebased onto latest `main` (picked up #612's independent 2.10→2.11 bump; this branch's bump renumbered to 2.12)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added `build-output validate` to verify build manifests, binaries, headers, digests, and evidence consistency.
  - Added an `auto-completed` output to the fact-collection action, indicating whether additional workflow steps are required.
  - Added optional identity and evidence-depth fields to scan and comparison JSON reports.

- **Bug Fixes**
  - Mode-incompatible inputs now generate non-failing warnings instead of being silently ignored.
  - Improved policy handling in leaf report output.

- **Documentation**
  - Added build-output reference documentation and clarified multi-library workflow behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->