### PR TITLE
feat: .abicheck.yml targets:/bundles:/profiles:/baseline: block (G30 P1.5, ADR-047 §3)

### DIFF
--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -641,6 +641,16 @@ class BuildConfig:
         return out
 
 
+#: Public re-export of every recognized ``.abicheck.yml`` top-level key —
+#: including the four ``project_targets.py``-owned ones. That sibling module
+#: reuses this (rather than its own partial guess) to reject a misspelled
+#: top-level key (e.g. ``tagrets:``) even though it only *parses* four of
+#: these keys itself — a key outside this whole set is unknown to every
+#: ``.abicheck.yml`` consumer, not just this one, so the strictness belongs
+#: to one shared source of truth.
+KNOWN_TOP_LEVEL_KEYS: frozenset[str] = BuildConfig._KNOWN_TOP_KEYS
+
+
 def load_build_config(path: Path) -> BuildConfig:
     """Load a ``.abicheck.yml`` build config; tolerant of a missing/empty file."""
     if not path.is_file():

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -226,7 +226,9 @@ class BuildConfig:
     #: newer schema read by an older abicheck) **warns**, never errors, so a
     #: project can adopt a future key without breaking older installs. Keys parsed
     #: by sibling modules (``risk_rules`` → ``risk.py``, ``crosschecks`` →
-    #: ``crosscheck.py``) are listed so they don't trip the warning.
+    #: ``crosscheck.py``, ``targets``/``bundles``/``profiles``/``baseline`` →
+    #: ``project_targets.py``, ADR-047 §3/G30 P1.5) are listed so they don't trip
+    #: the warning.
     _KNOWN_TOP_KEYS: ClassVar[frozenset[str]] = frozenset(
         {
             "build",
@@ -241,6 +243,10 @@ class BuildConfig:
             "version",
             "risk_rules",
             "crosschecks",
+            "targets",
+            "bundles",
+            "profiles",
+            "baseline",
         }
     )
     _KNOWN_BLOCK_KEYS: ClassVar[dict[str, frozenset[str]]] = {

--- a/abicheck/buildsource/project_targets.py
+++ b/abicheck/buildsource/project_targets.py
@@ -64,6 +64,18 @@ and deliberately left the choice to P1.5:
   target, which cannot itself be resolved further) but does not perform the
   redirection itself — that is G30 P1.2 (``resolve-baseline``)/P1.3
   (``check-target``)'s job at run time.
