### PR TITLE
fix: a qualified typedef resolves only by its exact key (ADR-049 replay)

### DIFF
--- a/abicheck/contract_evidence_collect.py
+++ b/abicheck/contract_evidence_collect.py
@@ -354,13 +354,16 @@ class _TypeIndex:
             self._nodes_by_spelling.setdefault(_type_identity(en), set()).add(
                 _enum_node(_type_identity(en))
             )
+        # A typedef resolves by its **exact** key and nothing else, because
+        # that is all `_walk_type_closure` does with one: `snap.typedefs.get(
+        # name)`, a plain dict lookup with no tail fallback. Records and enums
+        # get a bare tail above only because `_index_surface_types` gives them
+        # one. Registering a tail here too let a signature spelling the bare
+        # `Alias` reach a qualified `ns::Alias -> Secret`, so a private
+        # `Secret` layout change the live evaluator proved out of contract
+        # re-evaluated as `IN_CONTRACT` (Codex review, fresh evidence).
         for alias in snap.typedefs:
             self._nodes_by_spelling.setdefault(alias, set()).add(_typedef_node(alias))
-            if "::" in alias:
-                tail = alias.rsplit("::", 1)[1]
-                self._nodes_by_spelling.setdefault(tail, set()).add(
-                    _typedef_node(alias)
-                )
         self.ambiguous_type_names = set(scratch.ambiguous_type_names)
         self.all_types = set(scratch.all_types)
         self._owner_seed_nodes = self._build_owner_seed_index(

--- a/abicheck/contract_relevance_types.py
+++ b/abicheck/contract_relevance_types.py
@@ -323,6 +323,24 @@ EVALUATOR_VERSION: int = 1
 itself, independent of the schema versions above -- the same observed facts
 can classify differently under a new evaluator."""
 
-IDENTITY_ALGORITHM_VERSION: int = 1
+IDENTITY_ALGORITHM_VERSION: int = 2
 """Version of the canonical entity-identity/join algorithm (ADR-048) that
-produced the persisted evidence and decision receipt."""
+produced the persisted evidence and decision receipt.
+
+Bumped to 2 when ``contract_evidence_collect._TypeIndex`` stopped registering
+a qualified typedef's bare ``::`` tail as a spelling of that typedef: the
+same ``AbiSnapshot`` now yields a *different* ``TypeGraphSnapshot`` -- a
+signature spelling bare ``Alias`` no longer reaches a qualified
+``ns::Alias -> Secret`` -- so a context persisted before the fix and one
+persisted after it are not interchangeable evidence, even though the block's
+*shape* (and therefore ``CONTRACT_EVIDENCE_SCHEMA_VERSION``) is unchanged.
+That is exactly the split this counter exists for, and leaving it at 1 would
+have left both formats advertising one algorithm while resolving typedefs
+differently -- a consumer could neither tell them apart nor fail closed on
+the newer semantics (Codex review).
+
+The bump does not reject the older graphs: ADR-049 D6's rule is that a
+version *older than or equal to* this build's is accepted (possibly
+degraded) and only a *newer* one is refused, so a v1 context still replays
+here while a v2 context is refused by a build that predates the fix -- the
+fail-closed direction that matters."""

--- a/changelog.d/20260801_070000_claude_adr049_typedef_tail.md
+++ b/changelog.d/20260801_070000_claude_adr049_typedef_tail.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **ADR-049 replay: a qualified typedef resolves only by its exact key.**
+  `contract_evidence_collect` registered a typedef under its bare `::` tail
+  as well, the way records and enums are registered — but the live
+  public-surface walk follows a typedef with `snap.typedefs.get(name)`, a
+  plain dict lookup with no tail fallback. A public signature spelling the
+  bare `Alias` therefore reached a qualified `ns::Alias -> Secret` in the
+  persisted graph, and a private `Secret` layout change the live evaluator
+  recorded as `PROVEN_OUT_OF_CONTRACT` re-evaluated as `IN_CONTRACT` — a
+  strengthened replay decision, which `compare_decisions()` treats as a
+  defect. Affects only `compare --contract-evaluation`, which is advisory:
+  no verdict, exit code, or finding set changes.

--- a/changelog.d/20260801_070000_claude_adr049_typedef_tail.md
+++ b/changelog.d/20260801_070000_claude_adr049_typedef_tail.md
@@ -11,3 +11,9 @@
   strengthened replay decision, which `compare_decisions()` treats as a
   defect. Affects only `compare --contract-evaluation`, which is advisory:
   no verdict, exit code, or finding set changes.
+
+  Because the same snapshot now produces a different persisted type graph,
+  `IDENTITY_ALGORITHM_VERSION` bumps to 2 so the two formats are
+  distinguishable. Older (v1) contexts still load and replay; a v2 context
+  is refused by a build that predates the fix, which is the fail-closed
+  direction ADR-049 D6 specifies.

--- a/docs/contribute/plans/public-contract-default.md
+++ b/docs/contribute/plans/public-contract-default.md
@@ -2769,6 +2769,20 @@ node, and the public root inherited the private overload's edge to `Secret`.
 Every recorded linker identity is now reserved, so a display-name fallback
 yields to one whichever tier it came from.
 
+**A sixteenth round found the same over-resolution one type kind over.** A
+typedef was registered under its bare `::` tail as well as its exact key,
+the way records and enums are — but `_walk_type_closure` follows a typedef
+with `snap.typedefs.get(name)`, a plain dict lookup with no tail fallback at
+all. Records and enums get a tail only because `_index_surface_types` gives
+them one; a typedef has no such spelling. So a public signature spelling the
+bare `Alias` reached a qualified `ns::Alias -> Secret`, and a private
+`Secret` layout change the live evaluator proved out of contract
+re-evaluated as `IN_CONTRACT`. The tail registration is removed; the exact
+key still resolves, which is what live matches on. Worth noting the shape:
+this is the third distinct place where "resolve it the way the neighbouring
+kind is resolved" was wrong because the live walk treats the kinds
+differently — the mirror has to be per kind, not per intuition.
+
 One finding from an earlier round was **not** taken: replacing
 `report_finding_id`'s `"\x1f"` field delimiter with a length-prefixed or
 canonical-JSON encoding. The ambiguity it guards against requires a literal

--- a/docs/contribute/plans/public-contract-default.md
+++ b/docs/contribute/plans/public-contract-default.md
@@ -2783,6 +2783,25 @@ this is the third distinct place where "resolve it the way the neighbouring
 kind is resolved" was wrong because the live walk treats the kinds
 differently — the mirror has to be per kind, not per intuition.
 
+**A seventeenth round asked what that fix owes the persisted format, and
+the answer was a version bump.** Removing the tail registration means the
+same `AbiSnapshot` now yields a *different* `TypeGraphSnapshot` — the
+graph is persisted evidence a later build re-walks, so a context written
+before the fix and one written after it are not interchangeable, even
+though every block's *shape* is identical and no schema counter moved.
+Leaving `IDENTITY_ALGORITHM_VERSION` at 1 would have had both formats
+advertise one identity algorithm while resolving typedefs differently: a
+consumer could neither tell them apart nor refuse the newer semantics.
+Bumped to 2, which is precisely the concern this counter was split out to
+carry (the schema counters version a block's shape; this one versions the
+algorithm that filled it). The bump does not reject the older graphs —
+D6's rule accepts a version older than or equal to this build's, possibly
+degraded, and refuses only a newer one, so a v1 context still replays here
+while a v2 context is refused by a build that predates the fix. That is
+the direction that matters, and it is also the first time these four
+counters have actually diverged, which the version-strategy test now pins
+as executable proof that they can.
+
 One finding from an earlier round was **not** taken: replacing
 `report_finding_id`'s `"\x1f"` field delimiter with a length-prefixed or
 canonical-JSON encoding. The ambiguity it guards against requires a literal

--- a/tests/test_contract_evidence_collect.py
+++ b/tests/test_contract_evidence_collect.py
@@ -391,6 +391,33 @@ class TestTypeGraph:
         closure = closure_from_graph(graph, ["decl:ns::Widget::draw"])
         assert {"record:ns::Widget", "record:Payload"} <= closure
 
+    def test_a_qualified_typedef_resolves_only_by_its_exact_key(self) -> None:
+        """A typedef has no bare-tail spelling, unlike a record or an enum.
+
+        ``_walk_type_closure`` follows one with ``snap.typedefs.get(name)`` --
+        a plain dict lookup, no tail fallback -- so registering the tail let
+        a signature spelling bare ``Alias`` reach a qualified
+        ``ns::Alias -> Secret``, and a private ``Secret`` change the live
+        evaluator proved out of contract replayed as ``IN_CONTRACT`` (Codex
+        review, fresh evidence).
+        """
+        snap = _snap(
+            functions=[_public_fn("api", ret="Alias")],
+            typedefs={"ns::Alias": "Secret"},
+            types=[RecordType(name="Secret", kind="struct", fields=[])],
+        )
+        graph = build_type_graph(snap)
+        assert "record:Secret" not in closure_from_graph(graph, ["decl:api"])
+        # The exact key still resolves, which is what live matches on.
+        exact = _snap(
+            functions=[_public_fn("api", ret="ns::Alias")],
+            typedefs={"ns::Alias": "Secret"},
+            types=[RecordType(name="Secret", kind="struct", fields=[])],
+        )
+        assert "record:Secret" in closure_from_graph(
+            build_type_graph(exact), ["decl:api"]
+        )
+
     def test_an_enum_is_keyed_and_aliased_like_a_record(self) -> None:
         """``enum:`` is a first-class node kind, not a record afterthought.
 

--- a/tests/test_contract_evidence_collect.py
+++ b/tests/test_contract_evidence_collect.py
@@ -406,17 +406,22 @@ class TestTypeGraph:
             typedefs={"ns::Alias": "Secret"},
             types=[RecordType(name="Secret", kind="struct", fields=[])],
         )
-        graph = build_type_graph(snap)
-        assert "record:Secret" not in closure_from_graph(graph, ["decl:api"])
+        # Both nodes are asserted, not just the target: `record:Secret` alone
+        # would pass just as well if the typedef node *were* reached and only
+        # its own edge to the target were broken -- a different bug with the
+        # same symptom (CodeRabbit review).
+        bare_closure = closure_from_graph(build_type_graph(snap), ["decl:api"])
+        assert "typedef:ns::Alias" not in bare_closure
+        assert "record:Secret" not in bare_closure
         # The exact key still resolves, which is what live matches on.
         exact = _snap(
             functions=[_public_fn("api", ret="ns::Alias")],
             typedefs={"ns::Alias": "Secret"},
             types=[RecordType(name="Secret", kind="struct", fields=[])],
         )
-        assert "record:Secret" in closure_from_graph(
-            build_type_graph(exact), ["decl:api"]
-        )
+        exact_closure = closure_from_graph(build_type_graph(exact), ["decl:api"])
+        assert "typedef:ns::Alias" in exact_closure
+        assert "record:Secret" in exact_closure
 
     def test_an_enum_is_keyed_and_aliased_like_a_record(self) -> None:
         """``enum:`` is a first-class node kind, not a record afterthought.

--- a/tests/test_contract_relevance_types.py
+++ b/tests/test_contract_relevance_types.py
@@ -178,15 +178,23 @@ class TestContractReasonCodes:
 
 
 class TestSchemaVersionStrategy:
-    def test_all_version_counters_start_at_one(self):
+    def test_each_counter_pins_its_current_value(self):
+        # Not "they all start at one" any more: `IDENTITY_ALGORITHM_VERSION`
+        # has since bumped on its own (the qualified-typedef tail fix changed
+        # the produced type graph without changing any block's shape), which
+        # is the whole point of keeping four counters. Pin each one so a
+        # future change to a persisted format or algorithm has to state which
+        # concern it moved.
         assert CONTRACT_EVIDENCE_SCHEMA_VERSION == 1
         assert EVALUATION_CONTEXT_SCHEMA_VERSION == 1
         assert EVALUATOR_VERSION == 1
-        assert IDENTITY_ALGORITHM_VERSION == 1
+        assert IDENTITY_ALGORITHM_VERSION == 2
 
     def test_version_counters_are_independent_objects(self):
         # Each concern must be able to bump independently -- guard against a
-        # future refactor collapsing them into one shared constant.
+        # future refactor collapsing them into one shared constant. The
+        # identity counter having actually diverged from the other three is
+        # the executable proof of that, not just the key count.
         counters = {
             "contract_evidence": CONTRACT_EVIDENCE_SCHEMA_VERSION,
             "evaluation_context": EVALUATION_CONTEXT_SCHEMA_VERSION,
@@ -194,3 +202,4 @@ class TestSchemaVersionStrategy:
             "identity_algorithm": IDENTITY_ALGORITHM_VERSION,
         }
         assert len(counters) == 4
+        assert counters["identity_algorithm"] != counters["contract_evidence"]

--- a/tests/test_contract_replay.py
+++ b/tests/test_contract_replay.py
@@ -127,6 +127,12 @@ class TestVersionGate:
 
         Only an individual counter *above* this build's ceiling fails; a
         mixed pair below it is exactly what plan Section 5.1 describes.
+
+        The pinned ``identity_algorithm_version=1`` is now genuinely *below*
+        this build's ceiling (the qualified-typedef tail fix bumped it to 2),
+        so this exercises the real older-evidence path rather than an
+        equal-to-current one, which is all it could assert while every
+        counter still sat at 1.
         """
         _result, ctx = _run()
         mixed = replace(


### PR DESCRIPTION
## Summary

Follow-up to #661 (merged): a qualified typedef was resolvable by its bare `::` tail in the persisted type graph, which let a replayed decision out-claim the live one.

## Motivation

Found by a Codex review on `b34d0a6`, verified and fixed after #661 had already merged — so it lands as its own change rather than reopening a finished PR.

`contract_evidence_collect._TypeIndex` registered every typedef under its bare `::` tail as well as its exact key, the way records and enums are registered. But the live walk follows a typedef with `snap.typedefs.get(name)` — a plain dict lookup, **no tail fallback at all**. Records and enums have a tail only because `_index_surface_types` gives them one; a typedef has no such spelling.

A public signature spelling the bare `Alias` therefore reached a qualified `ns::Alias -> Secret` in the persisted graph. Reproduced end to end: a private `Secret` layout change recorded live as `PROVEN_OUT_OF_CONTRACT` re-evaluated as `IN_CONTRACT` — a *strengthened* replay decision, the one direction `compare_decisions()` treats as a defect.

This is the third distinct place where mirroring "the way the neighbouring kind is resolved" was wrong because the live walk treats the kinds differently. The mirror has to be per kind, not per intuition — noted in the plan doc so the next person reaching for the same shortcut sees it.

## Changes

- `abicheck/contract_evidence_collect.py`: a typedef is registered under its exact key only. The comment states which live lookup it mirrors and why records/enums legitimately differ.
- `tests/test_contract_evidence_collect.py`: `test_a_qualified_typedef_resolves_only_by_its_exact_key` — asserts the bare tail no longer reaches the target *and* that the exact key still does (so the fix can't pass by resolving nothing).
- `docs/contribute/plans/public-contract-default.md`: sixteenth-round entry.
- Changelog fragment.

## Checklist

- [x] Tests added / updated for new behaviour — confirmed failing with only the source reverted
- [x] Changelog fragment added (`changelog.d/20260801_070000_claude_adr049_typedef_tail.md`)
- [x] Docs updated if user-visible behaviour changed — advisory path only (`compare --contract-evaluation`); no verdict, exit code, or finding set changes
- [x] `scripts/verify.py --profile pr`: lint, typecheck, ai-readiness, unit-pr, fp-rate, tier-accuracy, usecase-docs-sync, docs-contract, repo-facts, schema-sync, fair-metadata all pass. `fmt-check` fails repo-wide on files this PR does not touch (pre-existing; CI's lint job runs `--only lint,typecheck,docs-build`)
- [x] No new `mypy` or `ruff` errors introduced (`mypy abicheck/` clean, 309 files)

Also re-ran all six replay repro scripts from #661's review rounds: every one agrees with the live decision, none strengthen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BED1UqfQYTbTdPsQiWH5pa

---
_Generated by [Claude Code](https://claude.ai/code/session_01BED1UqfQYTbTdPsQiWH5pa)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected qualified typedef resolution to require exact name matches.
  * Prevented bare aliases from incorrectly resolving to qualified typedefs during contract-evaluation comparisons.
  * Advisory replay behavior is now consistent with live resolution; verdicts, exit codes, and findings remain unchanged.

* **Documentation**
  * Added documentation covering the typedef resolution behavior and related replay fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->