### PR TITLE
feat: actions/resolve-baseline composite Action (G30 P1.2, ADR-047 §4/§6)

### DIFF
--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -382,13 +382,27 @@ def _load_manifest_or_result(
 #: against the real producers -- only two exist today:
 #: `abicheck/buildsource/source_extractors/clang.py`'s `ClangExtractor`
 #: stamps `"abicheck-cc-clang-extractor"` for *both* the wrapper and replay
-#: collection strategies (there is no third extractor, so this check cannot
-#: yet distinguish "wrapper" from "replay" evidence via fact_set.producer
-#: alone -- that distinction simply isn't recorded at this level today), and
-#: `contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp:3101` stamps
-#: `"abicheck-clang-plugin"` regardless of collect-facts' own `"clang-plugin"`
-#: producer name. Extend this table if/when a new extractor's producer id
-#: needs a public alias, not by guessing at an unverified mapping.
+#: collection strategies, and `contrib/abicheck-clang-plugin/
+#: AbicheckFactsPlugin.cpp:3101` stamps `"abicheck-clang-plugin"` regardless
+#: of collect-facts' own `"clang-plugin"` producer name.
+#:
+#: **Known, accepted limitation, not an oversight (Codex review):** because
+#: there is no third extractor, this check genuinely cannot distinguish
+#: "wrapper" from "replay" evidence via fact_set.producer alone -- both
+#: alias to the one real value, so a wrapper-produced baseline resolves for
+#: a "replay"-declared candidate and vice versa, and that specific
+#: cross-mismatch is NOT caught. The alternative -- aliasing "wrapper" and
+#: "replay" only to themselves -- was considered and rejected: since no real
+#: fact_set ever records the literal string "wrapper" or "replay", that
+#: would make every real wrapper/replay resolution report
+#: incompatible_evidence unconditionally, rejecting 100% of legitimate
+#: source-depth checks to guard against one narrow cross-mismatch. A correct
+#: fix needs `fact_set` to record the collection strategy as its own field
+#: (plumbed through `dump --sources`/`--build-info`, the wrapper, and
+#: replay) -- a schema change to `abicheck/buildsource/source_abi.py`
+#: outside this Action's/module's scope, not a resolver-side guess. Extend
+#: this table if/when a new extractor's producer id needs a public alias,
+#: not by guessing at an unverified mapping.
 _PRODUCER_ALIASES: dict[str, frozenset[str]] = {
     "wrapper": frozenset({"wrapper", "abicheck-cc-clang-extractor"}),
     "replay": frozenset({"replay", "abicheck-cc-clang-extractor"}),
@@ -524,6 +538,31 @@ def _snapshot_digest_issue(
     return None
 
 
+def _resolve_under_baseline_dir(baseline_dir: Path, rel: str) -> Path | None:
+    """Resolve *rel* under *baseline_dir*, refusing an absolute path or an
+    escape (e.g. ``"../../etc/passwd"``) -- ``None`` if refused.
+
+    A ``manifest.json``'s ``snapshot``/``binary`` fields are untrusted
+    content from a restored archive/cache entry (a hand-edited or corrupt
+    manifest, or a compromised baseline artifact); ``Path``'s own ``/``
+    operator silently *discards the left operand entirely* when the right
+    side is an absolute path (a well-known pathlib gotcha), so an absolute
+    or ``..``-escaping value must be checked explicitly rather than trusted
+    -- otherwise a corrupt manifest could point a "resolved" snapshot/binary
+    path at an arbitrary file outside the baseline-set, which a downstream
+    ``compare`` would then silently read as the old side (Codex review).
+    Mirrors :func:`~.build_output._resolve_under_root`'s identical guard for
+    ``build-output.json``.
+    """
+    if Path(rel).is_absolute():
+        return None
+    candidate = (baseline_dir / rel).resolve()
+    root_resolved = baseline_dir.resolve()
+    if candidate != root_resolved and not candidate.is_relative_to(root_resolved):
+        return None
+    return baseline_dir / rel
+
+
 def resolve_target(
     baseline_dir: Path | str,
     *,
@@ -579,7 +618,18 @@ def resolve_target(
             message=f"target {target!r}'s manifest entry has no snapshot filename.",
             manifest_path=manifest_path,
         )
-    snapshot_path = baseline_dir / artifact.snapshot
+    snapshot_path = _resolve_under_baseline_dir(baseline_dir, artifact.snapshot)
+    if snapshot_path is None:
+        return ResolveResult(
+            outcome=ResolveOutcome.AMBIGUOUS,
+            message=(
+                f"target {target!r}'s manifest entry names snapshot "
+                f"{artifact.snapshot!r}, which is an absolute path or "
+                "escapes the baseline-set directory -- refusing to resolve "
+                "it."
+            ),
+            manifest_path=manifest_path,
+        )
     if not snapshot_path.is_file():
         return ResolveResult(
             outcome=ResolveOutcome.AMBIGUOUS,
@@ -657,8 +707,8 @@ def resolve_bundle(
         if artifact is None or not artifact.binary:
             missing.append(member)
             continue
-        resolved = baseline_dir / artifact.binary
-        if not resolved.is_file():
+        resolved = _resolve_under_baseline_dir(baseline_dir, artifact.binary)
+        if resolved is None or not resolved.is_file():
             missing.append(member)
             continue
         binary_paths[member] = str(resolved)

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -581,19 +581,20 @@ def _schema_and_profile_check(
 def _snapshot_digest_issue(
     target: str, snapshot_path: Path, expected_sha256: str
 ) -> str | None:
-    """Verify a resolved snapshot's content against the manifest's recorded
-    digest -- ``None`` when it matches (or the manifest recorded no digest
-    to check, an older/hand-authored manifest).
+    """Verify a resolved snapshot is well-formed, and (when the manifest
+    recorded one) matches its digest -- ``None`` when both checks pass.
 
-    Without this, a truncated/corrupted/silently-replaced snapshot file (a
-    partial artifact download, a stale cache restore) would still resolve as
-    ``resolved`` purely because a file with the right name exists on disk --
-    letting ``compare`` consume the wrong old-side content and report a
-    verdict from data that was never actually part of this baseline set
-    (Codex review).
+    The JSON-shape check (readable, valid JSON, a JSON object) always runs,
+    even when the manifest recorded no ``sha256`` (an older/hand-authored
+    manifest): without it, a truncated/corrupted/non-JSON snapshot file
+    would still resolve as ``resolved`` purely because a file with the
+    right name exists on disk, for any baseline-set whose manifest happens
+    to have no recorded digest -- letting ``compare`` consume garbage
+    old-side content instead of getting this resolver's typed ``ambiguous``
+    outcome (Codex review). The digest comparison itself stays conditional
+    on ``expected_sha256`` being present, since older manifests never
+    recorded one.
     """
-    if not expected_sha256:
-        return None
     try:
         with snapshot_path.open(encoding="utf-8") as fh:
             raw = json.load(fh)
@@ -614,6 +615,8 @@ def _snapshot_digest_issue(
             f"target {target!r}'s snapshot {snapshot_path.name!r} does not "
             "contain a JSON object -- the baseline-set is corrupt."
         )
+    if not expected_sha256:
+        return None
     actual_sha256 = compute_snapshot_content_hash(raw)
     if actual_sha256 != expected_sha256:
         return (

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -708,7 +708,19 @@ def resolve_bundle(
             missing.append(member)
             continue
         resolved = _resolve_under_baseline_dir(baseline_dir, artifact.binary)
-        if resolved is None or not resolved.is_file():
+        # The documented bundle contract is that every member's binary lives
+        # under binaries_dir (the same directory the resolved binaries-dir
+        # output advertises) -- accepting any relative path elsewhere in the
+        # baseline-set would let binary-paths point outside binaries-dir
+        # while the output still claims that directory holds every member,
+        # and a downstream bundle compare using binaries-dir directly (as
+        # opposed to the per-member binary-paths) would then miss it or
+        # pick up an unrelated file (Codex review).
+        if (
+            resolved is None
+            or not resolved.resolve().is_relative_to(binaries_dir.resolve())
+            or not resolved.is_file()
+        ):
             missing.append(member)
             continue
         binary_paths[member] = str(resolved)

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -857,15 +857,24 @@ def resolve_bundle(
     problems: dict[str, str] = {}
     binary_paths: dict[str, str] = {}
     for member in members:
-        artifact = manifest.artifact_for(member)
-        if artifact is None or not artifact.binary:
-            problems[member] = "no staged binary declared in the manifest"
-            continue
+        # Check for duplicate artifacts[] entries before touching any
+        # artifact-specific field: artifact_for() returns only the first
+        # matching row, so if that row happens to lack .binary while a
+        # later duplicate has one, checking artifact.binary first would
+        # misreport "no staged binary declared" instead of the more
+        # accurate duplicate-entry ambiguity -- silently depending on
+        # manifest row order, the exact class of bug artifact_count_for was
+        # introduced to eliminate. Mirrors resolve_target's ordering
+        # (CodeRabbit review).
         if manifest.artifact_count_for(member) > 1:
             problems[member] = (
                 "multiple artifacts[] entries in this baseline-set's "
                 "manifest -- ambiguous which one is authoritative"
             )
+            continue
+        artifact = manifest.artifact_for(member)
+        if artifact is None or not artifact.binary:
+            problems[member] = "no staged binary declared in the manifest"
             continue
         resolved = _resolve_under_baseline_dir(baseline_dir, artifact.binary)
         # The documented bundle contract is that every member's binary lives

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -1,0 +1,469 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Baseline-set resolution (ADR-047 §4/§6, G30 P1.2).
+
+A *baseline-set* is what ``actions/baseline`` produces: ``manifest.json``
+plus one ``.abicheck.json`` snapshot per library — and, for a bundle-scoped
+baseline (ADR-047 §8's S14 correction, staged by a future G30 P1.6 change to
+``actions/baseline``), a ``binaries/`` directory of each member's real ELF
+binary, since ``abicheck/bundle.py``'s ``build_bundle_snapshot()`` skips
+non-ELF inputs and cannot read a bundle's old side from JSON snapshots alone.
+
+This module is the shared reader/resolver ``actions/resolve-baseline`` uses
+(and any future bundle-mode ``check-target`` call would reuse, per the G30
+plan's "extract a shared helper rather than duplicating the schema/digest-
+check code" note): parse a baseline-set directory's ``manifest.json`` and
+resolve ``channel × target/bundle × profile`` down to one of ADR-047 §6's
+five typed failure outcomes, or success — **never** a compatibility verdict.
+
+Reads ``manifest.json``'s raw JSON directly with defensive ``.get()`` access,
+mirroring ``actions/baseline/build_manifest.py``'s own reading philosophy for
+snapshot files (applied one level up, to the manifest itself) — a corrupt or
+hand-edited manifest.json produces a structured resolve outcome, never a
+Python traceback. Pure: reads files, never runs a tool or fetches anything
+(fetching from a baseline channel's storage backend is the calling
+workflow's job, per ADR-047 §10).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+#: The only ``manifest_version`` ``actions/baseline/build_manifest.py`` has
+#: ever emitted. A resolver that doesn't recognize the value on a real
+#: manifest reports ``stale_schema`` instead of guessing at an unfamiliar
+#: shape.
+SUPPORTED_MANIFEST_VERSIONS = frozenset({1})
+
+#: Filename ``actions/baseline`` writes the baseline-set descriptor to,
+#: inside a baseline-set directory. ADR-047 §3's "Filename reconciliation"
+#: note: ``baseline-set.json`` is this ADR's schema/doc term for the file's
+#: *content*, not a different on-disk name — the real file stays
+#: ``manifest.json``, unchanged from what ``actions/baseline`` already
+#: produces today.
+BASELINE_MANIFEST_FILENAME = "manifest.json"
+
+#: Subdirectory (relative to a baseline-set directory) a bundle-scoped
+#: baseline stages member ELF binaries into (ADR-047 §6/§8 S14 correction).
+#: Not populated by ``actions/baseline`` yet (G30 P1.6) — a hand-authored
+#: fixture directory is how this module's bundle resolution is exercised
+#: until then, the same "defines the contract, no producer yet" scoping
+#: G30 P1.1 used for ``build-output.json``.
+BASELINE_BINARIES_DIRNAME = "binaries"
+
+
+class ResolveOutcome:
+    """ADR-047 §6's ``resolve-baseline`` outcome taxonomy, plus ``RESOLVED``.
+
+    Kept as plain string constants (not an ``enum.Enum``) so a Python caller
+    and the Action's ``outcome`` output (a bare string written to
+    ``GITHUB_OUTPUT``) share one literal vocabulary with no serialization
+    step in between.
+    """
+
+    RESOLVED = "resolved"
+    NOT_FOUND = "not_found"
+    AMBIGUOUS = "ambiguous"
+    WRONG_PROFILE = "wrong_profile"
+    STALE_SCHEMA = "stale_schema"
+    INCOMPATIBLE_EVIDENCE = "incompatible_evidence"
+
+
+#: Every outcome value :func:`resolve_target`/:func:`resolve_bundle` can
+#: return — the six branches of ADR-047 §6's table (five failure rows plus
+#: the resolved/success case).
+ALL_OUTCOMES = frozenset(
+    {
+        ResolveOutcome.RESOLVED,
+        ResolveOutcome.NOT_FOUND,
+        ResolveOutcome.AMBIGUOUS,
+        ResolveOutcome.WRONG_PROFILE,
+        ResolveOutcome.STALE_SCHEMA,
+        ResolveOutcome.INCOMPATIBLE_EVIDENCE,
+    }
+)
+
+
+@dataclass
+class BaselineArtifact:
+    """One ``manifest.json`` ``artifacts[]`` entry (``build_manifest.py``).
+
+    Only the fields this module's resolution logic actually reads — not a
+    full mirror of every key ``build_manifest.py`` writes (``git_commit``,
+    ``created_at``, ``build_id``, ``dump_provenance``, ...), which stay
+    whatever the manifest happens to carry and are never round-tripped
+    through this dataclass.
+    """
+
+    library: str = ""
+    artifact: str = ""
+    snapshot: str = ""
+    #: Path (relative to the baseline-set directory, e.g.
+    #: ``"binaries/libpvxs.so.1.5"``) to this member's staged ELF binary —
+    #: only present for a bundle-scoped baseline (ADR-047 §8 S14). Empty for
+    #: an ordinary (non-bundle) baseline-set entry.
+    binary: str = ""
+    sha256: str = ""
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> BaselineArtifact:
+        return cls(
+            library=str(d.get("library") or ""),
+            artifact=str(d.get("artifact") or ""),
+            snapshot=str(d.get("snapshot") or ""),
+            binary=str(d.get("binary") or ""),
+            sha256=str(d.get("sha256") or ""),
+        )
+
+
+@dataclass
+class BaselineManifest:
+    """Parsed ``manifest.json`` (``actions/baseline/build_manifest.py``)."""
+
+    manifest_version: int | None = None
+    project_ref: str = ""
+    profile: str = ""
+    snapshot_schema: int | None = None
+    fact_set: dict[str, Any] | None = None
+    artifacts: list[BaselineArtifact] = field(default_factory=list)
+
+    def artifact_for(self, library: str) -> BaselineArtifact | None:
+        for entry in self.artifacts:
+            if entry.library == library:
+                return entry
+        return None
+
+
+def load_baseline_manifest(baseline_dir: Path | str) -> BaselineManifest | None:
+    """Read ``<baseline_dir>/manifest.json``.
+
+    Returns ``None`` if the file doesn't exist — the ordinary "no baseline
+    set here" case a caller turns into :data:`ResolveOutcome.NOT_FOUND`, not
+    an exception. Raises ``ValueError`` if the file exists but is not a
+    readable JSON object: a genuinely corrupt manifest is a different
+    problem than "no baseline published yet" and must not be silently
+    treated the same way.
+    """
+    path = Path(baseline_dir) / BASELINE_MANIFEST_FILENAME
+    if not path.is_file():
+        return None
+    with path.open(encoding="utf-8") as fh:
+        try:
+            data = json.load(fh)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"{path} is not valid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object.")
+
+    artifacts_raw = data.get("artifacts")
+    artifacts = (
+        [BaselineArtifact.from_dict(a) for a in artifacts_raw if isinstance(a, dict)]
+        if isinstance(artifacts_raw, list)
+        else []
+    )
+    manifest_version = data.get("manifest_version")
+    snapshot_schema = data.get("snapshot_schema")
+    fact_set = data.get("fact_set")
+    return BaselineManifest(
+        manifest_version=manifest_version
+        if isinstance(manifest_version, int)
+        else None,
+        project_ref=str(data.get("project_ref") or ""),
+        profile=str(data.get("profile") or ""),
+        snapshot_schema=snapshot_schema if isinstance(snapshot_schema, int) else None,
+        fact_set=fact_set if isinstance(fact_set, dict) else None,
+        artifacts=artifacts,
+    )
+
+
+@dataclass
+class ResolveResult:
+    """The result of one :func:`resolve_target`/:func:`resolve_bundle` call."""
+
+    outcome: str
+    message: str
+    #: ``True`` only for the :data:`ResolveOutcome.NOT_FOUND` bootstrap case
+    #: (``required=False`` and no baseline set exists yet) — an advisory,
+    #: non-fatal outcome. ``False`` for every other outcome, including a
+    #: ``required=True`` ``not_found``, which is a hard failure.
+    bootstrap: bool = False
+    manifest_path: str | None = None
+    #: ``kind: target`` only.
+    snapshot_path: str | None = None
+    #: ``kind: bundle`` only.
+    binaries_dir: str | None = None
+    binary_paths: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def ok(self) -> bool:
+        return self.outcome == ResolveOutcome.RESOLVED
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "outcome": self.outcome,
+            "message": self.message,
+            "bootstrap": self.bootstrap,
+            "manifest_path": self.manifest_path or "",
+            "snapshot_path": self.snapshot_path or "",
+            "binaries_dir": self.binaries_dir or "",
+            "binary_paths": dict(self.binary_paths),
+        }
+
+
+def _not_found_result(required: bool, message: str) -> ResolveResult:
+    return ResolveResult(
+        outcome=ResolveOutcome.NOT_FOUND,
+        message=message,
+        bootstrap=not required,
+    )
+
+
+def _evidence_incompatibility(
+    manifest: BaselineManifest, candidate_evidence_producer: dict[str, Any] | None
+) -> str | None:
+    """ADR-047 §6's ``incompatible_evidence`` check.
+
+    Compares the baseline's recorded ``fact_set.producer``/``producer_version``
+    (``build_manifest.py``'s own ADR-038 C.8-derived identity, e.g.
+    ``"wrapper"``/``"replay"``/``"clang-plugin"`` plus a tool version) against
+    the candidate build's ``build-output.json`` ``evidence_producer`` block
+    (ADR-047 §2: ``{"kind", "tool", "version"}``). Only compares when *both*
+    sides declare an evidence identity — a plain header/binary-depth check on
+    either side has nothing to compare and is never penalized for a producer
+    mismatch that doesn't actually affect it.
+    """
+    if not candidate_evidence_producer:
+        return None
+    candidate_kind = str(candidate_evidence_producer.get("kind") or "")
+    if not candidate_kind:
+        return None
+    baseline_fact_set = manifest.fact_set
+    if not baseline_fact_set:
+        return None
+    baseline_producer = str(baseline_fact_set.get("producer") or "")
+    if not baseline_producer:
+        return None
+    if baseline_producer != candidate_kind:
+        return (
+            f"baseline's evidence producer is {baseline_producer!r} but the "
+            f"candidate build's evidence producer is {candidate_kind!r} -- "
+            "comparing source-depth evidence across different producers "
+            "(e.g. wrapper vs. replay) is an infrastructure incompatibility, "
+            "not an ABI finding (ADR-047 §6)."
+        )
+    candidate_version = str(candidate_evidence_producer.get("version") or "")
+    baseline_producer_version = str(baseline_fact_set.get("producer_version") or "")
+    if (
+        candidate_version
+        and baseline_producer_version
+        and candidate_version != baseline_producer_version
+    ):
+        return (
+            f"baseline's evidence producer version is "
+            f"{baseline_producer_version!r} but the candidate build's is "
+            f"{candidate_version!r} -- a producer version change can alter "
+            "the evidence recipe (fact_set.py's comparability rules), so "
+            "this is treated as an infrastructure incompatibility rather "
+            "than silently comparing anyway (ADR-047 §6)."
+        )
+    return None
+
+
+def _schema_and_profile_check(
+    manifest: BaselineManifest, profile: str, manifest_path: str
+) -> ResolveResult | None:
+    """Shared ``stale_schema``/``wrong_profile`` checks for target and bundle
+    resolution -- returns ``None`` when both pass."""
+    if manifest.manifest_version not in SUPPORTED_MANIFEST_VERSIONS:
+        return ResolveResult(
+            outcome=ResolveOutcome.STALE_SCHEMA,
+            message=(
+                f"baseline-set manifest_version {manifest.manifest_version!r} "
+                "is not one this resolver understands (supported: "
+                f"{sorted(SUPPORTED_MANIFEST_VERSIONS)}) -- upgrade the "
+                "resolve-baseline Action, or regenerate the baseline-set "
+                "with a compatible actions/baseline version."
+            ),
+            manifest_path=manifest_path,
+        )
+    if manifest.profile != profile:
+        return ResolveResult(
+            outcome=ResolveOutcome.WRONG_PROFILE,
+            message=(
+                f"baseline-set was built for profile {manifest.profile!r}, "
+                f"not the requested {profile!r} -- never compare across "
+                "profiles."
+            ),
+            manifest_path=manifest_path,
+        )
+    return None
+
+
+def resolve_target(
+    baseline_dir: Path | str,
+    *,
+    target: str,
+    profile: str,
+    required: bool = True,
+    candidate_evidence_producer: dict[str, Any] | None = None,
+) -> ResolveResult:
+    """Resolve ``channel × target × profile`` (ADR-047 §6) to one snapshot.
+
+    ``channel`` itself is not a parameter here: this module trusts the
+    caller already selected the right physical ``baseline_dir`` for the
+    requested channel (see ``actions/resolve-baseline/action.yml``'s
+    ``baseline-path`` input doc) — this function only resolves *within* that
+    directory.
+    """
+    baseline_dir = Path(baseline_dir)
+    manifest = load_baseline_manifest(baseline_dir)
+    if manifest is None:
+        return _not_found_result(
+            required, f"No baseline-set found at {baseline_dir} (no manifest.json)."
+        )
+    manifest_path = str(baseline_dir / BASELINE_MANIFEST_FILENAME)
+
+    schema_or_profile_failure = _schema_and_profile_check(
+        manifest, profile, manifest_path
+    )
+    if schema_or_profile_failure is not None:
+        return schema_or_profile_failure
+
+    artifact = manifest.artifact_for(target)
+    if artifact is None:
+        known = sorted(a.library for a in manifest.artifacts if a.library)
+        return ResolveResult(
+            outcome=ResolveOutcome.AMBIGUOUS,
+            message=(
+                f"target {target!r} is not in this baseline-set's manifest "
+                f"(known targets: {known})."
+            ),
+            manifest_path=manifest_path,
+        )
+
+    incompatible = _evidence_incompatibility(manifest, candidate_evidence_producer)
+    if incompatible:
+        return ResolveResult(
+            outcome=ResolveOutcome.INCOMPATIBLE_EVIDENCE,
+            message=incompatible,
+            manifest_path=manifest_path,
+        )
+
+    if not artifact.snapshot:
+        return ResolveResult(
+            outcome=ResolveOutcome.AMBIGUOUS,
+            message=f"target {target!r}'s manifest entry has no snapshot filename.",
+            manifest_path=manifest_path,
+        )
+    snapshot_path = baseline_dir / artifact.snapshot
+    if not snapshot_path.is_file():
+        return ResolveResult(
+            outcome=ResolveOutcome.AMBIGUOUS,
+            message=(
+                f"target {target!r}'s manifest entry names snapshot "
+                f"{artifact.snapshot!r}, but that file does not exist under "
+                f"{baseline_dir}."
+            ),
+            manifest_path=manifest_path,
+        )
+
+    return ResolveResult(
+        outcome=ResolveOutcome.RESOLVED,
+        message=f"resolved target {target!r} at profile {profile!r}.",
+        manifest_path=manifest_path,
+        snapshot_path=str(snapshot_path),
+    )
+
+
+def resolve_bundle(
+    baseline_dir: Path | str,
+    *,
+    bundle: str,
+    members: list[str],
+    profile: str,
+    required: bool = True,
+    candidate_evidence_producer: dict[str, Any] | None = None,
+) -> ResolveResult:
+    """Resolve ``channel × bundle × profile`` (ADR-047 §6/§8 S14 correction).
+
+    Unlike :func:`resolve_target`, a bundle's resolution unit is not a single
+    snapshot: ``abicheck/bundle.py``'s ``build_bundle_snapshot()`` builds its
+    cross-library graph from real ELF binaries and explicitly skips non-ELF
+    (including JSON snapshot) inputs, so this returns paths to every member's
+    **staged binary** under the baseline-set's ``binaries/`` directory
+    instead. Every listed *member* must have one, or the whole bundle
+    resolution reports ``ambiguous`` — a partially-staged bundle baseline
+    would otherwise silently produce a bundle report missing one member's
+    old-side data.
+    """
+    baseline_dir = Path(baseline_dir)
+    manifest = load_baseline_manifest(baseline_dir)
+    if manifest is None:
+        return _not_found_result(
+            required, f"No baseline-set found at {baseline_dir} (no manifest.json)."
+        )
+    manifest_path = str(baseline_dir / BASELINE_MANIFEST_FILENAME)
+
+    schema_or_profile_failure = _schema_and_profile_check(
+        manifest, profile, manifest_path
+    )
+    if schema_or_profile_failure is not None:
+        return schema_or_profile_failure
+
+    incompatible = _evidence_incompatibility(manifest, candidate_evidence_producer)
+    if incompatible:
+        return ResolveResult(
+            outcome=ResolveOutcome.INCOMPATIBLE_EVIDENCE,
+            message=incompatible,
+            manifest_path=manifest_path,
+        )
+
+    binaries_dir = baseline_dir / BASELINE_BINARIES_DIRNAME
+    missing: list[str] = []
+    binary_paths: dict[str, str] = {}
+    for member in members:
+        artifact = manifest.artifact_for(member)
+        if artifact is None or not artifact.binary:
+            missing.append(member)
+            continue
+        resolved = baseline_dir / artifact.binary
+        if not resolved.is_file():
+            missing.append(member)
+            continue
+        binary_paths[member] = str(resolved)
+
+    if missing:
+        return ResolveResult(
+            outcome=ResolveOutcome.AMBIGUOUS,
+            message=(
+                f"bundle {bundle!r}'s member(s) {sorted(missing)} have no "
+                f"staged binary in this baseline-set's "
+                f"{BASELINE_BINARIES_DIRNAME}/ directory -- a bundle-scoped "
+                "baseline must stage every member's ELF binary (ADR-047 "
+                "§6/§8 S14), not just its snapshot."
+            ),
+            manifest_path=manifest_path,
+        )
+
+    return ResolveResult(
+        outcome=ResolveOutcome.RESOLVED,
+        message=f"resolved bundle {bundle!r} ({len(binary_paths)} member(s)) at profile {profile!r}.",
+        manifest_path=manifest_path,
+        binaries_dir=str(binaries_dir),
+        binary_paths=binary_paths,
+    )

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -45,6 +45,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .. import serialization
+
 #: The only ``manifest_version`` ``actions/baseline/build_manifest.py`` has
 #: ever emitted. A resolver that doesn't recognize the value on a real
 #: manifest reports ``stale_schema`` instead of guessing at an unfamiliar
@@ -512,6 +514,30 @@ def _schema_and_profile_check(
                 f"baseline-set was built for profile {manifest.profile!r}, "
                 f"not the requested {profile!r} -- never compare across "
                 "profiles."
+            ),
+            manifest_path=manifest_path,
+        )
+    # manifest_version above is this resolver's own manifest.json shape;
+    # snapshot_schema is the *separate* schema of the .abicheck.json
+    # snapshots it references (serialization.SCHEMA_VERSION) -- a baseline
+    # built by a newer abicheck than this checkout's installed reader would
+    # otherwise still report `resolved` here (only manifest_version was
+    # checked) and fail opaquely in the later compare step instead of
+    # surfacing the typed stale_schema outcome resolve-baseline exists to
+    # give callers (Codex review). A missing snapshot_schema (an
+    # older/hand-authored manifest) has nothing to compare, so it no-ops,
+    # same as the digest checks below.
+    if (
+        manifest.snapshot_schema is not None
+        and manifest.snapshot_schema > serialization.SCHEMA_VERSION
+    ):
+        return ResolveResult(
+            outcome=ResolveOutcome.STALE_SCHEMA,
+            message=(
+                f"baseline-set's snapshot_schema {manifest.snapshot_schema!r} "
+                "is newer than this checkout's installed reader supports "
+                f"(up to schema_version {serialization.SCHEMA_VERSION}) -- "
+                "upgrade abicheck before resolving against this baseline-set."
             ),
             manifest_path=manifest_path,
         )

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -433,17 +433,24 @@ def _evidence_incompatibility(
     mismatch that doesn't actually affect it.
 
     Deliberately does **not** also compare ``evidence_producer.version``
-    against ``fact_set.producer_version``: ADR-047 §2's own example styles
-    ``evidence_producer.version`` as a package release version
-    (``"0.x.y"``), but ``fact_set.producer_version`` is
-    ``CLANG_EXTRACTOR_VERSION`` — an independent internal extractor-recipe
-    version (``"0.7"`` today, per ``source_extractors/clang.py``) with no
-    correspondence to a package release number. Comparing the two directly
-    would reject nearly every real resolution on a coincidental mismatch
-    between two incommensurable version schemes, which is worse than not
-    checking at all — a real version-compatibility check needs a producer-
-    side fix (recording the same identity in both places), not a resolver-
-    side guess.
+    against ``fact_set.producer_version`` — re-raised in later review as a
+    "scanner/recipe version desync" gap; re-verified against **both** real
+    producers before staying with this decision, not just the one checked
+    originally. ADR-047 §2's own example styles ``evidence_producer.version``
+    as a package release version (``"0.x.y"``), but ``fact_set
+    .producer_version`` is an independent internal producer-build version in
+    both cases that exist: ``CLANG_EXTRACTOR_VERSION`` (``"0.7"`` today, per
+    ``source_extractors/clang.py``) for the Python clang extractor, and
+    ``kPluginVersion`` (``contrib/abicheck-clang-plugin/
+    AbicheckFactsPlugin.cpp``) for the C++ plugin — neither corresponds to a
+    package release number. Comparing the two directly would reject nearly
+    every real resolution on a coincidental mismatch between two
+    incommensurable version schemes, which is worse than not checking at all
+    — a real version-compatibility check needs a producer-side fix
+    (recording the same identity in both places, e.g. build-output.json's
+    emitter stamping the real producer-build version instead of the package
+    version), not a resolver-side guess at a mapping that doesn't exist
+    anywhere in the codebase today.
     """
     if not candidate_evidence_producer:
         return None
@@ -754,12 +761,18 @@ def resolve_bundle(
         )
 
     binaries_dir = baseline_dir / BASELINE_BINARIES_DIRNAME
-    missing: list[str] = []
+    # Tracks *why* each problem member was rejected, not just its name --
+    # three genuinely different causes (no manifest entry, an escaping/
+    # missing/mis-located binary, a digest mismatch) previously all
+    # collapsed into one generic "have no staged binary" sentence, pointing
+    # an operator diagnosing e.g. a corrupt-but-present binary at the wrong
+    # fix (CodeRabbit review).
+    problems: dict[str, str] = {}
     binary_paths: dict[str, str] = {}
     for member in members:
         artifact = manifest.artifact_for(member)
         if artifact is None or not artifact.binary:
-            missing.append(member)
+            problems[member] = "no staged binary declared in the manifest"
             continue
         resolved = _resolve_under_baseline_dir(baseline_dir, artifact.binary)
         # The documented bundle contract is that every member's binary lives
@@ -775,21 +788,25 @@ def resolve_bundle(
             or not resolved.resolve().is_relative_to(binaries_dir.resolve())
             or not resolved.is_file()
         ):
-            missing.append(member)
+            problems[member] = (
+                f"binary {artifact.binary!r} is missing, unreadable, or "
+                f"outside {BASELINE_BINARIES_DIRNAME}/"
+            )
             continue
-        if _binary_digest_issue(member, resolved, artifact.sha256):
-            missing.append(member)
+        digest_issue = _binary_digest_issue(member, resolved, artifact.sha256)
+        if digest_issue:
+            problems[member] = digest_issue
             continue
         binary_paths[member] = str(resolved)
 
-    if missing:
+    if problems:
+        detail = "; ".join(f"{m!r}: {problems[m]}" for m in sorted(problems))
         return ResolveResult(
             outcome=ResolveOutcome.AMBIGUOUS,
             message=(
-                f"bundle {bundle!r}'s member(s) {sorted(missing)} have no "
-                f"staged binary in this baseline-set's "
-                f"{BASELINE_BINARIES_DIRNAME}/ directory -- a bundle-scoped "
-                "baseline must stage every member's ELF binary (ADR-047 "
+                f"bundle {bundle!r} could not be resolved -- {detail} -- a "
+                "bundle-scoped baseline must stage every member's ELF "
+                "binary under a validated binaries/ directory (ADR-047 "
                 "section 6/section 8 S14), not just its snapshot."
             ),
             manifest_path=manifest_path,

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -376,18 +376,33 @@ def _load_manifest_or_result(
 ) -> tuple[BaselineManifest, None] | tuple[None, ResolveResult]:
     """Shared ``manifest.json`` load for :func:`resolve_target`/:func:`resolve_bundle`.
 
-    Converts both ways a load can fail into a typed :class:`ResolveResult`
-    instead of letting either escape as a raw exception: a missing manifest
-    becomes :data:`ResolveOutcome.NOT_FOUND` (with the usual bootstrap
-    split), and a manifest that exists but is corrupt/malformed (not valid
-    JSON, or not a JSON object) — a different failure than "not published
-    yet" — becomes :data:`ResolveOutcome.STALE_SCHEMA`, since either way this
-    resolver cannot understand the shape it's looking at. Without this, a
-    corrupt ``manifest.json`` (a truncated download, a hand edit) would raise
-    an unhandled ``ValueError`` all the way out of ``resolve_baseline.py``,
-    breaking the Action's typed-outcome contract for exactly the kind of
-    real baseline-resolution failure ADR-047 §6 exists to name.
+    Converts every way a load can fail into a typed :class:`ResolveResult`
+    instead of letting any of them escape as a raw exception or collapse
+    into the wrong outcome:
+
+    - ``baseline_dir`` itself does not exist becomes
+      :data:`ResolveOutcome.NOT_FOUND` (with the usual bootstrap split) --
+      the legitimate "nothing published for this channel yet" case.
+    - ``baseline_dir`` exists but has no ``manifest.json`` inside it (e.g.
+      an empty/partial ``actions/cache`` restore, or a stripped artifact
+      download) becomes :data:`ResolveOutcome.AMBIGUOUS`, not
+      ``not_found`` -- a directory a caller went to the trouble of staging
+      is a different, more concerning failure than "no baseline exists
+      yet" and must not silently bootstrap a `required: false` caller to a
+      green run with zero comparison performed (Codex review).
+    - a manifest that exists but is corrupt/malformed (not valid JSON, or
+      not a JSON object) -- a different failure than either of the above --
+      becomes :data:`ResolveOutcome.STALE_SCHEMA`, since this resolver
+      cannot understand the shape it's looking at. Without this, a corrupt
+      ``manifest.json`` (a truncated download, a hand edit) would raise an
+      unhandled ``ValueError`` all the way out of ``resolve_baseline.py``,
+      breaking the Action's typed-outcome contract for exactly the kind of
+      real baseline-resolution failure ADR-047 §6 exists to name.
     """
+    if not baseline_dir.is_dir():
+        return None, _not_found_result(
+            required, f"No baseline-set found at {baseline_dir} (path does not exist)."
+        )
     try:
         manifest = load_baseline_manifest(baseline_dir)
     except ValueError as exc:
@@ -401,8 +416,16 @@ def _load_manifest_or_result(
             ),
         )
     if manifest is None:
-        return None, _not_found_result(
-            required, f"No baseline-set found at {baseline_dir} (no manifest.json)."
+        return None, ResolveResult(
+            outcome=ResolveOutcome.AMBIGUOUS,
+            message=(
+                f"{baseline_dir} exists but does not contain a "
+                f"{BASELINE_MANIFEST_FILENAME} -- this looks like an "
+                "empty/partial cache restore or stripped artifact "
+                "directory, not simply an unpublished baseline (a "
+                "baseline-path that does not exist at all is the "
+                "not_found/bootstrap case)."
+            ),
         )
     return manifest, None
 

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -342,6 +342,16 @@ class ResolveResult:
         return self.outcome == ResolveOutcome.RESOLVED
 
     def to_dict(self) -> dict[str, Any]:
+        """JSON-serializable form of this result.
+
+        The ``resolve-baseline`` composite Action (this PR) prints its
+        fields individually via ``resolve_baseline.py``'s ``_print_outputs``
+        rather than going through this method -- ``to_dict()`` is exposed
+        for a future direct-Python caller (e.g. the not-yet-built
+        ``check-target`` composite Action, G30 P1.3) that wants the whole
+        result as one JSON-serializable object instead of discrete
+        ``GITHUB_OUTPUT`` keys.
+        """
         return {
             "outcome": self.outcome,
             "message": self.message,
@@ -900,7 +910,20 @@ def resolve_bundle(
             )
             continue
         artifact = manifest.artifact_for(member)
-        if artifact is None or not artifact.binary:
+        # Two distinct causes, not one generic message: "not in the
+        # manifest at all" (a bundle-members typo, or a target never
+        # staged into this baseline-set) points an operator at a
+        # different fix than "in the manifest but has no binary field"
+        # (a pre-P1.6 baseline-set that only ever staged snapshots) --
+        # mirrors resolve_target's own not-in-manifest branch, which
+        # already lists the known targets (code review).
+        if artifact is None:
+            known = sorted(a.library for a in manifest.artifacts if a.library)
+            problems[member] = (
+                f"not in this baseline-set's manifest (known targets: {known})"
+            )
+            continue
+        if not artifact.binary:
             problems[member] = "no staged binary declared in the manifest"
             continue
         resolved = _resolve_under_baseline_dir(baseline_dir, artifact.binary)

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -39,6 +39,7 @@ workflow's job, per ADR-047 §10).
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -65,6 +66,103 @@ BASELINE_MANIFEST_FILENAME = "manifest.json"
 #: until then, the same "defines the contract, no producer yet" scoping
 #: G30 P1.1 used for ``build-output.json``.
 BASELINE_BINARIES_DIRNAME = "binaries"
+
+# Keys that vary between two dumps/replays of otherwise ABI-identical
+# content -- timestamps, source-file mtimes, and wall-clock/cache-state
+# counters -- so a stable content hash must strip all of them, not hash raw
+# file bytes. Ported verbatim from actions/baseline/build_manifest.py's own
+# private copy of this list (which now imports compute_snapshot_content_hash
+# below instead of keeping its own): this is the ONE place both the
+# baseline-set producer and this resolver's digest-verification check
+# compute a snapshot's stable content hash, so they can never silently drift
+# apart and disagree on what "unchanged content" means.
+_VOLATILE_TOP_LEVEL_KEYS = ("created_at", "source_mtime", "source_mtime_epoch")
+_VOLATILE_BUILD_SOURCE_MANIFEST_KEYS = ("created_at",)
+_VOLATILE_BUILD_SOURCE_PACK_KEYS = ("path_hint",)
+_VOLATILE_COVERAGE_KEYS = (
+    "cache_lookup_s",
+    "extract_s",
+    "link_s",
+    "elapsed_s",
+    "cache_misses",
+    "cache_hits",
+    "extractor_jobs",
+)
+_VOLATILE_MANIFEST_COVERAGE_ROW_KEYS = ("detail", "elapsed_s")
+_VOLATILE_MANIFEST_EXTRACTOR_ROW_KEYS = ("detail", "started_at", "finished_at")
+
+
+def _strip_row_keys(rows: Any, volatile_keys: tuple[str, ...]) -> Any:
+    if not isinstance(rows, list):
+        return rows
+    return [
+        {k: v for k, v in row.items() if k not in volatile_keys}
+        if isinstance(row, dict)
+        else row
+        for row in rows
+    ]
+
+
+def strip_volatile_snapshot_fields(raw: dict[str, Any]) -> dict[str, Any]:
+    """Strip fields that vary run-to-run without the snapshot's actual
+    ABI/source-fact content changing (see the constants above) -- the
+    stable-content view :func:`compute_snapshot_content_hash` hashes."""
+    stable = dict(raw)
+    for key in _VOLATILE_TOP_LEVEL_KEYS:
+        stable.pop(key, None)
+
+    build_source_pack = stable.get("build_source_pack")
+    if isinstance(build_source_pack, dict):
+        build_source_pack = dict(build_source_pack)
+        for key in _VOLATILE_BUILD_SOURCE_PACK_KEYS:
+            build_source_pack.pop(key, None)
+        stable["build_source_pack"] = build_source_pack
+
+    build_source = stable.get("build_source")
+    if isinstance(build_source, dict):
+        build_source = dict(build_source)
+
+        manifest = build_source.get("manifest")
+        if isinstance(manifest, dict):
+            manifest = dict(manifest)
+            for key in _VOLATILE_BUILD_SOURCE_MANIFEST_KEYS:
+                manifest.pop(key, None)
+            if "coverage" in manifest:
+                manifest["coverage"] = _strip_row_keys(
+                    manifest["coverage"], _VOLATILE_MANIFEST_COVERAGE_ROW_KEYS
+                )
+            if "extractors" in manifest:
+                manifest["extractors"] = _strip_row_keys(
+                    manifest["extractors"], _VOLATILE_MANIFEST_EXTRACTOR_ROW_KEYS
+                )
+            build_source["manifest"] = manifest
+
+        source_abi = build_source.get("source_abi")
+        if isinstance(source_abi, dict):
+            source_abi = dict(source_abi)
+            coverage = source_abi.get("coverage")
+            if isinstance(coverage, dict):
+                coverage = dict(coverage)
+                for key in _VOLATILE_COVERAGE_KEYS:
+                    coverage.pop(key, None)
+                source_abi["coverage"] = coverage
+            build_source["source_abi"] = source_abi
+
+        stable["build_source"] = build_source
+
+    return stable
+
+
+def compute_snapshot_content_hash(raw: dict[str, Any]) -> str:
+    """The per-artifact ``sha256`` ``manifest.json`` records for a snapshot
+    (``actions/baseline/build_manifest.py``) -- hashes the *stable* view
+    (volatile fields stripped), not the raw file bytes, so re-dumping
+    ABI-identical content on a different run/host doesn't change the digest.
+    """
+    stable = strip_volatile_snapshot_fields(raw)
+    return hashlib.sha256(
+        json.dumps(stable, sort_keys=True).encode("utf-8")
+    ).hexdigest()
 
 
 class ResolveOutcome:
@@ -233,6 +331,42 @@ def _not_found_result(required: bool, message: str) -> ResolveResult:
     )
 
 
+def _load_manifest_or_result(
+    baseline_dir: Path, required: bool
+) -> tuple[BaselineManifest, None] | tuple[None, ResolveResult]:
+    """Shared ``manifest.json`` load for :func:`resolve_target`/:func:`resolve_bundle`.
+
+    Converts both ways a load can fail into a typed :class:`ResolveResult`
+    instead of letting either escape as a raw exception: a missing manifest
+    becomes :data:`ResolveOutcome.NOT_FOUND` (with the usual bootstrap
+    split), and a manifest that exists but is corrupt/malformed (not valid
+    JSON, or not a JSON object) — a different failure than "not published
+    yet" — becomes :data:`ResolveOutcome.STALE_SCHEMA`, since either way this
+    resolver cannot understand the shape it's looking at. Without this, a
+    corrupt ``manifest.json`` (a truncated download, a hand edit) would raise
+    an unhandled ``ValueError`` all the way out of ``resolve_baseline.py``,
+    breaking the Action's typed-outcome contract for exactly the kind of
+    real baseline-resolution failure ADR-047 §6 exists to name.
+    """
+    try:
+        manifest = load_baseline_manifest(baseline_dir)
+    except ValueError as exc:
+        return None, ResolveResult(
+            outcome=ResolveOutcome.STALE_SCHEMA,
+            message=(
+                f"{baseline_dir / BASELINE_MANIFEST_FILENAME} exists but "
+                f"could not be read as a baseline-set manifest: {exc} -- "
+                "treated as an unrecognized/unparseable schema, the same as "
+                "a manifest_version this resolver doesn't understand."
+            ),
+        )
+    if manifest is None:
+        return None, _not_found_result(
+            required, f"No baseline-set found at {baseline_dir} (no manifest.json)."
+        )
+    return manifest, None
+
+
 def _evidence_incompatibility(
     manifest: BaselineManifest, candidate_evidence_producer: dict[str, Any] | None
 ) -> str | None:
@@ -264,7 +398,7 @@ def _evidence_incompatibility(
             f"candidate build's evidence producer is {candidate_kind!r} -- "
             "comparing source-depth evidence across different producers "
             "(e.g. wrapper vs. replay) is an infrastructure incompatibility, "
-            "not an ABI finding (ADR-047 §6)."
+            "not an ABI finding (ADR-047 section 6)."
         )
     candidate_version = str(candidate_evidence_producer.get("version") or "")
     baseline_producer_version = str(baseline_fact_set.get("producer_version") or "")
@@ -279,7 +413,7 @@ def _evidence_incompatibility(
             f"{candidate_version!r} -- a producer version change can alter "
             "the evidence recipe (fact_set.py's comparability rules), so "
             "this is treated as an infrastructure incompatibility rather "
-            "than silently comparing anyway (ADR-047 §6)."
+            "than silently comparing anyway (ADR-047 section 6)."
         )
     return None
 
@@ -314,6 +448,48 @@ def _schema_and_profile_check(
     return None
 
 
+def _snapshot_digest_issue(
+    target: str, snapshot_path: Path, expected_sha256: str
+) -> str | None:
+    """Verify a resolved snapshot's content against the manifest's recorded
+    digest -- ``None`` when it matches (or the manifest recorded no digest
+    to check, an older/hand-authored manifest).
+
+    Without this, a truncated/corrupted/silently-replaced snapshot file (a
+    partial artifact download, a stale cache restore) would still resolve as
+    ``resolved`` purely because a file with the right name exists on disk --
+    letting ``compare`` consume the wrong old-side content and report a
+    verdict from data that was never actually part of this baseline set
+    (Codex review).
+    """
+    if not expected_sha256:
+        return None
+    try:
+        with snapshot_path.open(encoding="utf-8") as fh:
+            raw = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        return (
+            f"target {target!r}'s snapshot {snapshot_path.name!r} could not "
+            f"be read to verify its digest: {exc} -- the baseline-set is "
+            "corrupt or was truncated."
+        )
+    if not isinstance(raw, dict):
+        return (
+            f"target {target!r}'s snapshot {snapshot_path.name!r} does not "
+            "contain a JSON object -- the baseline-set is corrupt."
+        )
+    actual_sha256 = compute_snapshot_content_hash(raw)
+    if actual_sha256 != expected_sha256:
+        return (
+            f"target {target!r}'s snapshot {snapshot_path.name!r} content "
+            f"digest does not match the manifest (expected "
+            f"{expected_sha256!r}, got {actual_sha256!r}) -- the baseline-"
+            "set is corrupt, was tampered with, or was truncated/replaced "
+            "after the manifest was written."
+        )
+    return None
+
+
 def resolve_target(
     baseline_dir: Path | str,
     *,
@@ -331,11 +507,10 @@ def resolve_target(
     directory.
     """
     baseline_dir = Path(baseline_dir)
-    manifest = load_baseline_manifest(baseline_dir)
-    if manifest is None:
-        return _not_found_result(
-            required, f"No baseline-set found at {baseline_dir} (no manifest.json)."
-        )
+    manifest, failure = _load_manifest_or_result(baseline_dir, required)
+    if failure is not None:
+        return failure
+    assert manifest is not None
     manifest_path = str(baseline_dir / BASELINE_MANIFEST_FILENAME)
 
     schema_or_profile_failure = _schema_and_profile_check(
@@ -382,6 +557,14 @@ def resolve_target(
             manifest_path=manifest_path,
         )
 
+    digest_issue = _snapshot_digest_issue(target, snapshot_path, artifact.sha256)
+    if digest_issue:
+        return ResolveResult(
+            outcome=ResolveOutcome.AMBIGUOUS,
+            message=digest_issue,
+            manifest_path=manifest_path,
+        )
+
     return ResolveResult(
         outcome=ResolveOutcome.RESOLVED,
         message=f"resolved target {target!r} at profile {profile!r}.",
@@ -412,11 +595,10 @@ def resolve_bundle(
     old-side data.
     """
     baseline_dir = Path(baseline_dir)
-    manifest = load_baseline_manifest(baseline_dir)
-    if manifest is None:
-        return _not_found_result(
-            required, f"No baseline-set found at {baseline_dir} (no manifest.json)."
-        )
+    manifest, failure = _load_manifest_or_result(baseline_dir, required)
+    if failure is not None:
+        return failure
+    assert manifest is not None
     manifest_path = str(baseline_dir / BASELINE_MANIFEST_FILENAME)
 
     schema_or_profile_failure = _schema_and_profile_check(
@@ -455,7 +637,7 @@ def resolve_bundle(
                 f"staged binary in this baseline-set's "
                 f"{BASELINE_BINARIES_DIRNAME}/ directory -- a bundle-scoped "
                 "baseline must stage every member's ELF binary (ADR-047 "
-                "§6/§8 S14), not just its snapshot."
+                "section 6/section 8 S14), not just its snapshot."
             ),
             manifest_path=manifest_path,
         )

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -246,6 +246,19 @@ class BaselineManifest:
                 return entry
         return None
 
+    def artifact_count_for(self, library: str) -> int:
+        """How many ``artifacts[]`` rows declare this library.
+
+        A real ``actions/baseline``-produced manifest can never have more
+        than one (``run.sh``'s own input validation already rejects a
+        duplicate library name before anything is dumped), so >1 here means
+        a hand-edited or corrupted manifest -- :func:`artifact_for` would
+        otherwise silently return whichever duplicate happens to appear
+        first, letting ``resolve_target``/``resolve_bundle`` report
+        ``resolved`` against an arbitrarily-picked one (Codex review).
+        """
+        return sum(1 for entry in self.artifacts if entry.library == library)
+
 
 def load_baseline_manifest(baseline_dir: Path | str) -> BaselineManifest | None:
     """Read ``<baseline_dir>/manifest.json``.
@@ -664,6 +677,18 @@ def resolve_target(
             ),
             manifest_path=manifest_path,
         )
+    if manifest.artifact_count_for(target) > 1:
+        return ResolveResult(
+            outcome=ResolveOutcome.AMBIGUOUS,
+            message=(
+                f"target {target!r} has multiple artifacts[] entries in "
+                "this baseline-set's manifest -- ambiguous which one is "
+                "authoritative; a real actions/baseline-produced manifest "
+                "never has duplicate library entries, so this manifest is "
+                "hand-edited or corrupted."
+            ),
+            manifest_path=manifest_path,
+        )
 
     incompatible = _evidence_incompatibility(manifest, candidate_evidence_producer)
     if incompatible:
@@ -773,6 +798,12 @@ def resolve_bundle(
         artifact = manifest.artifact_for(member)
         if artifact is None or not artifact.binary:
             problems[member] = "no staged binary declared in the manifest"
+            continue
+        if manifest.artifact_count_for(member) > 1:
+            problems[member] = (
+                "multiple artifacts[] entries in this baseline-set's "
+                "manifest -- ambiguous which one is authoritative"
+            )
             continue
         resolved = _resolve_under_baseline_dir(baseline_dir, artifact.binary)
         # The documented bundle contract is that every member's binary lives

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -260,17 +260,25 @@ def load_baseline_manifest(baseline_dir: Path | str) -> BaselineManifest | None:
     path = Path(baseline_dir) / BASELINE_MANIFEST_FILENAME
     if not path.is_file():
         return None
-    with path.open(encoding="utf-8") as fh:
-        try:
+    try:
+        with path.open(encoding="utf-8") as fh:
             data = json.load(fh)
-        # UnicodeDecodeError (raised by the text-mode read itself, e.g. a
-        # truncated/binary-garbage manifest) is a ValueError subclass, not a
-        # json.JSONDecodeError -- must be caught alongside it, or a corrupt
-        # manifest with invalid UTF-8 bytes escapes as an unhandled
-        # exception instead of this function's documented ValueError
-        # contract (Codex review).
-        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
-            raise ValueError(f"{path} is not valid JSON: {exc}") from exc
+    # OSError -- e.g. a permission error, or the file disappearing between
+    # the is_file() check above and open() (a restored archive/cache race)
+    # -- is raised by open() itself, before the inner JSON decode even
+    # starts; must be caught here too, or a manifest that exists but can't
+    # actually be read escapes this function's documented ValueError
+    # contract as an unhandled exception (Codex review).
+    except OSError as exc:
+        raise ValueError(f"{path} could not be read: {exc}") from exc
+    # UnicodeDecodeError (raised by the text-mode read itself, e.g. a
+    # truncated/binary-garbage manifest) is a ValueError subclass, not a
+    # json.JSONDecodeError -- must be caught alongside it, or a corrupt
+    # manifest with invalid UTF-8 bytes escapes as an unhandled
+    # exception instead of this function's documented ValueError
+    # contract (Codex review).
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError(f"{path} is not valid JSON: {exc}") from exc
     if not isinstance(data, dict):
         raise ValueError(f"{path} must contain a JSON object.")
 
@@ -538,6 +546,52 @@ def _snapshot_digest_issue(
     return None
 
 
+def _binary_digest_issue(
+    member: str, binary_path: Path, expected_sha256: str
+) -> str | None:
+    """Verify a resolved bundle member's staged binary against the
+    manifest's recorded digest -- ``None`` when it matches (or the manifest
+    recorded no digest to check).
+
+    Reuses the same ``artifacts[].sha256`` field :func:`_snapshot_digest_issue`
+    checks for a target's snapshot -- one manifest row has exactly one
+    primary artifact to vouch for (the snapshot for a plain target row, the
+    staged binary for a bundle-scoped row), so one shared field name is
+    enough; no producer populates this for a staged binary yet (G30 P1.6,
+    not built here), so this is the contract this resolver defines, not one
+    it validates against real output. Unlike a snapshot's content hash, a
+    binary's digest is a plain whole-file SHA-256 -- no volatile-field
+    stripping needed, since dumper.py's timestamp-stamping doesn't apply to
+    an unmodified ELF file. Without this, a truncated/tampered staged
+    binary would still resolve purely because a file with the right name
+    exists under binaries/ (Codex review, mirroring the target-snapshot
+    finding).
+    """
+    if not expected_sha256:
+        return None
+    try:
+        h = hashlib.sha256()
+        with binary_path.open("rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                h.update(chunk)
+    except OSError as exc:
+        return (
+            f"bundle member {member!r}'s staged binary {binary_path.name!r} "
+            f"could not be read to verify its digest: {exc} -- the "
+            "baseline-set is corrupt or was truncated."
+        )
+    actual_sha256 = h.hexdigest()
+    if actual_sha256 != expected_sha256:
+        return (
+            f"bundle member {member!r}'s staged binary {binary_path.name!r} "
+            f"content digest does not match the manifest (expected "
+            f"{expected_sha256!r}, got {actual_sha256!r}) -- the baseline-"
+            "set is corrupt, was tampered with, or was truncated/replaced "
+            "after the manifest was written."
+        )
+    return None
+
+
 def _resolve_under_baseline_dir(baseline_dir: Path, rel: str) -> Path | None:
     """Resolve *rel* under *baseline_dir*, refusing an absolute path or an
     escape (e.g. ``"../../etc/passwd"``) -- ``None`` if refused.
@@ -721,6 +775,9 @@ def resolve_bundle(
             or not resolved.resolve().is_relative_to(binaries_dir.resolve())
             or not resolved.is_file()
         ):
+            missing.append(member)
+            continue
+        if _binary_digest_issue(member, resolved, artifact.sha256):
             missing.append(member)
             continue
         binary_paths[member] = str(resolved)

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -219,7 +219,21 @@ class BaselineArtifact:
     #: only present for a bundle-scoped baseline (ADR-047 §8 S14). Empty for
     #: an ordinary (non-bundle) baseline-set entry.
     binary: str = ""
+    #: sha256 of the *snapshot's* stable content (``build_manifest.py``'s
+    #: ``compute_snapshot_content_hash(raw)``) -- verified against
+    #: ``snapshot`` by :func:`_snapshot_digest_issue`.
     sha256: str = ""
+    #: sha256 of the staged *binary's* raw bytes -- a separate field from
+    #: ``sha256`` above and verified against ``binary`` by
+    #: :func:`_binary_digest_issue`, deliberately never conflated with it:
+    #: the snapshot and binary are different files with unrelated content,
+    #: so reusing one recorded digest for both would compare a JSON
+    #: snapshot's hash against an ELF file's hash and (mis)report every
+    #: bundle member as a digest mismatch. Empty (the default) for any
+    #: manifest that doesn't record one -- today that's every manifest
+    #: ``build_manifest.py`` produces, since it has no bundle-binary-staging
+    #: step yet (Codex review).
+    binary_sha256: str = ""
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> BaselineArtifact:
@@ -229,6 +243,7 @@ class BaselineArtifact:
             snapshot=str(d.get("snapshot") or ""),
             binary=str(d.get("binary") or ""),
             sha256=str(d.get("sha256") or ""),
+            binary_sha256=str(d.get("binary_sha256") or ""),
         )
 
 
@@ -580,9 +595,11 @@ def _schema_and_profile_check(
 
 def _snapshot_digest_issue(
     target: str, snapshot_path: Path, expected_sha256: str
-) -> str | None:
-    """Verify a resolved snapshot is well-formed, and (when the manifest
-    recorded one) matches its digest -- ``None`` when both checks pass.
+) -> tuple[str, str] | None:
+    """Verify a resolved snapshot is well-formed, not a newer schema than
+    this reader understands, and (when the manifest recorded one) matches
+    its digest -- ``None`` when every check passes, else ``(outcome,
+    message)``.
 
     The JSON-shape check (readable, valid JSON, a JSON object) always runs,
     even when the manifest recorded no ``sha256`` (an older/hand-authored
@@ -594,6 +611,18 @@ def _snapshot_digest_issue(
     outcome (Codex review). The digest comparison itself stays conditional
     on ``expected_sha256`` being present, since older manifests never
     recorded one.
+
+    The schema-version check also always runs, reading the *snapshot's
+    own* ``schema_version`` -- distinct from ``_schema_and_profile_check``,
+    which only looks at the manifest's aggregate ``snapshot_schema`` field.
+    An older/hand-authored manifest with no ``snapshot_schema`` has nothing
+    for that check to compare, but the snapshot file itself always carries
+    its own ``schema_version``; without checking it here too, a
+    forward-schema snapshot would still resolve as ``resolved`` and fail
+    opaquely in the later ``compare`` step instead of returning this
+    resolver's typed ``stale_schema`` outcome (Codex review). Returns the
+    ``stale_schema`` outcome for that case; every other issue here returns
+    ``ambiguous``, matching this function's previous behavior.
     """
     try:
         with snapshot_path.open(encoding="utf-8") as fh:
@@ -605,21 +634,33 @@ def _snapshot_digest_issue(
     # unhandled exception instead of this typed ambiguous outcome (Codex
     # review).
     except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        return (
+        return ResolveOutcome.AMBIGUOUS, (
             f"target {target!r}'s snapshot {snapshot_path.name!r} could not "
             f"be read to verify its digest: {exc} -- the baseline-set is "
             "corrupt or was truncated."
         )
     if not isinstance(raw, dict):
-        return (
+        return ResolveOutcome.AMBIGUOUS, (
             f"target {target!r}'s snapshot {snapshot_path.name!r} does not "
             "contain a JSON object -- the baseline-set is corrupt."
+        )
+    schema_version = raw.get("schema_version")
+    if (
+        isinstance(schema_version, int)
+        and schema_version > serialization.SCHEMA_VERSION
+    ):
+        return ResolveOutcome.STALE_SCHEMA, (
+            f"target {target!r}'s snapshot {snapshot_path.name!r} has "
+            f"schema_version {schema_version!r}, newer than this resolver "
+            f"understands (up to schema_version "
+            f"{serialization.SCHEMA_VERSION}) -- upgrade abicheck before "
+            "resolving against this baseline-set."
         )
     if not expected_sha256:
         return None
     actual_sha256 = compute_snapshot_content_hash(raw)
     if actual_sha256 != expected_sha256:
-        return (
+        return ResolveOutcome.AMBIGUOUS, (
             f"target {target!r}'s snapshot {snapshot_path.name!r} content "
             f"digest does not match the manifest (expected "
             f"{expected_sha256!r}, got {actual_sha256!r}) -- the baseline-"
@@ -636,19 +677,22 @@ def _binary_digest_issue(
     manifest's recorded digest -- ``None`` when it matches (or the manifest
     recorded no digest to check).
 
-    Reuses the same ``artifacts[].sha256`` field :func:`_snapshot_digest_issue`
-    checks for a target's snapshot -- one manifest row has exactly one
-    primary artifact to vouch for (the snapshot for a plain target row, the
-    staged binary for a bundle-scoped row), so one shared field name is
-    enough; no producer populates this for a staged binary yet (G30 P1.6,
-    not built here), so this is the contract this resolver defines, not one
-    it validates against real output. Unlike a snapshot's content hash, a
-    binary's digest is a plain whole-file SHA-256 -- no volatile-field
-    stripping needed, since dumper.py's timestamp-stamping doesn't apply to
-    an unmodified ELF file. Without this, a truncated/tampered staged
-    binary would still resolve purely because a file with the right name
-    exists under binaries/ (Codex review, mirroring the target-snapshot
-    finding).
+    Takes ``artifacts[].binary_sha256``, a field distinct from
+    ``artifacts[].sha256`` (the one :func:`_snapshot_digest_issue` checks
+    for a target's snapshot): a bundle-scoped manifest row can carry both a
+    ``snapshot`` and a ``binary`` field at once, so the two need separate
+    recorded digests -- reusing one field for both would compare a JSON
+    snapshot's content hash against an ELF binary's raw-byte hash and
+    (mis)report every bundle member as corrupt, since the two will never
+    coincidentally match (Codex review). No producer populates
+    ``binary_sha256`` for a staged binary yet (G30 P1.6, not built here), so
+    this is the contract this resolver defines, not one it validates
+    against real output. Unlike a snapshot's content hash, a binary's
+    digest is a plain whole-file SHA-256 -- no volatile-field stripping
+    needed, since dumper.py's timestamp-stamping doesn't apply to an
+    unmodified ELF file. Without this, a truncated/tampered staged binary
+    would still resolve purely because a file with the right name exists
+    under binaries/.
     """
     if not expected_sha256:
         return None
@@ -854,9 +898,10 @@ def resolve_target(
 
     digest_issue = _snapshot_digest_issue(target, snapshot_path, artifact.sha256)
     if digest_issue:
+        issue_outcome, issue_message = digest_issue
         return ResolveResult(
-            outcome=ResolveOutcome.AMBIGUOUS,
-            message=digest_issue,
+            outcome=issue_outcome,
+            message=issue_message,
             manifest_path=manifest_path,
         )
 
@@ -983,7 +1028,7 @@ def resolve_bundle(
         if elf_issue:
             problems[member] = elf_issue
             continue
-        digest_issue = _binary_digest_issue(member, resolved, artifact.sha256)
+        digest_issue = _binary_digest_issue(member, resolved, artifact.binary_sha256)
         if digest_issue:
             problems[member] = digest_issue
             continue

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -263,7 +263,13 @@ def load_baseline_manifest(baseline_dir: Path | str) -> BaselineManifest | None:
     with path.open(encoding="utf-8") as fh:
         try:
             data = json.load(fh)
-        except json.JSONDecodeError as exc:
+        # UnicodeDecodeError (raised by the text-mode read itself, e.g. a
+        # truncated/binary-garbage manifest) is a ValueError subclass, not a
+        # json.JSONDecodeError -- must be caught alongside it, or a corrupt
+        # manifest with invalid UTF-8 bytes escapes as an unhandled
+        # exception instead of this function's documented ValueError
+        # contract (Codex review).
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
             raise ValueError(f"{path} is not valid JSON: {exc}") from exc
     if not isinstance(data, dict):
         raise ValueError(f"{path} must contain a JSON object.")
@@ -367,19 +373,55 @@ def _load_manifest_or_result(
     return manifest, None
 
 
+#: Known aliases between ADR-047 section 2's build-output.json
+#: `evidence_producer.kind` vocabulary (`"wrapper"`/`"replay"`/
+#: `"clang-plugin"` -- also `actions/collect-facts/run.sh`'s own `producer`
+#: input values) and what a real baseline's `fact_set.producer` actually
+#: records today: the *extractor implementation's* self-reported id, a
+#: different vocabulary that was never reconciled with the ADR's. Verified
+#: against the real producers -- only two exist today:
+#: `abicheck/buildsource/source_extractors/clang.py`'s `ClangExtractor`
+#: stamps `"abicheck-cc-clang-extractor"` for *both* the wrapper and replay
+#: collection strategies (there is no third extractor, so this check cannot
+#: yet distinguish "wrapper" from "replay" evidence via fact_set.producer
+#: alone -- that distinction simply isn't recorded at this level today), and
+#: `contrib/abicheck-clang-plugin/AbicheckFactsPlugin.cpp:3101` stamps
+#: `"abicheck-clang-plugin"` regardless of collect-facts' own `"clang-plugin"`
+#: producer name. Extend this table if/when a new extractor's producer id
+#: needs a public alias, not by guessing at an unverified mapping.
+_PRODUCER_ALIASES: dict[str, frozenset[str]] = {
+    "wrapper": frozenset({"wrapper", "abicheck-cc-clang-extractor"}),
+    "replay": frozenset({"replay", "abicheck-cc-clang-extractor"}),
+    "clang-plugin": frozenset({"clang-plugin", "abicheck-clang-plugin"}),
+}
+
+
 def _evidence_incompatibility(
     manifest: BaselineManifest, candidate_evidence_producer: dict[str, Any] | None
 ) -> str | None:
     """ADR-047 §6's ``incompatible_evidence`` check.
 
-    Compares the baseline's recorded ``fact_set.producer``/``producer_version``
-    (``build_manifest.py``'s own ADR-038 C.8-derived identity, e.g.
-    ``"wrapper"``/``"replay"``/``"clang-plugin"`` plus a tool version) against
-    the candidate build's ``build-output.json`` ``evidence_producer`` block
-    (ADR-047 §2: ``{"kind", "tool", "version"}``). Only compares when *both*
-    sides declare an evidence identity — a plain header/binary-depth check on
+    Compares the baseline's recorded ``fact_set.producer`` (``build_manifest
+    .py``'s own ADR-038 C.8-derived identity) against the candidate build's
+    ``build-output.json`` ``evidence_producer.kind`` (ADR-047 §2:
+    ``{"kind", "tool", "version"}``), via :data:`_PRODUCER_ALIASES` since the
+    two are different vocabularies today. Only compares when *both* sides
+    declare an evidence identity — a plain header/binary-depth check on
     either side has nothing to compare and is never penalized for a producer
     mismatch that doesn't actually affect it.
+
+    Deliberately does **not** also compare ``evidence_producer.version``
+    against ``fact_set.producer_version``: ADR-047 §2's own example styles
+    ``evidence_producer.version`` as a package release version
+    (``"0.x.y"``), but ``fact_set.producer_version`` is
+    ``CLANG_EXTRACTOR_VERSION`` — an independent internal extractor-recipe
+    version (``"0.7"`` today, per ``source_extractors/clang.py``) with no
+    correspondence to a package release number. Comparing the two directly
+    would reject nearly every real resolution on a coincidental mismatch
+    between two incommensurable version schemes, which is worse than not
+    checking at all — a real version-compatibility check needs a producer-
+    side fix (recording the same identity in both places), not a resolver-
+    side guess.
     """
     if not candidate_evidence_producer:
         return None
@@ -392,28 +434,14 @@ def _evidence_incompatibility(
     baseline_producer = str(baseline_fact_set.get("producer") or "")
     if not baseline_producer:
         return None
-    if baseline_producer != candidate_kind:
+    aliases = _PRODUCER_ALIASES.get(candidate_kind, frozenset({candidate_kind}))
+    if baseline_producer not in aliases:
         return (
             f"baseline's evidence producer is {baseline_producer!r} but the "
             f"candidate build's evidence producer is {candidate_kind!r} -- "
             "comparing source-depth evidence across different producers "
             "(e.g. wrapper vs. replay) is an infrastructure incompatibility, "
             "not an ABI finding (ADR-047 section 6)."
-        )
-    candidate_version = str(candidate_evidence_producer.get("version") or "")
-    baseline_producer_version = str(baseline_fact_set.get("producer_version") or "")
-    if (
-        candidate_version
-        and baseline_producer_version
-        and candidate_version != baseline_producer_version
-    ):
-        return (
-            f"baseline's evidence producer version is "
-            f"{baseline_producer_version!r} but the candidate build's is "
-            f"{candidate_version!r} -- a producer version change can alter "
-            "the evidence recipe (fact_set.py's comparability rules), so "
-            "this is treated as an infrastructure incompatibility rather "
-            "than silently comparing anyway (ADR-047 section 6)."
         )
     return None
 
@@ -467,7 +495,13 @@ def _snapshot_digest_issue(
     try:
         with snapshot_path.open(encoding="utf-8") as fh:
             raw = json.load(fh)
-    except (OSError, json.JSONDecodeError) as exc:
+    # UnicodeDecodeError (the text-mode read itself, e.g. the snapshot was
+    # replaced by non-UTF-8/binary garbage) is a ValueError subclass, not a
+    # json.JSONDecodeError -- must be caught alongside it, or exactly the
+    # corrupted-baseline case this check exists to catch escapes as an
+    # unhandled exception instead of this typed ambiguous outcome (Codex
+    # review).
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         return (
             f"target {target!r}'s snapshot {snapshot_path.name!r} could not "
             f"be read to verify its digest: {exc} -- the baseline-set is "

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -46,6 +46,7 @@ from pathlib import Path
 from typing import Any
 
 from .. import serialization
+from ..elf_metadata import parse_elf_metadata
 
 #: The only ``manifest_version`` ``actions/baseline/build_manifest.py`` has
 #: ever emitted. A resolver that doesn't recognize the value on a real
@@ -642,17 +643,22 @@ _ELF_MAGIC = b"\x7fELF"
 
 
 def _not_elf_issue(member: str, binary_path: Path) -> str | None:
-    """Sniff *binary_path*'s ELF magic -- ``None`` when it starts with the
-    4-byte ELF header, a problem string otherwise.
+    """Check whether ``build_bundle_snapshot()`` would actually keep
+    *binary_path* -- ``None`` when it would, a problem string otherwise.
 
     ``build_bundle_snapshot()`` (``abicheck/bundle.py``) silently skips any
-    staged input that isn't a real ELF file rather than erroring, so a
-    non-ELF file staged under ``binaries/`` (e.g. a JSON snapshot placed at
-    the wrong path, or a truncated/replaced binary that happens to still
-    match its recorded digest) would otherwise resolve as ``resolved`` here
-    and then silently vanish from the bundle-scoped comparison downstream --
-    reported success on a comparison that never actually consulted this
-    member (Codex review).
+    staged input that isn't a real, parseable ELF file rather than erroring,
+    so a non-ELF file staged under ``binaries/`` (e.g. a JSON snapshot
+    placed at the wrong path) -- or a truncated/corrupted one that still
+    happens to start with the ELF magic and match its recorded digest --
+    would otherwise resolve as ``resolved`` here and then silently vanish
+    from the bundle-scoped comparison downstream, reporting success on a
+    comparison that never actually consulted this member. A bare magic-byte
+    sniff alone doesn't catch the truncated case, so this mirrors
+    ``build_bundle_snapshot()``'s own skip criteria exactly (magic check,
+    then a real parse, then the same "essentially empty" emptiness check)
+    so a ``resolved`` outcome here actually predicts survival there (Codex
+    review, two rounds).
     """
     try:
         with binary_path.open("rb") as fh:
@@ -670,6 +676,27 @@ def _not_elf_issue(member: str, binary_path: Path) -> str | None:
             "build_bundle_snapshot() silently skips non-ELF inputs, so this "
             "member would otherwise vanish from the bundle comparison "
             "despite resolve-baseline reporting success."
+        )
+    try:
+        meta = parse_elf_metadata(binary_path)
+    except Exception as exc:
+        return (
+            f"bundle member {member!r}'s staged binary {binary_path.name!r} "
+            f"starts with the ELF magic but could not be parsed as a valid "
+            f"ELF file ({exc}) -- it is truncated or corrupted, and "
+            "build_bundle_snapshot() would silently skip it, so this "
+            "member would vanish from the bundle comparison despite "
+            "resolve-baseline reporting success."
+        )
+    if meta is None or (
+        not meta.soname and not meta.symbols and not meta.imports and not meta.needed
+    ):
+        return (
+            f"bundle member {member!r}'s staged binary {binary_path.name!r} "
+            "parses as an essentially empty ELF file (no soname, symbols, "
+            "imports, or needed entries) -- build_bundle_snapshot() would "
+            "silently skip it, so this member would vanish from the bundle "
+            "comparison despite resolve-baseline reporting success."
         )
     return None
 

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -612,6 +612,42 @@ def _binary_digest_issue(
     return None
 
 
+_ELF_MAGIC = b"\x7fELF"
+
+
+def _not_elf_issue(member: str, binary_path: Path) -> str | None:
+    """Sniff *binary_path*'s ELF magic -- ``None`` when it starts with the
+    4-byte ELF header, a problem string otherwise.
+
+    ``build_bundle_snapshot()`` (``abicheck/bundle.py``) silently skips any
+    staged input that isn't a real ELF file rather than erroring, so a
+    non-ELF file staged under ``binaries/`` (e.g. a JSON snapshot placed at
+    the wrong path, or a truncated/replaced binary that happens to still
+    match its recorded digest) would otherwise resolve as ``resolved`` here
+    and then silently vanish from the bundle-scoped comparison downstream --
+    reported success on a comparison that never actually consulted this
+    member (Codex review).
+    """
+    try:
+        with binary_path.open("rb") as fh:
+            header = fh.read(len(_ELF_MAGIC))
+    except OSError as exc:
+        return (
+            f"bundle member {member!r}'s staged binary {binary_path.name!r} "
+            f"could not be read to verify it is an ELF file: {exc} -- the "
+            "baseline-set is corrupt or was truncated."
+        )
+    if header != _ELF_MAGIC:
+        return (
+            f"bundle member {member!r}'s staged binary {binary_path.name!r} "
+            "is not an ELF file (missing the \\x7fELF magic) -- "
+            "build_bundle_snapshot() silently skips non-ELF inputs, so this "
+            "member would otherwise vanish from the bundle comparison "
+            "despite resolve-baseline reporting success."
+        )
+    return None
+
+
 def _resolve_under_baseline_dir(baseline_dir: Path, rel: str) -> Path | None:
     """Resolve *rel* under *baseline_dir*, refusing an absolute path or an
     escape (e.g. ``"../../etc/passwd"``) -- ``None`` if refused.
@@ -823,6 +859,10 @@ def resolve_bundle(
                 f"binary {artifact.binary!r} is missing, unreadable, or "
                 f"outside {BASELINE_BINARIES_DIRNAME}/"
             )
+            continue
+        elf_issue = _not_elf_issue(member, resolved)
+        if elf_issue:
+            problems[member] = elf_issue
             continue
         digest_issue = _binary_digest_issue(member, resolved, artifact.sha256)
         if digest_issue:

--- a/abicheck/buildsource/baseline_set.py
+++ b/abicheck/buildsource/baseline_set.py
@@ -911,9 +911,17 @@ def resolve_bundle(
         # while the output still claims that directory holds every member,
         # and a downstream bundle compare using binaries-dir directly (as
         # opposed to the per-member binary-paths) would then miss it or
-        # pick up an unrelated file (Codex review).
+        # pick up an unrelated file (Codex review). Path.is_relative_to()
+        # is true for a path relative to *itself* too, so a manifest entry
+        # whose "binary" field is exactly "binaries" (equal to
+        # BASELINE_BINARIES_DIRNAME) would satisfy is_relative_to() against
+        # binaries_dir without actually being a child of it -- reject that
+        # explicitly, not just non-containment, so binaries-dir can never
+        # resolve to something other than a directory of member files
+        # (Codex review, fourth round).
         if (
             resolved is None
+            or resolved.resolve() == binaries_dir.resolve()
             or not resolved.resolve().is_relative_to(binaries_dir.resolve())
             or not resolved.is_file()
         ):

--- a/action.yml
+++ b/action.yml
@@ -169,6 +169,42 @@ inputs:
       deps-compare, and follow-deps.
     required: false
 
+  # ── Scoped comparison: app-usage / required-symbol contracts (compare mode) ──
+  used-by:
+    description: >
+      Application binary/binaries whose actual imports/required symbol
+      versions scope the comparison (space-separated; maps to repeated
+      compare --used-by). The full library comparison still runs; the
+      worst app-scoped result becomes the primary verdict/exit code, with
+      the full verdict kept as informational context. Mutually exclusive
+      with required-symbol/required-symbols (the CLI rejects both being
+      set). compare mode only.
+    required: false
+  verify-runtime:
+    description: >
+      With used-by: actually run each consumer binary once against the old
+      library and once against the new one (LD_BIND_NOW=1), recording a
+      runtime-load-failure finding when the dynamic linker reports an
+      undefined symbol against the new library after loading cleanly
+      against the old one. Linux-only; a no-op elsewhere. Ignored without
+      used-by. compare mode only.
+    required: false
+    default: 'false'
+  required-symbol:
+    description: >
+      An exported linker symbol a plugin host resolves via dlopen/dlsym
+      and requires (space-separated; maps to repeated compare
+      --required-symbol). Scopes the comparison to this explicit
+      entrypoint contract instead of the full diff. Mutually exclusive
+      with used-by. compare mode only.
+    required: false
+  required-symbols:
+    description: >
+      Path to a file of required symbols, one per line (blank lines and
+      '#' comments ignored) -- combined with any required-symbol values.
+      compare mode only.
+    required: false
+
   # ── Source-scan & build-source evidence (scan / dump modes) ──────────────────
   against:
     description: >
@@ -480,6 +516,10 @@ runs:
         INPUT_ABI_BASELINE: ${{ inputs.abi-baseline }}
         INPUT_ESTIMATE: ${{ inputs.estimate }}
         INPUT_AUDIT: ${{ inputs.audit }}
+        INPUT_USED_BY: ${{ inputs.used-by }}
+        INPUT_VERIFY_RUNTIME: ${{ inputs.verify-runtime }}
+        INPUT_REQUIRED_SYMBOL: ${{ inputs.required-symbol }}
+        INPUT_REQUIRED_SYMBOLS: ${{ inputs.required-symbols }}
       run: bash "${{ github.action_path }}/action/validate-inputs.sh"
 
     # ── 1. Python ─────────────────────────────────────────────────────────────
@@ -531,6 +571,10 @@ runs:
         INPUT_FOLLOW_DEPS: ${{ inputs.follow-deps }}
         INPUT_OLD_ROOT: ${{ inputs.old-root }}
         INPUT_NEW_ROOT: ${{ inputs.new-root }}
+        INPUT_USED_BY: ${{ inputs.used-by }}
+        INPUT_VERIFY_RUNTIME: ${{ inputs.verify-runtime }}
+        INPUT_REQUIRED_SYMBOL: ${{ inputs.required-symbol }}
+        INPUT_REQUIRED_SYMBOLS: ${{ inputs.required-symbols }}
         INPUT_AGAINST: ${{ inputs.against }}
         INPUT_SEARCH_PATH: ${{ inputs.search-path }}
         INPUT_LD_LIBRARY_PATH: ${{ inputs.ld-library-path }}

--- a/action/run.sh
+++ b/action/run.sh
@@ -374,6 +374,17 @@ elif [[ "$MODE" == "compare" ]]; then
     add_single_flag "--ld-library-path" "${INPUT_LD_LIBRARY_PATH:-}"
   fi
 
+  # Scoped comparison (ADR-043): --used-by/--required-symbol(s) contracts.
+  # The CLI itself enforces --used-by vs --required-symbol/--required-symbols
+  # mutual exclusivity (a UsageError, surfaced as VERDICT=ERROR below via the
+  # generic CLI-error detection) -- not re-validated here.
+  add_flag "--used-by" "${INPUT_USED_BY:-}"
+  if [[ "${INPUT_VERIFY_RUNTIME:-false}" == "true" ]]; then
+    CMD+=(--verify-runtime)
+  fi
+  add_flag "--required-symbol" "${INPUT_REQUIRED_SYMBOL:-}"
+  add_single_flag "--required-symbols" "${INPUT_REQUIRED_SYMBOLS:-}"
+
   # Note: --gcc-path, --gcc-prefix, --gcc-options, --sysroot, --nostdinc are
   # dump-only flags. In compare mode abicheck performs the dump internally
   # when an input is a binary, but these cross-compilation flags are not

--- a/action/validate-inputs.sh
+++ b/action/validate-inputs.sh
@@ -176,6 +176,29 @@ if [[ "$_JOBS" != "0" ]] && { [[ "$MODE" != "compare" ]] || [[ "$_RELEASE_STYLE_
   _warn "jobs is set but has no effect: it only applies to mode: compare with a directory/package old-library/new-library operand (mode is '$MODE')."
 fi
 
+# used-by/verify-runtime/required-symbol/required-symbols: compare mode only
+# (ADR-043 scoped-comparison contracts). --used-by and --required-symbol/
+# --required-symbols are mutually exclusive on the CLI itself, but that
+# UsageError only surfaces after Python setup/dependency install/pip
+# install -- fail here instead, before any of that, matching this script's
+# whole reason for existing (G30 P1.3, resolving the S22/S23 root-Action
+# gap: check-target's kind: app-consumer/plugin-contract route through
+# these two flags).
+_USED_BY="${INPUT_USED_BY:-}"
+_REQUIRED_SYMBOL="${INPUT_REQUIRED_SYMBOL:-}"
+_REQUIRED_SYMBOLS="${INPUT_REQUIRED_SYMBOLS:-}"
+if [[ -n "$_USED_BY" && ( -n "$_REQUIRED_SYMBOL" || -n "$_REQUIRED_SYMBOLS" ) ]]; then
+  _fail "used-by is mutually exclusive with required-symbol/required-symbols -- set only one contract per check."
+fi
+_scoped_input_names=(used-by verify-runtime required-symbol required-symbols)
+_scoped_input_values=("$_USED_BY" "${INPUT_VERIFY_RUNTIME:-false}" "$_REQUIRED_SYMBOL" "$_REQUIRED_SYMBOLS")
+_scoped_input_unset_values=("" "false" "" "")
+for _i in "${!_scoped_input_names[@]}"; do
+  if [[ "${_scoped_input_values[$_i]}" != "${_scoped_input_unset_values[$_i]}" && "$MODE" != "compare" ]]; then
+    _warn "${_scoped_input_names[$_i]} is set but has no effect: it only applies to mode: compare (mode is '$MODE')."
+  fi
+done
+
 # abi-baseline: compare mode (used as old-library) or scan mode (used as the
 # scan baseline) only.
 _ABI_BASELINE="${INPUT_ABI_BASELINE:-}"

--- a/actions/baseline/build_manifest.py
+++ b/actions/baseline/build_manifest.py
@@ -38,119 +38,15 @@ import sys
 from pathlib import Path
 from typing import Any
 
-# Keys that vary between two dumps/replays of otherwise ABI-identical
-# content -- timestamps, source-file mtimes, and wall-clock/cache-state
-# counters -- so a stable content hash must strip all of them, not hash raw
-# file bytes. This started as a single `created_at` pop and grew by three
-# separate review rounds (top-level created_at, then the nested
-# build_source.manifest.created_at, then this fuller set) as each left
-# something volatile behind; kept as one explicit list instead of another
-# one-off pop so the next volatile field lands here too (Codex review).
-_VOLATILE_TOP_LEVEL_KEYS = ("created_at", "source_mtime", "source_mtime_epoch")
-_VOLATILE_BUILD_SOURCE_MANIFEST_KEYS = ("created_at",)
-# BuildSourceRef.path_hint (abicheck/buildsource/model.py) -- the out-of-band
-# pack's on-disk location, documented on the field itself as "advisory only".
-# cli_buildsource.py's embed_build_source() defaults it to the --sources/
-# --build-info operand path when the caller doesn't pass a name hint, so the
-# same ABI/source facts dumped from a relative abicheck_inputs/ vs an
-# absolute restored pack path get a different path_hint and therefore a
-# different per-artifact sha256/content-digest, even though nothing semantic
-# changed (Codex review). content_hash/coverage_summary, the ref's other two
-# fields, are real content identity and stay.
-_VOLATILE_BUILD_SOURCE_PACK_KEYS = ("path_hint",)
-# Populated by abicheck/buildsource/source_replay.py's replay producer (and
-# inline.py's cache bookkeeping) -- wall-clock durations and cache hit/miss
-# counts that depend on the runner's cache warmth and load, not on the
-# semantic source-fact content itself.
-_VOLATILE_COVERAGE_KEYS = (
-    "cache_lookup_s",
-    "extract_s",
-    "link_s",
-    "elapsed_s",
-    "cache_misses",
-    "cache_hits",
-    # The replay producer's own parallelism setting (CPU count or
-    # ABICHECK_L4_JOBS), not a property of the extracted content -- the
-    # same ABI/source facts replayed on a differently-sized runner would
-    # otherwise still churn the digest (Codex review).
-    "extractor_jobs",
-)
-# LayerCoverage rows (abicheck/buildsource/model.py) embedded at
-# build_source.manifest.coverage: build_inline_coverage() (buildsource/
-# inline.py) copies the same cache/timing state into each row's "detail"
-# (a free-form human string that can embed "cache X/Y hit (Z%)" and
-# "N.NNs") and "elapsed_s" -- a *third* place the same volatile info
-# leaks into, after source_abi.coverage and build_source.manifest itself.
-# "layer"/"status"/"confidence" are the semantic identity; "detail" is by
-# its own docstring presentational, so both are dropped rather than parsed.
-_VOLATILE_MANIFEST_COVERAGE_ROW_KEYS = ("detail", "elapsed_s")
-# ExtractorRecord rows (abicheck/buildsource/model.py) embedded at
-# build_source.manifest.extractors: inline_graph_fold.py appends
-# "N.NNs, jobs=M" (last_elapsed_s/last_jobs) to a row's "detail", and
-# started_at/finished_at are ISO 8601 wall-clock bounds -- runner
-# load/CPU count and collection time, not source-fact content, so a
-# fourth leak of the same volatile-info-in-a-row-field shape. name/
-# version/status/inputs/artifacts/command/command_hash/capabilities/
-# diagnostics are the semantic identity and stay.
-_VOLATILE_MANIFEST_EXTRACTOR_ROW_KEYS = ("detail", "started_at", "finished_at")
-
-
-def _strip_row_keys(rows: Any, volatile_keys: tuple[str, ...]) -> Any:
-    if not isinstance(rows, list):
-        return rows
-    return [
-        {k: v for k, v in row.items() if k not in volatile_keys}
-        if isinstance(row, dict)
-        else row
-        for row in rows
-    ]
-
-
-def _strip_volatile_fields(raw: dict[str, Any]) -> dict[str, Any]:
-    stable = dict(raw)
-    for key in _VOLATILE_TOP_LEVEL_KEYS:
-        stable.pop(key, None)
-
-    build_source_pack = stable.get("build_source_pack")
-    if isinstance(build_source_pack, dict):
-        build_source_pack = dict(build_source_pack)
-        for key in _VOLATILE_BUILD_SOURCE_PACK_KEYS:
-            build_source_pack.pop(key, None)
-        stable["build_source_pack"] = build_source_pack
-
-    build_source = stable.get("build_source")
-    if isinstance(build_source, dict):
-        build_source = dict(build_source)
-
-        manifest = build_source.get("manifest")
-        if isinstance(manifest, dict):
-            manifest = dict(manifest)
-            for key in _VOLATILE_BUILD_SOURCE_MANIFEST_KEYS:
-                manifest.pop(key, None)
-            if "coverage" in manifest:
-                manifest["coverage"] = _strip_row_keys(
-                    manifest["coverage"], _VOLATILE_MANIFEST_COVERAGE_ROW_KEYS
-                )
-            if "extractors" in manifest:
-                manifest["extractors"] = _strip_row_keys(
-                    manifest["extractors"], _VOLATILE_MANIFEST_EXTRACTOR_ROW_KEYS
-                )
-            build_source["manifest"] = manifest
-
-        source_abi = build_source.get("source_abi")
-        if isinstance(source_abi, dict):
-            source_abi = dict(source_abi)
-            coverage = source_abi.get("coverage")
-            if isinstance(coverage, dict):
-                coverage = dict(coverage)
-                for key in _VOLATILE_COVERAGE_KEYS:
-                    coverage.pop(key, None)
-                source_abi["coverage"] = coverage
-            build_source["source_abi"] = source_abi
-
-        stable["build_source"] = build_source
-
-    return stable
+# Volatile-field stripping + the per-artifact content-hash algorithm now
+# live in abicheck.buildsource.baseline_set (G30 P1.2) -- the ONE place both
+# this producer and resolve-baseline's digest-verification check compute a
+# snapshot's stable content hash, so the two can never silently drift apart
+# and disagree on what "unchanged content" means. This script still has no
+# dependency on abicheck's AbiSnapshot/schema internals beyond that one pure
+# utility function -- it keeps reading raw JSON directly, per its own
+# docstring above.
+from abicheck.buildsource.baseline_set import compute_snapshot_content_hash
 
 
 def _read_snapshot_meta(path: Path) -> dict[str, Any]:
@@ -159,11 +55,8 @@ def _read_snapshot_meta(path: Path) -> dict[str, Any]:
     # Hash the snapshot with volatile fields removed, not the raw file
     # bytes: dumper.py/collect-facts stamp several fields fresh on every run
     # (absent SOURCE_DATE_EPOCH) even when the actual ABI/source-fact
-    # content is identical -- see _strip_volatile_fields above.
-    stable = _strip_volatile_fields(raw)
-    sha256 = hashlib.sha256(
-        json.dumps(stable, sort_keys=True).encode("utf-8")
-    ).hexdigest()
+    # content is identical -- see compute_snapshot_content_hash's docstring.
+    sha256 = compute_snapshot_content_hash(raw)
     fact_set = None
     build_source = raw.get("build_source")
     if isinstance(build_source, dict):

--- a/actions/resolve-baseline/action.yml
+++ b/actions/resolve-baseline/action.yml
@@ -1,0 +1,137 @@
+name: 'abicheck resolve-baseline'
+description: >-
+  Resolve one check's baseline: channel x target/bundle x profile against an
+  already-staged baseline-set, returning one of ADR-047 Section 6's typed
+  outcomes (resolved, not_found, ambiguous, wrong_profile, stale_schema,
+  incompatible_evidence) -- never a compatibility verdict, and never
+  silently degraded to "no baseline = compatible." Read-only: this Action
+  never fetches, commits, or pushes.
+
+branding:
+  icon: 'target'
+  color: 'blue'
+
+inputs:
+  baseline-path:
+    description: >
+      Path to this channel's baseline-set, already staged by the calling
+      workflow (e.g. via actions/cache, actions/download-artifact, or gh
+      release download -- this Action does not itself know how to fetch
+      from a baseline channel's storage backend, see ADR-047 §10). Either a
+      directory already containing manifest.json (plus per-target
+      snapshots, and binaries/ for a bundle-scoped baseline), or a
+      .tar.zst/.tar.gz/.tgz/.tar archive of the same, which is extracted
+      here. A path that does not exist at all is treated as "no baseline
+      set exists yet" (the not_found outcome), never a usage error.
+    required: true
+  channel:
+    description: >
+      Baseline channel name (release-contract, accepted-main, explicit, or
+      a project-defined custom channel) -- recorded on the outcome/output
+      only. This Action trusts the caller already resolved the right
+      physical baseline-path for this channel; it does not itself choose
+      between channels.
+    required: true
+  kind:
+    description: "'target' (default) or 'bundle' -- which resolution shape to use."
+    required: false
+    default: 'target'
+  target:
+    description: 'Target id to resolve. Required when kind is target.'
+    required: false
+    default: ''
+  bundle:
+    description: 'Bundle id to resolve. Required when kind is bundle.'
+    required: false
+    default: ''
+  bundle-members:
+    description: >
+      JSON array of the bundle's member target ids, e.g.
+      '["libpvxs", "libpvxsIoc"]'. Required when kind is bundle -- every
+      member must have a staged binary in the baseline-set's binaries/
+      directory for the bundle to resolve (ADR-047 §6/§8 S14: bundle
+      analysis reads real ELF binaries, never JSON snapshots).
+    required: false
+    default: '[]'
+  profile:
+    description: >
+      The build profile.id this check expects the baseline to have been
+      built for -- a baseline built for a different profile is always
+      wrong_profile, never silently compared.
+    required: true
+  required:
+    description: >
+      'true' (default) -- no baseline set yet is a hard failure
+      (not_found, required). 'false' -- explicit bootstrap opt-in (e.g. the
+      very first release-contract publish, before any release exists); no
+      baseline set yet resolves as not_found/bootstrap, an advisory,
+      non-fatal outcome.
+    required: false
+    default: 'true'
+  candidate-build-output:
+    description: >
+      Path to the candidate build's build-output.json (ADR-047 §2), read
+      only for its evidence_producer block, used for the
+      incompatible_evidence check (the baseline's recorded evidence
+      producer -- wrapper, clang-plugin, replay -- disagreeing with the
+      candidate's). Omit to skip that check.
+    required: false
+    default: ''
+  python-version:
+    description: 'Python version for setup-python.'
+    required: false
+    default: '3.13'
+
+outputs:
+  outcome:
+    description: 'resolved | not_found | ambiguous | wrong_profile | stale_schema | incompatible_evidence.'
+    value: ${{ steps.resolve.outputs.outcome }}
+  bootstrap:
+    description: "'true' when outcome is not_found and required was 'false' (advisory, non-fatal). 'false' otherwise."
+    value: ${{ steps.resolve.outputs.bootstrap }}
+  channel:
+    description: 'Echoes the channel input, for a caller that only has this step''s outputs in scope.'
+    value: ${{ steps.resolve.outputs.channel }}
+  manifest-path:
+    description: 'Path to the resolved baseline-set''s manifest.json, when one was found.'
+    value: ${{ steps.resolve.outputs.manifest-path }}
+  snapshot-path:
+    description: '(kind: target only) Path to the resolved target''s .abicheck.json snapshot.'
+    value: ${{ steps.resolve.outputs.snapshot-path }}
+  binaries-dir:
+    description: '(kind: bundle only) Path to the directory containing the resolved bundle''s staged member binaries.'
+    value: ${{ steps.resolve.outputs.binaries-dir }}
+  binary-paths:
+    description: '(kind: bundle only) JSON object mapping each member target id to its staged binary path.'
+    value: ${{ steps.resolve.outputs.binary-paths }}
+  message:
+    description: 'Human-readable explanation of the outcome.'
+    value: ${{ steps.resolve.outputs.message }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install abicheck
+      shell: bash
+      run: pip install "${{ github.action_path }}/../.."
+
+    - name: Resolve baseline
+      id: resolve
+      shell: bash
+      env:
+        INPUT_BASELINE_PATH: ${{ inputs.baseline-path }}
+        INPUT_CHANNEL: ${{ inputs.channel }}
+        INPUT_KIND: ${{ inputs.kind }}
+        INPUT_TARGET: ${{ inputs.target }}
+        INPUT_BUNDLE: ${{ inputs.bundle }}
+        INPUT_BUNDLE_MEMBERS: ${{ inputs.bundle-members }}
+        INPUT_PROFILE: ${{ inputs.profile }}
+        INPUT_REQUIRED: ${{ inputs.required }}
+        INPUT_CANDIDATE_BUILD_OUTPUT: ${{ inputs.candidate-build-output }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: bash "${{ github.action_path }}/run.sh"

--- a/actions/resolve-baseline/resolve_baseline.py
+++ b/actions/resolve-baseline/resolve_baseline.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CLI wrapper backing ``actions/resolve-baseline/run.sh`` (G30 P1.2,
+ADR-047 §4/§6).
+
+Resolves ``channel × target/bundle × profile`` against an already-staged
+baseline-set directory -- the calling workflow is responsible for
+downloading/restoring the right physical baseline-set for the requested
+channel (see ``action.yml``'s ``baseline-path`` input doc); this script only
+resolves *within* that directory. Thin argparse wrapper around
+``abicheck.buildsource.baseline_set``'s pure resolver -- prints
+``key=value`` lines on stdout that ``run.sh`` forwards to ``GITHUB_OUTPUT``,
+the same pattern ``actions/baseline/build_manifest.py`` uses.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from abicheck.buildsource.baseline_set import (
+    ResolveOutcome,
+    ResolveResult,
+    resolve_bundle,
+    resolve_target,
+)
+
+#: Usage error, matching the repo-wide convention documented in AGENTS.md
+#: ("64 = usage error (bad flags/inputs)").
+_EXIT_USAGE_ERROR = 64
+
+
+def _print_outputs(result: ResolveResult) -> None:
+    # One line per GITHUB_OUTPUT key. `message` is always built from f-strings
+    # with no embedded newlines (see baseline_set.py), so a plain key=value
+    # line is safe here -- no GITHUB_OUTPUT heredoc delimiter needed.
+    print(f"outcome={result.outcome}")
+    print(f"bootstrap={'true' if result.bootstrap else 'false'}")
+    print(f"manifest-path={result.manifest_path or ''}")
+    print(f"snapshot-path={result.snapshot_path or ''}")
+    print(f"binaries-dir={result.binaries_dir or ''}")
+    print(f"binary-paths={json.dumps(result.binary_paths)}")
+    print(f"message={result.message}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-dir", required=True, type=Path)
+    parser.add_argument("--kind", required=True, choices=["target", "bundle"])
+    parser.add_argument("--name", required=True, help="target id or bundle id")
+    parser.add_argument(
+        "--members",
+        default="[]",
+        help="JSON array of member target ids (kind: bundle only)",
+    )
+    parser.add_argument("--profile", required=True)
+    parser.add_argument("--required", required=True, choices=["true", "false"])
+    parser.add_argument(
+        "--candidate-evidence-producer",
+        default="",
+        help='JSON object {"kind", "tool", "version"}, or empty to skip the '
+        "incompatible_evidence check",
+    )
+    args = parser.parse_args(argv)
+
+    candidate_evidence_producer = None
+    if args.candidate_evidence_producer:
+        try:
+            candidate_evidence_producer = json.loads(args.candidate_evidence_producer)
+        except json.JSONDecodeError as exc:
+            print(
+                f"::error::--candidate-evidence-producer is not valid JSON: {exc}",
+                file=sys.stderr,
+            )
+            return _EXIT_USAGE_ERROR
+        if not isinstance(candidate_evidence_producer, dict):
+            print(
+                "::error::--candidate-evidence-producer must be a JSON object",
+                file=sys.stderr,
+            )
+            return _EXIT_USAGE_ERROR
+
+    required = args.required == "true"
+
+    if args.kind == "target":
+        result = resolve_target(
+            args.baseline_dir,
+            target=args.name,
+            profile=args.profile,
+            required=required,
+            candidate_evidence_producer=candidate_evidence_producer,
+        )
+    else:
+        try:
+            members_raw = json.loads(args.members)
+        except json.JSONDecodeError as exc:
+            print(f"::error::--members is not valid JSON: {exc}", file=sys.stderr)
+            return _EXIT_USAGE_ERROR
+        if not isinstance(members_raw, list) or not members_raw:
+            print(
+                "::error::--members must be a non-empty JSON array for --kind bundle",
+                file=sys.stderr,
+            )
+            return _EXIT_USAGE_ERROR
+        result = resolve_bundle(
+            args.baseline_dir,
+            bundle=args.name,
+            members=[str(m) for m in members_raw],
+            profile=args.profile,
+            required=required,
+            candidate_evidence_producer=candidate_evidence_producer,
+        )
+
+    _print_outputs(result)
+
+    if result.outcome == ResolveOutcome.RESOLVED:
+        return 0
+    if result.outcome == ResolveOutcome.NOT_FOUND and result.bootstrap:
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/actions/resolve-baseline/resolve_baseline.py
+++ b/actions/resolve-baseline/resolve_baseline.py
@@ -45,17 +45,43 @@ from abicheck.buildsource.baseline_set import (
 _EXIT_USAGE_ERROR = 64
 
 
-def _print_outputs(result: ResolveResult) -> None:
-    # One line per GITHUB_OUTPUT key. `message` is always built from f-strings
-    # with no embedded newlines (see baseline_set.py), so a plain key=value
-    # line is safe here -- no GITHUB_OUTPUT heredoc delimiter needed.
-    print(f"outcome={result.outcome}")
-    print(f"bootstrap={'true' if result.bootstrap else 'false'}")
-    print(f"manifest-path={result.manifest_path or ''}")
-    print(f"snapshot-path={result.snapshot_path or ''}")
-    print(f"binaries-dir={result.binaries_dir or ''}")
-    print(f"binary-paths={json.dumps(result.binary_paths)}")
-    print(f"message={result.message}")
+def _print_outputs(result: ResolveResult) -> int:
+    """Print ``key=value`` lines ``run.sh`` forwards to ``GITHUB_OUTPUT``.
+
+    Returns ``0`` normally, or :data:`_EXIT_USAGE_ERROR` if any value
+    contains a newline -- run.sh appends these lines to ``$GITHUB_OUTPUT``
+    as-is, one `key=value` pair per line, so an embedded newline in a value
+    would corrupt that file's parsing and could inject/override an
+    unrelated output key a later step reads. `message`/`binary-paths` are
+    normally safe (built via `!r`-escaped f-strings / ``json.dumps``, which
+    never emit a literal newline), but `manifest-path`/`snapshot-path`/
+    `binaries-dir` are plain filesystem paths traceable back to a
+    caller-supplied `baseline-path` (or an archive-nested directory name) --
+    checking every field uniformly here is simpler and more robust than
+    trusting each value's construction to stay newline-free forever
+    (CodeRabbit review).
+    """
+    fields = {
+        "outcome": result.outcome,
+        "bootstrap": "true" if result.bootstrap else "false",
+        "manifest-path": result.manifest_path or "",
+        "snapshot-path": result.snapshot_path or "",
+        "binaries-dir": result.binaries_dir or "",
+        "binary-paths": json.dumps(result.binary_paths),
+        "message": result.message,
+    }
+    for key, value in fields.items():
+        if "\n" in value or "\r" in value:
+            print(
+                f"::error::internal error: resolve-baseline output {key!r} "
+                "contains a newline, which would corrupt GITHUB_OUTPUT -- "
+                "refusing to write it.",
+                file=sys.stderr,
+            )
+            return _EXIT_USAGE_ERROR
+    for key, value in fields.items():
+        print(f"{key}={value}")
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -126,7 +152,9 @@ def main(argv: list[str] | None = None) -> int:
             candidate_evidence_producer=candidate_evidence_producer,
         )
 
-    _print_outputs(result)
+    output_status = _print_outputs(result)
+    if output_status != 0:
+        return output_status
 
     if result.outcome == ResolveOutcome.RESOLVED:
         return 0

--- a/actions/resolve-baseline/run.sh
+++ b/actions/resolve-baseline/run.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# Resolves channel x target/bundle x profile against an already-staged
+# baseline-set to one of ADR-047 Section 6's typed outcomes -- never a
+# compatibility verdict, never silently degraded to "no baseline = compatible".
+# See actions/resolve-baseline/action.yml for the input/output contract and
+# actions/resolve-baseline/resolve_baseline.py for the pure resolution logic
+# (abicheck/buildsource/baseline_set.py).
+set -uo pipefail
+
+_fail() {
+  echo "::error::$1"
+  exit 1
+}
+
+BASELINE_PATH="${INPUT_BASELINE_PATH:?baseline-path input is required}"
+CHANNEL="${INPUT_CHANNEL:?channel input is required}"
+KIND="${INPUT_KIND:-target}"
+TARGET="${INPUT_TARGET:-}"
+BUNDLE="${INPUT_BUNDLE:-}"
+BUNDLE_MEMBERS="${INPUT_BUNDLE_MEMBERS:-[]}"
+PROFILE="${INPUT_PROFILE:?profile input is required}"
+REQUIRED="${INPUT_REQUIRED:-true}"
+CANDIDATE_BUILD_OUTPUT="${INPUT_CANDIDATE_BUILD_OUTPUT:-}"
+ACTION_PATH="${ACTION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+case "$KIND" in
+  target | bundle) ;;
+  *) _fail "kind '$KIND' is not recognized. Use 'target' or 'bundle'." ;;
+esac
+case "$REQUIRED" in
+  true | false) ;;
+  *) _fail "required '$REQUIRED' is not recognized. Use 'true' or 'false'." ;;
+esac
+if [[ "$KIND" == "target" && -z "$TARGET" ]]; then
+  _fail "target input is required when kind is 'target'."
+fi
+if [[ "$KIND" == "bundle" && -z "$BUNDLE" ]]; then
+  _fail "bundle input is required when kind is 'bundle'."
+fi
+
+# Resolve BASELINE_PATH to a directory this run can read manifest.json from:
+# use it directly if it already is one (the calling workflow already
+# downloaded/restored it via actions/cache, actions/download-artifact, or gh
+# release download -- this Action does not itself know how to fetch from a
+# baseline channel's storage backend, that orchestration stays the caller's
+# job per ADR-047 Section 10's storage-backend table), or extract it here if
+# it's an archive.
+_EXTRACT_DIR=""
+if [[ -d "$BASELINE_PATH" ]]; then
+  BASELINE_DIR="$BASELINE_PATH"
+elif [[ -f "$BASELINE_PATH" ]]; then
+  _EXTRACT_DIR=$(mktemp -d)
+  BASELINE_DIR="$_EXTRACT_DIR"
+  echo "::group::Extract baseline-set archive $BASELINE_PATH"
+  case "$BASELINE_PATH" in
+    *.tar.zst)
+      tar --zstd -xf "$BASELINE_PATH" -C "$BASELINE_DIR" \
+        || _fail "failed to extract $BASELINE_PATH (tar --zstd)."
+      ;;
+    *.tar.gz | *.tgz)
+      tar -xzf "$BASELINE_PATH" -C "$BASELINE_DIR" \
+        || _fail "failed to extract $BASELINE_PATH (tar -xzf)."
+      ;;
+    *.tar)
+      tar -xf "$BASELINE_PATH" -C "$BASELINE_DIR" \
+        || _fail "failed to extract $BASELINE_PATH (tar -xf)."
+      ;;
+    *)
+      _fail "baseline-path '$BASELINE_PATH' is a file but not a recognized archive (.tar.zst/.tar.gz/.tgz/.tar)."
+      ;;
+  esac
+  echo "::endgroup::"
+  # An archive may itself contain one nested directory (e.g. the
+  # profile-named dir the archive was built from) rather than manifest.json
+  # at its root -- if there's no manifest.json at the extraction root but
+  # there's exactly one subdirectory, descend into it. 0 or >1 candidates is
+  # left to resolve_baseline.py's own not_found/ambiguous handling rather
+  # than guessed here.
+  if [[ ! -f "$BASELINE_DIR/manifest.json" ]]; then
+    _SUBDIRS=()
+    while IFS= read -r -d '' d; do _SUBDIRS+=("$d"); done \
+      < <(find "$BASELINE_DIR" -mindepth 1 -maxdepth 1 -type d -print0)
+    if [[ ${#_SUBDIRS[@]} -eq 1 && -f "${_SUBDIRS[0]}/manifest.json" ]]; then
+      BASELINE_DIR="${_SUBDIRS[0]}"
+    fi
+  fi
+else
+  # Neither a directory nor a file -- this is the not_found case, not a
+  # usage error: the calling workflow may legitimately have nothing staged
+  # yet (e.g. the very first release-contract publish). Let
+  # resolve_baseline.py's own not_found/bootstrap handling decide based on
+  # `required`, rather than hard-failing here regardless of that input.
+  BASELINE_DIR="$BASELINE_PATH"
+fi
+
+CANDIDATE_EVIDENCE_PRODUCER=""
+if [[ -n "$CANDIDATE_BUILD_OUTPUT" ]]; then
+  if [[ ! -f "$CANDIDATE_BUILD_OUTPUT" ]]; then
+    _fail "candidate-build-output '$CANDIDATE_BUILD_OUTPUT' does not exist."
+  fi
+  CANDIDATE_EVIDENCE_PRODUCER=$(python3 -c '
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    data = json.load(f)
+print(json.dumps(data.get("evidence_producer") or {}))
+' "$CANDIDATE_BUILD_OUTPUT") || _fail "failed to read evidence_producer from $CANDIDATE_BUILD_OUTPUT."
+fi
+
+RESOLVE_ARGS=(
+  --baseline-dir "$BASELINE_DIR"
+  --kind "$KIND"
+  --profile "$PROFILE"
+  --required "$REQUIRED"
+)
+if [[ "$KIND" == "target" ]]; then
+  RESOLVE_ARGS+=(--name "$TARGET")
+else
+  RESOLVE_ARGS+=(--name "$BUNDLE" --members "$BUNDLE_MEMBERS")
+fi
+if [[ -n "$CANDIDATE_EVIDENCE_PRODUCER" ]]; then
+  RESOLVE_ARGS+=(--candidate-evidence-producer "$CANDIDATE_EVIDENCE_PRODUCER")
+fi
+
+echo "::group::Resolve baseline ($CHANNEL / $KIND / $PROFILE)"
+set +e
+RESOLVE_STDOUT=$(python3 "$ACTION_PATH/resolve_baseline.py" "${RESOLVE_ARGS[@]}")
+RESOLVE_EXIT=$?
+set -e
+echo "$RESOLVE_STDOUT"
+echo "::endgroup::"
+
+{
+  echo "$RESOLVE_STDOUT"
+  echo "channel=$CHANNEL"
+} >> "${GITHUB_OUTPUT:-/dev/null}"
+
+OUTCOME=$(echo "$RESOLVE_STDOUT" | sed -n 's/^outcome=//p')
+MESSAGE=$(echo "$RESOLVE_STDOUT" | sed -n 's/^message=//p')
+BOOTSTRAP=$(echo "$RESOLVE_STDOUT" | sed -n 's/^bootstrap=//p')
+
+# NOTE: deliberately no cleanup of $_EXTRACT_DIR here. A `resolved` outcome's
+# snapshot-path/binaries-dir outputs point *inside* it -- a downstream step
+# in this same job (e.g. the root Action's compare step) still needs to read
+# from there. The runner reclaims the whole temp area when the job ends.
+if [[ $RESOLVE_EXIT -eq 64 ]]; then
+  _fail "resolve-baseline usage error: $MESSAGE"
+elif [[ "$OUTCOME" == "not_found" && "$BOOTSTRAP" == "true" ]]; then
+  echo "::notice::baseline not found for channel '$CHANNEL' ($MESSAGE) -- bootstrap: required=false, treating as an advisory 'no baseline yet' pass."
+  exit 0
+elif [[ $RESOLVE_EXIT -ne 0 ]]; then
+  _fail "resolve-baseline failed ($OUTCOME): $MESSAGE"
+fi
+
+echo "resolved baseline: outcome=$OUTCOME"
+exit 0

--- a/actions/resolve-baseline/run.sh
+++ b/actions/resolve-baseline/run.sh
@@ -5,7 +5,7 @@
 # See actions/resolve-baseline/action.yml for the input/output contract and
 # actions/resolve-baseline/resolve_baseline.py for the pure resolution logic
 # (abicheck/buildsource/baseline_set.py).
-set -uo pipefail
+set -euo pipefail
 
 _fail() {
   echo "::error::$1"
@@ -23,6 +23,14 @@ REQUIRED="${INPUT_REQUIRED:-true}"
 CANDIDATE_BUILD_OUTPUT="${INPUT_CANDIDATE_BUILD_OUTPUT:-}"
 ACTION_PATH="${ACTION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 
+# A newline in channel would corrupt the `channel=$CHANNEL` line this
+# script later appends to $GITHUB_OUTPUT (each line there is a plain
+# key=value pair) -- rejecting it up front is simpler and equally safe as
+# heredoc-encoding it, and channel is always meant to be a short identifier
+# anyway (Codex/CodeRabbit review).
+case "$CHANNEL" in
+  *$'\n'*) _fail "channel input must not contain a newline." ;;
+esac
 case "$KIND" in
   target | bundle) ;;
   *) _fail "kind '$KIND' is not recognized. Use 'target' or 'bundle'." ;;
@@ -52,24 +60,47 @@ elif [[ -f "$BASELINE_PATH" ]]; then
   _EXTRACT_DIR=$(mktemp -d)
   BASELINE_DIR="$_EXTRACT_DIR"
   echo "::group::Extract baseline-set archive $BASELINE_PATH"
+  # Stage the archive at a bash-native temp path before handing it to tar's
+  # -f rather than passing $BASELINE_PATH directly: on a Windows runner,
+  # $BASELINE_PATH is a native "C:\..." path, and GNU tar's archive-name
+  # parser treats a colon-containing -f argument as a [user@]host:file
+  # remote-tape spec (the classic drive-letter gotcha) instead of a local
+  # file, failing with "Cannot connect to C: resolve failed". $_EXTRACT_DIR
+  # (bash's own mktemp -d) never has this problem, so copying into it once
+  # sidesteps the issue for every tar variant without depending on
+  # --force-local support, which isn't guaranteed identical across GNU tar
+  # and macOS's bsdtar.
+  _ARCHIVE_COPY="$_EXTRACT_DIR.archive-input"
+  cp "$BASELINE_PATH" "$_ARCHIVE_COPY" || _fail "failed to stage $BASELINE_PATH for extraction."
   case "$BASELINE_PATH" in
     *.tar.zst)
-      tar --zstd -xf "$BASELINE_PATH" -C "$BASELINE_DIR" \
+      tar --zstd -xf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
         || _fail "failed to extract $BASELINE_PATH (tar --zstd)."
       ;;
     *.tar.gz | *.tgz)
-      tar -xzf "$BASELINE_PATH" -C "$BASELINE_DIR" \
+      tar -xzf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
         || _fail "failed to extract $BASELINE_PATH (tar -xzf)."
       ;;
     *.tar)
-      tar -xf "$BASELINE_PATH" -C "$BASELINE_DIR" \
+      tar -xf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
         || _fail "failed to extract $BASELINE_PATH (tar -xf)."
       ;;
     *)
+      rm -f "$_ARCHIVE_COPY" || true
       _fail "baseline-path '$BASELINE_PATH' is a file but not a recognized archive (.tar.zst/.tar.gz/.tgz/.tar)."
       ;;
   esac
+  rm -f "$_ARCHIVE_COPY" || true
   echo "::endgroup::"
+  # Reject any symlink the archive planted: a crafted/compromised baseline
+  # archive could stage a symlink at the path a later resolved
+  # snapshot-path/binaries-dir entry would follow, reading (or, chained with
+  # a second archive, writing) outside $_EXTRACT_DIR -- a baseline-set has
+  # no legitimate reason to contain one, so reject the whole extraction
+  # rather than silently following it (CodeRabbit review).
+  if find "$BASELINE_DIR" -type l | grep -q .; then
+    _fail "baseline-set archive $BASELINE_PATH contains a symlink, which is not supported -- baseline-set archives must contain only plain files/directories."
+  fi
   # An archive may itself contain one nested directory (e.g. the
   # profile-named dir the archive was built from) rather than manifest.json
   # at its root -- if there's no manifest.json at the extraction root but

--- a/actions/resolve-baseline/run.sh
+++ b/actions/resolve-baseline/run.sh
@@ -98,23 +98,31 @@ elif [[ -f "$BASELINE_PATH" ]]; then
   # --force-local support, which isn't guaranteed identical across GNU tar
   # and macOS's bsdtar.
   _ARCHIVE_COPY="$_EXTRACT_DIR.archive-input"
-  cp "$BASELINE_PATH" "$_ARCHIVE_COPY" || _fail "failed to stage $BASELINE_PATH for extraction."
+  # Every failure branch below uses _fail_ambiguous, not _fail: baseline-path
+  # WAS a file that existed, so a staging/extraction/format failure here
+  # means the archive itself is truncated, corrupted, or unusable -- the
+  # same class of malformed-baseline-set failure the no-manifest/ambiguous-
+  # subdirectory and symlink checks below already report as ambiguous, not
+  # a bare runner/input failure a continue-on-error caller can't tell apart
+  # from an unrelated problem (Codex review, third round).
+  cp "$BASELINE_PATH" "$_ARCHIVE_COPY" \
+    || _fail_ambiguous "failed to stage $BASELINE_PATH for extraction -- the archive may be truncated or unreadable."
   case "$BASELINE_PATH" in
     *.tar.zst)
       tar --zstd -xf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
-        || _fail "failed to extract $BASELINE_PATH (tar --zstd)."
+        || _fail_ambiguous "failed to extract $BASELINE_PATH (tar --zstd) -- the archive is truncated or corrupted."
       ;;
     *.tar.gz | *.tgz)
       tar -xzf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
-        || _fail "failed to extract $BASELINE_PATH (tar -xzf)."
+        || _fail_ambiguous "failed to extract $BASELINE_PATH (tar -xzf) -- the archive is truncated or corrupted."
       ;;
     *.tar)
       tar -xf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
-        || _fail "failed to extract $BASELINE_PATH (tar -xf)."
+        || _fail_ambiguous "failed to extract $BASELINE_PATH (tar -xf) -- the archive is truncated or corrupted."
       ;;
     *)
       rm -f "$_ARCHIVE_COPY" || true
-      _fail "baseline-path '$BASELINE_PATH' is a file but not a recognized archive (.tar.zst/.tar.gz/.tgz/.tar)."
+      _fail_ambiguous "baseline-path '$BASELINE_PATH' is a file but not a recognized archive (.tar.zst/.tar.gz/.tgz/.tar)."
       ;;
   esac
   rm -f "$_ARCHIVE_COPY" || true

--- a/actions/resolve-baseline/run.sh
+++ b/actions/resolve-baseline/run.sh
@@ -104,15 +104,24 @@ elif [[ -f "$BASELINE_PATH" ]]; then
   # An archive may itself contain one nested directory (e.g. the
   # profile-named dir the archive was built from) rather than manifest.json
   # at its root -- if there's no manifest.json at the extraction root but
-  # there's exactly one subdirectory, descend into it. 0 or >1 candidates is
-  # left to resolve_baseline.py's own not_found/ambiguous handling rather
-  # than guessed here.
+  # there's exactly one subdirectory, descend into it.
   if [[ ! -f "$BASELINE_DIR/manifest.json" ]]; then
     _SUBDIRS=()
     while IFS= read -r -d '' d; do _SUBDIRS+=("$d"); done \
       < <(find "$BASELINE_DIR" -mindepth 1 -maxdepth 1 -type d -print0)
     if [[ ${#_SUBDIRS[@]} -eq 1 && -f "${_SUBDIRS[0]}/manifest.json" ]]; then
       BASELINE_DIR="${_SUBDIRS[0]}"
+    else
+      # 0 or >1 candidates -- this archive was actually provided but is
+      # malformed/ambiguous, which is a different problem than "no baseline
+      # published yet" (the legitimate not_found/bootstrap case, only ever
+      # reached when baseline-path doesn't exist at all, below). Falling
+      # through here would leave $BASELINE_DIR at the extraction root (no
+      # manifest.json), and resolve_baseline.py would then report
+      # not_found -- silently letting a `required: false` caller treat a
+      # broken archive as an ordinary "nothing published yet" bootstrap
+      # instead of a real extraction failure (Codex review).
+      _fail "baseline-set archive $BASELINE_PATH does not contain a manifest.json at its root or in a single unambiguous subdirectory -- this archive is malformed, not simply an unpublished baseline."
     fi
   fi
 else

--- a/actions/resolve-baseline/run.sh
+++ b/actions/resolve-baseline/run.sh
@@ -12,6 +12,30 @@ _fail() {
   exit 1
 }
 
+# Like _fail, but for a failure that has a real resolution outcome (as
+# opposed to a usage/input error that never reached resolution logic at
+# all) -- writes the same typed outcome/bootstrap/message shape
+# resolve_baseline.py's own outputs use before failing the job, so a
+# caller inspecting this Action's outputs (or running under
+# continue-on-error) can distinguish "baseline archive was malformed" from
+# an unrelated input/runner failure instead of seeing no outputs at all
+# (Codex review). Callers may embed $BASELINE_PATH in $message since it is
+# newline-guarded below, same as $CHANNEL.
+_fail_ambiguous() {
+  local message="$1"
+  {
+    echo "outcome=ambiguous"
+    echo "bootstrap=false"
+    echo "manifest-path="
+    echo "snapshot-path="
+    echo "binaries-dir="
+    echo "binary-paths={}"
+    echo "message=$message"
+    echo "channel=$CHANNEL"
+  } >> "${GITHUB_OUTPUT:-/dev/null}"
+  _fail "$message"
+}
+
 BASELINE_PATH="${INPUT_BASELINE_PATH:?baseline-path input is required}"
 CHANNEL="${INPUT_CHANNEL:?channel input is required}"
 KIND="${INPUT_KIND:-target}"
@@ -23,13 +47,16 @@ REQUIRED="${INPUT_REQUIRED:-true}"
 CANDIDATE_BUILD_OUTPUT="${INPUT_CANDIDATE_BUILD_OUTPUT:-}"
 ACTION_PATH="${ACTION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 
-# A newline in channel would corrupt the `channel=$CHANNEL` line this
-# script later appends to $GITHUB_OUTPUT (each line there is a plain
-# key=value pair) -- rejecting it up front is simpler and equally safe as
-# heredoc-encoding it, and channel is always meant to be a short identifier
-# anyway (Codex/CodeRabbit review).
+# A newline in channel (or baseline-path, which _fail_ambiguous may embed
+# in a message written to $GITHUB_OUTPUT) would corrupt the key=value
+# lines this script appends there -- rejecting it up front is simpler and
+# equally safe as heredoc-encoding it, and both are always meant to be
+# short identifiers/paths anyway (Codex/CodeRabbit review).
 case "$CHANNEL" in
   *$'\n'*) _fail "channel input must not contain a newline." ;;
+esac
+case "$BASELINE_PATH" in
+  *$'\n'*) _fail "baseline-path input must not contain a newline." ;;
 esac
 case "$KIND" in
   target | bundle) ;;
@@ -120,8 +147,12 @@ elif [[ -f "$BASELINE_PATH" ]]; then
       # manifest.json), and resolve_baseline.py would then report
       # not_found -- silently letting a `required: false` caller treat a
       # broken archive as an ordinary "nothing published yet" bootstrap
-      # instead of a real extraction failure (Codex review).
-      _fail "baseline-set archive $BASELINE_PATH does not contain a manifest.json at its root or in a single unambiguous subdirectory -- this archive is malformed, not simply an unpublished baseline."
+      # instead of a real extraction failure (Codex review). Uses
+      # _fail_ambiguous, not _fail: this has a real resolution outcome
+      # (ambiguous), not merely a usage error, so it must carry the same
+      # typed outputs every other resolution failure does (Codex review,
+      # second round).
+      _fail_ambiguous "baseline-set archive $BASELINE_PATH does not contain a manifest.json at its root or in a single unambiguous subdirectory -- this archive is malformed, not simply an unpublished baseline."
     fi
   fi
 else

--- a/actions/resolve-baseline/run.sh
+++ b/actions/resolve-baseline/run.sh
@@ -114,34 +114,27 @@ elif [[ -f "$BASELINE_PATH" ]]; then
       # abicheck) -- on a minimal/self-hosted runner without one, tar fails
       # before resolution even though the archive itself is perfectly
       # valid, misreporting a good baseline as corrupt (Codex review, fifth
-      # round). Prefer the system zstd when present (fast, no extra
-      # dependency); fall back to the Python 'zstandard' package when it
-      # happens to be installed (abicheck's own package.py extractor uses
-      # the identical fallback for .conda archives); only then fail, with a
-      # message that names the actual gap instead of a generic "failed to
-      # extract".
-      if command -v zstd >/dev/null 2>&1; then
-        tar --zstd -xf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
-          || _fail_ambiguous "failed to extract $BASELINE_PATH (tar --zstd) -- the archive is truncated or corrupted."
-      elif python3 -c "import zstandard" >/dev/null 2>&1; then
-        python3 -c '
+      # round). Delegate to abicheck.package.TarExtractor's own
+      # _safe_extract_zst_tar (already installed by the earlier "Install
+      # abicheck" step) instead of reimplementing the same zstd-vs-
+      # zstandard fallback here: it tries the Python 'zstandard' package
+      # first, falls back to a system zstd binary, and -- unlike a plain
+      # `tarfile.extractall()` on Python <3.12, which has no member-path
+      # validation at all before PEP 706's `filter="data"` -- validates
+      # every member (rejects `..`-escaping paths, symlink-target escapes,
+      # and device/FIFO entries) before extracting, on every supported
+      # Python version, not just 3.12+ (Codex review, sixth round: a
+      # naive Python-side zstd fallback on Python 3.10/3.11 without a
+      # system zstd binary could extract a `../`-escaping member outside
+      # $BASELINE_DIR before the symlink/manifest checks below even run).
+      python3 -c '
 import sys
-import tarfile
-import zstandard
+from pathlib import Path
+from abicheck.package import TarExtractor
 
-with open(sys.argv[1], "rb") as compressed:
-    dctx = zstandard.ZstdDecompressor()
-    with dctx.stream_reader(compressed) as reader:
-        with tarfile.open(fileobj=reader, mode="r|") as tf:
-            if sys.version_info >= (3, 12):
-                tf.extractall(path=sys.argv[2], filter="data")
-            else:
-                tf.extractall(path=sys.argv[2])
+TarExtractor._safe_extract_zst_tar(Path(sys.argv[1]), Path(sys.argv[2]))
 ' "$_ARCHIVE_COPY" "$BASELINE_DIR" \
-          || _fail_ambiguous "failed to extract $BASELINE_PATH (python zstandard) -- the archive is truncated or corrupted."
-      else
-        _fail_ambiguous "baseline-path '$BASELINE_PATH' is a .tar.zst archive, but neither a 'zstd' command-line tool nor the Python 'zstandard' package is available on this runner -- install one of them (e.g. 'apt-get install zstd' or 'pip install zstandard') before calling resolve-baseline with a .tar.zst baseline."
-      fi
+        || _fail_ambiguous "failed to extract $BASELINE_PATH (.tar.zst) -- the archive is truncated or corrupted, or this runner has neither a 'zstd' command-line tool nor the Python 'zstandard' package available (install one of them, e.g. 'apt-get install zstd' or 'pip install zstandard')."
       ;;
     *.tar.gz | *.tgz)
       tar -xzf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \

--- a/actions/resolve-baseline/run.sh
+++ b/actions/resolve-baseline/run.sh
@@ -109,8 +109,39 @@ elif [[ -f "$BASELINE_PATH" ]]; then
     || _fail_ambiguous "failed to stage $BASELINE_PATH for extraction -- the archive may be truncated or unreadable."
   case "$BASELINE_PATH" in
     *.tar.zst)
-      tar --zstd -xf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
-        || _fail_ambiguous "failed to extract $BASELINE_PATH (tar --zstd) -- the archive is truncated or corrupted."
+      # GNU tar's --zstd filters through an external `zstd` binary this
+      # composite Action never installs (only setup-python + pip install
+      # abicheck) -- on a minimal/self-hosted runner without one, tar fails
+      # before resolution even though the archive itself is perfectly
+      # valid, misreporting a good baseline as corrupt (Codex review, fifth
+      # round). Prefer the system zstd when present (fast, no extra
+      # dependency); fall back to the Python 'zstandard' package when it
+      # happens to be installed (abicheck's own package.py extractor uses
+      # the identical fallback for .conda archives); only then fail, with a
+      # message that names the actual gap instead of a generic "failed to
+      # extract".
+      if command -v zstd >/dev/null 2>&1; then
+        tar --zstd -xf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
+          || _fail_ambiguous "failed to extract $BASELINE_PATH (tar --zstd) -- the archive is truncated or corrupted."
+      elif python3 -c "import zstandard" >/dev/null 2>&1; then
+        python3 -c '
+import sys
+import tarfile
+import zstandard
+
+with open(sys.argv[1], "rb") as compressed:
+    dctx = zstandard.ZstdDecompressor()
+    with dctx.stream_reader(compressed) as reader:
+        with tarfile.open(fileobj=reader, mode="r|") as tf:
+            if sys.version_info >= (3, 12):
+                tf.extractall(path=sys.argv[2], filter="data")
+            else:
+                tf.extractall(path=sys.argv[2])
+' "$_ARCHIVE_COPY" "$BASELINE_DIR" \
+          || _fail_ambiguous "failed to extract $BASELINE_PATH (python zstandard) -- the archive is truncated or corrupted."
+      else
+        _fail_ambiguous "baseline-path '$BASELINE_PATH' is a .tar.zst archive, but neither a 'zstd' command-line tool nor the Python 'zstandard' package is available on this runner -- install one of them (e.g. 'apt-get install zstd' or 'pip install zstandard') before calling resolve-baseline with a .tar.zst baseline."
+      fi
       ;;
     *.tar.gz | *.tgz)
       tar -xzf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
@@ -138,7 +169,19 @@ elif [[ -f "$BASELINE_PATH" ]]; then
   # reports as ambiguous, not a bare usage error -- a caller inspecting
   # this Action's outputs (or running under continue-on-error) must see the
   # same typed outcome/bootstrap/message shape for it (Codex review).
-  if find "$BASELINE_DIR" -type l | grep -q .; then
+  # Captured via command substitution, not piped into `grep -q`: under
+  # `set -o pipefail`, `grep -q` exits as soon as it sees the first match
+  # without draining find's remaining output, which can SIGPIPE find (exit
+  # 141) -- pipefail then reports the pipeline's exit status as find's 141
+  # (the rightmost *non-zero* exit among the pipeline's commands, since
+  # grep's own exit was 0), so `if find ... | grep -q .` evaluates FALSE
+  # and this guard never fires, letting a symlink-laden archive silently
+  # resolve (Codex review, fifth round -- reproduced with an archive
+  # containing hundreds of symlinks). Command substitution reads find's
+  # full output with no downstream reader racing to close the pipe early,
+  # so there's no SIGPIPE to misreport.
+  _SYMLINKS=$(find "$BASELINE_DIR" -type l)
+  if [[ -n "$_SYMLINKS" ]]; then
     _fail_ambiguous "baseline-set archive $BASELINE_PATH contains a symlink, which is not supported -- baseline-set archives must contain only plain files/directories."
   fi
   # An archive may itself contain one nested directory (e.g. the

--- a/actions/resolve-baseline/run.sh
+++ b/actions/resolve-baseline/run.sh
@@ -124,9 +124,14 @@ elif [[ -f "$BASELINE_PATH" ]]; then
   # snapshot-path/binaries-dir entry would follow, reading (or, chained with
   # a second archive, writing) outside $_EXTRACT_DIR -- a baseline-set has
   # no legitimate reason to contain one, so reject the whole extraction
-  # rather than silently following it (CodeRabbit review).
+  # rather than silently following it (CodeRabbit review). Uses
+  # _fail_ambiguous, not _fail: a symlink-containing archive is a malformed
+  # baseline-set, the same class of failure the manifest-shape check below
+  # reports as ambiguous, not a bare usage error -- a caller inspecting
+  # this Action's outputs (or running under continue-on-error) must see the
+  # same typed outcome/bootstrap/message shape for it (Codex review).
   if find "$BASELINE_DIR" -type l | grep -q .; then
-    _fail "baseline-set archive $BASELINE_PATH contains a symlink, which is not supported -- baseline-set archives must contain only plain files/directories."
+    _fail_ambiguous "baseline-set archive $BASELINE_PATH contains a symlink, which is not supported -- baseline-set archives must contain only plain files/directories."
   fi
   # An archive may itself contain one nested directory (e.g. the
   # profile-named dir the archive was built from) rather than manifest.json

--- a/actions/resolve-baseline/run.sh
+++ b/actions/resolve-baseline/run.sh
@@ -136,13 +136,23 @@ TarExtractor._safe_extract_zst_tar(Path(sys.argv[1]), Path(sys.argv[2]))
 ' "$_ARCHIVE_COPY" "$BASELINE_DIR" \
         || _fail_ambiguous "failed to extract $BASELINE_PATH (.tar.zst) -- the archive is truncated or corrupted, or this runner has neither a 'zstd' command-line tool nor the Python 'zstandard' package available (install one of them, e.g. 'apt-get install zstd' or 'pip install zstandard')."
       ;;
-    *.tar.gz | *.tgz)
-      tar -xzf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
-        || _fail_ambiguous "failed to extract $BASELINE_PATH (tar -xzf) -- the archive is truncated or corrupted."
-      ;;
-    *.tar)
-      tar -xf "$_ARCHIVE_COPY" -C "$BASELINE_DIR" \
-        || _fail_ambiguous "failed to extract $BASELINE_PATH (tar -xf) -- the archive is truncated or corrupted."
+    *.tar.gz | *.tgz | *.tar)
+      # Delegate to TarExtractor._safe_extract instead of plain `tar -x`:
+      # bare tar has no member validation at all, so a malformed archive
+      # could plant a `..`-escaping path, a symlink escaping $BASELINE_DIR,
+      # or a device/FIFO entry on disk before the symlink/manifest checks
+      # below even run -- the same class of risk the .tar.zst branch above
+      # already closed by routing through this same extractor (Codex
+      # review). `tarfile.open`'s default mode auto-detects gzip vs. plain
+      # tar from the file itself, so one call handles both extensions.
+      python3 -c '
+import sys
+from pathlib import Path
+from abicheck.package import TarExtractor
+
+TarExtractor._safe_extract(Path(sys.argv[1]), Path(sys.argv[2]))
+' "$_ARCHIVE_COPY" "$BASELINE_DIR" \
+        || _fail_ambiguous "failed to extract $BASELINE_PATH -- the archive is truncated or corrupted, or contains a disallowed member (path traversal, a symlink escaping the extraction root, or a device/FIFO entry)."
       ;;
     *)
       rm -f "$_ARCHIVE_COPY" || true

--- a/changelog.d/20260722_000000_noreply_g30_resolve_baseline.md
+++ b/changelog.d/20260722_000000_noreply_g30_resolve_baseline.md
@@ -1,0 +1,14 @@
+### Added
+
+- **New `actions/resolve-baseline` composite Action** (G30 P1.2, ADR-047
+  §4/§6) resolves one check's baseline — `channel × target/bundle × profile`
+  — against an already-staged baseline-set, returning one of six typed
+  outcomes (`resolved`, `not_found`, `ambiguous`, `wrong_profile`,
+  `stale_schema`, `incompatible_evidence`) instead of ever silently
+  degrading to "no baseline = compatible." Supports both `kind: target`
+  (returns a resolved `.abicheck.json` snapshot path) and `kind: bundle`
+  (returns every member's staged binary path, since bundle analysis reads
+  real ELF binaries, never JSON snapshots). New
+  `abicheck/buildsource/baseline_set.py` is the shared, pure resolver
+  backing it.
+

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -293,7 +293,9 @@ well as in the test suite).
 
 Implements ADR-047 §4/§6. New composite Action; consumes a baseline-set
 archive/cache entry + `channel`/`target`/`profile` inputs; outputs a
-resolved snapshot path or one of the five typed failure states.
+resolved snapshot path (a resolved bundle instead returns staged member
+binary paths, per the S14 correction below) or one of the five typed
+failure states.
 **Input gap, flagged by review: candidate evidence metadata is missing
 from this list, and the `incompatible_evidence` outcome cannot be detected
 without it.** §6's taxonomy requires `resolve-baseline` to reject a

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -289,7 +289,7 @@ failure taxonomy, including all three of the plan's required shared-pack
 test cases (verified against a hand-authored example directory manually as
 well as in the test suite).
 
-### P1.2 — `actions/resolve-baseline`
+### P1.2 — `actions/resolve-baseline` — **done**
 
 Implements ADR-047 §4/§6. New composite Action; consumes a baseline-set
 archive/cache entry + `channel`/`target`/`profile` inputs; outputs a
@@ -330,17 +330,49 @@ the logic is non-trivial).
 (ADR-047 §6 table); a bundle-scoped resolution fixture asserting binaries
 (not snapshots) come back for a bundle target.
 
-**Files:** new `actions/resolve-baseline/action.yml`, `run.sh`. Reuses
-`actions/baseline/build_manifest.py`'s manifest-reading logic — extract a
-shared helper rather than duplicating the schema/digest-check code (avoid
-recreating `IMPORT_CYCLE_ALLOWLIST`-style coupling; this is shell, not
-Python import structure, but the same "don't duplicate the parsing logic"
-principle applies — factor the manifest reader into
-`abicheck/buildsource/`-adjacent Python invoked by both Actions' `run.sh` if
-the logic is non-trivial).
+**Status:** implemented. New `abicheck/buildsource/baseline_set.py` is the
+shared reader/resolver — the "extract a shared helper" the plan asked for,
+factored into `abicheck/buildsource/`-adjacent Python rather than duplicated
+bash/`jq`. It parses `manifest.json` with the same defensive-`.get()`
+philosophy `build_manifest.py` itself uses for snapshot files (a corrupt or
+hand-edited manifest never raises, it produces a structured outcome), and
+implements `resolve_target()`/`resolve_bundle()` covering all six branches
+of §6's table: `not_found` (with the `required`/bootstrap split — `required:
+false` + missing baseline is an advisory, non-fatal pass, `required: true`
+is a hard failure), `ambiguous` (target missing from the manifest, or a
+resolved snapshot/binary missing from disk), `wrong_profile`,
+`stale_schema` (`manifest_version` outside `SUPPORTED_MANIFEST_VERSIONS =
+{1}`, the only version `build_manifest.py` has ever emitted),
+`incompatible_evidence` (comparing the baseline's `fact_set.producer`/
+`producer_version` against the candidate's `evidence_producer` block — the
+review-flagged input gap above, closed via a new `candidate-build-output`
+Action input read only for that block), and `resolved`. The bundle-scoped
+correction is implemented as specified: `resolve_bundle()` returns paths to
+every member's **staged binary** under the baseline-set's `binaries/`
+directory (`BASELINE_BINARIES_DIRNAME`), never a snapshot path — a member
+with no staged binary fails the whole bundle resolution as `ambiguous`
+rather than silently omitting that member. `actions/baseline` does not
+populate `binaries/` yet (that's G30 P1.6, not built here); bundle
+resolution is exercised against a hand-authored fixture in the meantime, the
+same "defines the contract, no producer yet" scoping G30 P1.1 used for
+`build-output.json`.
 
-**Tests:** shell-mapping tests for each of the five failure taxonomy rows
-(ADR-047 §6 table).
+`actions/resolve-baseline/action.yml`/`run.sh` wrap this in a composite
+Action: `baseline-path` accepts either an already-staged directory or a
+`.tar.zst`/`.tar.gz`/`.tgz`/`.tar` archive (extracted in `run.sh`, including
+a one-level directory descent when the archive nests the baseline-set under
+a single subdirectory rather than at its root) — this Action never fetches
+from a baseline channel's storage backend itself, that stays the calling
+workflow's job per §10, exactly as the "actions/baseline never fetches"
+precedent already established. `resolve_baseline.py` is the thin
+argparse/stdout-key=value CLI wrapper `run.sh` shells out to, mirroring
+`build_manifest.py`'s own pattern. `tests/test_baseline_set.py` (pure,
+21 cases) covers every resolver branch directly;
+`tests/test_action_resolve_baseline.py` (16 cases) covers the bash
+orchestration end-to-end, including one test per §6 failure-taxonomy row,
+bundle resolution, and archive extraction (flat and one-level-nested).
+`docs/reference/resolve-baseline.md` (new, linked from mkdocs nav)
+documents the Action's contract.
 
 ### P1.3 — `actions/check-target`
 

--- a/docs/reference/resolve-baseline.md
+++ b/docs/reference/resolve-baseline.md
@@ -91,6 +91,21 @@ member named in `bundle-members` must have one, or the whole resolution
 reports `ambiguous` — a partially-staged bundle baseline would otherwise
 silently produce a bundle report missing one member's old-side data.
 
+## Known limitation: `wrapper`/`replay` producer aliasing
+
+The `incompatible_evidence` check (see the outcome table above) compares
+each side's recorded evidence producer string. Both the `abicheck-cc`
+wrapper and the source-replay (L4) path populate `evidence_producer.tool`
+with the same underlying string, `abicheck-cc-clang-extractor` — there is
+currently no way to tell "the wrapper captured this" apart from "source
+replay reconstructed this after the fact" from the recorded producer alone.
+A baseline staged via one path and a candidate produced via the other will
+**not** be flagged `incompatible_evidence`, even though their evidence has
+different fidelity characteristics. Only a genuinely different tool (e.g.
+the Clang facts plugin vs. either of the above) is caught. Tightening this
+would need a distinct producer string per path, which is deferred rather
+than done in this PR.
+
 ## Example
 
 ```yaml

--- a/docs/reference/resolve-baseline.md
+++ b/docs/reference/resolve-baseline.md
@@ -1,0 +1,112 @@
+# `resolve-baseline` Action Reference
+
+`actions/resolve-baseline` resolves one check's baseline — `channel × target
+(or bundle) × profile` — against an already-staged baseline-set, returning
+one of [ADR-047](../development/adr/047-github-actions-integration-model.md)
+§6's typed outcomes. It never produces a compatibility verdict, and a missing
+baseline is never silently treated as "compatible."
+
+> **Status.** This page documents the `actions/resolve-baseline` composite
+> Action shipped in G30 P1.2. `actions/check-target`, the primitive that
+> composes this Action with the root `action.yml` and `collect-facts` into
+> one check, is G30 P1.3, not built yet — see the
+> [G30 plan](../development/plans/g30-github-actions-integration-model.md).
+> `actions/baseline` does not yet stage bundle-member ELF binaries into a
+> `binaries/` directory (G30 P1.6) — bundle-scoped resolution (below) is
+> defined and tested against a hand-authored fixture in the meantime, the
+> same "defines the contract, no producer yet" scoping G30 P1.1 used for
+> `build-output.json`.
+
+## Why a separate primitive
+
+Baseline resolution used to be inlined once, inside the root Action's
+`abi-baseline` handling. Every one of `not_found`/`ambiguous`/`wrong_profile`
+in [ADR-047](../development/adr/047-github-actions-integration-model.md)'s
+scenario catalog is really a baseline-resolution failure — separating it out
+lets a caller treat "baseline not found" as a distinct, typed condition
+instead of falling through to whatever `compare`'s own missing-file error
+text happens to be.
+
+## What it does *not* do
+
+`resolve-baseline` does not fetch anything from GitHub. Downloading a
+`release-contract` archive from a GitHub Release, or restoring an
+`accepted-main` entry from Actions cache, is the **calling workflow's** job
+(see [ADR-047 §10](../development/adr/047-github-actions-integration-model.md#10-baseline-storage-backends-compared)'s
+storage-backend table) — `actions/cache`, `actions/download-artifact`, or
+`gh release download`. `resolve-baseline` only resolves *within* whatever
+`baseline-path` the caller already staged.
+
+## Inputs
+
+| Input | Required | Default | Meaning |
+|-------|----------|---------|---------|
+| `baseline-path` | yes | — | A directory already containing `manifest.json` (+ per-target snapshots, and `binaries/` for a bundle), **or** a `.tar.zst`/`.tar.gz`/`.tgz`/`.tar` archive of the same, extracted automatically. A path that doesn't exist is `not_found`, not a usage error. |
+| `channel` | yes | — | `release-contract` \| `accepted-main` \| `explicit` \| a project-defined custom channel. Recorded on the output only — this Action trusts the caller already staged the right baseline-path for this channel. |
+| `kind` | no | `target` | `target` or `bundle`. |
+| `target` | when `kind: target` | — | Target id to resolve. |
+| `bundle` | when `kind: bundle` | — | Bundle id to resolve. |
+| `bundle-members` | when `kind: bundle` | `[]` | JSON array of the bundle's member target ids, e.g. `["libpvxs", "libpvxsIoc"]`. |
+| `profile` | yes | — | The build `profile.id` this check expects the baseline to have been built for. |
+| `required` | no | `true` | `true` — no baseline set yet is a hard failure. `false` — explicit bootstrap opt-in (e.g. the very first `release-contract` publish); no baseline set yet resolves as an advisory `not_found`/bootstrap pass. |
+| `candidate-build-output` | no | `''` | Path to the candidate build's `build-output.json`, read only for its `evidence_producer` block, feeding the `incompatible_evidence` check. Omit to skip that check. |
+
+## Outputs
+
+| Output | Meaning |
+|--------|---------|
+| `outcome` | `resolved` \| `not_found` \| `ambiguous` \| `wrong_profile` \| `stale_schema` \| `incompatible_evidence`. |
+| `bootstrap` | `'true'` only when `outcome: not_found` and `required: 'false'`. |
+| `channel` | Echoes the `channel` input. |
+| `manifest-path` | Path to the resolved baseline-set's `manifest.json`, when one was found. |
+| `snapshot-path` | (`kind: target` only) Path to the resolved target's `.abicheck.json` snapshot. |
+| `binaries-dir` | (`kind: bundle` only) Path to the directory containing the resolved bundle's staged member binaries. |
+| `binary-paths` | (`kind: bundle` only) JSON object mapping each member target id to its staged binary path. |
+| `message` | Human-readable explanation of the outcome. |
+
+## Failure taxonomy (ADR-047 §6)
+
+All fail-loud — none of these ever silently degrade to a compatibility
+verdict. Only `not_found` has a bootstrap carve-out, and only when the
+caller explicitly opts in with `required: false`:
+
+| `outcome` | Job exit | When |
+|-----------|----------|------|
+| `not_found` (bootstrap) | `0` | No baseline set exists for `channel` yet, and `required: false`. |
+| `not_found` (required) | `1` | No baseline set exists for `channel` yet, and `required: true` (default) — a typo in the channel name, a missing release asset, or a cache-resolution bug must never produce a green branch-protection status with zero comparison performed. |
+| `ambiguous` | `1` | The baseline set exists but this target isn't in it (or, for `kind: bundle`, one or more declared members have no staged binary in `binaries/`). |
+| `wrong_profile` | `1` | The baseline set was built for a different `profile.id`. |
+| `stale_schema` | `1` | `manifest.json`'s `manifest_version` is newer/older than this resolver understands. |
+| `incompatible_evidence` | `1` | The baseline's recorded evidence producer (`wrapper`/`clang-plugin`/`replay`) disagrees with the candidate's, per `candidate-build-output`'s `evidence_producer` block — an infrastructure mismatch, not an ABI finding. |
+| `resolved` | `0` | Success. |
+
+## Bundle-scoped resolution (S14)
+
+A bundle's resolution unit is not one snapshot. `abicheck/bundle.py`'s
+`build_bundle_snapshot()` builds its cross-library graph from real **ELF
+binaries** and explicitly skips non-ELF (including JSON snapshot) inputs, so
+`kind: bundle` resolves to the set of every member's **staged binary** under
+the baseline-set's `binaries/` directory instead of a snapshot path. Every
+member named in `bundle-members` must have one, or the whole resolution
+reports `ambiguous` — a partially-staged bundle baseline would otherwise
+silently produce a bundle report missing one member's old-side data.
+
+## Example
+
+```yaml
+- name: Resolve accepted-main baseline for libpvxs
+  id: baseline
+  uses: abicheck/abicheck/actions/resolve-baseline@v1
+  with:
+    baseline-path: ./restored-baseline # staged by an earlier actions/cache step
+    channel: accepted-main
+    target: libpvxs
+    profile: linux-x86_64-gcc13-release
+
+- name: Compare against resolved baseline
+  if: steps.baseline.outputs.outcome == 'resolved'
+  uses: abicheck/abicheck@v1
+  with:
+    old-library: ${{ steps.baseline.outputs.snapshot-path }}
+    new-library: build/lib/libpvxs.so
+```

--- a/docs/reference/resolve-baseline.md
+++ b/docs/reference/resolve-baseline.md
@@ -41,7 +41,7 @@ storage-backend table) — `actions/cache`, `actions/download-artifact`, or
 
 | Input | Required | Default | Meaning |
 |-------|----------|---------|---------|
-| `baseline-path` | yes | — | A directory already containing `manifest.json` (+ per-target snapshots, and `binaries/` for a bundle), **or** a `.tar.zst`/`.tar.gz`/`.tgz`/`.tar` archive of the same, extracted automatically. A path that doesn't exist is `not_found`, not a usage error. |
+| `baseline-path` | yes | — | A directory already containing `manifest.json` (+ per-target snapshots, and `binaries/` for a bundle), **or** a `.tar.zst`/`.tar.gz`/`.tgz`/`.tar` archive of the same, extracted automatically. A path that doesn't exist at all is `not_found`, not a usage error. A path that **does** exist (directory or extracted archive) but has no `manifest.json` inside it — e.g. an empty/partial `actions/cache` restore — is `ambiguous`, not `not_found`: it never bootstraps a `required: false` caller to a green run. |
 | `channel` | yes | — | `release-contract` \| `accepted-main` \| `explicit` \| a project-defined custom channel. Recorded on the output only — this Action trusts the caller already staged the right baseline-path for this channel. |
 | `kind` | no | `target` | `target` or `bundle`. |
 | `target` | when `kind: target` | — | Target id to resolve. |
@@ -72,9 +72,9 @@ caller explicitly opts in with `required: false`:
 
 | `outcome` | Job exit | When |
 |-----------|----------|------|
-| `not_found` (bootstrap) | `0` | No baseline set exists for `channel` yet, and `required: false`. |
-| `not_found` (required) | `1` | No baseline set exists for `channel` yet, and `required: true` (default) — a typo in the channel name, a missing release asset, or a cache-resolution bug must never produce a green branch-protection status with zero comparison performed. |
-| `ambiguous` | `1` | The baseline set exists but this target isn't in it (or, for `kind: bundle`, one or more declared members have no staged binary in `binaries/`). |
+| `not_found` (bootstrap) | `0` | `baseline-path` itself does not exist, and `required: false`. |
+| `not_found` (required) | `1` | `baseline-path` itself does not exist, and `required: true` (default) — a typo in the channel name, a missing release asset, or a cache-resolution bug must never produce a green branch-protection status with zero comparison performed. |
+| `ambiguous` | `1` | `baseline-path` exists but has no `manifest.json` (e.g. an empty/partial cache restore — a different, more concerning failure than "nothing published yet"); or the manifest exists but this target isn't in it; or, for `kind: bundle`, one or more declared members have no staged binary in `binaries/`. |
 | `wrong_profile` | `1` | The baseline set was built for a different `profile.id`. |
 | `stale_schema` | `1` | `manifest.json`'s `manifest_version` is newer/older than this resolver understands. |
 | `incompatible_evidence` | `1` | The baseline's recorded evidence producer (`wrapper`/`clang-plugin`/`replay`) disagrees with the candidate's, per `candidate-build-output`'s `evidence_producer` block — an infrastructure mismatch, not an ABI finding. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -94,6 +94,7 @@ nav:
     - Snapshot Format: reference/snapshot-format.md
     - Build Output Schema: reference/build-output-schema.md
     - Project Targets Schema: reference/project-targets-schema.md
+    - resolve-baseline Action: reference/resolve-baseline.md
     - Configuration File: reference/config-file.md
     - Environment Variables: reference/environment.md
     - Platforms: reference/platforms.md

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -703,6 +703,17 @@ class TestArchiveExtraction:
         assert outputs.get("bootstrap") == "false"
         assert outputs.get("channel") == "release-contract"
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "git-bash's tar on windows-latest CI does not reliably "
+            "recreate a symlink as a real NTFS reparse point on extraction "
+            "(same limitation as test_archive_with_symlink_hard_fails_"
+            "with_typed_outputs above) -- an extraction-tooling limitation "
+            "of the Windows test runner, not a gap in run.sh's detection "
+            "logic, which the Linux/macOS lanes still exercise."
+        ),
+    )
     def test_archive_with_many_symlinks_hard_fails_with_typed_outputs(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tarfile
@@ -469,6 +470,32 @@ class TestBundleResolution:
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/resolve-baseline/run.sh not found"
 )
+def _make_tar_zst(archive_path: Path, src_dir: Path) -> None:
+    """Build a .tar.zst using whichever zstd backend is available."""
+    if shutil.which("zstd") is not None:
+        tar_path = archive_path.with_suffix("")
+        with tarfile.open(tar_path, "w") as tf:
+            tf.add(src_dir, arcname=".")
+        subprocess.run(
+            ["zstd", "-f", "-q", str(tar_path), "-o", str(archive_path)],
+            check=True,
+        )
+        tar_path.unlink()
+        return
+    try:
+        import zstandard
+    except ImportError:
+        pytest.skip("neither zstd nor the zstandard package is available")
+    import io
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        tf.add(src_dir, arcname=".")
+    cctx = zstandard.ZstdCompressor()
+    with open(archive_path, "wb") as out, cctx.stream_writer(out) as writer:
+        writer.write(buf.getvalue())
+
+
 class TestArchiveExtraction:
     def test_tar_gz_archive_is_extracted_and_resolved(self, tmp_path: Path) -> None:
         baseline_dir = tmp_path / "baseline-src"
@@ -517,6 +544,33 @@ class TestArchiveExtraction:
         )
         assert result.returncode == 0
         assert outputs.get("outcome") == "resolved"
+
+    def test_tar_zst_archive_is_extracted_and_resolved(self, tmp_path: Path) -> None:
+        # .tar.zst is an advertised supported format (action.yml's
+        # baseline-path description) but this composite Action never
+        # installs a 'zstd' binary itself -- run.sh must extract it via
+        # whichever backend (system zstd, or the Python 'zstandard'
+        # package) happens to be available, not just fail outright on a
+        # minimal runner (Codex review, fifth round).
+        baseline_dir = tmp_path / "baseline-src"
+        _write_manifest(baseline_dir, artifacts=[_target_artifact("libpvxs")])
+        (baseline_dir / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+
+        archive_path = tmp_path / "baseline.tar.zst"
+        _make_tar_zst(archive_path, baseline_dir)
+
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(archive_path),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0
+        assert outputs.get("outcome") == "resolved"
+        assert Path(outputs["snapshot-path"]).is_file()
 
     def test_unrecognized_archive_extension_fails(self, tmp_path: Path) -> None:
         bogus = tmp_path / "baseline.zip"
@@ -648,6 +702,44 @@ class TestArchiveExtraction:
         assert outputs.get("outcome") == "ambiguous"
         assert outputs.get("bootstrap") == "false"
         assert outputs.get("channel") == "release-contract"
+
+    def test_archive_with_many_symlinks_hard_fails_with_typed_outputs(
+        self, tmp_path: Path
+    ) -> None:
+        # A single symlink may not reliably reproduce a SIGPIPE/pipefail
+        # race in the detection guard (find's small output can complete
+        # before grep -q closes the pipe, timing-dependent) -- with
+        # hundreds of symlinks, find is still writing when grep -q exits
+        # after the first match, SIGPIPEing find. Under `set -o pipefail`,
+        # `if find ... | grep -q .` must still evaluate true in that case
+        # (Codex review, fifth round: reproduced exactly this way, with the
+        # buggy form returning 141 and skipping the guard entirely).
+        baseline_dir = tmp_path / "baseline-src"
+        _write_manifest(baseline_dir, artifacts=[_target_artifact("libpvxs")])
+        (baseline_dir / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+        links_dir = baseline_dir / "links"
+        links_dir.mkdir()
+        for i in range(500):
+            (links_dir / f"link-{i}").symlink_to(baseline_dir / "manifest.json")
+
+        archive_path = tmp_path / "baseline-many-symlinks.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tf:
+            tf.add(baseline_dir, arcname=".")
+
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(archive_path),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_REQUIRED": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "symlink" in result.stdout
+        assert outputs.get("outcome") == "ambiguous"
+        assert outputs.get("bootstrap") == "false"
         assert "symlink" in outputs.get("message", "")
 
     def test_archive_with_ambiguous_subdirectories_hard_fails(

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import sys
 import tarfile
 from pathlib import Path
 
@@ -546,6 +547,18 @@ class TestArchiveExtraction:
         assert outputs.get("channel") == "release-contract"
         assert "malformed" in outputs.get("message", "")
 
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "git-bash's tar on windows-latest CI does not reliably "
+            "recreate a symlink as a real NTFS reparse point on extraction "
+            "(observed: the extracted tree has no symlink at all, so "
+            "run.sh's `find -type l` guard never fires and the baseline "
+            "resolves normally) -- an extraction-tooling limitation of the "
+            "Windows test runner, not a gap in run.sh's detection logic, "
+            "which the Linux/macOS lanes still exercise."
+        ),
+    )
     def test_archive_with_symlink_hard_fails_with_typed_outputs(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -243,6 +243,30 @@ class TestFailureTaxonomy:
         assert outputs.get("outcome") == "not_found"
         assert outputs.get("bootstrap") == "true"
 
+    def test_existing_dir_without_manifest_is_ambiguous_not_bootstrap(
+        self, tmp_path: Path
+    ) -> None:
+        # An existing baseline-path directory (e.g. an empty/partial
+        # actions/cache restore) with no manifest.json inside must not be
+        # treated the same as "no baseline published yet" -- even under
+        # required: false, this is a malformed baseline, not a legitimate
+        # bootstrap (Codex review).
+        empty_dir = tmp_path / "restored-but-empty"
+        empty_dir.mkdir()
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(empty_dir),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_REQUIRED": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert outputs.get("outcome") == "ambiguous"
+        assert outputs.get("bootstrap") == "false"
+
     def test_ambiguous_target_missing_from_set(self, tmp_path: Path) -> None:
         baseline_dir = tmp_path / "baseline"
         _write_manifest(baseline_dir, artifacts=[_target_artifact("libpvxsIoc")])

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -62,8 +62,15 @@ def _run_action(
     """Invoke the real script end-to-end with a GITHUB_OUTPUT file."""
     github_output = cwd / "github_output"
     github_output.write_text("")
+    # Strip any inherited INPUT_* from the host/CI environment before
+    # overlaying env_extra: the input-validation negative tests (e.g.
+    # test_missing_baseline_path_fails) assert failure purely on an input's
+    # *absence*, and a leaked INPUT_* value would make those tests pass for
+    # the wrong reason (or stop failing) instead of exercising the real
+    # guard (CodeRabbit review).
+    base_env = {k: v for k, v in os.environ.items() if not k.startswith("INPUT_")}
     env = {
-        **os.environ,
+        **base_env,
         "GITHUB_OUTPUT": str(github_output),
         "ACTION_PATH": str(ACTION_DIR),
         **env_extra,
@@ -112,11 +119,17 @@ def _write_manifest(
 
 
 def _target_artifact(name: str) -> dict:
+    # No real "sha256" -- these shell-level tests aren't about digest
+    # verification (that's covered at the unit level in
+    # tests/test_baseline_set.py), and an empty/absent recorded digest makes
+    # resolve_target()'s digest check a no-op rather than a false mismatch
+    # against whatever placeholder snapshot content each test happens to
+    # write.
     return {
         "library": name,
         "artifact": f"build/{name}.so",
         "snapshot": f"{name}.abicheck.json",
-        "sha256": "deadbeef",
+        "sha256": "",
     }
 
 
@@ -251,6 +264,29 @@ class TestFailureTaxonomy:
         )
         assert result.returncode == 1
         assert outputs.get("outcome") == "stale_schema"
+
+    def test_corrupt_manifest_is_a_typed_outcome_not_a_traceback(
+        self, tmp_path: Path
+    ) -> None:
+        # A manifest.json that exists but isn't valid JSON (partial
+        # download, hand edit) must still produce the Action's typed
+        # outcome/message contract, not let a Python ValueError escape
+        # resolve_baseline.py unhandled (Codex review).
+        baseline_dir = tmp_path / "baseline"
+        baseline_dir.mkdir(parents=True)
+        (baseline_dir / "manifest.json").write_text("{not valid json", encoding="utf-8")
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(baseline_dir),
+                "INPUT_CHANNEL": "accepted-main",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert outputs.get("outcome") == "stale_schema"
+        assert outputs.get("message")
 
     def test_incompatible_evidence(self, tmp_path: Path) -> None:
         baseline_dir = tmp_path / "baseline"

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -480,3 +480,56 @@ class TestArchiveExtraction:
         )
         assert result.returncode == 1
         assert "not a recognized archive" in result.stdout
+
+    def test_archive_with_no_manifest_anywhere_hard_fails_even_when_not_required(
+        self, tmp_path: Path
+    ) -> None:
+        # A malformed archive (no manifest.json at its root or in a single
+        # subdirectory) must never be treated as an ordinary "no baseline
+        # published yet" bootstrap, even under required: false -- the
+        # archive WAS present, just unusable, which is a real extraction
+        # failure distinct from nothing having been staged at all (Codex
+        # review).
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        (empty_dir / "readme.txt").write_text("not a baseline set", encoding="utf-8")
+        archive_path = tmp_path / "malformed.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tf:
+            tf.add(empty_dir, arcname=".")
+
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(archive_path),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_REQUIRED": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert outputs.get("outcome") != "not_found"
+        assert "malformed" in result.stdout
+
+    def test_archive_with_ambiguous_subdirectories_hard_fails(
+        self, tmp_path: Path
+    ) -> None:
+        root = tmp_path / "ambiguous-root"
+        (root / "a").mkdir(parents=True)
+        (root / "b").mkdir(parents=True)
+        archive_path = tmp_path / "ambiguous.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tf:
+            tf.add(root, arcname=".")
+
+        result, _ = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(archive_path),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_REQUIRED": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "malformed" in result.stdout

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -667,6 +667,49 @@ class TestArchiveExtraction:
         assert result.returncode == 1
         assert outputs.get("outcome") == "ambiguous"
 
+    def test_tar_gz_archive_rejects_path_traversal_member(
+        self, tmp_path: Path
+    ) -> None:
+        # Plain .tar.gz/.tar inputs now route through the same
+        # TarExtractor._safe_extract member validation as the .tar.zst
+        # branch above, instead of a bare `tar -x` with no member
+        # validation at all -- confirm a "../"-escaping member is rejected
+        # before extraction (Codex review).
+        archive_path = tmp_path / "baseline-traversal.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tf:
+            manifest_bytes = json.dumps(
+                {
+                    "manifest_version": 1,
+                    "project_ref": "v1.0.0",
+                    "profile": PROFILE,
+                    "snapshot_schema": 9,
+                    "fact_set": None,
+                    "artifacts": [_target_artifact("libpvxs")],
+                },
+                indent=2,
+            ).encode("utf-8")
+            info = tarfile.TarInfo("manifest.json")
+            info.size = len(manifest_bytes)
+            tf.addfile(info, io.BytesIO(manifest_bytes))
+
+            evil_bytes = b"escaped"
+            evil = tarfile.TarInfo("../escaped.txt")
+            evil.size = len(evil_bytes)
+            tf.addfile(evil, io.BytesIO(evil_bytes))
+
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(archive_path),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_REQUIRED": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert outputs.get("outcome") == "ambiguous"
+
     def test_unrecognized_archive_extension_fails(self, tmp_path: Path) -> None:
         bogus = tmp_path / "baseline.zip"
         bogus.write_bytes(b"PK\x03\x04not-really-a-zip")

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -1,0 +1,446 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for ``actions/resolve-baseline/run.sh`` (G30 P1.2,
+ADR-047 §4/§6).
+
+Covers the bash orchestration layer: input validation, archive extraction,
+and each of ADR-047 §6's typed outcomes end-to-end through the real script
+(``resolve_baseline.py`` + ``abicheck.buildsource.baseline_set``, unit-tested
+in isolation in ``tests/test_baseline_set.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tarfile
+from pathlib import Path
+
+import pytest
+
+ACTION_DIR = Path(__file__).resolve().parents[1] / "actions" / "resolve-baseline"
+RUN_SH = ACTION_DIR / "run.sh"
+
+PROFILE = "linux-x86_64-gcc13-release"
+
+
+def _bash_executable() -> str:
+    """Resolve a real bash, bypassing Windows' WSL-launcher stub.
+
+    See ``test_action_run_sh_helpers._bash_executable`` for the full
+    rationale.
+    """
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
+def _run_action(
+    env_extra: dict[str, str], cwd: Path
+) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+    """Invoke the real script end-to-end with a GITHUB_OUTPUT file."""
+    github_output = cwd / "github_output"
+    github_output.write_text("")
+    env = {
+        **os.environ,
+        "GITHUB_OUTPUT": str(github_output),
+        "ACTION_PATH": str(ACTION_DIR),
+        **env_extra,
+    }
+    result = subprocess.run(
+        [_bash_executable(), str(RUN_SH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd,
+        check=False,
+    )
+    outputs = _parse_kv_file(github_output)
+    return result, outputs
+
+
+def _parse_kv_file(path: Path) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            out[k] = v
+    return out
+
+
+def _write_manifest(
+    baseline_dir: Path,
+    *,
+    manifest_version: int | None = 1,
+    profile: str = PROFILE,
+    fact_set: dict | None = None,
+    artifacts: list[dict] | None = None,
+) -> None:
+    baseline_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "manifest_version": manifest_version,
+        "project_ref": "v1.0.0",
+        "profile": profile,
+        "snapshot_schema": 9,
+        "fact_set": fact_set,
+        "artifacts": artifacts if artifacts is not None else [],
+    }
+    (baseline_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+
+
+def _target_artifact(name: str) -> dict:
+    return {
+        "library": name,
+        "artifact": f"build/{name}.so",
+        "snapshot": f"{name}.abicheck.json",
+        "sha256": "deadbeef",
+    }
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/resolve-baseline/run.sh not found"
+)
+class TestInputValidation:
+    def test_missing_baseline_path_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {"INPUT_CHANNEL": "accepted-main", "INPUT_PROFILE": PROFILE}, tmp_path
+        )
+        assert result.returncode != 0
+
+    def test_missing_channel_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {"INPUT_BASELINE_PATH": str(tmp_path), "INPUT_PROFILE": PROFILE}, tmp_path
+        )
+        assert result.returncode != 0
+
+    def test_unknown_kind_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(tmp_path),
+                "INPUT_CHANNEL": "accepted-main",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_KIND": "bogus",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "not recognized" in result.stdout
+
+    def test_bundle_kind_without_bundle_name_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(tmp_path),
+                "INPUT_CHANNEL": "accepted-main",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_KIND": "bundle",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "bundle input is required" in result.stdout
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/resolve-baseline/run.sh not found"
+)
+class TestFailureTaxonomy:
+    """One test per ADR-047 §6 failure-taxonomy row, driven end-to-end."""
+
+    def test_not_found_required_hard_fails(self, tmp_path: Path) -> None:
+        missing_dir = tmp_path / "no-such-baseline"
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(missing_dir),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_REQUIRED": "true",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert outputs.get("outcome") == "not_found"
+        assert outputs.get("bootstrap") == "false"
+
+    def test_not_found_bootstrap_is_non_fatal(self, tmp_path: Path) -> None:
+        missing_dir = tmp_path / "no-such-baseline"
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(missing_dir),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_REQUIRED": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0
+        assert outputs.get("outcome") == "not_found"
+        assert outputs.get("bootstrap") == "true"
+
+    def test_ambiguous_target_missing_from_set(self, tmp_path: Path) -> None:
+        baseline_dir = tmp_path / "baseline"
+        _write_manifest(baseline_dir, artifacts=[_target_artifact("libpvxsIoc")])
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(baseline_dir),
+                "INPUT_CHANNEL": "accepted-main",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert outputs.get("outcome") == "ambiguous"
+
+    def test_wrong_profile(self, tmp_path: Path) -> None:
+        baseline_dir = tmp_path / "baseline"
+        _write_manifest(
+            baseline_dir,
+            profile="windows-x86_64-msvc-release",
+            artifacts=[_target_artifact("libpvxs")],
+        )
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(baseline_dir),
+                "INPUT_CHANNEL": "accepted-main",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert outputs.get("outcome") == "wrong_profile"
+
+    def test_stale_schema(self, tmp_path: Path) -> None:
+        baseline_dir = tmp_path / "baseline"
+        _write_manifest(
+            baseline_dir, manifest_version=999, artifacts=[_target_artifact("libpvxs")]
+        )
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(baseline_dir),
+                "INPUT_CHANNEL": "accepted-main",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert outputs.get("outcome") == "stale_schema"
+
+    def test_incompatible_evidence(self, tmp_path: Path) -> None:
+        baseline_dir = tmp_path / "baseline"
+        _write_manifest(
+            baseline_dir,
+            fact_set={
+                "name": "pvxs",
+                "version": 3,
+                "producer": "wrapper",
+                "producer_version": "0.5.0",
+            },
+            artifacts=[_target_artifact("libpvxs")],
+        )
+        (baseline_dir / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+        build_output = tmp_path / "build-output.json"
+        build_output.write_text(
+            json.dumps(
+                {
+                    "evidence_producer": {
+                        "kind": "replay",
+                        "tool": "abicheck",
+                        "version": "0.5.0",
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(baseline_dir),
+                "INPUT_CHANNEL": "accepted-main",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_CANDIDATE_BUILD_OUTPUT": str(build_output),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert outputs.get("outcome") == "incompatible_evidence"
+
+    def test_resolved(self, tmp_path: Path) -> None:
+        baseline_dir = tmp_path / "baseline"
+        _write_manifest(baseline_dir, artifacts=[_target_artifact("libpvxs")])
+        (baseline_dir / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(baseline_dir),
+                "INPUT_CHANNEL": "accepted-main",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0
+        assert outputs.get("outcome") == "resolved"
+        assert outputs.get("channel") == "accepted-main"
+        assert outputs.get("snapshot-path") == str(
+            baseline_dir / "libpvxs.abicheck.json"
+        )
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/resolve-baseline/run.sh not found"
+)
+class TestBundleResolution:
+    def test_bundle_returns_binaries_not_snapshots(self, tmp_path: Path) -> None:
+        baseline_dir = tmp_path / "baseline"
+        _write_manifest(
+            baseline_dir,
+            artifacts=[
+                {**_target_artifact("libpvxs"), "binary": "binaries/libpvxs.so.1.5"},
+                {
+                    **_target_artifact("libpvxsIoc"),
+                    "binary": "binaries/libpvxsIoc.so.1.5",
+                },
+            ],
+        )
+        binaries_dir = baseline_dir / "binaries"
+        binaries_dir.mkdir()
+        (binaries_dir / "libpvxs.so.1.5").write_bytes(b"\x7fELF-fake")
+        (binaries_dir / "libpvxsIoc.so.1.5").write_bytes(b"\x7fELF-fake")
+
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(baseline_dir),
+                "INPUT_CHANNEL": "accepted-main",
+                "INPUT_KIND": "bundle",
+                "INPUT_BUNDLE": "pvxs-release",
+                "INPUT_BUNDLE_MEMBERS": json.dumps(["libpvxs", "libpvxsIoc"]),
+                "INPUT_PROFILE": PROFILE,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0
+        assert outputs.get("outcome") == "resolved"
+        assert outputs.get("snapshot-path") == ""
+        assert outputs.get("binaries-dir") == str(binaries_dir)
+        binary_paths = json.loads(outputs["binary-paths"])
+        assert binary_paths == {
+            "libpvxs": str(binaries_dir / "libpvxs.so.1.5"),
+            "libpvxsIoc": str(binaries_dir / "libpvxsIoc.so.1.5"),
+        }
+
+    def test_bundle_ambiguous_when_member_binary_not_staged(
+        self, tmp_path: Path
+    ) -> None:
+        baseline_dir = tmp_path / "baseline"
+        # Legacy (pre-P1.6) manifest -- snapshots only, no staged binaries.
+        _write_manifest(
+            baseline_dir,
+            artifacts=[_target_artifact("libpvxs"), _target_artifact("libpvxsIoc")],
+        )
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(baseline_dir),
+                "INPUT_CHANNEL": "accepted-main",
+                "INPUT_KIND": "bundle",
+                "INPUT_BUNDLE": "pvxs-release",
+                "INPUT_BUNDLE_MEMBERS": json.dumps(["libpvxs", "libpvxsIoc"]),
+                "INPUT_PROFILE": PROFILE,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert outputs.get("outcome") == "ambiguous"
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/resolve-baseline/run.sh not found"
+)
+class TestArchiveExtraction:
+    def test_tar_gz_archive_is_extracted_and_resolved(self, tmp_path: Path) -> None:
+        baseline_dir = tmp_path / "baseline-src"
+        _write_manifest(baseline_dir, artifacts=[_target_artifact("libpvxs")])
+        (baseline_dir / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+
+        archive_path = tmp_path / "baseline.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tf:
+            tf.add(baseline_dir, arcname=".")
+
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(archive_path),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0
+        assert outputs.get("outcome") == "resolved"
+        assert Path(outputs["snapshot-path"]).is_file()
+
+    def test_tar_gz_archive_with_nested_directory_is_descended_into(
+        self, tmp_path: Path
+    ) -> None:
+        # An archive built by tarring the profile-named directory itself
+        # (rather than its contents) nests manifest.json one level down --
+        # run.sh must find it there, not just at the extraction root.
+        baseline_dir = tmp_path / "abicheck-baseline-linux-x86_64-gcc13-release"
+        _write_manifest(baseline_dir, artifacts=[_target_artifact("libpvxs")])
+        (baseline_dir / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+
+        archive_path = tmp_path / "baseline-nested.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tf:
+            tf.add(baseline_dir, arcname=baseline_dir.name)
+
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(archive_path),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0
+        assert outputs.get("outcome") == "resolved"
+
+    def test_unrecognized_archive_extension_fails(self, tmp_path: Path) -> None:
+        bogus = tmp_path / "baseline.zip"
+        bogus.write_bytes(b"PK\x03\x04not-really-a-zip")
+        result, _ = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(bogus),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "not a recognized archive" in result.stdout

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -24,6 +24,7 @@ in isolation in ``tests/test_baseline_set.py``).
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import shutil
@@ -571,6 +572,76 @@ class TestArchiveExtraction:
         assert result.returncode == 0
         assert outputs.get("outcome") == "resolved"
         assert Path(outputs["snapshot-path"]).is_file()
+
+    def test_tar_zst_archive_rejects_path_traversal_member(
+        self, tmp_path: Path
+    ) -> None:
+        # The .tar.zst extraction path delegates to
+        # abicheck.package.TarExtractor._safe_extract_zst_tar, which
+        # validates every member's path before extracting -- unlike a bare
+        # tarfile.extractall() on Python <3.12 (no filter="data" support),
+        # which would happily write a "../"-escaping member outside
+        # BASELINE_DIR before the symlink/manifest checks even run (Codex
+        # review, sixth round). Build the malicious member directly via
+        # TarInfo (not tf.add()), mirroring
+        # tests/test_package.py::TestTarExtractorSymlinks's own pattern for
+        # constructing an escaping archive member. The extraction root is
+        # run.sh's own mktemp -d (not this test's tmp_path), so there is no
+        # fixed path to assert non-existence of -- the outcome/exit-code
+        # assertions below are what prove the member was rejected before
+        # extraction, not written somewhere unverifiable.
+        tar_buf = io.BytesIO()
+        with tarfile.open(fileobj=tar_buf, mode="w") as tf:
+            manifest_bytes = json.dumps(
+                {
+                    "manifest_version": 1,
+                    "project_ref": "v1.0.0",
+                    "profile": PROFILE,
+                    "snapshot_schema": 9,
+                    "fact_set": None,
+                    "artifacts": [_target_artifact("libpvxs")],
+                },
+                indent=2,
+            ).encode("utf-8")
+            info = tarfile.TarInfo("manifest.json")
+            info.size = len(manifest_bytes)
+            tf.addfile(info, io.BytesIO(manifest_bytes))
+
+            evil_bytes = b"escaped"
+            evil = tarfile.TarInfo("../escaped.txt")
+            evil.size = len(evil_bytes)
+            tf.addfile(evil, io.BytesIO(evil_bytes))
+
+        if shutil.which("zstd") is not None:
+            tar_path = tmp_path / "payload.tar"
+            tar_path.write_bytes(tar_buf.getvalue())
+            archive_path = tmp_path / "baseline-traversal.tar.zst"
+            subprocess.run(
+                ["zstd", "-f", "-q", str(tar_path), "-o", str(archive_path)],
+                check=True,
+            )
+        else:
+            try:
+                import zstandard
+            except ImportError:
+                pytest.skip("neither zstd nor the zstandard package is available")
+            archive_path = tmp_path / "baseline-traversal.tar.zst"
+            cctx = zstandard.ZstdCompressor()
+            with open(archive_path, "wb") as out, cctx.stream_writer(out) as writer:
+                writer.write(tar_buf.getvalue())
+
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(archive_path),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_REQUIRED": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert outputs.get("outcome") == "ambiguous"
 
     def test_unrecognized_archive_extension_fails(self, tmp_path: Path) -> None:
         bogus = tmp_path / "baseline.zip"

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -546,6 +546,39 @@ class TestArchiveExtraction:
         assert outputs.get("channel") == "release-contract"
         assert "malformed" in outputs.get("message", "")
 
+    def test_archive_with_symlink_hard_fails_with_typed_outputs(
+        self, tmp_path: Path
+    ) -> None:
+        # A symlink-containing archive is a malformed baseline-set, the same
+        # class of failure as no-manifest/ambiguous-subdirectories above --
+        # it must carry the same typed outcome/bootstrap/message outputs, not
+        # fail before any outputs are written at all (Codex review).
+        baseline_dir = tmp_path / "baseline-src"
+        _write_manifest(baseline_dir, artifacts=[_target_artifact("libpvxs")])
+        (baseline_dir / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+        (baseline_dir / "evil-link").symlink_to(baseline_dir / "manifest.json")
+
+        archive_path = tmp_path / "baseline-symlink.tar.gz"
+        with tarfile.open(archive_path, "w:gz") as tf:
+            tf.add(baseline_dir, arcname=".")
+
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(archive_path),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_REQUIRED": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "symlink" in result.stdout
+        assert outputs.get("outcome") == "ambiguous"
+        assert outputs.get("bootstrap") == "false"
+        assert outputs.get("channel") == "release-contract"
+        assert "symlink" in outputs.get("message", "")
+
     def test_archive_with_ambiguous_subdirectories_hard_fails(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -378,6 +378,30 @@ class TestFailureTaxonomy:
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/resolve-baseline/run.sh not found"
 )
+def _real_elf_bytes() -> bytes:
+    """Return a known-good system .so's bytes for a real ELF round-trip.
+
+    Hand-crafting a minimal-but-valid ELF (dynamic section, section header
+    table, ...) via elftools' write APIs is heavy for a fixture; reusing a
+    real system library is the same trade-off
+    ``tests/test_bundle.py::test_build_bundle_snapshot_with_real_elf``
+    makes to exercise the real ``parse_elf_metadata`` path. This module
+    invokes ``run.sh`` as a real subprocess, so (unlike
+    ``tests/test_baseline_set.py``) there is no monkeypatch seam to stub
+    the deep ELF-parse check with.
+    """
+    for candidate in (
+        "/lib/x86_64-linux-gnu/libc.so.6",
+        "/lib64/libc.so.6",
+        "/usr/lib/libc.so.6",
+        "/usr/lib/x86_64-linux-gnu/libc.so.6",
+    ):
+        p = Path(candidate)
+        if p.is_file():
+            return p.read_bytes()
+    pytest.skip("no system libc available for ELF round-trip")
+
+
 class TestBundleResolution:
     def test_bundle_returns_binaries_not_snapshots(self, tmp_path: Path) -> None:
         baseline_dir = tmp_path / "baseline"
@@ -393,8 +417,9 @@ class TestBundleResolution:
         )
         binaries_dir = baseline_dir / "binaries"
         binaries_dir.mkdir()
-        (binaries_dir / "libpvxs.so.1.5").write_bytes(b"\x7fELF-fake")
-        (binaries_dir / "libpvxsIoc.so.1.5").write_bytes(b"\x7fELF-fake")
+        elf_bytes = _real_elf_bytes()
+        (binaries_dir / "libpvxs.so.1.5").write_bytes(elf_bytes)
+        (binaries_dir / "libpvxsIoc.so.1.5").write_bytes(elf_bytes)
 
         result, outputs = _run_action(
             {
@@ -496,7 +521,7 @@ class TestArchiveExtraction:
     def test_unrecognized_archive_extension_fails(self, tmp_path: Path) -> None:
         bogus = tmp_path / "baseline.zip"
         bogus.write_bytes(b"PK\x03\x04not-really-a-zip")
-        result, _ = _run_action(
+        result, outputs = _run_action(
             {
                 "INPUT_BASELINE_PATH": str(bogus),
                 "INPUT_CHANNEL": "release-contract",
@@ -507,6 +532,39 @@ class TestArchiveExtraction:
         )
         assert result.returncode == 1
         assert "not a recognized archive" in result.stdout
+        # baseline-path WAS a real file, so this is a real (if unusable)
+        # archive, not a bare usage error -- must carry the same typed
+        # outputs every other archive-processing failure does (Codex
+        # review, third round).
+        assert outputs.get("outcome") == "ambiguous"
+        assert outputs.get("bootstrap") == "false"
+        assert outputs.get("channel") == "release-contract"
+
+    def test_truncated_tar_gz_archive_fails_with_typed_outputs(
+        self, tmp_path: Path
+    ) -> None:
+        # A recognized extension whose contents are truncated/corrupted
+        # (a partial download, an interrupted upload) must fail through the
+        # same typed ambiguous path as an unrecognized extension or a
+        # malformed extracted shape -- not a bare runner-looking failure
+        # (Codex review, third round).
+        archive_path = tmp_path / "truncated.tar.gz"
+        archive_path.write_bytes(b"\x1f\x8b\x08\x00not-a-complete-gzip-stream")
+        result, outputs = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(archive_path),
+                "INPUT_CHANNEL": "release-contract",
+                "INPUT_TARGET": "libpvxs",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_REQUIRED": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "failed to extract" in result.stdout
+        assert outputs.get("outcome") == "ambiguous"
+        assert outputs.get("bootstrap") == "false"
+        assert outputs.get("channel") == "release-contract"
 
     def test_archive_with_no_manifest_anywhere_hard_fails_even_when_not_required(
         self, tmp_path: Path

--- a/tests/test_action_resolve_baseline.py
+++ b/tests/test_action_resolve_baseline.py
@@ -175,6 +175,32 @@ class TestInputValidation:
         assert result.returncode == 1
         assert "bundle input is required" in result.stdout
 
+    def test_channel_with_newline_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {
+                "INPUT_BASELINE_PATH": str(tmp_path),
+                "INPUT_CHANNEL": "accepted-main\nmalicious-key=evil",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_TARGET": "libpvxs",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "must not contain a newline" in result.stdout
+
+    def test_baseline_path_with_newline_fails(self, tmp_path: Path) -> None:
+        result, _ = _run_action(
+            {
+                "INPUT_BASELINE_PATH": f"{tmp_path}\nmalicious-key=evil",
+                "INPUT_CHANNEL": "accepted-main",
+                "INPUT_PROFILE": PROFILE,
+                "INPUT_TARGET": "libpvxs",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "must not contain a newline" in result.stdout
+
 
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/resolve-baseline/run.sh not found"
@@ -510,6 +536,15 @@ class TestArchiveExtraction:
         assert result.returncode == 1
         assert outputs.get("outcome") != "not_found"
         assert "malformed" in result.stdout
+        # Must carry the same typed outputs every other resolution failure
+        # does -- a caller running under continue-on-error or inspecting
+        # this Action's outputs must be able to distinguish "malformed
+        # archive" from an unrelated input/runner failure, not see no
+        # outputs at all (Codex review, second round).
+        assert outputs.get("outcome") == "ambiguous"
+        assert outputs.get("bootstrap") == "false"
+        assert outputs.get("channel") == "release-contract"
+        assert "malformed" in outputs.get("message", "")
 
     def test_archive_with_ambiguous_subdirectories_hard_fails(
         self, tmp_path: Path

--- a/tests/test_action_validate_inputs.py
+++ b/tests/test_action_validate_inputs.py
@@ -80,6 +80,10 @@ _VALIDATOR_INPUT_VARS = (
     "INPUT_ABI_BASELINE",
     "INPUT_ESTIMATE",
     "INPUT_AUDIT",
+    "INPUT_USED_BY",
+    "INPUT_VERIFY_RUNTIME",
+    "INPUT_REQUIRED_SYMBOL",
+    "INPUT_REQUIRED_SYMBOLS",
 )
 
 
@@ -644,6 +648,73 @@ class TestModeScopedInputWarnings:
 
     def test_no_mode_scoped_inputs_set_produces_no_warnings(self) -> None:
         result = _run_validate({"INPUT_MODE": "compare"})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" not in result.stdout
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(), reason="action/validate-inputs.sh not found"
+)
+class TestScopedComparisonInputs:
+    """ADR-043 --used-by/--required-symbol(s) contracts (G30 P1.3: resolves
+    the ADR-047 S22/S23 gap -- these were previously not forwarded by the
+    root Action at all)."""
+
+    def test_used_by_and_required_symbol_together_is_hard_error(self) -> None:
+        # The CLI itself rejects this combination, but only after Python
+        # setup/dependency install/pip install -- catch it here instead,
+        # before any of that (same rationale as every other check in this
+        # script).
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_USED_BY": "app1",
+                "INPUT_REQUIRED_SYMBOL": "abi_do_thing",
+            }
+        )
+        assert result.returncode == 1
+        assert "mutually exclusive" in result.stdout
+
+    def test_used_by_and_required_symbols_file_together_is_hard_error(self) -> None:
+        result = _run_validate(
+            {
+                "INPUT_MODE": "compare",
+                "INPUT_USED_BY": "app1",
+                "INPUT_REQUIRED_SYMBOLS": "symbols.txt",
+            }
+        )
+        assert result.returncode == 1
+        assert "mutually exclusive" in result.stdout
+
+    def test_used_by_alone_passes(self) -> None:
+        result = _run_validate({"INPUT_MODE": "compare", "INPUT_USED_BY": "app1"})
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    def test_required_symbol_alone_passes(self) -> None:
+        result = _run_validate(
+            {"INPUT_MODE": "compare", "INPUT_REQUIRED_SYMBOL": "abi_do_thing"}
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+
+    @pytest.mark.parametrize(
+        "env_name,value",
+        [
+            ("INPUT_USED_BY", "app1"),
+            ("INPUT_VERIFY_RUNTIME", "true"),
+            ("INPUT_REQUIRED_SYMBOL", "abi_do_thing"),
+            ("INPUT_REQUIRED_SYMBOLS", "symbols.txt"),
+        ],
+    )
+    def test_scoped_input_warns_on_non_compare_mode(
+        self, env_name: str, value: str
+    ) -> None:
+        result = _run_validate({"INPUT_MODE": "scan", env_name: value})
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert "::warning::" in result.stdout
+        assert "has no effect" in result.stdout
+
+    def test_no_scoped_inputs_set_produces_no_warnings(self) -> None:
+        result = _run_validate({"INPUT_MODE": "scan"})
         assert result.returncode == 0, result.stdout + result.stderr
         assert "::warning::" not in result.stdout
 

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -281,6 +281,28 @@ def test_resolve_target_missing_snapshot_schema_is_a_noop(tmp_path: Path) -> Non
     assert result.outcome == ResolveOutcome.RESOLVED
 
 
+def test_resolve_target_snapshot_own_schema_newer_than_reader_is_stale_schema(
+    tmp_path: Path,
+) -> None:
+    # _schema_and_profile_check only looks at the manifest's aggregate
+    # snapshot_schema field, which an older/hand-authored manifest may
+    # omit entirely -- but the snapshot file itself always carries its own
+    # schema_version. Without checking that too, this would previously
+    # resolve as RESOLVED (only JSON-shape validated) and fail opaquely in
+    # the later compare step instead of returning the typed stale_schema
+    # outcome resolve-baseline exists to give callers (Codex review).
+    _write_manifest(
+        tmp_path, snapshot_schema=None, artifacts=[_target_artifact("libpvxs")]
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text(
+        json.dumps({"schema_version": serialization.SCHEMA_VERSION + 1}),
+        encoding="utf-8",
+    )
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.STALE_SCHEMA
+    assert "schema_version" in result.message
+
+
 def test_resolve_target_wrong_profile(tmp_path: Path) -> None:
     _write_manifest(
         tmp_path,
@@ -1060,12 +1082,56 @@ def test_resolve_bundle_digest_match_resolves(tmp_path: Path) -> None:
         artifacts=[
             _target_artifact(
                 "libpvxs",
-                extra={"binary": "binaries/libpvxs.so.1.5", "sha256": real_digest},
+                extra={
+                    "binary": "binaries/libpvxs.so.1.5",
+                    "binary_sha256": real_digest,
+                },
             )
         ],
     )
     (tmp_path / "binaries").mkdir()
     (tmp_path / "binaries" / "libpvxs.so.1.5").write_bytes(content)
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.RESOLVED
+
+
+def test_resolve_bundle_snapshot_sha256_is_not_used_as_binary_digest(
+    tmp_path: Path,
+) -> None:
+    # A bundle-scoped manifest row can carry a "sha256" left over from the
+    # snapshot it was originally written for (build_manifest.py always sets
+    # it), plus a "binary" path added on top. If binary-digest verification
+    # ever reused that same "sha256" field, it would compare the JSON
+    # snapshot's content hash against the ELF binary's raw-byte hash --
+    # these can never coincidentally match, so the bundle would report
+    # ambiguous for every real baseline. binary_sha256 is a separate field
+    # and, when absent (as here), the binary-digest check must no-op just
+    # like an ordinary missing digest (Codex review).
+    binary_content = b"\x7fELF-fake-binary-contents"
+    snapshot_content = {"library": "libpvxs", "schema_version": 9}
+    snapshot_digest = compute_snapshot_content_hash(snapshot_content)
+    assert snapshot_digest != hashlib.sha256(binary_content).hexdigest()
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact(
+                "libpvxs",
+                extra={
+                    "binary": "binaries/libpvxs.so.1.5",
+                    "sha256": snapshot_digest,  # leftover snapshot digest
+                    # no binary_sha256 recorded
+                },
+            )
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    (tmp_path / "binaries" / "libpvxs.so.1.5").write_bytes(binary_content)
     result = resolve_bundle(
         tmp_path,
         bundle="pvxs-release",
@@ -1087,7 +1153,10 @@ def test_resolve_bundle_digest_mismatch_is_ambiguous(tmp_path: Path) -> None:
         artifacts=[
             _target_artifact(
                 "libpvxs",
-                extra={"binary": "binaries/libpvxs.so.1.5", "sha256": "0" * 64},
+                extra={
+                    "binary": "binaries/libpvxs.so.1.5",
+                    "binary_sha256": "0" * 64,
+                },
             )
         ],
     )
@@ -1118,11 +1187,17 @@ def test_resolve_bundle_message_reports_distinct_per_member_reasons(
         artifacts=[
             _target_artifact(
                 "libpvxs",
-                extra={"binary": "binaries/libpvxs.so.1.5", "sha256": real_digest},
+                extra={
+                    "binary": "binaries/libpvxs.so.1.5",
+                    "binary_sha256": real_digest,
+                },
             ),
             _target_artifact(
                 "libpvxsIoc",
-                extra={"binary": "binaries/libpvxsIoc.so.1.5", "sha256": "0" * 64},
+                extra={
+                    "binary": "binaries/libpvxsIoc.so.1.5",
+                    "binary_sha256": "0" * 64,
+                },
             ),
             # libpvxsExtra has no manifest entry at all.
         ],
@@ -1231,7 +1306,7 @@ def test_resolve_bundle_rejects_non_elf_binary_matching_digest(tmp_path: Path) -
         artifacts=[
             _target_artifact(
                 "libpvxs",
-                extra={"binary": "binaries/libpvxs.so", "sha256": digest},
+                extra={"binary": "binaries/libpvxs.so", "binary_sha256": digest},
             )
         ],
     )
@@ -1297,7 +1372,7 @@ def test_resolve_bundle_binary_digest_os_error_is_ambiguous(
         artifacts=[
             _target_artifact(
                 "libpvxs",
-                extra={"binary": "binaries/libpvxs.so", "sha256": "0" * 64},
+                extra={"binary": "binaries/libpvxs.so", "binary_sha256": "0" * 64},
             )
         ],
     )

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 import pytest
 
+from abicheck import serialization
 from abicheck.buildsource.baseline_set import (
     BASELINE_MANIFEST_FILENAME,
     ResolveOutcome,
@@ -47,6 +48,7 @@ def _write_manifest(
     *,
     manifest_version: int | None = 1,
     profile: str = PROFILE,
+    snapshot_schema: int | None = 9,
     fact_set: dict | None = None,
     artifacts: list[dict] | None = None,
 ) -> None:
@@ -55,7 +57,7 @@ def _write_manifest(
         "manifest_version": manifest_version,
         "project_ref": "v1.0.0",
         "profile": profile,
-        "snapshot_schema": 9,
+        "snapshot_schema": snapshot_schema,
         "fact_set": fact_set,
         "artifacts": artifacts if artifacts is not None else [],
     }
@@ -188,6 +190,51 @@ def test_resolve_target_stale_schema(tmp_path: Path) -> None:
     )
     result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
     assert result.outcome == ResolveOutcome.STALE_SCHEMA
+
+
+def test_resolve_target_snapshot_schema_newer_than_reader_is_stale_schema(
+    tmp_path: Path,
+) -> None:
+    # manifest_version (this resolver's own manifest.json shape) is a
+    # separate axis from snapshot_schema (the referenced .abicheck.json
+    # snapshots' serialization.SCHEMA_VERSION) -- a baseline built by a
+    # newer abicheck than this checkout's installed reader must be caught
+    # here as stale_schema, not silently reported resolved only to fail
+    # opaquely in the later compare step (Codex review).
+    _write_manifest(
+        tmp_path,
+        snapshot_schema=serialization.SCHEMA_VERSION + 1,
+        artifacts=[_target_artifact("libpvxs")],
+    )
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.STALE_SCHEMA
+    assert "snapshot_schema" in result.message
+
+
+def test_resolve_target_snapshot_schema_at_reader_version_resolves(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(
+        tmp_path,
+        snapshot_schema=serialization.SCHEMA_VERSION,
+        artifacts=[_target_artifact("libpvxs")],
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.RESOLVED
+
+
+def test_resolve_target_missing_snapshot_schema_is_a_noop(tmp_path: Path) -> None:
+    # An older/hand-authored manifest with no snapshot_schema field has
+    # nothing to compare against -- must not be treated as "newer than
+    # supported" by accident (same no-op-on-absence contract as the digest
+    # checks).
+    _write_manifest(
+        tmp_path, snapshot_schema=None, artifacts=[_target_artifact("libpvxs")]
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.RESOLVED
 
 
 def test_resolve_target_wrong_profile(tmp_path: Path) -> None:

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -195,16 +195,37 @@ def test_load_baseline_manifest_round_trip(tmp_path: Path) -> None:
 
 
 def test_resolve_target_not_found_required_is_hard_failure(tmp_path: Path) -> None:
-    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    # The baseline-path itself must not exist for the not_found/bootstrap
+    # case -- an *existing* directory with no manifest.json is a distinct,
+    # more concerning failure (see
+    # test_resolve_target_existing_dir_without_manifest_is_ambiguous below).
+    missing = tmp_path / "does-not-exist"
+    result = resolve_target(missing, target="libpvxs", profile=PROFILE, required=True)
     assert result.outcome == ResolveOutcome.NOT_FOUND
     assert result.bootstrap is False
     assert not result.ok
 
 
 def test_resolve_target_not_found_not_required_is_bootstrap(tmp_path: Path) -> None:
-    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=False)
+    missing = tmp_path / "does-not-exist"
+    result = resolve_target(missing, target="libpvxs", profile=PROFILE, required=False)
     assert result.outcome == ResolveOutcome.NOT_FOUND
     assert result.bootstrap is True
+
+
+def test_resolve_target_existing_dir_without_manifest_is_ambiguous(
+    tmp_path: Path,
+) -> None:
+    # An existing baseline-path directory (e.g. an empty/partial
+    # actions/cache restore) with no manifest.json inside it is malformed,
+    # not simply "unpublished" -- it must not silently bootstrap a
+    # required=False caller to a green run with zero comparison performed
+    # (Codex review).
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=False)
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert result.bootstrap is False
+    assert "does not contain a" in result.message
+    assert not result.ok
 
 
 def test_resolve_target_stale_schema(tmp_path: Path) -> None:
@@ -801,8 +822,9 @@ def _write_binary(baseline_dir: Path, rel_path: str) -> None:
 
 
 def test_resolve_bundle_not_found_required(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
     result = resolve_bundle(
-        tmp_path,
+        missing,
         bundle="pvxs-release",
         members=["libpvxs", "libpvxsIoc"],
         profile=PROFILE,
@@ -813,8 +835,9 @@ def test_resolve_bundle_not_found_required(tmp_path: Path) -> None:
 
 
 def test_resolve_bundle_not_found_bootstrap(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist"
     result = resolve_bundle(
-        tmp_path,
+        missing,
         bundle="pvxs-release",
         members=["libpvxs", "libpvxsIoc"],
         profile=PROFILE,
@@ -822,6 +845,21 @@ def test_resolve_bundle_not_found_bootstrap(tmp_path: Path) -> None:
     )
     assert result.outcome == ResolveOutcome.NOT_FOUND
     assert result.bootstrap is True
+
+
+def test_resolve_bundle_existing_dir_without_manifest_is_ambiguous(
+    tmp_path: Path,
+) -> None:
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs", "libpvxsIoc"],
+        profile=PROFILE,
+        required=False,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert result.bootstrap is False
+    assert "does not contain a" in result.message
 
 
 def test_resolve_bundle_wrong_profile(tmp_path: Path) -> None:

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -214,6 +214,27 @@ def test_resolve_target_ambiguous_snapshot_file_missing_on_disk(tmp_path: Path) 
     assert result.outcome == ResolveOutcome.AMBIGUOUS
 
 
+def test_resolve_target_ambiguous_duplicate_manifest_entries(tmp_path: Path) -> None:
+    # A real actions/baseline-produced manifest can never have two entries
+    # for the same library (run.sh's own input validation already rejects
+    # a duplicate library name before anything is dumped) -- two rows here
+    # means a hand-edited or corrupted manifest, and artifact_for() would
+    # otherwise silently pick whichever one happens to appear first
+    # (Codex review).
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact("libpvxs", extra={"snapshot": "a.abicheck.json"}),
+            _target_artifact("libpvxs", extra={"snapshot": "b.abicheck.json"}),
+        ],
+    )
+    (tmp_path / "a.abicheck.json").write_text("{}", encoding="utf-8")
+    (tmp_path / "b.abicheck.json").write_text("{}", encoding="utf-8")
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "multiple artifacts" in result.message
+
+
 def test_resolve_target_incompatible_evidence_producer_mismatch(tmp_path: Path) -> None:
     _write_manifest(
         tmp_path,
@@ -788,3 +809,25 @@ def test_resolve_bundle_message_reports_distinct_per_member_reasons(
     assert "digest does not match" in result.message  # libpvxsIoc
     assert "no staged binary declared" in result.message  # libpvxsExtra
     assert "'libpvxs':" not in result.message  # libpvxs itself resolved fine
+
+
+def test_resolve_bundle_ambiguous_duplicate_manifest_entries(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact("libpvxs", extra={"binary": "binaries/a.so"}),
+            _target_artifact("libpvxs", extra={"binary": "binaries/b.so"}),
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    (tmp_path / "binaries" / "a.so").write_bytes(b"\x7fELF-fake")
+    (tmp_path / "binaries" / "b.so").write_bytes(b"\x7fELF-fake")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "multiple artifacts" in result.message

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -583,7 +583,8 @@ def test_resolve_bundle_ambiguous_when_staged_binary_file_missing(
         required=True,
     )
     assert result.outcome == ResolveOutcome.AMBIGUOUS
-    assert "['libpvxsIoc']" in result.message
+    assert "'libpvxsIoc':" in result.message
+    assert "'libpvxs':" not in result.message
 
 
 def test_resolve_bundle_incompatible_evidence(tmp_path: Path) -> None:
@@ -673,7 +674,8 @@ def test_resolve_bundle_rejects_escaping_binary_path(tmp_path: Path) -> None:
         required=True,
     )
     assert result.outcome == ResolveOutcome.AMBIGUOUS
-    assert "['libpvxs']" in result.message
+    assert "'libpvxs':" in result.message
+    assert "'libpvxsIoc':" not in result.message
 
 
 def test_resolve_bundle_rejects_binary_outside_binaries_dir(tmp_path: Path) -> None:
@@ -746,3 +748,43 @@ def test_resolve_bundle_digest_mismatch_is_ambiguous(tmp_path: Path) -> None:
         required=True,
     )
     assert result.outcome == ResolveOutcome.AMBIGUOUS
+
+
+def test_resolve_bundle_message_reports_distinct_per_member_reasons(
+    tmp_path: Path,
+) -> None:
+    # Three different rejection causes (no manifest entry, digest mismatch,
+    # missing/mis-located binary) must surface as three distinct per-member
+    # reasons in one message, not one generic "have no staged binary"
+    # sentence that points every operator at the same wrong fix
+    # (CodeRabbit review).
+    content = b"\x7fELF-real"
+    real_digest = hashlib.sha256(content).hexdigest()
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact(
+                "libpvxs",
+                extra={"binary": "binaries/libpvxs.so.1.5", "sha256": real_digest},
+            ),
+            _target_artifact(
+                "libpvxsIoc",
+                extra={"binary": "binaries/libpvxsIoc.so.1.5", "sha256": "0" * 64},
+            ),
+            # libpvxsExtra has no "binary" field at all.
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    (tmp_path / "binaries" / "libpvxs.so.1.5").write_bytes(content)
+    (tmp_path / "binaries" / "libpvxsIoc.so.1.5").write_bytes(b"\x7fELF-wrong")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs", "libpvxsIoc", "libpvxsExtra"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "digest does not match" in result.message  # libpvxsIoc
+    assert "no staged binary declared" in result.message  # libpvxsExtra
+    assert "'libpvxs':" not in result.message  # libpvxs itself resolved fine

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -655,6 +655,24 @@ def test_resolve_target_digest_check_rejects_snapshot_that_is_not_a_json_object(
     assert "JSON object" in result.message
 
 
+def test_resolve_target_corrupt_snapshot_is_ambiguous_even_without_recorded_digest(
+    tmp_path: Path,
+) -> None:
+    # An older/hand-authored manifest with no recorded sha256 has nothing
+    # to compare a digest against, but that must not skip JSON-shape
+    # validation entirely -- a corrupt/non-JSON snapshot with no recorded
+    # digest was previously resolving as RESOLVED purely because a file
+    # with the right name existed on disk (Codex review).
+    _write_manifest(
+        tmp_path,
+        artifacts=[_target_artifact("libpvxs")],  # no sha256
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text("not valid json", encoding="utf-8")
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert not result.ok
+
+
 def test_strip_volatile_snapshot_fields_strips_nested_build_source_coverage(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -650,3 +650,24 @@ def test_resolve_bundle_rejects_escaping_binary_path(tmp_path: Path) -> None:
     )
     assert result.outcome == ResolveOutcome.AMBIGUOUS
     assert "['libpvxs']" in result.message
+
+
+def test_resolve_bundle_rejects_binary_outside_binaries_dir(tmp_path: Path) -> None:
+    # A "binary" entry that is a valid, non-escaping relative path but sits
+    # outside binaries/ must still be rejected -- the documented bundle
+    # contract is that every member's binary lives under binaries/ (the
+    # same directory the binaries-dir output advertises), not merely
+    # somewhere in the baseline-set (Codex review).
+    _write_manifest(
+        tmp_path,
+        artifacts=[_target_artifact("libpvxs", extra={"binary": "libpvxs.so"})],
+    )
+    (tmp_path / "libpvxs.so").write_bytes(b"\x7fELF-fake")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -1,0 +1,433 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``abicheck/buildsource/baseline_set.py`` (G30 P1.2,
+ADR-047 §4/§6).
+
+Pure-Python tests over hand-authored ``manifest.json``/snapshot/binary
+fixtures -- no compiler, no real ``abicheck dump``/``actions/baseline`` run
+needed. See ``tests/test_action_resolve_baseline.py`` for the bash/CLI-level
+orchestration this module's logic backs.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from abicheck.buildsource.baseline_set import (
+    BASELINE_MANIFEST_FILENAME,
+    ResolveOutcome,
+    load_baseline_manifest,
+    resolve_bundle,
+    resolve_target,
+)
+
+PROFILE = "linux-x86_64-gcc13-release"
+
+
+def _write_manifest(
+    baseline_dir: Path,
+    *,
+    manifest_version: int | None = 1,
+    profile: str = PROFILE,
+    fact_set: dict | None = None,
+    artifacts: list[dict] | None = None,
+) -> None:
+    baseline_dir.mkdir(parents=True, exist_ok=True)
+    manifest = {
+        "manifest_version": manifest_version,
+        "project_ref": "v1.0.0",
+        "profile": profile,
+        "snapshot_schema": 9,
+        "fact_set": fact_set,
+        "artifacts": artifacts if artifacts is not None else [],
+    }
+    (baseline_dir / BASELINE_MANIFEST_FILENAME).write_text(
+        json.dumps(manifest, indent=2), encoding="utf-8"
+    )
+
+
+def _target_artifact(
+    name: str, *, snapshot: bool = True, extra: dict | None = None
+) -> dict:
+    entry = {
+        "library": name,
+        "artifact": f"build/{name}.so",
+        "snapshot": f"{name}.abicheck.json" if snapshot else "",
+        "sha256": "deadbeef",
+    }
+    if extra:
+        entry.update(extra)
+    return entry
+
+
+# ── load_baseline_manifest ───────────────────────────────────────────────
+
+
+def test_load_baseline_manifest_missing_returns_none(tmp_path: Path) -> None:
+    assert load_baseline_manifest(tmp_path) is None
+
+
+def test_load_baseline_manifest_malformed_json_raises(tmp_path: Path) -> None:
+    (tmp_path / BASELINE_MANIFEST_FILENAME).write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        load_baseline_manifest(tmp_path)
+
+
+def test_load_baseline_manifest_not_a_dict_raises(tmp_path: Path) -> None:
+    (tmp_path / BASELINE_MANIFEST_FILENAME).write_text("[1, 2, 3]", encoding="utf-8")
+    with pytest.raises(ValueError, match="JSON object"):
+        load_baseline_manifest(tmp_path)
+
+
+def test_load_baseline_manifest_round_trip(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path,
+        fact_set={
+            "name": "pvxs",
+            "version": 3,
+            "producer": "wrapper",
+            "producer_version": "0.5.0",
+        },
+        artifacts=[_target_artifact("libpvxs")],
+    )
+    manifest = load_baseline_manifest(tmp_path)
+    assert manifest is not None
+    assert manifest.manifest_version == 1
+    assert manifest.profile == PROFILE
+    assert manifest.fact_set == {
+        "name": "pvxs",
+        "version": 3,
+        "producer": "wrapper",
+        "producer_version": "0.5.0",
+    }
+    artifact = manifest.artifact_for("libpvxs")
+    assert artifact is not None
+    assert artifact.snapshot == "libpvxs.abicheck.json"
+    assert manifest.artifact_for("nope") is None
+
+
+# ── resolve_target ───────────────────────────────────────────────────────
+
+
+def test_resolve_target_not_found_required_is_hard_failure(tmp_path: Path) -> None:
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.NOT_FOUND
+    assert result.bootstrap is False
+    assert not result.ok
+
+
+def test_resolve_target_not_found_not_required_is_bootstrap(tmp_path: Path) -> None:
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=False)
+    assert result.outcome == ResolveOutcome.NOT_FOUND
+    assert result.bootstrap is True
+
+
+def test_resolve_target_stale_schema(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path, manifest_version=999, artifacts=[_target_artifact("libpvxs")]
+    )
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.STALE_SCHEMA
+
+
+def test_resolve_target_wrong_profile(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path,
+        profile="windows-x86_64-msvc-release",
+        artifacts=[_target_artifact("libpvxs")],
+    )
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.WRONG_PROFILE
+
+
+def test_resolve_target_ambiguous_target_missing_from_set(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, artifacts=[_target_artifact("libpvxsIoc")])
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "libpvxsIoc" in result.message
+
+
+def test_resolve_target_ambiguous_snapshot_file_missing_on_disk(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, artifacts=[_target_artifact("libpvxs")])
+    # No libpvxs.abicheck.json actually written to disk.
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+
+
+def test_resolve_target_incompatible_evidence_producer_mismatch(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path,
+        fact_set={
+            "name": "pvxs",
+            "version": 3,
+            "producer": "wrapper",
+            "producer_version": "0.5.0",
+        },
+        artifacts=[_target_artifact("libpvxs")],
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+    result = resolve_target(
+        tmp_path,
+        target="libpvxs",
+        profile=PROFILE,
+        required=True,
+        candidate_evidence_producer={
+            "kind": "replay",
+            "tool": "abicheck",
+            "version": "0.5.0",
+        },
+    )
+    assert result.outcome == ResolveOutcome.INCOMPATIBLE_EVIDENCE
+    assert "wrapper" in result.message and "replay" in result.message
+
+
+def test_resolve_target_incompatible_evidence_producer_version_mismatch(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(
+        tmp_path,
+        fact_set={
+            "name": "pvxs",
+            "version": 3,
+            "producer": "wrapper",
+            "producer_version": "0.5.0",
+        },
+        artifacts=[_target_artifact("libpvxs")],
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+    result = resolve_target(
+        tmp_path,
+        target="libpvxs",
+        profile=PROFILE,
+        required=True,
+        candidate_evidence_producer={
+            "kind": "wrapper",
+            "tool": "abicheck-cc",
+            "version": "0.6.0",
+        },
+    )
+    assert result.outcome == ResolveOutcome.INCOMPATIBLE_EVIDENCE
+
+
+def test_resolve_target_evidence_check_skipped_when_baseline_has_no_fact_set(
+    tmp_path: Path,
+) -> None:
+    # A binary/header-depth-only baseline (no --build-info/--sources) has no
+    # fact_set at all -- a candidate that *does* declare an evidence
+    # producer must not be penalized for a comparison that isn't meaningful.
+    _write_manifest(tmp_path, fact_set=None, artifacts=[_target_artifact("libpvxs")])
+    (tmp_path / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+    result = resolve_target(
+        tmp_path,
+        target="libpvxs",
+        profile=PROFILE,
+        required=True,
+        candidate_evidence_producer={
+            "kind": "wrapper",
+            "tool": "abicheck-cc",
+            "version": "0.6.0",
+        },
+    )
+    assert result.outcome == ResolveOutcome.RESOLVED
+
+
+def test_resolve_target_resolved(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path,
+        fact_set={
+            "name": "pvxs",
+            "version": 3,
+            "producer": "wrapper",
+            "producer_version": "0.5.0",
+        },
+        artifacts=[_target_artifact("libpvxs")],
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+    result = resolve_target(
+        tmp_path,
+        target="libpvxs",
+        profile=PROFILE,
+        required=True,
+        candidate_evidence_producer={
+            "kind": "wrapper",
+            "tool": "abicheck-cc",
+            "version": "0.5.0",
+        },
+    )
+    assert result.outcome == ResolveOutcome.RESOLVED
+    assert result.ok
+    assert result.bootstrap is False
+    assert result.snapshot_path == str(tmp_path / "libpvxs.abicheck.json")
+    assert result.manifest_path == str(tmp_path / BASELINE_MANIFEST_FILENAME)
+
+
+# ── resolve_bundle ────────────────────────────────────────────────────────
+
+
+def _write_binary(baseline_dir: Path, rel_path: str) -> None:
+    full = baseline_dir / rel_path
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_bytes(b"\x7fELF-fake-binary-contents")
+
+
+def test_resolve_bundle_not_found_required(tmp_path: Path) -> None:
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs", "libpvxsIoc"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.NOT_FOUND
+    assert result.bootstrap is False
+
+
+def test_resolve_bundle_not_found_bootstrap(tmp_path: Path) -> None:
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs", "libpvxsIoc"],
+        profile=PROFILE,
+        required=False,
+    )
+    assert result.outcome == ResolveOutcome.NOT_FOUND
+    assert result.bootstrap is True
+
+
+def test_resolve_bundle_wrong_profile(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, profile="windows-x86_64-msvc-release")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs", "libpvxsIoc"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.WRONG_PROFILE
+
+
+def test_resolve_bundle_ambiguous_when_member_has_no_binary_field(
+    tmp_path: Path,
+) -> None:
+    # Snapshots exist for both members, but the manifest was produced by a
+    # non-bundle-aware actions/baseline (no "binary" field / binaries/ dir
+    # staged yet, pre-G30-P1.6) -- bundle resolution must not silently fall
+    # back to snapshots (build_bundle_snapshot() ignores them).
+    _write_manifest(
+        tmp_path,
+        artifacts=[_target_artifact("libpvxs"), _target_artifact("libpvxsIoc")],
+    )
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs", "libpvxsIoc"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "libpvxs" in result.message and "libpvxsIoc" in result.message
+
+
+def test_resolve_bundle_ambiguous_when_staged_binary_file_missing(
+    tmp_path: Path,
+) -> None:
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact("libpvxs", extra={"binary": "binaries/libpvxs.so.1.5"}),
+            _target_artifact(
+                "libpvxsIoc", extra={"binary": "binaries/libpvxsIoc.so.1.5"}
+            ),
+        ],
+    )
+    # Only one of the two declared binaries actually exists on disk.
+    _write_binary(tmp_path, "binaries/libpvxs.so.1.5")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs", "libpvxsIoc"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "['libpvxsIoc']" in result.message
+
+
+def test_resolve_bundle_incompatible_evidence(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path,
+        fact_set={
+            "name": "pvxs",
+            "version": 3,
+            "producer": "wrapper",
+            "producer_version": "0.5.0",
+        },
+        artifacts=[
+            _target_artifact("libpvxs", extra={"binary": "binaries/libpvxs.so.1.5"}),
+            _target_artifact(
+                "libpvxsIoc", extra={"binary": "binaries/libpvxsIoc.so.1.5"}
+            ),
+        ],
+    )
+    _write_binary(tmp_path, "binaries/libpvxs.so.1.5")
+    _write_binary(tmp_path, "binaries/libpvxsIoc.so.1.5")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs", "libpvxsIoc"],
+        profile=PROFILE,
+        required=True,
+        candidate_evidence_producer={
+            "kind": "replay",
+            "tool": "abicheck",
+            "version": "0.5.0",
+        },
+    )
+    assert result.outcome == ResolveOutcome.INCOMPATIBLE_EVIDENCE
+
+
+def test_resolve_bundle_resolved_returns_binaries_not_snapshots(tmp_path: Path) -> None:
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact("libpvxs", extra={"binary": "binaries/libpvxs.so.1.5"}),
+            _target_artifact(
+                "libpvxsIoc", extra={"binary": "binaries/libpvxsIoc.so.1.5"}
+            ),
+        ],
+    )
+    _write_binary(tmp_path, "binaries/libpvxs.so.1.5")
+    _write_binary(tmp_path, "binaries/libpvxsIoc.so.1.5")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs", "libpvxsIoc"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.RESOLVED
+    assert result.ok
+    assert result.snapshot_path is None
+    assert result.binaries_dir == str(tmp_path / "binaries")
+    assert result.binary_paths == {
+        "libpvxs": str(tmp_path / "binaries" / "libpvxs.so.1.5"),
+        "libpvxsIoc": str(tmp_path / "binaries" / "libpvxsIoc.so.1.5"),
+    }
+    for path in result.binary_paths.values():
+        assert Path(path).is_file()

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -339,6 +339,37 @@ def test_resolve_target_resolved(tmp_path: Path) -> None:
     assert result.manifest_path == str(tmp_path / BASELINE_MANIFEST_FILENAME)
 
 
+def test_resolve_target_rejects_absolute_snapshot_path(tmp_path: Path) -> None:
+    # A corrupt/hand-edited/tampered manifest.json pointing "snapshot" at an
+    # absolute path must never resolve -- Path's own "/" operator silently
+    # discards the left operand for an absolute right-hand side, so without
+    # an explicit guard this would hand a downstream compare an arbitrary
+    # file outside the baseline-set (Codex review).
+    outside = tmp_path.parent / "outside.abicheck.json"
+    outside.write_text("{}", encoding="utf-8")
+    _write_manifest(
+        tmp_path,
+        artifacts=[_target_artifact("libpvxs", extra={"snapshot": str(outside)})],
+    )
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "escapes" in result.message
+
+
+def test_resolve_target_rejects_traversing_snapshot_path(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside.abicheck.json"
+    outside.write_text("{}", encoding="utf-8")
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact("libpvxs", extra={"snapshot": f"../{outside.name}"})
+        ],
+    )
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "escapes" in result.message
+
+
 def test_resolve_target_digest_match_resolves(tmp_path: Path) -> None:
     snapshot_content = {"library": "libpvxs", "schema_version": 9}
     real_digest = compute_snapshot_content_hash(snapshot_content)
@@ -593,3 +624,29 @@ def test_resolve_bundle_resolved_returns_binaries_not_snapshots(tmp_path: Path) 
     }
     for path in result.binary_paths.values():
         assert Path(path).is_file()
+
+
+def test_resolve_bundle_rejects_escaping_binary_path(tmp_path: Path) -> None:
+    # Same path-traversal guard as resolve_target, applied to a bundle
+    # member's "binary" field (Codex review).
+    outside = tmp_path.parent / "outside.so"
+    outside.write_bytes(b"\x7fELF-fake")
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact("libpvxs", extra={"binary": f"../{outside.name}"}),
+            _target_artifact(
+                "libpvxsIoc", extra={"binary": "binaries/libpvxsIoc.so.1.5"}
+            ),
+        ],
+    )
+    _write_binary(tmp_path, "binaries/libpvxsIoc.so.1.5")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs", "libpvxsIoc"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "['libpvxs']" in result.message

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -1068,7 +1068,7 @@ def test_resolve_bundle_message_reports_distinct_per_member_reasons(
                 "libpvxsIoc",
                 extra={"binary": "binaries/libpvxsIoc.so.1.5", "sha256": "0" * 64},
             ),
-            # libpvxsExtra has no "binary" field at all.
+            # libpvxsExtra has no manifest entry at all.
         ],
     )
     (tmp_path / "binaries").mkdir()
@@ -1083,7 +1083,7 @@ def test_resolve_bundle_message_reports_distinct_per_member_reasons(
     )
     assert result.outcome == ResolveOutcome.AMBIGUOUS
     assert "digest does not match" in result.message  # libpvxsIoc
-    assert "no staged binary declared" in result.message  # libpvxsExtra
+    assert "not in this baseline-set's manifest" in result.message  # libpvxsExtra
     assert "'libpvxs':" not in result.message  # libpvxs itself resolved fine
 
 

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -98,6 +98,17 @@ def test_load_baseline_manifest_malformed_json_raises(tmp_path: Path) -> None:
         load_baseline_manifest(tmp_path)
 
 
+def test_load_baseline_manifest_invalid_utf8_raises_value_error(tmp_path: Path) -> None:
+    # UnicodeDecodeError (raised by the text-mode read itself) is a
+    # ValueError subclass, not a json.JSONDecodeError -- must be caught
+    # alongside it so this function's documented "raises ValueError"
+    # contract holds for a manifest replaced by binary garbage too, not
+    # just malformed-but-valid-UTF-8 JSON (Codex review).
+    (tmp_path / BASELINE_MANIFEST_FILENAME).write_bytes(b"\xff\xfe\x00not valid utf-8")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        load_baseline_manifest(tmp_path)
+
+
 def test_load_baseline_manifest_not_a_dict_raises(tmp_path: Path) -> None:
     (tmp_path / BASELINE_MANIFEST_FILENAME).write_text("[1, 2, 3]", encoding="utf-8")
     with pytest.raises(ValueError, match="JSON object"):
@@ -206,9 +217,16 @@ def test_resolve_target_incompatible_evidence_producer_mismatch(tmp_path: Path) 
     assert "wrapper" in result.message and "replay" in result.message
 
 
-def test_resolve_target_incompatible_evidence_producer_version_mismatch(
+def test_resolve_target_version_mismatch_alone_is_not_incompatible(
     tmp_path: Path,
 ) -> None:
+    # evidence_producer.version (candidate, package-release-styled per
+    # ADR-047 section 2's own example) and fact_set.producer_version
+    # (baseline, an independent internal extractor-recipe version e.g.
+    # "0.7") are two incommensurable numbering schemes -- comparing them
+    # directly would reject nearly every real resolution on a coincidental
+    # mismatch, so this check intentionally does NOT compare version when
+    # the producer kind itself matches (Codex review).
     _write_manifest(
         tmp_path,
         fact_set={
@@ -231,7 +249,42 @@ def test_resolve_target_incompatible_evidence_producer_version_mismatch(
             "version": "0.6.0",
         },
     )
-    assert result.outcome == ResolveOutcome.INCOMPATIBLE_EVIDENCE
+    assert result.outcome == ResolveOutcome.RESOLVED
+
+
+def test_resolve_target_clang_plugin_alias_matches_real_producer_id(
+    tmp_path: Path,
+) -> None:
+    # The C++ clang-plugin extractor self-reports fact_set.producer as
+    # "abicheck-clang-plugin" (contrib/abicheck-clang-plugin/
+    # AbicheckFactsPlugin.cpp), not the "clang-plugin" name
+    # actions/collect-facts/run.sh's own `producer` input/build-output.json
+    # evidence_producer.kind uses -- must not spuriously report
+    # incompatible_evidence for a candidate/baseline pair that are actually
+    # the same producer (Codex review).
+    _write_manifest(
+        tmp_path,
+        fact_set={
+            "name": "pvxs",
+            "version": 3,
+            "producer": "abicheck-clang-plugin",
+            "producer_version": "0.3",
+        },
+        artifacts=[_target_artifact("libpvxs")],
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+    result = resolve_target(
+        tmp_path,
+        target="libpvxs",
+        profile=PROFILE,
+        required=True,
+        candidate_evidence_producer={
+            "kind": "clang-plugin",
+            "tool": "abicheck-clang-plugin",
+            "version": "0.x.y",
+        },
+    )
+    assert result.outcome == ResolveOutcome.RESOLVED
 
 
 def test_resolve_target_evidence_check_skipped_when_baseline_has_no_fact_set(
@@ -315,6 +368,24 @@ def test_resolve_target_digest_mismatch_is_ambiguous(tmp_path: Path) -> None:
     result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
     assert result.outcome == ResolveOutcome.AMBIGUOUS
     assert "digest does not match" in result.message
+
+
+def test_resolve_target_digest_check_handles_invalid_utf8_snapshot(
+    tmp_path: Path,
+) -> None:
+    # A snapshot replaced by non-UTF-8/binary garbage must produce the same
+    # typed ambiguous outcome as any other corrupt snapshot, not an
+    # unhandled UnicodeDecodeError (Codex review) -- UnicodeDecodeError is a
+    # ValueError subclass, not a json.JSONDecodeError, so it needs its own
+    # except clause.
+    _write_manifest(
+        tmp_path,
+        artifacts=[_target_artifact("libpvxs", extra={"sha256": "0" * 64})],
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_bytes(b"\xff\xfe\x00not valid utf-8")
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert not result.ok
 
 
 def test_resolve_target_digest_ignores_volatile_fields(tmp_path: Path) -> None:

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -1017,3 +1017,29 @@ def test_resolve_bundle_rejects_truncated_elf_binary(
     )
     assert result.outcome == ResolveOutcome.AMBIGUOUS
     assert "essentially empty ELF file" in result.message
+
+
+def test_resolve_bundle_rejects_binary_field_equal_to_binaries_dir_itself(
+    tmp_path: Path,
+) -> None:
+    # Path.is_relative_to() is true for a path relative to *itself*, so a
+    # manifest entry whose "binary" field is exactly "binaries" (equal to
+    # BASELINE_BINARIES_DIRNAME) would otherwise satisfy the containment
+    # check without actually being a child of it. In a corrupted
+    # baseline-set where binaries/ was itself staged as a plain file (not
+    # a directory), this member would then "resolve" to that file --
+    # meaning the advertised binaries-dir output points at a file, not a
+    # directory containing member binaries (Codex review, fourth round).
+    _write_manifest(
+        tmp_path,
+        artifacts=[_target_artifact("libpvxs", extra={"binary": "binaries"})],
+    )
+    (tmp_path / "binaries").write_bytes(b"\x7fELF-fake")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -880,6 +880,35 @@ def test_resolve_bundle_ambiguous_duplicate_manifest_entries(tmp_path: Path) -> 
     assert "multiple artifacts" in result.message
 
 
+def test_resolve_bundle_duplicate_entries_reported_even_when_first_lacks_binary(
+    tmp_path: Path,
+) -> None:
+    # artifact_for() returns only the first matching row -- if that row
+    # happens to lack "binary" while a later duplicate has one, the
+    # duplicate-entry check must still win over the generic "no staged
+    # binary declared" message, not silently depend on manifest row order
+    # (CodeRabbit review).
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact("libpvxs", extra={"binary": ""}),
+            _target_artifact("libpvxs", extra={"binary": "binaries/b.so"}),
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    (tmp_path / "binaries" / "b.so").write_bytes(b"\x7fELF-fake")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "multiple artifacts" in result.message
+    assert "no staged binary declared" not in result.message
+
+
 def test_resolve_bundle_rejects_non_elf_binary_no_digest(tmp_path: Path) -> None:
     # build_bundle_snapshot() (abicheck/bundle.py) silently skips any staged
     # input that isn't a real ELF file -- a non-ELF file staged under

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -34,10 +34,12 @@ from abicheck import serialization
 from abicheck.buildsource.baseline_set import (
     BASELINE_MANIFEST_FILENAME,
     ResolveOutcome,
+    ResolveResult,
     compute_snapshot_content_hash,
     load_baseline_manifest,
     resolve_bundle,
     resolve_target,
+    strip_volatile_snapshot_fields,
 )
 from abicheck.elf_metadata import (
     ElfMetadata,
@@ -282,6 +284,16 @@ def test_resolve_target_ambiguous_snapshot_file_missing_on_disk(tmp_path: Path) 
     assert result.outcome == ResolveOutcome.AMBIGUOUS
 
 
+def test_resolve_target_ambiguous_empty_snapshot_filename(tmp_path: Path) -> None:
+    # A manifest entry with a "library"/"artifact" but an empty "snapshot"
+    # filename (snapshot=False) is a distinct problem from a missing file on
+    # disk -- the manifest itself never named one.
+    _write_manifest(tmp_path, artifacts=[_target_artifact("libpvxs", snapshot=False)])
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "no snapshot filename" in result.message
+
+
 def test_resolve_target_ambiguous_duplicate_manifest_entries(tmp_path: Path) -> None:
     # A real actions/baseline-produced manifest can never have two entries
     # for the same library (run.sh's own input validation already rejects
@@ -361,6 +373,54 @@ def test_resolve_target_version_mismatch_alone_is_not_incompatible(
             "tool": "abicheck-cc",
             "version": "0.6.0",
         },
+    )
+    assert result.outcome == ResolveOutcome.RESOLVED
+
+
+def test_resolve_target_incompatible_evidence_noop_when_candidate_kind_empty(
+    tmp_path: Path,
+) -> None:
+    # An empty/missing candidate "kind" has nothing to compare against --
+    # must no-op (resolve normally), not treat an unset field as a mismatch.
+    _write_manifest(
+        tmp_path,
+        fact_set={
+            "name": "pvxs",
+            "version": 3,
+            "producer": "wrapper",
+            "producer_version": "0.5.0",
+        },
+        artifacts=[_target_artifact("libpvxs")],
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+    result = resolve_target(
+        tmp_path,
+        target="libpvxs",
+        profile=PROFILE,
+        required=True,
+        candidate_evidence_producer={"kind": "", "tool": "abicheck"},
+    )
+    assert result.outcome == ResolveOutcome.RESOLVED
+
+
+def test_resolve_target_incompatible_evidence_noop_when_baseline_producer_empty(
+    tmp_path: Path,
+) -> None:
+    # A baseline fact_set with no (or empty) "producer" recorded has nothing
+    # to compare against either -- an older/hand-authored manifest, not an
+    # incompatibility.
+    _write_manifest(
+        tmp_path,
+        fact_set={"name": "pvxs", "version": 3, "producer": ""},
+        artifacts=[_target_artifact("libpvxs")],
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text("{}", encoding="utf-8")
+    result = resolve_target(
+        tmp_path,
+        target="libpvxs",
+        profile=PROFILE,
+        required=True,
+        candidate_evidence_producer={"kind": "wrapper", "tool": "abicheck"},
     )
     assert result.outcome == ResolveOutcome.RESOLVED
 
@@ -556,6 +616,154 @@ def test_resolve_target_digest_ignores_volatile_fields(tmp_path: Path) -> None:
     )
     result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
     assert result.outcome == ResolveOutcome.RESOLVED
+
+
+def test_resolve_target_digest_check_rejects_snapshot_that_is_not_a_json_object(
+    tmp_path: Path,
+) -> None:
+    # A snapshot file that parses as valid JSON but isn't an object (e.g. an
+    # array) must still be reported as corrupt, not crash or silently
+    # compare against something with no library/schema_version fields.
+    _write_manifest(
+        tmp_path,
+        artifacts=[_target_artifact("libpvxs", extra={"sha256": "0" * 64})],
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text("[1, 2, 3]", encoding="utf-8")
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "JSON object" in result.message
+
+
+def test_strip_volatile_snapshot_fields_strips_nested_build_source_coverage(
+    tmp_path: Path,
+) -> None:
+    # compute_snapshot_content_hash's stable view must strip volatile fields
+    # nested under build_source_pack/build_source.manifest(.coverage/
+    # .extractors)/build_source.source_abi.coverage too, not just the
+    # top-level keys -- a re-dump with fresh build-evidence timing/cache
+    # counters but otherwise identical content must still verify.
+    raw = {
+        "library": "libpvxs",
+        "created_at": "2026-01-01T00:00:00Z",
+        "build_source_pack": {"path_hint": "/tmp/run1", "kind": "embedded"},
+        "build_source": {
+            "manifest": {
+                "created_at": "2026-01-01T00:00:00Z",
+                "targets": 1,
+                "coverage": [{"detail": "x", "elapsed_s": 1.0, "state": "ok"}],
+                "extractors": [
+                    {
+                        "detail": "y",
+                        "started_at": "t0",
+                        "finished_at": "t1",
+                        "name": "clang",
+                    }
+                ],
+            },
+            "source_abi": {
+                "coverage": {
+                    "cache_lookup_s": 0.1,
+                    "extract_s": 0.2,
+                    "link_s": 0.3,
+                    "elapsed_s": 0.6,
+                    "cache_misses": 2,
+                    "cache_hits": 5,
+                    "extractor_jobs": 4,
+                    "units": 10,
+                },
+            },
+        },
+    }
+    redumped = {
+        "library": "libpvxs",
+        "created_at": "2026-07-22T12:00:00Z",
+        "build_source_pack": {"path_hint": "/tmp/run2", "kind": "embedded"},
+        "build_source": {
+            "manifest": {
+                "created_at": "2026-07-22T12:00:00Z",
+                "targets": 1,
+                "coverage": [{"detail": "z", "elapsed_s": 9.9, "state": "ok"}],
+                "extractors": [
+                    {
+                        "detail": "w",
+                        "started_at": "t9",
+                        "finished_at": "t10",
+                        "name": "clang",
+                    }
+                ],
+            },
+            "source_abi": {
+                "coverage": {
+                    "cache_lookup_s": 9.0,
+                    "extract_s": 9.0,
+                    "link_s": 9.0,
+                    "elapsed_s": 9.0,
+                    "cache_misses": 99,
+                    "cache_hits": 99,
+                    "extractor_jobs": 99,
+                    "units": 10,
+                },
+            },
+        },
+    }
+    stable_1 = strip_volatile_snapshot_fields(raw)
+    stable_2 = strip_volatile_snapshot_fields(redumped)
+    assert stable_1 == stable_2
+    assert "path_hint" not in stable_1["build_source_pack"]
+    assert stable_1["build_source_pack"]["kind"] == "embedded"
+    assert "created_at" not in stable_1["build_source"]["manifest"]
+    assert stable_1["build_source"]["manifest"]["coverage"] == [{"state": "ok"}]
+    assert stable_1["build_source"]["manifest"]["extractors"] == [{"name": "clang"}]
+    assert stable_1["build_source"]["source_abi"]["coverage"] == {"units": 10}
+    assert compute_snapshot_content_hash(raw) == compute_snapshot_content_hash(redumped)
+
+
+def test_strip_volatile_snapshot_fields_tolerates_malformed_shapes() -> None:
+    # Defensive fallbacks for a hand-edited/corrupt manifest whose nested
+    # fields don't match the producer's real shape -- must pass the
+    # malformed value through unchanged rather than raising, mirroring this
+    # whole module's "never crash on corrupt content" convention.
+    raw = {
+        "library": "libpvxs",
+        "build_source": {
+            # coverage/extractors as non-list values -- _strip_row_keys must
+            # return them unchanged instead of assuming list-of-dict shape.
+            "manifest": {"coverage": "not-a-list", "extractors": 42},
+            # source_abi missing entirely is the common case (already
+            # covered elsewhere); here it's present but not a dict.
+            "source_abi": "not-a-dict",
+        },
+    }
+    stable = strip_volatile_snapshot_fields(raw)
+    assert stable["build_source"]["manifest"]["coverage"] == "not-a-list"
+    assert stable["build_source"]["manifest"]["extractors"] == 42
+    assert stable["build_source"]["source_abi"] == "not-a-dict"
+
+    raw_coverage_not_dict = {
+        "library": "libpvxs",
+        "build_source": {"source_abi": {"coverage": "not-a-dict"}},
+    }
+    stable_2 = strip_volatile_snapshot_fields(raw_coverage_not_dict)
+    assert stable_2["build_source"]["source_abi"]["coverage"] == "not-a-dict"
+
+
+def test_resolve_result_to_dict(tmp_path: Path) -> None:
+    result = ResolveResult(
+        outcome=ResolveOutcome.RESOLVED,
+        message="resolved target 'libpvxs'.",
+        bootstrap=False,
+        manifest_path=str(tmp_path / "manifest.json"),
+        snapshot_path=str(tmp_path / "libpvxs.abicheck.json"),
+    )
+    assert result.to_dict() == {
+        "outcome": ResolveOutcome.RESOLVED,
+        "message": "resolved target 'libpvxs'.",
+        "bootstrap": False,
+        "manifest_path": str(tmp_path / "manifest.json"),
+        "snapshot_path": str(tmp_path / "libpvxs.abicheck.json"),
+        "binaries_dir": "",
+        "binary_paths": {},
+    }
 
 
 def test_resolve_target_corrupt_manifest_is_stale_schema_not_a_traceback(
@@ -1017,6 +1225,124 @@ def test_resolve_bundle_rejects_truncated_elf_binary(
     )
     assert result.outcome == ResolveOutcome.AMBIGUOUS
     assert "essentially empty ELF file" in result.message
+
+
+def test_resolve_bundle_binary_digest_os_error_is_ambiguous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A permission error (or the file disappearing mid-read) while hashing a
+    # staged binary must produce the same typed ambiguous outcome as any
+    # other corrupt binary, not an unhandled OSError. Simulated via
+    # monkeypatch since a real permission error isn't reliably reproducible
+    # when tests run as root (same rationale as
+    # test_load_baseline_manifest_os_error_raises_value_error).
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact(
+                "libpvxs",
+                extra={"binary": "binaries/libpvxs.so", "sha256": "0" * 64},
+            )
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    binary_path = tmp_path / "binaries" / "libpvxs.so"
+    binary_path.write_bytes(b"\x7fELF-fake")
+    real_open = Path.open
+    # _not_elf_issue opens+reads the same binary_path first (a 4-byte magic
+    # sniff) before _binary_digest_issue's own whole-file read -- let that
+    # first open succeed for real (so the ELF check passes normally, given
+    # the autouse fixture's non-empty ElfMetadata stub) and only fail
+    # starting from the second open of this path, which is the digest read
+    # this test is actually about.
+    open_count = 0
+
+    def _boom(self: Path, *args: object, **kwargs: object) -> object:
+        nonlocal open_count
+        if self == binary_path:
+            open_count += 1
+            if open_count > 1:
+                raise PermissionError("synthetic permission error")
+        return real_open(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", _boom)
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "could not be read to verify its digest" in result.message
+
+
+def test_resolve_bundle_not_elf_os_error_is_ambiguous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A permission error while reading the ELF-magic header must be caught
+    # too, not just the digest read (same rationale as the digest-OSError
+    # test above). No recorded digest, so _not_elf_issue's own read is the
+    # first one reached.
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact("libpvxs", extra={"binary": "binaries/libpvxs.so"})
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    binary_path = tmp_path / "binaries" / "libpvxs.so"
+    binary_path.write_bytes(b"\x7fELF-fake")
+    real_open = Path.open
+
+    def _boom(self: Path, *args: object, **kwargs: object) -> object:
+        if self == binary_path:
+            raise PermissionError("synthetic permission error")
+        return real_open(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", _boom)
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "could not be read to verify it is an ELF file" in result.message
+
+
+def test_resolve_bundle_not_elf_unexpected_parse_exception_is_ambiguous(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # parse_elf_metadata's own documented contract is "returns an empty
+    # ElfMetadata on any parse error" (it catches ELFError/OSError/
+    # ValueError internally) -- but a sufficiently pathological/adversarial
+    # input could still trip an exception type outside that tuple deep in
+    # pyelftools. _not_elf_issue's own except Exception clause is defensive
+    # coverage for that case; simulated directly since crafting real bytes
+    # that reproduce it is impractical.
+    def _boom(path: Path) -> object:
+        raise RuntimeError("synthetic unexpected parser failure")
+
+    monkeypatch.setattr("abicheck.buildsource.baseline_set.parse_elf_metadata", _boom)
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact("libpvxs", extra={"binary": "binaries/libpvxs.so"})
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    (tmp_path / "binaries" / "libpvxs.so").write_bytes(b"\x7fELF-fake")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "could not be parsed as a valid ELF file" in result.message
 
 
 def test_resolve_bundle_rejects_binary_field_equal_to_binaries_dir_itself(

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -24,6 +24,7 @@ orchestration this module's logic backs.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -106,6 +107,29 @@ def test_load_baseline_manifest_invalid_utf8_raises_value_error(tmp_path: Path) 
     # just malformed-but-valid-UTF-8 JSON (Codex review).
     (tmp_path / BASELINE_MANIFEST_FILENAME).write_bytes(b"\xff\xfe\x00not valid utf-8")
     with pytest.raises(ValueError, match="not valid JSON"):
+        load_baseline_manifest(tmp_path)
+
+
+def test_load_baseline_manifest_os_error_raises_value_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # OSError (e.g. a permission error, or the file disappearing between the
+    # is_file() check and open() -- a restored archive/cache race) is raised
+    # by open() itself, before JSON decoding even starts -- must be caught
+    # too, or a manifest that exists but can't be read escapes this
+    # function's documented ValueError contract (Codex review). Simulated
+    # via monkeypatch since a real permission error isn't reliably
+    # reproducible when tests run as root.
+    (tmp_path / BASELINE_MANIFEST_FILENAME).write_text("{}", encoding="utf-8")
+    real_open = Path.open
+
+    def _boom(self: Path, *args: object, **kwargs: object) -> object:
+        if self.name == BASELINE_MANIFEST_FILENAME:
+            raise PermissionError("synthetic permission error")
+        return real_open(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "open", _boom)
+    with pytest.raises(ValueError, match="could not be read"):
         load_baseline_manifest(tmp_path)
 
 
@@ -663,6 +687,57 @@ def test_resolve_bundle_rejects_binary_outside_binaries_dir(tmp_path: Path) -> N
         artifacts=[_target_artifact("libpvxs", extra={"binary": "libpvxs.so"})],
     )
     (tmp_path / "libpvxs.so").write_bytes(b"\x7fELF-fake")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+
+
+def test_resolve_bundle_digest_match_resolves(tmp_path: Path) -> None:
+    content = b"\x7fELF-fake-binary-contents"
+    real_digest = hashlib.sha256(content).hexdigest()
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact(
+                "libpvxs",
+                extra={"binary": "binaries/libpvxs.so.1.5", "sha256": real_digest},
+            )
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    (tmp_path / "binaries" / "libpvxs.so.1.5").write_bytes(content)
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.RESOLVED
+
+
+def test_resolve_bundle_digest_mismatch_is_ambiguous(tmp_path: Path) -> None:
+    # A truncated/replaced staged binary (partial download, stale cache
+    # restore) must never resolve just because a file with the right name
+    # exists under binaries/ -- the manifest's recorded digest is what
+    # actually vouches for its content (Codex review, mirroring the
+    # target-snapshot digest-verification finding).
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact(
+                "libpvxs",
+                extra={"binary": "binaries/libpvxs.so.1.5", "sha256": "0" * 64},
+            )
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    (tmp_path / "binaries" / "libpvxs.so.1.5").write_bytes(b"\x7fELF-fake")
     result = resolve_bundle(
         tmp_path,
         bundle="pvxs-release",

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -32,6 +32,7 @@ import pytest
 from abicheck.buildsource.baseline_set import (
     BASELINE_MANIFEST_FILENAME,
     ResolveOutcome,
+    compute_snapshot_content_hash,
     load_baseline_manifest,
     resolve_bundle,
     resolve_target,
@@ -65,11 +66,19 @@ def _write_manifest(
 def _target_artifact(
     name: str, *, snapshot: bool = True, extra: dict | None = None
 ) -> dict:
+    # No "sha256" by default -- an empty/absent recorded digest means
+    # resolve_target()'s digest-verification check has nothing to compare
+    # against and no-ops (see _snapshot_digest_issue), so tests that aren't
+    # specifically about digest verification aren't coupled to the exact
+    # bytes a fixture snapshot happens to contain. Tests that DO want digest
+    # verification pass extra={"sha256": compute_snapshot_content_hash(...)}
+    # explicitly (see the TestSnapshotDigestVerification-equivalent cases
+    # below).
     entry = {
         "library": name,
         "artifact": f"build/{name}.so",
         "snapshot": f"{name}.abicheck.json" if snapshot else "",
-        "sha256": "deadbeef",
+        "sha256": "",
     }
     if extra:
         entry.update(extra)
@@ -275,6 +284,88 @@ def test_resolve_target_resolved(tmp_path: Path) -> None:
     assert result.bootstrap is False
     assert result.snapshot_path == str(tmp_path / "libpvxs.abicheck.json")
     assert result.manifest_path == str(tmp_path / BASELINE_MANIFEST_FILENAME)
+
+
+def test_resolve_target_digest_match_resolves(tmp_path: Path) -> None:
+    snapshot_content = {"library": "libpvxs", "schema_version": 9}
+    real_digest = compute_snapshot_content_hash(snapshot_content)
+    _write_manifest(
+        tmp_path,
+        artifacts=[_target_artifact("libpvxs", extra={"sha256": real_digest})],
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text(
+        json.dumps(snapshot_content), encoding="utf-8"
+    )
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.RESOLVED
+
+
+def test_resolve_target_digest_mismatch_is_ambiguous(tmp_path: Path) -> None:
+    # A truncated/replaced snapshot file (partial download, stale cache
+    # restore) must never resolve just because a file with the right name
+    # exists -- the manifest's recorded digest is what actually vouches for
+    # its content (Codex review).
+    _write_manifest(
+        tmp_path,
+        artifacts=[_target_artifact("libpvxs", extra={"sha256": "0" * 64})],
+    )
+    (tmp_path / "libpvxs.abicheck.json").write_text(
+        json.dumps({"library": "libpvxs", "schema_version": 9}), encoding="utf-8"
+    )
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "digest does not match" in result.message
+
+
+def test_resolve_target_digest_ignores_volatile_fields(tmp_path: Path) -> None:
+    # created_at is stripped before hashing (same convention as
+    # actions/baseline/build_manifest.py) -- a snapshot re-dumped with a
+    # fresh timestamp but otherwise identical content must still verify.
+    original = {
+        "library": "libpvxs",
+        "schema_version": 9,
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+    real_digest = compute_snapshot_content_hash(original)
+    _write_manifest(
+        tmp_path,
+        artifacts=[_target_artifact("libpvxs", extra={"sha256": real_digest})],
+    )
+    redumped = {
+        "library": "libpvxs",
+        "schema_version": 9,
+        "created_at": "2026-07-22T12:00:00Z",
+    }
+    (tmp_path / "libpvxs.abicheck.json").write_text(
+        json.dumps(redumped), encoding="utf-8"
+    )
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.RESOLVED
+
+
+def test_resolve_target_corrupt_manifest_is_stale_schema_not_a_traceback(
+    tmp_path: Path,
+) -> None:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / BASELINE_MANIFEST_FILENAME).write_text(
+        "{not valid json", encoding="utf-8"
+    )
+    result = resolve_target(tmp_path, target="libpvxs", profile=PROFILE, required=True)
+    assert result.outcome == ResolveOutcome.STALE_SCHEMA
+    assert not result.ok
+
+
+def test_resolve_bundle_corrupt_manifest_is_stale_schema(tmp_path: Path) -> None:
+    tmp_path.mkdir(parents=True, exist_ok=True)
+    (tmp_path / BASELINE_MANIFEST_FILENAME).write_text("[]", encoding="utf-8")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.STALE_SCHEMA
 
 
 # ── resolve_bundle ────────────────────────────────────────────────────────

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -831,3 +831,57 @@ def test_resolve_bundle_ambiguous_duplicate_manifest_entries(tmp_path: Path) -> 
     )
     assert result.outcome == ResolveOutcome.AMBIGUOUS
     assert "multiple artifacts" in result.message
+
+
+def test_resolve_bundle_rejects_non_elf_binary_no_digest(tmp_path: Path) -> None:
+    # build_bundle_snapshot() (abicheck/bundle.py) silently skips any staged
+    # input that isn't a real ELF file -- a non-ELF file staged under
+    # binaries/ must not resolve just because a file with the right name
+    # exists and the manifest recorded no digest to catch it (Codex review).
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact("libpvxs", extra={"binary": "binaries/libpvxs.so"})
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    (tmp_path / "binaries" / "libpvxs.so").write_bytes(b"not an elf file at all")
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "not an ELF file" in result.message
+
+
+def test_resolve_bundle_rejects_non_elf_binary_matching_digest(tmp_path: Path) -> None:
+    # Even when the recorded digest matches the non-ELF bytes exactly (e.g.
+    # a JSON snapshot was staged at the binary path and the manifest was
+    # built from that same file), the ELF-magic check must still catch it --
+    # a matching digest only proves the staged bytes are what the manifest
+    # expects, not that they're a binary build_bundle_snapshot() can read.
+    content = b"{}"
+    digest = hashlib.sha256(content).hexdigest()
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact(
+                "libpvxs",
+                extra={"binary": "binaries/libpvxs.so", "sha256": digest},
+            )
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    (tmp_path / "binaries" / "libpvxs.so").write_bytes(content)
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "not an ELF file" in result.message

--- a/tests/test_baseline_set.py
+++ b/tests/test_baseline_set.py
@@ -39,8 +39,29 @@ from abicheck.buildsource.baseline_set import (
     resolve_bundle,
     resolve_target,
 )
+from abicheck.elf_metadata import (
+    ElfMetadata,
+    parse_elf_metadata as _real_parse_elf_metadata,
+)
 
 PROFILE = "linux-x86_64-gcc13-release"
+
+
+@pytest.fixture(autouse=True)
+def _stub_bundle_elf_parse(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bundle-resolution tests stage placeholder bytes (not a real ELF
+    structure) under ``binaries/`` -- stub the deep ELF parse
+    ``_not_elf_issue()`` runs (added to catch truncated/corrupted staged
+    binaries that still pass the magic-byte sniff, Codex review) so those
+    tests exercise ``resolve_bundle()``'s path/digest/output plumbing
+    rather than requiring a hand-built, fully valid ELF fixture.
+    ``test_resolve_bundle_rejects_truncated_elf_binary`` below restores
+    the real parser to test the deep-parse guard itself.
+    """
+    monkeypatch.setattr(
+        "abicheck.buildsource.baseline_set.parse_elf_metadata",
+        lambda path: ElfMetadata(soname=path.name),
+    )
 
 
 def _write_manifest(
@@ -961,3 +982,38 @@ def test_resolve_bundle_rejects_non_elf_binary_matching_digest(tmp_path: Path) -
     )
     assert result.outcome == ResolveOutcome.AMBIGUOUS
     assert "not an ELF file" in result.message
+
+
+def test_resolve_bundle_rejects_truncated_elf_binary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A bare magic-byte sniff isn't enough: a truncated/corrupted staged
+    # binary can still start with \x7fELF while being unparseable (or
+    # parsing to essentially-empty metadata) -- build_bundle_snapshot()
+    # would silently skip it just the same as a non-ELF file, so this must
+    # be caught too, not just the missing-magic case (Codex review, second
+    # round). Restores the real parser (undoing the autouse stub) since
+    # this test is specifically about the deep-parse guard.
+    monkeypatch.setattr(
+        "abicheck.buildsource.baseline_set.parse_elf_metadata",
+        _real_parse_elf_metadata,
+    )
+    _write_manifest(
+        tmp_path,
+        artifacts=[
+            _target_artifact("libpvxs", extra={"binary": "binaries/libpvxs.so"})
+        ],
+    )
+    (tmp_path / "binaries").mkdir()
+    (tmp_path / "binaries" / "libpvxs.so").write_bytes(
+        b"\x7fELF-truncated-not-a-real-elf-structure"
+    )
+    result = resolve_bundle(
+        tmp_path,
+        bundle="pvxs-release",
+        members=["libpvxs"],
+        profile=PROFILE,
+        required=True,
+    )
+    assert result.outcome == ResolveOutcome.AMBIGUOUS
+    assert "essentially empty ELF file" in result.message


### PR DESCRIPTION
## Summary

New `actions/resolve-baseline` composite Action — the next primitive in the G30 GitHub Actions integration model backlog (ADR-047), continuing from P1.1 (`build-output.json`, #611) and P1.5 (`.abicheck.yml` `targets:`/`profiles:`/`baseline:`, #616).

## Motivation

ADR-047 §4/§6 defines `resolve-baseline` as a new primitive: resolving `channel × target/bundle × profile` to a baseline, distinguishing `not_found`/`ambiguous`/`wrong_profile`/`stale_schema`/`incompatible_evidence` as typed failure outcomes instead of ever falling through to `compare`'s own generic missing-file error or silently treating "no baseline" as "compatible." This logic was previously only inlined once, inside the root Action's `abi-baseline` handling — separating it lets a future `check-target` (P1.3, not built yet) treat baseline resolution as a distinct, typed step.

## Changes

- **New `abicheck/buildsource/baseline_set.py`** — the shared, pure resolver: reads a baseline-set's `manifest.json` defensively (never raises on a corrupt/hand-edited file) and implements `resolve_target()`/`resolve_bundle()` covering all six outcomes of ADR-047 §6's table.
- **New `actions/resolve-baseline/`** (`action.yml`, `run.sh`, `resolve_baseline.py`) — the composite Action. `baseline-path` accepts either an already-staged directory or a `.tar.zst`/`.tar.gz`/`.tgz`/`.tar` archive (extracted in `run.sh`, with a one-level nested-directory descent). This Action never fetches from a channel's storage backend itself — that stays the calling workflow's job (`actions/cache`, `actions/download-artifact`, `gh release download`), per ADR-047 §10.
- **Bundle-scoped resolution (S14)** returns every member's staged **binary** path under `binaries/`, never a JSON snapshot — `abicheck/bundle.py`'s `build_bundle_snapshot()` skips non-ELF inputs, so a bundle baseline must preserve real binaries. `actions/baseline` doesn't populate `binaries/` yet (G30 P1.6); bundle resolution is exercised here against a hand-authored fixture, the same "defines the contract, no producer yet" scoping P1.1 used for `build-output.json`.
- **`incompatible_evidence` detection** via a new `candidate-build-output` input (reads the candidate's `evidence_producer` block only) compared against the baseline's recorded `fact_set.producer`/`producer_version`.
- New `docs/reference/resolve-baseline.md` (linked from mkdocs nav) documents the Action's contract and failure taxonomy.
- G30 plan doc's P1.2 section marked done with implementation notes.

## Tests

- `tests/test_baseline_set.py` — 21 pure unit tests covering every resolver branch (both `resolve_target`/`resolve_bundle`).
- `tests/test_action_resolve_baseline.py` — 16 subprocess-level tests covering the bash orchestration end-to-end: one test per ADR-047 §6 failure-taxonomy row, bundle resolution, and archive extraction (flat and one-level-nested).
- `mkdocs build --strict` and `python scripts/check_ai_readiness.py` both clean (0 errors, no new warnings).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`docs/reference/resolve-baseline.md`, mkdocs nav, G30 plan doc)
- [x] `ruff check`/`ruff format --check`/`mypy abicheck/` pass on changed files
- [ ] Full `scripts/verify.py --profile fast` run — in progress; will report back if it surfaces anything


---
_Generated by [Claude Code](https://claude.ai/code/session_01SuKifbiGGu2kaLzR48Hfzf)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `resolve-baseline` composite GitHub Action for resolving staged `channel × target/bundle × profile` baselines with explicit typed outcomes.
  * Supports archive extraction (tar/tgz/tar.zst), nested manifest layouts, and bundle member resolution that reports staged member binaries.
* **Documentation**
  * Added reference docs and updated the integration plan and site navigation.
* **Bug Fixes / Hardening**
  * Strengthened manifest/snapshot integrity verification and improved safety checks for artifact paths.
* **Tests**
  * Added unit and end-to-end coverage for the full failure taxonomy, archive handling, and digest verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->