### PR TITLE
ci: pin CastXML Superbuild toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Install system deps (Linux)
@@ -208,7 +208,10 @@ jobs:
           # tolerate `update` errors — the `install` below still fails loudly if any
           # of the packages it needs are genuinely unavailable.
           sudo apt-get update -qq || sudo apt-get update -qq || true
-          sudo apt-get install -y castxml gcc g++ cmake clang
+          sudo apt-get install -y gcc g++ cmake clang curl ca-certificates
+      - name: Set up pinned CastXML (Linux)
+        if: runner.os == 'Linux'
+        run: bash action/install-castxml.sh
       - name: Install system deps (macOS)
         if: runner.os == 'macOS'
         run: brew install castxml cmake
@@ -256,7 +259,7 @@ jobs:
         run: |
           pytest tests/ -v -m integration --tb=short -n auto --dist worksteal --ignore=tests/test_abi_examples.py
       - name: Upload integration coverage to Codecov
-        if: always() && matrix.os == 'ubuntu-latest'
+        if: always() && matrix.os == 'ubuntu-24.04'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
         with:
           use_oidc: true
@@ -265,14 +268,16 @@ jobs:
           fail_ci_if_error: false
 
   e2e:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y castxml zlib1g-dev
+          sudo apt-get install -y zlib1g-dev curl ca-certificates
+      - name: Set up pinned CastXML
+        run: bash action/install-castxml.sh
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.14'
@@ -381,15 +386,17 @@ jobs:
   libabigail-parity:
     needs: [heavy-parity-gate]
     if: needs.heavy-parity-gate.outputs.run-heavy == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y gcc g++ castxml
+          sudo apt-get install -y gcc g++ curl ca-certificates
           sudo apt-get install -y abigail-tools || sudo apt-get install -y libabigail-tools
+      - name: Set up pinned CastXML
+        run: bash action/install-castxml.sh
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.14'
@@ -410,14 +417,16 @@ jobs:
   abicc-parity:
     needs: [heavy-parity-gate]
     if: needs.heavy-parity-gate.outputs.run-heavy == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y gcc g++ castxml abi-compliance-checker
+          sudo apt-get install -y gcc g++ abi-compliance-checker curl ca-certificates
+      - name: Set up pinned CastXML
+        run: bash action/install-castxml.sh
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
         with:
           python-version: '3.14'

--- a/.github/workflows/examples-validation-nightly.yml
+++ b/.github/workflows/examples-validation-nightly.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y castxml gcc g++ clang cmake binutils
+          sudo apt-get install -y gcc g++ clang cmake binutils curl ca-certificates
+      - name: Set up pinned CastXML
+        run: bash action/install-castxml.sh
       - uses: actions/setup-python@v6
         with:
           python-version: "3.14"

--- a/.github/workflows/examples-validation.yml
+++ b/.github/workflows/examples-validation.yml
@@ -32,7 +32,7 @@ jobs:
   # cannot emit DW_AT_calling_convention for) are gated, not just benchmarked.
   validate-examples:
     name: Validate examples (${{ matrix.toolchain }}, debug-headers)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -54,7 +54,10 @@ jobs:
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y castxml gcc g++ clang cmake
+          sudo apt-get install -y gcc g++ clang cmake curl ca-certificates
+
+      - name: Set up pinned CastXML
+        run: bash action/install-castxml.sh
 
       - uses: ./.github/actions/cache-ast-dumps
         with:
@@ -127,7 +130,7 @@ jobs:
 
   clang-header-fallback:
     name: Clang header fallback regressions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v6
@@ -141,7 +144,10 @@ jobs:
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y castxml gcc g++ clang cmake
+          sudo apt-get install -y gcc g++ clang cmake curl ca-certificates
+
+      - name: Set up pinned CastXML
+        run: bash action/install-castxml.sh
 
       - uses: ./.github/actions/cache-ast-dumps
         with:
@@ -191,7 +197,7 @@ jobs:
   # debug ground truth calls COMPATIBLE/NO_CHANGE must never become BREAKING.
   artifact-modes:
     name: Artifact modes (release / stripped full-catalog / build-source)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v6
@@ -205,7 +211,10 @@ jobs:
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y castxml gcc g++ clang cmake binutils
+          sudo apt-get install -y gcc g++ clang cmake binutils curl ca-certificates
+
+      - name: Set up pinned CastXML
+        run: bash action/install-castxml.sh
 
       - uses: ./.github/actions/cache-ast-dumps
         with:
@@ -284,7 +293,7 @@ jobs:
 
   full-example-matrix:
     name: Full example matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [validate-examples, artifact-modes, clang-header-fallback]
     if: always()
 
@@ -306,7 +315,10 @@ jobs:
       - name: Install system deps
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y castxml gcc g++ clang cmake binutils
+          sudo apt-get install -y gcc g++ clang cmake binutils curl ca-certificates
+
+      - name: Set up pinned CastXML
+        run: bash action/install-castxml.sh
 
       # The owner-proofs/bundle/special-cli validators below also dump
       # bundle/G20/special-shape example headers through the same castxml/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,7 +58,7 @@ jobs:
     # (versions, git commit, ground-truth digest, per-tool accuracy) as a
     # read-only artifact so the README accuracy numbers are auditable evidence.
     if: github.event_name == 'release'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