+
+``bundles:`` entries also carry their own ``checks:`` (same shape as a
+target's) — the ADR-047 §5 run-plan emits a ``kind: "bundle"`` check
+alongside per-target ones (S14 bundle-scoped analysis), and that cell needs
+its own baseline-channel/depth/gate policy just like a target's does; see
+:class:`BundleSpec`.
+
+``ProjectTargetsConfig.from_dict`` validates every top-level key in the raw
+mapping against :data:`~.inline.KNOWN_TOP_LEVEL_KEYS` — the *full*
+``.abicheck.yml`` key set, not just this module's four owned keys — so a
+misspelled block (``tagrets:``) is a hard error rather than silently
+parsing as an empty, all-default config.
 """
 
 from __future__ import annotations
@@ -73,6 +85,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .inline import KNOWN_TOP_LEVEL_KEYS
 from .scan_levels import USER_DEPTHS
 
 #: The identifier charset every target/bundle/profile/channel id must satisfy
@@ -308,13 +321,26 @@ class TargetSpec:
 
 @dataclass
 class BundleSpec:
-    """One ``bundles:`` entry (ADR-047 §3) — a release group of library targets."""
+    """One ``bundles:`` entry (ADR-047 §3) — a release group of library targets.
+
+    ``checks:`` (same ``{channel, depth, required, gate_mode, profiles}``
+    shape as a target's — review finding, ADR-047 §5): the run-plan example
+    emits a ``kind: "bundle"`` check entry alongside per-target ones (S14
+    bundle-scoped analysis), and that cell needs its own baseline-channel/
+    depth/gate policy just like a target's checks do — this plan's own
+    ``checks:`` design note says "per target, **or per bundle**", which an
+    earlier draft of this schema only implemented the target half of.
+    """
 
     id: str = ""
     targets: list[str] = field(default_factory=list)
+    checks: list[CheckSpec] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
-        return {"targets": list(self.targets)}
+        d: dict[str, Any] = {"targets": list(self.targets)}
+        if self.checks:
+            d["checks"] = [c.to_dict() for c in self.checks]
+        return d
 
     @classmethod
     def from_dict(cls, name: str, d: dict[str, Any]) -> BundleSpec:
@@ -323,7 +349,7 @@ class BundleSpec:
             raise ValueError(
                 f"{where} must be a mapping, got {type(d).__name__}: {d!r}"
             )
-        unknown = sorted(set(d) - {"targets"})
+        unknown = sorted(set(d) - {"targets", "checks"})
         if unknown:
             raise ValueError(f"{where}: unknown key(s) {unknown}")
         targets = d.get("targets")
@@ -332,7 +358,15 @@ class BundleSpec:
         bad = [t for t in targets if not isinstance(t, str)]
         if bad:
             raise ValueError(f"{where}.targets must be a list of strings, got {bad!r}")
-        return cls(id=name, targets=[str(t) for t in targets])
+        checks_raw = d.get("checks")
+        if checks_raw is not None and not isinstance(checks_raw, list):
+            raise ValueError(f"{where}.checks must be a list")
+        checks: list[CheckSpec] = []
+        for i, c in enumerate(checks_raw or []):
+            if not isinstance(c, dict):
+                raise ValueError(f"{where}.checks[{i}] must be a mapping")
+            checks.append(CheckSpec.from_dict(c, where=f"{where}.checks[{i}]"))
+        return cls(id=name, targets=[str(t) for t in targets], checks=checks)
 
 
 @dataclass
@@ -463,7 +497,19 @@ class ProjectTargetsConfig:
         fields, identifier charset) are **not** raised here — see
         :func:`validate_project_targets`, which needs the fully-assembled
         config to check references across blocks.
+
+        Every key in *data* is checked against the *full* ``.abicheck.yml``
+        top-level key set (:data:`~.inline.KNOWN_TOP_LEVEL_KEYS`), not just
+        this module's own four owned keys — a misspelled block (e.g.
+        ``tagrets:``) would otherwise be silently ignored as an unrecognized,
+        unrelated key rather than caught as the typo it is (review finding).
+        Keys this module doesn't itself parse (``build``, ``severity``, ...)
+        are still accepted here and simply ignored, since a real
+        ``.abicheck.yml`` legitimately carries those alongside this block.
         """
+        unknown_top = sorted(set(data) - KNOWN_TOP_LEVEL_KEYS)
+        if unknown_top:
+            raise ValueError(f"unknown .abicheck.yml key(s) {unknown_top}")
         targets_raw = _require_mapping(data.get("targets"), "targets")
         bundles_raw = _require_mapping(data.get("bundles"), "bundles")
         profiles_raw = _require_mapping(data.get("profiles"), "profiles")
@@ -630,7 +676,7 @@ def _target_issues(config: ProjectTargetsConfig, target: TargetSpec) -> list[str
             )
         issues.extend(_library_reference_issues(config, target))
     for i, check in enumerate(target.checks):
-        issues.extend(_check_issues(config, target.id, i, check))
+        issues.extend(_check_issues(config, f"target {target.id!r}.checks[{i}]", check))
     return issues
 
 
@@ -656,9 +702,8 @@ def _library_reference_issues(
 
 
 def _check_issues(
-    config: ProjectTargetsConfig, target_id: str, index: int, check: CheckSpec
+    config: ProjectTargetsConfig, where: str, check: CheckSpec
 ) -> list[str]:
-    where = f"target {target_id!r}.checks[{index}]"
     issues: list[str] = []
     if (
         check.channel != NO_BASELINE_CHANNEL
@@ -704,6 +749,8 @@ def _bundle_issues(config: ProjectTargetsConfig, bundle: BundleSpec) -> list[str
                 f"{referenced.bundle!r}, not {bundle.id!r} — a target's own "
                 "bundle: field and its membership here must agree."
             )
+    for i, check in enumerate(bundle.checks):
+        issues.extend(_check_issues(config, f"bundle {bundle.id!r}.checks[{i}]", check))
     return issues
 
 

--- a/abicheck/buildsource/project_targets.py
+++ b/abicheck/buildsource/project_targets.py
@@ -75,7 +75,16 @@ its own baseline-channel/depth/gate policy just like a target's does; see
 mapping against :data:`~.inline.KNOWN_TOP_LEVEL_KEYS` — the *full*
 ``.abicheck.yml`` key set, not just this module's four owned keys — so a
 misspelled block (``tagrets:``) is a hard error rather than silently
-parsing as an empty, all-default config.
+parsing as an empty, all-default config. Every ``targets:``/``bundles:``/
+``profiles:``/``baseline.channels:`` mapping key must itself be a real YAML
+string (PyYAML's default resolver reads a bare ``on``/``off``/``yes``/``no``
+key as a bool and a bare digit key as an int; silently ``str()``-coercing
+either would mint an id the user never actually wrote). ``"none"`` is
+reserved and cannot be declared as a real ``baseline.channels`` id — it is
+:data:`NO_BASELINE_CHANNEL`, the sentinel a ``checks[].channel`` uses to
+bypass ``resolve-baseline`` entirely (ADR-047 §6 S5); allowing a real
+channel of that name would make the sentinel ambiguous with an actual
+baseline lookup.
 """
 
 from __future__ import annotations
@@ -159,6 +168,13 @@ def _require_mapping(data: object, block: str) -> dict[str, Any]:
         raise ValueError(
             f"{block} must be a mapping, got {type(data).__name__}: {data!r}"
         )
+    bad_keys = [k for k in data if not isinstance(k, str)]
+    if bad_keys:
+        # PyYAML's default (YAML 1.1) resolver reads a bare `on`/`off`/`yes`/`no`
+        # mapping key as a bool, and a bare digit key as an int -- silently
+        # stringifying either here (e.g. `str(True)` -> "True") would mint a
+        # target/bundle/profile/channel id the user never actually wrote.
+        raise ValueError(f"{block}: key(s) must be strings, got {bad_keys!r}")
     return data
 
 
@@ -522,19 +538,16 @@ class ProjectTargetsConfig:
         )
 
         targets = {
-            str(name): TargetSpec.from_dict(str(name), t)
-            for name, t in targets_raw.items()
+            name: TargetSpec.from_dict(name, t) for name, t in targets_raw.items()
         }
         bundles = {
-            str(name): BundleSpec.from_dict(str(name), b)
-            for name, b in bundles_raw.items()
+            name: BundleSpec.from_dict(name, b) for name, b in bundles_raw.items()
         }
         profiles = {
-            str(name): ProfileSpec.from_dict(str(name), p)
-            for name, p in profiles_raw.items()
+            name: ProfileSpec.from_dict(name, p) for name, p in profiles_raw.items()
         }
         baseline_channels = {
-            str(name): BaselineChannelSpec.from_dict(str(name), c)
+            name: BaselineChannelSpec.from_dict(name, c)
             for name, c in channels_raw.items()
         }
         return cls(
@@ -760,6 +773,14 @@ def _profile_issues(profile: ProfileSpec) -> list[str]:
 
 def _baseline_channel_issues(channel: BaselineChannelSpec) -> list[str]:
     issues = _identifier_issues("baseline channel", channel.id)
+    if channel.id == NO_BASELINE_CHANNEL:
+        issues.append(
+            f"baseline channel {channel.id!r} is reserved as the no-baseline "
+            "sentinel (ADR-047 §6 S5) and cannot be declared as a real "
+            "channel — a checks[].channel: 'none' entry would then be "
+            "ambiguous between 'skip resolve-baseline' and 'resolve this "
+            "declared channel', and check-target always takes the former."
+        )
     if channel.source == "github-release" and not channel.asset_pattern:
         issues.append(
             f"baseline channel {channel.id!r}: source: github-release requires "

--- a/abicheck/buildsource/project_targets.py
+++ b/abicheck/buildsource/project_targets.py
@@ -161,6 +161,20 @@ def _require_str_list(d: dict[str, Any], key: str, *, where: str) -> list[str]:
     return list(raw)
 
 
+def _parse_checks_list(d: dict[str, Any], *, where: str) -> list[CheckSpec]:
+    """Parse an optional ``checks:`` list, shared by ``TargetSpec``/
+    ``BundleSpec`` (both accept the identical shape — review finding)."""
+    checks_raw = d.get("checks")
+    if checks_raw is not None and not isinstance(checks_raw, list):
+        raise ValueError(f"{where}.checks must be a list")
+    checks: list[CheckSpec] = []
+    for i, c in enumerate(checks_raw or []):
+        if not isinstance(c, dict):
+            raise ValueError(f"{where}.checks[{i}] must be a mapping")
+        checks.append(CheckSpec.from_dict(c, where=f"{where}.checks[{i}]"))
+    return checks
+
+
 def _require_mapping(data: object, block: str) -> dict[str, Any]:
     if data is None:
         return {}
@@ -311,14 +325,7 @@ class TargetSpec:
         bundle_only = d.get("bundle_only", False)
         if not isinstance(bundle_only, bool):
             raise ValueError(f"{where}.bundle_only must be a boolean")
-        checks_raw = d.get("checks")
-        if checks_raw is not None and not isinstance(checks_raw, list):
-            raise ValueError(f"{where}.checks must be a list")
-        checks: list[CheckSpec] = []
-        for i, c in enumerate(checks_raw or []):
-            if not isinstance(c, dict):
-                raise ValueError(f"{where}.checks[{i}] must be a mapping")
-            checks.append(CheckSpec.from_dict(c, where=f"{where}.checks[{i}]"))
+        checks = _parse_checks_list(d, where=where)
         return cls(
             id=name,
             kind=kind,
@@ -374,14 +381,7 @@ class BundleSpec:
         bad = [t for t in targets if not isinstance(t, str)]
         if bad:
             raise ValueError(f"{where}.targets must be a list of strings, got {bad!r}")
-        checks_raw = d.get("checks")
-        if checks_raw is not None and not isinstance(checks_raw, list):
-            raise ValueError(f"{where}.checks must be a list")
-        checks: list[CheckSpec] = []
-        for i, c in enumerate(checks_raw or []):
-            if not isinstance(c, dict):
-                raise ValueError(f"{where}.checks[{i}] must be a mapping")
-            checks.append(CheckSpec.from_dict(c, where=f"{where}.checks[{i}]"))
+        checks = _parse_checks_list(d, where=where)
         return cls(id=name, targets=[str(t) for t in targets], checks=checks)
 
 
@@ -513,6 +513,17 @@ class ProjectTargetsConfig:
         fields, identifier charset) are **not** raised here — see
         :func:`validate_project_targets`, which needs the fully-assembled
         config to check references across blocks.
+
+        **A clean parse from this method alone does not mean the config is
+        usable.** ``CheckSpec.from_dict`` only checks ``depth``/``gate_mode``/
+        ``channel`` are non-empty strings here; it does *not* check ``depth``
+        is one of :data:`CHECK_DEPTHS`, ``gate_mode`` is one of
+        :data:`GATE_MODES`, or ``channel`` resolves to a declared baseline
+        channel — those (and every other cross-reference rule) are
+        :func:`validate_project_targets`'s job. Every real caller (today,
+        only ``abicheck project-targets validate``) must call both in
+        sequence; treating a successful ``from_dict`` alone as "this config
+        is valid" will let e.g. ``depth: "banana"`` through unnoticed.
 
         Every key in *data* is checked against the *full* ``.abicheck.yml``
         top-level key set (:data:`~.inline.KNOWN_TOP_LEVEL_KEYS`), not just

--- a/abicheck/buildsource/project_targets.py
+++ b/abicheck/buildsource/project_targets.py
@@ -175,6 +175,15 @@ def _parse_checks_list(d: dict[str, Any], *, where: str) -> list[CheckSpec]:
     return checks
 
 
+def _unknown_keys(d: dict[str, Any], known: set[str]) -> list[Any]:
+    """``sorted(set(d) - known)``, but safe when *d* carries a non-string key
+    (a bare PyYAML 1.1 ``on``/``off``/``yes``/``no`` mapping key parses as a
+    bool) alongside a string one -- plain ``sorted()`` would raise ``TypeError``
+    comparing ``bool``/``str`` instead of surfacing the documented ``ValueError``
+    usage error (Codex finding, mirrors the top-level key check's own fix)."""
+    return sorted(set(d) - known, key=repr)
+
+
 def _require_mapping(data: object, block: str) -> dict[str, Any]:
     if data is None:
         return {}
@@ -228,7 +237,7 @@ class CheckSpec:
     @classmethod
     def from_dict(cls, d: dict[str, Any], *, where: str) -> CheckSpec:
         known = {"channel", "depth", "required", "gate_mode", "profiles"}
-        unknown = sorted(set(d) - known)
+        unknown = _unknown_keys(d, known)
         if unknown:
             raise ValueError(f"{where}: unknown key(s) {unknown}")
         channel = d.get("channel")
@@ -326,7 +335,7 @@ class TargetSpec:
             "contract_file",
             "checks",
         }
-        unknown = sorted(set(d) - known)
+        unknown = _unknown_keys(d, known)
         if unknown:
             raise ValueError(f"{where}: unknown key(s) {unknown}")
         kind = d.get("kind", TARGET_KIND_LIBRARY)
@@ -384,7 +393,7 @@ class BundleSpec:
             raise ValueError(
                 f"{where} must be a mapping, got {type(d).__name__}: {d!r}"
             )
-        unknown = sorted(set(d) - {"targets", "checks"})
+        unknown = _unknown_keys(d, {"targets", "checks"})
         if unknown:
             raise ValueError(f"{where}: unknown key(s) {unknown}")
         targets = d.get("targets")
@@ -426,7 +435,7 @@ class ProfileSpec:
             raise ValueError(
                 f"{where} must be a mapping, got {type(d).__name__}: {d!r}"
             )
-        unknown = sorted(set(d) - {"contract", "os", "arch"})
+        unknown = _unknown_keys(d, {"contract", "os", "arch"})
         if unknown:
             raise ValueError(f"{where}: unknown key(s) {unknown}")
         contract = d.get("contract", True)
@@ -467,7 +476,7 @@ class BaselineChannelSpec:
             raise ValueError(
                 f"{where} must be a mapping, got {type(d).__name__}: {d!r}"
             )
-        unknown = sorted(set(d) - {"source", "asset_pattern", "key_prefix"})
+        unknown = _unknown_keys(d, {"source", "asset_pattern", "key_prefix"})
         if unknown:
             raise ValueError(f"{where}: unknown key(s) {unknown}")
         source = d.get("source")

--- a/abicheck/buildsource/project_targets.py
+++ b/abicheck/buildsource/project_targets.py
@@ -1,0 +1,700 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``.abicheck.yml`` ``targets:``/``bundles:``/``profiles:``/``baseline:``
+block (ADR-047 §3, G30 P1.5).
+
+Extends the project config with the portable, project-owned surface
+``check-project.yml``'s run-plan generator (G30 P1.4, not built yet) will
+consume: which libraries/consumers/plugin-contracts exist, how they group
+into release bundles, which build profiles are ABI contracts, which baseline
+channels exist, and — the schema gap ADR-047 §3 flags and this module
+resolves — exactly which ``{channel, depth, required, gate_mode, profiles}``
+checks run against each target/bundle.
+
+This module only defines the contract and validates a hand-authored
+``targets:``/``bundles:``/``profiles:``/``baseline:`` block — there is no
+run-plan generator here yet (that's G30 P1.4, which *consumes* this) and no
+``abicheck project-targets init`` scaffolding either. Pure: parses a dict,
+never touches the filesystem beyond reading the one YAML file.
+
+``BuildConfig`` (:mod:`abicheck.buildsource.inline`) recognizes
+``targets``/``bundles``/``profiles``/``baseline`` as known top-level
+``.abicheck.yml`` keys (so their presence doesn't trip its own strict
+unknown-key error) but does not parse them itself — the same
+recognized-but-not-parsed treatment it already gives ``risk_rules``/
+``crosschecks``, which are likewise owned by a sibling module. This module's
+own loader (:func:`load_project_targets_config`) re-reads the same YAML file
+and is the sole owner of this block's schema.
+
+Two design choices this module makes, where ADR-047 §3 flagged an open gap
+and deliberately left the choice to P1.5:
+
+- **Profile scoping for ``checks:`` entries.** Rather than assume the naive
+  "cross every check with every ``contract: true`` profile" product is safe
+  (ADR-047 §3 explicitly warns this produces impossible cells for a target
+  that doesn't exist on every profile), each ``checks:`` entry carries an
+  *optional* explicit ``profiles:`` selector. When set, the check runs only
+  on the listed profile ids (validated against ``profiles:`` block). When
+  omitted, this module does not resolve it to a profile list at all — G30
+  P1.4's run-plan generator is responsible for deriving the actual
+  ``(target, profile)`` cells from each profile's own ``build-output.json``
+  ``targets[]`` list (the ADR's second, safer option), never from a blind
+  cross-product. This module's validator does not and cannot enforce that
+  downstream behaviour; it only validates that an *explicit* ``profiles:``
+  selector, when present, names real declared profile ids.
+- **``app-consumer``/``plugin-contract`` redirection.** Per ADR-047 §3's
+  two "unstated rule" corrections, both the baseline-lookup key and the
+  candidate-artifact lookup for these two ``kind``s resolve through their
+  ``library`` field, while the check's own reporting identity stays the
+  contract target's own name. This module validates that ``library`` names
+  a real ``kind: library`` target (not an app-consumer/plugin-contract
+  target, which cannot itself be resolved further) but does not perform the
+  redirection itself — that is G30 P1.2 (``resolve-baseline``)/P1.3
+  (``check-target``)'s job at run time.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .scan_levels import USER_DEPTHS
+
+#: The identifier charset every target/bundle/profile/channel id must satisfy
+#: — matches the per-component pattern the report-identity envelope (ADR-047
+#: §7, ``compare_report.schema.json``'s ``check_id``) already enforces for
+#: ``target@profile#baseline_channel@depth``, so a name valid here can never
+#: produce an ambiguous/unparseable check_id downstream.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+#: ADR-047 §3 ``targets:`` ``kind`` discriminator.
+TARGET_KIND_LIBRARY = "library"
+TARGET_KIND_APP_CONSUMER = "app-consumer"
+TARGET_KIND_PLUGIN_CONTRACT = "plugin-contract"
+TARGET_KINDS = frozenset(
+    {TARGET_KIND_LIBRARY, TARGET_KIND_APP_CONSUMER, TARGET_KIND_PLUGIN_CONTRACT}
+)
+
+#: ADR-047 §4/§7 ``check-target`` gate-mode values.
+GATE_MODES = frozenset({"local", "deferred", "advisory"})
+
+#: ADR-047 §10 baseline storage backends (external object store is P2, out of
+#: scope here).
+BASELINE_SOURCES = frozenset({"github-release", "actions-cache", "git"})
+
+#: The evidence-depth ladder a ``checks:`` entry's ``depth`` must be one of —
+#: the same four public rungs ``requested_depth``/``effective_depth`` accept
+#: in the report schema (ADR-047 §7).
+CHECK_DEPTHS = frozenset(d.value for d in USER_DEPTHS)
+
+#: Sentinel ``channel`` value for a ``baseline: none`` check (ADR-047 §6 S5
+#: correction) — ``check-target`` (P1.3) must skip ``resolve-baseline``
+#: entirely for a check carrying this value, never look it up as a declared
+#: channel name.
+NO_BASELINE_CHANNEL = "none"
+
+
+def _str_list(d: dict[str, Any], key: str) -> list[str]:
+    raw = d.get(key)
+    return [str(x) for x in raw if isinstance(x, str)] if isinstance(raw, list) else []
+
+
+def _require_mapping(data: object, block: str) -> dict[str, Any]:
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"{block} must be a mapping, got {type(data).__name__}: {data!r}"
+        )
+    return data
+
+
+@dataclass
+class CheckSpec:
+    """One ``{channel, depth, required, gate_mode, profiles}`` tuple (ADR-047 §3).
+
+    Closes the gap ADR-047 §3 flags: ``baseline: channels:`` alone declares
+    which channels *exist*, not which channel/depth/policy a given target
+    actually runs — this is the per-check assignment that does.
+    """
+
+    channel: str = ""
+    depth: str = ""
+    required: bool = True
+    gate_mode: str = "local"
+    #: Explicit profile-id selector (see module docstring). Empty = every
+    #: ``contract: true`` profile, filtered against ``build-output.json`` by
+    #: G30 P1.4's run-plan generator — not resolved here.
+    profiles: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "channel": self.channel,
+            "depth": self.depth,
+            "required": self.required,
+            "gate_mode": self.gate_mode,
+        }
+        if self.profiles:
+            d["profiles"] = list(self.profiles)
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any], *, where: str) -> CheckSpec:
+        known = {"channel", "depth", "required", "gate_mode", "profiles"}
+        unknown = sorted(set(d) - known)
+        if unknown:
+            raise ValueError(f"{where}: unknown key(s) {unknown}")
+        channel = d.get("channel")
+        if not isinstance(channel, str) or not channel:
+            raise ValueError(f"{where}.channel must be a non-empty string")
+        depth = d.get("depth")
+        if not isinstance(depth, str) or not depth:
+            raise ValueError(f"{where}.depth must be a non-empty string")
+        required = d.get("required", True)
+        if not isinstance(required, bool):
+            raise ValueError(
+                f"{where}.required must be a boolean, got "
+                f"{type(required).__name__}: {required!r}"
+            )
+        gate_mode = d.get("gate_mode", "local")
+        if not isinstance(gate_mode, str):
+            raise ValueError(
+                f"{where}.gate_mode must be a string, got "
+                f"{type(gate_mode).__name__}: {gate_mode!r}"
+            )
+        profiles_raw = d.get("profiles")
+        if profiles_raw is not None and not isinstance(profiles_raw, list):
+            raise ValueError(f"{where}.profiles must be a list of strings")
+        profiles = _str_list(d, "profiles")
+        if profiles_raw is not None:
+            bad = [p for p in profiles_raw if not isinstance(p, str)]
+            if bad:
+                raise ValueError(
+                    f"{where}.profiles must be a list of strings, got {bad!r}"
+                )
+        return cls(
+            channel=channel,
+            depth=depth,
+            required=required,
+            gate_mode=gate_mode,
+            profiles=profiles,
+        )
+
+
+@dataclass
+class TargetSpec:
+    """One ``targets:`` entry (ADR-047 §3)."""
+
+    id: str = ""
+    kind: str = TARGET_KIND_LIBRARY
+    binary_pattern: str = ""
+    public_headers: list[str] = field(default_factory=list)
+    bundle: str = ""
+    bundle_only: bool = False
+    #: ``app-consumer`` only.
+    consumer_binary_pattern: str = ""
+    #: ``app-consumer``/``plugin-contract`` only — the ``kind: library``
+    #: target this one resolves its baseline/candidate lookup through.
+    library: str = ""
+    #: ``plugin-contract`` only — a ``.syms`` file (one required linker
+    #: symbol per line, ``#`` comments allowed), not YAML.
+    contract_file: str = ""
+    checks: list[CheckSpec] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"kind": self.kind}
+        if self.kind == TARGET_KIND_LIBRARY:
+            if self.binary_pattern:
+                d["binary_pattern"] = self.binary_pattern
+            if self.public_headers:
+                d["public_headers"] = list(self.public_headers)
+            if self.bundle:
+                d["bundle"] = self.bundle
+            if self.bundle_only:
+                d["bundle_only"] = self.bundle_only
+        elif self.kind == TARGET_KIND_APP_CONSUMER:
+            d["consumer_binary_pattern"] = self.consumer_binary_pattern
+            d["library"] = self.library
+        elif self.kind == TARGET_KIND_PLUGIN_CONTRACT:
+            d["contract_file"] = self.contract_file
+            d["library"] = self.library
+        if self.checks:
+            d["checks"] = [c.to_dict() for c in self.checks]
+        return d
+
+    @classmethod
+    def from_dict(cls, name: str, d: dict[str, Any]) -> TargetSpec:
+        where = f"targets.{name}"
+        if not isinstance(d, dict):
+            raise ValueError(
+                f"{where} must be a mapping, got {type(d).__name__}: {d!r}"
+            )
+        known = {
+            "kind",
+            "binary_pattern",
+            "public_headers",
+            "bundle",
+            "bundle_only",
+            "consumer_binary_pattern",
+            "library",
+            "contract_file",
+            "checks",
+        }
+        unknown = sorted(set(d) - known)
+        if unknown:
+            raise ValueError(f"{where}: unknown key(s) {unknown}")
+        kind = d.get("kind", TARGET_KIND_LIBRARY)
+        if not isinstance(kind, str) or kind not in TARGET_KINDS:
+            raise ValueError(
+                f"{where}.kind must be one of {sorted(TARGET_KINDS)}, got {kind!r}"
+            )
+        bundle_only = d.get("bundle_only", False)
+        if not isinstance(bundle_only, bool):
+            raise ValueError(f"{where}.bundle_only must be a boolean")
+        checks_raw = d.get("checks")
+        if checks_raw is not None and not isinstance(checks_raw, list):
+            raise ValueError(f"{where}.checks must be a list")
+        checks: list[CheckSpec] = []
+        for i, c in enumerate(checks_raw or []):
+            if not isinstance(c, dict):
+                raise ValueError(f"{where}.checks[{i}] must be a mapping")
+            checks.append(CheckSpec.from_dict(c, where=f"{where}.checks[{i}]"))
+        return cls(
+            id=name,
+            kind=kind,
+            binary_pattern=str(d.get("binary_pattern", "") or ""),
+            public_headers=_str_list(d, "public_headers"),
+            bundle=str(d.get("bundle", "") or ""),
+            bundle_only=bundle_only,
+            consumer_binary_pattern=str(d.get("consumer_binary_pattern", "") or ""),
+            library=str(d.get("library", "") or ""),
+            contract_file=str(d.get("contract_file", "") or ""),
+            checks=checks,
+        )
+
+
+@dataclass
+class BundleSpec:
+    """One ``bundles:`` entry (ADR-047 §3) — a release group of library targets."""
+
+    id: str = ""
+    targets: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"targets": list(self.targets)}
+
+    @classmethod
+    def from_dict(cls, name: str, d: dict[str, Any]) -> BundleSpec:
+        where = f"bundles.{name}"
+        if not isinstance(d, dict):
+            raise ValueError(
+                f"{where} must be a mapping, got {type(d).__name__}: {d!r}"
+            )
+        unknown = sorted(set(d) - {"targets"})
+        if unknown:
+            raise ValueError(f"{where}: unknown key(s) {unknown}")
+        targets = d.get("targets")
+        if not isinstance(targets, list) or not targets:
+            raise ValueError(f"{where}.targets must be a non-empty list of target ids")
+        bad = [t for t in targets if not isinstance(t, str)]
+        if bad:
+            raise ValueError(f"{where}.targets must be a list of strings, got {bad!r}")
+        return cls(id=name, targets=[str(t) for t in targets])
+
+
+@dataclass
+class ProfileSpec:
+    """One ``profiles:`` entry (ADR-047 §3) — a build-lane identity.
+
+    ``contract: true`` (default) means this profile is an ABI contract (gets
+    a baseline, gates CI); ``contract: false`` marks a test-only CI lane that
+    never gets a baseline (S17's point).
+    """
+
+    id: str = ""
+    contract: bool = True
+    os: str = ""
+    arch: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"contract": self.contract}
+        if self.os:
+            d["os"] = self.os
+        if self.arch:
+            d["arch"] = self.arch
+        return d
+
+    @classmethod
+    def from_dict(cls, name: str, d: dict[str, Any]) -> ProfileSpec:
+        where = f"profiles.{name}"
+        if not isinstance(d, dict):
+            raise ValueError(
+                f"{where} must be a mapping, got {type(d).__name__}: {d!r}"
+            )
+        unknown = sorted(set(d) - {"contract", "os", "arch"})
+        if unknown:
+            raise ValueError(f"{where}: unknown key(s) {unknown}")
+        contract = d.get("contract", True)
+        if not isinstance(contract, bool):
+            raise ValueError(f"{where}.contract must be a boolean")
+        for key in ("os", "arch"):
+            if key in d and not isinstance(d[key], str):
+                raise ValueError(f"{where}.{key} must be a string")
+        return cls(
+            id=name,
+            contract=contract,
+            os=str(d.get("os", "") or ""),
+            arch=str(d.get("arch", "") or ""),
+        )
+
+
+@dataclass
+class BaselineChannelSpec:
+    """One ``baseline: channels:`` entry (ADR-047 §3/§10)."""
+
+    id: str = ""
+    source: str = ""
+    asset_pattern: str = ""
+    key_prefix: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {"source": self.source}
+        if self.asset_pattern:
+            d["asset_pattern"] = self.asset_pattern
+        if self.key_prefix:
+            d["key_prefix"] = self.key_prefix
+        return d
+
+    @classmethod
+    def from_dict(cls, name: str, d: dict[str, Any]) -> BaselineChannelSpec:
+        where = f"baseline.channels.{name}"
+        if not isinstance(d, dict):
+            raise ValueError(
+                f"{where} must be a mapping, got {type(d).__name__}: {d!r}"
+            )
+        unknown = sorted(set(d) - {"source", "asset_pattern", "key_prefix"})
+        if unknown:
+            raise ValueError(f"{where}: unknown key(s) {unknown}")
+        source = d.get("source")
+        if not isinstance(source, str) or source not in BASELINE_SOURCES:
+            raise ValueError(
+                f"{where}.source must be one of {sorted(BASELINE_SOURCES)}, got {source!r}"
+            )
+        for key in ("asset_pattern", "key_prefix"):
+            if key in d and not isinstance(d[key], str):
+                raise ValueError(f"{where}.{key} must be a string")
+        return cls(
+            id=name,
+            source=source,
+            asset_pattern=str(d.get("asset_pattern", "") or ""),
+            key_prefix=str(d.get("key_prefix", "") or ""),
+        )
+
+
+@dataclass
+class ProjectTargetsConfig:
+    """Parsed ``targets:``/``bundles:``/``profiles:``/``baseline:`` block.
+
+    All four sub-blocks are optional; an absent block yields an empty dict,
+    matching the ``buildsource``-wide convention that a project not yet
+    using G30's CI-integration primitives sees no behavior change at all.
+    """
+
+    targets: dict[str, TargetSpec] = field(default_factory=dict)
+    bundles: dict[str, BundleSpec] = field(default_factory=dict)
+    profiles: dict[str, ProfileSpec] = field(default_factory=dict)
+    baseline_channels: dict[str, BaselineChannelSpec] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        if self.targets:
+            out["targets"] = {k: v.to_dict() for k, v in self.targets.items()}
+        if self.bundles:
+            out["bundles"] = {k: v.to_dict() for k, v in self.bundles.items()}
+        if self.profiles:
+            out["profiles"] = {k: v.to_dict() for k, v in self.profiles.items()}
+        if self.baseline_channels:
+            out["baseline"] = {
+                "channels": {k: v.to_dict() for k, v in self.baseline_channels.items()}
+            }
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ProjectTargetsConfig:
+        """Parse the four top-level blocks out of a raw ``.abicheck.yml`` mapping.
+
+        Structural/type errors raise ``ValueError`` immediately (ADR-043
+        strict-config convention — the same treatment ``BuildConfig`` gives
+        the rest of ``.abicheck.yml``). Cross-reference/semantic issues
+        (unknown ``library``/``bundle`` reference, kind-specific required
+        fields, identifier charset) are **not** raised here — see
+        :func:`validate_project_targets`, which needs the fully-assembled
+        config to check references across blocks.
+        """
+        targets_raw = _require_mapping(data.get("targets"), "targets")
+        bundles_raw = _require_mapping(data.get("bundles"), "bundles")
+        profiles_raw = _require_mapping(data.get("profiles"), "profiles")
+        baseline_raw = _require_mapping(data.get("baseline"), "baseline")
+        unknown_baseline = sorted(set(baseline_raw) - {"channels"})
+        if unknown_baseline:
+            raise ValueError(f"baseline: unknown key(s) {unknown_baseline}")
+        channels_raw = _require_mapping(
+            baseline_raw.get("channels"), "baseline.channels"
+        )
+
+        targets = {
+            str(name): TargetSpec.from_dict(str(name), t)
+            for name, t in targets_raw.items()
+        }
+        bundles = {
+            str(name): BundleSpec.from_dict(str(name), b)
+            for name, b in bundles_raw.items()
+        }
+        profiles = {
+            str(name): ProfileSpec.from_dict(str(name), p)
+            for name, p in profiles_raw.items()
+        }
+        baseline_channels = {
+            str(name): BaselineChannelSpec.from_dict(str(name), c)
+            for name, c in channels_raw.items()
+        }
+        return cls(
+            targets=targets,
+            bundles=bundles,
+            profiles=profiles,
+            baseline_channels=baseline_channels,
+        )
+
+
+def load_project_targets_config(path: Path) -> ProjectTargetsConfig:
+    """Load the ``targets:``/``bundles:``/``profiles:``/``baseline:`` block from
+    a ``.abicheck.yml`` at *path*.
+
+    Tolerant of a missing/empty file (yields an all-empty config), matching
+    :func:`abicheck.buildsource.inline.load_build_config`'s same contract.
+    """
+    if not path.is_file():
+        return ProjectTargetsConfig()
+    import yaml
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        raise ValueError(f"cannot read project config {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        return ProjectTargetsConfig()
+    return ProjectTargetsConfig.from_dict(raw)
+
+
+@dataclass
+class ProjectTargetsValidationReport:
+    """Result of :func:`validate_project_targets` (mirrors
+    :class:`~.build_output.BuildOutputValidationReport`'s shape)."""
+
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "errors": list(self.errors),
+            "warnings": list(self.warnings),
+        }
+
+
+def _identifier_issues(kind: str, name: str) -> list[str]:
+    if not _IDENTIFIER_RE.match(name):
+        return [
+            f"{kind} id {name!r} is not a valid identifier — must match "
+            f"{_IDENTIFIER_RE.pattern!r} (the same charset ADR-047 §7's "
+            "check_id components require, so every id stays embeddable in a "
+            "target@profile#baseline_channel@depth string without ambiguity)."
+        ]
+    return []
+
+
+def _target_issues(config: ProjectTargetsConfig, target: TargetSpec) -> list[str]:
+    issues = _identifier_issues("target", target.id)
+    if target.kind == TARGET_KIND_LIBRARY:
+        if not target.binary_pattern:
+            issues.append(
+                f"target {target.id!r}: kind: library requires binary_pattern."
+            )
+        for forbidden in ("consumer_binary_pattern", "contract_file"):
+            if getattr(target, forbidden):
+                issues.append(
+                    f"target {target.id!r}: kind: library must not set {forbidden}."
+                )
+        if target.bundle_only and not target.bundle:
+            issues.append(
+                f"target {target.id!r}: bundle_only requires bundle to be set."
+            )
+        if target.bundle and target.bundle not in config.bundles:
+            issues.append(
+                f"target {target.id!r}: bundle {target.bundle!r} is not declared "
+                "under bundles:."
+            )
+    elif target.kind == TARGET_KIND_APP_CONSUMER:
+        if not target.consumer_binary_pattern:
+            issues.append(
+                f"target {target.id!r}: kind: app-consumer requires "
+                "consumer_binary_pattern."
+            )
+        issues.extend(_library_reference_issues(config, target))
+        for forbidden in ("binary_pattern", "contract_file"):
+            if getattr(target, forbidden):
+                issues.append(
+                    f"target {target.id!r}: kind: app-consumer must not set {forbidden}."
+                )
+    elif target.kind == TARGET_KIND_PLUGIN_CONTRACT:
+        if not target.contract_file:
+            issues.append(
+                f"target {target.id!r}: kind: plugin-contract requires contract_file."
+            )
+        issues.extend(_library_reference_issues(config, target))
+        for forbidden in ("binary_pattern", "consumer_binary_pattern"):
+            if getattr(target, forbidden):
+                issues.append(
+                    f"target {target.id!r}: kind: plugin-contract must not set {forbidden}."
+                )
+    for i, check in enumerate(target.checks):
+        issues.extend(_check_issues(config, target.id, i, check))
+    return issues
+
+
+def _library_reference_issues(
+    config: ProjectTargetsConfig, target: TargetSpec
+) -> list[str]:
+    if not target.library:
+        return [f"target {target.id!r}: kind: {target.kind} requires library."]
+    referenced = config.targets.get(target.library)
+    if referenced is None:
+        return [
+            f"target {target.id!r}: library {target.library!r} is not declared "
+            "under targets:."
+        ]
+    if referenced.kind != TARGET_KIND_LIBRARY:
+        return [
+            f"target {target.id!r}: library {target.library!r} must be a "
+            f"kind: library target, not kind: {referenced.kind!r} — "
+            "app-consumer/plugin-contract targets resolve their baseline/"
+            "candidate lookup through a real library target only (ADR-047 §3)."
+        ]
+    return []
+
+
+def _check_issues(
+    config: ProjectTargetsConfig, target_id: str, index: int, check: CheckSpec
+) -> list[str]:
+    where = f"target {target_id!r}.checks[{index}]"
+    issues: list[str] = []
+    if (
+        check.channel != NO_BASELINE_CHANNEL
+        and check.channel not in config.baseline_channels
+    ):
+        issues.append(
+            f"{where}: channel {check.channel!r} is not declared under "
+            f"baseline.channels: (use {NO_BASELINE_CHANNEL!r} for a no-baseline "
+            "audit check, ADR-047 §6 S5)."
+        )
+    if check.depth not in CHECK_DEPTHS:
+        issues.append(
+            f"{where}: depth must be one of {sorted(CHECK_DEPTHS)}, got {check.depth!r}."
+        )
+    if check.gate_mode not in GATE_MODES:
+        issues.append(
+            f"{where}: gate_mode must be one of {sorted(GATE_MODES)}, got {check.gate_mode!r}."
+        )
+    for profile_id in check.profiles:
+        if profile_id not in config.profiles:
+            issues.append(
+                f"{where}: profiles entry {profile_id!r} is not declared under profiles:."
+            )
+    return issues
+
+
+def _bundle_issues(config: ProjectTargetsConfig, bundle: BundleSpec) -> list[str]:
+    issues = _identifier_issues("bundle", bundle.id)
+    for member in bundle.targets:
+        referenced = config.targets.get(member)
+        if referenced is None:
+            issues.append(
+                f"bundle {bundle.id!r}: target {member!r} is not declared under targets:."
+            )
+        elif referenced.kind != TARGET_KIND_LIBRARY:
+            issues.append(
+                f"bundle {bundle.id!r}: target {member!r} must be kind: library, "
+                f"not kind: {referenced.kind!r}."
+            )
+        elif referenced.bundle and referenced.bundle != bundle.id:
+            issues.append(
+                f"bundle {bundle.id!r}: target {member!r} declares bundle: "
+                f"{referenced.bundle!r}, not {bundle.id!r} — a target's own "
+                "bundle: field and its membership here must agree."
+            )
+    return issues
+
+
+def _profile_issues(profile: ProfileSpec) -> list[str]:
+    return _identifier_issues("profile", profile.id)
+
+
+def _baseline_channel_issues(channel: BaselineChannelSpec) -> list[str]:
+    issues = _identifier_issues("baseline channel", channel.id)
+    if channel.source == "github-release" and not channel.asset_pattern:
+        issues.append(
+            f"baseline channel {channel.id!r}: source: github-release requires "
+            "asset_pattern (ADR-047 §10)."
+        )
+    if channel.source == "actions-cache" and not channel.key_prefix:
+        issues.append(
+            f"baseline channel {channel.id!r}: source: actions-cache requires "
+            "key_prefix (ADR-047 §10)."
+        )
+    return issues
+
+
+def validate_project_targets(
+    config: ProjectTargetsConfig,
+) -> ProjectTargetsValidationReport:
+    """Validate cross-references and kind-specific rules across the whole block.
+
+    Never raises for a structurally-parsed :class:`ProjectTargetsConfig` —
+    problems are reported, not thrown, matching
+    :func:`~.build_output.validate_build_output`'s same contract. Structural/
+    type errors already raised during :meth:`ProjectTargetsConfig.from_dict`.
+    """
+    report = ProjectTargetsValidationReport()
+    if not config.targets and not config.bundles and not config.profiles:
+        report.warnings.append(
+            "no targets:/bundles:/profiles: declared — nothing for a G30 "
+            "run-plan generator to act on yet."
+        )
+    for target in config.targets.values():
+        report.errors.extend(_target_issues(config, target))
+    for bundle in config.bundles.values():
+        report.errors.extend(_bundle_issues(config, bundle))
+    for profile in config.profiles.values():
+        report.errors.extend(_profile_issues(profile))
+    for channel in config.baseline_channels.values():
+        report.errors.extend(_baseline_channel_issues(channel))
+    return report

