### PR TITLE
docs: ADR-050 comparability contract + G32 multi-TU manifest plan

### DIFF
--- a/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
@@ -117,6 +117,25 @@ default for ordinary additive fields, per ADR-041's `extractor_passes`
 precedent) — only the specific jump that first introduces a
 verdict-blocking field becomes a hard failure for an older reader.
 
+**Known, permanent limitation — not something a later phase can close.**
+This guard protects any reader running Phase-A-or-later code: it makes
+*that* code hard-reject a schema it doesn't support instead of warning past
+it, and is the right pattern for any *future* comparability-critical bump.
+It does **not**, and structurally cannot, protect an already-deployed
+pre-Phase-A binary — that binary's `snapshot_from_dict` has no
+`_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION` check compiled into it at
+all, only the unconditional warn-and-continue branch, and no change to
+future abicheck releases can retroactively alter code already running
+elsewhere. A fleet where some environments have upgraded past Phase A and
+others haven't can still see a not-yet-upgraded reader silently produce an
+ordinary verdict on a `contract`-bearing snapshot. This is the same
+unavoidable boundary every additive capability gate has (an abicheck old
+enough to predate `DumpDepthNotSatisfiedError` doesn't enforce it either)
+— the mitigation is operational (upgrade a comparison pipeline's producer
+and consumer together), not something this ADR's on-disk format can
+guarantee unilaterally. Documented here so it's a known, accepted limit,
+not a latent surprise discovered after Phase A ships.
+
 - `profile_fingerprint: str` — a `sha256:`-prefixed digest of the
   **resolved** compile context: compiler family/version, target triple,
   `abi_dialect` (Itanium/MSVC), language standard, pointer width/endianness,
@@ -145,12 +164,23 @@ verdict-blocking field becomes a hard failure for an older reader.
   comment, must not change the fingerprint; reordering includes *within*
   one TU, or changing either flag, must.
 
-Both fingerprints live in a new `contract: ExtractionContract` sub-object on
-`AbiSnapshot` rather than flattening two more top-level fields onto an
-already-large dataclass — this is the one new nested type this ADR
-introduces on the model, deliberately scoped to just the two fingerprints
-plus the resolved fields that produce them (so a report can show *what*
-differs, not just that the hashes don't match).
+Both fingerprints live in a new `contract: ExtractionContract | None` field
+on `AbiSnapshot` rather than flattening two more top-level fields onto an
+already-large dataclass — `ExtractionContract` is the one new nested type
+this ADR introduces on the model, deliberately scoped to just the two
+fingerprints plus the resolved fields that produce them (so a report can
+show *what* differs, not just that the hashes don't match).
+
+**Modeling the field is not the same as populating it, and this ADR
+requires both.** `dump()` (`dumper.py`) is the one place that already
+resolves every input both fingerprints are computed from — it must call
+`comparability.compute_extraction_contract(...)` and attach the result to
+the `AbiSnapshot` it returns, for every dump, not only a manifest-driven
+one (D3). Without this wired in from D1, `contract` stays `None` on every
+freshly-produced snapshot, and since D2's gate only ever raises when
+**both** sides carry a `contract`, two perfectly ordinary dumps would
+silently take the same code path as the intentionally-lenient mixed-pair
+case (D2) forever — the gate would be fully specified and fully inert.
 
 ### D2. Comparability gate — hard-fail before symbol diff, not a RISK finding
 
@@ -176,7 +206,17 @@ one: `abicheck/schemas/compare_report.schema.json` currently requires
 `tests/test_report_schema.py` validates emitted reports against exactly
 that file — both must change in the same phase that starts emitting
 `not_comparable`, or JSON output goes invalid (or the published schema goes
-stale) the moment the gate first fires.
+stale) the moment the gate first fires. **The exit code is part of this
+same contract and must be pinned explicitly, not left implicit.**
+`docs/reference/exit-codes.md` documents two co-existing `compare` exit
+schemes (legacy: 0/2/4; severity-aware, with any `--severity-*` flag:
+0/1/2/4) where `0` means *compatible* in both — a `not_comparable` result
+must never exit `0` in either scheme, or the exact failure mode this ADR
+exists to prevent (missing evidence reading as "safe") reappears one layer
+down, at the process-exit boundary instead of the JSON `verdict` field. D2
+reserves a new, distinct nonzero code for `not_comparable`, documented as
+its own row in both exit-code tables, not folded into either existing
+scheme's numbering.
 
 **Mixed pairs (one side has a `contract`, the other doesn't) never hard-fail
 — this is unambiguous, not left to implementer discretion.** The backward-
@@ -197,7 +237,16 @@ an otherwise-ordinary verdict — same shape and same authority-rule
 justification as the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`
 (`checker_policy.py:618`) — surfaced only for a mixed pair, to tell the
 reader "this comparison ran without being able to check profile/scope
-drift on one side," without withholding the verdict itself.
+drift on one side," without withholding the verdict itself. Since
+`SOURCE_FACT_COVERAGE_INCOMPLETE` is itself a real `ChangeKind`, not a
+free-floating report string, `UNKNOWN_PROFILE` is registered the same way,
+through the repository's standard four-step procedure (`ChangeKind` enum
+entry in `checker_policy.py`, one `ChangeKindMeta` entry in a
+`change_registry*.py` module with `default_verdict` placing it in
+`RISK_KINDS`, a detector in `comparability.py` wired via
+`@registry.detector(...)`, and a unit test) — not an ad-hoc string that
+would trip the AI-readiness `changekind-partition`/`changekind-detector`
+gates or bypass the registry's completeness assertion.
 
 ### D3. Manifest and real multi-TU dump
 

--- a/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
@@ -178,12 +178,23 @@ routine `compare` invocation fingerprint-mismatch and hard-fail as
 the exact inverse of what it's for. Each side's header/include/forced-
 include paths are therefore normalized **relative to that side's own
 resolution root** before folding into either fingerprint: for the legacy,
-non-manifest CLI path, the root is the longest common path prefix of that
-side's own resolved header/include paths (a pure function of that side's
-own inputs, no new flag needed); for the manifest-driven path (D3), the
-root is the manifest file's own directory. Two sides with the same logical
-directory layout (`include/foo.h` under each side's own root) normalize to
-identical relative paths and produce equal fingerprints regardless of where
+non-manifest CLI path, the root is the common ancestor **directory** of
+that side's own inputs — each header path's *parent* directory and each
+include directory itself, not the header paths taken literally (a pure
+function of that side's own inputs, no new flag needed). Computing it from
+the header paths directly, rather than their parents, degenerates in the
+single-header-per-side case that's actually the common one: the "common
+prefix" of a one-element path set is that whole path, so `old=v1/foo.h`
+and `new=v2/bar.h` would both normalize their sole header to the same
+empty/root marker, losing the filename entirely — two genuinely different
+public scopes would then hash identically and wrongly pass the gate, the
+opposite failure from the one this fix exists to close. Taking the parent
+directory first means a lone header's basename survives normalization
+(`v1/foo.h` → root `v1/`, normalized path `foo.h`); for the manifest-driven
+path (D3), the root is the manifest file's own directory. Two sides with
+the same logical directory layout (`include/foo.h` under each side's own
+root) normalize to identical relative paths and produce equal fingerprints
+regardless of where
 each checkout happens to live on disk; a side whose logical layout actually
 differs (a header moved to a different relative location) still changes the
 fingerprint, correctly.
@@ -205,6 +216,26 @@ freshly-produced snapshot, and since D2's gate only ever raises when
 **both** sides carry a `contract`, two perfectly ordinary dumps would
 silently take the same code path as the intentionally-lenient mixed-pair
 case (D2) forever — the gate would be fully specified and fully inert.
+
+**The whole-snapshot cache is the same bypass by a different route, and it
+matters from day one, not just at D6's later cache-key extension.**
+`service_dump_cache.cached_run_dump` looks up `snapshot_cache` *before*
+calling `run_dump`/`dump()` and returns a cache hit unchanged — so a warm
+cache entry written by a pre-this-ADR abicheck (schema 11, no `contract`
+computed at all) served after upgrading to a version that implements this
+ADR would still come back with `contract=None`, for the same reason a
+never-populated `dump()` would: the code path that would have called
+`compute_extraction_contract(...)` never runs on a cache hit. D1 therefore
+also bumps `snapshot_cache._SNAPSHOT_CACHE_VERSION` (`:48`, currently
+`"3"`) in the same change — folded into `_cache_key()` (`:196`) already, so
+every pre-this-ADR cache entry misses exactly once and gets rebuilt through
+the now-`contract`-populating `dump()`. This is deliberately separate from
+D6's later `profile_fingerprint`/`scope_fingerprint`-as-cache-key-input
+work: that closes a *different* gap (a pure compile-profile change with
+identical header content not invalidating the cache); this one closes
+"the cache doesn't know `contract` exists yet at all," and cannot wait for
+D6's phase without leaving the gate inert for every warm-cache user in the
+interim.
 
 ### D2. Comparability gate — hard-fail before symbol diff, not a RISK finding
 

--- a/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
@@ -164,6 +164,30 @@ not a latent surprise discovered after Phase A ships.
   comment, must not change the fingerprint; reordering includes *within*
   one TU, or changing either flag, must.
 
+**Both fingerprints hash root-relative paths, never absolute or
+side-specific ones — this is not optional, it protects abicheck's single
+most common workflow.** `compare` already supports side-scoped
+`--header old=v1/foo.h --header new=v2/foo.h` and
+`--include old=inc1 --include new=inc2` (ADR-040, `cli_options.py:230+`)
+for the ordinary two-checkout-tree comparison — the old and new sides
+*necessarily* resolve to different absolute paths even when they cover the
+identical logical surface, precisely because they live in different
+checkouts. Hashing resolved absolute paths directly would make every
+routine `compare` invocation fingerprint-mismatch and hard-fail as
+`not_comparable` — the gate would break its primary use case on day one,
+the exact inverse of what it's for. Each side's header/include/forced-
+include paths are therefore normalized **relative to that side's own
+resolution root** before folding into either fingerprint: for the legacy,
+non-manifest CLI path, the root is the longest common path prefix of that
+side's own resolved header/include paths (a pure function of that side's
+own inputs, no new flag needed); for the manifest-driven path (D3), the
+root is the manifest file's own directory. Two sides with the same logical
+directory layout (`include/foo.h` under each side's own root) normalize to
+identical relative paths and produce equal fingerprints regardless of where
+each checkout happens to live on disk; a side whose logical layout actually
+differs (a header moved to a different relative location) still changes the
+fingerprint, correctly.
+
 Both fingerprints live in a new `contract: ExtractionContract | None` field
 on `AbiSnapshot` rather than flattening two more top-level fields onto an
 already-large dataclass — `ExtractionContract` is the one new nested type
@@ -206,7 +230,16 @@ one: `abicheck/schemas/compare_report.schema.json` currently requires
 `tests/test_report_schema.py` validates emitted reports against exactly
 that file — both must change in the same phase that starts emitting
 `not_comparable`, or JSON output goes invalid (or the published schema goes
-stale) the moment the gate first fires. **The exit code is part of this
+stale) the moment the gate first fires. This includes the schema's own
+version metadata, not just its `verdict` constraint:
+`abicheck/schemas/__init__.py`'s `REPORT_SCHEMA_VERSION` (currently
+`"2.12"`, a documented `MAJOR.MINOR` policy — every JSON report emits it as
+`report_schema_version`) is bumped in the same change, and the published
+mirror `docs/schemas/v1/compare_report.schema.json` is regenerated via the
+existing `scripts/publish_schemas.py` so it stays byte-identical to the
+packaged schema — `tests/test_report_schema.py`'s
+`test_docs_mirror_matches_packaged_schema` already asserts that identity
+and fails the build otherwise. **The exit code is part of this
 same contract and must be pinned explicitly, not left implicit.**
 `docs/reference/exit-codes.md` documents two co-existing `compare` exit
 schemes (legacy: 0/2/4; severity-aware, with any `--severity-*` flag:

--- a/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
@@ -296,21 +296,39 @@ as a pair where neither side carries one, and comparing a newly-produced
 snapshot against a pre-ADR baseline (the common "upgrade abicheck, keep the
 stored CI baseline" workflow) never regresses into an unexpected
 `not_comparable` result. `UNKNOWN_PROFILE` is **not** a `not_comparable`
-reason and never blocks: it is a RISK-tier, non-authoritative annotation on
-an otherwise-ordinary verdict — same shape and same authority-rule
-justification as the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`
-(`checker_policy.py:618`) — surfaced only for a mixed pair, to tell the
+reason and never blocks: it is a non-authoritative annotation on
+an otherwise-ordinary verdict, surfaced only for a mixed pair, to tell the
 reader "this comparison ran without being able to check profile/scope
-drift on one side," without withholding the verdict itself. Since
-`SOURCE_FACT_COVERAGE_INCOMPLETE` is itself a real `ChangeKind`, not a
-free-floating report string, `UNKNOWN_PROFILE` is registered the same way,
-through the repository's standard four-step procedure (`ChangeKind` enum
-entry in `checker_policy.py`, one `ChangeKindMeta` entry in a
-`change_registry*.py` module with `default_verdict` placing it in
-`RISK_KINDS`, a detector in `comparability.py` wired via
-`@registry.detector(...)`, and a unit test) — not an ad-hoc string that
-would trip the AI-readiness `changekind-partition`/`changekind-detector`
-gates or bypass the registry's completeness assertion.
+drift on one side," without withholding the verdict itself.
+
+**`UNKNOWN_PROFILE` is `COMPATIBLE_KINDS`/`QUALITY_KINDS`-tier, deliberately
+not `RISK_KINDS`, even though it is registered the same way and reported
+the same way as the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`
+(`checker_policy.py:618`).** The two differ in what they mean, not just in
+name: `SOURCE_FACT_COVERAGE_INCOMPLETE` reports genuine *per-comparison*
+evidence uncertainty (a fact family that happened to fail or come back
+partial *this run*) — a `--severity-potential-breaking=error`/
+`--severity-preset strict` user reasonably wants that to fail their build,
+since it means this specific comparison can't be trusted. `UNKNOWN_PROFILE`
+is different in kind: it fires purely because one side predates this ADR,
+which is a one-time rollout artifact untied to any change in the library
+being compared, and will recur on *every* comparison against *every*
+not-yet-regenerated baseline until that baseline is refreshed. Classifying
+it `RISK_KINDS` would mean `potential_breaking` promotion turns it into a
+mass, abicheck-version-triggered CI failure the instant a team with strict
+severity settings upgrades — exactly the "upgrading abicheck breaks an
+unrelated, unchanged CI pipeline" regression this section's backward-
+compatibility promise exists to rule out, just relocated from the
+`not_comparable` layer to the severity-exit-code layer. `UNKNOWN_PROFILE`
+is therefore registered through the repository's standard four-step
+procedure (`ChangeKind` enum entry in `checker_policy.py`, one
+`ChangeKindMeta` entry in a `change_registry*.py` module with
+`default_verdict` placing it in `COMPATIBLE_KINDS`'s `QUALITY_KINDS`
+subset, a detector in `comparability.py` wired via
+`@registry.detector(...)`, and a unit test) — a real `ChangeKind`, not an
+ad-hoc string (avoiding the AI-readiness `changekind-partition`/
+`changekind-detector` gates), but one that never contributes to
+`potential_breaking` severity promotion under any `--severity-*` flag.
 
 ### D3. Manifest and real multi-TU dump
 

--- a/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
@@ -248,7 +248,32 @@ subclass at the CLI boundary (`cli.py`), a plain exception at the
 "Known gaps" section already names for the depth contract — this ADR's gate
 must not repeat that CLI-only mistake; D2 lands in `service.py`'s
 `ScanRequest`/`compare_snapshots` and `mcp_server.py`'s MCP tools from the
-start, not as a follow-up). On the reporting surface (`reporter.py`,
+start, not as a follow-up).
+
+**A fourth surface reaches `checker.compare` besides the three named
+above: `cli_compare_release.py`'s directory/package fan-out, and it needs
+its own explicit fix, not just inherited behavior.**
+`_compare_one_library` (`cli_compare_release.py:180-269`) wraps its entire
+per-library flow in `except (click.ClickException, click.UsageError):` /
+`except Exception:`, both returning `{"verdict": "ERROR", ...}` —
+documented at `:1142` as flooring the release's exit code at 4 "regardless
+of severity settings." `ProfileMismatchError`/`ScopeMismatchError` are
+plain exceptions (not `click.ClickException`), so today's broad
+`except Exception` would swallow them into the exact same `"ERROR"`/exit-4
+bucket as a genuine crash — meaning one incomparable library inside a
+release comparison would silently report as the *worst possible*
+classification (an ABI break) instead of `not_comparable`, precisely
+inverting this ADR's purpose on its one multi-library entry point.
+`_compare_one_library` therefore gains a dedicated
+`except (ProfileMismatchError, ScopeMismatchError) as exc:` branch, ordered
+before the generic `except Exception`, returning a distinct
+`{"verdict": "not_comparable", "reason": ...}` entry; the release-level
+aggregator and exit-code computation (`docs/reference/exit-codes.md`'s
+multi-library section) are extended to recognize that verdict value the
+same way the single-library path does, rather than folding it into
+`"ERROR"`.
+
+On the reporting surface (`reporter.py`,
 `sarif.py`, `junit_report.py`), a `not_comparable` result is a distinct
 top-level state — `verdict: null`, a `reason` object naming the mismatched
 fingerprint field(s) — never coerced into `COMPATIBLE`/`BREAKING`'s existing
@@ -301,34 +326,41 @@ an otherwise-ordinary verdict, surfaced only for a mixed pair, to tell the
 reader "this comparison ran without being able to check profile/scope
 drift on one side," without withholding the verdict itself.
 
-**`UNKNOWN_PROFILE` is `COMPATIBLE_KINDS`/`QUALITY_KINDS`-tier, deliberately
-not `RISK_KINDS`, even though it is registered the same way and reported
-the same way as the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`
-(`checker_policy.py:618`).** The two differ in what they mean, not just in
-name: `SOURCE_FACT_COVERAGE_INCOMPLETE` reports genuine *per-comparison*
-evidence uncertainty (a fact family that happened to fail or come back
-partial *this run*) — a `--severity-potential-breaking=error`/
-`--severity-preset strict` user reasonably wants that to fail their build,
-since it means this specific comparison can't be trusted. `UNKNOWN_PROFILE`
-is different in kind: it fires purely because one side predates this ADR,
-which is a one-time rollout artifact untied to any change in the library
-being compared, and will recur on *every* comparison against *every*
-not-yet-regenerated baseline until that baseline is refreshed. Classifying
-it `RISK_KINDS` would mean `potential_breaking` promotion turns it into a
-mass, abicheck-version-triggered CI failure the instant a team with strict
-severity settings upgrades — exactly the "upgrading abicheck breaks an
-unrelated, unchanged CI pipeline" regression this section's backward-
-compatibility promise exists to rule out, just relocated from the
-`not_comparable` layer to the severity-exit-code layer. `UNKNOWN_PROFILE`
-is therefore registered through the repository's standard four-step
-procedure (`ChangeKind` enum entry in `checker_policy.py`, one
-`ChangeKindMeta` entry in a `change_registry*.py` module with
-`default_verdict` placing it in `COMPATIBLE_KINDS`'s `QUALITY_KINDS`
-subset, a detector in `comparability.py` wired via
-`@registry.detector(...)`, and a unit test) — a real `ChangeKind`, not an
-ad-hoc string (avoiding the AI-readiness `changekind-partition`/
-`changekind-detector` gates), but one that never contributes to
-`potential_breaking` severity promotion under any `--severity-*` flag.
+**`UNKNOWN_PROFILE` is report-level metadata, not a `ChangeKind`/`Change`
+finding at all — this went through two wrong designs before landing here,
+worth recording so it isn't rediscovered.** The first attempt classified it
+`RISK_KINDS`, matching `SOURCE_FACT_COVERAGE_INCOMPLETE`
+(`checker_policy.py:618`)'s shape; that broke under
+`--severity-potential-breaking=error`/`--severity-preset strict`, which
+promotes any `RISK_KINDS` finding to a build failure (exit 2) — turning
+every comparison against a pre-this-ADR baseline into a mass,
+abicheck-version-triggered CI failure the instant a strict-severity team
+upgrades, exactly the "upgrading abicheck breaks an unrelated, unchanged
+pipeline" regression the backward-compatibility promise above exists to
+rule out. The second attempt reclassified it `COMPATIBLE_KINDS`'s
+`QUALITY_KINDS` subset instead, reasoning that `SOURCE_FACT_COVERAGE_INCOMPLETE`'s
+`RISK_KINDS` tier is justified by reporting genuine *per-comparison*
+evidence uncertainty (a fact family that failed or came back partial *this
+run*) — a "fair game to fail strict CI on" property `UNKNOWN_PROFILE`
+doesn't share, since it fires purely from being compared against a
+pre-ADR baseline, a one-time rollout artifact untied to any real change.
+That reclassification only relocated the same collision:
+`--severity-quality-issues=error`/`--severity-preset strict` promotes
+`QUALITY_KINDS` findings too (exit 1, "quality-only error") — proving the
+underlying problem was never "which `ChangeKind` category," it's that
+**every** category is reachable by *some* `--severity-*` flag, by design
+(that's the whole point of severity gating existing). No `ChangeKind`
+classification can be permanently severity-immune. `UNKNOWN_PROFILE`
+therefore isn't one: it's a new field on the comparison result (alongside
+the existing `assurance` field D2 already introduced for
+`--diagnostic-comparison`) — e.g. `contract_coverage: "partial"` — set
+whenever exactly one side carries a `contract`. It never enters the
+`changes`/findings list any `--severity-*` flag scans, so it is
+structurally, not just by convention, unreachable by severity promotion —
+true under every current and future severity flag, not merely the ones
+checked so far. `reporter.py`/`sarif.py`/`junit_report.py` surface it the
+same way they already surface `assurance` — a plain report field, not a
+finding.
 
 ### D3. Manifest and real multi-TU dump
 

--- a/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
@@ -92,15 +92,30 @@ were added the same additive, no-bump way, that old binary would silently
 compare two contract-bearing (and possibly incomparable) snapshots and
 produce an ordinary verdict — exactly the failure mode this ADR exists to
 close, just relocated to the reader-version boundary instead of the
-extraction boundary. `serialization.py` already has the right mechanism for
-this: an old reader rejects a snapshot whose `schema_version` is *newer*
-than it supports (`serialization.py:557-567`,
-`f"Snapshot schema_version {_schema_version} is newer than this abicheck..."`)
-rather than silently misreading it. `SCHEMA_VERSION` (`serialization.py:85`,
-currently 11) is therefore bumped to 12 the same release `contract` starts
-being written, so an old reader hits that existing forward-version error
-instead of silently producing a verdict on data whose comparability it has
-no way to check.
+extraction boundary.
+
+**`serialization.py`'s existing forward-version handling is not, on its
+own, that mechanism — it only warns.** `snapshot_from_dict` (`:556-572`)
+already inspects `schema_version` against the running `SCHEMA_VERSION` and,
+when the snapshot's is newer, calls `warnings.warn(...)` (a `UserWarning`)
+and then **continues deserializing** — it never raises. A bare
+`SCHEMA_VERSION` bump alone (11 → 12) does not close this ADR's gap: an old
+abicheck reading a schema-12, `contract`-bearing snapshot would print a
+warning most CI setups never surface, ignore the unrecognized `contract`
+key, and still produce an ordinary verdict — the exact silent-incomparable-
+data failure mode this ADR exists to prevent. D1 therefore adds a real
+incompatible-reader guard, not just a version bump: a new
+`_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION = 12` constant in
+`serialization.py` (same naming convention as the existing
+`_MIN_SCHEMA_VERSION_FOR_CV_FACTS`, `:88`), checked in `snapshot_from_dict`
+*before* today's warn-only branch: when the snapshot's `schema_version` is
+at or above that threshold and the running `SCHEMA_VERSION` is below it, a
+new `IncompatibleSnapshotSchemaError` (`errors.py`) is raised instead of a
+warning being emitted. Versions below the threshold keep today's
+warn-and-continue behavior unchanged (the existing, deliberately lenient
+default for ordinary additive fields, per ADR-041's `extractor_passes`
+precedent) — only the specific jump that first introduces a
+verdict-blocking field becomes a hard failure for an older reader.
 
 - `profile_fingerprint: str` — a `sha256:`-prefixed digest of the
   **resolved** compile context: compiler family/version, target triple,
@@ -333,8 +348,10 @@ explicitly in G32 so it isn't rediscovered the hard way.
 - `abicheck/checker_policy.py:618,1024` — `SOURCE_FACT_COVERAGE_INCOMPLETE`,
   `ReachabilityState`
 - `abicheck/snapshot_cache.py:130` — existing content-hash cache key
-- `abicheck/serialization.py:85,91-103,557-567` — `SCHEMA_VERSION`,
-  set-sorting, the existing forward-version rejection D1 relies on
+- `abicheck/serialization.py:85,88,91-103,556-572` — `SCHEMA_VERSION`,
+  `_MIN_SCHEMA_VERSION_FOR_CV_FACTS` (naming precedent), set-sorting, and the
+  existing forward-version handling, which today only warns — D1 adds a
+  real hard-rejection threshold rather than relying on it as-is
 - `abicheck/schemas/compare_report.schema.json`,
   `tests/test_report_schema.py` — the published JSON contract D2's
   `not_comparable` state must update alongside the reporters

--- a/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
@@ -1,0 +1,304 @@
+# ADR-049: Comparability Contract — Profile/Scope Fingerprints and the Multi-TU Manifest
+
+**Date:** 2026-07-22
+**Status:** Proposed — not implemented. This ADR records the target model and
+component surface; [G32](../plans/g32-comparability-contract-and-multi-tu-manifest.md)
+carries the phased implementation backlog.
+**Decision maker:** (pending — recorded per repository convention.)
+
+---
+
+## Context
+
+abicheck already solves several pieces of what "safe to compare" requires:
+`ScopeOrigin` classifies every declaration as
+`PUBLIC_HEADER`/`PRIVATE_HEADER`/`SYSTEM_HEADER`/`GENERATED`/`EXPORT_ONLY`
+(ADR-024, `model.py:131-147`), `DumpDepthNotSatisfiedError`
+(`cli_dump_helpers.py:313-431`) hard-fails rather than silently degrading
+when an explicitly requested `--depth` isn't reached, `snapshot_cache.py`
+hashes the actual transitively-reachable content of every header (not just a
+depfile's path list, so a shadowing header earlier in the search path is
+already a correct cache miss), and `serialization.py` already sorts every
+set before emitting JSON (ADR-015). None of this was reinvented by mistake —
+it means most of a "make snapshots trustworthy" proposal is already shipped
+under different names, and this ADR only needs to decide the parts that
+genuinely are not.
+
+Two gaps are real and unaddressed:
+
+1. **`dump()` collapses every requested header into one synthetic
+   translation unit.** `dumper.py:370` builds the AST input as
+   `"".join(f'#include "{h.resolve()}"\n' for h in hdrs)` and runs exactly
+   one castxml/clang invocation over it, with one flat 120s timeout
+   (`dumper.py:1043`). There is no way to give one header group its own
+   forced include (e.g. an Arrow-derived adapter header that needs
+   `arrow/api.h` included first) without injecting that include into every
+   other header's parse, and no way to mark one header group "optional
+   evidence" vs. "required — its absence must shrink the reported surface,
+   never silently disappear from it."
+2. **No gate runs before `checker.compare` to prove two snapshots were
+   extracted under a comparable contract.** `checker_policy.py` has
+   `SOURCE_FACT_COVERAGE_INCOMPLETE` (`:618`) and a tri-state
+   `ReachabilityState` (`:1024`), but both degrade to a RISK-tier finding
+   *inside* a verdict that still gets produced — they annotate, they don't
+   block. If an old snapshot was dumped with `-H oneapi/dal.hpp` and a new
+   snapshot was dumped with `-H oneapi/dal.hpp -H oneapi/dal/graph.hpp` (a
+   manifest/CLI-flag drift between two CI runs, not a real API change),
+   `compare` still runs and reports every `graph.hpp` declaration as an
+   addition. That is a true statement about the two snapshot *files* and a
+   false one about the *library* — the two snapshots don't cover the same
+   declared surface, and nothing records that the comparison itself isn't
+   sound, only its output.
+
+Both gaps were identified, in much greater depth, in a review of abicheck's
+snapshot architecture prompted by a real multi-TU/DPC++ scenario (a project
+whose public surface spans an umbrella header, an Arrow-derived adapter
+needing its own forced include, and a SYCL host/device compilation split).
+This ADR extracts the decisions from that review that are genuinely new
+work. Where the review's proposal re-described something abicheck already
+has — public/private/external classification, deterministic serialization,
+content-hash caching, RAM-aware parallel extraction (see D6) — this ADR
+cross-references the existing ADR instead of re-deciding it, so the two
+descriptions cannot drift apart.
+
+## The one rule that does not change
+
+Same authority boundary as ADR-028 D3, `buildsource/CLAUDE.md`'s "one rule,"
+and ADR-041's restatement of it: nothing in this ADR may **manufacture** a
+`BREAKING_KINDS`/`API_BREAK_KINDS` verdict, and nothing in it may
+**suppress** one that artifact-backed L0–L2 evidence already proves. What
+this ADR adds is a **precondition gate**: when two snapshots' extraction
+contracts are not comparable, `compare` must say so instead of producing
+*any* verdict — generalizing the same shape of decision
+`DumpDepthNotSatisfiedError` already makes for depth, to profile and scope.
+"Not comparable" must never render as `compatible` (a green check hiding
+risk) and must never render as `breaking` (a false positive that erodes
+trust in every other finding abicheck reports).
+
+## Decision
+
+### D1. `ExtractionContract` — profile fingerprint and scope fingerprint
+
+Two new fields on `AbiSnapshot` (`model.py`), additive — no
+`SCHEMA_VERSION` bump on their own, following the same forward-compatible
+pattern ADR-041's `extractor_passes`/`narrowed_passes` used:
+
+- `profile_fingerprint: str` — a `sha256:`-prefixed digest of the
+  **resolved** compile context: compiler family/version, target triple,
+  `abi_dialect` (Itanium/MSVC), language standard, pointer width/endianness,
+  and the *ordered* sequence of macro define/undef operations and include
+  paths (order matters for `-D`/`-U`/`-I` — last-one-wins semantics are
+  real). Computed from fields `dumper.py` already resolves today
+  (`ast_producer`, `ast_toolchain`, `build_context_defines`,
+  `language_profile`, `platform` — `model.py:507-648`); this is a
+  normalization + hashing pass over existing data, not new extraction.
+  Unknown/unrecognized compiler flags are hashed by default (fail closed,
+  matching the review's "unknown ⇒ contract-affecting until proven
+  otherwise" principle) rather than silently ignored.
+- `scope_fingerprint: str` — a `sha256:`-prefixed digest of the
+  **manifest-normalized** analysis scope: the set of translation units (by
+  `name`, not by list position), each TU's ordered includes and forced
+  includes, and the `public_header_paths`/`public_header_dirs`/filtering
+  policy already threaded through `dumper.py` today. Computed from the
+  *normalized* manifest (D3), not raw YAML bytes — reordering two
+  independent TU entries, or adding a comment, must not change the
+  fingerprint; reordering includes *within* one TU must.
+
+Both fingerprints live in a new `contract: ExtractionContract` sub-object on
+`AbiSnapshot` rather than flattening two more top-level fields onto an
+already-large dataclass — this is the one new nested type this ADR
+introduces on the model, deliberately scoped to just the two fingerprints
+plus the resolved fields that produce them (so a report can show *what*
+differs, not just that the hashes don't match).
+
+### D2. Comparability gate — hard-fail before symbol diff, not a RISK finding
+
+New `ProfileMismatchError` / `ScopeMismatchError` (`errors.py`), raised from
+a new `comparability.check_contracts_comparable(old, new)` called at the top
+of `checker.compare`, before any `diff_*` module runs. Mirrors
+`DumpDepthNotSatisfiedError`'s existing shape exactly: a `click.ClickException`
+subclass at the CLI boundary (`cli.py`), a plain exception at the
+`service.py`/`mcp_server.py` boundary (closing the same gap AGENTS.md's
+"Known gaps" section already names for the depth contract — this ADR's gate
+must not repeat that CLI-only mistake; D2 lands in `service.py`'s
+`ScanRequest`/`compare_snapshots` and `mcp_server.py`'s MCP tools from the
+start, not as a follow-up). On the reporting surface (`reporter.py`,
+`sarif.py`, `junit_report.py`), a `not_comparable` result is a distinct
+top-level state — `verdict: null`, a `reason` object naming the mismatched
+fingerprint field(s) — never coerced into `COMPATIBLE`/`BREAKING`'s existing
+enum values. A `--diagnostic-comparison` opt-in flag (default off) downgrades
+the hard-fail to a tentative diff with `assurance: none` stamped on every
+finding, for exploratory use — never the default, and never silent.
+
+A profile/scope fingerprint is only computed (and only gates) when both
+snapshots carry one; a snapshot from before this ADR (no `contract` field)
+compares exactly as it does today — this is an opt-in tightening for new
+snapshots, not a retroactive break of existing baselines. `UNKNOWN_PROFILE`
+is the report reason when one side has a contract and the other doesn't.
+
+### D3. Manifest and real multi-TU dump
+
+New `abicheck/dump_manifest.py`: a strict YAML parser (unknown fields are
+errors, not silently ignored) for a `roots` / `translation_units` document —
+each TU carries `name` (unique), `includes` (ordered), `forced_includes`
+(ordered, local to that TU only), `required: bool`, and
+`contributes_to_abi: bool`, with the invariant
+`contributes_to_abi=True ⇒ required=True` enforced at parse time (a TU whose
+declarations feed the ABI model cannot also be allowed to fail silently —
+this is the review's sharpest correctness point: "optional but
+contributes" is the exact shape that produces false removals). All existing
+single-header/`-H` CLI invocations construct a single-TU manifest internally
+(one `legacy-main` TU) — no behavior change for a caller not opting into a
+manifest file.
+
+`dumper.py`'s `dump()` gains a manifest-driven path: **one castxml/clang
+invocation per TU** (base compile profile + that TU's own forced includes),
+each producing a normalized `TuFragment` (entities keyed by `entity_key`,
+not raw AST), instead of today's single aggregate-then-parse call. This is
+additive — the existing single-TU code path becomes the manifest path's
+one-TU special case, not a parallel implementation to keep in sync.
+
+A base compile profile (compiler, target, language standard, global flags)
+is shared across all TUs in one manifest; **different compilers or target
+triples across TUs in the same manifest are rejected at parse time** — that
+is two different ABI contexts, which stay two separate snapshots (and two
+separate `profile_fingerprint`s) rather than one snapshot pretending to
+speak for both. Only forced includes and include order vary per TU.
+
+### D4. Compatible merge across translation units
+
+New `abicheck/tu_merge.py`, deliberately reusing `buildsource/crosscheck.py`
+(`:215`, `run_crosschecks`)'s existing merge/cross-validate shape rather
+than a new algorithm: for each `entity_key` seen in more than one TU's
+fragment, merge is only trivial (union provenance, keep the richer
+declaration) when the two declarations are **compatible** —
+forward-declaration + definition, declaration + redeclaration, differing
+only in an added default argument. Two full declarations disagreeing on
+return type, layout, or calling convention is an `INCONSISTENT_DECLARATION`
+conflict; a heterogeneous-context conflict (should D3's per-manifest
+single-profile rule ever be relaxed later) is
+`HETEROGENEOUS_ABI_CONTEXT`. A snapshot with unresolved conflicts is not a
+`CompleteSnapshot` and cannot feed D2's comparability gate as a clean side.
+
+`entity_key` deliberately excludes return type (keeping it in `abi_facts`,
+not the merge key) — folding return type into identity turns a return-type
+change into an unrelated add+remove pair instead of one detected change,
+the same failure mode ADR-045/048 already fixed for old/new type matching,
+applied here to same-version cross-TU identity instead.
+
+### D5. SYCL/DPC++ host vs. device AST context selection
+
+`sycl_metadata.py` today only classifies a **compiled binary's** exported
+`piextDevice*` symbols (`:234,238`) — it has no visibility into which AST
+context (host vs. `spir64` device target) a DPC++ frontend invocation
+actually parsed. New `abicheck/sycl_context.py`: when the L2 clang backend
+(`dumper_clang.py`) invokes a DPC++-capable compiler, it decodes the
+frontend's possibly-multi-document JSON output as a sequence of
+`{kind, target, ast}` contexts (streaming document boundaries, not a
+bracket/string split), tags each with the compiler-reported target triple,
+and selects the context matching the manifest's/CLI's requested
+`frontend_context` (`host` by default). A run that produces only a
+`spir64`/device context when `host` was requested is an extraction failure
+(`AST_CONTEXT_MISSING`), not a successful-but-wrong snapshot — it must not
+reach D1's fingerprinting at all. Fixture-first per the review's own
+sequencing advice: a real captured multi-document DPC++ AST fixture and a
+plain single-context clang fixture land before the stream parser, so the
+parser is built against real output shape, not an assumption of it.
+
+### D6. Resource-aware scheduling for the frontend, shared with `buildsource`
+
+`buildsource/source_replay.py` already implements exactly the scheduling
+policy the review asks for — a thread/process pool sized by
+`min(cpu-derived cap, cgroup-`MemAvailable`-derived cap)`, documented in
+`buildsource/CLAUDE.md`. Rather than a second implementation in `dumper.py`,
+the RAM-probing/pool-sizing helper is factored out of `source_replay.py`
+into a new leaf module, `abicheck/process_resources.py`, that both
+`source_replay.py` and `dumper.py`'s new per-TU invocation loop (D3) import
+— the "move the shared logic to a leaf module both sides can depend on"
+rule AGENTS.md's import-cycle guidance already states, applied here instead
+of growing a second scheduler. `dumper.py`'s per-TU castxml/clang calls run
+under this pool instead of today's fully sequential loop; a killed/timed-out
+TU is recorded with its exit signal, never silently retried as a clean
+empty TU.
+
+`snapshot_cache.py`'s existing content-hash cache key (`:130`) gains the
+`profile_fingerprint`/`scope_fingerprint` as additional key inputs — the
+cache already invalidates correctly on header-content drift (the review's
+"shadowing header" scenario is not a real gap here, see Context); it does
+not yet invalidate on a pure compile-profile change with identical header
+content, which the two new fingerprints close.
+
+## Non-goals
+
+- Not a rewrite of `AbiSnapshot` into a four-layer contract/model/evidence/
+  run-metadata document. `model.py`'s fields already sort into those
+  buckets informally (see Context); this ADR adds two fingerprint fields and
+  one gate, not a new top-level schema shape.
+- Not a change to `ScopeOrigin`, `provenance.py`'s classification, or any
+  existing public/private/external filtering — ADR-024 already solves the
+  "reportable vs. supporting entity" problem the review's §6/§7 asked for.
+- Not a rewrite of `crosscheck.py`'s intra-version evidence-source merge —
+  D4 reuses its shape for a new axis (cross-TU, same evidence source), it
+  does not change what `crosscheck.py` itself does today.
+- Not a canonical/hash-only serialization mode distinct from the persisted
+  JSON. `serialization.py` already sorts sets; D1's fingerprints are
+  computed from specific resolved fields, not a whole-snapshot canonical
+  hash, so no second serialization path is needed.
+- Not a coverage-of-expected-public-headers check (the review's §1.6). A
+  manifest-declared `expected_public_headers` inventory is a plausible
+  future addition once D3 ships, but is not required for the comparability
+  gate itself and is left to a follow-up phase (see G32) rather than
+  bundled into this decision.
+- Not a change to exit codes or the legacy (non-severity-aware) `compare`
+  contract for a snapshot pair that carries no `contract` field — see D2's
+  backward-compatibility note.
+
+## Consequences
+
+**Positive:** a manifest/flag drift between two extraction runs (the
+motivating oneDAL-style scenario — an umbrella header gaining a new
+top-level include between CI runs, unrelated to any real API change) is
+caught and reported as `SCOPE_MISMATCH` instead of a page of false
+`*_added` findings. A genuine per-TU forced-include need (Arrow-style
+adapter headers) becomes expressible without contaminating every other
+header's parse. DPC++ host/device context confusion becomes a hard
+extraction failure instead of a silently-wrong snapshot.
+
+**Costs:** D3 is the highest-risk, highest-effort piece — it changes
+`dumper.py`'s hot path from one invocation to N, and D4's merge lattice is
+new surface with real edge cases (the review's own worked examples:
+forward-decl + definition, ambiguous default-argument-only differences).
+D5 needs a real captured DPC++ multi-document fixture before implementation
+can proceed safely, which is external-tool-dependent to acquire. A
+snapshot's `profile_fingerprint` is sensitive to any resolved-field
+addition in future ADRs (a later ADR that adds a new ABI-affecting compile
+flag to what `dumper.py` resolves must remember to fold it into D1's
+fingerprint inputs, or the two silently drift apart) — this is called out
+explicitly in G32 so it isn't rediscovered the hard way.
+
+## References
+
+- `abicheck/model.py` — `AbiSnapshot`, `ScopeOrigin` (`:131-147`)
+- `abicheck/dumper.py:370,397,1043` — current single-aggregate-TU dump path
+- `abicheck/cli_dump_helpers.py:313-431` — `DumpDepthNotSatisfiedError`,
+  the existing hard-fail precedent this ADR generalizes
+- `abicheck/checker_policy.py:618,1024` — `SOURCE_FACT_COVERAGE_INCOMPLETE`,
+  `ReachabilityState`
+- `abicheck/snapshot_cache.py:130` — existing content-hash cache key
+- `abicheck/serialization.py:85,91-103` — `SCHEMA_VERSION`, set-sorting
+- `abicheck/sycl_metadata.py:234,238` — current binary-only SYCL/PI
+  classification
+- `abicheck/buildsource/crosscheck.py:215` — `run_crosschecks`, the merge
+  shape D4 reuses
+- `abicheck/buildsource/source_replay.py` — RAM-aware scheduling D6 factors
+  out (see `abicheck/buildsource/CLAUDE.md`)
+- [ADR-015](015-snapshot-serialization.md) (schema versioning),
+  [ADR-024](024-public-abi-surface-resolution.md) (`ScopeOrigin`),
+  [ADR-028](028-source-build-evidence-pack.md) D3 (authority rule),
+  [ADR-035](035-pr-tier-source-intelligence-and-crosscheck.md) D4
+  (`crosscheck.py`), [ADR-038](038-build-integrated-fact-collection-variants.md),
+  [ADR-041](041-compiler-facts-semantic-impact-graph.md) (coverage-honesty
+  pattern this ADR's gate follows), [ADR-045](045-identity-based-old-new-entity-matching.md)
+  (return-type-out-of-identity precedent for D4)
+- [G32](../plans/g32-comparability-contract-and-multi-tu-manifest.md) —
+  phased implementation plan

--- a/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
@@ -117,11 +117,18 @@ no way to check.
 - `scope_fingerprint: str` — a `sha256:`-prefixed digest of the
   **manifest-normalized** analysis scope: the set of translation units (by
   `name`, not by list position), each TU's ordered includes and forced
-  includes, and the `public_header_paths`/`public_header_dirs`/filtering
-  policy already threaded through `dumper.py` today. Computed from the
-  *normalized* manifest (D3), not raw YAML bytes — reordering two
-  independent TU entries, or adding a comment, must not change the
-  fingerprint; reordering includes *within* one TU must.
+  includes, each TU's `required`/`contributes_to_abi` flags, and the
+  `public_header_paths`/`public_header_dirs`/filtering policy already
+  threaded through `dumper.py` today. The `contributes_to_abi` flag is a
+  hashed input, not just a manifest-validation detail (D3): flipping a TU
+  from `contributes_to_abi: false` to `true` changes which declarations
+  feed the ABI model without necessarily changing that TU's includes at
+  all, so a fingerprint computed only from includes/forced-includes would
+  let exactly the kind of scope drift this ADR exists to catch pass through
+  as "identical scope." Computed from the *normalized* manifest (D3), not
+  raw YAML bytes — reordering two independent TU entries, or adding a
+  comment, must not change the fingerprint; reordering includes *within*
+  one TU, or changing either flag, must.
 
 Both fingerprints live in a new `contract: ExtractionContract` sub-object on
 `AbiSnapshot` rather than flattening two more top-level fields onto an
@@ -156,11 +163,26 @@ that file — both must change in the same phase that starts emitting
 `not_comparable`, or JSON output goes invalid (or the published schema goes
 stale) the moment the gate first fires.
 
-A profile/scope fingerprint is only computed (and only gates) when both
-snapshots carry one; a snapshot from before this ADR (no `contract` field)
-compares exactly as it does today — this is an opt-in tightening for new
-snapshots, not a retroactive break of existing baselines. `UNKNOWN_PROFILE`
-is the report reason when one side has a contract and the other doesn't.
+**Mixed pairs (one side has a `contract`, the other doesn't) never hard-fail
+— this is unambiguous, not left to implementer discretion.** The backward-
+compatibility promise ("a snapshot from before this ADR compares exactly as
+it does today") is not a soft goal to reconcile with the gate; a
+contract-less snapshot's *absence* of evidence is exactly the "missing
+evidence must never manufacture a block" situation ADR-028 D3's authority
+rule already covers, extended here to the comparability contract instead of
+symbol facts. `check_contracts_comparable` therefore only ever raises
+`ProfileMismatchError`/`ScopeMismatchError` when **both** sides carry a
+`contract` and it mismatches — a mixed pair takes the exact same code path
+as a pair where neither side carries one, and comparing a newly-produced
+snapshot against a pre-ADR baseline (the common "upgrade abicheck, keep the
+stored CI baseline" workflow) never regresses into an unexpected
+`not_comparable` result. `UNKNOWN_PROFILE` is **not** a `not_comparable`
+reason and never blocks: it is a RISK-tier, non-authoritative annotation on
+an otherwise-ordinary verdict — same shape and same authority-rule
+justification as the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`
+(`checker_policy.py:618`) — surfaced only for a mixed pair, to tell the
+reader "this comparison ran without being able to check profile/scope
+drift on one side," without withholding the verdict itself.
 
 ### D3. Manifest and real multi-TU dump
 

--- a/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/049-comparability-contract-and-multi-tu-manifest.md
@@ -79,9 +79,28 @@ trust in every other finding abicheck reports).
 
 ### D1. `ExtractionContract` — profile fingerprint and scope fingerprint
 
-Two new fields on `AbiSnapshot` (`model.py`), additive — no
-`SCHEMA_VERSION` bump on their own, following the same forward-compatible
-pattern ADR-041's `extractor_passes`/`narrowed_passes` used:
+Two new fields on `AbiSnapshot` (`model.py`), carried under a new
+`contract: ExtractionContract | None` sub-object. Unlike ADR-041's
+`extractor_passes`/`narrowed_passes` — purely advisory fields where an old
+reader silently not recognizing them degrades to the accepted, documented
+"under-call" failure mode (a RISK finding that doesn't fire, never a false
+compatible/breaking verdict) — the comparability gate this ADR adds (D2) is
+a **hard, verdict-blocking** mechanism whose entire purpose is preventing a
+false verdict on incomparable data. An old abicheck binary that predates
+this ADR has no code path that even looks for `contract`, so if the field
+were added the same additive, no-bump way, that old binary would silently
+compare two contract-bearing (and possibly incomparable) snapshots and
+produce an ordinary verdict — exactly the failure mode this ADR exists to
+close, just relocated to the reader-version boundary instead of the
+extraction boundary. `serialization.py` already has the right mechanism for
+this: an old reader rejects a snapshot whose `schema_version` is *newer*
+than it supports (`serialization.py:557-567`,
+`f"Snapshot schema_version {_schema_version} is newer than this abicheck..."`)
+rather than silently misreading it. `SCHEMA_VERSION` (`serialization.py:85`,
+currently 11) is therefore bumped to 12 the same release `contract` starts
+being written, so an old reader hits that existing forward-version error
+instead of silently producing a verdict on data whose comparability it has
+no way to check.
 
 - `profile_fingerprint: str` — a `sha256:`-prefixed digest of the
   **resolved** compile context: compiler family/version, target triple,
@@ -129,6 +148,13 @@ fingerprint field(s) — never coerced into `COMPATIBLE`/`BREAKING`'s existing
 enum values. A `--diagnostic-comparison` opt-in flag (default off) downgrades
 the hard-fail to a tentative diff with `assurance: none` stamped on every
 finding, for exploratory use — never the default, and never silent.
+`verdict: null` is a **published contract change**, not just an internal
+one: `abicheck/schemas/compare_report.schema.json` currently requires
+`verdict` and restricts it to a fixed string enum with no `null` member, and
+`tests/test_report_schema.py` validates emitted reports against exactly
+that file — both must change in the same phase that starts emitting
+`not_comparable`, or JSON output goes invalid (or the published schema goes
+stale) the moment the gate first fires.
 
 A profile/scope fingerprint is only computed (and only gates) when both
 snapshots carry one; a snapshot from before this ADR (no `contract` field)
@@ -285,7 +311,11 @@ explicitly in G32 so it isn't rediscovered the hard way.
 - `abicheck/checker_policy.py:618,1024` — `SOURCE_FACT_COVERAGE_INCOMPLETE`,
   `ReachabilityState`
 - `abicheck/snapshot_cache.py:130` — existing content-hash cache key
-- `abicheck/serialization.py:85,91-103` — `SCHEMA_VERSION`, set-sorting
+- `abicheck/serialization.py:85,91-103,557-567` — `SCHEMA_VERSION`,
+  set-sorting, the existing forward-version rejection D1 relies on
+- `abicheck/schemas/compare_report.schema.json`,
+  `tests/test_report_schema.py` — the published JSON contract D2's
+  `not_comparable` state must update alongside the reporters
 - `abicheck/sycl_metadata.py:234,238` — current binary-only SYCL/PI
   classification
 - `abicheck/buildsource/crosscheck.py:215` — `run_crosschecks`, the merge

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -718,6 +718,23 @@ is None` for a canonical `compare_report.schema.json` document, or
 `verdict == "not_comparable"` for a release `summary.json`/per-library
 entry.
 
+**`cli_compare_release.py` also needs `diagnostic_comparison` itself
+threaded, not just the exception branch above — it does not go through
+`CompareRequest`/`run_compare_request`, so fixing that chokepoint doesn't
+reach it.** `_compare_one_library` calls `_run_compare_pair`
+(`cli_compare_release.py:91-141`), whose own docstring says it "routes
+through the single Tier-2 chokepoint (`service.run_compare`, ADR-037
+D1)" — the legacy keyword shim, a different function from
+`run_compare_request`. `_run_compare_pair`'s own fixed, explicit signature
+has no `diagnostic_comparison` slot, and its `service.run_compare(...)`
+call only forwards parameters it already names, so giving
+`service.run_compare` the parameter (above) is not sufficient on its own.
+`_run_compare_pair` and `_compare_one_library` each gain their own
+`diagnostic_comparison: bool = False` parameter, threaded into
+`_run_compare_pair`'s `service.run_compare(...)` call — the same
+multi-layer threading this ADR has already had to apply more than once
+elsewhere.
+
 **A fifth surface calls `checker.compare` directly, with its own,
 independent exit-code contract that this ADR must not silently
 break: `abicheck/compat/cli.py`'s ABICC-compatible `compat check`
@@ -848,16 +865,25 @@ it.** `CompareRequest` (`api_types.py:125`) is, by its own docstring, "the
 single input to `run_compare`" that "every front-end (CLI, MCP,
 `compare-release` fan-out, `appcompat`)" assembles and hands to
 `service.run_compare_request` — the actual ADR-037 D1/D2 classification
-chokepoint, one level above `compare_snapshots`. **The docstring's own
-"appcompat" claim doesn't hold up against the actual code, the same kind
-of docstring/reality gap already caught once below for `mcp_server`:**
-`appcompat.py`'s `check_appcompat`/`check_plugin_host_contract` call
-`compare_snapshots(...)` directly too (see the dedicated bullet further
-below) — so "every documented front-end goes through `CompareRequest`" is
-already not literally true today; the CLI/MCP-facing front-ends this
-paragraph is really about (the ones a `--diagnostic-comparison` flag or
-equivalent API parameter needs to reach) are the ones this fix threads it
-through. `run_compare_request`
+chokepoint, one level above `compare_snapshots`. **Neither the "appcompat"
+nor the "`compare-release` fan-out" half of that docstring claim holds up
+against the actual code, the same kind of docstring/reality gap already
+caught once below for `mcp_server`:** `appcompat.py`'s
+`check_appcompat`/`check_plugin_host_contract` call `compare_snapshots(...)`
+directly (see the dedicated bullet further below), and
+`cli_compare_release.py`'s `_compare_one_library` → `_run_compare_pair`
+calls `service.run_compare` — the *legacy keyword shim*, whose own
+docstring says it "routes through the single Tier-2 chokepoint
+(`service.run_compare`, ADR-037 D1)," not `run_compare_request` — so
+"every documented front-end goes through `CompareRequest`" is already not
+literally true today for either. Both get their own dedicated
+`diagnostic_comparison` threading below (`appcompat.py`'s own bullet;
+`cli_compare_release.py`'s own bullet) rather than inheriting reachability
+from this fix — a test asserting `run_compare_request` accepts
+`diagnostic_comparison` proves nothing about either path. The
+CLI/MCP-facing front-ends this paragraph is really about (the ones a
+`--diagnostic-comparison` flag or equivalent API parameter needs to
+reach) are the ones this fix threads it through. `run_compare_request`
 calls `compare_snapshots(old, new, suppression=..., policy=..., ...,
 env_matrix=...)` today with a fixed keyword list that has no slot for this
 flag; adding `diagnostic_comparison` only to `compare_snapshots` itself

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -1544,14 +1544,20 @@ to surface before D5 is implemented against a guess.
 `buildsource/source_replay.py` already implements exactly the scheduling
 policy the review asks for — a thread/process pool sized by
 `min(cpu-derived cap, cgroup-`MemAvailable`-derived cap)`, documented in
-`buildsource/CLAUDE.md`. Rather than a second implementation in `dumper.py`,
-the RAM-probing/pool-sizing helper is factored out of `source_replay.py`
-into a new leaf module, `abicheck/process_resources.py`, that both
-`source_replay.py` and `dumper.py`'s new per-TU invocation loop (D3) import
-— the "move the shared logic to a leaf module both sides can depend on"
-rule AGENTS.md's import-cycle guidance already states, applied here instead
-of growing a second scheduler. `dumper.py`'s per-TU castxml/clang calls run
-under this pool instead of today's fully sequential loop; a killed/timed-out
+`buildsource/CLAUDE.md`. Rather than a second implementation in the
+manifest driver, the RAM-probing/pool-sizing helper is factored out of
+`source_replay.py` into a new leaf module, `abicheck/process_resources.py`,
+that both `source_replay.py` and the new per-TU invocation loop (D3)
+import — the "move the shared logic to a leaf module both sides can
+depend on" rule AGENTS.md's import-cycle guidance already states, applied
+here instead of growing a second scheduler. **The per-TU loop itself
+lives in a new sibling module, `abicheck/dumper_manifest.py`, not
+`dumper.py` — `dumper.py` is already at its file-size hard cap with no
+headroom, so D3's new per-TU logic (and this section's scheduler wiring)
+must not be added to it directly; `dumper.py` keeps only a thin
+manifest-vs.-single-TU dispatch that calls into the new module.** The
+per-TU castxml/clang calls in `dumper_manifest.py` run
+under this pool instead of a fully sequential loop; a killed/timed-out
 TU is recorded with its exit signal, never silently retried as a clean
 empty TU.
 

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -1186,7 +1186,41 @@ visible first-party consumer. `action/run.sh` gains a matching `VERDICT`
 value (e.g. `NOT_COMPARABLE`) for each new code, and
 `_maybe_post_pr_comment`'s `ERROR`-only skip is joined by an explicit
 carve-out that still posts for `NOT_COMPARABLE` — this result deserves the
-comment more than an ordinary pass, not less. **Mapping the `VERDICT`
+comment more than an ordinary pass, not less.
+
+**The bash-level `VERDICT != "ERROR"` carve-out is not what actually
+decides whether a comment gets posted — the real suppression point is one
+layer deeper, in the Python renderer `_maybe_post_pr_comment` delegates
+to, and it was never taught about `not_comparable` at all.** Verified
+against the actual code: `_maybe_post_pr_comment` (`action/run.sh:897`)
+invokes `python3 -m abicheck.cli_pr_comment` (`:968`), whose
+`build_model`/`should_post` (`abicheck/pr_comment.py:628,643`) decide the
+actual outcome. `should_post(model, on="changes")` — the Action's own
+default (`INPUT_PR_COMMENT_ON:-changes`) — returns `True` only when
+`model.total_changes > 0` or `removed_libraries`/`added_libraries` is
+non-empty; a `not_comparable` report has none of these (the gate raised
+before any `Change` was ever produced), so even though the bash-level
+carve-out above correctly avoids an early return, `cli_pr_comment` itself
+would still silently decide there is "nothing to report" and post no
+comment at all — the exact suppression this whole fix exists to prevent,
+just one call deeper. Closing this needs three changes in
+`abicheck/pr_comment.py`, not just the bash-level one: (1) `CommentModel`
+gains a `not_comparable_reason: str | None = None` field; (2)
+`build_model` (or the mode-specific builder it dispatches to,
+`_from_compare`/`_from_release`) detects the canonical `verdict: null`
+shape (compare mode) or a release library entry's string
+`verdict == "not_comparable"` (the pre-existing `summary.json` idiom,
+D2) and populates it from the report's `reason`; (3) `should_post` checks
+`model.not_comparable_reason is not None` **before** the `on == "changes"`
+bucket-count logic and returns `True` regardless of bucket counts (only
+`on == "never"` still suppresses it) — mirroring "this result deserves the
+comment more than an ordinary pass, not less" at the layer that actually
+enforces it. The rendered comment body also needs its own distinct
+not-comparable headline (a `_header`-level case checked before the
+existing `scoped_verdict`/`removed_libraries`/bucket-count branches,
+since a not-comparable result means none of that bucket data is
+trustworthy) rather than falling through to whatever an empty
+`breaking`/`review`/`safe` set would otherwise render. **Mapping the `VERDICT`
 string is necessary but not sufficient — `run.sh`'s separate final
 exit-code section has no `NOT_COMPARABLE` branch of its own, verified
 against the actual code (`:1074-1145`): it starts `FINAL_EXIT=0` and only

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -435,30 +435,50 @@ the whole-directory exclusion above exists to protect — still flips
 `profile_fingerprint` and hard-fails the gate, on a project layout common
 enough (any CMake/Meson build with a generated-headers directory) that
 this is not the same "unusual declaration shape" class as the
-nested-vendor-dependency gap below; it is a routine one. The legacy CLI
-gains an explicit escape hatch for exactly this case: a new, side-scoped,
-**labeled** `--project-include` option — but its value grammar cannot
-reuse the plain `<label>=<path>` shape naively: `abicheck/cli_params.py`'s
-existing `SidedPathParam`/`SidedStrParam` (ADR-040 Lever 1) already claim
-the `X=` prefix position exclusively for the side discriminator
-(`old=`/`new=`/`both=`, `_SIDES` at `:101`) — a value like
-`support=old/src` has no recognized side prefix (`support` isn't in
-`_SIDES`), so it would fall through to that parser's bare-value case and
-be parsed as `("both", Path("support=old/src"))`, the literal string
-`support=old/src` swallowed whole as a bogus path, not as a label at all.
-`--project-include` therefore needs its own dedicated Click param type,
-`SidedLabeledPathParam`, with a grammar that carries *both* pieces:
-`[old:|new:|both:]<label>=<path>` — a colon-terminated side prefix (same
-three words as `_SIDES`, colon instead of `=` to stay unambiguous against
-the label's own `=`), defaulting to `both:` when omitted, exactly
-mirroring "a bare value means both sides" for the existing sided params.
-A genuine two-checkout compare with side-specific support-root paths but
-one shared logical identity is declared as `--project-include
-old:support=old/src --project-include new:support=new/src` — same
-`support` label on both invocations (so the per-slot token below matches
-across sides for the same logical root), different paths (so each side
-resolves its own checkout's directory). Unlike `--include`,
-`--project-include` requires that label — not a path-derived name, a
+nested-vendor-dependency gap below; it is a routine one.
+
+**A separate, independently-repeatable `--project-include` option cannot
+carry this information at all, regardless of its own value grammar — Click
+does not preserve declaration order *across* two differently-named
+repeatable options.** Verified against Click's actual parsing model (and
+independently against real Click behavior): a `multiple=True` option's
+callback receives that option's own accumulated values as one tuple, in
+the order *that option* was repeated on the command line, but Click never
+records the interleaved position of one option's occurrences relative to
+a *different* option's — `--include dep --project-include support=src` and
+`--project-include support=src --include dep` arrive at the command
+callback as the identical `(include=('dep',), project_include=('support=src',))`,
+with no way to recover which came first. Since `profile_fingerprint`'s
+whole `-I` ordering design is search-precedence order — the actual
+relative position the compiler sees — a second, separately-declared
+option can never feed it correctly no matter how its own value is
+shaped; the earlier `SidedLabeledPathParam`-as-its-own-option design was
+wrong on this axis before its value grammar was even considered. **The fix
+is to not add a second option at all: the label rides on `--include`
+itself**, the one option whose repeated occurrences Click already keeps
+in true declaration order (the same guarantee the whole `-I`-sequence
+design already depends on for plain `--include`/`--include` pairs).
+`abicheck/cli_params.py`'s existing `SidedPathParam` (ADR-040 Lever 1,
+shared today by `--include`, `--header`, and other sided-path options) is
+extended for `--include` specifically into a new `SidedIncludePathParam`
+— `--header` and the other sided-path options keep the unchanged,
+2-tuple `SidedPathParam`, since only `--include` needs a label slot.
+`SidedIncludePathParam` recognizes an optional labeled form layered on
+top of the existing `[old=|new=|both=]PATH` grammar: `[old:|new:|both:]
+LABEL=PATH` — a colon-terminated side prefix (colon instead of `=` so it
+can't collide with the label's own `=`; unambiguous, since no existing
+`--include` value has ever started with `old:`/`new:`/`both:`), returning
+a `(side, label, path)` triple with `label=None` for every existing,
+unlabeled form (`PATH`, `old=PATH`, ...) so ordinary uses are
+byte-for-byte unaffected. A genuine two-checkout compare with
+side-specific support-root paths under one shared logical identity is
+declared `--include old:support=old/src --include new:support=new/src`
+— same `support` label on both invocations (so the per-slot token below
+matches across sides for the same logical root), different paths (each
+side resolves its own checkout's directory) — interleaved with any number
+of ordinary `--include old=/opt/dep` entries in exactly the order they
+were typed, since it is all one option's accumulated tuple. The label is
+required for this labeled form specifically — not a path-derived name, a
 short user-supplied logical identifier, the same "name a TU instead of
 inferring one from path shape" choice the manifest path (D3) already
 makes for its `name` field — because an explicitly-declared support root
@@ -466,10 +486,10 @@ has no natural "owned declared header" for the per-slot token below to
 derive from the way an ancestor-derived root does; asking the user for
 one avoids inventing yet another path-shape heuristic that could break in
 some other way, the repeated lesson of every rejected attempt in this
-section. `--project-include` is a legacy-CLI-only addition: the manifest
-path (D3) already has no such gap, since a manifest TU can declare a
-per-TU forced-include for exactly this directory instead of relying on
-directory-tree inference.
+section. This labeled `--include` form is a legacy-CLI-only addition: the
+manifest path (D3) already has no such gap, since a manifest TU can
+declare a per-TU forced-include for exactly this directory instead of
+relying on directory-tree inference.
 This is a strict partition on `-I` *directories*, not individual files:
 `scope_fingerprint` owns everything under a project-owned root (declared
 or not); `profile_fingerprint` owns only external roots, in full.
@@ -513,11 +533,12 @@ and new sides still tokenizes identically regardless of its own mount
 point, consistent with `scope_fingerprint` already treating declared
 header *names* (not paths) as legitimate, already-tracked identity, so
 this leaks nothing beyond what `scope_fingerprint` exposes today; for an
-explicitly-declared **`--project-include`** support root (which owns no
-declared header by construction — that is exactly why it needed its own
-flag above), the token is its required user-supplied **`label`** instead,
-namespaced separately from the ancestor-derived token space so a label
-string can never accidentally collide with a declared header name.
+explicitly-labeled **`--include old:LABEL=PATH`/`--include
+new:LABEL=PATH`** support root (which owns no declared header by
+construction — that is exactly why it needs the label form above), the
+token is its required user-supplied **`label`** instead, namespaced
+separately from the ancestor-derived token space so a label string can
+never accidentally collide with a declared header name.
 `-I project -I dep` (`project` ancestor of declared header `foo.h`)
 therefore hashes `[token(foo.h), digest(dep)]` and `-I dep -I project`
 hashes `[digest(dep), token(foo.h)]` — different sequences, different
@@ -525,8 +546,8 @@ hashes `[digest(dep), token(foo.h)]` — different sequences, different
 ancestor-derived roots for different declared headers (`include/` →
 `foo.h`, a second header root → `bar.h`) produce distinguishable,
 order-sensitive tokens instead of collapsing to one interchangeable
-constant, and two `--project-include` roots (`--project-include
-both:support=old/src`, `--project-include both:generated=old/gen`) are
+constant, and two labeled `--include` roots (`--include
+both:support=old/src`, `--include both:generated=old/gen`) are
 distinguished by their distinct labels the same way. **Residual
 limitation, same class as the vendored-nested-dependency
 gap below:** two separately declared `-I` roots that are both ancestors of
@@ -827,13 +848,21 @@ it.** `CompareRequest` (`api_types.py:125`) is, by its own docstring, "the
 single input to `run_compare`" that "every front-end (CLI, MCP,
 `compare-release` fan-out, `appcompat`)" assembles and hands to
 `service.run_compare_request` — the actual ADR-037 D1/D2 classification
-chokepoint, one level above `compare_snapshots`. `run_compare_request`
+chokepoint, one level above `compare_snapshots`. **The docstring's own
+"appcompat" claim doesn't hold up against the actual code, the same kind
+of docstring/reality gap already caught once below for `mcp_server`:**
+`appcompat.py`'s `check_appcompat`/`check_plugin_host_contract` call
+`compare_snapshots(...)` directly too (see the dedicated bullet further
+below) — so "every documented front-end goes through `CompareRequest`" is
+already not literally true today; the CLI/MCP-facing front-ends this
+paragraph is really about (the ones a `--diagnostic-comparison` flag or
+equivalent API parameter needs to reach) are the ones this fix threads it
+through. `run_compare_request`
 calls `compare_snapshots(old, new, suppression=..., policy=..., ...,
 env_matrix=...)` today with a fixed keyword list that has no slot for this
 flag; adding `diagnostic_comparison` only to `compare_snapshots` itself
-would be unreachable from every documented front-end, since none of them
-call `compare_snapshots` directly — they all go through
-`CompareRequest`/`run_compare_request`. `CompareRequest` therefore gains
+would be unreachable from `CompareRequest`-based front-ends specifically.
+`CompareRequest` therefore gains
 `diagnostic_comparison: bool = False`, and `run_compare_request` passes
 `diagnostic_comparison=request.diagnostic_comparison` into its
 `compare_snapshots(...)` call. The legacy keyword-argument shim
@@ -861,6 +890,24 @@ ScopeMismatchError)` branch in `abi_compare`, rendering a structured
 `{"status": "not_comparable", "reason": ...}` result distinct from
 `{"status": "error"}` — mirroring the CLI/service layers' `verdict: null`
 distinction, not merely exposing the escape-hatch flag.
+
+**`appcompat.py` is a third, independent bypass of the same shape, not
+covered by fixing `CompareRequest`/`run_compare_request` or `mcp_server.py`
+alone.** Verified against the actual code: `check_appcompat` and
+`check_plugin_host_contract` each call `compare_snapshots(...)` directly,
+with no surrounding `try` and no `CompareRequest` anywhere in either call
+path — and unlike `mcp_server.abi_compare`, there is no natural place to
+put a structured not-comparable result: both `AppCompatResult` and
+`PluginHostContractResult` carry `full_diff: DiffResult | None`, which has
+nothing to hold when the gate raises *before* any `DiffResult` exists.
+Rather than inventing a new outcome field on either dataclass for this
+phase, both functions gain the `diagnostic_comparison: bool = False`
+opt-in (forwarded into their own `compare_snapshots(...)` calls, the same
+as `run_compare_request`'s), and letting the mismatch exception propagate
+uncaught remains each function's *documented default* — made explicit in
+their docstrings rather than left as an unstated gap, since these two are
+public, directly user-callable Python API entry points, not internal
+helpers a wrapper could quietly retrofit around later.
 
 **`abicheck aggregate` is a consumer of these reports, not just a producer
 of new ones, and it has its own blind spot D2 must close.**

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -1218,18 +1218,24 @@ AGENTS.md's own module map lists it alongside
 `service_render.py`'s format dispatch (`:36-132`) routes `--format html` to
 `generate_html_report(result: DiffResult, ...)` exactly like the other three
 route to their renderers. **Verified against the actual code: `render_output`
-has five branches requiring a real `DiffResult` — `sarif` (`to_sarif_str`),
-`html` (`generate_html_report`), `junit` (`to_junit_xml`), `review`
-(`to_review_digest`), and the default `markdown` (`to_markdown`) — not
-`html` alone.** Two distinct gaps follow, for every one of these five, not
+has five format branches requiring a real `DiffResult` — `sarif`
+(`to_sarif_str`), `html` (`generate_html_report`), `junit`
+(`to_junit_xml`), `review` (`to_review_digest`), and the default
+`markdown` (`to_markdown`) — not `html` alone. **`--stat` is a sixth,
+cross-cutting path with the identical requirement, checked *before* any
+of those five format branches — `render_output`'s `if stat and fmt !=
+"junit":` guard calls `to_stat_json(result, ...)` for `--format json
+--stat` or `to_stat(result, ...)` for every other `--stat` combination,
+both requiring the same real `DiffResult` the five format renderers do.**
+Two distinct gaps follow, for every one of these six paths, not
 just HTML: for the hard-gate `not_comparable` case, no
 `DiffResult` exists at all (the gate raises before any diff runs), so
-`service_render.render_output` must not attempt to call any of these five
-renderers on that path — the front-end's exception handler renders (or
+`service_render.render_output` must not attempt to call any of these six
+renderers (or the `--stat` summarizer) on that path — the front-end's exception handler renders (or
 declines to render) each requested format directly, the same way it
-assembles `verdict: null` JSON, rather than any of the five growing an
+assembles `verdict: null` JSON, rather than any of them growing an
 optional-`DiffResult` parameter none was designed to accept. Two of these
-five carry a structured, externally-consumed schema and need a defined
+five format branches carry a structured, externally-consumed schema and need a defined
 not-comparable shape, not just "skip the call": **SARIF** represents it as
 one `run` with `invocations[0].executionSuccessful: false` and a
 `toolExecutionNotifications` entry carrying the reason — SARIF's own

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -503,10 +503,37 @@ has no natural "owned declared header" for the per-slot token below to
 derive from the way an ancestor-derived root does; asking the user for
 one avoids inventing yet another path-shape heuristic that could break in
 some other way, the repeated lesson of every rejected attempt in this
-section. This labeled `--include` form is a legacy-CLI-only addition: the
-manifest path (D3) already has no such gap, since a manifest TU can
-declare a per-TU forced-include for exactly this directory instead of
-relying on directory-tree inference.
+section. **This labeled `--include` form is legacy-CLI-only — but the
+manifest path (D3) is not automatically exempt from the same gap, and an
+earlier revision of this section wrongly claimed it was.**
+`forced_includes` (D3) is a per-TU list of individual header *files*
+force-included into that TU's compile (`-include foo.h`), the manifest
+equivalent of a single named header — it says nothing about a TU's
+`includes` list, the manifest's own `-I` *search-path* entries used for
+ordinary `#include "..."` resolution. A manifest TU declaring `includes:
+[../src]` or `includes: [generated/]` to resolve a private support header
+or a build-generated one has exactly the same problem the legacy CLI just
+got fixed for: `../src`/`generated/` is a *sibling* of the TU's own
+declared path, not an ancestor of it, so D1's ancestor rule alone
+classifies it **external**, and an ordinary edit to a header inside it
+still flips `profile_fingerprint` before the diff ever runs. The manifest
+schema therefore gains the same escape hatch, in its own idiom: an
+`includes` entry is either a bare path string (external-by-default,
+ancestor rule decides ownership, unchanged) or a mapping
+`{path: ..., project_owned: true}` explicitly asserting the entry is
+project-owned regardless of ancestry. Unlike the legacy CLI's labeled
+`--include` form, a manifest entry needs **no separate user-supplied
+label** for the per-slot token: manifest paths are already
+root-relative and side-normalized by design (D1's "both fingerprints hash
+root-relative paths" principle), so two manifests describing the same
+logical support root — `includes: [{path: ../src, project_owned: true}]`
+on both the old and new side's manifest — already share the same stable,
+mount-point-independent path string; that string itself serves as the
+per-slot token, the same way a manifest TU's declared `name` already
+serves as stable identity elsewhere in this ADR. This closes the gap in
+the manifest's own structured-YAML idiom rather than reusing the CLI's
+colon/`=` string grammar, which has no reason to exist in a schema that
+already supports mapping values natively.
 
 **`--include` is not one Click registration shared by `compare`/`dump`/`scan`
 — it is three separate ones today, and `SidedIncludePathParam` only fixes
@@ -721,6 +748,42 @@ subclass at the CLI boundary (`cli.py`), a plain exception at the
 must not repeat that CLI-only mistake; D2 lands in `service.py`'s
 `ScanRequest`/`compare_snapshots` and `mcp_server.py`'s MCP tools from the
 start, not as a follow-up).
+
+**A profile mismatch confined to target triple/pointer width/endianness
+must not preempt the existing, more specific platform-identity
+detectors — this is a required carve-out, not an edge case to leave
+implicit.** `profile_fingerprint` (D1) deliberately includes target
+triple, pointer width, and endianness, since they genuinely affect what
+the L2 AST frontend parses (a 32- vs. 64-bit `sizeof(long)`, an
+`__aarch64__`-gated declaration) — omitting them from the fingerprint
+would reintroduce the exact under-counting bug this whole design exists
+to close. But `diff_platform.py` already has artifact-backed, dedicated
+detectors for exactly this axis — `elf_machine_changed`,
+`elf_class_changed`, `elf_endianness_changed`, and the PE/Mach-O
+equivalents — computed directly from the binaries' own ELF/PE/Mach-O
+headers, independent of any AST extraction, and already classified
+`BREAKING` (a real, load-incompatible ABI difference: an x86_64 build
+compared against an aarch64 build of "the same" library). Comparing two
+binaries for genuinely different target architectures is `profile_fingerprint`'s single most likely mismatch source — and, unlike
+every other profile-drift case this ADR is built to catch, it is not an
+*unexplained* drift: the diff pipeline already has a specific, correct,
+artifact-grounded answer for it. Gating it into a generic
+`not_comparable` before `diff_platform.py` ever runs would silently
+downgrade a proven, informative `BREAKING` verdict into a strictly less
+useful "couldn't tell" result — the opposite of this ADR's purpose. The
+gate therefore inspects *which* resolved fields differ, not only whether
+the overall hash differs: `check_contracts_comparable` computes the
+mismatch at field granularity (the same resolved fields
+`ExtractionContract` already stores so a report can show *what* differs,
+not just that the hashes don't match — D1), and when the *only* differing
+fields are target triple/pointer width/endianness, the gate does not
+raise — it lets `compare()` proceed to the normal `diff_*` pipeline, where
+`diff_platform.py`'s existing detectors take over and produce their own,
+already-correct verdict. Any *other* differing field (compiler family,
+macros, `-I` content, language standard) still hard-fails exactly as
+before, even if a target difference happens to co-occur with it — this
+carve-out is scoped to the platform-identity fields alone, not a general
+loosening of the gate.
 
 **A fourth surface reaches `checker.compare` besides the three named
 above: `cli_compare_release.py`'s directory/package fan-out, and it needs

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -163,7 +163,12 @@ not a latent surprise discovered after Phase A ships.
   normalization + hashing pass over existing data, not new extraction.
   Unknown/unrecognized compiler flags are hashed by default (fail closed,
   matching the review's "unknown ⇒ contract-affecting until proven
-  otherwise" principle) rather than silently ignored.
+  otherwise" principle) rather than silently ignored. **`frontend_context`
+  (`host`/`device`, D5) is also one of these hashed fields, once D3/D5
+  introduce it** — this field doesn't exist at Phase-A-ships time (D1
+  ships before D3/D5), so it's necessarily added to the hash set later,
+  not omitted by design; see D5's own note for why this can't be deferred
+  once the field exists.
 - `scope_fingerprint: str` — a `sha256:`-prefixed digest of the
   **manifest-normalized** analysis scope: the set of translation units (by
   `name`, not by list position), each TU's ordered includes and forced
@@ -1109,18 +1114,35 @@ path (`None` — i.e. absent — on every ordinary comparison, matching
 `contract_coverage`'s own default).
 
 **`html_report.py` is a reporting surface too, not an omission this ADR can
-leave implicit.** AGENTS.md's own module map lists it alongside
+leave implicit — and it is not the only one that needs this treatment.**
+AGENTS.md's own module map lists it alongside
 `reporter.py`/`sarif.py`/`junit_report.py` under "Reporting," and
-`service_render.py`'s format dispatch (`:87-99`) routes `--format html` to
+`service_render.py`'s format dispatch (`:36-132`) routes `--format html` to
 `generate_html_report(result: DiffResult, ...)` exactly like the other three
-route to their renderers. Two distinct gaps follow from `generate_html_report`
-requiring a real `DiffResult`: for the hard-gate `not_comparable` case, no
+route to their renderers. **Verified against the actual code: `render_output`
+has five branches requiring a real `DiffResult` — `sarif` (`to_sarif_str`),
+`html` (`generate_html_report`), `junit` (`to_junit_xml`), `review`
+(`to_review_digest`), and the default `markdown` (`to_markdown`) — not
+`html` alone.** Two distinct gaps follow, for every one of these five, not
+just HTML: for the hard-gate `not_comparable` case, no
 `DiffResult` exists at all (the gate raises before any diff runs), so
-`service_render.render_output` must not attempt to call `generate_html_report`
-on that path — the front-end's exception handler renders (or declines to
-render) HTML the same way it assembles `verdict: null` JSON, rather than
-`generate_html_report` growing an optional-`DiffResult` parameter it was never
-designed to accept. For the mixed-pair `contract_coverage` case, a real
+`service_render.render_output` must not attempt to call any of these five
+renderers on that path — the front-end's exception handler renders (or
+declines to render) each requested format directly, the same way it
+assembles `verdict: null` JSON, rather than any of the five growing an
+optional-`DiffResult` parameter none was designed to accept. Two of these
+five carry a structured, externally-consumed schema and need a defined
+not-comparable shape, not just "skip the call": **SARIF** represents it as
+one `run` with `invocations[0].executionSuccessful: false` and a
+`toolExecutionNotifications` entry carrying the reason — SARIF's own
+mechanism for "the tool didn't complete analysis," so a downstream SARIF
+consumer (e.g. GitHub Code Scanning) can't misread an empty `results`
+array as a clean pass; **JUnit** represents it as one `<testsuite>` with a
+single `<testcase>` wrapping an `<error message="...">`, not a
+`<failure>` — JUnit's own convention for "the test itself couldn't run,"
+distinct from an ordinary reported ABI break. Markdown/review, being
+plain human-readable text with no schema to satisfy, get a simple "NOT
+COMPARABLE: `<reason>`" line. For the mixed-pair `contract_coverage` case, a real
 `DiffResult` does exist, so `generate_html_report` needs to surface
 `contract_coverage` in its headline cards the same way the JSON/Markdown/SARIF/JUnit
 reporters do — silently dropping it there would make the HTML report the one
@@ -1385,6 +1407,29 @@ Three outcomes, all extraction-time, none reaching D1's fingerprinting:
   is exactly the kind of "the extraction can't prove what it captured"
   situation this ADR's authority rule (ADR-028 D3) says must not be
   silently resolved in either direction.
+
+**Selecting the right context is not the same as the gate knowing which
+context was selected — `profile_fingerprint` must hash the resolved
+`frontend_context`/`kind`, or a host-vs-device mismatch passes D2's gate
+silently.** Two extractions requesting different `frontend_context`
+values (`host` on one side, `device` on the other) with identical
+compiler/target/macros/includes otherwise would parse genuinely different
+ASTs — different declarations, different macro state — but D1's
+`profile_fingerprint` field list (above) predates this section
+(`frontend_context` doesn't exist until D3/D5), so leaving it un-added
+would silently reopen exactly the under-counting bug D1 exists to close,
+one field short: a host/device extraction drift would be invisible to the
+gate, and any AST difference between the two contexts would surface as an
+ordinary reported `Change` — indistinguishable from a real ABI edit —
+instead of the pre-diff `not_comparable` this whole design exists to
+produce for exactly this class of drift. `profile_fingerprint`'s hashed
+fields therefore include the resolved `kind` (`"host"`/`"device"`) once
+this section's selection logic runs, not only the requested
+`frontend_context` string — the two would otherwise agree even when a
+`AST_CONTEXT_AMBIGUOUS`-adjacent frontend quirk resolved to a
+differently-labeled context on each side for the same requested value, an
+edge case the requested-string alone can't see but the actually-resolved
+`kind` can.
 
 A run that produces only a `spir64`/device context when `host` was
 requested is an extraction failure, not a successful-but-wrong snapshot.

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -174,7 +174,15 @@ not a latent surprise discovered after Phase A ships.
   `name`, not by list position), each TU's ordered includes and forced
   includes, each TU's `required`/`contributes_to_abi` flags, and the
   `public_header_paths`/`public_header_dirs`/filtering policy already
-  threaded through `dumper.py` today. The `contributes_to_abi` flag is a
+  threaded through `dumper.py` today. **For the legacy single-TU path this
+  filtering policy is exactly today's `--public-header`/`--public-header-dir`
+  CLI flags; for an explicit `--dump-manifest`, the same policy is a
+  base-profile field on the manifest document itself (D3), not the CLI
+  flags** — `--dump-manifest` and `--public-header`/`--public-header-dir`
+  are mutually exclusive on `dump`, so the manifest document is always the
+  complete, sole source of this fingerprint's inputs, never a CLI-flag/
+  manifest split that `plan --dump-manifest` (D3) couldn't see half of.
+  The `contributes_to_abi` flag is a
   hashed input, not just a manifest-validation detail (D3): flipping a TU
   from `contributes_to_abi: false` to `true` changes which declarations
   feed the ABI model without necessarily changing that TU's includes at
@@ -1433,7 +1441,10 @@ finding.
 ### D3. Manifest and real multi-TU dump
 
 New `abicheck/dump_manifest.py`: a strict YAML parser (unknown fields are
-errors, not silently ignored) for a `roots` / `translation_units` document —
+errors, and duplicate mapping keys are errors too — `yaml.safe_load`'s
+default last-value-wins duplicate-key handling is exactly the kind of
+silent scope drift this ADR exists to catch, not silently ignored) for a
+`roots` / `translation_units` document —
 each TU carries `name` (unique), `includes` (ordered), `forced_includes`
 (ordered, local to that TU only), `required: bool`, and
 `contributes_to_abi: bool`, with the invariant
@@ -1444,6 +1455,20 @@ contributes" is the exact shape that produces false removals). All existing
 single-header/`-H` CLI invocations construct a single-TU manifest internally
 (one `legacy-main` TU) — no behavior change for a caller not opting into a
 manifest file.
+
+The base profile also carries `public_header_paths`/`public_header_dirs`
+(both optional, root-relative, D1's provenance-classification inputs) —
+the manifest-mode equivalent of today's `--public-header`/
+`--public-header-dir` CLI flags. **`--dump-manifest` and `--public-header`/
+`--public-header-dir` are mutually exclusive on `dump`** (a `UsageError`,
+the same "manifest is the sole source of truth for scope" pattern D3
+already applies to `--frontend-context`'s CLI/manifest split): a caller
+using an explicit manifest declares provenance classification inside it,
+so `scope_fingerprint` (D1) always has one complete, manifest-only source
+for these inputs rather than a CLI-flag/manifest-field split that D3's
+`plan --dump-manifest` diagnostic (see below) — which reads the manifest
+document only, never invoking a compiler or resolving CLI flags — could
+never fully see.
 
 `dumper.py`'s `dump()` gains a manifest-driven path: **one castxml/clang
 invocation per TU** (base compile profile + that TU's own forced includes),

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -112,7 +112,20 @@ incompatible-reader guard, not just a version bump: a new
 is newer than what this reader supports," not "this reader predates the
 threshold"** — the two are not the same condition, and only the first one
 is actually what "Phase-A-or-later code hard-rejects unsupported schemas"
-requires: `IncompatibleSnapshotSchemaError` (`errors.py`) is raised when
+requires: `IncompatibleSnapshotSchemaError` (`errors.py`) — **a subclass of
+the existing `SnapshotError`, not a bare sibling of `AbicheckError`**,
+following the identical precedent `HeaderToolchainError(SnapshotError)`
+already documents ("a subclass of `SnapshotError` — existing `except
+SnapshotError` handling still catches it unchanged"). `cli_resolve.py`'s
+snapshot-loading paths (`:294-296`, `332-335`) already translate
+`ValidationError`/`SnapshotError` into a clean `click.UsageError`/
+`click.ClickException`; a schema-rejection raised while `compare`/`dump`
+loads an on-disk `.abi.json` snapshot must surface through that same
+existing translation, not bypass it as an unhandled internal failure the
+CLI has no branch for. Semantically it fits directly too —
+`SnapshotError`'s own docstring is "raised when an ABI snapshot cannot be
+loaded or parsed," exactly what a too-new `schema_version` is — is raised
+when
 the snapshot's `schema_version` is both **greater than the running
 `SCHEMA_VERSION`** (genuinely unsupported by this reader) *and* at or
 above the threshold — not merely "the running version is below the
@@ -1648,18 +1661,25 @@ selection key — a frontend could in principle label a context's target
 triple ambiguously or use a triple this ADR doesn't enumerate, and
 `sycl_context.py` must not be in the business of pattern-matching triple
 strings to guess intent when the compiler already states `kind` plainly.
-Three outcomes, all extraction-time, none reaching D1's fingerprinting:
+Three outcomes — only the two error outcomes are extraction-time failures
+that never reach D1's fingerprinting at all (there is no snapshot for
+either to describe); the successful-selection outcome instead *feeds*
+D1's fingerprinting, per the next paragraph below, not the reverse:
 
 - **Exactly one decoded context has the requested `kind`** — the normal
-  case, selected and passed on to normal extraction.
+  case, selected and passed on to normal extraction, whose resolved `kind`
+  is then hashed into `profile_fingerprint` (below) exactly like every
+  other resolved compile-context field.
 - **Zero decoded contexts have the requested `kind`** — `AST_CONTEXT_MISSING`
-  (e.g. only a `spir64`/device context when `host` was requested).
+  (e.g. only a `spir64`/device context when `host` was requested), an
+  extraction failure with no resulting snapshot, so nothing to fingerprint.
 - **More than one decoded context shares the requested `kind`** —
   `AST_CONTEXT_AMBIGUOUS`, never resolved by picking the first, the
   smallest, or any other implicit tiebreaker; an ambiguous frontend output
   is exactly the kind of "the extraction can't prove what it captured"
   situation this ADR's authority rule (ADR-028 D3) says must not be
-  silently resolved in either direction.
+  silently resolved in either direction — also an extraction failure with
+  no resulting snapshot, so nothing to fingerprint.
 
 **Selecting the right context is not the same as the gate knowing which
 context was selected — `profile_fingerprint` must hash the resolved

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -560,19 +560,32 @@ instead of one. `scan_cmd`'s inline registration switches to
 `SidedIncludePathParam` too (it already has old=/new= side semantics
 identical to `compare`'s, scoping to the current artifact vs. the
 `--against` side); its `split_sided_paths(include_pairs)` call becomes
-`split_sided_include_paths(include_pairs)`. `dump_cmd`'s inline
-registration switches to the *same* `SidedIncludePathParam`, rather than
-inventing a second, `dump`-only label grammar: `dump` has no old/new side
-to scope, but reusing one type keeps one label syntax across all three
-commands instead of asking users to remember a different one for `dump`
-(`--include old:support=path` on `compare`/`scan`, `--include
-both:support=path` on `dump` — side is parsed but ignored downstream,
-since `dump` has nothing to split by side in the first place; the label
-and path are what `dump` actually consumes). A bare, colon-less
-`--include` value on `dump` behaves exactly as it does today (label=None,
-side ignored) — inventing a colon-less-on-`dump`-only label shape would
-reopen the exact bare-`LABEL=PATH` ambiguity just closed above, for no
-real benefit.
+`split_sided_include_paths(include_pairs)`.
+
+**`dump_cmd` cannot reuse `SidedIncludePathParam` as-is — doing so
+silently breaks a currently-valid `dump --include` value, the exact class
+of regression this design has already had to catch twice for other
+grammars.** `SidedIncludePathParam` still honors the *unlabeled*
+`[old=|new=|both=]PATH` grammar `SidedPathParam` already implements —
+that's deliberate, so `compare`/`scan` (which already had this prefix
+rule) don't change behavior. But `dump_cmd`'s `--include` is a plain
+`click.Path` today: it has *never* recognized `old=`/`new=`/`both=` as a
+side prefix, so a directory literally named `old=foo/` is a valid,
+existing `--include` value there. Switching `dump_cmd` to
+`SidedIncludePathParam` wholesale would newly start stripping that prefix
+on `dump` too — a real, if narrow, behavior change on a flag that never
+had this ambiguity before, unlike `compare`/`scan`. `dump_cmd` therefore
+gets its own, `dump`-specific type, `LabeledIncludePathParam`: it
+recognizes **only** the colon-terminated `both:LABEL=PATH` form (colon
+was never meaningful to `dump`'s plain `click.Path` before, so adding it
+is purely additive) and treats *every other value* — bare, or one that
+happens to literally start with `old=`/`new=`/`both=` — as an ordinary,
+unlabeled path exactly as `click.Path` does today, with **no** equals-form
+side-prefix stripping at all. `dump`'s labeled form is therefore
+`--include both:support=path` (side is not a real concept for `dump`, so
+only `both:` is accepted — there is no `old:`/`new:` on a single-input
+command); a value like `--include old=foo/` keeps meaning the literal
+directory `old=foo/`, unchanged.
 This is a strict partition on `-I` *directories*, not individual files:
 `scope_fingerprint` owns everything under a project-owned root (declared
 or not); `profile_fingerprint` owns only external roots, in full.
@@ -780,15 +793,41 @@ gate therefore inspects *which* resolved fields differ, not only whether
 the overall hash differs: `check_contracts_comparable` computes the
 mismatch at field granularity (the same resolved fields
 `ExtractionContract` already stores so a report can show *what* differs,
-not just that the hashes don't match — D1), and when the *only* differing
-fields are target triple/pointer width/endianness, the gate does not
-raise — it lets `compare()` proceed to the normal `diff_*` pipeline, where
-`diff_platform.py`'s existing detectors take over and produce their own,
-already-correct verdict. Any *other* differing field (compiler family,
-macros, `-I` content, language standard) still hard-fails exactly as
-before, even if a target difference happens to co-occur with it — this
-carve-out is scoped to the platform-identity fields alone, not a general
-loosening of the gate.
+not just that the hashes don't match — D1). Any *other* differing field
+(compiler family, macros, `-I` content, language standard) still
+hard-fails exactly as before, even if a target difference happens to
+co-occur with it — this carve-out is scoped to the platform-identity
+fields alone, not a general loosening of the gate.
+
+**"Only the compile-context target differs" is necessary but not
+sufficient — the carve-out must also confirm the binaries themselves
+genuinely differ on that axis, or a misconfigured extraction slips
+through with nothing left to catch it.** A profile-only target mismatch
+can happen without the compared binaries actually targeting different
+architectures at all — a cross-compiler flag or `--gcc-prefix` set for
+only one side while both `.so`/`.dll` files are genuinely, say, `x86_64`
+is exactly this: `profile_fingerprint`'s target component differs (the
+*extraction* used a different target), but `diff_platform.py` has no
+`elf_machine_changed`/`elf_class_changed`/`elf_endianness_changed`
+finding to emit, because the binaries' own metadata never differed in the
+first place. Skipping the gate unconditionally in this case would let a
+misconfigured, genuinely non-comparable extraction proceed as an ordinary
+diff — any AST difference the wrong target introduced (a
+target-conditional `#ifdef` branch, a different `sizeof`) would surface
+as an apparently real reported `Change`, with no detector output to flag
+that anything was wrong, the opposite of "an artifact-backed detector
+already has a correct answer for this." The carve-out therefore requires
+*both* conditions, not just the profile-fingerprint one: (1) the only
+differing `profile_fingerprint` fields are target triple/pointer
+width/endianness, **and** (2) the old/new snapshots' own binary-derived
+platform metadata (the same ELF/PE/Mach-O header fields
+`elf_machine_changed` et al. already read) shows a genuine difference on
+that same axis. Only when both hold does the gate skip raising and let
+`compare()` proceed to `diff_platform.py`'s detectors; when (1) holds but
+(2) doesn't — the compile context's target differs but the real binaries
+agree — the gate still raises `ProfileMismatchError`, correctly treating
+it as an extraction misconfiguration rather than a legitimate
+cross-architecture comparison.
 
 **A fourth surface reaches `checker.compare` besides the three named
 above: `cli_compare_release.py`'s directory/package fan-out, and it needs
@@ -1100,7 +1139,19 @@ visible first-party consumer. `action/run.sh` gains a matching `VERDICT`
 value (e.g. `NOT_COMPARABLE`) for each new code, and
 `_maybe_post_pr_comment`'s `ERROR`-only skip is joined by an explicit
 carve-out that still posts for `NOT_COMPARABLE` — this result deserves the
-comment more than an ordinary pass, not less.
+comment more than an ordinary pass, not less. **Mapping the `VERDICT`
+string is necessary but not sufficient — `run.sh`'s separate final
+exit-code section has no `NOT_COMPARABLE` branch of its own, verified
+against the actual code (`:1074-1145`): it starts `FINAL_EXIT=0` and only
+ever sets it to `1` inside `ERROR`, or inside per-mode branches gated by
+their own `fail-on-*` inputs.** Adding only the `VERDICT` mapping leaves
+every mode's final-exit branch falling through unmatched, `FINAL_EXIT`
+staying `0` — a `compare`/`scan`/`deps-compare` step whose CLI exited
+`16`/`6`/`5` would still report a green composite Action step. This is
+fixed with its own unconditional check, alongside (not gated by, matching
+how `ERROR` itself is treated) the existing top-of-section `ERROR` check
+— whether a comparison could be attempted at all is not something a
+`fail-on-breaking`/`fail-on-api-break` toggle should be able to waive.
 
 **`assurance` is a single field on `DiffResult` (alongside
 `contract_coverage`), not a per-`Change` field.** A forced diagnostic

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -709,6 +709,25 @@ freshly-produced snapshot, and since D2's gate only ever raises when
 silently take the same code path as the intentionally-lenient mixed-pair
 case (D2) forever — the gate would be fully specified and fully inert.
 
+**"Every dump" means every dump that actually invoked an L2 header-AST
+frontend — a symbols-only/binary-only dump (no `--header`/`-H`, no
+manifest; native binaries fall back to this mode by design) attaches no
+`contract` at all, not a contract computed from unused inputs.**
+`profile_fingerprint` hashes the resolved compiler/macros/`-I` inputs a
+castxml/clang invocation actually used — for a symbols-only dump, no such
+invocation ever runs, so those fields describe nothing the snapshot
+actually depends on. Attaching a `profile_fingerprint` anyway (computed
+from whatever compile-context flags happen to be set on the CLI
+invocation, unused or not) would make two snapshots that are genuinely
+comparable at the L0/binary evidence tier spuriously mismatch on
+compile-context differences that never affected either snapshot — the
+opposite failure mode from the one D1/D2 exist to close, this time an
+*over*-counting bug instead of an under-counting one. `contract` staying
+`None` for a symbols-only dump is not a gap in D2's leniency rule; it is
+the existing "both sides `None` → gate doesn't fire" case (above) applying
+correctly to the one case where no L2 extraction happened on either side
+to disagree about in the first place.
+
 **The whole-snapshot cache is the same bypass by a different route, and it
 matters from day one, not just at D6's later cache-key extension.**
 `service_dump_cache.cached_run_dump` looks up `snapshot_cache` *before*

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -745,6 +745,29 @@ freshly-produced snapshot, and since D2's gate only ever raises when
 silently take the same code path as the intentionally-lenient mixed-pair
 case (D2) forever — the gate would be fully specified and fully inert.
 
+**Wiring the call site into `dumper.py` is not free real estate — `dumper.py`
+is already at its file-size hard cap with zero headroom, and D1 can ship
+before D3's manifest split exists to absorb the cost.** `dumper.py` is
+exactly `2000` lines today (`wc -l`), the same fact D3/D6's own per-TU-loop
+split (`dumper_manifest.py`, below) is justified by — but D1 lands
+independently of D3 (D1 requires only Phase 0; it does not depend on D3),
+so an implementation following D1 alone cannot rely on D3's later split
+having already created headroom. Any net-positive line addition to
+`dumper.py` — even the few lines this call site and its
+`project_include_labels` parameter need — immediately trips the
+AI-readiness `file-size` gate's `>2000` ERROR threshold. D1 therefore
+requires, in the same change that wires in `compute_extraction_contract`,
+a net-neutral-or-negative line-count delta to `dumper.py`: relocating a
+self-contained, currently-unrelated chunk of `dumper.py`'s own existing
+content to a suitable existing or new sibling module first, reclaiming
+enough headroom before (or alongside) adding the new call site — not
+prose alone, verified by the same `file-size` check in the same PR. This
+is deliberately not deferred to D3's later `dumper_manifest.py` split:
+that module is scoped to the per-TU loop D3 introduces, a different piece
+of work than D1's own attachment glue, and waiting for it would leave D1
+unable to land on its own at all, contradicting D1's own "ships
+independently" property.
+
 **"Every dump" means every dump with at least one resolved input to
 fingerprint — a symbols-only/binary-only dump (no `--header`/`-H`, no
 manifest; native binaries fall back to this mode by design) attaches no

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -994,20 +994,39 @@ contract: `abicheck scan --against`.** `cli_scan_baseline.py`'s
 `:852`) calls `service.compare_snapshots` — which, being a thin wrapper
 over `checker.compare` with no exception handling of its own, lets
 `ProfileMismatchError`/`ScopeMismatchError` through untouched, exactly as
-D2 intends at the `service.py` boundary. But `scan`'s own CLI command
+D2 intends at the `service.py` boundary. `scan`'s own CLI command
 (`cli_scan.py`'s `scan_cmd`) has an independent, narrower exit-code
-contract (`0`/`2`/`4`/`5`/`64`, `docs/reference/exit-codes.md`) and its own
-`try`/`except` around the `run_scan_core` call that today only catches
-`_BudgetOverflow` and `_EvidenceContractError` — not
-`ProfileMismatchError`/`ScopeMismatchError`, which would propagate
-uncaught out of `scan_cmd` entirely, an unhandled traceback rather than
-any of `scan`'s documented exit codes. Listing only `service.py`'s
-`ScanRequest`/`compare_snapshots` as "the gate reaches `scan`" describes
-where the exception passes through cleanly, not where `scan`'s own CLI
-command classifies it into a deliberate outcome — the same distinction
-already drawn for `compat/cli.py` above. `scan_cmd` gains a dedicated
-`except (ProfileMismatchError, ScopeMismatchError) as exc:` branch
-alongside its existing two, exiting **`6`** — the next integer after
+contract (`0`/`2`/`4`/`5`/`64`, `docs/reference/exit-codes.md`), but the
+catch does **not** belong in `scan_cmd`'s own `try`/`except` (which today
+only catches `_BudgetOverflow`/`_EvidenceContractError`): `scan_cmd`'s
+outer `try` only has a finished `ScanCoreResult` to work with once
+`run_scan_core` returns, and every existing exception branch there
+(`_BudgetOverflow`, `_EvidenceContractError`) bypasses `scan_cmd`'s own
+`_emit_scan_report` call — the one function that renders JSON/text, writes
+the `-o` file, and exits on a nonzero code — and exits/raises bare
+instead. A `scan_cmd`-level catch would inherit that same bypass: `scan
+--against ... --format json -o report.json` on a mismatched pair would
+exit `6` but write no report file at all, even though `scan`'s own
+`SCAN_SCHEMA_VERSION` bump (D2, above) is framed as versioning exactly
+this envelope's new verdict. The catch instead belongs inside
+`run_scan_core` itself, around the `_run_baseline_compare` call — where
+`ScanOutcome`'s other fields (mode, resolved method, depth, risk,
+coverage, etc.) are already locally resolved and about to feed the
+function's own `ScanOutcome(...)` construction a few lines below. A new
+`except (ProfileMismatchError, ScopeMismatchError) as exc:` branch there
+sets `verdict="NOT_COMPARABLE"`/`exit_code=6`/a reason field, skips the
+crosscheck-severity-promotion step (a `NOT_COMPARABLE` gate result is not
+something a promoted finding should be able to soften), and falls through
+to the normal `ScanOutcome` construction — so `scan_cmd`'s existing,
+unconditional `_emit_scan_report` call renders and writes it exactly like
+any other scan result, needing no `scan_cmd`-level change at all. Since
+`run_scan_core`'s own docstring already calls it "the one body the CLI,
+`service.run_scan`, and the MCP scan tool share," this single fix also
+reaches `service_scan.run_scan` (which already builds its typed
+`ScanResult` from `core.outcome` without re-running anything) and
+`run_scan_subprocess`'s worker/`mcp_server.abi_scan` (which no longer has
+an exception to swallow into a generic `RuntimeError` at all) without a
+separate change at either. Exit **`6`** is the next integer after
 `scan`'s own highest documented code (`5`, the budget-overflow exit),
 distinct from both native `compare`'s `16` and `compat check`'s `9` since
 all three commands maintain independent, non-overlapping exit-code

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -745,10 +745,10 @@ freshly-produced snapshot, and since D2's gate only ever raises when
 silently take the same code path as the intentionally-lenient mixed-pair
 case (D2) forever — the gate would be fully specified and fully inert.
 
-**"Every dump" means every dump that actually invoked an L2 header-AST
-frontend — a symbols-only/binary-only dump (no `--header`/`-H`, no
+**"Every dump" means every dump with at least one resolved input to
+fingerprint — a symbols-only/binary-only dump (no `--header`/`-H`, no
 manifest; native binaries fall back to this mode by design) attaches no
-`contract` at all, not a contract computed from unused inputs.**
+`profile_fingerprint`, not a fingerprint computed from unused inputs.**
 `profile_fingerprint` hashes the resolved compiler/macros/`-I` inputs a
 castxml/clang invocation actually used — for a symbols-only dump, no such
 invocation ever runs, so those fields describe nothing the snapshot
@@ -758,11 +758,48 @@ invocation, unused or not) would make two snapshots that are genuinely
 comparable at the L0/binary evidence tier spuriously mismatch on
 compile-context differences that never affected either snapshot — the
 opposite failure mode from the one D1/D2 exist to close, this time an
-*over*-counting bug instead of an under-counting one. `contract` staying
-`None` for a symbols-only dump is not a gap in D2's leniency rule; it is
-the existing "both sides `None` → gate doesn't fire" case (above) applying
-correctly to the one case where no L2 extraction happened on either side
-to disagree about in the first place.
+*over*-counting bug instead of an under-counting one.
+
+**But `--public-header`/`--public-header-dir` are still real, active
+inputs on a symbols-only dump, even with no `-H`/manifest at all — `dump()`
+calls `apply_provenance(snapshot, public_headers, public_header_dirs)`
+unconditionally at the end of every dump (`dumper.py:1267-1272`),
+regardless of whether an L2 frontend ran, and public-surface filtering
+(`--scope-public-headers`, ADR-024) reads the `ScopeOrigin` that call
+produces.** Two symbols-only dumps of otherwise-identical DWARF data but
+different `--public-header-dir` sets can therefore produce genuinely
+different *filtered* diffs — exactly the silent scope drift D1/D2 exist to
+catch — yet the blanket "no contract at all for a symbols-only dump" rule
+above would leave the gate blind to it, since neither side would carry
+anything to compare. `contract`'s two fingerprints are therefore
+independently optional, not an all-or-nothing pair: a symbols-only dump
+attaches a `contract` with `profile_fingerprint: None` (nothing to
+compute — no L2 invocation ran) but a real `scope_fingerprint`, computed
+from `public_header_paths`/`public_header_dirs`/the filtering policy
+alone, **whenever either is non-empty**; a symbols-only dump with *neither*
+`-H` nor `--public-header`/`--public-header-dir` still attaches no
+`contract` at all (both fingerprints would be computed from nothing), the
+original rule applying correctly to the one case where genuinely no
+scope-affecting input was used on either side.
+
+`check_contracts_comparable` (D2) compares each fingerprint
+independently rather than treating `contract` as one opaque all-or-nothing
+unit: `scope_fingerprint` is compared whenever both sides have one
+(regardless of whether either side's `profile_fingerprint` is present),
+and `profile_fingerprint` is compared whenever both sides have one. A
+symbols-only side with only a `scope_fingerprint` compared against a full
+L2 header-AST side (which has both) therefore still gets its scope
+checked — the real risk this fix closes — without spuriously hard-failing
+on `profile_fingerprint` alone just because one side never ran an L2
+frontend at all, which is an ordinary, intentional depth difference (e.g.
+`scan --depth binary` against a fuller stored baseline), not scope drift,
+and must stay lenient exactly like today's "mixed pair" case (D2) — this
+is a refinement of that leniency rule to per-fingerprint granularity, not
+a narrowing of it. `contract` staying entirely `None` for a symbols-only
+dump with no provenance inputs either is not a gap in D2's leniency rule;
+it is that same rule applying correctly to the one case where no
+scope-affecting input was used on either side to disagree about in the
+first place.
 
 **The whole-snapshot cache is the same bypass by a different route, and it
 matters from day one, not just at D6's later cache-key extension.**
@@ -1402,22 +1439,33 @@ be trusted to have correctly detected a removal either — an apparent
 of unproven inference this ADR exists to block, not a real removal
 finding entitled to its own exit code.
 
-**Mixed pairs (one side has a `contract`, the other doesn't) never hard-fail
-— this is unambiguous, not left to implementer discretion.** The backward-
-compatibility promise ("a snapshot from before this ADR compares exactly as
-it does today") is not a soft goal to reconcile with the gate; a
-contract-less snapshot's *absence* of evidence is exactly the "missing
+**Mixed pairs (one side lacks a given fingerprint, the other has it) never
+hard-fail on that fingerprint — this is unambiguous, not left to
+implementer discretion, and applies per-fingerprint (D1's independently-
+optional `profile_fingerprint`/`scope_fingerprint`), not only to a
+side missing `contract` entirely.** The backward-compatibility promise
+("a snapshot from before this ADR compares exactly as it does today") is
+not a soft goal to reconcile with the gate; a side's *absence* of a given
+fingerprint's evidence — whether because it carries no `contract` at all,
+or because it carries a `contract` with that one field unset (D1's
+symbols-only-with-provenance-inputs case) — is exactly the "missing
 evidence must never manufacture a block" situation ADR-028 D3's authority
-rule already covers, extended here to the comparability contract instead of
-symbol facts. `check_contracts_comparable` therefore only ever raises
-`ProfileMismatchError`/`ScopeMismatchError` when **both** sides carry a
-`contract` and it mismatches — a mixed pair takes the exact same code path
-as a pair where neither side carries one, and comparing a newly-produced
-snapshot against a pre-ADR baseline (the common "upgrade abicheck, keep the
-stored CI baseline" workflow) never regresses into an unexpected
-`not_comparable` result. `UNKNOWN_PROFILE` is **not** a `not_comparable`
+rule already covers, extended here to the comparability contract instead
+of symbol facts. `check_contracts_comparable` therefore only ever raises
+`ProfileMismatchError` when **both** sides have a non-`None`
+`profile_fingerprint` and it mismatches, and only ever raises
+`ScopeMismatchError` when **both** sides have a non-`None`
+`scope_fingerprint` and it mismatches — a side missing one fingerprint (or
+`contract` itself) takes the exact same lenient code path for *that*
+fingerprint as a pair where neither side carries one, so comparing a
+newly-produced snapshot against a pre-ADR baseline (the common "upgrade
+abicheck, keep the stored CI baseline" workflow), or a symbols-only side
+against a full-header-AST side, never regresses into an unexpected
+`not_comparable` result on the fingerprint that side never had to begin
+with. `UNKNOWN_PROFILE` is **not** a `not_comparable`
 reason and never blocks: it is a non-authoritative annotation on
-an otherwise-ordinary verdict, surfaced only for a mixed pair, to tell the
+an otherwise-ordinary verdict, surfaced whenever at least one side is
+missing a fingerprint the other side has, to tell the
 reader "this comparison ran without being able to check profile/scope
 drift on one side," without withholding the verdict itself.
 

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -464,13 +464,30 @@ extended for `--include` specifically into a new `SidedIncludePathParam`
 — `--header` and the other sided-path options keep the unchanged,
 2-tuple `SidedPathParam`, since only `--include` needs a label slot.
 `SidedIncludePathParam` recognizes an optional labeled form layered on
-top of the existing `[old=|new=|both=]PATH` grammar: `[old:|new:|both:]
-LABEL=PATH` — a colon-terminated side prefix (colon instead of `=` so it
-can't collide with the label's own `=`; unambiguous, since no existing
-`--include` value has ever started with `old:`/`new:`/`both:`), returning
-a `(side, label, path)` triple with `label=None` for every existing,
-unlabeled form (`PATH`, `old=PATH`, ...) so ordinary uses are
-byte-for-byte unaffected. A genuine two-checkout compare with
+top of the existing `[old=|new=|both=]PATH` grammar. **The labeled form
+requires the literal colon prefix — `old:`, `new:`, or `both:` — with no
+colon-less/bare labeled variant at all; the bracket in
+`[old:|new:|both:]LABEL=PATH` means "one of these three literal prefixes
+is present," never "the whole prefix segment, colon included, may be
+omitted while still parsing as `LABEL=PATH`."** Getting this backwards
+would silently break existing usage: `SidedPathParam.convert` (the type
+`--include` uses today) checks only `s.startswith("old=")` /
+`"new="` / `"both="`, so an ordinary external directory that happens to
+contain a literal `=` past that point — `build/config=asan/include`, a
+real, valid `--include` value today — never matches any of those three
+prefixes and falls through unchanged to `("both", Path(...))`. If the new
+type additionally tried a bare (colon-less) `LABEL=PATH` split on *any*
+value with no recognized prefix, `build/config=asan/include` would be
+reinterpreted as `label="build/config"`, `path="asan/include"` — a
+different compiler argument and a directory now wrongly eligible for the
+labeled per-slot token, breaking a currently-valid, unrelated value that
+never opted into labeling. The fix is definitional, not a runtime check to
+add: a value is only ever inspected for a label *after* one of the three
+literal `old:`/`new:`/`both:` prefixes has already matched; every other
+value — bare, `old=`/`new=`/`both=`-prefixed, or containing an unrelated
+`=` — takes the exact, unmodified path `SidedPathParam` already takes
+today, `label=None` unconditionally, `=` treated as an ordinary path
+character precisely as it is now. A genuine two-checkout compare with
 side-specific support-root paths under one shared logical identity is
 declared `--include old:support=old/src --include new:support=new/src`
 — same `support` label on both invocations (so the per-slot token below
@@ -490,6 +507,40 @@ section. This labeled `--include` form is a legacy-CLI-only addition: the
 manifest path (D3) already has no such gap, since a manifest TU can
 declare a per-TU forced-include for exactly this directory instead of
 relying on directory-tree inference.
+
+**`--include` is not one Click registration shared by `compare`/`dump`/`scan`
+— it is three separate ones today, and `SidedIncludePathParam` only fixes
+the one this section has been describing.** Verified against the actual
+code: `cli_options.py`'s `two_sided_input_options` (the `SIDED_PATH_PARAM`
+registration this section extends) is applied only to native `compare`;
+`dump_cmd`'s own `--include` (`cli.py:486`) is declared inline as a plain,
+non-sided `click.Path` (`dump` has one input, no old/new side concept at
+all, so it never carried `SidedPathParam` in the first place); `scan_cmd`'s
+own `--include` (`cli_scan.py:487-495`) is *also* declared inline, with its
+own separate `type=SIDED_PATH_PARAM` registration, not the `compare`
+decorator. Fixing only `compare`'s registration leaves a snapshot produced
+via `abicheck dump` or `abicheck scan --against` with no way to express a
+project-support label at all — `project_include_labels` stays empty for
+those commands, and a sibling support root a `dump`/`scan` invocation
+declares stays classified as external, reproducing the exact
+`PROFILE_MISMATCH` this whole fix exists to close, just on two commands
+instead of one. `scan_cmd`'s inline registration switches to
+`SidedIncludePathParam` too (it already has old=/new= side semantics
+identical to `compare`'s, scoping to the current artifact vs. the
+`--against` side); its `split_sided_paths(include_pairs)` call becomes
+`split_sided_include_paths(include_pairs)`. `dump_cmd`'s inline
+registration switches to the *same* `SidedIncludePathParam`, rather than
+inventing a second, `dump`-only label grammar: `dump` has no old/new side
+to scope, but reusing one type keeps one label syntax across all three
+commands instead of asking users to remember a different one for `dump`
+(`--include old:support=path` on `compare`/`scan`, `--include
+both:support=path` on `dump` — side is parsed but ignored downstream,
+since `dump` has nothing to split by side in the first place; the label
+and path are what `dump` actually consumes). A bare, colon-less
+`--include` value on `dump` behaves exactly as it does today (label=None,
+side ignored) — inventing a colon-less-on-`dump`-only label shape would
+reopen the exact bare-`LABEL=PATH` ambiguity just closed above, for no
+real benefit.
 This is a strict partition on `-I` *directories*, not individual files:
 `scope_fingerprint` owns everything under a project-owned root (declared
 or not); `profile_fingerprint` owns only external roots, in full.

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -338,6 +338,34 @@ underlying invocation. Every listed path is attributed to whichever declared
 one additional cheap compiler flag per TU, not a second compiler invocation
 or a directory-tree walk — rather than inventing new file-discovery logic.
 
+**Project-ownership isn't only a declared-`-I`-directory concept — a
+declared header's own parent directory is implicitly project-owned too,
+even with no `--include` naming it at all, or the single most common
+workflow (header-only, no `-I`) reintroduces this whole section's bug.**
+The C/C++ preprocessor resolves a quote-include (`#include "detail.h"`)
+by first searching the *including file's own directory*, independent of
+any `-I` search path — standard behavior no compiler flag is needed to
+get. A side declared with only `--header old/include/foo.h` (no
+`--include` at all — an entirely ordinary, minimal invocation) still has
+`foo.h`'s own directory searched for its quote-includes; if `foo.h`
+`#include`s a private `detail.h` from that same directory, the depfile
+lists `detail.h` under `old/include/`, but no `-I` directory was ever
+declared there for the ancestor rule above to classify. Left unhandled,
+this path falls through to "not under any declared `-I` directory" (the
+system/toolchain bucket described next) and gets full content hashing —
+so an ordinary, project-internal edit to `detail.h` flips
+`profile_fingerprint` and hard-fails the gate on the single most common
+compare shape (headers only, no explicit `-I`), not an edge case. The
+project-ownership predicate is therefore not "is this path under a
+*declared* `-I` directory that's project-owned" alone; it also treats the
+**parent directory of every declared `--header`/manifest TU path** as an
+implicitly project-owned root, whether or not that same directory was
+separately passed via `--include` — the same exclusion-in-entirety
+treatment (not file-by-file) the explicit ancestor rule already applies,
+just triggered by a header's own location instead of a declared `-I`
+flag. This closes the gap for exactly the workflow variant the explicitly-
+declared-`-I` fix above didn't cover: no `--include` present at all.
+
 **Not every `-MD`-listed path falls under a declared `-I` directory, and
 those paths cannot be silently dropped or mis-attributed.** `dumper.py`
 already introduces header search paths that are never part of the

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -1589,10 +1589,25 @@ existing mechanism, plus D1's own order-sensitivity fix (Phase A, not
 deferred here) already invalidates on the cases that matter; D6 adds no
 further cache-key work for the `-I`/profile side beyond that. D6's cache-key
 extension is instead scoped to what genuinely is pre-dump-knowable and not
-already covered: the manifest-driven `scope_fingerprint` inputs (TU
-`required`/`contributes_to_abi` flags, D3), which the existing
-`iter_cache_header_files` walk has no way to see since they aren't
-filesystem content at all.
+already covered: **the manifest-driven `scope_fingerprint`'s full set of
+inputs, not only its `required`/`contributes_to_abi` flags** — an earlier
+revision of this paragraph narrowed to just those two flags, but D1's own
+`scope_fingerprint` definition also covers each TU's *name*, its *ordered*
+`includes`/`forced_includes`, and (D1's sibling-support-root fix) each
+`includes` entry's `project_owned` bit. A manifest-only change confined to
+any of those — a TU rename, a per-TU include/forced-include reorder, or
+flipping `project_owned` on an unchanged path — leaves filesystem content
+untouched (so `iter_cache_header_files`'s content/mtime walk can't see it)
+while still changing what the extraction contract actually computes; a
+cache key scoped to only the two flags would miss exactly this class of
+drift and serve a stale `contract` from a warm cache, defeating D2's gate
+through a route this whole cache-key extension exists to close. D6
+therefore hashes the manifest-driven `scope_fingerprint`'s **full**
+computed input set — TU names, per-TU ordered includes/forced-includes,
+the `contributes_to_abi`/`required` flags, and each `includes` entry's
+`project_owned` bit, together, not any one piece in isolation — none of
+which the existing `iter_cache_header_files` walk has any way to see,
+since none of it is filesystem content at all.
 
 ## Non-goals
 

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -420,8 +420,41 @@ scope-adjacent, not environment, and is excluded from `profile_fingerprint`
 in its entirety, not file-by-file. A declared `-I` directory with no such
 relationship to any declared header is **external** and keeps the full
 per-file content digest described above — a genuine third-party dependency,
-where a change anywhere in it *is* meaningful profile drift. This is a
-strict partition on `-I` *directories*, not individual files:
+where a change anywhere in it *is* meaningful profile drift.
+
+**The ancestor rule alone misses a common, non-nested project layout: a
+support directory declared as a *sibling* of the public header root, not
+underneath it.** A public header `include/foo.h` frequently `#include`s a
+build-generated header from `generated/`, or a private implementation
+header from `src/` or `config/` — directories passed via their own
+`--include`, but not an ancestor of any declared `--header`, since they sit
+next to `include/`, not inside it. The ancestor rule classifies each of
+these as **external** today, so an ordinary edit to a build-generated or
+private support header — exactly the same routine-internal-change case
+the whole-directory exclusion above exists to protect — still flips
+`profile_fingerprint` and hard-fails the gate, on a project layout common
+enough (any CMake/Meson build with a generated-headers directory) that
+this is not the same "unusual declaration shape" class as the
+nested-vendor-dependency gap below; it is a routine one. The legacy CLI
+gains an explicit escape hatch for exactly this case: a new, side-scoped,
+**labeled** `--project-include <label>=<path>` option (`--project-include
+support=old/src --project-include support=new/src`, alongside the
+existing side-scoped `--include old=... --include new=...` convention,
+ADR-040) that asserts a declared `-I` directory is project-owned
+regardless of whether it is an ancestor of any declared header. Unlike
+`--include`, `--project-include` requires a `label` — not a path-derived
+name, a short user-supplied logical identifier, the same "name a TU
+instead of inferring one from path shape" choice the manifest path (D3)
+already makes for its `name` field — because an explicitly-declared
+support root has no natural "owned declared header" for the per-slot
+token below to derive from the way an ancestor-derived root does; asking
+the user for one avoids inventing yet another path-shape heuristic that
+could break in some other way, the repeated lesson of every rejected
+attempt in this section. `--project-include` is a legacy-CLI-only
+addition: the manifest path (D3) already has no such gap, since a
+manifest TU can declare a per-TU forced-include for exactly this
+directory instead of relying on directory-tree inference.
+This is a strict partition on `-I` *directories*, not individual files:
 `scope_fingerprint` owns everything under a project-owned root (declared
 or not); `profile_fingerprint` owns only external roots, in full.
 
@@ -443,19 +476,51 @@ failure mode this whole digest exists to close, reintroduced through the
 exclusion mechanism itself. The fix keeps the sequence positional: each
 declared `-I` directory still occupies its own slot in the ordered
 sequence, in declaration order; a project-owned slot's *content* is
-replaced with a single fixed sentinel value (a constant, not derived from
-the directory's path, name, or content) rather than being omitted, so two
-project-owned directories still compare equal to each other (no scope
-information leaks into `profile_fingerprint` through the sentinel) while
-their position relative to every external directory's real content digest
-is preserved. `-I project -I dep` therefore hashes
-`[SENTINEL, digest(dep)]` and `-I dep -I project` hashes
-`[digest(dep), SENTINEL]` — different sequences, different
-`profile_fingerprint`s, correctly flagging that the two extractions are not
-comparable, even though neither ordering's project-owned content
-individually affects the hash. The system/toolchain bucket is unaffected —
-it is explicitly unordered (see above) because its inputs were never part
-of a user-declared, precedence-bearing `-I` sequence to begin with.
+replaced with a per-slot logical token (not being omitted) rather than a
+single generic constant — **a single shared sentinel for every
+project-owned slot loses order information again, one level down, when
+there are two or more project-owned roots.** `-I include -I generated`
+vs. `-I generated -I include` (both directories project-owned, both
+byte-identical between old and new, but declared in swapped order) is the
+same ambiguous-`#include`-resolution problem as the project/external
+case above, and a shared constant sentinel hashes both orderings to the
+identical `[SENTINEL, SENTINEL]` sequence — silently losing exactly the
+order information this whole fix exists to keep. The token is instead
+derived per slot from one of two sources depending on *why* the slot is
+project-owned: for an **ancestor-derived** root, the **sorted set of
+declared `--header`/manifest TU names that directory is an ancestor of**
+(not its path, not its content) — two ancestor-derived directories that
+are ancestors of different declared headers get different tokens, so
+swapping their declared order changes the hashed sequence, while a
+directory that is ancestor of the *same* declared header set on both old
+and new sides still tokenizes identically regardless of its own mount
+point, consistent with `scope_fingerprint` already treating declared
+header *names* (not paths) as legitimate, already-tracked identity, so
+this leaks nothing beyond what `scope_fingerprint` exposes today; for an
+explicitly-declared **`--project-include`** support root (which owns no
+declared header by construction — that is exactly why it needed its own
+flag above), the token is its required user-supplied **`label`** instead,
+namespaced separately from the ancestor-derived token space so a label
+string can never accidentally collide with a declared header name.
+`-I project -I dep` (`project` ancestor of declared header `foo.h`)
+therefore hashes `[token(foo.h), digest(dep)]` and `-I dep -I project`
+hashes `[digest(dep), token(foo.h)]` — different sequences, different
+`profile_fingerprint`s, correctly flagging non-comparability; two
+ancestor-derived roots for different declared headers (`include/` →
+`foo.h`, a second header root → `bar.h`) produce distinguishable,
+order-sensitive tokens instead of collapsing to one interchangeable
+constant, and two `--project-include` roots (`--project-include
+support=old/src`, `--project-include generated=old/gen`) are
+distinguished by their distinct labels the same way. **Residual
+limitation, same class as the vendored-nested-dependency
+gap below:** two separately declared `-I` roots that are both ancestors of
+the *same* declared header (an outer directory and one of its own
+subdirectories, both passed as separate `-I` entries) tokenize identically
+and so remain order-indistinguishable from each other — an unusual
+declaration shape, not the routine case this fix targets. The
+system/toolchain bucket is unaffected — it is explicitly unordered (see
+above) because its inputs were never part of a user-declared,
+precedence-bearing `-I` sequence to begin with.
 A known, accepted residual gap: a vendored dependency nested *inside* a
 project-owned root (e.g. `include/thirdparty/foo.h` under the project's
 own `include/`) is swept into the project-owned exclusion along with

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -372,10 +372,23 @@ independent exit-code contract that this ADR must not silently
 break: `abicheck/compat/cli.py`'s ABICC-compatible `compat check`
 command** (`from ..checker import compare`, called around `:967`).
 Because `compare()` there is the exact same function D2's gate wraps,
-`ProfileMismatchError`/`ScopeMismatchError` propagate to `compat check`
-automatically — the gap is not "the gate doesn't fire," it's that nothing
-classifies the resulting exception into a *deliberate* compat-mode
-outcome. `compat/CLAUDE.md` documents a closed exit-code contract (`0`
+`ProfileMismatchError`/`ScopeMismatchError` propagate out of that call —
+but, verified against the actual call site, **not into any existing
+classifier**: unlike `check`'s other operations (descriptor parsing,
+logging setup, dump, report writing), each individually wrapped in its own
+narrow `except ... : _compat_fail(...)` block, the bare `result =
+compare(old_snap, new_snap, ...)` call has no surrounding `try` at all
+today. Left alone, the new exceptions would propagate uncaught out of the
+Click command entirely — not into `_classify_compat_error_exit_code`'s
+generic `10` fallback (which would at least be a *wrong but classified*
+outcome), but past classification altogether, as an unhandled traceback.
+This phase adds the missing `try`/`except (ProfileMismatchError,
+ScopeMismatchError) as exc: _compat_fail("comparing snapshots", exc)`
+around that call site — a real call-site change, not merely a classifier
+update — so the gap is not "the gate doesn't fire," it's that nothing
+today would catch the resulting exception at all, let alone classify it
+into a *deliberate* compat-mode outcome. `compat/CLAUDE.md` documents a
+closed exit-code contract (`0`
 compatible, `1` `BREAKING`, `2` `API_BREAK`, `3`–`11` errors via
 `_classify_compat_error_exit_code` in `compat/_errors.py`) that "requires
 a CHANGELOG note and downstream coordination" to change — this ADR cannot
@@ -398,8 +411,18 @@ On the reporting surface (`reporter.py`,
 top-level state — `verdict: null`, a `reason` object naming the mismatched
 fingerprint field(s) — never coerced into `COMPATIBLE`/`BREAKING`'s existing
 enum values. A `--diagnostic-comparison` opt-in flag (default off) downgrades
-the hard-fail to a tentative diff with `assurance: none` stamped on every
-finding, for exploratory use — never the default, and never silent.
+the hard-fail to a tentative diff, the whole result stamped `assurance:
+"none"` for exploratory use — never the default, and never silent.
+**`assurance` is a single field on `DiffResult` (alongside
+`contract_coverage`), not a per-`Change` field.** A forced diagnostic
+comparison is uniformly tentative — the contract gate failed for the pair
+as a whole, before any `diff_*` module ran, so every finding the tentative
+diff produces shares the identical, single reduced-assurance reason; there
+is no per-finding split to encode. `checker_types.Change` gains no new
+field for this; `checker_types.py` gains `assurance: str | None = None`
+on `DiffResult` itself, set to `"none"` only on the `--diagnostic-comparison`
+path (`None` — i.e. absent — on every ordinary comparison, matching
+`contract_coverage`'s own default).
 
 **`html_report.py` is a reporting surface too, not an omission this ADR can
 leave implicit.** AGENTS.md's own module map lists it alongside

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -108,10 +108,26 @@ incompatible-reader guard, not just a version bump: a new
 `_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION = 12` constant in
 `serialization.py` (same naming convention as the existing
 `_MIN_SCHEMA_VERSION_FOR_CV_FACTS`, `:88`), checked in `snapshot_from_dict`
-*before* today's warn-only branch: when the snapshot's `schema_version` is
-at or above that threshold and the running `SCHEMA_VERSION` is below it, a
-new `IncompatibleSnapshotSchemaError` (`errors.py`) is raised instead of a
-warning being emitted. Versions below the threshold keep today's
+*before* today's warn-only branch. **The guard is keyed off "the snapshot
+is newer than what this reader supports," not "this reader predates the
+threshold"** — the two are not the same condition, and only the first one
+is actually what "Phase-A-or-later code hard-rejects unsupported schemas"
+requires: `IncompatibleSnapshotSchemaError` (`errors.py`) is raised when
+the snapshot's `schema_version` is both **greater than the running
+`SCHEMA_VERSION`** (genuinely unsupported by this reader) *and* at or
+above the threshold — not merely "the running version is below the
+threshold." Keying it off the running version alone stops protecting the
+moment a reader itself reaches schema 12: that reader would correctly
+reject a schema-12 snapshot (a version *older or equal* to what it
+already knows), but would silently warn-and-continue on a hypothetical
+future schema-13 snapshot carrying its own new comparability-critical
+field, precisely the failure mode this guard exists to close, just moved
+one schema bump later. The `>` running-version comparison generalizes
+correctly to that future bump without any change to this guard's logic:
+a schema-13 bump only needs its own new threshold (or reuses `12` if 13
+doesn't add another hard-rejection-worthy field) — the guard doesn't need
+updating just because the running binary caught up to the current
+threshold. Versions below the threshold keep today's
 warn-and-continue behavior unchanged (the existing, deliberately lenient
 default for ordinary additive fields, per ADR-041's `extractor_passes`
 precedent) — only the specific jump that first introduces a

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -336,6 +336,29 @@ of the **ordered** sequence of per-`-I`-directory digests, **plus** this one
 additional system/toolchain bucket appended last, deterministically
 positioned so its presence or absence never depends on iteration order.
 
+**The depfile's own generated driver file must be excluded before any of
+this bucketing runs — not swept into the system/toolchain bucket as "just
+another unattributed path."** `dumper.py` writes a synthetic aggregate
+`#include` header via `tempfile.NamedTemporaryFile` (`:364,1019`) and
+compiles *that* as the TU's real source; `parse_depfile`'s own contract
+(`buildsource/include_graph.py:210-235`, confirmed by
+`tests/test_include_graph.py`'s `parse_depfile("foo.o: foo.cpp a.h b.h") ==
+["foo.cpp", "a.h", "b.h"]`) returns the compiled source itself as the first
+prerequisite, not only the headers it pulls in. That generated `/tmp` file
+is under no declared `-I` directory, so the rule above would otherwise
+sweep it straight into the system/toolchain bucket — and its *content*
+embeds the side-specific absolute `#include "..."` paths `dumper.py` wrote
+for that run's own header list, which necessarily differ between old and
+new sides for the ordinary two-checkout case (different checkout roots
+mean different absolute paths), even when the actual compile environment
+is identical. Bucketing it would make `profile_fingerprint` differ on
+*every* routine compare, not an edge case — the single worst-case version
+of the failure mode this whole redesign exists to close. The generated
+driver TU (identified as `dumper.py`'s own synthesized source path, not a
+declared `-I`/`-H` input) is therefore dropped before any bucketing runs,
+never hashed into either the per-`-I` digests or the system/toolchain
+bucket — it is abicheck's own scaffolding, not a dependency.
+
 **The digest must exclude every path already claimed by `scope_fingerprint`
 — this is not an optional refinement, it is the difference between a
 working gate and one that hard-fails on every ordinary compare.** The
@@ -591,6 +614,28 @@ fingerprint field(s) — never coerced into `COMPATIBLE`/`BREAKING`'s existing
 enum values. A `--diagnostic-comparison` opt-in flag (default off) downgrades
 the hard-fail to a tentative diff, the whole result stamped `assurance:
 "none"` for exploratory use — never the default, and never silent.
+
+**This has to be a parameter *into* `compare()`, not a CLI-level catch
+around it — a post-hoc recovery is structurally impossible here.** The
+gate runs "at the top of `checker.compare`, before any `diff_*` module
+runs" (above): once it raises, no `diff_*` module has executed and no
+`DiffResult` — tentative or otherwise — exists for any caller to recover.
+A CLI `except (ProfileMismatchError, ScopeMismatchError)` wrapped around
+`compare()`, the way every other surface in this ADR handles the gate,
+would have nothing left to downgrade; it can only report the failure, not
+resurrect a diff that never ran. `--diagnostic-comparison` therefore
+threads all the way to the gate check itself: `checker.compare(...,
+diagnostic_comparison: bool = False)` passes the flag to
+`comparability.check_contracts_comparable(old, new,
+diagnostic=diagnostic_comparison)`, which — only when set — returns a
+mismatch descriptor instead of raising, letting `compare()` proceed through
+the normal `diff_*` pipeline and stamp `assurance: "none"` on the resulting
+`DiffResult` afterward. `service.compare_snapshots` (a thin keyword-argument
+wrapper over `checker.compare`, not a request dataclass — unlike
+`service_scan.ScanRequest`) gains the same `diagnostic_comparison` keyword,
+and `mcp_server`'s compare tools expose it too, so the tentative-diff path
+is reachable identically through the Python API and MCP, not just `cli.py`'s
+flag.
 
 **`abicheck aggregate` is a consumer of these reports, not just a producer
 of new ones, and it has its own blind spot D2 must close.**

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -261,12 +261,16 @@ correctly keeps the common project-include-root workflow working (the
 thing that matters for the gate's primary use case), at the cost of not
 being able to detect a dependency-version change expressed purely as a
 different `-I` mount point with the same basename — that class of drift
-is undetectable by this fingerprint on the legacy CLI path. The
-manifest-driven path (D3) has no such gap, since every manifest-declared
-path is relative to one explicit document rather than inferred from
-directory shape — a user who needs reliable dependency-version detection
-without a manifest has `--diagnostic-comparison` (D2) as the sanctioned
-fallback, not a silent guess in either direction.
+is undetectable by this fingerprint on the legacy CLI path. **This is not a
+case `--diagnostic-comparison` (D2) can rescue**: that flag downgrades a
+*detected* fingerprint mismatch into a tentative diff, but this exact gap is
+the fingerprints *spuriously matching* — the gate never raises, so there is
+no hard-fail for the flag to soften. The only real fallback is the
+manifest-driven path (D3), which has no such gap at all, since every
+manifest-declared path is relative to one explicit document rather than
+inferred from directory shape — a user who needs reliable dependency-version
+detection for this specific shape must use a manifest; there is no
+legacy-CLI escape hatch for it, silent or otherwise.
 
 Both fingerprints live in a new `contract: ExtractionContract | None` field
 on `AbiSnapshot` rather than flattening two more top-level fields onto an

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -287,16 +287,30 @@ own problem one level deeper, through an under-counted file set instead of
 an ambiguous path. The digest is instead built from each `-I` directory's
 **actual resolved file list** — every file the preprocessor opened from
 inside it, declaration-bearing or not — obtained the same way
-`abicheck/buildsource/include_graph.py`'s existing `-MM`/`-MMD` depfile
-mechanism already does for the L3 include graph (`parse_depfile()`, a pure,
-already-unit-tested parser over standard Make-rule depfile output): the L2
-castxml/clang invocation additionally requests a depfile (`-MMD -MF
-<path>` for clang; castxml already wraps a real compiler, so the same flag
-applies to its underlying invocation) alongside the AST dump, and every
-listed path is attributed to whichever declared `-I` directory contains
-it. This reuses a proven parser at a new call site — one additional cheap
-compiler flag per TU, not a second compiler invocation or a directory-tree
-walk — rather than inventing new file-discovery logic. `profile_fingerprint`'s
+`abicheck/buildsource/include_graph.py`'s existing depfile mechanism
+already does for the L3 include graph (`parse_depfile()`, a pure,
+already-unit-tested parser over standard Make-rule depfile output), **using
+the same system-inclusive flag that module already had to learn to use for
+the same reason**: the L2 castxml/clang invocation additionally requests a
+depfile via `-MD -MF <path>` (not `-MMD`) alongside the AST dump — `-MD`
+lists system-classified headers (those reached via `-isystem`/the sysroot/
+standard library) as well as user headers, while `-MMD` silently omits them.
+`include_graph.py:354-356` already documents exactly this: it deliberately
+uses `-M`, not `-MM`, "so depfiles include *system*-classified headers,"
+after an earlier review caught the same omission there. Using `-MMD` here
+would reintroduce that identical bug on a new code path: a public header (or
+supporting header) reached only through a system/sysroot include path would
+never appear in the depfile, so two dumps that actually parsed different
+system-resolved headers (a libstdc++ upgrade changing an ABI-relevant macro,
+for instance) could still produce matching `profile_fingerprint`s — the
+exact under-counting failure mode this whole digest redesign exists to
+close, through a flag choice instead of a data-source choice this time.
+castxml already wraps a real compiler, so the same `-MD` flag applies to its
+underlying invocation. Every listed path is attributed to whichever declared
+`-I` directory contains it. This reuses a proven parser at a new call site —
+one additional cheap compiler flag per TU, not a second compiler invocation
+or a directory-tree walk — rather than inventing new file-discovery logic.
+`profile_fingerprint`'s
 `-I` component is the hash of the **ordered** sequence of per-directory
 digests.
 
@@ -555,6 +569,28 @@ fingerprint field(s) — never coerced into `COMPATIBLE`/`BREAKING`'s existing
 enum values. A `--diagnostic-comparison` opt-in flag (default off) downgrades
 the hard-fail to a tentative diff, the whole result stamped `assurance:
 "none"` for exploratory use — never the default, and never silent.
+
+**`abicheck aggregate` is a consumer of these reports, not just a producer
+of new ones, and it has its own blind spot D2 must close.**
+`aggregate.py`'s `parse_report_verdict` returns `None` whenever the
+`verdict` field isn't a string (`:589-596`) — which is exactly what
+`verdict: null` is by design, but it is *also* what a missing or corrupt
+report produces, and `aggregate.py` has no way today to tell these apart:
+both collapse into the same `compatibility_verdict=None`/"unavailable"
+`TargetReport` state. In **discovered-only** mode specifically,
+`coverage_blocking` is unconditionally `False` (`and not
+self.discovered_only`, `:406-410`) and an unavailable target's `gate` is
+`None`, so it contributes nothing to `exit_code()`'s `max(...)` — a
+`not_comparable` target can silently reduce to exit `0`, the exact
+"missing evidence reads as safe" failure this whole ADR exists to prevent,
+resurfacing at the one consumer surface this design hadn't yet reached.
+`aggregate.py` gains a way to distinguish a deliberate `not_comparable`
+report from a genuinely missing/corrupt one (its `reason` object is
+present only for the former), and treats it as an unconditionally blocking
+state — dominating `exit_code()` regardless of `discovered_only`, matching
+the same "a `not_comparable` result must never read as safe" rule D2
+already applies to the native `compare`/`compat check`/`scan`/`deps
+compare` schemes and the release-level rollup's rank-6 precedence.
 **`assurance` is a single field on `DiffResult` (alongside
 `contract_coverage`), not a per-`Change` field.** A forced diagnostic
 comparison is uniformly tentative — the contract gate failed for the pair

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -196,31 +196,55 @@ fix exists to close: the header paths then normalize relative to `/`, so
 checkout roots (`work/v1/foo.h` vs. `work/v2/foo.h`) into
 `scope_fingerprint`, hard-failing an otherwise-identical comparison.
 
-For the legacy, non-manifest CLI path: `scope_fingerprint`'s root is the
+For the legacy, non-manifest CLI path, `scope_fingerprint`'s root is the
 common ancestor **directory** of that side's own header paths' *parent*
-directories only (never `-I` directories); `profile_fingerprint`'s root is
-computed the same way but from that side's own `-I` directories only,
-independently. Computing either root from bare paths, rather than parent
-directories, degenerates in the single-entry case that's actually the
-common one: the "common prefix" of a one-element path set is that whole
-path, so `old=v1/foo.h` and `new=v2/bar.h` would both normalize their sole
-header to the same empty/root marker, losing the filename entirely — two
-genuinely different public scopes would then hash identically and wrongly
-pass the gate, the opposite failure from the one this fix exists to close.
-Taking the parent directory first means a lone header's basename survives
-normalization (`v1/foo.h` → root `v1/`, normalized path `foo.h`); for the
-manifest-driven path (D3), both roots are the manifest file's own
+directories only (never `-I` directories). Computing it from the header
+paths directly, rather than their parents, degenerates in the single-entry
+case that's actually the common one: the "common prefix" of a one-element
+path set is that whole path, so `old=v1/foo.h` and `new=v2/bar.h` would
+both normalize their sole header to the same empty/root marker, losing the
+filename entirely — two genuinely different public scopes would then hash
+identically and wrongly pass the gate. Taking the parent directory first
+means a lone header's basename survives normalization (`v1/foo.h` → root
+`v1/`, normalized path `foo.h`).
+
+**`profile_fingerprint`'s `-I` directories do *not* use the same
+parent-directory rule — a lone `-I` directory needs a different fix, not
+the header one applied by analogy.** The header fix's goal is "make the
+filename survive"; for a directory (no filename to preserve), taking its
+own parent as root strips *all* distinguishing structure in the
+single-entry case: `--include old=/opt/dep-v1/include --include
+new=/opt/dep-v2/include` would each normalize to `include` relative to
+their own root (`/opt/dep-v1`, `/opt/dep-v2` respectively) — hashing
+identically and silently erasing a genuine dependency-version difference
+this fingerprint should be able to catch, the same class of bug as the
+header case but with the opposite fix required. Whether a
+differently-rooted `-I` path represents "the same dependency, different
+checkout mount point" (should normalize) or "a genuinely different
+dependency version" (should not) is not decidable from path shape alone —
+unlike headers, where ADR-040's `old=`/`new=` design exists specifically
+for the "same project, two checkouts" case, an external `-I` directory has
+no comparably strong prior. `profile_fingerprint` therefore hashes each
+`-I` directory's **last two path components** (its own basename plus its
+immediate parent's basename) rather than attempting root-relative
+normalization at all: `/opt/dep-v1/include` → `dep-v1/include`,
+`/opt/dep-v2/include` → `dep-v2/include` — correctly distinct. This is a
+bounded, explicitly imperfect compromise, not a general solution: a
+checkout-root difference expressed exactly two segments above the `-I`
+directory (e.g. `--include old=/work/v1/vendor/include --include
+new=/work/v2/vendor/include`, if `vendor/include` is the last two
+segments) still spuriously mismatches, the mirror image of the problem
+this fix is closing. Multiple `-I` directories per side (2+) instead use
+the same common-ancestor-of-parents approach as headers, since real anchor
+points exist there the same way they do for multiple headers.
+
+For the manifest-driven path (D3), both roots are the manifest file's own
 directory (a manifest's `includes`/`forced_includes` and its base
-profile's search paths are declared relative to one document, so no
-external-directory contamination is possible there). Two sides with the
-same logical directory layout (`include/foo.h` under each side's own
-header root, `/opt/dep` identical or side-scoped independently under its
-own `-I` root) normalize to identical relative paths in both fingerprints
-and produce equal results regardless of where each checkout happens to
-live on disk or where its dependency directories are mounted; a side whose
-logical layout actually differs (a header moved to a different relative
-location, or a genuinely different dependency version under a differently
-laid-out path) still changes the corresponding fingerprint, correctly.
+profile's search paths are declared relative to one document, so neither
+the header nor the `-I` degenerate case, nor external-directory
+contamination, is possible there) — the manifest path is the fully
+general fix; the legacy-path heuristics above exist only because the
+legacy CLI has no such document to anchor against.
 
 Both fingerprints live in a new `contract: ExtractionContract | None` field
 on `AbiSnapshot` rather than flattening two more top-level fields onto an
@@ -407,12 +431,21 @@ not raw AST), instead of today's single aggregate-then-parse call. This is
 additive — the existing single-TU code path becomes the manifest path's
 one-TU special case, not a parallel implementation to keep in sync.
 
-A base compile profile (compiler, target, language standard, global flags)
+A base compile profile (compiler, target, language standard, global flags,
+and `frontend_context` — `host` by default, D5's requested AST context)
 is shared across all TUs in one manifest; **different compilers or target
 triples across TUs in the same manifest are rejected at parse time** — that
 is two different ABI contexts, which stay two separate snapshots (and two
 separate `profile_fingerprint`s) rather than one snapshot pretending to
 speak for both. Only forced includes and include order vary per TU.
+`frontend_context` is declared here, in the base profile, precisely
+because D5 needs an accepted input path to request it — a manifest schema
+that only carries `roots`/`translation_units` gives a DPC++ flow needing a
+non-default context nowhere to put the request. The legacy, non-manifest
+CLI path gains a matching `--frontend-context host|device` flag (default
+`host`), threaded the same way `--lang`/other base-profile flags already
+are, so a caller not using a manifest can still opt into the non-default
+context.
 
 ### D4. Compatible merge across translation units
 
@@ -426,8 +459,28 @@ only in an added default argument. Two full declarations disagreeing on
 return type, layout, or calling convention is an `INCONSISTENT_DECLARATION`
 conflict; a heterogeneous-context conflict (should D3's per-manifest
 single-profile rule ever be relaxed later) is
-`HETEROGENEOUS_ABI_CONTEXT`. A snapshot with unresolved conflicts is not a
-`CompleteSnapshot` and cannot feed D2's comparability gate as a clean side.
+`HETEROGENEOUS_ABI_CONTEXT`.
+
+**Both are extraction-time conflict codes on a new `TuMergeError`
+(`errors.py`), not `ChangeKind` enum members — this needs saying
+explicitly, since the all-caps naming otherwise reads exactly like one.**
+The distinction is structural, not stylistic: a `ChangeKind` is something
+`checker.compare`'s diff produces when comparing two already-`Complete`
+snapshots; these two fire *before* a snapshot is ever considered complete
+enough to diff at all — a snapshot with unresolved conflicts is not a
+`CompleteSnapshot` and cannot feed D2's comparability gate as a clean
+side. A merge conflict at TU-fragment level is the D3/D4 layer's own
+extraction-time failure (parallel to `IncompatibleSnapshotSchemaError` from
+D1, or `DumpDepthNotSatisfiedError`'s existing precedent), not a
+comparison finding — so they are correctly *outside* the `ChangeKind`
+registry and its four-step procedure, `changekind-partition`/
+`changekind-detector` completeness gates, and `RISK_KINDS`/`QUALITY_KINDS`
+severity classification entirely. `tu_merge.merge_fragments(...)` raises
+`TuMergeError(code=...)` (`code` one of the two strings above, plus the
+conflicting `entity_key` and both fragments' provenance) when any conflict
+is unresolved; `dumper.py`'s manifest-driven `dump()` lets it propagate,
+producing an `IncompleteAttempt`/extraction failure the same way a
+required TU's compile failure already does (D3).
 
 `entity_key` deliberately excludes return type (keeping it in `abi_facts`,
 not the merge key) — folding return type into identity turns a return-type

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -367,6 +367,32 @@ multi-library section) are extended to recognize that verdict value the
 same way the single-library path does, rather than folding it into
 `"ERROR"`.
 
+**A fifth surface calls `checker.compare` directly, with its own,
+independent exit-code contract that this ADR must not silently
+break: `abicheck/compat/cli.py`'s ABICC-compatible `compat check`
+command** (`from ..checker import compare`, called around `:967`).
+Because `compare()` there is the exact same function D2's gate wraps,
+`ProfileMismatchError`/`ScopeMismatchError` propagate to `compat check`
+automatically — the gap is not "the gate doesn't fire," it's that nothing
+classifies the resulting exception into a *deliberate* compat-mode
+outcome. `compat/CLAUDE.md` documents a closed exit-code contract (`0`
+compatible, `1` `BREAKING`, `2` `API_BREAK`, `3`–`11` errors via
+`_classify_compat_error_exit_code` in `compat/_errors.py`) that "requires
+a CHANGELOG note and downstream coordination" to change — this ADR cannot
+reuse `16` here (that would silently break the documented ABICC-mimicking
+numbering, which has nothing to do with the native `compare` command's own
+scheme) nor let the exception fall through to `_classify_compat_error_exit_code`'s
+generic `10` fallback (an existing, different meaning — "generic
+internal/tool error" — that a `not_comparable` result must not be
+conflated with, for the same reason it must not be folded into `"ERROR"`
+on the release path). `_classify_compat_error_exit_code` gains an explicit
+`isinstance(exc, (ProfileMismatchError, ScopeMismatchError))` check —
+mirroring its existing `KeyboardInterrupt` special case — returning **`9`**,
+the one integer the current 3–11 range documents no meaning for
+(3/4/5/6/7/8/10/11 are all taken; 9 is the sole gap), with `compat/CLAUDE.md`'s
+exit-code table and a changelog fragment updated in the same phase per that
+file's own stated policy.
+
 On the reporting surface (`reporter.py`,
 `sarif.py`, `junit_report.py`), a `not_comparable` result is a distinct
 top-level state — `verdict: null`, a `reason` object naming the mismatched
@@ -374,6 +400,26 @@ fingerprint field(s) — never coerced into `COMPATIBLE`/`BREAKING`'s existing
 enum values. A `--diagnostic-comparison` opt-in flag (default off) downgrades
 the hard-fail to a tentative diff with `assurance: none` stamped on every
 finding, for exploratory use — never the default, and never silent.
+
+**`verdict: null` is JSON-output shape, not a change to `checker_types.DiffResult`'s
+own typing — this needs to be explicit, or an implementer reasonably reads
+D2 as requiring `DiffResult.verdict: Verdict | None`.** `DiffResult`
+(`checker_types.py:234,239`, `verdict: Verdict = Verdict.NO_CHANGE`) is
+never constructed for a `ProfileMismatchError`/`ScopeMismatchError` case at
+all — the gate raises *before* any `diff_*` module runs, so there is no
+comparison to build a `DiffResult` from. `verdict: null` in JSON is
+assembled fresh by each front-end's own exception-handling path (`cli.py`,
+`service.py`, `mcp_server.py`, `cli_compare_release.py`'s dict literal,
+`compat/cli.py`) when it catches the exception — `DiffResult.verdict`
+itself stays exactly as typed today, `Verdict`, never `Verdict | None`, so
+no downstream consumer that already assumes a concrete `Verdict` needs to
+change. `contract_coverage` (the mixed-pair annotation) is a genuinely
+different case, and does need a real field: unlike the hard-fail path, a
+mixed pair *does* produce an ordinary `DiffResult` — `checker_types.py`
+gains `contract_coverage: str | None = None` on `DiffResult` itself
+(additive, mirroring how `assurance` already needs the same treatment for
+`--diagnostic-comparison`'s tentative-diff findings), and `checker.py`'s
+`compare()` sets it when exactly one side carries a `contract`.
 `verdict: null` is a **published contract change**, not just an internal
 one: `abicheck/schemas/compare_report.schema.json` currently requires
 `verdict` and restricts it to a fixed string enum with no `null` member, and

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -224,6 +224,28 @@ identically and wrongly pass the gate. Taking the parent directory first
 means a lone header's basename survives normalization (`v1/foo.h` → root
 `v1/`, normalized path `foo.h`).
 
+**Known, accepted limitation: this rule only preserves the basename, not
+the header's own subpath, so it can't distinguish a harmless checkout-root
+difference from a genuine relocation between two single-header inputs that
+happen to share a basename.** `old=old/include/foo.h` and
+`new=new/private/foo.h` both normalize to the identical `foo.h` — correct
+for the intended ADR-040 case (`old=v1/foo.h`/`new=v2/foo.h`, the same
+logical header at two checkout-version labels), but the identical
+normalization also fires when `foo.h` genuinely moved from a public
+`include/` directory to a `private/` one between the two sides — a real
+scope change (arguably: has the header stopped being public?) that this
+rule cannot tell apart from the harmless case, since both examples have the
+same shape (a single header, differing parent directory name) and opposite
+correct answers — the identical structural reason no `-I`-directory
+path-shape heuristic could be made correct either (see below). This is not
+solved by a cleverer rule; it's the same "undecidable from path shape
+alone" limitation this ADR already accepts for `-I` directories, now
+recorded for the single-header `scope_fingerprint` case too. The
+manifest-driven path (D3) has no such gap: a manifest's TU paths are
+explicit, declared identities, not inferred from directory shape, so a
+manifest that moved a header from one section to another would show up as
+a real, explicit scope change, not a silent non-event.
+
 **`profile_fingerprint`'s `-I` directories are fingerprinted by *resolved
 content*, not by path shape — three path-shape heuristics were tried and
 rejected in turn before landing here, worth recording in full so none of
@@ -537,6 +559,30 @@ aggregator and exit-code computation (`docs/reference/exit-codes.md`'s
 multi-library section) are extended to recognize that verdict value the
 same way the single-library path does, rather than folding it into
 `"ERROR"`.
+
+**This `"not_comparable"` string entry is a different JSON document from
+the canonical `verdict: null` shape, by design, not a second incompatible
+contract for the same shape.** `_compare_one_library`'s return dict feeds
+`summary.json`'s top-level `verdict` (`worst_verdict`) and its nested
+`libraries` array — both already string-only fields today (the existing
+`"ERROR"` case is exactly this: a non-`Verdict`-enum sentinel string, the
+same class `"not_comparable"` joins). That JSON document is not, and never
+was, governed by `compare_report.schema.json` — it is
+`cli_compare_release.py`'s own long-standing summary shape, extended in
+its own established idiom. Separately, when `--output-dir` is set,
+`_compare_one_library`'s success path *also* writes a full per-library
+report (`{stem}.json`) via `to_json(result)` — that file **is** governed
+by `compare_report.schema.json`, and for a `not_comparable` library it
+must use the canonical `verdict: null` + `reason` shape, assembled the
+same way every other front-end's exception handler assembles it (there is
+no `DiffResult` to call `to_json` on). The two documents disagreeing in
+shape is not an inconsistency to fix; each already followed its own
+distinct schema before this ADR existed, and each keeps doing so now —
+`aggregate.py`'s not-comparable detection (which reads whichever of these
+two document shapes it was actually pointed at) must check both: `verdict
+is None` for a canonical `compare_report.schema.json` document, or
+`verdict == "not_comparable"` for a release `summary.json`/per-library
+entry.
 
 **A fifth surface calls `checker.compare` directly, with its own,
 independent exit-code contract that this ADR must not silently

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -269,16 +269,36 @@ correctly on their own.** `profile_fingerprint` therefore does not compute
 a root from `-I` path text at all. Each `-I` directory (per side, in
 declared order — order is already a hashed input, per the note above)
 contributes its own, independent digest: the sorted set of (path relative
-to that `-I` directory, content hash) pairs for every header file
-extraction actually resolved from inside it. This is available at zero
-extra cost — `dumper_castxml.py`/`dumper_clang.py` already record each
-declaration's resolving header path (`_source_location`/
-`header_from_location`) to build `source_location`/`ast_toolchain` today;
-computing this digest only needs grouping those already-collected paths by
-which `-I` directory produced them and hashing their contents, not a new
-compiler invocation or a full directory-tree walk of (frequently huge)
-system/vendor include trees. `profile_fingerprint`'s `-I` component is the
-hash of the **ordered** sequence of per-directory digests.
+to that `-I` directory, content hash) pairs for every header file the
+preprocessor actually opened from inside it.
+
+**The digest's input must be the full transitive include list, not just
+headers that end up owning a declaration.** An earlier revision of this
+paragraph proposed sourcing it from `dumper_castxml.py`/`dumper_clang.py`'s
+existing per-declaration `_source_location`/`header_from_location`
+tracking — cheap, since that data is already collected, but wrong: a
+header pulled in purely for macros/pragmas/other preprocessing state (a
+`abi_config.h` that `#define`s an ABI-affecting layout macro but declares
+nothing itself) never owns a declaration, so it would never appear in that
+per-declaration set. Two dependency versions differing *only* in such a
+header would silently produce the same digest, letting a genuinely
+non-comparable pair back through the gate — reintroducing this section's
+own problem one level deeper, through an under-counted file set instead of
+an ambiguous path. The digest is instead built from each `-I` directory's
+**actual resolved file list** — every file the preprocessor opened from
+inside it, declaration-bearing or not — obtained the same way
+`abicheck/buildsource/include_graph.py`'s existing `-MM`/`-MMD` depfile
+mechanism already does for the L3 include graph (`parse_depfile()`, a pure,
+already-unit-tested parser over standard Make-rule depfile output): the L2
+castxml/clang invocation additionally requests a depfile (`-MMD -MF
+<path>` for clang; castxml already wraps a real compiler, so the same flag
+applies to its underlying invocation) alongside the AST dump, and every
+listed path is attributed to whichever declared `-I` directory contains
+it. This reuses a proven parser at a new call site — one additional cheap
+compiler flag per TU, not a second compiler invocation or a directory-tree
+walk — rather than inventing new file-discovery logic. `profile_fingerprint`'s
+`-I` component is the hash of the **ordered** sequence of per-directory
+digests.
 
 This is lossless with respect to every case the three rejected attempts
 traded off against each other, because content, unlike a path, is not
@@ -443,6 +463,32 @@ the one integer the current 3–11 range documents no meaning for
 (3/4/5/6/7/8/10/11 are all taken; 9 is the sole gap), with `compat/CLAUDE.md`'s
 exit-code table and a changelog fragment updated in the same phase per that
 file's own stated policy.
+
+**A sixth surface calls `compare_snapshots` through a different code path
+than any of the previous five, with yet another independent exit-code
+contract: `abicheck scan --against`.** `cli_scan_baseline.py`'s
+`_run_baseline_compare` (called from `scan_engine.run_scan_core` around
+`:852`) calls `service.compare_snapshots` — which, being a thin wrapper
+over `checker.compare` with no exception handling of its own, lets
+`ProfileMismatchError`/`ScopeMismatchError` through untouched, exactly as
+D2 intends at the `service.py` boundary. But `scan`'s own CLI command
+(`cli_scan.py`'s `scan_cmd`) has an independent, narrower exit-code
+contract (`0`/`2`/`4`/`5`/`64`, `docs/reference/exit-codes.md`) and its own
+`try`/`except` around the `run_scan_core` call that today only catches
+`_BudgetOverflow` and `_EvidenceContractError` — not
+`ProfileMismatchError`/`ScopeMismatchError`, which would propagate
+uncaught out of `scan_cmd` entirely, an unhandled traceback rather than
+any of `scan`'s documented exit codes. Listing only `service.py`'s
+`ScanRequest`/`compare_snapshots` as "the gate reaches `scan`" describes
+where the exception passes through cleanly, not where `scan`'s own CLI
+command classifies it into a deliberate outcome — the same distinction
+already drawn for `compat/cli.py` above. `scan_cmd` gains a dedicated
+`except (ProfileMismatchError, ScopeMismatchError) as exc:` branch
+alongside its existing two, exiting **`6`** — the next integer after
+`scan`'s own highest documented code (`5`, the budget-overflow exit),
+distinct from both native `compare`'s `16` and `compat check`'s `9` since
+all three commands maintain independent, non-overlapping exit-code
+schemes. `docs/reference/exit-codes.md`'s `scan` table gains this row.
 
 On the reporting surface (`reporter.py`,
 `sarif.py`, `junit_report.py`), a `not_comparable` result is a distinct

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -306,6 +306,31 @@ identical header content not invalidating the cache); this one closes
 D6's phase without leaving the gate inert for every warm-cache user in the
 interim.
 
+**A third, ongoing cache gap — not a one-time migration issue like the
+two above — also has to land in this phase: `_cache_key()`'s own hashing
+is order-*insensitive*, while D1's fingerprints are explicitly
+order-*sensitive*.** `snapshot_cache._cache_key()` (`:159,168`) iterates
+`sorted(headers)`/`sorted(includes)` when building the cache key — so
+`-I a -I b` and `-I b -I a` hash identically today. That was already a
+latent correctness gap independent of this ADR (include-search order
+affects real header shadowing/resolution in the underlying compile,
+regardless of caching), but D1 makes it acutely consequential: a caller
+that reorders `-I`/header flags between two runs would get a cache *hit*
+under the sorted key, and `cached_run_dump` returns that cached
+`AbiSnapshot` — whose `contract.profile_fingerprint`/`scope_fingerprint`
+were computed once, for whichever order happened to populate the cache
+entry first — without ever re-running `compute_extraction_contract(...)`
+for the new order. The comparability gate would then be working from a
+fingerprint that doesn't reflect the actual current invocation, in either
+direction: a real reorder-driven profile change could be silently
+cache-masked as unchanged, or an immaterial reorder could keep comparing
+against a stale fingerprint from a differently-ordered prior run. Fixed
+by dropping `sorted(...)` for `headers`/`includes` in `_cache_key()` and
+hashing them in caller-supplied order instead — landing in this phase,
+not deferred to D6, since D6's cache-key work addresses a different,
+narrower gap (a pure profile change with *identical* header content) and
+does not by itself make order-sensitive hashing order-preserving.
+
 ### D2. Comparability gate — hard-fail before symbol diff, not a RISK finding
 
 New `ProfileMismatchError` / `ScopeMismatchError` (`errors.py`), raised from

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -310,9 +310,31 @@ underlying invocation. Every listed path is attributed to whichever declared
 `-I` directory contains it. This reuses a proven parser at a new call site —
 one additional cheap compiler flag per TU, not a second compiler invocation
 or a directory-tree walk — rather than inventing new file-discovery logic.
-`profile_fingerprint`'s
-`-I` component is the hash of the **ordered** sequence of per-directory
-digests.
+
+**Not every `-MD`-listed path falls under a declared `-I` directory, and
+those paths cannot be silently dropped or mis-attributed.** `dumper.py`
+already introduces header search paths that are never part of the
+user-declared `includes` list: `--sysroot` (`--sysroot=<path>`), the
+GNU-toolchain `-isystem` directories `dumper.py` probes and injects
+automatically (`_probe_gnu_system_includes`), and any `-isystem`/`-I`
+embedded in `--gcc-options`/`--gcc-option` pass-through flags. A depfile
+entry resolved through one of these has no declared `-I` directory to be
+attributed to under the per-directory rule above. Leaving this case
+unspecified would recreate the exact under-counting bug this whole redesign
+exists to close, one layer further out: a toolchain/sysroot/stdlib upgrade
+changing an ABI-relevant system header would never be attributed anywhere,
+so it would never affect `profile_fingerprint`, silently letting a genuine
+environment change through the gate. These paths — everything the depfile
+lists that isn't under any declared `-I` directory — instead feed one
+additional, explicitly-labeled **system/toolchain bucket**: a content
+digest of that unordered set (no path-shape normalization attempted here,
+since these paths aren't tied to any user-declared, order-sensitive `-I`
+sequence to begin with — unlike declared `-I` directories, order doesn't
+carry search-precedence *meaning* the fingerprint needs to preserve for
+this bucket). `profile_fingerprint`'s `-I` component is therefore the hash
+of the **ordered** sequence of per-`-I`-directory digests, **plus** this one
+additional system/toolchain bucket appended last, deterministically
+positioned so its presence or absence never depends on iteration order.
 
 **The digest must exclude every path already claimed by `scope_fingerprint`
 — this is not an optional refinement, it is the difference between a

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -630,12 +630,34 @@ diagnostic_comparison: bool = False)` passes the flag to
 diagnostic=diagnostic_comparison)`, which — only when set — returns a
 mismatch descriptor instead of raising, letting `compare()` proceed through
 the normal `diff_*` pipeline and stamp `assurance: "none"` on the resulting
-`DiffResult` afterward. `service.compare_snapshots` (a thin keyword-argument
-wrapper over `checker.compare`, not a request dataclass — unlike
-`service_scan.ScanRequest`) gains the same `diagnostic_comparison` keyword,
-and `mcp_server`'s compare tools expose it too, so the tentative-diff path
-is reachable identically through the Python API and MCP, not just `cli.py`'s
-flag.
+`DiffResult` afterward. `service.compare_snapshots` gains the same
+`diagnostic_comparison` keyword, threaded from `compare()`.
+
+**`compare_snapshots` is not the front-end chokepoint, though — `api_types.CompareRequest`
+is, and it needs the field too, or the documented front-ends can never reach
+it.** `CompareRequest` (`api_types.py:125`) is, by its own docstring, "the
+single input to `run_compare`" that "every front-end (CLI, MCP,
+`compare-release` fan-out, `appcompat`)" assembles and hands to
+`service.run_compare_request` — the actual ADR-037 D1/D2 classification
+chokepoint, one level above `compare_snapshots`. `run_compare_request`
+calls `compare_snapshots(old, new, suppression=..., policy=..., ...,
+env_matrix=...)` today with a fixed keyword list that has no slot for this
+flag; adding `diagnostic_comparison` only to `compare_snapshots` itself
+would be unreachable from every documented front-end, since none of them
+call `compare_snapshots` directly — they all go through
+`CompareRequest`/`run_compare_request`. `CompareRequest` therefore gains
+`diagnostic_comparison: bool = False`, and `run_compare_request` passes
+`diagnostic_comparison=request.diagnostic_comparison` into its
+`compare_snapshots(...)` call. The legacy keyword-argument shim
+`run_compare` (`service.py:1757`, "existing callers keep working while the
+typed request is the real chokepoint") gains the same parameter too,
+appended after every pre-existing one — matching the precedent already set
+for `debuginfod_url`, so a positional caller's existing argument bindings
+don't shift. `mcp_server`'s compare tools expose the same field on their
+own request shape, so the tentative-diff path is reachable identically
+through the CLI, the Python API's `CompareRequest`/`run_compare`, and MCP —
+not just a direct `compare_snapshots` call nothing in this codebase
+actually makes.
 
 **`abicheck aggregate` is a consumer of these reports, not just a producer
 of new ones, and it has its own blind spot D2 must close.**

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -208,43 +208,49 @@ identically and wrongly pass the gate. Taking the parent directory first
 means a lone header's basename survives normalization (`v1/foo.h` → root
 `v1/`, normalized path `foo.h`).
 
-**`profile_fingerprint`'s `-I` directories do *not* use the same
-parent-directory rule — a lone `-I` directory needs a different fix, not
-the header one applied by analogy.** The header fix's goal is "make the
-filename survive"; for a directory (no filename to preserve), taking its
-own parent as root strips *all* distinguishing structure in the
-single-entry case: `--include old=/opt/dep-v1/include --include
-new=/opt/dep-v2/include` would each normalize to `include` relative to
-their own root (`/opt/dep-v1`, `/opt/dep-v2` respectively) — hashing
-identically and silently erasing a genuine dependency-version difference
-this fingerprint should be able to catch, the same class of bug as the
-header case but with the opposite fix required. Whether a
-differently-rooted `-I` path represents "the same dependency, different
-checkout mount point" (should normalize) or "a genuinely different
-dependency version" (should not) is not decidable from path shape alone —
-unlike headers, where ADR-040's `old=`/`new=` design exists specifically
-for the "same project, two checkouts" case, an external `-I` directory has
-no comparably strong prior. `profile_fingerprint` therefore hashes each
-`-I` directory's **last two path components** (its own basename plus its
-immediate parent's basename) rather than attempting root-relative
-normalization at all: `/opt/dep-v1/include` → `dep-v1/include`,
-`/opt/dep-v2/include` → `dep-v2/include` — correctly distinct. This is a
-bounded, explicitly imperfect compromise, not a general solution: a
-checkout-root difference expressed exactly two segments above the `-I`
-directory (e.g. `--include old=/work/v1/vendor/include --include
-new=/work/v2/vendor/include`, if `vendor/include` is the last two
-segments) still spuriously mismatches, the mirror image of the problem
-this fix is closing. Multiple `-I` directories per side (2+) instead use
-the same common-ancestor-of-parents approach as headers, since real anchor
-points exist there the same way they do for multiple headers.
+**`profile_fingerprint`'s `-I` directories use the *same* parent-directory
+rule as headers, uniformly — this went through two wrong "clever" fixes
+before landing on the simple one, worth recording so it isn't
+rediscovered.** A first attempt applied the header rule unchanged (root =
+the `-I` directory's own parent), which was right for the common
+real-world shape — `--include old=old/include --include new=new/include`
+(the project's own include root, exactly the ADR-040 "same project, two
+checkouts" case the header rule is designed for; the [user-guide's
+real-world compare
+example](../../user-guide/real-world-example.md) uses this exact shape) —
+but wrong for a lone *external dependency* directory:
+`--include old=/opt/dep-v1/include --include new=/opt/dep-v2/include`
+would normalize both to `include` relative to their own root
+(`/opt/dep-v1`, `/opt/dep-v2`), silently erasing a genuine dependency-
+version difference. A second attempt tried to fix that by hashing each
+`-I` directory's last two path components instead
+(`/opt/dep-v1/include` → `dep-v1/include`) — this broke the *other*
+direction: it made the ordinary `old/include` vs. `new/include` project-
+root case (the common, documented workflow) hash as different, hard-
+failing the routine two-checkout compare this whole fingerprint design
+exists to keep working.
 
-For the manifest-driven path (D3), both roots are the manifest file's own
-directory (a manifest's `includes`/`forced_includes` and its base
-profile's search paths are declared relative to one document, so neither
-the header nor the `-I` degenerate case, nor external-directory
-contamination, is possible there) — the manifest path is the fully
-general fix; the legacy-path heuristics above exist only because the
-legacy CLI has no such document to anchor against.
+Both attempts failed for the same underlying reason: **whether a
+differently-rooted `-I` path means "same dependency, different checkout
+mount point" (should normalize) or "a genuinely different dependency"
+(should not) is not decidable from path shape alone, and no heuristic can
+resolve it — the two examples above have *identical* shape** (`.../X →
+.../include`, two segments, differing prefix) and opposite correct
+answers. `profile_fingerprint` therefore uses the header rule as-is (root
+= common ancestor of that side's `-I` directories' own parent
+directories, single or multiple, no special case) rather than a bespoke
+heuristic invented to split a difference that path shape cannot express.
+This is a **known, accepted limitation, not a solved problem**: it
+correctly keeps the common project-include-root workflow working (the
+thing that matters for the gate's primary use case), at the cost of not
+being able to detect a dependency-version change expressed purely as a
+different `-I` mount point with the same basename — that class of drift
+is undetectable by this fingerprint on the legacy CLI path. The
+manifest-driven path (D3) has no such gap, since every manifest-declared
+path is relative to one explicit document rather than inferred from
+directory shape — a user who needs reliable dependency-version detection
+without a manifest has `--diagnostic-comparison` (D2) as the sanctioned
+fallback, not a silent guess in either direction.
 
 Both fingerprints live in a new `contract: ExtractionContract | None` field
 on `AbiSnapshot` rather than flattening two more top-level fields onto an
@@ -350,9 +356,35 @@ schemes (legacy: 0/2/4; severity-aware, with any `--severity-*` flag:
 must never exit `0` in either scheme, or the exact failure mode this ADR
 exists to prevent (missing evidence reading as "safe") reappears one layer
 down, at the process-exit boundary instead of the JSON `verdict` field. D2
-reserves a new, distinct nonzero code for `not_comparable`, documented as
-its own row in both exit-code tables, not folded into either existing
-scheme's numbering.
+reserves exit code **`8`** for `not_comparable` — pinned, not left as "a
+new code TBD" — in **both** schemes identically (legacy and
+severity-aware alike; `not_comparable` fires before any severity
+classification runs, so it is orthogonal to the flag that distinguishes
+the two schemes), continuing the existing legacy/severity-aware scheme's
+power-of-two pattern (0/1/2/4) one step further, and documented as its own
+row in both tables, not folded into either scheme's existing numbering.
+`8` is unused today in `compare`'s exit-code space (which tops out at `4`
+in both schemes — `compat`'s separate 3–11 error range is a different
+command's own codespace, per `docs/reference/exit-codes.md`'s per-command
+split, and does not constrain `compare`'s).
+
+**Release-level (directory/package) aggregation needs its own explicit
+precedence, not an implied one.** `cli_compare_release.py`'s
+`_RELEASE_VERDICT_ORDER` (`cli_compare_release_helpers.py:45`) already
+ranks per-library verdicts for the "worst verdict wins" release rollup —
+`NO_CHANGE` < `COMPATIBLE` < `COMPATIBLE_WITH_RISK` < `API_BREAK` <
+`BREAKING` < `ERROR` (rank 5, currently the ceiling). `not_comparable`
+gets its own rank **above** `ERROR` (rank 6): a `not_comparable` result is
+a definitive, correctly-diagnosed outcome (this ADR's whole point), not a
+crash, but it carries strictly less trustworthy information about the
+library than even an `ERROR` entry's partial context — so for the purpose
+of picking one release-level exit code, a `not_comparable` library
+dominates every other outcome in the same release, including a genuine
+`ERROR`. This closes the release fan-out gap directly (see below): once
+`not_comparable` is a real rank in this ordering, a mixed release
+(one `not_comparable` library, one `BREAKING`, N `COMPATIBLE`) reports and
+exits as `not_comparable` overall, not silently as `BREAKING` or folded
+into a generic `ERROR`.
 
 **Mixed pairs (one side has a `contract`, the other doesn't) never hard-fail
 — this is unambiguous, not left to implementer discretion.** The backward-
@@ -499,13 +531,41 @@ frontend's possibly-multi-document JSON output as a sequence of
 `{kind, target, ast}` contexts (streaming document boundaries, not a
 bracket/string split), tags each with the compiler-reported target triple,
 and selects the context matching the manifest's/CLI's requested
-`frontend_context` (`host` by default). A run that produces only a
-`spir64`/device context when `host` was requested is an extraction failure
-(`AST_CONTEXT_MISSING`), not a successful-but-wrong snapshot — it must not
-reach D1's fingerprinting at all. Fixture-first per the review's own
-sequencing advice: a real captured multi-document DPC++ AST fixture and a
-plain single-context clang fixture land before the stream parser, so the
-parser is built against real output shape, not an assumption of it.
+`frontend_context` (`host` by default).
+
+**Selection is by `kind`, not by target-triple string matching — this
+needs to be explicit, since "host vs. device" reads like it could mean
+either.** Each decoded context's `kind` (`"host"` or `"device"`, read
+directly from the compiler's own JSON output, the same authoritative
+source the target triple comes from) is what's compared against the
+requested `frontend_context`; the target triple (`spir64`, etc.) is
+carried alongside for diagnostics and provenance, never itself the
+selection key — a frontend could in principle label a context's target
+triple ambiguously or use a triple this ADR doesn't enumerate, and
+`sycl_context.py` must not be in the business of pattern-matching triple
+strings to guess intent when the compiler already states `kind` plainly.
+Three outcomes, all extraction-time, none reaching D1's fingerprinting:
+
+- **Exactly one decoded context has the requested `kind`** — the normal
+  case, selected and passed on to normal extraction.
+- **Zero decoded contexts have the requested `kind`** — `AST_CONTEXT_MISSING`
+  (e.g. only a `spir64`/device context when `host` was requested).
+- **More than one decoded context shares the requested `kind`** —
+  `AST_CONTEXT_AMBIGUOUS`, never resolved by picking the first, the
+  smallest, or any other implicit tiebreaker; an ambiguous frontend output
+  is exactly the kind of "the extraction can't prove what it captured"
+  situation this ADR's authority rule (ADR-028 D3) says must not be
+  silently resolved in either direction.
+
+A run that produces only a `spir64`/device context when `host` was
+requested is an extraction failure, not a successful-but-wrong snapshot.
+Fixture-first per the review's own sequencing advice: a real captured
+multi-document DPC++ AST fixture and a plain single-context clang fixture
+land before the stream parser (Phase 0), so the parser — and this `kind`
+vs. target-triple distinction — is built against real output shape, not
+an assumption of it; if a captured real fixture turns out not to carry a
+`kind` field at all, that is exactly the kind of discovery Phase 0 exists
+to surface before D5 is implemented against a guess.
 
 ### D6. Resource-aware scheduling for the frontend, shared with `buildsource`
 

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -224,53 +224,87 @@ identically and wrongly pass the gate. Taking the parent directory first
 means a lone header's basename survives normalization (`v1/foo.h` → root
 `v1/`, normalized path `foo.h`).
 
-**`profile_fingerprint`'s `-I` directories use the *same* parent-directory
-rule as headers, uniformly — this went through two wrong "clever" fixes
-before landing on the simple one, worth recording so it isn't
-rediscovered.** A first attempt applied the header rule unchanged (root =
-the `-I` directory's own parent), which was right for the common
-real-world shape — `--include old=old/include --include new=new/include`
-(the project's own include root, exactly the ADR-040 "same project, two
-checkouts" case the header rule is designed for; the [user-guide's
-real-world compare
-example](../../user-guide/real-world-example.md) uses this exact shape) —
-but wrong for a lone *external dependency* directory:
-`--include old=/opt/dep-v1/include --include new=/opt/dep-v2/include`
-would normalize both to `include` relative to their own root
-(`/opt/dep-v1`, `/opt/dep-v2`), silently erasing a genuine dependency-
-version difference. A second attempt tried to fix that by hashing each
-`-I` directory's last two path components instead
-(`/opt/dep-v1/include` → `dep-v1/include`) — this broke the *other*
-direction: it made the ordinary `old/include` vs. `new/include` project-
-root case (the common, documented workflow) hash as different, hard-
-failing the routine two-checkout compare this whole fingerprint design
-exists to keep working.
+**`profile_fingerprint`'s `-I` directories are fingerprinted by *resolved
+content*, not by path shape — three path-shape heuristics were tried and
+rejected in turn before landing here, worth recording in full so none of
+the three is rediscovered.** A first attempt applied the header
+parent-directory rule unchanged (root = the `-I` directory's own parent),
+right for the common real-world shape — `--include old=old/include
+--include new=new/include` (the project's own include root, exactly the
+ADR-040 "same project, two checkouts" case; the [user-guide's real-world
+compare example](../../user-guide/real-world-example.md) uses this exact
+shape) — but wrong for a lone *external dependency* directory: `--include
+old=/opt/dep-v1/include --include new=/opt/dep-v2/include` would normalize
+both to `include` relative to their own root, silently erasing a genuine
+dependency-version difference. A second attempt hashed each `-I`
+directory's last two path components instead (`/opt/dep-v1/include` →
+`dep-v1/include`) — this broke the *other* direction, making the ordinary
+`old/include`/`new/include` project-root case hash as different and
+hard-fail the routine, documented two-checkout compare. A third attempt
+reverted to the parent-directory rule uniformly (single or multiple `-I`
+directories, common ancestor of parents, no special case) and accepted the
+dependency-version gap as a documented limitation — this in turn broke a
+*third* direction once a side declares more than one `-I` directory of
+different kinds: a normal compare with a side-specific project include
+plus a shared external dependency (`old=/work/v1/include` +
+`old=/opt/dep`, `new=/work/v2/include` + `new=/opt/dep`, the dependency
+identical on both sides) computes each side's common ancestor as `/` (the
+external `/opt/dep` shares no meaningful prefix with `/work/v{1,2}`), which
+normalizes the project include back to its diverging checkout root
+(`work/v1/include` vs. `work/v2/include`) and hard-fails `PROFILE_MISMATCH`
+on an otherwise-identical, routine two-checkout upgrade — reintroducing
+the exact class of bug this whole fingerprint design exists to close, one
+level deeper (mixing heterogeneous `-I` *categories* into one shared root
+computation, the same mistake `scope_fingerprint`/`profile_fingerprint`
+splitting into separate roots already fixed once, recurring *within*
+`profile_fingerprint` itself).
 
-Both attempts failed for the same underlying reason: **whether a
-differently-rooted `-I` path means "same dependency, different checkout
-mount point" (should normalize) or "a genuinely different dependency"
-(should not) is not decidable from path shape alone, and no heuristic can
-resolve it — the two examples above have *identical* shape** (`.../X →
-.../include`, two segments, differing prefix) and opposite correct
-answers. `profile_fingerprint` therefore uses the header rule as-is (root
-= common ancestor of that side's `-I` directories' own parent
-directories, single or multiple, no special case) rather than a bespoke
-heuristic invented to split a difference that path shape cannot express.
-This is a **known, accepted limitation, not a solved problem**: it
-correctly keeps the common project-include-root workflow working (the
-thing that matters for the gate's primary use case), at the cost of not
-being able to detect a dependency-version change expressed purely as a
-different `-I` mount point with the same basename — that class of drift
-is undetectable by this fingerprint on the legacy CLI path. **This is not a
-case `--diagnostic-comparison` (D2) can rescue**: that flag downgrades a
-*detected* fingerprint mismatch into a tentative diff, but this exact gap is
-the fingerprints *spuriously matching* — the gate never raises, so there is
-no hard-fail for the flag to soften. The only real fallback is the
-manifest-driven path (D3), which has no such gap at all, since every
-manifest-declared path is relative to one explicit document rather than
-inferred from directory shape — a user who needs reliable dependency-version
-detection for this specific shape must use a manifest; there is no
-legacy-CLI escape hatch for it, silent or otherwise.
+All three attempts fail for the same underlying reason, and it's now clear
+no path-shape function of `-I` directories can be made correct: **whether
+a differently-rooted `-I` path means "same dependency, different checkout
+mount point" or "a genuinely different dependency" is not decidable from
+path shape alone, and combining multiple `-I` directories under one shared
+root additionally risks corrupting entries that would have normalized
+correctly on their own.** `profile_fingerprint` therefore does not compute
+a root from `-I` path text at all. Each `-I` directory (per side, in
+declared order — order is already a hashed input, per the note above)
+contributes its own, independent digest: the sorted set of (path relative
+to that `-I` directory, content hash) pairs for every header file
+extraction actually resolved from inside it. This is available at zero
+extra cost — `dumper_castxml.py`/`dumper_clang.py` already record each
+declaration's resolving header path (`_source_location`/
+`header_from_location`) to build `source_location`/`ast_toolchain` today;
+computing this digest only needs grouping those already-collected paths by
+which `-I` directory produced them and hashing their contents, not a new
+compiler invocation or a full directory-tree walk of (frequently huge)
+system/vendor include trees. `profile_fingerprint`'s `-I` component is the
+hash of the **ordered** sequence of per-directory digests.
+
+This is lossless with respect to every case the three rejected attempts
+traded off against each other, because content, unlike a path, is not
+ambiguous: two checkouts of a byte-identical dependency normalize
+identically regardless of mount point (`old=/opt/dep-v1`,
+`new=/opt/dep-v2`, same header content on both sides — attempt one's
+routine case, still correct); two mount points with genuinely different
+header content normalize differently regardless of naming, including the
+`dep-v1`/`dep-v2` case attempt one broke and attempt two overcorrected for;
+and a shared external dependency alongside a side-specific project
+include normalizes each independently, since there is no shared-root
+computation left to corrupt — attempt three's regression is structurally
+impossible here, not just untested for. If a resolved header's content
+cannot be read at fingerprint time (permission error, file removed between
+parse and fingerprinting), extraction fails outright with a dedicated
+error rather than folding an "unresolvable" sentinel into the hash — two
+runs that are each unresolvable for different underlying reasons must not
+spuriously fingerprint-match. `scope_fingerprint` is unaffected by any of
+this: it hashes header/TU *paths* because declared naming is itself part
+of the public surface being compared (a header renamed with identical
+content is still a scope change), whereas `profile_fingerprint`'s `-I`
+directories describe *how* `#include` resolves, where identity should
+track resolved content, not the path label pointing at it. The
+manifest-driven path (D3) is unaffected either way — it already had no
+such gap, since every manifest-declared path is relative to one explicit
+document rather than inferred from directory shape.
 
 Both fingerprints live in a new `contract: ExtractionContract | None` field
 on `AbiSnapshot` rather than flattening two more top-level fields onto an

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -401,6 +401,25 @@ enum values. A `--diagnostic-comparison` opt-in flag (default off) downgrades
 the hard-fail to a tentative diff with `assurance: none` stamped on every
 finding, for exploratory use — never the default, and never silent.
 
+**`html_report.py` is a reporting surface too, not an omission this ADR can
+leave implicit.** AGENTS.md's own module map lists it alongside
+`reporter.py`/`sarif.py`/`junit_report.py` under "Reporting," and
+`service_render.py`'s format dispatch (`:87-99`) routes `--format html` to
+`generate_html_report(result: DiffResult, ...)` exactly like the other three
+route to their renderers. Two distinct gaps follow from `generate_html_report`
+requiring a real `DiffResult`: for the hard-gate `not_comparable` case, no
+`DiffResult` exists at all (the gate raises before any diff runs), so
+`service_render.render_output` must not attempt to call `generate_html_report`
+on that path — the front-end's exception handler renders (or declines to
+render) HTML the same way it assembles `verdict: null` JSON, rather than
+`generate_html_report` growing an optional-`DiffResult` parameter it was never
+designed to accept. For the mixed-pair `contract_coverage` case, a real
+`DiffResult` does exist, so `generate_html_report` needs to surface
+`contract_coverage` in its headline cards the same way the JSON/Markdown/SARIF/JUnit
+reporters do — silently dropping it there would make the HTML report the one
+output format that can't tell a reader the comparison ran on unequal
+evidence.
+
 **`verdict: null` is JSON-output shape, not a change to `checker_types.DiffResult`'s
 own typing — this needs to be explicit, or an implementer reasonably reads
 D2 as requiring `DiffResult.verdict: Verdict | None`.** `DiffResult`

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -373,16 +373,45 @@ exists to compare — would feed `profile_fingerprint` too, and an ordinary,
 intentional edit to `foo.h` (changing its content hash) would flip
 `profile_fingerprint` and hard-fail `PROFILE_MISMATCH` *before* the diff
 ever ran, on literally the routine case this whole ADR exists to support.
-Each `-I` directory's digest is therefore built from its depfile-resolved
-file list **minus** the set of paths `scope_fingerprint` already covers for
-that side (the explicit `--header`/manifest TU entry points) — leaving only
-the supporting/dependency files a TU pulls in but never directly declares.
-This is a strict partition, not a heuristic: `scope_fingerprint` owns
-"what's declared and compared"; `profile_fingerprint` owns "what
-environment resolved it," and a file cannot honestly belong to both. A
-header that stops being resolved purely as a support file and becomes a
-directly-declared entry point (or vice versa) moves from one fingerprint's
-input set to the other's, not into both or neither.
+
+**Excluding only the explicitly-named header is not enough — the exclusion
+has to cover the whole project-owned `-I` directory, or an ordinary edit
+to any *unnamed* internal header still breaks the same way.** A first
+version of this fix excluded only the specific paths `scope_fingerprint`
+names (the explicit `--header`/manifest entry points) from the digest —
+correct for `foo.h` itself, but most real projects have far more headers
+than the ones named on the command line: `foo.h` typically
+`#include`s project-internal support headers (`detail.h`, a private
+implementation header) that are never individually named, reached only
+because they live under the same declared `-I` root. Those files are still
+depfile-listed and still fall under a declared `-I` directory, so the
+first-version fix would still feed their content into that directory's
+digest — meaning an ordinary internal refactor (renaming `detail_v1.h` to
+`detail_v2.h`, or editing its content, with `foo.h` itself untouched) would
+still flip `profile_fingerprint` and hard-fail the gate before the diff
+ran, on a routine internal change, not an edge case. The fix generalizes
+from "exclude the named file" to "exclude the whole `-I` directory when
+it's the project's own": a declared `-I` directory is **project-owned**
+when it equals, or is an ancestor of, any of that side's declared
+`--header`/manifest TU paths — every file under it (named or not) is
+scope-adjacent, not environment, and is excluded from `profile_fingerprint`
+in its entirety, not file-by-file. A declared `-I` directory with no such
+relationship to any declared header is **external** and keeps the full
+per-file content digest described above — a genuine third-party dependency,
+where a change anywhere in it *is* meaningful profile drift. This is a
+strict partition on `-I` *directories*, not individual files:
+`scope_fingerprint` owns everything under a project-owned root (declared
+or not); `profile_fingerprint` owns only external roots, in full.
+A known, accepted residual gap: a vendored dependency nested *inside* a
+project-owned root (e.g. `include/thirdparty/foo.h` under the project's
+own `include/`) is swept into the project-owned exclusion along with
+everything else there, so a content change confined to that nested vendor
+copy is invisible to `profile_fingerprint` on the legacy CLI path — the
+same class of "can't disambiguate from path/directory-tree shape alone"
+limitation this ADR already documents for the mixed-roots case, not a new
+kind of gap. The manifest path (D3) has no such gap: it can express a
+per-TU forced-include for exactly this case instead of relying on
+directory-tree inference.
 
 This is lossless with respect to every case the three rejected attempts
 traded off against each other, because content, unlike a path, is not
@@ -680,6 +709,23 @@ state — dominating `exit_code()` regardless of `discovered_only`, matching
 the same "a `not_comparable` result must never read as safe" rule D2
 already applies to the native `compare`/`compat check`/`scan`/`deps
 compare` schemes and the release-level rollup's rank-6 precedence.
+
+**The GitHub Action wrapper is another consumer with the same blind spot,
+one layer further from the Python package.** `action/run.sh` maps each
+command's known exit codes to a `VERDICT` string via `case` statements with
+an unconditional `*) VERDICT="ERROR"` fallback for anything unrecognized —
+native `compare`'s new `16`, `scan`'s new `6`, and `deps compare`'s new `5`
+all fall through it today, since the script predates this ADR. Worse,
+`_maybe_post_pr_comment` unconditionally skips posting when `VERDICT ==
+"ERROR"` — so a deliberate `not_comparable` result would both misreport as
+a generic internal error *and* silently suppress the one PR comment meant
+to surface it, the combination this ADR most needs to avoid on its most
+visible first-party consumer. `action/run.sh` gains a matching `VERDICT`
+value (e.g. `NOT_COMPARABLE`) for each new code, and
+`_maybe_post_pr_comment`'s `ERROR`-only skip is joined by an explicit
+carve-out that still posts for `NOT_COMPARABLE` — this result deserves the
+comment more than an ordinary pass, not less.
+
 **`assurance` is a single field on `DiffResult` (alongside
 `contract_coverage`), not a per-`Change` field.** A forced diagnostic
 comparison is uniformly tentative — the contract gate failed for the pair

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -770,6 +770,16 @@ state — dominating `exit_code()` regardless of `discovered_only`, matching
 the same "a `not_comparable` result must never read as safe" rule D2
 already applies to the native `compare`/`compat check`/`scan`/`deps
 compare` schemes and the release-level rollup's rank-6 precedence.
+**Pinned to `1`, not a new number:** `docs/reference/exit-codes.md`'s
+`aggregate` table already documents `1` as covering both a coverage gap
+and "a non-verdict per-report failure" (its own stated example being
+`scan`'s budget-overflow `5` folding in there) — `not_comparable` is
+exactly that same class of failure, so it joins the existing bucket rather
+than reserving a new disjoint code the way each *producer* command
+(`compare`/`scan`/`deps compare`) did for its own scheme; `aggregate`
+never invents a code per producer, it has one shared "not a clean verdict"
+bucket. Both the `aggregate` table and the `## Summary table` cross-command
+matrix in `docs/reference/exit-codes.md` gain the corresponding row.
 
 **The GitHub Action wrapper is another consumer with the same blind spot,
 one layer further from the Python package.** `action/run.sh` maps each

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -372,20 +372,27 @@ schemes (legacy: 0/2/4; severity-aware, with any `--severity-*` flag:
 must never exit `0` in either scheme, or the exact failure mode this ADR
 exists to prevent (missing evidence reading as "safe") reappears one layer
 down, at the process-exit boundary instead of the JSON `verdict` field. D2
-reserves exit code **`8`** for `not_comparable` — pinned, not left as "a
-new code TBD" — in **both** schemes identically (legacy and
-severity-aware alike; `not_comparable` fires before any severity
+reserves exit code **`16`** for `not_comparable` — pinned, not left as "a
+new code TBD" — in **both** single-library schemes identically (legacy
+and severity-aware alike; `not_comparable` fires before any severity
 classification runs, so it is orthogonal to the flag that distinguishes
-the two schemes), continuing the existing legacy/severity-aware scheme's
-power-of-two pattern (0/1/2/4) one step further, and documented as its own
-row in both tables, not folded into either scheme's existing numbering.
-`8` is unused today in `compare`'s exit-code space (which tops out at `4`
-in both schemes — `compat`'s separate 3–11 error range is a different
+the two schemes), continuing the doubling pattern the codebase already
+uses across `compare`'s exit-code space one step further. **Not `8`**: an
+earlier draft of this decision picked `8` by checking only the two
+single-library tables (which top out at `4`) and missed that `compare`'s
+*release* (directory/package) table — a separate, already-published
+scheme — already assigns `8` to `--fail-on-removed-library`
+(`docs/reference/exit-codes.md:134-139`). Reusing `8` would have either
+silently clobbered the removed-library signal or left release-level CI
+unable to tell the two states apart; `16` is unused across *all three*
+tables (both single-library schemes and the release table), so it is
+documented as its own new row in all three, not folded into any existing
+scheme's numbering. (`compat`'s separate 3–11 error range is a different
 command's own codespace, per `docs/reference/exit-codes.md`'s per-command
-split, and does not constrain `compare`'s).
+split, and does not constrain `compare`'s either way.)
 
 **Release-level (directory/package) aggregation needs its own explicit
-precedence, not an implied one.** `cli_compare_release.py`'s
+precedence against *two* existing mechanisms, not one.** `cli_compare_release.py`'s
 `_RELEASE_VERDICT_ORDER` (`cli_compare_release_helpers.py:45`) already
 ranks per-library verdicts for the "worst verdict wins" release rollup —
 `NO_CHANGE` < `COMPATIBLE` < `COMPATIBLE_WITH_RISK` < `API_BREAK` <
@@ -400,7 +407,16 @@ dominates every other outcome in the same release, including a genuine
 `not_comparable` is a real rank in this ordering, a mixed release
 (one `not_comparable` library, one `BREAKING`, N `COMPATIBLE`) reports and
 exits as `not_comparable` overall, not silently as `BREAKING` or folded
-into a generic `ERROR`.
+into a generic `ERROR`. It must also dominate the **separate**
+`--fail-on-removed-library` mechanism (exit `8`), which today has its own
+scheme-dependent precedence against `ERROR`/`2`/`4` — unlike that existing
+rule, `not_comparable`'s precedence over removed-library exit `8` is
+**unconditional in both schemes**: a `not_comparable` result means the
+comparison couldn't establish what actually changed at all, so it cannot
+be trusted to have correctly detected a removal either — an apparent
+"library removed" reading from an incomparable pair is exactly the kind
+of unproven inference this ADR exists to block, not a real removal
+finding entitled to its own exit code.
 
 **Mixed pairs (one side has a `contract`, the other doesn't) never hard-fail
 — this is unambiguous, not left to implementer discretion.** The backward-

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -682,11 +682,26 @@ call `compare_snapshots` directly — they all go through
 typed request is the real chokepoint") gains the same parameter too,
 appended after every pre-existing one — matching the precedent already set
 for `debuginfod_url`, so a positional caller's existing argument bindings
-don't shift. `mcp_server`'s compare tools expose the same field on their
-own request shape, so the tentative-diff path is reachable identically
-through the CLI, the Python API's `CompareRequest`/`run_compare`, and MCP —
-not just a direct `compare_snapshots` call nothing in this codebase
-actually makes.
+don't shift.
+
+**`mcp_server.abi_compare` is itself a direct `compare_snapshots` caller —
+the one this ADR previously (wrongly) said nothing in the codebase makes —
+and exposing the parameter there is not enough on its own.** Verified
+against the actual code: `abi_compare`'s inner `_do_compare` calls
+`compare_snapshots(...)` directly, bypassing `CompareRequest`/
+`run_compare_request` entirely; its result is awaited via
+`future.result(timeout=MCP_TIMEOUT)` under a narrow `except
+_futures.TimeoutError`, with a broader `except Exception as exc: ...
+{"status": "error", ...}` catching everything else, including
+`ProfileMismatchError`/`ScopeMismatchError` today — collapsing a
+deliberate not-comparable result into the same generic error shape as any
+other tool failure. Adding `diagnostic_comparison` as an input parameter
+lets a caller opt into the tentative diff, but the *default* hard-fail
+path still needs its own dedicated `except (ProfileMismatchError,
+ScopeMismatchError)` branch in `abi_compare`, rendering a structured
+`{"status": "not_comparable", "reason": ...}` result distinct from
+`{"status": "error"}` — mirroring the CLI/service layers' `verdict: null`
+distinction, not merely exposing the escape-hatch flag.
 
 **`abicheck aggregate` is a consumer of these reports, not just a producer
 of new ones, and it has its own blind spot D2 must close.**

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -168,36 +168,59 @@ not a latent surprise discovered after Phase A ships.
 side-specific ones — this is not optional, it protects abicheck's single
 most common workflow.** `compare` already supports side-scoped
 `--header old=v1/foo.h --header new=v2/foo.h` and
-`--include old=inc1 --include new=inc2` (ADR-040, `cli_options.py:230+`)
+`--include old=inc1 --include new=inc2` (ADR-040, `cli_options.py:225+`)
 for the ordinary two-checkout-tree comparison — the old and new sides
 *necessarily* resolve to different absolute paths even when they cover the
 identical logical surface, precisely because they live in different
 checkouts. Hashing resolved absolute paths directly would make every
 routine `compare` invocation fingerprint-mismatch and hard-fail as
 `not_comparable` — the gate would break its primary use case on day one,
-the exact inverse of what it's for. Each side's header/include/forced-
-include paths are therefore normalized **relative to that side's own
-resolution root** before folding into either fingerprint: for the legacy,
-non-manifest CLI path, the root is the common ancestor **directory** of
-that side's own inputs — each header path's *parent* directory and each
-include directory itself, not the header paths taken literally (a pure
-function of that side's own inputs, no new flag needed). Computing it from
-the header paths directly, rather than their parents, degenerates in the
-single-header-per-side case that's actually the common one: the "common
-prefix" of a one-element path set is that whole path, so `old=v1/foo.h`
-and `new=v2/bar.h` would both normalize their sole header to the same
-empty/root marker, losing the filename entirely — two genuinely different
-public scopes would then hash identically and wrongly pass the gate, the
-opposite failure from the one this fix exists to close. Taking the parent
-directory first means a lone header's basename survives normalization
-(`v1/foo.h` → root `v1/`, normalized path `foo.h`); for the manifest-driven
-path (D3), the root is the manifest file's own directory. Two sides with
-the same logical directory layout (`include/foo.h` under each side's own
-root) normalize to identical relative paths and produce equal fingerprints
-regardless of where
-each checkout happens to live on disk; a side whose logical layout actually
-differs (a header moved to a different relative location) still changes the
-fingerprint, correctly.
+the exact inverse of what it's for.
+
+**The two fingerprints normalize their path inputs *separately*, each
+against its own root — they must not share one combined root.**
+`scope_fingerprint`'s inputs are header/TU paths (the declared surface);
+`profile_fingerprint`'s inputs are `-I` include-*search* directories (how
+the compiler resolves `#include`, not what's declared). Header paths and
+include-search directories commonly point to unrelated places on disk — a
+project's own headers live under the checkout root, while `-I` dependency
+directories (`--include old=/opt/dep --include new=/opt/dep`, a shared,
+often *identical*, external path on both sides) can sit anywhere,
+including well outside either checkout. Computing one shared root from
+*both* categories together — a mistake an earlier revision of this
+paragraph made — lets an out-of-checkout `-I` directory drag the common
+ancestor up to the filesystem root (`/`) once it shares no meaningful
+prefix with the project headers, which reintroduces the exact bug this
+fix exists to close: the header paths then normalize relative to `/`, so
+`old=/work/v1/foo.h` and `new=/work/v2/foo.h` still carry their diverging
+checkout roots (`work/v1/foo.h` vs. `work/v2/foo.h`) into
+`scope_fingerprint`, hard-failing an otherwise-identical comparison.
+
+For the legacy, non-manifest CLI path: `scope_fingerprint`'s root is the
+common ancestor **directory** of that side's own header paths' *parent*
+directories only (never `-I` directories); `profile_fingerprint`'s root is
+computed the same way but from that side's own `-I` directories only,
+independently. Computing either root from bare paths, rather than parent
+directories, degenerates in the single-entry case that's actually the
+common one: the "common prefix" of a one-element path set is that whole
+path, so `old=v1/foo.h` and `new=v2/bar.h` would both normalize their sole
+header to the same empty/root marker, losing the filename entirely — two
+genuinely different public scopes would then hash identically and wrongly
+pass the gate, the opposite failure from the one this fix exists to close.
+Taking the parent directory first means a lone header's basename survives
+normalization (`v1/foo.h` → root `v1/`, normalized path `foo.h`); for the
+manifest-driven path (D3), both roots are the manifest file's own
+directory (a manifest's `includes`/`forced_includes` and its base
+profile's search paths are declared relative to one document, so no
+external-directory contamination is possible there). Two sides with the
+same logical directory layout (`include/foo.h` under each side's own
+header root, `/opt/dep` identical or side-scoped independently under its
+own `-I` root) normalize to identical relative paths in both fingerprints
+and produce equal results regardless of where each checkout happens to
+live on disk or where its dependency directories are mounted; a side whose
+logical layout actually differs (a header moved to a different relative
+location, or a genuinely different dependency version under a differently
+laid-out path) still changes the corresponding fingerprint, correctly.
 
 Both fingerprints live in a new `contract: ExtractionContract | None` field
 on `AbiSnapshot` rather than flattening two more top-level fields onto an

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -490,6 +490,39 @@ distinct from both native `compare`'s `16` and `compat check`'s `9` since
 all three commands maintain independent, non-overlapping exit-code
 schemes. `docs/reference/exit-codes.md`'s `scan` table gains this row.
 
+**A seventh surface imports `checker.compare` directly and swallows every
+exception, including these new ones, into an undifferentiated `None`:
+`stack_checker.py`'s `_run_abi_diff`, driving `abicheck deps compare`.**
+`stack_checker.py:32` imports `compare` from `checker` (not through
+`service.compare_snapshots`), and `_run_abi_diff` (`:396-410`) wraps its
+whole body — the `dump()` calls *and* the `compare()` call — in one broad
+`except Exception as exc: log.warning(...); return None`. A
+`ProfileMismatchError`/`ScopeMismatchError` from a changed dependency DSO
+would be swallowed into that same `None`, indistinguishable from the
+"file unreadable" case a few lines above (`:363-364`, also `abi_diff=None`)
+or a genuine crash — the per-library `StackChange` this produces carries no
+`not_comparable` reason at all, just a silent absence of a diff, which
+`cli_stack.py`'s `deps compare` reporters and exit-code contract (`0`/`1`
+`WARN`/`4` `FAIL`/`64`, `docs/reference/exit-codes.md`) then read no
+differently than "nothing to report for this library." `StackChange` gains
+a `not_comparable_reason: str | None = None` field (additive, alongside its
+existing `abi_diff: DiffResult | None`); `_run_abi_diff`'s caller (the loop
+building `StackChange` entries) gains a dedicated `except
+(ProfileMismatchError, ScopeMismatchError) as exc:` branch around the
+`_run_abi_diff(...)` call, ordered so it is never reached by
+`_run_abi_diff`'s own broad `except Exception` first — `_run_abi_diff`
+itself re-raises `ProfileMismatchError`/`ScopeMismatchError` rather than
+swallowing them, since only its caller can attach the result to a
+`StackChange` — setting `not_comparable_reason` instead of leaving
+`abi_diff` as an unexplained `None`. `deps compare` gains its own exit code
+for "at least one dependency was not_comparable": **`5`**, the next integer
+after the currently documented ceiling (`4`, `FAIL`) in that command's own
+`0`/`1`/`4`/`64` scheme — distinct from `scan`'s `6`, `compat check`'s `9`,
+and native `compare`'s `16`, continuing the same "each command keeps its
+own disjoint scheme" rule the previous three surfaces already established,
+never folded into the existing `FAIL`/`4` the way a swallowed exception
+would today.
+
 On the reporting surface (`reporter.py`,
 `sarif.py`, `junit_report.py`), a `not_comparable` result is a distinct
 top-level state — `verdict: null`, a `reason` object naming the mismatched

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -300,6 +300,31 @@ walk — rather than inventing new file-discovery logic. `profile_fingerprint`'s
 `-I` component is the hash of the **ordered** sequence of per-directory
 digests.
 
+**The digest must exclude every path already claimed by `scope_fingerprint`
+— this is not an optional refinement, it is the difference between a
+working gate and one that hard-fails on every ordinary compare.** The
+documented real-world workflow (`docs/user-guide/real-world-example.md:61-63`)
+passes the project's own include root as *both* `--header` (the declared
+public headers being compared) *and* `--include` (so `#include "foo.h"`
+resolves) — the same directory serves both roles. A depfile for that TU
+necessarily lists `foo.h` itself alongside its supporting headers, since
+`foo.h` is exactly what got compiled. If the naive digest above hashed
+every depfile-listed path unconditionally, `foo.h` — the header the diff
+exists to compare — would feed `profile_fingerprint` too, and an ordinary,
+intentional edit to `foo.h` (changing its content hash) would flip
+`profile_fingerprint` and hard-fail `PROFILE_MISMATCH` *before* the diff
+ever ran, on literally the routine case this whole ADR exists to support.
+Each `-I` directory's digest is therefore built from its depfile-resolved
+file list **minus** the set of paths `scope_fingerprint` already covers for
+that side (the explicit `--header`/manifest TU entry points) — leaving only
+the supporting/dependency files a TU pulls in but never directly declares.
+This is a strict partition, not a heuristic: `scope_fingerprint` owns
+"what's declared and compared"; `profile_fingerprint` owns "what
+environment resolved it," and a file cannot honestly belong to both. A
+header that stops being resolved purely as a support file and becomes a
+directly-declared entry point (or vice versa) moves from one fingerprint's
+input set to the other's, not into both or neither.
+
 This is lossless with respect to every case the three rejected attempts
 traded off against each other, because content, unlike a path, is not
 ambiguous: two checkouts of a byte-identical dependency normalize
@@ -357,12 +382,12 @@ also bumps `snapshot_cache._SNAPSHOT_CACHE_VERSION` (`:48`, currently
 `"3"`) in the same change — folded into `_cache_key()` (`:196`) already, so
 every pre-this-ADR cache entry misses exactly once and gets rebuilt through
 the now-`contract`-populating `dump()`. This is deliberately separate from
-D6's later `profile_fingerprint`/`scope_fingerprint`-as-cache-key-input
-work: that closes a *different* gap (a pure compile-profile change with
-identical header content not invalidating the cache); this one closes
-"the cache doesn't know `contract` exists yet at all," and cannot wait for
-D6's phase without leaving the gate inert for every warm-cache user in the
-interim.
+D6's later manifest-driven `scope_fingerprint` cache-key work (see D6): that
+closes a *different* gap (pre-dump-knowable manifest fields, `contributes_to_abi`/
+`required`, that today's filesystem-only cache key can't see); this one
+closes "the cache doesn't know `contract` exists yet at all," and cannot
+wait for D6's phase without leaving the gate inert for every warm-cache user
+in the interim.
 
 **A third, ongoing cache gap — not a one-time migration issue like the
 two above — also has to land in this phase: `_cache_key()`'s own hashing
@@ -845,12 +870,38 @@ under this pool instead of today's fully sequential loop; a killed/timed-out
 TU is recorded with its exit signal, never silently retried as a clean
 empty TU.
 
-`snapshot_cache.py`'s existing content-hash cache key (`:130`) gains the
-`profile_fingerprint`/`scope_fingerprint` as additional key inputs — the
-cache already invalidates correctly on header-content drift (the review's
-"shadowing header" scenario is not a real gap here, see Context); it does
-not yet invalidate on a pure compile-profile change with identical header
-content, which the two new fingerprints close.
+**Adding `profile_fingerprint` itself as a cache-key input is impossible,
+not merely undesirable — D1's own depfile design rules it out.**
+`service_dump_cache.cached_run_dump` looks up `snapshot_cache` *before*
+calling `dump()` (D1's "whole-snapshot cache is the same bypass" note
+above); `profile_fingerprint`'s `-I` component is a depfile-derived digest
+that only exists *after* an L2 castxml/clang invocation runs. A cache-key
+input computed only by running the extraction the cache exists to skip is
+circular — this was an error in an earlier revision of this paragraph, not
+a deferred detail. `scope_fingerprint`, for the manifest-driven path (D3),
+is different: it is fully determined by the normalized manifest document
+itself, known *before* any TU is dumped, so it genuinely can feed a cache
+key without running anything. `snapshot_cache.py`'s existing content-hash
+cache key (`:130`) already closes the practical gap this section originally
+set out to close for the legacy CLI path, without needing either
+fingerprint: it recurses every `-I`/`-H` directory
+(`header_utils.iter_cache_header_files`, `rglob` over header-suffix files)
+and hashes each matched file's content and mtime — entirely pre-dump, no
+compiler invocation required. This over-approximates deliberately (it hashes
+every header-like file reachable under the directory, not only files a
+given compile would actually resolve), which is the *correct* asymmetry for
+a cache key: a false cache **miss** just costs a redundant dump, while a
+false cache **hit** would serve a stale `contract`, so erring toward "hash
+too much" is the safe direction here — the opposite of `profile_fingerprint`
+itself, which must be exactly right or the gate spuriously fires. This
+existing mechanism, plus D1's own order-sensitivity fix (Phase A, not
+deferred here) already invalidates on the cases that matter; D6 adds no
+further cache-key work for the `-I`/profile side beyond that. D6's cache-key
+extension is instead scoped to what genuinely is pre-dump-knowable and not
+already covered: the manifest-driven `scope_fingerprint` inputs (TU
+`required`/`contributes_to_abi` flags, D3), which the existing
+`iter_cache_header_files` walk has no way to see since they aren't
+filesystem content at all.
 
 ## Non-goals
 

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -437,23 +437,39 @@ enough (any CMake/Meson build with a generated-headers directory) that
 this is not the same "unusual declaration shape" class as the
 nested-vendor-dependency gap below; it is a routine one. The legacy CLI
 gains an explicit escape hatch for exactly this case: a new, side-scoped,
-**labeled** `--project-include <label>=<path>` option (`--project-include
-support=old/src --project-include support=new/src`, alongside the
-existing side-scoped `--include old=... --include new=...` convention,
-ADR-040) that asserts a declared `-I` directory is project-owned
-regardless of whether it is an ancestor of any declared header. Unlike
-`--include`, `--project-include` requires a `label` — not a path-derived
-name, a short user-supplied logical identifier, the same "name a TU
-instead of inferring one from path shape" choice the manifest path (D3)
-already makes for its `name` field — because an explicitly-declared
-support root has no natural "owned declared header" for the per-slot
-token below to derive from the way an ancestor-derived root does; asking
-the user for one avoids inventing yet another path-shape heuristic that
-could break in some other way, the repeated lesson of every rejected
-attempt in this section. `--project-include` is a legacy-CLI-only
-addition: the manifest path (D3) already has no such gap, since a
-manifest TU can declare a per-TU forced-include for exactly this
-directory instead of relying on directory-tree inference.
+**labeled** `--project-include` option — but its value grammar cannot
+reuse the plain `<label>=<path>` shape naively: `abicheck/cli_params.py`'s
+existing `SidedPathParam`/`SidedStrParam` (ADR-040 Lever 1) already claim
+the `X=` prefix position exclusively for the side discriminator
+(`old=`/`new=`/`both=`, `_SIDES` at `:101`) — a value like
+`support=old/src` has no recognized side prefix (`support` isn't in
+`_SIDES`), so it would fall through to that parser's bare-value case and
+be parsed as `("both", Path("support=old/src"))`, the literal string
+`support=old/src` swallowed whole as a bogus path, not as a label at all.
+`--project-include` therefore needs its own dedicated Click param type,
+`SidedLabeledPathParam`, with a grammar that carries *both* pieces:
+`[old:|new:|both:]<label>=<path>` — a colon-terminated side prefix (same
+three words as `_SIDES`, colon instead of `=` to stay unambiguous against
+the label's own `=`), defaulting to `both:` when omitted, exactly
+mirroring "a bare value means both sides" for the existing sided params.
+A genuine two-checkout compare with side-specific support-root paths but
+one shared logical identity is declared as `--project-include
+old:support=old/src --project-include new:support=new/src` — same
+`support` label on both invocations (so the per-slot token below matches
+across sides for the same logical root), different paths (so each side
+resolves its own checkout's directory). Unlike `--include`,
+`--project-include` requires that label — not a path-derived name, a
+short user-supplied logical identifier, the same "name a TU instead of
+inferring one from path shape" choice the manifest path (D3) already
+makes for its `name` field — because an explicitly-declared support root
+has no natural "owned declared header" for the per-slot token below to
+derive from the way an ancestor-derived root does; asking the user for
+one avoids inventing yet another path-shape heuristic that could break in
+some other way, the repeated lesson of every rejected attempt in this
+section. `--project-include` is a legacy-CLI-only addition: the manifest
+path (D3) already has no such gap, since a manifest TU can declare a
+per-TU forced-include for exactly this directory instead of relying on
+directory-tree inference.
 This is a strict partition on `-I` *directories*, not individual files:
 `scope_fingerprint` owns everything under a project-owned root (declared
 or not); `profile_fingerprint` owns only external roots, in full.
@@ -510,7 +526,7 @@ ancestor-derived roots for different declared headers (`include/` →
 `foo.h`, a second header root → `bar.h`) produce distinguishable,
 order-sensitive tokens instead of collapsing to one interchangeable
 constant, and two `--project-include` roots (`--project-include
-support=old/src`, `--project-include generated=old/gen`) are
+both:support=old/src`, `--project-include both:generated=old/gen`) are
 distinguished by their distinct labels the same way. **Residual
 limitation, same class as the vendored-nested-dependency
 gap below:** two separately declared `-I` roots that are both ancestors of

--- a/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md
@@ -424,6 +424,38 @@ where a change anywhere in it *is* meaningful profile drift. This is a
 strict partition on `-I` *directories*, not individual files:
 `scope_fingerprint` owns everything under a project-owned root (declared
 or not); `profile_fingerprint` owns only external roots, in full.
+
+**Excluding a project-owned directory's *content* must not also erase its
+*position* in the declared `-I` sequence — flag order changes which root
+wins an ambiguous `#include`, and the fingerprint has to keep tracking
+that even though it stops tracking the directory's content.** `-I` order is
+search-precedence order: given `-I project -I dep` and `-I dep -I project`
+over otherwise-identical files, an `#include "config.h"` present in both
+`project/` and `dep/` resolves to a *different* file depending on which
+flag came first — a real difference in what got compiled, not a
+cosmetic reordering. If the project-owned exclusion above simply dropped
+that directory's slot from the per-`-I`-directory sequence, both orderings
+would degrade to the same single-element sequence (`dep`'s digest alone),
+since the project root contributes nothing once excluded — collapsing two
+extractions with genuinely different, ambiguity-resolving `#include`
+behavior into one identical `profile_fingerprint`, exactly the false-match
+failure mode this whole digest exists to close, reintroduced through the
+exclusion mechanism itself. The fix keeps the sequence positional: each
+declared `-I` directory still occupies its own slot in the ordered
+sequence, in declaration order; a project-owned slot's *content* is
+replaced with a single fixed sentinel value (a constant, not derived from
+the directory's path, name, or content) rather than being omitted, so two
+project-owned directories still compare equal to each other (no scope
+information leaks into `profile_fingerprint` through the sentinel) while
+their position relative to every external directory's real content digest
+is preserved. `-I project -I dep` therefore hashes
+`[SENTINEL, digest(dep)]` and `-I dep -I project` hashes
+`[digest(dep), SENTINEL]` — different sequences, different
+`profile_fingerprint`s, correctly flagging that the two extractions are not
+comparable, even though neither ordering's project-owned content
+individually affects the hash. The system/toolchain bucket is unaffected —
+it is explicitly unordered (see above) because its inputs were never part
+of a user-declared, precedence-bearing `-I` sequence to begin with.
 A known, accepted residual gap: a vendored dependency nested *inside* a
 project-owned root (e.g. `include/thirdparty/foo.h` under the project's
 own `include/`) is swept into the project-owned exclusion along with

--- a/docs/development/adr/index.md
+++ b/docs/development/adr/index.md
@@ -87,3 +87,4 @@ against the code as unverified, regardless of how confident it reads.
 | [046](046-source-graph-identity-v2-and-evidence-merge.md) | Source Graph Identity v2 — USR-Based Entity Resolution and Evidence-Preserving Merge | Proposed |
 | [047](047-github-actions-integration-model.md) | GitHub Actions Integration Model — Project Lifecycle Over Aggregate-Centric Design | Proposed — not implemented; see [G30](../plans/g30-github-actions-integration-model.md) |
 | [048](048-canonical-entity-identity-and-graph-reconciliation.md) | Canonical Entity Identity and Graph Reconciliation (G31 Phase B) | Accepted — implemented |
+| [049](049-comparability-contract-and-multi-tu-manifest.md) | Comparability Contract — Profile/Scope Fingerprints and the Multi-TU Manifest | Proposed — not implemented; see [G32](../plans/g32-comparability-contract-and-multi-tu-manifest.md) |

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -1014,16 +1014,29 @@ Implements ADR-050 D1 and D2.
   keyword-argument wrapper over `checker.compare`, not a request
   dataclass) gains the same `diagnostic_comparison` keyword.
 - **`compare_snapshots` is not the front-end chokepoint — `api_types.CompareRequest`
-  is, and it needs the field too, or every documented front-end stays
+  is, and it needs the field too, or `CompareRequest`-based front-ends stay
   unable to reach it.** `CompareRequest` (`api_types.py:125`) is, by its
   own docstring, "the single input to `run_compare`" that "every front-end
   (CLI, MCP, `compare-release` fan-out, `appcompat`)" assembles and hands
   to `service.run_compare_request` — the real ADR-037 D1/D2 classification
-  chokepoint, one level above `compare_snapshots`. `run_compare_request`
+  chokepoint, one level above `compare_snapshots`, for the front-ends that
+  actually use it. **That docstring's own "`compare-release` fan-out" and
+  "`appcompat`" claims don't hold up against the actual code, verified
+  directly: `mcp_server.abi_compare` and `appcompat.py`'s
+  `check_appcompat`/`check_plugin_host_contract` call `compare_snapshots`
+  directly, and `cli_compare_release.py`'s `_compare_one_library` →
+  `_run_compare_pair` routes through the legacy `run_compare` keyword shim,
+  not `run_compare_request` — so a `CompareRequest`/`run_compare_request`
+  reachability test proves the flag reaches CLI/MCP `compare`'s own
+  chokepoint only, never compare-release or appcompat.** Each of those
+  three gets its own dedicated `diagnostic_comparison` parameter and test
+  in this same phase (see their respective bullets/tests elsewhere in this
+  plan) — narrowing what this bullet's fix actually covers, not extending
+  it by assertion. `run_compare_request`
   calls `compare_snapshots(...)` today with a fixed keyword list that has
   no slot for this flag; adding `diagnostic_comparison` only to
-  `compare_snapshots` would be unreachable from every documented front-end,
-  since none of them call `compare_snapshots` directly. `CompareRequest`
+  `compare_snapshots` would be unreachable from `CompareRequest`-based
+  front-ends specifically. `CompareRequest`
   therefore gains `diagnostic_comparison: bool = False`, and
   `run_compare_request` passes `request.diagnostic_comparison` through.
   The legacy `run_compare` keyword shim gains the same parameter too,
@@ -1455,9 +1468,26 @@ Implements ADR-050 D3. The highest-risk phase — see Risk above.
   becomes this path's one-TU special case (`legacy-main`) — same code, not
   a parallel implementation.
 - A manifest declaring TUs with different compilers/target triples is
-  rejected at parse time (`HETEROGENEOUS_ABI_CONTEXT` at manifest-validation
-  time, before any extraction runs — cheaper failure than after a wasted
-  compile).
+  rejected at parse time — before any extraction runs, cheaper than
+  failing after a wasted compile — via a new `ManifestValidationError`
+  (`dump_manifest.py`), the same exception type and mechanism as this
+  phase's other parse-time schema violations (unknown fields, the
+  `contributes_to_abi=True ⇒ required=True` invariant above), not a new
+  one invented just for this check. **This is deliberately *not* Phase C's
+  `HETEROGENEOUS_ABI_CONTEXT` — that is a `TuMergeError` conflict code
+  Phase C defines later, and Phase B ships and lands before Phase C.**
+  Reusing that name/type here would force Phase B to either introduce
+  Phase C's `tu_merge.py`/`TuMergeError` contract early (a phase landing
+  out of order) or leave Phase B's own acceptance criterion referencing a
+  type that doesn't exist yet; `ManifestValidationError` is Phase B's own,
+  self-contained mechanism, with no dependency on `tu_merge.py`. The two
+  checks are conceptually related (both concern mixed compile contexts
+  across a manifest's TUs) but fire at different times for different
+  reasons: this one is unconditional and parse-time, over the manifest's
+  own declared fields, before `dump()` even starts; Phase C's
+  `HETEROGENEOUS_ABI_CONTEXT` is merge-time, over what fragments actually
+  extracted to, and — per Phase C's own text — not expected to ever fire
+  in practice given this parse-time rule already holds.
 - A required TU's compile failure is a hard extraction failure for the
   whole snapshot (`IncompleteAttempt`, never silently merged as if it
   succeeded); an optional (`required: false`) TU's failure degrades to a
@@ -1510,7 +1540,12 @@ Implements ADR-050 D3. The highest-risk phase — see Risk above.
   `--dump-manifest old=v1/abi.yml --dump-manifest new=v2/abi.yml` — while
   `dump`'s stays a bare path (it only ever has one side).
 
-**Files & surfaces.** New `abicheck/dump_manifest.py`, `abicheck/dumper.py`
+**Files & surfaces.** New `abicheck/dump_manifest.py` (strict YAML parser,
+and a new `ManifestValidationError` for every parse-time schema violation
+it raises — unknown fields, the `contributes_to_abi=True ⇒ required=True`
+invariant, and the heterogeneous-compiler/target-triple rejection above —
+self-contained to this phase, no dependency on Phase C's later
+`tu_merge.py`/`TuMergeError`), `abicheck/dumper.py`
 (per-TU invocation loop, `TuFragment` type, and the actual `--dump-manifest`
 termination point). `--dump-manifest` is a
 shared-concept option across `dump` and `compare` (side-scoped on `compare`

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -2073,11 +2073,18 @@ also fails fast via `_EVIDENCE_SET_INPUT_FLAGS`'s guard, the same way
 proving `--dump-manifest` can't reach `_dispatch_release_compare`'s
 kwargs (which never carries it) and silently do nothing on a release
 compare. A
-**`scan --frontend-context`**
-regression test asserting `abicheck scan --against` accepts `device` and
-threads it into the L2 header frontend the same way `dump`/`compare` do,
-proving `compile_context_options` (not a `dump`/`compare`-only decorator) is
-what carries the flag.
+**`scan --frontend-context` Phase-B rejection**
+test asserting `abicheck scan --against ... --frontend-context device`
+also raises the same Phase-B-only rejection `dump`/`compare` do (see the
+dedicated acceptance-criteria bullet above) — **not** that `scan` accepts
+and threads `device` yet, which Phase B cannot honor until Phase D's
+selector exists; the behavioral "`scan` actually threads `device` into
+the L2 header frontend" assertion belongs in Phase D's own tests instead
+(see there), once there is a real selector for it to reach. This test
+does still prove `compile_context_options` is the shared decorator
+`dump`/`compare`/`scan` all resolve through (not a `dump`/`compare`-only
+one) — `scan`'s rejection goes through the identical guard path, not a
+separate one that could drift.
 
 **Example fixtures.** Phase 0's external-STL-noise pair only, wired through
 the real manifest path end to end — **not** the ODR-safe pair. The
@@ -2267,7 +2274,14 @@ D2's gate — proving the resolved `kind` actually reaches
 `compute_extraction_contract`'s hash, not just `sycl_context.py`'s
 selection logic; a companion assertion with the *same* `frontend_context`
 on both sides leaves `profile_fingerprint` matching, the routine case this
-fix must not break.
+fix must not break. A **`scan --frontend-context device` acceptance**
+test — moved here from Phase B, not duplicated (P2 review: Phase B's own
+test asserts `device` is *rejected* there, since this phase's selector
+doesn't exist yet at that point) — asserting `abicheck scan --against ...
+--frontend-context device` now succeeds and threads the request into the
+L2 header frontend via `compile_context_options`/`resolve_compile_context`,
+proving `scan` reaches this phase's selector the same way `dump`/`compare`
+do once it actually exists, closing the loop Phase B's rejection opened.
 
 **Example fixtures.** None required beyond Phase 0's captures — this phase
 is extraction-layer, not diff-layer; no new `ChangeKind`.

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -998,7 +998,23 @@ Implements ADR-050 D1 and D2.
   (ProfileMismatchError, ScopeMismatchError) as exc:` branch alongside its
   existing two, returning `ScanResult(verdict="NOT_COMPARABLE",
   exit_code=6, ...)` — reusing `scan`'s own exit `6` rather than inventing
-  a second code for the same command. Fixing `run_scan` alone closes both
+  a second code for the same command. **This is a new possible value on
+  the versioned scan envelope, not schema-invisible internal plumbing —
+  `abicheck/schemas/__init__.py`'s own `SCAN_SCHEMA_VERSION` docstring
+  states outright that it versions both public scan dict shapes
+  (`ScanOutcome.to_dict`/`ScanResult.to_dict`) "including
+  verdict/exit_code," with the same additive/breaking bump policy
+  `REPORT_SCHEMA_VERSION` already gets in this same plan (the JSON schema
+  bullet above) — a new `verdict` string a pre-Phase-A `scan` consumer
+  could never have received before is exactly what that policy exists to
+  track.** `SCAN_SCHEMA_VERSION` (currently `"1.1"`) is bumped in this same
+  change, with a new version-history line in its docstring (`1.2` — added
+  the `NOT_COMPARABLE` verdict/exit `6`, mirroring `REPORT_SCHEMA_VERSION`'s
+  own `not_comparable`/`verdict: null` bump), plus a regression test
+  confirming old scan reports (pre-`1.2`) stay distinguishable from new
+  ones by this version, the same guarantee
+  `tests/test_report_schema.py` already provides for `compare`. Fixing
+  `run_scan` alone closes both
   gaps: `run_scan_subprocess`'s worker calls `run_scan(...)` directly, so
   a `NOT_COMPARABLE` result now flows through its normal `q.put(("ok",
   ...))` path — no separate `run_scan_subprocess`/`mcp_server.py` change
@@ -1585,6 +1601,13 @@ than raising, and a second test asserting `run_scan_subprocess` (and, by
 extension, `mcp_server.abi_scan`) surfaces that same structured result
 rather than a generic `RuntimeError` — proving the fix at `run_scan`
 actually reaches the MCP surface without any change needed there; a
+**scan schema-version** test asserting `SCAN_SCHEMA_VERSION` is bumped
+to `"1.2"` and that a `ScanResult.to_dict()`/`ScanOutcome.to_dict()`
+carrying `verdict="NOT_COMPARABLE"` emits that bumped
+`scan_schema_version` — proving a consumer parsing the older `"1.1"`
+envelope can tell it could never have received this verdict, the same
+version-distinguishability guarantee `compare`'s `REPORT_SCHEMA_VERSION`
+bump already provides; a
 **deps-compare exit-code** test asserting `abicheck deps
 compare` returns exactly `5` (never folded into `4`'s `FAIL`, never a
 silent `None` diff indistinguishable from the pre-existing
@@ -1719,6 +1742,24 @@ Implements ADR-050 D3. The highest-risk phase — see Risk above.
   DPC++ flow needing a non-default context with nowhere to request it
   (ADR-050 D3). The legacy, non-manifest CLI path gains a matching
   `--frontend-context host|device` flag (default `host`).
+  **Phase B accepting `device` at all is not safe on its own — Phase B can
+  ship (per Sequencing above) before Phase D, and in that window there is
+  no selector behind the request.** `sycl_context.py` and
+  `dumper_clang.py`'s multi-context decoding/selection are introduced in
+  Phase D, not here; if Phase B accepts and forwards a `device` request
+  with nothing downstream to act on it, `dumper.py`/`dumper_clang.py`
+  would silently extract whatever the existing single/default-context
+  path already does today and hand back an ordinary snapshot — which a
+  user who explicitly requested `device` would reasonably, but wrongly,
+  believe is device-derived. Phase B therefore accepts `frontend_context`/
+  `--frontend-context` in its schema and CLI surface (so Phase D has
+  somewhere to plug in without a follow-up schema change) but **rejects
+  any value other than `host`** with a clear "device context selection
+  requires Phase D" error, both in `dump_manifest.py`'s parser (a
+  manifest-declared `frontend_context: device` is a `ManifestValidationError`
+  in this phase) and in the CLI flag's own validation. Phase D, when it
+  lands, is what lifts this restriction once `sycl_context.py`'s selector
+  actually exists to honor the request — not before.
 - **The per-TU loop and `TuFragment` handling land in a new sibling
   module, not inline in `dumper.py` itself — `dumper.py` has zero lines of
   headroom left before the AI-readiness file-size gate's hard cap.**
@@ -1982,7 +2023,15 @@ choke point `compare`/`dump`/`scan` all resolve through, so no
 
 **Tests.** Manifest parser unit tests (the invariant violation, duplicate
 TU names, unknown fields, relative-path resolution, `frontend_context`
-accepted/defaulted/rejected-when-invalid). A **manifest support-root
+accepted/defaulted/rejected-when-invalid). A **Phase-B-only device
+rejection** test asserting a manifest declaring `frontend_context:
+device` raises `ManifestValidationError` (not silently accepted and
+extracted as if it were `host`), and a companion CLI test asserting
+`--frontend-context device` on `dump`/`compare`/`scan` fails the same way
+in a Phase-B-only build — proving Phase B never hands back a snapshot a
+user could mistake for device-derived before Phase D's selector actually
+exists to produce one; `frontend_context: host` (or omitted) still
+parses and defaults normally. A **manifest support-root
 ownership** test asserting a TU declaring `includes: [{path: ../src,
 project_owned: true}]` (a sibling of the TU's own declared path, not an
 ancestor) leaves `profile_fingerprint` matching across an old/new manifest
@@ -2120,6 +2169,18 @@ CLI flag this phase's selector reads are defined there, not here (Phase B
 tested against the `host` default without Phase B, but a real DPC++
 device-context request has nowhere to come from until Phase B's field/flag
 exist.
+
+**This phase also lifts a restriction Phase B deliberately imposed, not
+just adds new behavior.** Phase B ships with `dump_manifest.py`/the
+`--frontend-context` flag rejecting any value other than `host` (its own
+"Phase-B-only device rejection" acceptance criterion), precisely because
+Phase B alone has nowhere to route a `device` request — accepting and
+silently ignoring it would hand back a snapshot a user could mistake for
+device-derived. This phase's selector is what makes a `device` request
+meaningful, so it is also what removes Phase B's rejection: once
+`sycl_context.py` exists, `frontend_context: device`/`--frontend-context
+device` are accepted rather than raising `ManifestValidationError`/a CLI
+error.
 
 **Goal & acceptance criteria.**
 - New `abicheck/sycl_context.py`: decodes a DPC++ frontend's

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -1038,70 +1038,90 @@ Implements ADR-050 D1 and D2.
   the same phase, per that file's own stated policy that changing the
   exit-code contract "requires a CHANGELOG note and downstream coordination."
 - **A sixth entry point reaches `compare_snapshots` through a different
-  code path than the ones already named, with its own exit-code contract
-  too.** `abicheck scan --against` calls `service.compare_snapshots` from
+  code path than the ones already named, and the fix belongs one layer
+  deeper than the per-front-end catches used for the other five — inside
+  the shared engine core, not in `scan_cmd` or `run_scan` individually.**
+  `abicheck scan --against` calls `service.compare_snapshots` from
   `cli_scan_baseline._run_baseline_compare` (invoked from
   `scan_engine.run_scan_core` around `:852`) — `compare_snapshots` itself
   has no exception handling of its own (a thin wrapper over
   `checker.compare`), so `ProfileMismatchError`/`ScopeMismatchError`
   propagate through it cleanly, exactly as intended at the `service.py`
-  boundary. The gap is one level up: `cli_scan.py`'s `scan_cmd` wraps its
-  `run_scan_core` call in `try`/`except _BudgetOverflow`/`except
-  _EvidenceContractError` only — verified against the actual code, neither
-  clause catches `ProfileMismatchError`/`ScopeMismatchError`, so today they
-  would propagate uncaught out of `scan_cmd` entirely, an unhandled
-  traceback rather than any of `scan`'s own documented exit codes
-  (`0`/`2`/`4`/`5`/`64`). `scan_cmd` gains a third `except
-  (ProfileMismatchError, ScopeMismatchError) as exc:` branch alongside its
-  existing two, exiting **`6`** — the next integer after `scan`'s own
-  highest documented code (`5`), distinct from both native `compare`'s
-  `16` and `compat check`'s `9` since all three commands maintain
-  independent exit-code schemes; reusing either of those would imply a
-  shared numbering `scan` doesn't have. `docs/reference/exit-codes.md`'s
-  `scan` table gains this row.
-- **`cli_scan.py`'s `scan_cmd` is not the only front-end wrapping
-  `run_scan_core` — the typed Python API and MCP reach the same
-  `_run_baseline_compare` call through a separate, unfixed path.**
-  `service_scan.run_scan` (`:801-928`) is its own front-end over
-  `run_scan_core`, with its own `try`/`except _BudgetOverflow`/`except
-  _EvidenceContractError` — the identical gap as `scan_cmd`'s, on a
-  different call site: `ProfileMismatchError`/`ScopeMismatchError` would
-  propagate out of `run_scan` uncaught today. This matters beyond the
-  Python API itself because `run_scan_subprocess`'s worker (`:982-985`)
-  calls `run_scan(req).to_dict()` inside `except BaseException as exc:
-  q.put(("err", f"{type(exc).__name__}: {exc}"))` — a fully generic
-  catch-all that cannot distinguish a deliberate `not_comparable` result
-  from any other crash, and `run_scan_subprocess` (`:1108-1135`) turns that
-  into a bare `RuntimeError`. `mcp_server`'s `abi_scan` MCP tool goes
-  through `run_scan_subprocess`, so an AI agent calling `abi_scan(...
-  against=...)` on a mismatched pair would see an opaque worker-crash
-  `RuntimeError`, not a structured not-comparable result — losing the
-  ADR's semantics entirely on the one surface built specifically for
-  agent consumption. `run_scan` gains a fourth `except
-  (ProfileMismatchError, ScopeMismatchError) as exc:` branch alongside its
-  existing two, returning `ScanResult(verdict="NOT_COMPARABLE",
-  exit_code=6, ...)` — reusing `scan`'s own exit `6` rather than inventing
-  a second code for the same command. **This is a new possible value on
-  the versioned scan envelope, not schema-invisible internal plumbing —
-  `abicheck/schemas/__init__.py`'s own `SCAN_SCHEMA_VERSION` docstring
-  states outright that it versions both public scan dict shapes
-  (`ScanOutcome.to_dict`/`ScanResult.to_dict`) "including
-  verdict/exit_code," with the same additive/breaking bump policy
-  `REPORT_SCHEMA_VERSION` already gets in this same plan (the JSON schema
-  bullet above) — a new `verdict` string a pre-Phase-A `scan` consumer
-  could never have received before is exactly what that policy exists to
-  track.** `SCAN_SCHEMA_VERSION` (currently `"1.1"`) is bumped in this same
-  change, with a new version-history line in its docstring (`1.2` — added
-  the `NOT_COMPARABLE` verdict/exit `6`, mirroring `REPORT_SCHEMA_VERSION`'s
-  own `not_comparable`/`verdict: null` bump), plus a regression test
-  confirming old scan reports (pre-`1.2`) stay distinguishable from new
-  ones by this version, the same guarantee
-  `tests/test_report_schema.py` already provides for `compare`. Fixing
-  `run_scan` alone closes both
-  gaps: `run_scan_subprocess`'s worker calls `run_scan(...)` directly, so
-  a `NOT_COMPARABLE` result now flows through its normal `q.put(("ok",
-  ...))` path — no separate `run_scan_subprocess`/`mcp_server.py` change
-  needed beyond that.
+  boundary. `run_scan_core`'s own module docstring already states its
+  purpose: "the one body the CLI, `service.run_scan`, and the MCP scan
+  tool share" — catching one layer too high, separately in `scan_cmd` and
+  in `service_scan.run_scan`, would duplicate the fix across two call
+  sites this module exists specifically to keep from diverging, **and** it
+  would catch the exception *after* `run_scan_core` has already returned
+  (or failed to return) a `ScanCoreResult` — too late to build a real
+  `ScanOutcome`, since `scan_cmd`'s outer `try` only has `core.outcome` to
+  work with once `run_scan_core` returns normally, and its own
+  `_emit_scan_report(core.outcome, fmt, output)` call (the one function
+  that renders text/JSON, writes the `-o` file, and exits on `exit_code
+  != 0`, mirrored by the *existing* `_BudgetOverflow`/
+  `_EvidenceContractError` branches, which also skip `_emit_scan_report`
+  and just exit/raise bare, matching precedent) never runs on any
+  exception path at all. A bare `sys.exit(6)` in a new `scan_cmd` except
+  branch would therefore skip `_emit_scan_report` entirely: `abicheck scan
+  --against ... --format json -o report.json` on a mismatched pair would
+  exit `6` but **write no report file** — no `ScanOutcome` JSON, no bumped
+  `scan_schema_version`, no reason object — even though this same phase's
+  `SCAN_SCHEMA_VERSION` bump (below) is framed as versioning exactly that
+  envelope's new `NOT_COMPARABLE` verdict. The fix instead wraps only the
+  `_run_baseline_compare(...)` call inside `run_scan_core` (`:852`,
+  already inside a `try` catching `deadline.DeadlineExceeded`) in an
+  additional `except (ProfileMismatchError, ScopeMismatchError) as exc:`
+  branch. At that point every field `ScanOutcome` needs except the
+  baseline-diff-derived ones is already resolved locally (`scan_mode`,
+  `resolved`, `eff_depth_enum`, `collect_mode`, `risk`, `is_auto`,
+  `changed`, `changed_src`, `pattern`, `preproc`, `cc`'s coverage/findings,
+  `stage_timings` collected so far) — the branch sets
+  `verdict = "NOT_COMPARABLE"`, `exit_code = 6`,
+  `diff_summary = {"reason": str(exc)}`, and skips the crosscheck-severity
+  promotion step below it (a `NOT_COMPARABLE` gate result is not something
+  a promoted cross-check finding should be able to soften or override, the
+  same "hard-blocking gate, no soft-launch path" rule Phase A's own
+  section already establishes), then falls through to the function's
+  existing `ScanOutcome(...)` construction (`:902`) with those three
+  fields instead of the normal baseline-diff ones. **Fixing it here closes
+  all three front-ends in one change, not one at a time:** `scan_cmd`
+  needs no new `except` branch at all — `core.outcome.exit_code == 6`
+  already makes its existing, unconditional `_emit_scan_report(core.outcome,
+  fmt, output)` call (`:885`) write the real `ScanOutcome` JSON/text and
+  exit `6`, the same path every successful scan already takes, not a
+  bypass of it; `service_scan.run_scan` needs no new `except` branch
+  either, since (per `ScanCoreResult`'s own docstring) it already builds
+  its typed `ScanResult` from `core.outcome` "without re-running
+  anything," so `verdict="NOT_COMPARABLE"`/`exit_code=6` flow through
+  automatically; and `run_scan_subprocess`'s worker (`:982-985`) — whose
+  fully generic `except BaseException` catch-all today cannot distinguish
+  a deliberate not-comparable result from any other crash, turning it into
+  a bare `RuntimeError` `mcp_server`'s `abi_scan` MCP tool would see as an
+  opaque failure — needs no change either, because there is no longer an
+  exception for that catch-all to swallow: `run_scan(req)` returns
+  normally with a `NOT_COMPARABLE` `ScanResult`, flowing through the
+  worker's ordinary `q.put(("ok", ...))` success path, reaching the agent
+  as the structured result the ADR's semantics require. `docs/reference/
+  exit-codes.md`'s `scan` table gains a `6` row — the next integer after
+  `scan`'s own highest documented code (`5`), distinct from both native
+  `compare`'s `16` and `compat check`'s `9` since all three commands
+  maintain independent exit-code schemes; reusing either of those would
+  imply a shared numbering `scan` doesn't have.
+- **This is a new possible value on the versioned scan envelope, not
+  schema-invisible internal plumbing.** `abicheck/schemas/__init__.py`'s
+  own `SCAN_SCHEMA_VERSION` docstring states outright that it versions
+  both public scan dict shapes (`ScanOutcome.to_dict`/`ScanResult.to_dict`)
+  "including verdict/exit_code," with the same additive/breaking bump
+  policy `REPORT_SCHEMA_VERSION` already gets in this same plan (the JSON
+  schema bullet above) — a new `verdict` string a pre-Phase-A `scan`
+  consumer could never have received before is exactly what that policy
+  exists to track. `SCAN_SCHEMA_VERSION` (currently `"1.1"`) is bumped in
+  this same change, with a new version-history line in its docstring
+  (`1.2` — added the `NOT_COMPARABLE` verdict/exit `6`, mirroring
+  `REPORT_SCHEMA_VERSION`'s own `not_comparable`/`verdict: null` bump),
+  plus a regression test confirming old scan reports (pre-`1.2`) stay
+  distinguishable from new ones by this version, the same guarantee
+  `tests/test_report_schema.py` already provides for `compare`.
 - **A seventh entry point imports `checker.compare` directly and swallows
   every exception into an undifferentiated `None` today — a different
   failure mode than the previous six, and it needs its own fix.**
@@ -1536,18 +1556,21 @@ routing to the updated `_classify_compat_error_exit_code` via `_compat_fail`),
 `compat/_errors.py`
 (`_classify_compat_error_exit_code`'s new `ProfileMismatchError`/
 `ScopeMismatchError` branch returning `9`), `compat/CLAUDE.md` (exit-code
-table update), `cli_scan.py` (`scan_cmd`'s new third `except
-(ProfileMismatchError, ScopeMismatchError)` branch exiting `6`, alongside
-its existing `_BudgetOverflow`/`_EvidenceContractError` clauses — no change
-needed in `cli_scan_baseline.py`/`scan_engine.py` themselves, since
-neither catches these exceptions today and both must keep letting them
-propagate), `service_scan.py` (`run_scan`'s new fourth `except
-(ProfileMismatchError, ScopeMismatchError)` branch returning
-`ScanResult(verdict="NOT_COMPARABLE", exit_code=6, ...)`, alongside its
-existing `_BudgetOverflow`/`_EvidenceContractError` clauses — no separate
-`run_scan_subprocess`/`mcp_server.py` change needed, since the worker
-already calls `run_scan(...)` and forwards whatever `ScanResult` it
-returns), `stack_checker.py` (`StackChange.not_comparable_reason`
+table update), `scan_engine.py` (`run_scan_core`'s `_run_baseline_compare`
+call (`:852`) gains an `except (ProfileMismatchError, ScopeMismatchError)
+as exc:` branch alongside its existing `except deadline.DeadlineExceeded`,
+setting `verdict="NOT_COMPARABLE"`/`exit_code=6`/
+`diff_summary={"reason": str(exc)}`, skipping the crosscheck-severity
+promotion step, and falling through to the function's existing
+`ScanOutcome(...)` construction — the single shared fix point `scan_cmd`,
+`service_scan.run_scan`, and `mcp_server.abi_scan` all inherit from,
+per this module's own "one body the CLI/API/MCP share" docstring; **no
+change needed in `cli_scan.py`, `service_scan.py`, or `mcp_server.py`
+themselves** — `scan_cmd`'s existing, unconditional
+`_emit_scan_report(core.outcome, fmt, output)` call and
+`service_scan.run_scan`'s existing "build `ScanResult` from `core.outcome`
+without re-running anything" logic both already propagate whatever
+`ScanOutcome` `run_scan_core` returns), `stack_checker.py` (`StackChange.not_comparable_reason`
 field; `_run_abi_diff` re-raises `ProfileMismatchError`/`ScopeMismatchError`
 instead of swallowing them into its broad `except Exception`; its caller
 gains the dedicated `except` branch that sets `not_comparable_reason`),
@@ -1731,19 +1754,25 @@ seven entry points; a **compat-mode exit-code** test asserting
 `compat check` invocation on a mismatched pair — the latter is what proves
 the new `try`/`except` around the `compare()` call site actually catches the
 exception, not just that the classifier returns the right code once handed
-one; a **scan-mode exit-code** test asserting `abicheck scan --against`
-returns exactly `6` (never an unhandled traceback, never `5`'s
-budget-overflow code) for a `ProfileMismatchError`/`ScopeMismatchError`
-raised from the baseline compare, exercised through a real end-to-end
-`scan --against` invocation on a mismatched pair — proving `scan_cmd`'s new
-`except` clause actually catches what `_run_baseline_compare` lets through
-uncaught today; a **`run_scan` API/MCP** test asserting
+one; a **scan-mode exit-code and report-emission** test asserting
+`abicheck scan --against ... --format json -o report.json` returns exactly
+`6` (never an unhandled traceback, never `5`'s budget-overflow code) for a
+`ProfileMismatchError`/`ScopeMismatchError` raised from the baseline
+compare, exercised through a real end-to-end `scan --against` invocation
+on a mismatched pair, **and asserts `report.json` was actually written**
+with `verdict: "NOT_COMPARABLE"`, a populated `diff.reason`, and the
+bumped `scan_schema_version` — proving the fix lands inside
+`run_scan_core` so `scan_cmd`'s existing, unconditional
+`_emit_scan_report` call renders and writes it, not a bare `sys.exit(6)`
+that skips report emission the way `_BudgetOverflow`'s existing bare-exit
+path deliberately does; a **`run_scan` API/MCP** test asserting
 `service_scan.run_scan(ScanRequest(..., baseline=...))` on a mismatched
 pair returns `ScanResult(verdict="NOT_COMPARABLE", exit_code=6)` rather
 than raising, and a second test asserting `run_scan_subprocess` (and, by
 extension, `mcp_server.abi_scan`) surfaces that same structured result
-rather than a generic `RuntimeError` — proving the fix at `run_scan`
-actually reaches the MCP surface without any change needed there; a
+rather than a generic `RuntimeError` — proving the single fix inside
+`run_scan_core` reaches both the CLI and the MCP surface without any
+separate change at either front-end; a
 **scan schema-version** test asserting `SCAN_SCHEMA_VERSION` is bumped
 to `"1.2"` and that a `ScanResult.to_dict()`/`ScanOutcome.to_dict()`
 carrying `verdict="NOT_COMPARABLE"` emits that bumped

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -2327,7 +2327,10 @@ error.
   string alone can't see but the actually-resolved `kind` can.
 - `dumper_clang.py`'s existing single-context assumption is generalized to
   call this module when the detected frontend is DPC++-capable; a plain
-  (non-SYCL) clang/castxml invocation is unaffected.
+  (non-SYCL) clang/castxml invocation is unaffected **when the requested
+  `frontend_context` is `host` — see the dedicated bullet below for why a
+  non-`host` request on a plain invocation cannot take this same silent
+  path.**
 - **The legacy single-context fallback is gated on positive non-SYCL
   identification, never on the decoded context count.** "Zero contexts
   with the requested `kind`" (above, → `AST_CONTEXT_MISSING`) and "this
@@ -2346,6 +2349,30 @@ error.
   degradation is reserved for output that was never a context stream to
   begin with, so missing or malformed DPC++ context data can never result
   in silently selecting the wrong (or an arbitrary) AST.
+- **The non-SYCL fallback is only a valid "unaffected" outcome when the
+  requested `frontend_context` is `host` — a non-`host` request on a
+  positively-non-SYCL invocation must fail, not silently return the
+  ordinary host AST as if it satisfied the request.** Once Phase D lifts
+  Phase B's blanket `device` rejection (above), `--frontend-context
+  device` becomes reachable on *any* invocation, including a plain
+  clang/castxml one with no DPC++/multi-document capability at all. If
+  the "positively identified as non-SYCL" fallback (previous bullet)
+  fires unconditionally regardless of what was actually requested, a
+  `device` request on such an invocation would silently produce the
+  existing single/default-context AST — the ordinary host extraction —
+  while the user explicitly asked for `device`. This is exactly the
+  "accepted but silently doing the wrong thing" failure mode this whole
+  plan has already had to close for `--dump-manifest` on release inputs
+  and for `frontend_context` before Phase D existed at all, now
+  recurring one layer deeper, inside Phase D itself. The fallback
+  therefore checks the *requested* `frontend_context` first: `host` (the
+  default) on a positively-non-SYCL invocation is the ordinary,
+  unaffected case above; any other requested value on a
+  positively-non-SYCL invocation is a hard failure —
+  `AST_CONTEXT_MISSING` (there is no device context stream to select at
+  all, the same code a DPC++ invocation with zero matching contexts
+  already uses) rather than a distinct new error, since the underlying
+  condition is identical: the requested `kind` has nothing to select from.
 
 **Files & surfaces.** New `abicheck/sycl_context.py`, `dumper_clang.py`
 (wiring), `sycl_metadata.py` (unaffected — this phase adds frontend-level
@@ -2368,7 +2395,16 @@ asserting a DPC++-capable invocation whose decoded stream comes back empty
 `AST_CONTEXT_MISSING`, never silently falling back to the single-context
 path — proving the fallback distinguishes "genuinely not a multi-document
 invocation" from "was one, but decoded to nothing," the specific
-conflation this criterion exists to prevent. A **host/device
+conflation this criterion exists to prevent. A **non-host request on a
+plain frontend** test asserting `--frontend-context device` against a
+positively-non-SYCL, plain clang/castxml invocation (no DPC++/
+multi-document toolchain flag, no document-boundary markers) raises
+`AST_CONTEXT_MISSING` rather than silently returning the ordinary
+single-context host AST — proving a user who explicitly requests
+`device` on a frontend that can't produce one gets a clear failure, not a
+snapshot they'd reasonably mistake for device-derived; a companion
+assertion confirms `--frontend-context host` (the default) on the same
+plain invocation is still the unaffected, unchanged legacy path. A **host/device
 profile-fingerprint mismatch** test asserting an old/new pair extracted
 with `frontend_context=host` on one side and `frontend_context=device` on
 the other, otherwise identical compiler/target/macros/includes, produces
@@ -2432,6 +2468,44 @@ half depends on Phase B too (the per-TU loop it schedules).
 - `dumper_manifest.py`'s per-TU castxml/clang invocations (Phase B) run under this
   pool instead of a fully sequential loop; a killed/timed-out TU records
   its exit signal and never silently retries as a clean empty TU.
+- **A single manifest-driven `compare` can launch two full-sized per-TU
+  pools at once, each independently sized off *total* system
+  `MemAvailable` — this doubles the intended budget and must be closed,
+  not merely noted.** Verified against the actual code:
+  `service.run_compare_request` (`:1724`) already resolves the old and
+  new sides concurrently via `ThreadPoolExecutor(max_workers=2)` (opt-out
+  only via `ABICHECK_PARALLEL_EXTRACTION=0`), pre-dating this phase. If
+  either side's dump is manifest-driven, `process_resources.py`'s
+  pool-sizing helper computes its process cap from the *system-wide*
+  `MemAvailable` at call time, implicitly assuming it is the only such
+  pool active — but with both sides resolved concurrently, old's and
+  new's pool-sizing calls run at nearly the same instant, each seeing
+  roughly the same total `MemAvailable` and each sizing up to that same
+  budget independently. Both pools then launch concurrently, together
+  claiming up to twice the memory either sizing calculation actually
+  accounted for — precisely the OOM risk this phase's RAM-aware cap
+  exists to prevent, worst on exactly the large multi-TU workload this
+  phase targets. This phase does not introduce a new cross-process
+  budget-sharing mechanism to fix it (out of scope, per the bullet
+  below) — instead, `run_compare_request` (and the legacy `run_compare`
+  keyword shim `cli_compare_release.py`'s `_run_compare_pair` calls,
+  which reaches the same manifest-driven dump path) skips the old/new
+  `ThreadPoolExecutor` and resolves sequentially whenever either
+  resolved input is manifest-driven, so only one per-TU pool is ever
+  active system-wide for a manifest-driven compare and its own sizing
+  call sees an accurate, uncontended `MemAvailable`. Non-manifest
+  (legacy single-TU) dumps are entirely unaffected — they never spawn a
+  Phase E per-TU pool in the first place, so the existing old/new
+  concurrency stays exactly as it is today for the routine case.
+  **`compare-release`'s own cross-library fan-out (`ThreadPoolExecutor` in
+  `cli_compare_release.py`, `:500-503`) is a known, accepted residual gap
+  at this same granularity, not fixed by this bullet**: N libraries
+  compared in parallel, each manifest-driven, could still launch N
+  independently-sized pools concurrently. Serializing *that* layer too is
+  a coarser, separate tradeoff (release-level throughput vs. per-compare
+  memory safety) this phase does not resolve; closing it is deferred to
+  whoever revisits release-level scheduling policy, not silently assumed
+  fixed here.
 - **`profile_fingerprint` itself cannot be a cache-key input — this phase
   does not attempt it.** `cached_run_dump` looks up `snapshot_cache`
   *before* calling `dump()` (Phase A); `profile_fingerprint`'s `-I`
@@ -2533,12 +2607,28 @@ only one `includes` entry's `project_owned` bit (`true` on one call,
 `false`/absent on the next, same unchanged path) ⇒ cache miss — proving
 the bit is its own key material, not silently absorbed into content/mtime
 hashing (which can't see it) or any of the three fields above (none of
-which change when only this bit does).
+which change when only this bit does). A **pool-doubling** regression
+test asserting a manifest-driven `compare` (both sides manifest-driven,
+enough TUs to trigger the RAM-aware pool) resolves old and new
+*sequentially*, not concurrently — patch/spy on
+`process_resources`'s sizing helper and assert it is never called twice
+with overlapping wall-clock windows for the same `compare` invocation —
+proving `run_compare_request` actually disables its old/new
+`ThreadPoolExecutor` for this case rather than leaving both pools free to
+size off the same total `MemAvailable` at once; a companion assertion
+confirms a **non**-manifest-driven `compare` still resolves old/new
+concurrently exactly as it does today, proving the fix is scoped to
+manifest-driven dumps and doesn't regress the routine case's existing
+parallelism.
 
 **Out of scope.** No new scheduling *policy* — this phase ports the
 existing, already-proven `source_replay.py` policy verbatim; a different
 policy (e.g. per-manifest-declared memory budget) is future work, not
-scoped here.
+scoped here. `compare-release`'s own cross-library fan-out concurrency
+(a known, accepted residual gap at this same granularity — see the
+pool-doubling acceptance-criteria bullet above) is also not addressed by
+this phase; a coarser release-level scheduling policy is future work,
+not silently assumed fixed here.
 
 ---
 

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -362,11 +362,24 @@ Implements ADR-050 D1 and D2.
   and the rest keep the unchanged, 2-tuple `SidedPathParam`, since only
   `--include` needs a label slot. `SidedIncludePathParam` layers an
   optional labeled form on top of the existing `[old=|new=|both=]PATH`
-  grammar: `[old:|new:|both:]LABEL=PATH` — a colon-terminated side prefix
-  (colon instead of `=`, unambiguous since no `--include` value has ever
-  started with `old:`/`new:`/`both:`), returning a `(side, label, path)`
-  triple with `label=None` for every existing unlabeled form so ordinary
-  uses are byte-for-byte unaffected. A two-checkout compare with
+  grammar. **The labeled form requires the literal colon prefix — there is
+  no colon-less/bare `LABEL=PATH` variant at all.** `[old:|new:|both:]LABEL=PATH`
+  means "one of these three literal prefixes, colon included," never "the
+  prefix segment is optional, so a bare value is still tried as
+  `LABEL=PATH`." Getting this backwards breaks existing usage:
+  `SidedPathParam.convert` (today's `--include` type) only checks
+  `s.startswith("old=")`/`"new="`/`"both="`, so an ordinary directory
+  containing a literal `=` past that point — `build/config=asan/include`,
+  a valid `--include` value today — matches none of the three and falls
+  through unchanged to `("both", Path(...))`. A bare-`LABEL=PATH` reading
+  would instead reinterpret it as `label="build/config"`,
+  `path="asan/include"` — a different compiler argument, breaking a
+  currently-valid value that never opted into labeling. Fix: a value is
+  only ever split into a label after one of the three literal
+  `old:`/`new:`/`both:` prefixes has matched; every other value — bare,
+  `old=`/`new=`/`both=`-prefixed, or containing an unrelated `=` — takes
+  `SidedPathParam`'s existing, unmodified path, `label=None`
+  unconditionally. A two-checkout compare with
   side-specific paths for one shared logical root is declared `--include
   old:support=old/src --include new:support=new/src` — same `support`
   label on both invocations (so the per-slot token matches across sides
@@ -380,6 +393,40 @@ Implements ADR-050 D1 and D2.
   off of; asking for one avoids yet another path-shape heuristic. This
   labeled `--include` form is legacy-CLI-only: the manifest path (D3)
   already has no such gap via per-TU forced-includes.
+
+  **`--include` is three separate Click registrations today, not one —
+  `SidedIncludePathParam` only fixes `compare`'s.** Verified against the
+  actual code: `cli_options.py`'s `two_sided_input_options`
+  (`:206`, the `SIDED_PATH_PARAM` registration extended above) is applied
+  only at `cli.py:1513` (native `compare`). `dump_cmd`'s own `--include`
+  (`cli.py:486`) is a *separate*, inline registration — plain, non-sided
+  `click.Path` (`dump` has one input, never carried `SidedPathParam` at
+  all). `scan_cmd`'s own `--include` (`include_pairs`, `cli_scan.py:487-495`)
+  is *also* a separate inline registration, with its own
+  `type=SIDED_PATH_PARAM` — not `compare`'s decorator, and not touched by
+  extending it. Fixing only `two_sided_input_options` leaves `dump`/`scan`
+  with no way to express a label at all: `project_include_labels` stays
+  empty for snapshots produced through either command, and a sibling
+  support root declared via `dump --include .../src` or `scan --against
+  ... --include .../src` stays classified as external — reproducing this
+  whole fix's target bug on two more commands, not just leaving them
+  unimproved. Both need their own change: `scan_cmd`'s inline `--include`
+  switches `type=` to `SidedIncludePathParam` (it already has `old=`/`new=`
+  side semantics, current artifact vs. `--against`, identical to
+  `compare`'s), and its `split_sided_paths(include_pairs)` call
+  (`cli_scan.py:712`) becomes `split_sided_include_paths(include_pairs)`.
+  `dump_cmd`'s inline `--include` also switches to `SidedIncludePathParam`
+  — reusing the *same* type rather than inventing a second, `dump`-only
+  grammar, so there is one label syntax across all three commands instead
+  of a different one to remember for `dump` specifically; `dump` has no
+  side to scope, so its label form is always `--include
+  both:LABEL=PATH` (side parsed but ignored downstream — `dump`'s
+  `includes` never gets split by side in the first place, only label and
+  path are consumed). A colon-less `--include` value on `dump` keeps
+  today's exact behavior (`label=None`) for the same reason established
+  above: inventing a colon-less-on-`dump`-only labeled shape would reopen
+  the bare-`LABEL=PATH`-vs-ordinary-path-with-`=` ambiguity just closed,
+  for no benefit.
   `scope_fingerprint` owns everything
   under a project-owned root; `profile_fingerprint` owns only external
   roots, in full. **Excluding a project-owned directory's content must not
@@ -575,7 +622,14 @@ Implements ADR-050 D1 and D2.
   old:support=old/src` directly and asserts the side/label/path triple
   round-trips correctly through `SidedIncludePathParam`, and that a bare
   `--include old=v1/foo.h` still round-trips to `(side="old", label=None,
-  path=...)` unchanged.
+  path=...)` unchanged; a fourth assertion parses `--include
+  build/config=asan/include` (a bare, unprefixed value containing a
+  literal `=`, no `old:`/`new:`/`both:` colon prefix) and asserts it still
+  round-trips to `(side="both", label=None, path=Path("build/config=asan/include"))`
+  — proving the labeled form is only ever triggered by the literal colon
+  prefix, never inferred from an ambient `=` in an otherwise-ordinary
+  path, the exact regression a bare-`LABEL=PATH` grammar reading would
+  introduce (P2 review).
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -1077,7 +1131,16 @@ plain, unlabeled `--include` — and additionally returns a
 `dict[Path, str]` of resolved path → label for whichever entries carried
 one, while still returning the same flat `(both, old_only, new_only)`
 `Path` tuples `split_sided_paths` does, so the compiler-argv-building code
-that already consumes those tuples is unchanged).
+that already consumes those tuples is unchanged). **`--include` has two
+more, separate registrations that need the identical change, not covered
+by `cli_options.py` alone** (see the dedicated acceptance-criteria bullet
+above for why): `cli_scan.py` (`scan_cmd`'s own inline `--include`
+(`include_pairs`, `:487-495`) switches `type=` to `SidedIncludePathParam`
+too, and its `split_sided_paths(include_pairs)` call (`:712`) becomes
+`split_sided_include_paths(include_pairs)`), `cli.py` (`dump_cmd`'s own
+inline `--include` (`:486`, plain `click.Path` today) switches to the
+same `SidedIncludePathParam` as well, so `dump`/`scan`/`compare` share one
+label grammar rather than `dump` alone getting a second, narrower one).
 **Getting the label out of Click's parsed value is not enough — it still
 needs its own path down to `comparability.compute_extraction_contract`,
 the same per-layer threading already required (and already found

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -1591,7 +1591,32 @@ blocking, independent of `discovered_only`), `action/run.sh` (a new
 `VERDICT="NOT_COMPARABLE"` case-branch alongside each of the `compare`/
 `scan`/`deps compare` exit-code `case` statements, and an explicit
 carve-out in `_maybe_post_pr_comment` so `NOT_COMPARABLE` still posts a
-comment despite the existing `ERROR`-only skip).
+comment despite the existing `ERROR`-only skip). **The bash-level carve-out
+above is not what actually decides whether a comment gets posted — that
+decision lives one layer deeper, in `abicheck/pr_comment.py`, which
+`_maybe_post_pr_comment` delegates to via `python3 -m
+abicheck.cli_pr_comment` (`action/run.sh:968`), and it was never taught
+about `not_comparable` at all.** Verified against the actual code:
+`should_post(model, on="changes")` (`pr_comment.py:643`) — the Action's
+own default policy — returns `True` only when `model.total_changes > 0`
+or `removed_libraries`/`added_libraries` is non-empty; a `not_comparable`
+report has none of these (no `Change` was ever produced), so
+`cli_pr_comment` would still silently post nothing even though the
+bash-level carve-out correctly avoids its own early return — the exact
+suppression this fix exists to close, one call deeper than the
+`run.sh` fix alone reaches. `abicheck/pr_comment.py` (`CommentModel` gains
+`not_comparable_reason: str | None = None`; `build_model` — or the
+mode-specific builder it dispatches to, `_from_compare`/`_from_release`
+— detects the canonical `verdict: null` shape or a release library
+entry's string `verdict == "not_comparable"` and populates it from the
+report's `reason`; `should_post` checks
+`model.not_comparable_reason is not None` *before* the `on == "changes"`
+bucket-count logic and returns `True` regardless of bucket counts, only
+`on == "never"` still suppressing it; the rendered body gains its own
+distinct not-comparable headline, checked before the existing
+`scoped_verdict`/`removed_libraries`/bucket-count branches in `_header`,
+since none of that bucket data is trustworthy when the comparison never
+ran).
 
 **Tests.** A `dump()`-level test asserting a real (non-manifest) dump
 returns a snapshot with a populated, non-`None` `contract` — the specific
@@ -1811,7 +1836,22 @@ final-exit section is a separate code path from the `case`-statement
 mapping and, verified against the actual code, has no `NOT_COMPARABLE`
 branch of its own; without it, `FINAL_EXIT` stays `0` and the step
 reports green despite the underlying CLI call having failed to compare
-at all.
+at all. A **`pr_comment.py` not-comparable** test suite, distinct from
+the Action-wrapper test above (proving the real decision point, not just
+that `run.sh` avoids its own early return): `should_post(model, on="changes")`
+returns `True` for a `CommentModel` with `not_comparable_reason` set,
+even though `total_changes == 0` and `removed_libraries`/
+`added_libraries` are both empty — proving the fix targets the actual
+suppression logic (`pr_comment.py:643`), not the bash-level carve-out
+alone; `should_post(model, on="never")` still returns `False` for the
+same model — proving the `on=never` policy still fully suppresses,
+`not_comparable` isn't an unconditional override; `build_model` given a
+raw `verdict: null` compare report (and, separately, a release
+`summary.json` with one library's `verdict: "not_comparable"`) populates
+`not_comparable_reason` correctly in both shapes; and a rendered-body
+assertion that the not-comparable headline is emitted (not an empty
+Breaking/Review/Safe section that would otherwise result from zero
+buckets) — the specific silent-drop this whole fix exists to close.
 
 **Example fixtures.** The Phase 0 "scope drift" pair stays a `tests/`-level
 fixture, not an `examples/case*/` catalog entry: `tests/test_validate_examples_unit.py`'s

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -1544,18 +1544,28 @@ codes while the one table meant to summarize them across commands goes
 stale the same day), `reporter.py`,
 `sarif.py`, `junit_report.py`, `html_report.py` (`generate_html_report`'s
 `contract_coverage` headline card). **`service_render.render_output`
-has five branches that require a real `DiffResult` — `sarif`, `html`,
+has five format branches that require a real `DiffResult` — `sarif`, `html`,
 `junit`, `review`, and the default `markdown` — not just `html`; every
 one needs the identical bypass, not only the one this bullet previously
-named.** Verified against the actual code (`service_render.py:36-132`):
+named. `--stat` is a sixth, cross-cutting path with the same
+requirement, checked *before* the format dispatch — `render_output`'s
+`if stat and fmt != "junit":` guard calls `to_stat_json(result, ...)`
+(`--format json --stat`) or `to_stat(result, ...)` (every other `--stat`
+combination), both requiring the identical real `DiffResult` the five
+format renderers do; missing this one specifically would leave `compare
+--stat` on a `not_comparable` pair crashing or fabricating stats even
+after SARIF/HTML/JUnit/review/markdown are all fixed.**
+Verified against the actual code (`service_render.py:36-132`):
 `to_sarif_str(result, ...)`, `generate_html_report(result, ...)`,
-`to_junit_xml(result, ...)`, `to_review_digest(result, ...)`, and the
+`to_junit_xml(result, ...)`, `to_review_digest(result, ...)`,
+`to_stat_json(result, ...)`/`to_stat(result, ...)`, and the
 default `to_markdown(result, ...)` each take `result` as a required,
 non-`Optional` `DiffResult` positional argument — on the `not_comparable`
 path (no `DiffResult` ever constructed), calling any of them the normal
 way crashes or requires inventing a synthetic empty `DiffResult`, neither
 of which is what this ADR intends. The front-end's own exception handler
-therefore renders the not-comparable outcome directly, per format, the
+therefore renders the not-comparable outcome directly, per format (or
+`--stat` mode), the
 same way it already assembles `verdict: null` JSON, instead of calling
 `render_output` at all on this path: **SARIF** gets one `run` with
 `invocations[0].executionSuccessful: false` and a
@@ -1626,10 +1636,15 @@ against the updated `compare_report.schema.json`, and its existing
 regenerated `docs/schemas/v1` copy; a **multi-format not_comparable
 reporting** test suite asserting `render_output(..., fmt=...)` on a
 `not_comparable` path is never reached at all — for **each** of `sarif`,
-`html`, `junit`, `review`, and the default `markdown`, not only `html` —
-proving the front-end's own exception handler owns every one of those
+`html`, `junit`, `review`, and the default `markdown`, not only `html`,
+**plus a dedicated `--stat` assertion** (both `--format json --stat` and
+a non-JSON `--stat` combination) proving `to_stat_json`/`to_stat` are
+never called either, since `render_output`'s `stat` branch is checked
+*before* the format dispatch and has the identical missing-`DiffResult`
+problem — proving the front-end's own exception handler owns every one of those
 paths instead of calling `to_sarif_str`/`generate_html_report`/
-`to_junit_xml`/`to_review_digest`/`to_markdown` with a missing
+`to_junit_xml`/`to_review_digest`/`to_markdown`/`to_stat_json`/`to_stat`
+with a missing
 `DiffResult`; a dedicated **SARIF not-comparable** test asserting the
 emitted SARIF log has `invocations[0].executionSuccessful == false` and a
 `toolExecutionNotifications` entry carrying the not-comparable reason,

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -54,10 +54,19 @@ A's own section is explicit that there is no soft-launch/report-only mode
 (the gate hard-fails `not_comparable` from day one; see Phase A). "Ships
 independently" describes *when* Phase A can land relative to the other
 phases, not a different (report-only) behavior it has while doing so.
-Phase B and Phase D's *parser* may both start once Phase 0's fixtures
-exist — decoding/selecting AST contexts by `kind` doesn't itself depend on
-B or A. **But Phase D as a whole depends on both Phase A and Phase B, not
-Phase 0 alone.** Its own acceptance criteria require folding the resolved
+Phase B's manifest schema/parser and per-TU dump loop, and Phase D's AST-
+context parser, may both start once Phase 0's fixtures exist — neither
+the manifest grammar nor decoding/selecting AST contexts by `kind`
+themselves depend on A. **But Phase B as a whole depends on Phase A too,
+not Phase 0 alone — the identical "parser vs. whole phase" split Phase D
+and Phase E already have.** Phase B's own acceptance criteria require
+`plan --dump-manifest` to print a real `scope_fingerprint`, and its
+manifest support-root-ownership tests assert `profile_fingerprint`
+matching/mismatching across manifest pairs (see Phase B) — both fields
+are `ExtractionContract`/`comparability.compute_extraction_contract`,
+Phase A's deliverable, not something Phase B computes on its own. **Phase
+D as a whole depends on all of Phase 0, Phase A, and Phase B, not Phase 0
+alone.** Its own acceptance criteria require folding the resolved
 `kind` into `comparability.compute_extraction_contract`'s hashed fields
 and proving a host-vs-device mismatch through D2's gate (see Phase D) —
 both Phase A deliverables, the identical class of dependency Phase E
@@ -70,7 +79,10 @@ needs B," it is "Phase D is not done until this criterion is met,"
 making B a hard prerequisite for the phase as a whole, not just its
 non-default-context path. Phase C starts only after Phase B lands, since
 it operates on the `TuFragment` contract Phase B defines and produces —
-it is not a third parallel branch alongside B and D. **E depends on
+it is not a third parallel branch alongside B and D; since B now depends
+on A too, Phase C's effective prerequisite chain is Phase 0 → A → B → C,
+even though Phase C's own acceptance criteria don't reference A's
+fingerprint machinery directly. **E depends on
 *both* A and B — not on B alone.** `scope_fingerprint` as a *type* and
 *computation* (`ExtractionContract`, `comparability.compute_extraction_contract`)
 is Phase A's deliverable; Phase B only adds the manifest-driven *inputs*
@@ -97,9 +109,15 @@ more than one incoming dependency, which a simple tree can't render
 unambiguously):
 
 - **Phase A** — depends on Phase 0 only.
-- **Phase B** — depends on Phase 0 only.
+- **Phase B** — depends on **both** Phase 0 and Phase A, not Phase 0 alone.
+  The manifest schema/parser and per-TU dump loop need only Phase 0, but
+  `plan --dump-manifest` printing `scope_fingerprint` and the
+  support-root-ownership tests asserting `profile_fingerprint` (see Phase
+  B) both call `comparability.compute_extraction_contract` — Phase A's
+  deliverable, not reimplemented in Phase B.
 - **Phase C** — depends on Phase B (operates on the `TuFragment` contract
-  Phase B defines and produces).
+  Phase B defines and produces); transitively depends on Phase A through
+  B, since B itself now requires A.
 - **Phase D** — depends on **all three** of Phase 0 (the parser), Phase A
   (folding the resolved `kind` into `compute_extraction_contract`, testing
   the gate), **and** Phase B. The parser and `host`-default path alone
@@ -1870,7 +1888,24 @@ part of this phase.
 
 ## Phase B — Manifest and real multi-TU dump
 
-Implements ADR-050 D3. The highest-risk phase — see Risk above.
+Implements ADR-050 D3. The highest-risk phase — see Risk above. **Depends
+on Phase 0 and Phase A, not Phase 0 alone.** The manifest schema/parser
+(`dump_manifest.py`) and the per-TU dump loop only need Phase 0's
+fixtures, but this phase's own acceptance criteria go past that: `plan
+--dump-manifest` must print a real `scope_fingerprint` (below), and the
+manifest support-root-ownership tests assert `profile_fingerprint`
+matching/mismatching across manifest pairs (below). Both `scope_fingerprint`
+and `profile_fingerprint` are `ExtractionContract`/
+`comparability.compute_extraction_contract` — Phase A's deliverable, not
+something Phase B reimplements. Phase B supplies the manifest-driven
+*inputs* (TU names, per-TU ordered includes/forced-includes,
+`contributes_to_abi`/`required`) that feed that already-existing
+computation; it does not invent the fingerprints themselves, the same
+relationship Phase E's cache-key half already has with Phase A. Starting
+Phase B with Phase A unmerged leaves `plan --dump-manifest` with no real
+`compute_extraction_contract` to call and no way to satisfy its own
+`profile_fingerprint`-asserting tests short of an ad hoc reimplementation
+that risks drifting from what Phase A's gate actually computes.
 
 **Goal & acceptance criteria.**
 - New `abicheck/dump_manifest.py`: strict YAML parser (unknown fields

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -1650,6 +1650,27 @@ this ADR has already made and corrected once for `CompareRequest`
 `dumper.dump()` is where it actually terminates, alongside the existing
 `except (ProfileMismatchError, ScopeMismatchError)` fix already planned
 in `run_compare`.
+**`--dump-manifest` reaching native `compare` means directory/package
+`compare` accepts it too, on the exact same set-input path already
+established for evidence flags — and must reject it, not silently ignore
+it, the identical mistake this plan already caught once for
+`--frontend-context` (below).** Verified against the actual code:
+`run_compare`'s `{old_kind, new_kind} & {"directory", "package"}` branch
+(`cli_compare_helpers.py:1155-1168`) dispatches to
+`cli._dispatch_release_compare(...)` with its own explicit kwargs list —
+no `dump_manifest`/`manifest_path` field in it — so a directory/package
+`compare old_dir new_dir --dump-manifest old=... --dump-manifest new=...`
+would be accepted by Click, never forwarded into the release fan-out, and
+silently do nothing. `--dump-manifest` is conceptually the same kind of
+"how do I resolve this side's dump input" flag `_EVIDENCE_SET_INPUT_FLAGS`
+(`cli_resolve.py:618-622`) already exists to reject on set inputs
+(`--sources`, `--build-info`) — not a compile-context flag — so it gains
+its own entry there (the raw, pre-side-normalization Click dest, matching
+how `sources`/`build_info` are keyed), and
+`_reject_evidence_flags_for_set_inputs` picks it up automatically once
+listed, the same way `frontend_context`'s own fix (below) inherits
+`_COMPILE_CONTEXT_SET_INPUT_FLAGS`'s existing rejection path rather than
+writing a new one.
 **`--frontend-context` reaching `compile_context_options` means directory/package
 `compare` accepts it too — and must reject it, not silently ignore it.**
 The release/set-input fan-out (`cli_compare_release.py`) never threads a
@@ -1765,7 +1786,14 @@ rejects `--frontend-context`** test asserting `compare old_dir new_dir
 --frontend-context device` fails fast via `cli_resolve.py`'s existing
 set-input guard, the same way it already fails fast for `--gcc-path`/
 `--ast-frontend` on a directory/package input — proving the flag can't be
-silently accepted and then ignored by the release backend. A
+silently accepted and then ignored by the release backend. A companion
+**release rejects `--dump-manifest`** test asserting `compare old_dir
+new_dir --dump-manifest old=v1/abi.yml --dump-manifest new=v2/abi.yml`
+also fails fast via `_EVIDENCE_SET_INPUT_FLAGS`'s guard, the same way
+`--sources`/`--build-info` already do on a directory/package input —
+proving `--dump-manifest` can't reach `_dispatch_release_compare`'s
+kwargs (which never carries it) and silently do nothing on a release
+compare. A
 **`scan --frontend-context`**
 regression test asserting `abicheck scan --against` accepts `device` and
 threads it into the L2 header frontend the same way `dump`/`compare` do,

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -917,7 +917,20 @@ Implements ADR-050 D1 and D2.
   real guard alongside the bump: a new
   `_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION = 12` constant (same naming
   convention as the existing `_MIN_SCHEMA_VERSION_FOR_CV_FACTS`) and a new
-  `IncompatibleSnapshotSchemaError` (`errors.py`), raised by
+  `IncompatibleSnapshotSchemaError` (`errors.py`) — **declared as
+  `class IncompatibleSnapshotSchemaError(SnapshotError):`, not a bare
+  sibling of `AbicheckError`** — following the exact precedent
+  `HeaderToolchainError(SnapshotError)` already documents in its own
+  docstring ("a subclass of `SnapshotError` — existing `except
+  SnapshotError` handling still catches it unchanged"). Verified against
+  the actual code: `cli_resolve.py`'s snapshot-loading paths (`:294-296`,
+  `332-335`) only translate `ValidationError`/`SnapshotError` into a clean
+  `click.UsageError`/`click.ClickException` — a sibling `AbicheckError`
+  that isn't a `SnapshotError` would fall through both `except` clauses
+  and surface as an unhandled/internal failure the next time `compare`/
+  `dump` loads a too-new on-disk `.abi.json` snapshot, instead of the
+  intended clean incompatibility message this bullet exists to produce.
+  Raised by
   `snapshot_from_dict` *before* the existing warn-only branch when the
   snapshot's `schema_version` is **both greater than the running
   `SCHEMA_VERSION` and at or above the threshold** — not "the running
@@ -1774,7 +1787,15 @@ threshold" condition would silently stop protecting, per the corrected
 `>` running-version comparison above; a regression test pinning that a
 schema bump *below* the threshold still only warns (today's lenient
 behavior for ordinary additive fields must not become accidentally
-stricter);
+stricter); a **CLI snapshot-load** regression test asserting
+`IncompatibleSnapshotSchemaError` `isinstance`-checks true against
+`SnapshotError`, and a real end-to-end `compare old.abi.json new.so`
+invocation where `old.abi.json` carries a stubbed future `schema_version`
+surfaces as a clean `click.ClickException` (exit `1`, a readable message)
+through `cli_resolve.py`'s existing `except SnapshotError` handling —
+never an unhandled traceback — proving the subclass relationship, not
+just the exception type existing, is what keeps the CLI's snapshot-load
+path working;
 `tests/test_report_schema.py` gains a `not_comparable` case validated
 against the updated `compare_report.schema.json`, and its existing
 `test_docs_mirror_matches_packaged_schema` must still pass against the

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -59,20 +59,34 @@ D's parser and `host`-default path don't depend on B, though selecting a
 *non-default* context needs Phase B's `frontend_context` field/flag to
 request it (see Phase D). Phase C starts only after Phase B lands, since
 it operates on the `TuFragment` contract Phase B defines and produces —
-it is not a third parallel branch alongside B and D. E depends on B, not
-directly on A: its cache-key half targets the manifest's full computed
-`scope_fingerprint` (TU names, per-TU ordered includes/forced-includes,
-`contributes_to_abi`/`required` flags — Phase B's schema), which genuinely
-is pre-dump-computable for a manifest-driven dump; `profile_fingerprint`
+it is not a third parallel branch alongside B and D. **E depends on
+*both* A and B — not on B alone.** `scope_fingerprint` as a *type* and
+*computation* (`ExtractionContract`, `comparability.compute_extraction_contract`)
+is Phase A's deliverable; Phase B only adds the manifest-driven *inputs*
+(TU names, per-TU ordered includes/forced-includes,
+`contributes_to_abi`/`required` flags) that feed that same, already-existing
+computation for a manifest-driven dump — Phase B does not invent
+`scope_fingerprint` itself. Phase E's cache-key half also concretely
+builds on Phase A's own cache-key work, not just its types: Phase E's own
+acceptance criteria say outright that "Phase A's own order-sensitivity fix
+(dropping `sorted(...)` for `headers`/`includes`) already closes the
+remaining gap that mattered for the legacy CLI path" (see Phase E) — a
+direct reference to work this same plan places in Phase A, not a
+restatement of something Phase E redoes. Starting E after B alone, with A
+unmerged, leaves either no `ExtractionContract`/`scope_fingerprint`
+machinery to hash at all, or an ad hoc reimplementation that risks
+drifting from whatever Phase A's gate actually computes — silently
+defeating the whole "cache key must track what the gate checks" premise
+this phase exists for. `profile_fingerprint`
 is the one that can never be a pre-dump cache-key input, on either path
 (see Phase E) — and its scheduling half schedules Phase B's per-TU loop.
 
 ```text
-Phase 0 (fixtures) ──┬──▶ Phase A (contract + gate)
-                      │
-                      ├──▶ Phase B (manifest/multi-TU) ─┬─▶ Phase C (compatible merge)
+                      ┌──▶ Phase A (contract + gate) ──────────┐
+                      │                                        │
+Phase 0 (fixtures) ───┼──▶ Phase B (manifest/multi-TU) ─┬──────┴─▶ Phase E (scheduling + cache)
                       │                                 │
-                      │                                 └─▶ Phase E (scheduling + cache)
+                      │                                 └─▶ Phase C (compatible merge)
                       └──▶ Phase D (SYCL host/device context)
 ```
 
@@ -1180,12 +1194,31 @@ this is a silent-loss bug, not a crash — harder to notice than the
 `diagnostic_comparison: bool = False` parameter, passed by name into the
 `compare_snapshots(diagnostic_comparison=diagnostic_comparison, ...)` call
 at `:1464`, mirroring how `old_dump_manifest`/`new_dump_manifest` are
-threaded through this same function. `cli_compare_release.py`
+threaded through this same function. **`cli_compare_release.py` needs the
+`diagnostic_comparison` parameter itself threaded, not just an exception
+branch — it does not go through `CompareRequest`/`run_compare_request` at
+all, so the `run_compare_request` reachability test elsewhere in this plan
+proves nothing about this path.** Verified against the actual code:
+`_compare_one_library` calls `_run_compare_pair` (`:91-141`), whose own
+docstring states it "routes through the single Tier-2 chokepoint
+(`service.run_compare`, ADR-037 D1)" — the *legacy keyword shim*, not
+`run_compare_request`/`CompareRequest`. `_run_compare_pair`'s own fixed,
+explicit signature has no `diagnostic_comparison` slot today, and its
+`service.run_compare(...)` call (`:124-141`) only forwards what it already
+names — so even with `service.run_compare` itself gaining the parameter
+(above), a value would never reach it through this path without both
+`_run_compare_pair` and `_compare_one_library` also naming it explicitly
+and threading it through, the identical multi-layer gap already found
+(twice) for `--dump-manifest`/`--frontend-context` elsewhere in this
+phase. `cli_compare_release.py`
 (`_compare_one_library`'s dedicated
 `except (ProfileMismatchError, ScopeMismatchError)` branch, ordered before
 `except Exception` — see the release-fan-out acceptance-criteria bullet
 above; this is not covered by the CLI's own exit-code handling, it is a
-separate call path), `cli_compare_release_helpers.py`
+separate call path — **plus** `_run_compare_pair`'s and
+`_compare_one_library`'s own new `diagnostic_comparison: bool = False`
+parameters, threaded into `_run_compare_pair`'s `service.run_compare(...)`
+call), `cli_compare_release_helpers.py`
 (`_RELEASE_VERDICT_ORDER`'s new rank-6 `not_comparable` entry),
 `compat/cli.py` (new `try`/`except (ProfileMismatchError, ScopeMismatchError)`
 wrapping the `compare()` call — there is no surrounding `try` there today —
@@ -1332,8 +1365,23 @@ test proving the Python API exposes the identical parameter, not only
 `cli.py`'s flag; a **`CompareRequest` reachability** test asserting
 `service.run_compare_request(CompareRequest(..., diagnostic_comparison=True))`
 on a mismatched pair also returns the tentative `DiffResult` rather than
-raising — proving the flag is reachable through the front-end chokepoint
-`compare-release`/`appcompat` go through; an **`mcp_server.abi_compare`
+raising — proving the flag reaches CLI/MCP `compare`'s own chokepoint;
+**this test does *not* cover `compare-release` or `appcompat`, which do
+not go through `CompareRequest`/`run_compare_request` at all (see their
+own dedicated bullets above) — each needs its own dedicated test instead**:
+a **`compare-release` diagnostic-comparison** test asserting
+`_run_compare_pair(..., diagnostic_comparison=True)` on a mismatched
+old/new pair returns a tentative `(DiffResult, ...)` tuple rather than
+raising, proving the parameter actually reaches `_run_compare_pair`'s own
+`service.run_compare(...)` call, not just `service.run_compare` itself;
+and two **`appcompat` diagnostic-comparison** tests asserting
+`check_appcompat(..., diagnostic_comparison=True)` and
+`check_plugin_host_contract(..., diagnostic_comparison=True)` each return
+a tentative result on a mismatched pair instead of raising, alongside a
+companion assertion that *without* the flag, both still raise
+`ProfileMismatchError`/`ScopeMismatchError` uncaught — the documented
+default this phase deliberately keeps (see the `appcompat.py` bullet
+above); an **`mcp_server.abi_compare`
 not_comparable** test asserting a mismatched pair through `abi_compare`
 (the default, non-diagnostic path) returns `{"status": "not_comparable",
 "reason": ...}`, never the generic `{"status": "error"}` its existing
@@ -1788,7 +1836,15 @@ is extraction-layer, not diff-layer; no new `ChangeKind`.
 Implements ADR-050 D6. The cache-key half targets the manifest's full
 computed `scope_fingerprint` (TU names, per-TU ordered includes/
 forced-includes, and `contributes_to_abi`/`required` flags together), so
-it depends on Phase B (the manifest schema those inputs live on) — not on
+it depends on **both** Phase A and Phase B — not Phase B alone.
+`scope_fingerprint` as a type and computation
+(`ExtractionContract`/`comparability.compute_extraction_contract`) is
+Phase A's deliverable; Phase B only supplies the manifest-driven *inputs*
+that feed it for a manifest-driven dump, it doesn't invent the fingerprint
+itself. This phase's own acceptance criteria below also build directly on
+Phase A's cache-key fix (the `sorted(...)`-dropping order-sensitivity
+change), not merely on Phase A's types — so starting this phase with A
+unmerged leaves nothing concrete to extend. Not on
 `profile_fingerprint`, which can **never** be a pre-dump cache-key input at
 all, on either path (see the acceptance-criteria bullet below for why).
 `scope_fingerprint` is the one exception: for a manifest-driven dump it's

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -54,10 +54,15 @@ A's own section is explicit that there is no soft-launch/report-only mode
 (the gate hard-fails `not_comparable` from day one; see Phase A). "Ships
 independently" describes *when* Phase A can land relative to the other
 phases, not a different (report-only) behavior it has while doing so.
-Phase B and Phase D may both start once Phase 0's fixtures exist — Phase
-D's parser and `host`-default path don't depend on B, though selecting a
-*non-default* context needs Phase B's `frontend_context` field/flag to
-request it (see Phase D). Phase C starts only after Phase B lands, since
+Phase B and Phase D's *parser* may both start once Phase 0's fixtures
+exist — decoding/selecting AST contexts by `kind` doesn't itself depend on
+B. **But Phase D as a whole also depends on Phase A, not Phase 0 alone:**
+its own acceptance criteria require folding the resolved `kind` into
+`comparability.compute_extraction_contract`'s hashed fields and proving a
+host-vs-device mismatch through D2's gate (see Phase D) — both Phase A
+deliverables, the identical class of dependency Phase E already has on A.
+Selecting a *non-default* context also needs Phase B's
+`frontend_context` field/flag to request it (see Phase D). Phase C starts only after Phase B lands, since
 it operates on the `TuFragment` contract Phase B defines and produces —
 it is not a third parallel branch alongside B and D. **E depends on
 *both* A and B — not on B alone.** `scope_fingerprint` as a *type* and
@@ -81,14 +86,20 @@ this phase exists for. `profile_fingerprint`
 is the one that can never be a pre-dump cache-key input, on either path
 (see Phase E) — and its scheduling half schedules Phase B's per-TU loop.
 
-```text
-                      ┌──▶ Phase A (contract + gate) ──────────┐
-                      │                                        │
-Phase 0 (fixtures) ───┼──▶ Phase B (manifest/multi-TU) ─┬──────┴─▶ Phase E (scheduling + cache)
-                      │                                 │
-                      │                                 └─▶ Phase C (compatible merge)
-                      └──▶ Phase D (SYCL host/device context)
-```
+Dependency edges (not a parallel-branch diagram — several phases now have
+more than one incoming dependency, which a simple tree can't render
+unambiguously):
+
+- **Phase A** — depends on Phase 0 only.
+- **Phase B** — depends on Phase 0 only.
+- **Phase C** — depends on Phase B (operates on the `TuFragment` contract
+  Phase B defines and produces).
+- **Phase D** — depends on Phase 0 (the parser) **and** Phase A (folding
+  the resolved `kind` into `compute_extraction_contract`, testing the
+  gate) — see above. Its *non-default*-context path additionally needs
+  Phase B's `frontend_context` field/flag, though the phase as a whole
+  does not depend on B.
+- **Phase E** — depends on **both** Phase A and Phase B — see above.
 
 ---
 
@@ -697,11 +708,19 @@ Implements ADR-050 D1 and D2.
   match, exactly the regression this per-slot-token fix (as opposed to
   the simpler single-sentinel fix test (12) alone would validate) exists
   to close; (14) a sibling support root declared via a labeled `--include`
-  entry, not nested under any declared `--header` — `old`/`new` both
-  declare `--header .../include/foo.h --include .../include --include
-  both:support=.../src` (`src/` a sibling of `include/`, containing a
-  private header `foo.h` `#include`s) — with a **content edit confined to
-  `src/`'s private header** between old and new leaves `profile_fingerprint`
+  entry, not nested under any declared `--header` — `old` declares
+  `--header old/include/foo.h --include old/include --include
+  old:support=old/src`, `new` declares the analogous
+  `--header new/include/foo.h --include new/include --include
+  new:support=new/src` (**genuinely side-scoped paths, `old/src` vs.
+  `new/src`, not `both:` applied to one shared literal path — `both:`
+  cannot represent two different two-checkout roots at all, so it would
+  either force an artificial same-path scenario or silently feed one
+  side's directory to both snapshots, proving nothing about the
+  side-aware label path this fix actually adds** — P2 review) — `src/` a
+  sibling of `include/`, containing a private header `foo.h`
+  `#include`s — with a **content edit confined to `src/`'s private
+  header** between old and new leaves `profile_fingerprint`
   matching, proving the labeled form extends project-ownership to a
   sibling directory the ancestor rule alone would otherwise classify as
   external (and thus spuriously flip on this routine internal edit); a
@@ -2199,13 +2218,25 @@ verdict-producing comparison, so it doesn't fit the example catalog's
 
 ## Phase D — SYCL/DPC++ host vs. device AST context selection
 
-Implements ADR-050 D5. Independent of Phase C's merge work; depends only
-on Phase 0's captured DPC++ fixture for the parser itself. Selecting a
-*non-default* context does have a soft dependency on Phase B, though: the
+Implements ADR-050 D5. Independent of Phase C's merge work. **Depends on
+both Phase 0 and Phase A — not Phase 0 alone.** The parser
+(`sycl_context.py`'s document-boundary decoding and `kind`-based
+selection) only needs Phase 0's captured DPC++ fixture, but this phase's
+own acceptance criteria also require folding the resolved `kind` into
+`comparability.compute_extraction_contract`'s hashed fields and testing a
+host-vs-device `profile_fingerprint` mismatch through D2's gate (see the
+dedicated acceptance-criteria bullet below) — both of those are Phase A's
+`ExtractionContract`/`compute_extraction_contract`/gate machinery.
+Starting or landing D before A leaves nothing concrete for that bullet to
+extend, and — worse than merely blocked — could ship a selector whose
+chosen context is invisible to the comparability gate if the fingerprint
+half is skipped or deferred, the identical risk already identified and
+fixed for Phase E's dependency on Phase A. Selecting a
+*non-default* context also has a soft dependency on Phase B: the
 `frontend_context` field (manifest base profile) and `--frontend-context`
 CLI flag this phase's selector reads are defined there, not here (Phase B
-"Goal & acceptance criteria"). Everything in this phase can be built and
-tested against the `host` default without Phase B, but a real DPC++
+"Goal & acceptance criteria"). The parser and `host`-default path can be
+built and tested without Phase B, but a real DPC++
 device-context request has nowhere to come from until Phase B's field/flag
 exist.
 

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -1909,7 +1909,17 @@ that risks drifting from what Phase A's gate actually computes.
 
 **Goal & acceptance criteria.**
 - New `abicheck/dump_manifest.py`: strict YAML parser (unknown fields
-  error), `roots`/`translation_units` schema, `name`-uniqueness,
+  error, **and duplicate mapping keys error too** — `yaml.safe_load` on
+  the repo's existing PyYAML stack silently accepts a duplicate key with
+  last-value-wins semantics, so `required: false` followed later by
+  `required: true` in the same TU mapping would otherwise pass unnoticed;
+  since `required`, `contributes_to_abi`, `project_owned`, and
+  `frontend_context` all control extraction scope or hard-fail behavior,
+  the parser installs a `yaml.SafeLoader` subclass overriding
+  `construct_mapping` to raise `ManifestValidationError` on any duplicate
+  key, the same mechanism and error type as the unknown-field/invariant
+  checks below, not a separate ad hoc check), `roots`/`translation_units`
+  schema, `name`-uniqueness,
   `contributes_to_abi=True ⇒ required=True` invariant enforced at parse
   time (a validation error, not a silent coercion). A TU's `includes`
   entries accept either a bare path string (external-by-default, D1's
@@ -1941,6 +1951,28 @@ that risks drifting from what Phase A's gate actually computes.
   in this phase) and in the CLI flag's own validation. Phase D, when it
   lands, is what lifts this restriction once `sycl_context.py`'s selector
   actually exists to honor the request — not before.
+- **The base-profile section also accepts optional `public_header_paths`/
+  `public_header_dirs` (root-relative), and `--dump-manifest` rejects
+  `--public-header`/`--public-header-dir` outright when combined on
+  `dump`.** ADR-050 D1 already documents `scope_fingerprint` hashing
+  `public_header_paths`/`public_header_dirs`/filtering policy — for
+  today's legacy single-header path that's literally the existing
+  `--public-header`/`--public-header-dir` CLI flags (ADR-015, D1), but a
+  manifest schema that only carried `roots`/`translation_units` would
+  leave `plan --dump-manifest`'s `scope_fingerprint` (below) computed from
+  the manifest document alone while the *actual* `dump --dump-manifest
+  ... --public-header foo.h` invocation folded in a CLI flag `plan` never
+  saw — a real, silent divergence between the diagnostic and gate values,
+  not just an omission. Rather than teaching `plan` to also resolve CLI
+  flags (breaking its "manifest document alone, no compiler/CLI-state
+  needed" design), the manifest itself gains these two optional
+  base-profile fields, and `dump` raises a `UsageError` if `--dump-manifest`
+  and either `--public-header`/`--public-header-dir` are given together —
+  the same "manifest is the sole source of truth once selected" pattern
+  this phase already applies to `--frontend-context`'s CLI/manifest split
+  above. A manifest caller who needs provenance classification declares it
+  in the manifest; a legacy caller keeps using the CLI flags exactly as
+  today.
 - **The per-TU loop and `TuFragment` handling land in a new sibling
   module, not inline in `dumper.py` itself — `dumper.py` has zero lines of
   headroom left before the AI-readiness file-size gate's hard cap.**
@@ -2218,7 +2250,14 @@ count still passes `<= COMPARE_FLAG_BUDGET` once `--dump-manifest` and
 gained both ledger entries in this same phase rather than the flags
 landing unaccounted-for. Manifest parser unit tests (the invariant violation, duplicate
 TU names, unknown fields, relative-path resolution, `frontend_context`
-accepted/defaulted/rejected-when-invalid). A **Phase-B-only device
+accepted/defaulted/rejected-when-invalid). A **duplicate-key rejection**
+test asserting a manifest re-declaring the same mapping key twice within
+one TU (e.g. `required: false` followed by `required: true` in the same
+block) raises `ManifestValidationError` rather than silently taking
+PyYAML's last-value-wins result — covering `required`, `contributes_to_abi`,
+`project_owned`, and `frontend_context` as the fields whose silent
+last-value-wins would actually change extraction scope or hard-fail
+behavior. A **Phase-B-only device
 rejection** test asserting a manifest declaring `frontend_context:
 device` raises `ManifestValidationError` (not silently accepted and
 extracted as if it were `host`), and a companion CLI test asserting
@@ -2240,7 +2279,17 @@ redundant with the ancestor rule. `dumper.py` multi-TU
 integration tests (`@pytest.mark.integration`, needs castxml/clang) using
 Phase 0's fixtures. A `plan --dump-manifest` unit test asserting it never
 invokes a compiler and prints `scope_fingerprint` only — never a
-`profile_fingerprint` value, which would require one. A `--frontend-context` CLI-flag unit test for the legacy
+`profile_fingerprint` value, which would require one. A **manifest-mode
+public-header exclusivity** test asserting `dump --dump-manifest
+manifest.yml --public-header foo.h` fails fast with a `UsageError` (and
+the same for `--public-header-dir`), proving the CLI flags can't silently
+combine with an explicit manifest and leave `plan --dump-manifest`'s
+printed `scope_fingerprint` blind to an input the real `dump` invocation
+actually used; a companion test asserting a manifest declaring
+`public_header_paths`/`public_header_dirs` in its base profile changes
+`scope_fingerprint` the same way `--public-header`/`--public-header-dir`
+already change it on the legacy path, confirming the manifest fields are
+a genuine replacement, not a no-op. A `--frontend-context` CLI-flag unit test for the legacy
 (non-manifest) path, mirroring the manifest-field test. A **side-scoped
 `compare --dump-manifest`** test asserting `compare old.so new.so
 --dump-manifest old=v1/abi.yml --dump-manifest new=v2/abi.yml` dumps each

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -798,6 +798,34 @@ Implements ADR-050 D1 and D2.
   **both** sides carry one, two ordinary dumps would silently take the same
   code path as the intentionally-lenient mixed-pair case forever — a fully
   specified, fully inert gate.
+- **Wiring the call site into `dumper.py` is not free real estate here,
+  and this phase cannot lean on Phase B's later split to make room for
+  it.** `dumper.py` is exactly `2000` lines today (`wc -l`) — the same
+  fact Phase B's own acceptance criteria already cite to justify moving
+  its per-TU loop into a new `dumper_manifest.py` sibling rather than
+  growing `dumper.py` directly (see Phase B, below). But Phase A depends
+  on Phase 0 only, not on Phase B (see Sequencing) — Phase A can land,
+  and per this plan's own ordering is likely to land, *before* Phase B's
+  split exists to absorb any cost. An implementation that follows this
+  phase's own acceptance criteria literally — adding the
+  `compute_extraction_contract(...)` call site plus the new
+  `project_include_labels: dict[Path, str] | None = None` parameter
+  (below) straight into `dumper.py`'s `dump()` — trips the AI-readiness
+  `file-size` gate's `>2000` ERROR the moment it lands, since `dumper.py`
+  has zero lines of headroom to spend, not "headroom Phase B hasn't used
+  yet." This phase therefore requires, in the same PR that wires in
+  `compute_extraction_contract`, a net-neutral-or-negative line-count
+  change to `dumper.py`: relocate a self-contained, currently-unrelated
+  chunk of `dumper.py`'s own existing content to a suitable existing or
+  new sibling module first — reclaiming enough headroom for this phase's
+  own additions — verified by re-running `scripts/check_ai_readiness.py`
+  (or `wc -l abicheck/dumper.py`) in the same change, not asserted by
+  prose alone. This is deliberately not deferred to Phase B's later
+  `dumper_manifest.py` split: that module is scoped to Phase B's own
+  per-TU loop, a different piece of work than this phase's attachment
+  glue, and deferring to it would leave Phase A unable to land on its own
+  at all — contradicting Sequencing's own "Phase A can ship and start
+  providing value independently of B–E" property.
   **"Every dump" means every dump with at least one resolved input to
   fingerprint — a symbols-only/binary-only dump (no `-H`/`--header`, no
   manifest) attaches no `profile_fingerprint`, computed from nothing
@@ -1690,7 +1718,13 @@ distinct not-comparable headline, checked before the existing
 since none of that bucket data is trustworthy when the comparison never
 ran).
 
-**Tests.** A `dump()`-level test asserting a real (non-manifest) dump
+**Tests.** A **file-size headroom** check (not a `pytest` test — the same
+`scripts/check_ai_readiness.py` gate CI already runs) asserting
+`dumper.py` is at or below its pre-Phase-A line count once this phase's
+`dump()` changes land, proving the required offsetting relocation
+actually happened rather than merely being described; this is the
+acceptance gate for the bullet above, not a separate optional check. A
+`dump()`-level test asserting a real (non-manifest) dump
 returns a snapshot with a populated, non-`None` `contract` — the specific
 gap that would otherwise leave the gate permanently inert. A companion
 **symbols-only no-contract** test asserting a symbols-only dump (no
@@ -2309,7 +2343,32 @@ side-effect `from . import (...)` block gains `cli_dump_manifest`, or
 list gains `abicheck.cli_dump_manifest` alongside the existing per-module
 entries, or the typed-decorator mypy lane fails on its `@click` decorators
 (both required steps of the root `CLAUDE.md`'s "Adding a new top-level
-command" procedure, steps 3–4) — `cli_dump_helpers.py` (extend
+command" procedure, steps 3–4). **Step 5 of that same procedure also
+applies, and must not be skipped: `cli_dump_manifest.py` importing `main`
+back from `cli.py` (to register `@main.command("plan")`) forms a new
+`{cli, cli_dump_manifest}` two-module cycle that `scripts/
+check_ai_readiness.py`'s `import-cycle-growth` check does not already
+know about.** Verified against the actual gate: `IMPORT_CYCLE_ALLOWLIST`
+(`check_ai_readiness.py:910`) is a `frozenset` of exact per-module-pair
+entries — `frozenset({"cli", "cli_compare_release"})`,
+`frozenset({"cli", "cli_baseline"})`, and seven more, one per existing
+sibling command module — matched by literal subset comparison, not by
+recognizing "this cycle has the same *shape* as an already-allowed one";
+a brand-new `{cli, cli_dump_manifest}` pair is not a subset of any
+existing entry and *will* be flagged as a new SCC member, failing the
+gate, unless `IMPORT_CYCLE_ALLOWLIST` gains a matching
+`frozenset({"cli", "cli_dump_manifest"})` entry in this same phase.
+**This is squarely the allowlist's own documented, accepted pattern, not
+an exception needing an ADR** — root `AGENTS.md`'s "What NOT to do"
+section reserves the ADR/sign-off bar for a cycle *outside* the
+documented "Click sibling command imports `main` back from `cli.py`,
+`cli.py` imports it at its registration tail" shape; `cli_dump_manifest`
+is that exact shape, identical to all nine existing entries, so adding
+its entry is the same routine step every other sibling command module in
+this list already took, not a new architectural exception. Skipping this
+step leaves an implementer who followed every other instruction in this
+bullet still hitting an unexplained `import-cycle-growth` ERROR. —
+`cli_dump_helpers.py` (extend
 `resolve_dump_depth`/`check_requested_depth_satisfied` to operate per-TU),
 `service_scan.py` (`CompileContext.frontend_context: str = "host"`),
 `cli_options.py` (`resolve_compile_context`'s new `frontend_context`
@@ -2317,7 +2376,13 @@ parameter, threaded into the `CompileContext` it builds — the single
 choke point `compare`/`dump`/`scan` all resolve through, so no
 `scan_engine.py` dump-call-site change is needed beyond this).
 
-**Tests.** A **flag-budget ledger** test (`tests/test_config_rebalance.py::TestFlagBudget`,
+**Tests.** An **import-cycle allowlist** check (the existing
+`scripts/check_ai_readiness.py` `import-cycle-growth` gate, re-run after
+this phase's changes, not a new `pytest` test) asserting the gate stays
+clean with `cli_dump_manifest.py` added — proving
+`IMPORT_CYCLE_ALLOWLIST` gained the `frozenset({"cli",
+"cli_dump_manifest"})` entry described above rather than the new sibling
+module landing as an unaccounted-for SCC member. A **flag-budget ledger** test (`tests/test_config_rebalance.py::TestFlagBudget`,
 already run, not a new test file) asserting `compare`'s visible flag
 count still passes `<= COMPARE_FLAG_BUDGET` once `--dump-manifest` and
 `--frontend-context` are both visible, proving `COMPARE_FLAG_BUDGET_RAISES`

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -715,6 +715,20 @@ Implements ADR-050 D1 and D2.
   **both** sides carry one, two ordinary dumps would silently take the same
   code path as the intentionally-lenient mixed-pair case forever — a fully
   specified, fully inert gate.
+  **"Every dump" means every dump that actually ran an L2 header-AST
+  frontend — a symbols-only/binary-only dump (no `-H`/`--header`, no
+  manifest) attaches no `contract` at all, computed from nothing rather
+  than computed from unused inputs.** `profile_fingerprint` hashes the
+  resolved compiler/macros/`-I` inputs an actual castxml/clang invocation
+  used; a symbols-only dump never runs one, so those fields would describe
+  nothing the snapshot depends on. Attaching a fingerprint anyway (from
+  whatever compile-context flags happen to be set, used or not) would make
+  two genuinely comparable L0/binary-only snapshots spuriously mismatch on
+  compile-context differences that never affected either one — an
+  over-counting regression, not the under-counting bug this design
+  otherwise guards against. `contract` staying `None` here is not a gap in
+  the leniency rule below; it's that same rule correctly applying to the
+  one case where no L2 extraction ran on either side to disagree about.
 - **The whole-snapshot cache is the same bypass by a different route — this
   phase closes it too, not just Phase E's later cache-key work.**
   `service_dump_cache.cached_run_dump` looks up `snapshot_cache` *before*
@@ -1470,7 +1484,16 @@ comment despite the existing `ERROR`-only skip).
 
 **Tests.** A `dump()`-level test asserting a real (non-manifest) dump
 returns a snapshot with a populated, non-`None` `contract` — the specific
-gap that would otherwise leave the gate permanently inert. A **warm-cache**
+gap that would otherwise leave the gate permanently inert. A companion
+**symbols-only no-contract** test asserting a symbols-only dump (no
+`-H`/`--header`, no manifest) returns a snapshot with `contract is None`,
+and that comparing two such symbols-only snapshots produced under
+genuinely *different*, but entirely unused, compile-context flags
+(different `--gcc-path`/`--gcc-options`, neither ever invoking an L2
+frontend) leaves the pair comparable — never raising
+`ProfileMismatchError` on compile-context differences that never affected
+either snapshot, the specific over-counting regression this exemption
+exists to prevent. A **warm-cache**
 regression test: seed `snapshot_cache` with a pre-bump-version entry (no
 `contract`), call `cached_run_dump` for the same inputs post-bump, and
 assert it misses and rebuilds with `contract` populated rather than
@@ -1696,9 +1719,31 @@ Implements ADR-050 D3. The highest-risk phase — see Risk above.
   DPC++ flow needing a non-default context with nowhere to request it
   (ADR-050 D3). The legacy, non-manifest CLI path gains a matching
   `--frontend-context host|device` flag (default `host`).
+- **The per-TU loop and `TuFragment` handling land in a new sibling
+  module, not inline in `dumper.py` itself — `dumper.py` has zero lines of
+  headroom left before the AI-readiness file-size gate's hard cap.**
+  Verified against the actual repo: `dumper.py` is exactly `2000` lines
+  today (`wc -l`), and `scripts/check_ai_readiness.py`'s `file-size` check
+  ERRORs at `> 2000` — this phase's own new logic (the per-TU invocation
+  loop, `TuFragment` construction/normalization, manifest-driven dispatch)
+  would push it past that threshold immediately, failing a required CI
+  gate before any functional test even runs. This follows the same
+  established split precedent `dumper_castxml.py`/`dumper_clang.py`
+  already set for per-backend logic: a new `abicheck/dumper_manifest.py`
+  (or similarly-named sibling) holds the per-TU loop and `TuFragment`
+  construction; `dumper.py`'s own `dump()` gains only a thin
+  manifest-vs.-single-TU dispatch, calling into the new module rather than
+  growing its own body. Splitting `dumper.py` itself down first (moving
+  existing, unrelated logic out to reclaim headroom) is an alternative
+  this phase could also take, but the new-sibling-module route is
+  preferred since it needs no change to `dumper.py`'s existing, unrelated
+  content and matches the repo's own stated convention ("prefer extending
+  a split-out module over growing the parent toward the cap" —
+  `AGENTS.md`).
 - `dumper.py` gains a manifest-driven `dump()` path: one castxml/clang
   invocation per TU (shared base profile + that TU's own forced includes),
-  each producing a `TuFragment`. The existing single-header CLI path
+  each producing a `TuFragment`, via the new sibling module above. The
+  existing single-header CLI path
   becomes this path's one-TU special case (`legacy-main`) — same code, not
   a parallel implementation.
 - A manifest declaring TUs with different compilers/target triples is
@@ -1779,9 +1824,13 @@ and a new `ManifestValidationError` for every parse-time schema violation
 it raises — unknown fields, the `contributes_to_abi=True ⇒ required=True`
 invariant, and the heterogeneous-compiler/target-triple rejection above —
 self-contained to this phase, no dependency on Phase C's later
-`tu_merge.py`/`TuMergeError`), `abicheck/dumper.py`
-(per-TU invocation loop, `TuFragment` type, and the actual `--dump-manifest`
-termination point). `--dump-manifest` is a
+`tu_merge.py`/`TuMergeError`), new `abicheck/dumper_manifest.py`
+(the per-TU invocation loop and `TuFragment` type — not `dumper.py`
+itself, which is already at its 2000-line file-size cap with no headroom
+left, see the dedicated acceptance-criteria bullet above), `abicheck/dumper.py`
+(gains only the thin manifest-vs.-single-TU dispatch and the actual
+`--dump-manifest` termination point, delegating the per-TU work to the
+new sibling module). `--dump-manifest` is a
 shared-concept option across `dump` and `compare` (side-scoped on `compare`
 via `SIDED_PATH_PARAM`, bare on `dump` — see the acceptance-criteria bullet
 above), added as one decorator in `cli_options.py` and applied at `dump`'s

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -56,13 +56,19 @@ independently" describes *when* Phase A can land relative to the other
 phases, not a different (report-only) behavior it has while doing so.
 Phase B and Phase D's *parser* may both start once Phase 0's fixtures
 exist — decoding/selecting AST contexts by `kind` doesn't itself depend on
-B. **But Phase D as a whole also depends on Phase A, not Phase 0 alone:**
-its own acceptance criteria require folding the resolved `kind` into
-`comparability.compute_extraction_contract`'s hashed fields and proving a
-host-vs-device mismatch through D2's gate (see Phase D) — both Phase A
-deliverables, the identical class of dependency Phase E already has on A.
-Selecting a *non-default* context also needs Phase B's
-`frontend_context` field/flag to request it (see Phase D). Phase C starts only after Phase B lands, since
+B or A. **But Phase D as a whole depends on both Phase A and Phase B, not
+Phase 0 alone.** Its own acceptance criteria require folding the resolved
+`kind` into `comparability.compute_extraction_contract`'s hashed fields
+and proving a host-vs-device mismatch through D2's gate (see Phase D) —
+both Phase A deliverables, the identical class of dependency Phase E
+already has on A. They also require *lifting* Phase B's blanket
+non-`host` rejection and exercising `--frontend-context device`/a
+manifest `frontend_context: device` end to end (see Phase D) — neither is
+implementable without Phase B's field/flag already existing to lift a
+restriction on, so this is not merely "selecting a non-default context
+needs B," it is "Phase D is not done until this criterion is met,"
+making B a hard prerequisite for the phase as a whole, not just its
+non-default-context path. Phase C starts only after Phase B lands, since
 it operates on the `TuFragment` contract Phase B defines and produces —
 it is not a third parallel branch alongside B and D. **E depends on
 *both* A and B — not on B alone.** `scope_fingerprint` as a *type* and
@@ -94,11 +100,19 @@ unambiguously):
 - **Phase B** — depends on Phase 0 only.
 - **Phase C** — depends on Phase B (operates on the `TuFragment` contract
   Phase B defines and produces).
-- **Phase D** — depends on Phase 0 (the parser) **and** Phase A (folding
-  the resolved `kind` into `compute_extraction_contract`, testing the
-  gate) — see above. Its *non-default*-context path additionally needs
-  Phase B's `frontend_context` field/flag, though the phase as a whole
-  does not depend on B.
+- **Phase D** — depends on **all three** of Phase 0 (the parser), Phase A
+  (folding the resolved `kind` into `compute_extraction_contract`, testing
+  the gate), **and** Phase B. The parser and `host`-default path alone
+  need only Phase 0, but Phase D's *own* acceptance criteria go further
+  than that: they require lifting Phase B's blanket non-`host` rejection
+  and exercising `--frontend-context device` end to end (both the
+  "lifts a restriction Phase B imposed" and the "reject device on a
+  plain frontend" bullets below) — neither is implementable, let alone
+  testable, without Phase B's `frontend_context` manifest field/CLI flag
+  already existing to lift a restriction *on*. Treating this as a "soft"
+  dependency understates it: Phase D is not done until those criteria are
+  met, so Phase B is a hard prerequisite for completing Phase D, not only
+  for its non-default-context path.
 - **Phase E** — depends on **both** Phase A and Phase B — see above.
 
 ---
@@ -2153,10 +2167,17 @@ at a mock of any intermediate layer) — proving `cli_compare_helpers.py`,
 `cli_resolve.py`, and `service.py` were all updated together, not just
 `cli.py`. A **release
 rejects `--frontend-context`** test asserting `compare old_dir new_dir
---frontend-context device` fails fast via `cli_resolve.py`'s existing
-set-input guard, the same way it already fails fast for `--gcc-path`/
-`--ast-frontend` on a directory/package input — proving the flag can't be
-silently accepted and then ignored by the release backend. A companion
+--frontend-context host` — deliberately `host`, not `device`, so the
+only thing that can make this fail is `cli_resolve.py`'s set-input guard
+itself, not Phase B's separate, temporary rejection of every non-`host`
+value (`host` is always accepted there); using `device` here would let
+this test pass via that unrelated rejection without ever proving the
+set-input guard rejects the flag at all, silently resurfacing once
+Phase D makes `device` a normally-accepted value too — fails fast via
+`cli_resolve.py`'s existing set-input guard, the same way it already
+fails fast for `--gcc-path`/`--ast-frontend` on a directory/package input
+— proving the flag can't be silently accepted and then ignored by the
+release backend. A companion
 **release rejects `--dump-manifest`** test asserting `compare old_dir
 new_dir --dump-manifest old=v1/abi.yml --dump-manifest new=v2/abi.yml`
 also fails fast via `_EVIDENCE_SET_INPUT_FLAGS`'s guard, the same way
@@ -2259,26 +2280,32 @@ verdict-producing comparison, so it doesn't fit the example catalog's
 ## Phase D — SYCL/DPC++ host vs. device AST context selection
 
 Implements ADR-050 D5. Independent of Phase C's merge work. **Depends on
-both Phase 0 and Phase A — not Phase 0 alone.** The parser
+Phase 0, Phase A, *and* Phase B — not Phase 0 alone, and not a "soft"
+dependency on B either.** The parser
 (`sycl_context.py`'s document-boundary decoding and `kind`-based
 selection) only needs Phase 0's captured DPC++ fixture, but this phase's
-own acceptance criteria also require folding the resolved `kind` into
-`comparability.compute_extraction_contract`'s hashed fields and testing a
-host-vs-device `profile_fingerprint` mismatch through D2's gate (see the
-dedicated acceptance-criteria bullet below) — both of those are Phase A's
-`ExtractionContract`/`compute_extraction_contract`/gate machinery.
-Starting or landing D before A leaves nothing concrete for that bullet to
-extend, and — worse than merely blocked — could ship a selector whose
-chosen context is invisible to the comparability gate if the fingerprint
-half is skipped or deferred, the identical risk already identified and
-fixed for Phase E's dependency on Phase A. Selecting a
-*non-default* context also has a soft dependency on Phase B: the
-`frontend_context` field (manifest base profile) and `--frontend-context`
-CLI flag this phase's selector reads are defined there, not here (Phase B
-"Goal & acceptance criteria"). The parser and `host`-default path can be
-built and tested without Phase B, but a real DPC++
-device-context request has nowhere to come from until Phase B's field/flag
-exist.
+own acceptance criteria go well past the parser: they require folding the
+resolved `kind` into `comparability.compute_extraction_contract`'s hashed
+fields and testing a host-vs-device `profile_fingerprint` mismatch
+through D2's gate (both Phase A's `ExtractionContract`/
+`compute_extraction_contract`/gate machinery — see the dedicated
+acceptance-criteria bullet below), **and** they require lifting Phase B's
+blanket non-`host` rejection and exercising `--frontend-context device`
+end to end (see the "this phase also lifts a restriction" bullet below)
+— unimplementable without Phase B's `frontend_context` manifest
+field/CLI flag already existing to lift a restriction *on*. Starting or
+landing D before A leaves nothing concrete for the fingerprint-folding
+bullet to extend, and — worse than merely blocked — could ship a
+selector whose chosen context is invisible to the comparability gate if
+that half is skipped or deferred, the identical risk already identified
+and fixed for Phase E's dependency on Phase A. Starting or landing D
+before B leaves the "lift the restriction" criterion equally
+unimplementable — there is no restriction to lift, and no
+`--frontend-context`/manifest field to test `device` through, until B's
+field/flag exist. The parser and `host`-default path alone can be built
+and tested without either A or B, but Phase D as a *whole* — the phase
+this document tracks completion of — cannot be considered done without
+both.
 
 **This phase also lifts a restriction Phase B deliberately imposed, not
 just adds new behavior.** Phase B ships with `dump_manifest.py`/the

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -1368,9 +1368,34 @@ all six of its columns, or the per-command detail tables gain their new
 codes while the one table meant to summarize them across commands goes
 stale the same day), `reporter.py`,
 `sarif.py`, `junit_report.py`, `html_report.py` (`generate_html_report`'s
-`contract_coverage` headline card), `service_render.py` (`render_output`'s
-`--format html` branch skips `generate_html_report` on the `not_comparable`
-path instead of calling it with no `DiffResult`), `abicheck/schemas/compare_report.schema.json`,
+`contract_coverage` headline card). **`service_render.render_output`
+has five branches that require a real `DiffResult` — `sarif`, `html`,
+`junit`, `review`, and the default `markdown` — not just `html`; every
+one needs the identical bypass, not only the one this bullet previously
+named.** Verified against the actual code (`service_render.py:36-132`):
+`to_sarif_str(result, ...)`, `generate_html_report(result, ...)`,
+`to_junit_xml(result, ...)`, `to_review_digest(result, ...)`, and the
+default `to_markdown(result, ...)` each take `result` as a required,
+non-`Optional` `DiffResult` positional argument — on the `not_comparable`
+path (no `DiffResult` ever constructed), calling any of them the normal
+way crashes or requires inventing a synthetic empty `DiffResult`, neither
+of which is what this ADR intends. The front-end's own exception handler
+therefore renders the not-comparable outcome directly, per format, the
+same way it already assembles `verdict: null` JSON, instead of calling
+`render_output` at all on this path: **SARIF** gets one `run` with
+`invocations[0].executionSuccessful: false` and a
+`toolExecutionNotifications` entry carrying the not-comparable reason —
+SARIF's own defined mechanism for "the tool didn't complete analysis,"
+so a SARIF consumer (e.g. GitHub Code Scanning) can't misread an empty
+`results` array as a clean pass; **JUnit** gets one `<testsuite>` with a
+single `<testcase>` wrapping an `<error message="...">` (not
+`<failure>` — JUnit's own convention for "the test itself couldn't run,"
+distinct from an ordinary reported ABI break, which stays a `<failure>`);
+**markdown/review** (human-readable, no schema to satisfy) get a plain
+"NOT COMPARABLE: `<reason>`" summary line. `service_render.py`
+(`render_output`'s `sarif`/`html`/`junit`/`review`/default-`markdown`
+branches are all skipped on the `not_comparable` path, not just `html`),
+`abicheck/schemas/compare_report.schema.json`,
 `abicheck/schemas/__init__.py` (`REPORT_SCHEMA_VERSION` bump),
 `docs/schemas/v1/compare_report.schema.json` (regenerated via
 `scripts/publish_schemas.py`, not hand-edited), `aggregate.py`
@@ -1414,10 +1439,22 @@ stricter);
 `tests/test_report_schema.py` gains a `not_comparable` case validated
 against the updated `compare_report.schema.json`, and its existing
 `test_docs_mirror_matches_packaged_schema` must still pass against the
-regenerated `docs/schemas/v1` copy; an **HTML reporting** test asserting
-`render_output(..., fmt="html")` on a `not_comparable` path never reaches
-`generate_html_report` with a missing `DiffResult` (the front-end's exception
-handler owns that path instead), and a second test asserting a mixed-pair
+regenerated `docs/schemas/v1` copy; a **multi-format not_comparable
+reporting** test suite asserting `render_output(..., fmt=...)` on a
+`not_comparable` path is never reached at all — for **each** of `sarif`,
+`html`, `junit`, `review`, and the default `markdown`, not only `html` —
+proving the front-end's own exception handler owns every one of those
+paths instead of calling `to_sarif_str`/`generate_html_report`/
+`to_junit_xml`/`to_review_digest`/`to_markdown` with a missing
+`DiffResult`; a dedicated **SARIF not-comparable** test asserting the
+emitted SARIF log has `invocations[0].executionSuccessful == false` and a
+`toolExecutionNotifications` entry carrying the not-comparable reason,
+never an empty `results` array that a SARIF consumer could misread as a
+clean pass; a dedicated **JUnit not-comparable** test asserting the
+emitted XML has exactly one `<testcase>` wrapping an `<error
+message="...">`, not a `<failure>` — proving JUnit's own
+couldn't-run-the-test convention is used, distinct from an ordinary
+reported ABI break; and a second test asserting a mixed-pair
 `contract_coverage` comparison's HTML output surfaces `contract_coverage`
 the same way its JSON/Markdown/SARIF/JUnit siblings do; a root-relative-path fingerprint test
 (the acceptance-criteria bullet above — same-tree-different-root compare
@@ -1974,6 +2011,23 @@ exist.
   extraction failure, never a successful snapshot with the wrong target
   silently selected; more than one context sharing the requested `kind` →
   `AST_CONTEXT_AMBIGUOUS`, never resolved by an implicit tiebreaker.
+- **The resolved `kind` must be folded into `profile_fingerprint`'s hashed
+  fields — selecting the right context is not the same as the gate
+  knowing which one was selected.** Phase A's `profile_fingerprint` field
+  list predates this phase (`frontend_context` doesn't exist until Phase
+  B/this phase), so it was never added there; leaving it un-added here
+  would silently reopen the exact under-counting bug Phase A exists to
+  close, one field short — two extractions requesting different
+  `frontend_context` values (`host` vs. `device`), otherwise identical in
+  compiler/target/macros/includes, parse genuinely different ASTs, but
+  D2's gate would never see the difference and any resulting AST
+  difference would surface as an ordinary reported `Change` instead of a
+  pre-diff `not_comparable`. `comparability.compute_extraction_contract`
+  gains the resolved `kind` as a hashed input, not just the *requested*
+  `frontend_context` string — the two would still agree even when an
+  ambiguity-adjacent frontend quirk resolved to a differently-labeled
+  context on each side for the same requested value, which the requested
+  string alone can't see but the actually-resolved `kind` can.
 - `dumper_clang.py`'s existing single-context assumption is generalized to
   call this module when the detected frontend is DPC++-capable; a plain
   (non-SYCL) clang/castxml invocation is unaffected.
@@ -2017,7 +2071,16 @@ asserting a DPC++-capable invocation whose decoded stream comes back empty
 `AST_CONTEXT_MISSING`, never silently falling back to the single-context
 path — proving the fallback distinguishes "genuinely not a multi-document
 invocation" from "was one, but decoded to nothing," the specific
-conflation this criterion exists to prevent.
+conflation this criterion exists to prevent. A **host/device
+profile-fingerprint mismatch** test asserting an old/new pair extracted
+with `frontend_context=host` on one side and `frontend_context=device` on
+the other, otherwise identical compiler/target/macros/includes, produces
+*different* `profile_fingerprint`s and raises `ProfileMismatchError` from
+D2's gate — proving the resolved `kind` actually reaches
+`compute_extraction_contract`'s hash, not just `sycl_context.py`'s
+selection logic; a companion assertion with the *same* `frontend_context`
+on both sides leaves `profile_fingerprint` matching, the routine case this
+fix must not break.
 
 **Example fixtures.** None required beyond Phase 0's captures — this phase
 is extraction-layer, not diff-layer; no new `ChangeKind`.

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -185,13 +185,29 @@ Implements ADR-050 D1 and D2.
   verdict into a strictly less useful "couldn't tell" result. Fix:
   `check_contracts_comparable` inspects *which* resolved fields differ
   (the same per-field data `ExtractionContract` already stores for
-  reporting, not just the opaque hash), and when the *only* differing
-  fields are target/pointer-width/endianness, it does not raise —
-  `compare()` proceeds to the normal `diff_*` pipeline and lets the
-  existing platform detectors produce their own verdict. Any other
+  reporting, not just the opaque hash). Any other
   differing field still hard-fails as before, even alongside a
   co-occurring target difference — scoped to platform-identity fields
-  alone, not a general loosening.
+  alone, not a general loosening. **"Only the profile-fingerprint target
+  differs" is necessary but not sufficient — the carve-out must also
+  confirm the binaries themselves genuinely differ on that axis, or a
+  misconfigured extraction slips through uncaught.** A profile-only
+  target mismatch can happen with no real architecture difference at
+  all: a cross-compiler flag/`--gcc-prefix` set for only one side while
+  both `.so`/`.dll` files are genuinely the same architecture. In that
+  case `diff_platform.py` has no `elf_machine_changed`/etc. finding to
+  emit — the binaries never differed — so skipping the gate would let a
+  misconfigured, actually-non-comparable extraction through as an
+  ordinary diff, any AST artifact the wrong target introduced surfacing
+  as an apparently real `Change` with nothing flagging the underlying
+  problem. The carve-out therefore requires *both*: (1) the only
+  differing `profile_fingerprint` fields are target/pointer-width/
+  endianness, **and** (2) the snapshots' own binary-derived platform
+  metadata (the same header fields `elf_machine_changed` et al. already
+  read) shows a genuine difference on that same axis. Only when both hold
+  does `compare()` proceed instead of raising; (1) alone, with (2) false,
+  still raises `ProfileMismatchError` — an extraction misconfiguration,
+  not a legitimate cross-architecture compare.
 - **Both fingerprints hash root-relative paths, never raw absolute ones —
   the single highest-priority correctness requirement in this phase — and
   each normalizes against its *own* root, never a root shared across both.**
@@ -456,18 +472,28 @@ Implements ADR-050 D1 and D2.
   side semantics, current artifact vs. `--against`, identical to
   `compare`'s), and its `split_sided_paths(include_pairs)` call
   (`cli_scan.py:712`) becomes `split_sided_include_paths(include_pairs)`.
-  `dump_cmd`'s inline `--include` also switches to `SidedIncludePathParam`
-  — reusing the *same* type rather than inventing a second, `dump`-only
-  grammar, so there is one label syntax across all three commands instead
-  of a different one to remember for `dump` specifically; `dump` has no
-  side to scope, so its label form is always `--include
-  both:LABEL=PATH` (side parsed but ignored downstream — `dump`'s
-  `includes` never gets split by side in the first place, only label and
-  path are consumed). A colon-less `--include` value on `dump` keeps
-  today's exact behavior (`label=None`) for the same reason established
-  above: inventing a colon-less-on-`dump`-only labeled shape would reopen
-  the bare-`LABEL=PATH`-vs-ordinary-path-with-`=` ambiguity just closed,
-  for no benefit.
+  **`dump_cmd` cannot reuse `SidedIncludePathParam` as-is, though — doing
+  so silently breaks a currently-valid `dump --include` value.**
+  `SidedIncludePathParam` still honors the *unlabeled*
+  `[old=|new=|both=]PATH` grammar `SidedPathParam` already implements
+  (deliberate, so `compare`/`scan` — which already had this prefix rule —
+  don't change behavior). But `dump_cmd`'s `--include` is a plain
+  `click.Path` today and has *never* recognized `old=`/`new=`/`both=` as a
+  side prefix, so a directory literally named `old=foo/` is a valid,
+  existing value there; reusing `SidedIncludePathParam` wholesale would
+  newly start stripping that prefix on `dump` too, a real behavior change
+  unique to `dump` (unlike `compare`/`scan`, which already had it).
+  `dump_cmd` instead gets its own type, `LabeledIncludePathParam`: it
+  recognizes **only** the colon-terminated `both:LABEL=PATH` form (colon
+  was never meaningful to `dump`'s plain `click.Path` before, so adding it
+  is purely additive) and treats every other value — bare, or one that
+  happens to literally start with `old=`/`new=`/`both=` — as an ordinary,
+  unlabeled path exactly as `click.Path` does today, with no equals-form
+  side-prefix stripping at all. `dump`'s labeled form is therefore
+  `--include both:support=path` (only `both:` is accepted — there is no
+  real side concept, and no `old:`/`new:`, on a single-input command); a
+  value like `--include old=foo/` keeps meaning the literal directory
+  `old=foo/`, unchanged.
   `scope_fingerprint` owns everything
   under a project-owned root; `profile_fingerprint` owns only external
   roots, in full. **Excluding a project-owned directory's content must not
@@ -670,7 +696,15 @@ Implements ADR-050 D1 and D2.
   — proving the labeled form is only ever triggered by the literal colon
   prefix, never inferred from an ambient `=` in an otherwise-ordinary
   path, the exact regression a bare-`LABEL=PATH` grammar reading would
-  introduce (P2 review).
+  introduce (P2 review); a fifth assertion parses `dump --include
+  old=foo/` through `LabeledIncludePathParam` (`dump`'s own type, not
+  `SidedIncludePathParam`) and asserts it resolves to the literal
+  directory `Path("old=foo/")`, unlabeled — proving `dump`'s type never
+  strips an equals-form side prefix at all, the specific backward-compat
+  break reusing `SidedIncludePathParam` on `dump` would have introduced
+  (P2 review), alongside a companion assertion that `dump --include
+  both:support=path` still parses to `(label="support", path=Path("path"))`
+  through the same `dump`-specific type.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -1036,6 +1070,27 @@ Implements ADR-050 D1 and D2.
   ;;`), and `_maybe_post_pr_comment`'s `ERROR`-only skip is joined by an
   explicit exception that still posts for `NOT_COMPARABLE` — this result
   deserves the comment more than an ordinary pass, not less.
+  **Mapping the `VERDICT` string alone is not enough — the script's final
+  exit-code section never checks it, so the step still exits `0`.**
+  Verified against the actual code: `run.sh`'s final gate (`:1074-1145`)
+  starts `FINAL_EXIT=0` and only ever sets it to `1` inside branches keyed
+  on `ERROR`, or on `BREAKING`/`API_BREAK`/`FAIL`/`WARN`/`REMOVED_LIBRARY`/
+  `SEVERITY_ERROR`/`BUDGET_OVERFLOW` gated by their respective
+  `fail-on-*` inputs, across the `compare`/`scan`/`deps-compare`/`dump`
+  branches — there is no `NOT_COMPARABLE` check anywhere in that section.
+  Adding only the `case`-statement mapping above means `VERDICT` now
+  correctly *reads* `"NOT_COMPARABLE"`, but every mode's final-exit branch
+  still falls through unmatched and leaves `FINAL_EXIT=0` — a `compare`/
+  `scan`/`deps-compare` step whose underlying CLI exited `16`/`6`/`5` would
+  still report a **green** composite Action step, silently downgrading a
+  result that (per D2/the release-verdict-order fix elsewhere in this
+  plan) is supposed to be *more* blocking than an ordinary break, not
+  less. `NOT_COMPARABLE` gets its own unconditional check, alongside (not
+  gated by) the existing `ERROR` check at the top of the final-exit
+  section — not folded into any mode-specific `fail-on-*`-gated branch,
+  since (matching `ERROR`'s own treatment) whether a comparison could even
+  be attempted is not something a `fail-on-breaking`/`fail-on-api-break`
+  toggle should be able to opt out of.
 - **`html_report.py`/`service_render.py` are the fourth reporting surface,
   not an optional add-on.** AGENTS.md's own module map groups `html_report.py`
   with `reporter.py`/`sarif.py`/`junit_report.py` under "Reporting," and
@@ -1179,9 +1234,14 @@ above for why): `cli_scan.py` (`scan_cmd`'s own inline `--include`
 (`include_pairs`, `:487-495`) switches `type=` to `SidedIncludePathParam`
 too, and its `split_sided_paths(include_pairs)` call (`:712`) becomes
 `split_sided_include_paths(include_pairs)`), `cli.py` (`dump_cmd`'s own
-inline `--include` (`:486`, plain `click.Path` today) switches to the
-same `SidedIncludePathParam` as well, so `dump`/`scan`/`compare` share one
-label grammar rather than `dump` alone getting a second, narrower one).
+inline `--include` (`:486`, plain `click.Path` today) switches to a new,
+`dump`-specific `LabeledIncludePathParam` instead — not
+`SidedIncludePathParam` itself, which would silently start stripping
+`old=`/`new=`/`both=` off a `dump --include` value for the first time
+ever, breaking a directory literally named that way; `dump`'s type
+recognizes only the colon-terminated `both:LABEL=PATH` label form and
+leaves every other value, including one that happens to start with
+`old=`/`new=`/`both=`, untouched).
 **Getting the label out of Click's parsed value is not enough — it still
 needs its own path down to `comparability.compute_extraction_contract`,
 the same per-layer threading already required (and already found
@@ -1520,7 +1580,15 @@ otherwise identical in every other profile field, does **not** raise
 **plus** a genuinely different macro definition asserts the gate still
 raises `ProfileMismatchError` — proving the carve-out is scoped to
 target-only mismatches, not a blanket exemption whenever a target
-difference happens to be present; a **diagnostic-comparison API** test asserting `checker.compare(old, new,
+difference happens to be present; a **misconfigured-extraction** test
+asserting that when `profile_fingerprint`'s target component differs but
+the old/new binaries' *own* ELF/PE/Mach-O metadata is identical (a
+`--gcc-prefix` cross-compile flag applied to only one side, both actual
+`.so` files genuinely the same architecture), the gate still raises
+`ProfileMismatchError` rather than skipping — proving the carve-out
+requires artifact-confirmed platform drift, not merely a differing
+compile-context target, the specific misconfiguration this stricter
+condition exists to keep catching; a **diagnostic-comparison API** test asserting `checker.compare(old, new,
 diagnostic_comparison=True)` on a mismatched pair returns a real
 `DiffResult` (never raises) with `assurance == "none"` — proving the flag
 reaches the gate check itself, not just a CLI-level catch with nothing to
@@ -1582,7 +1650,16 @@ each map to `VERDICT="NOT_COMPARABLE"`, never the `*) VERDICT="ERROR"`
 fallback, plus a `_maybe_post_pr_comment` test asserting a `NOT_COMPARABLE`
 verdict still posts a PR comment despite the existing `ERROR`-only skip —
 proving the Action doesn't both misreport and silently suppress the one
-comment meant to surface a deliberate not-comparable result.
+comment meant to surface a deliberate not-comparable result. A
+**separate, dedicated final-exit** test asserting the composite Action
+step itself exits non-zero (not just that `VERDICT` reads correctly) for
+each of `compare`/`scan`/`deps-compare` given exit `16`/`6`/`5` — proving
+the mapping fix alone doesn't already cover this, since `run.sh`'s
+final-exit section is a separate code path from the `case`-statement
+mapping and, verified against the actual code, has no `NOT_COMPARABLE`
+branch of its own; without it, `FINAL_EXIT` stays `0` and the step
+reports green despite the underlying CLI call having failed to compare
+at all.
 
 **Example fixtures.** The Phase 0 "scope drift" pair stays a `tests/`-level
 fixture, not an `examples/case*/` catalog entry: `tests/test_validate_examples_unit.py`'s

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -573,7 +573,22 @@ Implements ADR-050 D1 and D2.
   and hashes them in caller-supplied order instead; deferring this to
   Phase E doesn't help, since Phase E's cache-key work is scoped to a
   different, manifest-only gap (see Phase E) and wouldn't by itself make
-  the existing sorted hashing order-preserving.
+  the existing sorted hashing order-preserving. **The same key must also
+  carry the `--project-include` side/label/path triples, not just
+  `headers`/`includes`.** Both the project-ownership predicate and the
+  per-slot logical token depend on which directories are marked
+  project-owned and under which label — two dumps with identical
+  `headers`/`includes` but a different `--project-include` label on the
+  same directory (or the marker present on one run and absent on the
+  next, the directory otherwise unchanged) would otherwise hit the same
+  cache entry under a key that never saw the label at all, and
+  `cached_run_dump` would serve back a stale `contract.profile_fingerprint`
+  computed under the old labeling — a warm-cache bypass of this whole
+  phase's ownership fix, the identical class of gap already found and
+  fixed above for a cold `contract=None` cache entry. `_cache_key()` folds
+  the normalized `(side, label, path)` triples into its key material
+  alongside `headers`/`includes`, in caller-supplied order for the same
+  reason those two are no longer sorted.
 - `serialization.SCHEMA_VERSION` is bumped (11 → 12) in the same change
   that starts writing `contract` — **not** treated as a free additive field
   the way ADR-041's advisory `extractor_passes`/`narrowed_passes` were. The
@@ -994,7 +1009,33 @@ Implements ADR-050 D1 and D2.
 label at once, see the sibling-support-root acceptance-criteria bullet
 above), `cli_options.py` (new side-scoped, labeled `--project-include`
 option built on it, alongside the existing `--include`/`--header`
-`SIDED_PATH_PARAM` family, ADR-040 — legacy CLI only),
+`SIDED_PATH_PARAM` family, ADR-040 — legacy CLI only).
+**Declaring the option is not enough — `--project-include` needs the same
+per-layer threading already required (and already found missing, twice)
+for `--dump-manifest`/`--diagnostic-comparison`/`--frontend-context` in
+this same phase/plan, and this bullet was the one surface that skipped
+that step on the first pass.** `compare_cmd` forwards `**kwargs` to
+`cli_compare_helpers.run_compare`, whose signature is fixed and explicit
+(no `project_include` slot today); `dump_cmd`/`scan_cmd` are themselves
+fixed Click callbacks Click invokes directly, not `**kwargs` forwarders.
+Each of `run_compare`, `dump_cmd`, and `scan_cmd` gains its own
+`old_project_includes`/`new_project_includes` (or the `scan`/`dump`
+single-side equivalent) parameter carrying the parsed side/label/path
+triples, threaded down through the same chains already established for
+`--dump-manifest` and `--frontend-context` in this phase — `run_compare` →
+`cli_resolve._resolve_compare_snapshots` → `cli_resolve._resolve_input` →
+`service.resolve_input`/`run_dump` for `compare`; `dump_cmd` →
+`cli_dump_helpers` → `service.resolve_input`/`run_dump` for `dump`;
+`scan_cmd` → `service.resolve_input`/`run_dump` for `scan` — terminating
+in `dumper.dump()`, which passes the triples into
+`comparability.compute_extraction_contract(...)` so the project-ownership
+predicate can actually consult them. Without this, the sibling
+support-root acceptance tests (test (14) below) either fail with an
+"unexpected keyword argument" at the Click-callback boundary or silently
+run with `--project-include` accepted and parsed but never reaching the
+predicate — the flag would parse successfully and do nothing, the same
+silent-loss failure mode already caught once for
+`--diagnostic-comparison` on `run_compare` in this phase.
 `model.py` (new `ExtractionContract`), new
 `abicheck/comparability.py` (fingerprint computation, `compute_extraction_contract`
 — its project-ownership predicate takes both ancestor-derived headers and

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -168,6 +168,30 @@ Implements ADR-050 D1 and D2.
   declarations feed the ABI model without necessarily touching a TU's
   includes, so leaving it out of the hash would let that exact class of
   scope drift pass the gate undetected.
+- **A profile mismatch confined to target triple/pointer width/endianness
+  must not preempt `diff_platform.py`'s existing, more specific
+  platform-identity detectors.** `profile_fingerprint` deliberately
+  includes target triple/pointer width/endianness (they genuinely affect
+  AST extraction — omitting them reopens the under-counting bug this
+  design exists to close), but `elf_machine_changed`/`elf_class_changed`/
+  `elf_endianness_changed` (and PE/Mach-O equivalents) already detect the
+  exact same axis directly from the binaries' own headers, already
+  classified `BREAKING` — comparing genuinely different target
+  architectures is `profile_fingerprint`'s single most likely mismatch
+  source, and unlike every other drift case this gate exists to catch, it
+  is not unexplained: the diff pipeline already has a correct,
+  artifact-grounded answer. Gating it into a generic `not_comparable`
+  before `diff_platform.py` ever runs would downgrade a proven `BREAKING`
+  verdict into a strictly less useful "couldn't tell" result. Fix:
+  `check_contracts_comparable` inspects *which* resolved fields differ
+  (the same per-field data `ExtractionContract` already stores for
+  reporting, not just the opaque hash), and when the *only* differing
+  fields are target/pointer-width/endianness, it does not raise —
+  `compare()` proceeds to the normal `diff_*` pipeline and lets the
+  existing platform detectors produce their own verdict. Any other
+  differing field still hard-fails as before, even alongside a
+  co-occurring target difference — scoped to platform-identity fields
+  alone, not a general loosening.
 - **Both fingerprints hash root-relative paths, never raw absolute ones —
   the single highest-priority correctness requirement in this phase — and
   each normalizes against its *own* root, never a root shared across both.**
@@ -391,8 +415,25 @@ Implements ADR-050 D1 and D2.
   field already makes) because a support root with no owned declared
   header has nothing for the ancestor-derived per-slot token below to key
   off of; asking for one avoids yet another path-shape heuristic. This
-  labeled `--include` form is legacy-CLI-only: the manifest path (D3)
-  already has no such gap via per-TU forced-includes.
+  labeled `--include` form is legacy-CLI-only. **The manifest path (D3) is
+  not automatically exempt from the same gap — an earlier revision of this
+  bullet wrongly claimed `forced_includes` already covered it.**
+  `forced_includes` is a per-TU list of individual force-included header
+  *files*, the manifest equivalent of a single named header — it says
+  nothing about a TU's `includes` list, the manifest's own `-I`
+  search-path entries. A manifest TU declaring `includes: [../src]` or
+  `includes: [generated/]` to resolve a private/generated support header
+  has the identical problem: that directory is a *sibling* of the TU's own
+  path, not an ancestor, so the ancestor rule classifies it external and
+  an ordinary edit inside it still flips `profile_fingerprint`. Fix, in the
+  manifest's own idiom: an `includes` entry is either a bare path string
+  (unchanged — ancestor rule decides) or a mapping `{path: ...,
+  project_owned: true}` explicitly marking it project-owned. No separate
+  label is needed here, unlike the CLI form — manifest paths are already
+  root-relative/side-normalized by design, so the same relative path
+  string on both the old and new manifest already is a stable,
+  mount-point-independent per-slot token, the same way a TU's `name`
+  already serves as stable identity elsewhere in this design.
 
   **`--include` is three separate Click registrations today, not one —
   `SidedIncludePathParam` only fixes `compare`'s.** Verified against the
@@ -1431,7 +1472,18 @@ silent `None` diff indistinguishable from the pre-existing
 raised while diffing a changed dependency DSO, and asserting the resulting
 `StackChange.not_comparable_reason` is populated rather than `abi_diff`
 being left an unexplained `None` — proving `_run_abi_diff`'s caller, not
-`_run_abi_diff` itself, is what classifies the exception; a **diagnostic-comparison API** test asserting `checker.compare(old, new,
+`_run_abi_diff` itself, is what classifies the exception; a
+**platform-identity dominance** test asserting that an old/new pair built
+for genuinely different target triples (e.g. `x86_64` vs. `aarch64`),
+otherwise identical in every other profile field, does **not** raise
+`ProfileMismatchError` and instead produces a real `DiffResult` carrying
+`elf_machine_changed` classified `BREAKING` — proving the gate defers to
+`diff_platform.py`'s existing detector rather than preempting it with
+`not_comparable`; a companion assertion with the *same* target mismatch
+**plus** a genuinely different macro definition asserts the gate still
+raises `ProfileMismatchError` — proving the carve-out is scoped to
+target-only mismatches, not a blanket exemption whenever a target
+difference happens to be present; a **diagnostic-comparison API** test asserting `checker.compare(old, new,
 diagnostic_comparison=True)` on a mismatched pair returns a real
 `DiffResult` (never raises) with `assurance == "none"` — proving the flag
 reaches the gate check itself, not just a CLI-level catch with nothing to
@@ -1518,7 +1570,12 @@ Implements ADR-050 D3. The highest-risk phase — see Risk above.
 - New `abicheck/dump_manifest.py`: strict YAML parser (unknown fields
   error), `roots`/`translation_units` schema, `name`-uniqueness,
   `contributes_to_abi=True ⇒ required=True` invariant enforced at parse
-  time (a validation error, not a silent coercion). The base-profile
+  time (a validation error, not a silent coercion). A TU's `includes`
+  entries accept either a bare path string (external-by-default, D1's
+  ancestor rule decides ownership, unchanged) or a mapping `{path: ...,
+  project_owned: true}` explicitly marking a sibling support root
+  project-owned — see the dedicated acceptance-criteria bullet above for
+  why `forced_includes` alone doesn't already cover this. The base-profile
   section also accepts `frontend_context` (`host` default) — the field
   Phase D's context selector needs an accepted input path for; a manifest
   schema that only carried `roots`/`translation_units` would leave a
@@ -1762,7 +1819,17 @@ choke point `compare`/`dump`/`scan` all resolve through, so no
 
 **Tests.** Manifest parser unit tests (the invariant violation, duplicate
 TU names, unknown fields, relative-path resolution, `frontend_context`
-accepted/defaulted/rejected-when-invalid). `dumper.py` multi-TU
+accepted/defaulted/rejected-when-invalid). A **manifest support-root
+ownership** test asserting a TU declaring `includes: [{path: ../src,
+project_owned: true}]` (a sibling of the TU's own declared path, not an
+ancestor) leaves `profile_fingerprint` matching across an old/new manifest
+pair when the edit is confined to a private header inside `../src` —
+proving the mapping form extends project-ownership the same way the
+legacy CLI's labeled `--include` does — alongside a companion assertion
+that a bare `includes: [../src]` (no `project_owned` marker) on the same
+layout still classifies `../src` external and flips `profile_fingerprint`
+on that same edit, confirming the mapping form is genuinely required, not
+redundant with the ancestor rule. `dumper.py` multi-TU
 integration tests (`@pytest.mark.integration`, needs castxml/clang) using
 Phase 0's fixtures. A `plan --dump-manifest` unit test asserting it never
 invokes a compiler and prints `scope_fingerprint` only — never a

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -322,31 +322,50 @@ Implements ADR-050 D1 and D2.
   `--include` but never an ancestor of any declared `--header`. The
   ancestor rule classifies these as external today, so an ordinary edit to
   a generated or private support header still flips `profile_fingerprint`
-  on a routine CMake/Meson-style layout, not an edge case. Legacy CLI gains
-  a new, side-scoped, **labeled** `--project-include` option — its value
-  grammar cannot naively reuse `<label>=<path>`, though: `cli_params.py`'s
-  existing `SidedPathParam`/`SidedStrParam` (ADR-040 Lever 1) already
-  reserve the `X=` prefix position exclusively for the side discriminator
-  (`old=`/`new=`/`both=`, `_SIDES`) — `support=old/src` has no recognized
-  side prefix, so it would fall through to that parser's bare-value case
-  as `("both", Path("support=old/src"))`, the literal string swallowed
-  whole as a bogus path, never parsed as a label. `--project-include`
-  therefore needs its own dedicated param type, `SidedLabeledPathParam`,
-  carrying both pieces: `[old:|new:|both:]<label>=<path>` — a
-  colon-terminated side prefix (colon instead of `=` so it can't collide
-  with the label's own `=`), defaulting to `both:` when omitted, the same
-  "bare value means both sides" convention as the existing sided params.
-  A two-checkout compare with side-specific paths for one shared logical
-  root is declared `--project-include old:support=old/src
-  --project-include new:support=new/src` — same `support` label on both
-  invocations (so the per-slot token matches across sides for the same
-  logical root), different paths per side. `--project-include` requires
-  that label (a user-supplied logical name, not path-derived — the same
-  choice D3's manifest `name` field already makes) because a support root
-  with no owned declared header has nothing for the ancestor-derived
-  per-slot token below to key off of; asking for one avoids yet another
-  path-shape heuristic. Legacy-CLI-only: the manifest path (D3) already
-  has no such gap via per-TU forced-includes.
+  on a routine CMake/Meson-style layout, not an edge case.
+
+  **A separate `--project-include` option cannot carry this at all,
+  regardless of its own value grammar — Click doesn't preserve declaration
+  order *across* two differently-named repeatable options.** Verified
+  against Click's actual parsing model: a `multiple=True` option's
+  callback gets that option's own values as one tuple, in that option's
+  own declaration order, but Click never records one option's occurrences
+  relative to a *different* option's. `--include dep --project-include
+  support=src` and `--project-include support=src --include dep` arrive
+  at the callback as the identical `(include=('dep',),
+  project_include=('support=src',))` — no way to recover which came
+  first. Since `profile_fingerprint`'s `-I` ordering is search-precedence
+  order (the actual relative position the compiler sees), a second,
+  separate option can never feed it correctly, no matter how its value is
+  shaped — this sinks the separate-option design before its grammar is
+  even considered. **Fix: no second option — the label rides on
+  `--include` itself**, the one option Click already keeps in true
+  declaration order (the same guarantee the whole `-I`-sequence design
+  already relies on for plain `--include`/`--include` pairs).
+  `cli_params.py`'s existing `SidedPathParam` (shared today by
+  `--include`, `--header`, and other sided-path options) is extended for
+  `--include` specifically into a new `SidedIncludePathParam` — `--header`
+  and the rest keep the unchanged, 2-tuple `SidedPathParam`, since only
+  `--include` needs a label slot. `SidedIncludePathParam` layers an
+  optional labeled form on top of the existing `[old=|new=|both=]PATH`
+  grammar: `[old:|new:|both:]LABEL=PATH` — a colon-terminated side prefix
+  (colon instead of `=`, unambiguous since no `--include` value has ever
+  started with `old:`/`new:`/`both:`), returning a `(side, label, path)`
+  triple with `label=None` for every existing unlabeled form so ordinary
+  uses are byte-for-byte unaffected. A two-checkout compare with
+  side-specific paths for one shared logical root is declared `--include
+  old:support=old/src --include new:support=new/src` — same `support`
+  label on both invocations (so the per-slot token matches across sides
+  for the same logical root), different paths per side, interleaved with
+  any number of ordinary `--include old=/opt/dep` entries in exactly
+  their typed order, since it's all one option's accumulated tuple. The
+  label is required for this labeled form specifically (a user-supplied
+  logical name, not path-derived — the same choice D3's manifest `name`
+  field already makes) because a support root with no owned declared
+  header has nothing for the ancestor-derived per-slot token below to key
+  off of; asking for one avoids yet another path-shape heuristic. This
+  labeled `--include` form is legacy-CLI-only: the manifest path (D3)
+  already has no such gap via per-TU forced-includes.
   `scope_fingerprint` owns everything
   under a project-owned root; `profile_fingerprint` owns only external
   roots, in full. **Excluding a project-owned directory's content must not
@@ -380,16 +399,16 @@ Implements ADR-050 D1 and D2.
   header set tokenizes identically regardless of mount point, consistent
   with `scope_fingerprint` already treating declared header *names* as
   legitimate, already-tracked identity, so no new information leaks
-  through the token; a `--project-include` support root's token is its
-  required user-supplied **`label`** instead (it owns no declared header
-  by construction — that's exactly why it needed its own flag), namespaced
-  separately from the ancestor-derived token space so a label can never
-  collide with a header name. `-I project -I dep` (project ancestor of
-  declared `foo.h`) hashes `[token(foo.h), digest(dep)]`; `-I dep -I
-  project` hashes `[digest(dep), token(foo.h)]` — different, correctly
-  flagged as non-comparable; `--project-include both:support=old/src` vs.
-  the same directory declared last instead of first is distinguished the
-  same way via `token(support)`. **Residual limitation (same class as the
+  through the token; a labeled `--include old:LABEL=PATH` support root's
+  token is its required user-supplied **`label`** instead (it owns no
+  declared header by construction — that's exactly why it needs the label
+  form), namespaced separately from the ancestor-derived token space so a
+  label can never collide with a header name. `-I project -I dep` (project
+  ancestor of declared `foo.h`) hashes `[token(foo.h), digest(dep)]`; `-I
+  dep -I project` hashes `[digest(dep), token(foo.h)]` — different,
+  correctly flagged as non-comparable; `--include both:support=old/src`
+  vs. the same directory declared last instead of first is distinguished
+  the same way via `token(support)`. **Residual limitation (same class as the
   vendored-nested-dependency gap below):** two separately declared `-I`
   roots that are both ancestors of the *same* declared header (an outer
   directory and one of its own subdirectories, each passed as its own
@@ -517,26 +536,32 @@ Implements ADR-050 D1 and D2.
   orderings to the same `[SENTINEL, SENTINEL]` sequence and spuriously
   match, exactly the regression this per-slot-token fix (as opposed to
   the simpler single-sentinel fix test (12) alone would validate) exists
-  to close; (14) a sibling support root declared via `--project-include`,
-  not nested under any declared `--header` — `old`/`new` both declare
-  `--header .../include/foo.h --include .../include --project-include
+  to close; (14) a sibling support root declared via a labeled `--include`
+  entry, not nested under any declared `--header` — `old`/`new` both
+  declare `--header .../include/foo.h --include .../include --include
   both:support=.../src` (`src/` a sibling of `include/`, containing a
   private header `foo.h` `#include`s) — with a **content edit confined to
   `src/`'s private header** between old and new leaves `profile_fingerprint`
-  matching, proving `--project-include` extends project-ownership to a
+  matching, proving the labeled form extends project-ownership to a
   sibling directory the ancestor rule alone would otherwise classify as
   external (and thus spuriously flip on this routine internal edit); a
-  companion assertion swapping `--project-include old:support=old/src
-  --project-include new:support=new/src` to declaration-last on one side
-  while an unrelated ancestor-derived root keeps its position produces a
-  *different* `profile_fingerprint`, confirming the label-derived token
-  participates in the same order-sensitive sequence as every other
-  project-owned slot; a third assertion parses `--project-include
-  old:support=old/src` and asserts the side/label/path triple round-trips
-  correctly through `SidedLabeledPathParam`, the exact grammar this fix
-  exists to get right (P2 review: a naive `<label>=<path>` grammar would
-  have silently misparsed as `("both", Path("support=old/src"))` instead
-  of raising or splitting a side/label/path triple).
+  companion assertion declares `--include old:support=old/src --include
+  old=/opt/dep` vs. `--include old=/opt/dep --include old:support=old/src`
+  (the labeled support root and an unrelated external root swapped in
+  declaration order, same two directories, same label) and asserts
+  *different* `profile_fingerprint`s, confirming the label-derived token
+  participates in the same order-sensitive sequence as every other slot
+  **and** that interleaving a labeled and an unlabeled `--include` entry
+  preserves their true relative order — the exact guarantee a second,
+  separately-named `--project-include` option could not have provided,
+  since Click never records cross-option interleaving (P2 review: verified
+  against Click's own parsing model — two differently-named repeatable
+  options each get their own accumulated tuple with no relative-order
+  record between them); a third assertion parses `--include
+  old:support=old/src` directly and asserts the side/label/path triple
+  round-trips correctly through `SidedIncludePathParam`, and that a bare
+  `--include old=v1/foo.h` still round-trips to `(side="old", label=None,
+  path=...)` unchanged.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -573,22 +598,24 @@ Implements ADR-050 D1 and D2.
   and hashes them in caller-supplied order instead; deferring this to
   Phase E doesn't help, since Phase E's cache-key work is scoped to a
   different, manifest-only gap (see Phase E) and wouldn't by itself make
-  the existing sorted hashing order-preserving. **The same key must also
-  carry the `--project-include` side/label/path triples, not just
-  `headers`/`includes`.** Both the project-ownership predicate and the
-  per-slot logical token depend on which directories are marked
-  project-owned and under which label — two dumps with identical
-  `headers`/`includes` but a different `--project-include` label on the
-  same directory (or the marker present on one run and absent on the
-  next, the directory otherwise unchanged) would otherwise hit the same
-  cache entry under a key that never saw the label at all, and
-  `cached_run_dump` would serve back a stale `contract.profile_fingerprint`
-  computed under the old labeling — a warm-cache bypass of this whole
-  phase's ownership fix, the identical class of gap already found and
-  fixed above for a cold `contract=None` cache entry. `_cache_key()` folds
-  the normalized `(side, label, path)` triples into its key material
-  alongside `headers`/`includes`, in caller-supplied order for the same
-  reason those two are no longer sorted.
+  the existing sorted hashing order-preserving. **The `includes` key
+  material must carry each entry's *label* too, not just its path — since
+  `--include`'s labeled form (`old:LABEL=PATH`) folds the label into
+  `includes` itself rather than a separate option, "hash `includes` in
+  caller-supplied order" is only correct if that per-entry hash covers the
+  full `(side, label, path)` triple.** Both the project-ownership
+  predicate and the per-slot logical token depend on which directories are
+  marked project-owned and under which label — two dumps with identical
+  paths but a different label on the same directory (or the label present
+  on one run and absent on the next, the path otherwise unchanged) would
+  otherwise hit the same cache entry under a key that only ever hashed the
+  path, and `cached_run_dump` would serve back a stale
+  `contract.profile_fingerprint` computed under the old labeling — a
+  warm-cache bypass of this whole phase's ownership fix, the identical
+  class of gap already found and fixed above for a cold `contract=None`
+  cache entry. `_cache_key()` hashes each `includes` entry's full
+  `(side, label, path)` triple, not `path` alone, in caller-supplied order
+  for the same reason it's no longer sorted.
 - `serialization.SCHEMA_VERSION` is bumped (11 → 12) in the same change
   that starts writing `contract` — **not** treated as a free additive field
   the way ADR-041's advisory `extractor_passes`/`narrowed_passes` were. The
@@ -693,7 +720,13 @@ Implements ADR-050 D1 and D2.
   `compare_snapshots` alone doesn't already cover it), **and**
   `stack_checker.py`'s `_run_abi_diff`, driving `abicheck deps compare`
   (which imports `checker.compare` directly too, and today swallows every
-  exception — see its own dedicated bullet below).
+  exception — see its own dedicated bullet below). `appcompat.py`'s
+  `check_appcompat`/`check_plugin_host_contract` reach the same gate
+  (via `compare_snapshots`) but are deliberately **not** among these
+  seven: per the dedicated `diagnostic_comparison` bullet below, letting
+  the mismatch exception propagate is these two functions' documented
+  default behavior (a `diagnostic_comparison` opt-in is added, but no
+  outcome-conversion wrapper), not an oversight to close here.
 - **The release fan-out needs a dedicated fix, not inherited behavior.**
   `_compare_one_library` (`cli_compare_release.py:180-269`) wraps its
   entire per-library flow in `except (click.ClickException,
@@ -1003,43 +1036,57 @@ Implements ADR-050 D1 and D2.
   ADR-041's header-graph flag flip, which changed behavior for an
   already-common default-off-to-on transition.
 
-**Files & surfaces.** `cli_params.py` (new `SidedLabeledPathParam` —
-`[old:|new:|both:]<label>=<path>`, a dedicated param type distinct from
-`SidedPathParam`/`SidedStrParam` since neither carries a side *and* a
-label at once, see the sibling-support-root acceptance-criteria bullet
-above), `cli_options.py` (new side-scoped, labeled `--project-include`
-option built on it, alongside the existing `--include`/`--header`
-`SIDED_PATH_PARAM` family, ADR-040 — legacy CLI only).
-**Declaring the option is not enough — `--project-include` needs the same
-per-layer threading already required (and already found missing, twice)
-for `--dump-manifest`/`--diagnostic-comparison`/`--frontend-context` in
-this same phase/plan, and this bullet was the one surface that skipped
-that step on the first pass.** `compare_cmd` forwards `**kwargs` to
-`cli_compare_helpers.run_compare`, whose signature is fixed and explicit
-(no `project_include` slot today); `dump_cmd`/`scan_cmd` are themselves
-fixed Click callbacks Click invokes directly, not `**kwargs` forwarders.
-Each of `run_compare`, `dump_cmd`, and `scan_cmd` gains its own
-`old_project_includes`/`new_project_includes` (or the `scan`/`dump`
-single-side equivalent) parameter carrying the parsed side/label/path
-triples, threaded down through the same chains already established for
-`--dump-manifest` and `--frontend-context` in this phase — `run_compare` →
+**Files & surfaces.** `cli_params.py` (new `SidedIncludePathParam` —
+`[old:|new:|both:]LABEL=PATH` layered on the existing
+`[old=|new=|both=]PATH` grammar, returning `(side, label, path)` with
+`label=None` for every unlabeled form — a dedicated param type used only
+by `--include`'s own Click option, distinct from the unchanged, 2-tuple
+`SidedPathParam` `--header`/`--sources`/etc. keep, see the
+sibling-support-root acceptance-criteria bullet above), `cli_options.py`
+(`--include`'s existing option switches `type=` from `SIDED_PATH_PARAM`
+to the new param type; a new `split_sided_include_paths` function sits
+alongside the existing `split_sided_paths` — shared by `--header` and
+plain, unlabeled `--include` — and additionally returns a
+`dict[Path, str]` of resolved path → label for whichever entries carried
+one, while still returning the same flat `(both, old_only, new_only)`
+`Path` tuples `split_sided_paths` does, so the compiler-argv-building code
+that already consumes those tuples is unchanged).
+**Getting the label out of Click's parsed value is not enough — it still
+needs its own path down to `comparability.compute_extraction_contract`,
+the same per-layer threading already required (and already found
+missing, twice) for `--dump-manifest`/`--diagnostic-comparison`/
+`--frontend-context` in this same phase/plan, and this bullet was the one
+surface that skipped that step on the first pass.** `dumper.dump()`'s
+`extra_includes: list[Path]` parameter (`dumper.py:1119`, and every
+internal per-TU helper it threads through, e.g. `:152,264,453,813,994`)
+stays a bare `Path` list, deliberately unchanged — rippling a label into
+every one of those internal helpers would be a far wider blast radius
+than this fix needs, since only the top-level `compute_extraction_contract`
+call actually reads labels. `dump()` instead gains one new, separate,
+optional parameter, `project_include_labels: dict[Path, str] | None =
+None`, passed alongside `extra_includes` (not folded into it) straight
+into `compute_extraction_contract(extra_includes, headers,
+project_include_labels=project_include_labels, ...)`. That parameter is
+threaded down the same chains already established for `--dump-manifest`
+and `--frontend-context` in this phase: `cli_compare_helpers.run_compare`
+(gains the parameter itself; `compare_cmd` forwards `**kwargs`, so Click
+already passes it through once `run_compare`'s signature names it) →
 `cli_resolve._resolve_compare_snapshots` → `cli_resolve._resolve_input` →
-`service.resolve_input`/`run_dump` for `compare`; `dump_cmd` →
-`cli_dump_helpers` → `service.resolve_input`/`run_dump` for `dump`;
-`scan_cmd` → `service.resolve_input`/`run_dump` for `scan` — terminating
-in `dumper.dump()`, which passes the triples into
-`comparability.compute_extraction_contract(...)` so the project-ownership
-predicate can actually consult them. Without this, the sibling
-support-root acceptance tests (test (14) below) either fail with an
-"unexpected keyword argument" at the Click-callback boundary or silently
-run with `--project-include` accepted and parsed but never reaching the
-predicate — the flag would parse successfully and do nothing, the same
-silent-loss failure mode already caught once for
-`--diagnostic-comparison` on `run_compare` in this phase.
+`service.resolve_input`/`run_dump` for `compare`; `dump_cmd`/`scan_cmd`
+(themselves fixed Click callbacks Click invokes directly, each gaining
+the parameter in their own signature) → `cli_dump_helpers`/`scan_engine`
+→ `service.resolve_input`/`run_dump` for `dump`/`scan` — terminating in
+`dumper.dump()`. Without this, the sibling support-root acceptance tests
+(test (14) below) either fail with an "unexpected keyword argument" at
+the Click-callback boundary or silently run with the label parsed by
+Click but never reaching the predicate — the labeled `--include` form
+would parse successfully and do nothing, the same silent-loss failure
+mode already caught once for `--diagnostic-comparison` on `run_compare`
+in this phase.
 `model.py` (new `ExtractionContract`), new
 `abicheck/comparability.py` (fingerprint computation, `compute_extraction_contract`
 — its project-ownership predicate takes both ancestor-derived headers and
-declared `--project-include` labels as inputs, not headers alone —
+the new `project_include_labels` mapping as inputs, not headers alone —
 the gate, and `contract_coverage` metadata computation — no detector, since
 `UNKNOWN_PROFILE` is report metadata, not a `Change`; reuses
 `abicheck/buildsource/include_graph.py`'s existing `parse_depfile()` to turn
@@ -1083,7 +1130,29 @@ everything else into `{"status": "error", ...}` today; exposing
 `abi_compare` also gains a dedicated `except (ProfileMismatchError,
 ScopeMismatchError)` branch, ordered before that generic catch, rendering
 `{"status": "not_comparable", "reason": ...}` distinct from
-`{"status": "error"}` for the default hard-fail path), `cli.py`
+`{"status": "error"}` for the default hard-fail path). **`appcompat.py` is a
+third, independent instance of this exact bypass, not covered by fixing
+`CompareRequest`/`run_compare_request` or `mcp_server.py` alone — verified
+against the actual code:** `check_appcompat` (`:1018`) and
+`check_plugin_host_contract` (`:1227`) each call `service.compare_snapshots(...)`
+directly (`:1078`, `:1248`), with no surrounding `try` today, no
+`CompareRequest` in either call path, and no route through `run_compare_request`
+at all — these are themselves public Python-API entry points (documented,
+user-callable functions, not internal helpers), so a mismatched pair raises
+a raw `ProfileMismatchError`/`ScopeMismatchError` straight out of them,
+uncaught, with no `AppCompatResult`/`PluginHostContractResult` to carry a
+`not_comparable` outcome (both dataclasses' `full_diff: DiffResult | None`
+has nowhere to put a result when the gate raises *before* any `DiffResult`
+exists). Both functions gain a `diagnostic_comparison: bool = False`
+parameter, forwarded into their own `compare_snapshots(...)` calls exactly
+like `run_compare_request`'s equivalent parameter — giving a caller of the
+Python API the same tentative-diff escape hatch every other front-end
+gets. Raw exception propagation remains the *default* (undiagnosed) behavior
+for both functions, same as any other direct `compare_snapshots` caller
+that doesn't opt in — this phase documents that explicitly as these two
+functions' intended contract (in their docstrings) rather than leaving it
+implicit, closing the ambiguity Codex flagged rather than silently
+choosing one reading. `cli.py`
 (the `--diagnostic-comparison` flag definition and the new, distinct
 `not_comparable` exit `16` constant), **`cli_compare_helpers.py`** (the new
 `except (ProfileMismatchError, ScopeMismatchError)` branch around the real

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -1402,7 +1402,17 @@ everything else into `{"status": "error", ...}` today; exposing
 `abi_compare` also gains a dedicated `except (ProfileMismatchError,
 ScopeMismatchError)` branch, ordered before that generic catch, rendering
 `{"status": "not_comparable", "reason": ...}` distinct from
-`{"status": "error"}` for the default hard-fail path). **`appcompat.py` is a
+`{"status": "error"}` for the default hard-fail path). **Adding
+`diagnostic_comparison` to `abi_compare`'s parameters is not just an
+`mcp_server.py`/`cli.py` change: `scripts/check_ai_readiness.py`'s
+`cli-contract` check (`_check_mcp_cli_name_map`, ADR-037 D10.3, mirrored
+in `tests/test_cli_contract.py::test_mcp_cli_name_map_complete`) ERRORs on
+any `abi_compare` parameter absent from `cli_options.MCP_CLI_NAME_MAP`**
+— the single source of truth reconciling every MCP param against its
+`compare` CLI flag. `MCP_CLI_NAME_MAP` (`cli_options.py:1651`) gains a
+new `"diagnostic_comparison": "--diagnostic-comparison"` row in this same
+phase; skipping it fails this CI gate the moment the parameter lands, not
+as a follow-up cleanup. **`appcompat.py` is a
 third, independent instance of this exact bypass, not covered by fixing
 `CompareRequest`/`run_compare_request` or `mcp_server.py` alone — verified
 against the actual code:** `check_appcompat` (`:1018`) and
@@ -1424,7 +1434,17 @@ for both functions, same as any other direct `compare_snapshots` caller
 that doesn't opt in — this phase documents that explicitly as these two
 functions' intended contract (in their docstrings) rather than leaving it
 implicit, closing the ambiguity Codex flagged rather than silently
-choosing one reading. `cli.py`
+choosing one reading. **`--diagnostic-comparison` is a new visible
+`compare` flag, and `compare` is already at its flag-budget ceiling —
+`tests/test_config_rebalance.py::TestFlagBudget` asserts visible flag
+count `<= COMPARE_FLAG_BUDGET`, currently exactly met, and
+`COMPARE_FLAG_BUDGET` is itself derived as
+`COMPARE_FLAG_BUDGET_BASE + len(COMPARE_FLAG_BUDGET_RAISES)` — every flag
+beyond the base needs its own ledger entry, not just a Click
+definition, or this test fails on the very PR that adds the flag.**
+`cli_options.py`'s `COMPARE_FLAG_BUDGET_RAISES` gains a new
+`"--diagnostic-comparison": "..."` entry (a short rationale, matching the
+style of every existing entry there) in this same change. `cli.py`
 (the `--diagnostic-comparison` flag definition and the new, distinct
 `not_comparable` exit `16` constant), **`cli_compare_helpers.py`** (the new
 `except (ProfileMismatchError, ScopeMismatchError)` branch around the real
@@ -1720,7 +1740,13 @@ own direct `compare_snapshots` call (bypassing `CompareRequest` entirely)
 got its own dedicated catch, not just the `diagnostic_comparison`
 parameter; and a second `abi_compare` test asserting
 `diagnostic_comparison=True` on the same mismatched pair returns a real
-tentative result instead; a `--diagnostic-comparison` end-to-end test asserting the report's
+tentative result instead; an **`MCP_CLI_NAME_MAP` completeness** test
+(already run by `tests/test_cli_contract.py::test_mcp_cli_name_map_complete`,
+extended to cover the new parameter, not a new test file) asserting
+`"diagnostic_comparison"` is present in `cli_options.MCP_CLI_NAME_MAP`
+mapped to `"--diagnostic-comparison"` — proving the `cli-contract`
+AI-readiness check stays green rather than ERROR-ing on the first PR that
+adds this parameter; a `--diagnostic-comparison` end-to-end test asserting the report's
 top-level `assurance` field is `"none"` and that no individual finding
 carries its own `assurance` value; a
 backward-compat test asserting a contract-less snapshot pair compares
@@ -1929,7 +1955,16 @@ above), added as one decorator in `cli_options.py` and applied at `dump`'s
 and `compare`'s existing declarations directly, not merely implied by
 registering a new command module — deliberately not named `--manifest`,
 which `@release_options` already registers on `compare` for the unrelated
-ADR-023 release manifest. `cli_resolve.py` (`_resolve_compare_snapshots`
+ADR-023 release manifest. **Both `--dump-manifest` and `--frontend-context`
+(below) are new visible `compare` flags, and `compare` is already at its
+flag-budget ceiling — `tests/test_config_rebalance.py::TestFlagBudget`
+fails the moment either lands without its own
+`COMPARE_FLAG_BUDGET_RAISES` ledger entry, the same gate Phase A's
+`--diagnostic-comparison` has to satisfy.** `cli_options.py`'s
+`COMPARE_FLAG_BUDGET_RAISES` gains two new entries in this phase —
+`"--dump-manifest": "..."` and `"--frontend-context": "..."` — each a
+short rationale in the style of the existing entries there.
+`cli_resolve.py` (`_resolve_compare_snapshots`
 and `_resolve_input` each gain the same manifest parameter, threaded
 through to `service.py`) and `service.py` (`resolve_input`/`run_dump` gain
 it too, the actual entry points into `dumper.py`) — see the dedicated
@@ -2072,7 +2107,12 @@ parameter, threaded into the `CompileContext` it builds — the single
 choke point `compare`/`dump`/`scan` all resolve through, so no
 `scan_engine.py` dump-call-site change is needed beyond this).
 
-**Tests.** Manifest parser unit tests (the invariant violation, duplicate
+**Tests.** A **flag-budget ledger** test (`tests/test_config_rebalance.py::TestFlagBudget`,
+already run, not a new test file) asserting `compare`'s visible flag
+count still passes `<= COMPARE_FLAG_BUDGET` once `--dump-manifest` and
+`--frontend-context` are both visible, proving `COMPARE_FLAG_BUDGET_RAISES`
+gained both ledger entries in this same phase rather than the flags
+landing unaccounted-for. Manifest parser unit tests (the invariant violation, duplicate
 TU names, unknown fields, relative-path resolution, `frontend_context`
 accepted/defaulted/rejected-when-invalid). A **Phase-B-only device
 rejection** test asserting a manifest declaring `frontend_context:

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -798,20 +798,42 @@ Implements ADR-050 D1 and D2.
   **both** sides carry one, two ordinary dumps would silently take the same
   code path as the intentionally-lenient mixed-pair case forever — a fully
   specified, fully inert gate.
-  **"Every dump" means every dump that actually ran an L2 header-AST
-  frontend — a symbols-only/binary-only dump (no `-H`/`--header`, no
-  manifest) attaches no `contract` at all, computed from nothing rather
-  than computed from unused inputs.** `profile_fingerprint` hashes the
-  resolved compiler/macros/`-I` inputs an actual castxml/clang invocation
-  used; a symbols-only dump never runs one, so those fields would describe
-  nothing the snapshot depends on. Attaching a fingerprint anyway (from
-  whatever compile-context flags happen to be set, used or not) would make
-  two genuinely comparable L0/binary-only snapshots spuriously mismatch on
-  compile-context differences that never affected either one — an
-  over-counting regression, not the under-counting bug this design
-  otherwise guards against. `contract` staying `None` here is not a gap in
-  the leniency rule below; it's that same rule correctly applying to the
-  one case where no L2 extraction ran on either side to disagree about.
+  **"Every dump" means every dump with at least one resolved input to
+  fingerprint — a symbols-only/binary-only dump (no `-H`/`--header`, no
+  manifest) attaches no `profile_fingerprint`, computed from nothing
+  rather than computed from unused inputs.** `profile_fingerprint` hashes
+  the resolved compiler/macros/`-I` inputs an actual castxml/clang
+  invocation used; a symbols-only dump never runs one, so those fields
+  would describe nothing the snapshot depends on. Attaching a fingerprint
+  anyway (from whatever compile-context flags happen to be set, used or
+  not) would make two genuinely comparable L0/binary-only snapshots
+  spuriously mismatch on compile-context differences that never affected
+  either one — an over-counting regression, not the under-counting bug
+  this design otherwise guards against.
+  **But `--public-header`/`--public-header-dir` are still real, active
+  inputs on a symbols-only dump — `dump()` calls
+  `apply_provenance(snapshot, public_headers, public_header_dirs)`
+  unconditionally at the end of every dump (`dumper.py:1267-1272`),
+  regardless of whether an L2 frontend ran, feeding the `ScopeOrigin`
+  tags `--scope-public-headers` filtering (ADR-024) reads at diff time.**
+  Two symbols-only dumps of otherwise-identical DWARF data but different
+  `--public-header-dir` sets can produce genuinely different *filtered*
+  diffs — exactly the scope drift D1/D2 exist to catch — so the two
+  fingerprints are independently optional, not an all-or-nothing pair: a
+  symbols-only dump attaches a `contract` with `profile_fingerprint: None`
+  but a real `scope_fingerprint` (computed from
+  `public_header_paths`/`public_header_dirs` alone) whenever either is
+  non-empty. Only a symbols-only dump with *neither* `-H` nor
+  `--public-header`/`--public-header-dir` attaches no `contract` at all —
+  that narrower case is not a gap in the leniency rule below; it's that
+  same rule correctly applying to the one case where no scope-affecting
+  input ran on either side to disagree about. `check_contracts_comparable`
+  compares each fingerprint independently (below), so a symbols-only side
+  with only a `scope_fingerprint` compared against a full L2 side (which
+  has both) still gets its scope checked without spuriously hard-failing
+  on `profile_fingerprint` alone — an ordinary depth difference (e.g.
+  `scan --depth binary` against a fuller stored baseline), not scope
+  drift.
 - **The whole-snapshot cache is the same bypass by a different route — this
   phase closes it too, not just Phase E's later cache-key work.**
   `service_dump_cache.cached_run_dump` looks up `snapshot_cache` *before*
@@ -881,15 +903,24 @@ Implements ADR-050 D1 and D2.
   hard-rejection threshold, from either direction of the running/
   snapshot version pair, becomes a hard failure (ADR-050 D1).
 - `comparability.check_contracts_comparable(old, new)` raises
-  `ProfileMismatchError`/`ScopeMismatchError` (`errors.py`) **only when
-  both sides carry a `contract`** and the fingerprints differ. A **mixed**
-  pair (one side has a `contract`, the other doesn't) is unambiguous, not
-  an implementer's judgment call: it takes the exact same code path as a
-  pair where neither side has one — never hard-fails, never becomes
-  `not_comparable` — so comparing a freshly-produced snapshot against a
-  pre-ADR stored CI baseline (a common real workflow) never regresses on
-  upgrade — **including under strict severity settings, not only the
-  default ones.**
+  `ProfileMismatchError` **only when both sides have a non-`None`
+  `profile_fingerprint`** and it differs, and raises `ScopeMismatchError`
+  **only when both sides have a non-`None` `scope_fingerprint`** and it
+  differs — each fingerprint gated independently, not `contract` treated
+  as one opaque all-or-nothing unit (D1's symbols-only-with-provenance
+  case attaches a `contract` with `profile_fingerprint: None` but a real
+  `scope_fingerprint`, so the two genuinely need independent gating, not
+  just a `contract is None` check). A **mixed** pair on a given
+  fingerprint (one side has it, the other doesn't — whether because it
+  lacks `contract` entirely, or because that one field is unset) is
+  unambiguous, not an implementer's judgment call: it takes the exact same
+  code path as a pair where neither side has that fingerprint — never
+  hard-fails on it, never becomes `not_comparable` because of it — so
+  comparing a freshly-produced snapshot against a pre-ADR stored CI
+  baseline, or a symbols-only side against a full-header-AST side, never
+  regresses into an unexpected `not_comparable` result on a fingerprint
+  neither side (or only one side) ever had — **including under strict
+  severity settings, not only the default ones.**
 - **`UNKNOWN_PROFILE` is report-level metadata, not a `ChangeKind`/`Change`
   finding — this took two wrong designs to converge on, worth getting
   right the first time here.** Classifying it `RISK_KINDS` (matching
@@ -1663,14 +1694,28 @@ ran).
 returns a snapshot with a populated, non-`None` `contract` — the specific
 gap that would otherwise leave the gate permanently inert. A companion
 **symbols-only no-contract** test asserting a symbols-only dump (no
-`-H`/`--header`, no manifest) returns a snapshot with `contract is None`,
+`-H`/`--header`, no manifest, **and no `--public-header`/
+`--public-header-dir`**) returns a snapshot with `contract is None`,
 and that comparing two such symbols-only snapshots produced under
 genuinely *different*, but entirely unused, compile-context flags
 (different `--gcc-path`/`--gcc-options`, neither ever invoking an L2
 frontend) leaves the pair comparable — never raising
 `ProfileMismatchError` on compile-context differences that never affected
 either snapshot, the specific over-counting regression this exemption
-exists to prevent. A **warm-cache**
+exists to prevent. A **symbols-only scope-fingerprint** test asserting a
+symbols-only dump given `--public-header-dir` (still no `-H`/manifest)
+returns a snapshot with `contract.profile_fingerprint is None` but a real,
+non-`None` `contract.scope_fingerprint`, and that comparing two such
+symbols-only snapshots built from otherwise-identical DWARF data but
+*different* `--public-header-dir` sets raises `ScopeMismatchError` — the
+specific under-counting gap this fix closes, `apply_provenance` running
+unconditionally even with no L2 frontend (`dumper.py:1267-1272`) — plus a
+companion assertion that comparing that same symbols-only-with-
+`--public-header-dir` snapshot against a full `-H` header-AST snapshot of
+the identical library does **not** raise `ProfileMismatchError` (only one
+side has a `profile_fingerprint` to compare), proving the per-fingerprint
+gate stays lenient on an ordinary depth difference while still checking
+scope. A **warm-cache**
 regression test: seed `snapshot_cache` with a pre-bump-version entry (no
 `contract`), call `cached_run_dump` for the same inputs post-bump, and
 assert it misses and rebuilds with `contract` populated rather than

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -312,6 +312,28 @@ Implements ADR-050 D1 and D2.
   `-I` directory contains it — one extra cheap compiler flag per TU,
   reusing a proven parser at a new call site, not a second compiler
   invocation or a directory-tree walk.
+  **Project-ownership isn't only a declared-`-I`-directory concept — a
+  declared header's own parent directory is implicitly project-owned too,
+  with no `--include` needed, or the single most common workflow
+  (header-only, no `-I`) reintroduces this whole fix's bug.** The
+  preprocessor resolves a quote-include (`#include "detail.h"`) by first
+  searching the *including file's own directory*, independent of any `-I`
+  flag — standard behavior, no compiler option required. A side declared
+  with only `--header old/include/foo.h` (no `--include` at all) still has
+  `foo.h`'s own directory searched for its quote-includes; if `foo.h`
+  `#include`s a private `detail.h` from that same directory, the depfile
+  lists it under `old/include/`, but no `-I` directory was ever declared
+  there for the ancestor rule to classify. Unhandled, this path falls
+  through to "not under any declared `-I` directory" (the system/toolchain
+  bucket below) and gets full content hashing, so an ordinary edit to
+  `detail.h` flips `profile_fingerprint` on the single most common compare
+  shape (headers only, no explicit `-I`), not an edge case. The
+  ownership predicate therefore also treats the **parent directory of
+  every declared `--header`/manifest TU path** as an implicitly
+  project-owned root, whether or not that directory is separately passed
+  via `--include` — the same whole-directory exclusion the explicit
+  ancestor rule already applies, just triggered by a header's own
+  location instead of a declared `-I` flag.
   **Not every `-MD`-listed path falls under a declared `-I` directory.**
   `dumper.py` already introduces search paths outside the user-declared
   `includes` list: `--sysroot`, the GNU-toolchain `-isystem` dirs it probes
@@ -568,7 +590,7 @@ Implements ADR-050 D1 and D2.
   the manifest file's own directory — none of these legacy-CLI cases
   exist there.
 
-  Fifteen dedicated tests (numbered 1–14, with 8b alongside 8) are non-negotiable for this phase to be considered
+  Sixteen dedicated tests (numbered 1–14, with 8b and 8c alongside 8) are non-negotiable for this phase to be considered
   done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
   identical trees under different roots asserts the resulting
   **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
@@ -618,7 +640,17 @@ Implements ADR-050 D1 and D2.
   matching, proving the exclusion covers the *whole* project-owned `-I`
   directory, not only the explicitly-named header; excluding only the
   named file would still hash `detail.h`'s change and spuriously
-  hard-fail this routine internal-refactor case; (9) a header reached only through a
+  hard-fail this routine internal-refactor case; (8c) the same shape as
+  (8b), but **no `--include` is declared at all** — `--header
+  old/include/foo.h --header new/include/foo.h`, nothing else — and
+  `foo.h` quote-includes a private `detail.h` from its own directory,
+  resolved purely by the preprocessor's implicit same-directory search
+  (no `-I` naming `include/` anywhere); an edit confined to `detail.h`
+  still leaves `profile_fingerprint` matching, proving the parent
+  directory of a declared header is implicitly project-owned even with
+  zero `--include` flags — the single most common compare shape, and the
+  specific case (8)/(8b)'s explicit-`--include` fixtures don't exercise;
+  (9) a header reached only through a
   system/`-isystem`-classified include path (not a plain user `-I`) with
   genuinely different content between old and new produces *different*
   `profile_fingerprint`s — proving the depfile request uses `-MD`, not
@@ -2310,12 +2342,23 @@ needed, so it genuinely can feed the cache key pre-dump. The scheduling
 half depends on Phase B too (the per-TU loop it schedules).
 
 **Goal & acceptance criteria.**
-- The RAM-probing/pool-sizing helper in `buildsource/source_replay.py` is
+- **The scheduler targets `dumper_manifest.py`'s per-TU loop, not
+  `dumper.py`'s — Phase B already moved that loop out, and this phase
+  must not point at where it used to live.** Phase B's own acceptance
+  criteria (above) put the per-TU invocation loop and `TuFragment`
+  handling in a new `abicheck/dumper_manifest.py` specifically because
+  `dumper.py` is already at its 2000-line file-size cap with no headroom;
+  `dumper.py` itself keeps only a thin manifest-vs.-single-TU dispatch.
+  Following an unrevised "`dumper.py`'s per-TU loop" instruction here
+  would mean either scheduling a loop that no longer exists in that file,
+  or adding the scheduler back into the capped file and re-tripping the
+  same file-size gate Phase B's split exists to avoid. The RAM-probing/
+  pool-sizing helper in `buildsource/source_replay.py` is
   factored out into new leaf module `abicheck/process_resources.py`; both
-  `source_replay.py` and `dumper.py`'s per-TU loop import it — one
+  `source_replay.py` and `dumper_manifest.py`'s per-TU loop import it — one
   implementation, not two, per AGENTS.md's own import-cycle guidance ("move
   shared logic to a leaf module both sides can depend on").
-- `dumper.py`'s per-TU castxml/clang invocations (Phase B) run under this
+- `dumper_manifest.py`'s per-TU castxml/clang invocations (Phase B) run under this
   pool instead of a fully sequential loop; a killed/timed-out TU records
   its exit signal and never silently retries as a clean empty TU.
 - **`profile_fingerprint` itself cannot be a cache-key input — this phase
@@ -2352,19 +2395,42 @@ half depends on Phase B too (the per-TU loop it schedules).
   genuinely is available before `dump()` runs; `snapshot_cache.py`'s
   `_cache_key()` (`:130`) hashes the **full computed `scope_fingerprint`**
   for a manifest-driven dump (TU names, per-TU ordered includes/
-  forced-includes, and the `contributes_to_abi`/`required` flags together,
-  not any one piece in isolation), closing the whole class of
+  forced-includes, the `contributes_to_abi`/`required` flags, **and each
+  `includes` entry's `project_owned` bit** — the mapping form
+  `{path: ..., project_owned: true}` a sibling support root uses —
+  together, not any one piece in isolation), closing the whole class of
   pre-dump-knowable manifest drift `iter_cache_header_files`'s
-  filesystem-content walk structurally cannot see.
+  filesystem-content walk structurally cannot see. `project_owned` needs
+  its own key material specifically because toggling it on an otherwise
+  unchanged path changes neither the file's content/mtime nor any of the
+  other hashed fields — without it, a warm cache could still serve a
+  `contract.profile_fingerprint` computed under the previous ownership
+  predicate after a manifest edit that only flipped this one bit, the
+  same class of gap already closed for the legacy CLI's labeled
+  `--include` form.
 
 **Files & surfaces.** New `abicheck/process_resources.py`,
 `buildsource/source_replay.py` (import from it instead of its own inline
-implementation), `dumper.py` (per-TU pool), `snapshot_cache.py`
+implementation), `abicheck/dumper_manifest.py` (per-TU pool — not
+`dumper.py`, which only holds the thin dispatch after Phase B's split),
+`snapshot_cache.py`
 (`_cache_key` gains the full computed `scope_fingerprint` — TU names,
 per-TU ordered includes/forced-includes, and `contributes_to_abi`/
-`required` flags together — as an additional key input for manifest-driven
+`required` flags together, **plus each `includes` entry's `project_owned`
+bit** (Phase B's manifest mapping form, `{path: ..., project_owned: true}`)
+— as an additional key input for manifest-driven
 dumps; still never `profile_fingerprint`, which cannot be a pre-dump input
-at all, per the bullet above).
+at all, per the bullet above). **The `project_owned` bit needs its own key
+material, not just the path it's attached to — verified this was missing:
+toggling it on an unchanged file changes neither the file's content/mtime
+nor (per the field list above, before this fix) anything `_cache_key()`
+already hashes, so a warm cache could serve a `contract.profile_fingerprint`
+computed under the previous ownership predicate even after a manifest
+edit that only flipped this one flag.** This is the identical class of gap
+already found and fixed for the legacy CLI's `--project-include`/labeled
+`--include` label (Phase A's cache-key bullet) — the manifest form of the
+same escape hatch needs the same treatment, just missed here when Phase B
+added it after this bullet was first written.
 **Modifying `_cache_key()`'s own internals is not sufficient — the caller
 that decides what to pass it never sees the manifest today.**
 `service_dump_cache.cached_run_dump` is what actually builds the pre-dump
@@ -2390,7 +2456,13 @@ order* (same files, reordered) ⇒ cache miss; identical TUs and flags,
 differing only one TU's *name* ⇒ cache miss — the three independent
 components of the pre-dump-knowable gap this phase closes,
 distinct from Phase A's already-completed order-sensitivity and
-whole-snapshot-cache-version fixes.
+whole-snapshot-cache-version fixes. A fourth, **`project_owned`
+cache-key** test: identical manifest TU includes and flags, differing
+only one `includes` entry's `project_owned` bit (`true` on one call,
+`false`/absent on the next, same unchanged path) ⇒ cache miss — proving
+the bit is its own key material, not silently absorbed into content/mtime
+hashing (which can't see it) or any of the three fields above (none of
+which change when only this bit does).
 
 **Out of scope.** No new scheduling *policy* — this phase ports the
 existing, already-proven `source_replay.py` policy verbatim; a different

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -275,28 +275,42 @@ Implements ADR-050 D1 and D2.
   so it's structurally unreachable by severity promotion rather than
   merely unreachable by the flags checked so far.
 - **The exit code is part of the published contract too, not an
-  afterthought — and it must be a pinned value, not "a new code TBD."**
-  `docs/reference/exit-codes.md` documents two co-existing `compare`
-  schemes (legacy: 0/2/4; severity-aware: 0/1/2/4) where `0`
-  means *compatible* in both. `not_comparable` must never exit `0` in
-  either scheme — otherwise the exact "missing evidence reads as safe"
-  failure this ADR exists to prevent reappears at the process-exit
-  boundary, undoing the JSON-level fix. This phase reserves exit code
-  **`8`** — identical in both schemes, since `not_comparable` fires before
-  severity classification ever runs — continuing the existing power-of-two
-  pattern, and adds it as its own row to both tables in
-  `docs/reference/exit-codes.md`, not folded into either scheme's existing
-  numbering. `8` is unused in `compare`'s own exit-code space today (which
-  tops out at `4` in both schemes).
+  afterthought — and it must be a pinned, actually-free value, not "a new
+  code TBD."** `docs/reference/exit-codes.md` documents two co-existing
+  single-library `compare` schemes (legacy: 0/2/4; severity-aware:
+  0/1/2/4) where `0` means *compatible* in both, **plus a separate
+  release/multi-library table** (directory/package inputs) that already
+  uses `0/2/4/8` — `8` is `--fail-on-removed-library`
+  (`docs/reference/exit-codes.md:134-139`), not free. `not_comparable`
+  must never exit `0` in either single-library scheme — otherwise the
+  exact "missing evidence reads as safe" failure this ADR exists to
+  prevent reappears at the process-exit boundary, undoing the JSON-level
+  fix. This phase reserves exit code **`16`** (not `8` — that collides
+  with the release table's existing removed-library code, a mistake an
+  earlier draft of this criterion made by checking only the two
+  single-library tables) — identical across all three tables, since
+  `not_comparable` fires before severity classification or the
+  removed-library check ever run — continuing the doubling pattern the
+  existing codes already use, and adds it as its own row to all three
+  tables in `docs/reference/exit-codes.md`, not folded into any existing
+  scheme's numbering.
 - **Release-level (directory/package) aggregation gets an explicit
-  precedence, not an implied one.** `cli_compare_release_helpers.py`'s
+  precedence against *two* existing mechanisms, not one.**
+  `cli_compare_release_helpers.py`'s
   `_RELEASE_VERDICT_ORDER` (currently `NO_CHANGE` < `COMPATIBLE` <
   `COMPATIBLE_WITH_RISK` < `API_BREAK` < `BREAKING` < `ERROR`, rank 5 as
   the ceiling) gains `not_comparable` at rank 6, above `ERROR` — a
   correctly-diagnosed `not_comparable` result carries less trustworthy
   information about a library than even a partial `ERROR`, so it
   dominates the release-level "worst verdict wins" rollup over every other
-  outcome in the same release, including a genuine crash. This is what
+  outcome in the same release, including a genuine crash. It also
+  dominates the separate `--fail-on-removed-library` mechanism
+  **unconditionally, in both schemes** — unlike that mechanism's own
+  existing scheme-dependent precedence against `ERROR`/`2`/`4`: a
+  `not_comparable` result means the comparison couldn't establish what
+  changed at all, so an apparent "library removed" reading from an
+  incomparable pair is an unproven inference, not a real removal finding
+  entitled to its own exit code. This is what
   makes the release fan-out fix (below) actually surface at the release
   level instead of being computed per-library and then silently
   outranked.
@@ -428,7 +442,7 @@ against the updated `compare_report.schema.json`, and its existing
 regenerated `docs/schemas/v1` copy; a root-relative-path fingerprint test
 (the acceptance-criteria bullet above — same-tree-different-root compare
 must not fingerprint-mismatch); an exit-code test
-asserting `not_comparable` returns exactly `8`, never `0`, from
+asserting `not_comparable` returns exactly `16`, never `0`, from
 both the legacy and severity-aware `compare` invocations; a **release
 fan-out** test asserting a `not_comparable`-triggering library inside a
 directory/package `compare` reports `verdict: "not_comparable"` in its
@@ -438,7 +452,13 @@ its fourth entry point; a **release-precedence** test asserting a mixed
 release (one `not_comparable` library, one `BREAKING`, N `COMPATIBLE`)
 reports and exits as `not_comparable` overall, proving
 `_RELEASE_VERDICT_ORDER`'s new rank actually wins the rollup rather than
-being silently outranked by the co-occurring `BREAKING`; gate unit tests
+being silently outranked by the co-occurring `BREAKING`; a
+**removed-library-precedence** test asserting a release combining a
+`not_comparable` library with a separately-removed library (triggering
+`--fail-on-removed-library`) exits `16`, not `8`, in *both* the legacy and
+severity-aware release schemes — proving `not_comparable`'s precedence
+over the removed-library mechanism is unconditional, unlike that
+mechanism's own existing scheme-dependent precedence; gate unit tests
 for all
 four entry points; a `--diagnostic-comparison` end-to-end test; a
 backward-compat test asserting a contract-less snapshot pair compares

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -213,14 +213,27 @@ Implements ADR-050 D1 and D2.
   dependency-content difference expressed only through such a header —
   the same "gap through under-counting" this whole redesign exists to
   close, reintroduced one level deeper. The digest is instead built the
-  same way `abicheck/buildsource/include_graph.py`'s existing `-MM`/`-MMD`
-  depfile mechanism already builds the L3 include graph (`parse_depfile()`,
-  a pure, already-unit-tested Make-rule-depfile parser): the L2
-  castxml/clang invocation additionally requests a depfile (`-MMD -MF
-  <path>`) alongside the AST dump, and every listed path is attributed to
-  whichever declared `-I` directory contains it — one extra cheap compiler
-  flag per TU, reusing a proven parser at a new call site, not a second
-  compiler invocation or a directory-tree walk. `profile_fingerprint`'s
+  same way `abicheck/buildsource/include_graph.py`'s existing depfile
+  mechanism already builds the L3 include graph (`parse_depfile()`, a pure,
+  already-unit-tested Make-rule-depfile parser), **using the same
+  system-inclusive flag that module already had to learn to use, for the
+  same reason:** the L2 castxml/clang invocation additionally requests a
+  depfile via **`-MD -MF <path>`, not `-MMD`** — `-MD` lists
+  system-classified headers (reached via `-isystem`/the sysroot/standard
+  library) alongside user headers, while `-MMD` silently omits them.
+  `include_graph.py:354-356` already documents exactly this precedent ("`-M`
+  (not `-MM`) so depfiles include *system*-classified headers"), added
+  after an earlier review caught the identical omission there. `-MMD` here
+  would reintroduce that same bug on a new path: a header reached only
+  through a system/sysroot include (a libstdc++ upgrade changing an
+  ABI-relevant macro, for instance) would never appear in the depfile, so
+  two dumps that actually parsed different system-resolved headers could
+  still match `profile_fingerprint` — the exact under-counting failure this
+  redesign exists to close, via a flag choice this time instead of a
+  data-source choice. Every listed path is attributed to whichever declared
+  `-I` directory contains it — one extra cheap compiler flag per TU,
+  reusing a proven parser at a new call site, not a second compiler
+  invocation or a directory-tree walk. `profile_fingerprint`'s
   `-I` component is the hash of the **ordered** sequence of per-directory
   digests — **after excluding every path `scope_fingerprint` already
   covers for that side (the explicit `--header`/manifest TU entry points),
@@ -253,7 +266,7 @@ Implements ADR-050 D1 and D2.
   the manifest file's own directory — none of these legacy-CLI cases
   exist there.
 
-  Eight dedicated tests are non-negotiable for this phase to be considered
+  Nine dedicated tests are non-negotiable for this phase to be considered
   done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
   identical trees under different roots asserts the resulting
   **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
@@ -295,7 +308,15 @@ Implements ADR-050 D1 and D2.
   the diff reports the parameter addition as an ordinary `Change` —
   `not_comparable` never fires on the routine case of "the thing being
   compared changed," which is this whole tool's primary purpose, not an
-  edge case to special-case around.
+  edge case to special-case around; (9) a header reached only through a
+  system/`-isystem`-classified include path (not a plain user `-I`) with
+  genuinely different content between old and new produces *different*
+  `profile_fingerprint`s — proving the depfile request uses `-MD`, not
+  `-MMD`, since `-MMD` would omit a system-classified header from its
+  output entirely and silently miss this difference, the exact regression
+  `include_graph.py:354-356` already had to fix once for the L3 include
+  graph and this digest must not reintroduce on its own, separate call
+  site.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -539,6 +560,25 @@ Implements ADR-050 D1 and D2.
 - Reporting: `reporter.py`/`sarif.py`/`junit_report.py` gain a
   `not_comparable` top-level result distinct from every existing verdict
   value — never coerced into `compatible`/`breaking`.
+- **`abicheck aggregate` consumes these reports in CI and has its own blind
+  spot this phase must close, not just the commands that produce them.**
+  `aggregate.py:589-596`'s `parse_report_verdict` returns `None` whenever
+  `verdict` isn't a string — true for `verdict: null` by design, but also
+  true for a missing or corrupt report, and today nothing distinguishes
+  the two: both become the same `compatibility_verdict=None`/"unavailable"
+  `TargetReport`. Verified against the actual code: in **discovered-only**
+  mode, `coverage_blocking` is unconditionally `False`
+  (`aggregate.py:406-410`, `and not self.discovered_only`), and an
+  unavailable target's `gate` is `None`, so it contributes nothing to
+  `exit_code()`'s `max(...)` — a `not_comparable` target can silently
+  reduce the whole aggregate run to exit `0`, resurfacing the "missing
+  evidence reads as safe" failure this ADR exists to prevent, at the one
+  consumer surface untouched so far. `aggregate.py` gains a way to tell a
+  deliberate `not_comparable` report (its `reason` object is present) from
+  a genuinely missing/corrupt one, and folds it into `exit_code()` as an
+  unconditionally blocking contribution — regardless of `discovered_only`,
+  matching the same precedence `_RELEASE_VERDICT_ORDER`'s rank-6 entry
+  already gives `not_comparable` in the release rollup.
 - **`html_report.py`/`service_render.py` are the fourth reporting surface,
   not an optional add-on.** AGENTS.md's own module map groups `html_report.py`
   with `reporter.py`/`sarif.py`/`junit_report.py` under "Reporting," and
@@ -622,11 +662,11 @@ Implements ADR-050 D1 and D2.
 the gate, and `contract_coverage` metadata computation — no detector, since
 `UNKNOWN_PROFILE` is report metadata, not a `Change`; reuses
 `abicheck/buildsource/include_graph.py`'s existing `parse_depfile()` to turn
-a per-TU `-MMD` depfile into the per-`-I`-directory resolved-file lists
-`profile_fingerprint` hashes — see the acceptance-criteria bullet above),
-`dumper_castxml.py`/`dumper_clang.py` (request a depfile alongside the AST
-dump for every L2 invocation, not only when `buildsource` L3 evidence is
-also being collected), `dumper.py` (`dump()`
+a per-TU `-MD` depfile (system-inclusive, never `-MMD` — see the
+acceptance-criteria bullet above) into the per-`-I`-directory resolved-file
+lists `profile_fingerprint` hashes), `dumper_castxml.py`/`dumper_clang.py`
+(request a `-MD` depfile alongside the AST dump for every L2 invocation, not
+only when `buildsource` L3 evidence is also being collected), `dumper.py` (`dump()`
 calls `compute_extraction_contract(...)` and attaches it to every returned
 snapshot — see the acceptance-criteria bullet above; this is not optional
 plumbing), `snapshot_cache.py` (`_SNAPSHOT_CACHE_VERSION` bump and the
@@ -678,7 +718,11 @@ stale the same day), `reporter.py`,
 path instead of calling it with no `DiffResult`), `abicheck/schemas/compare_report.schema.json`,
 `abicheck/schemas/__init__.py` (`REPORT_SCHEMA_VERSION` bump),
 `docs/schemas/v1/compare_report.schema.json` (regenerated via
-`scripts/publish_schemas.py`, not hand-edited).
+`scripts/publish_schemas.py`, not hand-edited), `aggregate.py`
+(`parse_report_verdict`/`GateInfo`/`TargetReport` gain a way to
+distinguish a deliberate `not_comparable` report from a missing/corrupt
+one, and `exit_code()`/`coverage_blocking` treat it as unconditionally
+blocking, independent of `discovered_only`).
 
 **Tests.** A `dump()`-level test asserting a real (non-manifest) dump
 returns a snapshot with a populated, non-`None` `contract` — the specific
@@ -771,7 +815,12 @@ comparison run under *every* `--severity-*` flag (`--severity-potential-breaking
 `--severity-quality-issues=error`, and `--severity-preset strict`) still
 exits successfully — proving `contract_coverage` is structurally outside
 the findings list any severity flag scans, not merely untested against the
-one flag checked last time.
+one flag checked last time; an **aggregate not_comparable** test asserting
+`abicheck aggregate` in **discovered-only** mode exits non-zero when one
+target's report is `not_comparable` — never silently `0` — and a second
+test asserting a `not_comparable` report is never conflated with a
+genuinely missing/corrupt one in `aggregate`'s rendered per-target output,
+proving the two "unavailable"-shaped states stay distinguishable.
 
 **Example fixtures.** The Phase 0 "scope drift" pair stays a `tests/`-level
 fixture, not an `examples/case*/` catalog entry: `tests/test_validate_examples_unit.py`'s
@@ -1123,27 +1172,44 @@ scheduling half depends on Phase B too (the per-TU loop it schedules).
   `profile_fingerprint` itself, which must be exact or the gate spuriously
   fires. Phase A's own order-sensitivity fix (dropping `sorted(...)` for
   `headers`/`includes`) already closes the remaining gap that mattered for
-  the legacy CLI path. `snapshot_cache.py`'s `_cache_key()` (`:130`)
-  instead gains the manifest-driven `scope_fingerprint` inputs that
-  genuinely are pre-dump-knowable and that `iter_cache_header_files`'s
-  filesystem walk has no way to see, since they aren't file content at
-  all: a TU's `contributes_to_abi`/`required` flags (D3/D4) — flipping
-  either changes which declarations feed the ABI model without necessarily
-  touching any file content, so today's content-hash-only key would miss
-  that class of drift on a manifest-driven dump.
+  the legacy CLI path.
+  **For the manifest-driven path, the cache key must cover the full
+  normalized manifest scope, not a hand-picked subset of it.** An earlier
+  revision of this bullet keyed only on a TU's `contributes_to_abi`/
+  `required` flags — too narrow: `scope_fingerprint`'s own definition (D1)
+  also covers each TU's *name* and its *ordered* `includes`/
+  `forced_includes`, and reordering a TU's includes, changing its
+  forced-includes, or renaming a TU changes extraction semantics (and
+  `scope_fingerprint` itself) without necessarily touching any flag or any
+  file's content — a gap the flags-only key would miss exactly like the
+  content-hash-only key missed the flags. `scope_fingerprint` is fully
+  determined by parsing and normalizing the manifest document — no
+  compiler invocation needed — so, unlike `profile_fingerprint`, it
+  genuinely is available before `dump()` runs; `snapshot_cache.py`'s
+  `_cache_key()` (`:130`) hashes the **full computed `scope_fingerprint`**
+  for a manifest-driven dump (TU names, per-TU ordered includes/
+  forced-includes, and the `contributes_to_abi`/`required` flags together,
+  not any one piece in isolation), closing the whole class of
+  pre-dump-knowable manifest drift `iter_cache_header_files`'s
+  filesystem-content walk structurally cannot see.
 
 **Files & surfaces.** New `abicheck/process_resources.py`,
 `buildsource/source_replay.py` (import from it instead of its own inline
 implementation), `dumper.py` (per-TU pool), `snapshot_cache.py`
-(`_cache_key` gains the manifest's per-TU `contributes_to_abi`/`required`
-flags as additional key inputs — not `profile_fingerprint`/
-`scope_fingerprint` themselves).
+(`_cache_key` gains the full computed `scope_fingerprint` — TU names,
+per-TU ordered includes/forced-includes, and `contributes_to_abi`/
+`required` flags together — as an additional key input for manifest-driven
+dumps; still never `profile_fingerprint`, which cannot be a pre-dump input
+at all, per the bullet above).
 
 **Tests.** `process_resources.py` unit tests migrated from
 `source_replay.py`'s existing RAM-probing tests (same behavior, new import
-path — a refactor test, not new coverage). Cache-key test: identical
+path — a refactor test, not new coverage). Cache-key tests: identical
 manifest TU includes, differing only a TU's `contributes_to_abi` flag ⇒
-cache miss — the specific pre-dump-knowable gap this phase closes,
+cache miss; identical TUs and flags, differing only one TU's *include
+order* (same files, reordered) ⇒ cache miss; identical TUs and flags,
+differing only one TU's *name* ⇒ cache miss — the three independent
+components of the pre-dump-knowable gap this phase closes,
 distinct from Phase A's already-completed order-sensitivity and
 whole-snapshot-cache-version fixes.
 

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -105,15 +105,26 @@ real data.
 
 **Files & surfaces.** New fixtures under `tests/fixtures/g32/` (raw AST
 captures, not committed as generated `.abi.json` — those are produced by
-the tests themselves once Phase A/B land). These stay `tests/`-level
-fixtures throughout, not a future `examples/case2xx_*/` catalog entry:
-`not_comparable` (Phase A), `UNKNOWN_PROFILE`/`contract_coverage` metadata
-(Phase A), and `INCONSISTENT_DECLARATION`/`HETEROGENEOUS_ABI_CONTEXT`
-(Phase C) are all extraction-time outcomes, not `ChangeKind`s or `Verdict`
-values — `tests/test_validate_examples_unit.py`'s `_VALID_VERDICTS`
-frozenset only accepts the five real `Verdict` strings, so none of this
-phase's fixtures ever becomes a catalogued example (see Phase A's and
-Phase C's own "Example fixtures" sections for the same reasoning).
+the tests themselves once Phase A/B land).
+**Not every Phase 0 fixture is a `tests/`-only artifact — only the ones
+whose *outcome* is genuinely non-verdict-producing are.** The "scope drift"
+pair (Phase A's `not_comparable`/`SCOPE_MISMATCH`) and the
+conflicting-return-type pair (Phase C's `INCONSISTENT_DECLARATION`/
+`HETEROGENEOUS_ABI_CONTEXT`) are extraction-time outcomes, not `ChangeKind`s
+or `Verdict` values — `tests/test_validate_examples_unit.py`'s
+`_VALID_VERDICTS` frozenset only accepts the five real `Verdict` strings,
+so *these two specifically* never become catalogued examples (see Phase
+A's and Phase C's own "Example fixtures" sections for the same reasoning).
+The **ODR-safe** pair's compatible-merge half is different: it produces an
+ordinary, verdict-bearing comparison once Phase C's real merge lands, and
+is exactly what becomes `examples/case2xx_multi_tu_compatible_merge/`
+(Phase C's own "Example fixtures" section) — it is not swept into this
+tests-only rule. The DPC++/plain-clang AST captures aren't diff fixtures at
+all (they feed Phase D's parser directly), so the examples-catalog
+question doesn't apply to them either way. The external-STL-noise pair is
+wired through Phase B's real manifest path (see Phase B's own "Example
+fixtures" section) as a `tests/`-level check of the supporting-vs-reportable
+merge boundary, with no catalog promotion currently planned for it.
 
 **Tests.** No new production tests yet — this phase is fixture capture and
 a short `tests/test_g32_fixtures.py` asserting the fixtures are non-empty
@@ -1028,9 +1039,20 @@ Implements ADR-050 D3. The highest-risk phase — see Risk above.
   diagnostic command (same flag spelling, for consistency — `plan` is a new
   command so `--manifest` wouldn't itself collide there, but using two
   different names for the same concept across sibling commands would be its
-  own inconsistency) that prints the normalized manifest and both D1
-  fingerprints without running extraction — cheap to run in CI before
-  committing to a full dump.
+  own inconsistency) that prints the normalized manifest and its
+  **`scope_fingerprint`** — genuinely computable from the manifest document
+  alone, no compiler invocation needed (established in Phase E's cache-key
+  discussion) — without running extraction. **It does not print
+  `profile_fingerprint`**: that fingerprint's `-I` component is a
+  `-MD`-depfile digest (Phase A) that only exists once an L2 castxml/clang
+  invocation actually runs, so promising it here would either be
+  impossible to compute honestly or require inventing a pre-extraction
+  surrogate the compare gate would later have to treat as authoritative —
+  exactly the kind of guessed value this ADR's whole design exists to
+  avoid. `plan --dump-manifest` is scoped to what's genuinely
+  pre-extraction-knowable — manifest validity and `scope_fingerprint` — cheap
+  to run in CI before committing to a full dump; a real `profile_fingerprint`
+  check still needs an actual `dump`/`compare` invocation.
 - **`--dump-manifest` must be side-scoped on `compare`, not a single shared
   path.** `dump` produces one snapshot from one manifest, so a bare
   `--dump-manifest path` is correct there. `compare OLD_INPUT NEW_INPUT` is
@@ -1107,7 +1129,8 @@ TU names, unknown fields, relative-path resolution, `frontend_context`
 accepted/defaulted/rejected-when-invalid). `dumper.py` multi-TU
 integration tests (`@pytest.mark.integration`, needs castxml/clang) using
 Phase 0's fixtures. A `plan --dump-manifest` unit test asserting it never
-invokes a compiler. A `--frontend-context` CLI-flag unit test for the legacy
+invokes a compiler and prints `scope_fingerprint` only — never a
+`profile_fingerprint` value, which would require one. A `--frontend-context` CLI-flag unit test for the legacy
 (non-manifest) path, mirroring the manifest-field test. A **side-scoped
 `compare --dump-manifest`** test asserting `compare old.so new.so
 --dump-manifest old=v1/abi.yml --dump-manifest new=v2/abi.yml` dumps each

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -93,8 +93,11 @@ real data.
   entity boundary at the merge layer (this boundary itself is ADR-024's, not
   new — the fixture just needs to exist for the merge tests to use it).
 - A "scope drift" fixture pair: same manifest structure, new side adds one
-  extra TU — used to assert Phase A's `SCOPE_MISMATCH` fires correctly and
-  that a *report-only* mode correctly demotes it instead of hard-failing.
+  extra TU — used to assert Phase A's gate hard-fails `not_comparable` on it
+  by default, and that the explicit `--diagnostic-comparison` opt-in (D2's
+  one sanctioned escape hatch, not a separate always-on report-only mode)
+  correctly downgrades it to a tentative, `assurance: "none"`-stamped diff
+  instead.
 
 **Files & surfaces.** New fixtures under `tests/fixtures/g32/` (raw AST
 captures, not committed as generated `.abi.json` — those are produced by

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -1,0 +1,337 @@
+# G32 — Comparability Contract: Profile/Scope Fingerprints and the Multi-TU Manifest
+
+**Origin:** A review of abicheck's snapshot architecture, prompted by a
+real multi-TU/DPC++ scenario (umbrella header + Arrow-derived adapter
+header needing its own forced include + SYCL host/device compilation
+split), found two unaddressed gaps: `dump()` collapses every requested
+header into one synthetic translation unit (no per-TU forced includes, no
+required-vs-optional TU semantics), and `checker.compare` has no gate that
+proves two snapshots were extracted under a comparable contract before
+running a symbol diff — a manifest/flag drift between two extraction runs
+today produces a page of false additions/removals instead of a clear
+"these two snapshots aren't comparable" result. Most of what the review
+also raised (public/private/external classification, deterministic
+serialization, content-hash caching, RAM-aware parallel extraction) turned
+out to already be shipped under different names — see ADR-049's Context
+for the full audit. This plan implements only the genuinely new decisions.
+
+**ADR:** [ADR-049](../adr/049-comparability-contract-and-multi-tu-manifest.md)
+(Proposed — records the target model; this plan carries the phased
+backlog).
+**Type:** Initiative plan (cross-cutting; spans `abicheck/model.py`,
+`abicheck/dumper.py`, `abicheck/checker.py`, `abicheck/service.py`,
+`abicheck/mcp_server.py`, `abicheck/cli.py`, `abicheck/snapshot_cache.py`,
+`abicheck/sycl_metadata.py`, `abicheck/buildsource/source_replay.py`, new
+top-level modules).
+**Effort:** Phase 0 — S. Phase A — M. Phase B — XL. Phase C — L. Phase D —
+L. Phase E — M. Total: XL, phased over multiple PRs.
+**Risk:** Phase 0 — low (fixtures only, no production code path changes).
+Phase A — low-medium (new gate at a well-defined entry point, additive
+fields, rollout behind report-only mode before hard-fail default — see
+Phase A below). Phase B — **high** — changes `dumper.py`'s single hottest
+path (every `dump`/`compare` call goes through it) from one frontend
+invocation to N. Phase C — medium (new merge surface, but scoped to
+data `dumper.py` produces, no external-tool dependency). Phase D — medium
+(needs a real captured DPC++ AST fixture before implementation can proceed
+safely — see Phase 0). Phase E — low (extends an already-proven pattern
+from `buildsource/source_replay.py`).
+
+---
+
+## Sequencing
+
+Phase 0 first, always — it is what makes Phase D (and to a lesser extent B)
+design-by-evidence instead of design-by-assumption, per the originating
+review's own strongest procedural point ("don't build a stream parser
+against a guessed format; capture the real thing first"). Phase A can ship
+and start providing value (as a report-only signal) independently of B–E —
+it does not require multi-TU support to be useful, since even today's
+single-aggregate-TU snapshots have a real, checkable `profile_fingerprint`.
+B, C, and D can proceed in parallel once Phase 0's fixtures exist (C
+depends on B landing first; D does not depend on B or C). E depends on A
+(needs the fingerprints to extend the cache key) and loosely on B (the
+per-TU loop it schedules); the cache-key half of E can land right after A
+without waiting for B if useful on its own.
+
+```
+Phase 0 (fixtures) ──┬──▶ Phase A (contract + gate) ──┬──▶ Phase E (scheduling + cache)
+                      │                                │
+                      ├──▶ Phase B (manifest/multi-TU) ─┴─▶ Phase C (compatible merge)
+                      │
+                      └──▶ Phase D (SYCL host/device context)
+```
+
+---
+
+## Phase 0 — Regression fixtures and example cases
+
+**Problem.** Every downstream phase needs ground truth to test against, and
+two of them (B's merge lattice, D's AST-context selection) are exactly the
+kind of thing that goes wrong when designed from a description instead of
+real data.
+
+**Goal & acceptance criteria.**
+- A real captured DPC++/`clang -ast-dump=json` multi-document output
+  fixture exists (from an actual `icpx`/DPC++ invocation, not synthesized),
+  alongside a plain single-context clang fixture for contrast.
+- A synthetic "ODR-safe" multi-TU fixture pair: one struct forward-declared
+  in TU A, fully defined in TU B (must merge cleanly); one function
+  declared with different return types across two TUs (must conflict).
+- An "external STL noise" fixture: a public function taking
+  `std::vector<int>` by value, to exercise D4's supporting-vs-reportable
+  entity boundary at the merge layer (this boundary itself is ADR-024's, not
+  new — the fixture just needs to exist for the merge tests to use it).
+- A "scope drift" fixture pair: same manifest structure, new side adds one
+  extra TU — used to assert Phase A's `SCOPE_MISMATCH` fires correctly and
+  that a *report-only* mode correctly demotes it instead of hard-failing.
+
+**Files & surfaces.** New fixtures under `tests/fixtures/g32/` (raw AST
+captures, not committed as generated `.abi.json` — those are produced by
+the tests themselves once Phase A/B land) and, once ChangeKinds exist
+(Phase A/C), `examples/case2xx_*/` per the standard example-catalog
+convention (`ground_truth.json` entry, `README.md`, AI-readiness
+`examples-ground-truth`/`examples-readme-sync` checks).
+
+**Tests.** No new production tests yet — this phase is fixture capture and
+a short `tests/test_g32_fixtures.py` asserting the fixtures parse as valid
+JSON / are non-empty, so a later phase's tests have something real to load
+without a live DPC++ toolchain in every CI lane.
+
+**Out of scope.** No production code changes.
+
+---
+
+## Phase A — `ExtractionContract`: profile/scope fingerprints and the comparability gate
+
+Implements ADR-049 D1 and D2.
+
+**Goal & acceptance criteria.**
+- `AbiSnapshot.contract: ExtractionContract | None` (additive field,
+  `model.py`) carries `profile_fingerprint`/`scope_fingerprint` plus the
+  resolved inputs that produced them.
+- `comparability.check_contracts_comparable(old, new)` raises
+  `ProfileMismatchError`/`ScopeMismatchError` (`errors.py`) when both sides
+  carry a `contract` and the fingerprints differ; a snapshot with no
+  `contract` field compares exactly as it does today (backward compatible
+  with every existing baseline).
+- The gate is wired at **all three** entry points in one phase, closing the
+  gap AGENTS.md's "Known gaps" section already names for the depth
+  contract rather than repeating the CLI-only mistake: `checker.compare`
+  (core), `service.py`'s `ScanRequest`/`compare_snapshots`, and
+  `mcp_server.py`'s MCP compare tools.
+- Reporting: `reporter.py`/`sarif.py`/`junit_report.py` gain a
+  `not_comparable` top-level result distinct from every existing verdict
+  value — never coerced into `compatible`/`breaking`.
+- `--diagnostic-comparison` opt-in flag: downgrades the hard-fail to a
+  tentative diff, every finding stamped `assurance: none`.
+- **Rollout, matching this repo's existing default-on-after-validation
+  pattern (ADR-041's `--header-graph` flag flip):** ships behind a
+  `--strict-comparability` flag, default **off**, for one release cycle —
+  a mismatch demotes to a `PROFILE_SCOPE_DRIFT_DETECTED` RISK-tier finding
+  (reusing the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`-style
+  degrade-not-block pattern) rather than hard-failing, so real-world
+  fingerprint false-positives (an overlooked resolved-field gap — see
+  ADR-049 Consequences) surface as a visible warning before the gate can
+  ever block a CI pipeline outright. Flip to default-on is a follow-up PR
+  once the fixture corpus (Phase 0) and a real-world dry run both show
+  zero unexpected mismatches.
+
+**Files & surfaces.** `model.py` (new `ExtractionContract`), new
+`abicheck/comparability.py` (fingerprint computation + gate), `errors.py`
+(two new exception classes), `checker.py` (gate call at the top of
+`compare`), `service.py`, `mcp_server.py`, `cli.py`/`cli_compare_release.py`
+(flag + `not_comparable` exit-code handling — see `docs/reference/exit-codes.md`,
+which needs a new row), `reporter.py`, `sarif.py`, `junit_report.py`.
+
+**Tests.** Unit tests for fingerprint stability (same manifest,
+independent-TU reordering unaffected; include-order-within-a-TU changes
+the fingerprint); gate unit tests for all three entry points; a
+`--diagnostic-comparison` end-to-end test; a backward-compat test asserting
+a contract-less snapshot pair compares unchanged.
+
+**Example fixtures.** The Phase 0 "scope drift" pair, promoted to a real
+`examples/case2xx_profile_scope_mismatch_gate/` once the gate exists.
+
+**Out of scope (deferred to later phases or explicitly not planned).**
+`expected_public_headers` coverage inventory (ADR-049 non-goals) is not
+part of this phase.
+
+---
+
+## Phase B — Manifest and real multi-TU dump
+
+Implements ADR-049 D3. The highest-risk phase — see Risk above.
+
+**Goal & acceptance criteria.**
+- New `abicheck/dump_manifest.py`: strict YAML parser (unknown fields
+  error), `roots`/`translation_units` schema, `name`-uniqueness,
+  `contributes_to_abi=True ⇒ required=True` invariant enforced at parse
+  time (a validation error, not a silent coercion).
+- `dumper.py` gains a manifest-driven `dump()` path: one castxml/clang
+  invocation per TU (shared base profile + that TU's own forced includes),
+  each producing a `TuFragment`. The existing single-header CLI path
+  becomes this path's one-TU special case (`legacy-main`) — same code, not
+  a parallel implementation.
+- A manifest declaring TUs with different compilers/target triples is
+  rejected at parse time (`HETEROGENEOUS_ABI_CONTEXT` at manifest-validation
+  time, before any extraction runs — cheaper failure than after a wasted
+  compile).
+- A required TU's compile failure is a hard extraction failure for the
+  whole snapshot (`IncompleteAttempt`, never silently merged as if it
+  succeeded); an optional (`required: false`) TU's failure degrades to a
+  diagnostic, and — enforced by the parse-time invariant above — an
+  optional TU can never be `contributes_to_abi: true`, so this can never
+  produce a false removal.
+- New CLI surface: `abicheck dump --manifest path/to/manifest.yml` (or
+  `compare --manifest`), plus a `abicheck plan --manifest ...` diagnostic
+  command that prints the normalized manifest and both D1 fingerprints
+  without running extraction — cheap to run in CI before committing to a
+  full dump.
+
+**Files & surfaces.** New `abicheck/dump_manifest.py`, `abicheck/dumper.py`
+(per-TU invocation loop, `TuFragment` type), new `cli_dump_manifest.py`
+sibling command module (per the root `CLAUDE.md`'s "larger command → sibling
+module" convention), `cli_dump_helpers.py` (extend
+`resolve_dump_depth`/`check_requested_depth_satisfied` to operate per-TU).
+
+**Tests.** Manifest parser unit tests (the invariant violation, duplicate
+TU names, unknown fields, relative-path resolution). `dumper.py` multi-TU
+integration tests (`@pytest.mark.integration`, needs castxml/clang) using
+Phase 0's fixtures. A `plan --manifest` unit test asserting it never invokes
+a compiler.
+
+**Example fixtures.** Phase 0's ODR-safe and external-STL-noise pairs,
+wired through the real manifest path end to end.
+
+**Out of scope.** D4 (merge across TUs) is Phase C — Phase B's
+`TuFragment`s are produced but not yet merged into one `AbiSnapshot`
+usable by `checker.compare`; Phase B ships with a minimal "no conflicts
+possible" merge (concatenate, error loudly on any duplicate `entity_key`)
+as a placeholder, replaced by Phase C's real compatible-merge lattice.
+
+---
+
+## Phase C — Compatible merge across translation units
+
+Implements ADR-049 D4. Depends on Phase B.
+
+**Goal & acceptance criteria.**
+- New `abicheck/tu_merge.py`: for each `entity_key` seen in more than one
+  `TuFragment`, classify as trivial-merge (forward-decl + definition,
+  declaration + redeclaration, default-argument-only difference — union
+  provenance, keep the richer declaration), `INCONSISTENT_DECLARATION`
+  (same-context conflict — different return type/layout/calling
+  convention), or `HETEROGENEOUS_ABI_CONTEXT` (should Phase B's
+  single-profile-per-manifest rule ever be relaxed — not expected in this
+  phase).
+- `entity_key` excludes return type (kept in `abi_facts`) — reuses the
+  ADR-045/048 "prefer specific identity, never fold a mutable fact into the
+  key" principle explicitly, not a fresh design.
+- A snapshot with unresolved conflicts cannot pass Phase A's comparability
+  gate as a clean side — it is not a `CompleteSnapshot`.
+- Merge is deterministic regardless of TU-completion order (a required
+  property, tested directly — shuffle TU processing order, assert
+  byte-identical merged output).
+
+**Files & surfaces.** New `abicheck/tu_merge.py`, reusing
+`buildsource/crosscheck.py`'s existing merge/classify shape (not a new
+algorithm — see ADR-049 D4). `dumper.py`'s manifest path calls this instead
+of Phase B's placeholder concatenation.
+
+**Tests.** Phase 0's ODR-safe fixture (must merge cleanly) and
+conflicting-return-type fixture (must produce `INCONSISTENT_DECLARATION`);
+an order-independence property test (`tests/test_detector_properties.py`
+style, per the repo's existing metamorphic-test convention).
+
+**Example fixtures.** `examples/case2xx_multi_tu_compatible_merge/`,
+`examples/case2xx_multi_tu_inconsistent_declaration/`.
+
+---
+
+## Phase D — SYCL/DPC++ host vs. device AST context selection
+
+Implements ADR-049 D5. Independent of Phases B/C; depends only on Phase 0's
+captured DPC++ fixture.
+
+**Goal & acceptance criteria.**
+- New `abicheck/sycl_context.py`: decodes a DPC++ frontend's
+  (possibly-multi-document) JSON output as a stream of `{kind, target,
+  ast}` contexts — real document-boundary streaming, not a bracket/string
+  split; rejects trailing garbage and truncated documents.
+- Context selection is explicit: the manifest/CLI's `frontend_context`
+  (`host` default) is matched against the compiler-reported target triple
+  of each decoded context; a run producing only a mismatched context
+  (e.g. only `spir64` when `host` was requested) is `AST_CONTEXT_MISSING`,
+  an extraction failure — never a successful snapshot with the wrong
+  target silently selected.
+- `dumper_clang.py`'s existing single-context assumption is generalized to
+  call this module when the detected frontend is DPC++-capable; a plain
+  (non-SYCL) clang/castxml invocation is unaffected — zero-context-stream
+  output degrades to the existing single-context path, not a new failure
+  mode for the common case.
+
+**Files & surfaces.** New `abicheck/sycl_context.py`, `dumper_clang.py`
+(wiring), `sycl_metadata.py` (unaffected — this phase adds frontend-level
+context selection, D5 explicitly does not touch the existing binary-symbol
+classifier).
+
+**Tests.** Fixture-driven parser tests against Phase 0's real captured
+output (multi-document, malformed/truncated variants added once the happy
+path is proven — matching the review's own "fixture-first, don't guess the
+parser" sequencing advice). `AST_CONTEXT_MISSING`/`AST_CONTEXT_AMBIGUOUS`
+error-path tests.
+
+**Example fixtures.** None required beyond Phase 0's captures — this phase
+is extraction-layer, not diff-layer; no new `ChangeKind`.
+
+---
+
+## Phase E — Resource-aware frontend scheduling and cache-key extension
+
+Implements ADR-049 D6. Depends on Phase A (fingerprints for the cache key);
+the scheduling half loosely depends on Phase B (the per-TU loop it
+schedules) but the cache-key half can land immediately after Phase A.
+
+**Goal & acceptance criteria.**
+- The RAM-probing/pool-sizing helper in `buildsource/source_replay.py` is
+  factored out into new leaf module `abicheck/process_resources.py`; both
+  `source_replay.py` and `dumper.py`'s per-TU loop import it — one
+  implementation, not two, per AGENTS.md's own import-cycle guidance ("move
+  shared logic to a leaf module both sides can depend on").
+- `dumper.py`'s per-TU castxml/clang invocations (Phase B) run under this
+  pool instead of a fully sequential loop; a killed/timed-out TU records
+  its exit signal and never silently retries as a clean empty TU.
+- `snapshot_cache.py`'s `_cache_key()` (`:130`) gains
+  `profile_fingerprint`/`scope_fingerprint` as additional key inputs — a
+  pure compile-profile change with identical header content now correctly
+  invalidates the cache, closing the one real gap in an otherwise-already-
+  correct (content-hash-based) cache design.
+
+**Files & surfaces.** New `abicheck/process_resources.py`,
+`buildsource/source_replay.py` (import from it instead of its own inline
+implementation), `dumper.py` (per-TU pool), `snapshot_cache.py`
+(`_cache_key` inputs).
+
+**Tests.** `process_resources.py` unit tests migrated from
+`source_replay.py`'s existing RAM-probing tests (same behavior, new import
+path — a refactor test, not new coverage). Cache-key test: identical
+headers, differing `profile_fingerprint` ⇒ cache miss.
+
+**Out of scope.** No new scheduling *policy* — this phase ports the
+existing, already-proven `source_replay.py` policy verbatim; a different
+policy (e.g. per-manifest-declared memory budget) is future work, not
+scoped here.
+
+---
+
+## How to pick up this plan
+
+1. Read [ADR-049](../adr/049-comparability-contract-and-multi-tu-manifest.md)
+   in full before starting any phase — it has the authority-boundary rule
+   (`The one rule that does not change`) every phase must preserve.
+2. Start with Phase 0 regardless of which later phase you're aiming for.
+3. Implement against each phase's acceptance criteria above; add a
+   `changelog.d/` fragment per AGENTS.md convention for any
+   `abicheck/**/*.py` change.
+4. Update this doc's Effort/Risk line for a phase once it ships (matching
+   the convention `g31`/`g19` already use — "Phase A — S, done").

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -191,19 +191,32 @@ Implements ADR-049 D1 and D2.
   pair where neither side has one — never hard-fails, never becomes
   `not_comparable` — so comparing a freshly-produced snapshot against a
   pre-ADR stored CI baseline (a common real workflow) never regresses on
-  upgrade. It instead surfaces `UNKNOWN_PROFILE` as a RISK-tier,
-  non-authoritative annotation on the ordinary verdict that still gets
-  produced — same shape as the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`
-  (`checker_policy.py:618`), not a second meaning for `not_comparable`.
-  `UNKNOWN_PROFILE` is registered as a real `ChangeKind` via the repo's
-  standard four-step procedure (AGENTS.md "Adding a new ChangeKind"), the
-  same as `SOURCE_FACT_COVERAGE_INCOMPLETE` was — enum entry
-  (`checker_policy.py`), one `ChangeKindMeta` entry with `default_verdict`
-  placing it in `RISK_KINDS` (a `change_registry*.py` module), a detector in
-  `comparability.py` wired via `@registry.detector(...)`, and a unit test.
-  Not an ad-hoc report string: that would trip the AI-readiness
-  `changekind-partition`/`changekind-detector` gates or bypass the
-  registry's own import-time completeness assertion.
+  upgrade — **including under strict severity settings, not only the
+  default ones.** It surfaces `UNKNOWN_PROFILE` as a non-authoritative
+  annotation on the ordinary verdict that still gets produced, but
+  classified `COMPATIBLE_KINDS`/`QUALITY_KINDS`-tier, **not** `RISK_KINDS`
+  — deliberately different from the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`
+  (`checker_policy.py:618`) it otherwise resembles. `SOURCE_FACT_COVERAGE_INCOMPLETE`
+  reports genuine per-comparison evidence uncertainty, which a
+  `--severity-potential-breaking=error`/`--severity-preset strict` user
+  reasonably wants to fail their build on. `UNKNOWN_PROFILE` fires purely
+  from comparing against a pre-this-ADR baseline — a one-time rollout
+  artifact untied to any real library change, recurring on every
+  comparison until that baseline is regenerated. Classifying it
+  `RISK_KINDS` would let `potential_breaking` promotion turn it into a
+  mass CI failure the moment a team with strict severity settings upgrades
+  abicheck — exactly the regression the "never regresses on upgrade"
+  promise above exists to rule out, just at the severity-exit-code layer
+  instead of `not_comparable`. `UNKNOWN_PROFILE` is registered as a real
+  `ChangeKind` via the repo's standard four-step procedure (AGENTS.md
+  "Adding a new ChangeKind") — enum entry (`checker_policy.py`), one
+  `ChangeKindMeta` entry with `default_verdict` placing it in
+  `COMPATIBLE_KINDS`'s `QUALITY_KINDS` subset (a `change_registry*.py`
+  module), a detector in `comparability.py` wired via
+  `@registry.detector(...)`, and a unit test. Not an ad-hoc report string:
+  that would trip the AI-readiness `changekind-partition`/
+  `changekind-detector` gates or bypass the registry's own import-time
+  completeness assertion.
 - **The exit code is part of the published contract too, not an
   afterthought.** `docs/reference/exit-codes.md` documents two co-existing
   `compare` schemes (legacy: 0/2/4; severity-aware: 0/1/2/4) where `0`
@@ -317,9 +330,14 @@ three entry points; a `--diagnostic-comparison` end-to-end test; a
 backward-compat test asserting a contract-less snapshot pair compares
 unchanged; a **mixed-pair** test (one side `contract`, one side none)
 asserting the comparison never hard-fails and instead carries a
-`UNKNOWN_PROFILE` RISK-tier finding alongside an otherwise-ordinary
+`UNKNOWN_PROFILE` `QUALITY_KINDS` finding alongside an otherwise-ordinary
 verdict — the specific case the ADR calls out as unambiguous, not left to
-interpretation.
+interpretation; a **severity-neutrality** test asserting a mixed-pair
+comparison run with `--severity-potential-breaking=error` (or
+`--severity-preset strict`) still exits successfully — `UNKNOWN_PROFILE`
+must never itself trigger `potential_breaking` promotion, or the "never
+regresses on upgrade" promise breaks for exactly the users who opted into
+strict severity gating.
 
 **Example fixtures.** The Phase 0 "scope drift" pair, promoted to a real
 `examples/case2xx_profile_scope_mismatch_gate/` once the gate exists.
@@ -363,7 +381,14 @@ Implements ADR-049 D3. The highest-risk phase — see Risk above.
 **Files & surfaces.** New `abicheck/dump_manifest.py`, `abicheck/dumper.py`
 (per-TU invocation loop, `TuFragment` type), new `cli_dump_manifest.py`
 sibling command module (per the root `CLAUDE.md`'s "larger command → sibling
-module" convention), `cli_dump_helpers.py` (extend
+module" convention) — registering it is not implicit: `cli.py`'s bottom
+side-effect `from . import (...)` block gains `cli_dump_manifest`, or the
+new `plan --manifest`/`dump --manifest` commands never attach to `main` at
+all, and `pyproject.toml`'s `disallow_untyped_decorators = false` override
+list gains `abicheck.cli_dump_manifest` alongside the existing per-module
+entries, or the typed-decorator mypy lane fails on its `@click` decorators
+(both required steps of the root `CLAUDE.md`'s "Adding a new top-level
+command" procedure, steps 3–4) — `cli_dump_helpers.py` (extend
 `resolve_dump_depth`/`check_requested_depth_satisfied` to operate per-TU).
 
 **Tests.** Manifest parser unit tests (the invariant violation, duplicate

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -378,6 +378,21 @@ Implements ADR-050 D1 and D2.
 - Reporting: `reporter.py`/`sarif.py`/`junit_report.py` gain a
   `not_comparable` top-level result distinct from every existing verdict
   value — never coerced into `compatible`/`breaking`.
+- **`html_report.py`/`service_render.py` are the fourth reporting surface,
+  not an optional add-on.** AGENTS.md's own module map groups `html_report.py`
+  with `reporter.py`/`sarif.py`/`junit_report.py` under "Reporting," and
+  `service_render.py:87-99` routes `--format html` to
+  `generate_html_report(result: DiffResult, ...)` the same way it routes the
+  other three formats. Since `generate_html_report` requires a real
+  `DiffResult`, the `not_comparable` case (no `DiffResult` ever constructed)
+  means `render_output` must not call it at all on that path — the
+  gate-raising front-end handles HTML the same way it assembles `verdict: null`
+  JSON, without `generate_html_report` growing an optional-`DiffResult`
+  parameter. The mixed-pair `contract_coverage` case does produce a real
+  `DiffResult`, so `generate_html_report` gains a headline-card surface for
+  `contract_coverage`, matching the other three reporters — otherwise HTML is
+  the one format that can't tell a reader the comparison ran on unequal
+  evidence.
 - **`verdict: null` is JSON-output shape, not a `checker_types.DiffResult`
   typing change.** `DiffResult` (`verdict: Verdict = Verdict.NO_CHANGE`,
   non-nullable) is never constructed at all for a
@@ -461,7 +476,10 @@ separate call path), `cli_compare_release_helpers.py`
 table update), `docs/reference/exit-codes.md` (a
 new row in both the legacy and severity-aware tables, **and** the
 multi-library section, **and** the `compat check` table's `9` row), `reporter.py`,
-`sarif.py`, `junit_report.py`, `abicheck/schemas/compare_report.schema.json`,
+`sarif.py`, `junit_report.py`, `html_report.py` (`generate_html_report`'s
+`contract_coverage` headline card), `service_render.py` (`render_output`'s
+`--format html` branch skips `generate_html_report` on the `not_comparable`
+path instead of calling it with no `DiffResult`), `abicheck/schemas/compare_report.schema.json`,
 `abicheck/schemas/__init__.py` (`REPORT_SCHEMA_VERSION` bump),
 `docs/schemas/v1/compare_report.schema.json` (regenerated via
 `scripts/publish_schemas.py`, not hand-edited).
@@ -497,7 +515,12 @@ stricter);
 `tests/test_report_schema.py` gains a `not_comparable` case validated
 against the updated `compare_report.schema.json`, and its existing
 `test_docs_mirror_matches_packaged_schema` must still pass against the
-regenerated `docs/schemas/v1` copy; a root-relative-path fingerprint test
+regenerated `docs/schemas/v1` copy; an **HTML reporting** test asserting
+`render_output(..., fmt="html")` on a `not_comparable` path never reaches
+`generate_html_report` with a missing `DiffResult` (the front-end's exception
+handler owns that path instead), and a second test asserting a mixed-pair
+`contract_coverage` comparison's HTML output surfaces `contract_coverage`
+the same way its JSON/Markdown/SARIF/JUnit siblings do; a root-relative-path fingerprint test
 (the acceptance-criteria bullet above — same-tree-different-root compare
 must not fingerprint-mismatch); an exit-code test
 asserting `not_comparable` returns exactly `16`, never `0`, from

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -391,7 +391,7 @@ Implements ADR-050 D1 and D2.
   makes the release fan-out fix (below) actually surface at the release
   level instead of being computed per-library and then silently
   outranked.
-- The gate is wired at **all six** entry points in one phase, closing the
+- The gate is wired at **all seven** entry points in one phase, closing the
   gap AGENTS.md's "Known gaps" section already names for the depth
   contract rather than repeating the CLI-only mistake: `checker.compare`
   (core), `service.py`'s `ScanRequest`/`compare_snapshots`,
@@ -399,10 +399,13 @@ Implements ADR-050 D1 and D2.
   directory/package fan-out, `compat/cli.py`'s ABICC-compatible
   `compat check` (which calls `checker.compare` directly too — see the
   dedicated bullet below for its own, independent exit-code contract),
-  **and** `cli_scan.py`'s `scan --against` (which reaches
+  `cli_scan.py`'s `scan --against` (which reaches
   `compare_snapshots` through `cli_scan_baseline._run_baseline_compare` —
   see its own dedicated bullet below for why listing `service.py`'s
-  `compare_snapshots` alone doesn't already cover it).
+  `compare_snapshots` alone doesn't already cover it), **and**
+  `stack_checker.py`'s `_run_abi_diff`, driving `abicheck deps compare`
+  (which imports `checker.compare` directly too, and today swallows every
+  exception — see its own dedicated bullet below).
 - **The release fan-out needs a dedicated fix, not inherited behavior.**
   `_compare_one_library` (`cli_compare_release.py:180-269`) wraps its
   entire per-library flow in `except (click.ClickException,
@@ -473,6 +476,34 @@ Implements ADR-050 D1 and D2.
   independent exit-code schemes; reusing either of those would imply a
   shared numbering `scan` doesn't have. `docs/reference/exit-codes.md`'s
   `scan` table gains this row.
+- **A seventh entry point imports `checker.compare` directly and swallows
+  every exception into an undifferentiated `None` today — a different
+  failure mode than the previous six, and it needs its own fix.**
+  `stack_checker.py:32` imports `compare` from `checker` (not through
+  `service.compare_snapshots`), driving `abicheck deps compare`.
+  `_run_abi_diff` (`:396-410`) wraps its whole body — both the `dump()`
+  calls and the `compare()` call — in one broad `except Exception as exc:
+  log.warning(...); return None`. Verified against the actual code: a
+  `ProfileMismatchError`/`ScopeMismatchError` from a changed dependency DSO
+  would be swallowed into that same `None`, indistinguishable from the
+  pre-existing "file unreadable" case a few lines above (`:363-364`, also
+  `abi_diff=None`) or a genuine crash — the resulting `StackChange` carries
+  no `not_comparable` reason at all, and `cli_stack.py`'s `deps compare`
+  reporters/exit-code contract (`0`/`1`/`4`/`64`) read it no differently
+  than "nothing to report for this library." `StackChange` (`stack_checker.py`)
+  gains an additive `not_comparable_reason: str | None = None` field
+  alongside its existing `abi_diff: DiffResult | None`. `_run_abi_diff`
+  itself re-raises `ProfileMismatchError`/`ScopeMismatchError` instead of
+  swallowing them (only its caller can attach a result to a `StackChange`);
+  its caller (the loop building `StackChange` entries) gains a dedicated
+  `except (ProfileMismatchError, ScopeMismatchError) as exc:` branch around
+  the `_run_abi_diff(...)` call, setting `not_comparable_reason` instead of
+  leaving `abi_diff` an unexplained `None`. `deps compare` gains its own
+  exit code for "at least one dependency was not_comparable": **`5`**, the
+  next integer after that command's own currently-documented ceiling (`4`,
+  `FAIL`) — distinct from `scan`'s `6`, `compat check`'s `9`, and native
+  `compare`'s `16`, continuing the same disjoint-per-command scheme rule,
+  never folded into the existing `FAIL`/`4`.
 - Reporting: `reporter.py`/`sarif.py`/`junit_report.py` gain a
   `not_comparable` top-level result distinct from every existing verdict
   value — never coerced into `compatible`/`breaking`.
@@ -596,10 +627,15 @@ table update), `cli_scan.py` (`scan_cmd`'s new third `except
 its existing `_BudgetOverflow`/`_EvidenceContractError` clauses — no change
 needed in `cli_scan_baseline.py`/`scan_engine.py` themselves, since
 neither catches these exceptions today and both must keep letting them
-propagate), `docs/reference/exit-codes.md` (a
+propagate), `stack_checker.py` (`StackChange.not_comparable_reason`
+field; `_run_abi_diff` re-raises `ProfileMismatchError`/`ScopeMismatchError`
+instead of swallowing them into its broad `except Exception`; its caller
+gains the dedicated `except` branch that sets `not_comparable_reason`),
+`cli_stack.py` (`deps_compare_cmd`'s new exit-`5` branch alongside its
+existing `0`/`1`/`4`/`64` logic), `docs/reference/exit-codes.md` (a
 new row in both the legacy and severity-aware `compare` tables, the
-multi-library section, the `compat check` table's `9` row, **and** the
-`scan` table's `6` row), `reporter.py`,
+multi-library section, the `compat check` table's `9` row, the
+`scan` table's `6` row, **and** the `deps compare` table's `5` row), `reporter.py`,
 `sarif.py`, `junit_report.py`, `html_report.py` (`generate_html_report`'s
 `contract_coverage` headline card), `service_render.py` (`render_output`'s
 `--format html` branch skips `generate_html_report` on the `not_comparable`
@@ -665,7 +701,7 @@ severity-aware release schemes — proving `not_comparable`'s precedence
 over the removed-library mechanism is unconditional, unlike that
 mechanism's own existing scheme-dependent precedence; gate unit tests
 for all
-six entry points; a **compat-mode exit-code** test asserting
+seven entry points; a **compat-mode exit-code** test asserting
 `compat check` returns exactly `9` (never `10`'s generic fallback, never
 `16`, and never an unhandled traceback) for a
 `ProfileMismatchError`/`ScopeMismatchError`, exercised both through
@@ -679,7 +715,14 @@ budget-overflow code) for a `ProfileMismatchError`/`ScopeMismatchError`
 raised from the baseline compare, exercised through a real end-to-end
 `scan --against` invocation on a mismatched pair — proving `scan_cmd`'s new
 `except` clause actually catches what `_run_baseline_compare` lets through
-uncaught today; a `--diagnostic-comparison` end-to-end test asserting the report's
+uncaught today; a **deps-compare exit-code** test asserting `abicheck deps
+compare` returns exactly `5` (never folded into `4`'s `FAIL`, never a
+silent `None` diff indistinguishable from the pre-existing
+"file unreadable" case) for a `ProfileMismatchError`/`ScopeMismatchError`
+raised while diffing a changed dependency DSO, and asserting the resulting
+`StackChange.not_comparable_reason` is populated rather than `abi_diff`
+being left an unexplained `None` — proving `_run_abi_diff`'s caller, not
+`_run_abi_diff` itself, is what classifies the exception; a `--diagnostic-comparison` end-to-end test asserting the report's
 top-level `assurance` field is `"none"` and that no individual finding
 carries its own `assurance` value; a
 backward-compat test asserting a contract-less snapshot pair compares
@@ -739,35 +782,50 @@ Implements ADR-050 D3. The highest-risk phase — see Risk above.
   diagnostic, and — enforced by the parse-time invariant above — an
   optional TU can never be `contributes_to_abi: true`, so this can never
   produce a false removal.
-- New CLI surface: `--manifest path/to/manifest.yml` and
+- **New CLI surface is `--dump-manifest`, not `--manifest` — that spelling
+  is already taken.** Native `compare` already registers a `--manifest`
+  option today, via `@release_options` (`cli.py:1499-1507`,
+  `cli_options.py:883-889`): the ADR-023 release instantiation manifest
+  listing symbols a directory/package release publicly promises, visible
+  in `compare --help-all`. Reusing the same flag spelling for this ADR's
+  extraction/TU manifest would either collide at Click's option-registration
+  level or silently reinterpret an existing `compare old_dir new_dir
+  --manifest manifest.yml` release workflow as a TU-dump manifest instead —
+  a real, user-visible ambiguity, not a naming nitpick. This ADR's manifest
+  flag is therefore `--dump-manifest path/to/manifest.yml`, alongside
   `--frontend-context host|device` **options added to the existing
   `dump`/`compare` commands** (not new commands — a new sibling module
   cannot retroactively add options to a command already declared
-  elsewhere), plus a genuinely new `abicheck plan --manifest ...`
-  diagnostic command that prints the normalized manifest and both D1
+  elsewhere), plus a genuinely new `abicheck plan --dump-manifest ...`
+  diagnostic command (same flag spelling, for consistency — `plan` is a new
+  command so `--manifest` wouldn't itself collide there, but using two
+  different names for the same concept across sibling commands would be its
+  own inconsistency) that prints the normalized manifest and both D1
   fingerprints without running extraction — cheap to run in CI before
   committing to a full dump.
-- **`--manifest` must be side-scoped on `compare`, not a single shared
+- **`--dump-manifest` must be side-scoped on `compare`, not a single shared
   path.** `dump` produces one snapshot from one manifest, so a bare
-  `--manifest path` is correct there. `compare OLD_INPUT NEW_INPUT` is
+  `--dump-manifest path` is correct there. `compare OLD_INPUT NEW_INPUT` is
   different: it already dumps both sides from independently-rooted
   header/include trees via `--header`/`--include`'s `old=`/`new=` prefix
   convention (`SIDED_PATH_PARAM`, ADR-040) precisely because old and new
-  live under different roots. A single unsided `--manifest v1/abi.yml`
+  live under different roots. A single unsided `--dump-manifest v1/abi.yml`
   would either apply the same manifest to both sides (unable to express
   the normal two-checkout case) or leave no way to also pass `v2/abi.yml`
-  for the new side. `compare`'s `--manifest` therefore reuses
-  `SIDED_PATH_PARAM` exactly like `--header`/`--include` do — `--manifest
-  old=v1/abi.yml --manifest new=v2/abi.yml` — while `dump`'s stays a bare
-  path (it only ever has one side).
+  for the new side. `compare`'s `--dump-manifest` therefore reuses
+  `SIDED_PATH_PARAM` exactly like `--header`/`--include` do —
+  `--dump-manifest old=v1/abi.yml --dump-manifest new=v2/abi.yml` — while
+  `dump`'s stays a bare path (it only ever has one side).
 
 **Files & surfaces.** New `abicheck/dump_manifest.py`, `abicheck/dumper.py`
-(per-TU invocation loop, `TuFragment` type). `--manifest` is a shared-concept
-option across `dump` and `compare` (side-scoped on `compare` via
-`SIDED_PATH_PARAM`, bare on `dump` — see the acceptance-criteria bullet
+(per-TU invocation loop, `TuFragment` type). `--dump-manifest` is a
+shared-concept option across `dump` and `compare` (side-scoped on `compare`
+via `SIDED_PATH_PARAM`, bare on `dump` — see the acceptance-criteria bullet
 above), added as one decorator in `cli_options.py` and applied at `dump`'s
 and `compare`'s existing declarations directly, not merely implied by
-registering a new command module.
+registering a new command module — deliberately not named `--manifest`,
+which `@release_options` already registers on `compare` for the unrelated
+ADR-023 release manifest.
 **`--frontend-context` is not a `dump`/`compare`-only option — it belongs in
 the existing `compile_context_options` decorator (`cli_options.py`), the same
 shared L2 compile-context family `dump`, `compare`, *and* `cli_scan.py`'s
@@ -782,11 +840,11 @@ same way it already inherits `--ast-frontend` and the cross-toolchain
 `--gcc-*`/`--sysroot`/`--nostdinc` flags from that decorator, with no
 separate `scan_cmd` edit required beyond that decorator already being
 applied there today. New `cli_dump_manifest.py`
-sibling command module for the genuinely new `plan --manifest` command
+sibling command module for the genuinely new `plan --dump-manifest` command
 only (per the root `CLAUDE.md`'s "larger command → sibling module"
 convention) — registering it is not implicit: `cli.py`'s bottom
 side-effect `from . import (...)` block gains `cli_dump_manifest`, or
-`plan --manifest` never attaches to `main` at all, and `pyproject.toml`'s
+`plan --dump-manifest` never attaches to `main` at all, and `pyproject.toml`'s
 `disallow_untyped_decorators = false` override
 list gains `abicheck.cli_dump_manifest` alongside the existing per-module
 entries, or the typed-decorator mypy lane fails on its `@click` decorators
@@ -798,13 +856,17 @@ command" procedure, steps 3–4) — `cli_dump_helpers.py` (extend
 TU names, unknown fields, relative-path resolution, `frontend_context`
 accepted/defaulted/rejected-when-invalid). `dumper.py` multi-TU
 integration tests (`@pytest.mark.integration`, needs castxml/clang) using
-Phase 0's fixtures. A `plan --manifest` unit test asserting it never invokes
-a compiler. A `--frontend-context` CLI-flag unit test for the legacy
+Phase 0's fixtures. A `plan --dump-manifest` unit test asserting it never
+invokes a compiler. A `--frontend-context` CLI-flag unit test for the legacy
 (non-manifest) path, mirroring the manifest-field test. A **side-scoped
-`compare --manifest`** test asserting `compare old.so new.so --manifest
-old=v1/abi.yml --manifest new=v2/abi.yml` dumps each side from its own
-manifest (not both from one), plus a `dump --manifest path` test confirming
-the single-sided form is unaffected. A **`scan --frontend-context`**
+`compare --dump-manifest`** test asserting `compare old.so new.so
+--dump-manifest old=v1/abi.yml --dump-manifest new=v2/abi.yml` dumps each
+side from its own manifest (not both from one), plus a `dump --dump-manifest
+path` test confirming the single-sided form is unaffected. A test asserting
+`compare --dump-manifest` and the pre-existing `--manifest` (ADR-023 release
+manifest) coexist as distinct, independently-settable options on the same
+`compare` invocation — the specific collision this naming choice exists to
+avoid. A **`scan --frontend-context`**
 regression test asserting `abicheck scan --against` accepts `device` and
 threads it into the L2 header frontend the same way `dump`/`compare` do,
 proving `compile_context_options` (not a `dump`/`compare`-only decorator) is

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -851,7 +851,17 @@ front-end chokepoint, not `compare_snapshots` itself, see the
 acceptance-criteria bullet above; the legacy `run_compare` keyword shim
 gains the same parameter appended last, matching the `debuginfod_url`
 precedent), `api_types.py` (`CompareRequest.diagnostic_comparison: bool =
-False`), `mcp_server.py` (compare tools expose the same parameter), `cli.py`
+False`), `mcp_server.py` (**`abi_compare`'s inner `_do_compare` calls
+`compare_snapshots(...)` directly, bypassing `CompareRequest`/
+`run_compare_request` entirely** — verified against the actual code, its
+`future.result(...)` is awaited under a narrow `except
+_futures.TimeoutError` with a broader `except Exception` catching
+everything else into `{"status": "error", ...}` today; exposing
+`diagnostic_comparison` as an input parameter is not enough on its own —
+`abi_compare` also gains a dedicated `except (ProfileMismatchError,
+ScopeMismatchError)` branch, ordered before that generic catch, rendering
+`{"status": "not_comparable", "reason": ...}` distinct from
+`{"status": "error"}` for the default hard-fail path), `cli.py`
 (the `--diagnostic-comparison` flag definition and the new, distinct
 `not_comparable` exit `16` constant), **`cli_compare_helpers.py`** (the new
 `except (ProfileMismatchError, ScopeMismatchError)` branch around the real
@@ -1013,10 +1023,17 @@ test proving the Python API exposes the identical parameter, not only
 `cli.py`'s flag; a **`CompareRequest` reachability** test asserting
 `service.run_compare_request(CompareRequest(..., diagnostic_comparison=True))`
 on a mismatched pair also returns the tentative `DiffResult` rather than
-raising — proving the flag is reachable through the actual front-end
-chokepoint every documented caller (CLI, MCP, `compare-release`,
-`appcompat`) goes through, not only a direct `compare_snapshots` call
-nothing in the codebase makes; a `--diagnostic-comparison` end-to-end test asserting the report's
+raising — proving the flag is reachable through the front-end chokepoint
+`compare-release`/`appcompat` go through; an **`mcp_server.abi_compare`
+not_comparable** test asserting a mismatched pair through `abi_compare`
+(the default, non-diagnostic path) returns `{"status": "not_comparable",
+"reason": ...}`, never the generic `{"status": "error"}` its existing
+broad `except Exception` would otherwise produce — proving `abi_compare`'s
+own direct `compare_snapshots` call (bypassing `CompareRequest` entirely)
+got its own dedicated catch, not just the `diagnostic_comparison`
+parameter; and a second `abi_compare` test asserting
+`diagnostic_comparison=True` on the same mismatched pair returns a real
+tentative result instead; a `--diagnostic-comparison` end-to-end test asserting the report's
 top-level `assurance` field is `"none"` and that no individual finding
 carries its own `assurance` value; a
 backward-compat test asserting a contract-less snapshot pair compares

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -323,16 +323,30 @@ Implements ADR-050 D1 and D2.
   ancestor rule classifies these as external today, so an ordinary edit to
   a generated or private support header still flips `profile_fingerprint`
   on a routine CMake/Meson-style layout, not an edge case. Legacy CLI gains
-  a new, side-scoped, **labeled** `--project-include <label>=<path>` option
-  (`--project-include support=old/src --project-include support=new/src`,
-  alongside the existing `--include old=... --include new=...` side-scoping,
-  ADR-040) asserting a directory is project-owned regardless of ancestry.
-  `--project-include` requires a `label` (a user-supplied logical name, not
-  path-derived — the same choice D3's manifest `name` field already makes)
-  because a support root with no owned declared header has nothing for the
-  ancestor-derived per-slot token below to key off of; asking for one
-  avoids yet another path-shape heuristic. Legacy-CLI-only: the manifest
-  path (D3) already has no such gap via per-TU forced-includes.
+  a new, side-scoped, **labeled** `--project-include` option — its value
+  grammar cannot naively reuse `<label>=<path>`, though: `cli_params.py`'s
+  existing `SidedPathParam`/`SidedStrParam` (ADR-040 Lever 1) already
+  reserve the `X=` prefix position exclusively for the side discriminator
+  (`old=`/`new=`/`both=`, `_SIDES`) — `support=old/src` has no recognized
+  side prefix, so it would fall through to that parser's bare-value case
+  as `("both", Path("support=old/src"))`, the literal string swallowed
+  whole as a bogus path, never parsed as a label. `--project-include`
+  therefore needs its own dedicated param type, `SidedLabeledPathParam`,
+  carrying both pieces: `[old:|new:|both:]<label>=<path>` — a
+  colon-terminated side prefix (colon instead of `=` so it can't collide
+  with the label's own `=`), defaulting to `both:` when omitted, the same
+  "bare value means both sides" convention as the existing sided params.
+  A two-checkout compare with side-specific paths for one shared logical
+  root is declared `--project-include old:support=old/src
+  --project-include new:support=new/src` — same `support` label on both
+  invocations (so the per-slot token matches across sides for the same
+  logical root), different paths per side. `--project-include` requires
+  that label (a user-supplied logical name, not path-derived — the same
+  choice D3's manifest `name` field already makes) because a support root
+  with no owned declared header has nothing for the ancestor-derived
+  per-slot token below to key off of; asking for one avoids yet another
+  path-shape heuristic. Legacy-CLI-only: the manifest path (D3) already
+  has no such gap via per-TU forced-includes.
   `scope_fingerprint` owns everything
   under a project-owned root; `profile_fingerprint` owns only external
   roots, in full. **Excluding a project-owned directory's content must not
@@ -373,9 +387,9 @@ Implements ADR-050 D1 and D2.
   collide with a header name. `-I project -I dep` (project ancestor of
   declared `foo.h`) hashes `[token(foo.h), digest(dep)]`; `-I dep -I
   project` hashes `[digest(dep), token(foo.h)]` — different, correctly
-  flagged as non-comparable; `--project-include support=old/src` vs. the
-  same directory declared last instead of first is distinguished the same
-  way via `token(support)`. **Residual limitation (same class as the
+  flagged as non-comparable; `--project-include both:support=old/src` vs.
+  the same directory declared last instead of first is distinguished the
+  same way via `token(support)`. **Residual limitation (same class as the
   vendored-nested-dependency gap below):** two separately declared `-I`
   roots that are both ancestors of the *same* declared header (an outer
   directory and one of its own subdirectories, each passed as its own
@@ -506,17 +520,23 @@ Implements ADR-050 D1 and D2.
   to close; (14) a sibling support root declared via `--project-include`,
   not nested under any declared `--header` — `old`/`new` both declare
   `--header .../include/foo.h --include .../include --project-include
-  support=.../src` (`src/` a sibling of `include/`, containing a private
-  header `foo.h` `#include`s) — with a **content edit confined to `src/`'s
-  private header** between old and new leaves `profile_fingerprint`
+  both:support=.../src` (`src/` a sibling of `include/`, containing a
+  private header `foo.h` `#include`s) — with a **content edit confined to
+  `src/`'s private header** between old and new leaves `profile_fingerprint`
   matching, proving `--project-include` extends project-ownership to a
   sibling directory the ancestor rule alone would otherwise classify as
   external (and thus spuriously flip on this routine internal edit); a
-  companion assertion swapping `--project-include support=.../src` to
-  declaration-last on one side while an unrelated ancestor-derived root
-  keeps its position produces a *different* `profile_fingerprint`,
-  confirming the label-derived token participates in the same
-  order-sensitive sequence as every other project-owned slot.
+  companion assertion swapping `--project-include old:support=old/src
+  --project-include new:support=new/src` to declaration-last on one side
+  while an unrelated ancestor-derived root keeps its position produces a
+  *different* `profile_fingerprint`, confirming the label-derived token
+  participates in the same order-sensitive sequence as every other
+  project-owned slot; a third assertion parses `--project-include
+  old:support=old/src` and asserts the side/label/path triple round-trips
+  correctly through `SidedLabeledPathParam`, the exact grammar this fix
+  exists to get right (P2 review: a naive `<label>=<path>` grammar would
+  have silently misparsed as `("both", Path("support=old/src"))` instead
+  of raising or splitting a side/label/path triple).
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -968,10 +988,13 @@ Implements ADR-050 D1 and D2.
   ADR-041's header-graph flag flip, which changed behavior for an
   already-common default-off-to-on transition.
 
-**Files & surfaces.** `cli_options.py` (new side-scoped, labeled
-`--project-include <label>=<path>` option, alongside the existing
-`--include`/`--header` `SIDED_PATH_PARAM` family, ADR-040 — legacy CLI
-only, see the sibling-support-root acceptance-criteria bullet above),
+**Files & surfaces.** `cli_params.py` (new `SidedLabeledPathParam` —
+`[old:|new:|both:]<label>=<path>`, a dedicated param type distinct from
+`SidedPathParam`/`SidedStrParam` since neither carries a side *and* a
+label at once, see the sibling-support-root acceptance-criteria bullet
+above), `cli_options.py` (new side-scoped, labeled `--project-include`
+option built on it, alongside the existing `--include`/`--header`
+`SIDED_PATH_PARAM` family, ADR-040 — legacy CLI only),
 `model.py` (new `ExtractionContract`), new
 `abicheck/comparability.py` (fingerprint computation, `compute_extraction_contract`
 — its project-ownership predicate takes both ancestor-derived headers and

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -125,12 +125,23 @@ Implements ADR-049 D1 and D2.
   Hashing absolute paths directly would fingerprint-mismatch and hard-fail
   *every routine compare* as `not_comparable` — breaking the gate's primary
   use case on day one. Each side's paths are normalized relative to that
-  side's own resolution root (legacy CLI path: the longest common prefix of
-  that side's own resolved paths; manifest path: the manifest file's own
-  directory) before hashing (ADR-049 D1). A dedicated test using
-  `--header old=v1/foo.h --header new=v2/foo.h` against logically identical
-  trees under different roots, asserting the resulting `profile_fingerprint`s
-  match, is non-negotiable for this phase to be considered done.
+  side's own resolution root (legacy CLI path: the common ancestor
+  **directory** of that side's inputs — each header's *parent* directory
+  plus each include directory itself, **not** the header paths taken
+  literally; manifest path: the manifest file's own directory) before
+  hashing (ADR-049 D1). Deriving the root from header paths directly instead
+  of their parents breaks the single-header-per-side case — the common
+  ancestor of a one-element path set is that whole path, so `old=v1/foo.h`
+  and `new=v2/bar.h` would both normalize to the same empty marker and hash
+  identically despite being different scopes, the opposite failure from the
+  one this fix exists to close; taking the parent directory first preserves
+  the filename (`v1/foo.h` → root `v1/`, normalized `foo.h`). A dedicated
+  test using `--header old=v1/foo.h --header new=v2/foo.h` against
+  logically identical trees under different roots, asserting the resulting
+  `profile_fingerprint`s match — **and** a second test asserting
+  `old=v1/foo.h`/`new=v2/bar.h` (genuinely different header names) produce
+  *different* fingerprints — is non-negotiable for this phase to be
+  considered done.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -141,6 +152,19 @@ Implements ADR-049 D1 and D2.
   **both** sides carry one, two ordinary dumps would silently take the same
   code path as the intentionally-lenient mixed-pair case forever — a fully
   specified, fully inert gate.
+- **The whole-snapshot cache is the same bypass by a different route — this
+  phase closes it too, not just Phase E's later cache-key work.**
+  `service_dump_cache.cached_run_dump` looks up `snapshot_cache` *before*
+  calling `dump()`; a warm cache entry from a pre-Phase-A abicheck (no
+  `contract` computed) served after upgrading would still come back with
+  `contract=None`, defeating the fix above through a different code path.
+  `snapshot_cache._SNAPSHOT_CACHE_VERSION` (`:48`, currently `"3"`) is
+  bumped in this same phase so every pre-Phase-A cache entry misses once
+  and gets rebuilt through the now-`contract`-populating `dump()`. This is
+  separate from Phase E's later `profile_fingerprint`/`scope_fingerprint`-
+  as-cache-key work (a different gap: a pure profile change with identical
+  headers not invalidating) and cannot be deferred to it without leaving
+  the gate inert for every warm-cache user until Phase E ships.
 - `serialization.SCHEMA_VERSION` is bumped (11 → 12) in the same change
   that starts writing `contract` — **not** treated as a free additive field
   the way ADR-041's advisory `extractor_passes`/`narrowed_passes` were. The
@@ -242,7 +266,8 @@ Implements ADR-049 D1 and D2.
 the gate, and the `UNKNOWN_PROFILE` detector), `dumper.py` (`dump()` calls
 `compute_extraction_contract(...)` and attaches it to every returned
 snapshot — see the acceptance-criteria bullet above; this is not optional
-plumbing), `errors.py`
+plumbing), `snapshot_cache.py` (`_SNAPSHOT_CACHE_VERSION` bump — see the
+warm-cache acceptance-criteria bullet above), `errors.py`
 (`ProfileMismatchError`/`ScopeMismatchError`/`IncompatibleSnapshotSchemaError`),
 `serialization.py` (`SCHEMA_VERSION` bump,
 `_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION` threshold + the
@@ -261,8 +286,13 @@ new row in both the legacy and severity-aware tables), `reporter.py`,
 
 **Tests.** A `dump()`-level test asserting a real (non-manifest) dump
 returns a snapshot with a populated, non-`None` `contract` — the specific
-gap that would otherwise leave the gate permanently inert. Unit tests for
-fingerprint stability (same manifest,
+gap that would otherwise leave the gate permanently inert. A **warm-cache**
+regression test: seed `snapshot_cache` with a pre-bump-version entry (no
+`contract`), call `cached_run_dump` for the same inputs post-bump, and
+assert it misses and rebuilds with `contract` populated rather than
+serving the stale hit — the cache-layer analogue of the `dump()` test
+above, closing the same class of bypass through a different code path.
+Unit tests for fingerprint stability (same manifest,
 independent-TU reordering unaffected; include-order-within-a-TU changes
 the fingerprint; flipping one TU's `contributes_to_abi` or `required` flag
 with its includes held identical also changes `scope_fingerprint`); a

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -328,12 +328,14 @@ Implements ADR-050 D1 and D2.
   makes the release fan-out fix (below) actually surface at the release
   level instead of being computed per-library and then silently
   outranked.
-- The gate is wired at **all four** entry points in one phase, closing the
+- The gate is wired at **all five** entry points in one phase, closing the
   gap AGENTS.md's "Known gaps" section already names for the depth
   contract rather than repeating the CLI-only mistake: `checker.compare`
   (core), `service.py`'s `ScanRequest`/`compare_snapshots`,
-  `mcp_server.py`'s MCP compare tools, **and** `cli_compare_release.py`'s
-  directory/package fan-out.
+  `mcp_server.py`'s MCP compare tools, `cli_compare_release.py`'s
+  directory/package fan-out, **and** `compat/cli.py`'s ABICC-compatible
+  `compat check` (which calls `checker.compare` directly too — see the
+  dedicated bullet below for its own, independent exit-code contract).
 - **The release fan-out needs a dedicated fix, not inherited behavior.**
   `_compare_one_library` (`cli_compare_release.py:180-269`) wraps its
   entire per-library flow in `except (click.ClickException,
@@ -354,9 +356,41 @@ Implements ADR-050 D1 and D2.
   library and then silently outranked by a co-occurring `BREAKING`, and
   `docs/reference/exit-codes.md`'s multi-library section documents both
   together.
+- **A fifth entry point needs its own exit code, not the fourth one's.**
+  `abicheck/compat/cli.py`'s ABICC-compatible `compat check` command calls
+  `checker.compare` directly (`from ..checker import compare`, the call
+  around `:967`) — a separate front-end from native `compare`, with its own
+  independent 0–2/3–11 exit-code contract (`_classify_compat_error_exit_code`
+  in `compat/_errors.py`) that this phase must not silently break by leaving
+  a `ProfileMismatchError`/`ScopeMismatchError` to fall into that function's
+  generic fallback code. `_classify_compat_error_exit_code` gains an explicit
+  `isinstance(exc, (ProfileMismatchError, ScopeMismatchError))` check —
+  mirroring its existing `KeyboardInterrupt` special case — returning **`9`**,
+  the one integer the current 3–11 range documents no meaning for (3/4/5/6/7/8/10/11
+  are all taken; 9 is the sole gap). This is deliberately a different number
+  from native `compare`'s `16`: the two commands already use disjoint,
+  independently-documented exit-code schemes (native `compare`'s legacy/severity-aware
+  0/1/2/4 doubling vs. `compat check`'s ABICC-mimicking 0/1/2/3-11), so reusing
+  `16` here would misleadingly imply a shared numbering that doesn't exist.
+  `compat/CLAUDE.md`'s exit-code table and a changelog fragment are updated in
+  the same phase, per that file's own stated policy that changing the
+  exit-code contract "requires a CHANGELOG note and downstream coordination."
 - Reporting: `reporter.py`/`sarif.py`/`junit_report.py` gain a
   `not_comparable` top-level result distinct from every existing verdict
   value — never coerced into `compatible`/`breaking`.
+- **`verdict: null` is JSON-output shape, not a `checker_types.DiffResult`
+  typing change.** `DiffResult` (`verdict: Verdict = Verdict.NO_CHANGE`,
+  non-nullable) is never constructed at all for a
+  `ProfileMismatchError`/`ScopeMismatchError` case — the gate raises before
+  any diff runs, so each front-end's own exception handler assembles the
+  `verdict: null` JSON shape; `DiffResult` itself needs no new field for
+  that path. The **mixed-pair** case (below) is different: it's an ordinary,
+  non-exception comparison that completes and produces real `DiffResult`s,
+  just with reduced evidence on one side — so `contract_coverage` is a
+  genuinely new field, not report-assembly shape. `checker_types.py` gains
+  `contract_coverage: str | None = None` on `DiffResult` itself, and
+  `checker.py`'s `compare()` sets it when exactly one side carries a
+  `contract`.
 - The published JSON contract moves with the reporters, in this phase, not
   after: `abicheck/schemas/compare_report.schema.json` currently requires
   `verdict` and restricts it to a fixed string enum with no `null` member.
@@ -410,8 +444,9 @@ warm-cache acceptance-criteria bullets above), `errors.py`
 `_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION` threshold + the
 `snapshot_from_dict` hard-rejection branch, `contract` round-trip through
 `snapshot_to_dict`/`snapshot_from_dict`), `checker.py` (gate call at the
-top of `compare`, `contract_coverage` field on the result), `service.py`,
-`mcp_server.py`, `cli.py` (flag + the new,
+top of `compare`, `contract_coverage` field on the result),
+`checker_types.py` (`DiffResult.contract_coverage: str | None = None`),
+`service.py`, `mcp_server.py`, `cli.py` (flag + the new,
 distinct `not_comparable` exit code), `cli_compare_release.py`
 (`_compare_one_library`'s dedicated
 `except (ProfileMismatchError, ScopeMismatchError)` branch, ordered before
@@ -419,9 +454,13 @@ distinct `not_comparable` exit code), `cli_compare_release.py`
 above; this is not covered by the CLI's own exit-code handling, it is a
 separate call path), `cli_compare_release_helpers.py`
 (`_RELEASE_VERDICT_ORDER`'s new rank-6 `not_comparable` entry),
-`docs/reference/exit-codes.md` (a
+`compat/cli.py` (no call-site change beyond routing through the updated
+`_classify_compat_error_exit_code`), `compat/_errors.py`
+(`_classify_compat_error_exit_code`'s new `ProfileMismatchError`/
+`ScopeMismatchError` branch returning `9`), `compat/CLAUDE.md` (exit-code
+table update), `docs/reference/exit-codes.md` (a
 new row in both the legacy and severity-aware tables, **and** the
-multi-library section), `reporter.py`,
+multi-library section, **and** the `compat check` table's `9` row), `reporter.py`,
 `sarif.py`, `junit_report.py`, `abicheck/schemas/compare_report.schema.json`,
 `abicheck/schemas/__init__.py` (`REPORT_SCHEMA_VERSION` bump),
 `docs/schemas/v1/compare_report.schema.json` (regenerated via
@@ -479,7 +518,11 @@ severity-aware release schemes — proving `not_comparable`'s precedence
 over the removed-library mechanism is unconditional, unlike that
 mechanism's own existing scheme-dependent precedence; gate unit tests
 for all
-four entry points; a `--diagnostic-comparison` end-to-end test; a
+five entry points; a **compat-mode exit-code** test asserting
+`compat check` returns exactly `9` (never `10`'s generic fallback, never
+`16`) for a `ProfileMismatchError`/`ScopeMismatchError`, exercised through
+`_classify_compat_error_exit_code` directly and through a `compat check`
+end-to-end invocation; a `--diagnostic-comparison` end-to-end test; a
 backward-compat test asserting a contract-less snapshot pair compares
 unchanged; a **mixed-pair** test (one side `contract`, one side none)
 asserting the comparison never hard-fails and instead carries a
@@ -492,8 +535,14 @@ exits successfully — proving `contract_coverage` is structurally outside
 the findings list any severity flag scans, not merely untested against the
 one flag checked last time.
 
-**Example fixtures.** The Phase 0 "scope drift" pair, promoted to a real
-`examples/case2xx_profile_scope_mismatch_gate/` once the gate exists.
+**Example fixtures.** The Phase 0 "scope drift" pair stays a `tests/`-level
+fixture, not an `examples/case*/` catalog entry: `tests/test_validate_examples_unit.py`'s
+`_VALID_VERDICTS` frozenset accepts only the five real `Verdict` strings, and
+`not_comparable` is deliberately not one of them (it is a precondition
+failure, never a verdict) — the same reasoning Phase C already applies to
+`INCONSISTENT_DECLARATION`. Adding it to `examples/` would need a change to
+that frozenset and the catalog machinery it gates, which is out of scope
+here.
 
 **Out of scope (deferred to later phases or explicitly not planned).**
 `expected_public_headers` coverage inventory (ADR-050 non-goals) is not

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -638,16 +638,41 @@ Implements ADR-050 D3. The highest-risk phase — see Risk above.
   diagnostic command that prints the normalized manifest and both D1
   fingerprints without running extraction — cheap to run in CI before
   committing to a full dump.
+- **`--manifest` must be side-scoped on `compare`, not a single shared
+  path.** `dump` produces one snapshot from one manifest, so a bare
+  `--manifest path` is correct there. `compare OLD_INPUT NEW_INPUT` is
+  different: it already dumps both sides from independently-rooted
+  header/include trees via `--header`/`--include`'s `old=`/`new=` prefix
+  convention (`SIDED_PATH_PARAM`, ADR-040) precisely because old and new
+  live under different roots. A single unsided `--manifest v1/abi.yml`
+  would either apply the same manifest to both sides (unable to express
+  the normal two-checkout case) or leave no way to also pass `v2/abi.yml`
+  for the new side. `compare`'s `--manifest` therefore reuses
+  `SIDED_PATH_PARAM` exactly like `--header`/`--include` do — `--manifest
+  old=v1/abi.yml --manifest new=v2/abi.yml` — while `dump`'s stays a bare
+  path (it only ever has one side).
 
 **Files & surfaces.** New `abicheck/dump_manifest.py`, `abicheck/dumper.py`
-(per-TU invocation loop, `TuFragment` type). `--manifest`/
-`--frontend-context` are shared-concept options per multiple existing
-commands (`dump` and `compare`), so — following `cli_options.py`'s own
-existing convention for `-v/--verbose`, `output_options(...)`, and
-`lang_option(...)` — they're added as one shared decorator in
-`cli_options.py` and applied at `dump`'s and `compare`'s existing
-declarations directly (wherever those already live: `cli.py`), not merely
-implied by registering a new command module. New `cli_dump_manifest.py`
+(per-TU invocation loop, `TuFragment` type). `--manifest` is a shared-concept
+option across `dump` and `compare` (side-scoped on `compare` via
+`SIDED_PATH_PARAM`, bare on `dump` — see the acceptance-criteria bullet
+above), added as one decorator in `cli_options.py` and applied at `dump`'s
+and `compare`'s existing declarations directly, not merely implied by
+registering a new command module.
+**`--frontend-context` is not a `dump`/`compare`-only option — it belongs in
+the existing `compile_context_options` decorator (`cli_options.py`), the same
+shared L2 compile-context family `dump`, `compare`, *and* `cli_scan.py`'s
+`scan_cmd` already apply (`# dump↔scan L2 compile-context parity (ADR-037
+D3)`), not a new, narrower decorator applied only to two of those three.**
+Leaving `scan` out would strand the one-shot `abicheck scan --against`
+workflow on the `host` default with no way to request `device` — the same
+SYCL/DPC++ target a `scan`-driven audit can already reach via that command's
+side-aware `-H`/`-I` options. Adding `--frontend-context` to
+`compile_context_options` itself means `scan` picks it up automatically, the
+same way it already inherits `--ast-frontend` and the cross-toolchain
+`--gcc-*`/`--sysroot`/`--nostdinc` flags from that decorator, with no
+separate `scan_cmd` edit required beyond that decorator already being
+applied there today. New `cli_dump_manifest.py`
 sibling command module for the genuinely new `plan --manifest` command
 only (per the root `CLAUDE.md`'s "larger command → sibling module"
 convention) — registering it is not implicit: `cli.py`'s bottom
@@ -666,7 +691,15 @@ accepted/defaulted/rejected-when-invalid). `dumper.py` multi-TU
 integration tests (`@pytest.mark.integration`, needs castxml/clang) using
 Phase 0's fixtures. A `plan --manifest` unit test asserting it never invokes
 a compiler. A `--frontend-context` CLI-flag unit test for the legacy
-(non-manifest) path, mirroring the manifest-field test.
+(non-manifest) path, mirroring the manifest-field test. A **side-scoped
+`compare --manifest`** test asserting `compare old.so new.so --manifest
+old=v1/abi.yml --manifest new=v2/abi.yml` dumps each side from its own
+manifest (not both from one), plus a `dump --manifest path` test confirming
+the single-sided form is unaffected. A **`scan --frontend-context`**
+regression test asserting `abicheck scan --against` accepts `device` and
+threads it into the L2 header frontend the same way `dump`/`compare` do,
+proving `compile_context_options` (not a `dump`/`compare`-only decorator) is
+what carries the flag.
 
 **Example fixtures.** Phase 0's ODR-safe and external-STL-noise pairs,
 wired through the real manifest path end to end.

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -721,9 +721,23 @@ Implements ADR-050 D1 and D2.
   consumer surface untouched so far. `aggregate.py` gains a way to tell a
   deliberate `not_comparable` report (its `reason` object is present) from
   a genuinely missing/corrupt one, and folds it into `exit_code()` as an
-  unconditionally blocking contribution — regardless of `discovered_only`,
-  matching the same precedence `_RELEASE_VERDICT_ORDER`'s rank-6 entry
-  already gives `not_comparable` in the release rollup.
+  unconditionally blocking contribution — regardless of `discovered_only`.
+  **The resulting code is pinned to `1`, not left to whatever an
+  implementer picks.** `docs/reference/exit-codes.md`'s own `aggregate`
+  table already establishes the precedent this fits, not a new one:
+  `1` is documented as covering both a coverage gap *and* "a non-verdict
+  per-report failure" (its own example being `scan`'s budget-overflow
+  exit `5` folding in there) — `not_comparable` is exactly that same class
+  of non-verdict per-report failure, so it folds into `aggregate`'s
+  existing `1`, the same way `scan`'s `5` already does, rather than
+  reserving a fifth disjoint number the way `compare`/`scan`/`deps compare`
+  each did for their *own* schemes (`aggregate` never invents a new code
+  per producer; it has one shared bucket for "this target isn't a clean
+  verdict"). `docs/reference/exit-codes.md`'s `aggregate` table gains an
+  explicit `not_comparable` row alongside the existing budget-overflow
+  example, and its `## Summary table` cross-command matrix gains a row
+  too, so both are updated in the same change, not just the aggregate
+  section in isolation.
 - **`action/run.sh` is another consumer with the same blind spot, one layer
   further from the Python package, and it compounds into a worse failure
   than a generic misreport.** Verified against the actual script:
@@ -1081,8 +1095,10 @@ comparison run under *every* `--severity-*` flag (`--severity-potential-breaking
 exits successfully — proving `contract_coverage` is structurally outside
 the findings list any severity flag scans, not merely untested against the
 one flag checked last time; an **aggregate not_comparable** test asserting
-`abicheck aggregate` in **discovered-only** mode exits non-zero when one
-target's report is `not_comparable` — never silently `0` — and a second
+`abicheck aggregate` in **discovered-only** mode exits exactly `1` when one
+target's report is `not_comparable` — never silently `0`, and not any
+other non-zero code either, matching the same bucket `scan`'s
+budget-overflow already folds into — and a second
 test asserting a `not_comparable` report is never conflated with a
 genuinely missing/corrupt one in `aggregate`'s rendered per-target output,
 proving the two "unavailable"-shaped states stay distinguishable; an
@@ -1186,14 +1202,20 @@ Implements ADR-050 D3. The highest-risk phase — see Risk above.
   `dump`'s stays a bare path (it only ever has one side).
 
 **Files & surfaces.** New `abicheck/dump_manifest.py`, `abicheck/dumper.py`
-(per-TU invocation loop, `TuFragment` type). `--dump-manifest` is a
+(per-TU invocation loop, `TuFragment` type, and the actual `--dump-manifest`
+termination point). `--dump-manifest` is a
 shared-concept option across `dump` and `compare` (side-scoped on `compare`
 via `SIDED_PATH_PARAM`, bare on `dump` — see the acceptance-criteria bullet
 above), added as one decorator in `cli_options.py` and applied at `dump`'s
 and `compare`'s existing declarations directly, not merely implied by
 registering a new command module — deliberately not named `--manifest`,
 which `@release_options` already registers on `compare` for the unrelated
-ADR-023 release manifest.
+ADR-023 release manifest. `cli_resolve.py` (`_resolve_compare_snapshots`
+and `_resolve_input` each gain the same manifest parameter, threaded
+through to `service.py`) and `service.py` (`resolve_input`/`run_dump` gain
+it too, the actual entry points into `dumper.py`) — see the dedicated
+acceptance-criteria bullet below for why every layer needs its own
+explicit update, not just `cli_compare_helpers.py`.
 **Declaring the Click option is not enough for `compare` — `cli_compare_helpers.py`
 needs the actual plumbing, the same gap already fixed once for the
 gate's own exception handling on this exact command.** `compare_cmd`
@@ -1203,10 +1225,24 @@ code — it already carries `manifest_path` for the unrelated ADR-023
 release manifest, confirming the pattern: a new Click option's dest must
 also appear here or it either raises "unexpected keyword argument" or
 never reaches the per-side dump resolution). `run_compare` gains the new
-`old_dump_manifest`/`new_dump_manifest` parameters and threads them into
-its per-side header/include resolution (`_resolve_compare_snapshots`),
-alongside the existing `except (ProfileMismatchError, ScopeMismatchError)`
-fix already planned there.
+`old_dump_manifest`/`new_dump_manifest` parameters — but `run_compare`
+itself is not the bottom of this chain either: it calls
+`cli_resolve._resolve_compare_snapshots`, which has its own large explicit
+signature (verified against the actual code — no manifest parameter today)
+and calls `cli_resolve._resolve_input` (also explicit, also no manifest
+parameter, "a thin CLI wrapper over `service.resolve_input`"), which calls
+`service.resolve_input`/`service.run_dump` — the actual entry points into
+`dumper.py`. Each of these four layers (`run_compare` →
+`_resolve_compare_snapshots` → `_resolve_input` →
+`service.resolve_input`/`run_dump`) has its own fixed, explicit
+keyword-argument signature with no existing manifest slot, so the new
+parameter must be threaded through every one of them individually, not
+just declared once at the top and assumed to flow — the exact mistake
+this ADR has already made and corrected once for `CompareRequest`
+(`run_compare_request` → `compare_snapshots`) earlier in this same phase.
+`dumper.dump()` is where it actually terminates, alongside the existing
+`except (ProfileMismatchError, ScopeMismatchError)` fix already planned
+in `run_compare`.
 **`--frontend-context` reaching `compile_context_options` means directory/package
 `compare` accepts it too — and must reject it, not silently ignore it.**
 The release/set-input fan-out (`cli_compare_release.py`) never threads a
@@ -1285,9 +1321,11 @@ manifest) coexist as distinct, independently-settable options on the same
 `compare` invocation — the specific collision this naming choice exists to
 avoid; and an end-to-end test asserting `compare old.so new.so
 --dump-manifest old=v1/abi.yml --dump-manifest new=v2/abi.yml` actually
-dumps each side from its own manifest through `run_compare`'s real
-resolution path (not just that Click accepts the flags) — proving
-`cli_compare_helpers.py`, not only `cli.py`, was updated. A **release
+dumps each side from its own manifest all the way through
+`dumper.dump()` (not just that Click accepts the flags, and not stopping
+at a mock of any intermediate layer) — proving `cli_compare_helpers.py`,
+`cli_resolve.py`, and `service.py` were all updated together, not just
+`cli.py`. A **release
 rejects `--frontend-context`** test asserting `compare old_dir new_dir
 --frontend-context device` fails fast via `cli_resolve.py`'s existing
 set-input guard, the same way it already fails fast for `--gcc-path`/

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -284,13 +284,18 @@ Implements ADR-050 D1 and D2.
   (8) the documented real-world shape — `--header old=old/include/foo.h
   --header new=new/include/foo.h --include old=old/include --include
   new=new/include`, the same directory serving both roles — with an
-  **ordinary content edit to `foo.h` itself** between old and new produces
-  a *different* `scope_fingerprint` (correctly reflecting the compared
-  surface changed) but the *same* `profile_fingerprint` (the environment
-  that resolved it did not) — proving the exclusion actually prevents the
-  routine, intentional-header-edit case from spuriously hard-failing
-  `PROFILE_MISMATCH`, the specific regression this exclusion exists to
-  close.
+  **ordinary content edit to `foo.h` itself** (e.g. adding a parameter to a
+  declared function) between old and new leaves **both**
+  `scope_fingerprint` **and** `profile_fingerprint` matching: neither
+  fingerprint hashes the declared header's own content — `scope_fingerprint`
+  tracks declared TU/header *identity* (names, include structure, flags),
+  never content, precisely so an ordinary API/ABI edit is an unremarkable,
+  comparable case, not a mismatch; `profile_fingerprint` excludes exactly
+  this file per the bullet above. The comparison proceeds past the gate and
+  the diff reports the parameter addition as an ordinary `Change` —
+  `not_comparable` never fires on the routine case of "the thing being
+  compared changed," which is this whole tool's primary purpose, not an
+  edge case to special-case around.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -861,12 +866,29 @@ D3)`), not a new, narrower decorator applied only to two of those three.**
 Leaving `scan` out would strand the one-shot `abicheck scan --against`
 workflow on the `host` default with no way to request `device` — the same
 SYCL/DPC++ target a `scan`-driven audit can already reach via that command's
-side-aware `-H`/`-I` options. Adding `--frontend-context` to
-`compile_context_options` itself means `scan` picks it up automatically, the
-same way it already inherits `--ast-frontend` and the cross-toolchain
-`--gcc-*`/`--sysroot`/`--nostdinc` flags from that decorator, with no
-separate `scan_cmd` edit required beyond that decorator already being
-applied there today. New `cli_dump_manifest.py`
+side-aware `-H`/`-I` options.
+**The decorator alone only makes Click accept the flag — it does not by
+itself thread the value anywhere, and this phase must not stop at the
+decorator.** Verified against the actual code: `cli_options.resolve_compile_context`
+(the single function the `@compile_context_options` family resolves to for
+`compare`/`dump`/`scan` alike) has a fixed, explicit keyword-argument list
+and builds a `service_scan.CompileContext` from exactly those fields —
+neither has a slot for a host/device context today. Adding
+`--frontend-context` to the decorator without also extending
+`resolve_compile_context`'s signature and `CompileContext` would either
+raise a "got an unexpected keyword argument" error at the Click-callback
+boundary, or (if the new option is simply left unread) silently accept the
+flag and drop it before it ever reaches a dump. This phase therefore also
+adds `CompileContext.frontend_context: str = "host"` and a matching
+`frontend_context` parameter to `resolve_compile_context`, threaded into
+the `CompileContext(...)` it constructs. Because `scan_engine.run_scan_core`
+already passes the *whole* `CompileContext` object through to
+`service.resolve_input` (`compile=compile_context`, not individual
+unpacked fields — verified at `scan_engine.py:243-254`) the same way
+`dump`/`compare` do, `dump()`'s Phase-B addition of a `compile.frontend_context`
+read (needed there regardless, for the legacy CLI path) automatically
+reaches `scan` too once `CompileContext` carries the field — no
+`scan_engine.py`-specific dump-call change beyond that. New `cli_dump_manifest.py`
 sibling command module for the genuinely new `plan --dump-manifest` command
 only (per the root `CLAUDE.md`'s "larger command → sibling module"
 convention) — registering it is not implicit: `cli.py`'s bottom
@@ -877,7 +899,12 @@ list gains `abicheck.cli_dump_manifest` alongside the existing per-module
 entries, or the typed-decorator mypy lane fails on its `@click` decorators
 (both required steps of the root `CLAUDE.md`'s "Adding a new top-level
 command" procedure, steps 3–4) — `cli_dump_helpers.py` (extend
-`resolve_dump_depth`/`check_requested_depth_satisfied` to operate per-TU).
+`resolve_dump_depth`/`check_requested_depth_satisfied` to operate per-TU),
+`service_scan.py` (`CompileContext.frontend_context: str = "host"`),
+`cli_options.py` (`resolve_compile_context`'s new `frontend_context`
+parameter, threaded into the `CompileContext` it builds — the single
+choke point `compare`/`dump`/`scan` all resolve through, so no
+`scan_engine.py` dump-call-site change is needed beyond this).
 
 **Tests.** Manifest parser unit tests (the invariant violation, duplicate
 TU names, unknown fields, relative-path resolution, `frontend_context`

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -98,10 +98,15 @@ real data.
 
 **Files & surfaces.** New fixtures under `tests/fixtures/g32/` (raw AST
 captures, not committed as generated `.abi.json` — those are produced by
-the tests themselves once Phase A/B land) and, once ChangeKinds exist
-(Phase A/C), `examples/case2xx_*/` per the standard example-catalog
-convention (`ground_truth.json` entry, `README.md`, AI-readiness
-`examples-ground-truth`/`examples-readme-sync` checks).
+the tests themselves once Phase A/B land). These stay `tests/`-level
+fixtures throughout, not a future `examples/case2xx_*/` catalog entry:
+`not_comparable` (Phase A), `UNKNOWN_PROFILE`/`contract_coverage` metadata
+(Phase A), and `INCONSISTENT_DECLARATION`/`HETEROGENEOUS_ABI_CONTEXT`
+(Phase C) are all extraction-time outcomes, not `ChangeKind`s or `Verdict`
+values — `tests/test_validate_examples_unit.py`'s `_VALID_VERDICTS`
+frozenset only accepts the five real `Verdict` strings, so none of this
+phase's fixtures ever becomes a catalogued example (see Phase A's and
+Phase C's own "Example fixtures" sections for the same reasoning).
 
 **Tests.** No new production tests yet — this phase is fixture capture and
 a short `tests/test_g32_fixtures.py` asserting the fixtures are non-empty
@@ -162,28 +167,38 @@ Implements ADR-050 D1 and D2.
   failure from the one this fix exists to close; taking the parent
   directory first preserves the filename (`v1/foo.h` → root `v1/`,
   normalized `foo.h`).
-  **`profile_fingerprint`'s `-I` directories do not use that same
-  parent-directory rule.** A lone `-I` directory has no filename to
-  preserve, so taking its parent as root strips all distinguishing
-  structure: `--include old=/opt/dep-v1/include --include
-  new=/opt/dep-v2/include` would both normalize to `include`, silently
-  erasing a genuine dependency-version difference. Whether a
+  **`profile_fingerprint`'s `-I` directories use that same parent-directory
+  rule too, uniformly — this went through two rejected "clever" fixes
+  before landing on the simple one; both are worth recording so neither is
+  rediscovered.** A first attempt applied the header rule unchanged, which
+  is right for the common real-world shape (`--include old=old/include
+  --include new=new/include`, the project's own include root across two
+  checkouts — the exact shape `docs/user-guide/real-world-example.md`
+  documents) but wrong for a lone *external dependency* directory:
+  `--include old=/opt/dep-v1/include --include new=/opt/dep-v2/include`
+  would normalize both to `include` relative to their own root, silently
+  erasing a genuine dependency-version difference. A second attempt tried
+  hashing each `-I` directory's last two path components instead
+  (`/opt/dep-v1/include` → `dep-v1/include`) — this broke the *other*
+  direction, making the ordinary `old/include`/`new/include` project-root
+  case hash as different and hard-fail the routine, documented two-checkout
+  compare. Both attempts fail for the same underlying reason: **whether a
   differently-rooted `-I` path means "same dependency, different checkout
-  mount point" or "genuinely different dependency version" isn't decidable
-  from path shape alone, unlike headers (where ADR-040's `old=`/`new=`
-  design exists specifically for the same-project-two-checkouts case).
-  `profile_fingerprint` therefore hashes each **single** `-I` directory's
-  last two path components (its own basename plus its immediate parent's
-  basename) instead of attempting root-relative normalization at all —
-  `dep-v1/include` vs. `dep-v2/include`, correctly distinct — a bounded,
-  explicitly imperfect compromise (a checkout-root difference expressed
-  exactly two segments up still spuriously mismatches), not a general fix.
-  Multiple `-I` directories per side (2+) use the same
-  common-ancestor-of-parents approach as headers instead, since real
-  anchor points exist there. For the manifest path (D3), both fingerprints'
-  roots are simply the manifest file's own directory — none of these
-  legacy-path degenerate cases exist there, since every manifest-declared
-  path is already relative to one document.
+  mount point" or "genuinely different dependency version" is not decidable
+  from path shape alone, and no heuristic can resolve it** — the two
+  examples above have identical shape (two segments, differing prefix) and
+  opposite correct answers. `profile_fingerprint` therefore uses the header
+  rule as-is, single or multiple `-I` directories, no special case — a
+  **known, accepted limitation, not a solved problem**: it keeps the common
+  project-include-root workflow working (the gate's primary use case), at
+  the cost of not detecting a dependency-version change expressed purely as
+  a differently-named `-I` mount point with the same basename; that class
+  of drift is undetectable by this fingerprint on the legacy CLI path (a
+  user who needs it has `--diagnostic-comparison`, D2, as the sanctioned
+  fallback). For the manifest path (D3), both fingerprints' roots are
+  simply the manifest file's own directory — none of these legacy-path
+  degenerate cases exist there, since every manifest-declared path is
+  already relative to one document.
 
   Four dedicated tests are non-negotiable for this phase to be considered
   done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
@@ -196,11 +211,15 @@ Implements ADR-050 D1 and D2.
   `--include old=/opt/dep --include new=/opt/dep` alongside case (1)'s
   headers still leaves `scope_fingerprint` matching — the specific
   external-dependency-directory regression this criterion exists to
-  prevent; (4) `--include old=/opt/dep-v1/include --include
-  new=/opt/dep-v2/include` (a lone, genuinely different `-I` directory per
-  side) produces *different* `profile_fingerprint`s — the specific
-  degenerate-single-`-I`-directory regression this criterion exists to
-  prevent.
+  prevent; (4) `--include old=old/include --include new=new/include` (the
+  common two-checkout project-include-root shape) leaves `profile_fingerprint`
+  matching, and a documented, deliberately-not-fixed regression test pinning
+  that `--include old=/opt/dep-v1/include --include new=/opt/dep-v2/include`
+  (a lone, genuinely different `-I` directory sharing the same basename)
+  currently produces the *same* `profile_fingerprint` on both sides — the
+  known, accepted limitation above, asserted so a future change doesn't
+  silently start "fixing" it into a heuristic that breaks case (4)'s first
+  half again.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -27,8 +27,10 @@ top-level modules).
 L. Phase E — M. Total: XL, phased over multiple PRs.
 **Risk:** Phase 0 — low (fixtures only, no production code path changes).
 Phase A — low-medium (new gate at a well-defined entry point, additive
-fields, rollout behind report-only mode before hard-fail default — see
-Phase A below). Phase B — **high** — changes `dumper.py`'s single hottest
+fields; ships as a hard default per ADR-049 D2 from day one — risk is
+mitigated by Phase 0 fixture coverage and a pre-merge dry run, not by a
+runtime soft-default — see Phase A below). Phase B — **high** — changes
+`dumper.py`'s single hottest
 path (every `dump`/`compare` call goes through it) from one frontend
 invocation to N. Phase C — medium (new merge surface, but scoped to
 data `dumper.py` produces, no external-tool dependency). Phase D — medium
@@ -124,17 +126,26 @@ Implements ADR-049 D1 and D2.
   value — never coerced into `compatible`/`breaking`.
 - `--diagnostic-comparison` opt-in flag: downgrades the hard-fail to a
   tentative diff, every finding stamped `assurance: none`.
-- **Rollout, matching this repo's existing default-on-after-validation
-  pattern (ADR-041's `--header-graph` flag flip):** ships behind a
-  `--strict-comparability` flag, default **off**, for one release cycle —
-  a mismatch demotes to a `PROFILE_SCOPE_DRIFT_DETECTED` RISK-tier finding
-  (reusing the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`-style
-  degrade-not-block pattern) rather than hard-failing, so real-world
-  fingerprint false-positives (an overlooked resolved-field gap — see
-  ADR-049 Consequences) surface as a visible warning before the gate can
-  ever block a CI pipeline outright. Flip to default-on is a follow-up PR
-  once the fixture corpus (Phase 0) and a real-world dry run both show
-  zero unexpected mismatches.
+- **Rollout: the hard gate is the default from the first shipped version of
+  this phase — no soft-launch flag, and no second flag with a default that
+  contradicts ADR-049 D2.** D2 is explicit that a contract mismatch is a
+  precondition failure producing `not_comparable`, never an ordinary
+  verdict with a RISK-tier finding attached; a runtime default that quietly
+  downgraded that to "warn, still produce a verdict" would ship exactly the
+  behavior the ADR forbids. The two things that *do* need to be true before
+  this phase merges — real-world fingerprint false positives from an
+  overlooked resolved-field gap must not exist in practice — are handled at
+  merge-review time, not at runtime: Phase 0's fixture corpus must cover the
+  common drift/no-drift cases, and a dry run over a real multi-snapshot
+  corpus using the **already-specified** `--diagnostic-comparison` flag
+  (D2's one sanctioned escape hatch, not a new one) must show zero
+  unexpected mismatches before Phase A is considered done. Backward
+  compatibility for every *existing* baseline is unaffected regardless,
+  since a snapshot with no `contract` field (everything produced before
+  this phase) compares exactly as it does today (see the bullet above) —
+  there is no legacy flow this gate could break on day one, unlike
+  ADR-041's header-graph flag flip, which changed behavior for an
+  already-common default-off-to-on transition.
 
 **Files & surfaces.** `model.py` (new `ExtractionContract`), new
 `abicheck/comparability.py` (fingerprint computation + gate), `errors.py`

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -314,7 +314,26 @@ Implements ADR-050 D1 and D2.
   not, is excluded from `profile_fingerprint` entirely. A declared `-I`
   directory unrelated to any declared header is **external** and keeps the
   full per-file content digest — a real dependency, where a change
-  anywhere in it is meaningful drift. `scope_fingerprint` owns everything
+  anywhere in it is meaningful drift. **The ancestor rule misses a common
+  non-nested layout: a support directory declared as a *sibling* of the
+  public header root, not underneath it** — a build-generated headers
+  directory (`generated/`) or a private-implementation directory (`src/`,
+  `config/`) that `include/foo.h` `#include`s from, passed via its own
+  `--include` but never an ancestor of any declared `--header`. The
+  ancestor rule classifies these as external today, so an ordinary edit to
+  a generated or private support header still flips `profile_fingerprint`
+  on a routine CMake/Meson-style layout, not an edge case. Legacy CLI gains
+  a new, side-scoped, **labeled** `--project-include <label>=<path>` option
+  (`--project-include support=old/src --project-include support=new/src`,
+  alongside the existing `--include old=... --include new=...` side-scoping,
+  ADR-040) asserting a directory is project-owned regardless of ancestry.
+  `--project-include` requires a `label` (a user-supplied logical name, not
+  path-derived — the same choice D3's manifest `name` field already makes)
+  because a support root with no owned declared header has nothing for the
+  ancestor-derived per-slot token below to key off of; asking for one
+  avoids yet another path-shape heuristic. Legacy-CLI-only: the manifest
+  path (D3) already has no such gap via per-TU forced-includes.
+  `scope_fingerprint` owns everything
   under a project-owned root; `profile_fingerprint` owns only external
   roots, in full. **Excluding a project-owned directory's content must not
   also erase its position in the declared `-I` sequence.** `-I` order is
@@ -330,17 +349,41 @@ Implements ADR-050 D1 and D2.
   digest exists to close, reintroduced through the exclusion mechanism
   itself. The fix keeps the sequence **positional**: every declared `-I`
   directory keeps its own slot in declaration order; a project-owned
-  slot's content is replaced with one fixed sentinel constant (not derived
-  from the directory's path, name, or content — so no scope information
-  leaks into `profile_fingerprint`, and two project-owned directories
-  still compare equal to each other) instead of being omitted, so its
-  position relative to every external directory's real digest survives.
-  `-I project -I dep` hashes `[SENTINEL, digest(dep)]`; `-I dep -I
-  project` hashes `[digest(dep), SENTINEL]` — different sequences,
-  correctly flagged as non-comparable. The system/toolchain bucket stays
-  unordered, since its inputs were never part of a declared,
-  precedence-bearing `-I` sequence to begin with. **Known, accepted
-  residual gap:** a vendored dependency
+  slot's content is replaced with a **per-slot logical token**, not one
+  shared constant — a single generic sentinel for every project-owned
+  slot loses order information again, one level down, once there are two
+  or more project-owned roots: `-I include -I generated` vs. `-I
+  generated -I include` (both project-owned, byte-identical content,
+  swapped declared order) would both hash to the same `[SENTINEL,
+  SENTINEL]` sequence under one shared constant, silently losing the same
+  order information this fix exists to preserve. The token comes from one
+  of two sources depending on *why* the slot is project-owned: an
+  **ancestor-derived** root's token is the **sorted set of declared
+  `--header`/manifest TU names that directory is an ancestor of** (never
+  its path or content) — two ancestor-derived directories owning
+  different declared headers get different tokens (so swapping their
+  order changes the sequence), while a directory owning the same declared
+  header set tokenizes identically regardless of mount point, consistent
+  with `scope_fingerprint` already treating declared header *names* as
+  legitimate, already-tracked identity, so no new information leaks
+  through the token; a `--project-include` support root's token is its
+  required user-supplied **`label`** instead (it owns no declared header
+  by construction — that's exactly why it needed its own flag), namespaced
+  separately from the ancestor-derived token space so a label can never
+  collide with a header name. `-I project -I dep` (project ancestor of
+  declared `foo.h`) hashes `[token(foo.h), digest(dep)]`; `-I dep -I
+  project` hashes `[digest(dep), token(foo.h)]` — different, correctly
+  flagged as non-comparable; `--project-include support=old/src` vs. the
+  same directory declared last instead of first is distinguished the same
+  way via `token(support)`. **Residual limitation (same class as the
+  vendored-nested-dependency gap below):** two separately declared `-I`
+  roots that are both ancestors of the *same* declared header (an outer
+  directory and one of its own subdirectories, each passed as its own
+  `-I` entry) tokenize identically and stay order-indistinguishable from
+  each other — an unusual declaration shape, not the routine case this
+  fix targets. The system/toolchain bucket stays unordered, since its
+  inputs were never part of a declared, precedence-bearing `-I` sequence
+  to begin with. **Known, accepted residual gap:** a vendored dependency
   nested *inside* a project-owned root is swept into that exclusion too,
   so a content change confined there is invisible to `profile_fingerprint`
   on the legacy CLI path — the same "can't disambiguate from directory
@@ -364,7 +407,7 @@ Implements ADR-050 D1 and D2.
   the manifest file's own directory — none of these legacy-CLI cases
   exist there.
 
-  Thirteen dedicated tests (numbered 1–12, with 8b alongside 8) are non-negotiable for this phase to be considered
+  Fifteen dedicated tests (numbered 1–14, with 8b alongside 8) are non-negotiable for this phase to be considered
   done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
   identical trees under different roots asserts the resulting
   **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
@@ -443,11 +486,37 @@ Implements ADR-050 D1 and D2.
   `--include new=/opt/dep --include new=/work/include` (`/work/include`
   project-owned on both sides via a shared `--header`, `/opt/dep`
   byte-identical on both sides) — produce *different* `profile_fingerprint`s,
-  proving the project-owned slot is replaced with a positional sentinel
-  rather than dropped: if the slot were simply omitted, both sides would
-  degrade to the same single-element `[digest(/opt/dep)]` sequence and
-  spuriously match despite the order swap being a genuine, ambiguity-
-  affecting difference in `#include` search precedence.
+  proving the project-owned slot is replaced with a positional per-slot
+  token rather than dropped: if the slot were simply omitted, both sides
+  would degrade to the same single-element `[digest(/opt/dep)]` sequence
+  and spuriously match despite the order swap being a genuine, ambiguity-
+  affecting difference in `#include` search precedence; (13) **two**
+  project-owned `-I` roots declared in swapped order — `old` declares
+  `--header old=old/include/foo.h --header old=old/generated/bar.h
+  --include old=old/include --include old=old/generated`, `new` declares
+  the identical, byte-identical-content pair but swapped:
+  `--include new=new/generated --include new=new/include` (both `foo.h`
+  and `bar.h` unchanged) — produce *different* `profile_fingerprint`s,
+  proving the per-slot token is derived from each root's own owned-header
+  set (`token(foo.h)` vs. `token(bar.h)`), not one shared constant: a
+  single generic sentinel for every project-owned slot would hash both
+  orderings to the same `[SENTINEL, SENTINEL]` sequence and spuriously
+  match, exactly the regression this per-slot-token fix (as opposed to
+  the simpler single-sentinel fix test (12) alone would validate) exists
+  to close; (14) a sibling support root declared via `--project-include`,
+  not nested under any declared `--header` — `old`/`new` both declare
+  `--header .../include/foo.h --include .../include --project-include
+  support=.../src` (`src/` a sibling of `include/`, containing a private
+  header `foo.h` `#include`s) — with a **content edit confined to `src/`'s
+  private header** between old and new leaves `profile_fingerprint`
+  matching, proving `--project-include` extends project-ownership to a
+  sibling directory the ancestor rule alone would otherwise classify as
+  external (and thus spuriously flip on this routine internal edit); a
+  companion assertion swapping `--project-include support=.../src` to
+  declaration-last on one side while an unrelated ancestor-derived root
+  keeps its position produces a *different* `profile_fingerprint`,
+  confirming the label-derived token participates in the same
+  order-sensitive sequence as every other project-owned slot.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -899,8 +968,14 @@ Implements ADR-050 D1 and D2.
   ADR-041's header-graph flag flip, which changed behavior for an
   already-common default-off-to-on transition.
 
-**Files & surfaces.** `model.py` (new `ExtractionContract`), new
-`abicheck/comparability.py` (fingerprint computation, `compute_extraction_contract`,
+**Files & surfaces.** `cli_options.py` (new side-scoped, labeled
+`--project-include <label>=<path>` option, alongside the existing
+`--include`/`--header` `SIDED_PATH_PARAM` family, ADR-040 — legacy CLI
+only, see the sibling-support-root acceptance-criteria bullet above),
+`model.py` (new `ExtractionContract`), new
+`abicheck/comparability.py` (fingerprint computation, `compute_extraction_contract`
+— its project-ownership predicate takes both ancestor-derived headers and
+declared `--project-include` labels as inputs, not headers alone —
 the gate, and `contract_coverage` metadata computation — no detector, since
 `UNKNOWN_PROFILE` is report metadata, not a `Change`; reuses
 `abicheck/buildsource/include_graph.py`'s existing `parse_depfile()` to turn

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -95,9 +95,15 @@ convention (`ground_truth.json` entry, `README.md`, AI-readiness
 `examples-ground-truth`/`examples-readme-sync` checks).
 
 **Tests.** No new production tests yet — this phase is fixture capture and
-a short `tests/test_g32_fixtures.py` asserting the fixtures parse as valid
-JSON / are non-empty, so a later phase's tests have something real to load
-without a live DPC++ toolchain in every CI lane.
+a short `tests/test_g32_fixtures.py` asserting the fixtures are non-empty
+and readable, so a later phase's tests have something real to load without
+a live DPC++ toolchain in every CI lane. The multi-document DPC++ capture
+is **not** asserted to parse as one JSON value — by design it's a stream
+of concatenated documents, the exact shape Phase D's stream parser exists
+to handle; requiring single-document JSON-parseability here would reject
+the real capture and push Phase 0 toward synthesizing a fake one,
+undermining the fixture-first point of this phase. It's validated only for
+non-emptiness now, and by the real stream parser once Phase D exists.
 
 **Out of scope.** No production code changes.
 
@@ -192,31 +198,23 @@ Implements ADR-049 D1 and D2.
   `not_comparable` — so comparing a freshly-produced snapshot against a
   pre-ADR stored CI baseline (a common real workflow) never regresses on
   upgrade — **including under strict severity settings, not only the
-  default ones.** It surfaces `UNKNOWN_PROFILE` as a non-authoritative
-  annotation on the ordinary verdict that still gets produced, but
-  classified `COMPATIBLE_KINDS`/`QUALITY_KINDS`-tier, **not** `RISK_KINDS`
-  — deliberately different from the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`
-  (`checker_policy.py:618`) it otherwise resembles. `SOURCE_FACT_COVERAGE_INCOMPLETE`
-  reports genuine per-comparison evidence uncertainty, which a
-  `--severity-potential-breaking=error`/`--severity-preset strict` user
-  reasonably wants to fail their build on. `UNKNOWN_PROFILE` fires purely
-  from comparing against a pre-this-ADR baseline — a one-time rollout
-  artifact untied to any real library change, recurring on every
-  comparison until that baseline is regenerated. Classifying it
-  `RISK_KINDS` would let `potential_breaking` promotion turn it into a
-  mass CI failure the moment a team with strict severity settings upgrades
-  abicheck — exactly the regression the "never regresses on upgrade"
-  promise above exists to rule out, just at the severity-exit-code layer
-  instead of `not_comparable`. `UNKNOWN_PROFILE` is registered as a real
-  `ChangeKind` via the repo's standard four-step procedure (AGENTS.md
-  "Adding a new ChangeKind") — enum entry (`checker_policy.py`), one
-  `ChangeKindMeta` entry with `default_verdict` placing it in
-  `COMPATIBLE_KINDS`'s `QUALITY_KINDS` subset (a `change_registry*.py`
-  module), a detector in `comparability.py` wired via
-  `@registry.detector(...)`, and a unit test. Not an ad-hoc report string:
-  that would trip the AI-readiness `changekind-partition`/
-  `changekind-detector` gates or bypass the registry's own import-time
-  completeness assertion.
+  default ones.**
+- **`UNKNOWN_PROFILE` is report-level metadata, not a `ChangeKind`/`Change`
+  finding — this took two wrong designs to converge on, worth getting
+  right the first time here.** Classifying it `RISK_KINDS` (matching
+  `SOURCE_FACT_COVERAGE_INCOMPLETE`'s shape) broke under
+  `--severity-potential-breaking=error`/`--severity-preset strict`
+  (promotes to exit 2). Reclassifying it `COMPATIBLE_KINDS`'s
+  `QUALITY_KINDS` instead only relocated the same collision:
+  `--severity-quality-issues=error`/`--severity-preset strict` promotes
+  `QUALITY_KINDS` too (exit 1) — proving no `ChangeKind` category is
+  permanently severity-immune, since severity gating can reach any of them
+  by design. `UNKNOWN_PROFILE` is instead a new field on the comparison
+  result (e.g. `contract_coverage: "partial"`), alongside the existing
+  `assurance` field this same phase adds for `--diagnostic-comparison` —
+  never entering the `changes`/findings list any `--severity-*` flag scans,
+  so it's structurally unreachable by severity promotion rather than
+  merely unreachable by the flags checked so far.
 - **The exit code is part of the published contract too, not an
   afterthought.** `docs/reference/exit-codes.md` documents two co-existing
   `compare` schemes (legacy: 0/2/4; severity-aware: 0/1/2/4) where `0`
@@ -227,11 +225,29 @@ Implements ADR-049 D1 and D2.
   distinct nonzero code and adds it as its own row to both tables in
   `docs/reference/exit-codes.md`, not folded into either scheme's existing
   numbering.
-- The gate is wired at **all three** entry points in one phase, closing the
+- The gate is wired at **all four** entry points in one phase, closing the
   gap AGENTS.md's "Known gaps" section already names for the depth
   contract rather than repeating the CLI-only mistake: `checker.compare`
-  (core), `service.py`'s `ScanRequest`/`compare_snapshots`, and
-  `mcp_server.py`'s MCP compare tools.
+  (core), `service.py`'s `ScanRequest`/`compare_snapshots`,
+  `mcp_server.py`'s MCP compare tools, **and** `cli_compare_release.py`'s
+  directory/package fan-out.
+- **The release fan-out needs a dedicated fix, not inherited behavior.**
+  `_compare_one_library` (`cli_compare_release.py:180-269`) wraps its
+  entire per-library flow in `except (click.ClickException,
+  click.UsageError):` / `except Exception:`, both returning
+  `{"verdict": "ERROR", ...}` — documented at `:1142` as flooring the
+  release's exit code at 4 regardless of severity settings.
+  `ProfileMismatchError`/`ScopeMismatchError` are plain exceptions, so
+  today's broad `except Exception` would swallow them into that same
+  `"ERROR"`/exit-4 bucket — one incomparable library in a release would
+  silently report as the *worst possible* classification (an ABI break)
+  instead of `not_comparable`, inverting this ADR's purpose on its one
+  multi-library surface. `_compare_one_library` gains a dedicated
+  `except (ProfileMismatchError, ScopeMismatchError) as exc:` branch,
+  ordered before the generic `except Exception`, returning
+  `{"verdict": "not_comparable", "reason": ...}`; the release aggregator
+  and `docs/reference/exit-codes.md`'s multi-library section recognize
+  that verdict value distinctly, not folded into `"ERROR"`.
 - Reporting: `reporter.py`/`sarif.py`/`junit_report.py` gain a
   `not_comparable` top-level result distinct from every existing verdict
   value — never coerced into `compatible`/`breaking`.
@@ -276,8 +292,9 @@ Implements ADR-049 D1 and D2.
 
 **Files & surfaces.** `model.py` (new `ExtractionContract`), new
 `abicheck/comparability.py` (fingerprint computation, `compute_extraction_contract`,
-the gate, and the `UNKNOWN_PROFILE` detector), `dumper.py` (`dump()` calls
-`compute_extraction_contract(...)` and attaches it to every returned
+the gate, and `contract_coverage` metadata computation — no detector, since
+`UNKNOWN_PROFILE` is report metadata, not a `Change`), `dumper.py` (`dump()`
+calls `compute_extraction_contract(...)` and attaches it to every returned
 snapshot — see the acceptance-criteria bullet above; this is not optional
 plumbing), `snapshot_cache.py` (`_SNAPSHOT_CACHE_VERSION` bump — see the
 warm-cache acceptance-criteria bullet above), `errors.py`
@@ -285,13 +302,17 @@ warm-cache acceptance-criteria bullet above), `errors.py`
 `serialization.py` (`SCHEMA_VERSION` bump,
 `_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION` threshold + the
 `snapshot_from_dict` hard-rejection branch, `contract` round-trip through
-`snapshot_to_dict`/`snapshot_from_dict`), `checker_policy.py`
-(`UNKNOWN_PROFILE` enum entry) and a `change_registry*.py` module (its
-`ChangeKindMeta` entry), `checker.py` (gate call at the
-top of `compare`), `service.py`,
-`mcp_server.py`, `cli.py`/`cli_compare_release.py` (flag + the new,
-distinct `not_comparable` exit code), `docs/reference/exit-codes.md` (a
-new row in both the legacy and severity-aware tables), `reporter.py`,
+`snapshot_to_dict`/`snapshot_from_dict`), `checker.py` (gate call at the
+top of `compare`, `contract_coverage` field on the result), `service.py`,
+`mcp_server.py`, `cli.py` (flag + the new,
+distinct `not_comparable` exit code), `cli_compare_release.py`
+(`_compare_one_library`'s dedicated
+`except (ProfileMismatchError, ScopeMismatchError)` branch, ordered before
+`except Exception` — see the release-fan-out acceptance-criteria bullet
+above; this is not covered by the CLI's own exit-code handling, it is a
+separate call path), `docs/reference/exit-codes.md` (a
+new row in both the legacy and severity-aware tables, **and** the
+multi-library section), `reporter.py`,
 `sarif.py`, `junit_report.py`, `abicheck/schemas/compare_report.schema.json`,
 `abicheck/schemas/__init__.py` (`REPORT_SCHEMA_VERSION` bump),
 `docs/schemas/v1/compare_report.schema.json` (regenerated via
@@ -322,22 +343,24 @@ regenerated `docs/schemas/v1` copy; a root-relative-path fingerprint test
 (the acceptance-criteria bullet above — same-tree-different-root compare
 must not fingerprint-mismatch); an exit-code test
 asserting `not_comparable` returns the new dedicated code, never `0`, from
-both the legacy and severity-aware `compare` invocations; a
-`changekind-partition`/`changekind-detector`-gate-compliant unit test for
-the `UNKNOWN_PROFILE` detector, matching the existing test pattern for
-`SOURCE_FACT_COVERAGE_INCOMPLETE`; gate unit tests for all
-three entry points; a `--diagnostic-comparison` end-to-end test; a
+both the legacy and severity-aware `compare` invocations; a **release
+fan-out** test asserting a `not_comparable`-triggering library inside a
+directory/package `compare` reports `verdict: "not_comparable"` in its
+release-level entry, not `"ERROR"` — the specific inversion (incomparable
+reported as the worst-possible classification) this phase must close on
+its fourth entry point; gate unit tests for all
+four entry points; a `--diagnostic-comparison` end-to-end test; a
 backward-compat test asserting a contract-less snapshot pair compares
 unchanged; a **mixed-pair** test (one side `contract`, one side none)
 asserting the comparison never hard-fails and instead carries a
-`UNKNOWN_PROFILE` `QUALITY_KINDS` finding alongside an otherwise-ordinary
+`contract_coverage: "partial"` report field alongside an otherwise-ordinary
 verdict — the specific case the ADR calls out as unambiguous, not left to
 interpretation; a **severity-neutrality** test asserting a mixed-pair
-comparison run with `--severity-potential-breaking=error` (or
-`--severity-preset strict`) still exits successfully — `UNKNOWN_PROFILE`
-must never itself trigger `potential_breaking` promotion, or the "never
-regresses on upgrade" promise breaks for exactly the users who opted into
-strict severity gating.
+comparison run under *every* `--severity-*` flag (`--severity-potential-breaking=error`,
+`--severity-quality-issues=error`, and `--severity-preset strict`) still
+exits successfully — proving `contract_coverage` is structurally outside
+the findings list any severity flag scans, not merely untested against the
+one flag checked last time.
 
 **Example fixtures.** The Phase 0 "scope drift" pair, promoted to a real
 `examples/case2xx_profile_scope_mismatch_gate/` once the gate exists.

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -605,12 +605,17 @@ exist.
   (possibly-multi-document) JSON output as a stream of `{kind, target,
   ast}` contexts — real document-boundary streaming, not a bracket/string
   split; rejects trailing garbage and truncated documents.
-- Context selection is explicit: the manifest's/CLI's `frontend_context`
-  (`host` default, Phase B) is matched against the compiler-reported target triple
-  of each decoded context; a run producing only a mismatched context
-  (e.g. only `spir64` when `host` was requested) is `AST_CONTEXT_MISSING`,
-  an extraction failure — never a successful snapshot with the wrong
-  target silently selected.
+- Context selection is by **`kind`**, not by target-triple matching — the
+  manifest's/CLI's `frontend_context` (`host` default, Phase B) is matched
+  against each decoded context's `kind` field (`"host"`/`"device"`, read
+  directly from the compiler's own JSON output), never against the target
+  triple (`spir64`, etc.), which is diagnostic-only (ADR-050 D5). Three
+  outcomes: exactly one context with the requested `kind` → selected;
+  zero contexts with the requested `kind` (e.g. only a `spir64`/`device`
+  context when `host` was requested) → `AST_CONTEXT_MISSING`, an
+  extraction failure, never a successful snapshot with the wrong target
+  silently selected; more than one context sharing the requested `kind` →
+  `AST_CONTEXT_AMBIGUOUS`, never resolved by an implicit tiebreaker.
 - `dumper_clang.py`'s existing single-context assumption is generalized to
   call this module when the detected frontend is DPC++-capable; a plain
   (non-SYCL) clang/castxml invocation is unaffected — zero-context-stream
@@ -625,8 +630,14 @@ classifier).
 **Tests.** Fixture-driven parser tests against Phase 0's real captured
 output (multi-document, malformed/truncated variants added once the happy
 path is proven — matching the review's own "fixture-first, don't guess the
-parser" sequencing advice). `AST_CONTEXT_MISSING`/`AST_CONTEXT_AMBIGUOUS`
-error-path tests.
+parser" sequencing advice). Selection tests for all three outcomes: exactly
+one context with the requested `kind` selects correctly; zero contexts with
+the requested `kind` raises `AST_CONTEXT_MISSING`; two-or-more contexts
+sharing the requested `kind` raises `AST_CONTEXT_AMBIGUOUS`. A dedicated
+test asserting selection is by `kind`, not target-triple pattern-matching —
+a `{kind: "device", target: "spir64"}` context selected when `frontend_context`
+is `device`, and *not* rejected as a triple-mismatch, is the specific
+regression this criterion exists to prevent.
 
 **Example fixtures.** None required beyond Phase 0's captures — this phase
 is extraction-layer, not diff-layer; no new `ChangeKind`.

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -59,16 +59,19 @@ D's parser and `host`-default path don't depend on B, though selecting a
 *non-default* context needs Phase B's `frontend_context` field/flag to
 request it (see Phase D). Phase C starts only after Phase B lands, since
 it operates on the `TuFragment` contract Phase B defines and produces —
-it is not a third parallel branch alongside B and D. E depends on A
-(needs the fingerprints to extend the cache key) and loosely on B (the
-per-TU loop it schedules); the cache-key half of E can land right after A
-without waiting for B if useful on its own.
+it is not a third parallel branch alongside B and D. E depends on B, not
+directly on A: its cache-key half targets the manifest's
+`contributes_to_abi`/`required` flags (Phase B's schema), not
+`profile_fingerprint`/`scope_fingerprint` themselves — those can never be
+pre-dump cache-key inputs (see Phase E) — and its scheduling half schedules
+Phase B's per-TU loop.
 
 ```
-Phase 0 (fixtures) ──┬──▶ Phase A (contract + gate) ──┬──▶ Phase E (scheduling + cache)
-                      │                                │
-                      ├──▶ Phase B (manifest/multi-TU) ─┴─▶ Phase C (compatible merge)
+Phase 0 (fixtures) ──┬──▶ Phase A (contract + gate)
                       │
+                      ├──▶ Phase B (manifest/multi-TU) ─┬─▶ Phase C (compatible merge)
+                      │                                 │
+                      │                                 └─▶ Phase E (scheduling + cache)
                       └──▶ Phase D (SYCL host/device context)
 ```
 
@@ -219,7 +222,21 @@ Implements ADR-050 D1 and D2.
   flag per TU, reusing a proven parser at a new call site, not a second
   compiler invocation or a directory-tree walk. `profile_fingerprint`'s
   `-I` component is the hash of the **ordered** sequence of per-directory
-  digests. This is lossless: byte-identical dependency content at different mount points
+  digests — **after excluding every path `scope_fingerprint` already
+  covers for that side (the explicit `--header`/manifest TU entry points),
+  not the depfile's raw output.** The documented real-world workflow
+  (`docs/user-guide/real-world-example.md:61-63`) passes the project's own
+  include root as *both* `--header` (the headers being compared) and
+  `--include` (so `#include` resolves) — the same directory serves both
+  roles, so a depfile for that TU necessarily lists the very header being
+  compared alongside its support headers. Hashing the depfile's output
+  unfiltered would feed that header's content into `profile_fingerprint`
+  too, and an ordinary, intentional edit to it would flip
+  `profile_fingerprint` and hard-fail `PROFILE_MISMATCH` before the diff
+  ever ran — on the routine case this whole ADR exists to keep working, not
+  an edge case. `scope_fingerprint` owns "what's declared and compared";
+  `profile_fingerprint` owns "what environment resolved it"; a file cannot
+  honestly feed both. This is lossless: byte-identical dependency content at different mount points
   normalizes identically (attempt one's routine case, still correct);
   genuinely different content normalizes differently regardless of naming
   (the `dep-v1`/`dep-v2` case both attempt one and two mishandled); a
@@ -236,7 +253,7 @@ Implements ADR-050 D1 and D2.
   the manifest file's own directory — none of these legacy-CLI cases
   exist there.
 
-  Seven dedicated tests are non-negotiable for this phase to be considered
+  Eight dedicated tests are non-negotiable for this phase to be considered
   done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
   identical trees under different roots asserts the resulting
   **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
@@ -263,7 +280,17 @@ Implements ADR-050 D1 and D2.
   the target of any declaration's `source_location`) produce *different*
   `profile_fingerprint`s — proving the digest is sourced from the depfile's
   full resolved-file list, not the narrower per-declaration set, the
-  specific under-counting gap this design's own history exists to close.
+  specific under-counting gap this design's own history exists to close;
+  (8) the documented real-world shape — `--header old=old/include/foo.h
+  --header new=new/include/foo.h --include old=old/include --include
+  new=new/include`, the same directory serving both roles — with an
+  **ordinary content edit to `foo.h` itself** between old and new produces
+  a *different* `scope_fingerprint` (correctly reflecting the compared
+  surface changed) but the *same* `profile_fingerprint` (the environment
+  that resolved it did not) — proving the exclusion actually prevents the
+  routine, intentional-header-edit case from spuriously hard-failing
+  `PROFILE_MISMATCH`, the specific regression this exclusion exists to
+  close.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -283,10 +310,11 @@ Implements ADR-050 D1 and D2.
   `snapshot_cache._SNAPSHOT_CACHE_VERSION` (`:48`, currently `"3"`) is
   bumped in this same phase so every pre-Phase-A cache entry misses once
   and gets rebuilt through the now-`contract`-populating `dump()`. This is
-  separate from Phase E's later `profile_fingerprint`/`scope_fingerprint`-
-  as-cache-key work (a different gap: a pure profile change with identical
-  headers not invalidating) and cannot be deferred to it without leaving
-  the gate inert for every warm-cache user until Phase E ships.
+  separate from Phase E's later manifest-driven `scope_fingerprint`
+  cache-key work (a different gap: pre-dump-knowable manifest fields the
+  existing filesystem-only cache key can't see) and cannot be deferred to
+  it without leaving the gate inert for every warm-cache user until Phase E
+  ships.
 - **A third cache gap, ongoing rather than one-time, also lands here:**
   `_cache_key()` (`snapshot_cache.py:159,168`) hashes `sorted(headers)`/
   `sorted(includes)` — order-*insensitive* — while D1's fingerprints are
@@ -297,10 +325,9 @@ Implements ADR-050 D1 and D2.
   recomputed for the new order, since a cache hit skips `dump()` entirely.
   This phase drops `sorted(...)` for `headers`/`includes` in `_cache_key()`
   and hashes them in caller-supplied order instead; deferring this to
-  Phase E doesn't help, since Phase E's cache-key work addresses a
-  different, narrower gap (identical header *content*, pure profile
-  change) and wouldn't by itself make the existing sorted hashing
-  order-preserving.
+  Phase E doesn't help, since Phase E's cache-key work is scoped to a
+  different, manifest-only gap (see Phase E) and wouldn't by itself make
+  the existing sorted hashing order-preserving.
 - `serialization.SCHEMA_VERSION` is bumped (11 → 12) in the same change
   that starts writing `contract` — **not** treated as a free additive field
   the way ADR-041's advisory `extractor_passes`/`narrowed_passes` were. The
@@ -1022,9 +1049,12 @@ is extraction-layer, not diff-layer; no new `ChangeKind`.
 
 ## Phase E — Resource-aware frontend scheduling and cache-key extension
 
-Implements ADR-050 D6. Depends on Phase A (fingerprints for the cache key);
-the scheduling half loosely depends on Phase B (the per-TU loop it
-schedules) but the cache-key half can land immediately after Phase A.
+Implements ADR-050 D6. The cache-key half targets the manifest's
+`contributes_to_abi`/`required` flags, so it depends on Phase B (the
+manifest schema those flags live on), not on Phase A's fingerprints
+themselves — `profile_fingerprint`/`scope_fingerprint` are never used as
+cache-key inputs (see the acceptance-criteria bullet below for why). The
+scheduling half depends on Phase B too (the per-TU loop it schedules).
 
 **Goal & acceptance criteria.**
 - The RAM-probing/pool-sizing helper in `buildsource/source_replay.py` is
@@ -1035,21 +1065,47 @@ schedules) but the cache-key half can land immediately after Phase A.
 - `dumper.py`'s per-TU castxml/clang invocations (Phase B) run under this
   pool instead of a fully sequential loop; a killed/timed-out TU records
   its exit signal and never silently retries as a clean empty TU.
-- `snapshot_cache.py`'s `_cache_key()` (`:130`) gains
-  `profile_fingerprint`/`scope_fingerprint` as additional key inputs — a
-  pure compile-profile change with identical header content now correctly
-  invalidates the cache, closing the one real gap in an otherwise-already-
-  correct (content-hash-based) cache design.
+- **`profile_fingerprint` itself cannot be a cache-key input — this phase
+  does not attempt it.** `cached_run_dump` looks up `snapshot_cache`
+  *before* calling `dump()` (Phase A); `profile_fingerprint`'s `-I`
+  component is a depfile digest that only exists *after* an L2
+  castxml/clang invocation runs, so using it as a pre-lookup key input
+  would require running the very extraction the cache exists to skip —
+  circular, not merely undesirable. `_cache_key()` already closes the
+  practical gap this phase originally targeted, without either
+  fingerprint: it recurses every `-I`/`-H` directory
+  (`header_utils.iter_cache_header_files`) and hashes each matched file's
+  content and mtime, pre-dump, no compiler invocation needed. This
+  deliberately over-approximates (hashes every header-like file reachable
+  under the directory, not only ones a given compile would resolve) —
+  correct for a cache key, where a false miss just costs a redundant dump
+  and a false hit would serve a stale `contract`, unlike
+  `profile_fingerprint` itself, which must be exact or the gate spuriously
+  fires. Phase A's own order-sensitivity fix (dropping `sorted(...)` for
+  `headers`/`includes`) already closes the remaining gap that mattered for
+  the legacy CLI path. `snapshot_cache.py`'s `_cache_key()` (`:130`)
+  instead gains the manifest-driven `scope_fingerprint` inputs that
+  genuinely are pre-dump-knowable and that `iter_cache_header_files`'s
+  filesystem walk has no way to see, since they aren't file content at
+  all: a TU's `contributes_to_abi`/`required` flags (D3/D4) — flipping
+  either changes which declarations feed the ABI model without necessarily
+  touching any file content, so today's content-hash-only key would miss
+  that class of drift on a manifest-driven dump.
 
 **Files & surfaces.** New `abicheck/process_resources.py`,
 `buildsource/source_replay.py` (import from it instead of its own inline
 implementation), `dumper.py` (per-TU pool), `snapshot_cache.py`
-(`_cache_key` inputs).
+(`_cache_key` gains the manifest's per-TU `contributes_to_abi`/`required`
+flags as additional key inputs — not `profile_fingerprint`/
+`scope_fingerprint` themselves).
 
 **Tests.** `process_resources.py` unit tests migrated from
 `source_replay.py`'s existing RAM-probing tests (same behavior, new import
 path — a refactor test, not new coverage). Cache-key test: identical
-headers, differing `profile_fingerprint` ⇒ cache miss.
+manifest TU includes, differing only a TU's `contributes_to_abi` flag ⇒
+cache miss — the specific pre-dump-knowable gap this phase closes,
+distinct from Phase A's already-completed order-sensitivity and
+whole-snapshot-cache-version fixes.
 
 **Out of scope.** No new scheduling *policy* — this phase ports the
 existing, already-proven `source_replay.py` policy verbatim; a different

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -170,40 +170,60 @@ Implements ADR-050 D1 and D2.
   failure from the one this fix exists to close; taking the parent
   directory first preserves the filename (`v1/foo.h` → root `v1/`,
   normalized `foo.h`).
-  **`profile_fingerprint`'s `-I` directories use that same parent-directory
-  rule too, uniformly — this went through two rejected "clever" fixes
-  before landing on the simple one; both are worth recording so neither is
-  rediscovered.** A first attempt applied the header rule unchanged, which
-  is right for the common real-world shape (`--include old=old/include
-  --include new=new/include`, the project's own include root across two
-  checkouts — the exact shape `docs/user-guide/real-world-example.md`
-  documents) but wrong for a lone *external dependency* directory:
-  `--include old=/opt/dep-v1/include --include new=/opt/dep-v2/include`
-  would normalize both to `include` relative to their own root, silently
-  erasing a genuine dependency-version difference. A second attempt tried
-  hashing each `-I` directory's last two path components instead
-  (`/opt/dep-v1/include` → `dep-v1/include`) — this broke the *other*
-  direction, making the ordinary `old/include`/`new/include` project-root
-  case hash as different and hard-fail the routine, documented two-checkout
-  compare. Both attempts fail for the same underlying reason: **whether a
-  differently-rooted `-I` path means "same dependency, different checkout
-  mount point" or "genuinely different dependency version" is not decidable
-  from path shape alone, and no heuristic can resolve it** — the two
-  examples above have identical shape (two segments, differing prefix) and
-  opposite correct answers. `profile_fingerprint` therefore uses the header
-  rule as-is, single or multiple `-I` directories, no special case — a
-  **known, accepted limitation, not a solved problem**: it keeps the common
-  project-include-root workflow working (the gate's primary use case), at
-  the cost of not detecting a dependency-version change expressed purely as
-  a differently-named `-I` mount point with the same basename; that class
-  of drift is undetectable by this fingerprint on the legacy CLI path (a
-  user who needs it has `--diagnostic-comparison`, D2, as the sanctioned
-  fallback). For the manifest path (D3), both fingerprints' roots are
-  simply the manifest file's own directory — none of these legacy-path
-  degenerate cases exist there, since every manifest-declared path is
-  already relative to one document.
+  **`profile_fingerprint`'s `-I` directories are fingerprinted by resolved
+  content, not by path shape — three path-shape heuristics were tried and
+  rejected in turn (ADR-050 D1 records all three in full); a fourth,
+  path-shape-agnostic design is what actually ships.** Rejected attempt
+  one: header parent-directory rule applied unchanged — right for
+  `--include old=old/include --include new=new/include` (the routine
+  two-checkout project-root case), wrong for a lone external dependency
+  (`--include old=/opt/dep-v1/include --include new=/opt/dep-v2/include`
+  normalizes both to `include`, erasing a real version difference).
+  Rejected attempt two: hash each `-I` directory's last two path
+  components instead — fixes the dependency case, breaks the routine
+  project-root case (hashes `old/include` vs. `new/include` as different).
+  Rejected attempt three: revert to the parent-directory rule uniformly
+  and accept the dependency-version gap as documented — this breaks a
+  *third* direction once a side declares a project include **plus** a
+  shared external dependency (`old=/work/v1/include` + `old=/opt/dep`,
+  `new=/work/v2/include` + `new=/opt/dep`): each side's common ancestor
+  collapses to `/`, so the project include normalizes back to its
+  diverging checkout root and an otherwise-identical routine upgrade
+  hard-fails `PROFILE_MISMATCH` — the same "combining heterogeneous
+  categories under one shared root" mistake `scope_fingerprint`/
+  `profile_fingerprint` splitting apart already fixed once, recurring
+  *within* `profile_fingerprint` itself. No function of `-I` path shape
+  can be made correct, and combining multiple `-I` directories under one
+  shared root additionally risks corrupting entries that would have
+  normalized correctly alone. `profile_fingerprint` therefore computes no
+  root from `-I` path text at all: each `-I` directory (per side, in
+  declared order — order is already a hashed input) contributes its own
+  digest — the sorted set of (path relative to that `-I` directory,
+  content hash) pairs for every header file extraction actually resolved
+  from inside it, available at zero extra cost from the per-declaration
+  resolving-header paths `dumper_castxml.py`/`dumper_clang.py` already
+  collect (`_source_location`/`header_from_location`) — grouped by
+  originating `-I` directory and hashed, not a new compiler invocation or
+  a full directory-tree walk. `profile_fingerprint`'s `-I` component is
+  the hash of the **ordered** sequence of per-directory digests. This is
+  lossless: byte-identical dependency content at different mount points
+  normalizes identically (attempt one's routine case, still correct);
+  genuinely different content normalizes differently regardless of naming
+  (the `dep-v1`/`dep-v2` case both attempt one and two mishandled); a
+  side-specific project include alongside a shared external dependency
+  normalizes each independently, since no shared-root computation exists
+  left to corrupt (attempt three's regression is structurally impossible
+  here). If a resolved header's content can't be read at fingerprint time,
+  extraction fails outright with a dedicated error rather than folding an
+  "unresolvable" sentinel into the hash. `scope_fingerprint` is unaffected
+  — it hashes header/TU *paths* (declared naming is part of the compared
+  surface), unlike `profile_fingerprint`'s `-I` job of describing *how*
+  `#include` resolves, where identity should track content, not the path
+  label. For the manifest path (D3), both fingerprints' roots are simply
+  the manifest file's own directory — none of these legacy-CLI cases
+  exist there.
 
-  Four dedicated tests are non-negotiable for this phase to be considered
+  Six dedicated tests are non-negotiable for this phase to be considered
   done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
   identical trees under different roots asserts the resulting
   **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
@@ -212,17 +232,19 @@ Implements ADR-050 D1 and D2.
   `old=v1/foo.h`/`new=v2/bar.h` (genuinely different header names) produce
   *different* `scope_fingerprint`s; (3) adding an identical, out-of-checkout
   `--include old=/opt/dep --include new=/opt/dep` alongside case (1)'s
-  headers still leaves `scope_fingerprint` matching — the specific
-  external-dependency-directory regression this criterion exists to
-  prevent; (4) `--include old=old/include --include new=new/include` (the
-  common two-checkout project-include-root shape) leaves `profile_fingerprint`
-  matching, and a documented, deliberately-not-fixed regression test pinning
-  that `--include old=/opt/dep-v1/include --include new=/opt/dep-v2/include`
-  (a lone, genuinely different `-I` directory sharing the same basename)
-  currently produces the *same* `profile_fingerprint` on both sides — the
-  known, accepted limitation above, asserted so a future change doesn't
-  silently start "fixing" it into a heuristic that breaks case (4)'s first
-  half again.
+  headers still leaves `scope_fingerprint` matching; (4) `--include
+  old=old/include --include new=new/include` with byte-identical header
+  content on both sides leaves `profile_fingerprint` matching — the
+  routine two-checkout case every rejected attempt had to keep working;
+  (5) `--include old=/opt/dep-v1/include --include new=/opt/dep-v2/include`
+  with **genuinely different** header content produces *different*
+  `profile_fingerprint`s — the case attempts one and two got wrong in
+  opposite directions, now closed rather than documented as a gap; (6) a
+  side declaring a project include **plus** a shared, byte-identical
+  external dependency (`old=/work/v1/include` + `old=/opt/dep`,
+  `new=/work/v2/include` + `new=/opt/dep`) leaves `profile_fingerprint`
+  matching — the specific mixed-roots regression rejected attempt three
+  introduced, now a permanent regression test rather than a live bug.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -463,7 +485,9 @@ Implements ADR-050 D1 and D2.
   either fails `tests/test_report_schema.py::test_docs_mirror_matches_packaged_schema`,
   which already asserts the two stay byte-identical.
 - `--diagnostic-comparison` opt-in flag: downgrades the hard-fail to a
-  tentative diff, every finding stamped `assurance: none`.
+  tentative diff, the whole result stamped `assurance: "none"` — a single
+  `DiffResult`-level field (see the dedicated bullet below), never a
+  per-finding one.
 - **Rollout: the hard gate is the default from the first shipped version of
   this phase — no soft-launch flag, and no second flag with a default that
   contradicts ADR-050 D2.** D2 is explicit that a contract mismatch is a
@@ -823,9 +847,25 @@ exist.
   `AST_CONTEXT_AMBIGUOUS`, never resolved by an implicit tiebreaker.
 - `dumper_clang.py`'s existing single-context assumption is generalized to
   call this module when the detected frontend is DPC++-capable; a plain
-  (non-SYCL) clang/castxml invocation is unaffected — zero-context-stream
-  output degrades to the existing single-context path, not a new failure
-  mode for the common case.
+  (non-SYCL) clang/castxml invocation is unaffected.
+- **The legacy single-context fallback is gated on positive non-SYCL
+  identification, never on the decoded context count.** "Zero contexts
+  with the requested `kind`" (above, → `AST_CONTEXT_MISSING`) and "this
+  wasn't a multi-document DPC++ invocation at all" are different
+  conditions and must not be conflated: the fallback to the existing
+  single-context path fires only when the frontend invocation is
+  positively identified as non-SYCL *before* `sycl_context.py` is ever
+  invoked (e.g. no DPC++/multi-document toolchain flag was requested, or
+  the raw output never contains the module's document-boundary markers at
+  all) — never as a recovery path *after* handing DPC++-capable output to
+  the decoder and getting back an empty or malformed stream. A
+  DPC++-capable invocation that decodes to zero contexts (a broken
+  toolchain invocation, truncated output, or any other malformed-data
+  case) must still raise `AST_CONTEXT_MISSING` through the three-outcome
+  logic above, not silently degrade to the single-context path — that
+  degradation is reserved for output that was never a context stream to
+  begin with, so missing or malformed DPC++ context data can never result
+  in silently selecting the wrong (or an arbitrary) AST.
 
 **Files & surfaces.** New `abicheck/sycl_context.py`, `dumper_clang.py`
 (wiring), `sycl_metadata.py` (unaffected — this phase adds frontend-level
@@ -842,7 +882,13 @@ sharing the requested `kind` raises `AST_CONTEXT_AMBIGUOUS`. A dedicated
 test asserting selection is by `kind`, not target-triple pattern-matching —
 a `{kind: "device", target: "spir64"}` context selected when `frontend_context`
 is `device`, and *not* rejected as a triple-mismatch, is the specific
-regression this criterion exists to prevent.
+regression this criterion exists to prevent. A **fallback-gating** test
+asserting a DPC++-capable invocation whose decoded stream comes back empty
+(a broken toolchain invocation, truncated output) raises
+`AST_CONTEXT_MISSING`, never silently falling back to the single-context
+path — proving the fallback distinguishes "genuinely not a multi-document
+invocation" from "was one, but decoded to nothing," the specific
+conflation this criterion exists to prevent.
 
 **Example fixtures.** None required beyond Phase 0's captures — this phase
 is extraction-layer, not diff-layer; no new `ChangeKind`.

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -108,9 +108,16 @@ without a live DPC++ toolchain in every CI lane.
 Implements ADR-049 D1 and D2.
 
 **Goal & acceptance criteria.**
-- `AbiSnapshot.contract: ExtractionContract | None` (additive field,
-  `model.py`) carries `profile_fingerprint`/`scope_fingerprint` plus the
-  resolved inputs that produced them.
+- `AbiSnapshot.contract: ExtractionContract | None` (`model.py`) carries
+  `profile_fingerprint`/`scope_fingerprint` plus the resolved inputs that
+  produced them.
+- `serialization.SCHEMA_VERSION` is bumped (11 → 12) in the same change
+  that starts writing `contract` — **not** treated as a free additive field
+  the way ADR-041's advisory `extractor_passes`/`narrowed_passes` were (see
+  ADR-049 D1's rationale: the comparability gate is verdict-blocking, so an
+  old reader silently not knowing about `contract` must hit the existing
+  forward-version rejection, `serialization.py:557-567`, instead of
+  producing an ordinary verdict on data it can't check).
 - `comparability.check_contracts_comparable(old, new)` raises
   `ProfileMismatchError`/`ScopeMismatchError` (`errors.py`) when both sides
   carry a `contract` and the fingerprints differ; a snapshot with no
@@ -124,6 +131,15 @@ Implements ADR-049 D1 and D2.
 - Reporting: `reporter.py`/`sarif.py`/`junit_report.py` gain a
   `not_comparable` top-level result distinct from every existing verdict
   value — never coerced into `compatible`/`breaking`.
+- The published JSON contract moves with the reporters, in this phase, not
+  after: `abicheck/schemas/compare_report.schema.json` currently requires
+  `verdict` and restricts it to a fixed string enum with no `null` member.
+  It's updated to allow `verdict: null` alongside the new `not_comparable`
+  state (and a `reason` object), and `tests/test_report_schema.py` — which
+  already validates emitted reports against this exact file — gains a case
+  for a `not_comparable` report. Shipping the reporter change without this
+  either emits JSON that fails its own published schema, or ships a stale
+  schema — not an acceptable outcome for either.
 - `--diagnostic-comparison` opt-in flag: downgrades the hard-fail to a
   tentative diff, every finding stamped `assurance: none`.
 - **Rollout: the hard gate is the default from the first shipped version of
@@ -149,15 +165,23 @@ Implements ADR-049 D1 and D2.
 
 **Files & surfaces.** `model.py` (new `ExtractionContract`), new
 `abicheck/comparability.py` (fingerprint computation + gate), `errors.py`
-(two new exception classes), `checker.py` (gate call at the top of
-`compare`), `service.py`, `mcp_server.py`, `cli.py`/`cli_compare_release.py`
-(flag + `not_comparable` exit-code handling — see `docs/reference/exit-codes.md`,
-which needs a new row), `reporter.py`, `sarif.py`, `junit_report.py`.
+(two new exception classes), `serialization.py` (`SCHEMA_VERSION` bump,
+`contract` round-trip through `snapshot_to_dict`/`snapshot_from_dict`),
+`checker.py` (gate call at the top of `compare`), `service.py`,
+`mcp_server.py`, `cli.py`/`cli_compare_release.py` (flag + `not_comparable`
+exit-code handling — see `docs/reference/exit-codes.md`, which needs a new
+row), `reporter.py`, `sarif.py`, `junit_report.py`,
+`abicheck/schemas/compare_report.schema.json`.
 
 **Tests.** Unit tests for fingerprint stability (same manifest,
 independent-TU reordering unaffected; include-order-within-a-TU changes
-the fingerprint); gate unit tests for all three entry points; a
-`--diagnostic-comparison` end-to-end test; a backward-compat test asserting
+the fingerprint); a `SCHEMA_VERSION`-bump test asserting a pre-bump reader
+(a stubbed/patched `SCHEMA_VERSION`) hits the existing forward-version
+rejection on a `contract`-bearing snapshot rather than silently ignoring
+the field; `tests/test_report_schema.py` gains a `not_comparable` case
+validated against the updated `compare_report.schema.json`; gate unit tests
+for all three entry points; a `--diagnostic-comparison` end-to-end test; a
+backward-compat test asserting
 a contract-less snapshot pair compares unchanged.
 
 **Example fixtures.** The Phase 0 "scope drift" pair, promoted to a real

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -233,9 +233,23 @@ Implements ADR-050 D1 and D2.
   data-source choice. Every listed path is attributed to whichever declared
   `-I` directory contains it — one extra cheap compiler flag per TU,
   reusing a proven parser at a new call site, not a second compiler
-  invocation or a directory-tree walk. `profile_fingerprint`'s
+  invocation or a directory-tree walk.
+  **Not every `-MD`-listed path falls under a declared `-I` directory.**
+  `dumper.py` already introduces search paths outside the user-declared
+  `includes` list: `--sysroot`, the GNU-toolchain `-isystem` dirs it probes
+  and injects automatically (`_probe_gnu_system_includes`), and any
+  `-isystem`/`-I` embedded in `--gcc-options`/`--gcc-option` pass-through
+  flags. Leaving depfile entries resolved through these unattributed would
+  recreate this design's own under-counting bug one layer out — a
+  toolchain/sysroot upgrade changing an ABI-relevant system header would
+  never affect `profile_fingerprint`. Every depfile path not under any
+  declared `-I` directory instead feeds one additional, explicitly-labeled
+  **system/toolchain bucket** — a content digest of that unordered set (no
+  path-shape normalization attempted, since these paths carry no
+  user-declared search-order meaning to preserve). `profile_fingerprint`'s
   `-I` component is the hash of the **ordered** sequence of per-directory
-  digests — **after excluding every path `scope_fingerprint` already
+  digests, **plus this one system/toolchain bucket appended last** —
+  **after excluding every path `scope_fingerprint` already
   covers for that side (the explicit `--header`/manifest TU entry points),
   not the depfile's raw output.** The documented real-world workflow
   (`docs/user-guide/real-world-example.md:61-63`) passes the project's own
@@ -266,7 +280,7 @@ Implements ADR-050 D1 and D2.
   the manifest file's own directory — none of these legacy-CLI cases
   exist there.
 
-  Nine dedicated tests are non-negotiable for this phase to be considered
+  Ten dedicated tests are non-negotiable for this phase to be considered
   done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
   identical trees under different roots asserts the resulting
   **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
@@ -316,7 +330,14 @@ Implements ADR-050 D1 and D2.
   output entirely and silently miss this difference, the exact regression
   `include_graph.py:354-356` already had to fix once for the L3 include
   graph and this digest must not reintroduce on its own, separate call
-  site.
+  site; (10) a header reached only via a probed toolchain `-isystem` dir or
+  `--sysroot` — **not under any declared `-I` directory at all** — with
+  genuinely different content between old and new still produces
+  *different* `profile_fingerprint`s, proving the system/toolchain bucket
+  actually attributes and hashes paths outside every declared `-I`
+  directory rather than silently dropping them, the specific gap distinct
+  from test (9)'s (which covers a system-*classified* path still reachable
+  through a declared `-I`).
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -529,6 +550,33 @@ Implements ADR-050 D1 and D2.
   independent exit-code schemes; reusing either of those would imply a
   shared numbering `scan` doesn't have. `docs/reference/exit-codes.md`'s
   `scan` table gains this row.
+- **`cli_scan.py`'s `scan_cmd` is not the only front-end wrapping
+  `run_scan_core` — the typed Python API and MCP reach the same
+  `_run_baseline_compare` call through a separate, unfixed path.**
+  `service_scan.run_scan` (`:801-928`) is its own front-end over
+  `run_scan_core`, with its own `try`/`except _BudgetOverflow`/`except
+  _EvidenceContractError` — the identical gap as `scan_cmd`'s, on a
+  different call site: `ProfileMismatchError`/`ScopeMismatchError` would
+  propagate out of `run_scan` uncaught today. This matters beyond the
+  Python API itself because `run_scan_subprocess`'s worker (`:982-985`)
+  calls `run_scan(req).to_dict()` inside `except BaseException as exc:
+  q.put(("err", f"{type(exc).__name__}: {exc}"))` — a fully generic
+  catch-all that cannot distinguish a deliberate `not_comparable` result
+  from any other crash, and `run_scan_subprocess` (`:1108-1135`) turns that
+  into a bare `RuntimeError`. `mcp_server`'s `abi_scan` MCP tool goes
+  through `run_scan_subprocess`, so an AI agent calling `abi_scan(...
+  against=...)` on a mismatched pair would see an opaque worker-crash
+  `RuntimeError`, not a structured not-comparable result — losing the
+  ADR's semantics entirely on the one surface built specifically for
+  agent consumption. `run_scan` gains a fourth `except
+  (ProfileMismatchError, ScopeMismatchError) as exc:` branch alongside its
+  existing two, returning `ScanResult(verdict="NOT_COMPARABLE",
+  exit_code=6, ...)` — reusing `scan`'s own exit `6` rather than inventing
+  a second code for the same command. Fixing `run_scan` alone closes both
+  gaps: `run_scan_subprocess`'s worker calls `run_scan(...)` directly, so
+  a `NOT_COMPARABLE` result now flows through its normal `q.put(("ok",
+  ...))` path — no separate `run_scan_subprocess`/`mcp_server.py` change
+  needed beyond that.
 - **A seventh entry point imports `checker.compare` directly and swallows
   every exception into an undifferentiated `None` today — a different
   failure mode than the previous six, and it needs its own fix.**
@@ -699,7 +747,13 @@ table update), `cli_scan.py` (`scan_cmd`'s new third `except
 its existing `_BudgetOverflow`/`_EvidenceContractError` clauses — no change
 needed in `cli_scan_baseline.py`/`scan_engine.py` themselves, since
 neither catches these exceptions today and both must keep letting them
-propagate), `stack_checker.py` (`StackChange.not_comparable_reason`
+propagate), `service_scan.py` (`run_scan`'s new fourth `except
+(ProfileMismatchError, ScopeMismatchError)` branch returning
+`ScanResult(verdict="NOT_COMPARABLE", exit_code=6, ...)`, alongside its
+existing `_BudgetOverflow`/`_EvidenceContractError` clauses — no separate
+`run_scan_subprocess`/`mcp_server.py` change needed, since the worker
+already calls `run_scan(...)` and forwards whatever `ScanResult` it
+returns), `stack_checker.py` (`StackChange.not_comparable_reason`
 field; `_run_abi_diff` re-raises `ProfileMismatchError`/`ScopeMismatchError`
 instead of swallowing them into its broad `except Exception`; its caller
 gains the dedicated `except` branch that sets `not_comparable_reason`),
@@ -795,7 +849,14 @@ budget-overflow code) for a `ProfileMismatchError`/`ScopeMismatchError`
 raised from the baseline compare, exercised through a real end-to-end
 `scan --against` invocation on a mismatched pair — proving `scan_cmd`'s new
 `except` clause actually catches what `_run_baseline_compare` lets through
-uncaught today; a **deps-compare exit-code** test asserting `abicheck deps
+uncaught today; a **`run_scan` API/MCP** test asserting
+`service_scan.run_scan(ScanRequest(..., baseline=...))` on a mismatched
+pair returns `ScanResult(verdict="NOT_COMPARABLE", exit_code=6)` rather
+than raising, and a second test asserting `run_scan_subprocess` (and, by
+extension, `mcp_server.abi_scan`) surfaces that same structured result
+rather than a generic `RuntimeError` — proving the fix at `run_scan`
+actually reaches the MCP surface without any change needed there; a
+**deps-compare exit-code** test asserting `abicheck deps
 compare` returns exactly `5` (never folded into `4`'s `FAIL`, never a
 silent `None` diff indistinguishable from the pre-existing
 "file unreadable" case) for a `ProfileMismatchError`/`ScopeMismatchError`

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -116,6 +116,16 @@ Implements ADR-049 D1 and D2.
   declarations feed the ABI model without necessarily touching a TU's
   includes, so leaving it out of the hash would let that exact class of
   scope drift pass the gate undetected.
+- **Modeling `contract` is not the same as populating it — this phase must
+  do both.** `dump()` (`dumper.py`) is the one place that already resolves
+  every input both fingerprints need; it calls
+  `comparability.compute_extraction_contract(...)` and attaches the result
+  to the `AbiSnapshot` it returns, for every dump (not only a manifest-
+  driven one — Phase B). Without this, `contract` stays `None` on every
+  freshly-produced snapshot, and since the gate below only ever raises when
+  **both** sides carry one, two ordinary dumps would silently take the same
+  code path as the intentionally-lenient mixed-pair case forever — a fully
+  specified, fully inert gate.
 - `serialization.SCHEMA_VERSION` is bumped (11 → 12) in the same change
   that starts writing `contract` — **not** treated as a free additive field
   the way ADR-041's advisory `extractor_passes`/`narrowed_passes` were. The
@@ -146,6 +156,25 @@ Implements ADR-049 D1 and D2.
   non-authoritative annotation on the ordinary verdict that still gets
   produced — same shape as the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`
   (`checker_policy.py:618`), not a second meaning for `not_comparable`.
+  `UNKNOWN_PROFILE` is registered as a real `ChangeKind` via the repo's
+  standard four-step procedure (AGENTS.md "Adding a new ChangeKind"), the
+  same as `SOURCE_FACT_COVERAGE_INCOMPLETE` was — enum entry
+  (`checker_policy.py`), one `ChangeKindMeta` entry with `default_verdict`
+  placing it in `RISK_KINDS` (a `change_registry*.py` module), a detector in
+  `comparability.py` wired via `@registry.detector(...)`, and a unit test.
+  Not an ad-hoc report string: that would trip the AI-readiness
+  `changekind-partition`/`changekind-detector` gates or bypass the
+  registry's own import-time completeness assertion.
+- **The exit code is part of the published contract too, not an
+  afterthought.** `docs/reference/exit-codes.md` documents two co-existing
+  `compare` schemes (legacy: 0/2/4; severity-aware: 0/1/2/4) where `0`
+  means *compatible* in both. `not_comparable` must never exit `0` in
+  either scheme — otherwise the exact "missing evidence reads as safe"
+  failure this ADR exists to prevent reappears at the process-exit
+  boundary, undoing the JSON-level fix. This phase reserves one new,
+  distinct nonzero code and adds it as its own row to both tables in
+  `docs/reference/exit-codes.md`, not folded into either scheme's existing
+  numbering.
 - The gate is wired at **all three** entry points in one phase, closing the
   gap AGENTS.md's "Known gaps" section already names for the depth
   contract rather than repeating the CLI-only mistake: `checker.compare`
@@ -187,30 +216,44 @@ Implements ADR-049 D1 and D2.
   already-common default-off-to-on transition.
 
 **Files & surfaces.** `model.py` (new `ExtractionContract`), new
-`abicheck/comparability.py` (fingerprint computation + gate), `errors.py`
+`abicheck/comparability.py` (fingerprint computation, `compute_extraction_contract`,
+the gate, and the `UNKNOWN_PROFILE` detector), `dumper.py` (`dump()` calls
+`compute_extraction_contract(...)` and attaches it to every returned
+snapshot — see the acceptance-criteria bullet above; this is not optional
+plumbing), `errors.py`
 (`ProfileMismatchError`/`ScopeMismatchError`/`IncompatibleSnapshotSchemaError`),
 `serialization.py` (`SCHEMA_VERSION` bump,
 `_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION` threshold + the
 `snapshot_from_dict` hard-rejection branch, `contract` round-trip through
-`snapshot_to_dict`/`snapshot_from_dict`), `checker.py` (gate call at the
+`snapshot_to_dict`/`snapshot_from_dict`), `checker_policy.py`
+(`UNKNOWN_PROFILE` enum entry) and a `change_registry*.py` module (its
+`ChangeKindMeta` entry), `checker.py` (gate call at the
 top of `compare`), `service.py`,
-`mcp_server.py`, `cli.py`/`cli_compare_release.py` (flag + `not_comparable`
-exit-code handling — see `docs/reference/exit-codes.md`, which needs a new
-row), `reporter.py`, `sarif.py`, `junit_report.py`,
-`abicheck/schemas/compare_report.schema.json`.
+`mcp_server.py`, `cli.py`/`cli_compare_release.py` (flag + the new,
+distinct `not_comparable` exit code), `docs/reference/exit-codes.md` (a
+new row in both the legacy and severity-aware tables), `reporter.py`,
+`sarif.py`, `junit_report.py`, `abicheck/schemas/compare_report.schema.json`.
 
-**Tests.** Unit tests for fingerprint stability (same manifest,
+**Tests.** A `dump()`-level test asserting a real (non-manifest) dump
+returns a snapshot with a populated, non-`None` `contract` — the specific
+gap that would otherwise leave the gate permanently inert. Unit tests for
+fingerprint stability (same manifest,
 independent-TU reordering unaffected; include-order-within-a-TU changes
 the fingerprint; flipping one TU's `contributes_to_abi` or `required` flag
 with its includes held identical also changes `scope_fingerprint`); a
-a hard-rejection test asserting a pre-bump reader (a stubbed/patched
+hard-rejection test asserting a pre-bump reader (a stubbed/patched
 `SCHEMA_VERSION` below the threshold) raises `IncompatibleSnapshotSchemaError`
 on a schema-12 `contract`-bearing snapshot instead of the pre-existing
 warn-and-continue path; a regression test pinning that a schema bump
 *below* the threshold still only warns (today's lenient behavior for
 ordinary additive fields must not become accidentally stricter);
 `tests/test_report_schema.py` gains a `not_comparable` case validated
-against the updated `compare_report.schema.json`; gate unit tests for all
+against the updated `compare_report.schema.json`; an exit-code test
+asserting `not_comparable` returns the new dedicated code, never `0`, from
+both the legacy and severity-aware `compare` invocations; a
+`changekind-partition`/`changekind-detector`-gate-compliant unit test for
+the `UNKNOWN_PROFILE` detector, matching the existing test pattern for
+`SOURCE_FACT_COVERAGE_INCOMPLETE`; gate unit tests for all
 three entry points; a `--diagnostic-comparison` end-to-end test; a
 backward-compat test asserting a contract-less snapshot pair compares
 unchanged; a **mixed-pair** test (one side `contract`, one side none)

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -50,7 +50,9 @@ and start providing value (as a report-only signal) independently of B–E —
 it does not require multi-TU support to be useful, since even today's
 single-aggregate-TU snapshots have a real, checkable `profile_fingerprint`.
 B, C, and D can proceed in parallel once Phase 0's fixtures exist (C
-depends on B landing first; D does not depend on B or C). E depends on A
+depends on B landing first; D's parser and `host`-default path don't
+depend on B or C, though selecting a *non-default* context needs Phase B's
+`frontend_context` field/flag to request it — see Phase D). E depends on A
 (needs the fingerprints to extend the cache key) and loosely on B (the
 per-TU loop it schedules); the cache-key half of E can land right after A
 without waiting for B if useful on its own.
@@ -143,20 +145,41 @@ Implements ADR-050 D1 and D2.
   (`work/v1/foo.h` vs. `work/v2/foo.h`) and `scope_fingerprint` mismatches
   anyway — the exact bug this whole fix exists to close, reintroduced by
   mixing an unrelated path category into the same root computation.
-  Each root (legacy CLI path: the common ancestor **directory** of that
-  side's own paths in that one category — each header's *parent* directory
-  for `scope_fingerprint`, each `-I` directory itself for
-  `profile_fingerprint`; manifest path: the manifest file's own directory
-  for both) before
-  hashing (ADR-050 D1). Deriving a root from header paths directly instead
-  of their parents breaks the single-header-per-side case — the common
-  ancestor of a one-element path set is that whole path, so `old=v1/foo.h`
-  and `new=v2/bar.h` would both normalize to the same empty marker and hash
-  identically despite being different scopes, the opposite failure from the
-  one this fix exists to close; taking the parent directory first preserves
-  the filename (`v1/foo.h` → root `v1/`, normalized `foo.h`). Three
-  dedicated tests are non-negotiable for this phase to be considered done:
-  (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
+  For the legacy CLI path, `scope_fingerprint`'s root is the common
+  ancestor **directory** of that side's header paths' *parent* directories
+  only (never `-I` directories). Deriving it from header paths directly
+  instead of their parents breaks the single-header-per-side case — the
+  common ancestor of a one-element path set is that whole path, so
+  `old=v1/foo.h` and `new=v2/bar.h` would both normalize to the same empty
+  marker and hash identically despite being different scopes, the opposite
+  failure from the one this fix exists to close; taking the parent
+  directory first preserves the filename (`v1/foo.h` → root `v1/`,
+  normalized `foo.h`).
+  **`profile_fingerprint`'s `-I` directories do not use that same
+  parent-directory rule.** A lone `-I` directory has no filename to
+  preserve, so taking its parent as root strips all distinguishing
+  structure: `--include old=/opt/dep-v1/include --include
+  new=/opt/dep-v2/include` would both normalize to `include`, silently
+  erasing a genuine dependency-version difference. Whether a
+  differently-rooted `-I` path means "same dependency, different checkout
+  mount point" or "genuinely different dependency version" isn't decidable
+  from path shape alone, unlike headers (where ADR-040's `old=`/`new=`
+  design exists specifically for the same-project-two-checkouts case).
+  `profile_fingerprint` therefore hashes each **single** `-I` directory's
+  last two path components (its own basename plus its immediate parent's
+  basename) instead of attempting root-relative normalization at all —
+  `dep-v1/include` vs. `dep-v2/include`, correctly distinct — a bounded,
+  explicitly imperfect compromise (a checkout-root difference expressed
+  exactly two segments up still spuriously mismatches), not a general fix.
+  Multiple `-I` directories per side (2+) use the same
+  common-ancestor-of-parents approach as headers instead, since real
+  anchor points exist there. For the manifest path (D3), both fingerprints'
+  roots are simply the manifest file's own directory — none of these
+  legacy-path degenerate cases exist there, since every manifest-declared
+  path is already relative to one document.
+
+  Four dedicated tests are non-negotiable for this phase to be considered
+  done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
   identical trees under different roots asserts the resulting
   **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
   scope input, and a test that only checks `profile_fingerprint` here can
@@ -166,6 +189,10 @@ Implements ADR-050 D1 and D2.
   `--include old=/opt/dep --include new=/opt/dep` alongside case (1)'s
   headers still leaves `scope_fingerprint` matching — the specific
   external-dependency-directory regression this criterion exists to
+  prevent; (4) `--include old=/opt/dep-v1/include --include
+  new=/opt/dep-v2/include` (a lone, genuinely different `-I` directory per
+  side) produces *different* `profile_fingerprint`s — the specific
+  degenerate-single-`-I`-directory regression this criterion exists to
   prevent.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
@@ -398,7 +425,13 @@ Implements ADR-050 D3. The highest-risk phase — see Risk above.
 - New `abicheck/dump_manifest.py`: strict YAML parser (unknown fields
   error), `roots`/`translation_units` schema, `name`-uniqueness,
   `contributes_to_abi=True ⇒ required=True` invariant enforced at parse
-  time (a validation error, not a silent coercion).
+  time (a validation error, not a silent coercion). The base-profile
+  section also accepts `frontend_context` (`host` default) — the field
+  Phase D's context selector needs an accepted input path for; a manifest
+  schema that only carried `roots`/`translation_units` would leave a
+  DPC++ flow needing a non-default context with nowhere to request it
+  (ADR-050 D3). The legacy, non-manifest CLI path gains a matching
+  `--frontend-context host|device` flag (default `host`).
 - `dumper.py` gains a manifest-driven `dump()` path: one castxml/clang
   invocation per TU (shared base profile + that TU's own forced includes),
   each producing a `TuFragment`. The existing single-header CLI path
@@ -434,10 +467,12 @@ command" procedure, steps 3–4) — `cli_dump_helpers.py` (extend
 `resolve_dump_depth`/`check_requested_depth_satisfied` to operate per-TU).
 
 **Tests.** Manifest parser unit tests (the invariant violation, duplicate
-TU names, unknown fields, relative-path resolution). `dumper.py` multi-TU
+TU names, unknown fields, relative-path resolution, `frontend_context`
+accepted/defaulted/rejected-when-invalid). `dumper.py` multi-TU
 integration tests (`@pytest.mark.integration`, needs castxml/clang) using
 Phase 0's fixtures. A `plan --manifest` unit test asserting it never invokes
-a compiler.
+a compiler. A `--frontend-context` CLI-flag unit test for the legacy
+(non-manifest) path, mirroring the manifest-field test.
 
 **Example fixtures.** Phase 0's ODR-safe and external-STL-noise pairs,
 wired through the real manifest path end to end.
@@ -463,6 +498,21 @@ Implements ADR-050 D4. Depends on Phase B.
   convention), or `HETEROGENEOUS_ABI_CONTEXT` (should Phase B's
   single-profile-per-manifest rule ever be relaxed — not expected in this
   phase).
+- **`INCONSISTENT_DECLARATION`/`HETEROGENEOUS_ABI_CONTEXT` are conflict
+  codes on a new `TuMergeError` (`errors.py`), not `ChangeKind` enum
+  members — despite the naming convention looking identical to one.** They
+  fire during extraction/merge, before a snapshot is ever `Complete` enough
+  to diff (see the bullet below) — `checker.compare` never runs on a
+  conflicted merge, so there is no comparison for a `ChangeKind` to
+  describe. Registering them through the four-step `ChangeKind` procedure
+  would be a category error: they'd never fire from a detector during
+  `compare`, so `changekind-detector`'s orphan check would immediately flag
+  them, and severity/`RISK_KINDS`/`QUALITY_KINDS` classification doesn't
+  apply to something that blocks a comparison from happening at all.
+  `tu_merge.merge_fragments(...)` raises `TuMergeError(code=...)` directly;
+  `dumper.py`'s manifest-driven `dump()` lets it propagate as an
+  `IncompleteAttempt`, the same shape a required TU's compile failure
+  already produces (Phase B).
 - `entity_key` excludes return type (kept in `abi_facts`) — reuses the
   ADR-045/048 "prefer specific identity, never fold a mutable fact into the
   key" principle explicitly, not a fresh design.
@@ -474,31 +524,45 @@ Implements ADR-050 D4. Depends on Phase B.
 
 **Files & surfaces.** New `abicheck/tu_merge.py`, reusing
 `buildsource/crosscheck.py`'s existing merge/classify shape (not a new
-algorithm — see ADR-050 D4). `dumper.py`'s manifest path calls this instead
-of Phase B's placeholder concatenation.
+algorithm — see ADR-050 D4), `errors.py` (`TuMergeError`). `dumper.py`'s
+manifest path calls this instead of Phase B's placeholder concatenation.
 
 **Tests.** Phase 0's ODR-safe fixture (must merge cleanly) and
-conflicting-return-type fixture (must produce `INCONSISTENT_DECLARATION`);
-an order-independence property test (`tests/test_detector_properties.py`
-style, per the repo's existing metamorphic-test convention).
+conflicting-return-type fixture (must raise `TuMergeError(code="INCONSISTENT_DECLARATION")`
+— not produce a `Change`/finding); an order-independence property test
+(`tests/test_detector_properties.py` style, per the repo's existing
+metamorphic-test convention); a test confirming `TuMergeError` is never
+registered as a `ChangeKind` (no `checker_policy.ChangeKind` member, no
+`change_registry*.py` entry) — guarding against the exact ambiguity this
+phase's own naming otherwise invites.
 
-**Example fixtures.** `examples/case2xx_multi_tu_compatible_merge/`,
-`examples/case2xx_multi_tu_inconsistent_declaration/`.
+**Example fixtures.** `examples/case2xx_multi_tu_compatible_merge/` only —
+the conflicting-return-type case is an extraction failure, not a
+verdict-producing comparison, so it doesn't fit the example catalog's
+`ground_truth.json` verdict convention; Phase 0's fixture plus the
+`TuMergeError` unit test above are its coverage instead.
 
 ---
 
 ## Phase D — SYCL/DPC++ host vs. device AST context selection
 
-Implements ADR-050 D5. Independent of Phases B/C; depends only on Phase 0's
-captured DPC++ fixture.
+Implements ADR-050 D5. Independent of Phase C's merge work; depends only
+on Phase 0's captured DPC++ fixture for the parser itself. Selecting a
+*non-default* context does have a soft dependency on Phase B, though: the
+`frontend_context` field (manifest base profile) and `--frontend-context`
+CLI flag this phase's selector reads are defined there, not here (Phase B
+"Goal & acceptance criteria"). Everything in this phase can be built and
+tested against the `host` default without Phase B, but a real DPC++
+device-context request has nowhere to come from until Phase B's field/flag
+exist.
 
 **Goal & acceptance criteria.**
 - New `abicheck/sycl_context.py`: decodes a DPC++ frontend's
   (possibly-multi-document) JSON output as a stream of `{kind, target,
   ast}` contexts — real document-boundary streaming, not a bracket/string
   split; rejects trailing garbage and truncated documents.
-- Context selection is explicit: the manifest/CLI's `frontend_context`
-  (`host` default) is matched against the compiler-reported target triple
+- Context selection is explicit: the manifest's/CLI's `frontend_context`
+  (`host` default, Phase B) is matched against the compiler-reported target triple
   of each decoded context; a run producing only a mismatched context
   (e.g. only `spir64` when `host` was requested) is `AST_CONTEXT_MISSING`,
   an extraction failure — never a successful snapshot with the wrong

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -224,6 +224,20 @@ Implements ADR-050 D1 and D2.
   as-cache-key work (a different gap: a pure profile change with identical
   headers not invalidating) and cannot be deferred to it without leaving
   the gate inert for every warm-cache user until Phase E ships.
+- **A third cache gap, ongoing rather than one-time, also lands here:**
+  `_cache_key()` (`snapshot_cache.py:159,168`) hashes `sorted(headers)`/
+  `sorted(includes)` — order-*insensitive* — while D1's fingerprints are
+  order-*sensitive* for the same inputs (`-I a -I b` vs. `-I b -I a`).
+  Reordering flags between two runs can therefore hit the cache under the
+  sorted key and return an `AbiSnapshot` whose `contract` fingerprints were
+  computed once, for whichever order first populated that entry — never
+  recomputed for the new order, since a cache hit skips `dump()` entirely.
+  This phase drops `sorted(...)` for `headers`/`includes` in `_cache_key()`
+  and hashes them in caller-supplied order instead; deferring this to
+  Phase E doesn't help, since Phase E's cache-key work addresses a
+  different, narrower gap (identical header *content*, pure profile
+  change) and wouldn't by itself make the existing sorted hashing
+  order-preserving.
 - `serialization.SCHEMA_VERSION` is bumped (11 → 12) in the same change
   that starts writing `contract` — **not** treated as a free additive field
   the way ADR-041's advisory `extractor_passes`/`narrowed_passes` were. The
@@ -388,8 +402,9 @@ the gate, and `contract_coverage` metadata computation — no detector, since
 `UNKNOWN_PROFILE` is report metadata, not a `Change`), `dumper.py` (`dump()`
 calls `compute_extraction_contract(...)` and attaches it to every returned
 snapshot — see the acceptance-criteria bullet above; this is not optional
-plumbing), `snapshot_cache.py` (`_SNAPSHOT_CACHE_VERSION` bump — see the
-warm-cache acceptance-criteria bullet above), `errors.py`
+plumbing), `snapshot_cache.py` (`_SNAPSHOT_CACHE_VERSION` bump and the
+`_cache_key()` order-preserving `headers`/`includes` hashing — see the two
+warm-cache acceptance-criteria bullets above), `errors.py`
 (`ProfileMismatchError`/`ScopeMismatchError`/`IncompatibleSnapshotSchemaError`),
 `serialization.py` (`SCHEMA_VERSION` bump,
 `_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION` threshold + the
@@ -419,8 +434,12 @@ regression test: seed `snapshot_cache` with a pre-bump-version entry (no
 `contract`), call `cached_run_dump` for the same inputs post-bump, and
 assert it misses and rebuilds with `contract` populated rather than
 serving the stale hit — the cache-layer analogue of the `dump()` test
-above, closing the same class of bypass through a different code path.
-Unit tests for fingerprint stability (same manifest,
+above, closing the same class of bypass through a different code path. A
+**cache order-sensitivity** test: call `cached_run_dump` with
+`includes=[a, b]`, then again with `includes=[b, a]` (same set, reordered)
+— assert the second call is a cache **miss**, not a hit serving the first
+call's `contract.profile_fingerprint`, proving `_cache_key()` no longer
+sorts these inputs away. Unit tests for fingerprint stability (same manifest,
 independent-TU reordering unaffected; include-order-within-a-TU changes
 the fingerprint; flipping one TU's `contributes_to_abi` or `required` flag
 with its includes held identical also changes `scope_fingerprint`); a

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -110,7 +110,12 @@ Implements ADR-049 D1 and D2.
 **Goal & acceptance criteria.**
 - `AbiSnapshot.contract: ExtractionContract | None` (`model.py`) carries
   `profile_fingerprint`/`scope_fingerprint` plus the resolved inputs that
-  produced them.
+  produced them. `scope_fingerprint`'s hashed inputs include each TU's
+  `required`/`contributes_to_abi` flags, not just its includes/forced
+  includes (ADR-049 D1) — flipping `contributes_to_abi` changes which
+  declarations feed the ABI model without necessarily touching a TU's
+  includes, so leaving it out of the hash would let that exact class of
+  scope drift pass the gate undetected.
 - `serialization.SCHEMA_VERSION` is bumped (11 → 12) in the same change
   that starts writing `contract` — **not** treated as a free additive field
   the way ADR-041's advisory `extractor_passes`/`narrowed_passes` were (see
@@ -119,10 +124,17 @@ Implements ADR-049 D1 and D2.
   forward-version rejection, `serialization.py:557-567`, instead of
   producing an ordinary verdict on data it can't check).
 - `comparability.check_contracts_comparable(old, new)` raises
-  `ProfileMismatchError`/`ScopeMismatchError` (`errors.py`) when both sides
-  carry a `contract` and the fingerprints differ; a snapshot with no
-  `contract` field compares exactly as it does today (backward compatible
-  with every existing baseline).
+  `ProfileMismatchError`/`ScopeMismatchError` (`errors.py`) **only when
+  both sides carry a `contract`** and the fingerprints differ. A **mixed**
+  pair (one side has a `contract`, the other doesn't) is unambiguous, not
+  an implementer's judgment call: it takes the exact same code path as a
+  pair where neither side has one — never hard-fails, never becomes
+  `not_comparable` — so comparing a freshly-produced snapshot against a
+  pre-ADR stored CI baseline (a common real workflow) never regresses on
+  upgrade. It instead surfaces `UNKNOWN_PROFILE` as a RISK-tier,
+  non-authoritative annotation on the ordinary verdict that still gets
+  produced — same shape as the existing `SOURCE_FACT_COVERAGE_INCOMPLETE`
+  (`checker_policy.py:618`), not a second meaning for `not_comparable`.
 - The gate is wired at **all three** entry points in one phase, closing the
   gap AGENTS.md's "Known gaps" section already names for the depth
   contract rather than repeating the CLI-only mistake: `checker.compare`
@@ -175,14 +187,20 @@ row), `reporter.py`, `sarif.py`, `junit_report.py`,
 
 **Tests.** Unit tests for fingerprint stability (same manifest,
 independent-TU reordering unaffected; include-order-within-a-TU changes
-the fingerprint); a `SCHEMA_VERSION`-bump test asserting a pre-bump reader
-(a stubbed/patched `SCHEMA_VERSION`) hits the existing forward-version
-rejection on a `contract`-bearing snapshot rather than silently ignoring
-the field; `tests/test_report_schema.py` gains a `not_comparable` case
-validated against the updated `compare_report.schema.json`; gate unit tests
-for all three entry points; a `--diagnostic-comparison` end-to-end test; a
-backward-compat test asserting
-a contract-less snapshot pair compares unchanged.
+the fingerprint; flipping one TU's `contributes_to_abi` or `required` flag
+with its includes held identical also changes `scope_fingerprint`); a
+`SCHEMA_VERSION`-bump test asserting a pre-bump reader (a stubbed/patched
+`SCHEMA_VERSION`) hits the existing forward-version rejection on a
+`contract`-bearing snapshot rather than silently ignoring the field;
+`tests/test_report_schema.py` gains a `not_comparable` case validated
+against the updated `compare_report.schema.json`; gate unit tests for all
+three entry points; a `--diagnostic-comparison` end-to-end test; a
+backward-compat test asserting a contract-less snapshot pair compares
+unchanged; a **mixed-pair** test (one side `contract`, one side none)
+asserting the comparison never hard-fails and instead carries a
+`UNKNOWN_PROFILE` RISK-tier finding alongside an otherwise-ordinary
+verdict — the specific case the ADR calls out as unambiguous, not left to
+interpretation.
 
 **Example fixtures.** The Phase 0 "scope drift" pair, promoted to a real
 `examples/case2xx_profile_scope_mismatch_gate/` once the gate exists.

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -237,11 +237,17 @@ Implements ADR-050 D1 and D2.
   convention as the existing `_MIN_SCHEMA_VERSION_FOR_CV_FACTS`) and a new
   `IncompatibleSnapshotSchemaError` (`errors.py`), raised by
   `snapshot_from_dict` *before* the existing warn-only branch when the
-  snapshot's `schema_version` is at or above that threshold and the running
-  `SCHEMA_VERSION` is below it. Versions below the threshold keep today's
-  warn-and-continue behavior unchanged — only the specific version that
-  first introduces a verdict-blocking field becomes a hard failure for an
-  older reader (ADR-050 D1).
+  snapshot's `schema_version` is **both greater than the running
+  `SCHEMA_VERSION` and at or above the threshold** — not "the running
+  version is below the threshold" alone, which stops protecting the
+  moment a reader's own `SCHEMA_VERSION` reaches 12 (that reader would
+  then silently warn-and-continue on a hypothetical future schema-13
+  snapshot instead of correctly hard-rejecting it, moving the exact gap
+  this guard closes one bump later rather than eliminating it). Versions
+  below the threshold keep today's
+  warn-and-continue behavior unchanged — only a jump that crosses a
+  hard-rejection threshold, from either direction of the running/
+  snapshot version pair, becomes a hard failure (ADR-050 D1).
 - `comparability.check_contracts_comparable(old, new)` raises
   `ProfileMismatchError`/`ScopeMismatchError` (`errors.py`) **only when
   both sides carry a `contract`** and the fingerprints differ. A **mixed**
@@ -407,9 +413,15 @@ with its includes held identical also changes `scope_fingerprint`); a
 hard-rejection test asserting a pre-bump reader (a stubbed/patched
 `SCHEMA_VERSION` below the threshold) raises `IncompatibleSnapshotSchemaError`
 on a schema-12 `contract`-bearing snapshot instead of the pre-existing
-warn-and-continue path; a regression test pinning that a schema bump
-*below* the threshold still only warns (today's lenient behavior for
-ordinary additive fields must not become accidentally stricter);
+warn-and-continue path; a **second** hard-rejection test asserting a
+reader whose own `SCHEMA_VERSION` is *already* 12 (at the threshold, not
+below it) still raises `IncompatibleSnapshotSchemaError` on a stubbed
+future schema-13 snapshot — the specific case a "running version below
+threshold" condition would silently stop protecting, per the corrected
+`>` running-version comparison above; a regression test pinning that a
+schema bump *below* the threshold still only warns (today's lenient
+behavior for ordinary additive fields must not become accidentally
+stricter);
 `tests/test_report_schema.py` gains a `not_comparable` case validated
 against the updated `compare_report.schema.json`, and its existing
 `test_docs_mirror_matches_packaged_schema` must still pass against the

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -116,6 +116,21 @@ Implements ADR-049 D1 and D2.
   declarations feed the ABI model without necessarily touching a TU's
   includes, so leaving it out of the hash would let that exact class of
   scope drift pass the gate undetected.
+- **Both fingerprints hash root-relative paths, never raw absolute ones —
+  the single highest-priority correctness requirement in this phase.**
+  `compare`'s side-scoped `--header old=v1/foo.h --header new=v2/foo.h` /
+  `--include old=inc1 --include new=inc2` (ADR-040) is the ordinary
+  two-checkout compare workflow, and its old/new sides necessarily resolve
+  to different absolute paths even for an identical logical surface.
+  Hashing absolute paths directly would fingerprint-mismatch and hard-fail
+  *every routine compare* as `not_comparable` — breaking the gate's primary
+  use case on day one. Each side's paths are normalized relative to that
+  side's own resolution root (legacy CLI path: the longest common prefix of
+  that side's own resolved paths; manifest path: the manifest file's own
+  directory) before hashing (ADR-049 D1). A dedicated test using
+  `--header old=v1/foo.h --header new=v2/foo.h` against logically identical
+  trees under different roots, asserting the resulting `profile_fingerprint`s
+  match, is non-negotiable for this phase to be considered done.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -191,7 +206,14 @@ Implements ADR-049 D1 and D2.
   already validates emitted reports against this exact file — gains a case
   for a `not_comparable` report. Shipping the reporter change without this
   either emits JSON that fails its own published schema, or ships a stale
-  schema — not an acceptable outcome for either.
+  schema — not an acceptable outcome for either. The schema's own version
+  metadata moves in lockstep, not as an afterthought:
+  `abicheck/schemas/__init__.py`'s `REPORT_SCHEMA_VERSION` (currently
+  `"2.12"`, emitted in every report as `report_schema_version`) is bumped,
+  and the published mirror `docs/schemas/v1/compare_report.schema.json` is
+  regenerated via the existing `scripts/publish_schemas.py` — skipping
+  either fails `tests/test_report_schema.py::test_docs_mirror_matches_packaged_schema`,
+  which already asserts the two stay byte-identical.
 - `--diagnostic-comparison` opt-in flag: downgrades the hard-fail to a
   tentative diff, every finding stamped `assurance: none`.
 - **Rollout: the hard gate is the default from the first shipped version of
@@ -232,7 +254,10 @@ top of `compare`), `service.py`,
 `mcp_server.py`, `cli.py`/`cli_compare_release.py` (flag + the new,
 distinct `not_comparable` exit code), `docs/reference/exit-codes.md` (a
 new row in both the legacy and severity-aware tables), `reporter.py`,
-`sarif.py`, `junit_report.py`, `abicheck/schemas/compare_report.schema.json`.
+`sarif.py`, `junit_report.py`, `abicheck/schemas/compare_report.schema.json`,
+`abicheck/schemas/__init__.py` (`REPORT_SCHEMA_VERSION` bump),
+`docs/schemas/v1/compare_report.schema.json` (regenerated via
+`scripts/publish_schemas.py`, not hand-edited).
 
 **Tests.** A `dump()`-level test asserting a real (non-manifest) dump
 returns a snapshot with a populated, non-`None` `contract` — the specific
@@ -248,7 +273,11 @@ warn-and-continue path; a regression test pinning that a schema bump
 *below* the threshold still only warns (today's lenient behavior for
 ordinary additive fields must not become accidentally stricter);
 `tests/test_report_schema.py` gains a `not_comparable` case validated
-against the updated `compare_report.schema.json`; an exit-code test
+against the updated `compare_report.schema.json`, and its existing
+`test_docs_mirror_matches_packaged_schema` must still pass against the
+regenerated `docs/schemas/v1` copy; a root-relative-path fingerprint test
+(the acceptance-criteria bullet above — same-tree-different-root compare
+must not fingerprint-mismatch); an exit-code test
 asserting `not_comparable` returns the new dedicated code, never `0`, from
 both the legacy and severity-aware `compare` invocations; a
 `changekind-partition`/`changekind-detector`-gate-compliant unit test for

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -724,10 +724,23 @@ Implements ADR-050 D1 and D2.
   normal `diff_*` pipeline and stamp `assurance: "none"` on the resulting
   `DiffResult` afterward. `service.compare_snapshots` (a thin
   keyword-argument wrapper over `checker.compare`, not a request
-  dataclass) gains the same `diagnostic_comparison` keyword, and
-  `mcp_server`'s compare tools expose it too, so the tentative-diff path
-  is reachable through the Python API and MCP identically, not just
-  `cli.py`'s flag.
+  dataclass) gains the same `diagnostic_comparison` keyword.
+- **`compare_snapshots` is not the front-end chokepoint — `api_types.CompareRequest`
+  is, and it needs the field too, or every documented front-end stays
+  unable to reach it.** `CompareRequest` (`api_types.py:125`) is, by its
+  own docstring, "the single input to `run_compare`" that "every front-end
+  (CLI, MCP, `compare-release` fan-out, `appcompat`)" assembles and hands
+  to `service.run_compare_request` — the real ADR-037 D1/D2 classification
+  chokepoint, one level above `compare_snapshots`. `run_compare_request`
+  calls `compare_snapshots(...)` today with a fixed keyword list that has
+  no slot for this flag; adding `diagnostic_comparison` only to
+  `compare_snapshots` would be unreachable from every documented front-end,
+  since none of them call `compare_snapshots` directly. `CompareRequest`
+  therefore gains `diagnostic_comparison: bool = False`, and
+  `run_compare_request` passes `request.diagnostic_comparison` through.
+  The legacy `run_compare` keyword shim gains the same parameter too,
+  appended after every pre-existing one — matching the precedent already
+  set for `debuginfod_url`, so a positional caller's bindings don't shift.
 - **Rollout: the hard gate is the default from the first shipped version of
   this phase — no soft-launch flag, and no second flag with a default that
   contradicts ADR-050 D2.** D2 is explicit that a contract mismatch is a
@@ -777,8 +790,14 @@ when set),
 `checker_types.py` (`DiffResult.contract_coverage: str | None = None` and
 `DiffResult.assurance: str | None = None`),
 `service.py` (`compare_snapshots`'s new `diagnostic_comparison` keyword,
-threaded to `compare()` — not a request dataclass, `compare_snapshots` has
-none), `mcp_server.py` (compare tools expose the same parameter), `cli.py` (flag + the new,
+threaded to `compare()`; `run_compare_request` passes
+`request.diagnostic_comparison` into its `compare_snapshots(...)` call —
+**not optional**, since `CompareRequest`/`run_compare_request` is the real
+front-end chokepoint, not `compare_snapshots` itself, see the
+acceptance-criteria bullet above; the legacy `run_compare` keyword shim
+gains the same parameter appended last, matching the `debuginfod_url`
+precedent), `api_types.py` (`CompareRequest.diagnostic_comparison: bool =
+False`), `mcp_server.py` (compare tools expose the same parameter), `cli.py` (flag + the new,
 distinct `not_comparable` exit code), `cli_compare_release.py`
 (`_compare_one_library`'s dedicated
 `except (ProfileMismatchError, ScopeMismatchError)` branch, ordered before
@@ -920,7 +939,13 @@ reaches the gate check itself, not just a CLI-level catch with nothing to
 recover — plus a CLI end-to-end `--diagnostic-comparison` test asserting
 the same, and a `service.compare_snapshots(..., diagnostic_comparison=True)`
 test proving the Python API exposes the identical parameter, not only
-`cli.py`'s flag; a `--diagnostic-comparison` end-to-end test asserting the report's
+`cli.py`'s flag; a **`CompareRequest` reachability** test asserting
+`service.run_compare_request(CompareRequest(..., diagnostic_comparison=True))`
+on a mismatched pair also returns the tentative `DiffResult` rather than
+raising — proving the flag is reachable through the actual front-end
+chokepoint every documented caller (CLI, MCP, `compare-release`,
+`appcompat`) goes through, not only a direct `compare_snapshots` call
+nothing in the codebase makes; a `--diagnostic-comparison` end-to-end test asserting the report's
 top-level `assurance` field is `"none"` and that no individual finding
 carries its own `assurance` value; a
 backward-compat test asserting a contract-less snapshot pair compares

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -185,6 +185,18 @@ Implements ADR-050 D1 and D2.
   failure from the one this fix exists to close; taking the parent
   directory first preserves the filename (`v1/foo.h` → root `v1/`,
   normalized `foo.h`).
+  **Known, accepted limitation: this only preserves the basename, not the
+  header's own subpath.** `old=old/include/foo.h` and
+  `new=new/private/foo.h` both normalize to `foo.h` — correct for the
+  intended two-checkout case, but identical to what a genuine relocation
+  (public `include/` → `private/`) would also produce; the rule cannot
+  tell the two apart, since both examples share the same shape (a single
+  header, differing parent name) and opposite correct answers — the same
+  "undecidable from path shape alone" limitation this document already
+  accepts for `-I` directories below, now also true for single-header
+  `scope_fingerprint`. Not a new heuristic to chase: the manifest path
+  (D3) has no such gap, since a manifest's TU paths are explicit declared
+  identities, not inferred from directory shape.
   **`profile_fingerprint`'s `-I` directories are fingerprinted by resolved
   content, not by path shape — three path-shape heuristics were tried and
   rejected in turn (ADR-050 D1 records all three in full); a fourth,
@@ -563,6 +575,28 @@ Implements ADR-050 D1 and D2.
   library and then silently outranked by a co-occurring `BREAKING`, and
   `docs/reference/exit-codes.md`'s multi-library section documents both
   together.
+- **This `"not_comparable"` string entry is a different JSON document from
+  the canonical `verdict: null` shape, by design, not a second incompatible
+  contract for the same shape.** `_compare_one_library`'s return dict feeds
+  `summary.json`'s top-level `verdict` (`worst_verdict`) and its nested
+  `libraries` array — both already string-only fields today (the existing
+  `"ERROR"` case is exactly this: a non-`Verdict`-enum sentinel string, the
+  same class `"not_comparable"` joins). That document was never governed by
+  `compare_report.schema.json` — it's `cli_compare_release.py`'s own
+  long-standing summary shape, extended in its own established idiom.
+  Separately, when `--output-dir` is set, `_compare_one_library`'s success
+  path *also* writes a full per-library report (`{stem}.json`) via
+  `to_json(result)` — that file **is** governed by
+  `compare_report.schema.json`, and for a `not_comparable` library must use
+  the canonical `verdict: null` + `reason` shape, assembled the same way
+  every other front-end's exception handler assembles it (there is no
+  `DiffResult` to call `to_json` on). The two documents disagreeing in
+  shape isn't an inconsistency to fix — each already followed its own
+  distinct schema before this ADR existed. `aggregate.py`'s not-comparable
+  detection (which reads whichever of these two shapes it's actually
+  pointed at) must check both: `verdict is None` for a canonical
+  `compare_report.schema.json` document, or `verdict == "not_comparable"`
+  for a release `summary.json`/per-library entry.
 - **A fifth entry point needs its own exit code, not the fourth one's.**
   `abicheck/compat/cli.py`'s ABICC-compatible `compat check` command calls
   `checker.compare` directly (`from ..checker import compare`, the call

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -60,11 +60,12 @@ D's parser and `host`-default path don't depend on B, though selecting a
 request it (see Phase D). Phase C starts only after Phase B lands, since
 it operates on the `TuFragment` contract Phase B defines and produces —
 it is not a third parallel branch alongside B and D. E depends on B, not
-directly on A: its cache-key half targets the manifest's
-`contributes_to_abi`/`required` flags (Phase B's schema), not
-`profile_fingerprint`/`scope_fingerprint` themselves — those can never be
-pre-dump cache-key inputs (see Phase E) — and its scheduling half schedules
-Phase B's per-TU loop.
+directly on A: its cache-key half targets the manifest's full computed
+`scope_fingerprint` (TU names, per-TU ordered includes/forced-includes,
+`contributes_to_abi`/`required` flags — Phase B's schema), which genuinely
+is pre-dump-computable for a manifest-driven dump; `profile_fingerprint`
+is the one that can never be a pre-dump cache-key input, on either path
+(see Phase E) — and its scheduling half schedules Phase B's per-TU loop.
 
 ```text
 Phase 0 (fixtures) ──┬──▶ Phase A (contract + gate)
@@ -246,7 +247,25 @@ Implements ADR-050 D1 and D2.
   declared `-I` directory instead feeds one additional, explicitly-labeled
   **system/toolchain bucket** — a content digest of that unordered set (no
   path-shape normalization attempted, since these paths carry no
-  user-declared search-order meaning to preserve). `profile_fingerprint`'s
+  user-declared search-order meaning to preserve).
+  **The depfile's own generated driver TU must be excluded before any of
+  this bucketing runs, not swept into the system/toolchain bucket as "just
+  another unattributed path."** `dumper.py` writes a synthetic aggregate
+  `#include` header via `tempfile.NamedTemporaryFile` (`:364,1019`) and
+  compiles *that* as the TU's real source; `parse_depfile` (reused here)
+  returns the compiled source itself as the first prerequisite, not only
+  the headers it pulls in (`tests/test_include_graph.py`:
+  `parse_depfile("foo.o: foo.cpp a.h b.h") == ["foo.cpp", "a.h", "b.h"]`).
+  That generated `/tmp` file is under no declared `-I` directory, so it
+  would otherwise land in the system/toolchain bucket — and its *content*
+  embeds the side-specific absolute `#include "..."` paths written for that
+  run's own header list, which necessarily differ between old and new sides
+  for the ordinary two-checkout case even when the compile environment is
+  identical, making `profile_fingerprint` differ on *every* routine
+  compare — the worst-case version of the failure mode this whole redesign
+  exists to close. The generated driver TU (identified as `dumper.py`'s own
+  synthesized source path, not a declared `-I`/`-H` input) is dropped
+  before any bucketing runs. `profile_fingerprint`'s
   `-I` component is the hash of the **ordered** sequence of per-directory
   digests, **plus this one system/toolchain bucket appended last** —
   **after excluding every path `scope_fingerprint` already
@@ -280,7 +299,7 @@ Implements ADR-050 D1 and D2.
   the manifest file's own directory — none of these legacy-CLI cases
   exist there.
 
-  Ten dedicated tests are non-negotiable for this phase to be considered
+  Eleven dedicated tests are non-negotiable for this phase to be considered
   done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
   identical trees under different roots asserts the resulting
   **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
@@ -337,7 +356,14 @@ Implements ADR-050 D1 and D2.
   actually attributes and hashes paths outside every declared `-I`
   directory rather than silently dropping them, the specific gap distinct
   from test (9)'s (which covers a system-*classified* path still reachable
-  through a declared `-I`).
+  through a declared `-I`); (11) an old/new pair with byte-identical
+  declared headers and `-I` directories, run from two different checkout
+  roots (so `dumper.py`'s generated aggregate driver file necessarily
+  embeds different absolute `#include` paths on each side), leaves
+  `profile_fingerprint` matching — proving the generated driver TU is
+  excluded from bucketing entirely, not swept into the system/toolchain
+  bucket where its run-specific absolute paths would make every routine
+  compare mismatch.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -684,6 +710,24 @@ Implements ADR-050 D1 and D2.
   tentative diff, the whole result stamped `assurance: "none"` — a single
   `DiffResult`-level field (see the dedicated bullet below), never a
   per-finding one.
+- **This must be a parameter into `compare()`, not a CLI-level catch around
+  it — a post-hoc recovery is structurally impossible.** The gate runs at
+  the top of `checker.compare`, before any `diff_*` module runs; once it
+  raises, no `DiffResult` exists yet for anything to recover. A CLI
+  `except (ProfileMismatchError, ScopeMismatchError)` around `compare()`
+  has nothing left to downgrade into a tentative diff — it can only report
+  the failure. `--diagnostic-comparison` therefore threads to the gate
+  check itself: `checker.compare(..., diagnostic_comparison: bool = False)`
+  passes the flag to `comparability.check_contracts_comparable(old, new,
+  diagnostic=diagnostic_comparison)`, which — only when set — returns a
+  mismatch descriptor instead of raising, letting `compare()` run the
+  normal `diff_*` pipeline and stamp `assurance: "none"` on the resulting
+  `DiffResult` afterward. `service.compare_snapshots` (a thin
+  keyword-argument wrapper over `checker.compare`, not a request
+  dataclass) gains the same `diagnostic_comparison` keyword, and
+  `mcp_server`'s compare tools expose it too, so the tentative-diff path
+  is reachable through the Python API and MCP identically, not just
+  `cli.py`'s flag.
 - **Rollout: the hard gate is the default from the first shipped version of
   this phase — no soft-launch flag, and no second flag with a default that
   contradicts ADR-050 D2.** D2 is explicit that a contract mismatch is a
@@ -725,10 +769,16 @@ warm-cache acceptance-criteria bullets above), `errors.py`
 `_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION` threshold + the
 `snapshot_from_dict` hard-rejection branch, `contract` round-trip through
 `snapshot_to_dict`/`snapshot_from_dict`), `checker.py` (gate call at the
-top of `compare`, `contract_coverage` field on the result),
+top of `compare`, new `diagnostic_comparison: bool = False` parameter
+threaded to `comparability.check_contracts_comparable`, `contract_coverage`
+field on the result), `comparability.py` (`check_contracts_comparable`'s
+new `diagnostic` keyword — returns a mismatch descriptor instead of raising
+when set),
 `checker_types.py` (`DiffResult.contract_coverage: str | None = None` and
 `DiffResult.assurance: str | None = None`),
-`service.py`, `mcp_server.py`, `cli.py` (flag + the new,
+`service.py` (`compare_snapshots`'s new `diagnostic_comparison` keyword,
+threaded to `compare()` — not a request dataclass, `compare_snapshots` has
+none), `mcp_server.py` (compare tools expose the same parameter), `cli.py` (flag + the new,
 distinct `not_comparable` exit code), `cli_compare_release.py`
 (`_compare_one_library`'s dedicated
 `except (ProfileMismatchError, ScopeMismatchError)` branch, ordered before
@@ -863,7 +913,14 @@ silent `None` diff indistinguishable from the pre-existing
 raised while diffing a changed dependency DSO, and asserting the resulting
 `StackChange.not_comparable_reason` is populated rather than `abi_diff`
 being left an unexplained `None` — proving `_run_abi_diff`'s caller, not
-`_run_abi_diff` itself, is what classifies the exception; a `--diagnostic-comparison` end-to-end test asserting the report's
+`_run_abi_diff` itself, is what classifies the exception; a **diagnostic-comparison API** test asserting `checker.compare(old, new,
+diagnostic_comparison=True)` on a mismatched pair returns a real
+`DiffResult` (never raises) with `assurance == "none"` — proving the flag
+reaches the gate check itself, not just a CLI-level catch with nothing to
+recover — plus a CLI end-to-end `--diagnostic-comparison` test asserting
+the same, and a `service.compare_snapshots(..., diagnostic_comparison=True)`
+test proving the Python API exposes the identical parameter, not only
+`cli.py`'s flag; a `--diagnostic-comparison` end-to-end test asserting the report's
 top-level `assurance` field is `"none"` and that no individual finding
 carries its own `assurance` value; a
 backward-compat test asserting a contract-less snapshot pair compares
@@ -1199,12 +1256,16 @@ is extraction-layer, not diff-layer; no new `ChangeKind`.
 
 ## Phase E — Resource-aware frontend scheduling and cache-key extension
 
-Implements ADR-050 D6. The cache-key half targets the manifest's
-`contributes_to_abi`/`required` flags, so it depends on Phase B (the
-manifest schema those flags live on), not on Phase A's fingerprints
-themselves — `profile_fingerprint`/`scope_fingerprint` are never used as
-cache-key inputs (see the acceptance-criteria bullet below for why). The
-scheduling half depends on Phase B too (the per-TU loop it schedules).
+Implements ADR-050 D6. The cache-key half targets the manifest's full
+computed `scope_fingerprint` (TU names, per-TU ordered includes/
+forced-includes, and `contributes_to_abi`/`required` flags together), so
+it depends on Phase B (the manifest schema those inputs live on) — not on
+`profile_fingerprint`, which can **never** be a pre-dump cache-key input at
+all, on either path (see the acceptance-criteria bullet below for why).
+`scope_fingerprint` is the one exception: for a manifest-driven dump it's
+fully computable by parsing the normalized manifest, no compiler invocation
+needed, so it genuinely can feed the cache key pre-dump. The scheduling
+half depends on Phase B too (the per-TU loop it schedules).
 
 **Goal & acceptance criteria.**
 - The RAM-probing/pool-sizing helper in `buildsource/source_replay.py` is

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -66,7 +66,7 @@ directly on A: its cache-key half targets the manifest's
 pre-dump cache-key inputs (see Phase E) — and its scheduling half schedules
 Phase B's per-TU loop.
 
-```
+```text
 Phase 0 (fixtures) ──┬──▶ Phase A (contract + gate)
                       │
                       ├──▶ Phase B (manifest/multi-TU) ─┬─▶ Phase C (compatible merge)

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -118,11 +118,22 @@ Implements ADR-049 D1 and D2.
   scope drift pass the gate undetected.
 - `serialization.SCHEMA_VERSION` is bumped (11 → 12) in the same change
   that starts writing `contract` — **not** treated as a free additive field
-  the way ADR-041's advisory `extractor_passes`/`narrowed_passes` were (see
-  ADR-049 D1's rationale: the comparability gate is verdict-blocking, so an
-  old reader silently not knowing about `contract` must hit the existing
-  forward-version rejection, `serialization.py:557-567`, instead of
-  producing an ordinary verdict on data it can't check).
+  the way ADR-041's advisory `extractor_passes`/`narrowed_passes` were. The
+  bump alone is not sufficient: `snapshot_from_dict`'s existing
+  newer-than-supported handling (`serialization.py:556-572`) only calls
+  `warnings.warn(...)` and keeps deserializing — it never raises, so an old
+  reader would print an easily-missed warning and still produce an ordinary
+  verdict on a `contract`-bearing snapshot it can't check. This phase adds a
+  real guard alongside the bump: a new
+  `_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION = 12` constant (same naming
+  convention as the existing `_MIN_SCHEMA_VERSION_FOR_CV_FACTS`) and a new
+  `IncompatibleSnapshotSchemaError` (`errors.py`), raised by
+  `snapshot_from_dict` *before* the existing warn-only branch when the
+  snapshot's `schema_version` is at or above that threshold and the running
+  `SCHEMA_VERSION` is below it. Versions below the threshold keep today's
+  warn-and-continue behavior unchanged — only the specific version that
+  first introduces a verdict-blocking field becomes a hard failure for an
+  older reader (ADR-049 D1).
 - `comparability.check_contracts_comparable(old, new)` raises
   `ProfileMismatchError`/`ScopeMismatchError` (`errors.py`) **only when
   both sides carry a `contract`** and the fingerprints differ. A **mixed**
@@ -177,9 +188,12 @@ Implements ADR-049 D1 and D2.
 
 **Files & surfaces.** `model.py` (new `ExtractionContract`), new
 `abicheck/comparability.py` (fingerprint computation + gate), `errors.py`
-(two new exception classes), `serialization.py` (`SCHEMA_VERSION` bump,
-`contract` round-trip through `snapshot_to_dict`/`snapshot_from_dict`),
-`checker.py` (gate call at the top of `compare`), `service.py`,
+(`ProfileMismatchError`/`ScopeMismatchError`/`IncompatibleSnapshotSchemaError`),
+`serialization.py` (`SCHEMA_VERSION` bump,
+`_MIN_SCHEMA_VERSION_REQUIRING_HARD_REJECTION` threshold + the
+`snapshot_from_dict` hard-rejection branch, `contract` round-trip through
+`snapshot_to_dict`/`snapshot_from_dict`), `checker.py` (gate call at the
+top of `compare`), `service.py`,
 `mcp_server.py`, `cli.py`/`cli_compare_release.py` (flag + `not_comparable`
 exit-code handling — see `docs/reference/exit-codes.md`, which needs a new
 row), `reporter.py`, `sarif.py`, `junit_report.py`,
@@ -189,9 +203,12 @@ row), `reporter.py`, `sarif.py`, `junit_report.py`,
 independent-TU reordering unaffected; include-order-within-a-TU changes
 the fingerprint; flipping one TU's `contributes_to_abi` or `required` flag
 with its includes held identical also changes `scope_fingerprint`); a
-`SCHEMA_VERSION`-bump test asserting a pre-bump reader (a stubbed/patched
-`SCHEMA_VERSION`) hits the existing forward-version rejection on a
-`contract`-bearing snapshot rather than silently ignoring the field;
+a hard-rejection test asserting a pre-bump reader (a stubbed/patched
+`SCHEMA_VERSION` below the threshold) raises `IncompatibleSnapshotSchemaError`
+on a schema-12 `contract`-bearing snapshot instead of the pre-existing
+warn-and-continue path; a regression test pinning that a schema bump
+*below* the threshold still only warns (today's lenient behavior for
+ordinary additive fields must not become accidentally stricter);
 `tests/test_report_schema.py` gains a `not_comparable` case validated
 against the updated `compare_report.schema.json`; gate unit tests for all
 three entry points; a `--diagnostic-comparison` end-to-end test; a

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -46,13 +46,20 @@ Phase 0 first, always — it is what makes Phase D (and to a lesser extent B)
 design-by-evidence instead of design-by-assumption, per the originating
 review's own strongest procedural point ("don't build a stream parser
 against a guessed format; capture the real thing first"). Phase A can ship
-and start providing value (as a report-only signal) independently of B–E —
-it does not require multi-TU support to be useful, since even today's
-single-aggregate-TU snapshots have a real, checkable `profile_fingerprint`.
-B, C, and D can proceed in parallel once Phase 0's fixtures exist (C
-depends on B landing first; D's parser and `host`-default path don't
-depend on B or C, though selecting a *non-default* context needs Phase B's
-`frontend_context` field/flag to request it — see Phase D). E depends on A
+and start providing value independently of B–E — it does not require
+multi-TU support to be useful, since even today's single-aggregate-TU
+snapshots have a real, checkable `profile_fingerprint` — **and it ships
+with the hard-blocking gate as its actual, only default behavior**: Phase
+A's own section is explicit that there is no soft-launch/report-only mode
+(the gate hard-fails `not_comparable` from day one; see Phase A). "Ships
+independently" describes *when* Phase A can land relative to the other
+phases, not a different (report-only) behavior it has while doing so.
+Phase B and Phase D may both start once Phase 0's fixtures exist — Phase
+D's parser and `host`-default path don't depend on B, though selecting a
+*non-default* context needs Phase B's `frontend_context` field/flag to
+request it (see Phase D). Phase C starts only after Phase B lands, since
+it operates on the `TuFragment` contract Phase B defines and produces —
+it is not a third parallel branch alongside B and D. E depends on A
 (needs the fingerprints to extend the cache key) and loosely on B (the
 per-TU loop it schedules); the cache-key half of E can land right after A
 without waiting for B if useful on its own.
@@ -262,15 +269,31 @@ Implements ADR-050 D1 and D2.
   so it's structurally unreachable by severity promotion rather than
   merely unreachable by the flags checked so far.
 - **The exit code is part of the published contract too, not an
-  afterthought.** `docs/reference/exit-codes.md` documents two co-existing
-  `compare` schemes (legacy: 0/2/4; severity-aware: 0/1/2/4) where `0`
+  afterthought — and it must be a pinned value, not "a new code TBD."**
+  `docs/reference/exit-codes.md` documents two co-existing `compare`
+  schemes (legacy: 0/2/4; severity-aware: 0/1/2/4) where `0`
   means *compatible* in both. `not_comparable` must never exit `0` in
   either scheme — otherwise the exact "missing evidence reads as safe"
   failure this ADR exists to prevent reappears at the process-exit
-  boundary, undoing the JSON-level fix. This phase reserves one new,
-  distinct nonzero code and adds it as its own row to both tables in
+  boundary, undoing the JSON-level fix. This phase reserves exit code
+  **`8`** — identical in both schemes, since `not_comparable` fires before
+  severity classification ever runs — continuing the existing power-of-two
+  pattern, and adds it as its own row to both tables in
   `docs/reference/exit-codes.md`, not folded into either scheme's existing
-  numbering.
+  numbering. `8` is unused in `compare`'s own exit-code space today (which
+  tops out at `4` in both schemes).
+- **Release-level (directory/package) aggregation gets an explicit
+  precedence, not an implied one.** `cli_compare_release_helpers.py`'s
+  `_RELEASE_VERDICT_ORDER` (currently `NO_CHANGE` < `COMPATIBLE` <
+  `COMPATIBLE_WITH_RISK` < `API_BREAK` < `BREAKING` < `ERROR`, rank 5 as
+  the ceiling) gains `not_comparable` at rank 6, above `ERROR` — a
+  correctly-diagnosed `not_comparable` result carries less trustworthy
+  information about a library than even a partial `ERROR`, so it
+  dominates the release-level "worst verdict wins" rollup over every other
+  outcome in the same release, including a genuine crash. This is what
+  makes the release fan-out fix (below) actually surface at the release
+  level instead of being computed per-library and then silently
+  outranked.
 - The gate is wired at **all four** entry points in one phase, closing the
   gap AGENTS.md's "Known gaps" section already names for the depth
   contract rather than repeating the CLI-only mistake: `checker.compare`
@@ -291,9 +314,12 @@ Implements ADR-050 D1 and D2.
   multi-library surface. `_compare_one_library` gains a dedicated
   `except (ProfileMismatchError, ScopeMismatchError) as exc:` branch,
   ordered before the generic `except Exception`, returning
-  `{"verdict": "not_comparable", "reason": ...}`; the release aggregator
-  and `docs/reference/exit-codes.md`'s multi-library section recognize
-  that verdict value distinctly, not folded into `"ERROR"`.
+  `{"verdict": "not_comparable", "reason": ...}`; `_RELEASE_VERDICT_ORDER`'s
+  new rank-6 entry (the bullet above) is what makes that verdict actually
+  win the release-level rollup instead of being computed correctly per
+  library and then silently outranked by a co-occurring `BREAKING`, and
+  `docs/reference/exit-codes.md`'s multi-library section documents both
+  together.
 - Reporting: `reporter.py`/`sarif.py`/`junit_report.py` gain a
   `not_comparable` top-level result distinct from every existing verdict
   value — never coerced into `compatible`/`breaking`.
@@ -356,7 +382,9 @@ distinct `not_comparable` exit code), `cli_compare_release.py`
 `except (ProfileMismatchError, ScopeMismatchError)` branch, ordered before
 `except Exception` — see the release-fan-out acceptance-criteria bullet
 above; this is not covered by the CLI's own exit-code handling, it is a
-separate call path), `docs/reference/exit-codes.md` (a
+separate call path), `cli_compare_release_helpers.py`
+(`_RELEASE_VERDICT_ORDER`'s new rank-6 `not_comparable` entry),
+`docs/reference/exit-codes.md` (a
 new row in both the legacy and severity-aware tables, **and** the
 multi-library section), `reporter.py`,
 `sarif.py`, `junit_report.py`, `abicheck/schemas/compare_report.schema.json`,
@@ -388,13 +416,18 @@ against the updated `compare_report.schema.json`, and its existing
 regenerated `docs/schemas/v1` copy; a root-relative-path fingerprint test
 (the acceptance-criteria bullet above — same-tree-different-root compare
 must not fingerprint-mismatch); an exit-code test
-asserting `not_comparable` returns the new dedicated code, never `0`, from
+asserting `not_comparable` returns exactly `8`, never `0`, from
 both the legacy and severity-aware `compare` invocations; a **release
 fan-out** test asserting a `not_comparable`-triggering library inside a
 directory/package `compare` reports `verdict: "not_comparable"` in its
 release-level entry, not `"ERROR"` — the specific inversion (incomparable
 reported as the worst-possible classification) this phase must close on
-its fourth entry point; gate unit tests for all
+its fourth entry point; a **release-precedence** test asserting a mixed
+release (one `not_comparable` library, one `BREAKING`, N `COMPATIBLE`)
+reports and exits as `not_comparable` overall, proving
+`_RELEASE_VERDICT_ORDER`'s new rank actually wins the rollup rather than
+being silently outranked by the co-occurring `BREAKING`; gate unit tests
+for all
 four entry points; a `--diagnostic-comparison` end-to-end test; a
 backward-compat test asserting a contract-less snapshot pair compares
 unchanged; a **mixed-pair** test (one side `contract`, one side none)
@@ -447,19 +480,30 @@ Implements ADR-050 D3. The highest-risk phase — see Risk above.
   diagnostic, and — enforced by the parse-time invariant above — an
   optional TU can never be `contributes_to_abi: true`, so this can never
   produce a false removal.
-- New CLI surface: `abicheck dump --manifest path/to/manifest.yml` (or
-  `compare --manifest`), plus a `abicheck plan --manifest ...` diagnostic
-  command that prints the normalized manifest and both D1 fingerprints
-  without running extraction — cheap to run in CI before committing to a
-  full dump.
+- New CLI surface: `--manifest path/to/manifest.yml` and
+  `--frontend-context host|device` **options added to the existing
+  `dump`/`compare` commands** (not new commands — a new sibling module
+  cannot retroactively add options to a command already declared
+  elsewhere), plus a genuinely new `abicheck plan --manifest ...`
+  diagnostic command that prints the normalized manifest and both D1
+  fingerprints without running extraction — cheap to run in CI before
+  committing to a full dump.
 
 **Files & surfaces.** New `abicheck/dump_manifest.py`, `abicheck/dumper.py`
-(per-TU invocation loop, `TuFragment` type), new `cli_dump_manifest.py`
-sibling command module (per the root `CLAUDE.md`'s "larger command → sibling
-module" convention) — registering it is not implicit: `cli.py`'s bottom
-side-effect `from . import (...)` block gains `cli_dump_manifest`, or the
-new `plan --manifest`/`dump --manifest` commands never attach to `main` at
-all, and `pyproject.toml`'s `disallow_untyped_decorators = false` override
+(per-TU invocation loop, `TuFragment` type). `--manifest`/
+`--frontend-context` are shared-concept options per multiple existing
+commands (`dump` and `compare`), so — following `cli_options.py`'s own
+existing convention for `-v/--verbose`, `output_options(...)`, and
+`lang_option(...)` — they're added as one shared decorator in
+`cli_options.py` and applied at `dump`'s and `compare`'s existing
+declarations directly (wherever those already live: `cli.py`), not merely
+implied by registering a new command module. New `cli_dump_manifest.py`
+sibling command module for the genuinely new `plan --manifest` command
+only (per the root `CLAUDE.md`'s "larger command → sibling module"
+convention) — registering it is not implicit: `cli.py`'s bottom
+side-effect `from . import (...)` block gains `cli_dump_manifest`, or
+`plan --manifest` never attaches to `main` at all, and `pyproject.toml`'s
+`disallow_untyped_decorators = false` override
 list gains `abicheck.cli_dump_manifest` alongside the existing per-module
 entries, or the typed-decorator mypy lane fails on its `@click` decorators
 (both required steps of the root `CLAUDE.md`'s "Adding a new top-level

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -279,21 +279,39 @@ Implements ADR-050 D1 and D2.
   before any bucketing runs. `profile_fingerprint`'s
   `-I` component is the hash of the **ordered** sequence of per-directory
   digests, **plus this one system/toolchain bucket appended last** —
-  **after excluding every path `scope_fingerprint` already
-  covers for that side (the explicit `--header`/manifest TU entry points),
-  not the depfile's raw output.** The documented real-world workflow
+  **after excluding every declared `-I` directory that is project-owned,
+  in its entirety, not just the specific paths `scope_fingerprint` names.**
+  The documented real-world workflow
   (`docs/user-guide/real-world-example.md:61-63`) passes the project's own
   include root as *both* `--header` (the headers being compared) and
   `--include` (so `#include` resolves) — the same directory serves both
   roles, so a depfile for that TU necessarily lists the very header being
-  compared alongside its support headers. Hashing the depfile's output
-  unfiltered would feed that header's content into `profile_fingerprint`
-  too, and an ordinary, intentional edit to it would flip
-  `profile_fingerprint` and hard-fail `PROFILE_MISMATCH` before the diff
-  ever ran — on the routine case this whole ADR exists to keep working, not
-  an edge case. `scope_fingerprint` owns "what's declared and compared";
-  `profile_fingerprint` owns "what environment resolved it"; a file cannot
-  honestly feed both. This is lossless: byte-identical dependency content at different mount points
+  compared alongside its support headers. **Excluding only the named
+  header is not enough**: `foo.h` typically `#include`s project-internal
+  support headers (a private `detail.h`) that are never individually
+  named, only reached because they live under the same declared `-I`
+  root — an exclusion scoped to just the explicit `--header`/manifest
+  entry points would still hash those unnamed support headers' content, so
+  an ordinary internal refactor (renaming `detail_v1.h` to `detail_v2.h`,
+  or editing it, with `foo.h` itself untouched) would still flip
+  `profile_fingerprint` and hard-fail the gate before the diff ran — a
+  routine case, not an edge case. The exclusion therefore applies at the
+  **whole `-I` directory** level: a declared `-I` directory is
+  **project-owned** when it equals or is an ancestor of any of that side's
+  declared `--header`/manifest TU paths — every file under it, named or
+  not, is excluded from `profile_fingerprint` entirely. A declared `-I`
+  directory unrelated to any declared header is **external** and keeps the
+  full per-file content digest — a real dependency, where a change
+  anywhere in it is meaningful drift. `scope_fingerprint` owns everything
+  under a project-owned root; `profile_fingerprint` owns only external
+  roots, in full. **Known, accepted residual gap:** a vendored dependency
+  nested *inside* a project-owned root is swept into that exclusion too,
+  so a content change confined there is invisible to `profile_fingerprint`
+  on the legacy CLI path — the same "can't disambiguate from directory
+  shape alone" class of limitation already documented for the mixed-roots
+  case, not a new kind of gap; the manifest path (D3) has no such gap,
+  since it can express a per-TU forced-include instead of relying on
+  directory-tree inference. This is lossless: byte-identical dependency content at different mount points
   normalizes identically (attempt one's routine case, still correct);
   genuinely different content normalizes differently regardless of naming
   (the `dep-v1`/`dep-v2` case both attempt one and two mishandled); a
@@ -310,7 +328,7 @@ Implements ADR-050 D1 and D2.
   the manifest file's own directory — none of these legacy-CLI cases
   exist there.
 
-  Eleven dedicated tests are non-negotiable for this phase to be considered
+  Twelve dedicated tests (numbered 1–11, with 8b alongside 8) are non-negotiable for this phase to be considered
   done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
   identical trees under different roots asserts the resulting
   **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
@@ -347,12 +365,20 @@ Implements ADR-050 D1 and D2.
   fingerprint hashes the declared header's own content — `scope_fingerprint`
   tracks declared TU/header *identity* (names, include structure, flags),
   never content, precisely so an ordinary API/ABI edit is an unremarkable,
-  comparable case, not a mismatch; `profile_fingerprint` excludes exactly
-  this file per the bullet above. The comparison proceeds past the gate and
-  the diff reports the parameter addition as an ordinary `Change` —
-  `not_comparable` never fires on the routine case of "the thing being
-  compared changed," which is this whole tool's primary purpose, not an
-  edge case to special-case around; (9) a header reached only through a
+  comparable case, not a mismatch; `profile_fingerprint` excludes the whole
+  project-owned `-I` root per the bullet above, `foo.h` included. The
+  comparison proceeds past the gate and the diff reports the parameter
+  addition as an ordinary `Change` — `not_comparable` never fires on the
+  routine case of "the thing being compared changed," which is this whole
+  tool's primary purpose, not an edge case to special-case around; (8b)
+  the same shape, but the edit lands in an **unnamed, project-internal
+  support header** `foo.h` `#include`s (a `detail.h` never itself passed to
+  `--header`) — renaming it (`detail_v1.h` → `detail_v2.h`) or editing its
+  content, `foo.h` itself untouched — still leaves `profile_fingerprint`
+  matching, proving the exclusion covers the *whole* project-owned `-I`
+  directory, not only the explicitly-named header; excluding only the
+  named file would still hash `detail.h`'s change and spuriously
+  hard-fail this routine internal-refactor case; (9) a header reached only through a
   system/`-isystem`-classified include path (not a plain user `-I`) with
   genuinely different content between old and new produces *different*
   `profile_fingerprint`s — proving the depfile request uses `-MD`, not
@@ -664,6 +690,23 @@ Implements ADR-050 D1 and D2.
   unconditionally blocking contribution — regardless of `discovered_only`,
   matching the same precedence `_RELEASE_VERDICT_ORDER`'s rank-6 entry
   already gives `not_comparable` in the release rollup.
+- **`action/run.sh` is another consumer with the same blind spot, one layer
+  further from the Python package, and it compounds into a worse failure
+  than a generic misreport.** Verified against the actual script:
+  `action/run.sh` maps each command's exit codes to a `VERDICT` string via
+  `case` statements ending in an unconditional `*) VERDICT="ERROR"`
+  fallback — native `compare`'s exit codes are matched at `:680-698` (no
+  `16` case), `scan`'s at `:656-666` (no `6` case), `deps compare`'s at
+  `:628-634` (no `5` case), so all three new codes fall through to
+  `VERDICT="ERROR"` today. `_maybe_post_pr_comment` (`:897`) then
+  unconditionally returns early when `VERDICT == "ERROR"` (`:907`) — so a
+  deliberate `not_comparable` result would both misreport as a generic
+  internal error *and* silently suppress the one PR comment meant to
+  surface it, on the Action's most visible first-party consumer. Each
+  `case` statement gains a matching branch (e.g. `16) VERDICT="NOT_COMPARABLE"
+  ;;`), and `_maybe_post_pr_comment`'s `ERROR`-only skip is joined by an
+  explicit exception that still posts for `NOT_COMPARABLE` — this result
+  deserves the comment more than an ordinary pass, not less.
 - **`html_report.py`/`service_render.py` are the fourth reporting surface,
   not an optional add-on.** AGENTS.md's own module map groups `html_report.py`
   with `reporter.py`/`sarif.py`/`junit_report.py` under "Reporting," and
@@ -808,8 +851,17 @@ front-end chokepoint, not `compare_snapshots` itself, see the
 acceptance-criteria bullet above; the legacy `run_compare` keyword shim
 gains the same parameter appended last, matching the `debuginfod_url`
 precedent), `api_types.py` (`CompareRequest.diagnostic_comparison: bool =
-False`), `mcp_server.py` (compare tools expose the same parameter), `cli.py` (flag + the new,
-distinct `not_comparable` exit code), `cli_compare_release.py`
+False`), `mcp_server.py` (compare tools expose the same parameter), `cli.py`
+(the `--diagnostic-comparison` flag definition and the new, distinct
+`not_comparable` exit `16` constant), **`cli_compare_helpers.py`** (the new
+`except (ProfileMismatchError, ScopeMismatchError)` branch around the real
+`compare_snapshots(...)` call in `run_compare` — verified against the
+actual code: `cli.py`'s `compare_cmd` is a thin `**kwargs` forwarder to
+`cli_compare_helpers.run_compare`, which is where `compare_snapshots(...)`
+is actually called (`:1464`) and where the output/exit-code rendering
+(`_finalize_compare_result` etc.) lives; a bare exception there today would
+propagate as an unhandled traceback, not the planned `verdict: null`
+report + exit `16` — `cli.py` alone has nothing to catch), `cli_compare_release.py`
 (`_compare_one_library`'s dedicated
 `except (ProfileMismatchError, ScopeMismatchError)` branch, ordered before
 `except Exception` — see the release-fan-out acceptance-criteria bullet
@@ -856,7 +908,11 @@ path instead of calling it with no `DiffResult`), `abicheck/schemas/compare_repo
 (`parse_report_verdict`/`GateInfo`/`TargetReport` gain a way to
 distinguish a deliberate `not_comparable` report from a missing/corrupt
 one, and `exit_code()`/`coverage_blocking` treat it as unconditionally
-blocking, independent of `discovered_only`).
+blocking, independent of `discovered_only`), `action/run.sh` (a new
+`VERDICT="NOT_COMPARABLE"` case-branch alongside each of the `compare`/
+`scan`/`deps compare` exit-code `case` statements, and an explicit
+carve-out in `_maybe_post_pr_comment` so `NOT_COMPARABLE` still posts a
+comment despite the existing `ERROR`-only skip).
 
 **Tests.** A `dump()`-level test asserting a real (non-manifest) dump
 returns a snapshot with a populated, non-`None` `contract` — the specific
@@ -897,7 +953,11 @@ handler owns that path instead), and a second test asserting a mixed-pair
 the same way its JSON/Markdown/SARIF/JUnit siblings do; a root-relative-path fingerprint test
 (the acceptance-criteria bullet above — same-tree-different-root compare
 must not fingerprint-mismatch); an exit-code test
-asserting `not_comparable` returns exactly `16`, never `0`, from
+asserting `not_comparable` returns exactly `16`, never `0` and never an
+unhandled traceback, from a real end-to-end native `compare` invocation on
+a mismatched pair — exercised through the actual `cli_compare_helpers.run_compare`
+call site, proving the new `except` clause there catches what `cli.py`'s
+thin forwarder has no chance to — from
 both the legacy and severity-aware `compare` invocations; a **release
 fan-out** test asserting a `not_comparable`-triggering library inside a
 directory/package `compare` reports `verdict: "not_comparable"` in its
@@ -974,7 +1034,14 @@ one flag checked last time; an **aggregate not_comparable** test asserting
 target's report is `not_comparable` — never silently `0` — and a second
 test asserting a `not_comparable` report is never conflated with a
 genuinely missing/corrupt one in `aggregate`'s rendered per-target output,
-proving the two "unavailable"-shaped states stay distinguishable.
+proving the two "unavailable"-shaped states stay distinguishable; an
+**Action wrapper** test (`action/run.sh`'s existing bats/shell test
+harness) asserting exit `16`/`6`/`5` from `compare`/`scan`/`deps compare`
+each map to `VERDICT="NOT_COMPARABLE"`, never the `*) VERDICT="ERROR"`
+fallback, plus a `_maybe_post_pr_comment` test asserting a `NOT_COMPARABLE`
+verdict still posts a PR comment despite the existing `ERROR`-only skip —
+proving the Action doesn't both misreport and silently suppress the one
+comment meant to surface a deliberate not-comparable result.
 
 **Example fixtures.** The Phase 0 "scope drift" pair stays a `tests/`-level
 fixture, not an `examples/case*/` catalog entry: `tests/test_validate_examples_unit.py`'s

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -363,7 +363,16 @@ Implements ADR-050 D1 and D2.
   independent 0–2/3–11 exit-code contract (`_classify_compat_error_exit_code`
   in `compat/_errors.py`) that this phase must not silently break by leaving
   a `ProfileMismatchError`/`ScopeMismatchError` to fall into that function's
-  generic fallback code. `_classify_compat_error_exit_code` gains an explicit
+  generic fallback code — or, worse, propagate out of the command entirely
+  unclassified. **This is a real call-site change, not just a classifier
+  update**: verified against the actual code, the `result = compare(old_snap,
+  new_snap, ...)` call has no surrounding `try` today, unlike `check`'s other
+  operations (descriptor parsing, logging setup, dump, report writing), each
+  wrapped in its own narrow `except ...: _compat_fail(...)` block. This phase
+  adds `try: result = compare(...) except (ProfileMismatchError,
+  ScopeMismatchError) as exc: _compat_fail("comparing snapshots", exc)`
+  around that call site so the new exceptions are ever caught at all, not
+  only classified correctly once caught. `_classify_compat_error_exit_code` gains an explicit
   `isinstance(exc, (ProfileMismatchError, ScopeMismatchError))` check —
   mirroring its existing `KeyboardInterrupt` special case — returning **`9`**,
   the one integer the current 3–11 range documents no meaning for (3/4/5/6/7/8/10/11
@@ -406,6 +415,15 @@ Implements ADR-050 D1 and D2.
   `contract_coverage: str | None = None` on `DiffResult` itself, and
   `checker.py`'s `compare()` sets it when exactly one side carries a
   `contract`.
+- **`assurance` (the `--diagnostic-comparison` stamp) is also a `DiffResult`
+  field, not a per-`Change` one.** A forced diagnostic comparison is
+  uniformly tentative — the gate failed for the pair as a whole before any
+  diff ran, so every finding a tentative diff produces shares one identical
+  reduced-assurance reason; there is no per-finding split to encode, and
+  `checker_types.Change` gains no new field for this. `checker_types.py`
+  gains `assurance: str | None = None` on `DiffResult` itself (alongside
+  `contract_coverage`), set to `"none"` only on the `--diagnostic-comparison`
+  path.
 - The published JSON contract moves with the reporters, in this phase, not
   after: `abicheck/schemas/compare_report.schema.json` currently requires
   `verdict` and restricts it to a fixed string enum with no `null` member.
@@ -460,7 +478,8 @@ warm-cache acceptance-criteria bullets above), `errors.py`
 `snapshot_from_dict` hard-rejection branch, `contract` round-trip through
 `snapshot_to_dict`/`snapshot_from_dict`), `checker.py` (gate call at the
 top of `compare`, `contract_coverage` field on the result),
-`checker_types.py` (`DiffResult.contract_coverage: str | None = None`),
+`checker_types.py` (`DiffResult.contract_coverage: str | None = None` and
+`DiffResult.assurance: str | None = None`),
 `service.py`, `mcp_server.py`, `cli.py` (flag + the new,
 distinct `not_comparable` exit code), `cli_compare_release.py`
 (`_compare_one_library`'s dedicated
@@ -469,8 +488,10 @@ distinct `not_comparable` exit code), `cli_compare_release.py`
 above; this is not covered by the CLI's own exit-code handling, it is a
 separate call path), `cli_compare_release_helpers.py`
 (`_RELEASE_VERDICT_ORDER`'s new rank-6 `not_comparable` entry),
-`compat/cli.py` (no call-site change beyond routing through the updated
-`_classify_compat_error_exit_code`), `compat/_errors.py`
+`compat/cli.py` (new `try`/`except (ProfileMismatchError, ScopeMismatchError)`
+wrapping the `compare()` call — there is no surrounding `try` there today —
+routing to the updated `_classify_compat_error_exit_code` via `_compat_fail`),
+`compat/_errors.py`
 (`_classify_compat_error_exit_code`'s new `ProfileMismatchError`/
 `ScopeMismatchError` branch returning `9`), `compat/CLAUDE.md` (exit-code
 table update), `docs/reference/exit-codes.md` (a
@@ -543,9 +564,15 @@ mechanism's own existing scheme-dependent precedence; gate unit tests
 for all
 five entry points; a **compat-mode exit-code** test asserting
 `compat check` returns exactly `9` (never `10`'s generic fallback, never
-`16`) for a `ProfileMismatchError`/`ScopeMismatchError`, exercised through
-`_classify_compat_error_exit_code` directly and through a `compat check`
-end-to-end invocation; a `--diagnostic-comparison` end-to-end test; a
+`16`, and never an unhandled traceback) for a
+`ProfileMismatchError`/`ScopeMismatchError`, exercised both through
+`_classify_compat_error_exit_code` directly and through a real end-to-end
+`compat check` invocation on a mismatched pair — the latter is what proves
+the new `try`/`except` around the `compare()` call site actually catches the
+exception, not just that the classifier returns the right code once handed
+one; a `--diagnostic-comparison` end-to-end test asserting the report's
+top-level `assurance` field is `"none"` and that no individual finding
+carries its own `assurance` value; a
 backward-compat test asserting a contract-less snapshot pair compares
 unchanged; a **mixed-pair** test (one side `contract`, one side none)
 asserting the comparison never hard-fails and instead carries a

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -199,14 +199,27 @@ Implements ADR-050 D1 and D2.
   root from `-I` path text at all: each `-I` directory (per side, in
   declared order — order is already a hashed input) contributes its own
   digest — the sorted set of (path relative to that `-I` directory,
-  content hash) pairs for every header file extraction actually resolved
-  from inside it, available at zero extra cost from the per-declaration
-  resolving-header paths `dumper_castxml.py`/`dumper_clang.py` already
-  collect (`_source_location`/`header_from_location`) — grouped by
-  originating `-I` directory and hashed, not a new compiler invocation or
-  a full directory-tree walk. `profile_fingerprint`'s `-I` component is
-  the hash of the **ordered** sequence of per-directory digests. This is
-  lossless: byte-identical dependency content at different mount points
+  content hash) pairs for every file the preprocessor actually opened from
+  inside it. **This must be the full transitive include list, not just
+  headers that end up owning a declaration** — a header pulled in purely
+  for macros/pragmas (an `abi_config.h` defining an ABI-affecting layout
+  macro but declaring nothing itself) never appears in
+  `dumper_castxml.py`/`dumper_clang.py`'s per-declaration
+  `_source_location`/`header_from_location` tracking, so sourcing the
+  digest from that data alone would silently miss a genuine
+  dependency-content difference expressed only through such a header —
+  the same "gap through under-counting" this whole redesign exists to
+  close, reintroduced one level deeper. The digest is instead built the
+  same way `abicheck/buildsource/include_graph.py`'s existing `-MM`/`-MMD`
+  depfile mechanism already builds the L3 include graph (`parse_depfile()`,
+  a pure, already-unit-tested Make-rule-depfile parser): the L2
+  castxml/clang invocation additionally requests a depfile (`-MMD -MF
+  <path>`) alongside the AST dump, and every listed path is attributed to
+  whichever declared `-I` directory contains it — one extra cheap compiler
+  flag per TU, reusing a proven parser at a new call site, not a second
+  compiler invocation or a directory-tree walk. `profile_fingerprint`'s
+  `-I` component is the hash of the **ordered** sequence of per-directory
+  digests. This is lossless: byte-identical dependency content at different mount points
   normalizes identically (attempt one's routine case, still correct);
   genuinely different content normalizes differently regardless of naming
   (the `dep-v1`/`dep-v2` case both attempt one and two mishandled); a
@@ -223,7 +236,7 @@ Implements ADR-050 D1 and D2.
   the manifest file's own directory — none of these legacy-CLI cases
   exist there.
 
-  Six dedicated tests are non-negotiable for this phase to be considered
+  Seven dedicated tests are non-negotiable for this phase to be considered
   done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
   identical trees under different roots asserts the resulting
   **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
@@ -244,7 +257,13 @@ Implements ADR-050 D1 and D2.
   external dependency (`old=/work/v1/include` + `old=/opt/dep`,
   `new=/work/v2/include` + `new=/opt/dep`) leaves `profile_fingerprint`
   matching — the specific mixed-roots regression rejected attempt three
-  introduced, now a permanent regression test rather than a live bug.
+  introduced, now a permanent regression test rather than a live bug; (7)
+  two dependency trees identical in every declaration-bearing header but
+  differing in one macro-only header pulled in transitively (never itself
+  the target of any declaration's `source_location`) produce *different*
+  `profile_fingerprint`s — proving the digest is sourced from the depfile's
+  full resolved-file list, not the narrower per-declaration set, the
+  specific under-counting gap this design's own history exists to close.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -372,14 +391,18 @@ Implements ADR-050 D1 and D2.
   makes the release fan-out fix (below) actually surface at the release
   level instead of being computed per-library and then silently
   outranked.
-- The gate is wired at **all five** entry points in one phase, closing the
+- The gate is wired at **all six** entry points in one phase, closing the
   gap AGENTS.md's "Known gaps" section already names for the depth
   contract rather than repeating the CLI-only mistake: `checker.compare`
   (core), `service.py`'s `ScanRequest`/`compare_snapshots`,
   `mcp_server.py`'s MCP compare tools, `cli_compare_release.py`'s
-  directory/package fan-out, **and** `compat/cli.py`'s ABICC-compatible
+  directory/package fan-out, `compat/cli.py`'s ABICC-compatible
   `compat check` (which calls `checker.compare` directly too — see the
-  dedicated bullet below for its own, independent exit-code contract).
+  dedicated bullet below for its own, independent exit-code contract),
+  **and** `cli_scan.py`'s `scan --against` (which reaches
+  `compare_snapshots` through `cli_scan_baseline._run_baseline_compare` —
+  see its own dedicated bullet below for why listing `service.py`'s
+  `compare_snapshots` alone doesn't already cover it).
 - **The release fan-out needs a dedicated fix, not inherited behavior.**
   `_compare_one_library` (`cli_compare_release.py:180-269`) wraps its
   entire per-library flow in `except (click.ClickException,
@@ -428,6 +451,28 @@ Implements ADR-050 D1 and D2.
   `compat/CLAUDE.md`'s exit-code table and a changelog fragment are updated in
   the same phase, per that file's own stated policy that changing the
   exit-code contract "requires a CHANGELOG note and downstream coordination."
+- **A sixth entry point reaches `compare_snapshots` through a different
+  code path than the ones already named, with its own exit-code contract
+  too.** `abicheck scan --against` calls `service.compare_snapshots` from
+  `cli_scan_baseline._run_baseline_compare` (invoked from
+  `scan_engine.run_scan_core` around `:852`) — `compare_snapshots` itself
+  has no exception handling of its own (a thin wrapper over
+  `checker.compare`), so `ProfileMismatchError`/`ScopeMismatchError`
+  propagate through it cleanly, exactly as intended at the `service.py`
+  boundary. The gap is one level up: `cli_scan.py`'s `scan_cmd` wraps its
+  `run_scan_core` call in `try`/`except _BudgetOverflow`/`except
+  _EvidenceContractError` only — verified against the actual code, neither
+  clause catches `ProfileMismatchError`/`ScopeMismatchError`, so today they
+  would propagate uncaught out of `scan_cmd` entirely, an unhandled
+  traceback rather than any of `scan`'s own documented exit codes
+  (`0`/`2`/`4`/`5`/`64`). `scan_cmd` gains a third `except
+  (ProfileMismatchError, ScopeMismatchError) as exc:` branch alongside its
+  existing two, exiting **`6`** — the next integer after `scan`'s own
+  highest documented code (`5`), distinct from both native `compare`'s
+  `16` and `compat check`'s `9` since all three commands maintain
+  independent exit-code schemes; reusing either of those would imply a
+  shared numbering `scan` doesn't have. `docs/reference/exit-codes.md`'s
+  `scan` table gains this row.
 - Reporting: `reporter.py`/`sarif.py`/`junit_report.py` gain a
   `not_comparable` top-level result distinct from every existing verdict
   value — never coerced into `compatible`/`breaking`.
@@ -512,7 +557,13 @@ Implements ADR-050 D1 and D2.
 **Files & surfaces.** `model.py` (new `ExtractionContract`), new
 `abicheck/comparability.py` (fingerprint computation, `compute_extraction_contract`,
 the gate, and `contract_coverage` metadata computation — no detector, since
-`UNKNOWN_PROFILE` is report metadata, not a `Change`), `dumper.py` (`dump()`
+`UNKNOWN_PROFILE` is report metadata, not a `Change`; reuses
+`abicheck/buildsource/include_graph.py`'s existing `parse_depfile()` to turn
+a per-TU `-MMD` depfile into the per-`-I`-directory resolved-file lists
+`profile_fingerprint` hashes — see the acceptance-criteria bullet above),
+`dumper_castxml.py`/`dumper_clang.py` (request a depfile alongside the AST
+dump for every L2 invocation, not only when `buildsource` L3 evidence is
+also being collected), `dumper.py` (`dump()`
 calls `compute_extraction_contract(...)` and attaches it to every returned
 snapshot — see the acceptance-criteria bullet above; this is not optional
 plumbing), `snapshot_cache.py` (`_SNAPSHOT_CACHE_VERSION` bump and the
@@ -540,9 +591,15 @@ routing to the updated `_classify_compat_error_exit_code` via `_compat_fail`),
 `compat/_errors.py`
 (`_classify_compat_error_exit_code`'s new `ProfileMismatchError`/
 `ScopeMismatchError` branch returning `9`), `compat/CLAUDE.md` (exit-code
-table update), `docs/reference/exit-codes.md` (a
-new row in both the legacy and severity-aware tables, **and** the
-multi-library section, **and** the `compat check` table's `9` row), `reporter.py`,
+table update), `cli_scan.py` (`scan_cmd`'s new third `except
+(ProfileMismatchError, ScopeMismatchError)` branch exiting `6`, alongside
+its existing `_BudgetOverflow`/`_EvidenceContractError` clauses — no change
+needed in `cli_scan_baseline.py`/`scan_engine.py` themselves, since
+neither catches these exceptions today and both must keep letting them
+propagate), `docs/reference/exit-codes.md` (a
+new row in both the legacy and severity-aware `compare` tables, the
+multi-library section, the `compat check` table's `9` row, **and** the
+`scan` table's `6` row), `reporter.py`,
 `sarif.py`, `junit_report.py`, `html_report.py` (`generate_html_report`'s
 `contract_coverage` headline card), `service_render.py` (`render_output`'s
 `--format html` branch skips `generate_html_report` on the `not_comparable`
@@ -608,7 +665,7 @@ severity-aware release schemes — proving `not_comparable`'s precedence
 over the removed-library mechanism is unconditional, unlike that
 mechanism's own existing scheme-dependent precedence; gate unit tests
 for all
-five entry points; a **compat-mode exit-code** test asserting
+six entry points; a **compat-mode exit-code** test asserting
 `compat check` returns exactly `9` (never `10`'s generic fallback, never
 `16`, and never an unhandled traceback) for a
 `ProfileMismatchError`/`ScopeMismatchError`, exercised both through
@@ -616,7 +673,13 @@ five entry points; a **compat-mode exit-code** test asserting
 `compat check` invocation on a mismatched pair — the latter is what proves
 the new `try`/`except` around the `compare()` call site actually catches the
 exception, not just that the classifier returns the right code once handed
-one; a `--diagnostic-comparison` end-to-end test asserting the report's
+one; a **scan-mode exit-code** test asserting `abicheck scan --against`
+returns exactly `6` (never an unhandled traceback, never `5`'s
+budget-overflow code) for a `ProfileMismatchError`/`ScopeMismatchError`
+raised from the baseline compare, exercised through a real end-to-end
+`scan --against` invocation on a mismatched pair — proving `scan_cmd`'s new
+`except` clause actually catches what `_run_baseline_compare` lets through
+uncaught today; a `--diagnostic-comparison` end-to-end test asserting the report's
 top-level `assurance` field is `"none"` and that no individual finding
 carries its own `assurance` value; a
 backward-compat test asserting a contract-less snapshot pair compares

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -316,7 +316,31 @@ Implements ADR-050 D1 and D2.
   full per-file content digest — a real dependency, where a change
   anywhere in it is meaningful drift. `scope_fingerprint` owns everything
   under a project-owned root; `profile_fingerprint` owns only external
-  roots, in full. **Known, accepted residual gap:** a vendored dependency
+  roots, in full. **Excluding a project-owned directory's content must not
+  also erase its position in the declared `-I` sequence.** `-I` order is
+  search-precedence order — `-I project -I dep` and `-I dep -I project`
+  over identical files can resolve an ambiguous `#include "config.h"`
+  present in both directories to a *different* file depending on which
+  flag came first, a real compiled-content difference, not cosmetic
+  reordering. Dropping an excluded directory's *slot* entirely (rather
+  than just its content) would collapse both orderings to the same
+  single-element sequence, since the project root then contributes
+  nothing — two extractions with genuinely different `#include`-resolution
+  behavior would hash identically, the exact false-match failure mode this
+  digest exists to close, reintroduced through the exclusion mechanism
+  itself. The fix keeps the sequence **positional**: every declared `-I`
+  directory keeps its own slot in declaration order; a project-owned
+  slot's content is replaced with one fixed sentinel constant (not derived
+  from the directory's path, name, or content — so no scope information
+  leaks into `profile_fingerprint`, and two project-owned directories
+  still compare equal to each other) instead of being omitted, so its
+  position relative to every external directory's real digest survives.
+  `-I project -I dep` hashes `[SENTINEL, digest(dep)]`; `-I dep -I
+  project` hashes `[digest(dep), SENTINEL]` — different sequences,
+  correctly flagged as non-comparable. The system/toolchain bucket stays
+  unordered, since its inputs were never part of a declared,
+  precedence-bearing `-I` sequence to begin with. **Known, accepted
+  residual gap:** a vendored dependency
   nested *inside* a project-owned root is swept into that exclusion too,
   so a content change confined there is invisible to `profile_fingerprint`
   on the legacy CLI path — the same "can't disambiguate from directory
@@ -340,7 +364,7 @@ Implements ADR-050 D1 and D2.
   the manifest file's own directory — none of these legacy-CLI cases
   exist there.
 
-  Twelve dedicated tests (numbered 1–11, with 8b alongside 8) are non-negotiable for this phase to be considered
+  Thirteen dedicated tests (numbered 1–12, with 8b alongside 8) are non-negotiable for this phase to be considered
   done: (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
   identical trees under different roots asserts the resulting
   **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
@@ -412,7 +436,18 @@ Implements ADR-050 D1 and D2.
   `profile_fingerprint` matching — proving the generated driver TU is
   excluded from bucketing entirely, not swept into the system/toolchain
   bucket where its run-specific absolute paths would make every routine
-  compare mismatch.
+  compare mismatch; (12) two declared `-I` lists with byte-identical
+  directory contents but **swapped order** between a project-owned root
+  and an external root — `old` declares `--include old=/work/include
+  --include old=/opt/dep`, `new` declares the same two directories as
+  `--include new=/opt/dep --include new=/work/include` (`/work/include`
+  project-owned on both sides via a shared `--header`, `/opt/dep`
+  byte-identical on both sides) — produce *different* `profile_fingerprint`s,
+  proving the project-owned slot is replaced with a positional sentinel
+  rather than dropped: if the slot were simply omitted, both sides would
+  degrade to the same single-element `[digest(/opt/dep)]` sequence and
+  spuriously match despite the order swap being a genuine, ambiguity-
+  affecting difference in `#include` search precedence.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls
@@ -919,7 +954,25 @@ actual code: `cli.py`'s `compare_cmd` is a thin `**kwargs` forwarder to
 is actually called (`:1464`) and where the output/exit-code rendering
 (`_finalize_compare_result` etc.) lives; a bare exception there today would
 propagate as an unhandled traceback, not the planned `verdict: null`
-report + exit `16` — `cli.py` alone has nothing to catch), `cli_compare_release.py`
+report + exit `16` — `cli.py` alone has nothing to catch). **The exception
+branch alone does not make `--diagnostic-comparison` reachable — `run_compare`
+must also accept and forward the flag itself, the same gap already found
+and fixed once for `--dump-manifest` on this exact function.** `run_compare`
+(`:992-1057`) has its own large, explicit, fixed keyword-argument signature
+with no `diagnostic_comparison` slot today; `compare_cmd` forwards `**kwargs`,
+so Click happily passes the new dest through, but `run_compare`'s own
+`compare_snapshots(...)` call (`:1464`) only passes what its signature
+already names — a `--diagnostic-comparison` value that reaches `run_compare`
+via `**kwargs` and is never read by name inside the function body is silently
+dropped before it ever reaches `compare_snapshots`, not rejected (there is no
+`**kwargs`-passthrough to `compare_snapshots` to raise on an unused key), so
+this is a silent-loss bug, not a crash — harder to notice than the
+`--dump-manifest` version of this same mistake, which at least raised
+"unexpected keyword argument." `run_compare` therefore gains a
+`diagnostic_comparison: bool = False` parameter, passed by name into the
+`compare_snapshots(diagnostic_comparison=diagnostic_comparison, ...)` call
+at `:1464`, mirroring how `old_dump_manifest`/`new_dump_manifest` are
+threaded through this same function. `cli_compare_release.py`
 (`_compare_one_library`'s dedicated
 `except (ProfileMismatchError, ScopeMismatchError)` branch, ordered before
 `except Exception` — see the release-fan-out acceptance-criteria bullet
@@ -1267,19 +1320,47 @@ SYCL/DPC++ target a `scan`-driven audit can already reach via that command's
 side-aware `-H`/`-I` options.
 **The decorator alone only makes Click accept the flag — it does not by
 itself thread the value anywhere, and this phase must not stop at the
-decorator.** Verified against the actual code: `cli_options.resolve_compile_context`
-(the single function the `@compile_context_options` family resolves to for
+decorator, and it does not stop at `resolve_compile_context` either.**
+Verified against the actual code: `dump_cmd` (`cli.py:569-592`) and
+`scan_cmd` (`cli_scan.py:634-663`) each have their own fixed, explicit
+callback parameter list — every other flag `compile_context_options` adds
+(`gcc_path`, `gcc_prefix`, `gcc_options`, `gcc_option_tokens`, `sysroot`,
+`nostdinc`, `header_backend`) is already listed there individually, not
+gathered via `**kwargs`. Click invokes these callbacks directly with one
+keyword per registered option, so adding `--frontend-context` to the shared
+decorator without adding a matching `frontend_context` parameter to
+*both* callback signatures is what actually raises "got an unexpected
+keyword argument" at the Click-callback boundary — `resolve_compile_context`
+is never in that call path; it is invoked manually from inside each
+callback's body, not by Click. `dump_cmd` gains `frontend_context: str =
+"host"`; `scan_cmd` gains the same (with its own existing defaulted-flags
+group, since `compile_context_options`' compile-context params already
+carry defaults there per `:657-663`). Native `compare`'s path is a third,
+separate instance of the identical gap: `compare_cmd` is a thin `**kwargs`
+forwarder (so it needs no change itself), but `cli_compare_helpers.run_compare`
+— the function Click's kwargs actually land in — has the same kind of
+fixed, explicit signature and gains its own `frontend_context: str = "host"`
+parameter too. Each of these three callback/helper layers then passes its
+new parameter into its own `resolve_compile_context(...)` call
+(`cli_dump_helpers.resolve_dump_compile_context` for `dump`, `cli_scan.py:722`
+for `scan`, `cli_compare_helpers.py:1258` for `compare`) — which is where
+`cli_options.resolve_compile_context`'s own signature and
+`CompileContext` construction come in: that function (the single function
+the `@compile_context_options` family ultimately resolves to for
 `compare`/`dump`/`scan` alike) has a fixed, explicit keyword-argument list
 and builds a `service_scan.CompileContext` from exactly those fields —
-neither has a slot for a host/device context today. Adding
-`--frontend-context` to the decorator without also extending
-`resolve_compile_context`'s signature and `CompileContext` would either
-raise a "got an unexpected keyword argument" error at the Click-callback
-boundary, or (if the new option is simply left unread) silently accept the
-flag and drop it before it ever reaches a dump. This phase therefore also
-adds `CompileContext.frontend_context: str = "host"` and a matching
+neither has a slot for a host/device context today. This phase therefore
+also adds `CompileContext.frontend_context: str = "host"` and a matching
 `frontend_context` parameter to `resolve_compile_context`, threaded into
-the `CompileContext(...)` it constructs. Because `scan_engine.run_scan_core`
+the `CompileContext(...)` it constructs — necessary, but (per the
+callback-layer paragraph above) not sufficient on its own; `dump_cmd`,
+`scan_cmd`, and `run_compare` each need the parameter in their own
+signature too, or the value never survives the trip from Click's callback
+invocation down to this function call. `cli_dump_helpers.resolve_dump_compile_context`
+(`:1168-1181`) sits between `dump_cmd` and `resolve_compile_context` and
+has the identical fixed-signature gap — it gains the same
+`frontend_context` parameter, threaded from `dump_cmd` into its own
+`resolve_compile_context(...)` call (`:1198`). Because `scan_engine.run_scan_core`
 already passes the *whole* `CompileContext` object through to
 `service.resolve_input` (`compile=compile_context`, not individual
 unpacked fields — verified at `scan_engine.py:243-254`) the same way

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -667,7 +667,11 @@ gains the dedicated `except` branch that sets `not_comparable_reason`),
 existing `0`/`1`/`4`/`64` logic), `docs/reference/exit-codes.md` (a
 new row in both the legacy and severity-aware `compare` tables, the
 multi-library section, the `compat check` table's `9` row, the
-`scan` table's `6` row, **and** the `deps compare` table's `5` row), `reporter.py`,
+`scan` table's `6` row, the `deps compare` table's `5` row, **and** the
+`## Summary table` cross-command matrix — a `not_comparable` row spanning
+all six of its columns, or the per-command detail tables gain their new
+codes while the one table meant to summarize them across commands goes
+stale the same day), `reporter.py`,
 `sarif.py`, `junit_report.py`, `html_report.py` (`generate_html_report`'s
 `contract_coverage` headline card), `service_render.py` (`render_output`'s
 `--format html` branch skips `generate_html_report` on the `not_comparable`
@@ -926,8 +930,17 @@ threads it into the L2 header frontend the same way `dump`/`compare` do,
 proving `compile_context_options` (not a `dump`/`compare`-only decorator) is
 what carries the flag.
 
-**Example fixtures.** Phase 0's ODR-safe and external-STL-noise pairs,
-wired through the real manifest path end to end.
+**Example fixtures.** Phase 0's external-STL-noise pair only, wired through
+the real manifest path end to end — **not** the ODR-safe pair. The
+ODR-safe fixture is a forward-declaration-in-one-TU,
+full-definition-in-another case, which is exactly a duplicate `entity_key`
+across TUs; Phase B's own placeholder merge (below) errors loudly on any
+duplicate `entity_key`, so wiring the ODR-safe pair through Phase B "end to
+end" would either require Phase C's real merge lattice to already exist
+here (collapsing the phase split) or fail outright against the deliberately
+strict placeholder. The ODR-safe pair's real end-to-end wiring belongs to
+Phase C (see its own "Tests" section), where the merge that actually
+handles this trivial-merge case exists.
 
 **Out of scope.** D4 (merge across TUs) is Phase C — Phase B's
 `TuFragment`s are produced but not yet merged into one `AbiSnapshot`

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -1194,6 +1194,32 @@ and `compare`'s existing declarations directly, not merely implied by
 registering a new command module — deliberately not named `--manifest`,
 which `@release_options` already registers on `compare` for the unrelated
 ADR-023 release manifest.
+**Declaring the Click option is not enough for `compare` — `cli_compare_helpers.py`
+needs the actual plumbing, the same gap already fixed once for the
+gate's own exception handling on this exact command.** `compare_cmd`
+forwards `**kwargs` to `cli_compare_helpers.run_compare`, whose signature
+is a large, explicit, fixed keyword list (verified against the actual
+code — it already carries `manifest_path` for the unrelated ADR-023
+release manifest, confirming the pattern: a new Click option's dest must
+also appear here or it either raises "unexpected keyword argument" or
+never reaches the per-side dump resolution). `run_compare` gains the new
+`old_dump_manifest`/`new_dump_manifest` parameters and threads them into
+its per-side header/include resolution (`_resolve_compare_snapshots`),
+alongside the existing `except (ProfileMismatchError, ScopeMismatchError)`
+fix already planned there.
+**`--frontend-context` reaching `compile_context_options` means directory/package
+`compare` accepts it too — and must reject it, not silently ignore it.**
+The release/set-input fan-out (`cli_compare_release.py`) never threads a
+per-library `CompileContext` at all; `cli_resolve.py`'s existing
+`_COMPILE_CONTEXT_SET_INPUT_FLAGS` dict is exactly the guard that rejects
+every other compile-context flag (`--gcc-path`, `--ast-frontend`, etc.) on
+a directory/package input, loudly, instead of silently accepting and then
+ignoring it. `frontend_context` gains its own entry in that same dict — the
+new option automatically inherits the existing rejection path once listed
+there, so `compare old_dir new_dir --frontend-context device` fails fast
+with the same clear error every other compile-context flag already
+produces on a set input, rather than being accepted and silently dropped
+by a backend that was never taught to use it.
 **`--frontend-context` is not a `dump`/`compare`-only option — it belongs in
 the existing `compile_context_options` decorator (`cli_options.py`), the same
 shared L2 compile-context family `dump`, `compare`, *and* `cli_scan.py`'s
@@ -1257,7 +1283,17 @@ path` test confirming the single-sided form is unaffected. A test asserting
 `compare --dump-manifest` and the pre-existing `--manifest` (ADR-023 release
 manifest) coexist as distinct, independently-settable options on the same
 `compare` invocation — the specific collision this naming choice exists to
-avoid. A **`scan --frontend-context`**
+avoid; and an end-to-end test asserting `compare old.so new.so
+--dump-manifest old=v1/abi.yml --dump-manifest new=v2/abi.yml` actually
+dumps each side from its own manifest through `run_compare`'s real
+resolution path (not just that Click accepts the flags) — proving
+`cli_compare_helpers.py`, not only `cli.py`, was updated. A **release
+rejects `--frontend-context`** test asserting `compare old_dir new_dir
+--frontend-context device` fails fast via `cli_resolve.py`'s existing
+set-input guard, the same way it already fails fast for `--gcc-path`/
+`--ast-frontend` on a directory/package input — proving the flag can't be
+silently accepted and then ignored by the release backend. A
+**`scan --frontend-context`**
 regression test asserting `abicheck scan --against` accepts `device` and
 threads it into the L2 header frontend the same way `dump`/`compare` do,
 proving `compile_context_options` (not a `dump`/`compare`-only decorator) is
@@ -1489,6 +1525,21 @@ per-TU ordered includes/forced-includes, and `contributes_to_abi`/
 `required` flags together — as an additional key input for manifest-driven
 dumps; still never `profile_fingerprint`, which cannot be a pre-dump input
 at all, per the bullet above).
+**Modifying `_cache_key()`'s own internals is not sufficient — the caller
+that decides what to pass it never sees the manifest today.**
+`service_dump_cache.cached_run_dump` is what actually builds the pre-dump
+key: it computes an `extra` string via `_dump_cache_extra_key(...)` and
+calls `snapshot_cache._cache_key(path, _headers, _cache_includes, version,
+lang, extra=extra)` *before* `dump()` runs (verified against the actual
+code, `:338-348`). Changing `_cache_key()`'s signature/behavior alone has
+no effect unless this call site is also updated to compute the
+manifest-driven `scope_fingerprint` and fold it into `extra` (or a new
+keyword) — otherwise a manifest-only change (a TU rename, reordered
+forced-includes) still hits a stale cache entry regardless of what
+`_cache_key()` itself is capable of hashing. `service_dump_cache.py` gains
+that plumbing: `cached_run_dump` computes the manifest's `scope_fingerprint`
+(cheap — no compiler invocation, per the acceptance-criteria bullet above)
+before its cache lookup and folds it into the key it builds.
 
 **Tests.** `process_resources.py` unit tests migrated from
 `source_replay.py`'s existing RAM-probing tests (same behavior, new import

--- a/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
+++ b/docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md
@@ -123,31 +123,50 @@ Implements ADR-050 D1 and D2.
   includes, so leaving it out of the hash would let that exact class of
   scope drift pass the gate undetected.
 - **Both fingerprints hash root-relative paths, never raw absolute ones —
-  the single highest-priority correctness requirement in this phase.**
+  the single highest-priority correctness requirement in this phase — and
+  each normalizes against its *own* root, never a root shared across both.**
   `compare`'s side-scoped `--header old=v1/foo.h --header new=v2/foo.h` /
   `--include old=inc1 --include new=inc2` (ADR-040) is the ordinary
   two-checkout compare workflow, and its old/new sides necessarily resolve
   to different absolute paths even for an identical logical surface.
   Hashing absolute paths directly would fingerprint-mismatch and hard-fail
   *every routine compare* as `not_comparable` — breaking the gate's primary
-  use case on day one. Each side's paths are normalized relative to that
-  side's own resolution root (legacy CLI path: the common ancestor
-  **directory** of that side's inputs — each header's *parent* directory
-  plus each include directory itself, **not** the header paths taken
-  literally; manifest path: the manifest file's own directory) before
-  hashing (ADR-050 D1). Deriving the root from header paths directly instead
+  use case on day one. `scope_fingerprint`'s root (header/TU paths) and
+  `profile_fingerprint`'s root (`-I` include-search directories) are
+  computed **separately**, from each category's own paths only — an
+  earlier revision of this criterion combined them into one shared root,
+  which breaks the moment an external dependency `-I` directory (e.g.
+  `--include old=/opt/dep --include new=/opt/dep`, commonly identical and
+  well outside either checkout) shares no meaningful prefix with the
+  project headers: the combined common ancestor collapses to `/`, so the
+  header paths normalize right back to their diverging checkout roots
+  (`work/v1/foo.h` vs. `work/v2/foo.h`) and `scope_fingerprint` mismatches
+  anyway — the exact bug this whole fix exists to close, reintroduced by
+  mixing an unrelated path category into the same root computation.
+  Each root (legacy CLI path: the common ancestor **directory** of that
+  side's own paths in that one category — each header's *parent* directory
+  for `scope_fingerprint`, each `-I` directory itself for
+  `profile_fingerprint`; manifest path: the manifest file's own directory
+  for both) before
+  hashing (ADR-050 D1). Deriving a root from header paths directly instead
   of their parents breaks the single-header-per-side case — the common
   ancestor of a one-element path set is that whole path, so `old=v1/foo.h`
   and `new=v2/bar.h` would both normalize to the same empty marker and hash
   identically despite being different scopes, the opposite failure from the
   one this fix exists to close; taking the parent directory first preserves
-  the filename (`v1/foo.h` → root `v1/`, normalized `foo.h`). A dedicated
-  test using `--header old=v1/foo.h --header new=v2/foo.h` against
-  logically identical trees under different roots, asserting the resulting
-  `profile_fingerprint`s match — **and** a second test asserting
+  the filename (`v1/foo.h` → root `v1/`, normalized `foo.h`). Three
+  dedicated tests are non-negotiable for this phase to be considered done:
+  (1) `--header old=v1/foo.h --header new=v2/foo.h` against logically
+  identical trees under different roots asserts the resulting
+  **`scope_fingerprint`s** match (not `profile_fingerprint` — headers are a
+  scope input, and a test that only checks `profile_fingerprint` here can
+  pass while `scope_fingerprint` still hard-fails on raw header paths); (2)
   `old=v1/foo.h`/`new=v2/bar.h` (genuinely different header names) produce
-  *different* fingerprints — is non-negotiable for this phase to be
-  considered done.
+  *different* `scope_fingerprint`s; (3) adding an identical, out-of-checkout
+  `--include old=/opt/dep --include new=/opt/dep` alongside case (1)'s
+  headers still leaves `scope_fingerprint` matching — the specific
+  external-dependency-directory regression this criterion exists to
+  prevent.
 - **Modeling `contract` is not the same as populating it — this phase must
   do both.** `dump()` (`dumper.py`) is the one place that already resolves
   every input both fingerprints need; it calls

--- a/docs/development/plans/index.md
+++ b/docs/development/plans/index.md
@@ -33,6 +33,7 @@ Initiative plans (cross-cutting, not tied to a single registry gap):
 | **G29** | [Impact-analysis layer: unified graph-driven impact model](g29-impact-analysis-layer.md) | [ADR-044](../adr/044-reachability-aware-suppression.md), [ADR-031](../adr/031-source-implementation-graph-augmentation.md), [ADR-046](../adr/046-source-graph-identity-v2-and-evidence-merge.md) · XL (phased: Phase 1 done — tri-state reachability, [PR #607](https://github.com/abicheck/abicheck/pull/607); Phase 2 ADR drafted (ADR-046, Proposed), implementation not started; Phases 3–6 open) |
 | **G30** | [GitHub Actions integration model: project lifecycle backlog](g30-github-actions-integration-model.md) | [ADR-047](../adr/047-github-actions-integration-model.md) · XL (phased P0/P1/P2, not started) |
 | **G31** | [Header-graph default-on: follow-up phases B–D](g31-header-graph-default-on-followup.md) — independent of G29 above; drafted as "G29" before that letter was found taken, see its own naming note | [ADR-041](../adr/041-compiler-facts-semantic-impact-graph.md) · Phase A done (header-graph/header-graph-includes flipped default-on); Phases B–D open |
+| **G32** | [Comparability contract: profile/scope fingerprints and the multi-TU manifest](g32-comparability-contract-and-multi-tu-manifest.md) | [ADR-049](../adr/049-comparability-contract-and-multi-tu-manifest.md) · XL (phased: Phase 0–E, none started) |
 
 Completed or decided plans are retained for implementation history:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -210,6 +210,7 @@ nav:
       - "046: Source Graph Identity v2": development/adr/046-source-graph-identity-v2-and-evidence-merge.md
       - "047: GitHub Actions Integration Model": development/adr/047-github-actions-integration-model.md
       - "048: Canonical Entity Identity and Graph Reconciliation": development/adr/048-canonical-entity-identity-and-graph-reconciliation.md
+      - "049: Comparability Contract & Multi-TU Manifest": development/adr/049-comparability-contract-and-multi-tu-manifest.md
 
 # Agent instructions are repo-internal context, not published documentation.
 exclude_docs: |


### PR DESCRIPTION
## Summary

Adds ADR-050 and its companion plan G32, recording the target model and phased backlog for making `compare` refuse to produce a verdict on two snapshots that weren't extracted under a comparable contract, and for supporting real multi-TU dumps.

## Motivation

A review of abicheck's snapshot architecture (prompted by a multi-TU/DPC++ scenario: umbrella header + an Arrow-derived adapter header needing its own forced include + a SYCL host/device compilation split) identified two real gaps:

1. `dumper.py` collapses every requested header into one synthetic translation unit (`dumper.py:370`) — no per-TU forced includes, no required-vs-optional TU semantics.
2. `checker.compare` has no gate proving two snapshots share a comparable extraction contract before running a symbol diff — a manifest/flag drift between two extraction runs today produces false additions/removals instead of a clear "not comparable" result.

Cross-checking the full review against the codebase (`model.py`, `dumper.py`, `buildsource/`, `snapshot_cache.py`, `serialization.py`, `checker_policy.py`, `sycl_metadata.py`) found most of the rest already shipped under different names (ADR-024's `ScopeOrigin`, ADR-015's deterministic serialization, `buildsource`'s RAM-aware scheduling and content-hash caching) — this PR documents only the genuinely new decisions, cross-referencing the rest rather than re-deciding it.

## Changes

- `docs/development/adr/050-comparability-contract-and-multi-tu-manifest.md` — new ADR (Proposed, not implemented): `ExtractionContract` profile/scope fingerprints, a hard-fail comparability gate generalizing the existing `DumpDepthNotSatisfiedError` precedent, manifest-driven multi-TU dumps, cross-TU compatible merge, DPC++ host/device AST context selection, and a shared resource-aware frontend scheduler. Numbered 050, not 049, since ADR-049 was independently claimed by PR #617 ("Contract Relevance and Compatibility Configuration") while this PR was in review.
- `docs/development/plans/g32-comparability-contract-and-multi-tu-manifest.md` — new phased implementation plan (Phase 0 fixtures → Phase A contract/gate → Phase B manifest/multi-TU → Phase C compatible merge → Phase D SYCL context → Phase E scheduling/cache), each phase with goals, acceptance criteria, files/surfaces, and tests.
- `docs/development/adr/index.md`, `docs/development/plans/index.md`, `mkdocs.yml` — registry/nav wiring for the new ADR (plan docs are intentionally excluded from the published nav per existing convention).

No production code changes — this is a decision record and backlog only; `scripts/check_ai_readiness.py` passes with 0 errors (52 pre-existing warnings, unrelated to this change).

## Checklist

- [x] Docs updated (this PR is docs-only)
- [ ] Tests added / updated for new behaviour — N/A, no production code in this PR
- [ ] Changelog fragment added — N/A, doesn't touch `abicheck/**/*.py`
- [x] `python scripts/check_ai_readiness.py` passes (0 errors)
- [ ] No new `mypy`/`ruff` errors — N/A, no `.py` changes


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZMKXj2JQo4kTSqJTAfMaW)_


## Summary by CodeRabbit

* **Documentation**
  * Added ADR-050 covering a comparability contract using profile/scope fingerprints and a multi-translation-unit manifest approach, including behavior for mismatches, mixed comparisons, and updated reporting/exit-code expectations.
  * Introduced initiative plan G32 with a phased rollout describing manifest-driven extraction, deterministic TU fragment merging, SYCL/DPC++ context handling, resource-aware scheduling, and snapshot/cache invalidation strategy.
  * Updated the ADR index and development documentation navigation to include the new ADR and G32 plan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ADR-050 documenting snapshot comparability contracts, profile and scope fingerprints, and multi-translation-unit workflows.
  * Added the phased G32 implementation plan, including diagnostic reporting, manifest-driven extraction, cross-unit merging, and frontend context selection.
  * Updated documentation indexes and navigation to link the new ADR and initiative plan.
  * Marked ADR-050 as proposed and not yet implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->