@@ -69,9 +69,12 @@ jobs:
       - name: Install system deps (oracles + toolchain)
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y gcc g++ castxml cmake
+          sudo apt-get install -y gcc g++ cmake curl ca-certificates
           sudo apt-get install -y abigail-tools || sudo apt-get install -y libabigail-tools
           sudo apt-get install -y abi-compliance-checker || true
+
+      - name: Set up pinned CastXML
+        run: bash action/install-castxml.sh
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6

--- a/.github/workflows/realworld-validation.yml
+++ b/.github/workflows/realworld-validation.yml
@@ -40,7 +40,10 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y castxml gcc g++ binutils zstd abigail-tools zlib1g-dev
+          sudo apt-get install -y gcc g++ binutils zstd abigail-tools zlib1g-dev curl ca-certificates
+
+      - name: Set up pinned CastXML
+        run: bash action/install-castxml.sh
 
       - name: Install abicheck
         run: |

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1066,9 +1066,11 @@ def _castxml_dump(
 
     # Use the host C driver for CastXML's ``gnu-c`` emulation.  Passing g++
     # makes its compiler probe advertise C++-only _Float* approximations even
-    # though the final frontend arguments contain ``-x c``.
+    # though the final frontend arguments contain ``-x c``.  Preserve an
+    # explicit path/prefix selection: callers choosing a C++ cross-driver rely
+    # on ``--gcc-prefix`` resolving to ``<prefix>g++`` even for a C header.
     resolved_compiler = compiler
-    if not force_cpp and not gcc_path:
+    if not force_cpp and not gcc_path and not gcc_prefix:
         resolved_compiler = {
             "c++": "cc",
             "g++": "gcc",

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -831,8 +831,13 @@ def _build_castxml_command(
     force_cpp20: bool = False,
 ) -> list[str]:
     """Build the castxml command line."""
+    # CastXML needs its language-specific compiler-emulation id in C mode.
+    # Using ``gnu`` together with ``-x c`` makes modern CastXML inject C++
+    # approximations for GCC's _Float* builtins (including ``operator``), then
+    # asks Clang to parse them as C.  ``gnu-c`` supplies the C approximations.
+    castxml_cc_id = "gnu-c" if not force_cpp and cc_id == "gnu" else cc_id
     cmd = ["castxml", "--castxml-output=1",
-           f"--castxml-cc-{cc_id}", cc_bin]
+           f"--castxml-cc-{castxml_cc_id}", cc_bin]
     for inc in extra_includes:
         cmd += ["-I", str(inc)]
 
@@ -1049,8 +1054,6 @@ def _castxml_dump(
             deadline.check()
             return cast(Element, _cached_root)
 
-    cc_bin, cc_id = _resolve_compiler_binary(compiler, gcc_path, gcc_prefix)
-
     with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as tmp:
         out_xml = Path(tmp.name)
 
@@ -1060,6 +1063,20 @@ def _castxml_dump(
         force_cpp = _detect_cpp_headers(headers) or has_explicit_cpp_std(
             gcc_options, gcc_option_tokens
         )
+
+    # Use the host C driver for CastXML's ``gnu-c`` emulation.  Passing g++
+    # makes its compiler probe advertise C++-only _Float* approximations even
+    # though the final frontend arguments contain ``-x c``.
+    resolved_compiler = compiler
+    if not force_cpp and not gcc_path:
+        resolved_compiler = {
+            "c++": "cc",
+            "g++": "gcc",
+            "clang++": "clang",
+        }.get(compiler, compiler)
+    cc_bin, cc_id = _resolve_compiler_binary(
+        resolved_compiler, gcc_path, gcc_prefix
+    )
 
     try:
         try:

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -835,9 +835,12 @@ def _build_castxml_command(
     # Using ``gnu`` together with ``-x c`` makes modern CastXML inject C++
     # approximations for GCC's _Float* builtins (including ``operator``), then
     # asks Clang to parse them as C.  ``gnu-c`` supplies the C approximations.
+    # Parentheses force an explicit g++ path/prefix to probe its builtins as C.
     castxml_cc_id = "gnu-c" if not force_cpp and cc_id == "gnu" else cc_id
-    cmd = ["castxml", "--castxml-output=1",
-           f"--castxml-cc-{castxml_cc_id}", cc_bin]
+    compiler_command = (["(", cc_bin, "-x", "c", ")"]
+                        if castxml_cc_id == "gnu-c" else [cc_bin])
+    cmd = ["castxml", "--castxml-output=1", f"--castxml-cc-{castxml_cc_id}",
+           *compiler_command]
     for inc in extra_includes:
         cmd += ["-I", str(inc)]
 

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -832,10 +832,8 @@ def _build_castxml_command(
 ) -> list[str]:
     """Build the castxml command line."""
     # CastXML needs its language-specific compiler-emulation id in C mode.
-    # Using ``gnu`` together with ``-x c`` makes modern CastXML inject C++
-    # approximations for GCC's _Float* builtins (including ``operator``), then
-    # asks Clang to parse them as C.  ``gnu-c`` supplies the C approximations.
-    # Parentheses force an explicit g++ path/prefix to probe its builtins as C.
+    # ``gnu`` + ``-x c`` can inject C++ _Float* approximations into C;
+    # ``gnu-c`` avoids that. Parentheses preserve an explicit g++ path/prefix.
     castxml_cc_id = "gnu-c" if not force_cpp and cc_id == "gnu" else cc_id
     compiler_command = (["(", cc_bin, "-x", "c", ")"]
                         if castxml_cc_id == "gnu-c" else [cc_bin])

--- a/action/AGENTS.md
+++ b/action/AGENTS.md
@@ -19,9 +19,10 @@ sequence that invokes these scripts in order:
    from `run.sh` — so this step has zero dependency on `run.sh`'s internal
    layout. `tests/test_action_validate_inputs.py` runs both copies against
    the same fixtures to catch drift between them.
-2. `action/install-deps.sh` — installs castxml/gcc/g++/clang/bear (Linux) or
-   castxml via Homebrew (macOS) when `install-deps: true`. Windows install is
-   not automated (warns only).
+2. `action/install-deps.sh` — installs gcc/g++/clang/bear and invokes the
+   checksum-pinned `action/install-castxml.sh` Superbuild installer on Linux,
+   or installs castxml via Homebrew on macOS, when `install-deps: true`.
+   Windows install is not automated (warns only).
 3. `action/run.sh` — assembles the `abicheck` CLI invocation from `INPUT_*`
    environment variables (one per `action.yml` input), runs it, and sets the
    Action's declared outputs from the exit code / report contents.

--- a/action/install-castxml.sh
+++ b/action/install-castxml.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Install the pinned CastXML Superbuild used by abicheck CI.
+#
+# The Ubuntu package currently bundles Clang 17, which cannot parse some GCC 13
+# libstdc++ headers (notably the statement form of __attribute__((__assume__))).
+# Keep the release tag and SHA256 values explicit so a runner image update cannot
+# silently change the header-AST frontend.
+set -euo pipefail
+
+readonly CASTXML_TAG="v2026.01.30"
+readonly CASTXML_RELEASE_BASE="https://github.com/CastXML/CastXMLSuperbuild/releases/download/${CASTXML_TAG}"
+readonly EXPECTED_CASTXML_VERSION="0.6.20260105-g9864b1e"
+readonly EXPECTED_BUNDLED_CLANG_VERSION="21.1.8"
+readonly MIN_BUNDLED_CLANG_MAJOR=18
+
+fail() {
+  echo "::error::$*" >&2
+  exit 1
+}
+
+[ "$(uname -s)" = "Linux" ] || fail "The pinned installer currently supports Linux only. Use Homebrew/conda-forge on this platform."
+[ -r /etc/os-release ] || fail "Cannot identify this Linux distribution (/etc/os-release is missing)."
+# shellcheck disable=SC1091
+. /etc/os-release
+[ "${ID:-}" = "ubuntu" ] || fail "The pinned CastXML assets are validated for Ubuntu; detected ${ID:-unknown}."
+
+case "${VERSION_ID:-}:$(uname -m)" in
+  22.04:x86_64)
+    asset="castxml-ubuntu-22.04-x86_64.tar.gz"
+    sha256="6df17fe726e48bbe1d584e6aa508de5427e65ab2dc9be4a7795c88f1679da9ab"
+    ;;
+  22.04:aarch64|22.04:arm64)
+    asset="castxml-ubuntu-22.04-arm-aarch64.tar.gz"
+    sha256="4ad76d41c8e82845f116ecef6d65e2e0b08801dd06b8f8eab8f84be0dad3c304"
+    ;;
+  24.04:x86_64)
+    asset="castxml-ubuntu-24.04-x86_64.tar.gz"
+    sha256="76e7183f8f15bf3ada2009e18e34717366771ca3d2bc23ab1acee315171fdc93"
+    ;;
+  24.04:aarch64|24.04:arm64)
+    asset="castxml-ubuntu-24.04-arm-aarch64.tar.gz"
+    sha256="6cacf64b8207c53a27da7f5604e9260374fa4470cbcf8ae2726506bce8f7f86f"
+    ;;
+  *)
+    fail "No pinned CastXML ${CASTXML_TAG} asset for Ubuntu ${VERSION_ID:-unknown} $(uname -m). Use conda-forge or install a verified Superbuild manually."
+    ;;
+esac
+
+command -v curl >/dev/null 2>&1 || fail "curl is required to download CastXML."
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required to verify CastXML."
+command -v tar >/dev/null 2>&1 || fail "tar is required to extract CastXML."
+
+install_base="${ABICHECK_CASTXML_INSTALL_ROOT:-${RUNNER_TEMP:-${TMPDIR:-/tmp}}/abicheck-castxml}"
+install_dir="${install_base}/${CASTXML_TAG}/${asset%.tar.gz}"
+bin_dir="${install_dir}/bin"
+castxml_bin="${bin_dir}/castxml"
+
+if [ ! -x "$castxml_bin" ]; then
+  work_dir="$(mktemp -d "${TMPDIR:-/tmp}/abicheck-castxml.XXXXXX")"
+  trap 'rm -rf "$work_dir"' EXIT
+  archive="${work_dir}/${asset}"
+  url="${CASTXML_RELEASE_BASE}/${asset}"
+
+  if [ -n "${ABICHECK_CASTXML_ARCHIVE:-}" ]; then
+    [ -f "$ABICHECK_CASTXML_ARCHIVE" ] || fail "ABICHECK_CASTXML_ARCHIVE does not exist: ${ABICHECK_CASTXML_ARCHIVE}"
+    echo "Installing pinned CastXML ${CASTXML_TAG} from local archive: ${ABICHECK_CASTXML_ARCHIVE}"
+    cp "$ABICHECK_CASTXML_ARCHIVE" "$archive"
+  else
+    echo "Downloading pinned CastXML ${CASTXML_TAG}: ${asset}"
+    curl --fail --location --silent --show-error --retry 3 --retry-all-errors \
+      --output "$archive" "$url"
+  fi
+  printf '%s  %s\n' "$sha256" "$archive" | sha256sum --check --strict -
+
+  extract_dir="${work_dir}/extract"
+  mkdir -p "$extract_dir"
+  # Official archives contain one top-level `castxml/` directory.
+  tar -xzf "$archive" -C "$extract_dir" --strip-components=1
+  [ -x "${extract_dir}/bin/castxml" ] || fail "Archive ${asset} does not contain castxml/bin/castxml."
+
+  mkdir -p "$(dirname "$install_dir")"
+  rm -rf "$install_dir"
+  mv "$extract_dir" "$install_dir"
+fi
+
+version_output="$($castxml_bin --version 2>&1)" || fail "Pinned CastXML failed its version probe."
+castxml_version="$(printf '%s\n' "$version_output" | sed -nE 's/^castxml version ([^[:space:]]+).*/\1/p' | head -1)"
+clang_version="$(printf '%s\n' "$version_output" | sed -nE 's/.*clang version ([^[:space:]]+).*/\1/p' | head -1)"
+clang_major="${clang_version%%.*}"
+[ "$castxml_version" = "$EXPECTED_CASTXML_VERSION" ] || \
+  fail "Expected CastXML ${EXPECTED_CASTXML_VERSION}, got ${castxml_version:-unknown}."
+[ "$clang_version" = "$EXPECTED_BUNDLED_CLANG_VERSION" ] || \
+  fail "Expected bundled Clang ${EXPECTED_BUNDLED_CLANG_VERSION}, got ${clang_version:-unknown}."
+[ "$clang_major" -ge "$MIN_BUNDLED_CLANG_MAJOR" ] || \
+  fail "CastXML bundles Clang ${clang_major}; Clang >= ${MIN_BUNDLED_CLANG_MAJOR} is required."
+
+export PATH="${bin_dir}:${PATH}"
+if [ -n "${GITHUB_PATH:-}" ]; then
+  printf '%s\n' "$bin_dir" >> "$GITHUB_PATH"
+fi
+
+printf '%s\n' "Selected CastXML: ${castxml_bin}"
+printf '%s\n' "$version_output"