--- a/abicheck/buildsource/project_targets.py
+++ b/abicheck/buildsource/project_targets.py
@@ -546,9 +546,9 @@ class ProjectTargetsConfig:
         are still accepted here and simply ignored, since a real
         ``.abicheck.yml`` legitimately carries those alongside this block.
         """
-        unknown_top = sorted(set(data) - KNOWN_TOP_LEVEL_KEYS)
+        unknown_top = sorted((set(data) - KNOWN_TOP_LEVEL_KEYS), key=repr)
         if unknown_top:
-            raise ValueError(f"unknown .abicheck.yml key(s) {unknown_top}")
+            raise ValueError(f"unknown .abicheck.yml key(s) {unknown_top!r}")
         targets_raw = _require_mapping(data.get("targets"), "targets")
         bundles_raw = _require_mapping(data.get("bundles"), "bundles")
         profiles_raw = _require_mapping(data.get("profiles"), "profiles")

--- a/abicheck/buildsource/project_targets.py
+++ b/abicheck/buildsource/project_targets.py
@@ -109,9 +109,34 @@ CHECK_DEPTHS = frozenset(d.value for d in USER_DEPTHS)
 NO_BASELINE_CHANNEL = "none"
 
 
-def _str_list(d: dict[str, Any], key: str) -> list[str]:
+def _opt_str_field(d: dict[str, Any], key: str, *, where: str) -> str:
+    """A strictly-typed optional string field: absent/``None`` -> ``""``, any
+    non-string present value is a hard error (ADR-043 strict-config
+    convention — never silently coerced via ``str(...)``, unlike a bare
+    ``str(d.get(key, "") or "")`` which would turn e.g. a YAML list into the
+    synthetic string ``"['x']"``)."""
+    value = d.get(key)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(
+            f"{where}.{key} must be a string, got {type(value).__name__}: {value!r}"
+        )
+    return value
+
+
+def _require_str_list(d: dict[str, Any], key: str, *, where: str) -> list[str]:
+    """A strictly-typed optional list-of-strings field: absent -> ``[]``, a
+    non-list or a list containing a non-string element is a hard error."""
     raw = d.get(key)
-    return [str(x) for x in raw if isinstance(x, str)] if isinstance(raw, list) else []
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise ValueError(f"{where}.{key} must be a list of strings, got {raw!r}")
+    bad = [x for x in raw if not isinstance(x, str)]
+    if bad:
+        raise ValueError(f"{where}.{key} must be a list of strings, got {bad!r}")
+    return list(raw)
 
 
 def _require_mapping(data: object, block: str) -> dict[str, Any]:
@@ -177,16 +202,7 @@ class CheckSpec:
                 f"{where}.gate_mode must be a string, got "
                 f"{type(gate_mode).__name__}: {gate_mode!r}"
             )
-        profiles_raw = d.get("profiles")
-        if profiles_raw is not None and not isinstance(profiles_raw, list):
-            raise ValueError(f"{where}.profiles must be a list of strings")
-        profiles = _str_list(d, "profiles")
-        if profiles_raw is not None:
-            bad = [p for p in profiles_raw if not isinstance(p, str)]
-            if bad:
-                raise ValueError(
-                    f"{where}.profiles must be a list of strings, got {bad!r}"
-                )
+        profiles = _require_str_list(d, "profiles", where=where)
         return cls(
             channel=channel,
             depth=depth,
@@ -277,13 +293,15 @@ class TargetSpec:
         return cls(
             id=name,
             kind=kind,
-            binary_pattern=str(d.get("binary_pattern", "") or ""),
-            public_headers=_str_list(d, "public_headers"),
-            bundle=str(d.get("bundle", "") or ""),
+            binary_pattern=_opt_str_field(d, "binary_pattern", where=where),
+            public_headers=_require_str_list(d, "public_headers", where=where),
+            bundle=_opt_str_field(d, "bundle", where=where),
             bundle_only=bundle_only,
-            consumer_binary_pattern=str(d.get("consumer_binary_pattern", "") or ""),
-            library=str(d.get("library", "") or ""),
-            contract_file=str(d.get("contract_file", "") or ""),
+            consumer_binary_pattern=_opt_str_field(
+                d, "consumer_binary_pattern", where=where
+            ),
+            library=_opt_str_field(d, "library", where=where),
+            contract_file=_opt_str_field(d, "contract_file", where=where),
             checks=checks,
         )
 
@@ -532,27 +550,72 @@ def _identifier_issues(kind: str, name: str) -> list[str]:
     return []
 
 
+#: Every kind-specific "content" field a ``targets:`` entry can carry
+#: (excludes ``kind``/``checks``, which every kind allows).
+_ALL_KIND_FIELDS = frozenset(
+    {
+        "binary_pattern",
+        "public_headers",
+        "bundle",
+        "bundle_only",
+        "consumer_binary_pattern",
+        "library",
+        "contract_file",
+    }
+)
+#: Which of `_ALL_KIND_FIELDS` each ``kind`` allows — the complement is each
+#: kind's forbidden set, so a newly-added field is automatically forbidden
+#: everywhere it isn't explicitly allowed (CodeRabbit review: a partial,
+#: hand-maintained forbidden list previously let e.g. a `kind: library`
+#: target silently set `library:`, or an `app-consumer` silently set
+#: `bundle:`/`bundle_only:`, neither of which means anything for those kinds).
+_KIND_ALLOWED_FIELDS: dict[str, frozenset[str]] = {
+    TARGET_KIND_LIBRARY: frozenset(
+        {"binary_pattern", "public_headers", "bundle", "bundle_only"}
+    ),
+    TARGET_KIND_APP_CONSUMER: frozenset({"consumer_binary_pattern", "library"}),
+    TARGET_KIND_PLUGIN_CONTRACT: frozenset({"contract_file", "library"}),
+}
+
+
+def _forbidden_field_issues(target: TargetSpec) -> list[str]:
+    allowed = _KIND_ALLOWED_FIELDS.get(target.kind, frozenset())
+    issues: list[str] = []
+    for name in sorted(_ALL_KIND_FIELDS - allowed):
+        if getattr(target, name):
+            issues.append(
+                f"target {target.id!r}: kind: {target.kind} must not set {name}."
+            )
+    return issues
+
+
 def _target_issues(config: ProjectTargetsConfig, target: TargetSpec) -> list[str]:
     issues = _identifier_issues("target", target.id)
+    issues.extend(_forbidden_field_issues(target))
     if target.kind == TARGET_KIND_LIBRARY:
         if not target.binary_pattern:
             issues.append(
                 f"target {target.id!r}: kind: library requires binary_pattern."
             )
-        for forbidden in ("consumer_binary_pattern", "contract_file"):
-            if getattr(target, forbidden):
-                issues.append(
-                    f"target {target.id!r}: kind: library must not set {forbidden}."
-                )
         if target.bundle_only and not target.bundle:
             issues.append(
                 f"target {target.id!r}: bundle_only requires bundle to be set."
             )
-        if target.bundle and target.bundle not in config.bundles:
-            issues.append(
-                f"target {target.id!r}: bundle {target.bundle!r} is not declared "
-                "under bundles:."
-            )
+        if target.bundle:
+            declared_bundle = config.bundles.get(target.bundle)
+            if declared_bundle is None:
+                issues.append(
+                    f"target {target.id!r}: bundle {target.bundle!r} is not "
+                    "declared under bundles:."
+                )
+            elif target.id not in declared_bundle.targets:
+                issues.append(
+                    f"target {target.id!r}: declares bundle: {target.bundle!r} "
+                    f"but bundles.{target.bundle}.targets does not list "
+                    f"{target.id!r} back — a target's own bundle: field and its "
+                    "membership in that bundle's targets: list must agree in "
+                    "both directions."
+                )
     elif target.kind == TARGET_KIND_APP_CONSUMER:
         if not target.consumer_binary_pattern:
             issues.append(
@@ -560,22 +623,12 @@ def _target_issues(config: ProjectTargetsConfig, target: TargetSpec) -> list[str
                 "consumer_binary_pattern."
             )
         issues.extend(_library_reference_issues(config, target))
-        for forbidden in ("binary_pattern", "contract_file"):
-            if getattr(target, forbidden):
-                issues.append(
-                    f"target {target.id!r}: kind: app-consumer must not set {forbidden}."
-                )
     elif target.kind == TARGET_KIND_PLUGIN_CONTRACT:
         if not target.contract_file:
             issues.append(
                 f"target {target.id!r}: kind: plugin-contract requires contract_file."
             )
         issues.extend(_library_reference_issues(config, target))
-        for forbidden in ("binary_pattern", "consumer_binary_pattern"):
-            if getattr(target, forbidden):
-                issues.append(
-                    f"target {target.id!r}: kind: plugin-contract must not set {forbidden}."
-                )
     for i, check in enumerate(target.checks):
         issues.extend(_check_issues(config, target.id, i, check))
     return issues

--- a/abicheck/buildsource/project_targets.py
+++ b/abicheck/buildsource/project_targets.py
@@ -204,6 +204,10 @@ class CheckSpec:
     channel: str = ""
     depth: str = ""
     required: bool = True
+    #: Direct-construction default is ``"local"`` (matching this field's own
+    #: default); ``from_dict`` instead derives an unset ``gate_mode`` from
+    #: ``channel`` — ``"advisory"`` for the ``NO_BASELINE_CHANNEL`` sentinel,
+    #: ``"local"`` otherwise (ADR-047 §8 S5: "Advisory by default").
     gate_mode: str = "local"
     #: Explicit profile-id selector (see module docstring). Empty = every
     #: ``contract: true`` profile, filtered against ``build-output.json`` by
@@ -239,12 +243,20 @@ class CheckSpec:
                 f"{where}.required must be a boolean, got "
                 f"{type(required).__name__}: {required!r}"
             )
-        gate_mode = d.get("gate_mode", "local")
-        if not isinstance(gate_mode, str):
-            raise ValueError(
-                f"{where}.gate_mode must be a string, got "
-                f"{type(gate_mode).__name__}: {gate_mode!r}"
-            )
+        if "gate_mode" in d:
+            gate_mode = d["gate_mode"]
+            if not isinstance(gate_mode, str):
+                raise ValueError(
+                    f"{where}.gate_mode must be a string, got "
+                    f"{type(gate_mode).__name__}: {gate_mode!r}"
+                )
+        else:
+            # ADR-047 §8: a channel: "none" no-baseline audit (S5) defaults
+            # to advisory, not local -- unlike a real-channel check, it has
+            # no baseline-drift verdict to gate CI on in the first place, so
+            # defaulting it to a blocking gate would surprise a minimal
+            # `{channel: none, depth: ...}` entry into failing CI.
+            gate_mode = "advisory" if channel == NO_BASELINE_CHANNEL else "local"
         profiles = _require_str_list(d, "profiles", where=where)
         return cls(
             channel=channel,

--- a/abicheck/buildsource/project_targets.py
+++ b/abicheck/buildsource/project_targets.py
@@ -660,6 +660,13 @@ def _target_issues(config: ProjectTargetsConfig, target: TargetSpec) -> list[str
             issues.append(
                 f"target {target.id!r}: bundle_only requires bundle to be set."
             )
+        if target.bundle_only and target.checks:
+            issues.append(
+                f"target {target.id!r}: bundle_only: true target must not set "
+                "its own checks: — it is checked only as a bundle member, "
+                "never standalone, so a target-level check here would never "
+                "run; declare it under bundles:.checks instead."
+            )
         if target.bundle:
             declared_bundle = config.bundles.get(target.bundle)
             if declared_bundle is None:
@@ -736,9 +743,23 @@ def _check_issues(
             f"{where}: gate_mode must be one of {sorted(GATE_MODES)}, got {check.gate_mode!r}."
         )
     for profile_id in check.profiles:
-        if profile_id not in config.profiles:
+        profile = config.profiles.get(profile_id)
+        if profile is None:
             issues.append(
                 f"{where}: profiles entry {profile_id!r} is not declared under profiles:."
+            )
+        elif not profile.contract and check.channel != NO_BASELINE_CHANNEL:
+            # contract: false profiles are documented as test-only lanes that
+            # never get a baseline (S17) -- a real-channel check scoped only
+            # to one can never be satisfied. A channel: "none" audit check has
+            # no baseline to resolve in the first place, so it's exempt (S5
+            # audits on a non-contract lane are a legitimate use case).
+            issues.append(
+                f"{where}: profiles entry {profile_id!r} has contract: false "
+                "(a test-only lane that never gets a baseline) but this check "
+                f"declares a real channel ({check.channel!r}) — only a "
+                f"{NO_BASELINE_CHANNEL!r}-channel audit check may scope to a "
+                "non-contract profile."
             )
     return issues
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1861,6 +1861,7 @@ from . import (  # noqa: E402  — must run after `main` and helpers are defined
     cli_aggregate,  # noqa: F401  — registers aggregate
     cli_build_output,  # noqa: F401  — registers build-output (validate)
     cli_buildsource,  # noqa: F401  — buildsource internals (no command of its own)
+    cli_project_targets,  # noqa: F401  — registers project-targets (validate)
     cli_scan,  # noqa: F401  — registers scan
     cli_stack,  # noqa: F401  — registers deps (tree, compare)
 )

--- a/abicheck/cli_project_targets.py
+++ b/abicheck/cli_project_targets.py
@@ -1,0 +1,134 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI — the ``project-targets`` group (G30 P1.5, ADR-047 §3).
+
+``project-targets validate`` checks a project's ``.abicheck.yml``
+``targets:``/``bundles:``/``profiles:``/``baseline:`` block — the config
+G30 P1.4's (not built yet) run-plan generator will consume — for structural
+validity and cross-reference integrity (kind-specific required fields,
+``library``/``bundle``/``profiles``/``channel`` references all resolve,
+identifiers stay embeddable in a report ``check_id``). Split out of
+:mod:`abicheck.cli` per the sibling-module pattern; imported for side-effect
+at the bottom of :mod:`abicheck.cli` so ``@main.group``/
+``@project_targets_group.command`` run.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import click
+
+from .buildsource.project_targets import (
+    ProjectTargetsConfig,
+    validate_project_targets,
+)
+from .cli import _safe_write_output, _setup_verbosity, main
+from .cli_options import output_options, verbose_option
+
+
+@main.group("project-targets")
+def project_targets_group() -> None:
+    """Validate a project's target/bundle/profile/release-channel setup.
+
+    \b
+    Subcommands:
+      validate  Check .abicheck.yml's targets/bundles/profiles/channels block.
+    """
+
+
+@project_targets_group.command("validate")
+@click.argument(
+    "config",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=".abicheck.yml",
+)
+@output_options(
+    ["text", "json"],
+    default="text",
+    format_help="Output format for the validation report.",
+)
+@verbose_option
+def project_targets_validate_cmd(
+    config: Path,
+    fmt: str,
+    output: Path | None,
+    verbose: bool,
+) -> None:
+    """Validate CONFIG's targets:/bundles:/profiles:/baseline: block (ADR-047 §3).
+
+    CONFIG defaults to ``.abicheck.yml`` in the current directory. Checks:
+    every target's ``kind``-specific required fields are set (and no
+    kind-inappropriate field is); ``app-consumer``/``plugin-contract``
+    targets' ``library`` resolves to a real ``kind: library`` target; every
+    ``bundle:`` reference and bundle membership resolves and agrees; every
+    ``checks[].channel`` resolves to a declared baseline channel (or is the
+    ``"none"`` no-baseline sentinel); ``checks[].depth``/``gate_mode`` are
+    valid; every ``checks[].profiles`` entry resolves to a declared profile;
+    every id is a valid, ``check_id``-embeddable identifier.
+
+    Structural/type errors in the YAML itself (unknown key, wrong type) fail
+    immediately as a usage error; this command's own validation report only
+    covers cross-reference/semantic issues on an already-well-formed block.
+
+    \b
+    Exit codes:
+      0   Valid — no errors (warnings may still be present).
+      1   One or more validation errors.
+      64  Usage error (CONFIG is not readable YAML, or fails strict parsing).
+    """
+    _setup_verbosity(verbose)
+
+    import yaml
+
+    try:
+        raw = yaml.safe_load(config.read_text(encoding="utf-8"))
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        raise click.UsageError(f"cannot read {config}: {exc}") from exc
+    if raw is None:
+        raw = {}
+    if not isinstance(raw, dict):
+        raise click.UsageError(f"{config} must contain a YAML mapping.")
+
+    try:
+        parsed = ProjectTargetsConfig.from_dict(raw)
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
+
+    report = validate_project_targets(parsed)
+
+    if fmt == "json":
+        text = json.dumps(report.to_dict(), indent=2)
+    else:
+        lines = [f"project-targets validation: {config}"]
+        if report.ok:
+            lines.append("OK — no errors.")
+        else:
+            lines.append(f"FAILED — {len(report.errors)} error(s):")
+            lines.extend(f"  - {e}" for e in report.errors)
+        if report.warnings:
+            lines.append(f"{len(report.warnings)} warning(s):")
+            lines.extend(f"  - {w}" for w in report.warnings)
+        text = "\n".join(lines)
+
+    if output is not None:
+        _safe_write_output(output, text)
+    else:
+        click.echo(text)
+
+    sys.exit(0 if report.ok else 1)

--- a/changelog.d/20260720_173653_noreply_g30_implementation_frifpq.md
+++ b/changelog.d/20260720_173653_noreply_g30_implementation_frifpq.md
@@ -1,0 +1,13 @@
+### Added
+
+- **`.abicheck.yml` gains a `targets:`/`bundles:`/`profiles:`/`baseline:`
+  block** (G30 P1.5, ADR-047 §3) declaring a project's CI-integration
+  topology — library/app-consumer/plugin-contract targets, release bundles,
+  which build profiles are ABI contracts, baseline channels, and a
+  per-target `checks:` list assigning `{channel, depth, required,
+  gate_mode, profiles}` tuples. New `abicheck project-targets validate
+  [CONFIG]` command checks cross-references and kind-specific rules
+  (`abicheck/buildsource/project_targets.py`). `dump`/`compare`/`scan`
+  don't read this block yet — it's the config surface G30 P1.4's (not
+  built yet) run-plan generator will consume.
+

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -528,7 +528,7 @@ a dependency while P1.5's own entry said it "should land before P1.4" —
 inconsistent instructions that would leave an implementer with no real
 config schema to generate the matrix from. P1.5 must land first.
 
-### P1.5 — `.abicheck.yml` `targets:`/`profiles:`/`baseline:` block
+### P1.5 — `.abicheck.yml` `targets:`/`profiles:`/`baseline:` block — **done**
 
 Implements ADR-047 §3. Config schema extension + `abicheck/policy_file.py`
 (or wherever `.abicheck.yml` is parsed) support; `docs/reference/config-file.md`
@@ -548,6 +548,67 @@ this new `checks:` shape is the missing piece P1.4 actually consumes.
 not merely "should" — since P1.4 depends on this item (corrected above);
 sequence P1.5 ahead of P1.4 in the actual PR order, not just in ordinal
 numbering.
+
+**Status:** implemented. New `abicheck/buildsource/project_targets.py`
+defines `TargetSpec`/`BundleSpec`/`ProfileSpec`/`BaselineChannelSpec`/
+`CheckSpec` (the `{channel, depth, required, gate_mode, profiles}` tuple
+that closes the gap above) plus `ProjectTargetsConfig.from_dict()` (strict
+structural/type validation, ADR-043 convention — raises immediately on an
+unknown key or wrong-typed value, matching `BuildConfig`'s own strict
+`.abicheck.yml` parsing) and `validate_project_targets()` (cross-reference/
+semantic validation: kind-specific required/forbidden fields per §3's
+`library`/`app-consumer`/`plugin-contract` discriminator, the
+`app-consumer`/`plugin-contract` → `library` redirect rule resolving both
+of §3's "unstated rule" corrections, bundle membership agreement, and every
+`checks[].channel`/`profiles[]` reference resolving — or the `channel:
+"none"` sentinel for a §6 S5 no-baseline audit check). Every
+target/bundle/profile/channel id is validated against the same
+`[A-Za-z0-9][A-Za-z0-9._-]*` charset the report-identity envelope (§7)
+already requires for `check_id` components, so no id produced here can
+later become an unparseable `check_id`.
+
+`targets`/`bundles`/`profiles`/`baseline` are registered as recognized
+`.abicheck.yml` top-level keys in `BuildConfig._KNOWN_TOP_KEYS`
+(`abicheck/buildsource/inline.py`) — the same recognized-but-not-parsed
+treatment already given `risk_rules`/`crosschecks` — so their presence
+never trips `BuildConfig`'s own strict unknown-key error, but `BuildConfig`
+does not parse them itself; `project_targets.py`'s own loader
+(`load_project_targets_config`) re-reads the same file. This keeps
+`inline.py` (already at the file-size soft-limit warning) unchanged in
+size and matches the existing sibling-module-owns-its-block precedent.
+
+**Profile-scoping gap resolution, per the module's own docstring:** rather
+than assume the naive cross-product of every `checks:` entry with every
+`contract: true` profile is safe (§3 explicitly warns this produces
+impossible cells for a target that doesn't exist on every profile), each
+`checks:` entry carries an *optional* explicit `profiles:` selector
+(validated against declared `profiles:` ids when set); when omitted, this
+schema deliberately does not resolve a profile list itself — G30 P1.4's
+run-plan generator is the one responsible for deriving the actual
+`(target, profile)` cells from each profile's own `build-output.json`
+`targets[]` list (the ADR's second, safer option), never from a blind
+cross-product. This module's validator cannot enforce that downstream
+behavior; it documents the split explicitly rather than silently picking
+the unsafe default.
+
+New `abicheck project-targets validate [CONFIG]` CLI command
+(`abicheck/cli_project_targets.py`, registered as a new top-level command
+group exactly like P1.1's `build-output validate` — `tests/
+test_cli_root_surface.py`/`test_cli_surface_diff.py` updated to include it
+in the public command set, and `scripts/check_ai_readiness.py`'s
+`IMPORT_CYCLE_ALLOWLIST` documents it joining the existing by-design
+CLI-registration SCC the same way `cli_build_output`/`cli_aggregate`
+already do). No producer/run-plan-generator tooling yet — `dump`/
+`compare`/`scan` do not read this block at all, matching P1.1's same
+"defines the contract, no consumer yet" scope. `docs/reference/
+project-targets-schema.md` (new, linked from mkdocs nav) documents the
+full schema; `docs/reference/config-file.md`'s top-level key table and
+`risk_rules:`/`crosschecks:` section gain the four new keys, pointing at
+the new page rather than duplicating it. `tests/test_project_targets.py`
+covers the schema round-trip, `BuildConfig`'s recognition of the new keys,
+the from_dict structural-error taxonomy, every cross-reference validation
+rule (including the exact ADR-047 §3 PVXS two-target-one-bundle shape as a
+positive case), the loader, and the CLI command.
 
 ### P1.6 — `publish-baseline.yml` / `update-main-baseline.yml`
 

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -67,6 +67,10 @@ an unknown-key error.
 | [`version:`](#version) | integer | `0` | Config schema version (forward-compat) |
 | [`risk_rules:`](#risk_rules-and-crosschecks) | mapping | — | Path-glob risk profile (loaded via `--risk-rules`) |
 | [`crosschecks:`](#risk_rules-and-crosschecks) | mapping | — | Reserved (recognized so it does not trip the unknown-key error) |
+| [`targets:`](#targets-bundles-profiles-and-baseline) | mapping | — | CI-integration target/consumer/plugin-contract topology (G30 P1.5) |
+| [`bundles:`](#targets-bundles-profiles-and-baseline) | mapping | — | Release groups of `targets:` (G30 P1.5) |
+| [`profiles:`](#targets-bundles-profiles-and-baseline) | mapping | — | Which build lanes are ABI contracts (G30 P1.5) |
+| [`baseline:`](#targets-bundles-profiles-and-baseline) | mapping | — | Baseline-channel declarations (G30 P1.5) |
 
 Recognized keys and defaults live in `BuildConfig` (`buildsource/inline.py`).
 
@@ -230,6 +234,20 @@ error), but they are handled outside the `compare` config merge:
 - **`crosschecks:`** — reserved. The active mechanism for tuning cross-checks is
   `scan`'s repeatable `--crosscheck KEY=LEVEL` flag; the current code does not
   read a `crosschecks:` block from the file.
+
+---
+
+### `targets:`, `bundles:`, `profiles:`, and `baseline:`
+
+Recognized top-level keys (so they do not trigger the unknown-key error),
+but — like `risk_rules:`/`crosschecks:` above — not parsed by `BuildConfig`
+itself. `dump`/`compare`/`scan` never read this block; it exists solely for
+G30's GitHub Actions CI-integration primitives (a run-plan generator that
+consumes it is planned but not built yet). Parsed and validated by
+`buildsource/project_targets.py`; see the
+**[Project Targets Schema reference](project-targets-schema.md)** for the
+full field-by-field schema, the `checks:` list, and the
+`abicheck project-targets validate` command.
 
 ---
 

--- a/docs/reference/project-targets-schema.md
+++ b/docs/reference/project-targets-schema.md
@@ -1,0 +1,216 @@
+# `.abicheck.yml` Project Targets Reference
+
+`.abicheck.yml`'s `targets:`/`bundles:`/`profiles:`/`baseline:` block is the
+portable, project-owned surface that declares a project's CI-integration
+topology: which libraries/consumers/plugin-contracts exist, how they group
+into release bundles, which build profiles are ABI contracts, which baseline
+channels exist, and exactly which `{channel, depth, required, gate_mode}`
+checks run against each target (G30/ADR-047 §3).
+
+> **Status.** This page documents the schema and the
+> `abicheck project-targets validate` command shipped in G30 P1.5. The
+> run-plan generator that reads a validated block to fan out CI checks
+> (`check-single.yml`/`check-project.yml`) is G30 P1.4, not built yet — see
+> the [G30 plan](../development/plans/g30-github-actions-integration-model.md).
+> A project not using G30's CI-integration primitives sees no behavior
+> change at all from adding (or omitting) this block: nothing in `dump`/
+> `compare`/`scan` reads it today.
+
+## Example
+
+```yaml
+# .abicheck.yml (excerpt)
+targets:
+  libpvxs:
+    kind: library          # default
+    binary_pattern: "lib/libpvxs.so*"
+    public_headers: ["headers/pvxs"]
+    bundle: pvxs-release
+    bundle_only: false     # run libpvxs both standalone AND as a bundle member
+    checks:
+      - channel: accepted-main
+        depth: headers
+        required: true
+        gate_mode: local
+  libpvxsIoc:
+    kind: library
+    binary_pattern: "lib/libpvxsIoc.so*"
+    public_headers: ["headers/pvxsIoc"]
+    bundle: pvxs-release
+  myapp-consumer:
+    kind: app-consumer     # compare --used-by
+    consumer_binary_pattern: "bin/myapp"
+    library: libpvxs
+  ioc-plugin-contract:
+    kind: plugin-contract  # compare --required-symbols
+    contract_file: "contracts/ioc-plugin.syms"
+    library: libpvxsIoc
+
+bundles:
+  pvxs-release:
+    targets: [libpvxs, libpvxsIoc]
+
+profiles:
+  linux-x86_64-gcc13-release:
+    contract: true          # this lane IS an ABI contract — gets a baseline, gates CI
+    os: linux
+    arch: x86_64
+  ubuntu-latest-clang-debug-sanitizer:
+    contract: false         # test-only CI lane — never gets a baseline
+
+baseline:
+  channels:
+    release-contract: {source: github-release, asset_pattern: "abicheck-baseline-*.tar.zst"}
+    accepted-main: {source: actions-cache, key_prefix: "abicheck-baseline-main"}
+```
+
+`abicheck project-targets validate` — like the rest of `.abicheck.yml` —
+loads this via [PyYAML's `safe_load`](https://pyyaml.org/wiki/PyYAMLDocumentation#loading-yaml),
+so no custom YAML tags are ever evaluated.
+
+## `targets:`
+
+A mapping of target id → target entry. Every id must match
+`^[A-Za-z0-9][A-Za-z0-9._-]*$` — the same charset the report-identity
+envelope (ADR-047 §7) requires for `check_id`'s
+`target@profile#baseline_channel@depth` components, so a valid id here can
+never produce an ambiguous identifier downstream.
+
+`kind` (default `library`) is a discriminator; the remaining fields it
+accepts/requires depend on it:
+
+| `kind` | Required fields | Forbidden fields | Meaning |
+|--------|------------------|-------------------|---------|
+| `library` (default) | `binary_pattern` | `consumer_binary_pattern`, `contract_file` | An ordinary shared-library ABI contract (S1–S17, S26). |
+| `app-consumer` | `consumer_binary_pattern`, `library` | `binary_pattern`, `contract_file` | An application compatibility check (S22, `compare --used-by`). |
+| `plugin-contract` | `contract_file`, `library` | `binary_pattern`, `consumer_binary_pattern` | A plugin/dlopen entrypoint contract (S23, `compare --required-symbols`). |
+
+Common optional fields for `kind: library`:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `public_headers` | list of string | Public header roots for this target. |
+| `bundle` | string | The `bundles:` entry this target belongs to. Must be declared under `bundles:`, and that bundle's own `targets:` list must include this target back (the two must agree). |
+| `bundle_only` | boolean, default `false` | When `true`, this target is checked only as a bundle member, never standalone. Requires `bundle` to be set. |
+| `checks` | list of check tuple | See [`checks:`](#checks) below. |
+
+`app-consumer`/`plugin-contract` fields:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `consumer_binary_pattern` | string | (`app-consumer` only) Path pattern to the consumer binary under test. |
+| `contract_file` | string | (`plugin-contract` only) A **`.syms` file** — one required linker symbol per line, `#` comments allowed. This is `--required-symbols`'s actual on-disk format (`abicheck/cli_compare_helpers.py`'s `_load_required_symbols`), not YAML. |
+| `library` | string | The `kind: library` target this entry resolves its baseline **and** candidate-artifact lookup through (ADR-047 §3's "unstated rule" correction). Must name a real, declared `kind: library` target — never another `app-consumer`/`plugin-contract` entry. The check's own reporting identity (`check_id`/`target_id`) stays this entry's own name; only the *lookup* redirects to `library`. |
+
+### `checks:`
+
+Each `targets:<id>.checks[]` entry is a `{channel, depth, required,
+gate_mode, profiles}` tuple — the assignment ADR-047 §3 itself identifies as
+missing from the plain `targets:`/`baseline: channels:` excerpt: declaring
+which channels *exist* doesn't say which channel/depth/policy a given
+target actually runs.
+
+| Field | Type | Default | Meaning |
+|-------|------|---------|---------|
+| `channel` | string | — (required) | A `baseline.channels` id, or the literal `"none"` for a no-baseline audit check (ADR-047 §6 S5 — `check-target` must skip `resolve-baseline` entirely for this sentinel, never look it up as a declared channel). |
+| `depth` | string | — (required) | One of `binary`, `headers`, `build`, `source` — the same four rungs `--depth`/the report envelope's `requested_depth` accept. |
+| `required` | boolean | `true` | Whether this check gates `aggregate`'s coverage requirement. |
+| `gate_mode` | string | `local` | One of `local`, `deferred`, `advisory` (ADR-047 §4/§7). |
+| `profiles` | list of string | *(unset)* | An **explicit** profile-id selector — see [Profile scoping](#profile-scoping-for-checks) below. |
+
+### Profile scoping for `checks:`
+
+ADR-047 §3 flags an open gap: naively crossing every `checks:` entry with
+every `contract: true` profile produces impossible cells for a target that
+doesn't exist on every profile (a Windows-only library, a Linux-only `.so`).
+This schema resolves it with two complementary mechanisms:
+
+- An **explicit `profiles:` selector** on a `checks:` entry restricts that
+  check to the listed profile ids (each validated against `profiles:`).
+  Use this when a check is genuinely profile-specific.
+- When `profiles:` is **omitted**, this schema does not itself resolve a
+  profile list — G30 P1.4's run-plan generator is responsible for deriving
+  the actual `(target, profile)` cells from each profile's own
+  `build-output.json` `targets[]` list (only generating a cell where the
+  target actually appears in that profile's declared targets), never from a
+  blind cross-product. `abicheck project-targets validate` cannot check that
+  downstream behavior — it only validates that an explicit selector, when
+  given, names real profile ids.
+
+## `bundles:`
+
+A mapping of bundle id → `{targets: [...]}`. Every listed target must be a
+declared `kind: library` target, and if that target itself sets a `bundle:`
+field, it must name this same bundle back — the validator flags a
+mismatch (e.g. a target claims `bundle: bundle-a` but only `bundle-b` lists
+it as a member) as an integrity error, not a silent inconsistency.
+
+## `profiles:`
+
+A mapping of profile id → `{contract, os, arch}`. `contract` (default
+`true`) decides whether this build lane is an ABI contract (gets a
+baseline, gates CI) or a test-only CI lane that never gets one — "not every
+CI lane gets a baseline" is the whole point of this field (S17). The map
+key is the same `profile.id` string used throughout `build-output.json`,
+`run-plan.json`, and the report envelope's `profile_id` field.
+
+## `baseline:`
+
+Currently one recognized sub-key, `channels:` — a mapping of channel id →
+`{source, asset_pattern, key_prefix}`:
+
+| `source` | Requires | Backend (ADR-047 §10) |
+|----------|----------|------------------------|
+| `github-release` | `asset_pattern` | A GitHub Release asset — atomic single-tarball upload. |
+| `actions-cache` | `key_prefix` | GitHub Actions cache — cheap, no push, naturally ages out. |
+| `git` | *(neither)* | Committed to the repo — S1's minimal case only, must go through a PR. |
+
+An external object store (a fourth backend ADR-047 §10 lists) is out of
+scope for P0/P1 and not a valid `source` value here.
+
+## Validation
+
+`abicheck project-targets validate [CONFIG]` (`CONFIG` defaults to
+`.abicheck.yml` in the current directory) checks, per ADR-047 §3:
+
+1. Every target's `kind`-specific required fields are set, and no
+   kind-inappropriate field is (see the table above).
+2. `app-consumer`/`plugin-contract` targets' `library` resolves to a real,
+   declared `kind: library` target — never to another
+   `app-consumer`/`plugin-contract` entry, and never to an undeclared name.
+3. `bundle_only: true` requires `bundle` to be set.
+4. Every `bundle:` reference resolves to a declared `bundles:` entry, and
+   every `bundles:<id>.targets[]` member resolves to a declared `kind:
+   library` target whose own `bundle:` field (if set) agrees.
+5. Every `checks[].channel` resolves to a declared `baseline.channels` id,
+   or is the `"none"` no-baseline sentinel.
+6. `checks[].depth` is one of the four valid rungs; `checks[].gate_mode` is
+   one of `local`/`deferred`/`advisory`.
+7. Every `checks[].profiles` entry resolves to a declared `profiles:` id.
+8. Every target/bundle/profile/channel id matches the `check_id`-safe
+   identifier charset.
+
+Structural/type errors in the YAML itself (an unknown key, a value of the
+wrong type — e.g. `contract: "yes"` instead of a boolean) fail immediately,
+as a usage error, matching `.abicheck.yml`'s existing strict-parsing
+convention (ADR-043) — the validation report above only covers
+cross-reference/semantic issues on an already-well-formed block.
+
+### CLI
+
+```console
+$ abicheck project-targets validate .abicheck.yml
+project-targets validation: .abicheck.yml
+OK — no errors.
+
+$ abicheck project-targets validate .abicheck.yml --format json
+{
+  "ok": true,
+  "errors": [],
+  "warnings": []
+}
+```
+
+Exit codes: `0` valid (warnings may still be present), `1` one or more
+validation errors, `64` usage error (`CONFIG` is not readable YAML, or its
+`targets:`/`bundles:`/`profiles:`/`baseline:` block fails strict parsing).

--- a/docs/reference/project-targets-schema.md
+++ b/docs/reference/project-targets-schema.md
@@ -115,7 +115,7 @@ target actually runs.
 | `channel` | string | — (required) | A `baseline.channels` id, or the literal `"none"` for a no-baseline audit check (ADR-047 §6 S5 — `check-target` must skip `resolve-baseline` entirely for this sentinel, never look it up as a declared channel). |
 | `depth` | string | — (required) | One of `binary`, `headers`, `build`, `source` — the same four rungs `--depth`/the report envelope's `requested_depth` accept. |
 | `required` | boolean | `true` | Whether this check gates `aggregate`'s coverage requirement. |
-| `gate_mode` | string | `local` | One of `local`, `deferred`, `advisory` (ADR-047 §4/§7). |
+| `gate_mode` | string | `local` (`advisory` when `channel: "none"`) | One of `local`, `deferred`, `advisory` (ADR-047 §4/§7). A `channel: "none"` no-baseline audit check defaults to `advisory`, not `local` — it has no baseline-drift verdict to gate CI on, so a minimal `{channel: none, depth: ...}` entry must not unexpectedly block CI (ADR-047 §8's S5 row: "Advisory by default"). Set `gate_mode` explicitly to override either default. |
 | `profiles` | list of string | *(unset)* | An **explicit** profile-id selector — see [Profile scoping](#profile-scoping-for-checks) below. A profile with `contract: false` may only be named here by a `channel: "none"` audit check — a real-channel check can never resolve a baseline on a lane that's documented to never get one (S17). |
 
 ### Profile scoping for `checks:`

--- a/docs/reference/project-targets-schema.md
+++ b/docs/reference/project-targets-schema.md
@@ -91,7 +91,7 @@ Common optional fields for `kind: library`:
 |-------|------|---------|
 | `public_headers` | list of string | Public header roots for this target. |
 | `bundle` | string | The `bundles:` entry this target belongs to. Must be declared under `bundles:`, and that bundle's own `targets:` list must include this target back (the two must agree). |
-| `bundle_only` | boolean, default `false` | When `true`, this target is checked only as a bundle member, never standalone. Requires `bundle` to be set. |
+| `bundle_only` | boolean, default `false` | When `true`, this target is checked only as a bundle member, never standalone. Requires `bundle` to be set, and must **not** declare its own `checks:` — a `bundle_only` target's own checks would never run standalone, so declare the policy under `bundles:<id>.checks` instead. |
 | `checks` | list of check tuple | See [`checks:`](#checks) below. |
 
 `app-consumer`/`plugin-contract` fields:
@@ -116,7 +116,7 @@ target actually runs.
 | `depth` | string | — (required) | One of `binary`, `headers`, `build`, `source` — the same four rungs `--depth`/the report envelope's `requested_depth` accept. |
 | `required` | boolean | `true` | Whether this check gates `aggregate`'s coverage requirement. |
 | `gate_mode` | string | `local` | One of `local`, `deferred`, `advisory` (ADR-047 §4/§7). |
-| `profiles` | list of string | *(unset)* | An **explicit** profile-id selector — see [Profile scoping](#profile-scoping-for-checks) below. |
+| `profiles` | list of string | *(unset)* | An **explicit** profile-id selector — see [Profile scoping](#profile-scoping-for-checks) below. A profile with `contract: false` may only be named here by a `channel: "none"` audit check — a real-channel check can never resolve a baseline on a lane that's documented to never get one (S17). |
 
 ### Profile scoping for `checks:`
 
@@ -186,7 +186,9 @@ scope for P0/P1 and not a valid `source` value here.
 2. `app-consumer`/`plugin-contract` targets' `library` resolves to a real,
    declared `kind: library` target — never to another
    `app-consumer`/`plugin-contract` entry, and never to an undeclared name.
-3. `bundle_only: true` requires `bundle` to be set.
+3. `bundle_only: true` requires `bundle` to be set, and forbids the target
+   from declaring its own `checks:` (it's checked only as a bundle member;
+   a standalone check on it would never run).
 4. Every `bundle:` reference resolves to a declared `bundles:` entry, and
    every `bundles:<id>.targets[]` member resolves to a declared `kind:
    library` target whose own `bundle:` field (if set) agrees.
@@ -194,7 +196,9 @@ scope for P0/P1 and not a valid `source` value here.
    or is the `"none"` no-baseline sentinel.
 6. `checks[].depth` is one of the four valid rungs; `checks[].gate_mode` is
    one of `local`/`deferred`/`advisory`.
-7. Every `checks[].profiles` entry resolves to a declared `profiles:` id.
+7. Every `checks[].profiles` entry resolves to a declared `profiles:` id,
+   and a `contract: false` profile may only be named by a `channel: "none"`
+   audit check.
 8. Every target/bundle/profile/channel id matches the `check_id`-safe
    identifier charset.
 9. Rules 5-7 apply identically to a bundle's own `checks[]`, not just a

--- a/docs/reference/project-targets-schema.md
+++ b/docs/reference/project-targets-schema.md
@@ -139,11 +139,19 @@ This schema resolves it with two complementary mechanisms:
 
 ## `bundles:`
 
-A mapping of bundle id → `{targets: [...]}`. Every listed target must be a
-declared `kind: library` target, and if that target itself sets a `bundle:`
-field, it must name this same bundle back — the validator flags a
-mismatch (e.g. a target claims `bundle: bundle-a` but only `bundle-b` lists
-it as a member) as an integrity error, not a silent inconsistency.
+A mapping of bundle id → `{targets: [...], checks: [...]}`. Every listed
+target must be a declared `kind: library` target, and if that target itself
+sets a `bundle:` field, it must name this same bundle back — the validator
+flags a mismatch (e.g. a target claims `bundle: bundle-a` but only
+`bundle-b` lists it as a member) as an integrity error, not a silent
+inconsistency.
+
+`checks:` on a bundle uses the exact same `{channel, depth, required,
+gate_mode, profiles}` shape [described above](#checks) for a target — the
+ADR-047 §5 run-plan emits a `kind: "bundle"` check entry alongside
+per-target ones (S14 bundle-scoped analysis, e.g. soname/provider-set
+checks across the whole release), and that cell needs its own
+baseline-channel/depth/gate policy independent of its member targets'.
 
 ## `profiles:`
 
@@ -189,12 +197,16 @@ scope for P0/P1 and not a valid `source` value here.
 7. Every `checks[].profiles` entry resolves to a declared `profiles:` id.
 8. Every target/bundle/profile/channel id matches the `check_id`-safe
    identifier charset.
+9. Rules 5-7 apply identically to a bundle's own `checks[]`, not just a
+   target's.
 
-Structural/type errors in the YAML itself (an unknown key, a value of the
-wrong type — e.g. `contract: "yes"` instead of a boolean) fail immediately,
-as a usage error, matching `.abicheck.yml`'s existing strict-parsing
-convention (ADR-043) — the validation report above only covers
-cross-reference/semantic issues on an already-well-formed block.
+Structural/type errors in the YAML itself (an unknown key at any level —
+including a misspelled top-level block like `tagrets:`, checked against the
+*full* `.abicheck.yml` key set, not just this block's four keys — or a
+value of the wrong type, e.g. `contract: "yes"` instead of a boolean) fail
+immediately, as a usage error, matching `.abicheck.yml`'s existing
+strict-parsing convention (ADR-043) — the validation report above only
+covers cross-reference/semantic issues on an already-well-formed block.
 
 ### CLI
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,7 @@ nav:
     - Exit Codes: reference/exit-codes.md
     - Snapshot Format: reference/snapshot-format.md
     - Build Output Schema: reference/build-output-schema.md
+    - Project Targets Schema: reference/project-targets-schema.md
     - Configuration File: reference/config-file.md
     - Environment Variables: reference/environment.md
     - Platforms: reference/platforms.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,9 @@ disable_error_code = ["no-any-return", "misc"]
 # may be absent → ``import-untyped``). One block so the codes don't conflict.
 # ``cli_scan_baseline`` is the extracted ``--baseline``/``--estimate`` sub-flow
 # (same ``yaml`` + engine-``Any`` surface), so it shares the same relaxations.
-module = ["abicheck.cli_scan", "abicheck.cli_scan_baseline"]
+# ``cli_project_targets`` (G30 P1.5) reads ``.abicheck.yml`` directly for its
+# ``project-targets validate`` command, same ``yaml`` import.
+module = ["abicheck.cli_scan", "abicheck.cli_scan_baseline", "abicheck.cli_project_targets"]
 disallow_untyped_decorators = false
 disable_error_code = ["no-any-return", "misc", "import-untyped"]
 
@@ -201,6 +203,7 @@ module = [
     "abicheck.bundle_manifest",
     "abicheck.buildsource.extractor_manifest",
     "abicheck.buildsource.inline",
+    "abicheck.buildsource.project_targets",
 ]
 disable_error_code = ["import-untyped"]
 

--- a/repo_facts.json
+++ b/repo_facts.json
@@ -1,9 +1,9 @@
 {
   "canonical_python": "3.13",
   "example_cases": 195,
-  "fast_test_cases_collected": 17528,
-  "generated_utc": "2026-07-20T02:06:59+00:00",
+  "fast_test_cases_collected": 17711,
+  "generated_utc": "2026-07-20T17:39:24+00:00",
   "latest_release": "0.5.0",
   "project_version": "0.5.0",
-  "source_commit": "47919313624f700fddcd453d1cf9ea1fdcb974aa"
+  "source_commit": "77d5b2c9f906ce7e970b7d60f61829d10fdbf568"
 }

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -1060,6 +1060,15 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
                 "cli_plugin",
                 "cli_pr_comment",
                 "cli_probe",
+                # `cli_project_targets` (G30 P1.5) joins this SCC exactly like
+                # `cli_build_output`/`cli_aggregate`: its `project-targets
+                # validate` command reuses the shared `-o/--format` pair via
+                # `cli_options.output_options` (module-load import), and
+                # `cli_options` is already a member — so `cli ->
+                # cli_project_targets -> cli_options -> ... -> cli` closes
+                # through already-member modules, not a new dependency
+                # direction. No init deadlock.
+                "cli_project_targets",
                 "cli_resolve",
                 "cli_scan",
                 "cli_scan_baseline",

--- a/tests/test_cli_root_surface.py
+++ b/tests/test_cli_root_surface.py
@@ -17,9 +17,11 @@
 
 The pre-1.0 CLI reset requires the public root surface to show *exactly*
 ``dump``, ``compare``, ``scan``, ``deps``, ``compat`` — plus ``aggregate``
-(the multi-target CI fan-in gate) and ``build-output`` (the G30 P1.1
-``build-output.json`` validator group), both added afterward — with no
-hidden aliases, and no deprecated shims for the deleted commands
+(the multi-target CI fan-in gate), ``build-output`` (the G30 P1.1
+``build-output.json`` validator group), and ``project-targets`` (the G30
+P1.5 ``targets:``/``bundles:``/``profiles:``/``baseline:`` validator group),
+all added afterward — with no hidden aliases, and no deprecated shims for
+the deleted commands
 (``appcompat``, ``plugin-check``, ``baseline``, ``collect``, ``merge``,
 ``recommend-collect-mode``, ``debian-symbols``, ``doctor``, ``config``,
 ``init``, ``surface-report``, ``pr-comment``, ``suggest-suppressions``,
@@ -40,7 +42,16 @@ from click.testing import CliRunner
 from abicheck.cli import main
 
 _PUBLIC_COMMANDS = frozenset(
-    {"dump", "compare", "scan", "deps", "compat", "aggregate", "build-output"}
+    {
+        "dump",
+        "compare",
+        "scan",
+        "deps",
+        "compat",
+        "aggregate",
+        "build-output",
+        "project-targets",
+    }
 )
 
 _REMOVED_COMMANDS = (

--- a/tests/test_cli_surface_diff.py
+++ b/tests/test_cli_surface_diff.py
@@ -50,9 +50,11 @@ def diff_mod():  # type: ignore[no-untyped-def]
 
 def test_dump_surface_covers_root_commands(dump_mod) -> None:  # type: ignore[no-untyped-def]
     """The dumped surface exposes exactly the public root commands (ADR-043,
-    plus ``aggregate`` — the multi-target CI fan-in gate — and
-    ``build-output`` — the G30 P1.1 ``build-output.json`` validator group —
-    both added afterward).
+    plus ``aggregate`` — the multi-target CI fan-in gate —,
+    ``build-output`` — the G30 P1.1 ``build-output.json`` validator group —,
+    and ``project-targets`` — the G30 P1.5
+    ``targets:``/``bundles:``/``profiles:``/``baseline:`` validator group —
+    all added afterward).
 
     `pr-comment` is deliberately NOT here: it is Action/library-only tooling
     (`python -m abicheck.cli_pr_comment`), never a public `abicheck` subcommand.
