### PR TITLE
feat(action): actions/check-target composite Action (G30 P1.3, ADR-047 §4/§7)

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - 'action.yml'
       - 'action/**'
+      - 'actions/check-target/**'
+      - 'actions/resolve-baseline/**'
       - 'abicheck/**'
       - '.github/workflows/test-action.yml'
       - 'tests/fixtures/action/**'
@@ -16,6 +18,8 @@ on:
     paths:
       - 'action.yml'
       - 'action/**'
+      - 'actions/check-target/**'
+      - 'actions/resolve-baseline/**'
       - 'abicheck/**'
       - '.github/workflows/test-action.yml'
       - 'tests/fixtures/action/**'
@@ -216,6 +220,85 @@ jobs:
           test -f test-output.json
           python -m json.tool test-output.json > /dev/null
           echo "Output file is valid JSON"
+
+  # ── Test: check-target (G30 P1.3, ADR-047 §4/§7) ─────────────────────────
+  test-check-target:
+    name: 'check-target: gate-mode: deferred never fails on a real finding, report envelope is well-formed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Stage a fake baseline-set directly (no actions/baseline run needed --
+      # check-target only cares that resolve-baseline can read manifest.json
+      # + the snapshot it points at). action_test_v1.json/v2.json is the same
+      # pair test-compare-breaking already establishes as a real BREAKING
+      # finding -- reused here to prove check-target's own envelope/gate-mode
+      # logic on top of a known compatibility result, not to re-test compare
+      # itself.
+      - name: Stage baseline-set
+        shell: bash
+        run: |
+          mkdir -p /tmp/baseline-set
+          cp tests/fixtures/action/action_test_v1.json /tmp/baseline-set/libexample.abicheck.json
+          python3 -c "
+          import json
+          manifest = {
+              'manifest_version': 1,
+              'project_ref': 'v1.0.0',
+              'profile': 'linux-x86_64-gcc-test',
+              'snapshot_schema': 9,
+              'fact_set': None,
+              'artifacts': [
+                  {
+                      'library': 'libexample',
+                      'artifact': 'build/libexample.so',
+                      'snapshot': 'libexample.abicheck.json',
+                      'sha256': '',
+                  }
+              ],
+          }
+          with open('/tmp/baseline-set/manifest.json', 'w') as f:
+              json.dump(manifest, f, indent=2)
+          "
+
+      - name: 'Run check-target (gate-mode: deferred)'
+        id: check
+        uses: ./actions/check-target
+        with:
+          name: libexample
+          profile: linux-x86_64-gcc-test
+          baseline-channel: accepted-main
+          baseline-path: /tmp/baseline-set
+          requested-depth: headers
+          gate-mode: deferred
+          new-library: tests/fixtures/action/action_test_v2.json
+          install-deps: false
+
+      - name: "Verify outcome, envelope identity, and gate-mode: deferred's non-failing job"
+        shell: bash
+        run: |
+          echo "outcome=${{ steps.check.outputs.outcome }}"
+          echo "check-id=${{ steps.check.outputs.check-id }}"
+          echo "verdict=${{ steps.check.outputs.verdict }}"
+          echo "compatibility-verdict=${{ steps.check.outputs.compatibility-verdict }}"
+          echo "policy-gate-decision=${{ steps.check.outputs.policy-gate-decision }}"
+          test "${{ steps.check.outputs.outcome }}" = "resolved"
+          test "${{ steps.check.outputs.check-id }}" = "libexample@linux-x86_64-gcc-test#accepted-main@headers"
+          test "${{ steps.check.outputs.verdict }}" = "BREAKING"
+          test "${{ steps.check.outputs.compatibility-verdict }}" = "BREAKING"
+          test "${{ steps.check.outputs.policy-gate-decision }}" = "fail"
+          # gate-mode: deferred must not fail this job on a real finding --
+          # reaching this step at all (after a nonzero-exit internal compare)
+          # already proves that; also assert the persisted report kept its
+          # REAL severity (never neutralized for deferred -- only advisory
+          # neutralizes, since a trailing aggregate job needs the real value).
+          python -m json.tool "${{ steps.check.outputs.report-path }}" > /dev/null
+          python3 -c "import json, sys
+          report = json.load(open(sys.argv[1]))
+          assert report['severity']['exit_code'] == 4, report['severity']
+          assert report['operational_errors'] == []
+          assert report['check_evidence_coverage']['state'] == 'complete'
+          print('report envelope OK')" "${{ steps.check.outputs.report-path }}"
 
   # ── Test: multiplatform ─────────────────────────────────────────────────
   test-multiplatform:

--- a/abicheck/buildsource/check_report.py
+++ b/abicheck/buildsource/check_report.py
@@ -246,12 +246,26 @@ def augment_report(
     head_sha: str | None = None,
     base_ref: str | None = None,
     action_version: str | None = None,
+    analysis_exit_code: int | None = None,
 ) -> dict[str, Any]:
     """Layer ADR-047 §7's identity/new fields onto a real analysis report.
 
     *report* is the already-parsed JSON dict a ``compare``/``scan`` run
     produced (root ``action.yml``'s ``report-path`` output). Returns a new
     dict -- *report* itself is never mutated.
+
+    *analysis_exit_code*, when given, is the nested root Action's own real
+    process exit code (its ``exit-code`` output) -- folded into the gate
+    decision via ``max()`` alongside whatever ``_real_exit_code`` reads from
+    the report body itself. Needed because at least one root-Action gate,
+    ``--fail-on-removed-library`` (release/bundle compares), takes effect as
+    a dedicated exit code (8) that overrides the persisted severity scheme
+    rather than feeding into it -- ``compare_release_cmd``'s own
+    ``_exit_compare_release`` applies it "in preference to the severity
+    code," so a bundle report's own ``severity.exit_code`` can read 0 even
+    though the real process exited 8. Reading only the report body would
+    silently pass a removed-library gate the caller explicitly asked for
+    (Codex review).
     """
     if gate_mode not in GATE_MODES:
         raise ValueError(f"gate_mode must be one of {GATE_MODES}, got {gate_mode!r}")
@@ -296,7 +310,7 @@ def augment_report(
         out["action_version"] = action_version
 
     raw_verdict = report.get("verdict")
-    real_exit_code = _real_exit_code(report)
+    real_exit_code = max(_real_exit_code(report), analysis_exit_code or 0)
     out["policy_gate_decision"] = "fail" if real_exit_code != 0 else "pass"
     if raw_verdict in LEGACY_VERDICT_VALUES:
         out["compatibility_verdict"] = raw_verdict

--- a/abicheck/buildsource/check_report.py
+++ b/abicheck/buildsource/check_report.py
@@ -103,6 +103,13 @@ RESOLVE_FAILURE_OUTCOMES = frozenset(
 
 GATE_MODES = ("local", "deferred", "advisory")
 
+#: ``cli_compare_release_helpers._exit_compare_release``'s dedicated
+#: ``--fail-on-removed-library`` exit code -- applied "in preference to the
+#: severity code," so it's the one value the analysis step's real exit code
+#: can carry that the persisted ``severity`` block never independently
+#: reflects.
+_REMOVED_LIBRARY_EXIT_CODE = 8
+
 
 def validate_identifier(field_name: str, value: str) -> None:
     """Reject a ``target``/``profile``/``baseline_channel`` outside the safe
@@ -312,6 +319,40 @@ def augment_report(
     raw_verdict = report.get("verdict")
     real_exit_code = max(_real_exit_code(report), analysis_exit_code or 0)
     out["policy_gate_decision"] = "fail" if real_exit_code != 0 else "pass"
+    if analysis_exit_code == _REMOVED_LIBRARY_EXIT_CODE:
+        # --fail-on-removed-library's exit 8 is the *only* value
+        # cli_compare_release_helpers._exit_compare_release applies "in
+        # preference to the severity code" -- every other severity-aware
+        # exit path there just emits severity_exit_code directly, so 8 is
+        # the sole case where the real outcome can diverge from what's
+        # already in the persisted severity block. Escalating
+        # policy_gate_decision/real_exit_code above isn't enough on its
+        # own: gate-mode: deferred relies on check-project.yml's trailing
+        # aggregate job, and abicheck.aggregate.GateInfo.from_report_data
+        # reads ONLY the persisted severity.exit_code -- it has no way to
+        # see policy_gate_decision or analysis_exit_code at all. Without
+        # also updating severity here, a removed-library gate on a
+        # deferred bundle check would still be silently missed by
+        # aggregate, even though this check's own local exit code is
+        # correct (Codex review, second pass). A whole library
+        # disappearing is unambiguously an ABI break, so it's encoded as
+        # the abi_breaking tier (exit_code 4 -- the ceiling of
+        # aggregate.py's _VALID_GATE_EXIT = {0, 1, 2, 4}; 8 itself isn't a
+        # legal severity.exit_code and would raise _MalformedGate there).
+        # Only escalates -- never downgrades an already-≥4 severity block,
+        # though 4 is already that ceiling so there's nothing to downgrade
+        # from in this scheme.
+        severity = out.get("severity")
+        if isinstance(severity, dict) and severity.get("exit_code", 0) < 4:
+            cats = list(severity.get("blocking_categories") or [])
+            if "abi_breaking" not in cats:
+                cats.append("abi_breaking")
+            out["severity"] = {
+                **severity,
+                "exit_code": 4,
+                "blocking": True,
+                "blocking_categories": cats,
+            }
     if raw_verdict in LEGACY_VERDICT_VALUES:
         out["compatibility_verdict"] = raw_verdict
         out.setdefault("operational_errors", [])

--- a/abicheck/buildsource/check_report.py
+++ b/abicheck/buildsource/check_report.py
@@ -327,7 +327,11 @@ def build_operational_error_report(
         "baseline_channel": baseline_channel,
         "requested_depth": requested_depth,
         "check_evidence_coverage": {"state": "unknown", "reasons": [resolve_outcome]},
-        "compatibility_verdict": None,
+        # compatibility_verdict is omitted, not written as null: the schema
+        # declares it a plain string enum with no null alternative -- an
+        # operational failure has no compatibility result to report at all
+        # (§7: "ERROR" is the deliberate exception living in the legacy
+        # `verdict` field instead, never in this new one).
         "policy_gate_decision": "fail",
         "operational_errors": [{"kind": resolve_outcome, "message": resolve_message}],
         "publication": {"state": "skipped", "channels": []},
@@ -374,7 +378,9 @@ def build_bootstrap_report(
             "reasons": ["no_baseline_published_yet"],
         },
         "baseline_bootstrap": True,
-        "compatibility_verdict": None,
+        # compatibility_verdict omitted, not null -- same reasoning as
+        # build_operational_error_report above: a bootstrap pass never
+        # produced a compatibility result either.
         "policy_gate_decision": "pass",
         "operational_errors": [],
         "publication": {"state": "skipped", "channels": []},

--- a/abicheck/buildsource/check_report.py
+++ b/abicheck/buildsource/check_report.py
@@ -60,7 +60,7 @@ import re
 from typing import Any
 
 from ..checker_types import validate_check_id, validate_evidence_depth
-from ..schemas import REPORT_SCHEMA_VERSION
+from ..schemas import REPORT_SCHEMA_VERSION, SCAN_SCHEMA_VERSION
 
 #: Safe identifier charset shared by every ``check_id`` component (ADR-047
 #: §7's delimiter-unambiguity fix) -- target/bundle names, profile ids, and
@@ -258,7 +258,27 @@ def augment_report(
     out = dict(report)
     check_id = build_check_id(name, profile_id, baseline_channel, requested_depth)
     effective_depth, coverage = derive_effective_depth(report, requested_depth)
-    out["report_schema_version"] = REPORT_SCHEMA_VERSION
+    if "scan_schema_version" in report:
+        # A scan report (baseline-channel: none) has its own schema marker
+        # and shape (level/risk/coverage/... -- no library/old_file/summary/
+        # changes/...) -- bump it to the latest version for this envelope's
+        # new additive fields instead of also stamping report_schema_version
+        # (the *compare*-report schema's marker), which would make a
+        # downstream validator select compare_report.schema.json for a
+        # report that structurally can never satisfy it (Codex review).
+        out["scan_schema_version"] = SCAN_SCHEMA_VERSION
+    elif "libraries" in report and "old_dir" in report:
+        # A kind: bundle / directory-package compare report (the per-library
+        # release fan-out's own summary shape: verdict/old_dir/new_dir/
+        # libraries/... -- no singular library/old_file/new_file/summary/
+        # changes/... either) has never had a schema of its own; leave it
+        # unversioned here too rather than falsely claiming the single-pair
+        # compare schema (same rationale as the scan case above, Codex
+        # review). ADR-047 §7's identity/policy-gate fields below still
+        # apply regardless of report shape.
+        pass
+    else:
+        out["report_schema_version"] = REPORT_SCHEMA_VERSION
     out["check_id"] = check_id
     out["target_id"] = check_id
     out["profile_id"] = profile_id

--- a/abicheck/buildsource/check_report.py
+++ b/abicheck/buildsource/check_report.py
@@ -1,0 +1,379 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Report-envelope construction for ``actions/check-target`` (G30 P1.3,
+ADR-047 §7).
+
+``check-target`` composes ``resolve-baseline`` + root ``action.yml`` +
+``collect-facts`` (ADR-047 §4) and always emits the report envelope (§7),
+regardless of whether the baseline resolved, was a bootstrap "no baseline
+yet" pass, or failed outright. This module is the pure logic backing
+``actions/check-target/report_envelope.py``'s thin CLI wrapper (mirroring
+how ``abicheck.buildsource.baseline_set`` backs
+``actions/resolve-baseline/resolve_baseline.py``):
+
+- :func:`build_check_id` — the unconditional
+  ``target@profile#baseline_channel@requested_depth`` identity (§7's
+  "always includes ``requested_depth``, not only on collision" correction).
+- :func:`resolve_effective_depth` — the ``check_evidence_coverage``
+  degrade-to-``headers`` calculation when the requested build/source
+  evidence wasn't actually available.
+- :func:`augment_report` — the common path: layer §7's identity/new fields
+  onto an already-produced ``compare``/``scan`` JSON report, dual-writing
+  the legacy ``verdict``/``severity`` fields ``abicheck/aggregate.py``
+  already parses (§7's dual-write requirement) and neutralizing the legacy
+  gate for ``gate-mode: advisory`` (§7's third required sub-task) — but
+  *not* for ``deferred``, whose whole point is that ``aggregate``'s own
+  ``exit_code()`` (a ``max()`` over each report's real ``severity.exit_code``)
+  is what computes the gate centrally; neutralizing ``deferred`` reports too
+  would make that computation blind to the real finding.
+- :func:`build_operational_error_report` / :func:`build_bootstrap_report` —
+  synthesize a full envelope from scratch when ``resolve-baseline`` failed
+  or bootstrapped, so a report always exists even when no comparison ever
+  ran (§7: "a report can be fully computed and still fail to publish" — the
+  converse also matters here: a check can fail to ever start comparing and
+  must still produce a typed, consumable report).
+- :func:`final_exit_code` — ``check-target``'s own composite exit code:
+  ``gate-mode: local`` reflects the real outcome; ``deferred``/``advisory``
+  are 0 unless an operational error occurred (operational errors always
+  fail the job, regardless of gate-mode — resolve-baseline's failure
+  taxonomy is never silently degraded to a compatibility verdict).
+
+Pure: no file I/O, no subprocess. The CLI wrapper handles reading/writing
+JSON and printing ``GITHUB_OUTPUT`` lines.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ..checker_types import validate_check_id, validate_evidence_depth
+from ..schemas import REPORT_SCHEMA_VERSION
+
+#: Safe identifier charset shared by every ``check_id`` component (ADR-047
+#: §7's delimiter-unambiguity fix) -- target/bundle names, profile ids, and
+#: baseline channel names all validate against this.
+_IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+#: The five real ``Verdict`` enum values (``abicheck.change_registry_types.
+#: Verdict``), duplicated here as plain strings rather than importing the
+#: enum -- this module only ever compares/serializes the wire string, never
+#: constructs a ``Verdict`` instance, and a bare frozenset avoids a second
+#: import path into ``checker_policy``'s dependency graph for a five-item
+#: membership check.
+LEGACY_VERDICT_VALUES = frozenset(
+    {"NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING"}
+)
+
+#: ``aggregate.py``'s own operational-failure sentinel (``_load_report_file``
+#: special-cases this exact string before ever parsing ``severity``) --
+#: reused here, not reinvented, so ``check-target``'s operational-failure
+#: reports are recognized by the *existing* aggregate parser unchanged.
+OPERATIONAL_ERROR_VERDICT = "ERROR"
+
+#: A bootstrap ("no baseline published yet") pass is deliberately **not** a
+#: ``Verdict`` member and **not** ``"ERROR"`` either -- ADR-047 §6 requires
+#: it stay "an advisory pass ... never a compatibility verdict." Any string
+#: outside ``LEGACY_VERDICT_VALUES``/``OPERATIONAL_ERROR_VERDICT`` already
+#: fails ``aggregate.parse_report_verdict``'s ``Verdict(raw)`` parse (caught,
+#: returns ``None``), which is exactly the "unavailable, not a verdict"
+#: behavior a bootstrap check wants -- it is expected to be paired with
+#: ``required: false`` in the run-plan, so not contributing a parsed verdict
+#: never opens a coverage gap.
+BOOTSTRAP_VERDICT = "NO_BASELINE"
+
+#: ``resolve-baseline``'s five failure outcomes (ADR-047 §6) that are never
+#: a compatibility verdict -- distinct from ``not_found`` + bootstrap, which
+#: is an advisory pass, not a failure.
+RESOLVE_FAILURE_OUTCOMES = frozenset(
+    {"not_found", "ambiguous", "wrong_profile", "stale_schema", "incompatible_evidence"}
+)
+
+GATE_MODES = ("local", "deferred", "advisory")
+
+
+def validate_identifier(field_name: str, value: str) -> None:
+    """Reject a ``target``/``profile``/``baseline_channel`` outside the safe
+    identifier charset (ADR-047 §7's delimiter-unambiguity fix)."""
+    if not _IDENTIFIER_RE.match(value):
+        raise ValueError(
+            f"{field_name}: {value!r} is not a valid identifier -- must match "
+            r"^[A-Za-z0-9][A-Za-z0-9._-]*$"
+        )
+
+
+def build_check_id(
+    name: str, profile_id: str, baseline_channel: str, requested_depth: str
+) -> str:
+    """Build the unconditional ``target@profile#baseline_channel@depth`` id.
+
+    Always includes the ``@requested_depth`` suffix -- ADR-047 §7's
+    corrected rule, not only when a collision would occur (no run-plan-level
+    collision detection is available to a standalone ``check-target`` call).
+    """
+    validate_identifier("target/bundle", name)
+    validate_identifier("profile_id", profile_id)
+    validate_identifier("baseline_channel", baseline_channel)
+    validate_evidence_depth("requested_depth", requested_depth)
+    check_id = f"{name}@{profile_id}#{baseline_channel}@{requested_depth}"
+    validate_check_id(check_id)
+    return check_id
+
+
+def resolve_effective_depth(
+    requested_depth: str, *, evidence_ok: bool, degraded_reason: str | None = None
+) -> tuple[str, dict[str, Any]]:
+    """Compute ``effective_depth``/``check_evidence_coverage`` (ADR-047 §7).
+
+    ``binary``/``headers`` depth never needs build/source evidence, so it's
+    always "complete". ``build``/``source`` depth degrades to ``headers``
+    when the caller reports the requested evidence wasn't actually available
+    (e.g. a wrapper/clang-plugin pack that never reached ``phase: verify``,
+    or a replay step that failed to resolve a compile database) -- never
+    silently rendering as an unqualified pass at the requested depth.
+    """
+    validate_evidence_depth("requested_depth", requested_depth)
+    if requested_depth in ("binary", "headers") or evidence_ok:
+        return requested_depth, {"state": "complete", "reasons": []}
+    return "headers", {
+        "state": "degraded",
+        "reasons": [degraded_reason or "evidence_not_available"],
+    }
+
+
+def _real_exit_code(report: dict[str, Any]) -> int:
+    """Read whichever real gate exit code the underlying report carries.
+
+    ``compare``-shaped reports carry a ``severity`` block; ``scan``-shaped
+    reports carry a top-level ``exit_code`` alongside ``scan_schema_version``.
+    Returns 0 (pass) when neither shape is present.
+    """
+    severity = report.get("severity")
+    if isinstance(severity, dict):
+        exit_code = severity.get("exit_code")
+        if isinstance(exit_code, int):
+            return int(exit_code)
+    if "scan_schema_version" in report:
+        exit_code = report.get("exit_code")
+        if isinstance(exit_code, int):
+            return int(exit_code)
+    return 0
+
+
+def _neutralize_gate(report: dict[str, Any]) -> None:
+    """Zero the legacy gate in place for ``gate-mode: advisory`` (§7).
+
+    Only ``advisory`` reports are rewritten this way -- ``deferred`` reports
+    keep their real ``severity``/``exit_code`` untouched, since
+    ``check-project.yml``'s trailing ``aggregate`` job computes the actual
+    gate from exactly that real value (``abicheck/aggregate.py``'s
+    ``exit_code()`` is a ``max()`` over each report's real gate).
+    """
+    severity = report.get("severity")
+    if isinstance(severity, dict):
+        report["severity"] = {
+            **severity,
+            "exit_code": 0,
+            "blocking": False,
+            "blocking_categories": [],
+        }
+    elif "scan_schema_version" in report and "exit_code" in report:
+        report["exit_code"] = 0
+
+
+def augment_report(
+    report: dict[str, Any],
+    *,
+    name: str,
+    profile_id: str,
+    baseline_channel: str,
+    requested_depth: str,
+    gate_mode: str,
+    evidence_ok: bool,
+    degraded_reason: str | None = None,
+    project: str | None = None,
+    head_sha: str | None = None,
+    base_ref: str | None = None,
+    action_version: str | None = None,
+) -> dict[str, Any]:
+    """Layer ADR-047 §7's identity/new fields onto a real analysis report.
+
+    *report* is the already-parsed JSON dict a ``compare``/``scan`` run
+    produced (root ``action.yml``'s ``report-path`` output). Returns a new
+    dict -- *report* itself is never mutated.
+    """
+    if gate_mode not in GATE_MODES:
+        raise ValueError(f"gate_mode must be one of {GATE_MODES}, got {gate_mode!r}")
+    out = dict(report)
+    check_id = build_check_id(name, profile_id, baseline_channel, requested_depth)
+    effective_depth, coverage = resolve_effective_depth(
+        requested_depth, evidence_ok=evidence_ok, degraded_reason=degraded_reason
+    )
+    out["report_schema_version"] = REPORT_SCHEMA_VERSION
+    out["check_id"] = check_id
+    out["target_id"] = check_id
+    out["profile_id"] = profile_id
+    out["baseline_channel"] = baseline_channel
+    out["requested_depth"] = requested_depth
+    out["effective_depth"] = effective_depth
+    out["check_evidence_coverage"] = coverage
+    if project is not None:
+        out["project"] = project
+    if head_sha is not None:
+        out["head_sha"] = head_sha
+    if base_ref is not None:
+        out["base_ref"] = base_ref
+    if action_version is not None:
+        out["action_version"] = action_version
+
+    raw_verdict = report.get("verdict")
+    real_exit_code = _real_exit_code(report)
+    out["policy_gate_decision"] = "fail" if real_exit_code != 0 else "pass"
+    if raw_verdict in LEGACY_VERDICT_VALUES:
+        out["compatibility_verdict"] = raw_verdict
+    if raw_verdict == OPERATIONAL_ERROR_VERDICT:
+        out["operational_errors"] = [
+            {
+                "kind": "analysis_error",
+                "message": str(report.get("error") or "the analysis step failed"),
+            }
+        ]
+    else:
+        out.setdefault("operational_errors", [])
+    out.setdefault("publication", {"state": "published", "channels": ["job_summary"]})
+
+    if gate_mode == "advisory":
+        _neutralize_gate(out)
+    return out
+
+
+def build_operational_error_report(
+    *,
+    name: str,
+    profile_id: str,
+    baseline_channel: str,
+    requested_depth: str,
+    resolve_outcome: str,
+    resolve_message: str,
+    project: str | None = None,
+    head_sha: str | None = None,
+    base_ref: str | None = None,
+    tool_version: str | None = None,
+    action_version: str | None = None,
+) -> dict[str, Any]:
+    """Synthesize a full report envelope for a ``resolve-baseline`` failure.
+
+    ``verdict: "ERROR"`` matches ``abicheck/aggregate.py:_load_report_file``'s
+    existing special case (checked *before* it ever reads a ``severity``
+    block), so no ``severity`` block is written here at all -- omitting it
+    is the ADR-047 §7-documented choice, not an oversight.
+    """
+    check_id = build_check_id(name, profile_id, baseline_channel, requested_depth)
+    report: dict[str, Any] = {
+        "report_schema_version": REPORT_SCHEMA_VERSION,
+        "check_id": check_id,
+        "target_id": check_id,
+        "target": name,
+        "profile_id": profile_id,
+        "baseline_channel": baseline_channel,
+        "requested_depth": requested_depth,
+        "check_evidence_coverage": {"state": "unknown", "reasons": [resolve_outcome]},
+        "compatibility_verdict": None,
+        "policy_gate_decision": "fail",
+        "operational_errors": [{"kind": resolve_outcome, "message": resolve_message}],
+        "publication": {"state": "skipped", "channels": []},
+        "verdict": OPERATIONAL_ERROR_VERDICT,
+    }
+    if project is not None:
+        report["project"] = project
+    if head_sha is not None:
+        report["head_sha"] = head_sha
+    if base_ref is not None:
+        report["base_ref"] = base_ref
+    if tool_version is not None:
+        report["tool_version"] = tool_version
+    if action_version is not None:
+        report["action_version"] = action_version
+    return report
+
+
+def build_bootstrap_report(
+    *,
+    name: str,
+    profile_id: str,
+    baseline_channel: str,
+    requested_depth: str,
+    resolve_message: str,
+    project: str | None = None,
+    head_sha: str | None = None,
+    base_ref: str | None = None,
+    tool_version: str | None = None,
+    action_version: str | None = None,
+) -> dict[str, Any]:
+    """Synthesize the "no baseline published yet" advisory pass (§6)."""
+    check_id = build_check_id(name, profile_id, baseline_channel, requested_depth)
+    report: dict[str, Any] = {
+        "report_schema_version": REPORT_SCHEMA_VERSION,
+        "check_id": check_id,
+        "target_id": check_id,
+        "target": name,
+        "profile_id": profile_id,
+        "baseline_channel": baseline_channel,
+        "requested_depth": requested_depth,
+        "check_evidence_coverage": {
+            "state": "bootstrap",
+            "reasons": ["no_baseline_published_yet"],
+        },
+        "baseline_bootstrap": True,
+        "compatibility_verdict": None,
+        "policy_gate_decision": "pass",
+        "operational_errors": [],
+        "publication": {"state": "skipped", "channels": []},
+        "verdict": BOOTSTRAP_VERDICT,
+        "message": resolve_message,
+    }
+    if project is not None:
+        report["project"] = project
+    if head_sha is not None:
+        report["head_sha"] = head_sha
+    if base_ref is not None:
+        report["base_ref"] = base_ref
+    if tool_version is not None:
+        report["tool_version"] = tool_version
+    if action_version is not None:
+        report["action_version"] = action_version
+    return report
+
+
+def final_exit_code(
+    gate_mode: str, *, real_exit_code: int, operational_error: bool
+) -> int:
+    """``check-target``'s own composite exit code (ADR-047 §7).
+
+    Operational errors (a hard ``resolve-baseline`` failure, or the analysis
+    step itself erroring out on bad config -- never a genuine ABI/API
+    finding) always fail the job regardless of ``gate-mode`` -- "``deferred``
+    only defers the *compatibility* verdict's effect on exit code, never
+    operational errors" (§7), applied identically to ``advisory`` since
+    resolve-baseline's failure taxonomy is never silently degraded to a
+    passing/neutral outcome either.
+    """
+    if gate_mode not in GATE_MODES:
+        raise ValueError(f"gate_mode must be one of {GATE_MODES}, got {gate_mode!r}")
+    if operational_error:
+        return 1
+    if gate_mode == "local":
+        return real_exit_code
+    return 0

--- a/abicheck/buildsource/check_report.py
+++ b/abicheck/buildsource/check_report.py
@@ -132,24 +132,65 @@ def build_check_id(
     return check_id
 
 
-def resolve_effective_depth(
-    requested_depth: str, *, evidence_ok: bool, degraded_reason: str | None = None
+#: Ladder order (shallow -> deep), matching EVIDENCE_DEPTH_VALUES.
+_DEPTH_RANK = {"binary": 0, "headers": 1, "build": 2, "source": 3}
+
+
+def derive_effective_depth(
+    report: dict[str, Any], requested_depth: str
 ) -> tuple[str, dict[str, Any]]:
     """Compute ``effective_depth``/``check_evidence_coverage`` (ADR-047 §7).
 
-    ``binary``/``headers`` depth never needs build/source evidence, so it's
-    always "complete". ``build``/``source`` depth degrades to ``headers``
-    when the caller reports the requested evidence wasn't actually available
-    (e.g. a wrapper/clang-plugin pack that never reached ``phase: verify``,
-    or a replay step that failed to resolve a compile database) -- never
-    silently rendering as an unqualified pass at the requested depth.
+    Reads the depth the underlying ``compare``/``scan`` run *actually*
+    achieved straight from its own JSON output -- ``old_evidence_depth``/
+    ``new_evidence_depth`` (``compare``, always present for ``--format
+    json`` via ``cli_compare_helpers._fold_evidence_depth_into_json``) or
+    ``level.depth`` (``scan``, ``ScanOutcome.to_dict``) -- rather than
+    inferring it from which collect-facts producer step ran. This is the
+    authoritative signal: it's correct for every way a caller can supply
+    build/source evidence (a composed ``collect-facts`` producer, or a
+    direct out-of-band ``build-info``/``sources`` input with no producer at
+    all -- a case an earlier, producer-based heuristic here got wrong,
+    reporting a real build/source-depth result as "degraded" purely because
+    no ``collect-facts`` step ran, flagged by review). For ``compare``, the
+    shallower of the two sides is the check's own achieved depth (a
+    build/source result on only one side isn't a build/source-depth
+    *comparison*). Reports deeper than requested (e.g. real headers given
+    for a ``binary``-depth request) are reported honestly as achieved, not
+    capped down to the request.
     """
     validate_evidence_depth("requested_depth", requested_depth)
-    if requested_depth in ("binary", "headers") or evidence_ok:
-        return requested_depth, {"state": "complete", "reasons": []}
-    return "headers", {
+    old_d = report.get("old_evidence_depth")
+    new_d = report.get("new_evidence_depth")
+    achieved: str | None = None
+    source = ""
+    if (
+        isinstance(old_d, str)
+        and isinstance(new_d, str)
+        and old_d in _DEPTH_RANK
+        and new_d in _DEPTH_RANK
+    ):
+        achieved = old_d if _DEPTH_RANK[old_d] <= _DEPTH_RANK[new_d] else new_d
+        source = "compare"
+    else:
+        level = report.get("level")
+        scan_depth = level.get("depth") if isinstance(level, dict) else None
+        if isinstance(scan_depth, str) and scan_depth in _DEPTH_RANK:
+            achieved = scan_depth
+            source = "scan"
+    if achieved is None:
+        # Neither signal is present -- shouldn't happen for real compare/scan
+        # --format json output, but trust the request rather than silently
+        # guessing "complete" for whatever this report actually is.
+        return requested_depth, {
+            "state": "unknown",
+            "reasons": ["no_depth_signal_in_report"],
+        }
+    if _DEPTH_RANK[achieved] >= _DEPTH_RANK[requested_depth]:
+        return achieved, {"state": "complete", "reasons": []}
+    return achieved, {
         "state": "degraded",
-        "reasons": [degraded_reason or "evidence_not_available"],
+        "reasons": [f"{source}_achieved_{achieved}"],
     }
 
 
@@ -201,8 +242,6 @@ def augment_report(
     baseline_channel: str,
     requested_depth: str,
     gate_mode: str,
-    evidence_ok: bool,
-    degraded_reason: str | None = None,
     project: str | None = None,
     head_sha: str | None = None,
     base_ref: str | None = None,
@@ -218,9 +257,7 @@ def augment_report(
         raise ValueError(f"gate_mode must be one of {GATE_MODES}, got {gate_mode!r}")
     out = dict(report)
     check_id = build_check_id(name, profile_id, baseline_channel, requested_depth)
-    effective_depth, coverage = resolve_effective_depth(
-        requested_depth, evidence_ok=evidence_ok, degraded_reason=degraded_reason
-    )
+    effective_depth, coverage = derive_effective_depth(report, requested_depth)
     out["report_schema_version"] = REPORT_SCHEMA_VERSION
     out["check_id"] = check_id
     out["target_id"] = check_id

--- a/abicheck/buildsource/check_report.py
+++ b/abicheck/buildsource/check_report.py
@@ -300,7 +300,8 @@ def augment_report(
     out["policy_gate_decision"] = "fail" if real_exit_code != 0 else "pass"
     if raw_verdict in LEGACY_VERDICT_VALUES:
         out["compatibility_verdict"] = raw_verdict
-    if raw_verdict == OPERATIONAL_ERROR_VERDICT:
+        out.setdefault("operational_errors", [])
+    elif raw_verdict == OPERATIONAL_ERROR_VERDICT:
         out["operational_errors"] = [
             {
                 "kind": "analysis_error",
@@ -308,7 +309,23 @@ def augment_report(
             }
         ]
     else:
-        out.setdefault("operational_errors", [])
+        # Any other verdict string a scan run can produce (e.g. "BUDGET_OVERFLOW",
+        # "EVIDENCE_CONTRACT_ERROR" -- service_scan.py's guard sentinels) is not
+        # a compatibility finding either -- it's the scan never completing its
+        # comparison at all, the same class of problem as an analysis CLI error,
+        # not something ADR-047 §7's "deferred only defers the *compatibility*
+        # verdict" rule was ever meant to cover. Treated as operational so
+        # gate-mode: deferred/advisory can't turn a guard failure into a quiet
+        # pass (Codex review).
+        out["operational_errors"] = [
+            {
+                "kind": "scan_guard_triggered",
+                "message": str(
+                    report.get("error")
+                    or f"the analysis reported a non-compatibility verdict: {raw_verdict!r}"
+                ),
+            }
+        ]
     # check-target's own nested analysis step always disables add-job-summary/
     # pr-comment/upload-sarif (action.yml's "Run analysis" step), and the
     # finalize step itself only writes the report JSON to disk + sets

--- a/abicheck/buildsource/check_report.py
+++ b/abicheck/buildsource/check_report.py
@@ -309,7 +309,17 @@ def augment_report(
         ]
     else:
         out.setdefault("operational_errors", [])
-    out.setdefault("publication", {"state": "published", "channels": ["job_summary"]})
+    # check-target's own nested analysis step always disables add-job-summary/
+    # pr-comment/upload-sarif (action.yml's "Run analysis" step), and the
+    # finalize step itself only writes the report JSON to disk + sets
+    # GITHUB_OUTPUT values -- neither is a "publication" in ADR-047 §7's
+    # sense (surfaced to a human/dashboard via a real channel). Defaulting
+    # to state: "published"/channels: ["job_summary"] here was simply false
+    # for every real check-target run and could make a downstream consumer
+    # believe a report had actually been surfaced when it hadn't (Codex
+    # review). Nothing today computes a real publication state for this
+    # path, so the honest default is "nothing was published."
+    out.setdefault("publication", {"state": "skipped", "channels": []})
 
     if gate_mode == "advisory":
         _neutralize_gate(out)

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -143,7 +143,21 @@ from typing import Any
 #:       primitives G30 P1 will add (``resolve-baseline``, ``check-target``)
 #:       have a report-level place to record a check's identity. Omitted
 #:       entirely (never emitted as null) when unset.
-REPORT_SCHEMA_VERSION = "2.12"
+#:   2.13: added the remaining ADR-047 §7 report-envelope keys --
+#:       ``compatibility_verdict`` (``Verdict``-cased mirror of the legacy
+#:       ``verdict`` field), ``policy_gate_decision`` (``"pass"``/``"fail"``),
+#:       ``check_evidence_coverage`` (``{state, reasons}``, not
+#:       ``layer_coverage`` -- deliberately a different name/shape than that
+#:       existing per-layer array, see §7's field-naming corrections),
+#:       ``operational_errors`` (list of ``{kind, message}``), ``publication``
+#:       (``{state, channels}``), ``project``, ``head_sha``, ``base_ref``,
+#:       ``action_version``, and ``tool_version``. Populated by
+#:       ``actions/check-target`` (G30 P1.3, ``abicheck.buildsource.
+#:       check_report``), which reads/rewrites a report file after the CLI
+#:       has already produced it -- nothing in the CLI/service layer sets
+#:       these directly either, same as 2.12's five keys. All additive/
+#:       optional; omitted entirely (never emitted as null) when unset.
+REPORT_SCHEMA_VERSION = "2.13"
 
 #: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as
 #: ``scan_schema_version`` at the top level of both public scan dict shapes:
@@ -160,7 +174,14 @@ REPORT_SCHEMA_VERSION = "2.12"
 #:       ``baseline_channel`` — mirroring compare's 2.12 report-identity
 #:       envelope (ADR-047 §7, G30 P0.3). Reserved for G30 P1; not yet
 #:       populated. Omitted entirely (never emitted as null) when unset.
-SCAN_SCHEMA_VERSION = "1.1"
+#: 1.2 — mirrors compare's 2.13 bump: the remaining ADR-047 §7 keys
+#:       (``compatibility_verdict``, ``policy_gate_decision``,
+#:       ``check_evidence_coverage``, ``operational_errors``,
+#:       ``publication``, ``project``, ``head_sha``, ``base_ref``,
+#:       ``action_version``, ``tool_version``), populated the same way by
+#:       ``actions/check-target`` (G30 P1.3) for a ``scan``-mode audit
+#:       check (ADR-047 S5).
+SCAN_SCHEMA_VERSION = "1.2"
 
 _SCHEMA_DIR = Path(__file__).resolve().parent
 COMPARE_REPORT_SCHEMA_PATH = _SCHEMA_DIR / "compare_report.schema.json"

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -63,6 +63,77 @@
       "type": "string",
       "description": "Schema 2.12 (ADR-047 §7). Which baseline channel (e.g. \"accepted-main\", a release tag) old_file/old_version was resolved from. Reserved for G30 P1; not yet populated."
     },
+    "compatibility_verdict": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). Mirrors verdict's exact casing/enum -- a separate field name so aggregate.py's existing verdict/severity parsing stays untouched while richer consumers (PR comment, SARIF, humans) read this one. Populated by actions/check-target; omitted when the underlying report has no verdict in Verdict's five-value enum (e.g. an operational-failure or bootstrap report, which stay verdict: \"ERROR\"/\"NO_BASELINE\" instead).",
+      "enum": ["NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING"]
+    },
+    "policy_gate_decision": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). \"pass\" or \"fail\" -- this check's own real gate decision, computed from the report's real severity/exit_code before any gate-mode: advisory neutralization of the legacy severity block. New vocabulary, not a Verdict mirror.",
+      "enum": ["pass", "fail"]
+    },
+    "check_evidence_coverage": {
+      "type": "object",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). Not layer_coverage (a different, existing per-L0-L5-layer array) -- this is check-target's own state/reasons summary of whether requested_depth was actually achieved.",
+      "additionalProperties": true,
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": ["complete", "degraded", "bootstrap", "unknown"]
+        },
+        "reasons": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "operational_errors": {
+      "type": "array",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). Non-empty exactly when this check hit an infrastructure/config problem (e.g. a resolve-baseline failure) rather than -- or in addition to -- a compatibility finding. Empty means clean.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["kind", "message"],
+        "properties": {
+          "kind": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "publication": {
+      "type": "object",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). Whether/where this report was actually published -- distinct from whether it was computed, so a downstream consumer can tell \"no publication happened\" apart from \"no report was produced at all.\"",
+      "additionalProperties": true,
+      "properties": {
+        "state": { "type": "string", "enum": ["published", "skipped", "failed"] },
+        "channels": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "baseline_bootstrap": {
+      "type": "boolean",
+      "description": "Schema 2.13 (ADR-047 §6/§7, G30 P1.3). True only on a bootstrap \"no baseline published yet\" advisory pass (required: false with no baseline set yet) -- the explicit report field ADR-047 §6 requires for that case."
+    },
+    "project": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). The project identifier (e.g. \"owner/repo\") this check ran for."
+    },
+    "head_sha": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). The candidate commit SHA this check analyzed."
+    },
+    "base_ref": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). The base ref this check's candidate was compared against, when known (e.g. a PR's target branch)."
+    },
+    "tool_version": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). The abicheck version that produced this report."
+    },
+    "action_version": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). The abicheck/abicheck Action ref (e.g. \"abicheck/abicheck@v1\") that ran this check."
+    },
     "old_file": { "$ref": "#/$defs/fileMetadata" },
     "new_file": { "$ref": "#/$defs/fileMetadata" },
     "summary": { "$ref": "#/$defs/summary" },

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -6,22 +6,39 @@
   "type": "object",
   "required": [
     "report_schema_version",
-    "library",
-    "old_version",
-    "new_version",
-    "verdict",
-    "old_file",
-    "new_file",
-    "summary",
-    "policy",
-    "changes",
-    "suppression",
-    "detectors",
-    "confidence",
-    "evidence_tier",
-    "evidence_tiers"
+    "verdict"
   ],
   "additionalProperties": true,
+  "allOf": [
+    {
+      "description": "A real compatibility comparison (the five Verdict enum values) carries the full compare-report shape.",
+      "if": {
+        "properties": {
+          "verdict": {
+            "enum": ["NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING"]
+          }
+        },
+        "required": ["verdict"]
+      },
+      "then": {
+        "required": [
+          "library",
+          "old_version",
+          "new_version",
+          "old_file",
+          "new_file",
+          "summary",
+          "policy",
+          "changes",
+          "suppression",
+          "detectors",
+          "confidence",
+          "evidence_tier",
+          "evidence_tiers"
+        ]
+      }
+    }
+  ],
   "properties": {
     "report_schema_version": {
       "type": "string",
@@ -33,7 +50,8 @@
     "new_version": { "type": "string" },
     "verdict": {
       "type": "string",
-      "enum": ["NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING"]
+      "description": "The five real Verdict enum values for a computed compatibility comparison, plus two sentinel values for a report that never got that far: \"ERROR\" (an operational/infrastructure failure -- e.g. a library that failed to dump/extract/compare in the per-library release fan-out, or a resolve-baseline failure in actions/check-target; pre-dates check-target, see aggregate.py's _OPERATIONAL_ERROR_VERDICT) and \"NO_BASELINE\" (actions/check-target's bootstrap \"no baseline published yet\" advisory pass, ADR-047 §6 -- never a compatibility verdict). Only the five real values require the full compare-report shape below (see allOf); ERROR/NO_BASELINE reports carry whatever operational_errors/check_evidence_coverage context is available instead.",
+      "enum": ["NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING", "ERROR", "NO_BASELINE"]
     },
     "full_verdict": {
       "type": "string",

--- a/action.yml
+++ b/action.yml
@@ -217,25 +217,31 @@ inputs:
     description: >
       Source checkout / tree for source-intelligence analysis. The compile
       database is auto-discovered within it. Drives L4 source-ABI replay and
-      L5 source-graph collection. Used by scan and dump modes.
+      L5 source-graph collection. Used by scan and dump modes, and by compare
+      mode for the new (candidate) side only — mapped to compare's
+      --sources new=... (the old side's evidence, if any, is expected to
+      already be embedded in whatever old-library snapshot was resolved).
     required: false
   build-info:
     description: >
       Out-of-tree L3 build context: a build directory, a compile_commands.json,
       or a previously-collected evidence pack. Use when the build tree lives
-      outside --sources. Used by scan and dump modes.
+      outside --sources. Used by scan and dump modes, and by compare mode for
+      the new (candidate) side only — mapped to compare's
+      --build-info new=... (same old-side caveat as sources above).
     required: false
   compile-db:
     description: >
-      Explicit path to a compile_commands.json (scan mode). For dump mode this
-      is folded into build-info. Use when the compile DB is not under sources.
+      Explicit path to a compile_commands.json (scan mode; also compare
+      mode's new side when build-info is unset). For dump mode this is
+      folded into build-info. Use when the compile DB is not under sources.
     required: false
   build-config:
     description: >
       Path to a trusted .abicheck.yml. Supplying this alone (not
       allow-build-query) is what permits its build.query (compile-DB
       generation) command to run — see allow-build-query below. Used by scan
-      and dump modes.
+      and dump modes, and by compare mode (--config).
     required: false
   allow-build-query:
     description: >
@@ -250,11 +256,12 @@ inputs:
     default: 'false'
   depth:
     description: >
-      Evidence-depth selector (scan and dump modes): binary, headers, build,
-      or source. In scan mode, omit it for 'auto' (risk-driven); --depth source
-      analyses the whole current library target unless since/changed-path
-      seeds a narrower changed scope. Maps to --depth. (The deprecated
-      scan-mode/source-method inputs have been removed; use depth.)
+      Evidence-depth selector: binary, headers, build, or source. Used by
+      scan and dump modes, and by compare mode (--depth). In scan mode, omit
+      it for 'auto' (risk-driven); --depth source analyses the whole current
+      library target unless since/changed-path seeds a narrower changed
+      scope. Maps to --depth. (The deprecated scan-mode/source-method inputs
+      have been removed; use depth.)
     required: false
   since:
     description: >

--- a/action/run.sh
+++ b/action/run.sh
@@ -332,18 +332,27 @@ elif [[ "$MODE" == "compare" ]]; then
   # flagged by review: a --depth build/source compare request had no way to
   # actually reach the CLI's evidence flags at all.
   #
-  # Skipped entirely when either operand is a directory/package: the CLI's
-  # per-library release fan-out (ADR-037 D7) doesn't collect inline
-  # build/source evidence and rejects --sources/--build-info/--config/--depth
-  # outright for that shape (_reject_evidence_flags_for_set_inputs) — passing
-  # them here would turn every directory/package (e.g. check-target's
-  # kind: bundle) comparison into a hard usage error instead of the intended
-  # comparison (Codex review).
+  # --sources/--build-info/--depth are skipped entirely when either operand
+  # is a directory/package: the CLI's per-library release fan-out (ADR-037
+  # D7) doesn't collect inline build/source evidence and rejects those three
+  # outright for that shape (_reject_evidence_flags_for_set_inputs) —
+  # passing them here would turn every directory/package (e.g.
+  # check-target's kind: bundle) comparison into a hard usage error instead
+  # of the intended comparison (Codex review).
+  #
+  # --config is NOT one of the flags that rejection covers
+  # (_EVIDENCE_SET_INPUT_FLAGS in cli_resolve.py lists only depth/sources/
+  # build_info) — the release fan-out still consumes the project
+  # .abicheck.yml for severity/scope/suppression/exit-code settings
+  # (_resolve_compare_config runs before the directory/package dispatch), so
+  # it stays unconditional; an earlier fix lumped it in with the three
+  # rejected flags and silently dropped a bundle caller's build-config
+  # (Codex review, second round).
+  add_single_flag "--config" "${INPUT_BUILD_CONFIG:-}"
   if ! _is_release_style_operand "${INPUT_OLD_LIBRARY:-}" \
      && ! _is_release_style_operand "${INPUT_NEW_LIBRARY:-}"; then
     add_sided_flag "--sources" "new" "${INPUT_SOURCES:-}"
     add_sided_flag "--build-info" "new" "${INPUT_BUILD_INFO:-${INPUT_COMPILE_DB:-}}"
-    add_single_flag "--config" "${INPUT_BUILD_CONFIG:-}"
     add_single_flag "--depth" "${INPUT_DEPTH:-}"
   fi
 

--- a/action/run.sh
+++ b/action/run.sh
@@ -349,8 +349,23 @@ elif [[ "$MODE" == "compare" ]]; then
   # rejected flags and silently dropped a bundle caller's build-config
   # (Codex review, second round).
   add_single_flag "--config" "${INPUT_BUILD_CONFIG:-}"
-  if ! _is_release_style_operand "${INPUT_OLD_LIBRARY:-}" \
-     && ! _is_release_style_operand "${INPUT_NEW_LIBRARY:-}"; then
+  if _is_release_style_operand "${INPUT_OLD_LIBRARY:-}" \
+     || _is_release_style_operand "${INPUT_NEW_LIBRARY:-}"; then
+    # A caller that explicitly asked for build/source-depth evidence (via
+    # --depth build/source, or by supplying --sources/--build-info/
+    # --compile-db directly) against a directory/package operand would
+    # otherwise have that request silently dropped: the flags above are
+    # skipped rather than forwarded, so the comparison would quietly run
+    # without the requested evidence and could miss a source-only break
+    # while still reporting a clean/normal result -- fail loud instead
+    # (Codex review; --depth binary/headers is fine to drop silently, since
+    # nothing was actually requested that this shape can't provide).
+    if [[ "${INPUT_DEPTH:-}" == "build" || "${INPUT_DEPTH:-}" == "source" \
+       || -n "${INPUT_SOURCES:-}" || -n "${INPUT_BUILD_INFO:-}" || -n "${INPUT_COMPILE_DB:-}" ]]; then
+      echo "::error::mode: compare with a directory/package operand (a release/bundle comparison) does not support --depth build/source or inline --sources/--build-info/--compile-db evidence -- the CLI's per-library release fan-out never collects it, so the requested evidence would silently never be gathered and a source-only break could be missed. Compare the libraries individually (mode: compare with single-file operands) to use build/source-depth evidence."
+      exit 1
+    fi
+  else
     add_sided_flag "--sources" "new" "${INPUT_SOURCES:-}"
     add_sided_flag "--build-info" "new" "${INPUT_BUILD_INFO:-${INPUT_COMPILE_DB:-}}"
     add_single_flag "--depth" "${INPUT_DEPTH:-}"

--- a/action/run.sh
+++ b/action/run.sh
@@ -321,6 +321,21 @@ elif [[ "$MODE" == "compare" ]]; then
   add_single_flag "--lang" "${INPUT_LANG:-}"
   add_single_flag "--ast-frontend" "${INPUT_AST_FRONTEND:-}"
 
+  # Build/source evidence (--depth build/source) — new (candidate) side only.
+  # The old side's evidence, if any, already lives in whatever
+  # old-library/abi-baseline snapshot was resolved (e.g. a baseline archive
+  # built with its own embedded build_source) — this Action has no live old-
+  # side source tree to point --sources/--build-info at in compare mode, so
+  # these inputs scope to `new=` unconditionally rather than exposing a
+  # second old-sources/old-build-info input pair. Previously silently
+  # dropped in compare mode (only dump/scan forwarded them) — a real gap
+  # flagged by review: a --depth build/source compare request had no way to
+  # actually reach the CLI's evidence flags at all.
+  add_sided_flag "--sources" "new" "${INPUT_SOURCES:-}"
+  add_sided_flag "--build-info" "new" "${INPUT_BUILD_INFO:-${INPUT_COMPILE_DB:-}}"
+  add_single_flag "--config" "${INPUT_BUILD_CONFIG:-}"
+  add_single_flag "--depth" "${INPUT_DEPTH:-}"
+
   # Format — for SARIF, always write to a file so upload-sarif can find it.
   # sarif/html are rejected by the CLI itself (a clear UsageError, exit 64)
   # when the operands are directories/packages — surfaced as VERDICT=ERROR

--- a/action/run.sh
+++ b/action/run.sh
@@ -340,9 +340,9 @@ elif [[ "$MODE" == "compare" ]]; then
   # check-target's kind: bundle) comparison into a hard usage error instead
   # of the intended comparison (Codex review).
   #
-  # --config is NOT one of the flags that rejection covers
-  # (_EVIDENCE_SET_INPUT_FLAGS in cli_resolve.py lists only depth/sources/
-  # build_info) — the release fan-out still consumes the project
+  # --config is NOT one of the flags that rejection covers (cli_resolve.py's
+  # set-input evidence-flags allowlist lists only depth/sources/build_info)
+  # — the release fan-out still consumes the project
   # .abicheck.yml for severity/scope/suppression/exit-code settings
   # (_resolve_compare_config runs before the directory/package dispatch), so
   # it stays unconditional; an earlier fix lumped it in with the three

--- a/action/run.sh
+++ b/action/run.sh
@@ -331,10 +331,21 @@ elif [[ "$MODE" == "compare" ]]; then
   # dropped in compare mode (only dump/scan forwarded them) — a real gap
   # flagged by review: a --depth build/source compare request had no way to
   # actually reach the CLI's evidence flags at all.
-  add_sided_flag "--sources" "new" "${INPUT_SOURCES:-}"
-  add_sided_flag "--build-info" "new" "${INPUT_BUILD_INFO:-${INPUT_COMPILE_DB:-}}"
-  add_single_flag "--config" "${INPUT_BUILD_CONFIG:-}"
-  add_single_flag "--depth" "${INPUT_DEPTH:-}"
+  #
+  # Skipped entirely when either operand is a directory/package: the CLI's
+  # per-library release fan-out (ADR-037 D7) doesn't collect inline
+  # build/source evidence and rejects --sources/--build-info/--config/--depth
+  # outright for that shape (_reject_evidence_flags_for_set_inputs) — passing
+  # them here would turn every directory/package (e.g. check-target's
+  # kind: bundle) comparison into a hard usage error instead of the intended
+  # comparison (Codex review).
+  if ! _is_release_style_operand "${INPUT_OLD_LIBRARY:-}" \
+     && ! _is_release_style_operand "${INPUT_NEW_LIBRARY:-}"; then
+    add_sided_flag "--sources" "new" "${INPUT_SOURCES:-}"
+    add_sided_flag "--build-info" "new" "${INPUT_BUILD_INFO:-${INPUT_COMPILE_DB:-}}"
+    add_single_flag "--config" "${INPUT_BUILD_CONFIG:-}"
+    add_single_flag "--depth" "${INPUT_DEPTH:-}"
+  fi
 
   # Format — for SARIF, always write to a file so upload-sarif can find it.
   # sarif/html are rejected by the CLI itself (a clear UsageError, exit 64)

--- a/action/run.sh
+++ b/action/run.sh
@@ -320,6 +320,14 @@ elif [[ "$MODE" == "compare" ]]; then
   add_sided_flag "--version" "new" "${INPUT_NEW_VERSION:-}"
   add_single_flag "--lang" "${INPUT_LANG:-}"
   add_single_flag "--ast-frontend" "${INPUT_AST_FRONTEND:-}"
+  # Cross-compiler flags -- documented root-Action inputs, but previously
+  # only wired to dump mode's branch. Without them, a compare against a
+  # cross-target library silently falls back to the host toolchain/includes
+  # for header parsing and can produce false ABI results (Codex review).
+  add_single_flag "--gcc-path" "${INPUT_GCC_PATH:-}"
+  add_single_flag "--gcc-prefix" "${INPUT_GCC_PREFIX:-}"
+  add_single_flag "--gcc-options" "${INPUT_GCC_OPTIONS:-}"
+  add_single_flag "--sysroot" "${INPUT_SYSROOT:-}"
 
   # Build/source evidence (--depth build/source) — new (candidate) side only.
   # The old side's evidence, if any, already lives in whatever
@@ -556,6 +564,14 @@ elif [[ "$MODE" == "scan" ]]; then
   add_flag "-I" "${INPUT_INCLUDE:-}"
   add_sided_flag "-I" "old" "${INPUT_OLD_INCLUDE:-}"
   add_sided_flag "-I" "new" "${INPUT_NEW_INCLUDE:-}"
+
+  # Cross-compiler flags -- documented root-Action inputs, but previously
+  # only wired to dump mode's branch (Codex review, same gap as compare
+  # mode above).
+  add_single_flag "--gcc-path" "${INPUT_GCC_PATH:-}"
+  add_single_flag "--gcc-prefix" "${INPUT_GCC_PREFIX:-}"
+  add_single_flag "--gcc-options" "${INPUT_GCC_OPTIONS:-}"
+  add_single_flag "--sysroot" "${INPUT_SYSROOT:-}"
 
   # Build-source evidence inputs (L3/L4/L5)
   add_single_flag "--sources" "${INPUT_SOURCES:-}"

--- a/actions/check-target/action.yml
+++ b/actions/check-target/action.yml
@@ -444,7 +444,19 @@ runs:
         gcc-prefix: ${{ inputs.gcc-prefix }}
         gcc-options: ${{ inputs.gcc-options }}
         sysroot: ${{ inputs.sysroot }}
-        sources: ${{ inputs.sources }}
+        # collect-facts' own replay phase defaults an empty `sources` to '.'
+        # internally (run.sh: `SOURCES="${INPUT_SOURCES:-.}"`) but never
+        # surfaces that resolved value as an output -- it only prints a
+        # notice telling the caller to "pass sources: $SOURCES directly to
+        # dump/scan/compare". Forwarding the raw (still-empty) inputs.sources
+        # here instead left action/run.sh's add_single_flag skipping --sources
+        # entirely (it omits the flag for an empty value), so a replay check
+        # with sources: left unset would pass the collect-facts step but then
+        # run compare/scan with NO source evidence at all -- silently missing
+        # source-only findings at requested-depth: build/source (Codex
+        # review). Mirror collect-facts' own default here so the analysis
+        # step sees the same directory replay validated.
+        sources: ${{ inputs.sources != '' && inputs.sources || (inputs.evidence-producer == 'replay' && '.' || '') }}
         build-info: ${{ (inputs.evidence-producer == 'wrapper' || inputs.evidence-producer == 'clang-plugin') && inputs.evidence-pack-path || inputs.build-info }}
         compile-db: ${{ inputs.compile-db }}
         build-config: ${{ inputs.build-config }}

--- a/actions/check-target/action.yml
+++ b/actions/check-target/action.yml
@@ -234,7 +234,7 @@ inputs:
   action-version:
     description: 'Recorded in the report envelope as the abicheck Action ref that ran this check.'
     required: false
-    default: ${{ format('{0}@{1}', github.action_repository, github.action_ref) }}
+    default: ${{ format('{0}@{1}', github.action_repository || github.repository, github.action_ref || github.sha) }}
 
 outputs:
   outcome:
@@ -274,6 +274,30 @@ runs:
         INPUT_CONTRACT_FILE: ${{ inputs.contract-file }}
       run: bash "${{ github.action_path }}/validate-inputs.sh"
 
+    # ── Capture this Action's own identity before any nested `uses:` step ──
+    # overwrites it. `github.action_repository`/`github.action_ref` describe
+    # whichever action is *about to run* -- the runner updates them as it
+    # prepares each step, including composite-nested ones, and critically
+    # **before** evaluating that same step's own `with:` expressions. A
+    # first attempt at the self-checkout step below read `github.
+    # action_repository`/`github.action_ref` directly in its own `with:`
+    # block and got back its own target's identity (`actions/checkout`/
+    # `v6`) instead of check-target's -- confirmed against a real CI run
+    # (job 89082423642). Reading them here instead, in a plain `run:` step
+    # that is the *first* thing check-target does, captures the correct
+    # values before anything nested has a chance to overwrite them.
+    - name: Capture this Action's identity
+      id: identity
+      shell: bash
+      env:
+        ACTION_REPOSITORY: ${{ github.action_repository }}
+        ACTION_REF: ${{ github.action_ref }}
+        FALLBACK_REPOSITORY: ${{ github.repository }}
+        FALLBACK_REF: ${{ github.sha }}
+      run: |
+        echo "repository=${ACTION_REPOSITORY:-$FALLBACK_REPOSITORY}" >> "$GITHUB_OUTPUT"
+        echo "ref=${ACTION_REF:-$FALLBACK_REF}" >> "$GITHUB_OUTPUT"
+
     # ── Self-checkout for nested composite Actions ──────────────────────────
     # A relative `uses: ./x` step ALWAYS resolves against $GITHUB_WORKSPACE
     # (the calling workflow's own checkout) -- never against the repository
@@ -291,21 +315,18 @@ runs:
     # bare relative path happens to already work. Fix: check out this exact
     # abicheck/abicheck ref into a side directory of the caller's own
     # workspace first, then reference every nested Action relative to that
-    # directory instead of bare `./`. `github.action_repository`/
-    # `github.action_ref` are only set for a remote `owner/repo/path@ref`
-    # reference; for a local `uses: ./actions/check-target` call within this
-    # same repository (as `.github/workflows/test-action.yml` does), both
-    # are empty, so this falls back to `github.repository`/`github.sha` --
-    # checking out the same repo/commit the caller's own workspace already
-    # has, redundant but harmless. This step is unconditional rather than
-    # branching on which case applies, because `uses:` does not accept
-    # expressions -- there is no way to make the *reference itself*
-    # conditional, only its inputs.
+    # directory instead of bare `./`. For a local `uses: ./actions/
+    # check-target` call within this same repository (as `.github/
+    # workflows/test-action.yml` does), `github.action_repository`/
+    # `github.action_ref` are empty, so the identity step above falls back
+    # to `github.repository`/`github.sha` -- checking out the same repo/
+    # commit the caller's own workspace already has, redundant but
+    # harmless.
     - name: Checkout abicheck (for nested Action composition)
       uses: actions/checkout@v6
       with:
-        repository: ${{ github.action_repository || github.repository }}
-        ref: ${{ github.action_ref || github.sha }}
+        repository: ${{ steps.identity.outputs.repository }}
+        ref: ${{ steps.identity.outputs.ref }}
         path: .abicheck-check-target-src
         persist-credentials: false
 

--- a/actions/check-target/action.yml
+++ b/actions/check-target/action.yml
@@ -270,6 +270,7 @@ runs:
         INPUT_BASELINE_PATH: ${{ inputs.baseline-path }}
         INPUT_GATE_MODE: ${{ inputs.gate-mode }}
         INPUT_REQUESTED_DEPTH: ${{ inputs.requested-depth }}
+        INPUT_EVIDENCE_PRODUCER: ${{ inputs.evidence-producer }}
         INPUT_CONSUMER_BINARY: ${{ inputs.consumer-binary }}
         INPUT_CONTRACT_FILE: ${{ inputs.contract-file }}
       run: bash "${{ github.action_path }}/validate-inputs.sh"
@@ -392,10 +393,18 @@ runs:
     # ── Analysis: compare against the resolved baseline, or (baseline: ─────
     # none) a scan audit with no --against -- continue-on-error so the ─────
     # report-envelope step below always runs, per ADR-047 §7's required ─────
-    # "internal analysis step must run with continue-on-error: true" rule ───
+    # "internal analysis step must run with continue-on-error: true" rule. ──
+    # Also skipped when a required collect-facts step failed: without this,
+    # a broken/empty wrapper or clang-plugin pack (collect_verify failure)
+    # would still be handed to compare as --build-info, silently running the
+    # comparison against invalid evidence instead of surfacing the
+    # collection failure as the operational error it is (review). ──────────
     - name: Run analysis
       id: analysis
-      if: inputs.baseline-channel == 'none' || steps.resolve.outputs.outcome == 'resolved'
+      if: |
+        (inputs.baseline-channel == 'none' || steps.resolve.outputs.outcome == 'resolved') &&
+        steps.collect_verify.outcome != 'failure' &&
+        steps.collect_replay.outcome != 'failure'
       continue-on-error: true
       uses: ./.abicheck-check-target-src
       with:
@@ -461,5 +470,7 @@ runs:
         ANALYSIS_OUTCOME: ${{ steps.analysis.outcome }}
         ANALYSIS_VERDICT: ${{ steps.analysis.outputs.verdict }}
         ANALYSIS_REPORT_PATH: ${{ steps.analysis.outputs.report-path }}
+        COLLECT_VERIFY_OUTCOME: ${{ steps.collect_verify.outcome }}
+        COLLECT_REPLAY_OUTCOME: ${{ steps.collect_replay.outcome }}
         ACTION_PATH: ${{ github.action_path }}
       run: bash "${{ github.action_path }}/run.sh"

--- a/actions/check-target/action.yml
+++ b/actions/check-target/action.yml
@@ -1,0 +1,415 @@
+name: 'abicheck check-target'
+description: >-
+  Compose resolve-baseline + collect-facts + the root abicheck Action for
+  ONE resolved check (target or bundle), always emitting the ADR-047 §7
+  report envelope regardless of outcome. Accepts gate-mode: local|deferred|
+  advisory (ADR-047 §4/§7): local sets this job's own exit code (today's
+  root-action behavior); deferred/advisory always emit the report and only
+  fail this job on an operational error (resolve-baseline failure), leaving
+  the compatibility gate to check-project.yml's trailing aggregate job
+  (deferred) or nothing at all (advisory, shadow-rollout burn-in).
+
+branding:
+  icon: 'check-circle'
+  color: 'blue'
+
+inputs:
+  # ── Identity (ADR-047 §5/§7) ────────────────────────────────────────────
+  kind:
+    description: "'target' (default) or 'bundle' -- which resolution/compare shape this check uses."
+    required: false
+    default: 'target'
+  target-kind:
+    description: >
+      'library' (default), 'app-consumer', or 'plugin-contract' (ADR-047
+      §3's targets: kind discriminator) -- only meaningful when kind:
+      target. Selects which compare flags this check builds: a plain
+      compare for library, --used-by for app-consumer, --required-symbols
+      for plugin-contract. Never used for kind: bundle.
+    required: false
+    default: 'library'
+  name:
+    description: >
+      The target id (kind: target) or bundle id (kind: bundle) -- this
+      check's own reporting identity (check_id/target_id). For target-kind
+      app-consumer/plugin-contract this is the contract target's own name
+      (e.g. "myapp-consumer"), NOT the library it resolves through -- see
+      baseline-target below (ADR-047 §3's "library redirect").
+    required: true
+  baseline-target:
+    description: >
+      Which target's baseline actually gets resolved -- defaults to name.
+      Set this to the referenced library's id for target-kind: app-consumer/
+      plugin-contract (ADR-047 §3: "resolve-baseline resolves the baseline
+      for the target's library field ... while the check's own identity
+      stays the contract target's name"). Ignored for kind: bundle (use
+      bundle-members instead).
+    required: false
+    default: ''
+  bundle-members:
+    description: >
+      JSON array of the bundle's member target ids, e.g.
+      '["libpvxs", "libpvxsIoc"]'. Required when kind is bundle.
+    required: false
+    default: '[]'
+  profile:
+    description: 'The build profile.id this check runs under (ADR-047 §2/§3/§7).'
+    required: true
+  baseline-channel:
+    description: >
+      Baseline channel name (release-contract, accepted-main, explicit, or a
+      project-defined custom channel), or the literal 'none' for a
+      single-build audit with no baseline (ADR-047 §8 S5) -- when 'none',
+      resolve-baseline is skipped entirely and this check runs the existing
+      scan audit path directly (no --against) instead of compare.
+    required: true
+  baseline-path:
+    description: >
+      Path to baseline-channel's already-staged baseline-set (forwarded to
+      resolve-baseline's baseline-path input). Required unless
+      baseline-channel is 'none'.
+    required: false
+    default: ''
+  baseline-required:
+    description: >
+      'true' (default) -- no baseline set yet is a hard failure. 'false' --
+      explicit bootstrap opt-in (forwarded to resolve-baseline's required
+      input). Ignored when baseline-channel is 'none'.
+    required: false
+    default: 'true'
+  candidate-build-output:
+    description: >
+      Path to the candidate build's build-output.json, forwarded to
+      resolve-baseline for its incompatible_evidence check. Omit to skip
+      that check. Ignored when baseline-channel is 'none'.
+    required: false
+    default: ''
+  requested-depth:
+    description: 'Evidence-depth this check asks for: binary, headers, build, or source (ADR-047 §7).'
+    required: true
+  gate-mode:
+    description: "'local' (default), 'deferred', or 'advisory' (ADR-047 §7)."
+    required: false
+    default: 'local'
+  project:
+    description: 'Project identifier recorded in the report envelope, e.g. "owner/repo".'
+    required: false
+    default: ${{ github.repository }}
+  head-sha:
+    description: 'Candidate commit SHA recorded in the report envelope.'
+    required: false
+    default: ${{ github.sha }}
+  base-ref:
+    description: 'Base ref recorded in the report envelope, when known (e.g. a PR target branch).'
+    required: false
+    default: ''
+
+  # ── Evidence collection composition (ADR-047 §4) ────────────────────────
+  evidence-producer:
+    description: >
+      '' (default -- no source evidence needed, e.g. binary/headers depth),
+      'replay', 'wrapper', or 'clang-plugin'. wrapper/clang-plugin compose
+      collect-facts phase: verify (the caller's workflow must run
+      collect-facts phase: prepare before its own build step, earlier in
+      the job -- check-target runs after that build already happened and
+      cannot retroactively instrument it). replay composes collect-facts
+      phase: auto (no pre-build hook needed).
+    required: false
+    default: ''
+  evidence-pack-path:
+    description: >
+      Path to the wrapper/clang-plugin abicheck_inputs/ pack an earlier
+      collect-facts phase: prepare step wrote (must match that step's own
+      output path). Forwarded to compare/dump's --build-info. Ignored for
+      evidence-producer: replay/''.
+    required: false
+    default: 'abicheck_inputs'
+
+  # ── Candidate/new-side inputs (forwarded to root action.yml) ────────────
+  new-library:
+    description: >
+      Candidate binary (kind: target) or directory of candidate member
+      binaries (kind: bundle). Required.
+    required: true
+  header:
+    description: 'Public header file(s) applied to both sides (space-separated). Forwarded to the internal analysis step.'
+    required: false
+  old-header:
+    description: 'Public header(s) for the baseline side only. Forwarded to the internal analysis step.'
+    required: false
+  new-header:
+    description: 'Public header(s) for the candidate side only. Forwarded to the internal analysis step.'
+    required: false
+  include:
+    description: 'Extra include directories, applied to both sides. Forwarded to the internal analysis step.'
+    required: false
+  old-include:
+    description: 'Include directories for the baseline side only. Forwarded to the internal analysis step.'
+    required: false
+  new-include:
+    description: 'Include directories for the candidate side only. Forwarded to the internal analysis step.'
+    required: false
+  lang:
+    description: 'Language mode for header AST parsing: "c++" or "c". Forwarded to the internal analysis step.'
+    required: false
+    default: 'c++'
+  ast-frontend:
+    description: 'L2 header-AST frontend: auto, castxml, clang, or hybrid. Forwarded to the internal analysis step.'
+    required: false
+  gcc-path:
+    description: 'Path to GCC/G++ cross-compiler binary. Forwarded to the internal analysis step.'
+    required: false
+  gcc-prefix:
+    description: 'Cross-toolchain prefix, e.g. aarch64-linux-gnu-. Forwarded to the internal analysis step.'
+    required: false
+  gcc-options:
+    description: 'Extra compiler flags passed through to castxml. Forwarded to the internal analysis step.'
+    required: false
+  sysroot:
+    description: 'Alternative system root directory for cross-compilation. Forwarded to the internal analysis step.'
+    required: false
+  sources:
+    description: 'Source checkout for L3/L4/L5 evidence (forwarded to compare/dump --sources and to collect-facts).'
+    required: false
+  build-info:
+    description: >
+      Out-of-tree L3 build context. When evidence-producer is
+      wrapper/clang-plugin, this is set from evidence-pack-path
+      automatically -- set it directly only for a producer-less
+      build/source-depth check that already has an out-of-band pack.
+    required: false
+  compile-db:
+    description: 'Explicit path to a compile_commands.json. Forwarded to the internal analysis step.'
+    required: false
+  build-config:
+    description: 'Path to a trusted .abicheck.yml. Forwarded to the internal analysis step.'
+    required: false
+  consumer-binary:
+    description: 'target-kind: app-consumer only. Consumer binary/binaries whose imports scope the comparison (forwarded as --used-by).'
+    required: false
+  verify-runtime:
+    description: 'target-kind: app-consumer only. Forwarded to --verify-runtime.'
+    required: false
+    default: 'false'
+  contract-file:
+    description: 'target-kind: plugin-contract only. A .syms file (one required linker symbol per line, # comments allowed), forwarded as --required-symbols.'
+    required: false
+  policy:
+    description: 'Built-in policy profile: strict_abi (default), sdk_vendor, plugin_abi. Forwarded to the internal analysis step.'
+    required: false
+    default: 'strict_abi'
+  policy-file:
+    description: 'Path to a YAML policy file with per-kind verdict overrides. Forwarded to the internal analysis step.'
+    required: false
+  suppress:
+    description: 'Path to a YAML suppression file to filter known/intentional changes. Forwarded to the internal analysis step.'
+    required: false
+  severity-preset:
+    description: >
+      Forwarded to the internal compare step. Defaults to 'default' (not
+      left unset) so the analysis report always carries a severity block --
+      without one, a legacy compare report has no severity to neutralize for
+      gate-mode: advisory, and aggregate.py's own GateInfo.from_report_data
+      falls back to legacy_from_verdict(verdict) instead, which would still
+      see the real BREAKING/API_BREAK verdict and derive a blocking gate
+      regardless of gate-mode. Ignored for a scan-mode audit (baseline-
+      channel: none), which always carries its own top-level exit_code.
+    required: false
+    default: 'default'
+  severity-addition:
+    description: 'Severity for new public API additions: error, warning, or info. Forwarded to the internal analysis step.'
+    required: false
+  extra-args:
+    description: 'Additional CLI arguments passed directly to the internal abicheck invocation.'
+    required: false
+    default: ''
+  python-version:
+    description: 'Python version for setup-python.'
+    required: false
+    default: '3.13'
+  install-deps:
+    description: 'Install system dependencies (castxml, gcc). Set to false if pre-installed.'
+    required: false
+    default: 'true'
+  action-version:
+    description: 'Recorded in the report envelope as the abicheck Action ref that ran this check.'
+    required: false
+    default: ${{ format('{0}@{1}', github.action_repository, github.action_ref) }}
+
+outputs:
+  outcome:
+    description: 'resolve-baseline outcome (resolved, not_found, ambiguous, wrong_profile, stale_schema, incompatible_evidence), or "skipped" when baseline-channel is none.'
+    value: ${{ steps.finalize.outputs.outcome }}
+  check-id:
+    description: "This check's full identity: target@profile#baseline_channel@requested_depth."
+    value: ${{ steps.finalize.outputs.check-id }}
+  verdict:
+    description: 'The legacy verdict field (a Verdict enum value, "ERROR" for an operational failure, or "NO_BASELINE" for a bootstrap pass).'
+    value: ${{ steps.finalize.outputs.verdict }}
+  compatibility-verdict:
+    description: 'ADR-047 §7''s new compatibility_verdict field (empty when unavailable).'
+    value: ${{ steps.finalize.outputs.compatibility-verdict }}
+  policy-gate-decision:
+    description: '"pass" or "fail" -- this check''s own real gate decision, before any advisory neutralization.'
+    value: ${{ steps.finalize.outputs.policy-gate-decision }}
+  report-path:
+    description: 'Path to the final, enriched report JSON.'
+    value: ${{ steps.finalize.outputs.report-path }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Validate check-target inputs
+      shell: bash
+      env:
+        INPUT_KIND: ${{ inputs.kind }}
+        INPUT_TARGET_KIND: ${{ inputs.target-kind }}
+        INPUT_NAME: ${{ inputs.name }}
+        INPUT_BUNDLE_MEMBERS: ${{ inputs.bundle-members }}
+        INPUT_BASELINE_CHANNEL: ${{ inputs.baseline-channel }}
+        INPUT_BASELINE_PATH: ${{ inputs.baseline-path }}
+        INPUT_GATE_MODE: ${{ inputs.gate-mode }}
+        INPUT_REQUESTED_DEPTH: ${{ inputs.requested-depth }}
+        INPUT_CONSUMER_BINARY: ${{ inputs.consumer-binary }}
+        INPUT_CONTRACT_FILE: ${{ inputs.contract-file }}
+      run: bash "${{ github.action_path }}/validate-inputs.sh"
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+
+    - name: Install abicheck
+      shell: bash
+      run: pip install "${{ github.action_path }}/../.."
+
+    # ── Baseline resolution (skipped entirely for baseline-channel: none, ──
+    # ADR-047 §8 S5 -- never routed through not_found/bootstrap handling for
+    # a check that never wanted a baseline in the first place) ─────────────
+    - name: Resolve baseline
+      id: resolve
+      if: inputs.baseline-channel != 'none'
+      continue-on-error: true
+      uses: ./actions/resolve-baseline
+      with:
+        baseline-path: ${{ inputs.baseline-path }}
+        channel: ${{ inputs.baseline-channel }}
+        kind: ${{ inputs.kind }}
+        target: ${{ inputs.kind == 'target' && (inputs.baseline-target != '' && inputs.baseline-target || inputs.name) || '' }}
+        bundle: ${{ inputs.kind == 'bundle' && inputs.name || '' }}
+        bundle-members: ${{ inputs.bundle-members }}
+        profile: ${{ inputs.profile }}
+        required: ${{ inputs.baseline-required }}
+        candidate-build-output: ${{ inputs.candidate-build-output }}
+        python-version: ${{ inputs.python-version }}
+
+    # ── Evidence collection (ADR-047 §4's collect-facts composition note: ──
+    # phase: verify for wrapper/clang-plugin, phase: auto only for replay -- ─
+    # check-target runs after the caller's own build, so phase: prepare must
+    # be a separate, earlier step in the caller's workflow, not here) ───────
+    - name: Collect source facts (verify)
+      id: collect_verify
+      if: |
+        (inputs.evidence-producer == 'wrapper' || inputs.evidence-producer == 'clang-plugin') &&
+        (inputs.baseline-channel == 'none' || steps.resolve.outputs.outcome == 'resolved')
+      continue-on-error: true
+      uses: ./actions/collect-facts
+      with:
+        phase: 'verify'
+        producer: ${{ inputs.evidence-producer }}
+        output: ${{ inputs.evidence-pack-path }}
+        python-version: ${{ inputs.python-version }}
+
+    - name: Collect source facts (replay)
+      id: collect_replay
+      if: |
+        inputs.evidence-producer == 'replay' &&
+        (inputs.baseline-channel == 'none' || steps.resolve.outputs.outcome == 'resolved')
+      continue-on-error: true
+      uses: ./actions/collect-facts
+      with:
+        phase: 'auto'
+        producer: 'replay'
+        sources: ${{ inputs.sources }}
+        python-version: ${{ inputs.python-version }}
+
+    # ── Analysis: compare against the resolved baseline, or (baseline: ─────
+    # none) a scan audit with no --against -- continue-on-error so the ─────
+    # report-envelope step below always runs, per ADR-047 §7's required ─────
+    # "internal analysis step must run with continue-on-error: true" rule ───
+    - name: Run analysis
+      id: analysis
+      if: inputs.baseline-channel == 'none' || steps.resolve.outputs.outcome == 'resolved'
+      continue-on-error: true
+      uses: ./
+      with:
+        mode: ${{ inputs.baseline-channel == 'none' && 'scan' || 'compare' }}
+        old-library: ${{ inputs.kind == 'bundle' && steps.resolve.outputs.binaries-dir || steps.resolve.outputs.snapshot-path }}
+        new-library: ${{ inputs.new-library }}
+        header: ${{ inputs.header }}
+        old-header: ${{ inputs.old-header }}
+        new-header: ${{ inputs.new-header }}
+        include: ${{ inputs.include }}
+        old-include: ${{ inputs.old-include }}
+        new-include: ${{ inputs.new-include }}
+        lang: ${{ inputs.lang }}
+        ast-frontend: ${{ inputs.ast-frontend }}
+        gcc-path: ${{ inputs.gcc-path }}
+        gcc-prefix: ${{ inputs.gcc-prefix }}
+        gcc-options: ${{ inputs.gcc-options }}
+        sysroot: ${{ inputs.sysroot }}
+        sources: ${{ inputs.sources }}
+        build-info: ${{ (inputs.evidence-producer == 'wrapper' || inputs.evidence-producer == 'clang-plugin') && inputs.evidence-pack-path || inputs.build-info }}
+        compile-db: ${{ inputs.compile-db }}
+        build-config: ${{ inputs.build-config }}
+        depth: ${{ inputs.requested-depth }}
+        used-by: ${{ inputs.target-kind == 'app-consumer' && inputs.consumer-binary || '' }}
+        verify-runtime: ${{ inputs.target-kind == 'app-consumer' && inputs.verify-runtime || 'false' }}
+        required-symbols: ${{ inputs.target-kind == 'plugin-contract' && inputs.contract-file || '' }}
+        policy: ${{ inputs.policy }}
+        policy-file: ${{ inputs.policy-file }}
+        suppress: ${{ inputs.suppress }}
+        severity-preset: ${{ inputs.severity-preset }}
+        severity-addition: ${{ inputs.severity-addition }}
+        extra-args: ${{ inputs.extra-args }}
+        format: 'json'
+        output-file: 'check-target-analysis.json'
+        add-job-summary: 'false'
+        pr-comment: 'false'
+        upload-sarif: 'false'
+        python-version: ${{ inputs.python-version }}
+        install-deps: ${{ inputs.install-deps }}
+
+    # ── Always write the report envelope, regardless of the above steps' ───
+    # outcomes (ADR-047 §7: "always execute the report-envelope-writing ─────
+    # step") and own check-target's actual composite exit code last. ───────
+    - name: Write report envelope and finalize
+      id: finalize
+      shell: bash
+      env:
+        INPUT_KIND: ${{ inputs.kind }}
+        INPUT_NAME: ${{ inputs.name }}
+        INPUT_PROFILE: ${{ inputs.profile }}
+        INPUT_BASELINE_CHANNEL: ${{ inputs.baseline-channel }}
+        INPUT_REQUESTED_DEPTH: ${{ inputs.requested-depth }}
+        INPUT_GATE_MODE: ${{ inputs.gate-mode }}
+        INPUT_EVIDENCE_PRODUCER: ${{ inputs.evidence-producer }}
+        INPUT_PROJECT: ${{ inputs.project }}
+        INPUT_HEAD_SHA: ${{ inputs.head-sha }}
+        INPUT_BASE_REF: ${{ inputs.base-ref }}
+        INPUT_ACTION_VERSION: ${{ inputs.action-version }}
+        RESOLVE_RAN: ${{ inputs.baseline-channel != 'none' }}
+        RESOLVE_OUTCOME: ${{ steps.resolve.outputs.outcome }}
+        RESOLVE_BOOTSTRAP: ${{ steps.resolve.outputs.bootstrap }}
+        RESOLVE_MESSAGE: ${{ steps.resolve.outputs.message }}
+        ANALYSIS_RAN: ${{ steps.analysis.outcome != 'skipped' }}
+        ANALYSIS_OUTCOME: ${{ steps.analysis.outcome }}
+        ANALYSIS_VERDICT: ${{ steps.analysis.outputs.verdict }}
+        ANALYSIS_REPORT_PATH: ${{ steps.analysis.outputs.report-path }}
+        COLLECT_VERIFY_RAN: ${{ steps.collect_verify.outcome != 'skipped' }}
+        COLLECT_VERIFY_OUTCOME: ${{ steps.collect_verify.outcome }}
+        COLLECT_VERIFY_READY: ${{ steps.collect_verify.outputs.ready }}
+        COLLECT_REPLAY_RAN: ${{ steps.collect_replay.outcome != 'skipped' }}
+        COLLECT_REPLAY_OUTCOME: ${{ steps.collect_replay.outcome }}
+        ACTION_PATH: ${{ github.action_path }}
+      run: bash "${{ github.action_path }}/run.sh"

--- a/actions/check-target/action.yml
+++ b/actions/check-target/action.yml
@@ -274,6 +274,41 @@ runs:
         INPUT_CONTRACT_FILE: ${{ inputs.contract-file }}
       run: bash "${{ github.action_path }}/validate-inputs.sh"
 
+    # ── Self-checkout for nested composite Actions ──────────────────────────
+    # A relative `uses: ./x` step ALWAYS resolves against $GITHUB_WORKSPACE
+    # (the calling workflow's own checkout) -- never against the repository
+    # that contains *this* composite Action. This is a well-documented
+    # GitHub Actions limitation (github/docs: "When referencing an action
+    # using a relative path, the path is always relative to
+    # $GITHUB_WORKSPACE"; see also actions/runner#1348). When check-target
+    # is consumed externally (`uses: abicheck/abicheck/actions/check-target@
+    # v1` from a caller's own repository), a bare `uses: ./actions/
+    # resolve-baseline` below would resolve against the CALLER's own
+    # checkout, which has no such path, and fail before ever reaching
+    # baseline resolution -- confirmed by review; the existing
+    # test-action.yml fixture never caught this because it invokes
+    # check-target from *within* this same repository, the one case where a
+    # bare relative path happens to already work. Fix: check out this exact
+    # abicheck/abicheck ref into a side directory of the caller's own
+    # workspace first, then reference every nested Action relative to that
+    # directory instead of bare `./`. `github.action_repository`/
+    # `github.action_ref` are only set for a remote `owner/repo/path@ref`
+    # reference; for a local `uses: ./actions/check-target` call within this
+    # same repository (as `.github/workflows/test-action.yml` does), both
+    # are empty, so this falls back to `github.repository`/`github.sha` --
+    # checking out the same repo/commit the caller's own workspace already
+    # has, redundant but harmless. This step is unconditional rather than
+    # branching on which case applies, because `uses:` does not accept
+    # expressions -- there is no way to make the *reference itself*
+    # conditional, only its inputs.
+    - name: Checkout abicheck (for nested Action composition)
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ github.action_repository || github.repository }}
+        ref: ${{ github.action_ref || github.sha }}
+        path: .abicheck-check-target-src
+        persist-credentials: false
+
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
@@ -290,7 +325,7 @@ runs:
       id: resolve
       if: inputs.baseline-channel != 'none'
       continue-on-error: true
-      uses: ./actions/resolve-baseline
+      uses: ./.abicheck-check-target-src/actions/resolve-baseline
       with:
         baseline-path: ${{ inputs.baseline-path }}
         channel: ${{ inputs.baseline-channel }}
@@ -313,7 +348,7 @@ runs:
         (inputs.evidence-producer == 'wrapper' || inputs.evidence-producer == 'clang-plugin') &&
         (inputs.baseline-channel == 'none' || steps.resolve.outputs.outcome == 'resolved')
       continue-on-error: true
-      uses: ./actions/collect-facts
+      uses: ./.abicheck-check-target-src/actions/collect-facts
       with:
         phase: 'verify'
         producer: ${{ inputs.evidence-producer }}
@@ -326,7 +361,7 @@ runs:
         inputs.evidence-producer == 'replay' &&
         (inputs.baseline-channel == 'none' || steps.resolve.outputs.outcome == 'resolved')
       continue-on-error: true
-      uses: ./actions/collect-facts
+      uses: ./.abicheck-check-target-src/actions/collect-facts
       with:
         phase: 'auto'
         producer: 'replay'
@@ -341,7 +376,7 @@ runs:
       id: analysis
       if: inputs.baseline-channel == 'none' || steps.resolve.outputs.outcome == 'resolved'
       continue-on-error: true
-      uses: ./
+      uses: ./.abicheck-check-target-src
       with:
         mode: ${{ inputs.baseline-channel == 'none' && 'scan' || 'compare' }}
         old-library: ${{ inputs.kind == 'bundle' && steps.resolve.outputs.binaries-dir || steps.resolve.outputs.snapshot-path }}
@@ -393,7 +428,6 @@ runs:
         INPUT_BASELINE_CHANNEL: ${{ inputs.baseline-channel }}
         INPUT_REQUESTED_DEPTH: ${{ inputs.requested-depth }}
         INPUT_GATE_MODE: ${{ inputs.gate-mode }}
-        INPUT_EVIDENCE_PRODUCER: ${{ inputs.evidence-producer }}
         INPUT_PROJECT: ${{ inputs.project }}
         INPUT_HEAD_SHA: ${{ inputs.head-sha }}
         INPUT_BASE_REF: ${{ inputs.base-ref }}
@@ -406,10 +440,5 @@ runs:
         ANALYSIS_OUTCOME: ${{ steps.analysis.outcome }}
         ANALYSIS_VERDICT: ${{ steps.analysis.outputs.verdict }}
         ANALYSIS_REPORT_PATH: ${{ steps.analysis.outputs.report-path }}
-        COLLECT_VERIFY_RAN: ${{ steps.collect_verify.outcome != 'skipped' }}
-        COLLECT_VERIFY_OUTCOME: ${{ steps.collect_verify.outcome }}
-        COLLECT_VERIFY_READY: ${{ steps.collect_verify.outputs.ready }}
-        COLLECT_REPLAY_RAN: ${{ steps.collect_replay.outcome != 'skipped' }}
-        COLLECT_REPLAY_OUTCOME: ${{ steps.collect_replay.outcome }}
         ACTION_PATH: ${{ github.action_path }}
       run: bash "${{ github.action_path }}/run.sh"

--- a/actions/check-target/action.yml
+++ b/actions/check-target/action.yml
@@ -400,6 +400,26 @@ runs:
     # would still be handed to compare as --build-info, silently running the
     # comparison against invalid evidence instead of surfacing the
     # collection failure as the operational error it is (review). ──────────
+    # The analysis output filename below is a fixed workspace-relative path
+    # (unlike the final envelope, which is already scoped per check-id) --
+    # if a job runs check-target more than once and a LATER invocation's
+    # nested root Action crashes before ever reaching its own report-write
+    # step (e.g. a CLI usage/config error), an EARLIER invocation's file
+    # would still be sitting at that same path. run.sh's own "only emit
+    # report-path when a real report file was produced" check
+    # (`-f "$OUTPUT_FILE"`) would then find the stale file and report it as
+    # this run's own report-path, so the finalize step below would augment
+    # the PREVIOUS check's JSON as if it were this check's real result --
+    # with gate-mode: deferred/advisory, silently turning a genuine
+    # operational failure into a false pass, since operational_errors would
+    # be read from the stale (successful) report instead (Codex review).
+    # Deleting any stale file first, unconditionally (not gated on this
+    # step's own `if:` below), closes that window regardless of whether
+    # analysis runs this time.
+    - name: Clean stale analysis output
+      shell: bash
+      run: rm -f check-target-analysis.json
+
     - name: Run analysis
       id: analysis
       if: |

--- a/actions/check-target/action.yml
+++ b/actions/check-target/action.yml
@@ -470,6 +470,7 @@ runs:
         ANALYSIS_OUTCOME: ${{ steps.analysis.outcome }}
         ANALYSIS_VERDICT: ${{ steps.analysis.outputs.verdict }}
         ANALYSIS_REPORT_PATH: ${{ steps.analysis.outputs.report-path }}
+        ANALYSIS_EXIT_CODE: ${{ steps.analysis.outputs.exit-code }}
         COLLECT_VERIFY_OUTCOME: ${{ steps.collect_verify.outcome }}
         COLLECT_REPLAY_OUTCOME: ${{ steps.collect_replay.outcome }}
         ACTION_PATH: ${{ github.action_path }}

--- a/actions/check-target/action.yml
+++ b/actions/check-target/action.yml
@@ -265,6 +265,7 @@ runs:
         INPUT_KIND: ${{ inputs.kind }}
         INPUT_TARGET_KIND: ${{ inputs.target-kind }}
         INPUT_NAME: ${{ inputs.name }}
+        INPUT_PROFILE: ${{ inputs.profile }}
         INPUT_BUNDLE_MEMBERS: ${{ inputs.bundle-members }}
         INPUT_BASELINE_CHANNEL: ${{ inputs.baseline-channel }}
         INPUT_BASELINE_PATH: ${{ inputs.baseline-path }}

--- a/actions/check-target/report_envelope.py
+++ b/actions/check-target/report_envelope.py
@@ -190,7 +190,14 @@ def main(argv: list[str] | None = None) -> int:
             base_ref=base_ref,
             action_version=action_version,
         )
-        operational_error = report.get("verdict") == "ERROR"
+        # augment_report already classifies any non-compatibility verdict
+        # (the literal "ERROR", or a scan guard sentinel like
+        # "BUDGET_OVERFLOW"/"EVIDENCE_CONTRACT_ERROR") as operational by
+        # populating operational_errors -- reuse that instead of
+        # re-deriving it from verdict alone, which used to miss the scan
+        # guard sentinels entirely and let gate-mode: deferred/advisory
+        # silently swallow them (Codex review).
+        operational_error = bool(report.get("operational_errors"))
 
     real_exit_code = 0
     if args.mode == "augment":

--- a/actions/check-target/report_envelope.py
+++ b/actions/check-target/report_envelope.py
@@ -103,8 +103,6 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "--gate-mode", default="local", choices=["local", "deferred", "advisory"]
     )
-    parser.add_argument("--evidence-ok", choices=["true", "false"], default="true")
-    parser.add_argument("--degraded-reason", default="")
     parser.add_argument("--resolve-outcome", default="")
     parser.add_argument("--resolve-message", default="")
     parser.add_argument("--project", default="")
@@ -187,8 +185,6 @@ def main(argv: list[str] | None = None) -> int:
             baseline_channel=args.baseline_channel,
             requested_depth=args.requested_depth,
             gate_mode=args.gate_mode,
-            evidence_ok=args.evidence_ok == "true",
-            degraded_reason=args.degraded_reason or None,
             project=project,
             head_sha=head_sha,
             base_ref=base_ref,

--- a/actions/check-target/report_envelope.py
+++ b/actions/check-target/report_envelope.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CLI wrapper backing ``actions/check-target/run.sh`` (G30 P1.3, ADR-047
+§7).
+
+Thin argparse wrapper around ``abicheck.buildsource.check_report``'s pure
+report-envelope construction -- mirrors ``actions/resolve-baseline/
+resolve_baseline.py``'s pattern: reads/writes the report JSON file, prints
+``key=value`` lines on stdout that ``run.sh`` forwards to ``GITHUB_OUTPUT``.
+
+Exactly one of three modes runs, selected by ``--mode``:
+
+- ``augment`` -- the common path: read the analysis step's own JSON report
+  (``--report-in``), layer the ADR-047 §7 identity/new fields onto it, write
+  the result to ``--report-out``.
+- ``operational-error`` -- ``resolve-baseline`` failed; synthesize a report
+  from scratch (no ``--report-in``).
+- ``bootstrap`` -- ``resolve-baseline`` returned ``not_found``/bootstrap; no
+  comparison ever ran, synthesize the advisory "no baseline yet" report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from abicheck.buildsource.check_report import (
+    RESOLVE_FAILURE_OUTCOMES,
+    augment_report,
+    build_bootstrap_report,
+    build_operational_error_report,
+    final_exit_code,
+)
+
+#: Usage error, matching the repo-wide convention documented in AGENTS.md
+#: ("64 = usage error (bad flags/inputs)").
+_EXIT_USAGE_ERROR = 64
+
+
+def _print_outputs(fields: dict[str, str]) -> int:
+    """Print ``key=value`` lines ``run.sh`` forwards to ``GITHUB_OUTPUT``.
+
+    Same newline guard as ``resolve_baseline.py``'s ``_print_outputs``: an
+    embedded newline in any value would corrupt ``$GITHUB_OUTPUT``'s
+    line-oriented parsing.
+    """
+    for key, value in fields.items():
+        if "\n" in value or "\r" in value:
+            print(
+                f"::error::internal error: check-target output {key!r} "
+                "contains a newline, which would corrupt GITHUB_OUTPUT -- "
+                "refusing to write it.",
+                file=sys.stderr,
+            )
+            return _EXIT_USAGE_ERROR
+    for key, value in fields.items():
+        print(f"{key}={value}")
+    return 0
+
+
+def _outputs_for_report(report: dict[str, object], report_out: Path) -> dict[str, str]:
+    verdict = str(report.get("verdict") or "")
+    compat = report.get("compatibility_verdict")
+    return {
+        "check-id": str(report.get("check_id") or ""),
+        "verdict": verdict,
+        "compatibility-verdict": str(compat) if compat is not None else "",
+        "policy-gate-decision": str(report.get("policy_gate_decision") or ""),
+        "report-path": str(report_out),
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode", required=True, choices=["augment", "operational-error", "bootstrap"]
+    )
+    parser.add_argument(
+        "--report-in",
+        default="",
+        help="Path to the analysis step's own JSON report (mode: augment only)",
+    )
+    parser.add_argument("--report-out", required=True, type=Path)
+    parser.add_argument("--name", required=True, help="target or bundle id")
+    parser.add_argument("--profile-id", required=True)
+    parser.add_argument("--baseline-channel", required=True)
+    parser.add_argument("--requested-depth", required=True)
+    parser.add_argument(
+        "--gate-mode", default="local", choices=["local", "deferred", "advisory"]
+    )
+    parser.add_argument("--evidence-ok", choices=["true", "false"], default="true")
+    parser.add_argument("--degraded-reason", default="")
+    parser.add_argument("--resolve-outcome", default="")
+    parser.add_argument("--resolve-message", default="")
+    parser.add_argument("--project", default="")
+    parser.add_argument("--head-sha", default="")
+    parser.add_argument("--base-ref", default="")
+    parser.add_argument("--tool-version", default="")
+    parser.add_argument("--action-version", default="")
+    args = parser.parse_args(argv)
+
+    project = args.project or None
+    head_sha = args.head_sha or None
+    base_ref = args.base_ref or None
+    action_version = args.action_version or None
+    tool_version = args.tool_version or None
+
+    operational_error = False
+
+    if args.mode == "operational-error":
+        if args.resolve_outcome not in RESOLVE_FAILURE_OUTCOMES:
+            print(
+                f"::error::--resolve-outcome {args.resolve_outcome!r} is not a "
+                f"recognized resolve-baseline failure outcome (expected one of "
+                f"{sorted(RESOLVE_FAILURE_OUTCOMES)})",
+                file=sys.stderr,
+            )
+            return _EXIT_USAGE_ERROR
+        report = build_operational_error_report(
+            name=args.name,
+            profile_id=args.profile_id,
+            baseline_channel=args.baseline_channel,
+            requested_depth=args.requested_depth,
+            resolve_outcome=args.resolve_outcome,
+            resolve_message=args.resolve_message,
+            project=project,
+            head_sha=head_sha,
+            base_ref=base_ref,
+            tool_version=tool_version,
+            action_version=action_version,
+        )
+        operational_error = True
+    elif args.mode == "bootstrap":
+        report = build_bootstrap_report(
+            name=args.name,
+            profile_id=args.profile_id,
+            baseline_channel=args.baseline_channel,
+            requested_depth=args.requested_depth,
+            resolve_message=args.resolve_message,
+            project=project,
+            head_sha=head_sha,
+            base_ref=base_ref,
+            tool_version=tool_version,
+            action_version=action_version,
+        )
+    else:
+        if not args.report_in:
+            print(
+                "::error::--report-in is required for --mode augment", file=sys.stderr
+            )
+            return _EXIT_USAGE_ERROR
+        report_in_path = Path(args.report_in)
+        if not report_in_path.is_file():
+            print(
+                f"::error::--report-in {args.report_in!r} does not exist -- the "
+                "analysis step did not produce a report file.",
+                file=sys.stderr,
+            )
+            return _EXIT_USAGE_ERROR
+        try:
+            base_report = json.loads(report_in_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            print(f"::error::failed to read --report-in: {exc}", file=sys.stderr)
+            return _EXIT_USAGE_ERROR
+        if not isinstance(base_report, dict):
+            print("::error::--report-in is not a JSON object", file=sys.stderr)
+            return _EXIT_USAGE_ERROR
+        report = augment_report(
+            base_report,
+            name=args.name,
+            profile_id=args.profile_id,
+            baseline_channel=args.baseline_channel,
+            requested_depth=args.requested_depth,
+            gate_mode=args.gate_mode,
+            evidence_ok=args.evidence_ok == "true",
+            degraded_reason=args.degraded_reason or None,
+            project=project,
+            head_sha=head_sha,
+            base_ref=base_ref,
+            action_version=action_version,
+        )
+        operational_error = report.get("verdict") == "ERROR"
+
+    real_exit_code = 0
+    if args.mode == "augment":
+        severity = report.get("severity")
+        if isinstance(severity, dict) and isinstance(severity.get("exit_code"), int):
+            real_exit_code = severity["exit_code"]
+        elif isinstance(report.get("exit_code"), int):
+            real_exit_code = report["exit_code"]  # type: ignore[assignment]
+
+    args.report_out.parent.mkdir(parents=True, exist_ok=True)
+    args.report_out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+    outputs = _outputs_for_report(report, args.report_out)
+    output_status = _print_outputs(outputs)
+    if output_status != 0:
+        return output_status
+
+    exit_code = final_exit_code(
+        args.gate_mode,
+        real_exit_code=real_exit_code,
+        operational_error=operational_error,
+    )
+    print(f"exit-code={exit_code}")
+    # This process's own exit status reports whether the envelope was
+    # written successfully -- not check-target's gate decision. run.sh reads
+    # the exit-code=N line above (already flushed to stdout) and performs
+    # the actual `exit $N` itself, after this step (which must never be
+    # continue-on-error'd, unlike the resolve/analysis steps) has completed.
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/actions/check-target/report_envelope.py
+++ b/actions/check-target/report_envelope.py
@@ -110,6 +110,19 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--base-ref", default="")
     parser.add_argument("--tool-version", default="")
     parser.add_argument("--action-version", default="")
+    parser.add_argument(
+        "--analysis-exit-code",
+        type=int,
+        default=0,
+        help=(
+            "The nested root Action's own real process exit code (mode: "
+            "augment only). Some root-Action gates (e.g. "
+            "--fail-on-removed-library on a directory/package compare) take "
+            "effect as a dedicated exit code that overrides the persisted "
+            "severity scheme rather than feeding into it, so the report "
+            "body alone can under-report the real outcome."
+        ),
+    )
     args = parser.parse_args(argv)
 
     project = args.project or None
@@ -189,6 +202,7 @@ def main(argv: list[str] | None = None) -> int:
             head_sha=head_sha,
             base_ref=base_ref,
             action_version=action_version,
+            analysis_exit_code=args.analysis_exit_code,
         )
         # augment_report already classifies any non-compatibility verdict
         # (the literal "ERROR", or a scan guard sentinel like
@@ -206,6 +220,10 @@ def main(argv: list[str] | None = None) -> int:
             real_exit_code = severity["exit_code"]
         elif isinstance(report.get("exit_code"), int):
             real_exit_code = report["exit_code"]  # type: ignore[assignment]
+        # Same fold augment_report already applied for policy_gate_decision
+        # -- keep this local real_exit_code (used for final_exit_code below)
+        # consistent with it, not just the persisted report field.
+        real_exit_code = max(real_exit_code, args.analysis_exit_code)
 
     args.report_out.parent.mkdir(parents=True, exist_ok=True)
     args.report_out.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")

--- a/actions/check-target/run.sh
+++ b/actions/check-target/run.sh
@@ -29,6 +29,21 @@ RESOLVE_MESSAGE="${RESOLVE_MESSAGE:-}"
 
 ANALYSIS_RAN="${ANALYSIS_RAN:-false}"
 ANALYSIS_REPORT_PATH="${ANALYSIS_REPORT_PATH:-}"
+# The nested root Action's own real process exit code (its `exit-code`
+# output) -- some of its gates (e.g. --fail-on-removed-library on a
+# directory/package compare) take effect as a dedicated exit code that
+# overrides the persisted severity scheme rather than feeding into it, so
+# the report body alone can under-report the real outcome (Codex review).
+# Defensively defaulted to 0 for anything not a clean non-negative integer
+# (an empty output when the nested step never reached its own exit-code
+# step, or any unexpected content) rather than letting a malformed value
+# reach report_envelope.py's --analysis-exit-code (an argparse int).
+ANALYSIS_EXIT_CODE_RAW="${ANALYSIS_EXIT_CODE:-0}"
+if [[ "$ANALYSIS_EXIT_CODE_RAW" =~ ^[0-9]+$ ]]; then
+  ANALYSIS_EXIT_CODE="$ANALYSIS_EXIT_CODE_RAW"
+else
+  ANALYSIS_EXIT_CODE=0
+fi
 
 COLLECT_VERIFY_OUTCOME="${COLLECT_VERIFY_OUTCOME:-}"
 COLLECT_REPLAY_OUTCOME="${COLLECT_REPLAY_OUTCOME:-}"
@@ -96,7 +111,7 @@ ENVELOPE_ARGS=(
   --action-version "$ACTION_VERSION"
 )
 if [[ "$MODE" == "augment" ]]; then
-  ENVELOPE_ARGS+=(--report-in "$ANALYSIS_REPORT_PATH")
+  ENVELOPE_ARGS+=(--report-in "$ANALYSIS_REPORT_PATH" --analysis-exit-code "$ANALYSIS_EXIT_CODE")
 elif [[ "$MODE" == "bootstrap" ]]; then
   ENVELOPE_ARGS+=(--resolve-message "${RESOLVE_MESSAGE:-no baseline set exists yet for this channel.}")
 else

--- a/actions/check-target/run.sh
+++ b/actions/check-target/run.sh
@@ -17,7 +17,6 @@ PROFILE="${INPUT_PROFILE:?}"
 BASELINE_CHANNEL="${INPUT_BASELINE_CHANNEL:?}"
 REQUESTED_DEPTH="${INPUT_REQUESTED_DEPTH:?}"
 GATE_MODE="${INPUT_GATE_MODE:-local}"
-EVIDENCE_PRODUCER="${INPUT_EVIDENCE_PRODUCER:-}"
 PROJECT="${INPUT_PROJECT:-}"
 HEAD_SHA="${INPUT_HEAD_SHA:-}"
 BASE_REF="${INPUT_BASE_REF:-}"
@@ -30,12 +29,6 @@ RESOLVE_MESSAGE="${RESOLVE_MESSAGE:-}"
 
 ANALYSIS_RAN="${ANALYSIS_RAN:-false}"
 ANALYSIS_REPORT_PATH="${ANALYSIS_REPORT_PATH:-}"
-
-COLLECT_VERIFY_RAN="${COLLECT_VERIFY_RAN:-false}"
-COLLECT_VERIFY_OUTCOME="${COLLECT_VERIFY_OUTCOME:-}"
-COLLECT_VERIFY_READY="${COLLECT_VERIFY_READY:-}"
-COLLECT_REPLAY_RAN="${COLLECT_REPLAY_RAN:-false}"
-COLLECT_REPLAY_OUTCOME="${COLLECT_REPLAY_OUTCOME:-}"
 
 ACTION_PATH="${ACTION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 REPORT_OUT="check-target-report.json"
@@ -62,29 +55,6 @@ else
   MODE="augment"
 fi
 
-# ── Evidence-availability signal feeding effective_depth degradation ───────
-EVIDENCE_OK="false"
-DEGRADED_REASON=""
-case "$EVIDENCE_PRODUCER" in
-  wrapper | clang-plugin)
-    if [[ "$COLLECT_VERIFY_RAN" == "true" && "$COLLECT_VERIFY_OUTCOME" == "success" && "$COLLECT_VERIFY_READY" == "true" ]]; then
-      EVIDENCE_OK="true"
-    else
-      DEGRADED_REASON="collect_facts_not_ready"
-    fi
-    ;;
-  replay)
-    if [[ "$COLLECT_REPLAY_RAN" == "true" && "$COLLECT_REPLAY_OUTCOME" == "success" ]]; then
-      EVIDENCE_OK="true"
-    else
-      DEGRADED_REASON="source_replay_failed"
-    fi
-    ;;
-  *)
-    DEGRADED_REASON="no_evidence_producer_configured"
-    ;;
-esac
-
 ENVELOPE_ARGS=(
   --mode "$MODE"
   --report-out "$REPORT_OUT"
@@ -93,8 +63,6 @@ ENVELOPE_ARGS=(
   --baseline-channel "$BASELINE_CHANNEL"
   --requested-depth "$REQUESTED_DEPTH"
   --gate-mode "$GATE_MODE"
-  --evidence-ok "$EVIDENCE_OK"
-  --degraded-reason "$DEGRADED_REASON"
   --project "$PROJECT"
   --head-sha "$HEAD_SHA"
   --base-ref "$BASE_REF"

--- a/actions/check-target/run.sh
+++ b/actions/check-target/run.sh
@@ -34,7 +34,21 @@ COLLECT_VERIFY_OUTCOME="${COLLECT_VERIFY_OUTCOME:-}"
 COLLECT_REPLAY_OUTCOME="${COLLECT_REPLAY_OUTCOME:-}"
 
 ACTION_PATH="${ACTION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
-REPORT_OUT="check-target-report.json"
+
+# A fixed "check-target-report.json" collides across multiple check-target
+# invocations in the same job (e.g. the same target checked against two
+# baseline channels, or several targets in one job without per-step output
+# dirs) -- each call would overwrite the previous one's report file, so an
+# earlier step's own `report-path` output would end up pointing at a LATER
+# check's envelope by the time anything reads it (Codex review). Scope the
+# filename to this check's own identity components instead; `tr -c` maps
+# any character outside the safe identifier charset to `_` so an
+# unsanitized NAME/PROFILE/BASELINE_CHANNEL can never escape the workspace
+# directory or collide with an unrelated file.
+_slug() {
+  printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'
+}
+REPORT_OUT="check-target-report-$(_slug "$NAME")-$(_slug "$PROFILE")-$(_slug "$BASELINE_CHANNEL")-$(_slug "$REQUESTED_DEPTH").json"
 
 # ── Decide which report_envelope.py mode this check needs ──────────────────
 MODE=""

--- a/actions/check-target/run.sh
+++ b/actions/check-target/run.sh
@@ -30,6 +30,9 @@ RESOLVE_MESSAGE="${RESOLVE_MESSAGE:-}"
 ANALYSIS_RAN="${ANALYSIS_RAN:-false}"
 ANALYSIS_REPORT_PATH="${ANALYSIS_REPORT_PATH:-}"
 
+COLLECT_VERIFY_OUTCOME="${COLLECT_VERIFY_OUTCOME:-}"
+COLLECT_REPLAY_OUTCOME="${COLLECT_REPLAY_OUTCOME:-}"
+
 ACTION_PATH="${ACTION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 REPORT_OUT="check-target-report.json"
 
@@ -43,6 +46,16 @@ elif [[ "$RESOLVE_RAN" == "true" && "$RESOLVE_OUTCOME" != "resolved" ]]; then
   OUTCOME="${RESOLVE_OUTCOME:-ambiguous}"
   MESSAGE="${RESOLVE_MESSAGE:-resolve-baseline did not produce an outcome.}"
   RESOLVE_ARGS+=(--resolve-outcome "$OUTCOME" --resolve-message "$MESSAGE")
+elif [[ "$COLLECT_VERIFY_OUTCOME" == "failure" ]]; then
+  # A wrapper/clang-plugin pack that failed phase: verify (e.g. missing or
+  # empty) never reaches the analysis step at all (action.yml gates on this)
+  # -- surfaced as its own typed operational error, not silently run against
+  # an invalid pack or lost as an unexplained "no report" ambiguous below.
+  MODE="operational-error"
+  RESOLVE_ARGS+=(--resolve-outcome "ambiguous" --resolve-message "collect-facts phase: verify failed -- the wrapper/clang-plugin evidence pack is missing or invalid.")
+elif [[ "$COLLECT_REPLAY_OUTCOME" == "failure" ]]; then
+  MODE="operational-error"
+  RESOLVE_ARGS+=(--resolve-outcome "ambiguous" --resolve-message "collect-facts phase: auto (replay) failed to resolve source evidence.")
 elif [[ "$ANALYSIS_RAN" != "true" || -z "$ANALYSIS_REPORT_PATH" || ! -f "$ANALYSIS_REPORT_PATH" ]]; then
   # Baseline resolution succeeded (or was skipped for baseline-channel:
   # none), but the analysis step never produced a report -- a genuine

--- a/actions/check-target/run.sh
+++ b/actions/check-target/run.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Writes the ADR-047 §7 report envelope and owns check-target's own
+# composite exit code -- this step always runs (never continue-on-error),
+# regardless of whether the earlier resolve/collect-facts/analysis steps
+# succeeded, failed, or were skipped. See action.yml for the step
+# orchestration and report_envelope.py for the pure-logic-backed CLI this
+# script drives.
+set -euo pipefail
+
+_fail() {
+  echo "::error::$1"
+  exit 1
+}
+
+NAME="${INPUT_NAME:?}"
+PROFILE="${INPUT_PROFILE:?}"
+BASELINE_CHANNEL="${INPUT_BASELINE_CHANNEL:?}"
+REQUESTED_DEPTH="${INPUT_REQUESTED_DEPTH:?}"
+GATE_MODE="${INPUT_GATE_MODE:-local}"
+EVIDENCE_PRODUCER="${INPUT_EVIDENCE_PRODUCER:-}"
+PROJECT="${INPUT_PROJECT:-}"
+HEAD_SHA="${INPUT_HEAD_SHA:-}"
+BASE_REF="${INPUT_BASE_REF:-}"
+ACTION_VERSION="${INPUT_ACTION_VERSION:-}"
+
+RESOLVE_RAN="${RESOLVE_RAN:-false}"
+RESOLVE_OUTCOME="${RESOLVE_OUTCOME:-}"
+RESOLVE_BOOTSTRAP="${RESOLVE_BOOTSTRAP:-false}"
+RESOLVE_MESSAGE="${RESOLVE_MESSAGE:-}"
+
+ANALYSIS_RAN="${ANALYSIS_RAN:-false}"
+ANALYSIS_REPORT_PATH="${ANALYSIS_REPORT_PATH:-}"
+
+COLLECT_VERIFY_RAN="${COLLECT_VERIFY_RAN:-false}"
+COLLECT_VERIFY_OUTCOME="${COLLECT_VERIFY_OUTCOME:-}"
+COLLECT_VERIFY_READY="${COLLECT_VERIFY_READY:-}"
+COLLECT_REPLAY_RAN="${COLLECT_REPLAY_RAN:-false}"
+COLLECT_REPLAY_OUTCOME="${COLLECT_REPLAY_OUTCOME:-}"
+
+ACTION_PATH="${ACTION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+REPORT_OUT="check-target-report.json"
+
+# ── Decide which report_envelope.py mode this check needs ──────────────────
+MODE=""
+RESOLVE_ARGS=()
+if [[ "$RESOLVE_RAN" == "true" && "$RESOLVE_OUTCOME" == "not_found" && "$RESOLVE_BOOTSTRAP" == "true" ]]; then
+  MODE="bootstrap"
+elif [[ "$RESOLVE_RAN" == "true" && "$RESOLVE_OUTCOME" != "resolved" ]]; then
+  MODE="operational-error"
+  OUTCOME="${RESOLVE_OUTCOME:-ambiguous}"
+  MESSAGE="${RESOLVE_MESSAGE:-resolve-baseline did not produce an outcome.}"
+  RESOLVE_ARGS+=(--resolve-outcome "$OUTCOME" --resolve-message "$MESSAGE")
+elif [[ "$ANALYSIS_RAN" != "true" || -z "$ANALYSIS_REPORT_PATH" || ! -f "$ANALYSIS_REPORT_PATH" ]]; then
+  # Baseline resolution succeeded (or was skipped for baseline-channel:
+  # none), but the analysis step never produced a report -- a genuine
+  # orchestration/infrastructure failure (e.g. the nested root Action
+  # crashed before its own report-writing step), not a resolve-baseline
+  # outcome. Surface it the same typed way, never silently as a clean pass.
+  MODE="operational-error"
+  RESOLVE_ARGS+=(--resolve-outcome "ambiguous" --resolve-message "the analysis step did not produce a report file (check-target-analysis.json).")
+else
+  MODE="augment"
+fi
+
+# ── Evidence-availability signal feeding effective_depth degradation ───────
+EVIDENCE_OK="false"
+DEGRADED_REASON=""
+case "$EVIDENCE_PRODUCER" in
+  wrapper | clang-plugin)
+    if [[ "$COLLECT_VERIFY_RAN" == "true" && "$COLLECT_VERIFY_OUTCOME" == "success" && "$COLLECT_VERIFY_READY" == "true" ]]; then
+      EVIDENCE_OK="true"
+    else
+      DEGRADED_REASON="collect_facts_not_ready"
+    fi
+    ;;
+  replay)
+    if [[ "$COLLECT_REPLAY_RAN" == "true" && "$COLLECT_REPLAY_OUTCOME" == "success" ]]; then
+      EVIDENCE_OK="true"
+    else
+      DEGRADED_REASON="source_replay_failed"
+    fi
+    ;;
+  *)
+    DEGRADED_REASON="no_evidence_producer_configured"
+    ;;
+esac
+
+ENVELOPE_ARGS=(
+  --mode "$MODE"
+  --report-out "$REPORT_OUT"
+  --name "$NAME"
+  --profile-id "$PROFILE"
+  --baseline-channel "$BASELINE_CHANNEL"
+  --requested-depth "$REQUESTED_DEPTH"
+  --gate-mode "$GATE_MODE"
+  --evidence-ok "$EVIDENCE_OK"
+  --degraded-reason "$DEGRADED_REASON"
+  --project "$PROJECT"
+  --head-sha "$HEAD_SHA"
+  --base-ref "$BASE_REF"
+  --action-version "$ACTION_VERSION"
+)
+if [[ "$MODE" == "augment" ]]; then
+  ENVELOPE_ARGS+=(--report-in "$ANALYSIS_REPORT_PATH")
+elif [[ "$MODE" == "bootstrap" ]]; then
+  ENVELOPE_ARGS+=(--resolve-message "${RESOLVE_MESSAGE:-no baseline set exists yet for this channel.}")
+else
+  ENVELOPE_ARGS+=("${RESOLVE_ARGS[@]}")
+fi
+
+echo "::group::Write check-target report envelope (mode: $MODE)"
+set +e
+ENVELOPE_STDOUT=$(python3 "$ACTION_PATH/report_envelope.py" "${ENVELOPE_ARGS[@]}")
+ENVELOPE_EXIT=$?
+set -e
+echo "$ENVELOPE_STDOUT"
+echo "::endgroup::"
+
+if [[ $ENVELOPE_EXIT -ne 0 ]]; then
+  _fail "check-target failed to write its report envelope (see the group above)."
+fi
+
+if [[ "$RESOLVE_RAN" == "true" ]]; then
+  OUTCOME_OUTPUT="$RESOLVE_OUTCOME"
+else
+  OUTCOME_OUTPUT="skipped"
+fi
+{
+  # grep -v always has other lines to pass through (check-id/verdict/... are
+  # always printed before exit-code=), but || true guards the pipeline's exit
+  # status against pipefail anyway, matching resolve-baseline/run.sh's own
+  # documented caution around grep inside `set -o pipefail`.
+  echo "$ENVELOPE_STDOUT" | grep -v '^exit-code=' || true
+  echo "outcome=$OUTCOME_OUTPUT"
+} >> "${GITHUB_OUTPUT:-/dev/null}"
+
+FINAL_EXIT=$(echo "$ENVELOPE_STDOUT" | sed -n 's/^exit-code=//p')
+echo "check-target report: $REPORT_OUT (mode: $MODE, exit-code: $FINAL_EXIT)"
+exit "${FINAL_EXIT:-1}"

--- a/actions/check-target/validate-inputs.sh
+++ b/actions/check-target/validate-inputs.sh
@@ -12,6 +12,7 @@ _fail() {
 KIND="${INPUT_KIND:-target}"
 TARGET_KIND="${INPUT_TARGET_KIND:-library}"
 NAME="${INPUT_NAME:-}"
+PROFILE="${INPUT_PROFILE:-}"
 BUNDLE_MEMBERS="${INPUT_BUNDLE_MEMBERS:-[]}"
 BASELINE_CHANNEL="${INPUT_BASELINE_CHANNEL:?baseline-channel input is required}"
 BASELINE_PATH="${INPUT_BASELINE_PATH:-}"
@@ -43,6 +44,19 @@ case "$EVIDENCE_PRODUCER" in
 esac
 if [[ -z "$NAME" ]]; then
   _fail "name input is required."
+fi
+if [[ -z "$PROFILE" ]]; then
+  # action.yml declares profile: required: true, but GitHub Actions does
+  # NOT actually enforce `required: true` for composite-action inputs --
+  # it's documentation only; an omitted input simply arrives as an empty
+  # string (github.com/orgs/community/discussions/26777). Without this
+  # check, a workflow that forgot `profile:` would sail past this step and
+  # only fail deep inside run.sh's `PROFILE="${INPUT_PROFILE:?}"` bash
+  # parameter expansion -- which aborts the finalize step immediately,
+  # before report_envelope.py ever runs, so the check produces no
+  # check-target-report*.json/outputs at all despite ADR-047 §7's "the
+  # report-envelope step always executes" contract (Codex review).
+  _fail "profile input is required."
 fi
 if [[ "$KIND" == "bundle" ]]; then
   if [[ "$TARGET_KIND" != "library" ]]; then

--- a/actions/check-target/validate-inputs.sh
+++ b/actions/check-target/validate-inputs.sh
@@ -14,13 +14,50 @@ TARGET_KIND="${INPUT_TARGET_KIND:-library}"
 NAME="${INPUT_NAME:-}"
 PROFILE="${INPUT_PROFILE:-}"
 BUNDLE_MEMBERS="${INPUT_BUNDLE_MEMBERS:-[]}"
-BASELINE_CHANNEL="${INPUT_BASELINE_CHANNEL:?baseline-channel input is required}"
+BASELINE_CHANNEL="${INPUT_BASELINE_CHANNEL:-}"
 BASELINE_PATH="${INPUT_BASELINE_PATH:-}"
 GATE_MODE="${INPUT_GATE_MODE:-local}"
-REQUESTED_DEPTH="${INPUT_REQUESTED_DEPTH:?requested-depth input is required}"
+REQUESTED_DEPTH="${INPUT_REQUESTED_DEPTH:-}"
 EVIDENCE_PRODUCER="${INPUT_EVIDENCE_PRODUCER:-}"
 CONSUMER_BINARY="${INPUT_CONSUMER_BINARY:-}"
 CONTRACT_FILE="${INPUT_CONTRACT_FILE:-}"
+
+# ── Required-input checks run before the enum/case validations below, so an
+# empty required input (name, profile, baseline-channel, requested-depth)
+# gets the clearer "input is required" message instead of being caught by
+# a case statement's generic "not recognized" branch first (an empty string
+# never matches any case pattern, so it would otherwise fall through to
+# that branch's *) arm).
+if [[ -z "$NAME" ]]; then
+  _fail "name input is required."
+fi
+if [[ -z "$PROFILE" ]]; then
+  # action.yml declares profile: required: true, but GitHub Actions does
+  # NOT actually enforce `required: true` for composite-action inputs --
+  # it's documentation only; an omitted input simply arrives as an empty
+  # string (github.com/orgs/community/discussions/26777). Without this
+  # check, a workflow that forgot `profile:` would sail past this step and
+  # only fail deep inside run.sh's `PROFILE="${INPUT_PROFILE:?}"` bash
+  # parameter expansion -- which aborts the finalize step immediately,
+  # before report_envelope.py ever runs, so the check produces no
+  # check-target-report*.json/outputs at all despite ADR-047 §7's "the
+  # report-envelope step always executes" contract (Codex review).
+  _fail "profile input is required."
+fi
+if [[ -z "$BASELINE_CHANNEL" ]]; then
+  # baseline-channel is declared required: true, same GitHub-Actions-doesn't-
+  # enforce-required-inputs caveat as profile above -- was previously a bare
+  # `:?` parameter expansion, which does fire on empty but exits 1 with a raw
+  # bash stderr message and no `::error::` annotation, diverging from every
+  # other required-input check here (CodeRabbit review).
+  _fail "baseline-channel input is required."
+fi
+if [[ -z "$REQUESTED_DEPTH" ]]; then
+  # Same rationale as baseline-channel above. Must run before the
+  # REQUESTED_DEPTH case statement below, or an empty value would instead
+  # get caught there with the less precise "not recognized" message.
+  _fail "requested-depth input is required."
+fi
 
 case "$KIND" in
   target | bundle) ;;
@@ -42,22 +79,6 @@ case "$EVIDENCE_PRODUCER" in
   "" | wrapper | clang-plugin | replay) ;;
   *) _fail "evidence-producer '$EVIDENCE_PRODUCER' is not recognized. Use '' (none), 'wrapper', 'clang-plugin', or 'replay' -- a misspelled value silently skips fact collection instead of failing loud." ;;
 esac
-if [[ -z "$NAME" ]]; then
-  _fail "name input is required."
-fi
-if [[ -z "$PROFILE" ]]; then
-  # action.yml declares profile: required: true, but GitHub Actions does
-  # NOT actually enforce `required: true` for composite-action inputs --
-  # it's documentation only; an omitted input simply arrives as an empty
-  # string (github.com/orgs/community/discussions/26777). Without this
-  # check, a workflow that forgot `profile:` would sail past this step and
-  # only fail deep inside run.sh's `PROFILE="${INPUT_PROFILE:?}"` bash
-  # parameter expansion -- which aborts the finalize step immediately,
-  # before report_envelope.py ever runs, so the check produces no
-  # check-target-report*.json/outputs at all despite ADR-047 §7's "the
-  # report-envelope step always executes" contract (Codex review).
-  _fail "profile input is required."
-fi
 if [[ "$KIND" == "bundle" ]]; then
   if [[ "$TARGET_KIND" != "library" ]]; then
     _fail "target-kind must be 'library' when kind is 'bundle' -- app-consumer/plugin-contract are single-target concepts."

--- a/actions/check-target/validate-inputs.sh
+++ b/actions/check-target/validate-inputs.sh
@@ -17,6 +17,7 @@ BASELINE_CHANNEL="${INPUT_BASELINE_CHANNEL:?baseline-channel input is required}"
 BASELINE_PATH="${INPUT_BASELINE_PATH:-}"
 GATE_MODE="${INPUT_GATE_MODE:-local}"
 REQUESTED_DEPTH="${INPUT_REQUESTED_DEPTH:?requested-depth input is required}"
+EVIDENCE_PRODUCER="${INPUT_EVIDENCE_PRODUCER:-}"
 CONSUMER_BINARY="${INPUT_CONSUMER_BINARY:-}"
 CONTRACT_FILE="${INPUT_CONTRACT_FILE:-}"
 
@@ -35,6 +36,10 @@ esac
 case "$REQUESTED_DEPTH" in
   binary | headers | build | source) ;;
   *) _fail "requested-depth '$REQUESTED_DEPTH' is not recognized. Use 'binary', 'headers', 'build', or 'source'." ;;
+esac
+case "$EVIDENCE_PRODUCER" in
+  "" | wrapper | clang-plugin | replay) ;;
+  *) _fail "evidence-producer '$EVIDENCE_PRODUCER' is not recognized. Use '' (none), 'wrapper', 'clang-plugin', or 'replay' -- a misspelled value silently skips fact collection instead of failing loud." ;;
 esac
 if [[ -z "$NAME" ]]; then
   _fail "name input is required."

--- a/actions/check-target/validate-inputs.sh
+++ b/actions/check-target/validate-inputs.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Fails fast on an unsupported check-target input combination, before Python
+# setup or any nested Action runs -- mirrors action/validate-inputs.sh's
+# rationale for the root Action. See action.yml for the full input contract.
+set -euo pipefail
+
+_fail() {
+  echo "::error::$1"
+  exit 64
+}
+
+KIND="${INPUT_KIND:-target}"
+TARGET_KIND="${INPUT_TARGET_KIND:-library}"
+NAME="${INPUT_NAME:-}"
+BUNDLE_MEMBERS="${INPUT_BUNDLE_MEMBERS:-[]}"
+BASELINE_CHANNEL="${INPUT_BASELINE_CHANNEL:?baseline-channel input is required}"
+BASELINE_PATH="${INPUT_BASELINE_PATH:-}"
+GATE_MODE="${INPUT_GATE_MODE:-local}"
+REQUESTED_DEPTH="${INPUT_REQUESTED_DEPTH:?requested-depth input is required}"
+CONSUMER_BINARY="${INPUT_CONSUMER_BINARY:-}"
+CONTRACT_FILE="${INPUT_CONTRACT_FILE:-}"
+
+case "$KIND" in
+  target | bundle) ;;
+  *) _fail "kind '$KIND' is not recognized. Use 'target' or 'bundle'." ;;
+esac
+case "$TARGET_KIND" in
+  library | app-consumer | plugin-contract) ;;
+  *) _fail "target-kind '$TARGET_KIND' is not recognized. Use 'library', 'app-consumer', or 'plugin-contract'." ;;
+esac
+case "$GATE_MODE" in
+  local | deferred | advisory) ;;
+  *) _fail "gate-mode '$GATE_MODE' is not recognized. Use 'local', 'deferred', or 'advisory'." ;;
+esac
+case "$REQUESTED_DEPTH" in
+  binary | headers | build | source) ;;
+  *) _fail "requested-depth '$REQUESTED_DEPTH' is not recognized. Use 'binary', 'headers', 'build', or 'source'." ;;
+esac
+if [[ -z "$NAME" ]]; then
+  _fail "name input is required."
+fi
+if [[ "$KIND" == "bundle" ]]; then
+  if [[ "$TARGET_KIND" != "library" ]]; then
+    _fail "target-kind must be 'library' when kind is 'bundle' -- app-consumer/plugin-contract are single-target concepts."
+  fi
+  if [[ "$BUNDLE_MEMBERS" == "[]" ]]; then
+    _fail "bundle-members must be a non-empty JSON array when kind is 'bundle'."
+  fi
+fi
+if [[ "$TARGET_KIND" == "app-consumer" && -z "$CONSUMER_BINARY" ]]; then
+  _fail "consumer-binary is required when target-kind is 'app-consumer'."
+fi
+if [[ "$TARGET_KIND" == "plugin-contract" && -z "$CONTRACT_FILE" ]]; then
+  _fail "contract-file is required when target-kind is 'plugin-contract'."
+fi
+if [[ "$BASELINE_CHANNEL" != "none" && -z "$BASELINE_PATH" ]]; then
+  _fail "baseline-path is required when baseline-channel is not 'none'."
+fi
+
+exit 0

--- a/actions/check-target/validate-inputs.sh
+++ b/actions/check-target/validate-inputs.sh
@@ -51,6 +51,17 @@ if [[ "$KIND" == "bundle" ]]; then
   if [[ "$BUNDLE_MEMBERS" == "[]" ]]; then
     _fail "bundle-members must be a non-empty JSON array when kind is 'bundle'."
   fi
+  if [[ "$REQUESTED_DEPTH" == "build" || "$REQUESTED_DEPTH" == "source" ]]; then
+    # kind: bundle always compares directories (the resolved binaries-dir vs.
+    # the candidate bundle directory), which routes through the CLI's
+    # per-library release fan-out -- that fan-out never collects inline
+    # build/source evidence and the root Action's run.sh now fails loud
+    # rather than silently dropping a build/source-depth request for a
+    # directory operand (Codex review). Failing here, before resolve-
+    # baseline/collect-facts even run, gives a clearer and cheaper error
+    # than letting the nested analysis step fail later.
+    _fail "requested-depth '$REQUESTED_DEPTH' is not supported when kind is 'bundle' -- a bundle compares directories, which the CLI's per-library release fan-out never collects inline build/source evidence for. Use requested-depth: binary or headers for a bundle check, or kind: target to compare one library at build/source depth."
+  fi
 fi
 if [[ "$TARGET_KIND" == "app-consumer" && -z "$CONSUMER_BINARY" ]]; then
   _fail "consumer-binary is required when target-kind is 'app-consumer'."

--- a/actions/check-target/validate-inputs.sh
+++ b/actions/check-target/validate-inputs.sh
@@ -58,6 +58,16 @@ fi
 if [[ "$TARGET_KIND" == "plugin-contract" && -z "$CONTRACT_FILE" ]]; then
   _fail "contract-file is required when target-kind is 'plugin-contract'."
 fi
+if [[ "$BASELINE_CHANNEL" == "none" && "$TARGET_KIND" != "library" ]]; then
+  # baseline-channel: none routes the analysis step to `scan` (a one-build
+  # audit), but the root Action's --used-by/--required-symbols contract
+  # scoping only exists in its `compare` branch -- `scan` has no equivalent
+  # flag at all. Without this check, an app-consumer/plugin-contract check
+  # with no baseline would silently run as a plain unscoped scan under the
+  # contract target's name and could pass without ever checking the
+  # consumer/plugin contract it claims to (Codex review).
+  _fail "target-kind '$TARGET_KIND' is not supported with baseline-channel: none -- a single-build audit (scan) has no --used-by/--required-symbols equivalent to scope the contract check against. Use target-kind: library for a baseline-channel: none audit, or set a real baseline-channel to run the scoped compare."
+fi
 if [[ "$BASELINE_CHANNEL" != "none" && -z "$BASELINE_PATH" ]]; then
   _fail "baseline-path is required when baseline-channel is not 'none'."
 fi

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -2,8 +2,8 @@
 
 - **`actions/check-target` composite Action** — composes `actions/resolve-baseline`,
   `actions/collect-facts`, and the root Action into one resolved ABI/API check
-  (ADR-047 §4, G30 P1.3), always emitting the report-identity envelope (§7):
-  unconditional depth-suffixed `check_id`/`target_id`, the new
+  (ADR-047 §4, G30 P1.3), emitting the report-identity envelope (§7) for
+  every validated invocation: unconditional depth-suffixed `check_id`/`target_id`, the new
   `compatibility_verdict`/`policy_gate_decision`/`check_evidence_coverage`/
   `operational_errors`/`publication` fields alongside the legacy `verdict`/
   `severity` fields `abicheck/aggregate.py` already parses. Supports
@@ -31,7 +31,10 @@
   produced. The internal per-invocation analysis output is now cleared
   before every analysis attempt, so a job that runs `check-target` more
   than once can't have a later invocation's crashed analysis silently pick
-  up an earlier invocation's stale report file. See
+  up an earlier invocation's stale report file. An `evidence-producer:
+  replay` check that leaves `sources:` unset now forwards the same `.`
+  default `collect-facts` already resolves internally, instead of silently
+  running the comparison with no source evidence at all. See
   `docs/reference/check-target.md`.
 
 <!--

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -81,6 +81,17 @@ it should read in CHANGELOG.md. Delete the other sections.
   `verdict`'s enum now also allows `ERROR`/`NO_BASELINE`, and the
   compare-specific fields are only required (via an `allOf`/`if`/`then`)
   when `verdict` is one of the five real values.
+- **`actions/check-target` no longer falsely claims the compare-report schema
+  for scan or `kind: bundle` reports** — `augment_report` unconditionally
+  stamped `report_schema_version` (the *compare*-report schema's marker) onto
+  every report regardless of its actual shape, so a successful
+  `baseline-channel: none` scan report (its own `scan_schema_version`
+  shape) or a `kind: bundle` directory-compare report (the release
+  fan-out's `verdict`/`old_dir`/`new_dir`/`libraries` shape) would validate
+  as broken against `compare_report.schema.json`'s single-pair-compare
+  required fields. A scan report now only bumps its own
+  `scan_schema_version`; a bundle/release report gets neither marker (it has
+  never had a schema of its own).
 
 <!--
 ### Performance

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -1,11 +1,3 @@
-<!--
-A new changelog fragment. See changelog.d/README.md for the workflow.
-
-Uncomment exactly ONE '### <Category>' section below (remove its comment
-wrapper) and replace the example bullet with your entry, written the way
-it should read in CHANGELOG.md. Delete the other sections.
--->
-
 ### Added
 
 - **`actions/check-target` composite Action** — composes `actions/resolve-baseline`,
@@ -17,8 +9,12 @@ it should read in CHANGELOG.md. Delete the other sections.
   `severity` fields `abicheck/aggregate.py` already parses. Supports
   `gate-mode: local|deferred|advisory`, a `baseline-channel: none` single-build
   audit bypass (no `resolve-baseline` call), and `target-kind: library|app-consumer|
-  plugin-contract` (`--used-by`/`--required-symbols` routing). See
-  `docs/reference/check-target.md`.
+  plugin-contract` (`--used-by`/`--required-symbols` routing, rejected up front
+  when combined with `baseline-channel: none` since `scan` has no equivalent
+  scoping flag). `kind: bundle` compares a directory of member binaries and
+  fails fast rather than silently degrading if `requested-depth: build`/`source`
+  is asked of it, since the underlying per-library release engine can't collect
+  that evidence for a directory operand. See `docs/reference/check-target.md`.
 
 <!--
 ### Changed
@@ -44,80 +40,14 @@ it should read in CHANGELOG.md. Delete the other sections.
   `--policy-file`.
 
 -->
+<!--
 ### Fixed
 
-- **GitHub Action `compare` mode now forwards build/source evidence** — `sources`,
-  `build-info`, `compile-db`, `build-config`, and `depth` were previously only
-  wired to `dump`/`scan` mode in `action/run.sh`, so a `compare`-mode Action run
-  requesting `--depth build`/`source` evidence had no way to actually reach the
-  CLI's evidence flags. Now forwarded (scoped to the new/candidate side for
-  `sources`/`build-info`, matching `compare`'s own `new=`-prefixed syntax).
-- **GitHub Action `compare` mode no longer forwards `--depth`/`--sources`/
-  `--build-info` for directory or package operands** — the CLI's per-library
-  release fan-out rejects those three flags outright for that shape, so
-  every `check-target` `kind: bundle` check (or any other directory/package
-  `compare` invocation) with a baseline resolved would fail as a usage error
-  before comparing anything. `action/run.sh` now skips those three when
-  either operand is a directory/package. `--config` is not one of the
-  rejected flags and keeps being forwarded unconditionally (an intermediate
-  fix had incorrectly grouped it with the other three, silently dropping a
-  bundle caller's `build-config`).
-- **`actions/check-target` now rejects `target-kind: app-consumer`/
-  `plugin-contract` combined with `baseline-channel: none`** — that
-  combination routes the analysis step to `scan` (a single-build audit),
-  but `scan` has no `--used-by`/`--required-symbols` equivalent to scope the
-  contract check against, so the check previously ran as a plain unscoped
-  scan under the contract target's name and could pass without ever
-  checking the consumer/plugin contract it claimed to. `validate-inputs.sh`
-  now fails loud on this combination instead.
-- **`compare_report.schema.json` now accepts the operational-error/bootstrap
-  report envelopes it's supposed to always be able to produce** — the schema
-  required compare-specific fields (`library`, `old_file`, `summary`,
-  `changes`, ...) and restricted `verdict` to the five real `Verdict` values
-  unconditionally, so `actions/check-target`'s synthesized
-  `verdict: "ERROR"`/`"NO_BASELINE"` envelopes (and the pre-existing
-  per-library release fan-out's own `verdict: "ERROR"` shape) never actually
-  validated against the schema they declare via `report_schema_version`.
-  `verdict`'s enum now also allows `ERROR`/`NO_BASELINE`, and the
-  compare-specific fields are only required (via an `allOf`/`if`/`then`)
-  when `verdict` is one of the five real values.
-- **`actions/check-target` no longer falsely claims the compare-report schema
-  for scan or `kind: bundle` reports** — `augment_report` unconditionally
-  stamped `report_schema_version` (the *compare*-report schema's marker) onto
-  every report regardless of its actual shape, so a successful
-  `baseline-channel: none` scan report (its own `scan_schema_version`
-  shape) or a `kind: bundle` directory-compare report (the release
-  fan-out's `verdict`/`old_dir`/`new_dir`/`libraries` shape) would validate
-  as broken against `compare_report.schema.json`'s single-pair-compare
-  required fields. A scan report now only bumps its own
-  `scan_schema_version`; a bundle/release report gets neither marker (it has
-  never had a schema of its own).
-- **GitHub Action `compare` mode now fails loud instead of silently dropping
-  a build/source-depth evidence request against a directory or package
-  operand** — `--depth build`/`source`, or an explicit `--sources`/
-  `--build-info`/`--compile-db`, against a directory/package operand (e.g.
-  `check-target`'s `kind: bundle`) used to be silently skipped so the
-  comparison would still succeed, but at whatever shallower depth the CLI's
-  per-library release fan-out naturally reaches — a source-only break could
-  be missed while the check still reported a clean/normal result.
-  `action/run.sh` now exits with an error explaining why instead;
-  `actions/check-target`'s `validate-inputs.sh` additionally rejects
-  `kind: bundle` combined with `requested-depth: build`/`source` up front,
-  before `resolve-baseline`/`collect-facts` even run. `--depth binary`/
-  `headers` against a directory/package operand is unaffected (still
-  silently dropped, since nothing requested there is actually unservable).
-- **`actions/check-target`'s successful-report `publication` default no
-  longer falsely claims a job summary was posted** — `augment_report`
-  defaulted every successful report's `publication` to
-  `{"state": "published", "channels": ["job_summary"]}`, but check-target's
-  own nested analysis step always disables `add-job-summary`/`pr-comment`/
-  `upload-sarif`, and the finalize step only writes the report JSON to disk.
-  Nothing is actually published anywhere for a real check-target run, so a
-  downstream consumer reading `publication` could wrongly conclude the
-  report had been surfaced to a human. Defaults to
-  `{"state": "skipped", "channels": []}` now, matching the existing
-  operational-error/bootstrap sentinel envelopes.
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
 
+-->
 <!--
 ### Performance
 

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -17,8 +17,12 @@
   that evidence for a directory operand. A `baseline-channel: none` scan run
   that hits a guard (e.g. `--budget` exceeded) is treated as an operational
   error rather than a deferrable compatibility finding, so `gate-mode:
-  deferred`/`advisory` can't turn a guard failure into a quiet pass. See
-  `docs/reference/check-target.md`.
+  deferred`/`advisory` can't turn a guard failure into a quiet pass. A
+  bundle/directory compare's `--fail-on-removed-library` gate (a dedicated
+  exit code that overrides the persisted severity scheme rather than
+  feeding into it) is folded into the check's own gate decision too, so
+  `gate-mode: local` doesn't silently pass a removed library the caller
+  explicitly asked to gate on. See `docs/reference/check-target.md`.
 
 <!--
 ### Changed

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -92,6 +92,31 @@ it should read in CHANGELOG.md. Delete the other sections.
   required fields. A scan report now only bumps its own
   `scan_schema_version`; a bundle/release report gets neither marker (it has
   never had a schema of its own).
+- **GitHub Action `compare` mode now fails loud instead of silently dropping
+  a build/source-depth evidence request against a directory or package
+  operand** — `--depth build`/`source`, or an explicit `--sources`/
+  `--build-info`/`--compile-db`, against a directory/package operand (e.g.
+  `check-target`'s `kind: bundle`) used to be silently skipped so the
+  comparison would still succeed, but at whatever shallower depth the CLI's
+  per-library release fan-out naturally reaches — a source-only break could
+  be missed while the check still reported a clean/normal result.
+  `action/run.sh` now exits with an error explaining why instead;
+  `actions/check-target`'s `validate-inputs.sh` additionally rejects
+  `kind: bundle` combined with `requested-depth: build`/`source` up front,
+  before `resolve-baseline`/`collect-facts` even run. `--depth binary`/
+  `headers` against a directory/package operand is unaffected (still
+  silently dropped, since nothing requested there is actually unservable).
+- **`actions/check-target`'s successful-report `publication` default no
+  longer falsely claims a job summary was posted** — `augment_report`
+  defaulted every successful report's `publication` to
+  `{"state": "published", "channels": ["job_summary"]}`, but check-target's
+  own nested analysis step always disables `add-job-summary`/`pr-comment`/
+  `upload-sarif`, and the finalize step only writes the report JSON to disk.
+  Nothing is actually published anywhere for a real check-target run, so a
+  downstream consumer reading `publication` could wrongly conclude the
+  report had been surfaced to a human. Defaults to
+  `{"state": "skipped", "channels": []}` now, matching the existing
+  operational-error/bootstrap sentinel envelopes.
 
 <!--
 ### Performance

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -14,7 +14,11 @@
   scoping flag). `kind: bundle` compares a directory of member binaries and
   fails fast rather than silently degrading if `requested-depth: build`/`source`
   is asked of it, since the underlying per-library release engine can't collect
-  that evidence for a directory operand. See `docs/reference/check-target.md`.
+  that evidence for a directory operand. A `baseline-channel: none` scan run
+  that hits a guard (e.g. `--budget` exceeded) is treated as an operational
+  error rather than a deferrable compatibility finding, so `gate-mode:
+  deferred`/`advisory` can't turn a guard failure into a quiet pass. See
+  `docs/reference/check-target.md`.
 
 <!--
 ### Changed

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -1,0 +1,78 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Added
+
+- **`actions/check-target` composite Action** — composes `actions/resolve-baseline`,
+  `actions/collect-facts`, and the root Action into one resolved ABI/API check
+  (ADR-047 §4, G30 P1.3), always emitting the report-identity envelope (§7):
+  unconditional depth-suffixed `check_id`/`target_id`, the new
+  `compatibility_verdict`/`policy_gate_decision`/`check_evidence_coverage`/
+  `operational_errors`/`publication` fields alongside the legacy `verdict`/
+  `severity` fields `abicheck/aggregate.py` already parses. Supports
+  `gate-mode: local|deferred|advisory`, a `baseline-channel: none` single-build
+  audit bypass (no `resolve-baseline` call), and `target-kind: library|app-consumer|
+  plugin-contract` (`--used-by`/`--required-symbols` routing). See
+  `docs/reference/check-target.md`.
+
+<!--
+### Changed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Deprecated
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Removed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Fixed
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Performance
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Security
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->
+<!--
+### Documentation
+
+- **Short bold summary** — the rest of the sentence: what changed, for
+  whom, and why it matters. Backtick identifiers like `ChangeKind` or
+  `--policy-file`.
+
+-->

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -22,7 +22,10 @@
   exit code that overrides the persisted severity scheme rather than
   feeding into it) is folded into the check's own gate decision too, so
   `gate-mode: local` doesn't silently pass a removed library the caller
-  explicitly asked to gate on. See `docs/reference/check-target.md`.
+  explicitly asked to gate on — and the persisted `severity` block is
+  escalated to the `abi_breaking` tier for it too, so `gate-mode: deferred`'s
+  later `aggregate` read (which only ever looks at `severity.exit_code`)
+  can't miss it either. See `docs/reference/check-target.md`.
 
 <!--
 ### Changed

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -44,14 +44,15 @@ it should read in CHANGELOG.md. Delete the other sections.
   `--policy-file`.
 
 -->
-<!--
 ### Fixed
 
-- **Short bold summary** — the rest of the sentence: what changed, for
-  whom, and why it matters. Backtick identifiers like `ChangeKind` or
-  `--policy-file`.
+- **GitHub Action `compare` mode now forwards build/source evidence** — `sources`,
+  `build-info`, `compile-db`, `build-config`, and `depth` were previously only
+  wired to `dump`/`scan` mode in `action/run.sh`, so a `compare`-mode Action run
+  requesting `--depth build`/`source` evidence had no way to actually reach the
+  CLI's evidence flags. Now forwarded (scoped to the new/candidate side for
+  `sources`/`build-info`, matching `compare`'s own `new=`-prefixed syntax).
 
--->
 <!--
 ### Performance
 

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -28,7 +28,11 @@
   can't miss it either. `profile` is validated as required up front (GitHub
   Actions doesn't actually enforce `required: true` for composite-action
   inputs), instead of only failing deep inside a later step with no report
-  produced. See `docs/reference/check-target.md`.
+  produced. The internal per-invocation analysis output is now cleared
+  before every analysis attempt, so a job that runs `check-target` more
+  than once can't have a later invocation's crashed analysis silently pick
+  up an earlier invocation's stale report file. See
+  `docs/reference/check-target.md`.
 
 <!--
 ### Changed

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -53,12 +53,34 @@ it should read in CHANGELOG.md. Delete the other sections.
   CLI's evidence flags. Now forwarded (scoped to the new/candidate side for
   `sources`/`build-info`, matching `compare`'s own `new=`-prefixed syntax).
 - **GitHub Action `compare` mode no longer forwards `--depth`/`--sources`/
-  `--build-info`/`--config` for directory or package operands** — the CLI's
-  per-library release fan-out rejects those flags outright for that shape, so
+  `--build-info` for directory or package operands** — the CLI's per-library
+  release fan-out rejects those three flags outright for that shape, so
   every `check-target` `kind: bundle` check (or any other directory/package
   `compare` invocation) with a baseline resolved would fail as a usage error
-  before comparing anything. `action/run.sh` now skips that flag block when
-  either operand is a directory/package.
+  before comparing anything. `action/run.sh` now skips those three when
+  either operand is a directory/package. `--config` is not one of the
+  rejected flags and keeps being forwarded unconditionally (an intermediate
+  fix had incorrectly grouped it with the other three, silently dropping a
+  bundle caller's `build-config`).
+- **`actions/check-target` now rejects `target-kind: app-consumer`/
+  `plugin-contract` combined with `baseline-channel: none`** — that
+  combination routes the analysis step to `scan` (a single-build audit),
+  but `scan` has no `--used-by`/`--required-symbols` equivalent to scope the
+  contract check against, so the check previously ran as a plain unscoped
+  scan under the contract target's name and could pass without ever
+  checking the consumer/plugin contract it claimed to. `validate-inputs.sh`
+  now fails loud on this combination instead.
+- **`compare_report.schema.json` now accepts the operational-error/bootstrap
+  report envelopes it's supposed to always be able to produce** — the schema
+  required compare-specific fields (`library`, `old_file`, `summary`,
+  `changes`, ...) and restricted `verdict` to the five real `Verdict` values
+  unconditionally, so `actions/check-target`'s synthesized
+  `verdict: "ERROR"`/`"NO_BASELINE"` envelopes (and the pre-existing
+  per-library release fan-out's own `verdict: "ERROR"` shape) never actually
+  validated against the schema they declare via `report_schema_version`.
+  `verdict`'s enum now also allows `ERROR`/`NO_BASELINE`, and the
+  compare-specific fields are only required (via an `allOf`/`if`/`then`)
+  when `verdict` is one of the five real values.
 
 <!--
 ### Performance

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -52,6 +52,13 @@ it should read in CHANGELOG.md. Delete the other sections.
   requesting `--depth build`/`source` evidence had no way to actually reach the
   CLI's evidence flags. Now forwarded (scoped to the new/candidate side for
   `sources`/`build-info`, matching `compare`'s own `new=`-prefixed syntax).
+- **GitHub Action `compare` mode no longer forwards `--depth`/`--sources`/
+  `--build-info`/`--config` for directory or package operands** — the CLI's
+  per-library release fan-out rejects those flags outright for that shape, so
+  every `check-target` `kind: bundle` check (or any other directory/package
+  `compare` invocation) with a baseline resolved would fail as a usage error
+  before comparing anything. `action/run.sh` now skips that flag block when
+  either operand is a directory/package.
 
 <!--
 ### Performance

--- a/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
+++ b/changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md
@@ -25,7 +25,10 @@
   explicitly asked to gate on — and the persisted `severity` block is
   escalated to the `abi_breaking` tier for it too, so `gate-mode: deferred`'s
   later `aggregate` read (which only ever looks at `severity.exit_code`)
-  can't miss it either. See `docs/reference/check-target.md`.
+  can't miss it either. `profile` is validated as required up front (GitHub
+  Actions doesn't actually enforce `required: true` for composite-action
+  inputs), instead of only failing deep inside a later step with no report
+  produced. See `docs/reference/check-target.md`.
 
 <!--
 ### Changed

--- a/changelog.d/20260723_013500_noreply_g30_implementation_t5o3or_action_compare_evidence.md
+++ b/changelog.d/20260723_013500_noreply_g30_implementation_t5o3or_action_compare_evidence.md
@@ -14,3 +14,10 @@
   shallower comparison and reporting a clean result while a source-only
   break could have been missed; `--config` is unaffected and always
   forwarded, since the release fan-out does consume it.
+- **GitHub Action `compare`/`scan` modes now forward cross-compiler flags**
+  — `gcc-path`, `gcc-prefix`, `gcc-options`, and `sysroot` were already
+  documented root-Action inputs but were previously only wired to `dump`
+  mode in `action/run.sh`; a `compare`/`scan` run against a cross-target
+  library silently fell back to the host toolchain/includes for header
+  parsing, which can produce false ABI results. Now forwarded in both
+  modes.

--- a/changelog.d/20260723_013500_noreply_g30_implementation_t5o3or_action_compare_evidence.md
+++ b/changelog.d/20260723_013500_noreply_g30_implementation_t5o3or_action_compare_evidence.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **GitHub Action `compare` mode now forwards build/source evidence, and
+  fails loud instead of silently dropping an unservable request** — `sources`,
+  `build-info`, `compile-db`, `build-config`, and `depth` were already
+  documented root-Action inputs but were previously only wired to `dump`/
+  `scan` mode in `action/run.sh`, so a `compare`-mode Action run requesting
+  `--depth build`/`source` evidence had no way to actually reach the CLI's
+  evidence flags. Now forwarded (scoped to the new/candidate side for
+  `sources`/`build-info`, matching `compare`'s own `new=`-prefixed syntax).
+  For a directory or package operand (the CLI's per-library release
+  fan-out), `--sources`/`--build-info`/`--depth` are not supported at all —
+  the Action now fails with an explicit error instead of silently running a
+  shallower comparison and reporting a clean result while a source-only
+  break could have been missed; `--config` is unaffected and always
+  forwarded, since the release fan-out does consume it.

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -840,6 +840,31 @@ one follow-up commit:
   shape) now validate. `docs/schemas/v1/compare_report.schema.json`
   re-synced via `scripts/publish_schemas.py`.
 
+The same review round separately caught that the schema fix above didn't
+cover every report shape `augment_report` can receive: a successful
+`baseline-channel: none` scan report (its own `scan_schema_version` shape --
+`level`/`risk`/`coverage`/... , no `library`/`old_file`/`summary`/`changes`)
+or a `kind: bundle` directory-compare report (the per-library release
+fan-out's own summary shape -- `verdict`/`old_dir`/`new_dir`/`libraries`,
+also no singular `library`/`old_file`/`summary`/`changes`) still got
+`report_schema_version` stamped onto them unconditionally, same as a normal
+single-pair compare report. Confirmed by reading `scan_engine.py`'s report
+dict and `cli_compare_release_helpers.py`'s `_format_release_json` by hand
+— neither shape has ever had a schema, let alone this one. A downstream
+validator selecting a schema by `report_schema_version`'s presence would
+pick `compare_report.schema.json` for either shape and reject it against
+that schema's real-verdict branch. Fixed in `augment_report`: a report
+carrying `scan_schema_version` gets that field bumped to the current
+`SCAN_SCHEMA_VERSION` instead of also gaining `report_schema_version`; a
+report shaped like the release fan-out's summary (`libraries` + `old_dir`
+present) gets neither schema marker, since that shape has never had one to
+claim. ADR-047 §7's identity/policy-gate-decision fields (`check_id`,
+`policy_gate_decision`, etc.) are unaffected either way — only the schema
+marker choice is shape-aware now. New
+`test_scan_report_gets_scan_schema_version_not_report_schema_version` /
+`test_bundle_release_report_gets_no_schema_version_stamp` cases in
+`tests/test_check_report.py`.
+
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 
 Implements ADR-047 §4/§5 (`run-plan.json` generation + matrix + trailing

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -834,10 +834,18 @@ one follow-up commit:
   when `verdict` is one of the five real values, and `verdict`'s enum grew
   `ERROR`/`NO_BASELINE` (additive, consistent with the existing
   `report_schema_version` MINOR-bump convention for new enum members).
-  Verified against all four shapes by hand: a full compare report validates
-  and still rejects a truncated one, and both sentinel envelopes (plus the
-  minimal pre-existing release-fan-out `{library, verdict: "ERROR", error}`
-  shape) now validate. `docs/schemas/v1/compare_report.schema.json`
+  Verified by hand: a full compare report validates and still rejects a
+  truncated one, and both sentinel envelopes validate once `augment_report`
+  has stamped `report_schema_version` onto them. The pre-existing per-
+  library release-fan-out's own minimal `{library, verdict: "ERROR",
+  error}` entry (`cli_compare_release.py`, not new to this task) does
+  **not** validate on its own -- it never carries `report_schema_version`
+  at all, and this schema's `required` still demands that field
+  unconditionally regardless of `verdict`. That's fine: it's a per-library
+  entry inside the release fan-out's own `libraries` list, never a
+  `compare_report.schema.json` document in its own right, and (per the
+  next round below) the fan-out's top-level summary is deliberately never
+  stamped with this schema's marker either. `docs/schemas/v1/compare_report.schema.json`
   re-synced via `scripts/publish_schemas.py`.
 
 The same review round separately caught that the schema fix above didn't
@@ -1127,6 +1135,106 @@ precedent for the same kind of `action.yml`-only fix. New
 in `tests/test_action_check_target.py` asserts the cleanup step exists,
 is unconditional (no `if:`), sits immediately before "Run analysis", and
 targets the same filename the analysis step's `output-file` writes.
+
+A tenth round of Codex review then caught a related but distinct evidence-
+forwarding gap: `actions/collect-facts`'s replay phase defaults an unset
+`sources` input to `.` internally (confirmed by reading its `run.sh`:
+`SOURCES="${INPUT_SOURCES:-.}"`), but that resolved value is never
+surfaced as an output — the phase only prints a notice telling the caller
+to "pass `sources: $SOURCES` directly to dump/scan/compare". check-target's
+"Run analysis" step was instead forwarding the raw, still-empty
+`inputs.sources` straight through, and `action/run.sh`'s `add_single_flag`
+helper (confirmed by reading it) omits `--sources` entirely for an empty
+value. The net effect: an `evidence-producer: replay` check that leaves
+`sources:` unset — a supported, documented configuration, since replay's
+whole point is "a bare `sources:` pointer, no build step needed" — would
+pass the collect-facts step cleanly and then silently run `compare`/`scan`
+with zero source evidence, missing any source-only finding at
+`requested-depth: build`/`source` without any error or warning. Fixed by
+changing the analysis step's `sources:` forward from a bare
+`${{ inputs.sources }}` to
+`${{ inputs.sources != '' && inputs.sources || (inputs.evidence-producer
+== 'replay' && '.' || '') }}`, mirroring collect-facts' own default
+exactly for the one producer where an empty `sources` is meaningful and
+expected; wrapper/clang-plugin/no-producer checks are unaffected since
+they route source evidence through `build-info`, not `sources`, so the
+fallback only ever fires for `evidence-producer: replay`. New
+`TestReplaySourcesForwardedWithDefault` in
+`tests/test_action_check_target.py`: one test pins the exact expression
+string against the parsed YAML (so an accidental edit back to a bare
+forward fails loud), and two more independently exercise a pure-Python
+mirror of the ternary's actual selection semantics (empty `sources`
+resolves to `.` only for `replay`; any explicit `sources` value always
+wins) — the same structural-plus-semantic pairing used for the report-path
+scoping fix's `test_action_yml_format_input_has_no_static_default`-style
+precedent, since `action.yml`'s own step orchestration still needs a real
+GitHub Actions runner to exercise end-to-end.
+
+CodeRabbit's first full review pass on the PR then raised three findings.
+First, `validate-inputs.sh`'s `baseline-channel`/`requested-depth` inputs
+(both `required: true`) were still using the bare `:?` parameter-expansion
+pattern the `profile` fix above replaced — `:?` does fire on an empty
+value, but exits 1 with a raw bash stderr message and no `::error::`
+annotation, diverging from the exit-64 `_fail` convention every other
+required-input check here uses. Fixed by converting both to the same
+`-z`/`_fail` pattern as `name`/`profile`. Doing so exposed a real ordering
+bug the mechanical conversion would otherwise have introduced silently:
+`requested-depth` already has a `case` statement validating it against
+`binary`/`headers`/`build`/`source`, and that case statement ran *before*
+where the new required-check would have been added — an empty value never
+matches any case pattern, so it would have been caught there first with
+the vaguer "requested-depth '' is not recognized" message, making the new
+"requested-depth input is required" check dead code. Fixed by moving all
+four required-input checks (`name`, `profile`, `baseline-channel`,
+`requested-depth`) to run as a block before any of the enum/case
+validations, restoring the same "required check fires before the enum
+check" ordering the original `:?` expansions had for free (parameter
+expansion runs at variable-assignment time, before any of the script's
+`case` statements). New
+`test_missing_baseline_channel_fails_with_required_message`/
+`test_missing_requested_depth_fails_with_required_message_not_enum_message`
+in `tests/test_action_check_target.py` — the second one asserts
+`"not recognized" not in result.stdout` specifically to pin the ordering,
+not just the exit code.
+
+Second, `docs/reference/check-target.md`'s "always emits the report
+envelope... regardless of whether the baseline resolved... or failed
+outright" claim (twice, in the intro and in the "What it does" numbered
+list) didn't account for the `profile`-required fix two rounds above:
+an invalid invocation (missing `name`/`profile`/`baseline-channel`/
+`requested-depth`, or any of `validate-inputs.sh`'s other rejected
+combinations) is now rejected by the very first step, before
+`report_envelope.py` ever runs, producing no report or outputs at all.
+Reworded both spots to qualify the guarantee as applying once input
+validation has passed, and `changelog.d/20260722_232114_noreply_g30_implementation_t5o3or.md`'s
+matching "always emitting" phrase similarly.
+
+Third, and most substantively: `docs/reference/check-target.md`'s Report
+envelope section described the starting shape check-target's own analysis
+step produces as unconditionally `abicheck/reporter.py`'s compare-report
+shape (`report_schema_version: "2.13"`) — but by the time of this round,
+the scan/bundle shape-awareness fix (several rounds above) had already
+made clear that's only true for a normal single-library `compare`; a
+`baseline-channel: none` audit starts from a `scan_schema_version` shape
+and a `kind: bundle` check starts from the CLI's per-library release
+fan-out summary, neither of which carries `report_schema_version` at all.
+Reworded to name all three starting shapes explicitly instead of
+implying one shape covers every case. The same finding also flagged a
+factually incorrect claim in this plan document itself, in the schema-fix
+round's own "verified against all four shapes by hand" sentence: it
+claimed the pre-existing per-library release-fan-out's minimal
+`{library, verdict: "ERROR", error}` entry "now validates" against
+`compare_report.schema.json`. Re-verified by hand with `jsonschema.validate`
+against the actual schema: it does **not** — that minimal dict never
+carries `report_schema_version`, and the schema's top-level `required`
+demands that field unconditionally, independent of the `verdict`-gated
+`allOf`/`if`/`then` branch. The claim was never actually exercised by any
+test; corrected the sentence to say so, and noted that this is harmless in
+practice since that dict is a per-library entry inside the fan-out's own
+`libraries` list, never validated as a `compare_report.schema.json`
+document in its own right — the fan-out's actual top-level summary is the
+`libraries`/`old_dir` shape the later round already documented as never
+receiving this schema's marker.
 
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -664,6 +664,35 @@ implementation (PR #625), not anticipated above:**
   where both are empty) without a conditional branch — `uses:` cannot itself
   be an expression, so the checkout step had to be unconditional instead.
 
+**A third bug, in the fix for the second one above, caught by the real CI
+run of the new `test-check-target` fixture (job 89082423642) rather than by
+review or local testing — the self-checkout step read back its own
+identity, not check-target's.** `github.action_repository`/`github.
+action_ref` describe whichever action is *about to run* — the runner
+updates them while preparing each step, including composite-nested ones,
+**before** evaluating that same step's own `with:` expressions. The
+`Checkout abicheck (for nested Action composition)` step's own `with:`
+block read `${{ github.action_repository || github.repository }}`/`${{
+github.action_ref || github.sha }}` directly — but by the time those
+expressions were evaluated, the context had already flipped to describe
+*that step's own target*, `actions/checkout@v6`. The real CI run confirmed
+this exactly: the step's resolved `with:` logged `repository:
+actions/checkout` / `ref: v6`, checking out the wrong repository entirely
+and leaving `.abicheck-check-target-src/actions/resolve-baseline` empty —
+`Resolve baseline` then failed with "Can't find 'action.yml' ... Did you
+forget to run actions/checkout". **Fixed** by adding a `Capture this
+Action's identity` step (`id: identity`, a plain `run:` step, the first
+thing `check-target` does) that reads `github.action_repository`/`github.
+action_ref` into `$GITHUB_OUTPUT` before any nested `uses:` step has a
+chance to overwrite them, and pointing the checkout step's `with:` at `${{
+steps.identity.outputs.repository }}`/`${{ steps.identity.outputs.ref }}`
+instead of reading the raw context directly. The `action-version` input's
+default (evaluated once, before any of check-target's own steps run —
+a different, earlier timing than the checkout step's `with:`, so it was
+never affected by this specific bug) gained the same `||` fallback for
+consistency, so a local same-repo test run reports a real identity instead
+of an empty `"@"`.
+
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 
 Implements ADR-047 §4/§5 (`run-plan.json` generation + matrix + trailing

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -1031,6 +1031,45 @@ follow-up commit:
   `run.sh` end-to-end against a fake `abicheck` stub to prove the flags
   reach the actual command line.
 
+Codex's second pass on the same PR then pushed back on the removed-library
+fix above being incomplete: escalating `policy_gate_decision`/the local
+exit code isn't enough on its own, because `gate-mode: deferred` relies on
+`check-project.yml`'s trailing `aggregate` job, and
+`abicheck.aggregate.GateInfo.from_report_data` reads **only** the persisted
+`severity.exit_code` — it has no way to see `policy_gate_decision` or the
+analysis step's raw exit code at all (confirmed by reading
+`from_report_data` directly). Without also updating the persisted
+`severity` block, a removed-library gate on a `deferred` bundle check would
+still be silently missed by a later `aggregate` pass, even though the
+check's own composite exit code was already correct. Fixed properly this
+time: when `analysis_exit_code == 8` (the specific, well-known
+`--fail-on-removed-library` sentinel — confirmed by reading
+`_exit_compare_release`'s full body that it's the *only* value that
+diverges from `severity_exit_code` in the severity-aware scheme check-target
+always uses), `augment_report` now also escalates the persisted
+`severity` block itself: `exit_code` → 4, `blocking` → `True`,
+`"abi_breaking"` added to `blocking_categories` (a whole library
+disappearing is unambiguously an ABI break) — landing on 4 specifically
+because it's the ceiling of `aggregate.py`'s own `_VALID_GATE_EXIT = {0, 1,
+2, 4}`; writing the literal `8` there would make `aggregate.py`'s strict,
+fail-closed `from_report_data` raise `_MalformedGate` instead of silently
+missing the gate, which is arguably worse (it would crash the *entire*
+aggregate computation, not just misjudge one target). The escalation only
+ever raises an already-`< 4` severity block, never downgrades one already
+at the ceiling, and is a no-op when no `severity` block exists at all (a
+scan-shaped report — exit 8 only ever comes from the release/bundle
+compare path in the first place, but the check stays defensive). New
+`test_removed_library_exit_code_escalates_persisted_severity`/
+`test_removed_library_escalation_does_not_downgrade_an_already_worse_severity`/
+`test_removed_library_escalation_only_triggers_on_exit_code_8`/
+`test_removed_library_escalation_is_a_no_op_without_a_severity_block` in
+`tests/test_check_report.py`; a real end-to-end proof
+(`test_removed_library_gate_survives_deferred_mode_for_a_real_aggregate_read`
+in `tests/test_action_check_target.py`) feeds the persisted report straight
+into the actual `abicheck.aggregate.GateInfo.from_report_data` for
+`gate-mode: deferred` and asserts it reads a blocking gate — not just that
+the shell/Python logic looks right on paper.
+
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 
 Implements ADR-047 §4/§5 (`run-plan.json` generation + matrix + trailing

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -693,6 +693,77 @@ never affected by this specific bug) gained the same `||` fallback for
 consistency, so a local same-repo test run reports a real identity instead
 of an empty `"@"`.
 
+**A fourth, fifth, and sixth real bug, all caught by a second Codex review
+round, all fixed:**
+
+- **The root `action.yml`'s `compare` mode branch never forwarded
+  `sources`/`build-info`/`compile-db`/`build-config`/`depth` at all** —
+  confirmed by grepping `action/run.sh`: those five inputs were only wired
+  in the `dump`/`scan` branches (`action.yml`'s own input descriptions said
+  "Used by scan and dump modes," which was accurate but incomplete —
+  `compare` genuinely supports `--sources`/`--build-info`/`--depth`/
+  `--config` directly, confirmed via `abicheck compare --help`). This meant
+  a `check-target` build/source-depth check against a real baseline (the
+  normal, non-audit `compare`-mode path) had no way to actually reach the
+  CLI's evidence flags — `requested-depth: source` would silently only ever
+  achieve `headers`, regardless of what `sources`/`build-info` were set to.
+  Fixed by adding the missing forwarding to `action/run.sh`'s `compare`
+  branch, scoped to the **new (candidate) side only**
+  (`--sources new=...`/`--build-info new=...`, falling back to `compile-db`
+  when `build-info` is unset, matching `dump` mode's own fallback) — the old
+  side's evidence, if any, is expected to already be embedded in whatever
+  baseline snapshot was resolved; this Action has no live old-side source
+  tree to point at in `compare` mode. `action.yml`'s five input descriptions
+  updated to document the new `compare`-mode support. This is a general fix
+  to the root Action, benefiting any direct `compare`-mode caller wanting
+  build/source-depth evidence, not `check-target`-specific.
+- **A collect-facts verify/replay failure was never checked before running
+  analysis** — `collect_verify`/`collect_replay` run with
+  `continue-on-error: true` (correctly, so the finalize step always runs),
+  but the `Run analysis` step's own `if:` only checked
+  `resolve.outcome == 'resolved'`, never `collect_verify`/`collect_replay`'s
+  outcome — so a broken/empty wrapper or clang-plugin pack (a real
+  `collect-facts phase: verify` failure) would still be handed to `compare`
+  as `--build-info`, silently running the comparison against invalid
+  evidence and reporting a plain degraded-or-normal result instead of the
+  operational error it actually is. Fixed by adding
+  `steps.collect_verify.outcome != 'failure' && steps.collect_replay.outcome
+  != 'failure'` to the analysis step's `if:`, and giving `run.sh`'s finalize
+  logic two new, specific `operational-error` branches (ahead of the
+  generic "analysis produced no report" catch-all) so the resulting report
+  names collection failure specifically, not an ambiguous unexplained gap.
+- **`validate-inputs.sh` never validated `evidence-producer`** — every other
+  enum-like input (`kind`/`target-kind`/`gate-mode`/`requested-depth`) is
+  checked up front, but a misspelled `evidence-producer` value would just
+  silently fall through the `case` statement composing `collect-facts`
+  (neither `wrapper`/`clang-plugin`/`replay` branch matches), skipping fact
+  collection entirely with no error — a build/source-depth check would then
+  silently run at whatever depth the analysis naturally reached, never
+  telling the caller their typo was ignored. Fixed by adding the same
+  `case` validation for `evidence-producer`
+  (`''`/`wrapper`/`clang-plugin`/`replay`) as every other enum input already
+  has.
+
+Also, separately: the two synthesized envelope builders
+(`build_operational_error_report`/`build_bootstrap_report`) wrote
+`compatibility_verdict: null` — schema-invalid, since the schema declares
+that field a plain string enum with no null alternative (Codex review,
+third round). Fixed by omitting the key entirely for those two cases
+instead (matching how `augment_report` already only sets it when there's a
+real value) — the broader "these two envelope shapes don't satisfy compare's
+full `required` field list either" question Codex also raised is real but
+out of scope here, matching the same precedent ADR-047 §7 already
+established for the pre-existing `verdict: "ERROR"` enum gap (a known,
+accepted limitation of the sentinel-envelope pattern, not something this
+task resolves).
+
+`tests/test_action_run_sh_compare_build_source.py` (new) runs the real
+`action/run.sh` end-to-end against a fake `abicheck` stub on `$PATH` to
+prove the evidence-forwarding fix reaches the actual command line, not just
+that the shell logic looks right on paper; `tests/test_action_check_target.py`
+gained cases for both new collect-facts-failure branches and the
+`evidence-producer` validation.
+
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 
 Implements ADR-047 §4/§5 (`run-plan.json` generation + matrix + trailing

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -909,6 +909,63 @@ A sixth review round on the same commit caught two more real issues:
   `test_publication_defaults_to_skipped_not_a_false_claim` case in
   `tests/test_check_report.py`.
 
+A sixth round of Codex review caught two more issues, both fixed in one
+follow-up commit: the fixed report filename risked collisions across
+multiple `check-target` invocations in the same job, and `augment_report`'s
+operational-error classification missed scan guard sentinels.
+
+- **A fixed `check-target-report.json` filename collides across multiple
+  `check-target` invocations in the same job** — e.g. the same target
+  checked against two baseline channels, or several targets checked without
+  per-step output directories. Each call overwrote the previous one's
+  report file, so an earlier step's own `report-path` output would end up
+  pointing at a *later* check's envelope by the time anything read it.
+  Fixed: the filename is now scoped to
+  `check-target-report-<name>-<profile>-<baseline_channel>-<requested_depth>.json`,
+  sanitized via `tr -c 'A-Za-z0-9._-' '_'` (a slug helper) so an
+  unsanitized identifier component can't affect the filesystem path
+  regardless of when Python-side identifier validation runs. Deriving the
+  name from the check's own already-unique identity components was chosen
+  over adding a new caller-specified output path input, since no caller
+  input was actually needed. New
+  `test_two_invocations_in_the_same_job_do_not_overwrite_each_others_report`
+  in `tests/test_action_check_target.py` runs two finalize calls against
+  the same `tmp_path` and asserts both report files survive with distinct
+  content. `docs/reference/check-target.md` updated to document the
+  filename pattern and point at the `report-path` output instead of
+  hard-coding the old name. (Mechanically, every test hard-coding the old
+  filename was switched to read `outputs["report-path"]` instead, since the
+  filename is no longer predictable from the identity fixture alone.)
+- **`augment_report`'s operational-error classification only checked
+  `verdict == "ERROR"`, missing scan guard sentinels** — a
+  `baseline-channel: none` scan run that exceeds `--budget` (or hits
+  `service_scan.py`'s other guard, `EVIDENCE_CONTRACT_ERROR`) gets
+  `verdict: "BUDGET_OVERFLOW"`/`"EVIDENCE_CONTRACT_ERROR"` and a nonzero
+  `exit_code`, and the root Action's own `run.sh` already treats
+  `BUDGET_OVERFLOW` as an always-failing guard (never gated by a
+  `fail-on-*` flag, unlike `BREAKING`/`API_BREAK`) — confirmed by grepping
+  `action/run.sh`. But neither of these verdict strings is `"ERROR"` or one
+  of the five real `Verdict` values, so the old classifier fell through to
+  the "else: leave `operational_errors` empty" branch, and
+  `report_envelope.py`'s own `operational_error = report.get("verdict") ==
+  "ERROR"` check missed it too — meaning `gate-mode: deferred`/`advisory`
+  would return exit `0` for a scan that never actually completed its
+  comparison, silently turning an infrastructure guard trip into a green
+  check, in direct contradiction of `final_exit_code`'s own documented rule
+  that "deferred only defers the *compatibility* verdict's effect on exit
+  code, never operational errors." Fixed: `augment_report` now treats *any*
+  verdict outside the five real `Verdict` values (not just the literal
+  `"ERROR"`) as operational, populating `operational_errors` with a new
+  `"scan_guard_triggered"` kind for the non-`"ERROR"` case;
+  `report_envelope.py` now derives its own `operational_error` flag by
+  reusing `augment_report`'s already-computed `operational_errors` list
+  rather than re-deriving it from `verdict` a second, narrower way. New
+  `test_scan_guard_sentinel_verdicts_are_operational_errors` (parametrized
+  over both guard strings) in `tests/test_check_report.py`, and
+  `TestFinalizeScanGuardSentinel::test_budget_overflow_always_fails_regardless_of_gate_mode`
+  (parametrized over all three `gate-mode` values) in
+  `tests/test_action_check_target.py`.
+
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 
 Implements ADR-047 §4/§5 (`run-plan.json` generation + matrix + trailing

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -966,6 +966,71 @@ operational-error classification missed scan guard sentinels.
   (parametrized over all three `gate-mode` values) in
   `tests/test_action_check_target.py`.
 
+A seventh round of Codex review caught two more issues, both fixed in one
+follow-up commit:
+
+- **A removed-library gate on a bundle/directory compare could silently
+  pass `gate-mode: local`** — `abicheck compare`'s per-library release
+  engine gives `--fail-on-removed-library` its own dedicated exit code (8),
+  applied "in preference to the severity code"
+  (`cli_compare_release_helpers._exit_compare_release`'s own docstring) —
+  meaning the persisted JSON report's `severity.exit_code` can read `0`
+  (e.g. `verdict: COMPATIBLE_WITH_RISK`, the removal only shows up in
+  `unmatched_old`) even though the real CLI process exited 8. Since
+  `augment_report`'s `real_exit_code` was computed purely from the report
+  body, and `report_envelope.py`'s own `real_exit_code` variable did the
+  same, `gate-mode: local` would read `real_exit_code: 0` and both the
+  composite job exit code and the persisted `policy_gate_decision` would
+  read as a clean pass — silently allowing a removed library the caller
+  explicitly asked to gate on. Confirmed by reading
+  `_exit_compare_release`'s docstring and code directly. Fixed: the nested
+  root Action's own real `exit-code` output is now captured
+  (`actions/check-target/action.yml`'s finalize step gains
+  `ANALYSIS_EXIT_CODE: ${{ steps.analysis.outputs.exit-code }}`), forwarded
+  through `run.sh` (defensively defaulted to 0 for anything not a clean
+  non-negative integer) and `report_envelope.py`'s new
+  `--analysis-exit-code` flag, and folded into `augment_report`'s
+  `real_exit_code` via `max()` alongside whatever the report body itself
+  says — the same precedence pattern `_exit_compare_release` already uses
+  internally. `report_envelope.py`'s own `real_exit_code` (used for
+  `final_exit_code()`) applies the identical fold, so the persisted
+  `policy_gate_decision` field and the actual composite exit code agree.
+  Scoped deliberately to `gate-mode: local`'s correctness, the most severe
+  form of the bug (the job silently passed outright); `gate-mode: deferred`
+  still defers to `check-project.yml`'s trailing `aggregate` job, and
+  `abicheck/aggregate.py`'s own `GateInfo.from_report_data` reads only the
+  persisted `severity.exit_code` (unaffected by this fix, since that field
+  is deliberately left untouched — only the gate *decision* folds in the
+  analysis exit code, not the persisted severity block itself) — so a
+  removed-library gate on a `deferred` bundle check can still be missed by
+  a later `aggregate` pass; that gap is in `aggregate.py` itself, predates
+  this task, and applies to any consumer of `compare`'s bundle JSON output
+  relying on `severity.exit_code` alone, not something check-target
+  introduced or is positioned to fix on its own. New
+  `test_analysis_exit_code_overrides_a_clean_severity_block`/
+  `test_analysis_exit_code_of_zero_does_not_flip_a_clean_report` in
+  `tests/test_check_report.py`, and
+  `test_analysis_exit_code_folds_into_local_gate_even_with_clean_severity`
+  (full `run.sh` + `report_envelope.py` integration) in
+  `tests/test_action_check_target.py`.
+- **`compare`/`scan` modes never forwarded cross-compiler flags** —
+  `--gcc-path`/`--gcc-prefix`/`--gcc-options`/`--sysroot` are documented
+  root-Action inputs and `abicheck compare --help-all`/`abicheck scan
+  --help` both expose the equivalent CLI flags, but `action/run.sh` only
+  ever wired them into `dump` mode's branch — confirmed by grepping the
+  file. A `check-target` compare/scan needing a cross compiler or sysroot
+  to parse headers correctly would silently fall back to the host
+  toolchain/includes and could produce false ABI results for cross-target
+  libraries. Fixed by adding the same four `add_single_flag` calls to both
+  the `compare` and `scan` branches (check-target's own `action.yml`
+  already forwarded these inputs to the nested root Action's `with:` block
+  — the gap was entirely inside `action/run.sh`). New
+  `TestCompareModeForwardsCrossCompilerFlags`/
+  `TestScanModeForwardsCrossCompilerFlags` classes in
+  `tests/test_action_run_sh_compare_build_source.py`, each running the real
+  `run.sh` end-to-end against a fake `abicheck` stub to prove the flags
+  reach the actual command line.
+
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 
 Implements ADR-047 §4/§5 (`run-plan.json` generation + matrix + trailing

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -790,6 +790,56 @@ same directory/package shape) — checked against both `old-library` and
 flags are omitted when either operand is a directory, even when the
 corresponding evidence inputs are set.
 
+A fifth round of Codex review then caught three more issues, all fixed in
+one follow-up commit:
+
+- **The directory/package guard above over-suppressed `--config` too** —
+  `--config` is not one of the flags `_reject_evidence_flags_for_set_inputs`
+  actually rejects (`_EVIDENCE_SET_INPUT_FLAGS` lists only `depth`/`sources`/
+  `build_info`); the release fan-out still consumes the project
+  `.abicheck.yml` for severity/scope/suppression/exit-code settings
+  (`_resolve_compare_config` runs before the directory/package dispatch), so
+  a bundle caller's `build-config` was being silently dropped. Fixed by
+  pulling `--config` out of the release-style-operand guard entirely — it
+  now always reaches the CLI, matching every other compare mode.
+- **`target-kind: app-consumer`/`plugin-contract` combined with
+  `baseline-channel: none` silently ran an unscoped audit** —
+  `baseline-channel: none` routes the analysis step to `scan`, but `scan`
+  has no `--used-by`/`--required-symbols` equivalent at all (confirmed via
+  `abicheck scan --help`); those flags only exist in the `compare` branch of
+  `action/run.sh`. A contract check with no baseline therefore ran as a
+  plain unscoped scan under the contract target's name and could pass
+  without ever checking the consumer/plugin contract it claimed to. Fixed
+  by rejecting the combination up front in `validate-inputs.sh` — there is
+  no way to honor a contract scope without a two-sided comparison, so
+  failing loud (rather than trying to thread `--used-by`/`--required-symbols`
+  through a mode that structurally can't use them) is the correct fix.
+- **The operational-error/bootstrap sentinel envelopes still didn't validate
+  against `compare_report.schema.json`** — the earlier `compatibility_verdict:
+  null` fix (third review round, above) only addressed one field; the schema
+  unconditionally required compare-specific fields (`library`, `old_file`,
+  `summary`, `changes`, `policy`, `suppression`, `detectors`, `confidence`,
+  `evidence_tier`, `evidence_tiers`, ...) and restricted `verdict` to the
+  five real `Verdict` values, so `build_operational_error_report`/
+  `build_bootstrap_report`'s `verdict: "ERROR"`/`"NO_BASELINE"` envelopes —
+  and the pre-existing per-library release fan-out's own `verdict: "ERROR"`
+  shape in `cli_compare_release.py` (not new to this task) — never actually
+  validated, confirmed by running `jsonschema.validate` against both shapes
+  by hand. The "out of scope, mirrors an accepted ADR-047 §7 gap" reply
+  given in the third round was too quick to wave this away as unfixable;
+  Codex's fourth pass on it correctly pushed back with concrete schema
+  evidence. Fixed properly this time: `compare_report.schema.json`'s
+  top-level `required` now only demands `report_schema_version`/`verdict`,
+  an `allOf`/`if`/`then` requires the full compare-specific field list only
+  when `verdict` is one of the five real values, and `verdict`'s enum grew
+  `ERROR`/`NO_BASELINE` (additive, consistent with the existing
+  `report_schema_version` MINOR-bump convention for new enum members).
+  Verified against all four shapes by hand: a full compare report validates
+  and still rejects a truncated one, and both sentinel envelopes (plus the
+  minimal pre-existing release-fan-out `{library, verdict: "ERROR", error}`
+  shape) now validate. `docs/schemas/v1/compare_report.schema.json`
+  re-synced via `scripts/publish_schemas.py`.
+
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 
 Implements ADR-047 §4/§5 (`run-plan.json` generation + matrix + trailing

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -865,6 +865,50 @@ marker choice is shape-aware now. New
 `test_bundle_release_report_gets_no_schema_version_stamp` cases in
 `tests/test_check_report.py`.
 
+A sixth review round on the same commit caught two more real issues:
+
+- **A `kind: bundle` (or any directory/package `compare`) request for
+  build/source-depth evidence was silently downgraded instead of failing** —
+  the directory/package guard added earlier (fifth round) correctly stopped
+  forwarding `--depth`/`--sources`/`--build-info` to avoid the CLI's hard
+  rejection, but that meant a caller who explicitly asked for
+  `requested-depth: build`/`source` (or supplied `--sources`/`--build-info`/
+  `--compile-db` directly) had that request silently dropped: the
+  comparison would still run and report a normal/clean result, just without
+  ever actually gathering the requested evidence — a source-only break
+  could be missed with no signal anything was wrong (`effective_depth` even
+  falls into `derive_effective_depth`'s "no depth signal in report" branch,
+  which trusts the *request* rather than reporting a real degradation, since
+  the release fan-out's own JSON never carries `old_evidence_depth`/
+  `new_evidence_depth` at all). Fixed in two places: `action/run.sh` now
+  exits with an explicit error when a directory/package operand is combined
+  with `--depth build`/`source` or an explicit `--sources`/`--build-info`/
+  `--compile-db` (covers any direct caller of the root Action, not just
+  check-target) — `--depth binary`/`headers` against a directory/package
+  operand is untouched, since nothing requested there is actually
+  unservable. `actions/check-target/validate-inputs.sh` additionally
+  rejects `kind: bundle` combined with `requested-depth: build`/`source` up
+  front, before `resolve-baseline`/`collect-facts` even run, for a cheaper
+  and clearer failure than waiting for the nested analysis step to fail.
+  New `TestCompareModeFailsFastOnUnservableDirectoryEvidenceRequest` class
+  in `tests/test_action_run_sh_compare_build_source.py` (four failure cases
+  plus one confirming `headers` depth still succeeds) and
+  `test_bundle_kind_rejects_build_depth`/`test_bundle_kind_rejects_source_depth`/
+  `test_bundle_kind_allows_headers_depth` in `tests/test_action_check_target.py`.
+- **`augment_report`'s successful-path `publication` default was simply
+  false** — it defaulted every successful report's `publication` to
+  `{"state": "published", "channels": ["job_summary"]}`, but check-target's
+  own "Run analysis" step always passes `add-job-summary: 'false'`,
+  `pr-comment: 'false'`, `upload-sarif: 'false'` to the nested root Action
+  (confirmed by reading `action.yml`), and the finalize step itself only
+  writes the report JSON to disk plus `GITHUB_OUTPUT` values — nothing is
+  actually published anywhere for a real check-target run. The
+  operational-error/bootstrap sentinel envelopes already got this right
+  (`{"state": "skipped", "channels": []}`); only the common success-path
+  default was wrong. Fixed to match. New
+  `test_publication_defaults_to_skipped_not_a_false_claim` case in
+  `tests/test_check_report.py`.
+
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 
 Implements ADR-047 §4/§5 (`run-plan.json` generation + matrix + trailing

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -376,7 +376,7 @@ bundle resolution, and archive extraction (flat and one-level-nested).
 `docs/reference/resolve-baseline.md` (new, linked from mkdocs nav)
 documents the Action's contract.
 
-### P1.3 — `actions/check-target`
+### P1.3 — `actions/check-target` — **done**
 
 **Scope note, required by review — this item is not done until the S22/S23
 root-action gap is resolved, not merely acknowledged.** ADR-047 §4 flags
@@ -505,6 +505,107 @@ already exercises the root action per AGENTS.md's tag-pinning note on that
 file — extend it, don't create a parallel test harness); add a
 multi-profile-same-target fixture case asserting `aggregate` does not
 collide/error.
+
+**Status:** implemented. **First required sub-task (S22/S23 root-action
+gap) — resolved, correcting the ADR's own stale premise:** re-reading
+`action.yml`/`action/run.sh` as they exist today (not as ADR-047 §3/§4
+describe them) shows `used-by`/`verify-runtime`/`required-symbol`/
+`required-symbols` are already declared inputs, already forwarded to
+`compare --used-by`/`--required-symbol`/`--required-symbols`
+(`action/run.sh:377-386`) — added by #570/#579, both landed *before*
+ADR-047 (#610) was written. The ADR's "the root action.yml cannot express
+`--used-by`/`--required-symbols` today" finding (§3) was already false at
+the time it was written; neither of its two proposed fixes (extend
+`action.yml`, or have `check-target` call the CLI directly) was needed.
+`check-target` simply exposes its own `target-kind: library|app-consumer|
+plugin-contract` input and forwards `consumer-binary`/`contract-file` to
+the root Action's existing `used-by`/`required-symbols` inputs when
+building its nested `Run analysis` step. The *other* gap ADR-047 §3
+correctly identifies — the "library redirect" (an `app-consumer`/
+`plugin-contract` target's baseline/candidate lookup must resolve through
+its `library` field, while the check's own identity stays the contract
+target's name) — is real and is implemented via a separate
+`baseline-target` input (defaults to `name`; the caller sets it to the
+referenced library's id), keeping `resolve-baseline`'s lookup key and the
+report envelope's `check_id`/`target_id` deliberately distinct, per §3.
+**Second required sub-task (`baseline: none` bypass) — implemented as a
+real branch, not documentation:** `action.yml`'s `Resolve baseline` step
+carries `if: inputs.baseline-channel != 'none'`, and every downstream step
+(`Run analysis`, the two `collect-facts` steps) conditions on
+`inputs.baseline-channel == 'none' || steps.resolve.outputs.outcome ==
+'resolved'` — a skipped `resolve` step's outputs are empty strings, so this
+expression evaluates correctly with no separate branch needed.
+`baseline-channel: none` runs `mode: scan` (no `--against`) instead of
+`compare`, matching S5's audit path exactly; `tests/test_action_check_target.py::
+TestFinalizeAugmentMode::test_baseline_channel_none_skips_resolve_and_still_augments`
+covers it end-to-end at the shell level, and `test-check-target` in
+`.github/workflows/test-action.yml` exercises the full YAML composition
+(including this bypass's sibling branches) against a real `abicheck
+compare` run. **Third/fourth required sub-tasks (unconditional depth-suffixed
+`check_id`/`target_id`, dual-write, `gate-mode`-aware neutralization,
+`continue-on-error` + trailing finalize step) — all implemented exactly as
+specified,** in a new pure module, `abicheck/buildsource/check_report.py`
+(`build_check_id`, `resolve_effective_depth`, `augment_report`,
+`build_operational_error_report`, `build_bootstrap_report`,
+`final_exit_code`), backing a thin CLI wrapper
+(`actions/check-target/report_envelope.py`, mirroring
+`resolve_baseline.py`'s pattern) that `run.sh` drives. **A real gap found
+and closed during implementation, not anticipated by the ADR:** the root
+Action's *legacy* (no `--severity-*` flag) compare exit scheme omits the
+`severity` JSON block entirely — confirmed by running `abicheck compare`
+directly — which would leave `gate-mode: advisory` with nothing to
+neutralize and let `abicheck/aggregate.py`'s `GateInfo.from_report_data`
+fall back to `legacy_from_verdict(verdict)`, still deriving a blocking gate
+from the real `BREAKING`/`API_BREAK` verdict regardless of `gate-mode`.
+Fixed by giving `check-target`'s own `severity-preset` input a `'default'`
+default (root `action.yml`'s own input is deliberately left unset) instead
+of leaving it unset, so the nested `Run analysis` step always requests the
+severity-aware scheme and a `severity` block is always present to dual-write
+and (for `advisory`) neutralize. `deferred` reports keep that block's real
+`exit_code`/`blocking` untouched by design — `check-project.yml`'s future
+trailing `aggregate` job (P1.4) needs the real value to compute the gate
+centrally; only `advisory` zeroes it. Verified end-to-end by hand (not only
+via the test suite): staged a real `manifest.json` + snapshot, ran
+`actions/resolve-baseline/run.sh`, then a real `abicheck compare
+--severity-preset default`, then `actions/check-target/run.sh`'s finalize
+step, for all three `gate-mode` values, confirming the exit
+codes/persisted-severity behavior documented above. The S14 bundle-scoped
+path is implemented as ADR-047 §8's correction actually resolves it: no
+separate "bundle compare" CLI command exists (`compare-release` is
+intentionally unregistered on `main`, invoked only by `compare`'s own
+directory-operand fan-out per ADR-037 D7), so `kind: bundle` simply hands
+`resolve-baseline`'s `binaries-dir` output to the same nested `Run analysis`
+step as a directory `old-library` — `compare`'s existing directory fan-out
+handles the rest. `actions/baseline` still doesn't stage a `binaries/`
+directory (G30 P1.6, not built here), so this path is exercised against a
+hand-authored fixture in the same "defines the contract, no producer yet"
+scoping P1.1/P1.2 already used. **The multi-profile-same-target `aggregate`
+non-collision fixture is deferred to P1.4, not skipped:** `check-target` on
+its own never invokes `aggregate` or produces more than one report per
+call, so there is nothing to fan in yet; `build_check_id`'s own uniqueness
+across `requested_depth` is unit-tested here
+(`tests/test_check_report.py::TestBuildCheckId::
+test_unconditional_depth_suffix_disambiguates_shadow_checks`), and the real
+multi-check `aggregate` fixture belongs with P1.4's `run-plan.json`
+generator, which is what actually produces more than one `check-target`
+call to fan in. `abicheck/schemas/compare_report.schema.json` gained
+`compatibility_verdict`/`policy_gate_decision`/`check_evidence_coverage`/
+`operational_errors`/`publication`/`baseline_bootstrap`/`project`/
+`head_sha`/`base_ref`/`tool_version`/`action_version` as additive/optional
+properties (`report_schema_version` bumped `2.12` → `2.13`,
+`scan_schema_version` `1.1` → `1.2`, both documented in
+`abicheck/schemas/__init__.py`); `docs/reference/check-target.md` (new,
+linked from mkdocs nav) documents the full contract, and
+`docs/reference/resolve-baseline.md`'s "not built yet" status note is
+updated to point at it. `tests/test_check_report.py` (35 cases) covers the
+pure logic; `tests/test_action_check_target.py` (22 cases) covers
+`validate-inputs.sh`/`run.sh`'s bash orchestration end-to-end, including
+every `gate-mode` × outcome (resolved/operational-error/bootstrap)
+combination and the evidence-degradation branch; `test-check-target` in
+`.github/workflows/test-action.yml` is the required end-to-end fixture job,
+exercising the real nested `uses:` composition (`resolve-baseline` → the
+root Action → the finalize step) against real `abicheck compare` output,
+not simulated env vars.
 
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -597,15 +597,72 @@ properties (`report_schema_version` bumped `2.12` → `2.13`,
 `abicheck/schemas/__init__.py`); `docs/reference/check-target.md` (new,
 linked from mkdocs nav) documents the full contract, and
 `docs/reference/resolve-baseline.md`'s "not built yet" status note is
-updated to point at it. `tests/test_check_report.py` (35 cases) covers the
-pure logic; `tests/test_action_check_target.py` (22 cases) covers
-`validate-inputs.sh`/`run.sh`'s bash orchestration end-to-end, including
-every `gate-mode` × outcome (resolved/operational-error/bootstrap)
-combination and the evidence-degradation branch; `test-check-target` in
+updated to point at it. `tests/test_check_report.py` (100% line/branch
+coverage of `check_report.py`) covers the pure logic;
+`tests/test_action_check_target.py` covers `validate-inputs.sh`/`run.sh`'s
+bash orchestration end-to-end, including every `gate-mode` × outcome
+(resolved/operational-error/bootstrap) combination and the
+effective-depth-degradation branch; `test-check-target` in
 `.github/workflows/test-action.yml` is the required end-to-end fixture job,
 exercising the real nested `uses:` composition (`resolve-baseline` → the
 root Action → the finalize step) against real `abicheck compare` output,
 not simulated env vars.
+
+**Two real, confirmed bugs found and fixed via PR review after initial
+implementation (PR #625), not anticipated above:**
+
+- **Effective-depth degradation was computed from the wrong signal.** The
+  first implementation guessed `effective_depth`/`check_evidence_coverage`
+  from whether the composed `collect-facts` step reported readiness — but a
+  caller can legitimately reach build/source depth via a direct `build-info`/
+  `sources` input with **no** `collect-facts` composition at all (the
+  "producer-less" path this same page's input table already documents). That
+  heuristic misreported a real build/source-depth result as `degraded` purely
+  because no producer step ran (Codex review). **Fixed by reading the
+  authoritative signal the tool itself already emits**, not inferring one:
+  `abicheck compare --format json` always carries `old_evidence_depth`/
+  `new_evidence_depth` (`cli_compare_helpers._fold_evidence_depth_into_json`,
+  unconditional for JSON output) and `scan`'s JSON carries `level.depth` — the
+  real depth *achieved*, independent of how it was achieved. Renamed
+  `resolve_effective_depth(requested_depth, evidence_ok, degraded_reason)` to
+  `derive_effective_depth(report, requested_depth)`, dropped the
+  `evidence-ok`/`degraded-reason` plumbing from `report_envelope.py`/`run.sh`/
+  `action.yml`'s finalize step entirely (the `collect-facts` composition
+  steps themselves are unchanged — they still produce the pack the analysis
+  step consumes; only the *finalize* step's now-redundant success/readiness
+  reads were removed). For `compare`, the shallower of the two sides is the
+  check's own achieved depth (a build/source result on only one side isn't a
+  build/source-depth comparison); a report deeper than requested is reported
+  honestly as achieved, not capped down to the request.
+- **Nested `uses: ./x` steps do not resolve against this Action's own
+  repository when consumed externally — a real, confirmed architectural gap,
+  not a false positive.** Verified independently (GitHub Community Discussion
+  actions/runner#1348 "Local composite actions always relative to top level
+  repository"; confirmed `uses:` accepts no expressions at all, ruling out a
+  dynamic-reference workaround) before fixing: a relative `uses: ./x` step
+  inside a composite Action **always** resolves against `$GITHUB_WORKSPACE`
+  — the *calling workflow's* own checkout — never against the repository
+  that contains the composite Action doing the `uses:`. `check-target`'s
+  nested `uses: ./actions/resolve-baseline`/`./actions/collect-facts`/`./`
+  (root Action) therefore only ever worked because the added
+  `test-check-target` fixture happens to invoke `check-target` from *within*
+  `abicheck/abicheck`'s own workflow — the one case where the caller's
+  checkout and this Action's own repository are the same thing. A real
+  external consumer (`uses: abicheck/abicheck/actions/check-target@v1` from
+  their own repository, exactly as this page's own examples show) would have
+  every nested `uses:` fail before ever reaching baseline resolution. Fixed
+  by adding an unconditional `Checkout abicheck (for nested Action
+  composition)` step (first thing `check-target` does, before any nested
+  `uses:`) that checks out `${{ github.action_repository ||
+  github.repository }}` at `${{ github.action_ref || github.sha }}` into a
+  side directory (`.abicheck-check-target-src`, `persist-credentials:
+  false`), and rewrote every nested `uses:` to reference that directory
+  instead of bare `./`. The `||` fallback makes this correct for both the
+  external-reference case (`github.action_repository`/`github.action_ref`
+  set) and the local same-repository case
+  (`.github/workflows/test-action.yml`'s own `uses: ./actions/check-target`,
+  where both are empty) without a conditional branch — `uses:` cannot itself
+  be an expression, so the checkout step had to be unconditional instead.
 
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -764,6 +764,32 @@ that the shell logic looks right on paper; `tests/test_action_check_target.py`
 gained cases for both new collect-facts-failure branches and the
 `evidence-producer` validation.
 
+A fourth round of Codex review then caught a regression the evidence-
+forwarding fix above (73f1143) itself introduced: **`action.yml` always
+sets `depth: inputs.requested-depth` on the analysis step**, and for
+`kind: bundle` (or any directory/package comparison), `old-library`/
+`new-library` are directories, which routes `compare` through the CLI's
+per-library release fan-out (ADR-037 D7) — and that fan-out's own
+`_reject_evidence_flags_for_set_inputs` rejects `--depth`/`--sources`/
+`--build-info` outright as a `UsageError`, since the per-library fan-out
+never collects inline build/source evidence for a set input. Confirmed
+by reading `abicheck/cli_resolve.py`'s `_reject_evidence_flags_for_set_inputs`
+and its call site in `cli_compare_helpers.py` (fires whenever either operand
+classifies as `directory`/`package`). Before this fix, **every** `kind:
+bundle` check-target invocation with a resolved baseline would fail as a
+hard usage/orchestration error before ever producing the intended bundle
+comparison — `requested-depth` stays required in the envelope identity
+regardless, only the CLI flag was wrong to force. Fixed by gating the
+`--sources`/`--build-info`/`--config`/`--depth` block in `action/run.sh`'s
+`compare` branch on `action/run.sh`'s existing `_is_release_style_operand`
+helper (already used a few lines above to skip `--secondary-format` for the
+same directory/package shape) — checked against both `old-library` and
+`new-library`, matching the CLI's own either-side rejection condition.
+`tests/test_action_run_sh_compare_build_source.py` gained a
+`TestCompareModeSkipsEvidenceFlagsForDirectoryOperands` class proving the
+flags are omitted when either operand is a directory, even when the
+corresponding evidence inputs are set.
+
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 
 Implements ADR-047 §4/§5 (`run-plan.json` generation + matrix + trailing

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -1091,6 +1091,43 @@ is empty, the same way it already does for `name`. New
 `test_missing_profile_fails_here_not_deep_in_run_sh` in
 `tests/test_action_check_target.py`.
 
+A ninth round of Codex review then found that the per-check report-filename
+fix (above) only scoped the *final envelope* — the internal analysis-step
+output, `check-target-analysis.json`, is still a single fixed workspace-
+relative path shared by every `check-target` invocation in a job. If a job
+runs check-target twice and the *second* invocation's nested root Action
+crashes before ever writing its own report (e.g. a CLI usage/config error),
+`action/run.sh`'s "only emit report-path when a real report file was
+produced" check (confirmed by reading it: `if [[ -n "${OUTPUT_FILE:-}" &&
+-f "${OUTPUT_FILE}" ]]`) tests file *existence*, not freshness — so it would
+find the *first* invocation's still-present file and report it as this
+run's own `report-path`. The finalize step would then augment the
+*previous* check's JSON as if it were the current check's real result, and
+with `gate-mode: deferred`/`advisory` that silently turns a genuine
+operational failure into a false pass, since `operational_errors` would be
+read from the stale (successful) report instead. Considered giving the
+analysis output a per-check filename too, the same way the final envelope
+already is, but rejected it: the final envelope's filename is built from a
+`_slug()`-sanitized `name`/`profile`/`baseline-channel`/`requested-depth`,
+and no such sanitization runs before the analysis step — interpolating
+those raw input values into a second filename here would trade a staleness
+bug for a path-injection one. Fixed instead by adding an unconditional
+"Clean stale analysis output" step (`rm -f check-target-analysis.json`)
+immediately before "Run analysis" in `action.yml`, deliberately *not*
+gated behind "Run analysis"'s own `if:` — a same-job resolve/collect
+failure that skips analysis this run must still clear out whatever a prior
+invocation left behind, or the next invocation in the same job would find
+it. Since `action.yml`'s own step orchestration needs a real GitHub Actions
+runner to exercise end-to-end (no way to unit-test the composite steps
+directly, per this section's existing testing approach), verified via a
+structural assertion over the parsed YAML instead — mirroring
+`test_action_validate_inputs.py`'s `TestUnsetFormatUsesEachModesOwnDefault`
+precedent for the same kind of `action.yml`-only fix. New
+`TestStaleAnalysisOutputIsCleanedBeforeEachRun::test_cleanup_step_runs_unconditionally_immediately_before_analysis`
+in `tests/test_action_check_target.py` asserts the cleanup step exists,
+is unconditional (no `if:`), sits immediately before "Run analysis", and
+targets the same filename the analysis step's `output-file` writes.
+
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 
 Implements ADR-047 §4/§5 (`run-plan.json` generation + matrix + trailing

--- a/docs/development/plans/g30-github-actions-integration-model.md
+++ b/docs/development/plans/g30-github-actions-integration-model.md
@@ -1070,6 +1070,27 @@ into the actual `abicheck.aggregate.GateInfo.from_report_data` for
 `gate-mode: deferred` and asserts it reads a blocking gate — not just that
 the shell/Python logic looks right on paper.
 
+An eighth round of Codex review then caught that `profile` — declared
+`required: true` in `action.yml` — was never actually validated anywhere:
+`validate-inputs.sh` checks `name` but never read `INPUT_PROFILE` at all,
+and the "Validate check-target inputs" step's own env block didn't even
+forward it. This matters because **GitHub Actions does not actually
+enforce `required: true` for composite-action inputs** — confirmed via
+`github.com/orgs/community/discussions/26777` and GitHub's own metadata-
+syntax docs: an omitted required input simply arrives as an empty string,
+with no automatic failure. Without an explicit check, a workflow that
+forgot `profile:` would sail past validation and only fail deep inside
+`run.sh`'s `PROFILE="${INPUT_PROFILE:?}"` bash parameter expansion, which
+aborts the finalize step immediately — before `report_envelope.py` ever
+runs — so the check would produce no `check-target-report*.json` and no
+outputs at all, despite ADR-047 §7's "the report-envelope step always
+executes" contract. Fixed: `INPUT_PROFILE: ${{ inputs.profile }}` added to
+the validate step's env block, and `validate-inputs.sh` now fails loud
+(exit 64, matching every other required-input check there) when `profile`
+is empty, the same way it already does for `name`. New
+`test_missing_profile_fails_here_not_deep_in_run_sh` in
+`tests/test_action_check_target.py`.
+
 ### P1.4 — `check-single.yml` / `check-project.yml` reusable workflows
 
 Implements ADR-047 §4/§5 (`run-plan.json` generation + matrix + trailing

--- a/docs/reference/check-target.md
+++ b/docs/reference/check-target.md
@@ -1,0 +1,189 @@
+# `check-target` Action Reference
+
+`actions/check-target` composes [`resolve-baseline`](resolve-baseline.md) +
+`collect-facts` + the root `abicheck/abicheck` Action into **one resolved
+check** — [ADR-047](../development/adr/047-github-actions-integration-model.md)
+§4's single high-level primitive — and always emits the
+[report envelope](#report-envelope-adr-047-7) (§7), regardless of whether
+the baseline resolved, was a bootstrap "no baseline yet" pass, or failed
+outright.
+
+> **Status.** This page documents the `actions/check-target` composite
+> Action shipped in G30 P1.3. The reusable workflows that generate a
+> `run-plan.json` and fan this Action out over a matrix
+> (`check-single.yml`/`check-project.yml`) are G30 P1.4, not built yet — see
+> the [G30 plan](../development/plans/g30-github-actions-integration-model.md).
+> Until then, `check-target` can be called directly as a step (ADR-047's S4
+> shortcut) or from a hand-written per-target workflow (S1/S2/S5/S6/S15/S21).
+
+## What it does
+
+1. **Resolves the baseline** by composing [`resolve-baseline`](resolve-baseline.md)
+   — skipped entirely when `baseline-channel: none` (a single-build audit
+   with no baseline, ADR-047 §8 S5).
+2. **Composes `collect-facts`** when `evidence-producer` requests build/source
+   evidence: `phase: verify` for `wrapper`/`clang-plugin` (the caller's own
+   workflow must run `collect-facts phase: prepare` *before* its build step,
+   earlier in the job — `check-target` runs after that build already
+   happened and cannot retroactively instrument it), or `phase: auto` for
+   `replay` (no pre-build hook needed).
+3. **Runs the analysis** — the root Action's `compare` mode against the
+   resolved baseline, or (`baseline-channel: none`) `scan` mode with no
+   `--against` (a one-build audit).
+4. **Always writes the report envelope**, even when steps 1 or 3 failed —
+   the internal resolve/analysis steps run with `continue-on-error: true`
+   specifically so this step always runs (ADR-047 §7).
+5. **Owns its own composite exit code**, per `gate-mode` (below) — the very
+   last thing this Action does, never an implicit pass-through of an
+   internal step's raw exit code.
+
+## `gate-mode`
+
+| Mode | This job's exit code | Who computes the real gate |
+|------|----------------------|------------------------------|
+| `local` (default) | Reflects the real compatibility finding (today's root-Action behavior). | This job itself. |
+| `deferred` | `0` for a compatibility finding, whatever it is — **but still nonzero on an operational error** (a `resolve-baseline` failure, or the analysis step never producing a report). | A trailing fan-in `aggregate` job, reading this check's *real*, un-neutralized `severity`/`exit_code` from its report. |
+| `advisory` | Same as `deferred`. | Nobody — findings are visible (in `compatibility_verdict`/`policy_gate_decision`) but never gate CI (shadow-rollout burn-in, S26). |
+
+**`deferred` vs. `advisory` reports differ in one important way:** a
+`deferred` report's `severity`/`exit_code` block stays the **real** value —
+that's exactly what a trailing `aggregate` job's `exit_code()` (a `max()`
+over every report's real gate) needs to compute the actual gate centrally.
+An `advisory` report's legacy `severity.exit_code`/`blocking` are
+**neutralized to `0`/`false`** so an advisory check can never accidentally
+raise `aggregate`'s computed exit code above what the required cells alone
+would produce — the real finding stays fully visible in the new
+`compatibility_verdict`/`policy_gate_decision` fields for humans/PR
+comments/SARIF, just never in the field `aggregate` gates on.
+
+**Operational errors are never deferred or hidden**, regardless of
+`gate-mode`: a `resolve-baseline` failure (`not_found`/`ambiguous`/
+`wrong_profile`/`stale_schema`/`incompatible_evidence`) or the analysis step
+never producing a report always fails this job's own exit code, exactly
+like `resolve-baseline`'s own fail-loud contract requires.
+
+## Target kinds (ADR-047 §3)
+
+`target-kind` selects which `compare` flags this check builds — only
+meaningful when `kind: target` (never `kind: bundle`):
+
+| `target-kind` | Compare shape | Extra inputs |
+|---|---|---|
+| `library` (default) | A plain `compare`. | — |
+| `app-consumer` | `compare --used-by` (S22, application compatibility). | `consumer-binary`, `verify-runtime` |
+| `plugin-contract` | `compare --required-symbols` (S23, plugin/dlopen contract). | `contract-file` — a `.syms` file, one required linker symbol per line, `#` comments allowed; **not** YAML |
+
+**The "library redirect" (ADR-047 §3):** `app-consumer`/`plugin-contract`
+targets have no binary/baseline of their own — they resolve *through* the
+library they scope. Set `baseline-target` to that library's id so
+`resolve-baseline` looks up the right baseline, while `name` stays the
+contract target's own name (`myapp-consumer`, `ioc-plugin-contract`) for
+this check's own `check_id`/`target_id` identity, and `new-library` points
+at that library's own candidate binary (candidate lookup needs the same
+redirect as the baseline lookup — an app-consumer/plugin-contract target
+has no `binary_pattern` of its own to resolve either side from).
+
+## `kind: bundle` (S14)
+
+A bundle-scoped check never resolves a single snapshot — `resolve-baseline`
+returns the bundle's staged member **binaries** (`binaries-dir`), since
+`abicheck/bundle.py`'s cross-library graph reads real ELF binaries, not JSON
+snapshots. `check-target` hands that directory to the root Action's
+`compare` mode as `old-library` directly — a plain directory-operand
+compare, which `compare` already fans out to a per-library comparison
+(including cross-library bundle findings) automatically; no separate
+"bundle compare" mode or CLI command is invoked. `new-library` is the
+caller-provided directory of the candidate build's own member binaries.
+
+## Inputs
+
+| Input | Required | Default | Meaning |
+|-------|----------|---------|---------|
+| `kind` | no | `target` | `target` or `bundle`. |
+| `target-kind` | no | `library` | `library` \| `app-consumer` \| `plugin-contract` (`kind: target` only). |
+| `name` | yes | — | This check's own identity (`check_id`/`target_id`) — the target or bundle id. |
+| `baseline-target` | no | (= `name`) | Which target's baseline actually resolves — set to the referenced library for `app-consumer`/`plugin-contract`. Ignored for `kind: bundle`. |
+| `bundle-members` | when `kind: bundle` | `[]` | JSON array of the bundle's member target ids. |
+| `profile` | yes | — | The build `profile.id` this check runs under. |
+| `baseline-channel` | yes | — | A channel name, or the literal `none` for a no-baseline audit (S5). |
+| `baseline-path` | when channel ≠ `none` | `''` | Forwarded to `resolve-baseline`. |
+| `baseline-required` | no | `true` | Forwarded to `resolve-baseline`'s `required`. |
+| `candidate-build-output` | no | `''` | Forwarded to `resolve-baseline`'s `incompatible_evidence` check. |
+| `requested-depth` | yes | — | `binary` \| `headers` \| `build` \| `source`. |
+| `gate-mode` | no | `local` | `local` \| `deferred` \| `advisory`. |
+| `project` | no | `${{ github.repository }}` | Recorded in the report envelope. |
+| `head-sha` | no | `${{ github.sha }}` | Recorded in the report envelope. |
+| `base-ref` | no | `''` | Recorded in the report envelope. |
+| `evidence-producer` | no | `''` | `''` (no source evidence needed) \| `replay` \| `wrapper` \| `clang-plugin`. |
+| `evidence-pack-path` | no | `abicheck_inputs` | Must match an earlier `collect-facts phase: prepare` step's own output path (`wrapper`/`clang-plugin` only). |
+| `new-library` | yes | — | Candidate binary (`kind: target`) or directory of candidate member binaries (`kind: bundle`). |
+| `consumer-binary` | when `target-kind: app-consumer` | — | Forwarded as `--used-by`. |
+| `verify-runtime` | no | `false` | Forwarded when `target-kind: app-consumer`. |
+| `contract-file` | when `target-kind: plugin-contract` | — | Forwarded as `--required-symbols`. |
+| `header`, `old-header`, `new-header`, `include`, `old-include`, `new-include`, `lang`, `ast-frontend`, `gcc-path`, `gcc-prefix`, `gcc-options`, `sysroot`, `sources`, `build-info`, `compile-db`, `build-config`, `policy`, `policy-file`, `suppress`, `severity-preset`, `severity-addition`, `extra-args`, `python-version`, `install-deps` | no | (mirror the root Action) | Forwarded straight through to the internal analysis step. |
+
+## Outputs
+
+| Output | Meaning |
+|--------|---------|
+| `outcome` | The `resolve-baseline` outcome, or `skipped` when `baseline-channel: none`. |
+| `check-id` | `target@profile#baseline_channel@requested_depth` — always includes the depth suffix, even in the common single-depth case (ADR-047 §7). |
+| `verdict` | The legacy `verdict` field: one of the five `Verdict` values, `ERROR` (operational failure), or `NO_BASELINE` (bootstrap pass — deliberately not a `Verdict` member, never a compatibility verdict). |
+| `compatibility-verdict` | Mirrors `verdict`'s casing, empty when unavailable (an operational-failure or bootstrap report). |
+| `policy-gate-decision` | `pass` or `fail` — this check's own real gate decision, computed before any `gate-mode: advisory` neutralization. |
+| `report-path` | Path to the final, enriched report JSON. |
+
+## Report envelope (ADR-047 §7)
+
+Every run writes a single JSON report at `check-target-report.json`,
+starting from whatever the underlying `compare`/`scan` run already produced
+(`abicheck/reporter.py`'s existing shape — `report_schema_version: "2.13"`)
+and layering on:
+
+- `check_id`/`target_id` — always the same, fully-qualified,
+  depth-suffixed value, so `abicheck aggregate`'s exact-match lookup lines
+  up for every check, not only ones sharing a target with another check.
+- `profile_id`, `baseline_channel`, `requested_depth`, `effective_depth`
+  (may be shallower than requested when the evidence wasn't actually
+  available — `check_evidence_coverage` records why).
+- `compatibility_verdict`/`policy_gate_decision` — the new, richer fields —
+  **alongside**, never instead of, the legacy `verdict`/`severity` fields
+  `abicheck/aggregate.py` already parses (the dual-write requirement).
+- `operational_errors` — non-empty exactly when this check hit an
+  infrastructure/config problem rather than (or in addition to) a
+  compatibility finding.
+- `publication` — whether/where this report was actually published.
+
+A `resolve-baseline` failure or a bootstrap ("no baseline published yet")
+pass synthesizes this same envelope from scratch — a report always exists,
+even when no comparison ever ran.
+
+## Example
+
+```yaml
+- name: Check libpvxs against accepted-main
+  uses: abicheck/abicheck/actions/check-target@v1
+  with:
+    name: libpvxs
+    profile: linux-x86_64-gcc13-release
+    baseline-channel: accepted-main
+    baseline-path: ./restored-baseline # staged by an earlier actions/cache step
+    requested-depth: headers
+    gate-mode: local
+    new-library: build/lib/libpvxs.so
+    header: headers/pvxs/*.h
+```
+
+```yaml
+# S5: single-build audit, no baseline.
+- name: Audit libpvxs (no baseline)
+  uses: abicheck/abicheck/actions/check-target@v1
+  with:
+    name: libpvxs
+    profile: linux-x86_64-gcc13-release
+    baseline-channel: none
+    requested-depth: headers
+    gate-mode: advisory
+    new-library: build/lib/libpvxs.so
+    header: headers/pvxs/*.h
+```

--- a/docs/reference/check-target.md
+++ b/docs/reference/check-target.md
@@ -135,8 +135,13 @@ caller-provided directory of the candidate build's own member binaries.
 
 ## Report envelope (ADR-047 §7)
 
-Every run writes a single JSON report at `check-target-report.json`,
-starting from whatever the underlying `compare`/`scan` run already produced
+Every run writes a single JSON report at
+`check-target-report-<name>-<profile>-<baseline_channel>-<requested_depth>.json`
+(the exact path is always available via the `report-path` output — don't
+hard-code the filename, since running `check-target` more than once in the
+same job, e.g. the same target against two baseline channels, would
+otherwise overwrite an earlier run's report), starting from whatever the
+underlying `compare`/`scan` run already produced
 (`abicheck/reporter.py`'s existing shape — `report_schema_version: "2.13"`)
 and layering on:
 

--- a/docs/reference/check-target.md
+++ b/docs/reference/check-target.md
@@ -3,10 +3,12 @@
 `actions/check-target` composes [`resolve-baseline`](resolve-baseline.md) +
 `collect-facts` + the root `abicheck/abicheck` Action into **one resolved
 check** — [ADR-047](../development/adr/047-github-actions-integration-model.md)
-§4's single high-level primitive — and always emits the
-[report envelope](#report-envelope-adr-047-7) (§7), regardless of whether
-the baseline resolved, was a bootstrap "no baseline yet" pass, or failed
-outright.
+§4's single high-level primitive — and, once its own input validation
+passes, always emits the [report envelope](#report-envelope-adr-047-7)
+(§7), regardless of whether the baseline resolved, was a bootstrap "no
+baseline yet" pass, or failed outright. An invalid invocation (e.g. a
+missing required input, or an unsupported input combination) is rejected
+up front, before any of that, and produces no report or outputs at all.
 
 > **Status.** This page documents the `actions/check-target` composite
 > Action shipped in G30 P1.3. The reusable workflows that generate a
@@ -30,9 +32,11 @@ outright.
 3. **Runs the analysis** — the root Action's `compare` mode against the
    resolved baseline, or (`baseline-channel: none`) `scan` mode with no
    `--against` (a one-build audit).
-4. **Always writes the report envelope**, even when steps 1 or 3 failed —
-   the internal resolve/analysis steps run with `continue-on-error: true`
-   specifically so this step always runs (ADR-047 §7).
+4. **Writes the report envelope**, once input validation (the very first
+   step) has passed — even when steps 1 or 3 above then fail, since the
+   internal resolve/analysis steps run with `continue-on-error: true`
+   specifically so this step always runs afterward (ADR-047 §7). A
+   validation failure short-circuits before any of steps 1-4 run at all.
 5. **Owns its own composite exit code**, per `gate-mode` (below) — the very
    last thing this Action does, never an implicit pass-through of an
    internal step's raw exit code.
@@ -141,9 +145,14 @@ Every run writes a single JSON report at
 hard-code the filename, since running `check-target` more than once in the
 same job, e.g. the same target against two baseline channels, would
 otherwise overwrite an earlier run's report), starting from whatever the
-underlying `compare`/`scan` run already produced
-(`abicheck/reporter.py`'s existing shape — `report_schema_version: "2.13"`)
-and layering on:
+underlying `compare`/`scan` run already produced and layering on the
+fields below. For a normal single-library `compare` (the common case),
+that starting shape is `abicheck/reporter.py`'s existing compare-report
+shape (`report_schema_version: "2.13"`). A `baseline-channel: none` audit
+instead starts from a `scan` report (its own `scan_schema_version` shape),
+and a `kind: bundle` check starts from the CLI's per-library release
+fan-out summary (`libraries`/`old_dir`, no schema-version marker of its
+own) — neither of those two carries `report_schema_version`.
 
 - `check_id`/`target_id` — always the same, fully-qualified,
   depth-suffixed value, so `abicheck aggregate`'s exact-match lookup lines

--- a/docs/reference/resolve-baseline.md
+++ b/docs/reference/resolve-baseline.md
@@ -7,14 +7,14 @@ one of [ADR-047](../development/adr/047-github-actions-integration-model.md)
 baseline is never silently treated as "compatible."
 
 > **Status.** This page documents the `actions/resolve-baseline` composite
-> Action shipped in G30 P1.2. `actions/check-target`, the primitive that
-> composes this Action with the root `action.yml` and `collect-facts` into
-> one check, is G30 P1.3, not built yet — see the
-> [G30 plan](../development/plans/g30-github-actions-integration-model.md).
-> `actions/baseline` does not yet stage bundle-member ELF binaries into a
-> `binaries/` directory (G30 P1.6) — bundle-scoped resolution (below) is
-> defined and tested against a hand-authored fixture in the meantime, the
-> same "defines the contract, no producer yet" scoping G30 P1.1 used for
+> Action shipped in G30 P1.2. `actions/check-target` (G30 P1.3), the
+> primitive that composes this Action with the root `action.yml` and
+> `collect-facts` into one check, is documented separately — see the
+> [check-target Action reference](check-target.md). `actions/baseline`
+> does not yet stage bundle-member ELF binaries into a `binaries/`
+> directory (G30 P1.6) — bundle-scoped resolution (below) is defined and
+> tested against a hand-authored fixture in the meantime, the same "defines
+> the contract, no producer yet" scoping G30 P1.1 used for
 > `build-output.json`.
 
 ## Why a separate primitive

--- a/docs/schemas/v1/compare_report.schema.json
+++ b/docs/schemas/v1/compare_report.schema.json
@@ -63,6 +63,77 @@
       "type": "string",
       "description": "Schema 2.12 (ADR-047 §7). Which baseline channel (e.g. \"accepted-main\", a release tag) old_file/old_version was resolved from. Reserved for G30 P1; not yet populated."
     },
+    "compatibility_verdict": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). Mirrors verdict's exact casing/enum -- a separate field name so aggregate.py's existing verdict/severity parsing stays untouched while richer consumers (PR comment, SARIF, humans) read this one. Populated by actions/check-target; omitted when the underlying report has no verdict in Verdict's five-value enum (e.g. an operational-failure or bootstrap report, which stay verdict: \"ERROR\"/\"NO_BASELINE\" instead).",
+      "enum": ["NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING"]
+    },
+    "policy_gate_decision": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). \"pass\" or \"fail\" -- this check's own real gate decision, computed from the report's real severity/exit_code before any gate-mode: advisory neutralization of the legacy severity block. New vocabulary, not a Verdict mirror.",
+      "enum": ["pass", "fail"]
+    },
+    "check_evidence_coverage": {
+      "type": "object",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). Not layer_coverage (a different, existing per-L0-L5-layer array) -- this is check-target's own state/reasons summary of whether requested_depth was actually achieved.",
+      "additionalProperties": true,
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": ["complete", "degraded", "bootstrap", "unknown"]
+        },
+        "reasons": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "operational_errors": {
+      "type": "array",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). Non-empty exactly when this check hit an infrastructure/config problem (e.g. a resolve-baseline failure) rather than -- or in addition to -- a compatibility finding. Empty means clean.",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["kind", "message"],
+        "properties": {
+          "kind": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "publication": {
+      "type": "object",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). Whether/where this report was actually published -- distinct from whether it was computed, so a downstream consumer can tell \"no publication happened\" apart from \"no report was produced at all.\"",
+      "additionalProperties": true,
+      "properties": {
+        "state": { "type": "string", "enum": ["published", "skipped", "failed"] },
+        "channels": { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "baseline_bootstrap": {
+      "type": "boolean",
+      "description": "Schema 2.13 (ADR-047 §6/§7, G30 P1.3). True only on a bootstrap \"no baseline published yet\" advisory pass (required: false with no baseline set yet) -- the explicit report field ADR-047 §6 requires for that case."
+    },
+    "project": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). The project identifier (e.g. \"owner/repo\") this check ran for."
+    },
+    "head_sha": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). The candidate commit SHA this check analyzed."
+    },
+    "base_ref": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). The base ref this check's candidate was compared against, when known (e.g. a PR's target branch)."
+    },
+    "tool_version": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). The abicheck version that produced this report."
+    },
+    "action_version": {
+      "type": "string",
+      "description": "Schema 2.13 (ADR-047 §7, G30 P1.3). The abicheck/abicheck Action ref (e.g. \"abicheck/abicheck@v1\") that ran this check."
+    },
     "old_file": { "$ref": "#/$defs/fileMetadata" },
     "new_file": { "$ref": "#/$defs/fileMetadata" },
     "summary": { "$ref": "#/$defs/summary" },

--- a/docs/schemas/v1/compare_report.schema.json
+++ b/docs/schemas/v1/compare_report.schema.json
@@ -6,22 +6,39 @@
   "type": "object",
   "required": [
     "report_schema_version",
-    "library",
-    "old_version",
-    "new_version",
-    "verdict",
-    "old_file",
-    "new_file",
-    "summary",
-    "policy",
-    "changes",
-    "suppression",
-    "detectors",
-    "confidence",
-    "evidence_tier",
-    "evidence_tiers"
+    "verdict"
   ],
   "additionalProperties": true,
+  "allOf": [
+    {
+      "description": "A real compatibility comparison (the five Verdict enum values) carries the full compare-report shape.",
+      "if": {
+        "properties": {
+          "verdict": {
+            "enum": ["NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING"]
+          }
+        },
+        "required": ["verdict"]
+      },
+      "then": {
+        "required": [
+          "library",
+          "old_version",
+          "new_version",
+          "old_file",
+          "new_file",
+          "summary",
+          "policy",
+          "changes",
+          "suppression",
+          "detectors",
+          "confidence",
+          "evidence_tier",
+          "evidence_tiers"
+        ]
+      }
+    }
+  ],
   "properties": {
     "report_schema_version": {
       "type": "string",
@@ -33,7 +50,8 @@
     "new_version": { "type": "string" },
     "verdict": {
       "type": "string",
-      "enum": ["NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING"]
+      "description": "The five real Verdict enum values for a computed compatibility comparison, plus two sentinel values for a report that never got that far: \"ERROR\" (an operational/infrastructure failure -- e.g. a library that failed to dump/extract/compare in the per-library release fan-out, or a resolve-baseline failure in actions/check-target; pre-dates check-target, see aggregate.py's _OPERATIONAL_ERROR_VERDICT) and \"NO_BASELINE\" (actions/check-target's bootstrap \"no baseline published yet\" advisory pass, ADR-047 §6 -- never a compatibility verdict). Only the five real values require the full compare-report shape below (see allOf); ERROR/NO_BASELINE reports carry whatever operational_errors/check_evidence_coverage context is available instead.",
+      "enum": ["NO_CHANGE", "COMPATIBLE", "COMPATIBLE_WITH_RISK", "API_BREAK", "BREAKING", "ERROR", "NO_BASELINE"]
     },
     "full_verdict": {
       "type": "string",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ nav:
     - Build Output Schema: reference/build-output-schema.md
     - Project Targets Schema: reference/project-targets-schema.md
     - resolve-baseline Action: reference/resolve-baseline.md
+    - check-target Action: reference/check-target.md
     - Configuration File: reference/config-file.md
     - Environment Variables: reference/environment.md
     - Platforms: reference/platforms.md

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -389,6 +389,35 @@ class TestFinalizeAugmentMode:
         assert report["severity"]["exit_code"] == 4  # aggregate needs the real value
         assert report["policy_gate_decision"] == "fail"
 
+    def test_analysis_exit_code_folds_into_local_gate_even_with_clean_severity(
+        self, tmp_path: Path
+    ) -> None:
+        """The exact Codex-flagged gap: --fail-on-removed-library on a
+        bundle/directory compare makes the CLI process exit 8 "in
+        preference to the severity code" -- the persisted report's own
+        severity.exit_code can read 0 even though a library was actually
+        removed. run.sh must forward the analysis step's own real exit code
+        (ANALYSIS_EXIT_CODE) so gate-mode: local doesn't silently pass."""
+        report_path = tmp_path / "analysis.json"
+        _write_compare_report(report_path, verdict="COMPATIBLE_WITH_RISK", exit_code=0)
+        result, outputs = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(report_path),
+                "ANALYSIS_EXIT_CODE": "8",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 8, result.stderr
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
+        assert report["policy_gate_decision"] == "fail"
+        assert (
+            report["severity"]["exit_code"] == 0
+        )  # untouched -- only the gate folds it
+
     def test_advisory_gate_mode_neutralizes_severity(self, tmp_path: Path) -> None:
         report_path = tmp_path / "analysis.json"
         _write_compare_report(report_path, verdict="BREAKING", exit_code=4)

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -90,7 +90,6 @@ _BASE_IDENTITY = {
     "INPUT_BASELINE_CHANNEL": "accepted-main",
     "INPUT_REQUESTED_DEPTH": "headers",
     "INPUT_GATE_MODE": "local",
-    "INPUT_EVIDENCE_PRODUCER": "",
     "INPUT_PROJECT": "epics-base/pvxs",
     "INPUT_HEAD_SHA": "deadbeef",
     "INPUT_BASE_REF": "main",
@@ -99,7 +98,12 @@ _BASE_IDENTITY = {
 
 
 def _write_compare_report(
-    path: Path, *, verdict: str = "BREAKING", exit_code: int = 4
+    path: Path,
+    *,
+    verdict: str = "BREAKING",
+    exit_code: int = 4,
+    old_depth: str = "headers",
+    new_depth: str = "headers",
 ) -> None:
     path.write_text(
         json.dumps(
@@ -107,6 +111,8 @@ def _write_compare_report(
                 "report_schema_version": "2.12",
                 "library": "libpvxs",
                 "verdict": verdict,
+                "old_evidence_depth": old_depth,
+                "new_evidence_depth": new_depth,
                 "severity": {
                     "config": {},
                     "categories": {},
@@ -412,23 +418,32 @@ class TestFinalizeBootstrap:
     not RUN_SH.is_file(), reason="actions/check-target/run.sh not found"
 )
 class TestFinalizeEvidenceDegradation:
-    def test_source_depth_degrades_without_ready_wrapper_pack(
+    """ADR-047 §7's effective_depth reads the real achieved depth straight
+    from the analysis report's own old_evidence_depth/new_evidence_depth --
+    correct regardless of *how* that depth was achieved (a composed
+    collect-facts producer, or a direct --build-info/--sources input with no
+    producer at all -- the case an earlier producer-based heuristic here got
+    wrong, Codex review)."""
+
+    def test_source_depth_degrades_when_report_only_reached_headers(
         self, tmp_path: Path
     ) -> None:
         report_path = tmp_path / "analysis.json"
-        _write_compare_report(report_path, verdict="COMPATIBLE", exit_code=0)
+        _write_compare_report(
+            report_path,
+            verdict="COMPATIBLE",
+            exit_code=0,
+            old_depth="headers",
+            new_depth="headers",
+        )
         result, _ = _run_finalize(
             {
                 **_BASE_IDENTITY,
                 "INPUT_REQUESTED_DEPTH": "source",
-                "INPUT_EVIDENCE_PRODUCER": "wrapper",
                 "RESOLVE_RAN": "true",
                 "RESOLVE_OUTCOME": "resolved",
                 "ANALYSIS_RAN": "true",
                 "ANALYSIS_REPORT_PATH": str(report_path),
-                "COLLECT_VERIFY_RAN": "true",
-                "COLLECT_VERIFY_OUTCOME": "success",
-                "COLLECT_VERIFY_READY": "false",
             },
             tmp_path,
         )
@@ -438,21 +453,55 @@ class TestFinalizeEvidenceDegradation:
         assert report["effective_depth"] == "headers"
         assert report["check_evidence_coverage"]["state"] == "degraded"
 
-    def test_source_depth_stays_when_wrapper_pack_ready(self, tmp_path: Path) -> None:
+    def test_source_depth_stays_when_report_reached_source(
+        self, tmp_path: Path
+    ) -> None:
         report_path = tmp_path / "analysis.json"
-        _write_compare_report(report_path, verdict="COMPATIBLE", exit_code=0)
+        _write_compare_report(
+            report_path,
+            verdict="COMPATIBLE",
+            exit_code=0,
+            old_depth="source",
+            new_depth="source",
+        )
         result, _ = _run_finalize(
             {
                 **_BASE_IDENTITY,
                 "INPUT_REQUESTED_DEPTH": "source",
-                "INPUT_EVIDENCE_PRODUCER": "wrapper",
                 "RESOLVE_RAN": "true",
                 "RESOLVE_OUTCOME": "resolved",
                 "ANALYSIS_RAN": "true",
                 "ANALYSIS_REPORT_PATH": str(report_path),
-                "COLLECT_VERIFY_RAN": "true",
-                "COLLECT_VERIFY_OUTCOME": "success",
-                "COLLECT_VERIFY_READY": "true",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        assert report["effective_depth"] == "source"
+        assert report["check_evidence_coverage"]["state"] == "complete"
+
+    def test_source_depth_via_direct_build_info_with_no_producer_is_not_degraded(
+        self, tmp_path: Path
+    ) -> None:
+        """The exact Codex-flagged regression: evidence-producer is unset
+        (a producer-less check using --build-info/--sources directly), but
+        the analysis genuinely reached source depth on both sides."""
+        report_path = tmp_path / "analysis.json"
+        _write_compare_report(
+            report_path,
+            verdict="COMPATIBLE",
+            exit_code=0,
+            old_depth="source",
+            new_depth="source",
+        )
+        result, _ = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_REQUESTED_DEPTH": "source",
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(report_path),
             },
             tmp_path,
         )

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -813,3 +813,67 @@ class TestFinalizeScanGuardSentinel:
                 "message": "the analysis reported a non-compatibility verdict: 'BUDGET_OVERFLOW'",
             }
         ]
+
+
+@pytest.mark.skipif(
+    not (ACTION_DIR / "action.yml").is_file(),
+    reason="actions/check-target/action.yml not found",
+)
+class TestStaleAnalysisOutputIsCleanedBeforeEachRun:
+    """Regression (Codex review): the nested analysis step always writes to
+    the same fixed workspace-relative path (``check-target-analysis.json``),
+    unlike the final envelope, which is already scoped per check-id. If a
+    job runs check-target more than once and a LATER invocation's nested
+    root Action crashes before ever writing its own report (e.g. a CLI
+    usage/config error), run.sh's "only emit report-path when a real report
+    file was produced" check only tests file *existence*, not freshness --
+    so it would find an EARLIER invocation's stale file and hand it to the
+    finalize step as if it were the current run's real result. With
+    gate-mode: deferred/advisory that silently turns a genuine operational
+    failure into a false pass, since operational_errors would be read from
+    the stale (successful) report instead. action.yml must unconditionally
+    delete that file immediately before the analysis step runs, every time,
+    regardless of whether the analysis step itself ends up running (its
+    own `if:` gates skip it for a prior resolve/collect failure).
+
+    action.yml's own step orchestration needs a real GitHub Actions runner
+    to exercise end-to-end (see this module's docstring), so this is a
+    structural assertion over the parsed YAML rather than a behavioral one
+    -- mirroring test_action_validate_inputs.py's
+    TestUnsetFormatUsesEachModesOwnDefault precedent for the same
+    action.yml-only-fix problem.
+    """
+
+    def test_cleanup_step_runs_unconditionally_immediately_before_analysis(
+        self,
+    ) -> None:
+        import yaml
+
+        action_yml = ACTION_DIR / "action.yml"
+        data = yaml.safe_load(action_yml.read_text(encoding="utf-8"))
+        steps = data["runs"]["steps"]
+        names = [s.get("name") for s in steps]
+        assert "Clean stale analysis output" in names, (
+            "action.yml must have a step that removes the stale "
+            "check-target-analysis.json before the analysis step runs"
+        )
+        assert "Run analysis" in names
+        cleanup_index = names.index("Clean stale analysis output")
+        analysis_index = names.index("Run analysis")
+        assert cleanup_index == analysis_index - 1, (
+            "the cleanup step must run immediately before the analysis "
+            "step, so no other step can write check-target-analysis.json "
+            "in between"
+        )
+        cleanup_step = steps[cleanup_index]
+        assert "if" not in cleanup_step, (
+            "the cleanup step must be unconditional -- it has to run even "
+            "when the analysis step's own `if:` will skip it (e.g. a "
+            "prior resolve/collect failure), or a stale file from an "
+            "earlier invocation in the same job would survive"
+        )
+        assert "check-target-analysis.json" in cleanup_step.get("run", "")
+        analysis_step = steps[analysis_index]
+        assert analysis_step["with"]["output-file"] == "check-target-analysis.json", (
+            "the cleanup step must target the same filename the analysis step writes"
+        )

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -177,6 +177,37 @@ class TestValidateInputs:
         )
         assert result.returncode == 64
 
+    def test_missing_baseline_channel_fails_with_required_message(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression (CodeRabbit review): baseline-channel was previously a
+        bare `:?` parameter expansion, which fires on empty but exits 1 with
+        a raw bash message and no `::error::` annotation -- diverging from
+        every other required-input check here. Must now use the same
+        exit-64 + `::error::` `_fail` convention as name/profile."""
+        env = dict(_BASE_IDENTITY)
+        del env["INPUT_BASELINE_CHANNEL"]
+        result = _run(VALIDATE_SH, env, tmp_path)
+        assert result.returncode == 64
+        assert "::error::baseline-channel input is required." in result.stdout
+
+    def test_missing_requested_depth_fails_with_required_message_not_enum_message(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression (CodeRabbit review): same `:?` -> `_fail` conversion
+        as baseline-channel above. Also pins the check ordering: the
+        required-input check must run BEFORE the requested-depth enum/case
+        validation, or an empty value would instead be caught there with
+        the less precise "not recognized" message (an empty string never
+        matches any case pattern, so it falls through to that branch's
+        catch-all arm)."""
+        env = dict(_BASE_IDENTITY)
+        del env["INPUT_REQUESTED_DEPTH"]
+        result = _run(VALIDATE_SH, env, tmp_path)
+        assert result.returncode == 64
+        assert "::error::requested-depth input is required." in result.stdout
+        assert "not recognized" not in result.stdout
+
     def test_unknown_kind_fails(self, tmp_path: Path) -> None:
         result = _run(
             VALIDATE_SH,
@@ -877,3 +908,63 @@ class TestStaleAnalysisOutputIsCleanedBeforeEachRun:
         assert analysis_step["with"]["output-file"] == "check-target-analysis.json", (
             "the cleanup step must target the same filename the analysis step writes"
         )
+
+
+@pytest.mark.skipif(
+    not (ACTION_DIR / "action.yml").is_file(),
+    reason="actions/check-target/action.yml not found",
+)
+class TestReplaySourcesForwardedWithDefault:
+    """Regression (Codex review): actions/collect-facts's replay phase
+    defaults an unset `sources` input to '.' internally
+    (actions/collect-facts/run.sh: ``SOURCES="${INPUT_SOURCES:-.}"``) but
+    never surfaces that resolved value as an output -- it only prints a
+    notice telling the caller to pass `sources: $SOURCES` straight to
+    dump/scan/compare. check-target's analysis step was instead forwarding
+    the raw, still-empty `inputs.sources`, and action/run.sh's
+    `add_single_flag` skips `--sources` entirely for an empty value -- so a
+    check with `evidence-producer: replay` and `sources:` left unset would
+    pass the collect-facts step but then run compare/scan with NO source
+    evidence at all, silently missing source-only findings at
+    requested-depth: build/source. action.yml must forward the same
+    resolved default collect-facts used.
+    """
+
+    def test_sources_expression_matches_collect_facts_own_default(self) -> None:
+        import yaml
+
+        action_yml = ACTION_DIR / "action.yml"
+        data = yaml.safe_load(action_yml.read_text(encoding="utf-8"))
+        steps = data["runs"]["steps"]
+        analysis_step = next(s for s in steps if s.get("name") == "Run analysis")
+        expr = analysis_step["with"]["sources"]
+        assert expr == (
+            "${{ inputs.sources != '' && inputs.sources || "
+            "(inputs.evidence-producer == 'replay' && '.' || '') }}"
+        ), (
+            "the analysis step's `sources` must fall back to '.' for "
+            "evidence-producer: replay when inputs.sources is empty, "
+            "mirroring collect-facts' own default -- a bare "
+            "`${{ inputs.sources }}` forward would leave --sources unset "
+            "entirely for that case"
+        )
+
+    @staticmethod
+    def _resolve(sources: str, evidence_producer: str) -> str:
+        """Pure-Python mirror of the GitHub Actions ternary asserted above,
+        to pin down its actual selection behavior independent of the raw
+        expression string."""
+        if sources != "":
+            return sources
+        return "." if evidence_producer == "replay" else ""
+
+    def test_empty_sources_defaults_to_dot_only_for_replay(self) -> None:
+        assert self._resolve("", "replay") == "."
+        assert self._resolve("", "wrapper") == ""
+        assert self._resolve("", "clang-plugin") == ""
+        assert self._resolve("", "") == ""
+
+    def test_explicit_sources_always_wins(self) -> None:
+        assert self._resolve("./mysrc", "replay") == "./mysrc"
+        assert self._resolve("./mysrc", "wrapper") == "./mysrc"
+        assert self._resolve("./mysrc", "") == "./mysrc"

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -214,6 +214,52 @@ class TestValidateInputs:
         )
         assert result.returncode == 64
 
+    def test_bundle_kind_rejects_build_depth(self, tmp_path: Path) -> None:
+        # kind: bundle compares directories, which the CLI's per-library
+        # release fan-out never collects build/source evidence for -- must
+        # fail loud rather than silently running at a shallower depth
+        # (Codex review).
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_KIND": "bundle",
+                "INPUT_REQUESTED_DEPTH": "build",
+                "INPUT_BASELINE_PATH": "./b",
+                "INPUT_BUNDLE_MEMBERS": '["libpvxs", "libpvxsIoc"]',
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+    def test_bundle_kind_rejects_source_depth(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_KIND": "bundle",
+                "INPUT_REQUESTED_DEPTH": "source",
+                "INPUT_BASELINE_PATH": "./b",
+                "INPUT_BUNDLE_MEMBERS": '["libpvxs", "libpvxsIoc"]',
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+    def test_bundle_kind_allows_headers_depth(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_KIND": "bundle",
+                "INPUT_REQUESTED_DEPTH": "headers",
+                "INPUT_BASELINE_PATH": "./b",
+                "INPUT_BUNDLE_MEMBERS": '["libpvxs", "libpvxsIoc"]',
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+
     def test_bundle_kind_rejects_non_library_target_kind(self, tmp_path: Path) -> None:
         result = _run(
             VALIDATE_SH,

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -252,6 +252,48 @@ class TestValidateInputs:
         )
         assert result.returncode == 64
 
+    def test_app_consumer_rejects_baseline_channel_none(self, tmp_path: Path) -> None:
+        # baseline-channel: none routes to `scan`, which has no --used-by
+        # equivalent -- an app-consumer check would silently run unscoped
+        # (Codex review).
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_BASELINE_CHANNEL": "none",
+                "INPUT_TARGET_KIND": "app-consumer",
+                "INPUT_CONSUMER_BINARY": "./consumer.so",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+    def test_plugin_contract_rejects_baseline_channel_none(
+        self, tmp_path: Path
+    ) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_BASELINE_CHANNEL": "none",
+                "INPUT_TARGET_KIND": "plugin-contract",
+                "INPUT_CONTRACT_FILE": "./contract.syms",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+    def test_library_target_allows_baseline_channel_none(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_BASELINE_CHANNEL": "none",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0
+
 
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/check-target/run.sh not found"

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -157,6 +157,26 @@ class TestValidateInputs:
         result = _run(VALIDATE_SH, {**_BASE_IDENTITY}, tmp_path)
         assert result.returncode == 64
 
+    def test_missing_profile_fails_here_not_deep_in_run_sh(
+        self, tmp_path: Path
+    ) -> None:
+        """action.yml declares profile: required: true, but GitHub Actions
+        does not actually enforce `required: true` for composite-action
+        inputs -- an omitted input just arrives as an empty string. Without
+        this check, a workflow that forgot `profile:` would sail past this
+        step and only fail deep inside run.sh's bash parameter expansion,
+        producing no report/outputs at all (Codex review)."""
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_PROFILE": "",
+                "INPUT_BASELINE_PATH": "./baseline",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
     def test_unknown_kind_fails(self, tmp_path: Path) -> None:
         result = _run(
             VALIDATE_SH,

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -364,7 +364,7 @@ class TestFinalizeAugmentMode:
         assert outputs["outcome"] == "resolved"
         assert outputs["verdict"] == "BREAKING"
         assert outputs["compatibility-verdict"] == "BREAKING"
-        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert report["check_id"] == f"libpvxs@{PROFILE}#accepted-main@headers"
         assert report["severity"]["exit_code"] == 4
 
@@ -373,7 +373,7 @@ class TestFinalizeAugmentMode:
     ) -> None:
         report_path = tmp_path / "analysis.json"
         _write_compare_report(report_path, verdict="BREAKING", exit_code=4)
-        result, _ = _run_finalize(
+        result, outputs = _run_finalize(
             {
                 **_BASE_IDENTITY,
                 "INPUT_GATE_MODE": "deferred",
@@ -385,14 +385,14 @@ class TestFinalizeAugmentMode:
             tmp_path,
         )
         assert result.returncode == 0, result.stderr
-        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert report["severity"]["exit_code"] == 4  # aggregate needs the real value
         assert report["policy_gate_decision"] == "fail"
 
     def test_advisory_gate_mode_neutralizes_severity(self, tmp_path: Path) -> None:
         report_path = tmp_path / "analysis.json"
         _write_compare_report(report_path, verdict="BREAKING", exit_code=4)
-        result, _ = _run_finalize(
+        result, outputs = _run_finalize(
             {
                 **_BASE_IDENTITY,
                 "INPUT_GATE_MODE": "advisory",
@@ -404,7 +404,7 @@ class TestFinalizeAugmentMode:
             tmp_path,
         )
         assert result.returncode == 0, result.stderr
-        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert report["severity"]["exit_code"] == 0
         assert report["severity"]["blocking"] is False
         assert report["compatibility_verdict"] == "BREAKING"
@@ -427,6 +427,52 @@ class TestFinalizeAugmentMode:
         )
         assert result.returncode == 0, result.stderr
         assert outputs["outcome"] == "skipped"
+
+    def test_two_invocations_in_the_same_job_do_not_overwrite_each_others_report(
+        self, tmp_path: Path
+    ) -> None:
+        """A fixed "check-target-report.json" filename would collide across
+        two check-target calls in the same job (e.g. the same target against
+        two baseline channels) -- an earlier step's own report-path output
+        would end up pointing at the LATER check's envelope by the time
+        anything reads it (Codex review). The filename must be scoped to
+        each check's own identity."""
+        report_path = tmp_path / "analysis.json"
+        _write_compare_report(report_path, verdict="BREAKING", exit_code=4)
+        first_result, first_outputs = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_BASELINE_CHANNEL": "accepted-main",
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(report_path),
+            },
+            tmp_path,
+        )
+        assert first_result.returncode == 4, first_result.stderr
+        second_report_path = tmp_path / "analysis2.json"
+        _write_compare_report(second_report_path, verdict="COMPATIBLE", exit_code=0)
+        second_result, second_outputs = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_BASELINE_CHANNEL": "release-contract",
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(second_report_path),
+            },
+            tmp_path,
+        )
+        assert second_result.returncode == 0, second_result.stderr
+        assert first_outputs["report-path"] != second_outputs["report-path"]
+        # The first report is still on disk, unmodified by the second call.
+        first_report = json.loads((tmp_path / first_outputs["report-path"]).read_text())
+        assert first_report["severity"]["exit_code"] == 4
+        second_report = json.loads(
+            (tmp_path / second_outputs["report-path"]).read_text()
+        )
+        assert second_report["severity"]["exit_code"] == 0
 
 
 @pytest.mark.skipif(
@@ -451,7 +497,7 @@ class TestFinalizeOperationalError:
         assert result.returncode == 1, result.stderr
         assert outputs["outcome"] == "wrong_profile"
         assert outputs["verdict"] == "ERROR"
-        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert report["operational_errors"] == [
             {
                 "kind": "wrong_profile",
@@ -463,7 +509,7 @@ class TestFinalizeOperationalError:
     def test_analysis_never_producing_a_report_is_an_operational_error(
         self, tmp_path: Path
     ) -> None:
-        result, _ = _run_finalize(
+        result, outputs = _run_finalize(
             {
                 **_BASE_IDENTITY,
                 "RESOLVE_RAN": "true",
@@ -473,7 +519,7 @@ class TestFinalizeOperationalError:
             tmp_path,
         )
         assert result.returncode == 1, result.stderr
-        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert report["operational_errors"][0]["kind"] == "ambiguous"
 
     def test_collect_verify_failure_is_a_distinct_operational_error(
@@ -494,7 +540,7 @@ class TestFinalizeOperationalError:
         )
         assert result.returncode == 1, result.stderr
         assert outputs["verdict"] == "ERROR"
-        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert "verify failed" in report["operational_errors"][0]["message"]
 
     def test_collect_replay_failure_is_a_distinct_operational_error(
@@ -512,7 +558,7 @@ class TestFinalizeOperationalError:
         )
         assert result.returncode == 1, result.stderr
         assert outputs["verdict"] == "ERROR"
-        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert "replay" in report["operational_errors"][0]["message"]
 
 
@@ -536,7 +582,7 @@ class TestFinalizeBootstrap:
         assert result.returncode == 0, result.stderr
         assert outputs["outcome"] == "not_found"
         assert outputs["verdict"] == "NO_BASELINE"
-        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert report["baseline_bootstrap"] is True
         assert report["operational_errors"] == []
 
@@ -563,7 +609,7 @@ class TestFinalizeEvidenceDegradation:
             old_depth="headers",
             new_depth="headers",
         )
-        result, _ = _run_finalize(
+        result, outputs = _run_finalize(
             {
                 **_BASE_IDENTITY,
                 "INPUT_REQUESTED_DEPTH": "source",
@@ -575,7 +621,7 @@ class TestFinalizeEvidenceDegradation:
             tmp_path,
         )
         assert result.returncode == 0, result.stderr
-        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert report["requested_depth"] == "source"
         assert report["effective_depth"] == "headers"
         assert report["check_evidence_coverage"]["state"] == "degraded"
@@ -591,7 +637,7 @@ class TestFinalizeEvidenceDegradation:
             old_depth="source",
             new_depth="source",
         )
-        result, _ = _run_finalize(
+        result, outputs = _run_finalize(
             {
                 **_BASE_IDENTITY,
                 "INPUT_REQUESTED_DEPTH": "source",
@@ -603,7 +649,7 @@ class TestFinalizeEvidenceDegradation:
             tmp_path,
         )
         assert result.returncode == 0, result.stderr
-        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert report["effective_depth"] == "source"
         assert report["check_evidence_coverage"]["state"] == "complete"
 
@@ -621,7 +667,7 @@ class TestFinalizeEvidenceDegradation:
             old_depth="source",
             new_depth="source",
         )
-        result, _ = _run_finalize(
+        result, outputs = _run_finalize(
             {
                 **_BASE_IDENTITY,
                 "INPUT_REQUESTED_DEPTH": "source",
@@ -633,6 +679,6 @@ class TestFinalizeEvidenceDegradation:
             tmp_path,
         )
         assert result.returncode == 0, result.stderr
-        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert report["effective_depth"] == "source"
         assert report["check_evidence_coverage"]["state"] == "complete"

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -388,6 +388,45 @@ class TestFinalizeOperationalError:
         report = json.loads((tmp_path / "check-target-report.json").read_text())
         assert report["operational_errors"][0]["kind"] == "ambiguous"
 
+    def test_collect_verify_failure_is_a_distinct_operational_error(
+        self, tmp_path: Path
+    ) -> None:
+        """action.yml gates the analysis step on collect_verify not having
+        failed -- a broken/empty wrapper or clang-plugin pack must never be
+        silently handed to compare as --build-info (review)."""
+        result, outputs = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "false",
+                "COLLECT_VERIFY_OUTCOME": "failure",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1, result.stderr
+        assert outputs["verdict"] == "ERROR"
+        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        assert "verify failed" in report["operational_errors"][0]["message"]
+
+    def test_collect_replay_failure_is_a_distinct_operational_error(
+        self, tmp_path: Path
+    ) -> None:
+        result, outputs = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "false",
+                "COLLECT_REPLAY_OUTCOME": "failure",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1, result.stderr
+        assert outputs["verdict"] == "ERROR"
+        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        assert "replay" in report["operational_errors"][0]["message"]
+
 
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/check-target/run.sh not found"

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -397,7 +397,11 @@ class TestFinalizeAugmentMode:
         preference to the severity code" -- the persisted report's own
         severity.exit_code can read 0 even though a library was actually
         removed. run.sh must forward the analysis step's own real exit code
-        (ANALYSIS_EXIT_CODE) so gate-mode: local doesn't silently pass."""
+        (ANALYSIS_EXIT_CODE) so gate-mode: local doesn't silently pass, and
+        the persisted severity block must also be escalated (exit_code 4,
+        abi_breaking) so a later gate-mode: deferred aggregate pass -- which
+        reads only severity.exit_code, never policy_gate_decision -- can't
+        silently miss it either (Codex review, second pass)."""
         report_path = tmp_path / "analysis.json"
         _write_compare_report(report_path, verdict="COMPATIBLE_WITH_RISK", exit_code=0)
         result, outputs = _run_finalize(
@@ -414,9 +418,40 @@ class TestFinalizeAugmentMode:
         assert result.returncode == 8, result.stderr
         report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert report["policy_gate_decision"] == "fail"
-        assert (
-            report["severity"]["exit_code"] == 0
-        )  # untouched -- only the gate folds it
+        assert report["severity"]["exit_code"] == 4
+        assert report["severity"]["blocking"] is True
+        assert "abi_breaking" in report["severity"]["blocking_categories"]
+
+    def test_removed_library_gate_survives_deferred_mode_for_a_real_aggregate_read(
+        self, tmp_path: Path
+    ) -> None:
+        """End-to-end proof this doesn't just look right on paper: feed the
+        persisted report straight into the real
+        abicheck.aggregate.GateInfo.from_report_data and confirm it reads a
+        blocking gate, for gate-mode: deferred specifically (the mode that
+        actually depends on aggregate re-reading the report later)."""
+        from abicheck.aggregate import GateInfo
+
+        report_path = tmp_path / "analysis.json"
+        _write_compare_report(report_path, verdict="COMPATIBLE_WITH_RISK", exit_code=0)
+        result, outputs = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_GATE_MODE": "deferred",
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(report_path),
+                "ANALYSIS_EXIT_CODE": "8",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stderr  # deferred never fails locally
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
+        gate = GateInfo.from_report_data(report)
+        assert gate is not None
+        assert gate.blocking is True
+        assert gate.exit_code == 4
 
     def test_advisory_gate_mode_neutralizes_severity(self, tmp_path: Path) -> None:
         report_path = tmp_path / "analysis.json"

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -682,3 +682,50 @@ class TestFinalizeEvidenceDegradation:
         report = json.loads((tmp_path / outputs["report-path"]).read_text())
         assert report["effective_depth"] == "source"
         assert report["check_evidence_coverage"]["state"] == "complete"
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/check-target/run.sh not found"
+)
+class TestFinalizeScanGuardSentinel:
+    """A baseline-channel: none scan run that hits a guard (--budget
+    exceeded, service_scan.py's BUDGET_OVERFLOW) is not a compatibility
+    finding -- the scan never completed its comparison. gate-mode: deferred/
+    advisory must not turn that into a quiet pass the way they do for a real
+    BREAKING/API_BREAK compatibility verdict (Codex review)."""
+
+    @pytest.mark.parametrize("gate_mode", ["local", "deferred", "advisory"])
+    def test_budget_overflow_always_fails_regardless_of_gate_mode(
+        self, gate_mode: str, tmp_path: Path
+    ) -> None:
+        report_path = tmp_path / "analysis.json"
+        report_path.write_text(
+            json.dumps(
+                {
+                    "scan_schema_version": "1.1",
+                    "verdict": "BUDGET_OVERFLOW",
+                    "exit_code": 5,
+                    "level": {"depth": "headers"},
+                }
+            ),
+            encoding="utf-8",
+        )
+        result, outputs = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_BASELINE_CHANNEL": "none",
+                "INPUT_GATE_MODE": gate_mode,
+                "RESOLVE_RAN": "false",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(report_path),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1, result.stderr
+        report = json.loads((tmp_path / outputs["report-path"]).read_text())
+        assert report["operational_errors"] == [
+            {
+                "kind": "scan_guard_triggered",
+                "message": "the analysis reported a non-compatibility verdict: 'BUDGET_OVERFLOW'",
+            }
+        ]

--- a/tests/test_action_check_target.py
+++ b/tests/test_action_check_target.py
@@ -1,0 +1,462 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral tests for ``actions/check-target``'s shell layer (G30 P1.3,
+ADR-047 §4/§7).
+
+``action.yml``'s own step orchestration (composing ``resolve-baseline`` +
+``collect-facts`` + the root Action as nested ``uses:`` steps) needs a real
+GitHub Actions runner to exercise end-to-end -- these tests instead drive
+``validate-inputs.sh`` and ``run.sh`` directly, simulating the env vars
+``action.yml`` would inject from those steps' own outputs (``RESOLVE_*``,
+``ANALYSIS_*``, ``COLLECT_*``). The pure report-envelope logic those two
+scripts delegate to is unit-tested in isolation in
+``tests/test_check_report.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ACTION_DIR = Path(__file__).resolve().parents[1] / "actions" / "check-target"
+RUN_SH = ACTION_DIR / "run.sh"
+VALIDATE_SH = ACTION_DIR / "validate-inputs.sh"
+
+PROFILE = "linux-x86_64-gcc13-release"
+
+
+def _bash_executable() -> str:
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
+def _run(
+    script: Path, env_extra: dict[str, str], cwd: Path
+) -> subprocess.CompletedProcess[str]:
+    base_env = {k: v for k, v in os.environ.items() if not k.startswith("INPUT_")}
+    env = {**base_env, "ACTION_PATH": str(ACTION_DIR), **env_extra}
+    return subprocess.run(
+        [_bash_executable(), str(script)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=cwd,
+        check=False,
+    )
+
+
+def _run_finalize(
+    env_extra: dict[str, str], cwd: Path
+) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+    github_output = cwd / "github_output"
+    github_output.write_text("")
+    result = _run(RUN_SH, {"GITHUB_OUTPUT": str(github_output), **env_extra}, cwd)
+    outputs: dict[str, str] = {}
+    for line in github_output.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            k, v = line.split("=", 1)
+            outputs[k] = v
+    return result, outputs
+
+
+_BASE_IDENTITY = {
+    "INPUT_NAME": "libpvxs",
+    "INPUT_PROFILE": PROFILE,
+    "INPUT_BASELINE_CHANNEL": "accepted-main",
+    "INPUT_REQUESTED_DEPTH": "headers",
+    "INPUT_GATE_MODE": "local",
+    "INPUT_EVIDENCE_PRODUCER": "",
+    "INPUT_PROJECT": "epics-base/pvxs",
+    "INPUT_HEAD_SHA": "deadbeef",
+    "INPUT_BASE_REF": "main",
+    "INPUT_ACTION_VERSION": "abicheck/abicheck@v1",
+}
+
+
+def _write_compare_report(
+    path: Path, *, verdict: str = "BREAKING", exit_code: int = 4
+) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "report_schema_version": "2.12",
+                "library": "libpvxs",
+                "verdict": verdict,
+                "severity": {
+                    "config": {},
+                    "categories": {},
+                    "exit_code": exit_code,
+                    "blocking": exit_code != 0,
+                    "blocking_categories": ["abi_breaking"] if exit_code else [],
+                },
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.skipif(
+    not VALIDATE_SH.is_file(),
+    reason="actions/check-target/validate-inputs.sh not found",
+)
+class TestValidateInputs:
+    def test_valid_library_target_passes(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_BASELINE_PATH": "./baseline",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_baseline_channel_none_does_not_require_baseline_path(
+        self, tmp_path: Path
+    ) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {**_BASE_IDENTITY, "INPUT_BASELINE_CHANNEL": "none"},
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_missing_baseline_path_fails_for_real_channel(self, tmp_path: Path) -> None:
+        result = _run(VALIDATE_SH, {**_BASE_IDENTITY}, tmp_path)
+        assert result.returncode == 64
+
+    def test_unknown_kind_fails(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {**_BASE_IDENTITY, "INPUT_KIND": "bogus", "INPUT_BASELINE_PATH": "./b"},
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+    def test_unknown_target_kind_fails(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_TARGET_KIND": "bogus",
+                "INPUT_BASELINE_PATH": "./b",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+    def test_unknown_gate_mode_fails(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_GATE_MODE": "bogus",
+                "INPUT_BASELINE_PATH": "./b",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+    def test_unknown_requested_depth_fails(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_REQUESTED_DEPTH": "bogus",
+                "INPUT_BASELINE_PATH": "./b",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+    def test_bundle_kind_requires_bundle_members(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_KIND": "bundle",
+                "INPUT_BASELINE_PATH": "./b",
+                "INPUT_BUNDLE_MEMBERS": "[]",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+    def test_bundle_kind_rejects_non_library_target_kind(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_KIND": "bundle",
+                "INPUT_TARGET_KIND": "app-consumer",
+                "INPUT_BASELINE_PATH": "./b",
+                "INPUT_BUNDLE_MEMBERS": '["libpvxs", "libpvxsIoc"]',
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+    def test_app_consumer_requires_consumer_binary(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_TARGET_KIND": "app-consumer",
+                "INPUT_BASELINE_PATH": "./b",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+    def test_plugin_contract_requires_contract_file(self, tmp_path: Path) -> None:
+        result = _run(
+            VALIDATE_SH,
+            {
+                **_BASE_IDENTITY,
+                "INPUT_TARGET_KIND": "plugin-contract",
+                "INPUT_BASELINE_PATH": "./b",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 64
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/check-target/run.sh not found"
+)
+class TestFinalizeAugmentMode:
+    """The common path: baseline resolved (or channel: none), analysis ran."""
+
+    def test_local_gate_mode_reflects_real_exit_code(self, tmp_path: Path) -> None:
+        report_path = tmp_path / "analysis.json"
+        _write_compare_report(report_path, verdict="BREAKING", exit_code=4)
+        result, outputs = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(report_path),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 4, result.stderr
+        assert outputs["outcome"] == "resolved"
+        assert outputs["verdict"] == "BREAKING"
+        assert outputs["compatibility-verdict"] == "BREAKING"
+        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        assert report["check_id"] == f"libpvxs@{PROFILE}#accepted-main@headers"
+        assert report["severity"]["exit_code"] == 4
+
+    def test_deferred_gate_mode_never_fails_job_but_keeps_real_severity(
+        self, tmp_path: Path
+    ) -> None:
+        report_path = tmp_path / "analysis.json"
+        _write_compare_report(report_path, verdict="BREAKING", exit_code=4)
+        result, _ = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_GATE_MODE": "deferred",
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(report_path),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        assert report["severity"]["exit_code"] == 4  # aggregate needs the real value
+        assert report["policy_gate_decision"] == "fail"
+
+    def test_advisory_gate_mode_neutralizes_severity(self, tmp_path: Path) -> None:
+        report_path = tmp_path / "analysis.json"
+        _write_compare_report(report_path, verdict="BREAKING", exit_code=4)
+        result, _ = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_GATE_MODE": "advisory",
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(report_path),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        assert report["severity"]["exit_code"] == 0
+        assert report["severity"]["blocking"] is False
+        assert report["compatibility_verdict"] == "BREAKING"
+        assert report["policy_gate_decision"] == "fail"
+
+    def test_baseline_channel_none_skips_resolve_and_still_augments(
+        self, tmp_path: Path
+    ) -> None:
+        report_path = tmp_path / "analysis.json"
+        _write_compare_report(report_path, verdict="COMPATIBLE", exit_code=0)
+        result, outputs = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_BASELINE_CHANNEL": "none",
+                "RESOLVE_RAN": "false",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(report_path),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        assert outputs["outcome"] == "skipped"
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/check-target/run.sh not found"
+)
+class TestFinalizeOperationalError:
+    @pytest.mark.parametrize("gate_mode", ["local", "deferred", "advisory"])
+    def test_resolve_failure_always_fails_regardless_of_gate_mode(
+        self, gate_mode: str, tmp_path: Path
+    ) -> None:
+        result, outputs = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_GATE_MODE": gate_mode,
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "wrong_profile",
+                "RESOLVE_MESSAGE": "baseline built for a different profile.",
+                "ANALYSIS_RAN": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1, result.stderr
+        assert outputs["outcome"] == "wrong_profile"
+        assert outputs["verdict"] == "ERROR"
+        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        assert report["operational_errors"] == [
+            {
+                "kind": "wrong_profile",
+                "message": "baseline built for a different profile.",
+            }
+        ]
+        assert "severity" not in report
+
+    def test_analysis_never_producing_a_report_is_an_operational_error(
+        self, tmp_path: Path
+    ) -> None:
+        result, _ = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1, result.stderr
+        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        assert report["operational_errors"][0]["kind"] == "ambiguous"
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/check-target/run.sh not found"
+)
+class TestFinalizeBootstrap:
+    def test_bootstrap_pass_never_fails_the_job(self, tmp_path: Path) -> None:
+        result, outputs = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_BASELINE_REQUIRED": "false",
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "not_found",
+                "RESOLVE_BOOTSTRAP": "true",
+                "RESOLVE_MESSAGE": "no baseline set exists yet.",
+                "ANALYSIS_RAN": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        assert outputs["outcome"] == "not_found"
+        assert outputs["verdict"] == "NO_BASELINE"
+        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        assert report["baseline_bootstrap"] is True
+        assert report["operational_errors"] == []
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/check-target/run.sh not found"
+)
+class TestFinalizeEvidenceDegradation:
+    def test_source_depth_degrades_without_ready_wrapper_pack(
+        self, tmp_path: Path
+    ) -> None:
+        report_path = tmp_path / "analysis.json"
+        _write_compare_report(report_path, verdict="COMPATIBLE", exit_code=0)
+        result, _ = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_REQUESTED_DEPTH": "source",
+                "INPUT_EVIDENCE_PRODUCER": "wrapper",
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(report_path),
+                "COLLECT_VERIFY_RAN": "true",
+                "COLLECT_VERIFY_OUTCOME": "success",
+                "COLLECT_VERIFY_READY": "false",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        assert report["requested_depth"] == "source"
+        assert report["effective_depth"] == "headers"
+        assert report["check_evidence_coverage"]["state"] == "degraded"
+
+    def test_source_depth_stays_when_wrapper_pack_ready(self, tmp_path: Path) -> None:
+        report_path = tmp_path / "analysis.json"
+        _write_compare_report(report_path, verdict="COMPATIBLE", exit_code=0)
+        result, _ = _run_finalize(
+            {
+                **_BASE_IDENTITY,
+                "INPUT_REQUESTED_DEPTH": "source",
+                "INPUT_EVIDENCE_PRODUCER": "wrapper",
+                "RESOLVE_RAN": "true",
+                "RESOLVE_OUTCOME": "resolved",
+                "ANALYSIS_RAN": "true",
+                "ANALYSIS_REPORT_PATH": str(report_path),
+                "COLLECT_VERIFY_RAN": "true",
+                "COLLECT_VERIFY_OUTCOME": "success",
+                "COLLECT_VERIFY_READY": "true",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stderr
+        report = json.loads((tmp_path / "check-target-report.json").read_text())
+        assert report["effective_depth"] == "source"
+        assert report["check_evidence_coverage"]["state"] == "complete"

--- a/tests/test_action_run_sh_compare_build_source.py
+++ b/tests/test_action_run_sh_compare_build_source.py
@@ -144,11 +144,17 @@ class TestCompareModeForwardsBuildSourceEvidence:
 class TestCompareModeSkipsEvidenceFlagsForDirectoryOperands:
     """The CLI's per-library release fan-out (directory/package operands --
     e.g. check-target's kind: bundle) rejects --sources/--build-info/
-    --config/--depth outright (_reject_evidence_flags_for_set_inputs) --
-    forwarding them here would turn every bundle comparison into a hard
-    usage error instead of running it (Codex review, PR #625)."""
+    --depth outright (_reject_evidence_flags_for_set_inputs) -- forwarding
+    them here would turn every bundle comparison into a hard usage error
+    instead of running it (Codex review, PR #625). --config is NOT one of
+    the rejected flags (_EVIDENCE_SET_INPUT_FLAGS lists only depth/sources/
+    build_info) -- the release fan-out still consumes the project
+    .abicheck.yml, so it must keep reaching the CLI even for a directory
+    operand (Codex review, second round)."""
 
-    def test_directory_new_library_gets_no_evidence_flags(self, tmp_path: Path) -> None:
+    def test_directory_new_library_gets_no_evidence_flags_but_keeps_config(
+        self, tmp_path: Path
+    ) -> None:
         old_dir = tmp_path / "old-bundle"
         new_dir = tmp_path / "new-bundle"
         old_dir.mkdir()
@@ -166,8 +172,8 @@ class TestCompareModeSkipsEvidenceFlagsForDirectoryOperands:
         )
         assert "--sources" not in cmd
         assert "--build-info" not in cmd
-        assert "--config" not in cmd
         assert "--depth" not in cmd
+        assert "--config /cfg.yml" in cmd
 
     def test_directory_old_library_alone_also_skips_evidence_flags(
         self, tmp_path: Path

--- a/tests/test_action_run_sh_compare_build_source.py
+++ b/tests/test_action_run_sh_compare_build_source.py
@@ -139,3 +139,49 @@ class TestCompareModeForwardsBuildSourceEvidence:
         assert "--build-info" not in cmd
         assert "--config" not in cmd
         assert "--depth" not in cmd
+
+
+class TestCompareModeSkipsEvidenceFlagsForDirectoryOperands:
+    """The CLI's per-library release fan-out (directory/package operands --
+    e.g. check-target's kind: bundle) rejects --sources/--build-info/
+    --config/--depth outright (_reject_evidence_flags_for_set_inputs) --
+    forwarding them here would turn every bundle comparison into a hard
+    usage error instead of running it (Codex review, PR #625)."""
+
+    def test_directory_new_library_gets_no_evidence_flags(self, tmp_path: Path) -> None:
+        old_dir = tmp_path / "old-bundle"
+        new_dir = tmp_path / "new-bundle"
+        old_dir.mkdir()
+        new_dir.mkdir()
+        cmd = _run_compare(
+            {
+                "INPUT_OLD_LIBRARY": str(old_dir),
+                "INPUT_NEW_LIBRARY": str(new_dir),
+                "INPUT_SOURCES": "/src",
+                "INPUT_BUILD_INFO": "/build",
+                "INPUT_BUILD_CONFIG": "/cfg.yml",
+                "INPUT_DEPTH": "source",
+            },
+            tmp_path,
+        )
+        assert "--sources" not in cmd
+        assert "--build-info" not in cmd
+        assert "--config" not in cmd
+        assert "--depth" not in cmd
+
+    def test_directory_old_library_alone_also_skips_evidence_flags(
+        self, tmp_path: Path
+    ) -> None:
+        old_dir = tmp_path / "old-bundle"
+        old_dir.mkdir()
+        new_json = tmp_path / "new.json"
+        new_json.write_text("{}", encoding="utf-8")
+        cmd = _run_compare(
+            {
+                "INPUT_OLD_LIBRARY": str(old_dir),
+                "INPUT_NEW_LIBRARY": str(new_json),
+                "INPUT_DEPTH": "build",
+            },
+            tmp_path,
+        )
+        assert "--depth" not in cmd

--- a/tests/test_action_run_sh_compare_build_source.py
+++ b/tests/test_action_run_sh_compare_build_source.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Behavioral test: ``action/run.sh``'s compare-mode branch forwards
+build/source evidence (Codex review, PR #625).
+
+``sources``/``build-info``/``compile-db``/``build-config``/``depth`` were
+only ever forwarded to the CLI in ``dump``/``scan`` mode -- a ``compare``
+mode invocation (the normal, non-audit path ``actions/check-target`` uses
+for a ``--depth build``/``source`` check) silently dropped all five, so the
+underlying ``compare`` CLI call never received the evidence needed to
+actually reach that depth, regardless of what the report envelope later
+claimed was requested. This runs the real ``action/run.sh`` end-to-end
+(not the CLI itself, which is a fake shell stub on ``$PATH`` capturing its
+own argv) to prove the fix reaches the real command line, not just that the
+scripted intent looks right on paper.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+RUN_SH = Path(__file__).resolve().parents[1] / "action" / "run.sh"
+
+
+def _bash_executable() -> str:
+    if os.name != "nt":
+        return "bash"
+    for candidate in (
+        os.environ.get("GIT_BASH_PATH"),
+        r"C:\Program Files\Git\bin\bash.exe",
+        r"C:\Program Files\Git\usr\bin\bash.exe",
+    ):
+        if candidate and Path(candidate).is_file():
+            return candidate
+    return "bash"
+
+
+def _run_compare(env_extra: dict[str, str], tmp_path: Path) -> str:
+    """Run the real run.sh in compare mode against a fake `abicheck` on
+    $PATH that records its own argv; returns the captured command line."""
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir()
+    captured = tmp_path / "captured_argv.txt"
+    abicheck_stub = fake_bin / "abicheck"
+    abicheck_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf \'%s\\n\' "$*" >> "{captured}"\n'
+        'echo \'{"verdict":"COMPATIBLE"}\'\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    abicheck_stub.chmod(0o755)
+
+    old_json = tmp_path / "old.json"
+    new_json = tmp_path / "new.json"
+    old_json.write_text("{}", encoding="utf-8")
+    new_json.write_text("{}", encoding="utf-8")
+
+    github_output = tmp_path / "github_output"
+    github_output.write_text("")
+    github_step_summary = tmp_path / "github_step_summary"
+    github_step_summary.write_text("")
+
+    base_env = {k: v for k, v in os.environ.items() if not k.startswith("INPUT_")}
+    env = {
+        **base_env,
+        "PATH": f"{fake_bin}{os.pathsep}{base_env.get('PATH', '')}",
+        "INPUT_MODE": "compare",
+        "INPUT_OLD_LIBRARY": str(old_json),
+        "INPUT_NEW_LIBRARY": str(new_json),
+        "INPUT_ADD_JOB_SUMMARY": "false",
+        "INPUT_PR_COMMENT": "false",
+        "GITHUB_OUTPUT": str(github_output),
+        "GITHUB_STEP_SUMMARY": str(github_step_summary),
+        **env_extra,
+    }
+    result = subprocess.run(
+        [_bash_executable(), str(RUN_SH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert captured.is_file(), "abicheck stub was never invoked"
+    return captured.read_text(encoding="utf-8").strip()
+
+
+class TestCompareModeForwardsBuildSourceEvidence:
+    def test_sources_and_depth_reach_the_cli(self, tmp_path: Path) -> None:
+        cmd = _run_compare({"INPUT_SOURCES": "/src", "INPUT_DEPTH": "source"}, tmp_path)
+        assert "--sources new=/src" in cmd
+        assert "--depth source" in cmd
+
+    def test_build_info_reaches_the_cli_scoped_to_new_side(
+        self, tmp_path: Path
+    ) -> None:
+        cmd = _run_compare({"INPUT_BUILD_INFO": "/build"}, tmp_path)
+        assert "--build-info new=/build" in cmd
+
+    def test_compile_db_falls_back_when_build_info_unset(self, tmp_path: Path) -> None:
+        cmd = _run_compare({"INPUT_COMPILE_DB": "/compile_commands.json"}, tmp_path)
+        assert "--build-info new=/compile_commands.json" in cmd
+
+    def test_build_info_takes_precedence_over_compile_db(self, tmp_path: Path) -> None:
+        cmd = _run_compare(
+            {
+                "INPUT_BUILD_INFO": "/build",
+                "INPUT_COMPILE_DB": "/compile_commands.json",
+            },
+            tmp_path,
+        )
+        assert "--build-info new=/build" in cmd
+        assert "compile_commands.json" not in cmd
+
+    def test_build_config_reaches_the_cli_as_config(self, tmp_path: Path) -> None:
+        cmd = _run_compare({"INPUT_BUILD_CONFIG": "/cfg.yml"}, tmp_path)
+        assert "--config /cfg.yml" in cmd
+
+    def test_no_evidence_inputs_adds_no_flags(self, tmp_path: Path) -> None:
+        cmd = _run_compare({}, tmp_path)
+        assert "--sources" not in cmd
+        assert "--build-info" not in cmd
+        assert "--config" not in cmd
+        assert "--depth" not in cmd

--- a/tests/test_action_run_sh_compare_build_source.py
+++ b/tests/test_action_run_sh_compare_build_source.py
@@ -50,9 +50,13 @@ def _bash_executable() -> str:
     return "bash"
 
 
-def _run_compare(env_extra: dict[str, str], tmp_path: Path) -> str:
+def _run_compare_raw(
+    env_extra: dict[str, str], tmp_path: Path
+) -> tuple[subprocess.CompletedProcess[str], Path]:
     """Run the real run.sh in compare mode against a fake `abicheck` on
-    $PATH that records its own argv; returns the captured command line."""
+    $PATH that records its own argv; returns the raw result plus the path
+    the argv would have been captured to (may not exist if run.sh exited
+    before ever invoking the stub)."""
     fake_bin = tmp_path / "fakebin"
     fake_bin.mkdir()
     captured = tmp_path / "captured_argv.txt"
@@ -97,6 +101,13 @@ def _run_compare(env_extra: dict[str, str], tmp_path: Path) -> str:
         cwd=tmp_path,
         check=False,
     )
+    return result, captured
+
+
+def _run_compare(env_extra: dict[str, str], tmp_path: Path) -> str:
+    """Like _run_compare_raw, but asserts success and returns the captured
+    command line."""
+    result, captured = _run_compare_raw(env_extra, tmp_path)
     assert result.returncode == 0, result.stdout + result.stderr
     assert captured.is_file(), "abicheck stub was never invoked"
     return captured.read_text(encoding="utf-8").strip()
@@ -163,10 +174,8 @@ class TestCompareModeSkipsEvidenceFlagsForDirectoryOperands:
             {
                 "INPUT_OLD_LIBRARY": str(old_dir),
                 "INPUT_NEW_LIBRARY": str(new_dir),
-                "INPUT_SOURCES": "/src",
-                "INPUT_BUILD_INFO": "/build",
                 "INPUT_BUILD_CONFIG": "/cfg.yml",
-                "INPUT_DEPTH": "source",
+                "INPUT_DEPTH": "headers",
             },
             tmp_path,
         )
@@ -186,8 +195,70 @@ class TestCompareModeSkipsEvidenceFlagsForDirectoryOperands:
             {
                 "INPUT_OLD_LIBRARY": str(old_dir),
                 "INPUT_NEW_LIBRARY": str(new_json),
-                "INPUT_DEPTH": "build",
+                "INPUT_DEPTH": "headers",
             },
             tmp_path,
+        )
+        assert "--depth" not in cmd
+
+
+class TestCompareModeFailsFastOnUnservableDirectoryEvidenceRequest:
+    """A directory/package operand can never actually collect build/source
+    evidence (the CLI's per-library release fan-out rejects it outright),
+    so silently dropping a real evidence request there would let the
+    comparison run without the evidence and still report a clean/normal
+    result -- e.g. missing a source-only break. Must fail loud instead
+    (Codex review, PR #625)."""
+
+    def test_depth_source_against_directory_operand_fails(self, tmp_path: Path) -> None:
+        new_dir = tmp_path / "new-bundle"
+        new_dir.mkdir()
+        result, captured = _run_compare_raw(
+            {"INPUT_NEW_LIBRARY": str(new_dir), "INPUT_DEPTH": "source"}, tmp_path
+        )
+        assert result.returncode != 0
+        assert not captured.is_file(), "abicheck stub must never be invoked"
+
+    def test_depth_build_against_directory_operand_fails(self, tmp_path: Path) -> None:
+        new_dir = tmp_path / "new-bundle"
+        new_dir.mkdir()
+        result, captured = _run_compare_raw(
+            {"INPUT_NEW_LIBRARY": str(new_dir), "INPUT_DEPTH": "build"}, tmp_path
+        )
+        assert result.returncode != 0
+        assert not captured.is_file()
+
+    def test_explicit_sources_against_directory_operand_fails_even_without_depth(
+        self, tmp_path: Path
+    ) -> None:
+        new_dir = tmp_path / "new-bundle"
+        new_dir.mkdir()
+        result, captured = _run_compare_raw(
+            {"INPUT_NEW_LIBRARY": str(new_dir), "INPUT_SOURCES": "/src"}, tmp_path
+        )
+        assert result.returncode != 0
+        assert not captured.is_file()
+
+    def test_explicit_build_info_against_directory_operand_fails(
+        self, tmp_path: Path
+    ) -> None:
+        new_dir = tmp_path / "new-bundle"
+        new_dir.mkdir()
+        result, captured = _run_compare_raw(
+            {"INPUT_NEW_LIBRARY": str(new_dir), "INPUT_BUILD_INFO": "/build"}, tmp_path
+        )
+        assert result.returncode != 0
+        assert not captured.is_file()
+
+    def test_headers_depth_against_directory_operand_still_succeeds(
+        self, tmp_path: Path
+    ) -> None:
+        """binary/headers never needed sources/build-info to begin with --
+        nothing requested is actually unservable, so this must keep working,
+        not regress into the new fail-fast path."""
+        new_dir = tmp_path / "new-bundle"
+        new_dir.mkdir()
+        cmd = _run_compare(
+            {"INPUT_NEW_LIBRARY": str(new_dir), "INPUT_DEPTH": "headers"}, tmp_path
         )
         assert "--depth" not in cmd

--- a/tests/test_action_run_sh_compare_build_source.py
+++ b/tests/test_action_run_sh_compare_build_source.py
@@ -152,6 +152,104 @@ class TestCompareModeForwardsBuildSourceEvidence:
         assert "--depth" not in cmd
 
 
+def _run_scan(env_extra: dict[str, str], tmp_path: Path) -> str:
+    """Like _run_compare, but drives run.sh's scan-mode branch instead."""
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir()
+    captured = tmp_path / "captured_argv.txt"
+    abicheck_stub = fake_bin / "abicheck"
+    abicheck_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf \'%s\\n\' "$*" >> "{captured}"\n'
+        'echo \'{"scan_schema_version":"1.2","verdict":"COMPATIBLE","exit_code":0}\'\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    abicheck_stub.chmod(0o755)
+
+    artifact = tmp_path / "new.json"
+    artifact.write_text("{}", encoding="utf-8")
+
+    github_output = tmp_path / "github_output"
+    github_output.write_text("")
+    github_step_summary = tmp_path / "github_step_summary"
+    github_step_summary.write_text("")
+
+    base_env = {k: v for k, v in os.environ.items() if not k.startswith("INPUT_")}
+    env = {
+        **base_env,
+        "PATH": f"{fake_bin}{os.pathsep}{base_env.get('PATH', '')}",
+        "INPUT_MODE": "scan",
+        "INPUT_NEW_LIBRARY": str(artifact),
+        "INPUT_ADD_JOB_SUMMARY": "false",
+        "GITHUB_OUTPUT": str(github_output),
+        "GITHUB_STEP_SUMMARY": str(github_step_summary),
+        **env_extra,
+    }
+    result = subprocess.run(
+        [_bash_executable(), str(RUN_SH)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=tmp_path,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert captured.is_file(), "abicheck stub was never invoked"
+    return captured.read_text(encoding="utf-8").strip()
+
+
+class TestScanModeForwardsCrossCompilerFlags:
+    """Same gap as compare mode above, in scan mode's branch (Codex
+    review, PR #625)."""
+
+    def test_all_four_reach_the_cli(self, tmp_path: Path) -> None:
+        cmd = _run_scan(
+            {
+                "INPUT_GCC_PATH": "/opt/cross/bin/aarch64-linux-gnu-g++",
+                "INPUT_GCC_PREFIX": "aarch64-linux-gnu-",
+                "INPUT_GCC_OPTIONS": "-D__ARM_NEON",
+                "INPUT_SYSROOT": "/opt/sysroots/aarch64",
+            },
+            tmp_path,
+        )
+        assert "--gcc-path /opt/cross/bin/aarch64-linux-gnu-g++" in cmd
+        assert "--gcc-prefix aarch64-linux-gnu-" in cmd
+        assert "--gcc-options -D__ARM_NEON" in cmd
+        assert "--sysroot /opt/sysroots/aarch64" in cmd
+
+
+class TestCompareModeForwardsCrossCompilerFlags:
+    """--gcc-path/--gcc-prefix/--gcc-options/--sysroot are documented root-
+    Action inputs and both dump AND compare/scan support them at the CLI
+    level, but were previously only wired into dump mode's branch --
+    a cross-target compare/scan silently fell back to the host toolchain
+    for header parsing and could produce false ABI results (Codex review,
+    PR #625)."""
+
+    def test_all_four_reach_the_cli(self, tmp_path: Path) -> None:
+        cmd = _run_compare(
+            {
+                "INPUT_GCC_PATH": "/opt/cross/bin/aarch64-linux-gnu-g++",
+                "INPUT_GCC_PREFIX": "aarch64-linux-gnu-",
+                "INPUT_GCC_OPTIONS": "-D__ARM_NEON",
+                "INPUT_SYSROOT": "/opt/sysroots/aarch64",
+            },
+            tmp_path,
+        )
+        assert "--gcc-path /opt/cross/bin/aarch64-linux-gnu-g++" in cmd
+        assert "--gcc-prefix aarch64-linux-gnu-" in cmd
+        assert "--gcc-options -D__ARM_NEON" in cmd
+        assert "--sysroot /opt/sysroots/aarch64" in cmd
+
+    def test_none_set_adds_no_flags(self, tmp_path: Path) -> None:
+        cmd = _run_compare({}, tmp_path)
+        assert "--gcc-path" not in cmd
+        assert "--gcc-prefix" not in cmd
+        assert "--gcc-options" not in cmd
+        assert "--sysroot" not in cmd
+
+
 class TestCompareModeSkipsEvidenceFlagsForDirectoryOperands:
     """The CLI's per-library release fan-out (directory/package operands --
     e.g. check-target's kind: bundle) rejects --sources/--build-info/

--- a/tests/test_check_report.py
+++ b/tests/test_check_report.py
@@ -33,8 +33,8 @@ from abicheck.buildsource.check_report import (
     build_bootstrap_report,
     build_check_id,
     build_operational_error_report,
+    derive_effective_depth,
     final_exit_code,
-    resolve_effective_depth,
     validate_identifier,
 )
 
@@ -71,42 +71,100 @@ class TestBuildCheckId:
         with pytest.raises(ValueError):
             build_check_id("lib@pvxs", "p", "c", "headers")
 
+    def test_rejects_unsafe_profile(self):
+        with pytest.raises(ValueError):
+            build_check_id("libpvxs", "p@bad", "c", "headers")
 
-class TestResolveEffectiveDepth:
-    @pytest.mark.parametrize("depth", ["binary", "headers"])
-    def test_binary_and_headers_never_degrade(self, depth):
-        effective, coverage = resolve_effective_depth(depth, evidence_ok=False)
+    def test_rejects_unsafe_channel(self):
+        with pytest.raises(ValueError):
+            build_check_id("libpvxs", "p", "c#bad", "headers")
+
+
+class TestDeriveEffectiveDepth:
+    """ADR-047 §7's authoritative-signal design: read the depth actually
+    achieved straight from the compare/scan report's own output, never from
+    a caller-supplied heuristic (Codex review: an earlier collect-facts-
+    producer-based heuristic misreported a real build/source-depth result
+    achieved via a direct --build-info/--sources input, with no producer
+    step at all, as "degraded")."""
+
+    @pytest.mark.parametrize("depth", ["binary", "headers", "build", "source"])
+    def test_compare_report_matching_depth_is_complete(self, depth):
+        report = {"old_evidence_depth": depth, "new_evidence_depth": depth}
+        effective, coverage = derive_effective_depth(report, depth)
         assert effective == depth
         assert coverage == {"state": "complete", "reasons": []}
 
-    @pytest.mark.parametrize("depth", ["build", "source"])
-    def test_build_and_source_stay_when_evidence_ok(self, depth):
-        effective, coverage = resolve_effective_depth(depth, evidence_ok=True)
-        assert effective == depth
-        assert coverage["state"] == "complete"
-
-    @pytest.mark.parametrize("depth", ["build", "source"])
-    def test_build_and_source_degrade_to_headers_without_evidence(self, depth):
-        effective, coverage = resolve_effective_depth(
-            depth, evidence_ok=False, degraded_reason="wrapper_pack_empty_for_target"
-        )
+    def test_compare_report_takes_shallower_side(self):
+        report = {"old_evidence_depth": "source", "new_evidence_depth": "headers"}
+        effective, coverage = derive_effective_depth(report, "source")
         assert effective == "headers"
         assert coverage == {
             "state": "degraded",
-            "reasons": ["wrapper_pack_empty_for_target"],
+            "reasons": ["compare_achieved_headers"],
         }
 
-    def test_default_reason_when_none_given(self):
-        _, coverage = resolve_effective_depth("source", evidence_ok=False)
-        assert coverage["reasons"] == ["evidence_not_available"]
+    def test_compare_report_shallower_than_requested_degrades(self):
+        report = {"old_evidence_depth": "headers", "new_evidence_depth": "headers"}
+        effective, coverage = derive_effective_depth(report, "source")
+        assert effective == "headers"
+        assert coverage["state"] == "degraded"
+        assert coverage["reasons"] == ["compare_achieved_headers"]
+
+    def test_compare_report_deeper_than_requested_is_honestly_reported(self):
+        """Achieving more than requested isn't a degradation -- report the
+        real depth, don't artificially cap it down to the request."""
+        report = {"old_evidence_depth": "source", "new_evidence_depth": "source"}
+        effective, coverage = derive_effective_depth(report, "binary")
+        assert effective == "source"
+        assert coverage["state"] == "complete"
+
+    def test_scan_report_level_depth_used_when_no_compare_fields(self):
+        report = {"level": {"depth": "build", "source_method": "s4"}}
+        effective, coverage = derive_effective_depth(report, "build")
+        assert effective == "build"
+        assert coverage["state"] == "complete"
+
+    def test_scan_report_shallower_than_requested_degrades(self):
+        report = {"level": {"depth": "headers"}}
+        effective, coverage = derive_effective_depth(report, "source")
+        assert effective == "headers"
+        assert coverage == {"state": "degraded", "reasons": ["scan_achieved_headers"]}
+
+    def test_no_depth_signal_falls_back_to_requested_as_unknown(self):
+        effective, coverage = derive_effective_depth({}, "source")
+        assert effective == "source"
+        assert coverage == {
+            "state": "unknown",
+            "reasons": ["no_depth_signal_in_report"],
+        }
+
+    def test_malformed_level_field_is_treated_as_no_signal(self):
+        effective, coverage = derive_effective_depth({"level": "not-a-dict"}, "headers")
+        assert effective == "headers"
+        assert coverage["state"] == "unknown"
+
+    def test_non_string_evidence_depth_fields_are_ignored(self):
+        report = {"old_evidence_depth": 1, "new_evidence_depth": None}
+        effective, coverage = derive_effective_depth(report, "headers")
+        assert coverage["state"] == "unknown"
+        assert effective == "headers"
+
+    def test_rejects_bad_requested_depth(self):
+        with pytest.raises(ValueError):
+            derive_effective_depth({}, "bogus")
 
 
 class TestAugmentReport:
-    def _base_compare_report(self, verdict="BREAKING", exit_code=4):
+    def _base_compare_report(
+        self, verdict="BREAKING", exit_code=4, old_depth="headers", new_depth="headers"
+    ):
         return {
             "report_schema_version": "2.12",
             "library": "libpvxs",
             "verdict": verdict,
+            "old_evidence_depth": old_depth,
+            "new_evidence_depth": new_depth,
             "severity": {
                 "config": {},
                 "categories": {},
@@ -118,13 +176,12 @@ class TestAugmentReport:
 
     def test_writes_identity_fields(self):
         out = augment_report(
-            self._base_compare_report(),
+            self._base_compare_report(old_depth="source", new_depth="source"),
             name="libpvxs",
             profile_id="linux-x86_64-gcc13-release",
             baseline_channel="accepted-main",
             requested_depth="source",
             gate_mode="local",
-            evidence_ok=True,
         )
         assert (
             out["check_id"] == "libpvxs@linux-x86_64-gcc13-release#accepted-main@source"
@@ -135,6 +192,23 @@ class TestAugmentReport:
         assert out["requested_depth"] == "source"
         assert out["effective_depth"] == "source"
         assert out["check_evidence_coverage"] == {"state": "complete", "reasons": []}
+        assert out["report_schema_version"] != "2.12"  # bumped to the current version
+
+    def test_degrades_effective_depth_from_real_report_signal(self):
+        """The Codex-flagged bug: a producer-less build/source check (direct
+        --build-info/--sources, no collect-facts composition) must not be
+        misreported as degraded just because no producer step ran -- the
+        real signal comes from the report itself."""
+        out = augment_report(
+            self._base_compare_report(old_depth="source", new_depth="source"),
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="source",
+            gate_mode="local",
+        )
+        assert out["effective_depth"] == "source"
+        assert out["check_evidence_coverage"]["state"] == "complete"
 
     def test_dual_writes_compatibility_verdict_matching_legacy_casing(self):
         out = augment_report(
@@ -144,7 +218,6 @@ class TestAugmentReport:
             baseline_channel="c",
             requested_depth="headers",
             gate_mode="local",
-            evidence_ok=True,
         )
         assert out["verdict"] == "BREAKING"
         assert out["compatibility_verdict"] == "BREAKING"
@@ -157,7 +230,6 @@ class TestAugmentReport:
             baseline_channel="c",
             requested_depth="headers",
             gate_mode="local",
-            evidence_ok=True,
         )
         assert out["policy_gate_decision"] == "fail"
 
@@ -168,7 +240,6 @@ class TestAugmentReport:
             baseline_channel="c",
             requested_depth="headers",
             gate_mode="local",
-            evidence_ok=True,
         )
         assert clean["policy_gate_decision"] == "pass"
 
@@ -181,7 +252,6 @@ class TestAugmentReport:
                 baseline_channel="c",
                 requested_depth="headers",
                 gate_mode=gate_mode,
-                evidence_ok=True,
             )
             assert out["severity"]["exit_code"] == 4
             assert out["severity"]["blocking"] is True
@@ -199,7 +269,6 @@ class TestAugmentReport:
             baseline_channel="c",
             requested_depth="headers",
             gate_mode="advisory",
-            evidence_ok=True,
         )
         assert out["severity"]["exit_code"] == 0
         assert out["severity"]["blocking"] is False
@@ -214,6 +283,7 @@ class TestAugmentReport:
             "scan_schema_version": "1.1",
             "verdict": "BREAKING",
             "exit_code": 4,
+            "level": {"depth": "headers"},
         }
         out = augment_report(
             scan_report,
@@ -222,10 +292,56 @@ class TestAugmentReport:
             baseline_channel="c",
             requested_depth="headers",
             gate_mode="advisory",
-            evidence_ok=True,
         )
         assert out["exit_code"] == 0
         assert out["compatibility_verdict"] == "BREAKING"
+
+    def test_scan_report_with_no_severity_block_defaults_pass(self):
+        scan_report = {
+            "scan_schema_version": "1.1",
+            "verdict": "COMPATIBLE",
+            "exit_code": 0,
+            "level": {"depth": "headers"},
+        }
+        out = augment_report(
+            scan_report,
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert out["policy_gate_decision"] == "pass"
+
+    def test_malformed_severity_exit_code_treated_as_pass(self):
+        report = self._base_compare_report()
+        report["severity"]["exit_code"] = "not-an-int"
+        out = augment_report(
+            report,
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert out["policy_gate_decision"] == "pass"
+
+    def test_malformed_scan_exit_code_treated_as_pass(self):
+        report = {
+            "scan_schema_version": "1.1",
+            "verdict": "COMPATIBLE",
+            "exit_code": "not-an-int",
+            "level": {"depth": "headers"},
+        }
+        out = augment_report(
+            report,
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert out["policy_gate_decision"] == "pass"
 
     def test_analysis_cli_error_populates_operational_errors(self):
         out = augment_report(
@@ -235,13 +351,93 @@ class TestAugmentReport:
             baseline_channel="c",
             requested_depth="headers",
             gate_mode="local",
-            evidence_ok=True,
         )
         assert out["verdict"] == "ERROR"
         assert "compatibility_verdict" not in out
         assert out["operational_errors"] == [
             {"kind": "analysis_error", "message": "bad flag combination"}
         ]
+
+    def test_advisory_neutralize_is_a_no_op_when_report_has_no_gate_block(self):
+        out = augment_report(
+            {"verdict": OPERATIONAL_ERROR_VERDICT, "error": "usage error"},
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="advisory",
+        )
+        assert "severity" not in out
+        assert "exit_code" not in out
+
+    def test_analysis_cli_error_with_no_message_gets_a_generic_one(self):
+        out = augment_report(
+            {"verdict": OPERATIONAL_ERROR_VERDICT},
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert out["operational_errors"] == [
+            {"kind": "analysis_error", "message": "the analysis step failed"}
+        ]
+
+    def test_existing_operational_errors_are_not_overwritten(self):
+        out = augment_report(
+            self._base_compare_report(verdict="COMPATIBLE", exit_code=0),
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert out["operational_errors"] == []
+
+    def test_existing_publication_is_not_overwritten(self):
+        report = self._base_compare_report()
+        report["publication"] = {"state": "failed", "channels": []}
+        out = augment_report(
+            report,
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert out["publication"] == {"state": "failed", "channels": []}
+
+    def test_optional_identity_fields_omitted_when_none(self):
+        out = augment_report(
+            self._base_compare_report(),
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert "project" not in out
+        assert "head_sha" not in out
+        assert "base_ref" not in out
+        assert "action_version" not in out
+
+    def test_optional_identity_fields_set_when_provided(self):
+        out = augment_report(
+            self._base_compare_report(),
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            project="epics-base/pvxs",
+            head_sha="deadbeef",
+            base_ref="main",
+            action_version="abicheck/abicheck@v1",
+        )
+        assert out["project"] == "epics-base/pvxs"
+        assert out["head_sha"] == "deadbeef"
+        assert out["base_ref"] == "main"
+        assert out["action_version"] == "abicheck/abicheck@v1"
 
     def test_rejects_unknown_gate_mode(self):
         with pytest.raises(ValueError):
@@ -252,7 +448,6 @@ class TestAugmentReport:
                 baseline_channel="c",
                 requested_depth="headers",
                 gate_mode="bogus",
-                evidence_ok=True,
             )
 
     def test_does_not_mutate_input(self):
@@ -265,7 +460,6 @@ class TestAugmentReport:
             baseline_channel="c",
             requested_depth="headers",
             gate_mode="advisory",
-            evidence_ok=True,
         )
         assert original == snapshot
 
@@ -281,6 +475,9 @@ class TestBuildOperationalErrorReport:
             resolve_message="baseline built for a different profile.",
             project="epics-base/pvxs",
             head_sha="deadbeef",
+            base_ref="main",
+            tool_version="abicheck 0.x.y",
+            action_version="abicheck/abicheck@v1",
         )
         assert report["verdict"] == OPERATIONAL_ERROR_VERDICT
         assert "severity" not in report
@@ -295,7 +492,25 @@ class TestBuildOperationalErrorReport:
         assert report["publication"] == {"state": "skipped", "channels": []}
         assert report["project"] == "epics-base/pvxs"
         assert report["head_sha"] == "deadbeef"
+        assert report["base_ref"] == "main"
+        assert report["tool_version"] == "abicheck 0.x.y"
+        assert report["action_version"] == "abicheck/abicheck@v1"
         assert report["check_id"] == report["target_id"]
+
+    def test_optional_fields_omitted_when_not_given(self):
+        report = build_operational_error_report(
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="accepted-main",
+            requested_depth="headers",
+            resolve_outcome="not_found",
+            resolve_message="no baseline set exists.",
+        )
+        assert "project" not in report
+        assert "head_sha" not in report
+        assert "base_ref" not in report
+        assert "tool_version" not in report
+        assert "action_version" not in report
 
 
 class TestBuildBootstrapReport:
@@ -306,6 +521,11 @@ class TestBuildBootstrapReport:
             baseline_channel="release-contract",
             requested_depth="headers",
             resolve_message="no baseline set exists yet.",
+            project="epics-base/pvxs",
+            head_sha="deadbeef",
+            base_ref="main",
+            tool_version="abicheck 0.x.y",
+            action_version="abicheck/abicheck@v1",
         )
         assert report["verdict"] == BOOTSTRAP_VERDICT
         assert report["verdict"] not in {
@@ -319,6 +539,23 @@ class TestBuildBootstrapReport:
         assert report["baseline_bootstrap"] is True
         assert report["operational_errors"] == []
         assert report["policy_gate_decision"] == "pass"
+        assert report["message"] == "no baseline set exists yet."
+        assert report["project"] == "epics-base/pvxs"
+        assert report["tool_version"] == "abicheck 0.x.y"
+
+    def test_optional_fields_omitted_when_not_given(self):
+        report = build_bootstrap_report(
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="release-contract",
+            requested_depth="headers",
+            resolve_message="no baseline set exists yet.",
+        )
+        assert "project" not in report
+        assert "head_sha" not in report
+        assert "base_ref" not in report
+        assert "tool_version" not in report
+        assert "action_version" not in report
 
 
 class TestFinalExitCode:

--- a/tests/test_check_report.py
+++ b/tests/test_check_report.py
@@ -194,6 +194,63 @@ class TestAugmentReport:
         assert out["check_evidence_coverage"] == {"state": "complete", "reasons": []}
         assert out["report_schema_version"] != "2.12"  # bumped to the current version
 
+    def test_scan_report_gets_scan_schema_version_not_report_schema_version(self):
+        """A scan report (baseline-channel: none) has its own schema marker
+        and shape -- no library/old_file/summary/changes/... -- so it must
+        never be stamped with report_schema_version (the *compare*-report
+        schema's marker): a downstream validator selecting a schema by that
+        key's presence would pick compare_report.schema.json for a report
+        that structurally can never satisfy it (Codex review)."""
+        scan_report = {
+            "scan_schema_version": "1.1",
+            "verdict": "COMPATIBLE",
+            "exit_code": 0,
+            "level": {"depth": "headers"},
+        }
+        out = augment_report(
+            scan_report,
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert "report_schema_version" not in out
+        assert out["scan_schema_version"] != "1.1"  # bumped to the current version
+
+    def test_bundle_release_report_gets_no_schema_version_stamp(self):
+        """A kind: bundle / directory-package compare report (the per-library
+        release fan-out's own verdict/old_dir/new_dir/libraries shape) has
+        never had a schema of its own -- must not be falsely stamped with
+        the single-pair compare schema's report_schema_version either
+        (Codex review)."""
+        bundle_report = {
+            "verdict": "BREAKING",
+            "old_dir": "/old",
+            "new_dir": "/new",
+            "libraries": [{"library": "libpvxs", "verdict": "BREAKING"}],
+            "severity": {
+                "config": {},
+                "categories": {},
+                "exit_code": 4,
+                "blocking": True,
+                "blocking_categories": ["abi_breaking"],
+            },
+        }
+        out = augment_report(
+            bundle_report,
+            name="pvxs-bundle",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert "report_schema_version" not in out
+        assert "scan_schema_version" not in out
+        # ADR-047 identity/policy-gate fields still apply regardless of shape.
+        assert out["check_id"] == "pvxs-bundle@p#c@headers"
+        assert out["policy_gate_decision"] == "fail"
+
     def test_degrades_effective_depth_from_real_report_signal(self):
         """The Codex-flagged bug: a producer-less build/source check (direct
         --build-info/--sources, no collect-facts composition) must not be

--- a/tests/test_check_report.py
+++ b/tests/test_check_report.py
@@ -320,10 +320,86 @@ class TestAugmentReport:
             analysis_exit_code=8,
         )
         assert out["policy_gate_decision"] == "fail"
-        # The persisted severity block is untouched -- only the gate
-        # decision folds in the analysis exit code, since gate-mode: local
-        # doesn't neutralize anything.
+
+    def test_removed_library_exit_code_escalates_persisted_severity(self):
+        """Escalating policy_gate_decision alone isn't enough: gate-mode:
+        deferred relies on check-project.yml's trailing aggregate job, and
+        abicheck.aggregate.GateInfo.from_report_data reads ONLY the
+        persisted severity.exit_code -- it has no way to see
+        policy_gate_decision. Without also updating severity here, a
+        removed-library gate on a deferred bundle check would still be
+        silently missed downstream (Codex review, second pass). Escalated
+        to exit_code 4 (abi_breaking) -- 8 itself isn't a legal
+        severity.exit_code (aggregate.py's _VALID_GATE_EXIT is {0,1,2,4})
+        and would raise _MalformedGate there."""
+        report = self._base_compare_report(verdict="COMPATIBLE_WITH_RISK", exit_code=0)
+        out = augment_report(
+            report,
+            name="libpvxs-bundle",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            analysis_exit_code=8,
+        )
+        assert out["severity"]["exit_code"] == 4
+        assert out["severity"]["blocking"] is True
+        assert "abi_breaking" in out["severity"]["blocking_categories"]
+
+    def test_removed_library_escalation_does_not_downgrade_an_already_worse_severity(
+        self,
+    ):
+        report = self._base_compare_report(verdict="BREAKING", exit_code=4)
+        report["severity"]["blocking_categories"] = ["abi_breaking"]
+        out = augment_report(
+            report,
+            name="libpvxs-bundle",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            analysis_exit_code=8,
+        )
+        assert out["severity"]["exit_code"] == 4
+        assert out["severity"]["blocking_categories"] == ["abi_breaking"]
+
+    def test_removed_library_escalation_only_triggers_on_exit_code_8(self):
+        """Any other nonzero analysis_exit_code folds into policy_gate_decision
+        (already covered above) but must NOT rewrite the severity block --
+        8 is the one specific, well-known value that bypasses severity."""
+        report = self._base_compare_report(verdict="COMPATIBLE", exit_code=0)
+        out = augment_report(
+            report,
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            analysis_exit_code=64,
+        )
         assert out["severity"]["exit_code"] == 0
+        assert out["policy_gate_decision"] == "fail"  # still folded via max()
+
+    def test_removed_library_escalation_is_a_no_op_without_a_severity_block(self):
+        """A scan-shaped report has no severity block at all -- the
+        escalation must not crash or invent one (exit 8 only ever comes
+        from the release/bundle compare path, never scan, but stay
+        defensive)."""
+        out = augment_report(
+            {
+                "scan_schema_version": "1.1",
+                "verdict": "COMPATIBLE",
+                "exit_code": 0,
+                "level": {"depth": "headers"},
+            },
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            analysis_exit_code=8,
+        )
+        assert "severity" not in out
 
     def test_analysis_exit_code_of_zero_does_not_flip_a_clean_report(self):
         out = augment_report(

--- a/tests/test_check_report.py
+++ b/tests/test_check_report.py
@@ -451,6 +451,22 @@ class TestAugmentReport:
         )
         assert out["operational_errors"] == []
 
+    def test_publication_defaults_to_skipped_not_a_false_claim(self):
+        """check-target's own nested analysis step always disables
+        add-job-summary/pr-comment/upload-sarif, and finalize only writes
+        the report JSON to disk -- none of that is a real ADR-047 §7
+        publication channel, so the default must not falsely claim
+        published/job_summary (Codex review)."""
+        out = augment_report(
+            self._base_compare_report(verdict="COMPATIBLE", exit_code=0),
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert out["publication"] == {"state": "skipped", "channels": []}
+
     def test_existing_publication_is_not_overwritten(self):
         report = self._base_compare_report()
         report["publication"] = {"state": "failed", "channels": []}

--- a/tests/test_check_report.py
+++ b/tests/test_check_report.py
@@ -440,6 +440,39 @@ class TestAugmentReport:
             {"kind": "analysis_error", "message": "the analysis step failed"}
         ]
 
+    @pytest.mark.parametrize(
+        "guard_verdict", ["BUDGET_OVERFLOW", "EVIDENCE_CONTRACT_ERROR"]
+    )
+    def test_scan_guard_sentinel_verdicts_are_operational_errors(self, guard_verdict):
+        """A scan guard sentinel (service_scan.py's BUDGET_OVERFLOW/
+        EVIDENCE_CONTRACT_ERROR) is not a compatibility finding -- the scan
+        never completed its comparison at all. Must be classified
+        operational (populating operational_errors) so gate-mode: deferred/
+        advisory can't turn a guard failure into a quiet pass (Codex
+        review) -- it was previously only checking verdict == "ERROR"."""
+        out = augment_report(
+            {
+                "scan_schema_version": "1.1",
+                "verdict": guard_verdict,
+                "exit_code": 5 if guard_verdict == "BUDGET_OVERFLOW" else 1,
+                "level": {"depth": "headers"},
+            },
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+        )
+        assert out["verdict"] == guard_verdict
+        assert "compatibility_verdict" not in out
+        assert out["operational_errors"] == [
+            {
+                "kind": "scan_guard_triggered",
+                "message": f"the analysis reported a non-compatibility verdict: {guard_verdict!r}",
+            }
+        ]
+        assert out["policy_gate_decision"] == "fail"
+
     def test_existing_operational_errors_are_not_overwritten(self):
         out = augment_report(
             self._base_compare_report(verdict="COMPATIBLE", exit_code=0),

--- a/tests/test_check_report.py
+++ b/tests/test_check_report.py
@@ -346,6 +346,21 @@ class TestAugmentReport:
         assert out["severity"]["blocking"] is True
         assert "abi_breaking" in out["severity"]["blocking_categories"]
 
+    def test_removed_library_escalation_does_not_duplicate_an_existing_category(self):
+        report = self._base_compare_report(verdict="COMPATIBLE_WITH_RISK", exit_code=2)
+        report["severity"]["blocking_categories"] = ["abi_breaking"]
+        out = augment_report(
+            report,
+            name="libpvxs-bundle",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            analysis_exit_code=8,
+        )
+        assert out["severity"]["exit_code"] == 4
+        assert out["severity"]["blocking_categories"] == ["abi_breaking"]
+
     def test_removed_library_escalation_does_not_downgrade_an_already_worse_severity(
         self,
     ):

--- a/tests/test_check_report.py
+++ b/tests/test_check_report.py
@@ -481,7 +481,9 @@ class TestBuildOperationalErrorReport:
         )
         assert report["verdict"] == OPERATIONAL_ERROR_VERDICT
         assert "severity" not in report
-        assert report["compatibility_verdict"] is None
+        # Omitted, not null -- the schema declares compatibility_verdict a
+        # plain string enum with no null alternative.
+        assert "compatibility_verdict" not in report
         assert report["policy_gate_decision"] == "fail"
         assert report["operational_errors"] == [
             {
@@ -537,6 +539,7 @@ class TestBuildBootstrapReport:
             "ERROR",
         }
         assert report["baseline_bootstrap"] is True
+        assert "compatibility_verdict" not in report
         assert report["operational_errors"] == []
         assert report["policy_gate_decision"] == "pass"
         assert report["message"] == "no baseline set exists yet."

--- a/tests/test_check_report.py
+++ b/tests/test_check_report.py
@@ -300,6 +300,43 @@ class TestAugmentReport:
         )
         assert clean["policy_gate_decision"] == "pass"
 
+    def test_analysis_exit_code_overrides_a_clean_severity_block(self):
+        """The exact Codex-flagged gap: --fail-on-removed-library on a
+        directory/package compare makes the CLI process exit 8 "in
+        preference to the severity code" (cli_compare_release_helpers.py's
+        _exit_compare_release), so a bundle report's own severity.exit_code
+        can read 0/COMPATIBLE_WITH_RISK even though the real process exited
+        nonzero. analysis_exit_code must win via max() so the gate doesn't
+        silently pass a removed-library check the caller explicitly asked
+        for."""
+        report = self._base_compare_report(verdict="COMPATIBLE_WITH_RISK", exit_code=0)
+        out = augment_report(
+            report,
+            name="libpvxs-bundle",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            analysis_exit_code=8,
+        )
+        assert out["policy_gate_decision"] == "fail"
+        # The persisted severity block is untouched -- only the gate
+        # decision folds in the analysis exit code, since gate-mode: local
+        # doesn't neutralize anything.
+        assert out["severity"]["exit_code"] == 0
+
+    def test_analysis_exit_code_of_zero_does_not_flip_a_clean_report(self):
+        out = augment_report(
+            self._base_compare_report(verdict="COMPATIBLE", exit_code=0),
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            analysis_exit_code=0,
+        )
+        assert out["policy_gate_decision"] == "pass"
+
     def test_local_and_deferred_never_neutralize_severity(self):
         for gate_mode in ("local", "deferred"):
             out = augment_report(

--- a/tests/test_check_report.py
+++ b/tests/test_check_report.py
@@ -1,0 +1,341 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``abicheck/buildsource/check_report.py`` (G30 P1.3,
+ADR-047 §7).
+
+Pure-Python tests over hand-authored report dicts -- no compiler, no real
+``abicheck compare``/``check-target`` run needed. See
+``tests/test_action_check_target.py`` for the bash/CLI-level orchestration
+this module's logic backs.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from abicheck.buildsource.check_report import (
+    BOOTSTRAP_VERDICT,
+    OPERATIONAL_ERROR_VERDICT,
+    augment_report,
+    build_bootstrap_report,
+    build_check_id,
+    build_operational_error_report,
+    final_exit_code,
+    resolve_effective_depth,
+    validate_identifier,
+)
+
+
+class TestValidateIdentifier:
+    def test_accepts_safe_charset(self):
+        validate_identifier("target", "libpvxs")
+        validate_identifier("target", "libpvxs-Ioc.v2")
+
+    @pytest.mark.parametrize("value", ["", "@bad", "has space", "has#hash", "has@at"])
+    def test_rejects_unsafe_charset(self, value):
+        with pytest.raises(ValueError):
+            validate_identifier("target", value)
+
+
+class TestBuildCheckId:
+    def test_shape(self):
+        check_id = build_check_id(
+            "libpvxs", "linux-x86_64-gcc13-release", "accepted-main", "source"
+        )
+        assert check_id == "libpvxs@linux-x86_64-gcc13-release#accepted-main@source"
+
+    def test_unconditional_depth_suffix_disambiguates_shadow_checks(self):
+        """ADR-047 §7: two checks differing only in requested_depth must not collide."""
+        header_id = build_check_id("libpvxs", "p", "accepted-main", "headers")
+        source_id = build_check_id("libpvxs", "p", "accepted-main", "source")
+        assert header_id != source_id
+
+    def test_rejects_bad_depth(self):
+        with pytest.raises(ValueError):
+            build_check_id("libpvxs", "p", "c", "bogus-depth")
+
+    def test_rejects_unsafe_component(self):
+        with pytest.raises(ValueError):
+            build_check_id("lib@pvxs", "p", "c", "headers")
+
+
+class TestResolveEffectiveDepth:
+    @pytest.mark.parametrize("depth", ["binary", "headers"])
+    def test_binary_and_headers_never_degrade(self, depth):
+        effective, coverage = resolve_effective_depth(depth, evidence_ok=False)
+        assert effective == depth
+        assert coverage == {"state": "complete", "reasons": []}
+
+    @pytest.mark.parametrize("depth", ["build", "source"])
+    def test_build_and_source_stay_when_evidence_ok(self, depth):
+        effective, coverage = resolve_effective_depth(depth, evidence_ok=True)
+        assert effective == depth
+        assert coverage["state"] == "complete"
+
+    @pytest.mark.parametrize("depth", ["build", "source"])
+    def test_build_and_source_degrade_to_headers_without_evidence(self, depth):
+        effective, coverage = resolve_effective_depth(
+            depth, evidence_ok=False, degraded_reason="wrapper_pack_empty_for_target"
+        )
+        assert effective == "headers"
+        assert coverage == {
+            "state": "degraded",
+            "reasons": ["wrapper_pack_empty_for_target"],
+        }
+
+    def test_default_reason_when_none_given(self):
+        _, coverage = resolve_effective_depth("source", evidence_ok=False)
+        assert coverage["reasons"] == ["evidence_not_available"]
+
+
+class TestAugmentReport:
+    def _base_compare_report(self, verdict="BREAKING", exit_code=4):
+        return {
+            "report_schema_version": "2.12",
+            "library": "libpvxs",
+            "verdict": verdict,
+            "severity": {
+                "config": {},
+                "categories": {},
+                "exit_code": exit_code,
+                "blocking": exit_code != 0,
+                "blocking_categories": ["abi_breaking"] if exit_code else [],
+            },
+        }
+
+    def test_writes_identity_fields(self):
+        out = augment_report(
+            self._base_compare_report(),
+            name="libpvxs",
+            profile_id="linux-x86_64-gcc13-release",
+            baseline_channel="accepted-main",
+            requested_depth="source",
+            gate_mode="local",
+            evidence_ok=True,
+        )
+        assert (
+            out["check_id"] == "libpvxs@linux-x86_64-gcc13-release#accepted-main@source"
+        )
+        assert out["target_id"] == out["check_id"]
+        assert out["profile_id"] == "linux-x86_64-gcc13-release"
+        assert out["baseline_channel"] == "accepted-main"
+        assert out["requested_depth"] == "source"
+        assert out["effective_depth"] == "source"
+        assert out["check_evidence_coverage"] == {"state": "complete", "reasons": []}
+
+    def test_dual_writes_compatibility_verdict_matching_legacy_casing(self):
+        out = augment_report(
+            self._base_compare_report(verdict="BREAKING"),
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            evidence_ok=True,
+        )
+        assert out["verdict"] == "BREAKING"
+        assert out["compatibility_verdict"] == "BREAKING"
+
+    def test_policy_gate_decision_reflects_real_exit_code(self):
+        out = augment_report(
+            self._base_compare_report(verdict="BREAKING", exit_code=4),
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            evidence_ok=True,
+        )
+        assert out["policy_gate_decision"] == "fail"
+
+        clean = augment_report(
+            self._base_compare_report(verdict="COMPATIBLE", exit_code=0),
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            evidence_ok=True,
+        )
+        assert clean["policy_gate_decision"] == "pass"
+
+    def test_local_and_deferred_never_neutralize_severity(self):
+        for gate_mode in ("local", "deferred"):
+            out = augment_report(
+                self._base_compare_report(verdict="BREAKING", exit_code=4),
+                name="libpvxs",
+                profile_id="p",
+                baseline_channel="c",
+                requested_depth="headers",
+                gate_mode=gate_mode,
+                evidence_ok=True,
+            )
+            assert out["severity"]["exit_code"] == 4
+            assert out["severity"]["blocking"] is True
+            # The real finding must still be visible, unmutated.
+            assert out["policy_gate_decision"] == "fail"
+
+    def test_advisory_neutralizes_severity_but_keeps_real_finding_visible(self):
+        """ADR-047 §7's third required sub-task: an advisory cell with a real
+        BREAKING compatibility_verdict must not raise aggregate's computed
+        exit_code() -- so the persisted severity block must read clean."""
+        out = augment_report(
+            self._base_compare_report(verdict="BREAKING", exit_code=4),
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="advisory",
+            evidence_ok=True,
+        )
+        assert out["severity"]["exit_code"] == 0
+        assert out["severity"]["blocking"] is False
+        assert out["severity"]["blocking_categories"] == []
+        # Real finding stays visible in the new, richer fields:
+        assert out["compatibility_verdict"] == "BREAKING"
+        assert out["policy_gate_decision"] == "fail"
+        assert out["verdict"] == "BREAKING"
+
+    def test_advisory_neutralizes_scan_exit_code(self):
+        scan_report = {
+            "scan_schema_version": "1.1",
+            "verdict": "BREAKING",
+            "exit_code": 4,
+        }
+        out = augment_report(
+            scan_report,
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="advisory",
+            evidence_ok=True,
+        )
+        assert out["exit_code"] == 0
+        assert out["compatibility_verdict"] == "BREAKING"
+
+    def test_analysis_cli_error_populates_operational_errors(self):
+        out = augment_report(
+            {"verdict": OPERATIONAL_ERROR_VERDICT, "error": "bad flag combination"},
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="local",
+            evidence_ok=True,
+        )
+        assert out["verdict"] == "ERROR"
+        assert "compatibility_verdict" not in out
+        assert out["operational_errors"] == [
+            {"kind": "analysis_error", "message": "bad flag combination"}
+        ]
+
+    def test_rejects_unknown_gate_mode(self):
+        with pytest.raises(ValueError):
+            augment_report(
+                self._base_compare_report(),
+                name="libpvxs",
+                profile_id="p",
+                baseline_channel="c",
+                requested_depth="headers",
+                gate_mode="bogus",
+                evidence_ok=True,
+            )
+
+    def test_does_not_mutate_input(self):
+        original = self._base_compare_report()
+        snapshot = dict(original)
+        augment_report(
+            original,
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="c",
+            requested_depth="headers",
+            gate_mode="advisory",
+            evidence_ok=True,
+        )
+        assert original == snapshot
+
+
+class TestBuildOperationalErrorReport:
+    def test_shape(self):
+        report = build_operational_error_report(
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="accepted-main",
+            requested_depth="headers",
+            resolve_outcome="wrong_profile",
+            resolve_message="baseline built for a different profile.",
+            project="epics-base/pvxs",
+            head_sha="deadbeef",
+        )
+        assert report["verdict"] == OPERATIONAL_ERROR_VERDICT
+        assert "severity" not in report
+        assert report["compatibility_verdict"] is None
+        assert report["policy_gate_decision"] == "fail"
+        assert report["operational_errors"] == [
+            {
+                "kind": "wrong_profile",
+                "message": "baseline built for a different profile.",
+            }
+        ]
+        assert report["publication"] == {"state": "skipped", "channels": []}
+        assert report["project"] == "epics-base/pvxs"
+        assert report["head_sha"] == "deadbeef"
+        assert report["check_id"] == report["target_id"]
+
+
+class TestBuildBootstrapReport:
+    def test_shape_is_never_a_compatibility_verdict(self):
+        report = build_bootstrap_report(
+            name="libpvxs",
+            profile_id="p",
+            baseline_channel="release-contract",
+            requested_depth="headers",
+            resolve_message="no baseline set exists yet.",
+        )
+        assert report["verdict"] == BOOTSTRAP_VERDICT
+        assert report["verdict"] not in {
+            "NO_CHANGE",
+            "COMPATIBLE",
+            "COMPATIBLE_WITH_RISK",
+            "API_BREAK",
+            "BREAKING",
+            "ERROR",
+        }
+        assert report["baseline_bootstrap"] is True
+        assert report["operational_errors"] == []
+        assert report["policy_gate_decision"] == "pass"
+
+
+class TestFinalExitCode:
+    def test_local_reflects_real_exit_code(self):
+        assert final_exit_code("local", real_exit_code=4, operational_error=False) == 4
+        assert final_exit_code("local", real_exit_code=0, operational_error=False) == 0
+
+    @pytest.mark.parametrize("gate_mode", ["deferred", "advisory"])
+    def test_deferred_and_advisory_never_fail_on_a_real_finding(self, gate_mode):
+        assert (
+            final_exit_code(gate_mode, real_exit_code=4, operational_error=False) == 0
+        )
+
+    @pytest.mark.parametrize("gate_mode", ["local", "deferred", "advisory"])
+    def test_operational_error_always_fails_regardless_of_gate_mode(self, gate_mode):
+        assert final_exit_code(gate_mode, real_exit_code=0, operational_error=True) == 1
+
+    def test_rejects_unknown_gate_mode(self):
+        with pytest.raises(ValueError):
+            final_exit_code("bogus", real_exit_code=0, operational_error=False)


### PR DESCRIPTION
## Summary

Implements G30 P1.3: `actions/check-target`, the composite Action that composes `actions/resolve-baseline` + `actions/collect-facts` + the root Action into **one resolved check**, always emitting the ADR-047 §7 report envelope.

## Motivation

`docs/development/plans/g30-github-actions-integration-model.md`'s P1.3 item is the next unblocked step in the G30 GitHub Actions integration-model backlog (ADR-047), depending only on P1.1/P1.2/P0.3, all already merged. `check-project.yml`/`check-single.yml` (P1.4) depend on this primitive existing.

## Changes

- New `actions/check-target/` composite Action (`action.yml`, `run.sh`, `validate-inputs.sh`, `report_envelope.py`):
  - Skips `resolve-baseline` entirely for `baseline-channel: none` (S5 single-build audit), running a `scan` audit instead of `compare`.
  - `target-kind: library|app-consumer|plugin-contract` routes to a plain compare / `--used-by` / `--required-symbols` — the root Action already supports these flags (added in #570/#579, predating ADR-047), correcting the ADR's stale premise that this needed a root-Action change.
  - `gate-mode: local|deferred|advisory`: `local` reflects the real outcome; `deferred`/`advisory` never fail the job on a compatibility finding but always fail on an operational error (a `resolve-baseline` failure); only `advisory` neutralizes the persisted `severity` block (`deferred` keeps it real for a future `aggregate` job to read).
  - Unconditional depth-suffixed `check_id`/`target_id` (`target@profile#baseline_channel@requested_depth`), dual-writing the new `compatibility_verdict`/`policy_gate_decision`/`check_evidence_coverage`/`operational_errors`/`publication` fields alongside the legacy `verdict`/`severity` fields `abicheck/aggregate.py` already parses.
  - Internal resolve/analysis steps run `continue-on-error: true` so the report-envelope step always runs and owns the composite's final exit code.
- New `abicheck/buildsource/check_report.py` — the pure logic backing the CLI wrapper (mirrors `baseline_set.py`/`resolve_baseline.py`'s existing split).
- Bumped `report_schema_version` 2.12 → 2.13 and `scan_schema_version` 1.1 → 1.2 for the new additive envelope fields (`abicheck/schemas/compare_report.schema.json`, `docs/schemas/v1/` mirror via `scripts/publish_schemas.py`).
- New `docs/reference/check-target.md` (linked from mkdocs nav); updated `resolve-baseline.md`'s "not built yet" status note.
- New end-to-end `test-check-target` job in `.github/workflows/test-action.yml`, exercising the real nested `uses:` composition against a real `abicheck compare` run (verified by hand for all three `gate-mode` values before adding).
- `changelog.d/` fragment.
- Updated `docs/development/plans/g30-github-actions-integration-model.md` marking P1.3 done, including a note on the corrected S22/S23 root-Action premise and a real gap found/fixed during implementation (the legacy no-`--severity-*` compare scheme omits the `severity` block entirely, which would defeat `gate-mode: advisory`'s neutralization — fixed by defaulting `check-target`'s own `severity-preset` input to `'default'`).

## Checklist

- [x] Tests added/updated: `tests/test_check_report.py` (35 cases, pure logic), `tests/test_action_check_target.py` (22 cases, shell orchestration), plus the new `test-check-target` CI fixture job.
- [x] Changelog fragment added.
- [x] Docs updated (`docs/reference/check-target.md`, `resolve-baseline.md`, plan doc).
- [x] `ruff check`/`ruff format --check` clean on all new/changed files; `mypy abicheck/` clean; `scripts/check_ai_readiness.py` 0 errors; `mkdocs build --strict` passes; full fast test suite (17973 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016J68Hw1Ek7BLzFnzzEJaBG)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `check-target` GitHub Action for end-to-end ABI/API checks, baseline resolution, evidence collection, configurable gating, and standardized report outputs.
  * Added support for bootstrap audits when no baseline is available.
  * Compare and scan workflows now support cross-compilation settings and relevant build/source evidence.
  * Reports now include expanded identity, evidence, policy, publication, and operational status details.

* **Bug Fixes**
  * Prevented stale analysis results and ambiguous evidence handling.
  * Improved operational-error detection and gate exit-code behavior.

* **Documentation**
  * Added comprehensive `check-target` reference documentation and updated schema documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->