--- a/action/install-deps.sh
+++ b/action/install-deps.sh
@@ -26,9 +26,17 @@ case "$OS" in
     if ! command -v apt-get &> /dev/null; then
       echo "::warning::apt-get not found. Skipping automatic dependency installation on Linux."
       echo "Please ensure castxml, clang, and a C++ compiler are installed manually."
+      # Preserve the historical warning-only path on minimal/self-hosted
+      # runners. Use the pin only if all installer prerequisites already exist.
+      for prerequisite in curl sha256sum tar; do
+        command -v "$prerequisite" &> /dev/null || pinned_castxml=false
+      done
     elif ! command -v sudo &> /dev/null; then
       echo "::warning::sudo not found. Skipping automatic dependency installation."
       echo "Please ensure castxml, clang, and a C++ compiler are installed manually."
+      for prerequisite in curl sha256sum tar; do
+        command -v "$prerequisite" &> /dev/null || pinned_castxml=false
+      done
     else
       sudo apt-get update -qq
       # clang enables L4 source-ABI replay + L5 graphs for `scan --sources`;

--- a/action/install-deps.sh
+++ b/action/install-deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Install system dependencies for abicheck:
-#   - castxml + gcc/g++  → L2 public-header analysis (always)
+#   - pinned CastXML Superbuild + gcc/g++ → L2 public-header analysis (always)
 #   - clang/clang++      → L4 source-ABI replay, the S2 preprocessor pre-scan,
 #                          and L5 call/include graphs used by `scan --sources`
 # Called by the composite action when install-deps=true.