@@ -65,6 +67,7 @@ def test_dump_surface_covers_root_commands(dump_mod) -> None:  # type: ignore[no
         "compat",
         "deps",
         "dump",
+        "project-targets",
         "scan",
     }
 

--- a/tests/test_project_targets.py
+++ b/tests/test_project_targets.py
@@ -774,6 +774,32 @@ def test_check_spec_gate_mode_wrong_type_raises() -> None:
         )
 
 
+# ── gate_mode default depends on channel (ADR-047 §8 S5: advisory) ─────────
+
+
+def test_check_spec_none_channel_defaults_gate_mode_to_advisory() -> None:
+    """A `channel: "none"` (S5 no-baseline audit) check has no baseline-drift
+    verdict to gate CI on, so it must default to advisory, not local -- a
+    minimal `{channel: none, depth: ...}` entry must not unexpectedly block
+    CI (ADR-047 §8's S5 row: "Advisory by default")."""
+    check = CheckSpec.from_dict({"channel": "none", "depth": "headers"}, where="x")
+    assert check.gate_mode == "advisory"
+
+
+def test_check_spec_real_channel_defaults_gate_mode_to_local() -> None:
+    check = CheckSpec.from_dict(
+        {"channel": "accepted-main", "depth": "headers"}, where="x"
+    )
+    assert check.gate_mode == "local"
+
+
+def test_check_spec_explicit_gate_mode_overrides_none_channel_default() -> None:
+    check = CheckSpec.from_dict(
+        {"channel": "none", "depth": "headers", "gate_mode": "local"}, where="x"
+    )
+    assert check.gate_mode == "local"
+
+
 def test_check_spec_to_dict_includes_profiles_when_set() -> None:
     check = CheckSpec(
         channel="accepted-main", depth="headers", profiles=["linux-x86_64"]
@@ -909,9 +935,16 @@ def test_bundle_checks_round_trip_and_validate() -> None:
             },
         }
     )
