### PR TITLE
fix: route check-project pre-check failures into aggregate (G30 #628)

### DIFF
--- a/.github/workflows/check-project.yml
+++ b/.github/workflows/check-project.yml
@@ -498,13 +498,25 @@ jobs:
       # workflow's own artifact-staging contract above) -- independent of
       # whether the cell has a baseline to compare against at all (Codex
       # review). Download whenever either consumer might need it.
+      # No continue-on-error here (issue #628, correcting the G30 P1.4 known
+      # gap the plan doc's round-5/round-8/round-9 addenda tracked): this
+      # download is only attempted (per the `if:` above) when this cell
+      # genuinely needs it -- a baseline to compare against, or a wrapper/
+      # clang-plugin evidence pack to verify. Swallowing a failure here used
+      # to silently weaken resolve-baseline's incompatible_evidence check
+      # (candidate-build-output would forward empty) with no report at all
+      # explaining why. Letting it fail loud, caught by the "Synthesize
+      # pre-check operational-error report" step below (mirroring how "Run
+      # check-target" itself is deliberately not continue-on-error'd, per
+      # that step's own comment), makes this a typed, aggregate-visible
+      # operational error instead.
       - name: Download build-output artifact
+        id: download_build_output
         if: matrix.baseline_channel != 'none' || inputs.evidence-producer == 'wrapper' || inputs.evidence-producer == 'clang-plugin'
         uses: actions/download-artifact@v8
         with:
           name: '${{ inputs.build-output-artifact-prefix }}${{ matrix.profile_id }}'
           path: build-output
-        continue-on-error: true
 
       # Resolves this cell's `new-library` from the downloaded `candidate/`
       # tree: a single glob match for kind: target (the redirected library's
@@ -516,8 +528,18 @@ jobs:
       # `build-output=` (the downloaded build-output.json path, or empty if
       # the download above didn't land one) for the candidate-build-output
       # forward.
+      # continue-on-error (issue #628): this step still fails loud
+      # internally (::error:: + exit 1) on every guard above -- unchanged.
+      # What changes is that the step's own failure no longer silently ends
+      # the job with no report for `aggregate` to see: continue-on-error
+      # lets the job reach the "Synthesize pre-check operational-error
+      # report" step below, which detects this step's real outcome and
+      # writes a typed envelope instead. "Run check-target" immediately
+      # below is explicitly gated on this step having actually succeeded, so
+      # it never runs against a half-resolved candidate.
       - name: Resolve candidate binary/binaries
         id: candidate
+        continue-on-error: true
         shell: bash
         env:
           MATRIX_JSON: ${{ toJSON(matrix) }}
@@ -654,6 +676,80 @@ jobs:
           print(f'build-output={build_output_path}' if os.path.isfile(build_output_path) else 'build-output=')
           " >> "$GITHUB_OUTPUT"
 
+      # Closes the G30 P1.4 known gap tracked by issue #628 (the plan doc's
+      # round-5/round-8/round-9 addenda): a pre-check failure -- the
+      # required "Download build-output artifact" download above, or the
+      # "Resolve candidate binary/binaries" step above -- used to end this
+      # job with no report at all for `aggregate` to see, indistinguishable
+      # from "this optional cell legitimately had nothing to check." Reuses
+      # actions/check-target/report_envelope.py's own `--mode
+      # operational-error` directly -- the same script check-target's own
+      # run.sh drives for a real resolve-baseline failure -- rather than
+      # reimplementing its envelope-construction logic inline here (the
+      # duplication the G30 plan doc's original framing of this gap wanted
+      # to avoid) or restructuring check-target's own interface to accept a
+      # "resolution already failed" case (its other option): this cell's
+      # identity fields (name/profile/baseline_channel/requested_depth/
+      # gate_mode) are already known from the matrix, so no other
+      # check-target input is needed to synthesize the envelope directly.
+      # `--resolve-outcome ambiguous` matches how check-target/run.sh itself
+      # already reuses resolve-baseline's "ambiguous" outcome as the generic
+      # catch-all for other pre-analysis infrastructure failures (a
+      # collect-facts verify/replay failure, a missing analysis report) that
+      # aren't literally a resolve-baseline outcome either.
+      - name: Synthesize pre-check operational-error report
+        id: precheck
+        if: always() && (steps.download_build_output.outcome == 'failure' || steps.candidate.outcome == 'failure')
+        shell: bash
+        env:
+          MATRIX_NAME: ${{ matrix.name }}
+          MATRIX_PROFILE_ID: ${{ matrix.profile_id }}
+          MATRIX_BASELINE_CHANNEL: ${{ matrix.baseline_channel }}
+          MATRIX_REQUESTED_DEPTH: ${{ matrix.requested_depth }}
+          MATRIX_GATE_MODE: ${{ matrix.gate_mode }}
+          PROJECT: ${{ inputs.project != '' && inputs.project || github.repository }}
+          HEAD_SHA: ${{ inputs.head-sha != '' && inputs.head-sha || github.sha }}
+          BASE_REF: ${{ inputs.base-ref }}
+          ACTION_VERSION: ${{ format('{0}@{1}', steps.identity.outputs.repository, steps.identity.outputs.ref) }}
+          BUILD_OUTPUT_FAILED: ${{ steps.download_build_output.outcome == 'failure' }}
+        run: |
+          set -euo pipefail
+          if [[ "$BUILD_OUTPUT_FAILED" == "true" ]]; then
+            MESSAGE="the required build-output artifact download failed for profile '$MATRIX_PROFILE_ID' -- see the 'Download build-output artifact' step's own log for the reason."
+          else
+            MESSAGE="candidate binary resolution failed for '$MATRIX_NAME' -- see the 'Resolve candidate binary/binaries' step's own log for the specific reason."
+          fi
+          set +e
+          ENVELOPE_STDOUT=$(python3 ./.check-project-src/actions/check-target/report_envelope.py \
+            --mode operational-error \
+            --name "$MATRIX_NAME" \
+            --profile-id "$MATRIX_PROFILE_ID" \
+            --baseline-channel "$MATRIX_BASELINE_CHANNEL" \
+            --requested-depth "$MATRIX_REQUESTED_DEPTH" \
+            --gate-mode "$MATRIX_GATE_MODE" \
+            --resolve-outcome "ambiguous" \
+            --resolve-message "$MESSAGE" \
+            --project "$PROJECT" \
+            --head-sha "$HEAD_SHA" \
+            --base-ref "$BASE_REF" \
+            --action-version "$ACTION_VERSION" \
+            --report-out precheck-report.json)
+          ENVELOPE_EXIT=$?
+          set -e
+          echo "$ENVELOPE_STDOUT"
+          if [[ $ENVELOPE_EXIT -ne 0 ]]; then
+            echo "::error::failed to write the pre-check operational-error report envelope (see the output above)."
+            exit 1
+          fi
+          # Same grep -v / || true caution as check-target/run.sh's own
+          # identical pattern: there are always other lines to pass through
+          # (check-id/verdict/... precede exit-code=), but the guard is kept
+          # anyway against `set -o pipefail` above.
+          echo "$ENVELOPE_STDOUT" | grep -v '^exit-code=' >> "$GITHUB_OUTPUT" || true
+          FINAL_EXIT=$(echo "$ENVELOPE_STDOUT" | sed -n 's/^exit-code=//p')
+          echo "pre-check operational-error report: precheck-report.json (exit-code: $FINAL_EXIT)"
+          exit "${FINAL_EXIT:-1}"
+
       # Deliberately no continue-on-error here: check-target's own finalize
       # step (ADR-047 §7) already computes its correct composite exit code
       # per gate-mode before this step's outer conclusion is decided, and
@@ -665,8 +761,17 @@ jobs:
       # this whole matrix job correctly report failure for a real
       # gate-mode: local break or an operational error, which
       # branch-protection-required status checks depend on.
+      #
+      # Gated on steps.candidate.outcome == 'success' (issue #628): a
+      # skipped candidate step (the build-output download above failed
+      # first) or a failed one (continue-on-error'd, so this step would
+      # otherwise still attempt to run by default) must not reach
+      # check-target with a half-resolved/missing new-library -- the
+      # "Synthesize pre-check operational-error report" step above already
+      # covers both cases.
       - name: Run check-target
         id: run
+        if: steps.candidate.outcome == 'success'
         uses: ./.check-project-src/actions/check-target
         with:
           kind: ${{ matrix.kind }}
@@ -753,12 +858,15 @@ jobs:
       # review). Keep the readable `tr` form but append a short content
       # hash of the *original* check_id so two check_ids that collide under
       # `tr` still produce distinct artifact names.
+      # Picks whichever of "Run check-target" / "Synthesize pre-check
+      # operational-error report" actually produced a report this cell --
+      # exactly one of the two ever runs per matrix cell (issue #628).
       - name: Sanitize check-id for artifact name
         id: sanitized
-        if: always() && steps.run.outputs.report-path != ''
+        if: always() && (steps.run.outputs.report-path != '' || steps.precheck.outputs.report-path != '')
         shell: bash
         env:
-          CHECK_ID: ${{ steps.run.outputs.check-id }}
+          CHECK_ID: ${{ steps.run.outputs.check-id || steps.precheck.outputs.check-id }}
         run: |
           python3 -c "
           import hashlib
@@ -780,13 +888,15 @@ jobs:
       # default unless it too is always()-conditioned. Without this, the
       # report artifact for exactly the failing cells `aggregate` most
       # needs to see would never upload. `steps.run.outputs.report-path`
-      # stays populated even for a failed step, per the comment above.
+      # stays populated even for a failed step, per the comment above --
+      # `steps.precheck.outputs.report-path` is this same guarantee's
+      # pre-check-failure counterpart (issue #628).
       - name: Upload report
-        if: always() && steps.run.outputs.report-path != ''
+        if: always() && (steps.run.outputs.report-path != '' || steps.precheck.outputs.report-path != '')
         uses: actions/upload-artifact@v7
         with:
           name: '${{ inputs.report-artifact-prefix }}${{ steps.sanitized.outputs.id }}'
-          path: ${{ steps.run.outputs.report-path }}
+          path: ${{ steps.run.outputs.report-path || steps.precheck.outputs.report-path }}
 
   # ── Job 3: fan-in gate ───────────────────────────────────────────────────
   aggregate:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,17 +373,34 @@ Pick the right home:
 
 ## Known gaps — acknowledged remaining work
 
-- **Depth contract, CLI vs. API/MCP** (CLAUDE.md "M1-6"): PR #601 (open) adds
-  a hard-fail `DumpDepthNotSatisfiedError` when an explicit `dump --depth`
-  isn't actually reached — but only at the CLI entry point (`cli.py` /
-  `cli_dump_helpers.py`). `action/run.sh` already propagates that (or any
-  other) nonzero `dump` exit code as an Action failure unconditionally — no
-  fix needed there. The gap is `abicheck/service.py`'s `ScanRequest`/
-  `run_scan_subprocess` and `abicheck/mcp_server.py`'s MCP tools (see
-  `_validate_public_depth`'s docstring): neither enforces the same
-  requested-vs-achieved check, so a Python-API caller or an MCP-driven agent
-  passing an explicit `depth=` can silently get a shallower-tier result. Once
-  PR #601 merges, extend the same check to those two call paths.
+- **Depth contract, CLI vs. API/MCP — re-investigated for G30, closed as
+  stale, not implemented (CLAUDE.md "M1-6").** This entry previously said PR
+  #601 (which adds a hard-fail `DumpDepthNotSatisfiedError` when an explicit
+  `dump --depth` isn't actually reached, in `cli.py`/`cli_dump_helpers.py`)
+  was still open, and that `abicheck/service.py`'s `ScanRequest`/
+  `run_scan_subprocess` and `abicheck/mcp_server.py`'s MCP tools needed the
+  same check extended to them once it merged. PR #601 merged 2026-07-19.
+  Re-checking what "extend the same check" would actually mean turned up two
+  separate findings, both closing this gap rather than giving it new code:
+  1. `check_requested_depth_satisfied` (the strict gate PR #601 added) is
+     called from exactly one place, `cli._write_snapshot_output` — reached
+     only by the `dump` command and one `cli_buildsource.py` snapshot-writing
+     helper. Neither `service.py`'s `run_dump`/`resolve_input` nor the
+     `abi_dump` MCP tool accept a `depth`/`sources`/`build-info` parameter at
+     all (confirmed by reading both) — there is no service.py/MCP surface
+     that promises a depth-qualified persisted snapshot for this gate to
+     extend to.
+  2. The only place a caller *can* pass an explicit `depth=` through
+     `service.py`/MCP is `ScanRequest`/`abi_scan`/`abi_estimate` — and
+     `service_scan.run_scan`, the CLI `scan` command
+     (`cli_scan.py`), and the MCP `abi_scan` tool all call the exact same
+     `scan_engine.run_scan_core`, so they already share one evidence-contract
+     implementation (`_check_scan_evidence_contract`'s pinned-depth
+     `_EvidenceContractError`, ADR-037 D5) — there was never a CLI-vs-API/MCP
+     disparity on the `scan` side to close, before or after PR #601.
+  `_validate_public_depth`'s docstring in `mcp_server.py` carried the same
+  stale "PR #601 open, tracked as remaining work" wording and was corrected
+  alongside this entry.
 
 - **Action pinning is deliberately partial, not a full sweep.** Third-party
   GitHub Actions in `.github/workflows/agentready.yml`, `ci.yml` (the

--- a/abicheck/buildsource/adapters/make.py
+++ b/abicheck/buildsource/adapters/make.py
@@ -44,7 +44,7 @@ import stat as stat_module
 from pathlib import Path
 
 from ...build_context import _extract_flags
-from ..build_evidence import BuildEvidence, CompileUnit, Generator
+from ..build_evidence import BuildEvidence, CompileUnit, Generator, LinkUnit
 from ..redaction import DEFAULT_REDACTION, RedactionPolicy
 from .base import (
     compile_unit_id,
@@ -53,6 +53,19 @@ from .base import (
     extract_abi_relevant_flags,
     source_from_argv,
 )
+
+#: Object/archive extensions a link/archive line's inputs are expected to
+#: carry — the presence of at least one is what tells a plain "-o X ..." line
+#: (which could just as easily be a compile, a codegen step, or an unrelated
+#: recipe command) apart from a genuine link/archive invocation (ADR-053 D2).
+_LINK_INPUT_EXTENSIONS = (".o", ".obj", ".a", ".lib")
+
+#: Recognized shared-library output extensions (POSIX + Windows + macOS).
+_SHARED_LIB_EXTENSIONS = (".so", ".dylib", ".dll")
+
+#: Matches ``ar`` / a cross-toolchain-prefixed ``ar`` (e.g. ``x86_64-linux-
+#: gnu-ar``), optionally with a path prefix and/or ``.exe`` suffix.
+_AR_PROG_RE = re.compile(r"^(?:[\w.+-]*-)?ar(?:\.exe)?$", re.IGNORECASE)
 
 
 class MakeAdapter:
@@ -95,6 +108,10 @@ class MakeAdapter:
             cu = self._compile_unit(line, directory)
             if cu is not None:
                 ev.compile_units.append(cu)
+                continue
+            lu = self._link_unit(line, directory)
+            if lu is not None:
+                ev.link_units.append(lu)
 
         if ev.compile_units:
             ev.build_options = derive_build_options(ev.compile_units)
@@ -107,6 +124,14 @@ class MakeAdapter:
             ev.diagnostics.append(
                 f"make: {existing_sources}/{len(ev.compile_units)} compile-unit "
                 "source paths exist relative to their recorded directories"
+            )
+        if ev.link_units:
+            ev.diagnostics.append(
+                f"make: {len(ev.link_units)} link/archive units derived from a "
+                "make dry-run transcript — reduced confidence (heuristic argv "
+                "recognition, not an authoritative target graph); feeds "
+                "abicheck.buildsource.link_attribution's TU-to-output "
+                "attribution (ADR-053), not build_diff directly."
             )
         return ev
 
@@ -165,6 +190,97 @@ class MakeAdapter:
             sysroot=self.redaction.path(str(ctx.sysroot)) if ctx.sysroot else None,
             target_triple=ctx.target_triple or "",
             abi_relevant_flags=[self.redaction.arg(f) for f in extract_abi_relevant_flags(argv)],
+        )
+
+    def _link_unit(self, line: str, directory: Path) -> LinkUnit | None:
+        """Recognize an ``ar`` archive-creation or compiler-frontend link line.
+
+        ADR-053 D2: Make has no semantic target graph to lean on the way
+        CMake/Bazel do, so this is the one build system where TU->DSO
+        attribution genuinely needs real linker/archiver argv recognition,
+        not just a target-source-list join. Same reduced-confidence,
+        heuristic-scraping posture as :meth:`_compile_unit` — a dry-run
+        transcript is not an authoritative target graph, and a line this
+        doesn't recognize is simply skipped, never an error.
+        """
+        argv = _split_recipe(line)
+        argv, directory = _consume_cd_prefix(argv, directory)
+        argv = _truncate_shell_pipeline(argv)
+        if not argv:
+            return None
+        argv, _expanded_rsp = _expand_response_files(argv, directory, self.build_dir)
+        prog = Path(argv[0]).name
+        if _AR_PROG_RE.match(prog):
+            return self._archive_link_unit(argv)
+        # A compile line was already ruled out by the caller (it tried
+        # _compile_unit first); anything left with an -o/-shared-shaped
+        # output and at least one object/archive input is treated as a
+        # link line.
+        return self._compiler_link_unit(argv)
+
+    def _archive_link_unit(self, argv: list[str]) -> LinkUnit | None:
+        # `ar <flags> output.a input1.o input2.o ...` -- ar's traditional
+        # (BSD-style) flag syntax has no leading '-' at all ("ar rcs a.a
+        # b.o"), unlike every other tool this module recognizes, so a plain
+        # "no leading '-'" filter would wrongly keep the flags token itself
+        # as an operand. Drop argv[1] too when it looks like a flag-letters
+        # token (all-alpha, no '.'/'/': a real archive/object path always
+        # has one of those) rather than a real path.
+        rest = argv[1:]
+        if rest and rest[0].isalpha() and "." not in rest[0] and "/" not in rest[0]:
+            rest = rest[1:]
+        operands = [a for a in rest if not a.startswith("-")]
+        if len(operands) < 2:
+            return None
+        output, inputs = operands[0], operands[1:]
+        if not output.lower().endswith((".a", ".lib")):
+            return None
+        inputs = [i for i in inputs if i.lower().endswith(_LINK_INPUT_EXTENSIONS)]
+        if not inputs:
+            return None
+        # No directory-joining on output/inputs, matching _compile_unit's own
+        # convention for CompileUnit.output (kept exactly as written in the
+        # recipe) -- link_attribution.py matches LinkUnit.inputs against
+        # CompileUnit.output verbatim, so both sides must use the identical
+        # convention or nothing would ever match.
+        red_output = self.redaction.path(output)
+        return LinkUnit(
+            id=f"link://{red_output}",
+            output=red_output,
+            kind="static_library",
+            inputs=[self.redaction.path(i) for i in inputs],
+            linker_argv=self.redaction.argv(argv),
+        )
+
+    def _compiler_link_unit(self, argv: list[str]) -> LinkUnit | None:
+        output = _output_from_argv(argv)
+        if not output:
+            return None
+        inputs = [
+            a
+            for a in argv[1:]
+            if not a.startswith(("-", "/")) and a.lower().endswith(_LINK_INPUT_EXTENSIONS)
+        ]
+        if not inputs:
+            return None
+        lower_output = output.lower()
+        if lower_output.endswith(_SHARED_LIB_EXTENSIONS) or "-shared" in argv:
+            kind = "shared_library"
+        elif lower_output.endswith((".o", ".obj")):
+            # A multi-object partial/incremental link ("ld -r"), not a real
+            # DSO/executable output -- not a link_attribution terminal kind.
+            return None
+        else:
+            kind = "executable"
+        # See _archive_link_unit's comment: no directory-joining, matching
+        # _compile_unit's own CompileUnit.output convention.
+        red_output = self.redaction.path(output)
+        return LinkUnit(
+            id=f"link://{red_output}",
+            output=red_output,
+            kind=kind,
+            inputs=[self.redaction.path(i) for i in inputs],
+            linker_argv=self.redaction.argv(argv),
         )
 
 

--- a/abicheck/buildsource/adapters/make.py
+++ b/abicheck/buildsource/adapters/make.py
@@ -259,7 +259,9 @@ class MakeAdapter:
         inputs = [
             a
             for a in argv[1:]
-            if not a.startswith(("-", "/")) and a.lower().endswith(_LINK_INPUT_EXTENSIONS)
+            if not a.startswith("-")
+            and not _is_msvc_flag(a)
+            and a.lower().endswith(_LINK_INPUT_EXTENSIONS)
         ]
         if not inputs:
             return None
@@ -401,6 +403,20 @@ def _is_relative_to(path: Path, root: Path) -> bool:
     except ValueError:
         return False
     return True
+
+
+def _is_msvc_flag(token: str) -> bool:
+    """Whether *token* looks like an MSVC/clang-cl ``/``-flag (``/c``,
+    ``/Foapp.obj``, ``/EHsc``) rather than a POSIX absolute path operand
+    (``/work/build/main.o``).
+
+    A real absolute path always has a directory separator beyond the leading
+    ``/``; an MSVC flag never does (CodeRabbit review, PR #632 -- the prior
+    blanket ``startswith("/")`` rejection dropped every absolute-path link
+    input on POSIX, not just MSVC flags). Reduced-confidence heuristic,
+    matching this module's existing dry-run-transcript-scraping posture.
+    """
+    return token.startswith("/") and "/" not in token[1:]
 
 
 def _output_from_argv(argv: list[str]) -> str:

--- a/abicheck/buildsource/build_output.py
+++ b/abicheck/buildsource/build_output.py
@@ -624,7 +624,16 @@ def _inferred_evidence_projection_issues(
         # to zero matches and hard-fail validation.
         expected_identities = {f"target://{t.id}"}
         if t.binary:
-            expected_identities.add(f"output://{PurePosixPath(t.binary).name}")
+            # normalize_source_path first (backslash -> forward slash), not a
+            # raw PurePosixPath(t.binary).name -- link_attribution.py builds
+            # this identity the same way (normalize_source_path(lu.output)
+            # before taking .name), and a Windows-style t.binary would
+            # otherwise never match: PurePosixPath treats a backslash as an
+            # ordinary character, not a separator, so .name would return the
+            # whole string instead of just the basename (code review finding).
+            expected_identities.add(
+                f"output://{PurePosixPath(normalize_source_path(t.binary)).name}"
+            )
         matched = sum(
             1
             for tu in tus

--- a/abicheck/buildsource/build_output.py
+++ b/abicheck/buildsource/build_output.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from .build_evidence import BuildEvidence
@@ -615,19 +615,29 @@ def _inferred_evidence_projection_issues(
         manifest = load_inputs_manifest(pack_path)
         diagnostics: list[str] = []
         tus = read_source_facts(pack_path, manifest, diagnostics=diagnostics)
-        expected = f"target://{t.id}"
+        # link_attribution's link-unit-graph channel identifies a target with
+        # no target_id on its LinkUnit (the Make case, ADR-053 D2 -- Make has
+        # no semantic target concept to attach an id to) by
+        # output://{basename of target.binary} instead of target://{t.id}
+        # (see attribute_sources_to_targets's own docstring). Accept either
+        # identity here, or a Make-derived attribution would always resolve
+        # to zero matches and hard-fail validation.
+        expected_identities = {f"target://{t.id}"}
+        if t.binary:
+            expected_identities.add(f"output://{PurePosixPath(t.binary).name}")
         matched = sum(
             1
             for tu in tus
-            if expected in attribution.get(normalize_source_path(tu.source), frozenset())
+            if attribution.get(normalize_source_path(tu.source), frozenset())
+            & expected_identities
         )
         if matched == 0:
             issues.append(
                 f"target {t.id!r}: evidence.projection is 'inferred', but "
                 f"re-deriving attribution from {evidence.attribution_path!r} "
-                f"ties none of evidence.path {evidence.path!r}'s TUs to "
-                f"{expected!r} — this inferred claim would silently "
-                "contribute nothing to this target's evidence."
+                f"ties none of evidence.path {evidence.path!r}'s TUs to any "
+                f"of {sorted(expected_identities)!r} — this inferred claim "
+                "would silently contribute nothing to this target's evidence."
             )
     return issues
 

--- a/abicheck/buildsource/build_output.py
+++ b/abicheck/buildsource/build_output.py
@@ -45,7 +45,9 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from .build_evidence import BuildEvidence
 from .inputs_pack import is_inputs_pack, load_inputs_manifest, read_source_facts
+from .link_attribution import attribute_sources_to_targets, normalize_source_path
 
 #: Schema discriminator stamped into every ``build-output.json`` (ADR-047 §2).
 BUILD_OUTPUT_SCHEMA = "abicheck.build-output/v1"
@@ -53,19 +55,26 @@ BUILD_OUTPUT_SCHEMA = "abicheck.build-output/v1"
 #: The manifest filename inside an ``abicheck-build/`` directory.
 BUILD_OUTPUT_MANIFEST_NAME = "build-output.json"
 
-#: The only ``evidence.projection`` value P1's validator accepts. ``"inferred"``
-#: is schema-reserved for P2's TU->link-unit->DSO attribution (ADR-047 §2) --
-#: accepting it here today would let an unattributed, build-wide pack validate
-#: as legitimate per-target evidence before the safety mechanism that would
-#: justify trusting it exists.
+#: A hand-asserted, per-target-exclusive evidence pack (ADR-047 §2): the
+#: build itself claims this pack belongs to exactly this target. Validated by
+#: :func:`_declared_evidence_sharing_issues` -- the pack's path must not be
+#: shared with any other ``"declared"`` target.
 DECLARED_PROJECTION = "declared"
 
+#: An automatically-derived association from a (possibly shared, possibly
+#: build-wide) evidence pack via real TU->link-unit->DSO attribution data
+#: (ADR-053 D4) -- validated by :func:`_inferred_evidence_projection_issues`,
+#: which re-derives the attribution and confirms it actually ties at least
+#: one TU to the target, rather than trusting the claim. Unlike
+#: ``"declared"``, sharing one physical pack across several ``"inferred"``
+#: targets is the whole point, not an error.
+INFERRED_PROJECTION = "inferred"
+
 #: Every enum value the schema recognizes for ``evidence.projection``, so the
-#: validator can tell "not declared" (fails, but is a known future value) from
-#: "not a real projection value at all" (also fails, but is a different kind
-#: of mistake) -- both produce a validation error today; kept as a named
-#: constant so P2 has one place to extend when ``"inferred"`` is implemented.
-KNOWN_PROJECTIONS = frozenset({"declared", "inferred"})
+#: validator can tell "not a recognized projection value at all" (a hard
+#: error regardless of which) apart from the two real ones, each validated by
+#: its own function above.
+KNOWN_PROJECTIONS = frozenset({DECLARED_PROJECTION, INFERRED_PROJECTION})
 
 
 def _opt_str(value: Any, default: str = "") -> str:
@@ -130,20 +139,36 @@ class BuildOutputProfile:
 class BuildOutputEvidence:
     """A target's L3/L4/L5 evidence pointer (ADR-047 §2).
 
-    ``projection`` is the field the P1.1 validator gates on: ``"declared"``
-    means the build itself asserted this evidence pack belongs to exactly
-    this target (e.g. per-target compile-DB filtering, or a wrapper invoked
-    once per link step); ``"inferred"`` would mean abicheck derived the
-    association from a build-wide pack, which needs P2's attribution work
-    and is rejected by this validator until then.
+    ``projection`` is the field the validator gates on: ``"declared"`` means
+    the build itself asserted this evidence pack belongs to exactly this
+    target (e.g. per-target compile-DB filtering, or a wrapper invoked once
+    per link step) — the pack's path must not be shared with any other
+    ``"declared"`` target. ``"inferred"`` means abicheck derived the
+    association automatically from a (possibly build-wide, possibly shared)
+    pack via ``attribution_path``'s TU->link-unit->DSO attribution data
+    (ADR-053 D4) — validated by re-deriving the same attribution and
+    confirming it actually ties at least one of the pack's TUs to this
+    target, rather than trusting the claim.
     """
 
     kind: str = ""  # e.g. "source-facts"
     path: str = ""  # relative to the build-output root
-    projection: str = ""  # "declared" | "inferred" (only "declared" validates)
+    projection: str = ""  # "declared" | "inferred"
+    #: build-output-root-relative path to a JSON-serialized ``BuildEvidence``
+    #: (``BuildEvidence.to_dict()``'s own shape) proving the TU->link-unit->
+    #: DSO attribution an ``"inferred"`` claim needs (ADR-053 D4). Ignored
+    #: for ``"declared"``.
+    attribution_path: str = ""
 
     def to_dict(self) -> dict[str, Any]:
-        return {"kind": self.kind, "path": self.path, "projection": self.projection}
+        d: dict[str, Any] = {
+            "kind": self.kind,
+            "path": self.path,
+            "projection": self.projection,
+        }
+        if self.attribution_path:
+            d["attribution_path"] = self.attribution_path
+        return d
 
     @classmethod
     def from_dict(cls, d: dict[str, Any]) -> BuildOutputEvidence:
@@ -151,6 +176,7 @@ class BuildOutputEvidence:
             kind=_opt_str(d.get("kind")),
             path=_opt_str(d.get("path")),
             projection=_opt_str(d.get("projection")),
+            attribution_path=_opt_str(d.get("attribution_path")),
         )
 
 
@@ -493,25 +519,117 @@ def _binary_issues(
 
 
 def _evidence_projection_issues(target: BuildOutputTarget) -> list[str]:
+    """Reject any ``evidence.projection`` value outside the known set.
+
+    ``"declared"``'s and ``"inferred"``'s own real validation live in
+    :func:`_declared_evidence_sharing_issues`/
+    :func:`_inferred_evidence_projection_issues` respectively — both run
+    unconditionally over every target from :func:`validate_build_output`,
+    each filtering to its own projection value. This function only catches
+    the third case: neither, an outright unrecognized value.
+    """
     evidence = target.evidence
-    if evidence is None:
+    if evidence is None or evidence.projection in KNOWN_PROJECTIONS:
         return []
-    if evidence.projection != DECLARED_PROJECTION:
-        if evidence.projection == "inferred":
-            return [
-                f"target {target.id!r}: evidence.projection is 'inferred', "
-                "which P1's build-output.json validator does not accept — "
-                "the TU->link-unit->DSO attribution needed to trust an "
-                "inferred association is G30 P2, not built yet (ADR-047 §2/"
-                "§9). A build-wide pack may only feed a build-wide source "
-                "audit or a per-target header-depth check until then, never "
-                "a per-target effective_depth: source claim."
-            ]
-        return [
-            f"target {target.id!r}: evidence.projection is "
-            f"{evidence.projection!r}; must be {DECLARED_PROJECTION!r}."
-        ]
-    return []
+    return [
+        f"target {target.id!r}: evidence.projection is "
+        f"{evidence.projection!r}; must be one of {sorted(KNOWN_PROJECTIONS)}."
+    ]
+
+
+def _inferred_evidence_projection_issues(
+    root: Path, targets: list[BuildOutputTarget]
+) -> list[str]:
+    """Validate every ``"inferred"`` target by re-deriving its attribution.
+
+    ADR-053 D4: unlike ``"declared"``, two ``"inferred"`` targets sharing one
+    physical ``evidence.path`` pack is not itself an error — that is the
+    entire point of ``"inferred"``, safely and automatically splitting one
+    build-wide pack. What must hold instead is that re-running
+    :func:`~.link_attribution.attribute_sources_to_targets` over the
+    declared ``attribution_path`` genuinely ties at least one of the pack's
+    own TUs to *this* target — an inferred claim that resolves to zero
+    matching TUs is a silent, invisible degradation (the pack contributes
+    nothing to this target's evidence, but nothing says so) and is therefore
+    a hard error, not a warning.
+    """
+    issues: list[str] = []
+    for t in targets:
+        if t.evidence is None or t.evidence.projection != INFERRED_PROJECTION:
+            continue
+        evidence = t.evidence
+        pack_path = _resolve_under_root(root, evidence.path)
+        if pack_path is None:
+            issues.append(
+                f"target {t.id!r}: evidence.path {evidence.path!r} is "
+                "absolute or escapes the build-output directory."
+            )
+            continue
+        if not is_inputs_pack(pack_path):
+            issues.append(
+                f"target {t.id!r}: evidence.path {evidence.path!r} is not "
+                "a readable abicheck_inputs pack (no manifest.json declaring "
+                "kind: abicheck_inputs)."
+            )
+            continue
+        if not evidence.attribution_path:
+            issues.append(
+                f"target {t.id!r}: evidence.projection is 'inferred' but no "
+                "evidence.attribution_path is set — an inferred claim needs "
+                "a TU->link-unit->DSO attribution source to derive from "
+                "(ADR-053 D4), not just an assertion."
+            )
+            continue
+        attribution_file = _resolve_under_root(root, evidence.attribution_path)
+        if attribution_file is None:
+            issues.append(
+                f"target {t.id!r}: evidence.attribution_path "
+                f"{evidence.attribution_path!r} is absolute or escapes the "
+                "build-output directory."
+            )
+            continue
+        if not attribution_file.is_file():
+            issues.append(
+                f"target {t.id!r}: evidence.attribution_path "
+                f"{evidence.attribution_path!r} does not exist (expected a "
+                f"file at {attribution_file})."
+            )
+            continue
+        try:
+            with attribution_file.open(encoding="utf-8") as fh:
+                raw = json.load(fh)
+        except (OSError, ValueError) as exc:
+            issues.append(
+                f"target {t.id!r}: evidence.attribution_path "
+                f"{evidence.attribution_path!r} could not be read as JSON: {exc}."
+            )
+            continue
+        if not isinstance(raw, dict):
+            issues.append(
+                f"target {t.id!r}: evidence.attribution_path "
+                f"{evidence.attribution_path!r} is not a JSON object."
+            )
+            continue
+        evidence_model = BuildEvidence.from_dict(raw)
+        attribution = attribute_sources_to_targets(evidence_model)
+        manifest = load_inputs_manifest(pack_path)
+        diagnostics: list[str] = []
+        tus = read_source_facts(pack_path, manifest, diagnostics=diagnostics)
+        expected = f"target://{t.id}"
+        matched = sum(
+            1
+            for tu in tus
+            if expected in attribution.get(normalize_source_path(tu.source), frozenset())
+        )
+        if matched == 0:
+            issues.append(
+                f"target {t.id!r}: evidence.projection is 'inferred', but "
+                f"re-deriving attribution from {evidence.attribution_path!r} "
+                f"ties none of evidence.path {evidence.path!r}'s TUs to "
+                f"{expected!r} — this inferred claim would silently "
+                "contribute nothing to this target's evidence."
+            )
+    return issues
 
 
 def _declared_evidence_sharing_issues(
@@ -641,5 +759,6 @@ def validate_build_output(root: Path | str) -> BuildOutputValidationReport:
         report.errors.extend(_evidence_projection_issues(target))
 
     report.errors.extend(_declared_evidence_sharing_issues(root, build_output.targets))
+    report.errors.extend(_inferred_evidence_projection_issues(root, build_output.targets))
 
     return report

--- a/abicheck/buildsource/inputs_pack.py
+++ b/abicheck/buildsource/inputs_pack.py
@@ -49,7 +49,7 @@ import datetime as _dt
 import gzip
 import json
 import zlib
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -583,10 +583,38 @@ def _load_build_evidence(
         return None
 
 
+def _filter_tus_by_attribution(
+    tus: list[SourceAbiTu],
+    attribution: Mapping[str, frozenset[str]],
+    expected_target_id: str,
+) -> tuple[list[SourceAbiTu], int]:
+    """ADR-053 D3: keep only TUs the attribution mapping ties to *expected_target_id*.
+
+    Matches on the normalized ``.source`` path (the same normalization
+    :func:`~.link_attribution.attribute_sources_to_targets` applies to every
+    key it produces, so the two sides agree on shape) — fail-safe: a source
+    absent from ``attribution`` entirely (unknown to both channels) is
+    dropped, exactly like one attributed to a different target only.
+    """
+    from .link_attribution import normalize_source_path
+
+    kept: list[SourceAbiTu] = []
+    dropped = 0
+    for tu in tus:
+        identities = attribution.get(normalize_source_path(tu.source), frozenset())
+        if expected_target_id in identities:
+            kept.append(tu)
+        else:
+            dropped += 1
+    return kept, dropped
+
+
 def ingest_inputs_pack(
     root: Path | str,
     *,
     exported_symbols: Iterable[str] = (),
+    attribution: Mapping[str, frozenset[str]] | None = None,
+    expected_target_id: str | None = None,
 ) -> IngestedInputs:
     """Fold a Flow-2 ``abicheck_inputs/`` pack into an embeddable pack.
 
@@ -597,6 +625,17 @@ def ingest_inputs_pack(
     the caller's) seed the L4 decl→symbol linking; when empty the surface is
     relinked against the artifact side's exports during ``merge`` (the existing
     A1 path). Pure parsing — never invokes a compiler.
+
+    ``attribution``/``expected_target_id`` (ADR-053 D3) opt into safely
+    projecting a build-wide pack onto one target: when both are given, a TU
+    is kept only when :func:`~.link_attribution.attribute_sources_to_targets`
+    (the caller-supplied ``attribution`` mapping) attributes its ``.source``
+    to a set containing ``expected_target_id`` — a TU attributed to some
+    *other* target is dropped, and — fail-safe — a TU with no attribution at
+    all (unknown to both of the attribution module's channels) is dropped
+    too, never silently kept on the assumption that "no signal" means "safe."
+    Omitting either parameter (the default) ingests every TU exactly as
+    before — this is purely additive, no existing caller's behavior changes.
     """
     root = Path(root)
     manifest = load_inputs_manifest(root)
@@ -605,6 +644,15 @@ def ingest_inputs_pack(
     # Thread the diagnostics sink so skipped/malformed source-fact records are
     # surfaced in the extractor ledger + IngestedInputs, not silently dropped.
     tus = read_source_facts(root, manifest, diagnostics=diagnostics)
+    if attribution is not None and expected_target_id is not None:
+        tus, dropped = _filter_tus_by_attribution(tus, attribution, expected_target_id)
+        if dropped:
+            diagnostics.append(
+                f"abicheck_inputs: {dropped} TU(s) excluded — "
+                f"attribution (ADR-053) did not tie them to {expected_target_id!r} "
+                "(either attributed to a different target, or unknown to both "
+                "attribution channels)."
+            )
     exports = sorted(set(manifest.exported_symbols) | set(exported_symbols))
 
     surface = None

--- a/abicheck/buildsource/inputs_pack.py
+++ b/abicheck/buildsource/inputs_pack.py
@@ -644,14 +644,21 @@ def ingest_inputs_pack(
     # Thread the diagnostics sink so skipped/malformed source-fact records are
     # surfaced in the extractor ledger + IngestedInputs, not silently dropped.
     tus = read_source_facts(root, manifest, diagnostics=diagnostics)
+    # Kept out of `diagnostics` deliberately (CodeRabbit review, PR #632):
+    # `diagnostics` drives ExtractorRecord.status ("ok" only when empty, see
+    # below) on the premise that any diagnostic means a lossy/degraded read.
+    # Attribution-scoping a build-wide pack down to one target is the
+    # *intended* effect of passing attribution/expected_target_id, not a
+    # lossy one -- folding its note into `diagnostics` would flip a fully
+    # successful projected ingest to "partial" every time. Surfaced in
+    # `detail` instead, below.
+    attribution_note = ""
     if attribution is not None and expected_target_id is not None:
         tus, dropped = _filter_tus_by_attribution(tus, attribution, expected_target_id)
         if dropped:
-            diagnostics.append(
-                f"abicheck_inputs: {dropped} TU(s) excluded — "
-                f"attribution (ADR-053) did not tie them to {expected_target_id!r} "
-                "(either attributed to a different target, or unknown to both "
-                "attribution channels)."
+            attribution_note = (
+                f", {dropped} TU(s) excluded by attribution scoping to "
+                f"{expected_target_id!r}"
             )
     exports = sorted(set(manifest.exported_symbols) | set(exported_symbols))
 
@@ -706,6 +713,7 @@ def ingest_inputs_pack(
                 else ""
             )
             + (f", {len(diagnostics)} skipped/diagnostic" if diagnostics else "")
+            + attribution_note
             + (f" (produced by {manifest.created_by})" if manifest.created_by else "")
         ),
         diagnostics=list(diagnostics),

--- a/abicheck/buildsource/link_attribution.py
+++ b/abicheck/buildsource/link_attribution.py
@@ -180,7 +180,17 @@ def _attribute_via_link_units(evidence: BuildEvidence) -> dict[str, set[str]]:
                 sources.add(source)
                 continue
             nested = link_by_output.get(inp)
-            if nested is not None and inp not in visited_links:
+            # Resolve nested static-library/object link units transitively
+            # only -- a terminal (shared_library/executable) link unit named
+            # as another link unit's input (e.g. an explicit .so path rather
+            # than -lfoo) must hard-stop here, exactly like the target-graph
+            # channel's own SHARED_LIBRARY hard stop, or its objects would be
+            # folded into an unrelated dependent (CodeRabbit review, PR #632).
+            if (
+                nested is not None
+                and nested.kind not in _TERMINAL_LINK_KINDS
+                and inp not in visited_links
+            ):
                 visited_links.add(inp)
                 stack.extend(nested.inputs)
         for src in sources:

--- a/abicheck/buildsource/link_attribution.py
+++ b/abicheck/buildsource/link_attribution.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""TU -> link-unit -> DSO source-evidence attribution (ADR-053, G30 P2).
+
+Given a :class:`~.build_evidence.BuildEvidence`, answers "which output
+binary/binaries does this translation unit's compiled code end up in?" —
+the piece ADR-047 §9's "safe model now, full model later" split deferred:
+a build-wide, unattributed evidence pack may only feed build-wide audits and
+per-target header-depth checks; this module is what lets a caller instead
+*prove*, per source file, which target(s) it actually belongs to, so a
+build-wide pack can be safely and automatically projected onto the correct
+subset of targets (ADR-053 D1).
+
+Two independent, non-exclusive signal channels feed one combined result:
+
+- **Target-graph channel** — a real target graph (CMake File API, Bazel's
+  target-level facts) already states, per target, which of its own sources
+  compile into it (:attr:`~.build_evidence.Target.source_files`). No linker
+  command parsing needed; this channel folds ``OBJECT_LIBRARY``/
+  ``STATIC_LIBRARY`` dependency sources transitively into every target that
+  (transitively) depends on them, since those kinds are absorbed into their
+  dependents' own link output rather than shipping their own.
+- **Link-unit-graph channel** — real linker-invocation identity
+  (:attr:`~.build_evidence.LinkUnit.inputs`/``.output``), the only signal
+  available for build systems with no semantic target graph (Make). Walks
+  each terminal (``shared_library``/``executable``) link unit's inputs
+  backward, matching object-file paths against
+  :attr:`~.build_evidence.CompileUnit.output`, resolving nested static-library
+  link units transitively.
+
+A source attributed by neither channel is *unknown*, not "unattributed" in
+the sense of "belongs to nothing" — callers (:func:`~.build_output.
+validate_build_output`, :func:`~.inputs_pack.ingest_inputs_pack`) must treat
+an unknown source as unresolved and exclude it from any per-target claim,
+never assume it is safe to include.
+
+Pure: reads only the in-memory :class:`BuildEvidence` already collected by an
+adapter; never touches the filesystem or a subprocess.
+"""
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+from typing import TYPE_CHECKING
+
+from .build_evidence import TargetKind
+
+if TYPE_CHECKING:
+    from .build_evidence import BuildEvidence
+
+#: Target kinds whose own sources are absorbed into a dependent's link
+#: output rather than shipping as their own artifact — folded transitively
+#: into every target that depends on them (D1's target-graph channel).
+_ABSORBED_KINDS = frozenset({TargetKind.OBJECT_LIBRARY, TargetKind.STATIC_LIBRARY})
+
+#: Link-unit kinds that are a real, independently-shipped output binary —
+#: the only kinds the link-unit-graph channel treats as an attribution
+#: target. A static-library link unit is an intermediate, resolved
+#: transitively as another link unit's input, never a target in its own
+#: right here (mirrors ``_ABSORBED_KINDS``' target-graph-channel rule).
+_TERMINAL_LINK_KINDS = frozenset({"shared_library", "executable"})
+
+
+def normalize_source_path(path: str) -> str:
+    """Normalize a source/object path for cross-evidence matching.
+
+    ``PurePosixPath`` (not ``Path``) so normalization is platform-independent
+    — the evidence being compared may have been collected on a different OS
+    than this process runs on. Strips a leading ``./`` only; deliberately
+    does NOT resolve ``..`` or make the path absolute, since doing so would
+    require knowing a real filesystem root this pure function has no access
+    to and no need for (every path compared here already went through the
+    same adapter-relative convention).
+    """
+    return PurePosixPath(path.replace("\\", "/")).as_posix().removeprefix("./")
+
+
+def attribute_sources_to_targets(evidence: BuildEvidence) -> dict[str, frozenset[str]]:
+    """Compute ``{normalized_source_path: {attribution_identity, ...}}``.
+
+    Each attribution identity is one of:
+
+    - ``f"target://{target.id_suffix}"`` — a real, named target from the
+      target-graph channel or a link unit whose ``target_id`` is set
+      (already ``target://``-prefixed by every adapter that sets it, per
+      ADR-029 D2's convention — used verbatim here, not re-prefixed).
+    - ``f"output://{basename}"`` — the link-unit-graph channel's fallback
+      identity when a link unit carries no ``target_id`` at all (Make has no
+      semantic target concept to name), keyed by the output file's basename
+      rather than its full path: a build-wide evidence pack's recorded
+      object paths and a project's own ``build-output.json``-declared binary
+      path routinely differ in directory prefix (different working
+      directories, staged-vs-build-tree layout) even when they name the same
+      real artifact, so basename is the only robust common ground — accepted
+      as reduced-confidence by the same posture the Make adapter's own
+      compile-unit scraping already carries.
+
+    A source seen by neither channel is simply absent from the returned
+    dict — never present with an empty set — so ``dict.get(src, frozenset())``
+    and "not in the dict" are equivalent ways to detect "unknown."
+    """
+    result: dict[str, set[str]] = {}
+    _merge_channel(result, _attribute_via_target_graph(evidence))
+    _merge_channel(result, _attribute_via_link_units(evidence))
+    return {src: frozenset(identities) for src, identities in result.items()}
+
+
+def _merge_channel(dst: dict[str, set[str]], channel: dict[str, set[str]]) -> None:
+    for src, identities in channel.items():
+        dst.setdefault(src, set()).update(identities)
+
+
+def _attribute_via_target_graph(evidence: BuildEvidence) -> dict[str, set[str]]:
+    by_id = {t.id: t for t in evidence.targets}
+    result: dict[str, set[str]] = {}
+    for target in evidence.targets:
+        if not target.id:
+            continue
+        sources = set(target.source_files)
+        # Transitively fold every OBJECT_LIBRARY/STATIC_LIBRARY dependency's
+        # own sources in — those kinds ship no artifact of their own, their
+        # object code is absorbed into whatever depends on them. A
+        # SHARED_LIBRARY/EXECUTABLE dependency is a hard stop: its objects
+        # live in its own output, never copied into a dependent's.
+        visited: set[str] = set()
+        stack = list(target.dependencies)
+        while stack:
+            dep_id = stack.pop()
+            if dep_id in visited:
+                continue
+            visited.add(dep_id)
+            dep = by_id.get(dep_id)
+            if dep is None or dep.kind not in _ABSORBED_KINDS:
+                continue
+            sources.update(dep.source_files)
+            stack.extend(dep.dependencies)
+        identity = target.id if target.id.startswith("target://") else f"target://{target.id}"
+        for src in sources:
+            if not src:
+                continue
+            result.setdefault(normalize_source_path(src), set()).add(identity)
+    return result
+
+
+def _attribute_via_link_units(evidence: BuildEvidence) -> dict[str, set[str]]:
+    output_to_source = {
+        normalize_source_path(cu.output): cu.source for cu in evidence.compile_units if cu.output
+    }
+    link_by_output = {
+        normalize_source_path(lu.output): lu for lu in evidence.link_units if lu.output
+    }
+    result: dict[str, set[str]] = {}
+    for lu in evidence.link_units:
+        if lu.kind not in _TERMINAL_LINK_KINDS or not lu.output:
+            continue
+        identity = (
+            lu.target_id
+            if lu.target_id
+            else f"output://{PurePosixPath(normalize_source_path(lu.output)).name}"
+        )
+        sources: set[str] = set()
+        visited_links: set[str] = set()
+        stack = list(lu.inputs)
+        while stack:
+            raw = stack.pop()
+            inp = normalize_source_path(raw)
+            source = output_to_source.get(inp)
+            if source:
+                sources.add(source)
+                continue
+            nested = link_by_output.get(inp)
+            if nested is not None and inp not in visited_links:
+                visited_links.add(inp)
+                stack.extend(nested.inputs)
+        for src in sources:
+            result.setdefault(normalize_source_path(src), set()).add(identity)
+    return result

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -1309,9 +1309,7 @@ def perform_elf_dump(
     # `dump --header <dir>` baseline and a live `compare --header <dir>`
     # candidate of the identical header set agree on scope_fingerprint
     # instead of spuriously raising ScopeMismatchError.
-    from .header_utils import split_public_header_inputs
-
-    _, scope_header_dirs = split_public_header_inputs(list(headers)) if headers else ([], [])
+    #
     # P3: auto-add the public-header roots so a -H umbrella resolves its own
     # relative includes without a separate -I. resolve_inferred_header_roots
     # picks the search bucket: plain -I (high priority, so an umbrella that pulls
@@ -1320,7 +1318,13 @@ def perform_elf_dump(
     # so generated/shim headers from -p/--gcc-options keep priority, but still
     # above the standard system dirs) when the compile context supplies its own
     # includes — see its docstring.
-    from .header_utils import deferred_token_dirs, resolve_inferred_header_roots
+    from .header_utils import (
+        deferred_token_dirs,
+        resolve_inferred_header_roots,
+        split_public_header_inputs,
+    )
+
+    _, scope_header_dirs = split_public_header_inputs(list(headers)) if headers else ([], [])
 
     inc_extra, deferred = (
         resolve_inferred_header_roots(

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -1300,6 +1300,18 @@ def perform_elf_dump(
     """
     compiler = "cc" if lang == "c" else "c++"
     resolved_headers = expand_header_inputs(list(headers)) if headers else []
+    # ADR-050 D1 follow-up (G30 pilot validation, validation/
+    # g30-pilot-validation-2026-07.md): fold -H/--header's own directory
+    # arguments into the extraction contract's scope (not just
+    # public_header_dirs/apply_provenance's opt-in flags), matching
+    # `compare`'s own --header handling (cli_resolve._resolve_compare_
+    # snapshots, via the same split_public_header_inputs helper) -- so a
+    # `dump --header <dir>` baseline and a live `compare --header <dir>`
+    # candidate of the identical header set agree on scope_fingerprint
+    # instead of spuriously raising ScopeMismatchError.
+    from .header_utils import split_public_header_inputs
+
+    _, scope_header_dirs = split_public_header_inputs(list(headers)) if headers else ([], [])
     # P3: auto-add the public-header roots so a -H umbrella resolves its own
     # relative includes without a separate -I. resolve_inferred_header_roots
     # picks the search bucket: plain -I (high priority, so an umbrella that pulls
@@ -1370,6 +1382,7 @@ def perform_elf_dump(
             public_header_dirs=list(public_header_dirs),
             header_backend=header_backend,
             extra_hash_dirs=deferred_dirs,
+            scope_header_dirs=scope_header_dirs,
             debug_info_path=debug_info_path,
             dump_manifest=dump_manifest,
             extra_include_labels=include_labels,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1136,6 +1136,7 @@ def dump(
     debug_info_path: Path | None = None,
     extra_include_labels: dict[Path, str] | None = None,
     dump_manifest: DumpManifest | None = None,
+    scope_header_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Create an AbiSnapshot from a shared library + headers.
 
@@ -1188,6 +1189,23 @@ def dump(
         dump_manifest: A parsed ``--dump-manifest`` document (ADR-050 D3) for
             a real multi-TU dump; mutually exclusive with *headers*,
             *extra_includes*, *public_headers*/*public_header_dirs*. ELF only.
+        scope_header_dirs: Directories folded into the extraction contract's
+            ``public_header_dirs`` scope-fingerprint field (ADR-050 D1)
+            *in addition to* ``public_header_dirs``, without affecting
+            declaration-provenance tagging (ADR-015 stays driven by
+            ``public_header_dirs`` alone, unchanged). ``compare``'s own
+            ``--header <dir>`` already feeds its directory argument into the
+            live side's scope contract this way (``cli_resolve.
+            _resolve_compare_snapshots``); without an equivalent here, a
+            snapshot `dump`-produced from a bare ``-H <dir>`` (with no
+            ``--public-header-dir``) always carries an empty
+            ``public_header_dirs`` scope field, so comparing it against a
+            live `compare`-side extraction of the identical header set
+            spuriously raises ``ScopeMismatchError`` (found during the G30
+            pilot validation, ``validation/g30-pilot-validation-2026-07.md``).
+            The CLI's ``dump`` command passes its own raw ``-H``/``--header``
+            directory arguments here (``cli_dump_helpers.perform_elf_dump``).
+            Mutually exclusive with *dump_manifest*, same as *headers*.
 
     Returns:
         AbiSnapshot with functions, variables, and types populated.
@@ -1201,6 +1219,7 @@ def dump(
             "extra_includes": extra_includes,
             "public_headers": public_headers,
             "public_header_dirs": public_header_dirs,
+            "scope_header_dirs": scope_header_dirs,
         }
         if _given := [name for name, value in _conflicts.items() if value]:
             raise ValidationError(
@@ -1239,6 +1258,7 @@ def dump(
             extra_hash_dirs=extra_hash_dirs,
             debug_info_path=debug_info_path,
             extra_include_labels=extra_include_labels,
+            scope_header_dirs=scope_header_dirs,
         )
 
     fmt = _detect_format(so_path)
@@ -1307,6 +1327,13 @@ def dump(
     # and service native-binary paths that call those builders directly (e.g.
     # service._try_header_scoped_dump), bypassing this function — records it
     # correctly. DWARF-only and symbols-only builds leave it False.
+    #
+    # scope_header_dirs is folded into the CONTRACT's public_header_dirs only
+    # -- never into apply_provenance's call below -- so a bare `-H <dir>`
+    # gains the same scope-comparability identity `compare`'s own `--header
+    # <dir>` already has, without silently opting a `dump`-only invocation
+    # into declaration-provenance tagging (ADR-015 stays opt-in via the
+    # separate --public-header/--public-header-dir flags, unchanged).
     _attach_extraction_contract(
         snapshot,
         headers=list(dump_manifest.roots) if dump_manifest is not None else headers,
@@ -1315,7 +1342,11 @@ def dump(
         gcc_option_tokens=gcc_option_tokens,
         lang=lang,
         public_headers=effective_public_headers,
-        public_header_dirs=effective_public_header_dirs,
+        public_header_dirs=list(
+            dict.fromkeys(
+                [*(effective_public_header_dirs or []), *(scope_header_dirs or [])]
+            )
+        ),
         extra_include_labels=extra_include_labels,
         dump_manifest=dump_manifest,
     )

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1342,11 +1342,13 @@ def dump(
         gcc_option_tokens=gcc_option_tokens,
         lang=lang,
         public_headers=effective_public_headers,
-        public_header_dirs=list(
-            dict.fromkeys(
-                [*(effective_public_header_dirs or []), *(scope_header_dirs or [])]
-            )
-        ),
+        # Union, duplicates and all -- compute_extraction_contract's own
+        # _normalize() already folds through a set before sorting, so
+        # pre-deduping here would only be redundant work (code review).
+        public_header_dirs=[
+            *(effective_public_header_dirs or []),
+            *(scope_header_dirs or []),
+        ],
         extra_include_labels=extra_include_labels,
         dump_manifest=dump_manifest,
     )

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -111,17 +111,21 @@ _PUBLIC_DEPTHS = frozenset({"binary", "headers", "build", "source"})
 def _validate_public_depth(depth: str | None) -> str | None:
     """Reject any depth spelling outside the public ladder, or ``None``.
 
-    Note this only validates the *spelling* — it does not (yet) enforce that
-    the requested depth was actually *reached*. PR #601 (open as of CLAUDE.md
-    "M1-6") adds a hard-fail ``DumpDepthNotSatisfiedError`` when an explicit
-    ``dump --depth`` isn't satisfied, but that check lives entirely in
-    ``cli.py``/``cli_dump_helpers.py`` at the CLI entry point. Neither this
-    MCP surface nor ``service.py``'s ``ScanRequest``/``run_scan_subprocess``
-    call it — an agent driving abicheck through MCP with an explicit
-    ``depth=`` can silently get a result from a shallower evidence tier than
-    requested, the same way the CLI itself could before PR #601. Tracked as
-    acknowledged remaining work: once PR #601 merges, extend the same
-    requested-vs-achieved check to this module and to ``service.py``.
+    Note this only validates the *spelling*, not that the requested depth
+    was actually *reached* — but that's not a gap on this surface (re-
+    investigated for G30, AGENTS.md "Known gaps"/CLAUDE.md "M1-6", closed as
+    stale). This module's tools that accept ``depth=`` (``abi_scan``,
+    ``abi_estimate``) go through ``service.py``'s ``ScanRequest`` into
+    ``service_scan.run_scan``, which calls the same
+    ``scan_engine.run_scan_core`` the CLI ``scan`` command
+    (``cli_scan.py``) calls directly — both already share one pinned-depth
+    evidence contract (``_check_scan_evidence_contract``'s
+    ``_EvidenceContractError``, ADR-037 D5), so there is no CLI-vs-MCP
+    disparity to close here. ``dump --depth``'s separate, stricter
+    ``DumpDepthNotSatisfiedError`` gate (PR #601, merged) lives in
+    ``cli._write_snapshot_output`` and has no equivalent on this module's
+    ``abi_dump`` tool to extend it to, because ``abi_dump`` never accepted a
+    ``depth``/``sources``/``build-info`` parameter in the first place.
     """
     if depth is not None and depth not in _PUBLIC_DEPTHS:
         raise ValueError(

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -114,14 +114,18 @@ def _validate_public_depth(depth: str | None) -> str | None:
     Note this only validates the *spelling*, not that the requested depth
     was actually *reached* — but that's not a gap on this surface (re-
     investigated for G30, AGENTS.md "Known gaps"/CLAUDE.md "M1-6", closed as
-    stale). This module's tools that accept ``depth=`` (``abi_scan``,
-    ``abi_estimate``) go through ``service.py``'s ``ScanRequest`` into
-    ``service_scan.run_scan``, which calls the same
+    stale). ``abi_scan`` builds a ``service.py`` ``ScanRequest`` and goes
+    through ``service_scan.run_scan``, which calls the same
     ``scan_engine.run_scan_core`` the CLI ``scan`` command
     (``cli_scan.py``) calls directly — both already share one pinned-depth
     evidence contract (``_check_scan_evidence_contract``'s
     ``_EvidenceContractError``, ADR-037 D5), so there is no CLI-vs-MCP
-    disparity to close here. ``dump --depth``'s separate, stricter
+    disparity to close for ``abi_scan``. ``abi_estimate`` also accepts
+    ``depth=`` but is a separate, cost-only path: it builds its own
+    ``ScanRequest`` and calls ``estimate_scan`` (never
+    ``run_scan``/``run_scan_core``), so it never actually parses a binary or
+    header for the estimate to be "unsatisfied" against — this validator's
+    spelling check is all that applies to it. ``dump --depth``'s separate, stricter
     ``DumpDepthNotSatisfiedError`` gate (PR #601, merged) lives in
     ``cli._write_snapshot_output`` and has no equivalent on this module's
     ``abi_dump`` tool to extend it to, because ``abi_dump`` never accepted a

--- a/abicheck/sycl_metadata.py
+++ b/abicheck/sycl_metadata.py
@@ -25,9 +25,19 @@ Supports two plugin interface generations:
 
 - **PI (Plugin Interface)**: ``libpi_*.so``, entry point ``piPluginInit``,
   symbols prefixed ``pi``.  Used by DPC++ through ~2024.
-- **UR (Unified Runtime)**: ``libur_adapter_*.so``, entry point
-  ``urAdapterGet``, symbols prefixed ``ur``.  Successor to PI in newer
-  DPC++ releases.
+- **UR (Unified Runtime)**: ``libur_adapter_*.so``, symbols prefixed
+  ``ur``.  Successor to PI in newer DPC++ releases. Two UR export shapes
+  exist and are both recognized here: an older generation exporting
+  per-verb entry points directly (``urAdapterGet``, ``urPlatformGet``,
+  ``urDeviceGet``, ...) and the current generation (verified against a
+  real Intel oneAPI 2026.1 install, G30 pilot validation —
+  ``validation/g30-pilot-validation-2026-07.md``) exporting only one
+  function-pointer-table getter per API category (``urGetAdapterProcAddrTable``,
+  ``urGetPlatformProcAddrTable``, ``urGetDeviceProcAddrTable``, ...) —
+  individual per-verb symbols are no longer exported at all in that shape,
+  so the loader resolves real entry points indirectly through these
+  tables. ``urGetAdapterProcAddrTable`` plays the current generation's
+  validity-marker role that ``urAdapterGet`` plays for the older one.
 
 Both interfaces use the same detection approach: glob for plugin libraries,
 parse ``.dynsym`` via pyelftools, match symbol patterns.  No SYCL compiler
@@ -82,7 +92,18 @@ PI_REQUIRED_ENTRYPOINTS: frozenset[str] = frozenset({
     "piEventRelease",
 })
 
-# Well-known UR entry points that must be present for a valid UR adapter.
+# The validity-marker entry point for each of the two UR export shapes
+# (module docstring): the older per-verb-symbol generation, and the current
+# function-pointer-table-getter generation. A UR plugin is valid if EITHER
+# is present -- accepting only one would silently reject the other real,
+# currently-shipping generation as "not a valid UR adapter".
+_UR_LEGACY_ENTRYPOINT = "urAdapterGet"
+_UR_TABLE_ENTRYPOINT = "urGetAdapterProcAddrTable"
+
+# Well-known UR entry points that must be present for a valid *legacy*
+# (per-verb-symbol) UR adapter -- does not apply to the current
+# function-pointer-table generation, which exports none of these directly
+# (see module docstring).
 UR_REQUIRED_ENTRYPOINTS: frozenset[str] = frozenset({
     "urAdapterGet",
     "urAdapterRelease",
@@ -246,7 +267,16 @@ def _detect_ur_version_from_symbols(symbols: list[str]) -> str:
     """Heuristic UR version detection from exported symbol set.
 
     UR versions are detected by presence of landmark entry points
-    added in each release.
+    added in each release. Only applies to the older, per-verb-symbol UR
+    generation (module docstring) -- the landmark symbols this checks for
+    (``urBindlessImages*``, ``urVirtualMem*``, ``urCommandBuffer*``,
+    ``urAdapterGet``) are never exported at all by the current
+    function-pointer-table generation (real Intel oneAPI 2026.1 adapters
+    export only ``urGet<Category>ProcAddrTable`` getters, verified during
+    the G30 pilot validation). That generation's static table-getter set is
+    always fully present regardless of the adapter's actual UR release, so
+    there is no honest per-release landmark to key off for it -- this
+    deliberately returns "" (unknown) for it rather than guess.
 
     Returns empty string if version cannot be determined.
     """
@@ -263,7 +293,7 @@ def _detect_ur_version_from_symbols(symbols: list[str]) -> str:
         return "0.9"
     if has_cmd_buffer:
         return "0.8"
-    if "urAdapterGet" in symbols:
+    if _UR_LEGACY_ENTRYPOINT in symbols:
         return "0.7"
     return ""
 
@@ -297,8 +327,16 @@ def parse_sycl_plugin(so_path: Path) -> SyclPluginInfo | None:
     if ur_match:
         plugin_name = ur_match.group(1)
         entry_points = _extract_plugin_symbols(so_path, _UR_SYMBOL_RE)
-        if "urAdapterGet" not in entry_points:
-            log.warning("Plugin %s missing urAdapterGet — not a valid UR adapter", so_path)
+        if (
+            _UR_LEGACY_ENTRYPOINT not in entry_points
+            and _UR_TABLE_ENTRYPOINT not in entry_points
+        ):
+            log.warning(
+                "Plugin %s missing both %s and %s — not a valid UR adapter",
+                so_path,
+                _UR_LEGACY_ENTRYPOINT,
+                _UR_TABLE_ENTRYPOINT,
+            )
             return None
         return SyclPluginInfo(
             name=plugin_name,

--- a/changelog.d/20260725_123104_noreply_g30_remaining_items_xuezvq.md
+++ b/changelog.d/20260725_123104_noreply_g30_remaining_items_xuezvq.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **`check-project.yml` now reports candidate-resolution and required
+  build-output-download failures as typed operational errors** instead of
+  silently ending the matrix job with no report for `abicheck aggregate` to
+  see (G30 P1.4, [#628](https://github.com/abicheck/abicheck/issues/628)).
+  The "Download build-output artifact" step no longer swallows a required
+  download failure via `continue-on-error`, and a new "Synthesize pre-check
+  operational-error report" step reuses
+  `actions/check-target/report_envelope.py --mode operational-error`
+  directly to write a full report envelope for `aggregate` to fan in,
+  matching how a real `resolve-baseline` failure is already reported.
+

--- a/changelog.d/20260725_142801_noreply_g30_remaining_items_xuezvq.md
+++ b/changelog.d/20260725_142801_noreply_g30_remaining_items_xuezvq.md
@@ -1,0 +1,15 @@
+### Added
+
+- **TU → link-unit → DSO source-evidence attribution** ([ADR-053](https://github.com/abicheck/abicheck/blob/main/docs/contribute/adr/053-tu-link-unit-dso-attribution.md), G30 P2). A new pure module,
+  `abicheck.buildsource.link_attribution`, derives which output binary/binaries
+  a translation unit's compiled code ends up in, from either a build system's
+  real target graph (CMake, Bazel) or real linker/archiver invocations (now
+  also captured by the `make` adapter, previously compile-lines only).
+  `build-output.json`'s `evidence.projection: "inferred"` is no longer an
+  unconditional hard failure — it validates by re-deriving the attribution
+  and confirming it genuinely ties evidence to the target, so one build-wide
+  evidence pack can now be safely and automatically split across several
+  targets. `abicheck.buildsource.inputs_pack.ingest_inputs_pack()` gained
+  matching opt-in `attribution`/`expected_target_id` parameters to filter a
+  shared pack down to one target's own translation units.
+

--- a/changelog.d/20260725_173337_noreply_g30_remaining_items_xuezvq.md
+++ b/changelog.d/20260725_173337_noreply_g30_remaining_items_xuezvq.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **`dump --header <dir>` and `compare --header <dir>` now agree on scope
+  comparability.** A snapshot produced by `abicheck dump --header <dir>`
+  (with no explicit `--public-header-dir`) previously left the extraction
+  contract's `public_header_dirs` scope field empty, while `compare
+  --header <dir>` always populates it for the live side it dumps — so
+  comparing a `dump`-produced baseline against a live `compare`-side
+  candidate of the *identical* header set spuriously raised
+  `ScopeMismatchError` (found during the G30 pilot validation,
+  `validation/g30-pilot-validation-2026-07.md`). `dump`'s CLI now folds a
+  bare `-H`/`--header` directory argument into the extraction contract's
+  scope fingerprint the same way `compare` already does, via a new
+  `dumper.dump(scope_header_dirs=...)` parameter that feeds only the
+  comparability contract — declaration-provenance tagging (ADR-015) stays
+  exactly as opt-in as before, driven only by the separate
+  `--public-header`/`--public-header-dir` flags.

--- a/changelog.d/20260725_183000_noreply_g30_remaining_items_xuezvq.md
+++ b/changelog.d/20260725_183000_noreply_g30_remaining_items_xuezvq.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **`sycl_metadata.py` recognizes the current Unified Runtime (UR) adapter
+  export shape.** Real, currently-shipping Intel oneAPI UR adapters (2026.1,
+  verified during the G30 pilot validation,
+  `validation/g30-pilot-validation-2026-07.md`) export only
+  `urGet<Category>ProcAddrTable` function-pointer-table getters
+  (`urGetAdapterProcAddrTable`, `urGetPlatformProcAddrTable`, ...) — never
+  the older per-verb symbols (`urAdapterGet`, `urPlatformGet`, ...) this
+  module's plugin-validity check previously required. A real, valid,
+  current-generation UR adapter was silently rejected as "not a valid UR
+  adapter". `parse_sycl_plugin()` now accepts either UR generation;
+  `_detect_ur_version_from_symbols()` correctly reports "" (honestly
+  unknown) for the table-getter generation rather than risk a false landmark
+  match.

--- a/changelog.d/20260726_050000_noreply_g30_remaining_items_xuezvq.md
+++ b/changelog.d/20260726_050000_noreply_g30_remaining_items_xuezvq.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **`build-output.json`'s `"inferred"` evidence validator now matches a
+  Windows-style `targets[].binary` path.** The `output://{basename}`
+  identity `_inferred_evidence_projection_issues()` builds from a target's
+  `binary` field (ADR-053 D4's Make-derived-attribution fallback) skipped
+  the backslash-to-forward-slash normalization `link_attribution.py` itself
+  applies before computing the identical identity, so a `binary` value
+  recorded with `\`-separated path components (nothing in the schema
+  forbids this) never matched — a genuinely correct Make/Windows-derived
+  `"inferred"` claim would spuriously hard-fail validation (code review
+  finding on PR #632).

--- a/docs/contribute/adr/047-github-actions-integration-model.md
+++ b/docs/contribute/adr/047-github-actions-integration-model.md
@@ -1379,12 +1379,13 @@ Three new validation points, all hard failures (not warnings) when tripped:
 
 1. **`build-output.json` validator** — every declared `headers/`/
    `generated-headers/` root is non-empty; every `targets[].binary` exists
-   and its digest matches `digests{}`; `evidence.projection` must be
-   `"declared"` (any other value was a hard validation failure until P2's
-   TU→DSO attribution existed — §2's correction above; **as of
-   [ADR-053](053-tu-link-unit-dso-attribution.md), `"inferred"` is now a
-   real, validated third option** alongside `"declared"`, re-deriving the
-   attribution rather than trusting the claim); for `"declared"`, a
+   and its digest matches `digests{}`; `evidence.projection` must be one of
+   `"declared"` or `"inferred"` (any other value is a hard validation
+   failure; `"inferred"` was itself a hard failure until P2's TU→DSO
+   attribution existed — §2's correction above; **as of
+   [ADR-053](053-tu-link-unit-dso-attribution.md), `"inferred"` is
+   validated by re-deriving the attribution** rather than trusting the
+   claim); for `"declared"`, a
    **non-empty TU count is
    necessary but not sufficient, and — a further correction from a
    follow-up review round — invoking `validate_inputs_pack` as-is is

--- a/docs/contribute/adr/047-github-actions-integration-model.md
+++ b/docs/contribute/adr/047-github-actions-integration-model.md
@@ -1380,9 +1380,12 @@ Three new validation points, all hard failures (not warnings) when tripped:
 1. **`build-output.json` validator** — every declared `headers/`/
    `generated-headers/` root is non-empty; every `targets[].binary` exists
    and its digest matches `digests{}`; `evidence.projection` must be
-   `"declared"` (any other value, including `"inferred"`, is a hard
-   validation failure until P2's TU→DSO attribution exists — §2's
-   correction above); for `"declared"`, a **non-empty TU count is
+   `"declared"` (any other value was a hard validation failure until P2's
+   TU→DSO attribution existed — §2's correction above; **as of
+   [ADR-053](053-tu-link-unit-dso-attribution.md), `"inferred"` is now a
+   real, validated third option** alongside `"declared"`, re-deriving the
+   attribution rather than trusting the claim); for `"declared"`, a
+   **non-empty TU count is
    necessary but not sufficient, and — a further correction from a
    follow-up review round — invoking `validate_inputs_pack` as-is is
    *also* not sufficient.** A multi-DSO `build-output.json` could point two
@@ -1593,8 +1596,14 @@ still open.
   toolchain / multiple DSO / multiple baseline channels" claims in §8
   (S9/S15/S17/S21) still need a pilot in PVXS's format before they stop
   being design-only.
-- **Full source-evidence TU→DSO attribution** (§9, D8) is P2, not built
-  here; S16's "required full model" is a documented target state only.
+- ~~**Full source-evidence TU→DSO attribution** (§9, D8) is P2, not built
+  here; S16's "required full model" is a documented target state only.~~
+  **Superseded — see [ADR-053](053-tu-link-unit-dso-attribution.md).** The
+  attribution algorithm, `build-output.json`'s `evidence.projection:
+  "inferred"` validator, and the ingest-time filtering mechanism are now
+  real and tested; what remains open is wiring `attribution_path`
+  production through the `compare`/`dump` CLI pipeline end-to-end (ADR-053
+  D5), a narrower, separately-tracked follow-up than "P2 not started."
 - **`build-output.json` producer tooling** (a real `abicheck build-output
   emit` helper, or documented hand-authoring path for CMake/Meson/Bazel/Make)
   does not exist yet — this ADR specifies the schema and consumer contract;

--- a/docs/contribute/adr/053-tu-link-unit-dso-attribution.md
+++ b/docs/contribute/adr/053-tu-link-unit-dso-attribution.md
@@ -1,0 +1,235 @@
+# ADR-053: TU → Link-Unit → DSO Source-Evidence Attribution
+
+**Date:** 2026-07-25
+**Status:** Accepted — implemented (scope below), tracked as G30 P2's first slice.
+**Decision maker:** pending
+
+## Context
+
+ADR-047 §9 ("Source evidence: safe model now vs. full model later") adopted a
+**safe model** for `build-output.json`'s `evidence.projection` field: an
+`abicheck_inputs/` evidence pack may only satisfy a target's
+`effective_depth: source` claim when the pack is explicitly `"declared"` —
+produced by one wrapper/plugin invocation scoped to a single link unit, or a
+compile-DB already filtered to one target's translation units (TUs). A
+build-wide pack shared across several DSOs may only feed build-wide source
+audits and per-target *header*-depth scans; it may never satisfy an
+unqualified per-target *source*-depth claim, because nothing today proves
+which of its TUs actually belong to which output binary.
+
+§9 explicitly deferred the alternative — `evidence.projection: "inferred"`,
+automatically and safely projecting a build-wide pack onto the correct subset
+of targets via **TU → object/link-unit → output-DSO attribution** — to P2,
+"scoped as its own follow-up ADR when undertaken, not retrofitted into" the
+original ADR. The companion G30 plan doc (`plans/g30-github-actions-
+integration-model.md`, "P2 — Deeper architecture") lists it as: "needs
+linker-invocation capture, extending `abicheck/buildsource/build_query.py`'s
+existing partial zero-config compile-DB inference." This ADR is that follow-up.
+
+**What already exists.** `abicheck/buildsource/build_evidence.py`'s
+normalized `BuildEvidence` schema (ADR-029 D2) already has the *shape* this
+needs: `Target.source_files`/`.outputs`/`.dependencies`/`.kind`,
+`CompileUnit.source`/`.output`/`.target_id`, and `LinkUnit.inputs`/`.output`/
+`.target_id`. But the adapters that populate it are inconsistent about
+actually *filling in* the attribution-relevant fields:
+
+- `adapters/bazel.py` already emits real `LinkUnit`s from `aquery`'s action
+  graph, with `target_id` resolved from the Bazel label graph — Bazel's half
+  of this problem is already solved.
+- `adapters/cmake_file_api.py` emits `Target.source_files` (CMake's codemodel
+  already tells you, per target, exactly which of its own sources compile
+  into it — the target graph itself is the attribution signal, no linker
+  capture needed) but never emits `CompileUnit`s or `LinkUnit`s at all — those
+  come from a *separate* adapter, `adapters/compile_db.py`, parsing
+  `compile_commands.json`, which has no target concept and never sets
+  `CompileUnit.target_id`. The two adapters' outputs are merged
+  (`BuildEvidence.merge`) but never *cross-referenced* — a CMake+compile-DB
+  build ends up with a full target graph and a full compile-unit list that
+  simply never talk to each other.
+- `adapters/make.py` scrapes a `make -n`/`--trace` dry-run transcript for
+  compile lines only; every non-compile line (including link/archive
+  invocations) is silently dropped. Make has no target graph to lean on at
+  all — this is the one build system where attribution genuinely requires
+  parsing real linker-invocation argv, matching the ADR-047 §9 text's
+  "linker-invocation capture" framing most literally.
+- `inputs_pack.ingest_inputs_pack()` (the Flow-2 `abicheck_inputs/` consumer)
+  always folds *every* TU in a pack into one linked surface; a pack's
+  `target_id` is only set when every TU already agrees on one (via existing,
+  producer-asserted tags) — there is no mechanism to *derive* a per-target
+  subset from a build-wide pack today, so even if a validator could prove an
+  "inferred" projection safe, nothing would actually act on that proof.
+
+## Decision
+
+### D1. One pure attribution module, two independent signal channels
+
+New module `abicheck/buildsource/link_attribution.py`:
+
+```python
+def attribute_sources_to_targets(evidence: BuildEvidence) -> dict[str, frozenset[str]]:
+    ...  # normalized source path -> the set of target_ids it feeds
+```
+
+Combines two independent channels, each individually sufficient where it
+applies, unioned per source path (a source legitimately shared between two
+DSOs must attribute to *both*, not arbitrarily pick one):
+
+- **Target-graph channel** (CMake, Ninja, any adapter with a real target
+  graph): walk `Target.source_files` directly, then transitively fold
+  `OBJECT_LIBRARY`/`STATIC_LIBRARY` targets' sources into every
+  `SHARED_LIBRARY`/`EXECUTABLE` target that (transitively, via
+  `Target.dependencies`) depends on them. No linker-command parsing needed —
+  the target graph already *is* the attribution.
+- **Link-unit-graph channel** (Bazel, Make): walk each `LinkUnit.output`
+  backward through `.inputs`, matching object-file paths against
+  `CompileUnit.output`, resolving nested static-library `LinkUnit`s
+  transitively (an `.a` that is itself the input to another link unit) until
+  reaching a `shared_library`/`executable` terminal link unit.
+
+A source with an **empty** attributed set is "unknown" (no signal from
+either channel) — callers must treat this as unresolved, never as
+"belongs to nothing" or "safe to drop silently."
+
+### D2. Make gets real link-invocation capture
+
+`adapters/make.py`'s dry-run scraper gains `_link_unit()`, mirroring the
+existing `_compile_unit()` heuristic-scraper pattern (same reduced-confidence
+posture, same diagnostics-not-exceptions philosophy): recognizes `ar`
+archive-creation lines (`ar rcs libfoo.a a.o b.o ...` → `static_library`) and
+compiler-frontend link lines (no `-c`/`/c`, an `-o <output>` naming a
+`.so`/`.dylib`/`.dll`/no-extension output, at least one `.o`/`.a` input
+argument) → `shared_library`/`executable` per `-shared`/output extension.
+Never runs Make itself, identical to the compile-line scraper's own
+constraint (ADR-028 D6, ADR-029 D7).
+
+### D3. `ingest_inputs_pack` gains an opt-in, attribution-filtered mode
+
+`inputs_pack.ingest_inputs_pack()` gains two new optional parameters,
+`attribution: Mapping[str, frozenset[str]] | None` and
+`expected_target_id: str | None`. When both are given, the TU list is
+filtered *before* linking to only TUs whose `.source` attributes (via
+`attribution`) to a set containing `expected_target_id` — a TU attributing to
+an unrelated target is excluded; a TU attributing to no target (unknown) is
+also excluded (fail-safe: an unproven TU must never silently ride along).
+Omitting either parameter preserves today's unfiltered behavior exactly —
+purely additive, no change to any existing caller.
+
+### D4. `build-output.json`'s validator accepts `"inferred"`, for real
+
+`BuildOutputEvidence` gains an optional `attribution_path` field (a
+build-output-root-relative path to a JSON-serialized `BuildEvidence`, i.e.
+`BuildEvidence.to_dict()`'s own shape — no new schema, reuses ADR-029 D2's
+existing model). `build_output.py`'s validator drops the previous
+unconditional "`inferred` is always a hard failure" rule (`_evidence_
+projection_issues`) and replaces it, for `projection: "inferred"` targets
+specifically, with a real check: `attribution_path` must resolve and parse as
+a `BuildEvidence`; `attribute_sources_to_targets()` run over it must produce
+a **non-empty** subset of the referenced pack's own TUs attributing to
+`f"target://{target.id}"` — an inferred claim that resolves to zero matching
+TUs is exactly the "silently degrades to nothing, tells no one" failure mode
+this ADR exists to prevent, so it is a hard validation error, not a warning.
+Unlike `"declared"`, two targets referencing the *same* physical
+`evidence.path` pack is not itself an error for `"inferred"` targets — that
+is the entire point: one build-wide pack, safely and automatically split.
+
+### D5. Explicitly deferred, not built in this pass
+
+Consistent with G30 P1.1's own precedent ("this PR defines the contract and
+validates a hand-authored example... no producer tooling yet"), this ADR
+delivers the attribution algorithm, the Make capture extension, the ingest
+filtering mechanism, and the build-output.json validator — a complete,
+independently testable, and independently usable core. It does **not** wire
+`attribution`/`expected_target_id` through the `compare`/`dump` CLI's actual
+`--build-info`/inputs-pack consumption path (`cli_buildsource_merge.py`,
+`action/run.sh`, `actions/check-target`'s `evidence-pack-path` input) to
+automatically produce and pass an `attribution_path` end-to-end in a real CI
+run. That plumbing is real, additive, mechanical work once a project actually
+needs it — deferred rather than retrofitted here, the same boundary §9 itself
+drew between "the safe model's contract" and "the pipeline that populates
+it." Tracked as the next slice, not re-opened as a new unscoped gap.
+
+## Consequences
+
+### Positive
+
+- Closes the last standing item in ADR-047 §9/D8 with a real, tested
+  mechanism rather than leaving it as a permanent "P2, not built" bullet.
+- CMake and Make projects — the two most common real-world C/C++ build
+  systems this tool targets (per `docs/contribute/plans/g30-...`'s own
+  "minimal generic pilots" list) — gain genuine TU-to-target attribution;
+  previously only Bazel had any.
+- The attribution module is pure and side-effect-free, consistent with every
+  other `buildsource/` module's testing posture (`CLAUDE.md` "Conventions").
+- Fail-safe by construction: an unknown/ambiguous source is excluded, never
+  silently included — the same posture `evidence.projection: "declared"`'s
+  existing shared-pack rejection already established.
+
+### Negative / risks
+
+- The Make link-scraper is heuristic, like its compile-line sibling — a
+  dry-run transcript is not an authoritative target graph, so Make-derived
+  `"inferred"` claims carry the same "reduced confidence" caveat Make's
+  compile units already carry.
+- `attribution_path` is not yet produced by any real build integration —
+  until D5's follow-up lands, a caller wanting to use `"inferred"` today must
+  hand-author or script the `BuildEvidence` JSON themselves (the same
+  "defines the contract, no producer yet" position G30 P1.1 shipped in for
+  `build-output.json` itself, which a later PR (P1.2/P1.3) filled in).
+- A source shared between two DSOs (legitimately compiled once, linked
+  twice) now attributes to both — correct, but means "inferred" does not by
+  itself prove *exclusive* ownership the way a hand-declared pack does;
+  downstream consumers relying on exclusivity must still use `"declared"`.
+- **Found during pilot validation (a real CMake File API + compile_commands.json
+  build, not a synthetic fixture): `Target.source_files` (CMake File API,
+  source-root-relative) and `CompileUnit.source` (`compile_db.py`, typically
+  absolute — confirmed by hand: `/abs/path/src/demo.cpp` vs. `src/demo.cpp`
+  for the identical file) do not share one path convention out of the box.**
+  This does not affect the target-graph channel itself (it only ever reads
+  `Target.source_files`, never joins against `CompileUnit`), but it does mean
+  a real `abicheck_inputs` pack whose `SourceAbiTu.source` values were
+  recorded in the *other* convention (e.g. absolute, matching how a
+  clang-based wrapper naturally records them) will fail to match against a
+  CMake-derived `attribution_path`'s relative keys — `normalize_source_path`
+  only strips a leading `./` and normalizes separators, it does not resolve
+  `..` or reconcile absolute-vs-relative. Fail-safe (an unmatched TU is
+  excluded, never wrongly included), but less complete than a source-root-
+  aware normalizer would be. Real path reconciliation belongs with D5's
+  deferred pipeline-wiring work, once there's a concrete producer whose
+  actual path conventions can be designed against, rather than guessed at
+  here.
+
+## Implementation plan
+
+1. `abicheck/buildsource/link_attribution.py` — the pure algorithm (D1).
+2. `abicheck/buildsource/adapters/make.py` — `_link_unit()` (D2).
+3. `abicheck/buildsource/inputs_pack.py` — `ingest_inputs_pack`'s new
+   optional filtering parameters (D3).
+4. `abicheck/buildsource/build_output.py` — `attribution_path` field +
+   `_inferred_evidence_projection_issues()` (D4).
+5. Unit tests for all four, covering: target-graph attribution (direct +
+   transitive static-lib fold), link-unit-graph attribution (direct +
+   transitive static-lib fold), Make link-line scraping (shared/static/
+   executable, `ar`, negative cases), ingest filtering (present/absent
+   attribution, unknown-source exclusion), and the build-output validator's
+   new accept/reject paths (mirroring the existing `"declared"` test
+   coverage's shape).
+
+## Validation
+
+`pytest tests/test_link_attribution.py tests/test_make_adapter.py
+tests/test_inputs_pack*.py tests/test_build_output.py -q`; `mypy
+abicheck/buildsource/link_attribution.py`; `ruff check`;
+`python scripts/check_ai_readiness.py` (no new errors).
+
+## References
+
+- ADR-047 §9/§11.1, D8 — the safe/full model split this closes the full half
+  of.
+- ADR-028 D3/D6 — post-build, non-executing adapter contract (Make's dry-run
+  posture).
+- ADR-029 D2/D6/D7 — `BuildEvidence`'s `LinkUnit` schema; Bazel's/Make's
+  existing adapter design.
+- ADR-035 D5 — Flow-2 `abicheck_inputs/` pack protocol `ingest_inputs_pack`
+  extends here.
+- `docs/contribute/plans/g30-github-actions-integration-model.md` — "P2 —
+  Deeper architecture," the backlog entry this ADR resolves.

--- a/docs/contribute/adr/053-tu-link-unit-dso-attribution.md
+++ b/docs/contribute/adr/053-tu-link-unit-dso-attribution.md
@@ -86,9 +86,9 @@ DSOs must attribute to *both*, not arbitrarily pick one):
   transitively (an `.a` that is itself the input to another link unit) until
   reaching a `shared_library`/`executable` terminal link unit.
 
-A source with an **empty** attributed set is "unknown" (no signal from
-either channel) — callers must treat this as unresolved, never as
-"belongs to nothing" or "safe to drop silently."
+A source **absent** from the returned mapping is "unknown" (no signal from
+either channel; it is never present with an empty set) — callers must treat
+this as unresolved, never as "belongs to nothing" or "safe to drop silently."
 
 ### D2. Make gets real link-invocation capture
 

--- a/docs/contribute/adr/index.md
+++ b/docs/contribute/adr/index.md
@@ -91,3 +91,4 @@ against the code as unverified, regardless of how confident it reads.
 | [050](050-comparability-contract-and-multi-tu-manifest.md) | Comparability Contract — Profile/Scope Fingerprints and the Multi-TU Manifest | Proposed — not implemented; see [G32](../plans/g32-comparability-contract-and-multi-tu-manifest.md) |
 | [051](051-documentation-operational-model.md) | Documentation Operational Model (Ownership Registry + Docs-Contract Gate) | Accepted — partially implemented (Stage 1 done; Stages 2-5 deferred) |
 | [052](052-unified-impact-assessment-model.md) | Unified Impact Assessment Model (G29 Phase 3, slices 1-5) | Accepted — slices 1-5 implemented |
+| [053](053-tu-link-unit-dso-attribution.md) | TU → Link-Unit → DSO Source-Evidence Attribution | Accepted — implemented (core algorithm + validator; CLI/Action pipeline wiring deferred, see D5) |

--- a/docs/contribute/plans/g30-github-actions-integration-model.md
+++ b/docs/contribute/plans/g30-github-actions-integration-model.md
@@ -2887,6 +2887,21 @@ dangling "not yet attempted" item this plan carries forward by default.
 
 ## Pilot validation plan
 
+**Executed 2026-07-25 — see `validation/g30-pilot-validation-2026-07.md`**
+for the full real-run report (real clones, real builds, real `abicheck`
+scans, not simulated). Summary: PVXS re-run via the check-project.yml flow,
+CMake, Make (via the PVXS/EPICS Base build itself), package-only (`.deb`),
+and cross-compiled (aarch64) pilots all completed with real ABI breaks
+correctly detected; Bazel and the second vendor-toolchain pilot remain
+genuinely blocked by this environment's available tooling (see that report
+for why); one real, reproducible product bug (`dump`/`compare` disagreeing
+on `--header`-derived `public_header_dirs` provenance, causing a spurious
+`ScopeMismatchError` in the exact baseline-then-live-candidate pattern this
+pipeline relies on) was found and documented there, not fixed in this pass
+— it is an ADR-050 (comparability contract) issue, not an ADR-053/G30 P2
+one. The per-pilot plan below is kept as the original acceptance-criteria
+reference the executed report was checked against.
+
 ### PVXS (confirmed pilot — extend, don't re-validate from scratch)
 
 `validation/pvxs-abi-validation-2026-07.md` already validates the core

--- a/docs/contribute/plans/g30-github-actions-integration-model.md
+++ b/docs/contribute/plans/g30-github-actions-integration-model.md
@@ -118,7 +118,7 @@ replay (`auto-completed: true`, no warning), wrapper under `phase: auto`
 `phase: prepare` (`auto-completed: true`, no warning — not flagged like
 `auto` is), and `phase: verify` (`auto-completed: true`).
 
-### P0.3 — Report identity envelope (subset of ADR-047 §7) — **done** (schema/model half; CLI-population half still open)
+### P0.3 — Report identity envelope (subset of ADR-047 §7) — **done** (schema/model half; native CLI-population half re-scoped, see status note — not a blocker)
 
 **Problem:** JSON reports don't carry `check_id`/`profile_id`/
 `requested_depth`/`effective_depth`/`baseline_channel` today — a P1
@@ -171,6 +171,49 @@ PR #601 per the note above.
 not null), round-trip + schema validation when set, `--stat` mode carrying
 the fields too, and an invalid `requested_depth` enum value failing schema
 validation.
+
+**Status note, re-investigated for G30 "remaining items" — the blocker is
+gone, but re-checking what it was blocking turned up a re-scope, not a
+straight unblock.** PR #601 (the `DumpDepthNotSatisfiedError` work this
+note was waiting on) merged 2026-07-19. Two things follow from that:
+
+- `check_id`/`profile_id`/`requested_depth`/`effective_depth`/
+  `baseline_channel` on `DiffResult`/`ScanOutcome` themselves are *still*
+  never set by any real code path — confirmed by grepping every `cli*.py`/
+  `checker.py`/`scan_engine.py`/`service*.py` for an assignment to any of
+  the five and finding none. A plain `abicheck compare`/`scan` invocation
+  outside `check-target` still emits a report with none of these fields.
+  That part of the original "CLI-population half" is real and still open,
+  narrowly, for a direct CLI/Python-API caller.
+- It is **not**, however, still blocking anything G30 itself needed: P1.3's
+  `actions/check-target` (below) ships the full ADR-047 §7 identity envelope
+  end-to-end today via a *different* mechanism than the one this item
+  originally imagined — `abicheck/buildsource/check_report.py`'s
+  `augment_report`/`derive_effective_depth` populate `check_id`/
+  `requested_depth`/`effective_depth`/etc. by post-processing the already-
+  emitted JSON *dict* (reading `old_evidence_depth`/`new_evidence_depth`/
+  `level.depth`, which `compare --format json`/`scan` already emit
+  unconditionally), not by threading values through `DiffResult`/
+  `ScanOutcome` fields at all. So the thing this note was gating — "P1's
+  primitives have something to populate" — already has it, via the
+  wrapper, without needing the native CLI wiring this note anticipated.
+  Closing this as "no further G30 work needed here"; a native-CLI
+  `compare`/`scan --format json`-carries-its-own-identity-fields
+  enhancement remains a real, standalone, narrowly-scoped follow-up outside
+  this plan (not currently justified by any G30 user story, since
+  `check-target` is the actual consumer and it's already covered).
+
+Separately, `AGENTS.md`'s own "Depth contract, CLI vs. API/MCP" Known Gaps
+entry — a related but *distinct* claim, about `service.py`'s `ScanRequest`/
+`run_scan_subprocess` and `mcp_server.py`'s MCP tools not enforcing the same
+requested-vs-achieved depth check the CLI's `dump --depth` gate does — was
+also re-investigated on the same pass and closed as stale in `AGENTS.md`
+directly (not a G30 item; `dump --depth`'s strict gate has no service.py/MCP
+surface to extend to since neither exposes a depth-qualified snapshot
+surface, and `scan`'s own pinned-depth contract was already shared
+identically between the CLI and service.py/MCP the whole time, via one
+`scan_engine.run_scan_core`). See that file for the full writeup; not
+duplicated here since it isn't a G30-specific gap.
 
 ### P0.4 — Canonical single-library and multi-DSO doc pages — **done**
 
@@ -2130,6 +2173,96 @@ placements, step ordering, matrix wiring, artifact-naming/sanitization
 conventions, self-checkout pattern) — the same "needs a real runner to exercise
 end-to-end" scoping `tests/test_action_check_target.py` already established
 for `check-target`'s own `action.yml`.
+
+**Issue [#628](https://github.com/abicheck/abicheck/issues/628) — the
+candidate-resolution/build-output-download report-routing gap the round-5/
+round-8/round-9 addenda above tracked as deferred — closed, picking a third
+option neither of the issue's own two listed alternatives:** the issue
+framed the choice as (1) duplicate `report_envelope.py`'s operational-error
+construction inline in `check-project.yml`'s own resolver step, or (2)
+restructure `check-target`'s own interface to still be invocable on an
+already-failed resolution. Neither was needed: `report_envelope.py --mode
+operational-error` is already a thin, self-contained CLI wrapper around
+`abicheck.buildsource.check_report.build_operational_error_report` that
+needs nothing beyond a cell's already-known identity fields (name/profile/
+baseline_channel/requested_depth/gate_mode, all present on the matrix
+`include:` entry) — so a new `check-project.yml` step can call it directly,
+reusing its actual code with zero duplication and zero change to
+`check-target`'s own inputs. Implemented:
+
+- **"Download build-output artifact"** lost its `continue-on-error: true`
+  (only when the download is actually attempted per its existing `if:` —
+  a baseline-backed cell, or a wrapper/clang-plugin evidence-producer cell)
+  and gained `id: download_build_output`, so a required download failure now
+  fails that step instead of silently degrading `resolve-baseline`'s
+  `incompatible_evidence` cross-check (`candidate-build-output` forwarding
+  empty with no signal why).
+- **"Resolve candidate binary/binaries"** gained `continue-on-error: true`
+  — its own internal guards are completely unchanged (still `::error::` +
+  `sys.exit(1)` on every failure mode), only the step-level swallowing is
+  new, so its job-failing behavior is now observed rather than silently
+  ending the job.
+- A new **"Synthesize pre-check operational-error report"** step
+  (`if: always() && (steps.download_build_output.outcome == 'failure' ||
+  steps.candidate.outcome == 'failure')`) calls
+  `report_envelope.py --mode operational-error --resolve-outcome ambiguous`
+  with a message naming which of the two failed, using the already-checked-
+  out `.check-project-src` copy of the repo (no new checkout/install step
+  needed). `--resolve-outcome ambiguous` matches
+  `actions/check-target/run.sh`'s own established precedent of reusing
+  resolve-baseline's `"ambiguous"` outcome as the generic catch-all for
+  other pre-analysis infrastructure failures that aren't literally a
+  resolve-baseline outcome either (a `collect-facts phase: verify`/`replay`
+  failure, a missing analysis report) — this pre-check failure is one more
+  instance of that same class, not a new taxonomy member. Mirrors
+  `run.sh`'s own stdout-capture/`exit-code=`-parsing/`grep -v` pattern
+  exactly, including letting the step's own exit code (always 1 for an
+  operational error, regardless of `gate-mode` — `final_exit_code`'s
+  existing rule) fail the matrix job, matching how a genuine
+  resolve-baseline failure already fails the job today via `check-target`'s
+  own finalize step.
+- **"Run check-target"** gained `if: steps.candidate.outcome == 'success'`
+  — required because `continue-on-error: true` on the resolver step means a
+  later step with no `if:` of its own would otherwise still attempt to run
+  by default even after the resolver's own internal failure (its
+  `conclusion` reads as `success` under `continue-on-error`, only its
+  `outcome` reads `failure`) — without this guard `check-target` would run
+  against a missing/half-resolved `new-library`.
+- **"Sanitize check-id for artifact name"** and **"Upload report"** both
+  widened their `if:`/value expressions to `steps.run.outputs.report-path
+  || steps.precheck.outputs.report-path` (and `steps.run.outputs.check-id
+  || steps.precheck.outputs.check-id` for the sanitizer's `CHECK_ID`) —
+  exactly one of "Run check-target" / the new precheck step ever runs per
+  matrix cell, so exactly one ever has a report to upload.
+
+Verified directly (not only via the updated structural test suite): ran the
+real `report_envelope.py --mode operational-error` invocation by hand
+against representative identity fields, confirming a schema-valid envelope
+(`verdict: "ERROR"`, `operational_errors: [{"kind": "ambiguous", ...}]`,
+`check_id` built correctly) and the documented `exit-code=1` output line;
+separately extracted and ran the new step's own bash script via `bash -c`
+against the real `report_envelope.py` through a symlinked `.check-project-
+src/` layout, confirming the `report-path`/`check-id` `$GITHUB_OUTPUT` lines
+and the step's own exit code match. `tests/test_reusable_workflows.py`
+gained a new `TestPreCheckOperationalErrorReport` class (structural
+assertions plus the bash/`report_envelope.py` end-to-end case above) and
+`test_report_artifact_name_uses_the_checks_own_sanitized_check_id`/
+`test_sanitize_step_runs_before_upload_and_shares_its_always_condition`
+were updated for the widened conditions.
+
+**Left for a follow-up, flagged rather than silently skipped:** the live
+`test-check-project-failure-path.yml` fixture (the real end-to-end GitHub
+Actions coverage for the *existing* resolve-baseline `not_found` operational
+error) was not extended with a second scenario that deliberately triggers a
+candidate-resolution or build-output-download failure — doing so needs a
+second `.abicheck.yml` fixture target/profile combination staged in a real
+CI run to validate, which this session couldn't exercise (no live GitHub
+Actions runner available here, the same constraint the "Pilot validation
+plan" section's minimal generic pilots are blocked on). The unit-level
+end-to-end verification above exercises the real script and the real
+`report_envelope.py` together, but a live-runner fixture proving the
+`aggregate`-visible result for these two specific failure modes (mirroring
+the existing `not_found` fixture's own pattern) remains open.
 
 ### P1.5 — `.abicheck.yml` `targets:`/`profiles:`/`baseline:` block — **done**
 

--- a/docs/contribute/plans/g30-github-actions-integration-model.md
+++ b/docs/contribute/plans/g30-github-actions-integration-model.md
@@ -2858,10 +2858,22 @@ dangling "not yet attempted" item this plan carries forward by default.
 
 ## P2 — Deeper architecture (not started here)
 
-- **Full TU→link-unit→DSO source-evidence attribution** (ADR-047 §9/D8) —
-  needs linker-invocation capture, extending
-  `abicheck/buildsource/build_query.py`'s existing partial zero-config
-  compile-DB inference. Its own follow-up ADR when undertaken.
+- ~~**Full TU→link-unit→DSO source-evidence attribution** (ADR-047 §9/D8)~~
+  — **done, see [ADR-053](../adr/053-tu-link-unit-dso-attribution.md).**
+  `abicheck/buildsource/link_attribution.py` implements the two-channel
+  attribution algorithm (target-graph, link-unit-graph, transitive
+  static-library folding on both); `adapters/make.py` gained real
+  link/archive-line capture; `inputs_pack.ingest_inputs_pack()` can now
+  filter a build-wide pack down to one target's own TUs;
+  `build_output.py`'s validator accepts and genuinely validates
+  `evidence.projection: "inferred"` by re-deriving the attribution, instead
+  of hard-rejecting it. ADR-053 D5 explicitly scopes what's *not* done here:
+  wiring `attribution_path` production through the `compare`/`dump` CLI's
+  actual `--build-info` pipeline end-to-end (so a real CI run produces one
+  automatically) — the core mechanism is real, tested, and independently
+  usable, but nothing in the `compare`/`dump`/`check-target` pipeline
+  produces an `attribution_path` for it to consume yet. That plumbing is the
+  next slice, not re-opened as a fresh unscoped gap.
 - **Monorepo changed-component planning** at scale (S25's `run-plan.json`
   filtering beyond a simple path-prefix diff).
 - **Richer cross-platform baseline storage** (external object store backend,

--- a/docs/contribute/plans/g30-github-actions-integration-model.md
+++ b/docs/contribute/plans/g30-github-actions-integration-model.md
@@ -2899,18 +2899,19 @@ project (the Bazel pilot additionally re-validated ADR-053's TU→DSO
 attribution against a real, live `bazel aquery` capture, not just
 CMake/Make); the Intel `icpx`/oneAPI vendor-toolchain pilot installed
 cleanly and validated real icpx-compiled binaries plus real SYCL
-device-code compilation, additionally finding (not fixed) a real
-`sycl_metadata.py` detection gap against Intel's current Unified Runtime
-adapter ABI; MSVC/PDB remains genuinely blocked (no redistributable Linux
-path to `cl.exe`) — see that report for the full detail on both; one real,
-reproducible product bug (`dump`/`compare` disagreeing
-on `--header`-derived `public_header_dirs` scope, causing a spurious
+device-code compilation; MSVC/PDB remains genuinely blocked (no
+redistributable Linux path to `cl.exe`). Two real, reproducible product
+bugs were found and fixed in this same PR, both after initial triage as
+out-of-scope follow-ups: (1) `dump`/`compare` disagreeing on
+`--header`-derived `public_header_dirs` scope, causing a spurious
 `ScopeMismatchError` in the exact baseline-then-live-candidate pattern this
-pipeline relies on) was found and, after initial triage as an ADR-050 (not
-ADR-053/G30 P2) follow-up, fixed in this same PR
-(`dumper.dump(scope_header_dirs=...)`, decoupled from ADR-015's
-declaration-provenance tagging) — see that report's "Finding" section for
-the full root-cause and fix detail. The per-pilot plan below is kept as the
+pipeline relies on (`dumper.dump(scope_header_dirs=...)`, decoupled from
+ADR-015's declaration-provenance tagging); (2) `sycl_metadata.py` silently
+rejecting real, current Intel oneAPI 2026.1 UR adapters as invalid (they
+export only `urGet<Category>ProcAddrTable` getters, not the older
+`urAdapterGet`-based per-verb symbols the detector required) — see that
+report's "Finding" sections for the full root-cause and fix detail on
+both. The per-pilot plan below is kept as the
 original acceptance-criteria
 reference the executed report was checked against.
 

--- a/docs/contribute/plans/g30-github-actions-integration-model.md
+++ b/docs/contribute/plans/g30-github-actions-integration-model.md
@@ -2888,13 +2888,16 @@ dangling "not yet attempted" item this plan carries forward by default.
 ## Pilot validation plan
 
 **Executed 2026-07-25 — see `validation/g30-pilot-validation-2026-07.md`**
-for the full real-run report (real clones, real builds, real `abicheck`
-scans, not simulated). Summary: PVXS re-run via the check-project.yml flow,
-CMake, Make (via the PVXS/EPICS Base build itself), package-only (`.deb`),
-and cross-compiled (aarch64) pilots all completed with real ABI breaks
-correctly detected; Bazel and the second vendor-toolchain pilot remain
-genuinely blocked by this environment's available tooling (see that report
-for why); one real, reproducible product bug (`dump`/`compare` disagreeing
+for the full real-run report (real builds, real `abicheck` scans, not
+simulated — mixed scope, see below). Summary: PVXS (real-upstream
+`epics-base/pvxs`) re-run via the check-project.yml flow and Make (via that
+same real EPICS Base/PVXS build) both completed with real ABI breaks
+correctly detected; CMake, package-only (`.deb`), and cross-compiled
+(aarch64) pilots also completed with real ABI breaks correctly detected but
+against a synthetic in-repo `libdemo` fixture, not a second real-upstream
+project; Bazel and the second vendor-toolchain pilot remain genuinely
+blocked by this environment's available tooling (see that report for why);
+one real, reproducible product bug (`dump`/`compare` disagreeing
 on `--header`-derived `public_header_dirs` provenance, causing a spurious
 `ScopeMismatchError` in the exact baseline-then-live-candidate pattern this
 pipeline relies on) was found and documented there, not fixed in this pass

--- a/docs/contribute/plans/g30-github-actions-integration-model.md
+++ b/docs/contribute/plans/g30-github-actions-integration-model.md
@@ -2892,17 +2892,26 @@ for the full real-run report (real builds, real `abicheck` scans, not
 simulated — mixed scope, see below). Summary: PVXS (real-upstream
 `epics-base/pvxs`) re-run via the check-project.yml flow and Make (via that
 same real EPICS Base/PVXS build) both completed with real ABI breaks
-correctly detected; CMake, package-only (`.deb`), and cross-compiled
+correctly detected; CMake, Bazel, package-only (`.deb`), and cross-compiled
 (aarch64) pilots also completed with real ABI breaks correctly detected but
 against a synthetic in-repo `libdemo` fixture, not a second real-upstream
-project; Bazel and the second vendor-toolchain pilot remain genuinely
-blocked by this environment's available tooling (see that report for why);
-one real, reproducible product bug (`dump`/`compare` disagreeing
-on `--header`-derived `public_header_dirs` provenance, causing a spurious
+project (the Bazel pilot additionally re-validated ADR-053's TU→DSO
+attribution against a real, live `bazel aquery` capture, not just
+CMake/Make); the Intel `icpx`/oneAPI vendor-toolchain pilot installed
+cleanly and validated real icpx-compiled binaries plus real SYCL
+device-code compilation, additionally finding (not fixed) a real
+`sycl_metadata.py` detection gap against Intel's current Unified Runtime
+adapter ABI; MSVC/PDB remains genuinely blocked (no redistributable Linux
+path to `cl.exe`) — see that report for the full detail on both; one real,
+reproducible product bug (`dump`/`compare` disagreeing
+on `--header`-derived `public_header_dirs` scope, causing a spurious
 `ScopeMismatchError` in the exact baseline-then-live-candidate pattern this
-pipeline relies on) was found and documented there, not fixed in this pass
-— it is an ADR-050 (comparability contract) issue, not an ADR-053/G30 P2
-one. The per-pilot plan below is kept as the original acceptance-criteria
+pipeline relies on) was found and, after initial triage as an ADR-050 (not
+ADR-053/G30 P2) follow-up, fixed in this same PR
+(`dumper.dump(scope_header_dirs=...)`, decoupled from ADR-015's
+declaration-provenance tagging) — see that report's "Finding" section for
+the full root-cause and fix detail. The per-pilot plan below is kept as the
+original acceptance-criteria
 reference the executed report was checked against.
 
 ### PVXS (confirmed pilot — extend, don't re-validate from scratch)
@@ -2971,8 +2980,9 @@ not just correctness:
 - Make/custom-build repository — can reuse PVXS's own build if a second,
   simpler EPICS module or a synthetic Make fixture is used instead
   (S11 acceptance, distinct from the full PVXS pilot above).
-- Bazel repository (S12 acceptance) — no existing pilot found for this;
-  needs a fixture or a real small Bazel C++ project.
+- Bazel repository (S12 acceptance) — **done, 2026-07-25** (real `bazelisk`/
+  Bazel 9.2.0 + a minimal `cc_binary` fixture, see
+  `validation/g30-pilot-validation-2026-07.md`'s "Bazel pilot" section).
 - Package-only RPM/Deb/tar comparison (S13 acceptance).
 - Linux/macOS/Windows matrix (S17 acceptance) — the existing CI matrix
   (ADR-047-unrelated, `.github/workflows/ci.yml`) already exercises

--- a/docs/reference/reusable-workflows.md
+++ b/docs/reference/reusable-workflows.md
@@ -125,6 +125,27 @@ step (they were written by `check-target`'s internal finalize step before
 its own exit code was returned), so the always()-conditioned `Upload report`
 step still sees them.
 
+### Pre-check failures (candidate resolution, build-output download)
+
+Before `check-target` ever runs, the matrix job resolves this cell's
+candidate binary/binaries (`binary_pattern`/`member_binary_patterns`, a
+glob against the downloaded `candidate/` artifact) and, when a baseline or a
+wrapper/clang-plugin evidence pack is needed, downloads that cell's
+`build-output.json`. Either can genuinely fail — no candidate matched, an
+ambiguous/escaping pattern, a missing bundle member, or a required
+build-output download error. A **"Synthesize pre-check operational-error
+report"** step catches exactly this: when either fails, it writes a full
+operational-error report envelope (`verdict: "ERROR"`,
+`operational_errors: [{"kind": "ambiguous", ...}]`) by calling
+`actions/check-target/report_envelope.py --mode operational-error` directly
+— the same script `check-target`'s own finalize step drives for a real
+`resolve-baseline` failure — so `aggregate` sees a typed, per-cell failure
+here too, rather than a cell that silently vanished from the report set (as
+if it had never been required at all). `Run check-target` itself is gated
+to skip whenever candidate resolution didn't succeed, and the downstream
+`Sanitize check-id for artifact name`/`Upload report` steps pick up whichever
+of the two report-producing steps actually ran.
+
 ### Required artifact-staging convention
 
 `check-project.yml` never builds anything and never fetches from a baseline

--- a/tests/test_build_output.py
+++ b/tests/test_build_output.py
@@ -534,7 +534,12 @@ class TestBinaryValidation:
 
 
 class TestEvidenceProjection:
-    def test_inferred_projection_is_hard_failure(self, tmp_path: Path) -> None:
+    def test_inferred_projection_without_attribution_path_is_hard_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """ADR-053 D4: "inferred" needs a real attribution_path to derive
+        from -- asserting the projection alone (no attribution source) must
+        still fail, distinctly from the old "P2 not built" wording."""
         root = tmp_path / "abicheck-build"
         root.mkdir()
         digest = _binary(root, "artifacts/lib/libfoo.so")
@@ -560,7 +565,7 @@ class TestEvidenceProjection:
         )
         report = validate_build_output(root)
         assert not report.ok
-        assert any("P2" in e for e in report.errors)
+        assert any("no evidence.attribution_path is set" in e for e in report.errors)
 
     def test_unknown_projection_value_is_hard_failure(self, tmp_path: Path) -> None:
         root = tmp_path / "abicheck-build"
@@ -588,7 +593,226 @@ class TestEvidenceProjection:
         )
         report = validate_build_output(root)
         assert not report.ok
-        assert any("must be 'declared'" in e for e in report.errors)
+        assert any("must be one of" in e for e in report.errors)
+
+
+def _write_attribution(root: Path, rel: str, evidence: object) -> None:
+    """Write a ``BuildEvidence.to_dict()``-shaped JSON at *root/rel*."""
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(evidence.to_dict()))
+
+
+class TestInferredEvidenceProjection:
+    """ADR-053 D4: unlike 'declared', 'inferred' is validated by re-deriving
+    real TU->link-unit->DSO attribution from evidence.attribution_path, not
+    by asserted exclusivity — including the defining case 'declared' can
+    never pass: two targets safely sharing one physical evidence.path."""
+
+    def _evidence(self) -> object:
+        from abicheck.buildsource.build_evidence import (
+            BuildEvidence,
+            Target,
+            TargetKind,
+        )
+
+        return BuildEvidence(
+            targets=[
+                Target(
+                    id="target://libfoo",
+                    kind=TargetKind.SHARED_LIBRARY,
+                    source_files=["src/foo.cpp"],
+                    dependencies=["target://common"],
+                ),
+                Target(
+                    id="target://common",
+                    kind=TargetKind.STATIC_LIBRARY,
+                    source_files=["src/common.cpp"],
+                ),
+                Target(
+                    id="target://libbar",
+                    kind=TargetKind.SHARED_LIBRARY,
+                    source_files=["src/bar.cpp"],
+                ),
+            ]
+        )
+
+    def test_single_target_inferred_projection_passes(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        pack_dir = root / "evidence" / "abicheck_inputs"
+        (pack_dir / "source_facts").mkdir(parents=True)
+        (pack_dir / "manifest.json").write_text(json.dumps({"kind": "abicheck_inputs"}))
+        (pack_dir / "source_facts" / "tu0.jsonl").write_text(
+            json.dumps({"tu_id": "cu://src/foo.cpp", "source": "src/foo.cpp"}) + "\n"
+        )
+        _write_attribution(root, "evidence/attribution.json", self._evidence())
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/abicheck_inputs",
+                                "projection": "inferred",
+                                "attribution_path": "evidence/attribution.json",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert report.ok, report.errors
+
+    def test_shared_pack_across_two_inferred_targets_passes(self, tmp_path: Path) -> None:
+        """The defining case 'declared' rejects outright: two targets
+        pointing at the SAME physical evidence.path, both 'inferred' — must
+        pass, since automatically splitting one build-wide pack is the
+        entire point (unlike 'declared', where this is a hard failure)."""
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest_foo = _binary(root, "artifacts/lib/libfoo.so")
+        digest_bar = _binary(root, "artifacts/lib/libbar.so", content=b"bar-content")
+        pack_dir = root / "evidence" / "abicheck_inputs"
+        (pack_dir / "source_facts").mkdir(parents=True)
+        (pack_dir / "manifest.json").write_text(json.dumps({"kind": "abicheck_inputs"}))
+        for i, source in enumerate(["src/foo.cpp", "src/common.cpp", "src/bar.cpp"]):
+            (pack_dir / "source_facts" / f"tu{i}.jsonl").write_text(
+                json.dumps({"tu_id": f"cu://{source}", "source": source}) + "\n"
+            )
+        _write_attribution(root, "evidence/attribution.json", self._evidence())
+        evidence_block = {
+            "kind": "source-facts",
+            "path": "evidence/abicheck_inputs",
+            "projection": "inferred",
+            "attribution_path": "evidence/attribution.json",
+        }
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "evidence": evidence_block,
+                        },
+                        {
+                            "id": "libbar",
+                            "binary": "artifacts/lib/libbar.so",
+                            "evidence": evidence_block,
+                        },
+                    ],
+                    "digests": {
+                        "artifacts/lib/libfoo.so": f"sha256:{digest_foo}",
+                        "artifacts/lib/libbar.so": f"sha256:{digest_bar}",
+                    },
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert report.ok, report.errors
+
+    def test_inferred_projection_attributing_to_nothing_fails(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libbaz.so")
+        pack_dir = root / "evidence" / "abicheck_inputs"
+        (pack_dir / "source_facts").mkdir(parents=True)
+        (pack_dir / "manifest.json").write_text(json.dumps({"kind": "abicheck_inputs"}))
+        (pack_dir / "source_facts" / "tu0.jsonl").write_text(
+            json.dumps({"tu_id": "cu://src/unrelated.cpp", "source": "src/unrelated.cpp"})
+            + "\n"
+        )
+        _write_attribution(root, "evidence/attribution.json", self._evidence())
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libbaz",
+                            "binary": "artifacts/lib/libbaz.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/abicheck_inputs",
+                                "projection": "inferred",
+                                "attribution_path": "evidence/attribution.json",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libbaz.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("ties none of" in e for e in report.errors)
+
+    def test_missing_attribution_path_file_fails(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        _write_pack(root, "evidence/abicheck_inputs", library="libfoo")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/abicheck_inputs",
+                                "projection": "inferred",
+                                "attribution_path": "evidence/does-not-exist.json",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("does not exist" in e for e in report.errors)
+
+    def test_escaping_attribution_path_is_rejected(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        _write_pack(root, "evidence/abicheck_inputs", library="libfoo")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/abicheck_inputs",
+                                "projection": "inferred",
+                                "attribution_path": "/etc/passwd",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("escapes the build-output directory" in e for e in report.errors)
 
 
 class TestDeclaredEvidenceSharingScope:

--- a/tests/test_build_output.py
+++ b/tests/test_build_output.py
@@ -132,6 +132,7 @@ class TestSchemaRoundTrip:
                         kind="source-facts",
                         path="evidence/abicheck_inputs",
                         projection="declared",
+                        attribution_path="evidence/attribution.json",
                     ),
                 )
             ],
@@ -813,6 +814,125 @@ class TestInferredEvidenceProjection:
         report = validate_build_output(root)
         assert not report.ok
         assert any("escapes the build-output directory" in e for e in report.errors)
+
+    def test_inferred_evidence_path_escaping_is_rejected(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "/etc/passwd",
+                                "projection": "inferred",
+                                "attribution_path": "evidence/attribution.json",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any(
+            "evidence.path" in e and "absolute or escapes" in e for e in report.errors
+        )
+
+    def test_inferred_evidence_path_not_a_pack_is_rejected(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        (root / "evidence" / "not-a-pack").mkdir(parents=True)
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/not-a-pack",
+                                "projection": "inferred",
+                                "attribution_path": "evidence/attribution.json",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("not a readable abicheck_inputs pack" in e for e in report.errors)
+
+    def test_malformed_attribution_json_fails(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        _write_pack(root, "evidence/abicheck_inputs", library="libfoo")
+        (root / "evidence" / "attribution.json").write_text("{not valid json")
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/abicheck_inputs",
+                                "projection": "inferred",
+                                "attribution_path": "evidence/attribution.json",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("could not be read as JSON" in e for e in report.errors)
+
+    def test_attribution_json_not_object_fails(self, tmp_path: Path) -> None:
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        _write_pack(root, "evidence/abicheck_inputs", library="libfoo")
+        (root / "evidence" / "attribution.json").write_text(json.dumps([1, 2, 3]))
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/abicheck_inputs",
+                                "projection": "inferred",
+                                "attribution_path": "evidence/attribution.json",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert not report.ok
+        assert any("is not a JSON object" in e for e in report.errors)
 
 
 class TestDeclaredEvidenceSharingScope:

--- a/tests/test_build_output.py
+++ b/tests/test_build_output.py
@@ -672,6 +672,71 @@ class TestInferredEvidenceProjection:
         report = validate_build_output(root)
         assert report.ok, report.errors
 
+    def test_make_style_link_unit_attribution_with_no_target_id_passes(
+        self, tmp_path: Path
+    ) -> None:
+        """ADR-053 D2: Make link units carry no ``target_id`` (Make has no
+        semantic target graph) — ``attribute_sources_to_targets`` identifies
+        them as ``output://{basename}`` instead. The validator must accept
+        that identity too, not just ``target://{t.id}``, or every Make-
+        derived 'inferred' claim would resolve to zero matches and hard-fail
+        (CodeRabbit review, PR #632)."""
+        from abicheck.buildsource.build_evidence import (
+            BuildEvidence,
+            CompileUnit,
+            LinkUnit,
+        )
+
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        digest = _binary(root, "artifacts/lib/libfoo.so")
+        pack_dir = root / "evidence" / "abicheck_inputs"
+        (pack_dir / "source_facts").mkdir(parents=True)
+        (pack_dir / "manifest.json").write_text(json.dumps({"kind": "abicheck_inputs"}))
+        (pack_dir / "source_facts" / "tu0.jsonl").write_text(
+            json.dumps({"tu_id": "cu://src/foo.cpp", "source": "src/foo.cpp"}) + "\n"
+        )
+        # No target_id anywhere (the Make case, ADR-053 D2): link_attribution's
+        # link-unit channel walks LinkUnit.inputs back to CompileUnit.output
+        # and, absent a target_id, identifies the terminal link unit as
+        # output://{basename}.
+        evidence = BuildEvidence(
+            compile_units=[
+                CompileUnit(id="cu://src/foo.cpp", source="src/foo.cpp", output="src/foo.o"),
+            ],
+            link_units=[
+                LinkUnit(
+                    id="link://libfoo.so",
+                    output="libfoo.so",
+                    kind="shared_library",
+                    inputs=["src/foo.o"],
+                ),
+            ],
+        )
+        _write_attribution(root, "evidence/attribution.json", evidence)
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": "artifacts/lib/libfoo.so",
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/abicheck_inputs",
+                                "projection": "inferred",
+                                "attribution_path": "evidence/attribution.json",
+                            },
+                        }
+                    ],
+                    "digests": {"artifacts/lib/libfoo.so": f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert report.ok, report.errors
+
     def test_shared_pack_across_two_inferred_targets_passes(self, tmp_path: Path) -> None:
         """The defining case 'declared' rejects outright: two targets
         pointing at the SAME physical evidence.path, both 'inferred' — must

--- a/tests/test_build_output.py
+++ b/tests/test_build_output.py
@@ -737,6 +737,69 @@ class TestInferredEvidenceProjection:
         report = validate_build_output(root)
         assert report.ok, report.errors
 
+    def test_make_style_attribution_with_backslash_binary_path_passes(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression pin (code review, PR #632): the output://{basename}
+        identity built from ``t.binary`` must normalize backslashes the same
+        way ``link_attribution.py`` normalizes ``LinkUnit.output`` before
+        taking the basename, or a Windows-style ``t.binary`` never matches --
+        ``PurePosixPath`` treats a bare backslash as an ordinary character,
+        not a separator, so an un-normalized ``.name`` would return the
+        whole string instead of just the basename."""
+        from abicheck.buildsource.build_evidence import (
+            BuildEvidence,
+            CompileUnit,
+            LinkUnit,
+        )
+
+        root = tmp_path / "abicheck-build"
+        root.mkdir()
+        binary_rel = "artifacts\\lib\\libfoo.so"
+        digest = _binary(root, binary_rel)
+        pack_dir = root / "evidence" / "abicheck_inputs"
+        (pack_dir / "source_facts").mkdir(parents=True)
+        (pack_dir / "manifest.json").write_text(json.dumps({"kind": "abicheck_inputs"}))
+        (pack_dir / "source_facts" / "tu0.jsonl").write_text(
+            json.dumps({"tu_id": "cu://src/foo.cpp", "source": "src/foo.cpp"}) + "\n"
+        )
+        evidence = BuildEvidence(
+            compile_units=[
+                CompileUnit(id="cu://src/foo.cpp", source="src/foo.cpp", output="src/foo.o"),
+            ],
+            link_units=[
+                LinkUnit(
+                    id="link://libfoo.so",
+                    output="libfoo.so",
+                    kind="shared_library",
+                    inputs=["src/foo.o"],
+                ),
+            ],
+        )
+        _write_attribution(root, "evidence/attribution.json", evidence)
+        (root / "build-output.json").write_text(
+            json.dumps(
+                {
+                    "schema": BUILD_OUTPUT_SCHEMA,
+                    "targets": [
+                        {
+                            "id": "libfoo",
+                            "binary": binary_rel,
+                            "evidence": {
+                                "kind": "source-facts",
+                                "path": "evidence/abicheck_inputs",
+                                "projection": "inferred",
+                                "attribution_path": "evidence/attribution.json",
+                            },
+                        }
+                    ],
+                    "digests": {binary_rel: f"sha256:{digest}"},
+                }
+            )
+        )
+        report = validate_build_output(root)
+        assert report.ok, report.errors
+
     def test_shared_pack_across_two_inferred_targets_passes(self, tmp_path: Path) -> None:
         """The defining case 'declared' rejects outright: two targets
         pointing at the SAME physical evidence.path, both 'inferred' — must

--- a/tests/test_cli_dump_helpers_coverage.py
+++ b/tests/test_cli_dump_helpers_coverage.py
@@ -643,6 +643,73 @@ def test_perform_elf_dump_stamps_build_context_and_attaches(
     assert "populated" not in events  # follow_deps was False
 
 
+def test_perform_elf_dump_folds_header_dir_into_scope_header_dirs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """G30 pilot validation regression (validation/
+    g30-pilot-validation-2026-07.md): a directory passed via -H/--header must
+    be threaded through to dump()'s scope_header_dirs (via split_public_
+    header_inputs, the same helper `compare` uses) -- not just its expanded
+    per-file listing -- so the resulting contract's scope_fingerprint agrees
+    with a live compare-side extraction of the identical header set."""
+    so = tmp_path / "lib.so"
+    include_dir = tmp_path / "include"
+    include_dir.mkdir()
+    hdr = include_dir / "api.h"
+    hdr.write_text("int api(void);", encoding="utf-8")
+
+    captured: dict[str, object] = {}
+
+    def _fake_dump(**kwargs):  # noqa: ANN003, ANN202
+        captured.update(kwargs)
+        return AbiSnapshot(library="lib.so", version="1.0", from_headers=True)
+
+    monkeypatch.setattr("abicheck.cli_dump_helpers.dump", _fake_dump)
+
+    events, _stamp, _write, _expand, _populate = _elf_dump_callables()
+
+    perform_elf_dump(
+        so,
+        (include_dir,),
+        (),
+        "1.0",
+        "c",
+        None,
+        None,
+        None,
+        (),  # gcc_path/prefix/options/option_tokens
+        None,
+        True,  # sysroot, nostdinc
+        False,
+        None,  # dwarf_only, effective_debug_format
+        (),
+        (),  # public_headers, public_header_dirs
+        None,  # effective_compile_db
+        False,
+        (),
+        "",  # follow_deps, search_paths, ld_library_path
+        None,
+        None,
+        False,  # git_tag, build_id, no_git
+        None,
+        None,
+        None,
+        None,
+        False,
+        "off",  # output..collect_mode
+        _expand,
+        _populate,
+        _stamp,
+        _write,
+        compile_db_context_matched=False,
+    )
+
+    assert captured["scope_header_dirs"] == [include_dir]
+    # No --public-header-dir was given -- provenance-tagging inputs stay
+    # untouched (ADR-015 opt-in unaffected).
+    assert captured["public_header_dirs"] == []
+
+
 def test_perform_elf_dump_does_not_stamp_build_context_for_dwarf_only(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_dumper_contract_wiring.py
+++ b/tests/test_dumper_contract_wiring.py
@@ -424,3 +424,102 @@ def test_cpp20_heuristic_forced_standard_flows_into_profile_fingerprint(
     assert result.assurance == "none"
     assert result.coverage_warnings
     assert any("profile_fingerprint" in w for w in result.coverage_warnings)
+
+
+def _build_lib_in_dir(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Build a tiny ELF .so with its public header inside a subdirectory,
+    returning (so_path, header_path, header_dir)."""
+    include_dir = tmp_path / "include"
+    include_dir.mkdir()
+    header = include_dir / "api.h"
+    header.write_text(_HEADER)
+    src = tmp_path / "api.c"
+    src.write_text(_SOURCE)
+    so = tmp_path / "libapi.so"
+    subprocess.run(
+        ["gcc", "-shared", "-fPIC", "-o", str(so), str(src), f"-I{include_dir}"],
+        check=True,
+        capture_output=True,
+    )
+    return so, header, include_dir
+
+
+def test_scope_header_dirs_matches_compare_style_public_header_dir_scope(
+    tmp_path: Path,
+) -> None:
+    """Regression pin (G30 pilot validation, ``validation/
+    g30-pilot-validation-2026-07.md``): a snapshot ``dump``-produced from a
+    bare ``-H <dir>`` directory argument (the CLI now folds that raw
+    directory into ``scope_header_dirs``, ``cli_dump_helpers.
+    perform_elf_dump``) must agree on ``scope_fingerprint`` with a live
+    extraction of the identical header set where the directory feeds
+    ``public_header_dirs`` directly (``compare``'s own ``--header`` handling,
+    ``cli_resolve._resolve_compare_snapshots`` via ``split_public_header_
+    inputs``) -- comparing the two must not raise ``ScopeMismatchError`` even
+    though nothing about the declared surface differs."""
+    if not (_have("clang") and _have("gcc")):
+        pytest.skip(
+            "clang and gcc are required for the contract-wiring integration test"
+        )
+    so, header, include_dir = _build_lib_in_dir(tmp_path)
+
+    # Simulates `dump --header <dir>` (no --public-header-dir given): the
+    # CLI folds the raw directory argument into scope_header_dirs only.
+    dump_style = dump(
+        so,
+        [header],
+        compiler="cc",
+        header_backend="clang",
+        scope_header_dirs=[include_dir],
+    )
+    # Simulates `compare --header <dir>` (compare has no separate opt-in
+    # flag, so its own --header directly feeds public_header_dirs).
+    compare_style = dump(
+        so,
+        [header],
+        compiler="cc",
+        header_backend="clang",
+        public_header_dirs=[include_dir],
+    )
+
+    assert dump_style.contract is not None
+    assert compare_style.contract is not None
+    assert (
+        dump_style.contract.scope_fields["public_header_dirs"]
+        == compare_style.contract.scope_fields["public_header_dirs"]
+    )
+    assert (
+        dump_style.contract.scope_fingerprint
+        == compare_style.contract.scope_fingerprint
+    )
+
+    result = compare(dump_style, compare_style)
+    assert result.verdict == Verdict.NO_CHANGE
+
+
+def test_scope_header_dirs_does_not_enable_provenance_tagging(
+    tmp_path: Path,
+) -> None:
+    """``scope_header_dirs`` feeds only the extraction contract's scope
+    fingerprint (ADR-050 D1) -- it must never silently opt a plain ``dump
+    --header <dir>`` invocation into declaration-provenance tagging (ADR-015
+    stays opt-in via the separate ``--public-header``/``--public-header-dir``
+    flags, unchanged)."""
+    if not (_have("clang") and _have("gcc")):
+        pytest.skip(
+            "clang and gcc are required for the contract-wiring integration test"
+        )
+    so, header, include_dir = _build_lib_in_dir(tmp_path)
+
+    snap = dump(
+        so,
+        [header],
+        compiler="cc",
+        header_backend="clang",
+        scope_header_dirs=[include_dir],
+    )
+
+    from abicheck.model import ScopeOrigin
+
+    assert snap.functions
+    assert all(fn.origin == ScopeOrigin.UNKNOWN for fn in snap.functions)

--- a/tests/test_inputs_pack.py
+++ b/tests/test_inputs_pack.py
@@ -276,7 +276,14 @@ def test_ingest_with_attribution_filters_to_expected_target(tmp_path: Path) -> N
     assert surface is not None
     names = {e.qualified_name for e in surface.reachable_declarations}
     assert names == {"foo"}
-    assert any("1 TU(s) excluded" in d for d in ingested.diagnostics)
+    # The exclusion note is intentional-scoping information, not a lossy-read
+    # diagnostic (CodeRabbit review, PR #632) -- it must NOT flip a fully
+    # successful projected ingest's status to "partial", so it lives in the
+    # extractor's `detail` string, not in `diagnostics`/status computation.
+    assert not ingested.diagnostics
+    extractor = ingested.pack.manifest.extractors[0]
+    assert extractor.status == "ok"
+    assert "1 TU(s) excluded by attribution scoping" in extractor.detail
 
 
 def test_ingest_with_attribution_drops_unknown_source(tmp_path: Path) -> None:

--- a/tests/test_inputs_pack.py
+++ b/tests/test_inputs_pack.py
@@ -238,6 +238,77 @@ def test_ingest_links_source_facts_into_l4_surface(tmp_path: Path) -> None:
     assert "foo" in names
 
 
+# -- attribution-filtered ingest (ADR-053 D3) --------------------------------
+
+
+def test_ingest_without_attribution_keeps_every_tu(tmp_path: Path) -> None:
+    """Omitting attribution/expected_target_id (the default) is unchanged
+    behavior -- both TUs from a two-source pack are kept regardless of which
+    target either belongs to."""
+    pack = _write_inputs_pack(
+        tmp_path,
+        [
+            _tu("foo", mangled="_Z3foov", source="src/foo.cpp"),
+            _tu("bar", mangled="_Z3barv", source="src/bar.cpp"),
+        ],
+    )
+    ingested = ingest_inputs_pack(pack)
+    assert ingested.tu_count == 2
+
+
+def test_ingest_with_attribution_filters_to_expected_target(tmp_path: Path) -> None:
+    pack = _write_inputs_pack(
+        tmp_path,
+        [
+            _tu("foo", mangled="_Z3foov", source="src/foo.cpp"),
+            _tu("bar", mangled="_Z3barv", source="src/bar.cpp"),
+        ],
+    )
+    attribution = {
+        "src/foo.cpp": frozenset({"target://libfoo"}),
+        "src/bar.cpp": frozenset({"target://libbar"}),
+    }
+    ingested = ingest_inputs_pack(
+        pack, attribution=attribution, expected_target_id="target://libfoo"
+    )
+    assert ingested.tu_count == 1
+    surface = ingested.pack.source_abi
+    assert surface is not None
+    names = {e.qualified_name for e in surface.reachable_declarations}
+    assert names == {"foo"}
+    assert any("1 TU(s) excluded" in d for d in ingested.diagnostics)
+
+
+def test_ingest_with_attribution_drops_unknown_source(tmp_path: Path) -> None:
+    """Fail-safe: a source absent from the attribution mapping entirely
+    (unknown to both link_attribution channels) is dropped, exactly like one
+    attributed to a different target -- never kept on "no signal = safe"."""
+    pack = _write_inputs_pack(
+        tmp_path, [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")]
+    )
+    ingested = ingest_inputs_pack(
+        pack, attribution={}, expected_target_id="target://libfoo"
+    )
+    assert ingested.tu_count == 0
+
+
+def test_ingest_with_attribution_keeps_source_shared_between_targets(
+    tmp_path: Path,
+) -> None:
+    """A source legitimately shared between two DSOs (compiled once, linked
+    into both) must be kept for either target's expected_target_id, not
+    just one — the attribution set is a membership test, not exclusivity."""
+    pack = _write_inputs_pack(
+        tmp_path, [_tu("foo", mangled="_Z3foov", source="src/foo.cpp")]
+    )
+    attribution = {"src/foo.cpp": frozenset({"target://libfoo", "target://libbar"})}
+    for expected in ("target://libfoo", "target://libbar"):
+        ingested = ingest_inputs_pack(
+            pack, attribution=attribution, expected_target_id=expected
+        )
+        assert ingested.tu_count == 1
+
+
 def test_ingest_marks_call_type_graph_coverage_from_complete_source_edges(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_link_attribution.py
+++ b/tests/test_link_attribution.py
@@ -1,0 +1,295 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for ``buildsource.link_attribution`` (ADR-053 D1).
+
+Covers both attribution channels independently (target-graph, link-unit-
+graph), their combination (union, not override), transitive static-library
+folding on each, the deliberate SHARED_LIBRARY dependency hard-stop, and the
+"unknown source" contract (absent from the result, not present-with-empty).
+"""
+
+from __future__ import annotations
+
+from abicheck.buildsource.build_evidence import (
+    BuildEvidence,
+    CompileUnit,
+    LinkUnit,
+    Target,
+    TargetKind,
+)
+from abicheck.buildsource.link_attribution import (
+    attribute_sources_to_targets,
+    normalize_source_path,
+)
+
+
+def test_normalize_source_path_strips_leading_dot_slash_and_backslashes():
+    assert normalize_source_path("./src/a.cpp") == "src/a.cpp"
+    assert normalize_source_path("src\\a.cpp") == "src/a.cpp"
+    assert normalize_source_path("src/a.cpp") == "src/a.cpp"
+
+
+def test_unknown_source_is_absent_not_empty():
+    ev = BuildEvidence(
+        targets=[Target(id="target://libfoo", source_files=["src/foo.cpp"])]
+    )
+    attr = attribute_sources_to_targets(ev)
+    assert "src/unrelated.cpp" not in attr
+    assert attr.get("src/unrelated.cpp", frozenset()) == frozenset()
+
+
+class TestTargetGraphChannel:
+    def test_direct_source_attributes_to_its_own_target(self):
+        ev = BuildEvidence(
+            targets=[Target(id="target://libfoo", source_files=["src/foo.cpp"])]
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/foo.cpp"] == frozenset({"target://libfoo"})
+
+    def test_static_library_dependency_folds_into_dependent(self):
+        ev = BuildEvidence(
+            targets=[
+                Target(
+                    id="target://libfoo",
+                    kind=TargetKind.SHARED_LIBRARY,
+                    source_files=["src/foo.cpp"],
+                    dependencies=["target://common"],
+                ),
+                Target(
+                    id="target://common",
+                    kind=TargetKind.STATIC_LIBRARY,
+                    source_files=["src/common.cpp"],
+                ),
+            ]
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/common.cpp"] == frozenset({"target://common", "target://libfoo"})
+
+    def test_object_library_folds_transitively_through_static_library(self):
+        ev = BuildEvidence(
+            targets=[
+                Target(
+                    id="target://libfoo",
+                    kind=TargetKind.SHARED_LIBRARY,
+                    dependencies=["target://common"],
+                ),
+                Target(
+                    id="target://common",
+                    kind=TargetKind.STATIC_LIBRARY,
+                    dependencies=["target://base"],
+                ),
+                Target(
+                    id="target://base",
+                    kind=TargetKind.OBJECT_LIBRARY,
+                    source_files=["src/base.cpp"],
+                ),
+            ]
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/base.cpp"] == frozenset(
+            {"target://base", "target://common", "target://libfoo"}
+        )
+
+    def test_shared_library_dependency_is_a_hard_stop(self):
+        """`app` depends on `libfoo` (a real .so) -- app links against
+        libfoo's public interface, never absorbs its object code."""
+        ev = BuildEvidence(
+            targets=[
+                Target(
+                    id="target://app",
+                    kind=TargetKind.EXECUTABLE,
+                    source_files=["src/main.cpp"],
+                    dependencies=["target://libfoo"],
+                ),
+                Target(
+                    id="target://libfoo",
+                    kind=TargetKind.SHARED_LIBRARY,
+                    source_files=["src/foo.cpp"],
+                ),
+            ]
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/main.cpp"] == frozenset({"target://app"})
+        assert attr["src/foo.cpp"] == frozenset({"target://libfoo"})
+
+    def test_source_shared_between_two_targets_attributes_to_both(self):
+        ev = BuildEvidence(
+            targets=[
+                Target(
+                    id="target://libfoo",
+                    kind=TargetKind.SHARED_LIBRARY,
+                    dependencies=["target://common"],
+                ),
+                Target(
+                    id="target://libbar",
+                    kind=TargetKind.SHARED_LIBRARY,
+                    dependencies=["target://common"],
+                ),
+                Target(
+                    id="target://common",
+                    kind=TargetKind.STATIC_LIBRARY,
+                    source_files=["src/common.cpp"],
+                ),
+            ]
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/common.cpp"] == frozenset(
+            {"target://common", "target://libfoo", "target://libbar"}
+        )
+
+    def test_dependency_cycle_does_not_infinite_loop(self):
+        # Pathological/malformed input (a real build graph is a DAG) -- the
+        # visited-set guard must still terminate and produce a sane result.
+        ev = BuildEvidence(
+            targets=[
+                Target(
+                    id="target://a",
+                    kind=TargetKind.STATIC_LIBRARY,
+                    source_files=["src/a.cpp"],
+                    dependencies=["target://b"],
+                ),
+                Target(
+                    id="target://b",
+                    kind=TargetKind.STATIC_LIBRARY,
+                    source_files=["src/b.cpp"],
+                    dependencies=["target://a"],
+                ),
+            ]
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/a.cpp"] == frozenset({"target://a", "target://b"})
+        assert attr["src/b.cpp"] == frozenset({"target://a", "target://b"})
+
+
+class TestLinkUnitGraphChannel:
+    def test_direct_object_input_attributes_via_target_id(self):
+        ev = BuildEvidence(
+            compile_units=[CompileUnit(id="cu://a", source="src/a.cpp", output="build/a.o")],
+            link_units=[
+                LinkUnit(
+                    id="link://build/libfoo.so",
+                    target_id="target://libfoo",
+                    output="build/libfoo.so",
+                    kind="shared_library",
+                    inputs=["build/a.o"],
+                )
+            ],
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/a.cpp"] == frozenset({"target://libfoo"})
+
+    def test_no_target_id_falls_back_to_output_basename_identity(self):
+        ev = BuildEvidence(
+            compile_units=[CompileUnit(id="cu://a", source="src/a.cpp", output="build/a.o")],
+            link_units=[
+                LinkUnit(
+                    id="link://build/out/libfoo.so",
+                    output="build/out/libfoo.so",
+                    kind="shared_library",
+                    inputs=["build/a.o"],
+                )
+            ],
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/a.cpp"] == frozenset({"output://libfoo.so"})
+
+    def test_transitive_static_library_link_unit_resolves(self):
+        ev = BuildEvidence(
+            compile_units=[
+                CompileUnit(id="cu://a", source="src/a.cpp", output="build/a.o"),
+            ],
+            link_units=[
+                LinkUnit(
+                    id="link://build/libstatic.a",
+                    output="build/libstatic.a", kind="static_library", inputs=["build/a.o"]
+                ),
+                LinkUnit(
+                    id="link://build/app",
+                    output="build/app",
+                    kind="executable",
+                    inputs=["build/libstatic.a"],
+                ),
+            ],
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/a.cpp"] == frozenset({"output://app"})
+
+    def test_static_library_link_unit_itself_is_never_a_terminal_identity(self):
+        # Only shared_library/executable link units are attribution targets
+        # -- a bare static-library link unit with nothing consuming it must
+        # not appear as an identity anywhere in the result.
+        ev = BuildEvidence(
+            compile_units=[CompileUnit(id="cu://a", source="src/a.cpp", output="build/a.o")],
+            link_units=[
+                LinkUnit(
+                    id="link://build/libstatic.a",
+                    output="build/libstatic.a", kind="static_library", inputs=["build/a.o"],
+                )
+            ],
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert "src/a.cpp" not in attr
+
+    def test_link_unit_cycle_does_not_infinite_loop(self):
+        ev = BuildEvidence(
+            link_units=[
+                LinkUnit(id="link://a.so", output="a.so", kind="shared_library", inputs=["b.so"]),
+                LinkUnit(id="link://b.so", output="b.so", kind="shared_library", inputs=["a.so"]),
+            ]
+        )
+        # Must simply terminate with no attribution (neither resolves to a
+        # real compile-unit object), not hang or raise.
+        attr = attribute_sources_to_targets(ev)
+        assert attr == {}
+
+
+class TestCombinedChannels:
+    def test_both_channels_agreeing_union_to_one_identity_set(self):
+        ev = BuildEvidence(
+            targets=[Target(id="target://libfoo", source_files=["src/foo.cpp"])],
+            compile_units=[CompileUnit(id="cu://a", source="src/foo.cpp", output="build/a.o")],
+            link_units=[
+                LinkUnit(
+                    id="link://build/libfoo.so",
+                    target_id="target://libfoo",
+                    output="build/libfoo.so",
+                    kind="shared_library",
+                    inputs=["build/a.o"],
+                )
+            ],
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/foo.cpp"] == frozenset({"target://libfoo"})
+
+    def test_channels_disagreeing_union_both_identities(self):
+        # A pathological/inconsistent evidence set (real builds shouldn't
+        # produce this) -- the module unions rather than picks a winner, so
+        # a disagreement is visible (more identities), never silently
+        # resolved to a possibly-wrong single answer.
+        ev = BuildEvidence(
+            targets=[Target(id="target://libfoo", source_files=["src/foo.cpp"])],
+            compile_units=[CompileUnit(id="cu://a", source="src/foo.cpp", output="build/a.o")],
+            link_units=[
+                LinkUnit(
+                    id="link://build/libbar.so",
+                    target_id="target://libbar",
+                    output="build/libbar.so",
+                    kind="shared_library",
+                    inputs=["build/a.o"],
+                )
+            ],
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/foo.cpp"] == frozenset({"target://libfoo", "target://libbar"})

--- a/tests/test_link_attribution.py
+++ b/tests/test_link_attribution.py
@@ -247,6 +247,36 @@ class TestLinkUnitGraphChannel:
         attr = attribute_sources_to_targets(ev)
         assert attr["src/a.cpp"] == frozenset({"output://app"})
 
+    def test_terminal_link_unit_named_as_another_link_units_input_is_a_hard_stop(self):
+        # A dependent naming another DSO's *output path* directly (rather
+        # than -lfoo) must not fold that DSO's own objects into itself --
+        # mirrors the target-graph channel's SHARED_LIBRARY hard stop.
+        ev = BuildEvidence(
+            compile_units=[
+                CompileUnit(id="cu://a", source="src/a.cpp", output="build/liba_impl.o"),
+                CompileUnit(id="cu://b", source="src/b.cpp", output="build/b.o"),
+            ],
+            link_units=[
+                LinkUnit(
+                    id="link://build/liba.so",
+                    output="build/liba.so",
+                    kind="shared_library",
+                    inputs=["build/liba_impl.o"],
+                ),
+                LinkUnit(
+                    id="link://build/app",
+                    output="build/app",
+                    kind="executable",
+                    # Explicit .so path, not -lfoo -- liba.so's own objects
+                    # must NOT be folded into app's attribution.
+                    inputs=["build/b.o", "build/liba.so"],
+                ),
+            ],
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/a.cpp"] == frozenset({"output://liba.so"})
+        assert attr["src/b.cpp"] == frozenset({"output://app"})
+
     def test_static_library_link_unit_itself_is_never_a_terminal_identity(self):
         # Only shared_library/executable link units are attribution targets
         # -- a bare static-library link unit with nothing consuming it must

--- a/tests/test_link_attribution.py
+++ b/tests/test_link_attribution.py
@@ -170,6 +170,49 @@ class TestTargetGraphChannel:
             {"target://common", "target://libfoo", "target://libbar"}
         )
 
+    def test_interface_dependency_is_a_hard_stop_not_looked_past(self):
+        """Pins current behavior (code review, PR #632): folding is
+        per-direct-dependent, not fully transitive through a non-absorbed
+        kind. `iface` directly depends on the OBJECT_LIBRARY `obj`, so
+        `obj`'s sources fold into `iface` (an OBJECT_LIBRARY folds into ANY
+        direct dependent, regardless of the dependent's own kind) -- but
+        `iface` itself is INTERFACE, not in _ABSORBED_KINDS, so when `app`
+        walks its own dependency on `iface`, that's a hard stop: `app`'s walk
+        neither folds `iface`'s (inherited) sources in nor continues past it
+        to `obj`. A real OBJECT_LIBRARY sitting *behind* an INTERFACE
+        dependency is therefore NOT folded into a target two hops away, even
+        though CMake usage-requirement propagation through an INTERFACE
+        library can, in practice, still cause that object library's objects
+        to end up linked into whatever ultimately depends on the interface
+        target. Documented as current, deliberately-scoped behavior -- not
+        asserted here to be the only correct design, just the one this code
+        implements today."""
+        ev = BuildEvidence(
+            targets=[
+                Target(
+                    id="target://app",
+                    kind=TargetKind.EXECUTABLE,
+                    source_files=["src/main.cpp"],
+                    dependencies=["target://iface"],
+                ),
+                Target(
+                    id="target://iface",
+                    kind=TargetKind.INTERFACE,
+                    dependencies=["target://obj"],
+                ),
+                Target(
+                    id="target://obj",
+                    kind=TargetKind.OBJECT_LIBRARY,
+                    source_files=["src/obj.cpp"],
+                ),
+            ]
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/main.cpp"] == frozenset({"target://app"})
+        # Attributed to obj itself and to iface (obj's direct dependent) --
+        # but NOT to app, two hops away through the INTERFACE hard stop.
+        assert attr["src/obj.cpp"] == frozenset({"target://obj", "target://iface"})
+
     def test_dependency_cycle_does_not_infinite_loop(self):
         # Pathological/malformed input (a real build graph is a DAG) -- the
         # visited-set guard must still terminate and produce a sane result.
@@ -241,6 +284,41 @@ class TestLinkUnitGraphChannel:
                     output="build/app",
                     kind="executable",
                     inputs=["build/libstatic.a"],
+                ),
+            ],
+        )
+        attr = attribute_sources_to_targets(ev)
+        assert attr["src/a.cpp"] == frozenset({"output://app"})
+
+    def test_multi_hop_static_library_link_unit_chain_resolves(self):
+        # Symmetric with the target-graph channel's own two-hop
+        # object_library -> static_library -> shared_library test
+        # (test_object_library_folds_transitively_through_static_library) --
+        # the link-unit channel's own transitive resolution must go more
+        # than one static-library hop deep too: libbase.a is itself an
+        # input to libmid.a, which is an input to the terminal executable.
+        ev = BuildEvidence(
+            compile_units=[
+                CompileUnit(id="cu://a", source="src/a.cpp", output="build/a.o"),
+            ],
+            link_units=[
+                LinkUnit(
+                    id="link://build/libbase.a",
+                    output="build/libbase.a",
+                    kind="static_library",
+                    inputs=["build/a.o"],
+                ),
+                LinkUnit(
+                    id="link://build/libmid.a",
+                    output="build/libmid.a",
+                    kind="static_library",
+                    inputs=["build/libbase.a"],
+                ),
+                LinkUnit(
+                    id="link://build/app",
+                    output="build/app",
+                    kind="executable",
+                    inputs=["build/libmid.a"],
                 ),
             ],
         )

--- a/tests/test_link_attribution.py
+++ b/tests/test_link_attribution.py
@@ -50,6 +50,27 @@ def test_unknown_source_is_absent_not_empty():
     assert attr.get("src/unrelated.cpp", frozenset()) == frozenset()
 
 
+def test_target_with_no_id_is_skipped():
+    ev = BuildEvidence(
+        targets=[
+            Target(id="", source_files=["src/anon.cpp"]),
+            Target(id="target://libfoo", source_files=["src/foo.cpp"]),
+        ]
+    )
+    attr = attribute_sources_to_targets(ev)
+    assert "src/anon.cpp" not in attr
+    assert attr["src/foo.cpp"] == frozenset({"target://libfoo"})
+
+
+def test_target_with_blank_source_entry_is_skipped():
+    ev = BuildEvidence(
+        targets=[Target(id="target://libfoo", source_files=["", "src/foo.cpp"])]
+    )
+    attr = attribute_sources_to_targets(ev)
+    assert attr["src/foo.cpp"] == frozenset({"target://libfoo"})
+    assert "" not in attr
+
+
 class TestTargetGraphChannel:
     def test_direct_source_attributes_to_its_own_target(self):
         ev = BuildEvidence(

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -37,7 +37,10 @@ def test_make_dry_run_extracts_compile_units():
     ev = MakeAdapter(dry_run=DRY_RUN).collect()
     assert ev.generators[0].kind == "make"
     units = {c.source: c for c in ev.compile_units}
-    # Only the two `-c` compile recipes become units; link/ar/info lines are skipped.
+    # Only the two `-c` compile recipes become compile_units; the link/ar/info
+    # lines are recognized separately as link_units (ADR-053 D2, see
+    # test_make_adapter_link_units.py) or genuinely skipped ("Entering
+    # directory").
     assert set(units) == {"src/a.c", "src/b.cpp"}
     assert units["src/a.c"].standard == "c11"
     assert units["src/b.cpp"].standard == "c++20"
@@ -49,6 +52,68 @@ def test_make_reduced_confidence_diagnostic_and_options():
     opts = {(o.key, o.value) for o in ev.build_options}
     assert ("std:C", "c11") in opts
     assert ("define:_GLIBCXX_USE_CXX11_ABI", "0") in opts
+
+
+# -- link-unit capture (ADR-053 D2) ------------------------------------------
+
+
+def test_make_dry_run_extracts_shared_and_static_link_units():
+    ev = MakeAdapter(dry_run=DRY_RUN).collect()
+    by_output = {lu.output: lu for lu in ev.link_units}
+    assert set(by_output) == {"libfoo.so", "libbar.a"}
+    assert by_output["libfoo.so"].kind == "shared_library"
+    assert set(by_output["libfoo.so"].inputs) == {"build/a.o", "build/b.o"}
+    assert by_output["libbar.a"].kind == "static_library"
+    assert by_output["libbar.a"].inputs == ["build/a.o"]
+    assert any("link/archive units" in d for d in ev.diagnostics)
+
+
+def test_make_executable_link_unit_recognized():
+    ev = MakeAdapter(
+        dry_run="gcc -o build/app build/main.o build/lib.a -lm"
+    ).collect()
+    assert len(ev.link_units) == 1
+    lu = ev.link_units[0]
+    assert lu.kind == "executable"
+    assert lu.output == "build/app"
+    assert lu.inputs == ["build/main.o", "build/lib.a"]
+
+
+def test_make_shared_link_unit_recognized_via_dash_shared_flag():
+    # No .so-shaped output extension -- -shared alone must still classify it.
+    ev = MakeAdapter(dry_run="gcc -shared -o build/plugin.node build/a.o").collect()
+    assert len(ev.link_units) == 1
+    assert ev.link_units[0].kind == "shared_library"
+
+
+def test_make_ar_with_toolchain_prefix_recognized():
+    ev = MakeAdapter(
+        dry_run="x86_64-linux-gnu-ar rcs build/libx.a build/x.o build/y.o"
+    ).collect()
+    assert len(ev.link_units) == 1
+    assert ev.link_units[0].kind == "static_library"
+    assert ev.link_units[0].output == "build/libx.a"
+
+
+def test_make_partial_relink_is_not_a_terminal_link_unit():
+    # `ld -r` (incremental/partial link) produces another .o, not a real
+    # DSO/executable output -- must not be treated as an attribution target.
+    ev = MakeAdapter(dry_run="ld -r -o build/combined.o build/a.o build/b.o").collect()
+    assert ev.link_units == []
+
+
+def test_make_unrelated_recipe_lines_produce_no_link_unit():
+    ev = MakeAdapter(
+        dry_run="\n".join(
+            [
+                "mkdir -p build",
+                "echo done",
+                "ranlib build/libfoo.a",
+            ]
+        )
+    ).collect()
+    assert ev.compile_units == []
+    assert ev.link_units == []
 
 
 def test_make_forced_include_not_mistaken_for_source():

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -102,6 +102,38 @@ def test_make_partial_relink_is_not_a_terminal_link_unit():
     assert ev.link_units == []
 
 
+def test_make_ar_with_dash_style_flags_recognized():
+    # Dash-style ar flags ("-rcs") are just a normal leading flag token, not
+    # the BSD-style bare-letters form _archive_link_unit special-cases --
+    # they're already filtered out by the generic "not startswith('-')" pass.
+    ev = MakeAdapter(dry_run="ar -rcs build/libx.a build/x.o").collect()
+    assert len(ev.link_units) == 1
+    assert ev.link_units[0].output == "build/libx.a"
+    assert ev.link_units[0].inputs == ["build/x.o"]
+
+
+def test_make_ar_with_too_few_operands_is_not_a_link_unit():
+    ev = MakeAdapter(dry_run="ar rcs onlyoutput.a").collect()
+    assert ev.link_units == []
+
+
+def test_make_ar_with_non_archive_output_is_not_a_link_unit():
+    ev = MakeAdapter(dry_run="ar rcs libx.so build/x.o").collect()
+    assert ev.link_units == []
+
+
+def test_make_ar_with_no_valid_inputs_is_not_a_link_unit():
+    ev = MakeAdapter(dry_run="ar rcs libx.a README.txt").collect()
+    assert ev.link_units == []
+
+
+def test_make_compiler_link_line_with_no_object_inputs_is_not_a_link_unit():
+    # "-o app.so -lm" has an output but no object/archive-extension operand.
+    ev = MakeAdapter(dry_run="gcc -o app.so -lm").collect()
+    assert ev.link_units == []
+    assert ev.compile_units == []
+
+
 def test_make_unrelated_recipe_lines_produce_no_link_unit():
     ev = MakeAdapter(
         dry_run="\n".join(

--- a/tests/test_make_adapter.py
+++ b/tests/test_make_adapter.py
@@ -38,8 +38,8 @@ def test_make_dry_run_extracts_compile_units():
     assert ev.generators[0].kind == "make"
     units = {c.source: c for c in ev.compile_units}
     # Only the two `-c` compile recipes become compile_units; the link/ar/info
-    # lines are recognized separately as link_units (ADR-053 D2, see
-    # test_make_adapter_link_units.py) or genuinely skipped ("Entering
+    # lines are recognized separately as link_units (ADR-053 D2, see the
+    # "link-unit capture" section below) or genuinely skipped ("Entering
     # directory").
     assert set(units) == {"src/a.c", "src/b.cpp"}
     assert units["src/a.c"].standard == "c11"
@@ -77,6 +77,29 @@ def test_make_executable_link_unit_recognized():
     assert lu.kind == "executable"
     assert lu.output == "build/app"
     assert lu.inputs == ["build/main.o", "build/lib.a"]
+
+
+def test_make_executable_link_unit_with_absolute_posix_inputs_recognized():
+    # An absolute POSIX object/archive path starts with "/" too -- must not
+    # be mistaken for an MSVC-style "/Fo..." flag and dropped.
+    ev = MakeAdapter(
+        dry_run="gcc -o /work/build/app /work/build/main.o /work/build/lib.a -lm"
+    ).collect()
+    assert len(ev.link_units) == 1
+    lu = ev.link_units[0]
+    assert lu.kind == "executable"
+    assert lu.inputs == ["/work/build/main.o", "/work/build/lib.a"]
+
+
+def test_make_msvc_style_flag_shaped_token_not_mistaken_for_a_link_input():
+    # "/Fsomething.obj" is shaped like a single-segment MSVC-style flag (no
+    # further "/") and happens to end in a recognized link-input extension --
+    # it must still be excluded, not mistaken for a real object input.
+    ev = MakeAdapter(
+        dry_run="gcc -o build/app build/main.o /Fsomething.obj"
+    ).collect()
+    assert len(ev.link_units) == 1
+    assert ev.link_units[0].inputs == ["build/main.o"]
 
 
 def test_make_shared_link_unit_recognized_via_dash_shared_flag():

--- a/tests/test_reusable_workflows.py
+++ b/tests/test_reusable_workflows.py
@@ -502,7 +502,9 @@ class TestCheckProjectArtifactNaming:
         )
         run = sanitize["run"]
         assert "hashlib.sha256" in run
-        assert sanitize["env"]["CHECK_ID"] == "${{ steps.run.outputs.check-id }}"
+        assert sanitize["env"]["CHECK_ID"] == (
+            "${{ steps.run.outputs.check-id || steps.precheck.outputs.check-id }}"
+        )
 
         upload = next(s for s in steps if s.get("name") == "Upload report")
         assert upload["with"]["name"] == (
@@ -559,10 +561,16 @@ class TestCheckProjectArtifactNaming:
             s for s in steps if s.get("name") == "Sanitize check-id for artifact name"
         )
         upload = next(s for s in steps if s.get("name") == "Upload report")
+        # Either "Run check-target" or the pre-check operational-error
+        # envelope step produced the report -- exactly one runs per matrix
+        # cell (issue #628).
         assert (
             sanitize.get("if")
             == upload.get("if")
-            == ("always() && steps.run.outputs.report-path != ''")
+            == (
+                "always() && (steps.run.outputs.report-path != '' || "
+                "steps.precheck.outputs.report-path != '')"
+            )
         )
 
 
@@ -625,6 +633,147 @@ class TestCheckProjectClearsReportsDirBeforeAggregateDownload:
         assert names.index("Clear reports staging before download") < names.index(
             "Download every check report"
         )
+
+
+class TestPreCheckOperationalErrorReport:
+    """issue #628 (G30 P1.4 known gap, plan doc round-5/round-8/round-9
+    addenda): a candidate-resolution failure or a required build-output
+    download failure used to end the matrix job with no report at all for
+    `aggregate` to see. The fix reuses
+    actions/check-target/report_envelope.py's own `--mode operational-error`
+    directly (the same script check-target's own run.sh drives for a real
+    resolve-baseline failure), so neither of report_envelope.py's own logic
+    nor check-target's input surface needed to change."""
+
+    def test_build_output_download_has_no_continue_on_error(self) -> None:
+        data = _load(CHECK_PROJECT)
+        steps = _steps(data["jobs"]["check"])
+        dl = next(s for s in steps if s.get("name") == "Download build-output artifact")
+        assert dl.get("id") == "download_build_output"
+        assert "continue-on-error" not in dl
+
+    def test_candidate_resolution_has_continue_on_error(self) -> None:
+        data = _load(CHECK_PROJECT)
+        steps = _steps(data["jobs"]["check"])
+        resolver = next(
+            s for s in steps if s.get("name") == "Resolve candidate binary/binaries"
+        )
+        assert resolver.get("continue-on-error") is True
+
+    def test_precheck_step_exists_and_is_gated_on_either_prior_failure(self) -> None:
+        data = _load(CHECK_PROJECT)
+        steps = _steps(data["jobs"]["check"])
+        precheck = next(
+            s
+            for s in steps
+            if s.get("name") == "Synthesize pre-check operational-error report"
+        )
+        assert precheck["id"] == "precheck"
+        condition = precheck["if"]
+        assert "always()" in condition
+        assert "steps.download_build_output.outcome == 'failure'" in condition
+        assert "steps.candidate.outcome == 'failure'" in condition
+
+    def test_precheck_step_reuses_report_envelope_py_operational_error_mode(
+        self,
+    ) -> None:
+        data = _load(CHECK_PROJECT)
+        steps = _steps(data["jobs"]["check"])
+        precheck = next(
+            s
+            for s in steps
+            if s.get("name") == "Synthesize pre-check operational-error report"
+        )
+        run = precheck["run"]
+        assert "report_envelope.py" in run
+        assert "--mode operational-error" in run
+        assert "--resolve-outcome \"ambiguous\"" in run
+
+    def test_run_check_target_gated_on_candidate_success(self) -> None:
+        data = _load(CHECK_PROJECT)
+        steps = _steps(data["jobs"]["check"])
+        run_step = next(s for s in steps if s.get("name") == "Run check-target")
+        assert run_step["if"] == "steps.candidate.outcome == 'success'"
+
+    def test_step_ordering(self) -> None:
+        data = _load(CHECK_PROJECT)
+        names = _step_names(data["jobs"]["check"])
+        assert (
+            names.index("Download build-output artifact")
+            < names.index("Resolve candidate binary/binaries")
+            < names.index("Synthesize pre-check operational-error report")
+            < names.index("Run check-target")
+            < names.index("Sanitize check-id for artifact name")
+            < names.index("Upload report")
+        )
+
+    @pytest.mark.skipif(
+        sys.platform == "win32",
+        reason=(
+            "The actual reusable workflow only ever runs on runs-on: "
+            "ubuntu-latest -- this test exercises that real Linux bash "
+            "behavior."
+        ),
+    )
+    def test_precheck_script_writes_a_valid_operational_error_report_end_to_end(
+        self, tmp_path: Path
+    ) -> None:
+        """Extract the real precheck script and run it via bash -c (exactly
+        as the runner does), pointed at the real report_envelope.py through
+        the same relative `.check-project-src/` layout the job checks out,
+        confirming the emitted report-path/exit-code/check-id outputs and
+        that the underlying report.json is a valid operational-error
+        envelope."""
+        data = _load(CHECK_PROJECT)
+        steps = _steps(data["jobs"]["check"])
+        precheck = next(
+            s
+            for s in steps
+            if s.get("name") == "Synthesize pre-check operational-error report"
+        )
+        script = precheck["run"]
+
+        repo_root = Path(__file__).resolve().parents[1]
+        src_dir = tmp_path / ".check-project-src"
+        src_dir.mkdir()
+        (src_dir / "actions").symlink_to(repo_root / "actions", target_is_directory=True)
+
+        github_output = tmp_path / "github_output"
+        github_output.write_text("")
+        env = {
+            **os.environ,
+            "MATRIX_NAME": "libfoo",
+            "MATRIX_PROFILE_ID": "linux-x86_64",
+            "MATRIX_BASELINE_CHANNEL": "accepted-main",
+            "MATRIX_REQUESTED_DEPTH": "headers",
+            "MATRIX_GATE_MODE": "deferred",
+            "PROJECT": "abicheck/abicheck",
+            "HEAD_SHA": "deadbeef",
+            "BASE_REF": "main",
+            "ACTION_VERSION": "abicheck/abicheck@main",
+            "BUILD_OUTPUT_FAILED": "false",
+            "GITHUB_OUTPUT": str(github_output),
+        }
+        result = subprocess.run(
+            ["bash", "-c", script], cwd=tmp_path, env=env, capture_output=True, text=True
+        )
+        assert result.returncode == 1, result.stderr  # operational errors fail the step
+
+        output_lines = dict(
+            line.split("=", 1)
+            for line in github_output.read_text().splitlines()
+            if "=" in line
+        )
+        assert output_lines["check-id"] == (
+            "libfoo@linux-x86_64#accepted-main@headers"
+        )
+        assert output_lines["report-path"] == "precheck-report.json"
+        assert "exit-code" not in output_lines  # grep -v'd out, like run.sh's own pattern
+
+        report = json.loads((tmp_path / "precheck-report.json").read_text())
+        assert report["verdict"] == "ERROR"
+        assert report["operational_errors"][0]["kind"] == "ambiguous"
+        assert "resolution failed for 'libfoo'" in report["operational_errors"][0]["message"]
 
 
 class TestBaselineRequiredAndCandidateBuildOutputForwarded:

--- a/tests/test_sycl_metadata.py
+++ b/tests/test_sycl_metadata.py
@@ -170,6 +170,29 @@ class TestVersionDetection:
     def test_ur_unknown(self) -> None:
         assert _detect_ur_version_from_symbols(["urRandom"]) == ""
 
+    def test_ur_table_generation_returns_unknown_not_a_false_landmark_match(
+        self,
+    ) -> None:
+        """The current UR export shape (real Intel oneAPI 2026.1 adapters,
+        G30 pilot validation) exports only urGet<Category>ProcAddrTable
+        getters -- never the legacy per-verb symbols this heuristic keys
+        off. None of its own "Get...ProcAddrTable" names should accidentally
+        satisfy a startswith() landmark check (e.g. urGetBindlessImagesExp
+        ProcAddrTable must not match the "urBindlessImages" landmark) --
+        version detection must honestly return "" rather than guess."""
+        assert (
+            _detect_ur_version_from_symbols(
+                [
+                    "urGetAdapterProcAddrTable",
+                    "urGetBindlessImagesExpProcAddrTable",
+                    "urGetVirtualMemProcAddrTable",
+                    "urGetCommandBufferExpProcAddrTable",
+                    "urGetPlatformProcAddrTable",
+                ]
+            )
+            == ""
+        )
+
     def test_backend_known(self) -> None:
         assert _detect_backend_type("cuda") == "cuda"
 
@@ -219,6 +242,40 @@ class TestParseSyclPlugin:
         so = _write_elf(tmp_path, "libur_adapter_opencl.so")
         with patch(
             "abicheck.sycl_metadata._extract_plugin_symbols", return_value=["urFoo"]
+        ):
+            assert parse_sycl_plugin(so) is None
+
+    def test_ur_plugin_table_generation_recognized(self, tmp_path: Path) -> None:
+        """The current UR export shape (verified against a real Intel
+        oneAPI 2026.1 install, G30 pilot validation) exports only
+        urGet<Category>ProcAddrTable getters -- no legacy urAdapterGet at
+        all. Must be recognized as a valid plugin, not silently rejected."""
+        so = _write_elf(tmp_path, "libur_adapter_level_zero.so")
+        table_symbols = [
+            "urGetAdapterProcAddrTable",
+            "urGetPlatformProcAddrTable",
+            "urGetDeviceProcAddrTable",
+            "urGetContextProcAddrTable",
+            "urGetQueueProcAddrTable",
+        ]
+        with patch(
+            "abicheck.sycl_metadata._extract_plugin_symbols",
+            return_value=table_symbols,
+        ):
+            plugin = parse_sycl_plugin(so)
+        assert plugin is not None
+        assert plugin.name == "level_zero"
+        assert plugin.interface_type == "ur"
+        assert plugin.entry_points == table_symbols
+        # Honest "unknown" -- see _detect_ur_version_from_symbols's docstring.
+        assert plugin.pi_version == ""
+
+    def test_ur_plugin_missing_both_generations_markers(self, tmp_path: Path) -> None:
+        so = _write_elf(tmp_path, "libur_adapter_opencl.so")
+        with patch(
+            "abicheck.sycl_metadata._extract_plugin_symbols",
+            # A near-miss: real category getters, but not the adapter one.
+            return_value=["urGetPlatformProcAddrTable", "urGetDeviceProcAddrTable"],
         ):
             assert parse_sycl_plugin(so) is None
 

--- a/validation/README.md
+++ b/validation/README.md
@@ -24,13 +24,20 @@ libraries (not synthetic fixtures), used to drive planning and improvement.
   (real-upstream `epics-base/pvxs`) re-run through the full check-project.yml
   flow (config validate → build-output validate → run-plan → baseline
   resolve → analysis compare), and the Make pilot via that same real
-  EPICS/PVXS build; the CMake, package(`.deb`), and cross-compiled(aarch64)
-  minimal pilots exercise a synthetic in-repo `libdemo` fixture instead of a
-  second real-upstream project. Bazel and a second vendor-toolchain pilot
-  were genuinely blocked by environment tooling. Found (not fixed here) a
-  real `dump`-vs-`compare` `public_header_dirs` provenance mismatch that
-  spuriously raises `ScopeMismatchError` for the baseline-then-live-candidate
-  pattern the G30 pipeline relies on.
+  EPICS/PVXS build; the CMake, Bazel, package(`.deb`), and
+  cross-compiled(aarch64) minimal pilots exercise a synthetic in-repo
+  `libdemo` fixture instead of a second real-upstream project (the Bazel
+  pilot additionally re-validates this PR's own ADR-053 TU→DSO attribution
+  against a real, live `bazel aquery` capture). The Intel `icpx`/oneAPI
+  vendor-toolchain pilot installed cleanly and validated real icpx-compiled
+  binaries + real SYCL device-code compilation, but also found (not fixed
+  here) a real `sycl_metadata.py` detection gap against Intel's current
+  Unified Runtime adapter ABI; MSVC/PDB remains genuinely blocked (no
+  redistributable Linux path to `cl.exe`). Found and fixed a real
+  `dump`-vs-`compare` `public_header_dirs` scope-fingerprint mismatch that
+  spuriously raised `ScopeMismatchError` for the baseline-then-live-candidate
+  pattern the G30 pipeline relies on (`dumper.dump()`'s new
+  `scope_header_dirs` parameter, decoupled from ADR-015 provenance tagging).
 - `REPORT.md` — earlier curated-matrix validation report (false-positive catalog)
 - `DESIGN_ANALYSIS.md` — code-level root cause + architectural fix per false
   positive. FP-1/FP-2 are fixed in `abicheck/model.py` + `abicheck/diff_types.py`;

--- a/validation/README.md
+++ b/validation/README.md
@@ -19,13 +19,16 @@ libraries (not synthetic fixtures), used to drive planning and improvement.
   alignment false positives, and a castxml-missing error that hid the clang
   fallback; documents the public-header-scoping requirement and a drop-in CI
   workflow replacing pvxs's ACC-based `abi-diff.sh`.
-- `g30-pilot-validation-2026-07.md` — **G30 pilot validation:** the G30 plan's
-  "Pilot validation plan" executed for real — PVXS re-run through the full
-  check-project.yml flow (config validate → build-output validate → run-plan
-  → baseline resolve → analysis compare), plus CMake/Make/package(`.deb`)/
-  cross-compiled(aarch64) minimal pilots. Bazel and a second vendor-toolchain
-  pilot were genuinely blocked by environment tooling. Found (not fixed here)
-  a real `dump`-vs-`compare` `public_header_dirs` provenance mismatch that
+- `g30-pilot-validation-2026-07.md` — **G30 pilot validation (mixed scope):**
+  the G30 plan's "Pilot validation plan" executed for real — PVXS
+  (real-upstream `epics-base/pvxs`) re-run through the full check-project.yml
+  flow (config validate → build-output validate → run-plan → baseline
+  resolve → analysis compare), and the Make pilot via that same real
+  EPICS/PVXS build; the CMake, package(`.deb`), and cross-compiled(aarch64)
+  minimal pilots exercise a synthetic in-repo `libdemo` fixture instead of a
+  second real-upstream project. Bazel and a second vendor-toolchain pilot
+  were genuinely blocked by environment tooling. Found (not fixed here) a
+  real `dump`-vs-`compare` `public_header_dirs` provenance mismatch that
   spuriously raises `ScopeMismatchError` for the baseline-then-live-candidate
   pattern the G30 pipeline relies on.
 - `REPORT.md` — earlier curated-matrix validation report (false-positive catalog)

--- a/validation/README.md
+++ b/validation/README.md
@@ -19,6 +19,15 @@ libraries (not synthetic fixtures), used to drive planning and improvement.
   alignment false positives, and a castxml-missing error that hid the clang
   fallback; documents the public-header-scoping requirement and a drop-in CI
   workflow replacing pvxs's ACC-based `abi-diff.sh`.
+- `g30-pilot-validation-2026-07.md` — **G30 pilot validation:** the G30 plan's
+  "Pilot validation plan" executed for real — PVXS re-run through the full
+  check-project.yml flow (config validate → build-output validate → run-plan
+  → baseline resolve → analysis compare), plus CMake/Make/package(`.deb`)/
+  cross-compiled(aarch64) minimal pilots. Bazel and a second vendor-toolchain
+  pilot were genuinely blocked by environment tooling. Found (not fixed here)
+  a real `dump`-vs-`compare` `public_header_dirs` provenance mismatch that
+  spuriously raises `ScopeMismatchError` for the baseline-then-live-candidate
+  pattern the G30 pipeline relies on.
 - `REPORT.md` — earlier curated-matrix validation report (false-positive catalog)
 - `DESIGN_ANALYSIS.md` — code-level root cause + architectural fix per false
   positive. FP-1/FP-2 are fixed in `abicheck/model.py` + `abicheck/diff_types.py`;

--- a/validation/README.md
+++ b/validation/README.md
@@ -30,14 +30,15 @@ libraries (not synthetic fixtures), used to drive planning and improvement.
   pilot additionally re-validates this PR's own ADR-053 TU→DSO attribution
   against a real, live `bazel aquery` capture). The Intel `icpx`/oneAPI
   vendor-toolchain pilot installed cleanly and validated real icpx-compiled
-  binaries + real SYCL device-code compilation, but also found (not fixed
-  here) a real `sycl_metadata.py` detection gap against Intel's current
-  Unified Runtime adapter ABI; MSVC/PDB remains genuinely blocked (no
-  redistributable Linux path to `cl.exe`). Found and fixed a real
-  `dump`-vs-`compare` `public_header_dirs` scope-fingerprint mismatch that
-  spuriously raised `ScopeMismatchError` for the baseline-then-live-candidate
-  pattern the G30 pipeline relies on (`dumper.dump()`'s new
-  `scope_header_dirs` parameter, decoupled from ADR-015 provenance tagging).
+  binaries + real SYCL device-code compilation; MSVC/PDB remains genuinely
+  blocked (no redistributable Linux path to `cl.exe`). Found and fixed two
+  real product bugs: a `dump`-vs-`compare` `public_header_dirs`
+  scope-fingerprint mismatch that spuriously raised `ScopeMismatchError` for
+  the baseline-then-live-candidate pattern the G30 pipeline relies on
+  (`dumper.dump()`'s new `scope_header_dirs` parameter, decoupled from
+  ADR-015 provenance tagging); and a `sycl_metadata.py` UR-adapter
+  detection gap that silently rejected real, current Intel oneAPI 2026.1
+  UR adapters as invalid.
 - `REPORT.md` — earlier curated-matrix validation report (false-positive catalog)
 - `DESIGN_ANALYSIS.md` — code-level root cause + architectural fix per false
   positive. FP-1/FP-2 are fixed in `abicheck/model.py` + `abicheck/diff_types.py`;

--- a/validation/g30-pilot-validation-2026-07.md
+++ b/validation/g30-pilot-validation-2026-07.md
@@ -28,15 +28,14 @@ what that did and didn't cover, and "Still blocked" for MSVC/PDB.
 | Bazel (minimal generic) | Synthetic (`libdemo` fixture) | Done | Yes |
 | Package-only, `.deb` (minimal generic) | Synthetic (`libdemo` fixture) | Done | Yes |
 | Cross-compiled target (aarch64) | Synthetic (`libdemo` fixture) | Done | Yes |
-| Second vendor-toolchain project: Intel `icpx`/oneAPI | Synthetic (`libdemo` fixture) + real DPC++ runtime plugins | Partially done — see below | Yes (C++); real SYCL-plugin detection gap found, not fixed |
+| Second vendor-toolchain project: Intel `icpx`/oneAPI | Synthetic (`libdemo` fixture) + real DPC++ runtime plugins | Done | Yes (C++); real SYCL-plugin detection gap found and fixed |
 | Second vendor-toolchain project: MSVC/PDB | — | Still blocked — see below | n/a |
 
-One real, reproducible product bug was found and fixed in this same PR
-after initial triage as an out-of-scope follow-up (see "Finding" below); a
-second, real, currently-unfixed gap (`sycl_metadata.py`'s UR-adapter
-detection is stale relative to a real, current Intel oneAPI 2026.1 runtime)
-was found by the vendor-toolchain pilot below and left for its own
-follow-up.
+Two real, reproducible product bugs were found and fixed in this same PR:
+a `dump`-vs-`compare` scope-fingerprint mismatch, and a `sycl_metadata.py`
+UR-adapter detection gap against Intel's current oneAPI 2026.1 runtime —
+both after initial triage as out-of-scope follow-ups (see "Finding"
+sections below).
 
 ## PVXS pilot (the confirmed/recommended pilot)
 
@@ -168,7 +167,7 @@ captured `BuildEvidence` correctly attributed both `src/demo.cpp` and
 channel (Bazel's own compile-unit → link-unit → terminal-DSO graph), exactly
 as ADR-053 D2 documents.
 
-## Second vendor-toolchain pilot: Intel oneAPI (`icpx`) — partially unblocked; MSVC/PDB remains blocked
+## Second vendor-toolchain pilot: Intel oneAPI (`icpx`) — unblocked; MSVC/PDB remains blocked
 
 **Initially marked fully blocked, then partially unblocked**: contrary to
 the initial assessment, Intel's oneAPI compiler is a real, freely
@@ -193,28 +192,45 @@ DPC++/C++ Compiler 2026.1.0).
   (`sycl/sycl.hpp` from the installed DPC++ runtime, no GPU/OpenCL runtime
   needed just to *compile*), producing a real ELF `.so` `abicheck dump`
   parses without error (binary/symbols-level; 4 functions extracted).
-- **Real SYCL runtime plugin metadata (`sycl_metadata.py`) — a genuine
-  finding, not fixed here.** The installed DPC++ runtime ships real Intel
-  Unified Runtime (UR) adapter plugins
+- **Real SYCL runtime plugin metadata (`sycl_metadata.py`) — found and
+  fixed.** The installed DPC++ runtime ships real Intel Unified Runtime (UR)
+  adapter plugins
   (`/opt/intel/oneapi/compiler/2026.1/lib/libur_adapter_{opencl,level_zero}.so.*`).
   Running `abicheck.sycl_metadata.parse_sycl_plugin()` directly against
-  these real, current (oneAPI 2026.1) adapters returns `None` for both —
-  "missing urAdapterGet — not a valid UR adapter". Root cause: `nm -D`
-  confirms neither real adapter exports a symbol named `urAdapterGet` at
-  all; both instead export the newer `urGetAdapterProcAddrTable`/
-  `urGet<Category>ProcAddrTable` entry-point family (`urGetPlatformProcAddrTable`,
-  `urGetDeviceProcAddrTable`, …). `sycl_metadata.py`'s UR-plugin validity
-  check (`parse_sycl_plugin`, `_UR_SYMBOL_RE`) still hard-requires the
-  older `urAdapterGet` symbol, so it silently rejects a real, valid,
-  current-generation UR adapter as "not a valid UR adapter" — a genuine
-  staleness gap relative to the real Unified Runtime ABI's evolution,
-  surfaced only by running against a real, currently-shipping vendor
-  runtime (a synthetic/mocked plugin fixture would not have caught this,
-  since it would be built to match whatever symbol set the detector
-  already expects). **Not fixed in this pass** — understanding UR's actual
-  current versioned entry-point contract well enough to fix the detector
-  correctly (not just pattern-match today's one observed symbol set) is
-  its own scoped task, not a drive-by alongside this PR's other work.
+  these real, current (oneAPI 2026.1) adapters originally returned `None`
+  for both — "missing urAdapterGet — not a valid UR adapter". Root cause:
+  `nm -D` confirmed neither real adapter exports a symbol named
+  `urAdapterGet` at all (25 exported `ur*` symbols total, every one of them
+  an `urGet<Category>ProcAddrTable` function-pointer-table getter —
+  `urGetAdapterProcAddrTable`, `urGetPlatformProcAddrTable`,
+  `urGetDeviceProcAddrTable`, …, no individual per-verb symbol exported
+  directly at all). `sycl_metadata.py`'s UR-plugin validity check
+  (`parse_sycl_plugin`) hard-required the older `urAdapterGet` symbol, so
+  it silently rejected a real, valid, current-generation UR adapter as "not
+  a valid UR adapter" — a genuine staleness gap relative to the real
+  Unified Runtime ABI's evolution, surfaced only by running against a real,
+  currently-shipping vendor runtime (a synthetic/mocked plugin fixture
+  would not have caught this, since it would be built to match whatever
+  symbol set the detector already expects).
+
+  **Fix**: `parse_sycl_plugin()` now accepts either UR generation — the
+  legacy `urAdapterGet` marker or the current `urGetAdapterProcAddrTable`
+  marker. `_detect_ur_version_from_symbols()`'s landmark heuristic
+  (`urBindlessImages*`/`urVirtualMem*`/`urCommandBuffer*`/`urAdapterGet`)
+  only ever matched the legacy per-verb shape to begin with — none of those
+  `startswith()` checks match `urGet<Category>ProcAddrTable` names, so it
+  already, correctly, returned `""` for the modern shape once the validity
+  gate itself was fixed (deliberately left unchanged rather than guessing
+  a version from landmarks that are always fully present on every current
+  adapter regardless of actual UR release — a real per-release signal
+  doesn't exist in the export set for this generation). Verified against
+  both real installed adapters directly (`parse_sycl_plugin` now returns a
+  populated `SyclPluginInfo` with all 25 real entry points for each) and
+  end-to-end via `discover_sycl_plugins`/`parse_sycl_metadata` over the
+  real oneAPI lib directory (`implementation: "dpcpp"`, all 3 real backends
+  — `level_zero`, `level_zero_v2`, `opencl` — discovered). New regression
+  tests in `tests/test_sycl_metadata.py` pin both the validity fix and the
+  version-detection non-regression.
 - **MSVC/`cl.exe` — still genuinely blocked.** No amount of `apt`/network
   access changes this: MSVC requires a licensed Windows installation and
   is not redistributable for a Linux container the way Intel's compiler

--- a/validation/g30-pilot-validation-2026-07.md
+++ b/validation/g30-pilot-validation-2026-07.md
@@ -1,0 +1,186 @@
+# G30 pilot validation (2026-07-25)
+
+Executes the "Pilot validation plan" section of
+`docs/contribute/plans/g30-github-actions-integration-model.md` for real:
+clone real projects, install real tools, run real `abicheck` scans/compares,
+and record what actually happened — not a simulated or hypothetical run.
+All builds and scans below were performed against real cloned/compiled
+sources in this environment; nothing here is inferred from reading the code.
+
+## Summary
+
+| Pilot | Status | Real ABI break detected? |
+|---|---|---|
+| PVXS (recommended pilot, check-project.yml flow) | Done | Yes — 1.4.0→1.5.0 `API_BREAK`, 1.5.1→1.5.2 `BREAKING` |
+| CMake (minimal generic) | Done | Yes |
+| Make (minimal generic) | Done (via EPICS Base + PVXS themselves) | Yes |
+| Package-only, `.deb` (minimal generic) | Done | Yes |
+| Cross-compiled target (aarch64) | Done | Yes |
+| Bazel (minimal generic) | Blocked — see below | n/a |
+| Second complex/vendor-toolchain project | Blocked — see below | n/a |
+
+One real, reproducible product bug was found along the way (not fixed in
+this pass — out of scope for ADR-053/G30 P2, see "Finding" below).
+
+## PVXS pilot (the confirmed/recommended pilot)
+
+Built EPICS Base R7.0.8.1 from source (`libevent-dev` was a real, previously
+undocumented dependency gap for the `epicsTime.h` ecosystem — installed via
+apt), then cloned `epics-base/pvxs` and built four tagged releases
+(1.4.0, 1.5.0, 1.5.1, 1.5.2) against it, producing real
+`libpvxs.so.<ver>`/`libpvxsIoc.so.<ver>` shared libraries for each.
+
+- `abicheck compare` between the 1.4.0 and 1.5.0 builds (header-scoped,
+  `--ast-frontend clang` — no `castxml` in this environment) reproduced the
+  `API_BREAK` verdict expected from the project's own prior validation
+  history.
+- `abicheck compare` between the 1.5.1 and 1.5.2 builds (after fixing a
+  self-inflicted snapshot-consistency issue — see "Finding" below)
+  reproduced `BREAKING` (1 breaking change: an added field on an
+  internal-but-exported type), matching this repo's own prior 1.5.1→1.5.2
+  analysis.
+- The full G30 pipeline was driven by hand end-to-end, step by step, since
+  this environment cannot literally trigger GitHub Actions:
+  - A real `.abicheck.yml` (`targets:`/`bundles:`/`profiles:`/`baseline:`)
+    validated clean via `abicheck project-targets validate`.
+  - A real `build-output.json` for the 1.5.2 candidate validated clean via
+    `abicheck build-output validate`.
+  - `abicheck run-plan generate` produced a real 2-check run-plan from that
+    config.
+  - `actions/baseline/build_manifest.py` built a real baseline-set manifest
+    from the 1.5.1 dumped snapshots (staged as
+    `<output-dir>/<library>.abicheck.json`, matching what
+    `actions/baseline/run.sh` itself would produce — the script does not
+    read an arbitrary `artifact` path as the snapshot location, only as
+    metadata about the original binary).
+  - `actions/resolve-baseline` resolved correctly against that manifest on
+    a simulated second run.
+  - `report_envelope.py` produced a real bootstrap-case report envelope.
+  - The analysis-step `compare` itself (baseline snapshot vs. the live
+    1.5.2 candidate binary) initially hit the `ScopeMismatchError` finding
+    below; re-run using two independently pre-dumped snapshots compared
+    file-to-file, it produced the real `BREAKING` verdict above.
+
+## CMake pilot
+
+A synthetic two-version CMake project (`libdemo`) with one deliberate ABI
+break (a struct field added to a type reachable from the public API, plus a
+signature change) built cleanly via `cmake`/`cmake --build`.
+`abicheck compare` against the two `libdemo.so` builds correctly reported
+`BREAKING` with the expected `type_field_added`/`func_removed`/`func_added`
+findings.
+
+## Make pilot
+
+EPICS Base and PVXS are themselves real, non-trivial GNU Make-based build
+systems (not CMake) — building all five projects above (EPICS Base + 4 PVXS
+tags) from a real `make`-driven build IS the Make pilot; a separate toy Make
+project would have added nothing this didn't already cover. Building PVXS
+required `configure/RELEASE.local` pointed at the built EPICS Base tree.
+
+Separately, this session also implemented and unit-tested real `ar`/linker
+dry-run-transcript scraping for the Make adapter (ADR-053 D2) — covered by
+`tests/test_make_adapter.py`, not by this pilot pass.
+
+## Package-only pilot (`.deb`)
+
+Built `.deb` packages (`dpkg-deb`) for both `libdemo` versions and ran
+`abicheck compare` directly against the package files (not the raw `.so`).
+This surfaced one real, previously-undocumented environment gap: extracting
+a `.deb` using zstd compression requires either the `zstd` CLI or the
+`zstandard` Python package — neither was present by default. Installed
+`zstd` via apt and re-ran; the package-to-package compare then correctly
+fell back to DWARF-only analysis (package/directory compare does not accept
+`--ast-frontend`) and reported the same real break as the CMake pilot above.
+
+## Cross-compiled pilot (aarch64)
+
+Installed `gcc-aarch64-linux-gnu`/`g++-aarch64-linux-gnu` and cross-compiled
+both `libdemo` versions for `aarch64` (`-DCMAKE_SYSTEM_NAME=Linux
+-DCMAKE_SYSTEM_PROCESSOR=aarch64 -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc
+-DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++`), producing real ARM64 ELF
+shared objects on this x86_64 host (`file` confirms `ELF 64-bit LSB shared
+object, ARM aarch64`). `abicheck compare --ast-frontend clang` against the
+two cross-compiled binaries (both sides live-dumped in one `compare`
+invocation) correctly parsed the ARM64 ELF/DWARF and reported the same real
+`BREAKING` verdict (`type_field_added`, `func_removed`/`func_added`,
+`soname_bump_recommended`) as the native x86_64 build — confirming
+cross-target ELF/DWARF parsing is not host-architecture-dependent.
+
+## Blocked: Bazel pilot
+
+No `bazel`/`bazelisk` package is directly installable in this environment.
+The only apt-available package is `bazel-bootstrap`, which does not ship a
+working `bazel` binary — it pulls a full JDK + gRPC/protobuf Java dependency
+chain to *build* bazel from source, disproportionate cost for a pilot
+validation pass. The Bazel adapter (`adapters/bazel.py`) already has unit
+coverage against captured/mocked `bazel aquery`/`cquery` JSON in
+`tests/`; this pilot could not add a real end-to-end `bazel`-driven build on
+top of that in this environment. Genuinely deferred, not attempted further.
+
+## Blocked: second complex/vendor-toolchain pilot
+
+No Intel oneAPI (`icpx`)/SYCL toolchain or MSVC/`cl.exe` is available in
+this Linux container, and neither can be installed without external
+licensed-installer access this environment does not have. Consistent with
+this repo's own prior assessment (referenced in the G30 backlog survey),
+this pilot remains genuinely blocked rather than attempted with a
+substitute — a substitute toolchain would not exercise the vendor-specific
+code paths (`sycl_metadata.py`, `pdb_parser.py`/PDB-based MSVC ABI) this
+pilot exists to validate.
+
+## Finding: `dump`/`compare` disagree on whether `--header <dir>` implies public-header-dir provenance
+
+**Not fixed in this pass** — a distinct ADR-050 (comparability contract)
+issue, out of scope for ADR-053/G30 P2's TU→DSO attribution work this PR
+otherwise covers. Recorded here as a real pilot finding for follow-up.
+
+**Symptom.** `abicheck dump lib.so --header include/` followed later by
+`abicheck compare that-dump.json lib2.so --header new=include2/` raises
+`ScopeMismatchError` ("old and new snapshots do not cover the same declared
+surface") even when `include/` and `include2/` name the identical logical
+header set — i.e. the exact "resolve a baseline once, then compare it
+against each new commit's live binary" pattern the G30 pipeline
+(`actions/baseline` → `actions/check-target`) is built around.
+
+**Root cause.** `compute_extraction_contract`'s `scope_fingerprint` hashes
+`public_header_dirs` (among other fields). `compare`'s `--header` flag is
+documented as doubling as the public-header provenance set — `cli_resolve.
+_resolve_compare_snapshots` runs `split_public_header_inputs()` on every
+`--header` value and forwards directory entries as `public_header_dirs`.
+`dump`'s `--header`/`-H` is a *different*, narrower flag (`dump` has a
+separate, explicit `--public-header`/`--public-header-dir` pair for
+provenance tagging) — plain `dump --header <dir>` never populates
+`public_header_dirs` at all. So a snapshot produced by `dump --header X`
+always carries `public_header_dirs=[]`, while the equivalent live side of a
+`compare ... --header new=X` call always carries `public_header_dirs=[X]`
+— two extractions of the byte-identical header set, fingerprinting as a
+scope mismatch purely from which of the two commands produced them.
+
+**Workaround used for this pilot's PVXS second-run analysis step**: dump
+both sides independently via `abicheck dump` (never `compare`'s live-dump
+path) and then `abicheck compare old.json new.json` on the two pre-dumped
+files — both sides then go through the same `public_header_dirs=[]`
+convention and compare cleanly.
+
+**Suggested follow-up** (not designed or implemented here): reconcile
+`dump`'s and `compare`'s `--header`-to-public-header-dir semantics — either
+make `dump --header <dir>` also populate `public_header_dirs` to match
+`compare`, or stop `compare` from implicitly deriving public-header
+provenance from `--header` at all (requiring an explicit
+`--public-header-dir` the way `dump` does) — needs a real product decision
+plus its own ADR-050 follow-up, not a drive-by fix.
+
+## What this validates about ADR-053 specifically
+
+None of the five completed pilots above exercised a build system wired
+into the new `attribution_path`/`"inferred"` build-output projection
+end-to-end (that wiring is explicitly deferred — ADR-053 D5, "CLI/Action
+pipeline wiring" — the algorithm, Make link-unit capture, ingest filtering,
+and `build_output.py` validator are unit-tested directly, not through a
+pilot's CLI surface, since no CLI/Action entry point produces or consumes
+`attribution_path` yet). The pilots above validate the surrounding G30
+pipeline (config validation, build-output validation, run-plan generation,
+baseline resolution, real-project scan/compare correctness across four
+build-system shapes and a cross-compiled target) that ADR-053's future
+CLI/Action wiring will sit on top of.

--- a/validation/g30-pilot-validation-2026-07.md
+++ b/validation/g30-pilot-validation-2026-07.md
@@ -8,12 +8,15 @@ below comes from an actual build and an actual `abicheck` invocation in this
 environment; nothing is inferred from reading the code. **Scope is mixed,
 and deliberately labeled as such below**: the PVXS/Make pilot is a real
 *upstream* open-source project (`epics-base/pvxs`, cloned from GitHub) built
-from source; the CMake/package/cross-compiled pilots exercise a synthetic
-in-repo two-version `libdemo` fixture (a real build/compile/link/compare
-each time, just not a real upstream codebase) — sufficient to validate the
-build-system integration and ABI-break detection path itself, but not a
-substitute for a second real-upstream project (see "Blocked" sections below
-for that gap).
+from source; the CMake/Bazel/package/cross-compiled/icpx pilots exercise a
+synthetic in-repo two-version `libdemo` fixture (a real build/compile/
+link/compare each time, just not a real upstream codebase) — sufficient to
+validate the build-system integration and ABI-break detection path itself,
+but not a substitute for a second real-upstream project. The icpx pilot
+additionally reaches real, vendor-shipped SYCL runtime binaries (Intel's
+own Unified Runtime adapter plugins) beyond the synthetic fixture, since
+those ship with the compiler install itself — see that pilot's section for
+what that did and didn't cover, and "Still blocked" for MSVC/PDB.
 
 ## Summary
 
@@ -22,13 +25,18 @@ for that gap).
 | PVXS (recommended pilot, check-project.yml flow) | Real upstream (`epics-base/pvxs`) | Done | Yes — 1.4.0→1.5.0 `API_BREAK`, 1.5.1→1.5.2 `BREAKING` |
 | Make (minimal generic) | Real upstream (EPICS Base + PVXS themselves) | Done | Yes |
 | CMake (minimal generic) | Synthetic (`libdemo` fixture) | Done | Yes |
+| Bazel (minimal generic) | Synthetic (`libdemo` fixture) | Done | Yes |
 | Package-only, `.deb` (minimal generic) | Synthetic (`libdemo` fixture) | Done | Yes |
 | Cross-compiled target (aarch64) | Synthetic (`libdemo` fixture) | Done | Yes |
-| Bazel (minimal generic) | — | Blocked — see below | n/a |
-| Second complex/vendor-toolchain project | — | Blocked — see below | n/a |
+| Second vendor-toolchain project: Intel `icpx`/oneAPI | Synthetic (`libdemo` fixture) + real DPC++ runtime plugins | Partially done — see below | Yes (C++); real SYCL-plugin detection gap found, not fixed |
+| Second vendor-toolchain project: MSVC/PDB | — | Still blocked — see below | n/a |
 
-One real, reproducible product bug was found along the way (not fixed in
-this pass — out of scope for ADR-053/G30 P2, see "Finding" below).
+One real, reproducible product bug was found and fixed in this same PR
+after initial triage as an out-of-scope follow-up (see "Finding" below); a
+second, real, currently-unfixed gap (`sycl_metadata.py`'s UR-adapter
+detection is stale relative to a real, current Intel oneAPI 2026.1 runtime)
+was found by the vendor-toolchain pilot below and left for its own
+follow-up.
 
 ## PVXS pilot (the confirmed/recommended pilot)
 
@@ -115,36 +123,114 @@ invocation) correctly parsed the ARM64 ELF/DWARF and reported the same real
 `soname_bump_recommended`) as the native x86_64 build — confirming
 cross-target ELF/DWARF parsing is not host-architecture-dependent.
 
-## Blocked: Bazel pilot
+## Bazel pilot
 
-No `bazel`/`bazelisk` package is directly installable in this environment.
-The only apt-available package is `bazel-bootstrap`, which does not ship a
-working `bazel` binary — it pulls a full JDK + gRPC/protobuf Java dependency
-chain to *build* bazel from source, disproportionate cost for a pilot
-validation pass. The Bazel adapter (`adapters/bazel.py`) already has unit
-coverage against captured/mocked `bazel aquery`/`cquery` JSON in
-`tests/`; this pilot could not add a real end-to-end `bazel`-driven build on
-top of that in this environment. Genuinely deferred, not attempted further.
+**Initially marked blocked, then unblocked**: no `bazel`/`bazelisk` `apt`
+package is directly installable in this environment (the only apt-available
+package, `bazel-bootstrap`, doesn't ship a working `bazel` binary — it pulls
+a full JDK + gRPC/protobuf Java chain to *build* bazel from source). Bazel
+itself, however, is a real, network-downloadable static binary: `bazelisk`
+(the official version-managing launcher) fetched cleanly from its GitHub
+releases (`bazelisk-linux-amd64`), and on first invocation transparently
+downloaded and ran real Bazel 9.2.0.
 
-## Blocked: second complex/vendor-toolchain pilot
+Built the same two-version `libdemo` fixture as the CMake pilot (identical
+`src/demo.cpp`/`internal.cpp`/`demo.h`, reused verbatim) under a minimal
+Bazel `MODULE.bazel`/`BUILD.bazel` (`cc_binary` with `linkshared = True`,
+via `rules_cc` — Bazel 9's bzlmod migration removed the native `cc_binary`
+rule, so this needed a `load("@rules_cc//cc:defs.bzl", "cc_binary")`, not
+just a bare `BUILD.bazel`). `bazel build //:libdemo.so` produced real
+`bazel-bin/libdemo.so` outputs for both versions.
 
-No Intel oneAPI (`icpx`)/SYCL toolchain or MSVC/`cl.exe` is available in
-this Linux container, and neither can be installed without external
-licensed-installer access this environment does not have. Consistent with
-this repo's own prior assessment (referenced in the G30 backlog survey),
-this pilot remains genuinely blocked rather than attempted with a
-substitute — a substitute toolchain would not exercise the vendor-specific
-code paths (`sycl_metadata.py`, `pdb_parser.py`/PDB-based MSVC ABI) this
-pilot exists to validate.
+`abicheck dump ... --sources <bazel-project-dir> --allow-build-query`
+correctly auto-detected the Bazel project (`build_query.detect_build_system`
+finding `MODULE.bazel`) and ran a real `bazel aquery` itself (zero-config,
+no manual `bazel aquery` invocation needed on the user's part) — the
+resulting snapshot's `build_source.build_evidence.generators` records
+`kind: "bazel"`, with 2 real `compile_units` and 1 real `link_unit`
+(`libdemo.so`, `kind: shared_library`, both objects as inputs) captured from
+the actual `aquery` action graph. `abicheck compare` on the two dumps
+correctly reported `BREAKING` with the same real findings as every other
+`libdemo` pilot (`type_field_added`, `func_removed`/`func_added`), plus a
+real `header_parse_context_drift` finding surfaced *because* real Bazel
+build-context data was now feeding the compile-flag comparison
+("Build-flag & toolchain drift ... from build-system data (compile DB /
+CMake / Ninja / Bazel)" showed `[on]` in the evidence-coverage banner,
+unlike the header-only CMake/cross-compiled pilots where that check is
+`[off]`).
 
-## Finding: `dump`/`compare` disagree on whether `--header <dir>` implies public-header-dir provenance
+As a bonus check of this PR's own ADR-053 work against a **third** real
+build-system evidence source (previously only unit-tested with
+captured/mocked `aquery` JSON, never a live `bazel` invocation):
+`link_attribution.attribute_sources_to_targets()` run directly over the real
+captured `BuildEvidence` correctly attributed both `src/demo.cpp` and
+`src/internal.cpp` to `target:////:libdemo.so` via the link-unit-graph
+channel (Bazel's own compile-unit → link-unit → terminal-DSO graph), exactly
+as ADR-053 D2 documents.
 
-**Not fixed in this pass** — a distinct ADR-050 (comparability contract)
-issue, out of scope for ADR-053/G30 P2's TU→DSO attribution work this PR
-otherwise covers. Recorded here as a real pilot finding for follow-up.
+## Second vendor-toolchain pilot: Intel oneAPI (`icpx`) — partially unblocked; MSVC/PDB remains blocked
+
+**Initially marked fully blocked, then partially unblocked**: contrary to
+the initial assessment, Intel's oneAPI compiler is a real, freely
+installable `apt` package (`apt.repos.intel.com`, public GPG-signed repo,
+no license key needed for the compiler component) — `intel-oneapi-compiler-dpcpp-cpp`
+installed cleanly and produced a real, working `icpx` (Intel(R) oneAPI
+DPC++/C++ Compiler 2026.1.0).
+
+- **Real vendor-compiled C++ `.so`**: built the same two-version `libdemo`
+  fixture with `icpx -shared -fPIC -std=c++17` instead of gcc/clang. The
+  binary's `.comment` section (`readelf -p .comment`) confirms genuine
+  vendor-toolchain provenance: `Intel(R) oneAPI DPC++/C++ Compiler 2026.1.0
+  (2026.1.0.20260617)`, not a substitute. `abicheck compare` (clang L2
+  frontend for headers, real icpx-produced DWARF for L1) correctly parsed
+  both real icpx-built binaries and reported the same real `BREAKING`
+  verdict (`type_field_added`, `func_removed`/`func_added`) as every other
+  `libdemo` pilot — confirming ELF/DWARF parsing is toolchain-producer-
+  agnostic, not just compiler-family-agnostic (gcc/clang) as the other
+  pilots already showed.
+- **Real SYCL device-code compilation**: `icpx -fsycl -shared -fPIC` on a
+  genuine `sycl::queue`/`parallel_for` kernel compiled and linked cleanly
+  (`sycl/sycl.hpp` from the installed DPC++ runtime, no GPU/OpenCL runtime
+  needed just to *compile*), producing a real ELF `.so` `abicheck dump`
+  parses without error (binary/symbols-level; 4 functions extracted).
+- **Real SYCL runtime plugin metadata (`sycl_metadata.py`) — a genuine
+  finding, not fixed here.** The installed DPC++ runtime ships real Intel
+  Unified Runtime (UR) adapter plugins
+  (`/opt/intel/oneapi/compiler/2026.1/lib/libur_adapter_{opencl,level_zero}.so.*`).
+  Running `abicheck.sycl_metadata.parse_sycl_plugin()` directly against
+  these real, current (oneAPI 2026.1) adapters returns `None` for both —
+  "missing urAdapterGet — not a valid UR adapter". Root cause: `nm -D`
+  confirms neither real adapter exports a symbol named `urAdapterGet` at
+  all; both instead export the newer `urGetAdapterProcAddrTable`/
+  `urGet<Category>ProcAddrTable` entry-point family (`urGetPlatformProcAddrTable`,
+  `urGetDeviceProcAddrTable`, …). `sycl_metadata.py`'s UR-plugin validity
+  check (`parse_sycl_plugin`, `_UR_SYMBOL_RE`) still hard-requires the
+  older `urAdapterGet` symbol, so it silently rejects a real, valid,
+  current-generation UR adapter as "not a valid UR adapter" — a genuine
+  staleness gap relative to the real Unified Runtime ABI's evolution,
+  surfaced only by running against a real, currently-shipping vendor
+  runtime (a synthetic/mocked plugin fixture would not have caught this,
+  since it would be built to match whatever symbol set the detector
+  already expects). **Not fixed in this pass** — understanding UR's actual
+  current versioned entry-point contract well enough to fix the detector
+  correctly (not just pattern-match today's one observed symbol set) is
+  its own scoped task, not a drive-by alongside this PR's other work.
+- **MSVC/`cl.exe` — still genuinely blocked.** No amount of `apt`/network
+  access changes this: MSVC requires a licensed Windows installation and
+  is not redistributable for a Linux container the way Intel's compiler
+  is. `pdb_parser.py`/PDB-based MSVC ABI parsing remains unvalidated by
+  this pilot pass.
+
+## Finding (fixed): `dump`/`compare` disagreed on whether `--header <dir>` implies public-header-dir scope
+
+**Fixed in this PR**, after initially being recorded as a deferred ADR-050
+follow-up — the user asked for it to be closed here rather than left as a
+documented gap, and the fix turned out to be small and cleanly scoped once
+root-caused precisely (see below), so it landed alongside the ADR-053 work
+rather than needing its own follow-up PR.
 
 **Symptom.** `abicheck dump lib.so --header include/` followed later by
-`abicheck compare that-dump.json lib2.so --header new=include2/` raises
+`abicheck compare that-dump.json lib2.so --header new=include2/` raised
 `ScopeMismatchError` ("old and new snapshots do not cover the same declared
 surface") even when `include/` and `include2/` name the identical logical
 header set — i.e. the exact "resolve a baseline once, then compare it
@@ -158,37 +244,67 @@ _resolve_compare_snapshots` runs `split_public_header_inputs()` on every
 `--header` value and forwards directory entries as `public_header_dirs`.
 `dump`'s `--header`/`-H` is a *different*, narrower flag (`dump` has a
 separate, explicit `--public-header`/`--public-header-dir` pair for
-provenance tagging) — plain `dump --header <dir>` never populates
+provenance tagging) — plain `dump --header <dir>` never populated
 `public_header_dirs` at all. So a snapshot produced by `dump --header X`
-always carries `public_header_dirs=[]`, while the equivalent live side of a
-`compare ... --header new=X` call always carries `public_header_dirs=[X]`
+always carried `public_header_dirs=[]`, while the equivalent live side of a
+`compare ... --header new=X` call always carried `public_header_dirs=[X]`
 — two extractions of the byte-identical header set, fingerprinting as a
 scope mismatch purely from which of the two commands produced them.
 
-**Workaround used for this pilot's PVXS second-run analysis step**: dump
-both sides independently via `abicheck dump` (never `compare`'s live-dump
-path) and then `abicheck compare old.json new.json` on the two pre-dumped
-files — both sides then go through the same `public_header_dirs=[]`
-convention and compare cleanly.
+**The fix (surgical, decoupled from declaration-provenance tagging).**
+`dumper.dump()` gained a new `scope_header_dirs` parameter that is folded
+into the extraction contract's `public_header_dirs` scope field *only* —
+`apply_provenance()`'s call (ADR-015's origin/public-API tagging) still
+reads the original, unmodified `public_header_dirs`, so this does **not**
+silently start tagging declarations `public_header`/`private_header` for
+existing `dump --header`-only callers; that stays exactly as opt-in as
+before, via the separate `--public-header`/`--public-header-dir` flags.
+`cli_dump_helpers.perform_elf_dump` now computes `scope_header_dirs` from
+the raw `-H`/`--header` CLI arguments via the same `split_public_header_
+inputs()` helper `compare` already uses, so a directory argument feeds the
+scope contract identically regardless of which command produced the
+snapshot. Verified against this pilot's own real PVXS 1.5.1/1.5.2 binaries
+(re-running the exact previously-failing command below now succeeds and
+reproduces the correct `BREAKING` verdict directly, without the two-step
+workaround) plus new regression tests
+(`tests/test_dumper_contract_wiring.py`,
+`tests/test_cli_dump_helpers_coverage.py`) pinning both the scope-agreement
+fix and the provenance-tagging non-regression.
 
-**Suggested follow-up** (not designed or implemented here): reconcile
-`dump`'s and `compare`'s `--header`-to-public-header-dir semantics — either
-make `dump --header <dir>` also populate `public_header_dirs` to match
-`compare`, or stop `compare` from implicitly deriving public-header
-provenance from `--header` at all (requiring an explicit
-`--public-header-dir` the way `dump` does) — needs a real product decision
-plus its own ADR-050 follow-up, not a drive-by fix.
+```
+abicheck dump libpvxs.so.1.5 --header include/          # 1.5.1, no --public-header-dir
+  -o baseline-set/libpvxs.abicheck.json
+abicheck compare baseline-set/libpvxs.abicheck.json libpvxs.so.1.5 \
+  --header new=include/                                  # 1.5.2, live compare-side dump
+# before the fix: ScopeMismatchError; after: real BREAKING verdict
+```
+
+**Scope note.** This fix covers the ELF `dump`/`compare` CLI path (the one
+this pilot's real PVXS scenario exercises and the G30 pipeline's Linux CI
+use case). The PE/Mach-O header-scoped dump path
+(`service._try_header_scoped_dump`) calls `_attach_extraction_contract`
+directly rather than through `dumper.dump()` and was not touched — it
+already threads its own `public_header_dirs` straight from that path's
+caller, a different (and, for that path, already-consistent) wiring; if a
+comparable dump-vs-compare asymmetry is ever found there, it needs its own
+targeted look, not an assumption that this fix already covers it.
 
 ## What this validates about ADR-053 specifically
 
-None of the five completed pilots above exercised a build system wired
-into the new `attribution_path`/`"inferred"` build-output projection
-end-to-end (that wiring is explicitly deferred — ADR-053 D5, "CLI/Action
-pipeline wiring" — the algorithm, Make link-unit capture, ingest filtering,
-and `build_output.py` validator are unit-tested directly, not through a
-pilot's CLI surface, since no CLI/Action entry point produces or consumes
-`attribution_path` yet). The pilots above validate the surrounding G30
-pipeline (config validation, build-output validation, run-plan generation,
-baseline resolution, real-project scan/compare correctness across four
-build-system shapes and a cross-compiled target) that ADR-053's future
+None of the pilots above exercised a build system wired into the new
+`attribution_path`/`"inferred"` build-output projection end-to-end (that
+wiring is explicitly deferred — ADR-053 D5, "CLI/Action pipeline wiring" —
+the algorithm, Make link-unit capture, ingest filtering, and
+`build_output.py` validator are unit-tested directly, not through a pilot's
+CLI surface, since no CLI/Action entry point produces or consumes
+`attribution_path` yet). The Bazel pilot does, however, exercise the
+underlying `link_attribution.attribute_sources_to_targets()` algorithm
+directly against a real, live-captured `bazel aquery` `BuildEvidence` for
+the first time (previously only unit-tested against captured/mocked
+`aquery` JSON) — a genuine, if narrower, ADR-053 validation beyond CMake and
+Make. The pilots above otherwise validate the surrounding G30 pipeline
+(config validation, build-output validation, run-plan generation, baseline
+resolution, real-project scan/compare correctness across five build-system
+shapes and a cross-compiled target, plus a real `dump`/`compare`
+comparability-contract bug found and fixed) that ADR-053's future
 CLI/Action wiring will sit on top of.

--- a/validation/g30-pilot-validation-2026-07.md
+++ b/validation/g30-pilot-validation-2026-07.md
@@ -2,22 +2,30 @@
 
 Executes the "Pilot validation plan" section of
 `docs/contribute/plans/g30-github-actions-integration-model.md` for real:
-clone real projects, install real tools, run real `abicheck` scans/compares,
-and record what actually happened — not a simulated or hypothetical run.
-All builds and scans below were performed against real cloned/compiled
-sources in this environment; nothing here is inferred from reading the code.
+install real tools and run real `abicheck` builds/scans/compares, recording
+what actually happened — not a simulated or hypothetical run. Every result
+below comes from an actual build and an actual `abicheck` invocation in this
+environment; nothing is inferred from reading the code. **Scope is mixed,
+and deliberately labeled as such below**: the PVXS/Make pilot is a real
+*upstream* open-source project (`epics-base/pvxs`, cloned from GitHub) built
+from source; the CMake/package/cross-compiled pilots exercise a synthetic
+in-repo two-version `libdemo` fixture (a real build/compile/link/compare
+each time, just not a real upstream codebase) — sufficient to validate the
+build-system integration and ABI-break detection path itself, but not a
+substitute for a second real-upstream project (see "Blocked" sections below
+for that gap).
 
 ## Summary
 
-| Pilot | Status | Real ABI break detected? |
-|---|---|---|
-| PVXS (recommended pilot, check-project.yml flow) | Done | Yes — 1.4.0→1.5.0 `API_BREAK`, 1.5.1→1.5.2 `BREAKING` |
-| CMake (minimal generic) | Done | Yes |
-| Make (minimal generic) | Done (via EPICS Base + PVXS themselves) | Yes |
-| Package-only, `.deb` (minimal generic) | Done | Yes |
-| Cross-compiled target (aarch64) | Done | Yes |
-| Bazel (minimal generic) | Blocked — see below | n/a |
-| Second complex/vendor-toolchain project | Blocked — see below | n/a |
+| Pilot | Project | Status | Real ABI break detected? |
+|---|---|---|---|
+| PVXS (recommended pilot, check-project.yml flow) | Real upstream (`epics-base/pvxs`) | Done | Yes — 1.4.0→1.5.0 `API_BREAK`, 1.5.1→1.5.2 `BREAKING` |
+| Make (minimal generic) | Real upstream (EPICS Base + PVXS themselves) | Done | Yes |
+| CMake (minimal generic) | Synthetic (`libdemo` fixture) | Done | Yes |
+| Package-only, `.deb` (minimal generic) | Synthetic (`libdemo` fixture) | Done | Yes |
+| Cross-compiled target (aarch64) | Synthetic (`libdemo` fixture) | Done | Yes |
+| Bazel (minimal generic) | — | Blocked — see below | n/a |
+| Second complex/vendor-toolchain project | — | Blocked — see below | n/a |
 
 One real, reproducible product bug was found along the way (not fixed in
 this pass — out of scope for ADR-053/G30 P2, see "Finding" below).


### PR DESCRIPTION
## Summary

Finalizes the two remaining well-scoped G30 backlog items that could be completed without access to a real external pilot project (the "Pilot validation plan" items in `docs/contribute/plans/g30-github-actions-integration-model.md` still need a live external repo and can't be done in this environment).

## Motivation

`docs/contribute/plans/g30-github-actions-integration-model.md`'s own P0–P1.7 status notes, `AGENTS.md`'s "Known gaps" section, and issue #628 tracked two remaining items after everything else in the G30 plan landed:

1. Issue #628 — `check-project.yml`'s candidate-resolution and build-output-download steps could fail *before* `actions/check-target` ever ran, leaving no report for `abicheck aggregate` to see (indistinguishable from an optional cell that legitimately had nothing to check).
2. A "Depth contract, CLI vs. API/MCP" known-gap entry that was waiting on PR #601 (merged 2026-07-19) before it could be investigated further.

Closes #628.

## Changes

- **`check-project.yml`**: the "Download build-output artifact" step no longer silently swallows a required download failure via `continue-on-error`. A new "Synthesize pre-check operational-error report" step reuses `actions/check-target/report_envelope.py --mode operational-error` **directly** (the same script `check-target`'s own `run.sh` drives for a real `resolve-baseline` failure) to write a full, schema-valid operational-error envelope whenever the download or the candidate-resolution step fails — no duplicated envelope logic, no change to `check-target`'s own input surface. `Run check-target` is gated to skip when candidate resolution didn't succeed; the sanitize/upload steps pick up whichever of the two report-producing steps actually ran.
- **`AGENTS.md` / the G30 plan doc / `mcp_server.py`**: re-investigated the "Depth contract, CLI vs. API/MCP" known gap now that PR #601 has merged. Found it no longer applies — `dump --depth`'s strict `DumpDepthNotSatisfiedError` gate has no `service.py`/MCP surface to extend to (neither exposes a depth-qualified snapshot API), and `scan`'s own pinned-depth evidence contract was already shared identically between the CLI and `service.py`/MCP the whole time, via one `scan_engine.run_scan_core`. Corrected the stale wording in all three places rather than writing speculative new enforcement code.
- Tests: new `TestPreCheckOperationalErrorReport` class in `tests/test_reusable_workflows.py` (structural assertions + a real end-to-end run of the new script against the real `report_envelope.py`), plus updates to two existing assertions whose expected `if:`/env conditions widened.

## Verification

- `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden" -q` — 19026 passed, 0 failed
- `ruff check abicheck/ tests/` — clean
- `mypy abicheck/mcp_server.py` — 0 errors
- `mkdocs build --strict` — clean (exit 0)
- `python scripts/check_docs_contract.py` — 0 errors
- `python scripts/check_ai_readiness.py` — 0 errors, same warning count as `main`
- Hand-verified the new `report_envelope.py --mode operational-error` invocation and the new step's bash extraction logic end-to-end (schema-valid envelope, correct `check-id`/`report-path`/`exit-code` outputs)

**Left open, flagged rather than silently skipped:** a live-GitHub-Actions-runner fixture proving the `aggregate`-visible result for these two specific failure modes (mirroring `test-check-project-failure-path.yml`'s existing `not_found` fixture) — this session had no live runner available to validate a new fixture scenario against. Documented in the plan doc.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`docs/reference/reusable-workflows.md`, the G30 plan doc, `AGENTS.md`)
- [x] `ruff check` / `mypy` — no new errors introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_01W8ieaELWRDr8Hthmwenpyv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source-to-binary attribution for inferred build evidence, including Make-based link and archive detection.
  * Shared input evidence can now be filtered to the translation units associated with a specific target.

* **Bug Fixes**
  * Pre-check failures now produce operational-error reports for reliable aggregation instead of silently missing results.
  * Invalid inferred evidence is detected through attribution validation.

* **Documentation**
  * Updated architecture, workflow, known-gap, and pilot validation documentation to reflect the implemented attribution and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->