@@ -11,6 +11,14 @@ echo "::group::Install system dependencies for abicheck"
 OS="$(uname -s)"
 case "$OS" in
   Linux)
+    pinned_castxml=false
+    if [ -r /etc/os-release ]; then
+      # shellcheck disable=SC1091
+      . /etc/os-release
+      case "${ID:-}:${VERSION_ID:-}" in
+        ubuntu:22.04|ubuntu:24.04) pinned_castxml=true ;;
+      esac
+    fi
     if ! command -v apt-get &> /dev/null; then
       echo "::warning::apt-get not found. Skipping automatic dependency installation on Linux."
       echo "Please ensure castxml, clang, and a C++ compiler are installed manually."
@@ -20,10 +28,25 @@ case "$OS" in
     else
       sudo apt-get update -qq
       # clang enables L4 source-ABI replay + L5 graphs for `scan --sources`;
-      # castxml/gcc remain the L2 header path and the L4 declaration fallback;
+      # gcc/g++ provide compiler emulation for the pinned CastXML frontend;
       # bear generates a compile_commands.json for Make/Autotools projects that
       # do not emit one (`bear -- make …`), which is what unlocks L3/L4/L5 there.
-      sudo apt-get install -y -qq castxml gcc g++ clang bear > /dev/null
+      packages=(gcc g++ clang bear curl ca-certificates)
+      if [ "$pinned_castxml" != true ]; then
+        # Preserve the Action's previous best-effort behavior on unsupported
+        # Linux distributions instead of making the Ubuntu-only pin a new hard
+        # failure. The exact pin remains the authoritative CI path.
+        packages+=(castxml)
+      fi
+      sudo apt-get install -y -qq "${packages[@]}" > /dev/null
+    fi
+    if [ "$pinned_castxml" = true ]; then
+      # Source it so this step's verification sees the new PATH too;
+      # GITHUB_PATH still persists it for subsequent Action steps.
+      # shellcheck source=action/install-castxml.sh
+      . "$(dirname "$0")/install-castxml.sh"
+    else
+      echo "::warning::No pinned CastXML Superbuild for ${ID:-unknown} ${VERSION_ID:-unknown}; using the distribution/existing castxml."
     fi
     ;;
   Darwin)