-    assert config.bundles["rel"].checks == [CheckSpec(channel="none", depth="headers")]
+    assert config.bundles["rel"].checks == [
+        CheckSpec(channel="none", depth="headers", gate_mode="advisory")
+    ]
     assert config.bundles["rel"].to_dict()["checks"] == [
-        {"channel": "none", "depth": "headers", "required": True, "gate_mode": "local"}
+        {
+            "channel": "none",
+            "depth": "headers",
+            "required": True,
+            "gate_mode": "advisory",
+        }
     ]
     round_tripped = ProjectTargetsConfig.from_dict(config.to_dict())
     assert round_tripped == config
@@ -993,7 +1026,7 @@ def test_other_abicheck_yml_blocks_are_accepted_and_ignored() -> None:
     ],
 )
 def test_non_string_mapping_keys_are_rejected(raw: dict) -> None:
-    with pytest.raises(ValueError, match="key.*must be strings"):
+    with pytest.raises(ValueError, match=r"key.*must be strings"):
         ProjectTargetsConfig.from_dict(raw)
 
 

--- a/tests/test_project_targets.py
+++ b/tests/test_project_targets.py
@@ -804,6 +804,93 @@ def test_bundle_unknown_key_raises() -> None:
         )
 
 
+# ── Bundle-level checks: (review finding — ADR-047 §5 needs bundle cells) ──
+
+
+def test_bundle_checks_round_trip_and_validate() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "a": {"kind": "library", "binary_pattern": "a.so", "bundle": "rel"},
+                "b": {"kind": "library", "binary_pattern": "b.so", "bundle": "rel"},
+            },
+            "bundles": {
+                "rel": {
+                    "targets": ["a", "b"],
+                    "checks": [{"channel": "none", "depth": "headers"}],
+                }
+            },
+        }
+    )
+    assert config.bundles["rel"].checks == [CheckSpec(channel="none", depth="headers")]
+    assert config.bundles["rel"].to_dict()["checks"] == [
+        {"channel": "none", "depth": "headers", "required": True, "gate_mode": "local"}
+    ]
+    round_tripped = ProjectTargetsConfig.from_dict(config.to_dict())
+    assert round_tripped == config
+    report = validate_project_targets(config)
+    assert report.ok, report.errors
+
+
+def test_bundle_checks_not_a_list_raises() -> None:
+    with pytest.raises(ValueError, match=r"\.checks must be a list"):
+        ProjectTargetsConfig.from_dict(
+            {"bundles": {"rel": {"targets": ["a"], "checks": "not-a-list"}}}
+        )
+
+
+def test_bundle_checks_item_not_a_mapping_raises() -> None:
+    with pytest.raises(ValueError, match=r"\.checks\[0\] must be a mapping"):
+        ProjectTargetsConfig.from_dict(
+            {"bundles": {"rel": {"targets": ["a"], "checks": ["not-a-mapping"]}}}
+        )
+
+
+def test_bundle_checks_invalid_entry_is_flagged_by_validator() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {"a": {"kind": "library", "binary_pattern": "a.so"}},
+            "bundles": {
+                "rel": {
+                    "targets": ["a"],
+                    "checks": [{"channel": "none", "depth": "not-a-real-depth"}],
+                }
+            },
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any(
+        "bundle 'rel'.checks[0]" in e and "depth must be one of" in e
+        for e in report.errors
+    )
+
+
+# ── Top-level key strictness (review finding — a typo'd block was silently
+# ── ignored instead of caught) ──────────────────────────────────────────────
+
+
+def test_misspelled_top_level_key_is_rejected() -> None:
+    with pytest.raises(ValueError, match=r"unknown \.abicheck\.yml key"):
+        ProjectTargetsConfig.from_dict(
+            {"tagrets": {"foo": {"kind": "library", "binary_pattern": "x"}}}
+        )
+
+
+def test_other_abicheck_yml_blocks_are_accepted_and_ignored() -> None:
+    """A real `.abicheck.yml` legitimately carries blocks this module doesn't
+    own (severity, scope, ...) alongside targets/bundles/profiles/baseline —
+    those must not be rejected as unknown."""
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "severity": {"preset": "strict_abi"},
+            "scope": {"public": True},
+            "targets": {"foo": {"kind": "library", "binary_pattern": "x"}},
+        }
+    )
+    assert set(config.targets) == {"foo"}
+
+
 def test_profile_not_a_mapping_raises() -> None:
     with pytest.raises(ValueError, match="must be a mapping"):
         ProjectTargetsConfig.from_dict({"profiles": {"linux": "not-a-mapping"}})

