### PR TITLE
fix: probe real GNU gcc/g++ instead of icx/icpx/dpcpp clang aliases

### DIFF
--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -38,6 +38,7 @@ import subprocess
 from pathlib import Path
 
 from . import deadline
+from .dumper_clang import _is_clang_family_binary
 
 #: Env knob to disable the castxml↔clang system-include auto-detection. On by
 #: default; set to a falsey value to suppress the host-compiler probe (e.g. for a
@@ -164,16 +165,19 @@ def _resolve_probe_compiler(
 ) -> str | None:
     """Pick a GNU ``gcc``/``g++`` driver to probe for system includes, or None.
 
-    Prefers an explicit GNU ``--gcc-path`` (a clang there is useless for
-    discovering the host libstdc++, so it is skipped), then the cross
-    ``--gcc-prefix`` driver, then ``g++``/``gcc`` on PATH. Returns the first that
-    resolves, or ``None`` when no GNU compiler is available (then clang falls
-    back to its own detection).
+    Prefers an explicit GNU ``--gcc-path`` (a clang-family binary there is
+    useless for discovering the host libstdc++, so it is skipped — this
+    includes the non-"clang"-spelled aliases in
+    :data:`abicheck.dumper_clang._CLANG_FAMILY_ALIAS_NAMES`, e.g.
+    ``icx``/``icpx``/``dpcpp``/``dpcpp-cl``, not just names containing
+    "clang"), then the cross ``--gcc-prefix`` driver, then ``g++``/``gcc`` on
+    PATH. Returns the first that resolves, or ``None`` when no GNU compiler is
+    available (then clang falls back to its own detection).
     """
     cpp = compiler in ("c++", "g++", "clang++")
     primary = "g++" if cpp else "gcc"
     candidates: list[str] = []
-    if gcc_path and "clang" not in Path(gcc_path).name.lower():
+    if gcc_path and not _is_clang_family_binary(gcc_path):
         candidates.append(gcc_path)
     if gcc_prefix:
         candidates.append(f"{gcc_prefix}{primary}")

--- a/changelog.d/20260720_060636_noreply_abicheck_clang_alias_bug_7lj0gw.md
+++ b/changelog.d/20260720_060636_noreply_abicheck_clang_alias_bug_7lj0gw.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **`--ast-frontend clang --gcc-path` no longer misprobes Intel oneAPI compiler
+  aliases as GNU compilers** — the clang-frontend system-include probe in
+  `dumper_sysinc.py` used a bare `"clang" not in name` check to decide whether
+  a `--gcc-path` binary was GNU or clang-family, so `icx`/`icpx`/`dpcpp`/
+  `dpcpp-cl` (clang-based binaries under non-"clang" names) were treated as
+  real GCC and probed directly. Their own `-E -v` system-include report is
+  incomplete for libc (missing `/usr/include`), which surfaced as
+  `stdlib.h`/`cstdlib`-not-found errors even with a manually supplied
+  `-isystem`. `_resolve_probe_compiler` now reuses `dumper_clang`'s
+  `_is_clang_family_binary` (already used elsewhere for the same alias list)
+  so these aliases correctly fall through to a real `g++`/`gcc` on `PATH`.
+

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -2459,6 +2459,20 @@ def test_resolve_probe_compiler_prefers_gnu_gcc_path(
     assert _resolve_probe_compiler("cc", None, None) == "gcc"
 
 
+def test_resolve_probe_compiler_skips_clang_family_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A --gcc-path icx/icpx/dpcpp/dpcpp-cl is clang-family, not GNU — probing it
+    (instead of a real g++/gcc on PATH) yields incomplete system include dirs
+    (e.g. missing /usr/include with stdlib.h), since these are the same clang
+    binary under a different name, not real gcc/g++."""
+    from abicheck import dumper_sysinc
+
+    monkeypatch.setattr(dumper_sysinc.shutil, "which", lambda c: c)
+    for alias in ("icx", "icpx", "dpcpp", "dpcpp-cl"):
+        assert _resolve_probe_compiler("c++", f"/opt/intel/bin/{alias}", None) == "g++"
+
+
 def test_resolve_probe_compiler_none_when_no_compiler(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Fix `--ast-frontend clang --gcc-path <intel-alias>` misprobing Intel oneAPI compiler aliases as real GNU compilers when resolving the clang-frontend system-include probe.

## Motivation

`abicheck/dumper_sysinc.py`'s `_resolve_probe_compiler` decided whether a `--gcc-path` binary was GNU (safe to probe for system include dirs) or clang-family (skip, probe `g++`/`gcc` on `PATH` instead) using a bare `"clang" not in Path(gcc_path).name.lower()` check. Intel's oneAPI DPC++/C++ compiler aliases — `icx`, `icpx`, `dpcpp`, `dpcpp-cl` — are the same clang-based binary under non-"clang" names, so they slipped through this check and were misclassified as GNU.

The probe (`<cc> -E -x c++ -v -`) was then run against `icpx` itself instead of a real `g++`. `icpx`'s own reported system-include search list is incomplete for plain libc (it omits `/usr/include`), which surfaced as `stdlib.h`/`cstdlib`-not-found errors — even when a caller manually supplied a matching `-isystem` (the manually-added dir loses to `#include_next` ordering against clang's builtin-detected toolchain path).

`dumper_clang.py` already has the correct alias list (`_CLANG_FAMILY_ALIAS_NAMES = {"icx", "icpx", "dpcpp", "dpcpp-cl"}`) and a proper classifier (`_is_clang_family_binary`), used elsewhere in the same module for the equivalent decision — `dumper_sysinc.py` just wasn't reusing it.

## Changes

- `abicheck/dumper_sysinc.py`: `_resolve_probe_compiler` now imports and uses `dumper_clang._is_clang_family_binary` instead of its own `"clang" not in name` substring check, so `icx`/`icpx`/`dpcpp`/`dpcpp-cl` correctly fall through to a real `g++`/`gcc` on `PATH` for the system-include probe.
- `tests/test_dumper_clang.py`: added `test_resolve_probe_compiler_skips_clang_family_aliases` covering all four aliases.
- `changelog.d/`: added a `Fixed` fragment via `scriv create`.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed — not needed, internal probe-selection fix, no CLI/API surface change
- [x] `ruff check` / `mypy abicheck/` pass locally on the changed files
- [x] No new `mypy` or `ruff` errors introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_01YUHdcdzpR4XRnwqxtXg4kq)_