--- a/action/install-deps.sh
+++ b/action/install-deps.sh
@@ -12,11 +12,15 @@ OS="$(uname -s)"
 case "$OS" in
   Linux)
     pinned_castxml=false
+    machine="$(uname -m)"
     if [ -r /etc/os-release ]; then
       # shellcheck disable=SC1091
       . /etc/os-release
-      case "${ID:-}:${VERSION_ID:-}" in
-        ubuntu:22.04|ubuntu:24.04) pinned_castxml=true ;;
+      case "${ID:-}:${VERSION_ID:-}:${machine}" in
+        ubuntu:22.04:x86_64|ubuntu:22.04:aarch64|ubuntu:22.04:arm64|\
+        ubuntu:24.04:x86_64|ubuntu:24.04:aarch64|ubuntu:24.04:arm64)
+          pinned_castxml=true
+          ;;
       esac
     fi
     if ! command -v apt-get &> /dev/null; then
@@ -46,7 +50,7 @@ case "$OS" in
       # shellcheck source=action/install-castxml.sh
       . "$(dirname "$0")/install-castxml.sh"
     else
-      echo "::warning::No pinned CastXML Superbuild for ${ID:-unknown} ${VERSION_ID:-unknown}; using the distribution/existing castxml."
+      echo "::warning::No pinned CastXML Superbuild for ${ID:-unknown} ${VERSION_ID:-unknown} ${machine}; using the distribution/existing castxml."
     fi
     ;;
   Darwin)

--- a/changelog.d/20260719_212500_napetrov_castxml_c_emulation.md
+++ b/changelog.d/20260719_212500_napetrov_castxml_c_emulation.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **CastXML C-header parsing now uses C compiler emulation** — GNU C headers are probed with the host C driver and CastXML's `gnu-c` mode, avoiding invalid C++ `_Float*` builtin shims when the pinned Superbuild parses C APIs.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,12 +52,22 @@ All Python dependencies (`pyelftools`, `pefile`, `macholib`) come with the `abic
 > automatically). If you have no `castxml`, run **binary-only mode** by omitting the
 > header flags — abicheck falls back to DWARF/symbols analysis (weaker, but works).
 
-#### Option A: system packages
+#### Option A: conda-forge (recommended)
+
+Conda-forge supplies CastXML together with a compatible compiler toolchain:
 
 ```bash
-# Ubuntu / Debian
-sudo apt-get update && sudo apt-get install -y castxml gcc g++
+conda install -c conda-forge castxml
 ```
