### PR TITLE
fix: GCC resource-dir path normalization + SYCL double-JSON-document parse

### DIFF
--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -65,6 +65,7 @@ from .dumper_castxml_probe import (
 from .dumper_clang import (
     _clang_available as _clang_available,
     _ClangAstParser as _ClangAstParser,
+    _is_intel_sycl_driver,
     _resolve_clang_bin as _resolve_clang_bin,
 )
 from .dumper_clang_errors import (
@@ -181,16 +182,16 @@ def _resolve_header_backend(backend: str | None) -> str:
     return "castxml"
 
 
-def _needs_sycl_host_only(tokens: list[str]) -> bool:
-    """True if *tokens* enable SYCL without pinning a single compilation pass.
+def _needs_sycl_host_only(cc_bin: str, tokens: list[str]) -> bool:
+    """True if *tokens* enable SYCL on a driver that needs a pinned single pass.
 
-    A bare ``-fsycl`` makes a SYCL-capable driver (Intel's icpx/dpcpp, or
-    upstream clang's own SYCL support) run *two* separate ``-cc1`` passes for
-    one compile — a device-side pass (``-fsycl-is-device``, ``-triple
-    spir64-unknown-unknown``) and a host-side pass (``-fsycl-is-host``) —
-    each with its own ``-Xclang -ast-dump=json``, both writing a complete JSON
-    document to the same stdout stream abicheck captures, back-to-back with
-    no separator. ``json.load()`` in
+    A bare ``-fsycl`` makes Intel's oneAPI DPC++/C++ driver (icx/icpx/dpcpp[-cl],
+    :func:`abicheck.dumper_clang._is_intel_sycl_driver`) run *two* separate
+    ``-cc1`` passes for one compile — a device-side pass (``-fsycl-is-device``,
+    ``-triple spir64-unknown-unknown``) and a host-side pass
+    (``-fsycl-is-host``) — each with its own ``-Xclang -ast-dump=json``, both
+    writing a complete JSON document to the same stdout stream abicheck
+    captures, back-to-back with no separator. ``json.load()`` in
     :func:`abicheck.dumper_clang_errors._parse_clang_ast_result` parses only
     the first document and raises on the leftover bytes ("Extra data").
 
@@ -201,9 +202,19 @@ def _needs_sycl_host_only(tokens: list[str]) -> bool:
     is what actually links into the scanned binary. Skipped when the caller
     already pinned a single pass explicitly (``-fsycl-host-only`` or
     ``-fsycl-device-only``) so an explicit choice is never second-guessed.
+
+    Gated on *cc_bin* being specifically an Intel oneAPI driver, not any
+    clang-family binary: stock upstream clang also accepts a bare ``-fsycl``,
+    but does not split into two passes and does not recognize
+    ``-fsycl-host-only``/``-fsycl-device-only`` at all — it hard-rejects
+    either with "unknown argument" (Codex review, PR #643: verified against a
+    real clang 17/18 install). Appending the flag unconditionally would turn
+    a working ``--gcc-path clang`` + ``-fsycl`` parse into a hard failure.
     """
-    return "-fsycl" in tokens and not (
-        "-fsycl-host-only" in tokens or "-fsycl-device-only" in tokens
+    return (
+        _is_intel_sycl_driver(cc_bin)
+        and "-fsycl" in tokens
+        and not ("-fsycl-host-only" in tokens or "-fsycl-device-only" in tokens)
     )
 
 
@@ -238,11 +249,13 @@ def _build_clang_header_command(
     auto-detection stays a genuine fallback: a user-supplied ``-isystem`` for a
     cross/hermetic SDK is searched first and wins. Skipped under ``-nostdinc``.
 
-    A bare ``-fsycl`` in ``gcc_options``/``gcc_option_tokens`` gets
+    On an Intel oneAPI driver (``cc_bin`` one of icx/icpx/dpcpp[-cl]), a bare
+    ``-fsycl`` in ``gcc_options``/``gcc_option_tokens`` gets
     ``-fsycl-host-only`` appended (see :func:`_needs_sycl_host_only`) so the
     compile stays a single ``-cc1``/AST-dump pass instead of splitting into a
     SYCL device pass and a host pass that both write JSON to the same
-    stdout stream.
+    stdout stream. Left alone on stock clang, which does not recognize
+    either ``-fsycl-host-only`` or ``-fsycl-device-only``.
     """
     cmd = [cc_bin]
     for inc in extra_includes:
@@ -255,7 +268,7 @@ def _build_clang_header_command(
         cmd += shlex.split(gcc_options, posix=os.name != "nt")
     # Repeatable --gcc-option: one literal argument each (no shlex split).
     cmd += list(gcc_option_tokens)
-    if _needs_sycl_host_only(cmd):
+    if _needs_sycl_host_only(cc_bin, cmd):
         cmd.append("-fsycl-host-only")
     # Auto-probed host system dirs go *after* the user's pass-through flags, so a
     # user-supplied -isystem (cross/hermetic SDK) keeps higher search priority

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -181,6 +181,32 @@ def _resolve_header_backend(backend: str | None) -> str:
     return "castxml"
 
 
+def _needs_sycl_host_only(tokens: list[str]) -> bool:
+    """True if *tokens* enable SYCL without pinning a single compilation pass.
+
+    A bare ``-fsycl`` makes a SYCL-capable driver (Intel's icpx/dpcpp, or
+    upstream clang's own SYCL support) run *two* separate ``-cc1`` passes for
+    one compile — a device-side pass (``-fsycl-is-device``, ``-triple
+    spir64-unknown-unknown``) and a host-side pass (``-fsycl-is-host``) —
+    each with its own ``-Xclang -ast-dump=json``, both writing a complete JSON
+    document to the same stdout stream abicheck captures, back-to-back with
+    no separator. ``json.load()`` in
+    :func:`abicheck.dumper_clang_errors._parse_clang_ast_result` parses only
+    the first document and raises on the leftover bytes ("Extra data").
+
+    The device-side AST is also the wrong evidence even if it parsed: it
+    describes SPIR-V kernel code that never becomes part of a host ``.so``'s
+    exported symbols or public header surface. ``-fsycl-host-only`` collapses
+    the compile back to a single ``-cc1`` pass over the host-side AST, which
+    is what actually links into the scanned binary. Skipped when the caller
+    already pinned a single pass explicitly (``-fsycl-host-only`` or
+    ``-fsycl-device-only``) so an explicit choice is never second-guessed.
+    """
+    return "-fsycl" in tokens and not (
+        "-fsycl-host-only" in tokens or "-fsycl-device-only" in tokens
+    )
+
+
 def _build_clang_header_command(
     cc_bin: str,
     cc_id: str,
@@ -211,6 +237,12 @@ def _build_clang_header_command(
     user's ``-I`` *and* the pass-through ``--gcc-options``/``--gcc-option``) so
     auto-detection stays a genuine fallback: a user-supplied ``-isystem`` for a
     cross/hermetic SDK is searched first and wins. Skipped under ``-nostdinc``.
+
+    A bare ``-fsycl`` in ``gcc_options``/``gcc_option_tokens`` gets
+    ``-fsycl-host-only`` appended (see :func:`_needs_sycl_host_only`) so the
+    compile stays a single ``-cc1``/AST-dump pass instead of splitting into a
+    SYCL device pass and a host pass that both write JSON to the same
+    stdout stream.
     """
     cmd = [cc_bin]
     for inc in extra_includes:
@@ -223,6 +255,8 @@ def _build_clang_header_command(
         cmd += shlex.split(gcc_options, posix=os.name != "nt")
     # Repeatable --gcc-option: one literal argument each (no shlex split).
     cmd += list(gcc_option_tokens)
+    if _needs_sycl_host_only(cmd):
+        cmd.append("-fsycl-host-only")
     # Auto-probed host system dirs go *after* the user's pass-through flags, so a
     # user-supplied -isystem (cross/hermetic SDK) keeps higher search priority
     # (Codex review). Auto-detection is a fallback, never an override.

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -65,6 +65,7 @@ from .dumper_castxml_probe import (
 from .dumper_clang import (
     _clang_available as _clang_available,
     _ClangAstParser as _ClangAstParser,
+    _dpcpp_defaults_sycl_on,
     _is_intel_sycl_driver,
     _resolve_clang_bin as _resolve_clang_bin,
 )
@@ -220,12 +221,18 @@ def _needs_sycl_host_only(cc_bin: str, tokens: list[str]) -> bool:
     SYCL-only selector onto a non-SYCL compile — at best a no-op, at worst
     rejected by the driver as contradictory (Codex review, PR #643, round
     5). The *last* occurrence of either flag decides the effective state.
+
+    The initial state before scanning is not always "off": Intel's legacy
+    "dpcpp"/"dpcpp-cl" driver names imply SYCL is already on even with no
+    ``-fsycl`` token at all (:func:`_dpcpp_defaults_sycl_on`, Codex review,
+    PR #643, round 8) — an explicit ``-fno-sycl`` still overrides that
+    default via the same last-flag-wins scan.
     """
     if not _is_intel_sycl_driver(cc_bin):
         return False
     if "-fsycl-host-only" in tokens or "-fsycl-device-only" in tokens:
         return False
-    sycl_enabled = False
+    sycl_enabled = _dpcpp_defaults_sycl_on(cc_bin)
     for tok in tokens:
         if tok == "-fsycl":
             sycl_enabled = True

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -210,12 +210,28 @@ def _needs_sycl_host_only(cc_bin: str, tokens: list[str]) -> bool:
     either with "unknown argument" (Codex review, PR #643: verified against a
     real clang 17/18 install). Appending the flag unconditionally would turn
     a working ``--gcc-path clang`` + ``-fsycl`` parse into a hard failure.
+
+    A plain ``"-fsycl" in tokens`` membership check is not enough: the clang
+    driver applies ``-fsycl``/``-fno-sycl`` last-flag-wins, like any other
+    toggle flag (confirmed with ``clang++ -fsycl -fno-sycl -###``, which
+    emits one ordinary host ``-cc1`` invocation, no device pass). A caller
+    passing ``-fsycl -fno-sycl`` through ``--gcc-options`` has SYCL
+    *disabled* overall, so appending ``-fsycl-host-only`` would tack a
+    SYCL-only selector onto a non-SYCL compile — at best a no-op, at worst
+    rejected by the driver as contradictory (Codex review, PR #643, round
+    5). The *last* occurrence of either flag decides the effective state.
     """
-    return (
-        _is_intel_sycl_driver(cc_bin)
-        and "-fsycl" in tokens
-        and not ("-fsycl-host-only" in tokens or "-fsycl-device-only" in tokens)
-    )
+    if not _is_intel_sycl_driver(cc_bin):
+        return False
+    if "-fsycl-host-only" in tokens or "-fsycl-device-only" in tokens:
+        return False
+    sycl_enabled = False
+    for tok in tokens:
+        if tok == "-fsycl":
+            sycl_enabled = True
+        elif tok == "-fno-sycl":
+            sycl_enabled = False
+    return sycl_enabled
 
 
 def _build_clang_header_command(

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -131,6 +131,29 @@ def _is_intel_sycl_driver(path: str) -> bool:
     return Path(path).stem.lower() in _CLANG_FAMILY_ALIAS_NAMES
 
 
+#: Intel's legacy, now-deprecated "dpcpp"/"dpcpp-cl" driver names predate the
+#: unified icx/icpx compiler and its explicit ``-fsycl`` opt-in: "dpcpp" was
+#: historically the SYCL-specific entry point (Intel's own migration guidance
+#: frames it as "switch to the C++ driver with -fsycl", implying dpcpp itself
+#: never needed the flag), so invoking one of these two names can enable SYCL
+#: even with no ``-fsycl``/``-fno-sycl`` token at all (Codex review, PR #643,
+#: round 8). Not independently confirmed in the current open-source
+#: intel/llvm driver sources (which show ``-fsycl`` defaulting to off
+#: regardless of argv0) — this may be packaging-layer behavior specific to
+#: Intel's binary distribution rather than the public driver code. Guarded
+#: for anyway: the cost of wrongly treating a plain "dpcpp" invocation as
+#: SYCL-enabled is at most an unused ``-fsycl-host-only`` (clang warns on an
+#: unused flag, it does not hard-fail), while the cost of not guarding, if
+#: the premise holds, is silently reintroducing the exact double-JSON-document
+#: failure this whole fix exists to prevent for a chunk of the driver family.
+_SYCL_DEFAULT_ON_DRIVER_NAMES = frozenset({"dpcpp", "dpcpp-cl"})
+
+
+def _dpcpp_defaults_sycl_on(cc_bin: str) -> bool:
+    """True if *cc_bin* is one of Intel's SYCL-implied legacy driver names."""
+    return Path(cc_bin).stem.lower() in _SYCL_DEFAULT_ON_DRIVER_NAMES
+
+
 def _resolve_clang_bin(
     compiler: str,
     gcc_path: str | None,

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -113,6 +113,24 @@ def _is_clang_family_binary(path: str) -> bool:
     return "clang" in stem or stem in _CLANG_FAMILY_ALIAS_NAMES
 
 
+def _is_intel_sycl_driver(path: str) -> bool:
+    """True if *path* is Intel's oneAPI DPC++/C++ compiler (icx/icpx/dpcpp[-cl]).
+
+    These are the only clang-family drivers known to implement
+    ``-fsycl-host-only``/``-fsycl-device-only`` (Intel's SYCL
+    single-compilation-pass flags): stock upstream clang accepts a bare
+    ``-fsycl`` and parses it fine as a single pass, but hard-rejects both
+    flags with "unknown argument" (Codex review, PR #643: verified against a
+    real clang 17/18 install). Deliberately narrower than
+    :func:`_is_clang_family_binary` (which also matches plain
+    "clang"/"clang++") — widening this to that check would make
+    :func:`abicheck.dumper._needs_sycl_host_only` append a flag stock clang
+    cannot parse, breaking a ``--gcc-path clang`` + ``-fsycl`` combination
+    that previously worked.
+    """
+    return Path(path).stem.lower() in _CLANG_FAMILY_ALIAS_NAMES
+
+
 def _resolve_clang_bin(
     compiler: str,
     gcc_path: str | None,

--- a/abicheck/dumper_clang_errors.py
+++ b/abicheck/dumper_clang_errors.py
@@ -459,7 +459,10 @@ def retry_excluding_error_headers(
 
 
 def run_clang_to_ast_file(
-    cmd: list[str], *, timeout: float, on_created: Callable[[Path], None],
+    cmd: list[str],
+    *,
+    timeout: float,
+    on_created: Callable[[Path], None],
 ) -> subprocess.CompletedProcess[str]:
     """Run *cmd* with stdout spilled to a fresh temp file; return the result.
 
@@ -479,13 +482,20 @@ def run_clang_to_ast_file(
     on_created(path)
     with os.fdopen(fd, "wb") as out:
         return deadline.run_bounded(
-            cmd, stdout=out, stderr=subprocess.PIPE, text=True, timeout=timeout,
+            cmd,
+            stdout=out,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=timeout,
         )
 
 
 def _parse_clang_ast_result(
-    result: subprocess.CompletedProcess[str], cached: Path, ast_path: Path,
-    *, cache_write: bool = True,
+    result: subprocess.CompletedProcess[str],
+    cached: Path,
+    ast_path: Path,
+    *,
+    cache_write: bool = True,
 ) -> dict[str, Any]:
     """Validate a completed clang AST-dump, parse its JSON, and cache the tree.
 
@@ -530,7 +540,29 @@ def _parse_clang_ast_result(
         with open(ast_path, "rb") as fh:  # bytes: json detects encoding
             root = json.load(fh)
     except ValueError as exc:
-        raise SnapshotError(f"clang AST output was not valid JSON: {exc}") from exc
+        # "Extra data" means a second top-level JSON value follows the first —
+        # a driver flag that runs more than one -cc1 pass for this one compile
+        # (each with its own -Xclang -ast-dump=json) writes each pass's full
+        # document to this same stdout stream, back-to-back with no
+        # separator. A bare -fsycl is the known case (device pass + host
+        # pass; handled by auto-appending -fsycl-host-only, see
+        # dumper._needs_sycl_host_only), but any other multi-target offload
+        # flag (e.g. -fopenmp-targets=) that this codebase does not yet
+        # special-case would fail the same way — naming the likely cause here
+        # turns a cryptic byte-offset error into an actionable one.
+        hint = ""
+        if isinstance(exc, json.JSONDecodeError) and exc.msg == "Extra data":
+            hint = (
+                " -- this looks like more than one JSON document on stdout, "
+                "which happens when a compiler flag makes clang run multiple "
+                "-cc1 passes for one compile (e.g. a bare '-fsycl' without "
+                "'-fsycl-host-only'/'-fsycl-device-only', or an OpenMP/CUDA "
+                "offload target flag); pin a single compilation pass or use "
+                "--ast-frontend castxml"
+            )
+        raise SnapshotError(
+            f"clang AST output was not valid JSON: {exc}{hint}"
+        ) from exc
     # json.load() above can itself consume the remaining budget on a
     # multi-GB AST; re-check before the (also non-trivial, streamed) cache
     # copy so an expired deadline doesn't still complete it and hand the

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -118,7 +118,11 @@ def _is_gnu_compiler_resource_dir(path: str) -> bool:
     see the ``lib``/``gcc`` segments from the walked-back-out-of prefix and
     misclassify it. ``normpath`` only collapses ``.``/``..`` lexically (no
     filesystem access, no symlink resolution), keeping this pure/string-only
-    and unit-testable without a real toolchain.
+    and unit-testable without a real toolchain — a path traversing a symlink
+    needs OS-level (``realpath``) resolution for ``..`` to denote the same
+    directory the kernel would open, which is the caller's job when it wants
+    that guarantee (:func:`_probe_gnu_system_includes` does, since it already
+    knows *path* exists there).
     """
     parts = Path(os.path.normpath(path)).parts
     for prev, cur in zip(parts, parts[1:]):
@@ -137,6 +141,19 @@ def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
     :func:`_is_gnu_compiler_resource_dir`): feeding it to clang as
     ``-isystem`` makes clang use GCC's intrinsics headers, which reference
     GCC-only builtins clang does not implement and the parse fails.
+
+    The classifier itself only collapses ``.``/``..`` lexically
+    (``os.path.normpath``), which is correct as long as no traversed
+    component is a symlink — a symlink followed by ``..`` resolves relative
+    to the symlink's *target* directory at the OS level (``realpath``
+    semantics), not the symlink's own location, so lexical collapsing alone
+    can misjudge which directory an unresolved ``../``-bearing path actually
+    denotes. Classifying ``os.path.realpath(d)`` instead of the raw ``d``
+    here — safe and cheap since ``Path(d).is_dir()`` (short-circuiting
+    ``and``, evaluated first) has already confirmed ``d`` exists — makes the
+    decision symlink-correct for the one path that matters at runtime, while
+    :func:`_is_gnu_compiler_resource_dir` itself stays pure/string-only and
+    testable against synthetic paths that don't exist on disk (Codex review).
 
     Bounded by the tighter of its own 15s cap and the active deadline, and
     process-group-safe on timeout, same as the main clang/castxml subprocess
@@ -167,7 +184,7 @@ def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
     return [
         d
         for d in _parse_gnu_include_search_dirs(proc.stderr or "")
-        if Path(d).is_dir() and not _is_gnu_compiler_resource_dir(d)
+        if Path(d).is_dir() and not _is_gnu_compiler_resource_dir(os.path.realpath(d))
     ]
 
 

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -30,6 +30,7 @@ can inject them as ``-isystem``.
 Split out of :mod:`abicheck.dumper` (which is at the file-size soft limit) and
 re-exported there, so the public ``dumper._probe_*`` surface is unchanged.
 """
+
 from __future__ import annotations
 
 import os
@@ -106,10 +107,20 @@ def _is_gnu_compiler_resource_dir(path: str) -> bool:
 
     Matches the ``.../lib{,32,64,x32}/gcc[-cross]/<triple>/<ver>/include[-fixed]``
     layout by looking for a multilib library segment (:data:`_GNU_MULTILIB_DIRS`)
-    immediately followed by ``gcc``/``gcc-cross``. Pure/string-only so it is
-    unit-testable without a real toolchain.
+    immediately followed by ``gcc``/``gcc-cross``. The path is lexically
+    normalized (``os.path.normpath``) before splitting into parts: GCC and
+    Intel's icpx/icx report their ``-print-search-dirs``/``-v`` search paths
+    with the compiler's own install dir plus a literal ``../../../../`` walk
+    back up to the real location (e.g.
+    ``/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13``, which is
+    really ``/usr/include/c++/13`` — genuine libstdc++, not a GCC-internal
+    resource dir). Splitting the *unresolved* string into parts would still
+    see the ``lib``/``gcc`` segments from the walked-back-out-of prefix and
+    misclassify it. ``normpath`` only collapses ``.``/``..`` lexically (no
+    filesystem access, no symlink resolution), keeping this pure/string-only
+    and unit-testable without a real toolchain.
     """
-    parts = Path(path).parts
+    parts = Path(os.path.normpath(path)).parts
     for prev, cur in zip(parts, parts[1:]):
         if cur in _GNU_COMPILER_RESOURCE_SEGMENTS and prev in _GNU_MULTILIB_DIRS:
             return True
@@ -214,9 +225,7 @@ def _pass_through_suppresses_probe(
     if gcc_options and any(f in gcc_options for f in _PROBE_SUPPRESSING_FLAGS):
         return True
     return any(
-        tok.startswith(f)
-        for tok in gcc_option_tokens
-        for f in _PROBE_SUPPRESSING_FLAGS
+        tok.startswith(f) for tok in gcc_option_tokens for f in _PROBE_SUPPRESSING_FLAGS
     )
 
 

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -190,27 +190,48 @@ def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
     to the symlink's *target* directory at the OS level (``realpath``
     semantics), not the symlink's own location, so lexical collapsing alone
     can misjudge which directory an unresolved ``../``-bearing path actually
-    denotes. Classifying ``os.path.realpath(d)`` in *addition to* the raw
-    ``d`` — safe and cheap since ``Path(d).is_dir()`` (short-circuiting
-    ``and``, evaluated first) has already confirmed ``d`` exists — catches
-    that case (Codex review).
+    denotes.
 
-    Neither check alone is sufficient, so a path is dropped if *either*
-    flags it (never AND): a terminal symlink — the canonical, no-``..``
-    ``.../lib/gcc/<triple>/<ver>/include`` path itself is a symlink to
-    storage physically outside any ``lib/gcc`` hierarchy — is exactly the
-    opposite failure from the ``../``-walk-back case above. There
-    ``realpath`` corrects a lexical false negative (a real GCC-internal dir
-    that lexical collapsing alone would wrongly keep); here ``realpath``
-    alone would introduce a false negative of its own, losing the lexical
-    evidence that GCC itself names this its resource dir regardless of what
-    the symlink ultimately resolves to, and clang would get fed GCC's
-    incompatible intrinsics headers found via that resolved location
-    (Codex review, round 2 — confirmed with a real symlink where the raw
-    classifier returns ``True`` and a realpath-only classifier would have
-    returned ``False``). :func:`_is_gnu_compiler_resource_dir` itself stays
-    pure/string-only and testable against synthetic paths that don't exist
-    on disk either way.
+    Classifying the raw string ``d`` and its ``os.path.realpath(d)`` can each
+    be wrong depending on *why* the path is ambiguous, so which one to trust
+    is decided by whether ``d`` contains a literal ``..`` component at all
+    (:func:`Path(d).parts <pathlib.PurePath.parts>` keeps ``..`` as its own
+    element — unlike ``normpath``, it is not collapsed just by asking for
+    ``.parts``) — never both via ``or``:
+
+    - **No ``..`` at all** (the compiler reported the directory verbatim,
+      possibly itself a symlink): trust the *raw* string. A terminal
+      symlink — the canonical ``.../lib/gcc/<triple>/<ver>/include`` path
+      itself symlinked to storage outside any ``lib/gcc`` hierarchy — must
+      still classify as GCC's resource dir by the name it was reported
+      under; ``realpath`` would resolve straight past that lexical evidence
+      and wrongly keep it, feeding clang GCC's incompatible intrinsics
+      headers (Codex review, round 2 — confirmed with a real symlink where
+      the raw classifier returns ``True`` and a realpath-only classifier
+      would have returned ``False``).
+    - **``..`` is present**: trust *only* ``os.path.realpath(d)`` — safe and
+      cheap since ``Path(d).is_dir()`` (short-circuiting ``and``, evaluated
+      first) has already confirmed ``d`` exists. Once a path traverses a
+      ``..``, the lexical string can no longer be trusted either way: it can
+      wrongly say "not a resource dir" when a symlinked path component makes
+      the walk-back land back inside GCC's tree (round 1), or wrongly say
+      "is a resource dir" when a symlinked *mid-path* component makes a
+      lexically resource-shaped string actually resolve to a real,
+      unrelated system include dir elsewhere — confirmed with
+      ``.../lib/gcc/<triple>/<ver>/hop/../include`` where ``hop`` symlinks
+      to ``<external>/deep``: lexically this collapses right back to the
+      resource shape, but the compiler's ``open()`` call actually lands on
+      ``<external>/include``, a real, unrelated dir that must be *kept*
+      (Codex review, round 7). Checking the raw string in *addition to*
+      realpath here — as an earlier version of this fix did — would
+      wrongly drop that real include dir on the lexical match alone; only
+      realpath is trustworthy once ``..`` is involved, so ``or``-ing it
+      with the raw check is never correct, only checking realpath alone is.
+
+    :func:`_is_gnu_compiler_resource_dir` itself stays pure/string-only and
+    testable against synthetic paths that don't exist on disk either way —
+    this ``..``-presence decision lives here, in the one caller that already
+    knows the path exists and can afford a ``realpath`` syscall.
 
     Bounded by the tighter of its own 15s cap and the active deadline, and
     process-group-safe on timeout, same as the main clang/castxml subprocess
@@ -242,9 +263,8 @@ def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
         d
         for d in _parse_gnu_include_search_dirs(proc.stderr or "")
         if Path(d).is_dir()
-        and not (
-            _is_gnu_compiler_resource_dir(d)
-            or _is_gnu_compiler_resource_dir(os.path.realpath(d))
+        and not _is_gnu_compiler_resource_dir(
+            os.path.realpath(d) if ".." in Path(d).parts else d
         )
     ]
 

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -173,6 +173,22 @@ def _is_gnu_compiler_resource_dir(path: str) -> bool:
     return False
 
 
+def _is_gnu_compiler_resource_dir_for_existing(d: str) -> bool:
+    """Symlink-aware wrapper around :func:`_is_gnu_compiler_resource_dir`.
+
+    Only correct to call once the caller already knows *d* exists on disk
+    (:func:`_probe_gnu_system_includes` checks ``Path(d).is_dir()`` first) —
+    see that function's docstring for the full reasoning on why the raw
+    string and ``os.path.realpath(d)`` are combined differently depending on
+    whether *d* contains a literal ``..`` component.
+    """
+    if ".." in Path(d).parts:
+        return _is_gnu_compiler_resource_dir(os.path.realpath(d))
+    return _is_gnu_compiler_resource_dir(d) or _is_gnu_compiler_resource_dir(
+        os.path.realpath(d)
+    )
+
+
 def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
     """Probe *cc_bin* for the system include dirs it would search (best-effort).
 
@@ -200,15 +216,31 @@ def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
     ``.parts``) — never both via ``or``:
 
     - **No ``..`` at all** (the compiler reported the directory verbatim,
-      possibly itself a symlink): trust the *raw* string. A terminal
-      symlink — the canonical ``.../lib/gcc/<triple>/<ver>/include`` path
-      itself symlinked to storage outside any ``lib/gcc`` hierarchy — must
-      still classify as GCC's resource dir by the name it was reported
-      under; ``realpath`` would resolve straight past that lexical evidence
-      and wrongly keep it, feeding clang GCC's incompatible intrinsics
-      headers (Codex review, round 2 — confirmed with a real symlink where
-      the raw classifier returns ``True`` and a realpath-only classifier
-      would have returned ``False``).
+      possibly itself a symlink): check *both* the raw string and its
+      ``realpath`` — reject if *either* matches (an ``or``, safe here since
+      there is no ``..`` to make the lexical form ambiguous). Two
+      independent, mirror-image hazards need both directions covered:
+      (a) a terminal symlink — the canonical
+      ``.../lib/gcc/<triple>/<ver>/include`` path itself symlinked to
+      storage outside any ``lib/gcc`` hierarchy — must still classify as
+      GCC's resource dir by the name it was reported under; ``realpath``
+      alone would resolve straight past that lexical evidence and wrongly
+      keep it, feeding clang GCC's incompatible intrinsics headers (Codex
+      review, round 2 — confirmed with a real symlink where the raw
+      classifier returns ``True`` and a realpath-only classifier would have
+      returned ``False``); (b) the mirror case — an arbitrary alias path
+      (e.g. ``/opt/toolchain/include``, nothing resource-shaped about the
+      name itself) that is a symlink *to* the real resource dir — must
+      classify as a resource dir too; the raw string alone would miss that
+      evidence entirely, wrongly keeping GCC's intrinsics headers under an
+      innocuous-looking alias (Codex review, round 8 — confirmed with a
+      real symlink where the raw classifier returns ``False`` and the
+      realpath classifier returns ``True``). Neither direction is safe to
+      skip, but combining them with ``or`` here introduces no new false
+      positive: a real libstdc++/libc dir's own raw name or its resolved
+      target coincidentally matching the *exact* GCC resource shape would
+      have to be GCC's own resource dir to begin with (round 3 already
+      established the shape is that precise).
     - **``..`` is present**: trust *only* ``os.path.realpath(d)`` — safe and
       cheap since ``Path(d).is_dir()`` (short-circuiting ``and``, evaluated
       first) has already confirmed ``d`` exists. Once a path traverses a
@@ -230,8 +262,10 @@ def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
 
     :func:`_is_gnu_compiler_resource_dir` itself stays pure/string-only and
     testable against synthetic paths that don't exist on disk either way —
-    this ``..``-presence decision lives here, in the one caller that already
-    knows the path exists and can afford a ``realpath`` syscall.
+    this ``..``-presence decision lives in
+    :func:`_is_gnu_compiler_resource_dir_for_existing`, called only from
+    here, the one place that already knows the path exists and can afford a
+    ``realpath`` syscall.
 
     Bounded by the tighter of its own 15s cap and the active deadline, and
     process-group-safe on timeout, same as the main clang/castxml subprocess
@@ -262,10 +296,7 @@ def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
     return [
         d
         for d in _parse_gnu_include_search_dirs(proc.stderr or "")
-        if Path(d).is_dir()
-        and not _is_gnu_compiler_resource_dir(
-            os.path.realpath(d) if ".." in Path(d).parts else d
-        )
+        if Path(d).is_dir() and not _is_gnu_compiler_resource_dir_for_existing(d)
     ]
 
 

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -135,16 +135,42 @@ def _is_gnu_compiler_resource_dir(path: str) -> bool:
     directory the kernel would open, which is the caller's job when it wants
     that guarantee (:func:`_probe_gnu_system_includes` does, since it already
     knows *path* exists there).
+
+    Also matches Homebrew's packaged GCC layout, which nests an *extra*
+    alias segment and a second ``gcc``/``gcc-cross`` segment:
+    ``.../lib{,32,64,x32}/gcc[-cross]/current/gcc[-cross]/<triple>/<ver>/
+    include[-fixed]`` (confirmed against a real Homebrew GCC install: its
+    build is configured with ``--libdir=<prefix>/lib/gcc/current``, and
+    GCC's own build script always appends ``gcc/<target>/<version>`` beneath
+    whatever libdir it is given, regardless of prefix — so the literal
+    ``gcc`` segment reappears a second time, with Homebrew's version-alias
+    ``current`` sitting between the two occurrences; Codex review, PR #643,
+    round 6). The alias segment's value is not checked (only its structural
+    position between the two ``gcc`` segments) — genuinely arbitrary,
+    Homebrew just always spells it ``current`` in practice — so this stays a
+    *structural* shape match, not a hardcoded special case for that one
+    string, and does not loosen the leaf/gcc-segment checks that keep a
+    merely-nested libstdc++ dir (round 3) excluded.
     """
     parts = Path(os.path.normpath(path)).parts
-    if len(parts) < 5:
-        return False
-    multilib, gcc_segment, _triple, _ver, leaf = parts[-5:]
-    return (
-        leaf in ("include", "include-fixed")
-        and gcc_segment in _GNU_COMPILER_RESOURCE_SEGMENTS
-        and multilib in _GNU_MULTILIB_DIRS
-    )
+    if len(parts) >= 5:
+        multilib, gcc_segment, _triple, _ver, leaf = parts[-5:]
+        if (
+            leaf in ("include", "include-fixed")
+            and gcc_segment in _GNU_COMPILER_RESOURCE_SEGMENTS
+            and multilib in _GNU_MULTILIB_DIRS
+        ):
+            return True
+    if len(parts) >= 7:
+        multilib, gcc_segment, _alias, gcc_segment2, _triple, _ver, leaf = parts[-7:]
+        if (
+            leaf in ("include", "include-fixed")
+            and gcc_segment2 in _GNU_COMPILER_RESOURCE_SEGMENTS
+            and gcc_segment in _GNU_COMPILER_RESOURCE_SEGMENTS
+            and multilib in _GNU_MULTILIB_DIRS
+        ):
+            return True
+    return False
 
 
 def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -148,12 +148,27 @@ def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
     to the symlink's *target* directory at the OS level (``realpath``
     semantics), not the symlink's own location, so lexical collapsing alone
     can misjudge which directory an unresolved ``../``-bearing path actually
-    denotes. Classifying ``os.path.realpath(d)`` instead of the raw ``d``
-    here — safe and cheap since ``Path(d).is_dir()`` (short-circuiting
-    ``and``, evaluated first) has already confirmed ``d`` exists — makes the
-    decision symlink-correct for the one path that matters at runtime, while
-    :func:`_is_gnu_compiler_resource_dir` itself stays pure/string-only and
-    testable against synthetic paths that don't exist on disk (Codex review).
+    denotes. Classifying ``os.path.realpath(d)`` in *addition to* the raw
+    ``d`` — safe and cheap since ``Path(d).is_dir()`` (short-circuiting
+    ``and``, evaluated first) has already confirmed ``d`` exists — catches
+    that case (Codex review).
+
+    Neither check alone is sufficient, so a path is dropped if *either*
+    flags it (never AND): a terminal symlink — the canonical, no-``..``
+    ``.../lib/gcc/<triple>/<ver>/include`` path itself is a symlink to
+    storage physically outside any ``lib/gcc`` hierarchy — is exactly the
+    opposite failure from the ``../``-walk-back case above. There
+    ``realpath`` corrects a lexical false negative (a real GCC-internal dir
+    that lexical collapsing alone would wrongly keep); here ``realpath``
+    alone would introduce a false negative of its own, losing the lexical
+    evidence that GCC itself names this its resource dir regardless of what
+    the symlink ultimately resolves to, and clang would get fed GCC's
+    incompatible intrinsics headers found via that resolved location
+    (Codex review, round 2 — confirmed with a real symlink where the raw
+    classifier returns ``True`` and a realpath-only classifier would have
+    returned ``False``). :func:`_is_gnu_compiler_resource_dir` itself stays
+    pure/string-only and testable against synthetic paths that don't exist
+    on disk either way.
 
     Bounded by the tighter of its own 15s cap and the active deadline, and
     process-group-safe on timeout, same as the main clang/castxml subprocess
@@ -184,7 +199,11 @@ def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:
     return [
         d
         for d in _parse_gnu_include_search_dirs(proc.stderr or "")
-        if Path(d).is_dir() and not _is_gnu_compiler_resource_dir(os.path.realpath(d))
+        if Path(d).is_dir()
+        and not (
+            _is_gnu_compiler_resource_dir(d)
+            or _is_gnu_compiler_resource_dir(os.path.realpath(d))
+        )
     ]
 
 

--- a/abicheck/dumper_sysinc.py
+++ b/abicheck/dumper_sysinc.py
@@ -105,13 +105,25 @@ _GNU_MULTILIB_DIRS = frozenset({"lib", "lib32", "lib64", "libx32"})
 def _is_gnu_compiler_resource_dir(path: str) -> bool:
     """True if *path* is a GCC compiler-internal include dir (not libstdc++/libc).
 
-    Matches the ``.../lib{,32,64,x32}/gcc[-cross]/<triple>/<ver>/include[-fixed]``
-    layout by looking for a multilib library segment (:data:`_GNU_MULTILIB_DIRS`)
-    immediately followed by ``gcc``/``gcc-cross``. The path is lexically
-    normalized (``os.path.normpath``) before splitting into parts: GCC and
-    Intel's icpx/icx report their ``-print-search-dirs``/``-v`` search paths
-    with the compiler's own install dir plus a literal ``../../../../`` walk
-    back up to the real location (e.g.
+    Matches the full ``.../lib{,32,64,x32}/gcc[-cross]/<triple>/<ver>/include
+    [-fixed]`` shape at the *end* of the path — the multilib segment
+    (:data:`_GNU_MULTILIB_DIRS`) immediately followed by ``gcc``/``gcc-cross``,
+    then exactly a ``<triple>`` and a ``<ver>`` segment, then a final
+    ``include``/``include-fixed`` segment — rather than merely scanning for a
+    multilib+``gcc`` pair anywhere in the path. A scan-anywhere check
+    over-matches: a real libstdc++/libc dir can legitimately live *underneath*
+    a ``lib/gcc/...`` tree without being GCC's own resource dir itself (e.g.
+    ``.../lib/gcc/<triple>/<ver>/include/c++/<ver>`` — real ``std::`` headers
+    a distro nests inside its GCC install, not GCC's own intrinsics/builtins
+    dir), and would be wrongly dropped, starving clang of real stdlib headers
+    (Codex review, PR #643, round 3). Requiring the exact trailing shape
+    means only the literal resource dir itself (or ``include-fixed``) matches,
+    not anything merely nested inside the same ``lib/gcc`` subtree.
+
+    The path is lexically normalized (``os.path.normpath``) before splitting
+    into parts: GCC and Intel's icpx/icx report their ``-print-search-dirs``/
+    ``-v`` search paths with the compiler's own install dir plus a literal
+    ``../../../../`` walk back up to the real location (e.g.
     ``/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13``, which is
     really ``/usr/include/c++/13`` — genuine libstdc++, not a GCC-internal
     resource dir). Splitting the *unresolved* string into parts would still
@@ -125,10 +137,14 @@ def _is_gnu_compiler_resource_dir(path: str) -> bool:
     knows *path* exists there).
     """
     parts = Path(os.path.normpath(path)).parts
-    for prev, cur in zip(parts, parts[1:]):
-        if cur in _GNU_COMPILER_RESOURCE_SEGMENTS and prev in _GNU_MULTILIB_DIRS:
-            return True
-    return False
+    if len(parts) < 5:
+        return False
+    multilib, gcc_segment, _triple, _ver, leaf = parts[-5:]
+    return (
+        leaf in ("include", "include-fixed")
+        and gcc_segment in _GNU_COMPILER_RESOURCE_SEGMENTS
+        and multilib in _GNU_MULTILIB_DIRS
+    )
 
 
 def _probe_gnu_system_includes(cc_bin: str, *, cpp: bool) -> list[str]:

--- a/changelog.d/20260726_claude_gnu_compiler_resource_dir_normpath.md
+++ b/changelog.d/20260726_claude_gnu_compiler_resource_dir_normpath.md
@@ -1,0 +1,22 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **`_is_gnu_compiler_resource_dir` compared unresolved path segments**
+  (castxml↔clang system-include parity, `dumper_sysinc.py`): the classifier
+  walked `Path(path).parts` on the *raw, unresolved* string a host
+  compiler's `-v` probe reports, without normalizing it first. GCC and
+  Intel's `icpx`/`icx` both report real search dirs with a literal
+  `../../../../` walk-back baked in (e.g.
+  `/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13`, which is
+  really `/usr/include/c++/13` — genuine libstdc++, not GCC's own resource
+  dir). Because the string was never normalized, the `lib`/`gcc` segments
+  from the walked-*through* prefix still matched, and a real libstdc++/libc
+  dir was misclassified as GCC's compiler-internal resource dir and dropped
+  from the probe results — silently narrowing the `-isystem` dirs injected
+  into the clang L2 backend on any host using this reporting style. Fixed
+  by lexically normalizing (`os.path.normpath`, no filesystem access or
+  symlink resolution) before splitting into parts, so `..` segments collapse
+  before the multilib/`gcc` match runs.

--- a/changelog.d/20260726_claude_gnu_resource_dir_shape_tightening.md
+++ b/changelog.d/20260726_claude_gnu_resource_dir_shape_tightening.md
@@ -1,0 +1,23 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **`_is_gnu_compiler_resource_dir` over-matched any `lib`/`gcc` adjacency,
+  not just GCC's actual resource dir** (follow-up to the `realpath`
+  symlink-awareness fix above, `dumper_sysinc.py`): the classifier scanned
+  for a multilib segment (`lib`/`lib32`/`lib64`/`libx32`) immediately
+  followed by `gcc`/`gcc-cross` *anywhere* in the path, so a real
+  libstdc++/libc dir merely nested somewhere underneath a
+  `lib/gcc/<triple>/<ver>/...` tree — not GCC's own intrinsics dir itself —
+  was misclassified as the resource dir and dropped, starving clang of real
+  standard-library headers (Codex review, PR #643, round 3; concretely
+  demonstrated with a `-isystem` dir reached via a symlink whose target
+  physically resolves under a `lib/gcc` tree, e.g.
+  `/opt/lib/gcc/toolchain/13/include/c++/13`). Tightened to match the *full*
+  documented shape at the end of the path —
+  `lib{,32,64,x32}/gcc[-cross]/<triple>/<ver>/include[-fixed]`, exactly five
+  trailing segments — instead of a bare adjacency scan, so only the literal
+  resource dir (or `include-fixed`) matches, not anything merely living
+  inside the same subtree.

--- a/changelog.d/20260726_claude_gnu_resource_dir_shape_tightening.md
+++ b/changelog.d/20260726_claude_gnu_resource_dir_shape_tightening.md
@@ -20,4 +20,14 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   `lib{,32,64,x32}/gcc[-cross]/<triple>/<ver>/include[-fixed]`, exactly five
   trailing segments — instead of a bare adjacency scan, so only the literal
   resource dir (or `include-fixed`) matches, not anything merely living
-  inside the same subtree.
+  inside the same subtree. Also recognizes Homebrew's packaged GCC, which
+  nests an *extra* alias segment and a second literal `gcc` segment —
+  `.../lib{,32,64,x32}/gcc[-cross]/current/gcc[-cross]/<triple>/<ver>/
+  include[-fixed]` — since its build is configured with
+  `--libdir=<prefix>/lib/gcc/current` and GCC's own build script always
+  appends `gcc/<target>/<version>` beneath whatever libdir it is given,
+  regardless of prefix (confirmed against a real Homebrew GCC install;
+  Codex review, PR #643, round 6). Without this, that nested shape fell
+  through both the classic 5-segment check and the earlier over-broad
+  adjacency scan, so Homebrew's own resource dir was wrongly kept and fed
+  to clang as `-isystem`, breaking the parse on GCC-only builtins.

--- a/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
+++ b/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
@@ -41,7 +41,18 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   JSON error message to name this class of cause (multiple `-cc1` passes
   from one compile, e.g. an unpinned `-fsycl` on an Intel driver, or an
   OpenMP/CUDA offload target flag) instead of a bare byte-offset, for any
-  future flag combination that hits the same multi-document shape.
+  future flag combination that hits the same multi-document shape. Intel's
+  legacy, now-deprecated `dpcpp`/`dpcpp-cl` driver names can imply SYCL is
+  already on even with no `-fsycl` token at all (they predate `icx`/`icpx`'s
+  explicit opt-in), so `_needs_sycl_host_only`'s effective-state scan now
+  starts from `dumper_clang._dpcpp_defaults_sycl_on(cc_bin)` instead of
+  always `False` — an explicit `-fno-sycl` still overrides that default via
+  the same last-flag-wins scan (Codex review, PR #643, round 8; not
+  independently confirmed against the open-source intel/llvm driver, which
+  shows `-fsycl` defaulting to off regardless of binary name, but guarded
+  for anyway given the asymmetric cost — an unused, harmless
+  `-fsycl-host-only` on a false positive vs. silently reintroducing the
+  double-JSON-document failure on a false negative).
 - **`_is_gnu_compiler_resource_dir` (follow-up to the `normpath` fix above):
   a symlinked path component made lexical `..` collapsing wrong** — a
   symlink followed by `..` resolves relative to the symlink's *target*
@@ -53,17 +64,23 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   path (e.g. `.../lib/gcc/<triple>/<ver>/include` symlinked to storage
   outside any `lib/gcc` hierarchy) loses the lexical evidence that this is
   GCC's resource dir (round 2). Checking *both* the raw string and
-  `os.path.realpath(d)` — rejecting a directory when either matches — fixes
-  round 2 but is itself wrong once `..` is present: a *mid-path* symlink
-  (e.g. `.../lib/gcc/<triple>/<ver>/hop/../include` where `hop` symlinks
-  elsewhere) can lexically collapse right back to the resource shape while
-  physically resolving to a real, unrelated system include dir that must be
-  *kept* — checking the raw string here wrongly drops it (round 7).
-  `_probe_gnu_system_includes` now picks exactly one of the two checks
-  based on whether the raw reported string contains a literal `..`
-  component at all: no `..` → trust only the raw string (round 2's case);
-  `..` present → trust only `os.path.realpath(d)` (rounds 1 and 7's case) —
-  safe since the directory's existence (`Path(d).is_dir()`) is already
-  confirmed by that point — never both via `or`. `_is_gnu_compiler_resource_dir`
-  itself keeps its lexical-only, pure/string-testable contract for callers
-  that don't have (or need) a real path on disk.
+  `os.path.realpath(d)` unconditionally — rejecting a directory when either
+  matches — fixes round 2 but is itself wrong once `..` is present: a
+  *mid-path* symlink (e.g. `.../lib/gcc/<triple>/<ver>/hop/../include` where
+  `hop` symlinks elsewhere) can lexically collapse right back to the
+  resource shape while physically resolving to a real, unrelated system
+  include dir that must be *kept* — checking the raw string here wrongly
+  drops it (round 7). New helper
+  `_is_gnu_compiler_resource_dir_for_existing` now picks based on whether
+  the raw reported string contains a literal `..` component at all: no `..`
+  → check *both* the raw string and its `os.path.realpath(d)`, rejecting if
+  *either* matches (round 2's terminal-symlink case, plus its mirror —
+  round 8 — an arbitrary, non-resource-shaped alias symlinked *to* the real
+  resource dir, which the raw-only check alone would miss); `..` present →
+  trust *only* `os.path.realpath(d)` (rounds 1 and 7's case, where the raw
+  string can no longer be trusted in either direction once a symlink sits
+  ahead of a `..`) — safe since the directory's existence
+  (`Path(d).is_dir()`) is already confirmed by that point.
+  `_is_gnu_compiler_resource_dir` itself keeps its lexical-only,
+  pure/string-testable contract for callers that don't have (or need) a
+  real path on disk.

--- a/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
+++ b/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
@@ -41,9 +41,14 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   directory at the OS level, not the symlink's own location, so purely
   lexical normalization can misjudge which directory an unresolved
   `../`-bearing search-dir path actually denotes (Codex review, PR #643).
-  `_probe_gnu_system_includes` now classifies `os.path.realpath(d)` instead
-  of the raw reported string — safe since the directory's existence
-  (`Path(d).is_dir()`) is already confirmed by that point — while
-  `_is_gnu_compiler_resource_dir` itself keeps its lexical-only, pure/
-  string-testable contract for callers that don't have (or need) a real
-  path on disk.
+  Classifying only `os.path.realpath(d)` fixes that but reintroduces the
+  opposite failure — a *terminal* symlink at GCC's own canonical resource
+  path (e.g. `.../lib/gcc/<triple>/<ver>/include` symlinked to storage
+  outside any `lib/gcc` hierarchy) loses the lexical evidence that this is
+  GCC's resource dir, so `_probe_gnu_system_includes` now rejects a
+  directory when *either* the raw reported string or its
+  `os.path.realpath(d)` classifies as a resource dir — safe since the
+  directory's existence (`Path(d).is_dir()`) is already confirmed by that
+  point — while `_is_gnu_compiler_resource_dir` itself keeps its
+  lexical-only, pure/string-testable contract for callers that don't have
+  (or need) a real path on disk.

--- a/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
+++ b/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
@@ -52,10 +52,18 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   opposite failure — a *terminal* symlink at GCC's own canonical resource
   path (e.g. `.../lib/gcc/<triple>/<ver>/include` symlinked to storage
   outside any `lib/gcc` hierarchy) loses the lexical evidence that this is
-  GCC's resource dir, so `_probe_gnu_system_includes` now rejects a
-  directory when *either* the raw reported string or its
-  `os.path.realpath(d)` classifies as a resource dir — safe since the
-  directory's existence (`Path(d).is_dir()`) is already confirmed by that
-  point — while `_is_gnu_compiler_resource_dir` itself keeps its
-  lexical-only, pure/string-testable contract for callers that don't have
-  (or need) a real path on disk.
+  GCC's resource dir (round 2). Checking *both* the raw string and
+  `os.path.realpath(d)` — rejecting a directory when either matches — fixes
+  round 2 but is itself wrong once `..` is present: a *mid-path* symlink
+  (e.g. `.../lib/gcc/<triple>/<ver>/hop/../include` where `hop` symlinks
+  elsewhere) can lexically collapse right back to the resource shape while
+  physically resolving to a real, unrelated system include dir that must be
+  *kept* — checking the raw string here wrongly drops it (round 7).
+  `_probe_gnu_system_includes` now picks exactly one of the two checks
+  based on whether the raw reported string contains a literal `..`
+  component at all: no `..` → trust only the raw string (round 2's case);
+  `..` present → trust only `os.path.realpath(d)` (rounds 1 and 7's case) —
+  safe since the directory's existence (`Path(d).is_dir()`) is already
+  confirmed by that point — never both via `or`. `_is_gnu_compiler_resource_dir`
+  itself keeps its lexical-only, pure/string-testable contract for callers
+  that don't have (or need) a real path on disk.

--- a/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
+++ b/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
@@ -1,0 +1,39 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **`--ast-frontend clang` + `-fsycl` produced two concatenated JSON documents
+  on stdout, breaking `json.load()`** (`abicheck/dumper.py`,
+  `abicheck/dumper_clang_errors.py`): a bare `-fsycl` makes a SYCL-capable
+  driver (Intel's `icpx`/`dpcpp`, or upstream clang's own SYCL support) run
+  *two* separate `-cc1` passes for one compile — a SYCL device-side pass
+  (`-fsycl-is-device`) and a SYCL host-side pass (`-fsycl-is-host`) — each
+  with its own `-Xclang -ast-dump=json`, both writing a complete JSON
+  document to the same stdout stream abicheck captures, back-to-back with no
+  separator. `json.load()` parsed only the first document and raised
+  `Extra data: line N column 2 (char M)` on the leftover bytes (confirmed on
+  oneDAL's `cpp/oneapi/dal.hpp`, which transitively includes
+  `<sycl/sycl.hpp>`). `_build_clang_header_command` now appends
+  `-fsycl-host-only` whenever `-fsycl` is present in `--gcc-options`/
+  `--gcc-option` without an explicit `-fsycl-host-only`/`-fsycl-device-only`
+  already pinning a single pass — collapsing the compile back to the
+  single host-side AST that actually matches what links into the scanned
+  `.so` (the device pass's SPIR-V kernel code never does). Also improved
+  `_parse_clang_ast_result`'s JSON error message to name this class of cause
+  (multiple `-cc1` passes from one compile, e.g. an unpinned `-fsycl` or an
+  OpenMP/CUDA offload target flag) instead of a bare byte-offset, for any
+  future flag combination that hits the same multi-document shape.
+- **`_is_gnu_compiler_resource_dir` (follow-up to the `normpath` fix above):
+  a symlinked path component made lexical `..` collapsing wrong** — a
+  symlink followed by `..` resolves relative to the symlink's *target*
+  directory at the OS level, not the symlink's own location, so purely
+  lexical normalization can misjudge which directory an unresolved
+  `../`-bearing search-dir path actually denotes (Codex review, PR #643).
+  `_probe_gnu_system_includes` now classifies `os.path.realpath(d)` instead
+  of the raw reported string — safe since the directory's existence
+  (`Path(d).is_dir()`) is already confirmed by that point — while
+  `_is_gnu_compiler_resource_dir` itself keeps its lexical-only, pure/
+  string-testable contract for callers that don't have (or need) a real
+  path on disk.

--- a/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
+++ b/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
@@ -30,7 +30,14 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   "unknown argument" — appending the flag unconditionally would have turned
   a working `--gcc-path clang` + `-fsycl` parse into a guaranteed failure
   (Codex review, PR #643, caught after an initial version of this fix keyed
-  only on `-fsycl`'s presence). Also improved `_parse_clang_ast_result`'s
+  only on `-fsycl`'s presence). The gate also tracks the *effective* SYCL
+  state rather than a bare membership check: the clang driver applies
+  `-fsycl`/`-fno-sycl` last-flag-wins like any other toggle (confirmed with
+  `clang++ -fsycl -fno-sycl -###`, which emits one ordinary host `-cc1`, no
+  device pass), so `--gcc-options "-fsycl -fno-sycl"` has SYCL disabled
+  overall and must not get `-fsycl-host-only` appended either — that would
+  tack a SYCL-only selector onto a non-SYCL compile (Codex review, PR #643,
+  round 5). Also improved `_parse_clang_ast_result`'s
   JSON error message to name this class of cause (multiple `-cc1` passes
   from one compile, e.g. an unpinned `-fsycl` on an Intel driver, or an
   OpenMP/CUDA offload target flag) instead of a bare byte-offset, for any

--- a/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
+++ b/changelog.d/20260726_claude_sycl_double_json_and_symlink_followup.md
@@ -4,11 +4,12 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
 
 ### Fixed
 
-- **`--ast-frontend clang` + `-fsycl` produced two concatenated JSON documents
-  on stdout, breaking `json.load()`** (`abicheck/dumper.py`,
-  `abicheck/dumper_clang_errors.py`): a bare `-fsycl` makes a SYCL-capable
-  driver (Intel's `icpx`/`dpcpp`, or upstream clang's own SYCL support) run
-  *two* separate `-cc1` passes for one compile — a SYCL device-side pass
+- **`--ast-frontend clang` + `-fsycl` on Intel's oneAPI driver produced two
+  concatenated JSON documents on stdout, breaking `json.load()`**
+  (`abicheck/dumper.py`, `abicheck/dumper_clang.py`,
+  `abicheck/dumper_clang_errors.py`): a bare `-fsycl` makes Intel's oneAPI
+  DPC++/C++ driver (`icx`/`icpx`/`dpcpp`/`dpcpp-cl`) run *two* separate
+  `-cc1` passes for one compile — a SYCL device-side pass
   (`-fsycl-is-device`) and a SYCL host-side pass (`-fsycl-is-host`) — each
   with its own `-Xclang -ast-dump=json`, both writing a complete JSON
   document to the same stdout stream abicheck captures, back-to-back with no
@@ -17,12 +18,21 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   oneDAL's `cpp/oneapi/dal.hpp`, which transitively includes
   `<sycl/sycl.hpp>`). `_build_clang_header_command` now appends
   `-fsycl-host-only` whenever `-fsycl` is present in `--gcc-options`/
-  `--gcc-option` without an explicit `-fsycl-host-only`/`-fsycl-device-only`
-  already pinning a single pass — collapsing the compile back to the
-  single host-side AST that actually matches what links into the scanned
-  `.so` (the device pass's SPIR-V kernel code never does). Also improved
-  `_parse_clang_ast_result`'s JSON error message to name this class of cause
-  (multiple `-cc1` passes from one compile, e.g. an unpinned `-fsycl` or an
+  `--gcc-option` *and* the resolved compiler is specifically one of those
+  Intel aliases (new `dumper_clang._is_intel_sycl_driver`), without an
+  explicit `-fsycl-host-only`/`-fsycl-device-only` already pinning a single
+  pass — collapsing the compile back to the single host-side AST that
+  actually matches what links into the scanned `.so` (the device pass's
+  SPIR-V kernel code never does). The gate is deliberately narrower than
+  "any clang-family binary": stock upstream clang also accepts a bare
+  `-fsycl` and parses it fine as one pass, but does not recognize either
+  `-fsycl-host-only` or `-fsycl-device-only` and hard-rejects them with
+  "unknown argument" — appending the flag unconditionally would have turned
+  a working `--gcc-path clang` + `-fsycl` parse into a guaranteed failure
+  (Codex review, PR #643, caught after an initial version of this fix keyed
+  only on `-fsycl`'s presence). Also improved `_parse_clang_ast_result`'s
+  JSON error message to name this class of cause (multiple `-cc1` passes
+  from one compile, e.g. an unpinned `-fsycl` on an Intel driver, or an
   OpenMP/CUDA offload target flag) instead of a bare byte-offset, for any
   future flag combination that hits the same multi-document shape.
 - **`_is_gnu_compiler_resource_dir` (follow-up to the `normpath` fix above):

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -452,6 +452,16 @@ def test_probe_gnu_system_includes_bounded_by_local_cap_not_full_scan_budget(
         # back to the same resource path (not walked all the way out).
         ("/usr/lib/gcc/x86_64-linux-gnu/13/./include", True),
         ("/usr/lib/gcc/x86_64-linux-gnu/13/sub/../include-fixed", True),
+        # A real libstdc++ dir merely NESTED inside a lib/gcc/<triple>/<ver>
+        # tree (not the resource dir itself) must stay False: a scan for "any
+        # multilib+gcc pair" over-matches every descendant of that tree, not
+        # just the literal .../include[-fixed] resource dir (Codex review, PR
+        # #643, round 3).
+        ("/opt/lib/gcc/toolchain/13/include/c++/13", False),
+        ("/usr/lib/gcc/x86_64-linux-gnu/13/include/c++/13", False),
+        # A trailing segment after 'include'/'include-fixed' breaks the exact
+        # end-of-path shape -- this is not the resource dir itself either.
+        ("/usr/lib/gcc/x86_64-linux-gnu/13/include/nested", False),
     ],
 )
 def test_is_gnu_compiler_resource_dir(path: str, expected: bool) -> None:
@@ -538,27 +548,46 @@ def test_probe_gnu_system_includes_resolves_symlink_before_classifying(
     # symlink's *target* directory, not the symlink's own location. Build a
     # case where that distinction changes the classification: the reported
     # path's literal segments walk (lexically) all the way out of lib/gcc to
-    # what looks like a plain 'include' dir, but 'triple/13' is actually a
-    # symlink two levels *deeper* than a real version dir would be, so the
-    # same four '../' hops only physically escape back to 'lib/gcc/include'
-    # -- still inside GCC's own resource tree, not real system libstdc++.
+    # a location with no GCC-resource shape at all, but 'triple/13' is
+    # actually a symlink four levels *deeper* than a real version dir would
+    # be, so the same four '../' hops physically land back on a sibling
+    # '.../13.2.0/include-fixed' -- a real GCC resource dir, not system
+    # libstdc++ (the shape-tightening from round 3 of this same review means
+    # the landing spot must itself match the full resource-dir shape, not
+    # merely sit somewhere under lib/gcc).
     from abicheck import dumper_sysinc
 
     base = tmp_path / "base"
-    real_target = base / "lib" / "gcc" / "x86_64-linux-gnu" / "13.2.0" / "sub1" / "sub2"
+    real_target = (
+        base
+        / "lib"
+        / "gcc"
+        / "x86_64-linux-gnu"
+        / "13.2.0"
+        / "extra1"
+        / "extra2"
+        / "extra3"
+        / "extra4"
+    )
     real_target.mkdir(parents=True)
     symlinked_ver = base / "lib" / "gcc" / "x86_64-linux-gnu" / "13"
     symlinked_ver.symlink_to(real_target, target_is_directory=True)
     # Where the four '../' hops *physically* land, starting from real_target:
-    # sub2 -> sub1 -> 13.2.0 -> x86_64-linux-gnu -> gcc, then include/c++/13.
-    physically_resolved = base / "lib" / "gcc" / "include" / "c++" / "13"
+    # extra4 -> extra3 -> extra2 -> extra1 -> 13.2.0, then include-fixed.
+    physically_resolved = (
+        base / "lib" / "gcc" / "x86_64-linux-gnu" / "13.2.0" / "include-fixed"
+    )
     physically_resolved.mkdir(parents=True)
 
-    reported = str(symlinked_ver / ".." / ".." / ".." / ".." / "include" / "c++" / "13")
+    reported = str(symlinked_ver / ".." / ".." / ".." / ".." / "include-fixed")
     # Sanity check the fixture actually exercises the symlink hazard: lexical
     # normpath must disagree with realpath, or this test proves nothing.
     assert os.path.normpath(reported) != os.path.realpath(reported)
     assert os.path.realpath(reported) == str(physically_resolved)
+    assert dumper_sysinc._is_gnu_compiler_resource_dir(reported) is False
+    assert (
+        dumper_sysinc._is_gnu_compiler_resource_dir(os.path.realpath(reported)) is True
+    )
 
     class _P:
         stderr = "ignored"
@@ -613,6 +642,50 @@ def test_probe_gnu_system_includes_drops_terminal_symlinked_resource_dir(
     # This is GCC's own named resource dir regardless of where it's
     # symlinked to -- must be dropped, not kept.
     assert out == []
+
+
+def test_probe_gnu_system_includes_keeps_libstdcxx_symlinked_under_lib_gcc(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Codex review (PR #643, round 3): a real libstdc++ dir reported by a
+    # plain, no-'..' path (no lib/gcc trace at all in the raw string) can be
+    # a symlink whose *target* happens to be physically stored underneath a
+    # lib/gcc/<triple>/<ver> tree -- e.g. a distro nesting real std:: headers
+    # inside its GCC install rather than GCC's own intrinsics dir. Before the
+    # round-3 shape fix, realpath(d) would see the lib/gcc pair anywhere in
+    # that resolved path and wrongly drop this real libstdc++ dir; the
+    # trailing shape must be checked precisely (ends in a bare
+    # include/include-fixed after exactly <triple>/<ver>, not merely
+    # "somewhere under lib/gcc").
+    from abicheck import dumper_sysinc
+
+    base = tmp_path / "base"
+    real_target = (
+        base / "opt" / "lib" / "gcc" / "toolchain" / "13" / "include" / "c++" / "13"
+    )
+    real_target.mkdir(parents=True)
+    reported_dir = base / "opt" / "include" / "c++" / "13"
+    reported_dir.parent.mkdir(parents=True)
+    reported_dir.symlink_to(real_target, target_is_directory=True)
+
+    reported = str(reported_dir)
+    # Sanity check the fixture actually exercises the hazard: the realpath
+    # does sit under a lib/gcc tree, but not in the exact resource shape.
+    assert dumper_sysinc._is_gnu_compiler_resource_dir(reported) is False
+    assert (
+        dumper_sysinc._is_gnu_compiler_resource_dir(os.path.realpath(reported)) is False
+    )
+
+    class _P:
+        stderr = "ignored"
+
+    monkeypatch.setattr(dumper_sysinc.deadline, "run_bounded", lambda *a, **k: _P())
+    monkeypatch.setattr(
+        dumper_sysinc, "_parse_gnu_include_search_dirs", lambda s: [reported]
+    )
+    out = dumper_sysinc._probe_gnu_system_includes("g++", cpp=True)
+    # A real libstdc++ dir -- must be kept, not dropped.
+    assert out == [reported]
 
 
 def test_buildconfig_compile_frontend_case_insensitive() -> None:

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -463,6 +463,38 @@ def test_probe_gnu_system_includes_bounded_by_local_cap_not_full_scan_budget(
         # A trailing segment after 'include'/'include-fixed' breaks the exact
         # end-of-path shape -- this is not the resource dir itself either.
         ("/usr/lib/gcc/x86_64-linux-gnu/13/include/nested", False),
+        # Homebrew's packaged GCC nests an extra 'current' alias segment and
+        # a second literal 'gcc' segment: its build is configured with
+        # --libdir=<prefix>/lib/gcc/current, and GCC's own build script
+        # always appends gcc/<target>/<version> beneath whatever libdir it
+        # is given (confirmed against a real Homebrew GCC install; Codex
+        # review, PR #643, round 6).
+        (
+            "/opt/homebrew/Cellar/gcc/14.2.0/lib/gcc/current/gcc/"
+            "aarch64-apple-darwin23/14/include-fixed",
+            True,
+        ),
+        (
+            "/opt/homebrew/Cellar/gcc/14.2.0/lib/gcc/current/gcc/"
+            "aarch64-apple-darwin23/14/include",
+            True,
+        ),
+        # The alias segment's value isn't checked -- only its structural
+        # position between the two 'gcc' segments -- so a differently-named
+        # alias (not literally "current") still matches the same shape.
+        (
+            "/opt/homebrew/Cellar/gcc/14.2.0/lib/gcc/14/gcc/"
+            "aarch64-apple-darwin23/14/include",
+            True,
+        ),
+        # The nested shape still requires a genuine 'gcc'/'gcc-cross' pair at
+        # both positions -- an unrelated intervening segment structure with
+        # only one real 'gcc' occurrence must not match.
+        (
+            "/opt/homebrew/Cellar/gcc/14.2.0/lib/gcc/current/notgcc/"
+            "aarch64-apple-darwin23/14/include",
+            False,
+        ),
     ],
 )
 def test_is_gnu_compiler_resource_dir(path: str, expected: bool) -> None:
@@ -497,6 +529,42 @@ def test_probe_gnu_system_includes_drops_gcc_resource_dir(
     )
     out = dumper_sysinc._probe_gnu_system_includes("g++", cpp=True)
     assert out == [str(libstdcxx), str(libc)]  # gcc resource dir filtered out
+
+
+def test_probe_gnu_system_includes_drops_homebrew_nested_gcc_resource_dir(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Homebrew's packaged GCC reports its resource dir as
+    # .../lib/gcc/current/gcc/<triple>/<ver>/include[-fixed] (confirmed
+    # against a real Homebrew GCC install; Codex review, PR #643, round 6).
+    # This must be dropped like any other GCC resource dir, not kept.
+    from abicheck import dumper_sysinc
+
+    libstdcxx = tmp_path / "include" / "c++" / "13"
+    homebrew_gcc_res = (
+        tmp_path
+        / "lib"
+        / "gcc"
+        / "current"
+        / "gcc"
+        / "aarch64-apple-darwin23"
+        / "14"
+        / "include-fixed"
+    )
+    for d in (libstdcxx, homebrew_gcc_res):
+        d.mkdir(parents=True, exist_ok=True)
+
+    class _P:
+        stderr = "ignored"
+
+    monkeypatch.setattr(dumper_sysinc.deadline, "run_bounded", lambda *a, **k: _P())
+    monkeypatch.setattr(
+        dumper_sysinc,
+        "_parse_gnu_include_search_dirs",
+        lambda s: [str(homebrew_gcc_res), str(libstdcxx)],
+    )
+    out = dumper_sysinc._probe_gnu_system_includes("g++", cpp=True)
+    assert out == [str(libstdcxx)]  # Homebrew's nested gcc resource dir filtered out
 
 
 def test_probe_gnu_system_includes_keeps_unresolved_walk_back_libstdcxx(

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -435,6 +435,23 @@ def test_probe_gnu_system_includes_bounded_by_local_cap_not_full_scan_budget(
         # startswith('lib') to an exact multilib-name set).
         ("/home/gcc/include", False),
         ("/opt/libfoo/gcc/x86_64-linux-gnu/13/include", False),
+        # Unresolved paths containing a literal '../' walk-back: GCC and
+        # Intel's icpx/icx report search dirs this way. The '..' segments
+        # must be normalized away before matching, or a real libstdc++/libc
+        # dir that happens to be reached by walking back out of the gcc/
+        # version dir is misclassified as the GCC resource dir it walks
+        # *through* rather than the dir it actually names.
+        ("/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13", False),
+        ("/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include", False),
+        (
+            "/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/x86_64-linux-gnu/c++/13",
+            False,
+        ),
+        # A genuine GCC resource dir is still caught after normalization even
+        # when spelled with a redundant './'/'..' that lexically collapses
+        # back to the same resource path (not walked all the way out).
+        ("/usr/lib/gcc/x86_64-linux-gnu/13/./include", True),
+        ("/usr/lib/gcc/x86_64-linux-gnu/13/sub/../include-fixed", True),
     ],
 )
 def test_is_gnu_compiler_resource_dir(path: str, expected: bool) -> None:
@@ -469,6 +486,48 @@ def test_probe_gnu_system_includes_drops_gcc_resource_dir(
     )
     out = dumper_sysinc._probe_gnu_system_includes("g++", cpp=True)
     assert out == [str(libstdcxx), str(libc)]  # gcc resource dir filtered out
+
+
+def test_probe_gnu_system_includes_keeps_unresolved_walk_back_libstdcxx(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # GCC (and Intel's icpx/icx) report the real libstdc++ dir as an unresolved
+    # string that walks back out of the versioned gcc/ dir with literal '../'
+    # segments (e.g. '.../lib/gcc/<triple>/13/../../../../include/c++/13'),
+    # rather than the already-resolved '/usr/include/c++/13'. That must be
+    # kept, not dropped as though it were the GCC resource dir it walks
+    # *through* on the way there.
+    from abicheck import dumper_sysinc
+
+    real_libstdcxx = tmp_path / "include" / "c++" / "13"
+    real_libstdcxx.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "lib" / "gcc" / "x86_64-linux-gnu" / "13").mkdir(parents=True)
+    unresolved_libstdcxx = str(
+        tmp_path
+        / "lib"
+        / "gcc"
+        / "x86_64-linux-gnu"
+        / "13"
+        / ".."
+        / ".."
+        / ".."
+        / ".."
+        / "include"
+        / "c++"
+        / "13"
+    )
+
+    class _P:
+        stderr = "ignored"
+
+    monkeypatch.setattr(dumper_sysinc.deadline, "run_bounded", lambda *a, **k: _P())
+    monkeypatch.setattr(
+        dumper_sysinc,
+        "_parse_gnu_include_search_dirs",
+        lambda s: [unresolved_libstdcxx],
+    )
+    out = dumper_sysinc._probe_gnu_system_includes("g++", cpp=True)
+    assert out == [unresolved_libstdcxx]
 
 
 def test_buildconfig_compile_frontend_case_insensitive() -> None:

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -723,6 +723,53 @@ def test_probe_gnu_system_includes_drops_terminal_symlinked_resource_dir(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason=_SYMLINK_SKIP_REASON)
+def test_probe_gnu_system_includes_keeps_real_dir_via_midpath_symlink(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Codex review (PR #643, round 7): checking the raw string in *addition
+    # to* realpath (an "or", as an earlier version of this fix did) is wrong
+    # once '..' is involved, not just insufficient on its own. Here a
+    # mid-path symlink component ('hop') sits between the version dir and a
+    # trailing '..': lexically this collapses right back to the canonical
+    # resource shape, but the compiler's actual open() call resolves through
+    # the symlink to a real, unrelated include dir elsewhere. Checking the
+    # raw string here would wrongly drop that real include dir -- only
+    # realpath is trustworthy once '..' is present.
+    from abicheck import dumper_sysinc
+
+    base = tmp_path / "base"
+    real_deep = base / "external" / "deep"
+    real_deep.mkdir(parents=True)
+    real_include = base / "external" / "include"
+    real_include.mkdir(parents=True)
+    ver_dir = base / "lib" / "gcc" / "x86_64-linux-gnu" / "13"
+    ver_dir.mkdir(parents=True)
+    hop = ver_dir / "hop"
+    hop.symlink_to(real_deep, target_is_directory=True)
+
+    reported = str(hop / ".." / "include")
+    # Sanity check the fixture actually exercises the hazard: the raw path
+    # lexically matches the resource-dir shape, but its realpath is a real,
+    # differently-shaped, unrelated directory.
+    assert dumper_sysinc._is_gnu_compiler_resource_dir(reported) is True
+    assert os.path.realpath(reported) == str(real_include)
+    assert (
+        dumper_sysinc._is_gnu_compiler_resource_dir(os.path.realpath(reported)) is False
+    )
+
+    class _P:
+        stderr = "ignored"
+
+    monkeypatch.setattr(dumper_sysinc.deadline, "run_bounded", lambda *a, **k: _P())
+    monkeypatch.setattr(
+        dumper_sysinc, "_parse_gnu_include_search_dirs", lambda s: [reported]
+    )
+    out = dumper_sysinc._probe_gnu_system_includes("g++", cpp=True)
+    # This is a real, unrelated include dir -- must be kept, not dropped.
+    assert out == [reported]
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason=_SYMLINK_SKIP_REASON)
 def test_probe_gnu_system_includes_keeps_libstdcxx_symlinked_under_lib_gcc(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -572,6 +572,49 @@ def test_probe_gnu_system_includes_resolves_symlink_before_classifying(
     assert out == []
 
 
+def test_probe_gnu_system_includes_drops_terminal_symlinked_resource_dir(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Codex review (PR #643, round 2): the opposite symlink hazard from the
+    # walk-back case above. Here the reported path has no '..' at all -- it
+    # IS the canonical '.../lib/gcc/<triple>/<ver>/include' resource path --
+    # but that exact directory is itself a symlink to storage physically
+    # outside any lib/gcc hierarchy (e.g. a distro that stores GCC's
+    # intrinsics headers in a shared location). realpath() alone would
+    # resolve past the lib/gcc evidence and wrongly classify this as safe to
+    # keep, feeding clang GCC's incompatible intrinsics headers. The raw,
+    # lexically-normalized path must still be checked and win.
+    from abicheck import dumper_sysinc
+
+    base = tmp_path / "base"
+    external_storage = base / "external_storage" / "gcc13_include"
+    external_storage.mkdir(parents=True)
+    canonical_resource_dir = base / "lib" / "gcc" / "x86_64-linux-gnu" / "13"
+    canonical_resource_dir.mkdir(parents=True)
+    terminal_symlink = canonical_resource_dir / "include"
+    terminal_symlink.symlink_to(external_storage, target_is_directory=True)
+
+    reported = str(terminal_symlink)
+    # Sanity check the fixture actually exercises the hazard: the raw path
+    # lexically matches the resource-dir shape, but its realpath doesn't.
+    assert dumper_sysinc._is_gnu_compiler_resource_dir(reported) is True
+    assert (
+        dumper_sysinc._is_gnu_compiler_resource_dir(os.path.realpath(reported)) is False
+    )
+
+    class _P:
+        stderr = "ignored"
+
+    monkeypatch.setattr(dumper_sysinc.deadline, "run_bounded", lambda *a, **k: _P())
+    monkeypatch.setattr(
+        dumper_sysinc, "_parse_gnu_include_search_dirs", lambda s: [reported]
+    )
+    out = dumper_sysinc._probe_gnu_system_includes("g++", cpp=True)
+    # This is GCC's own named resource dir regardless of where it's
+    # symlinked to -- must be dropped, not kept.
+    assert out == []
+
+
 def test_buildconfig_compile_frontend_case_insensitive() -> None:
     from abicheck.buildsource.inline import BuildConfig
 

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -723,6 +723,47 @@ def test_probe_gnu_system_includes_drops_terminal_symlinked_resource_dir(
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason=_SYMLINK_SKIP_REASON)
+def test_probe_gnu_system_includes_drops_aliased_symlink_to_resource_dir(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Codex review (PR #643, round 8): the mirror case of the terminal-symlink
+    # test above. There, the raw path IS the canonical resource-dir name but
+    # is symlinked *away* from it; here the raw path is an arbitrary,
+    # non-resource-shaped alias (no '..' either) that is symlinked *to* the
+    # real resource dir. The raw string alone (round 2's fix) misses this
+    # evidence entirely and would wrongly keep GCC's intrinsics headers under
+    # the innocuous-looking alias name. Both directions must be checked when
+    # there's no '..' to make the lexical form ambiguous.
+    from abicheck import dumper_sysinc
+
+    base = tmp_path / "base"
+    real_resource_dir = base / "lib" / "gcc" / "x86_64-linux-gnu" / "13" / "include"
+    real_resource_dir.mkdir(parents=True)
+    alias = base / "opt" / "toolchain" / "include"
+    alias.parent.mkdir(parents=True)
+    alias.symlink_to(real_resource_dir, target_is_directory=True)
+
+    reported = str(alias)
+    # Sanity check the fixture actually exercises the hazard: the raw path
+    # does NOT lexically match the resource-dir shape, but its realpath does.
+    assert dumper_sysinc._is_gnu_compiler_resource_dir(reported) is False
+    assert (
+        dumper_sysinc._is_gnu_compiler_resource_dir(os.path.realpath(reported)) is True
+    )
+
+    class _P:
+        stderr = "ignored"
+
+    monkeypatch.setattr(dumper_sysinc.deadline, "run_bounded", lambda *a, **k: _P())
+    monkeypatch.setattr(
+        dumper_sysinc, "_parse_gnu_include_search_dirs", lambda s: [reported]
+    )
+    out = dumper_sysinc._probe_gnu_system_includes("g++", cpp=True)
+    # This alias resolves to GCC's own resource dir -- must be dropped.
+    assert out == []
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason=_SYMLINK_SKIP_REASON)
 def test_probe_gnu_system_includes_keeps_real_dir_via_midpath_symlink(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -27,6 +27,7 @@ sides while the per-side ``--old/new-ast-frontend`` override still wins.
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
 
 import click
@@ -540,6 +541,14 @@ def test_probe_gnu_system_includes_keeps_unresolved_walk_back_libstdcxx(
     assert out == [unresolved_libstdcxx]
 
 
+_SYMLINK_SKIP_REASON = (
+    "creates a directory symlink via Path.symlink_to(target_is_directory=True), "
+    "which needs SeCreateSymbolicLinkPrivilege/Developer Mode on native Windows "
+    "(same rationale as test_runtime_probe.py's symlink-dependent skips)"
+)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason=_SYMLINK_SKIP_REASON)
 def test_probe_gnu_system_includes_resolves_symlink_before_classifying(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -601,6 +610,7 @@ def test_probe_gnu_system_includes_resolves_symlink_before_classifying(
     assert out == []
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason=_SYMLINK_SKIP_REASON)
 def test_probe_gnu_system_includes_drops_terminal_symlinked_resource_dir(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -644,6 +654,7 @@ def test_probe_gnu_system_includes_drops_terminal_symlinked_resource_dir(
     assert out == []
 
 
+@pytest.mark.skipif(sys.platform == "win32", reason=_SYMLINK_SKIP_REASON)
 def test_probe_gnu_system_includes_keeps_libstdcxx_symlinked_under_lib_gcc(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -530,6 +530,48 @@ def test_probe_gnu_system_includes_keeps_unresolved_walk_back_libstdcxx(
     assert out == [unresolved_libstdcxx]
 
 
+def test_probe_gnu_system_includes_resolves_symlink_before_classifying(
+    monkeypatch, tmp_path: Path
+) -> None:
+    # Codex review (PR #643): lexically collapsing '..' is wrong once a
+    # symlink sits in the path -- the OS resolves '..' relative to the
+    # symlink's *target* directory, not the symlink's own location. Build a
+    # case where that distinction changes the classification: the reported
+    # path's literal segments walk (lexically) all the way out of lib/gcc to
+    # what looks like a plain 'include' dir, but 'triple/13' is actually a
+    # symlink two levels *deeper* than a real version dir would be, so the
+    # same four '../' hops only physically escape back to 'lib/gcc/include'
+    # -- still inside GCC's own resource tree, not real system libstdc++.
+    from abicheck import dumper_sysinc
+
+    base = tmp_path / "base"
+    real_target = base / "lib" / "gcc" / "x86_64-linux-gnu" / "13.2.0" / "sub1" / "sub2"
+    real_target.mkdir(parents=True)
+    symlinked_ver = base / "lib" / "gcc" / "x86_64-linux-gnu" / "13"
+    symlinked_ver.symlink_to(real_target, target_is_directory=True)
+    # Where the four '../' hops *physically* land, starting from real_target:
+    # sub2 -> sub1 -> 13.2.0 -> x86_64-linux-gnu -> gcc, then include/c++/13.
+    physically_resolved = base / "lib" / "gcc" / "include" / "c++" / "13"
+    physically_resolved.mkdir(parents=True)
+
+    reported = str(symlinked_ver / ".." / ".." / ".." / ".." / "include" / "c++" / "13")
+    # Sanity check the fixture actually exercises the symlink hazard: lexical
+    # normpath must disagree with realpath, or this test proves nothing.
+    assert os.path.normpath(reported) != os.path.realpath(reported)
+    assert os.path.realpath(reported) == str(physically_resolved)
+
+    class _P:
+        stderr = "ignored"
+
+    monkeypatch.setattr(dumper_sysinc.deadline, "run_bounded", lambda *a, **k: _P())
+    monkeypatch.setattr(
+        dumper_sysinc, "_parse_gnu_include_search_dirs", lambda s: [reported]
+    )
+    out = dumper_sysinc._probe_gnu_system_includes("g++", cpp=True)
+    # Physically this is still inside lib/gcc -- must be dropped, not kept.
+    assert out == []
+
+
 def test_buildconfig_compile_frontend_case_insensitive() -> None:
     from abicheck.buildsource.inline import BuildConfig
 

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -45,6 +45,7 @@ from abicheck.dumper_clang import (
     _Decl,
     _function_qualifiers,
     _is_clang_family_binary,
+    _is_intel_sycl_driver,
     _pointer_depth,
     _return_type,
 )
@@ -782,23 +783,31 @@ def test_build_clang_header_command_cpp_and_c(tmp_path: Path) -> None:
 
 
 @pytest.mark.parametrize(
-    "tokens,expected",
+    "cc_bin,tokens,expected",
     [
-        (["-fsycl"], True),
-        (["-fsycl", "-DFOO=1"], True),
+        ("icpx", ["-fsycl"], True),
+        ("icx", ["-fsycl", "-DFOO=1"], True),
+        ("/opt/oneapi/bin/dpcpp", ["-fsycl"], True),
+        ("dpcpp-cl", ["-fsycl"], True),
         # No -fsycl at all: nothing to pin.
-        (["-DFOO=1"], False),
-        ([], False),
+        ("icpx", ["-DFOO=1"], False),
+        ("icpx", [], False),
         # Caller already pinned a single pass explicitly: don't second-guess it.
-        (["-fsycl", "-fsycl-host-only"], False),
-        (["-fsycl", "-fsycl-device-only"], False),
+        ("icpx", ["-fsycl", "-fsycl-host-only"], False),
+        ("icpx", ["-fsycl", "-fsycl-device-only"], False),
         # A flag that merely starts with "-fsycl" is not the bare enabling
         # flag itself (exact-token match, not a prefix/substring check).
-        (["-fsycl-device-only"], False),
+        ("icpx", ["-fsycl-device-only"], False),
+        # Stock clang accepts a bare -fsycl as a single pass and does not
+        # recognize -fsycl-host-only at all (Codex review, PR #643) -- must
+        # never be gated on for a non-Intel clang-family binary.
+        ("clang", ["-fsycl"], False),
+        ("clang++", ["-fsycl"], False),
+        ("/usr/bin/clang-18", ["-fsycl"], False),
     ],
 )
-def test_needs_sycl_host_only(tokens: list[str], expected: bool) -> None:
-    assert _needs_sycl_host_only(tokens) is expected
+def test_needs_sycl_host_only(cc_bin: str, tokens: list[str], expected: bool) -> None:
+    assert _needs_sycl_host_only(cc_bin, tokens) is expected
 
 
 def test_build_clang_header_command_appends_sycl_host_only(tmp_path: Path) -> None:
@@ -834,6 +843,20 @@ def test_build_clang_header_command_respects_explicit_sycl_device_only(
 def test_build_clang_header_command_without_sycl_unaffected(tmp_path: Path) -> None:
     agg = tmp_path / "agg.hpp"
     cmd = _build_clang_header_command("clang++", "gnu", [], agg, force_cpp=True)
+    assert "-fsycl-host-only" not in cmd
+
+
+def test_build_clang_header_command_stock_clang_sycl_not_gated(tmp_path: Path) -> None:
+    # Codex review (PR #643): stock upstream clang accepts a bare -fsycl and
+    # parses it as a single pass fine, but does not recognize
+    # -fsycl-host-only at all -- it hard-rejects it with "unknown argument".
+    # Appending it here would turn a working --gcc-path clang + -fsycl parse
+    # into a guaranteed failure, so this must stay gated on the resolved
+    # binary actually being an Intel oneAPI driver (icx/icpx/dpcpp[-cl]).
+    agg = tmp_path / "agg.hpp"
+    cmd = _build_clang_header_command(
+        "clang++", "gnu", [], agg, force_cpp=True, gcc_options="-fsycl"
+    )
     assert "-fsycl-host-only" not in cmd
 
 
@@ -2474,6 +2497,30 @@ def test_is_clang_family_binary(path: str, expected: bool) -> None:
     alias-set branch (icx/icpx/dpcpp/dpcpp-cl) in isolation from the larger
     _clang_header_dump/_resolve_clang_bin call chain the tests below cover."""
     assert _is_clang_family_binary(path) is expected
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("icx", True),
+        ("icpx", True),
+        ("dpcpp", True),
+        ("dpcpp-cl", True),
+        ("/opt/intel/oneapi/compiler/2026.1/bin/icpx", True),
+        ("ICPX", True),  # case-insensitive
+        ("icpx.exe", True),  # extension stripped, still matches
+        # Stock clang is clang-family but NOT the Intel SYCL driver: it does
+        # not implement -fsycl-host-only/-fsycl-device-only at all.
+        ("clang", False),
+        ("clang++", False),
+        ("/usr/bin/clang-18", False),
+        ("clang-cl.exe", False),
+        ("gcc", False),
+        ("icc", False),
+    ],
+)
+def test_is_intel_sycl_driver(path: str, expected: bool) -> None:
+    assert _is_intel_sycl_driver(path) is expected
 
 
 def test_clang_header_dump_gcc_path_not_used_as_clang(

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -33,6 +33,7 @@ from abicheck.dumper import (
     _auto_system_includes_enabled,
     _build_clang_header_command,
     _clang_header_dump,
+    _dpcpp_defaults_sycl_on,
     _header_ast_parser,
     _needs_sycl_host_only,
     _parse_gnu_include_search_dirs,
@@ -813,10 +814,63 @@ def test_build_clang_header_command_cpp_and_c(tmp_path: Path) -> None:
         ("icpx", ["-fno-sycl", "-fsycl"], True),
         ("icpx", ["-fsycl", "-fno-sycl", "-fsycl"], True),
         ("icpx", ["-fno-sycl"], False),
+        # Intel's legacy "dpcpp"/"dpcpp-cl" driver names imply SYCL is
+        # already on even with no -fsycl token at all (Codex review, PR
+        # #643, round 8) -- an explicit -fno-sycl still overrides that
+        # default. icx/icpx are NOT in this default-on set: they need an
+        # explicit -fsycl, same as stock clang.
+        ("dpcpp", [], True),
+        ("dpcpp-cl", [], True),
+        ("/opt/oneapi/bin/dpcpp", [], True),
+        ("DPCPP", [], True),  # case-insensitive
+        ("dpcpp.exe", [], True),  # extension stripped, still matches
+        ("dpcpp", ["-DFOO=1"], True),
+        ("dpcpp", ["-fno-sycl"], False),
+        ("dpcpp", ["-fno-sycl", "-fsycl"], True),
+        ("icx", [], False),
     ],
 )
 def test_needs_sycl_host_only(cc_bin: str, tokens: list[str], expected: bool) -> None:
     assert _needs_sycl_host_only(cc_bin, tokens) is expected
+
+
+@pytest.mark.parametrize(
+    "cc_bin,expected",
+    [
+        ("dpcpp", True),
+        ("dpcpp-cl", True),
+        ("/opt/oneapi/bin/dpcpp", True),
+        ("DPCPP", True),
+        ("dpcpp.exe", True),
+        ("icx", False),
+        ("icpx", False),
+        ("clang", False),
+        ("clang++", False),
+        ("gcc", False),
+    ],
+)
+def test_dpcpp_defaults_sycl_on(cc_bin: str, expected: bool) -> None:
+    assert _dpcpp_defaults_sycl_on(cc_bin) is expected
+
+
+def test_build_clang_header_command_dpcpp_defaults_sycl_on(tmp_path: Path) -> None:
+    # Codex review (PR #643, round 8): "dpcpp" implies SYCL is already on
+    # even with no -fsycl token at all, so it must still get
+    # -fsycl-host-only pinned -- otherwise the double-JSON-document bug
+    # this whole fix targets reappears for this driver name.
+    agg = tmp_path / "agg.hpp"
+    cmd = _build_clang_header_command("dpcpp", "gnu", [], agg, force_cpp=True)
+    assert "-fsycl-host-only" in cmd
+
+
+def test_build_clang_header_command_dpcpp_explicit_fno_sycl_overrides_default(
+    tmp_path: Path,
+) -> None:
+    agg = tmp_path / "agg.hpp"
+    cmd = _build_clang_header_command(
+        "dpcpp", "gnu", [], agg, force_cpp=True, gcc_options="-fno-sycl"
+    )
+    assert "-fsycl-host-only" not in cmd
 
 
 def test_build_clang_header_command_appends_sycl_host_only(tmp_path: Path) -> None:

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -804,6 +804,15 @@ def test_build_clang_header_command_cpp_and_c(tmp_path: Path) -> None:
         ("clang", ["-fsycl"], False),
         ("clang++", ["-fsycl"], False),
         ("/usr/bin/clang-18", ["-fsycl"], False),
+        # The clang driver applies -fsycl/-fno-sycl last-flag-wins like any
+        # other toggle (confirmed via `clang++ -fsycl -fno-sycl -###`, which
+        # emits a single ordinary host -cc1, no device pass). A later
+        # -fno-sycl means SYCL is not actually enabled, so nothing needs
+        # pinning to a single pass (Codex review, PR #643, round 5).
+        ("icpx", ["-fsycl", "-fno-sycl"], False),
+        ("icpx", ["-fno-sycl", "-fsycl"], True),
+        ("icpx", ["-fsycl", "-fno-sycl", "-fsycl"], True),
+        ("icpx", ["-fno-sycl"], False),
     ],
 )
 def test_needs_sycl_host_only(cc_bin: str, tokens: list[str], expected: bool) -> None:
@@ -836,6 +845,17 @@ def test_build_clang_header_command_respects_explicit_sycl_device_only(
         agg,
         force_cpp=True,
         gcc_options="-fsycl -fsycl-device-only",
+    )
+    assert "-fsycl-host-only" not in cmd
+
+
+def test_build_clang_header_command_respects_later_fno_sycl(tmp_path: Path) -> None:
+    # A later -fno-sycl disables SYCL under the driver's last-flag-wins
+    # semantics -- appending -fsycl-host-only anyway would tack a SYCL-only
+    # selector onto a non-SYCL compile (Codex review, PR #643, round 5).
+    agg = tmp_path / "agg.hpp"
+    cmd = _build_clang_header_command(
+        "icpx", "gnu", [], agg, force_cpp=True, gcc_options="-fsycl -fno-sycl"
     )
     assert "-fsycl-host-only" not in cmd
 

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -34,6 +34,7 @@ from abicheck.dumper import (
     _build_clang_header_command,
     _clang_header_dump,
     _header_ast_parser,
+    _needs_sycl_host_only,
     _parse_gnu_include_search_dirs,
     _resolve_clang_system_includes,
     _resolve_header_backend,
@@ -778,6 +779,88 @@ def test_build_clang_header_command_cpp_and_c(tmp_path: Path) -> None:
     c_cmd = _build_clang_header_command("clang", "gnu", [], agg, force_cpp=False)
     assert "-std=gnu11" in c_cmd
     assert "-x" in c_cmd
+
+
+@pytest.mark.parametrize(
+    "tokens,expected",
+    [
+        (["-fsycl"], True),
+        (["-fsycl", "-DFOO=1"], True),
+        # No -fsycl at all: nothing to pin.
+        (["-DFOO=1"], False),
+        ([], False),
+        # Caller already pinned a single pass explicitly: don't second-guess it.
+        (["-fsycl", "-fsycl-host-only"], False),
+        (["-fsycl", "-fsycl-device-only"], False),
+        # A flag that merely starts with "-fsycl" is not the bare enabling
+        # flag itself (exact-token match, not a prefix/substring check).
+        (["-fsycl-device-only"], False),
+    ],
+)
+def test_needs_sycl_host_only(tokens: list[str], expected: bool) -> None:
+    assert _needs_sycl_host_only(tokens) is expected
+
+
+def test_build_clang_header_command_appends_sycl_host_only(tmp_path: Path) -> None:
+    # A bare -fsycl makes a SYCL-capable driver (icpx/dpcpp) run a device pass
+    # *and* a host pass, each emitting a full -ast-dump=json document to the
+    # same stdout stream -- the second document breaks json.load() with
+    # "Extra data". -fsycl-host-only pins the compile to the single pass that
+    # actually matches what links into the scanned binary.
+    agg = tmp_path / "agg.hpp"
+    cmd = _build_clang_header_command(
+        "icpx", "gnu", [], agg, force_cpp=True, gcc_options="-fsycl -DFOO=1"
+    )
+    assert "-fsycl-host-only" in cmd
+    assert cmd.count("-fsycl-host-only") == 1
+
+
+def test_build_clang_header_command_respects_explicit_sycl_device_only(
+    tmp_path: Path,
+) -> None:
+    # An explicit --gcc-options choice must never be second-guessed.
+    agg = tmp_path / "agg.hpp"
+    cmd = _build_clang_header_command(
+        "icpx",
+        "gnu",
+        [],
+        agg,
+        force_cpp=True,
+        gcc_options="-fsycl -fsycl-device-only",
+    )
+    assert "-fsycl-host-only" not in cmd
+
+
+def test_build_clang_header_command_without_sycl_unaffected(tmp_path: Path) -> None:
+    agg = tmp_path / "agg.hpp"
+    cmd = _build_clang_header_command("clang++", "gnu", [], agg, force_cpp=True)
+    assert "-fsycl-host-only" not in cmd
+
+
+def test_build_clang_header_command_sycl_via_gcc_option_tokens(tmp_path: Path) -> None:
+    # The repeatable --gcc-option path (gcc_option_tokens) must be checked the
+    # same way as the shlex-split --gcc-options string.
+    agg = tmp_path / "agg.hpp"
+    cmd = _build_clang_header_command(
+        "icpx", "gnu", [], agg, force_cpp=True, gcc_option_tokens=("-fsycl",)
+    )
+    assert "-fsycl-host-only" in cmd
+
+
+def test_parse_clang_ast_result_rejects_concatenated_json_documents(
+    tmp_path: Path,
+) -> None:
+    # A SYCL device pass + host pass (or any other flag that makes clang run
+    # more than one -cc1 pass for one compile) each write a complete
+    # -ast-dump=json document to the same stdout stream, back-to-back with no
+    # separator -- json.load() parses only the first and raises on the rest.
+    # The error must name the likely cause instead of a bare byte offset.
+    ast_path = tmp_path / "ast.json"
+    doc = '{"kind": "TranslationUnitDecl", "inner": []}'
+    ast_path.write_text(doc + doc, encoding="utf-8")
+    result = _fake_proc(stdout="", stderr="", returncode=0)
+    with pytest.raises(SnapshotError, match="more than one JSON document"):
+        _parse_clang_ast_result(result, tmp_path / "cache.json", ast_path)
 
 
 def test_clang_header_dump_missing_clang_raises(


### PR DESCRIPTION
## Summary

Two independent bugs fixed on the clang L2 header backend / system-include probe path, plus a symlink-correctness follow-up caught in review:

1. `_is_gnu_compiler_resource_dir` classified unresolved, unnormalized paths, misclassifying real libstdc++/libc dirs as GCC's own resource dir.
2. `--ast-frontend clang` + `-fsycl` produced two concatenated JSON documents on stdout (SYCL device + host `-cc1` passes), breaking `json.load()`.
3. (Follow-up from Codex review on this PR) `_is_gnu_compiler_resource_dir`'s lexical `..` collapsing was still wrong once a symlink sits in the path.

## Motivation

**Bug 1 — `_is_gnu_compiler_resource_dir` compares unresolved path segments.** `abicheck.dumper_sysinc._is_gnu_compiler_resource_dir` classifies a system-include path by walking `Path(path).parts` on the raw, unresolved string returned by the host-compiler `-v` probe. Both GCC and Intel's `icpx`/`icx` report their search paths with literal `../../../../` segments (e.g. `/usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13`, which is really `/usr/include/c++/13` — genuine libstdc++, not a GCC-internal resource dir). Because the function never normalized the path before splitting it into parts, the `lib`/`gcc` segments from the walked-*through* prefix still matched the resource-dir heuristic, silently dropping real libstdc++/libc dirs from the `-isystem` dirs injected into the clang L2 backend.

**Bug 2 — `--ast-frontend clang` + `-fsycl` → two concatenated JSON docs, `json.load()` chokes.** The clang header-AST backend assumes a single `-cc1 ... -Xclang -ast-dump=json` invocation produces exactly one JSON document on stdout. When `--gcc-options` includes `-fsycl` (needed for any header tree that transitively includes `<sycl/sycl.hpp>`, e.g. via `--gcc-path icpx`/`dpcpp`), the driver actually runs two separate `-cc1` passes for one compile — a SYCL device-side pass and a SYCL host-side pass — each emitting its own complete JSON document to the same stdout stream abicheck captures, back-to-back with no separator. `json.load()` parses only the first document and raises `Extra data: line N column 2 (char M)` on the rest (confirmed on oneDAL's `cpp/oneapi/dal.hpp`, which transitively includes `<sycl/sycl.hpp>` via `cpp/oneapi/dal/detail/common.hpp`).

**Follow-up — symlink-aware `..` resolution.** Codex review on this PR's first commit (the Bug 1 fix) pointed out that pure lexical `os.path.normpath` normalization is itself wrong once a symlinked path component is involved: the OS resolves `..` relative to the symlink's *target* directory, not the symlink's own location, so a path that lexically collapses out of `lib/gcc` can physically still resolve inside it (or vice versa).

## Changes

- `abicheck/dumper_sysinc.py`:
  - `_is_gnu_compiler_resource_dir` normalizes the path with `os.path.normpath` (lexical only) before splitting into parts.
  - `_probe_gnu_system_includes` now classifies `os.path.realpath(d)` instead of the raw string — safe since `Path(d).is_dir()` (short-circuiting `and`, evaluated first) has already confirmed `d` exists — making the classification symlink-correct at the one real call site, while the classifier itself stays lexical-only/pure/string-testable.
- `abicheck/dumper.py`:
  - New `_needs_sycl_host_only(tokens)` helper: true iff `-fsycl` is present without an explicit `-fsycl-host-only`/`-fsycl-device-only` already pinning a single compilation pass.
  - `_build_clang_header_command` appends `-fsycl-host-only` when `_needs_sycl_host_only` is true, collapsing the compile to the single host-side AST that actually links into the scanned binary (the device pass's SPIR-V kernel code never does).
- `abicheck/dumper_clang_errors.py`: `_parse_clang_ast_result`'s JSON parse error now names the likely cause (multiple `-cc1` passes from one compile — an unpinned `-fsycl`, or an OpenMP/CUDA offload target flag) instead of a bare byte-offset, generalizing the diagnostic beyond just the SYCL case.
- Tests (`tests/test_compile_context_parity.py`, `tests/test_dumper_clang.py`):
  - Parametrized `../`-walk-back and symlink-hazard cases for `_is_gnu_compiler_resource_dir`.
  - End-to-end `_probe_gnu_system_includes` tests reproducing both the unresolved-path and the symlink scenarios on real temp directories.
  - `_needs_sycl_host_only` / `_build_clang_header_command` parametrized cases (bare `-fsycl`, explicit override, `gcc_option_tokens` path, no-SYCL no-op).
  - `_parse_clang_ast_result` test with two concatenated JSON documents on disk, asserting the improved error message.
- `changelog.d/`: two fragments documenting both fixes.

**Why these were missed originally:** every existing test case for the resource-dir classifier used already-resolved, non-symlinked paths — nothing exercised the *actual* raw string shape real compilers emit (`../`-walk-back, symlinked version dirs). Similarly, nothing exercised the clang L2 backend against a multi-`-cc1`-pass compile, since SYCL support wasn't previously a tested code path for that backend. The added tests close both gaps with fixtures that reflect real compiler/toolchain output shapes rather than pre-cleaned inputs.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [ ] Docs updated if user-visible behaviour changed (n/a — internal bug fixes, no user-visible behavior contract change)
- [x] `pre-commit run --all-files` passes locally (`ruff check`, `ruff format --check`, `mypy abicheck/`, `check_ai_readiness.py` all pass)
- [x] No new `mypy` or `ruff` errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with Intel oneAPI SYCL compilers by selecting the correct host-only AST during analysis.
  - Added clearer diagnostics when clang produces multiple concatenated AST documents.
  - Improved detection of GCC compiler-resource directories, including normalized and symlinked paths, preventing valid system include paths from being omitted.
- **Tests**
  - Expanded coverage for SYCL handling, AST parsing errors, and complex GCC include-directory layouts.
- **Documentation**
  - Added changelog entries describing the compiler compatibility and include-path fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->