--- a/tests/test_project_targets.py
+++ b/tests/test_project_targets.py
@@ -1006,6 +1006,43 @@ def test_mixed_type_top_level_keys_raise_value_error_not_type_error() -> None:
         ProjectTargetsConfig.from_dict({True: {}, "tagrets": {}})
 
 
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"targets": {"foo": {True: 1, "unknown_field": 2, "kind": "library"}}},
+        {"bundles": {"b": {True: 1, "unknown_field": 2, "targets": ["x"]}}},
+        {"profiles": {"p": {True: 1, "unknown_field": 2}}},
+        {
+            "baseline": {
+                "channels": {"c": {True: 1, "unknown_field": 2, "source": "git"}}
+            }
+        },
+        {
+            "targets": {
+                "foo": {
+                    "kind": "library",
+                    "checks": [
+                        {
+                            True: 1,
+                            "unknown_field": 2,
+                            "channel": "c",
+                            "depth": "headers",
+                        }
+                    ],
+                }
+            }
+        },
+    ],
+)
+def test_mixed_type_nested_keys_raise_value_error_not_type_error(raw: dict) -> None:
+    """Same PyYAML 1.1 boolean-key pitfall as the top-level check, but inside
+    a target/bundle/profile/baseline-channel/check entry's own unknown-key
+    check (Codex finding — the top-level fix didn't cover these nested
+    ``sorted(set(d) - known)`` call sites)."""
+    with pytest.raises(ValueError, match="unknown key"):
+        ProjectTargetsConfig.from_dict(raw)
+
+
 def test_other_abicheck_yml_blocks_are_accepted_and_ignored() -> None:
     """A real `.abicheck.yml` legitimately carries blocks this module doesn't
     own (severity, scope, ...) alongside targets/bundles/profiles/baseline —

--- a/tests/test_project_targets.py
+++ b/tests/test_project_targets.py
@@ -997,6 +997,15 @@ def test_misspelled_top_level_key_is_rejected() -> None:
         )
 
 
+def test_mixed_type_top_level_keys_raise_value_error_not_type_error() -> None:
+    """A bare PyYAML 1.1 boolean-like top-level key (``on:``/``off:``/``yes:``/
+    ``no:``) alongside another unknown string key must still be reported as
+    the documented ``ValueError`` usage error, not crash with ``TypeError``
+    from comparing ``bool`` and ``str`` inside ``sorted()`` (Codex finding)."""
+    with pytest.raises(ValueError, match=r"unknown \.abicheck\.yml key"):
+        ProjectTargetsConfig.from_dict({True: {}, "tagrets": {}})
+
+
 def test_other_abicheck_yml_blocks_are_accepted_and_ignored() -> None:
     """A real `.abicheck.yml` legitimately carries blocks this module doesn't
     own (severity, scope, ...) alongside targets/bundles/profiles/baseline —

--- a/tests/test_project_targets.py
+++ b/tests/test_project_targets.py
@@ -146,7 +146,7 @@ def test_build_config_does_not_reject_the_new_top_level_keys() -> None:
 
 
 def test_build_config_still_rejects_unknown_top_level_keys() -> None:
-    with pytest.raises(ValueError, match="unknown .abicheck.yml key"):
+    with pytest.raises(ValueError, match=r"unknown \.abicheck\.yml key"):
         BuildConfig.from_dict({"totally_bogus_key": {}})
 
 
@@ -585,3 +585,445 @@ def test_bundle_profile_baseline_channel_round_trip() -> None:
         "source": "github-release",
         "asset_pattern": "*.tar.zst",
     }
