### PR TITLE
fix: post-merge follow-up on ADR-050 D5/D6 review findings

### DIFF
--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1266,6 +1266,8 @@ def dump(
             The CLI's ``dump`` command passes its own raw ``-H``/``--header``
             directory arguments here (``cli_dump_helpers.perform_elf_dump``).
             Mutually exclusive with *dump_manifest*, same as *headers*.
+        frontend_context: "host"/"device" (ADR-050 D5) DPC++/SYCL AST pass;
+            "device" on a non-DPC++-capable frontend raises ``AstContextMissingError``.
 
     Returns:
         AbiSnapshot with functions, variables, and types populated.

--- a/abicheck/dumper_manifest.py
+++ b/abicheck/dumper_manifest.py
@@ -114,6 +114,11 @@ def _tu_jobs(n_units: int) -> int:
         try:
             requested = max(1, int(env))
         except ValueError:
+            log.warning(
+                "ABICHECK_TU_JOBS=%r is not a valid integer; falling back to 1 "
+                "(serial) worker.",
+                env,
+            )
             return 1
         ceiling = process_resources.jobs_ceiling()
         if requested > ceiling:
@@ -319,15 +324,15 @@ def _run_tu_fragments(
             frontend_context=frontend_context,
         )
 
-    def _handle_failure(tu: TranslationUnit) -> None:
+    def _handle_failure(tu: TranslationUnit, exc: BaseException) -> None:
         if tu.required:
-            raise
+            raise exc
         log.warning(
             "Optional translation unit %r failed to extract; skipping "
             "(required=false). Its declarations are absent from this "
             "snapshot.",
             tu.name,
-            exc_info=True,
+            exc_info=exc,
         )
 
     fragments: list[TuFragment] = []
@@ -335,8 +340,8 @@ def _run_tu_fragments(
         for tu in tus:
             try:
                 fragments.append(_run_one(tu))
-            except Exception:
-                _handle_failure(tu)
+            except Exception as exc:
+                _handle_failure(tu, exc)
         return fragments
 
     # Results are recorded by INDEX (declared order), but observed in
@@ -380,7 +385,7 @@ def _run_tu_fragments(
         tu = tus[idx]
         try:
             results[idx] = fut.result()
-        except Exception:
+        except Exception as exc:
             if tu.required:
                 # Cancel whatever hasn't started yet (best effort -- a
                 # future already running its subprocess can't be
@@ -394,7 +399,7 @@ def _run_tu_fragments(
                 for other_fut in future_to_index:
                     other_fut.cancel()
                 pool.shutdown(wait=False)
-            _handle_failure(tu)
+            _handle_failure(tu, exc)
     pool.shutdown(wait=True)
     fragments.extend(r for r in results if r is not None)
     return fragments

--- a/abicheck/process_resources.py
+++ b/abicheck/process_resources.py
@@ -218,7 +218,15 @@ def job_mem_budget_gib(env_var: str, default_gib: float) -> float:
 
 def mem_cap(budget_gib: float) -> int | None:
     """Max concurrent workers that fit in available RAM at *budget_gib* each,
-    or ``None`` when RAM can't be read (the memory clamp is then skipped)."""
+    or ``None`` when RAM can't be read (the memory clamp is then skipped).
+
+    *budget_gib* is expected positive (:func:`job_mem_budget_gib` floors it at
+    0.25) -- a non-positive value would otherwise raise ``ZeroDivisionError``
+    or invert the clamp's meaning, so it is treated the same as "can't be
+    read" here rather than trusted unconditionally (CodeRabbit review).
+    """
+    if budget_gib <= 0:
+        return None
     avail = available_mem_gib()
     if avail is None:
         return None

--- a/abicheck/sycl_context.py
+++ b/abicheck/sycl_context.py
@@ -499,7 +499,13 @@ def decode_and_select_frontend_context_from_path(
     one chunk of over-read into the next document), not the combined size
     of every pass in the stream.
     """
-    with open(ast_path, encoding="utf-8") as fh:
-        return _select_from_document_stream(
-            lambda: fh.read(chunk_size), stderr, requested_kind
-        )
+    try:
+        with open(ast_path, encoding="utf-8") as fh:
+            return _select_from_document_stream(
+                lambda: fh.read(chunk_size), stderr, requested_kind
+            )
+    except UnicodeDecodeError as exc:
+        raise SnapshotError(
+            f"DPC++ frontend's AST document stream ({ast_path}) is not valid "
+            f"UTF-8: {exc}"
+        ) from exc

--- a/changelog.d/20260726_150000_claude_g32_phase_d_sycl_context.md
+++ b/changelog.d/20260726_150000_claude_g32_phase_d_sycl_context.md
@@ -296,3 +296,21 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   combined with an explicit `-fno-sycl` now fails fast with
   `AstContextMissingError` instead of silently resolving the contradiction
   either way (Codex review).
+- `sycl_context.decode_and_select_frontend_context_from_path` raised a bare
+  `UnicodeDecodeError` straight out of its own `open(...).read()` call on
+  non-UTF-8 bytes, inconsistent with every other decode failure in this
+  module being normalized to `SnapshotError` (CodeRabbit review).
+- `dumper_manifest._tu_jobs` silently fell back to 1 (serial) worker on an
+  unparsable `ABICHECK_TU_JOBS` value with no diagnostic explaining why the
+  requested parallelism was ignored. Now logs a warning naming the bad
+  value (CodeRabbit review).
+- `dumper_manifest.run_tu_loop`'s `_handle_failure` used a bare `raise`
+  (Ruff `PLE0704`, "misplaced bare raise" — the statement's own lexical
+  scope is a nested function, not directly inside the `except` block that
+  calls it) to re-propagate a required TU's failure. Now takes the caught
+  exception explicitly and re-raises it by reference (CodeRabbit review).
+- `process_resources.mem_cap` divided by its `budget_gib` argument
+  unconditionally, so a zero (or negative) budget raised `ZeroDivisionError`
+  instead of being treated like "can't be read" — latent today since its
+  only caller floors the budget at 0.25, but the function had no guard of
+  its own (CodeRabbit review).

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -49,6 +49,7 @@ from abicheck.dumper_clang import (
     _is_intel_sycl_driver,
     _pointer_depth,
     _return_type,
+    _user_explicitly_disabled_sycl,
 )
 from abicheck.dumper_clang_errors import _parse_clang_ast_result
 from abicheck.errors import SnapshotError
@@ -851,6 +852,59 @@ def test_needs_sycl_host_only(cc_bin: str, tokens: list[str], expected: bool) ->
 )
 def test_dpcpp_defaults_sycl_on(cc_bin: str, expected: bool) -> None:
     assert _dpcpp_defaults_sycl_on(cc_bin) is expected
+
+
+@pytest.mark.parametrize(
+    "tokens,expected",
+    [
+        ([], False),
+        (["-fsycl"], False),
+        (["-fno-sycl"], True),
+        (["-fsycl", "-fno-sycl"], True),
+        # Last-flag-wins: a later -fsycl re-enables it (Codex review, P2).
+        (["-fno-sycl", "-fsycl"], False),
+        (["-fsycl", "-fno-sycl", "-fsycl"], False),
+        (["-DFOO=1"], False),
+    ],
+)
+def test_user_explicitly_disabled_sycl(tokens: list[str], expected: bool) -> None:
+    assert _user_explicitly_disabled_sycl(tokens) is expected
+
+
+@pytest.mark.parametrize(
+    "clang_bin,frontend_context,tokens,expected",
+    [
+        ("icpx", "host", [], True),
+        ("icpx", "host", ["-fno-sycl"], False),
+        ("clang++", "host", [], False),
+        ("icpx", "device", [], True),
+    ],
+)
+def test_resolve_dpcpp_multi_context(
+    clang_bin: str, frontend_context: str, tokens: list[str], expected: bool
+) -> None:
+    assert (
+        dumper_clang._resolve_dpcpp_multi_context(
+            clang_bin, frontend_context, None, tuple(tokens)
+        )
+        is expected
+    )
+
+
+def test_resolve_dpcpp_multi_context_device_on_plain_clang_raises() -> None:
+    from abicheck.errors import AstContextMissingError
+
+    with pytest.raises(AstContextMissingError, match="DPC\\+\\+-capable"):
+        dumper_clang._resolve_dpcpp_multi_context("clang++", "device", None, ())
+
+
+def test_resolve_dpcpp_multi_context_device_with_fno_sycl_raises() -> None:
+    from abicheck.errors import AstContextMissingError
+
+    with pytest.raises(AstContextMissingError, match="-fno-sycl"):
+        dumper_clang._resolve_dpcpp_multi_context(
+            "icpx", "device", None, ("-fno-sycl",)
+        )
 
 
 def test_build_clang_header_command_dpcpp_defaults_sycl_on(tmp_path: Path) -> None:

--- a/tests/test_dumper_manifest.py
+++ b/tests/test_dumper_manifest.py
@@ -798,11 +798,19 @@ def test_tu_jobs_clamped_by_available_memory(monkeypatch):
     assert _tu_jobs(1000) == 2  # 6 GiB / 3.0 GiB-per-worker default == 2
 
 
-def test_tu_jobs_invalid_env_falls_back_to_serial(monkeypatch):
+def test_tu_jobs_invalid_env_falls_back_to_serial(monkeypatch, caplog):
+    import logging
+
     from abicheck.dumper_manifest import _tu_jobs
 
     monkeypatch.setenv("ABICHECK_TU_JOBS", "not-a-number")
-    assert _tu_jobs(100) == 1
+    with caplog.at_level(logging.WARNING):
+        jobs = _tu_jobs(100)
+    assert jobs == 1
+    # CodeRabbit review: an unparsable override used to fall back to serial
+    # silently, with no diagnostic explaining why the requested parallelism
+    # was ignored.
+    assert any("not-a-number" in r.message for r in caplog.records)
 
 
 def test_tu_jobs_explicit_env_clamped_by_oversubscription_ceiling(monkeypatch, caplog):

--- a/tests/test_process_resources.py
+++ b/tests/test_process_resources.py
@@ -214,3 +214,13 @@ def test_mem_cap_divides_available_by_budget(monkeypatch) -> None:
     monkeypatch.setattr(pr, "available_mem_gib", lambda: 6.0)
     assert pr.mem_cap(3.0) == 2
     assert pr.mem_cap(1.0) == 6
+
+
+def test_mem_cap_non_positive_budget_returns_none(monkeypatch) -> None:
+    """CodeRabbit review: a zero or negative budget used to raise
+    ZeroDivisionError (or invert the clamp for a negative budget) instead of
+    being treated like "can't be read" -- job_mem_budget_gib floors at 0.25
+    today, but mem_cap itself had no guard of its own."""
+    monkeypatch.setattr(pr, "available_mem_gib", lambda: 6.0)
+    assert pr.mem_cap(0.0) is None
+    assert pr.mem_cap(-1.0) is None

--- a/tests/test_sycl_context.py
+++ b/tests/test_sycl_context.py
@@ -515,6 +515,17 @@ def test_from_path_rejects_truncated_document_with_tiny_chunk_size(
         )
 
 
+def test_from_path_rejects_non_utf8_bytes_as_snapshot_error(tmp_path: Path) -> None:
+    """CodeRabbit review: non-UTF-8 bytes in *ast_path* used to raise a bare
+    ``UnicodeDecodeError`` straight out of ``open(...).read()``, inconsistent
+    with every other decode failure in this module being normalized to
+    ``SnapshotError``."""
+    ast_path = tmp_path / "ast_dump.json"
+    ast_path.write_bytes(b'{"kind": "TranslationUnitDecl", "inner": [\xff\xfe')
+    with pytest.raises(SnapshotError, match="not valid UTF-8"):
+        decode_and_select_frontend_context_from_path(ast_path, "", "host")
+
+
 def test_from_path_large_document_parses_json_exactly_once(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

Follow-up fixes for review findings that arrived on #636 (ADR-050 D5/D6, G32 Phase D/E) after that PR was merged. This branch was restarted from the current `main` tip (which already includes #636) rather than stacked onto the merged history.

## Motivation

Codex/CodeRabbit review comments continued to arrive on #636 after it merged. This PR addresses them as standalone follow-up fixes.

## Changes

- `dumper._clang_header_dump`'s `dpcpp_multi_context` unconditionally forced `-fsycl -v` onto every DPC++-capable invocation, silently overriding an explicit `-fno-sycl` in the caller's own `--gcc-options`/`--gcc-option`. New `dumper_clang._user_explicitly_disabled_sycl`/`_resolve_dpcpp_multi_context` detect the caller's own trailing `-fno-sycl` (last-flag-wins) and skip the multi-pass SYCL decode path for it; `--frontend-context device` combined with an explicit `-fno-sycl` now fails fast with `AstContextMissingError` instead of silently resolving the contradiction either way (Codex review).
- `sycl_context.decode_and_select_frontend_context_from_path` raised a bare `UnicodeDecodeError` on non-UTF-8 bytes instead of the module's usual `SnapshotError` (CodeRabbit review).
- `dumper_manifest._tu_jobs` now logs a warning naming the bad value on an unparsable `ABICHECK_TU_JOBS` override instead of silently falling back to serial (CodeRabbit review).
- `dumper_manifest.run_tu_loop`'s `_handle_failure` took the caught exception explicitly and re-raises it by reference instead of a bare `raise` (Ruff `PLE0704`, CodeRabbit review).
- `process_resources.mem_cap` guards against a non-positive `budget_gib` instead of raising `ZeroDivisionError` (CodeRabbit review).
- `dumper.dump()`'s docstring now documents the `frontend_context` parameter (CodeRabbit nitpick).

## Checklist

- [x] Tests added / updated for new behaviour (each fix verified to fail pre-fix via `git stash`)
- [x] Changelog fragment added (`changelog.d/20260726_150000_claude_g32_phase_d_sycl_context.md`)
- [ ] Docs updated if user-visible behaviour changed (no user-visible behavior change; internal fixes only)
- [x] `mypy abicheck/` / `ruff check` / `python scripts/check_ai_readiness.py` all pass locally
- [x] No new `mypy` or `ruff` errors introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_017oFpVQvw7kM9NYviQu9Xzr)_