+
+#### Option B: pinned CastXML Superbuild (Ubuntu CI/reproducers)
+
+Ubuntu 24.04's `apt` package currently bundles Clang 17, which cannot parse
+some GCC 13 libstdc++ headers. For reproducible Ubuntu runs, use a
+[CastXML Superbuild release](https://github.com/CastXML/CastXMLSuperbuild/releases),
+pin its tag and SHA256, extract it to a versioned directory, and prepend its
+`bin` directory to `PATH`. The abicheck GitHub Action does this automatically.
+The current CI pin is `v2026.01.30` (bundled Clang 21.1.8).
 
 ```bash
 # macOS
@@ -71,7 +81,7 @@ choco install castxml
 # plus MSVC Build Tools (cl.exe) for PE/PDB debug-info analysis
 ```
 
-#### Option B: conda-forge (recommended for reproducible envs)
+#### Option C: conda-forge abicheck environment
 
 ```bash
 # create env and install abicheck (recipe includes required analysis deps)

--- a/docs/reference/platforms.md
+++ b/docs/reference/platforms.md
@@ -143,18 +143,24 @@ jobs:
   abi-check:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-24.04, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: abicheck
       - name: Install abicheck (source)
-        run: pip install -e .
-      - name: Install castxml (Linux/macOS only)
-        if: runner.os != 'Windows'
+        shell: bash -el {0}
+        run: python -m pip install -e .
+      - name: Install CastXML (Linux/macOS only)
+        shell: bash -el {0}
         run: |
-          # sudo apt-get install -y castxml   # Ubuntu
-          # brew install castxml              # macOS
+          # On Ubuntu, avoid the Clang-17 apt package; use conda-forge or the
+          # checksum-pinned Superbuild installed by the abicheck Action.
+          conda install -y -c conda-forge castxml
       - name: ABI check
+        shell: bash -el {0}
         run: |
           abicheck compare old/libmylib.so new/libmylib.so \
             -H include/

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -14,15 +14,19 @@ so any command that passes headers (`--header` / `-H`) fails with
 this error until `castxml` is on your `PATH`.
 
 ```bash
-# Ubuntu / Debian
-sudo apt-get install -y castxml gcc g++
+# conda (any OS) — bundles castxml + compiler automatically
+conda install -c conda-forge abicheck
 # macOS
 brew install castxml
 # Windows (PowerShell, admin)
 choco install castxml
-# conda (any OS) — bundles castxml + compiler automatically
-conda install -c conda-forge abicheck
 ```
+
+On Ubuntu CI, prefer a checksum-pinned
+[CastXML Superbuild](https://github.com/CastXML/CastXMLSuperbuild/releases)
+over `apt install castxml`. Ubuntu 24.04 currently packages CastXML with bundled
+Clang 17, which is too old for some GCC 13 libstdc++ headers. The abicheck
+GitHub Action installs the pinned `v2026.01.30` Superbuild automatically.
 
 No castxml and can't install it? Run **binary-only mode** by omitting the header flags —
 abicheck falls back to DWARF/symbols analysis (weaker, but catches symbol- and
@@ -68,12 +72,21 @@ errors like:
   by **Clang ≥ 18**.
 
 The fix is a **castxml built against a newer Clang** — the recommended floor is
-**bundled Clang ≥ 18**. The `conda-forge` castxml package bundles a recent Clang
-and a matching compiler, which is the most reliable option:
+**bundled Clang ≥ 18**. Ubuntu 24.04's `castxml` package currently bundles Clang
+17 and is therefore not suitable for GCC 13 C++ header analysis. Use either the
+`conda-forge` package or a release- and checksum-pinned official Superbuild:
 
 ```bash
 conda install -c conda-forge castxml
+
+# Reproducible CI: download the matching asset from this pinned release,
+# verify its published SHA256, extract it, then prepend its bin/ to PATH.
+# https://github.com/CastXML/CastXMLSuperbuild/releases/tag/v2026.01.30
 ```
+
+The pinned abicheck Linux CI release bundles Clang 21.1.8. Always inspect the
+full `castxml --version` output: the CastXML version alone does not identify the
+bundled Clang frontend.
 
 abicheck detects this case and appends your detected `castxml --version` plus the
 recommended floor to the error. As an alternative, point abicheck at a

--- a/docs/user-guide/output-formats.md
+++ b/docs/user-guide/output-formats.md
@@ -587,13 +587,23 @@ on: [pull_request]
 
 jobs:
   abi-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        shell: bash -el {0}
     steps:
       - uses: actions/checkout@v4
 
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: abicheck
+
       - name: Install abicheck
         run: |
-          sudo apt-get update && sudo apt-get install -y castxml g++
+          # Avoid Ubuntu's Clang-17 CastXML build; conda-forge supplies a
+          # compatible toolchain. The abicheck Action uses a checksum-pinned
+          # official Superbuild instead.
+          conda install -y -c conda-forge castxml
           pip install abicheck
 
       - name: Dump ABI (baseline)

--- a/tests/test_castxml_errors.py
+++ b/tests/test_castxml_errors.py
@@ -407,7 +407,24 @@ def test_castxml_c_mode_user_std_token_not_overridden():
     assert "-std=gnu17" in cmd
     assert "-std=gnu11" not in cmd
     assert "-x" in cmd and "c" in cmd  # C language mode still forced
-    assert "--castxml-cc-gnu-c" in cmd
+    cc_index = cmd.index("--castxml-cc-gnu-c")
+    assert cmd[cc_index + 1:cc_index + 6] == ["(", "gcc", "-x", "c", ")"]
+
+
+def test_castxml_c_mode_forces_explicit_cpp_driver_probe_to_c():
+    """Keep an explicit g++ executable while probing its builtins as C."""
+    from pathlib import Path
+
+    from abicheck.dumper import _build_castxml_command
+
+    cmd = _build_castxml_command(
+        "/opt/cross/bin/g++", "gnu", [], Path("o.xml"), Path("a.h"),
+        force_cpp=False,
+    )
+    cc_index = cmd.index("--castxml-cc-gnu-c")
+    assert cmd[cc_index + 1:cc_index + 6] == [
+        "(", "/opt/cross/bin/g++", "-x", "c", ")",
+    ]
 
 
 def test_castxml_cpp_mode_keeps_gnu_emulation_id():

--- a/tests/test_castxml_errors.py
+++ b/tests/test_castxml_errors.py
@@ -407,6 +407,20 @@ def test_castxml_c_mode_user_std_token_not_overridden():
     assert "-std=gnu17" in cmd
     assert "-std=gnu11" not in cmd
     assert "-x" in cmd and "c" in cmd  # C language mode still forced
+    assert "--castxml-cc-gnu-c" in cmd
+
+
+def test_castxml_cpp_mode_keeps_gnu_emulation_id():
+    """The ``gnu-c`` workaround must be scoped to C parsing only."""
+    from pathlib import Path
+
+    from abicheck.dumper import _build_castxml_command
+
+    cmd = _build_castxml_command(
+        "g++", "gnu", [], Path("o.xml"), Path("a.hpp"), force_cpp=True
+    )
+    assert "--castxml-cc-gnu" in cmd
+    assert "--castxml-cc-gnu-c" not in cmd
 
 
 def _ast_parser_kwargs(tmp_path):

--- a/tests/test_castxml_installer.py
+++ b/tests/test_castxml_installer.py
@@ -88,6 +88,7 @@ def test_composite_installer_keeps_unsupported_linux_best_effort() -> None:
     assert "No pinned CastXML Superbuild" in text
 
 
+@pytest.mark.skipif(os.name == "nt", reason="exercises a Linux shell installer")
 def test_composite_installer_uses_distro_castxml_on_unsupported_arch(
     tmp_path: Path,
 ) -> None:
@@ -120,6 +121,7 @@ def test_composite_installer_uses_distro_castxml_on_unsupported_arch(
     assert "ppc64le" in result.stdout
 
 
+@pytest.mark.skipif(os.name == "nt", reason="exercises a Linux shell installer")
 def test_composite_installer_minimal_ubuntu_remains_warning_only(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_castxml_installer.py
+++ b/tests/test_castxml_installer.py
@@ -1,0 +1,132 @@
+"""Contract tests for the checksum-pinned CastXML Superbuild installer."""
+from __future__ import annotations
+
+import os
+import platform
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+INSTALLER = ROOT / "action" / "install-castxml.sh"
+WORKFLOWS = (
+    ROOT / ".github/workflows/ci.yml",
+    ROOT / ".github/workflows/examples-validation.yml",
+    ROOT / ".github/workflows/examples-validation-nightly.yml",
+    ROOT / ".github/workflows/publish.yml",
+    ROOT / ".github/workflows/realworld-validation.yml",
+)
+
+
+def _host_asset() -> str | None:
+    if platform.system() != "Linux" or not Path("/etc/os-release").exists():
+        return None
+    values = {}
+    for line in Path("/etc/os-release").read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, value = line.split("=", 1)
+            values[key] = value.strip('"')
+    machine = platform.machine()
+    key = (values.get("ID"), values.get("VERSION_ID"), machine)
+    return {
+        ("ubuntu", "22.04", "x86_64"): "castxml-ubuntu-22.04-x86_64",
+        ("ubuntu", "22.04", "aarch64"): "castxml-ubuntu-22.04-arm-aarch64",
+        ("ubuntu", "24.04", "x86_64"): "castxml-ubuntu-24.04-x86_64",
+        ("ubuntu", "24.04", "aarch64"): "castxml-ubuntu-24.04-arm-aarch64",
+    }.get(key)
+
+
+def test_installer_pins_release_versions_and_four_asset_digests() -> None:
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert 'CASTXML_TAG="v2026.01.30"' in text
+    assert 'EXPECTED_CASTXML_VERSION="0.6.20260105-g9864b1e"' in text
+    assert 'EXPECTED_BUNDLED_CLANG_VERSION="21.1.8"' in text
+    digests = re.findall(r'sha256="([0-9a-f]+)"', text)
+    assert len(digests) == 4
+    assert all(len(digest) == 64 for digest in digests)
+    assert len(set(digests)) == 4
+
+
+def test_installer_verifies_before_extracting_and_persists_path() -> None:
+    text = INSTALLER.read_text(encoding="utf-8")
+    assert text.index("sha256sum --check --strict") < text.index("tar -xzf")
+    assert '>> "$GITHUB_PATH"' in text
+    assert "--strip-components=1" in text
+
+
+def test_linux_workflow_jobs_using_installer_pin_supported_runner() -> None:
+    for path in WORKFLOWS:
+        workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
+        for name, job in workflow.get("jobs", {}).items():
+            steps = job.get("steps", [])
+            if not any(
+                "action/install-castxml.sh" in str(step.get("run", ""))
+                for step in steps
+            ):
+                continue
+            runs_on = job.get("runs-on")
+            if isinstance(runs_on, str) and "matrix.os" not in runs_on:
+                assert runs_on in {"ubuntu-22.04", "ubuntu-24.04", "ubuntu-24.04-arm"}, (
+                    path.name,
+                    name,
+                    runs_on,
+                )
+                continue
+            matrix_os = job.get("strategy", {}).get("matrix", {}).get("os", [])
+            linux_runners = [value for value in matrix_os if str(value).startswith("ubuntu")]
+            assert linux_runners
+            assert set(linux_runners) <= {"ubuntu-22.04", "ubuntu-24.04"}
+
+
+def test_composite_installer_keeps_unsupported_linux_best_effort() -> None:
+    text = (ROOT / "action/install-deps.sh").read_text(encoding="utf-8")
+    assert 'packages+=(castxml)' in text
+    assert '. "$(dirname "$0")/install-castxml.sh"' in text
+    assert "No pinned CastXML Superbuild" in text
+
+
+def test_cached_install_validates_versions_and_persists_path(tmp_path: Path) -> None:
+    asset = _host_asset()
+    if asset is None:
+        pytest.skip("behavioral installer test needs a supported Ubuntu runner")
+    castxml = tmp_path / "install" / "v2026.01.30" / asset / "bin" / "castxml"
+    castxml.parent.mkdir(parents=True)
+    castxml.write_text(
+        "#!/bin/sh\n"
+        "echo 'castxml version 0.6.20260105-g9864b1e'\n"
+        "echo 'clang version 21.1.8'\n",
+        encoding="utf-8",
+    )
+    castxml.chmod(0o755)
+    github_path = tmp_path / "github-path"
+    env = {
+        **os.environ,
+        "ABICHECK_CASTXML_INSTALL_ROOT": str(tmp_path / "install"),
+        "GITHUB_PATH": str(github_path),
+    }
+    result = subprocess.run(
+        ["bash", str(INSTALLER)], capture_output=True, text=True, env=env, check=False
+    )
+    assert result.returncode == 0, result.stderr
+    assert github_path.read_text(encoding="utf-8").strip() == str(castxml.parent)
+    assert "Selected CastXML" in result.stdout
+
+
+def test_local_archive_checksum_rejection_is_fail_closed(tmp_path: Path) -> None:
+    if _host_asset() is None:
+        pytest.skip("behavioral installer test needs a supported Ubuntu runner")
+    bad_archive = tmp_path / "untrusted.tar.gz"
+    bad_archive.write_bytes(b"not the pinned release")
+    env = {
+        **os.environ,
+        "ABICHECK_CASTXML_ARCHIVE": str(bad_archive),
+        "ABICHECK_CASTXML_INSTALL_ROOT": str(tmp_path / "install"),
+    }
+    result = subprocess.run(
+        ["bash", str(INSTALLER)], capture_output=True, text=True, env=env, check=False
+    )
+    assert result.returncode != 0
+    assert "FAILED" in result.stdout + result.stderr

--- a/tests/test_castxml_installer.py
+++ b/tests/test_castxml_installer.py
@@ -88,6 +88,38 @@ def test_composite_installer_keeps_unsupported_linux_best_effort() -> None:
     assert "No pinned CastXML Superbuild" in text
 
 
+def test_composite_installer_uses_distro_castxml_on_unsupported_arch(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log = tmp_path / "sudo.log"
+    (fake_bin / "uname").write_text(
+        "#!/bin/sh\n"
+        "case \"$1\" in -s) echo Linux ;; -m) echo ppc64le ;; esac\n",
+        encoding="utf-8",
+    )
+    (fake_bin / "apt-get").write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    (fake_bin / "sudo").write_text(
+        f"#!/bin/sh\nprintf '%s\\n' \"$*\" >> {log!s}\n",
+        encoding="utf-8",
+    )
+    for command in ("uname", "apt-get", "sudo"):
+        (fake_bin / command).chmod(0o755)
+
+    result = subprocess.run(
+        ["bash", str(ROOT / "action/install-deps.sh")],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": f"{fake_bin}:/usr/bin:/bin"},
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "castxml" in log.read_text(encoding="utf-8")
+    assert "No pinned CastXML Superbuild" in result.stdout
+    assert "ppc64le" in result.stdout
+
+
 def test_cached_install_validates_versions_and_persists_path(tmp_path: Path) -> None:
     asset = _host_asset()
     if asset is None:

--- a/tests/test_castxml_installer.py
+++ b/tests/test_castxml_installer.py
@@ -120,6 +120,32 @@ def test_composite_installer_uses_distro_castxml_on_unsupported_arch(
     assert "ppc64le" in result.stdout
 
 
+def test_composite_installer_minimal_ubuntu_remains_warning_only(
+    tmp_path: Path,
+) -> None:
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    uname = fake_bin / "uname"
+    uname.write_text(
+        "#!/bin/sh\n"
+        "case \"$1\" in -s) echo Linux ;; -m) echo x86_64 ;; esac\n",
+        encoding="utf-8",
+    )
+    uname.chmod(0o755)
+
+    result = subprocess.run(
+        ["/bin/bash", str(ROOT / "action/install-deps.sh")],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PATH": str(fake_bin)},
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "apt-get not found" in result.stdout
+    assert "No pinned CastXML Superbuild" in result.stdout
+    assert "curl is required" not in result.stderr
+
+
 def test_cached_install_validates_versions_and_persists_path(tmp_path: Path) -> None:
     asset = _host_asset()
     if asset is None:


### PR DESCRIPTION
## Summary

- install the checksum-pinned CastXML Superbuild `v2026.01.30` on supported Ubuntu runners
- verify release SHA256, CastXML `0.6.20260105-g9864b1e`, and bundled Clang `21.1.8`
- migrate Linux CI/example/release workflows away from runner-dependent `apt install castxml`
- preserve best-effort distro CastXML installation on unsupported Linux hosts
- document the pin and add static + behavioral installer contract tests

## Why

Ubuntu 24.04 currently packages CastXML with bundled Clang 17. That frontend rejects GCC 13 libstdc++'s statement-form `__assume__` and can force a materially different Clang fallback. A release URL/tag plus SHA256 makes the CI producer reproducible.

## Validation

- real Ubuntu 24.04 x86_64 archive install with SHA256 verification
- `castxml --castxml-gccxml -std=c++20` probe over a `<vector>` header: PASS (1,124,995-byte XML)
- `pytest -q tests/test_castxml_installer.py`: **6 passed**
- action-focused tests before review fixes: **136 passed**
- `bash -n action/install-castxml.sh action/install-deps.sh`: PASS
- all workflow YAML parsed with PyYAML; ruff and `git diff --check`: PASS

## Notes

- `/usr/bin/castxml` is not replaced; the installer uses a versioned isolated directory and `GITHUB_PATH`.
- affected Linux jobs are pinned to supported Ubuntu runner versions instead of `ubuntu-latest`.
- an unrelated existing `test_action_run_contract` failure (`--severity-addition`) reproduces unchanged on `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reproducible, checksum-verified CastXML installation for supported Linux environments.
  * Improved C header parsing by using C-specific compiler emulation.

* **Bug Fixes**
  * Prevented incompatible C++ approximations from being injected during C parsing.
  * Improved compatibility across supported platforms and architectures.

* **Documentation**
  * Updated installation, platform, troubleshooting, and workflow guidance for CastXML.

* **CI**
  * Standardized Linux validation on Ubuntu 24.04 and pinned CastXML versions across workflows.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->