+
+
+# ── Bidirectional bundle membership (code-review finding) ──────────────────
+
+
+def test_one_way_bundle_declaration_is_rejected() -> None:
+    """A target claiming `bundle: rel` that `bundles.rel.targets` doesn't list
+    back must fail — both directions must agree (review finding)."""
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "foo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/foo.so",
+                    "bundle": "rel",
+                },
+                "bar": {
+                    "kind": "library",
+                    "binary_pattern": "lib/bar.so",
+                    "bundle": "rel",
+                },
+            },
+            "bundles": {"rel": {"targets": ["bar"]}},
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any(
+        "does not list 'foo' back" in e and "must agree in both directions" in e
+        for e in report.errors
+    )
+
+
+# ── Kind-specific forbidden fields, derived exhaustively (review finding) ──
+
+
+def test_library_must_not_set_library_field() -> None:
+    """A `kind: library` target setting `library:` (meaningless for this
+    kind) must fail, not silently pass and get dropped by to_dict()."""
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "foo": {"kind": "library", "binary_pattern": "x", "library": "bar"},
+                "bar": {"kind": "library", "binary_pattern": "y"},
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("must not set library" in e for e in report.errors)
+
+
+@pytest.mark.parametrize("kind", ["app-consumer", "plugin-contract"])
+def test_consumer_kinds_must_not_set_bundle_fields(kind: str) -> None:
+    raw = {
+        "kind": kind,
+        "library": "bar",
+        "bundle": "rel",
+        "bundle_only": True,
+    }
+    if kind == "app-consumer":
+        raw["consumer_binary_pattern"] = "bin/app"
+    else:
+        raw["contract_file"] = "x.syms"
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "foo": raw,
+                "bar": {"kind": "library", "binary_pattern": "y"},
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("must not set bundle." in e for e in report.errors)
+    assert any("must not set bundle_only." in e for e in report.errors)
+
+
+# ── Strict type-checking on scalar/list target fields ───────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,match",
+    [
+        ({"binary_pattern": ["lib/foo.so"]}, r"binary_pattern must be a string"),
+        ({"bundle": 123}, r"bundle must be a string"),
+        ({"consumer_binary_pattern": []}, r"consumer_binary_pattern must be a string"),
+        ({"library": 1.5}, r"library must be a string"),
+        ({"contract_file": True}, r"contract_file must be a string"),
+        ({"public_headers": "not-a-list"}, r"public_headers must be a list"),
+        ({"public_headers": [1, 2]}, r"public_headers must be a list of strings"),
+    ],
+)
+def test_target_scalar_and_list_fields_reject_wrong_types(
+    raw: dict, match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        ProjectTargetsConfig.from_dict({"targets": {"foo": {"kind": "library", **raw}}})
+
+
+def test_target_not_a_mapping_raises() -> None:
+    with pytest.raises(ValueError, match="must be a mapping"):
+        ProjectTargetsConfig.from_dict({"targets": {"foo": "not-a-mapping"}})
+
+
+def test_target_bundle_only_wrong_type_raises() -> None:
+    with pytest.raises(ValueError, match="bundle_only must be a boolean"):
+        ProjectTargetsConfig.from_dict(
+            {"targets": {"foo": {"kind": "library", "bundle_only": "yes"}}}
+        )
+
+
+def test_target_checks_not_a_list_raises() -> None:
+    with pytest.raises(ValueError, match=r"\.checks must be a list"):
+        ProjectTargetsConfig.from_dict(
+            {"targets": {"foo": {"kind": "library", "checks": "not-a-list"}}}
+        )
+
+
+# ── CheckSpec.from_dict structural errors ───────────────────────────────────
+
+
+def test_check_spec_unknown_key_raises() -> None:
+    with pytest.raises(ValueError, match="unknown key"):
+        ProjectTargetsConfig.from_dict(
+            {
+                "targets": {
+                    "foo": {
+                        "kind": "library",
+                        "checks": [{"channel": "none", "depth": "headers", "bogus": 1}],
+                    }
+                }
+            }
+        )
+
+
+def test_check_spec_empty_depth_raises() -> None:
+    with pytest.raises(ValueError, match="depth must be a non-empty string"):
+        ProjectTargetsConfig.from_dict(
+            {
+                "targets": {
+                    "foo": {
+                        "kind": "library",
+                        "checks": [{"channel": "none", "depth": ""}],
+                    }
+                }
+            }
+        )
+
+
+def test_check_spec_gate_mode_wrong_type_raises() -> None:
+    with pytest.raises(ValueError, match="gate_mode must be a string"):
+        ProjectTargetsConfig.from_dict(
+            {
+                "targets": {
+                    "foo": {
+                        "kind": "library",
+                        "checks": [
+                            {"channel": "none", "depth": "headers", "gate_mode": 1}
+                        ],
+                    }
+                }
+            }
+        )
+
+
+def test_check_spec_to_dict_includes_profiles_when_set() -> None:
+    check = CheckSpec(
+        channel="accepted-main", depth="headers", profiles=["linux-x86_64"]
+    )
+    assert check.to_dict() == {
+        "channel": "accepted-main",
+        "depth": "headers",
+        "required": True,
+        "gate_mode": "local",
+        "profiles": ["linux-x86_64"],
+    }
+
+
+def test_check_profiles_selector_passes_when_declared() -> None:
+    """The positive counterpart of test_check_profiles_selector_must_resolve:
+    a profiles[] entry that *does* resolve must not be flagged."""
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "checks": [
+                        {
+                            "channel": "none",
+                            "depth": "headers",
+                            "profiles": ["linux-x86_64"],
+                        }
+                    ],
+                }
+            },
+            "profiles": {"linux-x86_64": {"contract": True}},
+        }
+    )
+    report = validate_project_targets(config)
+    assert report.ok, report.errors
+
+
+# ── BundleSpec/ProfileSpec/BaselineChannelSpec structural errors ───────────
+
+
+def test_bundle_not_a_mapping_raises() -> None:
+    with pytest.raises(ValueError, match="must be a mapping"):
+        ProjectTargetsConfig.from_dict({"bundles": {"rel": "not-a-mapping"}})
+
+
+def test_bundle_unknown_key_raises() -> None:
+    with pytest.raises(ValueError, match="unknown key"):
+        ProjectTargetsConfig.from_dict(
+            {"bundles": {"rel": {"targets": ["a"], "bogus": 1}}}
+        )
+
+
+def test_profile_not_a_mapping_raises() -> None:
+    with pytest.raises(ValueError, match="must be a mapping"):
+        ProjectTargetsConfig.from_dict({"profiles": {"linux": "not-a-mapping"}})
+
+
+def test_profile_unknown_key_raises() -> None:
+    with pytest.raises(ValueError, match="unknown key"):
+        ProjectTargetsConfig.from_dict({"profiles": {"linux": {"bogus": 1}}})
+
+
+@pytest.mark.parametrize("key", ["os", "arch"])
+def test_profile_os_arch_wrong_type_raises(key: str) -> None:
+    with pytest.raises(ValueError, match=f"{key} must be a string"):
+        ProjectTargetsConfig.from_dict({"profiles": {"linux": {key: 1}}})
+
+
+def test_baseline_channel_not_a_mapping_raises() -> None:
+    with pytest.raises(ValueError, match="must be a mapping"):
+        ProjectTargetsConfig.from_dict(
+            {"baseline": {"channels": {"c": "not-a-mapping"}}}
+        )
+
+
+def test_baseline_channel_unknown_key_raises() -> None:
+    with pytest.raises(ValueError, match="unknown key"):
+        ProjectTargetsConfig.from_dict(
+            {"baseline": {"channels": {"c": {"source": "git", "bogus": 1}}}}
+        )
+
+
+@pytest.mark.parametrize("key", ["asset_pattern", "key_prefix"])
+def test_baseline_channel_pattern_fields_wrong_type_raises(key: str) -> None:
+    with pytest.raises(ValueError, match=f"{key} must be a string"):
+        ProjectTargetsConfig.from_dict(
+            {"baseline": {"channels": {"c": {"source": "git", key: 1}}}}
+        )
+
+
+def test_baseline_channel_github_release_requires_asset_pattern() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {"baseline": {"channels": {"release-contract": {"source": "github-release"}}}}
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("requires asset_pattern" in e for e in report.errors)
+
+
+def test_baseline_channel_actions_cache_requires_key_prefix() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {"baseline": {"channels": {"accepted-main": {"source": "actions-cache"}}}}
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("requires key_prefix" in e for e in report.errors)
+
+
+# ── ProjectTargetsConfig.to_dict() partial-block branches ──────────────────
+
+
+def test_to_dict_targets_only() -> None:
+    config = ProjectTargetsConfig(
+        targets={"foo": TargetSpec(id="foo", kind="library", binary_pattern="x")}
+    )
+    d = config.to_dict()
+    assert set(d) == {"targets"}
+
+
+def test_to_dict_bundles_only() -> None:
+    config = ProjectTargetsConfig(bundles={"rel": BundleSpec(id="rel", targets=["a"])})
+    d = config.to_dict()
+    assert set(d) == {"bundles"}
+
+
+def test_to_dict_profiles_only() -> None:
+    config = ProjectTargetsConfig(profiles={"linux": ProfileSpec(id="linux")})
+    d = config.to_dict()
+    assert set(d) == {"profiles"}
+
+
+def test_to_dict_baseline_only() -> None:
+    config = ProjectTargetsConfig(
+        baseline_channels={
+            "c": BaselineChannelSpec(id="c", source="git"),
+        }
+    )
+    d = config.to_dict()
+    assert set(d) == {"baseline"}
+    assert d["baseline"] == {"channels": {"c": {"source": "git"}}}
+
+
+# ── TargetSpec.to_dict() per-kind field combinations ────────────────────────
+
+
+def test_target_spec_to_dict_library_with_all_optional_fields() -> None:
+    target = TargetSpec(
+        id="libfoo",
+        kind="library",
+        binary_pattern="lib/libfoo.so",
+        public_headers=["headers/foo"],
+        bundle="rel",
+        bundle_only=True,
+        checks=[CheckSpec(channel="none", depth="headers")],
+    )
+    d = target.to_dict()
+    assert d["binary_pattern"] == "lib/libfoo.so"
+    assert d["public_headers"] == ["headers/foo"]
+    assert d["bundle"] == "rel"
+    assert d["bundle_only"] is True
+    assert d["checks"] == [
+        {"channel": "none", "depth": "headers", "required": True, "gate_mode": "local"}
+    ]
+
+
+def test_target_spec_to_dict_plugin_contract() -> None:
+    target = TargetSpec(
+        id="plugin",
+        kind="plugin-contract",
+        contract_file="x.syms",
+        library="libfoo",
+        checks=[CheckSpec(channel="none", depth="headers")],
+    )
+    d = target.to_dict()
+    assert d["kind"] == "plugin-contract"
+    assert d["contract_file"] == "x.syms"
+    assert d["library"] == "libfoo"
+    assert d["checks"]
+
+
+def test_target_spec_to_dict_library_with_no_optional_fields_set() -> None:
+    target = TargetSpec(id="libfoo", kind="library")
+    assert target.to_dict() == {"kind": "library"}
+
+
+def test_target_spec_to_dict_on_a_kind_that_bypasses_from_dict_validation() -> None:
+    """Same direct-construction scenario as the validator test below, for
+    `to_dict()`: an unrecognized `kind` emits no kind-specific fields."""
+    target = TargetSpec(id="foo", kind="totally-unknown-kind", binary_pattern="x")
+    assert target.to_dict() == {"kind": "totally-unknown-kind"}
+
+
+def test_target_issues_on_a_kind_that_bypasses_from_dict_validation() -> None:
+    """`TargetSpec` is a plain dataclass — direct construction (bypassing
+    `from_dict`'s `kind` enum check) with an unrecognized `kind` must not
+    crash `validate_project_targets`; it simply gets no kind-specific
+    required/forbidden-field checks (only the identifier check applies)."""
+    config = ProjectTargetsConfig(
+        targets={"foo": TargetSpec(id="foo", kind="totally-unknown-kind")}
+    )
+    report = validate_project_targets(config)
+    assert report.ok, report.errors
+
+
+# ── loader error paths ──────────────────────────────────────────────────────
+
+
+def test_load_project_targets_config_malformed_yaml_raises(tmp_path: Path) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text("targets: [this is not: valid: yaml: at: all\n")
+    with pytest.raises(ValueError, match="cannot read project config"):
+        load_project_targets_config(config_path)
+
+
+def test_load_project_targets_config_non_mapping_yaml_is_all_defaults(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text("- just\n- a\n- list\n")
+    config = load_project_targets_config(config_path)
+    assert config == ProjectTargetsConfig()
+
+
+# ── CLI error paths ──────────────────────────────────────────────────────
+
+
+def test_cli_validate_empty_file_is_ok(tmp_path: Path) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text("")
+    result = CliRunner().invoke(main, ["project-targets", "validate", str(config_path)])
+    assert result.exit_code == 0, result.output
+
+
+def test_cli_validate_non_mapping_yaml_is_usage_error(tmp_path: Path) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text("- just\n- a\n- list\n")
+    result = CliRunner().invoke(main, ["project-targets", "validate", str(config_path)])
+    assert result.exit_code == 64, result.output
+    assert "must contain a yaml mapping" in result.output.lower()
+
+
+def test_cli_validate_with_warnings_shown_in_text_output(tmp_path: Path) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text("")
+    result = CliRunner().invoke(main, ["project-targets", "validate", str(config_path)])
+    assert result.exit_code == 0, result.output
+    assert "warning(s)" in result.output
+
+
+def test_cli_validate_malformed_yaml_raises_usage_error(tmp_path: Path) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text("targets: [this is not: valid: yaml: at: all\n")
+    result = CliRunner().invoke(main, ["project-targets", "validate", str(config_path)])
+    assert result.exit_code == 64, result.output
+    assert "cannot read" in result.output.lower()
+
+
+def test_cli_validate_writes_to_output_file(tmp_path: Path) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text(
+        "targets:\n  libfoo:\n    kind: library\n    binary_pattern: lib/libfoo.so\n"
+    )
+    out_path = tmp_path / "report.txt"
+    result = CliRunner().invoke(
+        main,
+        [
+            "project-targets",
+            "validate",
+            str(config_path),
+            "-o",
+            str(out_path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "OK" in out_path.read_text()

--- a/tests/test_project_targets.py
+++ b/tests/test_project_targets.py
@@ -296,6 +296,29 @@ def test_bundle_only_requires_bundle() -> None:
     assert any("bundle_only requires bundle" in e for e in report.errors)
 
 
+def test_bundle_only_target_must_not_declare_its_own_checks() -> None:
+    """A bundle_only target is checked only as a bundle member, never
+    standalone (per this schema's own docs) -- its own checks: would never
+    run, so it's a validation error, not silently dead config."""
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "bundle": "rel",
+                    "bundle_only": True,
+                    "checks": [{"channel": "none", "depth": "headers"}],
+                }
+            },
+            "bundles": {"rel": {"targets": ["libfoo"]}},
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("must not set its own checks" in e for e in report.errors)
+
+
 def test_bundle_reference_must_be_declared() -> None:
     config = ProjectTargetsConfig.from_dict(
         {
@@ -783,6 +806,70 @@ def test_check_profiles_selector_passes_when_declared() -> None:
                 }
             },
             "profiles": {"linux-x86_64": {"contract": True}},
+        }
+    )
+    report = validate_project_targets(config)
+    assert report.ok, report.errors
+
+
+# ── checks[].profiles scoped to a non-contract (test-only) profile ─────────
+
+
+def test_check_with_real_channel_cannot_scope_to_a_non_contract_profile() -> None:
+    """contract: false profiles never get a baseline (S17) -- a check that
+    names a real channel and scopes only to such a profile can never be
+    satisfied, so it's a validation error."""
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "checks": [
+                        {
+                            "channel": "accepted-main",
+                            "depth": "headers",
+                            "profiles": ["test-lane"],
+                        }
+                    ],
+                }
+            },
+            "profiles": {"test-lane": {"contract": False}},
+            "baseline": {
+                "channels": {
+                    "accepted-main": {
+                        "source": "actions-cache",
+                        "key_prefix": "abicheck-baseline-main",
+                    }
+                }
+            },
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("contract: false" in e for e in report.errors)
+
+
+def test_check_with_none_channel_may_scope_to_a_non_contract_profile() -> None:
+    """The exemption: a channel: "none" audit check has no baseline to
+    resolve in the first place, so scoping it to a test-only lane is a
+    legitimate S5 use case, not an error."""
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "checks": [
+                        {
+                            "channel": "none",
+                            "depth": "headers",
+                            "profiles": ["test-lane"],
+                        }
+                    ],
+                }
+            },
+            "profiles": {"test-lane": {"contract": False}},
         }
     )
     report = validate_project_targets(config)

--- a/tests/test_project_targets.py
+++ b/tests/test_project_targets.py
@@ -891,6 +891,37 @@ def test_other_abicheck_yml_blocks_are_accepted_and_ignored() -> None:
     assert set(config.targets) == {"foo"}
 
 
+# ── Non-string mapping keys are rejected, not silently str()-coerced ───────
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"targets": {123: {"kind": "library", "binary_pattern": "x"}}},
+        {"bundles": {123: {"targets": ["a"]}}},
+        {"profiles": {123: {"contract": True}}},
+        {"baseline": {"channels": {123: {"source": "git"}}}},
+        # PyYAML's default (YAML 1.1) resolver reads a bare `on` key as `True`.
+        {"targets": {True: {"kind": "library", "binary_pattern": "x"}}},
+    ],
+)
+def test_non_string_mapping_keys_are_rejected(raw: dict) -> None:
+    with pytest.raises(ValueError, match="key.*must be strings"):
+        ProjectTargetsConfig.from_dict(raw)
+
+
+# ── "none" is reserved as the no-baseline sentinel ──────────────────────────
+
+
+def test_none_cannot_be_declared_as_a_real_baseline_channel() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {"baseline": {"channels": {"none": {"source": "git"}}}}
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("is reserved as the no-baseline sentinel" in e for e in report.errors)
+
+
 def test_profile_not_a_mapping_raises() -> None:
     with pytest.raises(ValueError, match="must be a mapping"):
         ProjectTargetsConfig.from_dict({"profiles": {"linux": "not-a-mapping"}})

--- a/tests/test_project_targets.py
+++ b/tests/test_project_targets.py
@@ -1,0 +1,587 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``buildsource.project_targets`` (ADR-047 §3, G30 P1.5).
+
+Covers the schema round-trip, ``BuildConfig``'s recognition of the four new
+top-level ``.abicheck.yml`` keys, and the cross-reference validator's rules:
+kind-specific required/forbidden fields, ``library``/``bundle``/``channel``/
+``profiles`` reference resolution, and the identifier charset every id must
+satisfy to stay embeddable in a report ``check_id``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from abicheck.buildsource.inline import BuildConfig
+from abicheck.buildsource.project_targets import (
+    BaselineChannelSpec,
+    BundleSpec,
+    CheckSpec,
+    ProfileSpec,
+    ProjectTargetsConfig,
+    TargetSpec,
+    load_project_targets_config,
+    validate_project_targets,
+)
+from abicheck.cli import main
+
+# A full, valid PVXS-shaped example matching ADR-047 §3's excerpt.
+_VALID_RAW = {
+    "targets": {
+        "libpvxs": {
+            "kind": "library",
+            "binary_pattern": "lib/libpvxs.so*",
+            "public_headers": ["headers/pvxs"],
+            "bundle": "pvxs-release",
+            "bundle_only": False,
+            "checks": [
+                {
+                    "channel": "accepted-main",
+                    "depth": "headers",
+                    "required": True,
+                    "gate_mode": "local",
+                }
+            ],
+        },
+        "libpvxsIoc": {
+            "kind": "library",
+            "binary_pattern": "lib/libpvxsIoc.so*",
+            "public_headers": ["headers/pvxsIoc"],
+            "bundle": "pvxs-release",
+        },
+        "myapp-consumer": {
+            "kind": "app-consumer",
+            "consumer_binary_pattern": "bin/myapp",
+            "library": "libpvxs",
+        },
+        "ioc-plugin-contract": {
+            "kind": "plugin-contract",
+            "contract_file": "contracts/ioc-plugin.syms",
+            "library": "libpvxsIoc",
+        },
+    },
+    "bundles": {"pvxs-release": {"targets": ["libpvxs", "libpvxsIoc"]}},
+    "profiles": {
+        "linux-x86_64-gcc13-release": {
+            "contract": True,
+            "os": "linux",
+            "arch": "x86_64",
+        },
+        "ubuntu-latest-clang-debug-sanitizer": {"contract": False},
+    },
+    "baseline": {
+        "channels": {
+            "release-contract": {
+                "source": "github-release",
+                "asset_pattern": "abicheck-baseline-*.tar.zst",
+            },
+            "accepted-main": {
+                "source": "actions-cache",
+                "key_prefix": "abicheck-baseline-main",
+            },
+        }
+    },
+}
+
+
+def test_valid_config_round_trips() -> None:
+    config = ProjectTargetsConfig.from_dict(_VALID_RAW)
+    assert set(config.targets) == {
+        "libpvxs",
+        "libpvxsIoc",
+        "myapp-consumer",
+        "ioc-plugin-contract",
+    }
+    assert config.targets["libpvxs"].checks == [
+        CheckSpec(
+            channel="accepted-main", depth="headers", required=True, gate_mode="local"
+        )
+    ]
+    round_tripped = ProjectTargetsConfig.from_dict(config.to_dict())
+    assert round_tripped == config
+
+
+def test_valid_config_has_no_validation_errors() -> None:
+    config = ProjectTargetsConfig.from_dict(_VALID_RAW)
+    report = validate_project_targets(config)
+    assert report.ok, report.errors
+
+
+def test_empty_config_is_all_defaults() -> None:
+    config = ProjectTargetsConfig.from_dict({})
+    assert config.targets == {}
+    assert config.bundles == {}
+    assert config.profiles == {}
+    assert config.baseline_channels == {}
+    report = validate_project_targets(config)
+    assert report.ok
+    assert report.warnings
+
+
+# ── BuildConfig recognizes the four new top-level keys ─────────────────────
+
+
+def test_build_config_does_not_reject_the_new_top_level_keys() -> None:
+    # BuildConfig itself doesn't parse targets/bundles/profiles/baseline (that's
+    # this module's job) but must not treat their presence as an unknown key.
+    config = BuildConfig.from_dict(_VALID_RAW)
+    assert isinstance(config, BuildConfig)
+
+
+def test_build_config_still_rejects_unknown_top_level_keys() -> None:
+    with pytest.raises(ValueError, match="unknown .abicheck.yml key"):
+        BuildConfig.from_dict({"totally_bogus_key": {}})
+
+
+# ── from_dict structural/type errors (raise, ADR-043 strict convention) ────
+
+
+@pytest.mark.parametrize(
+    "raw,match",
+    [
+        ({"targets": {"foo": {"kind": "bogus"}}}, "kind must be one of"),
+        ({"targets": {"foo": {"unknown_key": 1}}}, "unknown key"),
+        ({"targets": "not-a-mapping"}, "must be a mapping"),
+        ({"bundles": {"b": {"targets": []}}}, "non-empty list"),
+        ({"bundles": {"b": {"targets": [1, 2]}}}, "list of strings"),
+        ({"profiles": {"p": {"contract": "yes"}}}, "must be a boolean"),
+        ({"baseline": {"unexpected": {}}}, "unknown key"),
+        ({"baseline": {"channels": {"c": {"source": "ftp"}}}}, "source must be one of"),
+        (
+            {
+                "targets": {
+                    "foo": {
+                        "checks": [
+                            {"channel": "c", "depth": "headers", "required": "yes"}
+                        ]
+                    }
+                }
+            },
+            "required must be a boolean",
+        ),
+        (
+            {"targets": {"foo": {"checks": [{"depth": "headers"}]}}},
+            "channel must be a non-empty string",
+        ),
+        (
+            {"targets": {"foo": {"checks": ["not-a-mapping"]}}},
+            "must be a mapping",
+        ),
+    ],
+)
+def test_from_dict_rejects_malformed_input(raw: dict, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        ProjectTargetsConfig.from_dict(raw)
+
+
+# ── validate_project_targets cross-reference rules ──────────────────────────
+
+
+def test_library_kind_requires_binary_pattern() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {"targets": {"libfoo": {"kind": "library"}}}
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("requires binary_pattern" in e for e in report.errors)
+
+
+def test_app_consumer_requires_consumer_binary_pattern_and_library() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {"targets": {"consumer": {"kind": "app-consumer"}}}
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("consumer_binary_pattern" in e for e in report.errors)
+    assert any("requires library" in e for e in report.errors)
+
+
+def test_app_consumer_library_must_resolve_to_a_library_kind_target() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "consumer": {
+                    "kind": "app-consumer",
+                    "consumer_binary_pattern": "bin/app",
+                    "library": "other-consumer",
+                },
+                "other-consumer": {
+                    "kind": "app-consumer",
+                    "consumer_binary_pattern": "bin/other",
+                    "library": "libfoo",
+                },
+                "libfoo": {"kind": "library", "binary_pattern": "lib/libfoo.so"},
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("must be a kind: library target" in e for e in report.errors)
+
+
+def test_app_consumer_library_must_exist() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "consumer": {
+                    "kind": "app-consumer",
+                    "consumer_binary_pattern": "bin/app",
+                    "library": "does-not-exist",
+                }
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("is not declared under targets:" in e for e in report.errors)
+
+
+def test_plugin_contract_requires_contract_file_and_library() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {"targets": {"plugin": {"kind": "plugin-contract"}}}
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("requires contract_file" in e for e in report.errors)
+
+
+def test_kind_specific_forbidden_fields_are_rejected() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "contract_file": "x.syms",
+                }
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("must not set contract_file" in e for e in report.errors)
+
+
+def test_bundle_only_requires_bundle() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "bundle_only": True,
+                }
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("bundle_only requires bundle" in e for e in report.errors)
+
+
+def test_bundle_reference_must_be_declared() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "bundle": "no-such-bundle",
+                }
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("is not declared under bundles:" in e for e in report.errors)
+
+
+def test_bundle_members_must_exist_and_be_library_kind() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "consumer": {
+                    "kind": "app-consumer",
+                    "consumer_binary_pattern": "bin/app",
+                    "library": "consumer",  # bogus self-reference, irrelevant here
+                }
+            },
+            "bundles": {"rel": {"targets": ["consumer", "missing"]}},
+        }
+    )
+    report = validate_project_targets(config)
+    errors = "\n".join(report.errors)
+    assert "must be kind: library" in errors
+    assert "'missing' is not declared under targets:" in errors
+
+
+def test_bundle_membership_must_agree_with_target_bundle_field() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "bundle": "bundle-a",
+                }
+            },
+            "bundles": {
+                "bundle-a": {"targets": ["libfoo"]},
+                "bundle-b": {"targets": ["libfoo"]},
+            },
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("must agree" in e for e in report.errors)
+
+
+def test_check_channel_must_resolve_or_be_none_sentinel() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "checks": [{"channel": "no-such-channel", "depth": "headers"}],
+                }
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("is not declared under baseline.channels" in e for e in report.errors)
+
+
+def test_check_channel_none_sentinel_skips_baseline_lookup() -> None:
+    """ADR-047 §6 S5: `channel: none` must validate even with zero declared
+    baseline channels — it's the explicit no-baseline-audit bypass."""
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "checks": [
+                        {"channel": "none", "depth": "headers", "gate_mode": "local"}
+                    ],
+                }
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert report.ok, report.errors
+
+
+def test_check_depth_must_be_a_valid_rung() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "checks": [{"channel": "none", "depth": "quantum"}],
+                }
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("depth must be one of" in e for e in report.errors)
+
+
+def test_check_gate_mode_must_be_valid() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "checks": [
+                        {
+                            "channel": "none",
+                            "depth": "headers",
+                            "gate_mode": "aggressive",
+                        }
+                    ],
+                }
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("gate_mode must be one of" in e for e in report.errors)
+
+
+def test_check_profiles_selector_must_resolve() -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {
+            "targets": {
+                "libfoo": {
+                    "kind": "library",
+                    "binary_pattern": "lib/libfoo.so",
+                    "checks": [
+                        {
+                            "channel": "none",
+                            "depth": "headers",
+                            "profiles": ["no-such-profile"],
+                        }
+                    ],
+                }
+            }
+        }
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("is not declared under profiles:" in e for e in report.errors)
+
+
+@pytest.mark.parametrize(
+    "kind,name",
+    [
+        ("target", "libfoo bad name"),
+        ("target", "@libfoo"),
+        ("target", ""),
+    ],
+)
+def test_identifier_charset_is_enforced(kind: str, name: str) -> None:
+    config = ProjectTargetsConfig.from_dict(
+        {"targets": {name: {"kind": "library", "binary_pattern": "lib/libfoo.so"}}}
+    )
+    report = validate_project_targets(config)
+    assert not report.ok
+    assert any("is not a valid identifier" in e for e in report.errors)
+
+
+def test_two_targets_sharing_a_bundle_is_the_pvxs_shape_and_is_valid() -> None:
+    """The exact ADR-047 §3 excerpt: two library targets under one bundle,
+    each still individually checkable (S14/S15 coexistence)."""
+    config = ProjectTargetsConfig.from_dict(_VALID_RAW)
+    assert validate_project_targets(config).ok
+
+
+# ── loader ───────────────────────────────────────────────────────────────
+
+
+def test_load_project_targets_config_missing_file_is_all_defaults(
+    tmp_path: Path,
+) -> None:
+    config = load_project_targets_config(tmp_path / "no-such-file.yml")
+    assert config == ProjectTargetsConfig()
+
+
+def test_load_project_targets_config_reads_real_file(tmp_path: Path) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text(
+        "targets:\n  libfoo:\n    kind: library\n    binary_pattern: lib/libfoo.so\n"
+    )
+    config = load_project_targets_config(config_path)
+    assert set(config.targets) == {"libfoo"}
+    assert config.targets["libfoo"].binary_pattern == "lib/libfoo.so"
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────
+
+
+def test_cli_validate_ok(tmp_path: Path) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text(
+        "targets:\n  libfoo:\n    kind: library\n    binary_pattern: lib/libfoo.so\n"
+    )
+    result = CliRunner().invoke(main, ["project-targets", "validate", str(config_path)])
+    assert result.exit_code == 0, result.output
+    assert "OK" in result.output
+
+
+def test_cli_validate_reports_errors(tmp_path: Path) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text("targets:\n  libfoo:\n    kind: library\n")
+    result = CliRunner().invoke(main, ["project-targets", "validate", str(config_path)])
+    assert result.exit_code == 1, result.output
+    assert "requires binary_pattern" in result.output
+
+
+def test_cli_validate_json_output(tmp_path: Path) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text(
+        "targets:\n  libfoo:\n    kind: library\n    binary_pattern: lib/libfoo.so\n"
+    )
+    result = CliRunner().invoke(
+        main, ["project-targets", "validate", str(config_path), "--format", "json"]
+    )
+    assert result.exit_code == 0, result.output
+    assert '"ok": true' in result.output
+
+
+def test_cli_validate_malformed_yaml_is_usage_error(tmp_path: Path) -> None:
+    config_path = tmp_path / ".abicheck.yml"
+    config_path.write_text("targets:\n  libfoo:\n    kind: bogus-kind\n")
+    result = CliRunner().invoke(main, ["project-targets", "validate", str(config_path)])
+    assert result.exit_code == 64, result.output
+
+
+def test_cli_validate_missing_config_is_usage_error() -> None:
+    result = CliRunner().invoke(
+        main, ["project-targets", "validate", "/no/such/config.yml"]
+    )
+    assert result.exit_code != 0
+
+
+def test_cli_group_help() -> None:
+    result = CliRunner().invoke(main, ["project-targets", "--help"])
+    assert result.exit_code == 0
+    assert "validate" in result.output
+
+
+# ── dataclass sanity (mirrors build_output.py's own coverage shape) ────────
+
+
+def test_target_spec_to_dict_only_emits_kind_relevant_fields() -> None:
+    lib = TargetSpec(id="libfoo", kind="library", binary_pattern="lib/libfoo.so")
+    assert lib.to_dict() == {"kind": "library", "binary_pattern": "lib/libfoo.so"}
+
+    consumer = TargetSpec(
+        id="consumer",
+        kind="app-consumer",
+        consumer_binary_pattern="bin/app",
+        library="libfoo",
+        binary_pattern="should-not-appear",  # forbidden field, still stored on the dataclass
+    )
+    d = consumer.to_dict()
+    assert d["kind"] == "app-consumer"
+    assert d["consumer_binary_pattern"] == "bin/app"
+    assert d["library"] == "libfoo"
+    assert "binary_pattern" not in d
+
+
+def test_bundle_profile_baseline_channel_round_trip() -> None:
+    bundle = BundleSpec(id="rel", targets=["a", "b"])
+    assert bundle.to_dict() == {"targets": ["a", "b"]}
+
+    profile = ProfileSpec(id="linux", contract=True, os="linux", arch="x86_64")
+    assert profile.to_dict() == {"contract": True, "os": "linux", "arch": "x86_64"}
+
+    channel = BaselineChannelSpec(
+        id="release-contract", source="github-release", asset_pattern="*.tar.zst"
+    )
+    assert channel.to_dict() == {
+        "source": "github-release",
+        "asset_pattern": "*.tar.zst",
+    }


### PR DESCRIPTION
## Summary

Continues the G30 GitHub Actions integration-model backlog: implements **P1.5** — the `.abicheck.yml` `targets:`/`bundles:`/`profiles:`/`baseline:` block (ADR-047 §3).

## Motivation

P1.4 (`check-single.yml`/`check-project.yml`'s run-plan generator) depends on P1.5 per the plan's own sequencing note ("P1.5 must land before P1.4"). ADR-047 §3 also flags a real design gap this item has to close: the `targets:`/`baseline: channels:` excerpt declares which baseline channels *exist*, not which channel/depth/policy a given target actually runs — that assignment is what this PR's `checks:` list adds.

## Changes

- New `abicheck/buildsource/project_targets.py`: `TargetSpec`/`BundleSpec`/`ProfileSpec`/`BaselineChannelSpec`/`CheckSpec` dataclasses, strict `ProjectTargetsConfig.from_dict()` (ADR-043 convention — raises on unknown key/wrong type, matching `BuildConfig`'s existing strict `.abicheck.yml` parsing), and `validate_project_targets()` (cross-reference validation: kind-specific required/forbidden fields for the `library`/`app-consumer`/`plugin-contract` discriminator, the `app-consumer`/`plugin-contract` → `library` redirect rule, bundle membership agreement, `checks[]` reference resolution, and a shared `check_id`-safe identifier charset).
- Resolves ADR-047 §3's flagged profile-scoping gap: each `checks:` entry gets an *optional* explicit `profiles:` selector rather than assuming a naive cross-product of every check against every `contract: true` profile is safe (documented in the module docstring and the new reference page).
- `BuildConfig` (`abicheck/buildsource/inline.py`) recognizes the four new top-level keys without parsing them itself — the same treatment already given `risk_rules`/`crosschecks` — keeping `inline.py`'s size unchanged.
- New `abicheck project-targets validate [CONFIG]` CLI command (`abicheck/cli_project_targets.py`), registered as a new top-level command group exactly like P1.1's `build-output validate`.
- `docs/reference/project-targets-schema.md` (new) documents the full schema; `docs/reference/config-file.md` links to it. `docs/development/plans/g30-github-actions-integration-model.md` marks P1.5 done.
- No producer/run-plan-generator tooling yet — `dump`/`compare`/`scan` don't read this block at all (matching P1.1's same "defines the contract, no consumer yet" scope).

## Test plan

- [x] `tests/test_project_targets.py` (new, 45 tests): schema round-trip, `BuildConfig`'s recognition of the new keys, `from_dict` structural-error taxonomy, every cross-reference validation rule (including the exact ADR-047 §3 PVXS two-target-one-bundle shape as a positive case), the loader, and the CLI command.
- [x] `tests/test_cli_root_surface.py` / `tests/test_cli_surface_diff.py` updated for the new `project-targets` command.
- [x] Full fast unit suite: `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` — 17680 passed.
- [x] `ruff check` / `ruff format --check` clean on changed files.
- [x] `mypy abicheck/` — 0 errors.
- [x] `python scripts/check_ai_readiness.py` — 0 errors (import-cycle-growth documented in `IMPORT_CYCLE_ALLOWLIST` mirroring `cli_build_output`'s existing entry).
- [x] `mkdocs build --strict` passes.
- [x] Changelog fragment added (`changelog.d/20260720_173653_noreply_g30_implementation_frifpq.md`).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [x] Docs updated if user-visible behaviour changed
- [x] `pre-commit run --all-files` passes locally (ruff, mypy, ai-readiness all clean)
- [x] No new `mypy` or `ruff` errors introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hu2h7hHcX5XU32neLyL1vu)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `abicheck project-targets validate` to validate the project CI topology in `.abicheck.yml`.
  * Supports `targets`, `bundles`, `profiles`, and `baseline` (including baseline channels and per-target check definitions).
  * Validation reports output as human-readable text or JSON, with appropriate exit codes.

* **Documentation**
  * Added/updated reference docs for the new “Project Targets Schema” and config-file keys.
  * Marked the G30 GitHub Actions integration model section as implemented.

* **Bug Fixes**
  * Clarified recognition of new top-level `.abicheck.yml` keys to prevent unknown-key errors.

* **Tests**
  * Expanded CLI and schema/validation test coverage for structure, cross-references, and error/warning cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->