### PR TITLE
feat!: ADR-055 D1–D4 — one typed CompareResult, one shared resolution, one schema registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,6 +418,16 @@ Core pipeline (in order of data flow):
    - `type_metadata.py`, `dwarf_utils.py` — shared type helpers
    - `change_registry.py` — change kind registry
    - `service.py` — service layer (Python API)
+   - `service_compare_pipeline.py` — ADR-055 D1: `run_compare_request`'s two
+     phases (`resolve_compare_request` / `classify_compare_pair`), split so
+     the native `compare` CLI can run its Click-dependent ADR-049
+     `resolve_and_apply` step between them and still share one resolution
+     with the typed API and MCP instead of keeping a second copy.
+     `resolve_sides_sequentially` owns the one rule about resolving both
+     sides concurrently (a `dump_manifest` on either side, or
+     `ABICHECK_PARALLEL_EXTRACTION=0`, forces sequential — a manifest dump
+     sizes its per-TU pool off a live `MemAvailable` reading, so two at once
+     jointly overcommit)
    - `stack_checker.py`, `stack_report.py`, `stack_html.py` — stack analysis
 9. **Build-source evidence (optional L3–L5 layers)** — `buildsource/` package
    (collect/merge/source-ABI replay/source graph; ADR-028…033). See

--- a/README.md
+++ b/README.md
@@ -176,16 +176,22 @@ Full references:
 from pathlib import Path
 from abicheck.service import run_compare
 
-result, old_snapshot, new_snapshot = run_compare(
+result = run_compare(
     old_input=Path("libfoo.so.1"),
     new_input=Path("libfoo.so.2"),
     old_headers=[Path("include/v1/foo.h")],
     new_headers=[Path("include/v2/foo.h")],
 )
 
-print(result.verdict)       # e.g. Verdict.BREAKING
-print(len(result.changes))  # number of detected changes
+print(result.diff.verdict)       # e.g. Verdict.BREAKING
+print(len(result.diff.changes))  # number of detected changes
+print(result.old_snapshot.library, result.new_snapshot.library)
 ```
+
+`run_compare` returns a `CompareResult` — `diff`, `old_snapshot`,
+`new_snapshot`, and the resolved `suppression` list. It returned a bare
+3-tuple before 0.6; a positional caller migrates in one line with
+`result, old, new = run_compare(...).as_tuple()`.
 
 See the [Python API guide](https://abicheck.github.io/abicheck/user-guide/python-api/)
 for snapshots, custom policies, and rendering, plus the

--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -279,6 +279,29 @@ class CompareRequest:
     # since a binary-only depth request that still carries headers would
     # otherwise silently keep running L2.
     depth: str | None = None
+    # ADR-055 D1, second slice: the last four concepts `compare`'s own
+    # resolution (`cli_resolve._resolve_compare_snapshots`) could express and
+    # this request could not, so a Python/MCP caller had to drop to loose
+    # kwargs on `resolve_input` to reach them. All both-sides, mirroring the
+    # CLI flags they come from, which are single-valued too.
+    #
+    # `--dwarf-only` / `--debug-format`: restrict a side's debug-info parse to
+    # DWARF, or pin which debug format is read, instead of auto-detecting.
+    dwarf_only: bool = False
+    debug_format: str | None = None
+    # ADR-050 D1's resolved `path -> label` map for a labeled include set.
+    # A tuple of pairs rather than a `dict` so the request stays hashable, the
+    # property `InputSpec`'s own docstring calls out; `run_compare_request`
+    # converts it back for `resolve_input`.
+    include_labels: tuple[tuple[Path, str], ...] = ()
+    # `--follow-deps` / `--search-path` / `--ld-library-path`: after both
+    # sides resolve, populate each ELF side's transitive `DependencyInfo`.
+    # Off by default, matching the CLI flag: it costs a full dependency-graph
+    # resolution per side, so it stays opt-in rather than becoming a silent
+    # cost for every typed caller.
+    follow_dependencies: bool = False
+    dependency_search_paths: tuple[Path, ...] = ()
+    ld_library_path: str = ""
     # ADR-055 D1 / ADR-050: request-level default for `CompileContext.
     # frontend_context` (`--frontend-context`, host|device), applied to a
     # side whose own `InputSpec.compile.frontend_context` reads as the class

--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -36,17 +36,15 @@ Gap 1 documents: ``CompareRequest`` previously had no way to express
 per-side ``CompileContext`` feature set at all, so a Python caller wanting
 that had to fall back to loose keyword arguments on lower-level functions.
 ``service.run_compare_request`` reads these new fields directly (see its own
-docstring for exactly how); it does not match every capability of the CLI's
-own, separately-maintained ``cli_resolve._resolve_compare_snapshots``
-(project-config ``source.method`` inference, the set-input evidence-flag
-rejection guard, per-side AST-frontend override). Keeping those two paths —
-extending this one in parallel rather than migrating the CLI onto it — is a
-recorded decision, not an unfinished migration: ADR-055's
-"Two-resolution-path finding" answers it as option (b), on the grounds that
-the *capability* gap is what D1 existed to close, while rewriting the CLI's
-most heavily-tested resolution path buys nothing a user can observe. The
-three CLI-only capabilities are listed above so a future reader does not
-have to re-derive the actual scope of the difference.
+docstring for exactly how). A second D1 slice then closed the rest of the
+gap against the CLI's own, separately-maintained
+``cli_resolve._resolve_compare_snapshots`` — ``dwarf_only``,
+``debug_format``, ``include_labels``, and ``--follow-deps`` — so the two
+paths now differ in *structure*, not in what they can express. Keeping both,
+rather than migrating the CLI onto this one, is a recorded decision:
+ADR-055's "Two-resolution-path finding" answers it as option (b), since
+rewriting the CLI's most heavily-tested resolution path buys nothing a user
+can observe.
 
 ADR-055 D2 adds :class:`CompareResult`, the result side of the same pair, and
 D4 adds ``InputSpec.follow_linker_scripts`` — see each one's own docstring.
@@ -77,6 +75,14 @@ SUPPORTED_LANGS = frozenset({"c", "c++"})
 #: pre-captured header-abi dump and has no header-AST path), so selecting it
 #: without source inputs is a validation error (D9).
 SUPPORTED_FRONTENDS = frozenset({"auto", "castxml", "clang", "hybrid", "android"})
+
+#: ELF debug formats ``--debug-format`` accepts, matching its ``click.Choice``
+#: exactly (including ``auto``). Compared case-insensitively, the way that
+#: choice is declared ``case_sensitive=False`` -- so an API caller passing
+#: ``"DWARF"`` behaves like the CLI caller who typed it, instead of reaching
+#: ``dumper_debug._resolve_debug_metadata`` and failing its lowercase-only
+#: comparison there (Codex review).
+SUPPORTED_DEBUG_FORMATS = frozenset({"auto", "dwarf", "btf", "ctf"})
 
 #: The subset of :data:`SUPPORTED_FRONTENDS` valid for header-AST parsing.
 #: "hybrid" (G28 Phase 3) runs both castxml and clang and merges them —
@@ -288,6 +294,10 @@ class CompareRequest:
     # `--dwarf-only` / `--debug-format`: restrict a side's debug-info parse to
     # DWARF, or pin which debug format is read, instead of auto-detecting.
     dwarf_only: bool = False
+    # Validated against SUPPORTED_DEBUG_FORMATS and lowercased before use, so a
+    # typo fails through this module's ValidationError contract rather than a
+    # raw ValueError deep in extraction, and "DWARF" works here exactly as it
+    # does for the CLI's case-insensitive choice.
     debug_format: str | None = None
     # ADR-050 D1's resolved `path -> label` map for a labeled include set.
     # A tuple of pairs rather than a `dict` so the request stays hashable, the
@@ -363,6 +373,14 @@ class CompareRequest:
         # helpers from the CLI/service import-cycle-allowlisted cluster this
         # leaf module deliberately stays out of, so it's checked at runtime
         # in service.run_compare_request instead of here.
+        if (
+            self.debug_format is not None
+            and self.debug_format.lower() not in SUPPORTED_DEBUG_FORMATS
+        ):
+            allowed = ", ".join(sorted(SUPPORTED_DEBUG_FORMATS))
+            errors.append(
+                f"unsupported debug format {self.debug_format!r}: choose from {allowed}"
+            )
         if not self.policy:
             errors.append("policy profile name must not be empty")
         # D9 pre-flight: a --policy-file path that doesn't exist is a hard error
@@ -487,6 +505,7 @@ class CompareResult:
 
 __all__ = [
     "HEADER_AST_FRONTENDS",
+    "SUPPORTED_DEBUG_FORMATS",
     "SUPPORTED_FRONTENDS",
     "SUPPORTED_LANGS",
     "CompareRequest",

--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -460,15 +460,15 @@ class CompareRequest:
 class CompareResult:
     """What one :class:`CompareRequest` produced — the typed result (ADR-055 D2).
 
-    :func:`abicheck.service.run_compare_request` returns a bare
-    ``tuple[DiffResult, AbiSnapshot, AbiSnapshot]``, so every new thing a
-    comparison resolves has nowhere to land except a fourth tuple slot — a
-    break for every positional caller. This wraps that same tuple (``diff``/
-    ``old_snapshot``/``new_snapshot`` are exactly its three elements, in
-    order) so a future field (a resolved-depth record, ADR-049's evaluation
-    receipt, a coverage summary) is an additive attribute instead. The same
-    reasoning ADR-035 applied to ``ScanRequest``/``ScanResult``, generalized
-    to ``compare``.
+    Returned by :func:`abicheck.service.run_compare_request` and by the
+    ``run_compare`` kwargs shim. Both returned a bare
+    ``tuple[DiffResult, AbiSnapshot, AbiSnapshot]`` before 0.6, which left
+    every new thing a comparison resolves nowhere to land but a fourth tuple
+    slot — a break for every positional caller. As a struct, a future field
+    (a resolved-depth record, ADR-049's evaluation receipt, a coverage
+    summary) is an additive attribute instead. The same reasoning ADR-035
+    applied to ``ScanRequest``/``ScanResult``, generalized to ``compare``.
+    :meth:`as_tuple` reproduces the pre-0.6 shape in one line.
 
     ``suppression`` is the one field beyond that rename, and it is not
     speculative: it is what ADR-055 D4 needed to exist. ``run_compare_request``
@@ -495,10 +495,15 @@ class CompareResult:
     suppression: SuppressionList | None = None
 
     def as_tuple(self) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
-        """Return the legacy ``run_compare_request`` 3-tuple shape.
+        """Return ``(diff, old_snapshot, new_snapshot)`` — the pre-0.6 shape.
 
-        The tuple-returning entry points are implemented in terms of this, so
-        the two shapes cannot drift apart into two orderings.
+        A one-line migration for a caller that unpacked the tuple
+        ``run_compare``/``run_compare_request`` used to return::
+
+            result, old, new = run_compare(...).as_tuple()
+
+        Nothing in abicheck itself returns that shape any more; this exists
+        only so a caller need not restructure to adopt the typed result.
         """
         return self.diff, self.old_snapshot, self.new_snapshot
 

--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -37,14 +37,17 @@ per-side ``CompileContext`` feature set at all, so a Python caller wanting
 that had to fall back to loose keyword arguments on lower-level functions.
 ``service.run_compare_request`` reads these new fields directly (see its own
 docstring for exactly how). A second D1 slice then closed the rest of the
-gap against the CLI's own, separately-maintained
+gap against the CLI's own, then separately-maintained
 ``cli_resolve._resolve_compare_snapshots`` — ``dwarf_only``,
-``debug_format``, ``include_labels``, and ``--follow-deps`` — so the two
-paths now differ in *structure*, not in what they can express. Keeping both,
-rather than migrating the CLI onto this one, is a recorded decision:
-ADR-055's "Two-resolution-path finding" answers it as option (b), since
-rewriting the CLI's most heavily-tested resolution path buys nothing a user
-can observe.
+``debug_format``, ``include_labels``, and ``--follow-deps``. A third slice
+then removed that second implementation outright: ``run_compare_request``
+was split into its two phases (``service_compare_pipeline``), which gave the
+CLI's Click-dependent ADR-049 ``resolve_and_apply`` step a seam to run in —
+the thing that had made a shared resolution look impossible — and
+``_resolve_compare_snapshots`` now builds one of these requests and
+delegates. So this really is the one resolution every front end uses.
+ADR-055's "Two-resolution-path finding", first answered as option (b), is
+recorded as settled the other way in D1's "Structural half" note.
 
 ADR-055 D2 adds :class:`CompareResult`, the result side of the same pair, and
 D4 adds ``InputSpec.follow_linker_scripts`` — see each one's own docstring.

--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -36,12 +36,20 @@ Gap 1 documents: ``CompareRequest`` previously had no way to express
 per-side ``CompileContext`` feature set at all, so a Python caller wanting
 that had to fall back to loose keyword arguments on lower-level functions.
 ``service.run_compare_request`` reads these new fields directly (see its own
-docstring for exactly how); it does not yet match every capability of the
-CLI's own, separately-maintained ``cli_resolve._resolve_compare_snapshots``
+docstring for exactly how); it does not match every capability of the CLI's
+own, separately-maintained ``cli_resolve._resolve_compare_snapshots``
 (project-config ``source.method`` inference, the set-input evidence-flag
-rejection guard, per-side AST-frontend override) — migrating the CLI onto
-this path, or extending it further to match, is deliberately left as
-follow-up work (ADR-055's own "Two-resolution-path finding").
+rejection guard, per-side AST-frontend override). Keeping those two paths —
+extending this one in parallel rather than migrating the CLI onto it — is a
+recorded decision, not an unfinished migration: ADR-055's
+"Two-resolution-path finding" answers it as option (b), on the grounds that
+the *capability* gap is what D1 existed to close, while rewriting the CLI's
+most heavily-tested resolution path buys nothing a user can observe. The
+three CLI-only capabilities are listed above so a future reader does not
+have to re-derive the actual scope of the difference.
+
+ADR-055 D2 adds :class:`CompareResult`, the result side of the same pair, and
+D4 adds ``InputSpec.follow_linker_scripts`` — see each one's own docstring.
 """
 
 from __future__ import annotations
@@ -54,8 +62,11 @@ from typing import TYPE_CHECKING, Any
 from .errors import ValidationError
 
 if TYPE_CHECKING:
+    from .checker_types import DiffResult
     from .compile_context import CompileContext
     from .dump_manifest import DumpManifest
+    from .model import AbiSnapshot
+    from .suppression import SuppressionList
 
 #: Languages the C/C++ frontends accept (mirrors the CLI ``--lang`` choices).
 SUPPORTED_LANGS = frozenset({"c", "c++"})
@@ -133,6 +144,17 @@ class InputSpec:
     # already inferred by splitting `headers` into files/dirs
     # (`split_public_header_inputs`) -- mirrors `--public-header-dir`.
     public_header_dirs: tuple[Path, ...] = ()
+    # ADR-055 D4: whether resolving `path` may follow a GNU ld linker script's
+    # INPUT()/GROUP() target to the real library. Default True matches
+    # `resolve_input`'s own default (and therefore every pre-existing caller);
+    # the MCP server sets it False because it enforces MCP_MAX_FILE_SIZE on the
+    # *caller-supplied* path before resolving, and following a script would
+    # reach a target that never went through that guard -- a tiny script
+    # pointing at a huge library would otherwise defeat the resource limit.
+    # Without this field, routing `abi_compare` through `run_compare_request`
+    # (D4) would have silently dropped that guard, so it is request surface,
+    # not an MCP-local wrapper concern.
+    follow_linker_scripts: bool = True
 
     @classmethod
     def of(
@@ -150,6 +172,7 @@ class InputSpec:
         dump_manifest: DumpManifest | None = None,
         compile: CompileContext | None = None,
         public_header_dirs: Iterable[Path | str] | None = None,
+        follow_linker_scripts: bool = True,
     ) -> InputSpec:
         """Build an :class:`InputSpec`, coercing loose front-end values."""
         return cls(
@@ -165,6 +188,7 @@ class InputSpec:
             dump_manifest=dump_manifest,
             compile=compile,
             public_header_dirs=_path_tuple(public_header_dirs),
+            follow_linker_scripts=follow_linker_scripts,
         )
 
 
@@ -391,11 +415,59 @@ class CompareRequest:
         return replace(self, **changes)
 
 
+@dataclass(frozen=True)
+class CompareResult:
+    """What one :class:`CompareRequest` produced — the typed result (ADR-055 D2).
+
+    :func:`abicheck.service.run_compare_request` returns a bare
+    ``tuple[DiffResult, AbiSnapshot, AbiSnapshot]``, so every new thing a
+    comparison resolves has nowhere to land except a fourth tuple slot — a
+    break for every positional caller. This wraps that same tuple (``diff``/
+    ``old_snapshot``/``new_snapshot`` are exactly its three elements, in
+    order) so a future field (a resolved-depth record, ADR-049's evaluation
+    receipt, a coverage summary) is an additive attribute instead. The same
+    reasoning ADR-035 applied to ``ScanRequest``/``ScanResult``, generalized
+    to ``compare``.
+
+    ``suppression`` is the one field beyond that rename, and it is not
+    speculative: it is what ADR-055 D4 needed to exist. ``run_compare_request``
+    resolves the suppression list internally from
+    ``CompareRequest.suppress``, but a front end applying a *post*-
+    classification concern still needs the resolved object — ``appcompat``'s
+    ``scope_diff_to_app(..., suppression=...)`` is the concrete case. Without
+    it here, the MCP server would have had to keep its own
+    ``SuppressionList.load`` call purely to re-derive a value the service had
+    already loaded, which is precisely the duplication D4 removes. The
+    resolved policy file needs no equivalent field — ``DiffResult.policy_file``
+    already carries it.
+
+    Placed here rather than in ``service.py`` (where ADR-055's own file sketch
+    put it) so the request and its result live in one leaf module: this one is
+    already "typed request/response structs", imports nothing at runtime from
+    the service layer, and keeps a caller able to type-annotate a result
+    without importing ``service``'s much heavier graph.
+    """
+
+    diff: DiffResult
+    old_snapshot: AbiSnapshot
+    new_snapshot: AbiSnapshot
+    suppression: SuppressionList | None = None
+
+    def as_tuple(self) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
+        """Return the legacy ``run_compare_request`` 3-tuple shape.
+
+        The tuple-returning entry points are implemented in terms of this, so
+        the two shapes cannot drift apart into two orderings.
+        """
+        return self.diff, self.old_snapshot, self.new_snapshot
+
+
 __all__ = [
     "HEADER_AST_FRONTENDS",
     "SUPPORTED_FRONTENDS",
     "SUPPORTED_LANGS",
     "CompareRequest",
+    "CompareResult",
     "InputSpec",
     "OutputSpec",
 ]

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING
 
 import click
 
+from .api_types import CompareResult
 from .bundle import BundleDiffResult
 from .checker import Change, DiffResult
 from .cli import (
@@ -108,7 +109,7 @@ def _run_compare_pair(
     scope_to_public_surface: bool = True,
     pattern_verdicts: bool = False,
     include_dependencies: bool = True,
-) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
+) -> CompareResult:
     """Run compare for one old/new pair and return result + resolved snapshots.
 
     Routes through the single Tier-2 chokepoint (:func:`service.run_compare`,
@@ -225,7 +226,7 @@ def _compare_one_library(
     try:
         old_dbg = resolve_debug_info(old_path, old_debug_dir) if old_debug_dir else None
         new_dbg = resolve_debug_info(new_path, new_debug_dir) if new_debug_dir else None
-        result, _, _ = _run_compare_pair(
+        compare_result = _run_compare_pair(
             old_path,
             new_path,
             old_h,
@@ -243,6 +244,7 @@ def _compare_one_library(
             scope_to_public_surface=scope_to_public_surface,
             include_dependencies=include_dependencies,
         )
+        result = compare_result.diff
         v = result.verdict.value
         # compatible_additions historically counts *all* compatible changes
         # (additions + quality issues). Emit the quality subset separately so
@@ -616,7 +618,7 @@ def _collect_release_extras(
         old_dbg = resolve_debug_info(old_path, old_debug_dir) if old_debug_dir else None
         new_dbg = resolve_debug_info(new_path, new_debug_dir) if new_debug_dir else None
         try:
-            result, old_snap, _ = _run_compare_pair(
+            compare_result = _run_compare_pair(
                 old_path,
                 new_path,
                 old_h,
@@ -640,6 +642,7 @@ def _collect_release_extras(
                 err=True,
             )
             continue
+        result, old_snap = compare_result.diff, compare_result.old_snapshot
         if worst_verdict == "BREAKING":
             _drop_lockstep_soname_finding(result)
         if collect_diff_results:

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -360,51 +360,18 @@ def _populate_dependency_info(
     sysroot: Path | None,
     ld_library_path: str,
 ) -> None:
-    """Resolve transitive deps and store DependencyInfo in the snapshot."""
-    from .binder import BindingStatus, compute_bindings
-    from .model import DependencyInfo
-    from .resolver import resolve_dependencies
+    """Back-compat alias — the implementation now lives in the service layer.
 
-    graph = resolve_dependencies(
-        so_path,
-        search_paths=search_paths or None,
-        sysroot=sysroot,
-        ld_library_path=ld_library_path,
-    )
-    bindings = compute_bindings(graph)
+    ADR-055 D1's second slice gave ``run_compare_request`` ``--follow-deps``
+    parity, so this gained a second caller outside the CLI. It reads only
+    leaf modules (``binder``/``model``/``resolver``), so it moved to the leaf
+    ``dependency_info`` module both layers can depend on rather than either
+    importing the other (AGENTS.md's rule for exactly this shape). Kept as a
+    name here because ``cli.py`` imports and re-exports it.
+    """
+    from .dependency_info import populate_dependency_info
 
-    summary: dict[str, int] = {}
-    for b in bindings:
-        summary[b.status.value] = summary.get(b.status.value, 0) + 1
-
-    missing = [
-        {"consumer": b.consumer, "symbol": b.symbol, "version": b.version}
-        for b in bindings
-        if b.status == BindingStatus.MISSING
-    ]
-
-    snap.dependency_info = DependencyInfo(
-        nodes=[
-            {
-                "path": str(node.path),
-                "soname": node.soname,
-                "needed": node.needed,
-                "depth": node.depth,
-                "resolution_reason": node.resolution_reason,
-            }
-            for node in sorted(graph.nodes.values(), key=lambda n: (n.depth, n.soname))
-        ],
-        edges=[
-            {"consumer": consumer, "provider": provider}
-            for consumer, provider in graph.edges
-        ],
-        unresolved=[
-            {"consumer": consumer, "soname": soname}
-            for consumer, soname in graph.unresolved
-        ],
-        bindings_summary=summary,
-        missing_symbols=missing,
-    )
+    populate_dependency_info(snap, so_path, search_paths, sysroot, ld_library_path)
 
 
 def _is_supported_compare_input(path: Path) -> bool:

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -37,7 +37,7 @@ import click
 
 from .buildsource.build_query import PRUNED_HEADER_DIR_SEGMENTS
 from .compat.abicc_dump_import import looks_like_perl_dump
-from .header_utils import iter_directory_headers, split_public_header_inputs
+from .header_utils import iter_directory_headers
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -536,73 +536,85 @@ def _resolve_compare_snapshots(
     handles a ``SourceGraphSummary`` from any evidence tier uniformly, so
     populating it here from headers alone (no build system required) makes it
     reachable from plain ``compare``.
+
+    **ADR-055 D1: this no longer resolves anything itself.** It assembles a
+    :class:`~abicheck.api_types.CompareRequest` from ``compare``'s loose
+    arguments and hands it to the shared
+    :func:`abicheck.service.resolve_compare_request`, which is the same
+    resolution the typed Python API and the MCP ``abi_compare`` tool run. It
+    kept a parallel implementation until now only because
+    ``run_compare_request`` was one function with no seam for ``compare``'s
+    Click-dependent ADR-049 ``resolve_and_apply`` step to sit in; splitting
+    that function into its two phases removed the reason for the copy. What
+    stays CLI-specific is exactly what is genuinely CLI-specific: the
+    ``click.echo`` notifier, translating the framework-free errors into
+    ``click`` exceptions (the contract ``_resolve_input`` documented), and
+    ``allow_parallel=False`` to keep both sides resolving sequentially the way
+    this path always has.
     """
-    old_backend = old_header_backend or header_backend
-    new_backend = new_header_backend or header_backend
-    # compare's --header is documented as "Public header file or directory"
-    # (unlike dump's split -H/--public-header, compare has no lower-level
-    # "parse only, don't classify" mode) — so the same paths given via
-    # --header double as the public-header set for provenance tagging. Split
-    # into files/directories first (not passed through unsplit): a directory
-    # entry fingerprinted as an individual file identity corrupts
-    # compute_extraction_contract's scope_fingerprint common-root computation
-    # (see split_public_header_inputs's docstring) — a single `-H <dir>`
-    # umbrella otherwise made a byte-identical self-comparison spuriously
-    # raise ScopeMismatchError.
-    old_public_headers, old_public_header_dirs = split_public_header_inputs(old_h)
-    new_public_headers, new_public_header_dirs = split_public_header_inputs(new_h)
-    old = _resolve_input(
-        old_input,
-        old_h,
-        old_inc,
-        old_version,
-        lang,
-        is_elf=True if old_fmt == "elf" else None,
-        pdb_path=old_pdb_path if old_pdb_path else pdb_path,
+    from .api_types import CompareRequest, InputSpec
+    from .errors import SnapshotError, ValidationError
+
+    def _side_compile(backend_override: str | None) -> CompileContext | None:
+        # The per-side --old/new-ast-frontend rides on that side's own
+        # CompileContext.frontend, which `_run_dump_uncached` documents as
+        # outranking the bare both-sides `header_backend`. The caller has
+        # already neutralised `compile_context.frontend` to "auto" for exactly
+        # this reason, so there is nothing to lose by replacing it.
+        if backend_override is None:
+            return compile_context
+        import dataclasses
+
+        from .compile_context import CompileContext as _CompileContext
+
+        base = compile_context if compile_context is not None else _CompileContext()
+        return dataclasses.replace(base, frontend=backend_override)
+
+    request = CompareRequest(
+        old=InputSpec(
+            path=old_input,
+            headers=tuple(old_h),
+            includes=tuple(old_inc),
+            version=old_version,
+            pdb=old_pdb_path if old_pdb_path else pdb_path,
+            debug_roots=tuple(old_debug_roots or ()),
+            include_dependencies=include_dependencies,
+            dump_manifest=old_dump_manifest,
+            compile=_side_compile(old_header_backend),
+        ),
+        new=InputSpec(
+            path=new_input,
+            headers=tuple(new_h),
+            includes=tuple(new_inc),
+            version=new_version,
+            pdb=new_pdb_path if new_pdb_path else pdb_path,
+            debug_roots=tuple(new_debug_roots or ()),
+            include_dependencies=include_dependencies,
+            dump_manifest=new_dump_manifest,
+            compile=_side_compile(new_header_backend),
+        ),
+        lang=lang,
+        frontend=header_backend,
         dwarf_only=dwarf_only,
         debug_format=debug_format,
-        debug_roots=old_debug_roots,
+        include_labels=tuple((include_labels or {}).items()),
+        follow_dependencies=follow_deps,
+        dependency_search_paths=tuple(search_paths),
+        ld_library_path=ld_library_path,
         enable_debuginfod=enable_debuginfod,
         debuginfod_url=debuginfod_url,
-        header_backend=old_backend,
-        compile=compile_context,
-        public_headers=old_public_headers,
-        public_header_dirs=old_public_header_dirs,
-        include_labels=include_labels,
-        dump_manifest=old_dump_manifest,
-        include_dependencies=include_dependencies,
     )
-    new = _resolve_input(
-        new_input,
-        new_h,
-        new_inc,
-        new_version,
-        lang,
-        is_elf=True if new_fmt == "elf" else None,
-        pdb_path=new_pdb_path if new_pdb_path else pdb_path,
-        dwarf_only=dwarf_only,
-        debug_format=debug_format,
-        debug_roots=new_debug_roots,
-        enable_debuginfod=enable_debuginfod,
-        debuginfod_url=debuginfod_url,
-        header_backend=new_backend,
-        compile=compile_context,
-        public_headers=new_public_headers,
-        public_header_dirs=new_public_header_dirs,
-        include_labels=include_labels,
-        dump_manifest=new_dump_manifest,
-        include_dependencies=include_dependencies,
-    )
-    if follow_deps:
-        if old_fmt == "elf":
-            _populate_dependency_info(
-                old, old_input, list(search_paths), None, ld_library_path
-            )
-        if new_fmt == "elf":
-            _populate_dependency_info(
-                new, new_input, list(search_paths), None, ld_library_path
-            )
-    return old, new
+    from . import service
+
+    try:
+        pair = service.resolve_compare_request(
+            request, notify=_click_notify, allow_parallel=False
+        )
+    except ValidationError as exc:
+        raise click.UsageError(str(exc)) from exc
+    except SnapshotError as exc:
+        raise click.ClickException(str(exc)) from exc
+    return pair.old, pair.new
 
 
 # ── Set-input (directory/package) compare guards (ADR-037 D3/D12) ─────────────

--- a/abicheck/dependency_info.py
+++ b/abicheck/dependency_info.py
@@ -139,16 +139,25 @@ def _dependency_source(side: InputSpec, fmt: str | None) -> Path | None:
     the *original* path would be no better: ``resolve_dependencies`` needs the
     ELF, not the script that names it.
 
-    So this follows the script the same way ``resolve_input`` does, and only
-    when that side opted into following at all
+    So this follows the script the same way ``resolve_input`` does — including
+    a *chain* of them, since that function recurses (it calls itself on the
+    resolved target with ``follow_linker_scripts`` still set). Following only
+    one hop meant a script naming another script produced a snapshot fine
+    while the dependency scan silently skipped that side, which is exactly the
+    asymmetry this helper exists to remove (Codex review, second round; the
+    first round's fix handled a single hop and called it conservative — it was
+    just inconsistent).
+
+    Following is skipped entirely for a side that opted out
     (``InputSpec.follow_linker_scripts``) — an MCP request that pinned it off
     to keep its size guard authoritative must not get scripts followed here by
     a side door.
 
-    A script naming another script resolves to a non-ELF target and yields
-    ``None``: one hop is what ``resolve_linker_script`` answers, and stopping
-    there is the same conservative "skip rather than guess" direction this
-    function already takes for every other non-ELF input.
+    Cycle-protected: a script naming itself, or a pair naming each other,
+    terminates and yields ``None`` rather than looping. (``resolve_input``'s
+    own recursion guards only the self-reference case, so a two-script cycle
+    would recurse there until Python's stack gives out — real, pre-existing,
+    and not this function's to fix.)
     """
     from .binary_utils import detect_binary_format, resolve_linker_script
 
@@ -156,7 +165,17 @@ def _dependency_source(side: InputSpec, fmt: str | None) -> Path | None:
         return side.path
     if not side.follow_linker_scripts:
         return None
-    target, is_script = resolve_linker_script(side.path)
-    if is_script and target is not None and detect_binary_format(target) == "elf":
-        return target
-    return None
+
+    current = side.path
+    seen = {current.resolve()}
+    while True:
+        target, is_script = resolve_linker_script(current)
+        if not is_script or target is None:
+            return None
+        resolved = target.resolve()
+        if resolved in seen:
+            return None
+        seen.add(resolved)
+        if detect_binary_format(target) == "elf":
+            return target
+        current = target

--- a/abicheck/dependency_info.py
+++ b/abicheck/dependency_info.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from .api_types import CompareRequest
+    from .api_types import CompareRequest, InputSpec
     from .model import AbiSnapshot
 
 
@@ -120,7 +120,43 @@ def populate_pair_dependency_info(
         return
     search_paths = list(request.dependency_search_paths)
     for snap, side, fmt in ((old, request.old, old_fmt), (new, request.new, new_fmt)):
-        if fmt == "elf":
+        elf_path = _dependency_source(side, fmt)
+        if elf_path is not None:
             populate_dependency_info(
-                snap, side.path, search_paths, None, request.ld_library_path
+                snap, elf_path, search_paths, None, request.ld_library_path
             )
+
+
+def _dependency_source(side: InputSpec, fmt: str | None) -> Path | None:
+    """The ELF this side's dependency graph should be read from, or ``None``.
+
+    Not simply ``side.path if fmt == "elf"``. A distribution's ``libfoo.so`` is
+    routinely a GNU ld *linker script* pointing at the real ``libfoo.so.1``:
+    ``detect_binary_format`` sees a text file and answers ``None``, so a plain
+    format check would silently skip the dependency resolution the caller
+    explicitly asked for — while ``resolve_input`` had already followed the
+    script and produced a perfectly good ELF snapshot (Codex review). Reading
+    the *original* path would be no better: ``resolve_dependencies`` needs the
+    ELF, not the script that names it.
+
+    So this follows the script the same way ``resolve_input`` does, and only
+    when that side opted into following at all
+    (``InputSpec.follow_linker_scripts``) — an MCP request that pinned it off
+    to keep its size guard authoritative must not get scripts followed here by
+    a side door.
+
+    A script naming another script resolves to a non-ELF target and yields
+    ``None``: one hop is what ``resolve_linker_script`` answers, and stopping
+    there is the same conservative "skip rather than guess" direction this
+    function already takes for every other non-ELF input.
+    """
+    from .binary_utils import detect_binary_format, resolve_linker_script
+
+    if fmt == "elf":
+        return side.path
+    if not side.follow_linker_scripts:
+        return None
+    target, is_script = resolve_linker_script(side.path)
+    if is_script and target is not None and detect_binary_format(target) == "elf":
+        return target
+    return None

--- a/abicheck/dependency_info.py
+++ b/abicheck/dependency_info.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Transitive ELF dependency resolution into a snapshot's ``DependencyInfo``.
+
+What ``compare --follow-deps`` (and ``run_compare_request``'s
+``follow_dependencies``) actually does. A leaf module on purpose: it depends
+only on ``binder``/``model``/``resolver``, and both the CLI
+(``cli_resolve._populate_dependency_info``) and the service layer
+(``service.run_compare_request``) need it — so neither has to import the
+other for it. ADR-055 D1's second slice, which gave the typed request
+``--follow-deps`` parity, is what made the second caller exist; before that
+it lived in ``cli_resolve`` with only CLI callers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from .api_types import CompareRequest
+    from .model import AbiSnapshot
+
+
+def populate_dependency_info(
+    snap: AbiSnapshot,
+    so_path: Path,
+    search_paths: list[Path],
+    sysroot: Path | None,
+    ld_library_path: str,
+) -> None:
+    """Resolve transitive deps and store DependencyInfo in the snapshot.
+
+    Moved here from ``cli_resolve`` for ADR-055 D1's second slice: it is what
+    ``--follow-deps`` does, ``run_compare_request`` needed the same thing to
+    reach parity with the CLI's own resolution, and it depends on nothing but
+    leaf modules — so the service layer is its home and the CLI depends on
+    the service rather than the reverse. ``cli_resolve._populate_dependency_info``
+    remains as a thin alias for ``cli.py``'s existing re-export.
+    """
+    from .binder import BindingStatus, compute_bindings
+    from .model import DependencyInfo
+    from .resolver import resolve_dependencies
+
+    graph = resolve_dependencies(
+        so_path,
+        search_paths=search_paths or None,
+        sysroot=sysroot,
+        ld_library_path=ld_library_path,
+    )
+    bindings = compute_bindings(graph)
+
+    summary: dict[str, int] = {}
+    for b in bindings:
+        summary[b.status.value] = summary.get(b.status.value, 0) + 1
+
+    missing = [
+        {"consumer": b.consumer, "symbol": b.symbol, "version": b.version}
+        for b in bindings
+        if b.status == BindingStatus.MISSING
+    ]
+
+    snap.dependency_info = DependencyInfo(
+        nodes=[
+            {
+                "path": str(node.path),
+                "soname": node.soname,
+                "needed": node.needed,
+                "depth": node.depth,
+                "resolution_reason": node.resolution_reason,
+            }
+            for node in sorted(graph.nodes.values(), key=lambda n: (n.depth, n.soname))
+        ],
+        edges=[
+            {"consumer": consumer, "provider": provider}
+            for consumer, provider in graph.edges
+        ],
+        unresolved=[
+            {"consumer": consumer, "soname": soname}
+            for consumer, soname in graph.unresolved
+        ],
+        bindings_summary=summary,
+        missing_symbols=missing,
+    )
+
+
+def populate_pair_dependency_info(
+    request: CompareRequest,
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+    *,
+    old_fmt: str | None,
+    new_fmt: str | None,
+) -> None:
+    """Apply ``CompareRequest.follow_dependencies`` to both resolved sides.
+
+    A no-op unless the request opts in — populating this costs a full
+    dependency-graph resolution per side, so it stays opt-in for a typed
+    caller exactly as ``--follow-deps`` is for the CLI.
+
+    ELF-only, matching the CLI's own guard: ``resolver.resolve_dependencies``
+    reads ELF ``DT_NEEDED`` entries, so there is nothing for it to do on a
+    PE or Mach-O side (it would not merely be redundant, it would not work).
+    """
+    if not request.follow_dependencies:
+        return
+    search_paths = list(request.dependency_search_paths)
+    for snap, side, fmt in ((old, request.old, old_fmt), (new, request.new, new_fmt)):
+        if fmt == "elf":
+            populate_dependency_info(
+                snap, side.path, search_paths, None, request.ld_library_path
+            )

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -871,7 +871,7 @@ def abi_compare(
                 )
 
         # ADR-055 D4: one typed request through the Tier-2 chokepoint —
-        # `run_compare_request_v2` resolves both sides, loads policy and
+        # `run_compare_request` resolves both sides, loads policy and
         # suppression, and classifies. This tool used to do all three itself
         # (its own `_resolve_input` pair, its own `PolicyFile.load`/
         # `SuppressionList.load`, and `compare_snapshots` for the middle step

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -36,11 +36,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
-    from .policy_file import PolicyFile
     from .severity import SeverityConfig
-    from .suppression import SuppressionList
 
 from . import mcp_shared
+from .api_types import CompareRequest, CompareResult, InputSpec
 from .checker import DiffResult
 from .checker_policy import (
     API_BREAK_KINDS,
@@ -71,7 +70,6 @@ from .mcp_shared import (
 from .model import AbiSnapshot
 from .reporter import _finding_id, to_json, to_markdown
 from .serialization import snapshot_to_json
-from .service import compare_snapshots
 
 # ---------------------------------------------------------------------------
 # Configuration (environment variables or CLI flags)
@@ -872,51 +870,72 @@ def abi_compare(
                     {"status": "error", "error": f"Invalid show_only: {exc}"}
                 )
 
-        # Resolve inputs, load suppression/policy, and compare — all under
-        # a real timeout so we don't block the MCP stdio server.
-        def _do_compare() -> tuple[
-            AbiSnapshot, AbiSnapshot, DiffResult, PolicyFile | None, SuppressionList | None
-        ]:
-            old_snap = _resolve_input(
-                old_path, old_h, inc, "old", language, public_headers=old_h
+        # ADR-055 D4: one typed request through the Tier-2 chokepoint —
+        # `run_compare_request_v2` resolves both sides, loads policy and
+        # suppression, and classifies. This tool used to do all three itself
+        # (its own `_resolve_input` pair, its own `PolicyFile.load`/
+        # `SuppressionList.load`, and `compare_snapshots` for the middle step
+        # only), which made it a second compare engine that happened to share
+        # one internal function with the first.
+        #
+        # The MCP-specific resource guards stay here, ahead of the request:
+        # `_safe_read_path` (containment) and `_check_file_size` validate the
+        # caller-supplied policy/suppression paths *before* anything loads
+        # them, and `InputSpec.follow_linker_scripts=False` keeps
+        # MCP_MAX_FILE_SIZE authoritative for the library paths themselves
+        # (see `_resolve_input`'s docstring for why following a linker script
+        # would defeat it). Those are guards on untrusted input, not
+        # comparison logic — unlike the resolve/load/classify work above,
+        # they have no business in the shared service layer.
+        suppression_path = None
+        if suppression_file:
+            suppression_path = _safe_read_path(
+                suppression_file, label="suppression_file"
             )
-            new_snap = _resolve_input(
-                new_path, new_h, inc, "new", language, public_headers=new_h
-            )
-            suppression = None
-            if suppression_file:
-                from .suppression import SuppressionList
+            _check_file_size(suppression_path, label="suppression_file")
+        policy_path = None
+        if policy_file:
+            policy_path = _safe_read_path(policy_file, label="policy_file")
+            _check_file_size(policy_path, label="policy_file")
 
-                suppression_path = _safe_read_path(
-                    suppression_file, label="suppression_file"
-                )
-                _check_file_size(suppression_path, label="suppression_file")
-                suppression = SuppressionList.load(suppression_path)
-            pf = None
-            if policy_file:
-                from .policy_file import PolicyFile
+        def _do_compare() -> CompareResult:
+            from .service import run_compare_request_v2
 
-                policy_path = _safe_read_path(policy_file, label="policy_file")
-                _check_file_size(policy_path, label="policy_file")
-                pf = PolicyFile.load(policy_path)
-            return (
-                old_snap,
-                new_snap,
-                compare_snapshots(
-                    old_snap,
-                    new_snap,
-                    suppression=suppression,
-                    policy=policy,
-                    policy_file=pf,
-                    diagnostic_comparison=diagnostic_comparison,
-                    contract_evaluation=contract_evaluation,
+            request = CompareRequest(
+                old=InputSpec(
+                    path=old_path,
+                    headers=tuple(old_h),
+                    includes=tuple(inc),
+                    version="old",
+                    follow_linker_scripts=False,
                 ),
-                pf,
-                suppression,
+                new=InputSpec(
+                    path=new_path,
+                    headers=tuple(new_h),
+                    includes=tuple(inc),
+                    version="new",
+                    follow_linker_scripts=False,
+                ),
+                lang=language,
+                policy=policy,
+                policy_file_path=policy_path,
+                suppress=suppression_path,
+                diagnostic_comparison=diagnostic_comparison,
+                contract_evaluation=contract_evaluation,
             )
+            return run_compare_request_v2(request)
 
         try:
-            old_snap, new_snap, result, pf, suppression = _call_with_timeout(_do_compare)
+            compare_result = _call_with_timeout(_do_compare)
+            old_snap = compare_result.old_snapshot
+            new_snap = compare_result.new_snapshot
+            result = compare_result.diff
+            # The resolved policy/suppression the run actually classified with
+            # — read back off the result rather than re-derived here, so the
+            # `used_by`/`required_symbols` scoping below cannot apply a
+            # different policy than the comparison it is scoping.
+            pf = result.policy_file
+            suppression = compare_result.suppression
         except _futures.TimeoutError:
             elapsed = _time.monotonic() - t0
             _audit_log(

--- a/abicheck/mcp_server.py
+++ b/abicheck/mcp_server.py
@@ -899,7 +899,7 @@ def abi_compare(
             _check_file_size(policy_path, label="policy_file")
 
         def _do_compare() -> CompareResult:
-            from .service import run_compare_request_v2
+            from .service import run_compare_request
 
             request = CompareRequest(
                 old=InputSpec(
@@ -923,7 +923,7 @@ def abi_compare(
                 diagnostic_comparison=diagnostic_comparison,
                 contract_evaluation=contract_evaluation,
             )
-            return run_compare_request_v2(request)
+            return run_compare_request(request)
 
         try:
             compare_result = _call_with_timeout(_do_compare)

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -1637,10 +1637,8 @@ def run_compare_request(request: CompareRequest) -> CompareResult:
     Returns a :class:`~abicheck.api_types.CompareResult` (ADR-055 D2), not the
     bare ``(DiffResult, old, new)`` tuple it returned before 0.6: a struct can
     gain a field without breaking positional callers, which a tuple cannot.
-    The interim ``run_compare_request_v2`` seam that shipped alongside the
-    tuple is gone — pre-1.0 is exactly when to collapse two names for one
-    thing rather than carry them. ``CompareResult.as_tuple()`` reproduces the
-    old shape for a caller that wants it back in one line.
+    ``CompareResult.as_tuple()`` reproduces the old shape for a caller that
+    wants it back in one line.
 
     Raises:
         ValidationError: If the request fails :meth:`CompareRequest.validate`.

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -33,7 +33,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from .api_types import CompareRequest, InputSpec, OutputSpec
+from .api_types import CompareRequest, CompareResult, InputSpec, OutputSpec
 from .checker import compare
 from .checker_types import DiffResult, LibraryMetadata
 from .clang_layout_tool import attach_clang_layout
@@ -1634,8 +1634,38 @@ def run_compare_request(
     a ``CompareRequest`` and calls this, so defaults cannot diverge between
     invocation paths. The legacy keyword-argument :func:`run_compare` is a thin
     shim that builds the request and delegates here.
+
+    Unchanged for every existing caller (ADR-055 D2 is explicitly additive):
+    this is now a thin tuple-shaped view of
+    :func:`run_compare_request_v2`, which owns the implementation and returns
+    the typed :class:`~abicheck.api_types.CompareResult`. Delegating rather
+    than keeping a second copy is what stops the two shapes from drifting into
+    two different resolution behaviours — the failure this ADR exists to
+    prevent, not one to reintroduce inside the fix for it.
+
     Returns:
         A tuple of (DiffResult, old_snapshot, new_snapshot).
+    Raises:
+        ValidationError: If the request fails :meth:`CompareRequest.validate`.
+        SnapshotError: If either input cannot be loaded.
+    """
+    return run_compare_request_v2(request).as_tuple()
+
+
+def run_compare_request_v2(request: CompareRequest) -> CompareResult:
+    """Compare two ABI inputs and return a typed :class:`CompareResult`.
+
+    ADR-055 D2. Identical work to :func:`run_compare_request` — this is the
+    implementation both entry points share — differing only in the returned
+    shape: a struct whose future fields are additive, instead of a tuple whose
+    fourth element would break every positional caller.
+
+    The ``_v2`` name is deliberate and deliberately temporary: it is an
+    internal migration seam, not user-facing vocabulary a caller types daily
+    the way ``run_scan``/``run_compare_request`` are. Renaming it to something
+    permanent is out of scope for ADR-055 and belongs to whichever follow-up
+    retires the tuple-returning entry point (see that ADR's D2).
+
     Raises:
         ValidationError: If the request fails :meth:`CompareRequest.validate`.
         SnapshotError: If either input cannot be loaded.
@@ -1702,6 +1732,7 @@ def run_compare_request(
             public_header_dirs=public_header_dirs,
             include_dependencies=side.include_dependencies,
             dump_manifest=evidence.dump_manifest,
+            follow_linker_scripts=side.follow_linker_scripts,
         )
         if side.sources or side.build_info:
             # Codex: same roots as resolve_input, plus dump_manifest's declared-public roots only (project_owned TU includes are private, so dump_manifest_public_roots not dump_manifest_header_roots).
@@ -1786,7 +1817,12 @@ def run_compare_request(
     attach_evidence_metrics(result, evidence_metrics, extra_changes or [], quiet=True)
     result.old_metadata = collect_metadata(request.old.path)
     result.new_metadata = collect_metadata(request.new.path)
-    return result, old, new
+    # ADR-055 D2/D4: `suppression` is carried out so a front end applying a
+    # post-classification concern (appcompat's `scope_diff_to_app`) reuses the
+    # list this call already resolved instead of loading it a second time.
+    return CompareResult(
+        diff=result, old_snapshot=old, new_snapshot=new, suppression=suppression
+    )
 
 
 def run_compare(
@@ -1925,6 +1961,7 @@ from .service_scan import (  # noqa: E402,F401
 __all__ = [
     "Budget",
     "CompareRequest",
+    "CompareResult",
     "CompileContext",
     "CostEstimate",
     "InputSpec",
@@ -1945,6 +1982,7 @@ __all__ = [
     "run_audit",
     "run_compare",
     "run_compare_request",
+    "run_compare_request_v2",
     "run_dump",
     "run_scan",
     "run_scan_set",

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -24,12 +24,10 @@ Provides framework-agnostic functions for the core abicheck operations:
 
 from __future__ import annotations
 
-import concurrent.futures
 import functools
 import hashlib
 import importlib as _importlib
 import logging
-import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -37,13 +35,11 @@ from .api_types import CompareRequest, CompareResult, InputSpec, OutputSpec
 from .checker import compare
 from .checker_types import DiffResult, LibraryMetadata
 from .clang_layout_tool import attach_clang_layout
-from .dependency_info import populate_pair_dependency_info
 from .dumper_scoping import wrap_run_dump_with_dependency_scope
 from .errors import AbicheckError, SnapshotError, ValidationError
 from .header_utils import (
     deferred_token_dirs,
     resolve_inferred_header_roots,
-    split_public_header_inputs,
 )
 from .model import AbiSnapshot, EnumType, Function, RecordType, Visibility
 from .serialization import load_snapshot
@@ -85,7 +81,6 @@ if TYPE_CHECKING:
     from .dwarf_metadata import DwarfMetadata
     from .environment_matrix import EnvironmentMatrix
     from .policy_file import PolicyFile
-    from .service_compare_evidence import SideEvidence
     from .suppression import SuppressionList
 
 _logger = logging.getLogger(__name__)
@@ -1634,6 +1629,15 @@ def run_compare_request(request: CompareRequest) -> CompareResult:
     between invocation paths. The keyword-argument :func:`run_compare` is a
     thin shim that builds the request and delegates here.
 
+    Exactly the composition of the two phases in
+    :mod:`abicheck.service_compare_pipeline` —
+    :func:`~abicheck.service_compare_pipeline.resolve_compare_request` then
+    :func:`~abicheck.service_compare_pipeline.classify_compare_pair`. A front
+    end that must configure the run between them (the native ``compare`` CLI's
+    ADR-049 ``resolve_and_apply``, whose ``--pack`` can move the policy file
+    and severity levels the classification is scored under) calls the two
+    phases directly rather than keeping a second resolution implementation.
+
     Returns a :class:`~abicheck.api_types.CompareResult` (ADR-055 D2), not the
     bare ``(DiffResult, old, new)`` tuple it returned before 0.6: a struct can
     gain a field without breaking positional callers, which a tuple cannot.
@@ -1644,171 +1648,7 @@ def run_compare_request(request: CompareRequest) -> CompareResult:
         ValidationError: If the request fails :meth:`CompareRequest.validate`.
         SnapshotError: If either input cannot be loaded.
     """
-    request.validate()
-    # validate() accepts lang case-insensitively; the ELF dump path does case-sensitive lang == "c" checks, so normalise here. android (no header-AST path) falls back to "auto" for the binary dump.
-    lang = request.lang.lower()
-    # CodeRabbit review: this check moved into api_types.py's validation_errors() (Tier-2 pre-flight), reached via request.validate() above -- no longer duplicated here.
-    from .api_types import HEADER_AST_FRONTENDS
-    frontend_lower = request.frontend.lower()
-    header_backend = frontend_lower if frontend_lower in HEADER_AST_FRONTENDS else "auto"
-    old_fmt = detect_binary_format(request.old.path)
-    new_fmt = detect_binary_format(request.new.path)
-    # Pair-wide C++20 dialect resolution (P0 fix); folded into each side's effective CompileContext below. A dump_manifest replaces `headers` (empty), so its own forced_includes must feed the same C++20 scan too (Codex review) or a manifest-only side's C++20 signal goes undetected.
-    def _manifest_forced_includes(dm: object) -> list[Path]:
-        return [inc for tu in getattr(dm, "translation_units", ()) for inc in tu.forced_includes]
-    pair_compile: CompileContext | None = None
-    override = pair_wide_cxx20_std_override(lang, list(request.old.headers) + _manifest_forced_includes(request.old.dump_manifest), list(request.new.headers) + _manifest_forced_includes(request.new.dump_manifest), None, ())
-    if override is not None:
-        pair_compile = CompileContext(gcc_option_tokens=override)
-    # request.{old,new}.headers double as the public-header set for provenance tagging. Split into files/directories before tagging: an unsplit directory entry corrupts scope_fingerprint. InputSpec.public_header_dirs is unioned in afterward.
-    old_public_headers, old_public_header_dirs = split_public_header_inputs(request.old.headers)
-    new_public_headers, new_public_header_dirs = split_public_header_inputs(request.new.headers)
-    old_public_header_dirs += list(request.old.public_header_dirs)
-    new_public_header_dirs += list(request.new.public_header_dirs)
-    # Codex: binary depth clears evidence.headers, but a headerless dump still fingerprints these -- clear too, else differing lists spuriously ScopeMismatchError.
-    if request.depth is not None and request.depth.lower() == "binary":
-        old_public_headers = new_public_headers = old_public_header_dirs = new_public_header_dirs = []
-    from . import service_compare_evidence as _sce  # ADR-055 D1
-
-    _sce.reject_debug_format_for_non_elf(
-        _sce.normalized_debug_format(request), old_fmt, new_fmt
-    )
-    from .cli_buildsource import embed_build_source
-    old_evidence, new_evidence = _sce.resolve_compare_request_evidence(request, pair_compile)
-    # Codex: "hybrid" (explicit depth="source") and "android" have no real embed_build_source extractor -- reject only a raw tree needing real extraction, never a prebuilt pack or build_info alone (never feeds L4). Mirrors cli.py's own --depth source + --ast-frontend hybrid UsageError.
-    from .buildsource.inline import is_pack_dir
-    from .cli_buildsource_helpers import _is_inputs_pack_dir
-    def _is_raw_source_tree(p: Path | None) -> bool:
-        return p is not None and not (is_pack_dir(p) or _is_inputs_pack_dir(p))
-    if frontend_lower == "android" and any(_is_raw_source_tree(s.sources) for s in (request.old, request.new)):
-        raise ValidationError("the 'android' AST frontend's source-ABI replay is not yet wired into run_compare_request's inline evidence collection for a raw source tree -- pass a prebuilt evidence pack directory instead, or use has_sources=True with no inline sources/build_info.")
-    if request.depth is not None and request.depth.lower() == "source":
-        for side, evidence in ((request.old, old_evidence), (request.new, new_evidence)):
-            if _is_raw_source_tree(side.sources) and _sce.effective_frontend(evidence.compile, header_backend) == "hybrid":
-                raise ValidationError("depth='source' is incompatible with the 'hybrid' AST frontend: L4 source-ABI replay has no dual-backend hybrid extractor. Use 'castxml' or 'clang' for a depth='source' request.")
-    def _resolve_side(
-        side: InputSpec,
-        evidence: SideEvidence,
-        fmt: str | None,
-        public_headers: list[Path],
-        public_header_dirs: list[Path],
-    ) -> AbiSnapshot:
-        snap = resolve_input(
-            side.path,
-            evidence.headers,
-            list(side.includes),
-            side.version,
-            lang,
-            is_elf=True if fmt == "elf" else None,
-            pdb_path=side.pdb,
-            debug_roots=list(side.debug_roots) or None,
-            enable_debuginfod=request.enable_debuginfod,
-            debuginfod_url=request.debuginfod_url,
-            header_backend=header_backend,
-            compile=evidence.compile,
-            public_headers=public_headers,
-            public_header_dirs=public_header_dirs,
-            include_dependencies=side.include_dependencies,
-            dump_manifest=evidence.dump_manifest,
-            follow_linker_scripts=side.follow_linker_scripts,
-            dwarf_only=request.dwarf_only,
-            debug_format=_sce.normalized_debug_format(request),
-            include_labels=dict(request.include_labels) or None,
-        )
-        if side.sources or side.build_info:
-            # Codex: same roots as resolve_input, plus dump_manifest's declared-public roots only (project_owned TU includes are private, so dump_manifest_public_roots not dump_manifest_header_roots).
-            # Codex: a malformed pack raises click.ClickException deep inside embed_build_source -- no place in this Tier-2 API's ValidationError/SnapshotError contract.
-            import click
-
-            from .dumper_scoping import dump_manifest_public_roots
-            try:
-                embed_build_source(snap, build_info=side.build_info, sources=side.sources, collect_mode=evidence.collect_mode, extractor=_sce.effective_frontend(evidence.compile, header_backend), public_headers=tuple(str(p) for p in public_headers), public_header_dirs=tuple(str(p) for p in public_header_dirs) + tuple(str(p) for p in dump_manifest_public_roots(evidence.dump_manifest)), quiet=True)
-            except click.ClickException as exc:
-                raise SnapshotError(str(exc)) from exc
-        return snap
-
-    def _resolve_old_side() -> AbiSnapshot:
-        return _resolve_side(request.old, old_evidence, old_fmt, old_public_headers, old_public_header_dirs)
-    def _resolve_new_side() -> AbiSnapshot:
-        return _resolve_side(request.new, new_evidence, new_fmt, new_public_headers, new_public_header_dirs)
-
-    # Old/new resolution has no data dependency on each other until they're
-    # both fed into compare_snapshots() below, so run them concurrently —
-    # they're each dominated by a castxml/DWARF subprocess call and XML/JSON
-    # parsing, not CPU held under the GIL the whole time. Threads (not
-    # processes) avoid pickling the request/callables across a process
-    # boundary. On a memory-constrained runner comparing two large ABI
-    # surfaces (e.g. oneDAL-scale headers), two concurrent header-AST
-    # frontends roughly double peak RSS versus one at a time — set
-    # ABICHECK_PARALLEL_EXTRACTION=0 to fall back to the old sequential
-    # behavior if that trade-off doesn't fit.
-    if os.environ.get("ABICHECK_PARALLEL_EXTRACTION", "1").strip().lower() in (
-        "0",
-        "false",
-        "no",
-    ):
-        old = _resolve_old_side()
-        new = _resolve_new_side()
-    else:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
-            old_future = pool.submit(_resolve_old_side)
-            new_future = pool.submit(_resolve_new_side)
-            old = old_future.result()
-            new = new_future.result()
-    # ADR-055 D1, second slice: `--follow-deps`'s transitive DependencyInfo --
-    # the last thing `cli_resolve._resolve_compare_snapshots` did that this
-    # path could not. After both sides resolve, not inside `_resolve_side`: it
-    # reads the on-disk ELF, so it gains nothing from the extraction threads.
-    populate_pair_dependency_info(request, old, new, old_fmt=old_fmt, new_fmt=new_fmt)
-    # Codex: an explicitly requested depth (e.g. "source") that a raw input actually failed to reach (no usable compile database/extractor/linkable declarations) previously diffed whatever weaker evidence embed_build_source produced with no signal -- mirrors dump's own check_requested_depth_satisfied hard-fail, but raises ValidationError (a Tier-2 API has no ClickException concept) instead of reusing that CLI-only exception type.
-    if request.depth is not None:
-        from .cli_dump_helpers import _DEPTH_RANK, _gated_source_label
-        requested_rank = _DEPTH_RANK.get(request.depth.lower(), 0)  # validate() already restricts depth to USER_DEPTHS
-        for side_label, snap in (("old", old), ("new", new)):
-            effective = _gated_source_label(snap.build_source, snap)
-            if _DEPTH_RANK.get(effective, 0) < requested_rank:
-                raise ValidationError(f"depth={request.depth!r} was requested for the {side_label} side but the resolved snapshot only reached {effective!r} evidence depth. Supply the evidence this rung needs (headers, a build/compile database, or --sources with linkable declarations) or lower depth to match what is actually available.")
-    # Codex (known, accepted limitation, not fixed here): this is a floor, not a ceiling -- a side whose input is itself an already-serialized JSON snapshot with richer embedded evidence than `depth` requested (e.g. depth="binary" against an old.json that already embeds header/build/source facts) still diffs with all of it. resolve_input's `fmt == "json"` branch (above) returns `load_snapshot(path)` verbatim, ignoring headers/depth entirely -- matching the CLI's own long-documented default ("compare old.json new.json reads build-info + source facts embedded in each snapshot", cli_options.py), which `--depth` has never projected down for a pre-built snapshot either (it only dials how deep *fresh* inline extraction goes for a raw, non-JSON input). Capping/rejecting a richer pre-existing snapshot would diverge Tier-2 behavior from that established CLI contract and needs its own scoped design, not a drive-by extension of this floor check.
-    suppression, pf = load_suppression_and_policy(
-        request.suppress, request.policy, request.policy_file_path
-    )
-    # ADR-055 D1 (Codex review, P1 x2): diff the embedded evidence into
-    # extra_changes, or a source-only change reads as artifact-only
-    # compatible. The four Nones are the out-of-band pack-override params --
-    # reusing the raw sources/build_info paths would make _resolve_side_pack
-    # try (and fail) to reload them as packs; None uses embedded facts.
-    from .cli_buildsource import attach_evidence_metrics, prepare_embedded_build_source
-    extra_changes, layer_coverage_rows, evidence_metrics, _ev_changes = prepare_embedded_build_source(
-        old, new, old_evidence.collect_mode, None, None, None, None, None, policy_file=pf, quiet=True,
-    )
-    result = compare_snapshots(
-        old,
-        new,
-        suppression=suppression,
-        policy=request.policy,
-        policy_file=pf,
-        scope_to_public_surface=request.scope_public,
-        force_public_symbols=(set(request.force_public_symbols) if request.force_public_symbols else None),
-        extra_changes=extra_changes,
-        public_surface_allowlist=(set(request.public_surface_allowlist) if request.public_surface_allowlist is not None else None),
-        pattern_verdicts=request.pattern_verdicts,
-        reconcile_build_context=request.reconcile_build_context,
-        env_matrix=load_env_matrix(request.env_matrix_path),
-        diagnostic_comparison=request.diagnostic_comparison,
-        contract_evaluation=request.contract_evaluation,
-        contract_mode=request.contract_mode,
-    )
-    if layer_coverage_rows:
-        result.layer_coverage = layer_coverage_rows
-    attach_evidence_metrics(result, evidence_metrics, extra_changes or [], quiet=True)
-    result.old_metadata = collect_metadata(request.old.path)
-    result.new_metadata = collect_metadata(request.new.path)
-    # ADR-055 D2/D4: `suppression` is carried out so a front end applying a
-    # post-classification concern (appcompat's `scope_diff_to_app`) reuses the
-    # list this call already resolved instead of loading it a second time.
-    return CompareResult(
-        diff=result, old_snapshot=old, new_snapshot=new, suppression=suppression
-    )
+    return classify_compare_pair(request, resolve_compare_request(request))
 
 
 def run_compare(
@@ -1901,6 +1741,19 @@ def run_compare(
     )
     return run_compare_request(request)
 
+# ── Compare pipeline (ADR-055 D1): `run_compare_request`'s two phases live in
+# the leaf module ``service_compare_pipeline`` so the native ``compare`` CLI can
+# run its Click-dependent ADR-049 ``resolve_and_apply`` step between them and
+# still share this resolution instead of keeping a second copy. Re-exported here
+# so ``from abicheck.service import resolve_compare_request`` works and
+# ``run_compare_request`` above resolves both names at call time. ──────────────
+from .service_compare_pipeline import (  # noqa: E402,F401
+    ResolvedComparePair,
+    classify_compare_pair,
+    resolve_compare_request,
+    resolve_sides_sequentially,
+)
+
 # ── Output rendering (extracted to leaf module service_render, a non-
 # importing-us leaf) to stay under the AI-readiness size cap; re-exported
 # verbatim so ``from abicheck.service import render_output`` is unchanged. ──
@@ -1958,7 +1811,9 @@ __all__ = [
     "ScanArtifactResult",
     "ScanRequest",
     "ScanResult",
+    "ResolvedComparePair",
     "ScanSetResult",
+    "classify_compare_pair",
     "collect_metadata",
     "compare_snapshots",
     "detect_binary_format",
@@ -1966,6 +1821,7 @@ __all__ = [
     "expand_header_inputs",
     "load_suppression_and_policy",
     "render_output",
+    "resolve_compare_request",
     "resolve_input",
     "run_audit",
     "run_compare",

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -1626,44 +1626,21 @@ def compare_snapshots(
     )
 
 
-def run_compare_request(
-    request: CompareRequest,
-) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
+def run_compare_request(request: CompareRequest) -> CompareResult:
     """Compare two ABI inputs described by a :class:`CompareRequest`.
 
-    The single classification chokepoint (ADR-037 D1/D2): every front-end builds
-    a ``CompareRequest`` and calls this, so defaults cannot diverge between
-    invocation paths. The legacy keyword-argument :func:`run_compare` is a thin
-    shim that builds the request and delegates here.
+    The single classification chokepoint (ADR-037 D1/D2): every front-end
+    builds a ``CompareRequest`` and calls this, so defaults cannot diverge
+    between invocation paths. The keyword-argument :func:`run_compare` is a
+    thin shim that builds the request and delegates here.
 
-    Unchanged for every existing caller (ADR-055 D2 is additive): this is now
-    a tuple-shaped view of :func:`run_compare_request_v2`, which owns the
-    implementation. Delegating rather than keeping a second copy is what stops
-    the two shapes from drifting into two resolution behaviours — the failure
-    this ADR exists to prevent, not one to reintroduce inside its own fix.
-
-    Returns:
-        A tuple of (DiffResult, old_snapshot, new_snapshot).
-    Raises:
-        ValidationError: If the request fails :meth:`CompareRequest.validate`.
-        SnapshotError: If either input cannot be loaded.
-    """
-    return run_compare_request_v2(request).as_tuple()
-
-
-def run_compare_request_v2(request: CompareRequest) -> CompareResult:
-    """Compare two ABI inputs and return a typed :class:`CompareResult`.
-
-    ADR-055 D2. Identical work to :func:`run_compare_request` — this is the
-    implementation both entry points share — differing only in the returned
-    shape: a struct whose future fields are additive, instead of a tuple whose
-    fourth element would break every positional caller.
-
-    The ``_v2`` name is deliberate and deliberately temporary: it is an
-    internal migration seam, not user-facing vocabulary a caller types daily
-    the way ``run_scan``/``run_compare_request`` are. Renaming it to something
-    permanent is out of scope for ADR-055 and belongs to whichever follow-up
-    retires the tuple-returning entry point (see that ADR's D2).
+    Returns a :class:`~abicheck.api_types.CompareResult` (ADR-055 D2), not the
+    bare ``(DiffResult, old, new)`` tuple it returned before 0.6: a struct can
+    gain a field without breaking positional callers, which a tuple cannot.
+    The interim ``run_compare_request_v2`` seam that shipped alongside the
+    tuple is gone — pre-1.0 is exactly when to collapse two names for one
+    thing rather than carry them. ``CompareResult.as_tuple()`` reproduces the
+    old shape for a caller that wants it back in one line.
 
     Raises:
         ValidationError: If the request fails :meth:`CompareRequest.validate`.
@@ -1694,6 +1671,10 @@ def run_compare_request_v2(request: CompareRequest) -> CompareResult:
     if request.depth is not None and request.depth.lower() == "binary":
         old_public_headers = new_public_headers = old_public_header_dirs = new_public_header_dirs = []
     from . import service_compare_evidence as _sce  # ADR-055 D1
+
+    _sce.reject_debug_format_for_non_elf(
+        _sce.normalized_debug_format(request), old_fmt, new_fmt
+    )
     from .cli_buildsource import embed_build_source
     old_evidence, new_evidence = _sce.resolve_compare_request_evidence(request, pair_compile)
     # Codex: "hybrid" (explicit depth="source") and "android" have no real embed_build_source extractor -- reject only a raw tree needing real extraction, never a prebuilt pack or build_info alone (never feeds L4). Mirrors cli.py's own --depth source + --ast-frontend hybrid UsageError.
@@ -1860,7 +1841,7 @@ def run_compare(
     contract_evaluation: bool = False,
     include_dependencies: bool = True,
     contract_mode: str | None = None,
-) -> tuple[DiffResult, AbiSnapshot, AbiSnapshot]:
+) -> CompareResult:
     """Compare two ABI inputs and return the classified diff result.
 
     Keyword-argument shim over :func:`run_compare_request`: it assembles a
@@ -1873,7 +1854,9 @@ def run_compare(
     parameter it always did (Codex review, PR #551). ``include_dependencies``
     applies to *both* sides — build a ``CompareRequest`` for a per-side override.
     Returns:
-        A tuple of (DiffResult, old_snapshot, new_snapshot).
+        A :class:`~abicheck.api_types.CompareResult`. This returned the bare
+        ``(DiffResult, old, new)`` tuple before 0.6; ``.as_tuple()`` gives that
+        shape back for a caller that unpacks positionally.
     Raises:
         SnapshotError: If either input cannot be loaded.
         ValidationError: If inputs have unrecognised formats.
@@ -1989,7 +1972,6 @@ __all__ = [
     "run_audit",
     "run_compare",
     "run_compare_request",
-    "run_compare_request_v2",
     "run_dump",
     "run_scan",
     "run_scan_set",

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -37,6 +37,7 @@ from .api_types import CompareRequest, CompareResult, InputSpec, OutputSpec
 from .checker import compare
 from .checker_types import DiffResult, LibraryMetadata
 from .clang_layout_tool import attach_clang_layout
+from .dependency_info import populate_pair_dependency_info
 from .dumper_scoping import wrap_run_dump_with_dependency_scope
 from .errors import AbicheckError, SnapshotError, ValidationError
 from .header_utils import (
@@ -1635,13 +1636,11 @@ def run_compare_request(
     invocation paths. The legacy keyword-argument :func:`run_compare` is a thin
     shim that builds the request and delegates here.
 
-    Unchanged for every existing caller (ADR-055 D2 is explicitly additive):
-    this is now a thin tuple-shaped view of
-    :func:`run_compare_request_v2`, which owns the implementation and returns
-    the typed :class:`~abicheck.api_types.CompareResult`. Delegating rather
-    than keeping a second copy is what stops the two shapes from drifting into
-    two different resolution behaviours — the failure this ADR exists to
-    prevent, not one to reintroduce inside the fix for it.
+    Unchanged for every existing caller (ADR-055 D2 is additive): this is now
+    a tuple-shaped view of :func:`run_compare_request_v2`, which owns the
+    implementation. Delegating rather than keeping a second copy is what stops
+    the two shapes from drifting into two resolution behaviours — the failure
+    this ADR exists to prevent, not one to reintroduce inside its own fix.
 
     Returns:
         A tuple of (DiffResult, old_snapshot, new_snapshot).
@@ -1733,6 +1732,9 @@ def run_compare_request_v2(request: CompareRequest) -> CompareResult:
             include_dependencies=side.include_dependencies,
             dump_manifest=evidence.dump_manifest,
             follow_linker_scripts=side.follow_linker_scripts,
+            dwarf_only=request.dwarf_only,
+            debug_format=request.debug_format,
+            include_labels=dict(request.include_labels) or None,
         )
         if side.sources or side.build_info:
             # Codex: same roots as resolve_input, plus dump_manifest's declared-public roots only (project_owned TU includes are private, so dump_manifest_public_roots not dump_manifest_header_roots).
@@ -1774,6 +1776,11 @@ def run_compare_request_v2(request: CompareRequest) -> CompareResult:
             new_future = pool.submit(_resolve_new_side)
             old = old_future.result()
             new = new_future.result()
+    # ADR-055 D1, second slice: `--follow-deps`'s transitive DependencyInfo --
+    # the last thing `cli_resolve._resolve_compare_snapshots` did that this
+    # path could not. After both sides resolve, not inside `_resolve_side`: it
+    # reads the on-disk ELF, so it gains nothing from the extraction threads.
+    populate_pair_dependency_info(request, old, new, old_fmt=old_fmt, new_fmt=new_fmt)
     # Codex: an explicitly requested depth (e.g. "source") that a raw input actually failed to reach (no usable compile database/extractor/linkable declarations) previously diffed whatever weaker evidence embed_build_source produced with no signal -- mirrors dump's own check_requested_depth_satisfied hard-fail, but raises ValidationError (a Tier-2 API has no ClickException concept) instead of reusing that CLI-only exception type.
     if request.depth is not None:
         from .cli_dump_helpers import _DEPTH_RANK, _gated_source_label

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -1733,7 +1733,7 @@ def run_compare_request_v2(request: CompareRequest) -> CompareResult:
             dump_manifest=evidence.dump_manifest,
             follow_linker_scripts=side.follow_linker_scripts,
             dwarf_only=request.dwarf_only,
-            debug_format=request.debug_format,
+            debug_format=_sce.normalized_debug_format(request),
             include_labels=dict(request.include_labels) or None,
         )
         if side.sources or side.build_info:

--- a/abicheck/service_compare_evidence.py
+++ b/abicheck/service_compare_evidence.py
@@ -51,6 +51,7 @@ __all__ = [
     "SideEvidence",
     "effective_frontend",
     "normalized_debug_format",
+    "reject_debug_format_for_non_elf",
     "resolve_compare_request_evidence",
 ]
 
@@ -226,12 +227,51 @@ def resolve_compare_request_evidence(
 
 
 def normalized_debug_format(request: CompareRequest) -> str | None:
-    """``CompareRequest.debug_format`` lowercased for the extraction layer.
+    """``CompareRequest.debug_format`` in the form the extraction layer takes.
 
-    ``validate()`` accepts the same four values the CLI's ``--debug-format``
-    choice does, case-insensitively; every consumer below compares against the
-    lowercase literals (``dumper_debug._resolve_debug_metadata``), so an
-    accepted ``"DWARF"`` has to be normalized once rather than silently
-    behaving as "no format given" (Codex review).
+    Two normalizations, both mirroring what the CLI already does to the same
+    flag (``cli_compare_helpers``/``cli_dump_helpers``), so the typed path
+    behaves identically:
+
+    * lowercased — ``validate()`` accepts the four values case-insensitively,
+      the way ``--debug-format``'s ``case_sensitive=False`` choice does, but
+      ``dumper_debug._resolve_debug_metadata`` compares against lowercase
+      literals only;
+    * ``"auto"`` becomes ``None`` — auto-detection *is* "no format forced" at
+      that layer. Passing the literal string through instead reaches an
+      explicit ``raise ValueError`` for anything outside ``dwarf``/``btf``/
+      ``ctf``, so an accepted, documented value crashed during extraction
+      (Codex review, second round; the first round's fix validated the value
+      but still forwarded it verbatim).
     """
-    return request.debug_format.lower() if request.debug_format is not None else None
+    if request.debug_format is None:
+        return None
+    normalized = request.debug_format.lower()
+    return None if normalized == "auto" else normalized
+
+
+def reject_debug_format_for_non_elf(
+    debug_format: str | None, old_fmt: str | None, new_fmt: str | None
+) -> None:
+    """Raise if a forced ELF debug format meets a PE/Mach-O side.
+
+    The PE and Mach-O dump paths take no debug-format argument, so a forced
+    ``dwarf``/``btf``/``ctf`` is silently dropped there and the run reports
+    success having ignored what the caller asked for. The CLI rejects the
+    combination up front (``cli_compare_helpers._reject_debug_format_for_non_elf``);
+    without this the typed surface claimed that parity without having it
+    (Codex review).
+
+    A JSON-snapshot or dump input has ``fmt is None`` and is unaffected, same
+    as on the CLI side.
+    """
+    from .errors import ValidationError
+
+    if debug_format is None:
+        return
+    for side, binary_fmt in (("old", old_fmt), ("new", new_fmt)):
+        if binary_fmt in ("pe", "macho"):
+            raise ValidationError(
+                f"debug_format={debug_format!r} is only supported for ELF "
+                f"binaries, but the {side} input is {binary_fmt.upper()}."
+            )

--- a/abicheck/service_compare_evidence.py
+++ b/abicheck/service_compare_evidence.py
@@ -50,6 +50,7 @@ if TYPE_CHECKING:
 __all__ = [
     "SideEvidence",
     "effective_frontend",
+    "normalized_debug_format",
     "resolve_compare_request_evidence",
 ]
 
@@ -222,3 +223,15 @@ def resolve_compare_request_evidence(
             dump_manifest=_dump_manifest(request.new, request.depth),
         ),
     )
+
+
+def normalized_debug_format(request: CompareRequest) -> str | None:
+    """``CompareRequest.debug_format`` lowercased for the extraction layer.
+
+    ``validate()`` accepts the same four values the CLI's ``--debug-format``
+    choice does, case-insensitively; every consumer below compares against the
+    lowercase literals (``dumper_debug._resolve_debug_metadata``), so an
+    accepted ``"DWARF"`` has to be normalized once rather than silently
+    behaving as "no format given" (Codex review).
+    """
+    return request.debug_format.lower() if request.debug_format is not None else None

--- a/abicheck/service_compare_pipeline.py
+++ b/abicheck/service_compare_pipeline.py
@@ -1,0 +1,560 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-055 D1: ``run_compare_request`` split into its two real phases.
+
+``run_compare_request`` was one function doing two separable things — turning a
+:class:`CompareRequest` into a resolved pair of snapshots, then classifying that
+pair. The native ``compare`` CLI needs to run its own ADR-049 step *between*
+those two (``cli_compare_receipt.resolve_and_apply`` needs the Click context to
+answer "did the user type this?", and a ``--pack`` it selects can move the
+policy file and severity levels the classification is then scored under), so as
+one function it could not reuse either half and kept a parallel resolution
+implementation of its own (``cli_resolve._resolve_compare_snapshots``).
+
+Splitting it here gives all three front ends one resolution implementation:
+
+* :func:`resolve_compare_request` — validate, resolve both sides' evidence,
+  produce the two :class:`AbiSnapshot`\\ s, enrich dependencies, enforce the
+  requested depth.
+* :func:`classify_compare_pair` — load suppression/policy, diff the embedded
+  build-source evidence, classify, attach metrics.
+
+``service.run_compare_request`` is now exactly their composition, so a caller
+that does not need the seam keeps one call, and one that does (the CLI) gets
+the same resolution the typed path uses instead of a second copy.
+
+Two mechanical notes:
+
+* Everything this module needs from ``service`` is looked up **through the
+  module object at call time** (``from . import service`` inside the function),
+  never bound at import time. That is what keeps
+  ``monkeypatch.setattr(service, "resolve_input", ...)`` — and the same for
+  ``compare_snapshots`` — affecting this code exactly as it did when the body
+  lived in ``service.py``. Helpers ``service`` itself only *re-exports*
+  (``pair_wide_cxx20_std_override``, ``split_public_header_inputs``,
+  ``populate_pair_dependency_info``) are imported straight from the module
+  that defines them instead: nothing patches them through ``service``, and
+  going through a re-export would make them look like public service API
+  (mypy's ``no_implicit_reexport``) when they are not. The import is also
+  function-local so this module does not join ``service``'s import cycle
+  (AGENTS.md "What NOT to do").
+* This module holds no state and makes no policy decisions of its own; every
+  behavioural rule in it moved here verbatim from ``service.run_compare_request``.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import dataclasses
+import os
+from typing import TYPE_CHECKING
+
+from .api_types import CompareResult
+from .dependency_info import populate_pair_dependency_info
+from .errors import SnapshotError, ValidationError
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from .api_types import CompareRequest, InputSpec
+    from .compile_context import CompileContext
+    from .model import AbiSnapshot
+    from .service_compare_evidence import SideEvidence
+
+__all__ = [
+    "ResolvedComparePair",
+    "classify_compare_pair",
+    "resolve_compare_request",
+    "resolve_sides_sequentially",
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class ResolvedComparePair:
+    """Both sides of a comparison, resolved and ready to classify.
+
+    The seam between :func:`resolve_compare_request` and
+    :func:`classify_compare_pair`. It carries what classification genuinely
+    needs beyond the two snapshots — the detected binary formats (for a front
+    end reporting on them) and each side's resolved
+    :class:`~abicheck.service_compare_evidence.SideEvidence` (whose
+    ``collect_mode`` drives the embedded build-source diff).
+    """
+
+    old: AbiSnapshot
+    new: AbiSnapshot
+    old_fmt: str | None
+    new_fmt: str | None
+    old_evidence: SideEvidence
+    new_evidence: SideEvidence
+
+
+def resolve_sides_sequentially(request: CompareRequest) -> bool:
+    """Whether both sides must resolve one after the other, not concurrently.
+
+    Concurrency is the default: old/new resolution has no data dependency
+    until both feed ``compare_snapshots``, and each is dominated by a
+    castxml/DWARF subprocess and XML/JSON parsing rather than CPU held under
+    the GIL. Two cases force sequential resolution instead:
+
+    * ``ABICHECK_PARALLEL_EXTRACTION=0`` — the documented escape hatch for a
+      memory-constrained runner, where two concurrent header-AST frontends
+      roughly double peak RSS versus one at a time.
+    * **Either side carries a ``dump_manifest``** (ADR-050 D6 / G32 Phase E).
+      A manifest-driven dump sizes its own per-TU worker pool from a live
+      ``MemAvailable`` reading; two of them starting together each size a
+      full pool off the *same* reading and jointly overcommit. The native
+      ``compare`` CLI has always resolved sequentially and so never had this
+      problem, but ``InputSpec.dump_manifest`` made the manifest path
+      reachable from ``run_compare_request`` too — which resolves
+      concurrently — so the guard has to live here, where both front ends
+      now share one resolution, rather than in the CLI's own copy of it.
+    """
+    if os.environ.get("ABICHECK_PARALLEL_EXTRACTION", "1").strip().lower() in (
+        "0",
+        "false",
+        "no",
+    ):
+        return True
+    return request.old.dump_manifest is not None or request.new.dump_manifest is not None
+
+
+def _manifest_forced_includes(dump_manifest: object) -> list[Path]:
+    """Forced includes declared by a ``--dump-manifest``'s translation units.
+
+    A manifest replaces the side's ``headers`` (which is then empty), so its
+    own forced includes must feed the pair-wide C++20 scan too or a
+    manifest-only side's C++20 signal goes undetected (Codex review).
+    """
+    return [
+        inc
+        for tu in getattr(dump_manifest, "translation_units", ())
+        for inc in tu.forced_includes
+    ]
+
+
+def _pair_compile_context(
+    request: CompareRequest, lang: str
+) -> CompileContext | None:
+    """The pair-wide C++20 dialect override, if the header sets imply one."""
+    from .compile_context import CompileContext
+    from .service_scan import pair_wide_cxx20_std_override
+
+    override = pair_wide_cxx20_std_override(
+        lang,
+        list(request.old.headers) + _manifest_forced_includes(request.old.dump_manifest),
+        list(request.new.headers) + _manifest_forced_includes(request.new.dump_manifest),
+        None,
+        (),
+    )
+    return CompileContext(gcc_option_tokens=override) if override is not None else None
+
+
+def _public_header_sets(
+    request: CompareRequest,
+) -> tuple[list[Path], list[Path], list[Path], list[Path]]:
+    """Split each side's ``headers`` into the file/dir public-header sets.
+
+    ``request.{old,new}.headers`` double as the public-header set for
+    provenance tagging. They must be split into files and directories before
+    tagging: an unsplit directory entry corrupts ``scope_fingerprint``.
+    ``InputSpec.public_header_dirs`` is unioned in afterward.
+
+    ``depth="binary"`` clears all four (Codex review): that depth clears
+    ``evidence.headers``, but a headerless dump still fingerprints these, so
+    leaving them populated makes two otherwise-identical sides raise a
+    spurious ``ScopeMismatchError``.
+    """
+    from .header_utils import split_public_header_inputs
+
+    old_public_headers, old_public_header_dirs = split_public_header_inputs(
+        request.old.headers
+    )
+    new_public_headers, new_public_header_dirs = split_public_header_inputs(
+        request.new.headers
+    )
+    old_public_header_dirs += list(request.old.public_header_dirs)
+    new_public_header_dirs += list(request.new.public_header_dirs)
+    if request.depth is not None and request.depth.lower() == "binary":
+        return [], [], [], []
+    return (
+        old_public_headers,
+        old_public_header_dirs,
+        new_public_headers,
+        new_public_header_dirs,
+    )
+
+
+def _is_raw_source_tree(path: Path | None) -> bool:
+    """True for a source tree needing real extraction — not a prebuilt pack."""
+    from .buildsource.inline import is_pack_dir
+    from .cli_buildsource_helpers import _is_inputs_pack_dir
+
+    return path is not None and not (is_pack_dir(path) or _is_inputs_pack_dir(path))
+
+
+def _reject_unsupported_frontends(
+    request: CompareRequest,
+    frontend_lower: str,
+    header_backend: str,
+    old_evidence: SideEvidence,
+    new_evidence: SideEvidence,
+) -> None:
+    """Reject the two frontend/evidence combinations that have no extractor.
+
+    ``android`` and ``hybrid`` have no real ``embed_build_source`` extractor,
+    so a raw source tree needing real extraction under either is a usage
+    error rather than a silently weaker result. A prebuilt pack or a bare
+    ``build_info`` never feeds L4, so neither is rejected. Mirrors ``cli.py``'s
+    own ``--depth source`` + ``--ast-frontend hybrid`` ``UsageError``.
+    """
+    from . import service_compare_evidence as _sce
+
+    if frontend_lower == "android" and any(
+        _is_raw_source_tree(side.sources) for side in (request.old, request.new)
+    ):
+        raise ValidationError(
+            "the 'android' AST frontend's source-ABI replay is not yet wired "
+            "into run_compare_request's inline evidence collection for a raw "
+            "source tree -- pass a prebuilt evidence pack directory instead, "
+            "or use has_sources=True with no inline sources/build_info."
+        )
+    if request.depth is not None and request.depth.lower() == "source":
+        for side, evidence in ((request.old, old_evidence), (request.new, new_evidence)):
+            if (
+                _is_raw_source_tree(side.sources)
+                and _sce.effective_frontend(evidence.compile, header_backend) == "hybrid"
+            ):
+                raise ValidationError(
+                    "depth='source' is incompatible with the 'hybrid' AST "
+                    "frontend: L4 source-ABI replay has no dual-backend hybrid "
+                    "extractor. Use 'castxml' or 'clang' for a depth='source' "
+                    "request."
+                )
+
+
+def _enforce_requested_depth(
+    request: CompareRequest, old: AbiSnapshot, new: AbiSnapshot
+) -> None:
+    """Fail when an explicit ``depth`` was requested but not actually reached.
+
+    Mirrors ``dump``'s own ``check_requested_depth_satisfied`` hard-fail, but
+    raises ``ValidationError`` (a Tier-2 API has no ``ClickException``
+    concept). Without it, a raw input that could not reach the requested rung
+    — no usable compile database, extractor, or linkable declarations —
+    silently diffed whatever weaker evidence ``embed_build_source`` produced.
+
+    Known, accepted limitation (Codex review, not fixed here): this is a
+    floor, not a ceiling. A side whose input is an already-serialized JSON
+    snapshot with richer embedded evidence than ``depth`` requested still
+    diffs with all of it — ``resolve_input``'s ``fmt == "json"`` branch
+    returns ``load_snapshot(path)`` verbatim, matching the CLI's own
+    long-documented default, which ``--depth`` has never projected down for a
+    pre-built snapshot either.
+    """
+    if request.depth is None:
+        return
+    from .cli_dump_helpers import _DEPTH_RANK, _gated_source_label
+
+    # validate() already restricts depth to USER_DEPTHS.
+    requested_rank = _DEPTH_RANK.get(request.depth.lower(), 0)
+    for side_label, snap in (("old", old), ("new", new)):
+        effective = _gated_source_label(snap.build_source, snap)
+        if _DEPTH_RANK.get(effective, 0) < requested_rank:
+            raise ValidationError(
+                f"depth={request.depth!r} was requested for the {side_label} "
+                f"side but the resolved snapshot only reached {effective!r} "
+                "evidence depth. Supply the evidence this rung needs (headers, "
+                "a build/compile database, or --sources with linkable "
+                "declarations) or lower depth to match what is actually "
+                "available."
+            )
+
+
+def resolve_compare_request(
+    request: CompareRequest,
+    *,
+    notify: Callable[[str], None] | None = None,
+    allow_parallel: bool = True,
+) -> ResolvedComparePair:
+    """Resolve both sides of *request* into a classifiable pair.
+
+    The first half of :func:`abicheck.service.run_compare_request`, and the
+    single resolution implementation every front end uses — the native
+    ``compare`` CLI (through ``cli_resolve._resolve_compare_snapshots``), the
+    typed Python API, and the MCP ``abi_compare`` tool.
+
+    *notify* is forwarded to :func:`abicheck.service.resolve_input` for
+    user-facing progress notes ("following a linker script"); the CLI passes a
+    ``click.echo(..., err=True)`` wrapper, everything else leaves it ``None``
+    so the notes are logged instead.
+
+    *allow_parallel* is the caller's *permission* to resolve both sides
+    concurrently, not a demand: :func:`resolve_sides_sequentially` can still
+    veto it (a ``dump_manifest`` on either side, or
+    ``ABICHECK_PARALLEL_EXTRACTION=0``). The native ``compare`` CLI passes
+    ``False`` — it has always resolved sequentially, and its two dumps write
+    interleaving progress notes to the same stderr, so adopting this shared
+    resolution deliberately does not change its memory or output profile.
+    Flipping the CLI to concurrent extraction is a measurable change worth
+    making on its own evidence, not a side effect of removing a duplicate
+    implementation.
+
+    Raises:
+        ValidationError: If the request fails :meth:`CompareRequest.validate`,
+            names a frontend with no extractor for its evidence, or requests a
+            ``depth`` the resolved snapshots did not reach.
+        SnapshotError: If either input cannot be loaded.
+    """
+    from . import service, service_compare_evidence as _sce
+
+    request.validate()
+    # validate() accepts lang case-insensitively; the ELF dump path does
+    # case-sensitive `lang == "c"` checks, so normalise here. `android` (no
+    # header-AST path) falls back to "auto" for the binary dump.
+    lang = request.lang.lower()
+    from .api_types import HEADER_AST_FRONTENDS
+
+    frontend_lower = request.frontend.lower()
+    header_backend = (
+        frontend_lower if frontend_lower in HEADER_AST_FRONTENDS else "auto"
+    )
+    old_fmt = service.detect_binary_format(request.old.path)
+    new_fmt = service.detect_binary_format(request.new.path)
+    debug_format = _sce.normalized_debug_format(request)
+    _sce.reject_debug_format_for_non_elf(debug_format, old_fmt, new_fmt)
+
+    pair_compile = _pair_compile_context(request, lang)
+    (
+        old_public_headers,
+        old_public_header_dirs,
+        new_public_headers,
+        new_public_header_dirs,
+    ) = _public_header_sets(request)
+    old_evidence, new_evidence = _sce.resolve_compare_request_evidence(
+        request, pair_compile
+    )
+    _reject_unsupported_frontends(
+        request, frontend_lower, header_backend, old_evidence, new_evidence
+    )
+
+    def _resolve_side(
+        side: InputSpec,
+        evidence: SideEvidence,
+        fmt: str | None,
+        public_headers: list[Path],
+        public_header_dirs: list[Path],
+    ) -> AbiSnapshot:
+        snap = service.resolve_input(
+            side.path,
+            evidence.headers,
+            list(side.includes),
+            side.version,
+            lang,
+            is_elf=True if fmt == "elf" else None,
+            pdb_path=side.pdb,
+            debug_roots=list(side.debug_roots) or None,
+            enable_debuginfod=request.enable_debuginfod,
+            debuginfod_url=request.debuginfod_url,
+            header_backend=header_backend,
+            compile=evidence.compile,
+            public_headers=public_headers,
+            public_header_dirs=public_header_dirs,
+            include_dependencies=side.include_dependencies,
+            dump_manifest=evidence.dump_manifest,
+            follow_linker_scripts=side.follow_linker_scripts,
+            dwarf_only=request.dwarf_only,
+            debug_format=debug_format,
+            include_labels=dict(request.include_labels) or None,
+            notify=notify,
+        )
+        if side.sources or side.build_info:
+            _embed_side_build_source(
+                snap,
+                side,
+                evidence,
+                header_backend,
+                public_headers,
+                public_header_dirs,
+            )
+        return snap
+
+    def _resolve_old_side() -> AbiSnapshot:
+        return _resolve_side(
+            request.old,
+            old_evidence,
+            old_fmt,
+            old_public_headers,
+            old_public_header_dirs,
+        )
+
+    def _resolve_new_side() -> AbiSnapshot:
+        return _resolve_side(
+            request.new,
+            new_evidence,
+            new_fmt,
+            new_public_headers,
+            new_public_header_dirs,
+        )
+
+    if not allow_parallel or resolve_sides_sequentially(request):
+        old = _resolve_old_side()
+        new = _resolve_new_side()
+    else:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as pool:
+            old_future = pool.submit(_resolve_old_side)
+            new_future = pool.submit(_resolve_new_side)
+            old = old_future.result()
+            new = new_future.result()
+
+    # ADR-055 D1: `--follow-deps`'s transitive DependencyInfo. After both sides
+    # resolve, not inside `_resolve_side`: it reads the on-disk ELF, so it
+    # gains nothing from the extraction threads.
+    populate_pair_dependency_info(
+        request, old, new, old_fmt=old_fmt, new_fmt=new_fmt
+    )
+    _enforce_requested_depth(request, old, new)
+    return ResolvedComparePair(
+        old=old,
+        new=new,
+        old_fmt=old_fmt,
+        new_fmt=new_fmt,
+        old_evidence=old_evidence,
+        new_evidence=new_evidence,
+    )
+
+
+def _embed_side_build_source(
+    snap: AbiSnapshot,
+    side: InputSpec,
+    evidence: SideEvidence,
+    header_backend: str,
+    public_headers: list[Path],
+    public_header_dirs: list[Path],
+) -> None:
+    """Embed one side's inline L3-L5 build/source evidence into *snap*.
+
+    Same public roots as ``resolve_input``, plus a ``dump_manifest``'s
+    *declared-public* roots only (a manifest's project-owned TU includes are
+    private, hence ``dump_manifest_public_roots`` rather than
+    ``dump_manifest_header_roots``).
+
+    A malformed pack raises ``click.ClickException`` deep inside
+    ``embed_build_source`` — no place in this Tier-2 API's
+    ``ValidationError``/``SnapshotError`` contract, so it is translated here
+    (Codex review).
+    """
+    import click
+
+    from . import service_compare_evidence as _sce
+    from .cli_buildsource import embed_build_source
+    from .dumper_scoping import dump_manifest_public_roots
+
+    try:
+        embed_build_source(
+            snap,
+            build_info=side.build_info,
+            sources=side.sources,
+            collect_mode=evidence.collect_mode,
+            extractor=_sce.effective_frontend(evidence.compile, header_backend),
+            public_headers=tuple(str(p) for p in public_headers),
+            public_header_dirs=tuple(str(p) for p in public_header_dirs)
+            + tuple(str(p) for p in dump_manifest_public_roots(evidence.dump_manifest)),
+            quiet=True,
+        )
+    except click.ClickException as exc:
+        raise SnapshotError(str(exc)) from exc
+
+
+def classify_compare_pair(
+    request: CompareRequest, pair: ResolvedComparePair
+) -> CompareResult:
+    """Classify an already-resolved pair — the second half of ``run_compare_request``.
+
+    Loads the request's suppression list and policy file, diffs whatever
+    build-source evidence the snapshots carry into ``extra_changes`` (without
+    it a source-only change reads as artifact-only compatible), classifies
+    through the Tier-2 ``compare_snapshots`` chokepoint, and attaches the
+    coverage/metrics the diff itself does not produce.
+
+    A front end that must configure the run between the two phases (the native
+    ``compare`` CLI's ADR-049 ``resolve_and_apply``, which can move the policy
+    file and severity levels a ``--pack`` selects) calls
+    :func:`resolve_compare_request` and then classifies on its own terms
+    instead of calling this; everything else composes the two through
+    :func:`abicheck.service.run_compare_request`.
+    """
+    from . import service
+    from .cli_buildsource import attach_evidence_metrics, prepare_embedded_build_source
+
+    old, new = pair.old, pair.new
+    suppression, pf = service.load_suppression_and_policy(
+        request.suppress, request.policy, request.policy_file_path
+    )
+    # The four Nones are the out-of-band pack-override params -- reusing the
+    # raw sources/build_info paths would make `_resolve_side_pack` try (and
+    # fail) to reload them as packs; None uses the embedded facts.
+    (
+        extra_changes,
+        layer_coverage_rows,
+        evidence_metrics,
+        _ev_changes,
+    ) = prepare_embedded_build_source(
+        old,
+        new,
+        pair.old_evidence.collect_mode,
+        None,
+        None,
+        None,
+        None,
+        None,
+        policy_file=pf,
+        quiet=True,
+    )
+    result = service.compare_snapshots(
+        old,
+        new,
+        suppression=suppression,
+        policy=request.policy,
+        policy_file=pf,
+        scope_to_public_surface=request.scope_public,
+        force_public_symbols=(
+            set(request.force_public_symbols) if request.force_public_symbols else None
+        ),
+        extra_changes=extra_changes,
+        public_surface_allowlist=(
+            set(request.public_surface_allowlist)
+            if request.public_surface_allowlist is not None
+            else None
+        ),
+        pattern_verdicts=request.pattern_verdicts,
+        reconcile_build_context=request.reconcile_build_context,
+        env_matrix=service.load_env_matrix(request.env_matrix_path),
+        diagnostic_comparison=request.diagnostic_comparison,
+        contract_evaluation=request.contract_evaluation,
+        contract_mode=request.contract_mode,
+    )
+    if layer_coverage_rows:
+        result.layer_coverage = layer_coverage_rows
+    attach_evidence_metrics(result, evidence_metrics, extra_changes or [], quiet=True)
+    result.old_metadata = service.collect_metadata(request.old.path)
+    result.new_metadata = service.collect_metadata(request.new.path)
+    # ADR-055 D2/D4: `suppression` is carried out so a front end applying a
+    # post-classification concern (appcompat's `scope_diff_to_app`) reuses the
+    # list this call already resolved instead of loading it a second time.
+    return CompareResult(
+        diff=result, old_snapshot=old, new_snapshot=new, suppression=suppression
+    )

--- a/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
+++ b/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
@@ -1,0 +1,39 @@
+### Added
+
+- **`CompareResult`, a typed result for the `compare` service verb (ADR-055
+  D2).** `abicheck.service.run_compare_request_v2(request)` returns a
+  `CompareResult` (`diff`/`old_snapshot`/`new_snapshot`, plus the resolved
+  `suppression` list) instead of the bare 3-tuple, so a future field has
+  somewhere to land without breaking positional callers. The existing
+  `run_compare_request` keeps its exact tuple signature and is now a view over
+  the same implementation — no caller changes.
+- **`InputSpec.follow_linker_scripts` (ADR-055 D4).** Lets a request decline
+  to follow a GNU ld linker script's `INPUT()`/`GROUP()` target to the real
+  library. Defaults to `True`, matching the previous behaviour of every
+  caller; the MCP server sets it `False`, which is what keeps its
+  `MCP_MAX_FILE_SIZE` guard authoritative now that it resolves through the
+  shared service layer.
+
+### Changed
+
+- **The MCP `abi_compare` tool now routes through the Tier-2 chokepoint
+  (ADR-055 D4).** It previously resolved its own inputs, loaded its own
+  policy/suppression files, and used `compare_snapshots` for the middle
+  diffing step only — a second compare engine that could drift from the CLI's
+  without anything failing. It now builds one `CompareRequest` and calls
+  `run_compare_request_v2`. Output is unchanged: a new parity test asserts
+  `abi_compare`'s rendered report and exit code match the CLI `compare`
+  command's across policy-profile, policy-file, suppression, `--show-only`,
+  `--report-mode`, and severity-aware runs.
+- **`abi_compare` rejects an unsupported `language` instead of passing it
+  down.** A value outside `c`/`c++` (e.g. `"rust"`) is now a structured
+  validation error, matching what the CLI's `--lang` choice has always done.
+
+### Fixed
+
+- **Two documentation pages quoted long-superseded schema versions.**
+  `docs/use/output-formats.md` showed `report_schema_version` `"1.0"` and
+  `docs/reference/check-target.md` `"2.13"`, against a real `2.26`. The
+  `doc-count-sync` AI-readiness check now reads these values from
+  `abicheck.schemas.current()` and fails on drift, so the next bump cannot
+  leave them behind silently (ADR-055 D3).

--- a/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
+++ b/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
@@ -31,9 +31,13 @@
 
 ### Fixed
 
-- **Two documentation pages quoted long-superseded schema versions.**
+- **Four documentation pages quoted stale or duplicated schema versions.**
   `docs/use/output-formats.md` showed `report_schema_version` `"1.0"` and
-  `docs/reference/check-target.md` `"2.13"`, against a real `2.26`. The
-  `doc-count-sync` AI-readiness check now reads these values from
-  `abicheck.schemas.current()` and fails on drift, so the next bump cannot
-  leave them behind silently (ADR-055 D3).
+  still claimed a snapshot's `schema_version` "is currently `8`" — the exact
+  bug ADR-055 D3 was written about, alive on a second page after the first
+  was fixed — while `docs/reference/check-target.md` quoted `"2.13"` against
+  a real `2.26`. Where the version was incidental to the sentence, the page
+  now links to the fact owner and holds no copy. Where it must appear
+  literally (a JSON output sample, or the owner page's own statement of the
+  current value), the `doc-count-sync` AI-readiness check reads the expected
+  value from `abicheck.schemas.current()` and fails on drift.

--- a/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
+++ b/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
@@ -1,12 +1,11 @@
 ### Added
 
 - **`CompareResult`, a typed result for the `compare` service verb (ADR-055
-  D2).** `abicheck.service.run_compare_request_v2(request)` returns a
-  `CompareResult` (`diff`/`old_snapshot`/`new_snapshot`, plus the resolved
-  `suppression` list) instead of the bare 3-tuple, so a future field has
-  somewhere to land without breaking positional callers. The existing
-  `run_compare_request` keeps its exact tuple signature and is now a view over
-  the same implementation — no caller changes.
+  D2).** `diff` (the `DiffResult`), `old_snapshot`, `new_snapshot`, and the
+  resolved `suppression` list, so a future field has somewhere to land without
+  breaking positional callers. It is what `run_compare_request` and
+  `run_compare` return — see the Changed section for that break and its
+  one-line migration.
 - **`InputSpec.follow_linker_scripts` (ADR-055 D4).** Lets a request decline
   to follow a GNU ld linker script's `INPUT()`/`GROUP()` target to the real
   library. Defaults to `True`, matching the previous behaviour of every
@@ -37,10 +36,9 @@
 ### Changed
 
 - **BREAKING (pre-1.0): `run_compare` and `run_compare_request` return a
-  `CompareResult`, not a 3-tuple.** ADR-055 D2 introduced the typed result
-  beside the tuple and a temporary `run_compare_request_v2` seam; with the
-  project not yet holding API compatibility, the two names collapsed into one
-  rather than being carried indefinitely. A struct can gain a field without
+  `CompareResult`, not a 3-tuple.** With the project not yet holding API
+  compatibility, the typed result became the only shape rather than a second
+  one carried beside the tuple. A struct can gain a field without
   breaking positional callers, which a tuple cannot. Migrate a positional
   caller in one line: `result, old, new = run_compare(...).as_tuple()`.
 - **`CompareRequest.debug_format="auto"` no longer crashes during
@@ -58,7 +56,7 @@
   policy/suppression files, and used `compare_snapshots` for the middle
   diffing step only — a second compare engine that could drift from the CLI's
   without anything failing. It now builds one `CompareRequest` and calls
-  `run_compare_request_v2`. Output is unchanged: a new parity test asserts
+  `run_compare_request`. Output is unchanged: a new parity test asserts
   `abi_compare`'s rendered report and exit code match the CLI `compare`
   command's across policy-profile, policy-file, suppression, `--show-only`,
   `--report-mode`, and severity-aware runs.

--- a/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
+++ b/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
@@ -25,6 +25,15 @@
   the new leaf module `abicheck.dependency_info`, which the CLI and the
   service both depend on.
 
+- **`compare --follow-deps` now works for a GNU ld linker-script input.** A
+  distribution's `libfoo.so` is routinely a text linker script naming the real
+  `libfoo.so.1`; dependency enrichment gated on the *input's* detected format,
+  which is not ELF for a script, so it silently skipped the resolution the
+  caller asked for. It now follows the script the same way input resolution
+  does — and reads the graph from the resolved ELF rather than the script that
+  names it — for any side that hasn't opted out via
+  `InputSpec.follow_linker_scripts`.
+
 ### Changed
 
 - **The MCP `abi_compare` tool now routes through the Tier-2 chokepoint
@@ -39,6 +48,11 @@
 - **`abi_compare` rejects an unsupported `language` instead of passing it
   down.** A value outside `c`/`c++` (e.g. `"rust"`) is now a structured
   validation error, matching what the CLI's `--lang` choice has always done.
+- **`CompareRequest.debug_format` is validated and case-normalized.** It
+  accepts exactly what the CLI's case-insensitive `--debug-format` choice does
+  (`auto`/`dwarf`/`btf`/`ctf`); anything else raises `ValidationError` up front
+  rather than a bare `ValueError` from inside extraction, and `"DWARF"` now
+  behaves for an API caller as it does for the CLI caller who typed it.
 
 ### Fixed
 

--- a/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
+++ b/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
@@ -33,8 +33,36 @@
   names it — for any side that hasn't opted out via
   `InputSpec.follow_linker_scripts`.
 
+- **`resolve_compare_request` and `classify_compare_pair` — `run_compare_request`'s
+  two phases, now separately callable (ADR-055 D1).** Resolution (validate,
+  resolve both sides' evidence and snapshots, `--follow-deps` enrichment,
+  depth floor) and classification (suppression/policy, embedded build-source
+  diff, `compare_snapshots`, metrics) are individually reusable;
+  `run_compare_request` is exactly their composition, so a caller that needs
+  no seam is unaffected. `ResolvedComparePair` is the value between them.
+
 ### Changed
 
+- **The native `compare` CLI now shares the typed path's input resolution
+  (ADR-055 D1's structural half).** `cli_resolve._resolve_compare_snapshots`
+  was a second implementation of what `run_compare_request` already did — it
+  existed because `compare` must run its Click-dependent ADR-049
+  `resolve_and_apply` *between* resolving and classifying, and
+  `run_compare_request` was one function with no seam for that. Splitting it
+  into the two phases above removed the reason for the copy: the CLI helper
+  now builds a `CompareRequest` and delegates. Behaviour is unchanged, down
+  to the details that are genuinely CLI-specific — the `click.echo` progress
+  notifier, `ValidationError`/`SnapshotError` still surfacing as
+  `click.UsageError`/`click.ClickException`, and both sides still resolving
+  sequentially.
+- **A `--dump-manifest` comparison never resolves both sides at once, on any
+  front end.** The CLI resolved sequentially and so was safe; the typed
+  `run_compare_request` resolved concurrently and was documented as unable to
+  reach a manifest-driven dump at all — which stopped being true when
+  `InputSpec.dump_manifest` was added. Since a manifest dump sizes its per-TU
+  worker pool from a live `MemAvailable` reading, two starting together sized
+  two full pools off the same reading. `resolve_sides_sequentially` now states
+  the rule once for every caller.
 - **BREAKING (pre-1.0): `run_compare` and `run_compare_request` return a
   `CompareResult`, not a 3-tuple.** With the project not yet holding API
   compatibility, the typed result became the only shape rather than a second

--- a/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
+++ b/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
@@ -14,6 +14,17 @@
   `MCP_MAX_FILE_SIZE` guard authoritative now that it resolves through the
   shared service layer.
 
+- **`CompareRequest` reaches full parity with `compare`'s own input
+  resolution (ADR-055 D1).** Four concepts the CLI could express and a
+  Python/MCP caller could not are now request fields: `dwarf_only`,
+  `debug_format`, `include_labels` (ADR-050 D1's resolved `path -> label`
+  map, carried as a tuple of pairs so the request stays hashable), and
+  `--follow-deps` (`follow_dependencies` + `dependency_search_paths` +
+  `ld_library_path`). All default to off, so no existing caller changes
+  behaviour. `--follow-deps`'s implementation moved from `cli_resolve` into
+  the new leaf module `abicheck.dependency_info`, which the CLI and the
+  service both depend on.
+
 ### Changed
 
 - **The MCP `abi_compare` tool now routes through the Tier-2 chokepoint

--- a/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
+++ b/changelog.d/20260804_120000_claude_adr055_typed_result_and_mcp_convergence.md
@@ -36,6 +36,23 @@
 
 ### Changed
 
+- **BREAKING (pre-1.0): `run_compare` and `run_compare_request` return a
+  `CompareResult`, not a 3-tuple.** ADR-055 D2 introduced the typed result
+  beside the tuple and a temporary `run_compare_request_v2` seam; with the
+  project not yet holding API compatibility, the two names collapsed into one
+  rather than being carried indefinitely. A struct can gain a field without
+  breaking positional callers, which a tuple cannot. Migrate a positional
+  caller in one line: `result, old, new = run_compare(...).as_tuple()`.
+- **`CompareRequest.debug_format="auto"` no longer crashes during
+  extraction.** `dumper_debug` raises for anything outside
+  `dwarf`/`btf`/`ctf` and treats `None` as auto-detect, so the accepted
+  `"auto"` had to be translated rather than forwarded — the same translation
+  the CLI already does for `--debug-format auto`.
+- **A forced ELF debug format is rejected when a side is PE or Mach-O.** Those
+  dump paths take no debug-format argument, so the request was silently
+  dropped and the run reported success having ignored it; the CLI has always
+  rejected the combination up front.
+
 - **The MCP `abi_compare` tool now routes through the Tier-2 chokepoint
   (ADR-055 D4).** It previously resolved its own inputs, loaded its own
   policy/suppression files, and used `compare_snapshots` for the middle

--- a/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
+++ b/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
@@ -235,11 +235,68 @@ rather than reasoning about them, and all four are now on `CompareRequest`:
 both layers depend on — the shape AGENTS.md prescribes when a CLI helper
 gains a service-layer caller, instead of either importing the other.
 
-So the two paths now differ in *structure*, not in what they can express.
-Migrating the CLI onto `run_compare_request` remains a separate,
-independently-reviewable change needing its own before/after parity evidence
-over the CLI's full flag matrix — the kind of work that goes wrong when
-bundled into another decision's PR.
+So the two paths differed in *structure*, not in what they could express.
+
+**Structural half — now done too, and the answer flipped to (a).** The note
+above deferred migrating the CLI onto `run_compare_request` as separate work.
+That work is now landed, and doing it exposed *why* option (b) had looked
+inevitable: `run_compare_request` was one function that both resolved and
+classified, and the native `compare` CLI must run its Click-dependent ADR-049
+`resolve_and_apply` step **between** those two — the step needs the Click
+context to answer "did the user type this?", and a `--pack` it selects can
+move the policy file and severity levels the classification is then scored
+under. With no seam, the CLI could reuse neither half, so it kept a copy.
+
+The fix was therefore not "call `run_compare_request` from the CLI" but
+splitting it at its real joint (`abicheck/service_compare_pipeline.py`):
+
+| | |
+|---|---|
+| `resolve_compare_request(request, *, notify, allow_parallel)` | validate → resolve both sides' evidence → resolve both snapshots → `--follow-deps` enrichment → enforce the requested depth |
+| `classify_compare_pair(request, pair)` | load suppression/policy → diff embedded build-source evidence → `compare_snapshots` → attach coverage/metrics |
+| `run_compare_request(request)` | exactly their composition — one call for a caller that needs no seam |
+
+`cli_resolve._resolve_compare_snapshots` now builds a `CompareRequest` and
+calls `resolve_compare_request`; it resolves nothing itself. What stays
+CLI-specific is what genuinely is: the `click.echo` progress notifier,
+translating `ValidationError`/`SnapshotError` into `click.UsageError`/
+`click.ClickException` (the contract `_resolve_input` documented), and
+`allow_parallel=False`.
+
+That last one is deliberate and is *not* a leftover divergence.
+`allow_parallel` is the caller's **permission** to resolve both sides
+concurrently, not a demand — the shared `resolve_sides_sequentially` can
+still veto it. The CLI declines the permission because it has always resolved
+sequentially and its two dumps write interleaving progress notes to one
+stderr; flipping it to concurrent extraction changes the memory and output
+profile of every existing `compare` invocation, which deserves its own
+evidence rather than riding along with the removal of a duplicate.
+
+**A real defect the unification surfaced.** The sequential-resolution guard
+`tests/test_compare_dispatch.py` pinned for the CLI (ADR-050 D6 / G32 Phase
+E: a manifest-driven dump sizes its per-TU worker pool from a live
+`MemAvailable` reading, so two starting together size two full pools off the
+same reading and jointly overcommit) rested on a claim that had gone stale —
+that `run_compare_request` "has no `dump_manifest` field on
+`CompareRequest`/`InputSpec` at all, so it can never reach a manifest-driven
+dump". D1's own first slice added `InputSpec.dump_manifest`, so the typed
+path could reach a manifest *and* resolved concurrently: it had the exact
+risk the CLI test was written to prevent. `resolve_sides_sequentially` now
+states the rule once, for every front end — a `dump_manifest` on either side
+(or `ABICHECK_PARALLEL_EXTRACTION=0`) forces sequential resolution.
+
+**Import-cycle allowlist sign-off (AGENTS.md "What NOT to do").**
+`service_compare_pipeline` is added to `IMPORT_CYCLE_ALLOWLIST`'s existing
+CLI-registration/service-routing SCC. This is the `l0_export_delta` /
+`scan_engine` precedent, not a new dependency direction: the module is a
+*split of an existing member*, reaching `cli_buildsource`/`cli_dump_helpers`/
+`cli_buildsource_helpers`/`service` function-locally — the identical edge set
+`service.run_compare_request` already had, relocated rather than added — and
+`service` imports it back at its module-load tail. It imports only
+`api_types`/`dependency_info`/`errors` (leaves) at module load, so the package
+still imports cleanly. The net effect on the graph is a *reduction*:
+`cli_resolve` no longer carries its own copy of this resolution. This ADR is
+the record AGENTS.md asks for.
 
 ### D2. Typed `Result` wrappers for the existing typed-request verbs
 
@@ -471,13 +528,17 @@ exists and has no CLI-comparable rendering path here. The sibling
 |---|---|
 | `abicheck/api_types.py` | `InputSpec.sources`/`build_info`/`dump_manifest`/`compile`/`public_header_dirs` + `CompareRequest.depth`/`frontend_context` (D1); `InputSpec.follow_linker_scripts` (D4); `CompareResult` (D2 — here, not `service.py`, see its "As implemented" note) |
 | `abicheck/service_compare_evidence.py` | D1's resolution wiring, split out of `service.py` |
+| `abicheck/service_compare_pipeline.py` | D1's structural half: `resolve_compare_request`/`classify_compare_pair`/`resolve_sides_sequentially` — `run_compare_request`'s two phases, split out so the CLI shares them |
+| `abicheck/cli_resolve.py` | `_resolve_compare_snapshots` builds a `CompareRequest` and delegates to `resolve_compare_request`; it resolves nothing itself (D1 structural half) |
 | `abicheck/service.py` | `run_compare_request` returns `CompareResult`, and so does the `run_compare` kwargs shim (D2, after the 0.6 API break — no `_v2` function exists); per-side `follow_linker_scripts` forwarding (D4) |
 | `abicheck/schemas/__init__.py` | `current(name)` registry (D3) |
+| `scripts/check_ai_readiness.py` | `service_compare_pipeline` added to the existing SCC in `IMPORT_CYCLE_ALLOWLIST` (D1 structural half — sign-off recorded in D1 above) |
 | `scripts/check_ai_readiness.py` | `doc-count-sync` reads snapshot/compare versions from `schemas.current()` and pins the pages quoting them (D3's consumer half) |
 | `abicheck/mcp_server.py` | `abi_compare` builds a `CompareRequest` and calls `run_compare_request`; no local resolve, no policy/suppression load, no `compare_snapshots` import (D4) |
 | `docs/reference/python-api-reference.md`, `docs/reference/mcp-tools-reference.md` | Regenerated (generated files) |
 | `tests/test_api_types.py` | Field defaults for D1/D4; `TestCompareResult` (D2) |
-| `tests/test_service_unit.py` | `TestCompareRequestAdr055Evidence` (D1); `TestRunCompareRequestV2` (D2, incl. per-side `follow_linker_scripts`) |
+| `tests/test_service_unit.py` | `TestCompareRequestAdr055Evidence` (D1); `TestRunCompareRequestTypedResult` (D2, incl. per-side `follow_linker_scripts`); `TestComparePipelinePhases` + `TestResolveSidesSequentially` (D1 structural half) |
+| `tests/test_compare_dispatch.py` | `TestCompareCliSharesServiceResolution`: the CLI really delegates, and still translates the service errors into the `click` exceptions `_resolve_input` promised |
 | `tests/test_mcp_server_unit.py` | `TestAbiCompareCliParity`: the source-level D4 gate plus CLI-parity over a flag matrix |
 | `tests/test_mcp_server_coverage.py` | `TestAbiCompareTool` repointed to the service-layer names `abi_compare` now reaches |
 

--- a/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
+++ b/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
@@ -198,19 +198,44 @@ neither `service.py` comment this ADR quoted still exists.
 
 The open choice is now answered: **option (b)** — `run_compare_request` was
 extended in parallel, and the CLI `compare` command still resolves through
-`cli_resolve._resolve_compare_snapshots`. This is recorded as a decision, not
-as unfinished work, because the *capability* gap D1 set out to close is
-closed (a Python or MCP caller no longer has to drop to loose kwargs to reach
-`compare`'s depth/sources/build-info/manifest feature set), while option (a)
+`cli_resolve._resolve_compare_snapshots`. This is a decision, not unfinished
+work: the *capability* gap D1 set out to close is closed, while option (a)
 would rewrite the CLI's single most heavily-tested resolution path to gain
-nothing a user can observe. What remains genuinely two-implementation is
-narrower than the framing above suggests, and is listed explicitly so nobody
-has to re-derive it: project-config `source.method` inference, the set-input
-evidence-flag rejection guard, and the per-side AST-frontend override live
-only in the CLI path. Migrating the CLI onto `run_compare_request` is a
-separate, independently-reviewable change — it needs its own before/after
-parity evidence over the CLI's full flag matrix, which is exactly the kind of
-work that goes wrong when bundled into a different decision's PR.
+nothing a user can observe.
+
+**Correction, and how the capability gap was actually closed.** A first pass
+of this note claimed three things stayed CLI-only — project-config
+`source.method` inference, the set-input evidence-flag rejection guard, and
+the per-side AST-frontend override. Checking each against the code instead of
+asserting it found all three wrong, and found a different, real set:
+
+- The **per-side AST-frontend override** already worked. `InputSpec.compile.
+  frontend` reaches that side's `run_dump`, whose own precedence (an explicit
+  `compile.frontend` beats the request-wide `header_backend`) then applies.
+  Verified by spying on the per-side `run_dump` arguments, not by reading.
+- **`source.method` inference** is not a capability gap. The value is
+  expressible as `CompareRequest.depth`, and a Tier-2 API deliberately does
+  not discover `.abicheck.yml` from the working directory — resolving ambient
+  config is the front end's job, which is exactly how ADR-049 D7's own
+  precedence model already places `project_config` as a front-end tier.
+- The **set-input rejection guard** guards directory/package inputs — an
+  input *kind* `CompareRequest` does not accept at all. It protects a
+  CLI-only feature rather than covering a gap in the typed path.
+
+The real delta was four things, found by diffing the two parameter lists
+rather than reasoning about them, and all four are now on `CompareRequest`:
+`dwarf_only`, `debug_format`, ADR-050 D1's `include_labels`, and
+`--follow-deps` (`follow_dependencies`/`dependency_search_paths`/
+`ld_library_path`). `--follow-deps`'s implementation moved out of
+`cli_resolve` into the new leaf module `abicheck/dependency_info.py`, which
+both layers depend on — the shape AGENTS.md prescribes when a CLI helper
+gains a service-layer caller, instead of either importing the other.
+
+So the two paths now differ in *structure*, not in what they can express.
+Migrating the CLI onto `run_compare_request` remains a separate,
+independently-reviewable change needing its own before/after parity evidence
+over the CLI's full flag matrix — the kind of work that goes wrong when
+bundled into another decision's PR.
 
 ### D2. Typed `Result` wrappers for the existing typed-request verbs
 
@@ -515,9 +540,9 @@ gate in `TestAbiCompareCliParity`).
 **Still open after this ADR, deliberately.** Two items, each needing its own
 scoped change rather than an extension of this one:
 
-- The CLI's separate `_resolve_compare_snapshots` path (option (b) above) —
-  see D1's "As implemented" note for the exact three capabilities that
-  remain CLI-only.
+- The CLI's separate `_resolve_compare_snapshots` path (option (b) above).
+  Structural duplication only — the capability gap is closed; see D1's "As
+  implemented" note.
 - G33's Phase 5 (`abi_dump`/`abi_scan` reaching the same depth/sources/
   build-info/manifest parity `abi_compare` now has). That plan gates it on
   Phase 4, which this closes, so it is unblocked — but it is a change to two

--- a/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
+++ b/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
@@ -200,12 +200,20 @@ with the resolution wiring split out into
 `abicheck/service_compare_evidence.py`. Its stated acceptance test holds —
 neither `service.py` comment this ADR quoted still exists.
 
-The open choice is now answered: **option (b)** — `run_compare_request` was
-extended in parallel, and the CLI `compare` command still resolves through
-`cli_resolve._resolve_compare_snapshots`. This is a decision, not unfinished
-work: the *capability* gap D1 set out to close is closed, while option (a)
-would rewrite the CLI's single most heavily-tested resolution path to gain
-nothing a user can observe.
+The open choice was first answered as **option (b)** — `run_compare_request`
+extended in parallel, the CLI `compare` command still resolving through
+`cli_resolve._resolve_compare_snapshots` — as a decision rather than
+unfinished work: the *capability* gap D1 set out to close was closed, while
+option (a) would rewrite the CLI's single most heavily-tested resolution path
+to gain nothing a user can observe.
+
+> **Superseded — the answer is now (a).** See "Structural half" at the end of
+> this note. The reasoning above was not wrong about the cost; it was wrong
+> about the obstacle, which was never the CLI's test surface but
+> `run_compare_request` having no seam for ADR-049's Click-dependent step.
+> Once that was named, the change stopped being a rewrite of the CLI's
+> resolution and became a split of the service's. What follows is kept as the
+> record of what landed while (b) held.
 
 **Correction, and how the capability gap was actually closed.** A first pass
 of this note claimed three things stayed CLI-only — project-config
@@ -614,13 +622,17 @@ prose status. D1's and D4's both now do (the `service.py` comment-absence
 check by way of `TestCompareRequestAdr055Evidence`, and D4's source-level
 gate in `TestAbiCompareCliParity`).
 
-**Still open after this ADR, deliberately.** Two items, each needing its own
-scoped change rather than an extension of this one:
+**Still open after this ADR, deliberately.** One item, needing its own scoped
+change rather than an extension of this one:
 
-- The CLI's separate `_resolve_compare_snapshots` path (option (b) above).
-  Structural duplication only — the capability gap is closed; see D1's "As
-  implemented" note.
 - G33's Phase 5 (`abi_dump`/`abi_scan` reaching the same depth/sources/
   build-info/manifest parity `abi_compare` now has). That plan gates it on
   Phase 4, which this closes, so it is unblocked — but it is a change to two
   other tools' parameter surfaces, not part of this decision.
+
+This list said two items until the CLI's separate `_resolve_compare_snapshots`
+path was removed; that is now done, and D1's "Structural half" note above is
+the record. Which is worth naming, since it is the *third* instance in this
+one document of a status claim outliving the code it describes (D1's own
+"not started" line, the option-(b) decision, and now this list) — the reason
+each decision here carries an executable gate rather than only prose.

--- a/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
+++ b/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
@@ -3,10 +3,18 @@
 **Date:** 2026-07-27 (D1–D3); Gap 3/D4 added 2026-07-27 after a second,
 more detailed external review of the same subject was checked line-by-line
 against `mcp_server.py` (see "Amendment" note below Gap 2)
-**Status:** Proposed — D3 (schema-version registry) implemented
-(`abicheck/schemas/__init__.py`'s `current()`, see
-[G33](../plans/g33-typed-api-and-mcp-convergence.md) Phase 1); D1/D2/D4 not
-started. Written up after an external API-layer review of `abicheck`
+**Status:** Accepted — implemented (D1–D4). D3 (schema-version registry)
+landed first (`abicheck/schemas/__init__.py`'s `current()`); D1 landed inside
+PR #651, which is why this line and
+[G33](../plans/g33-typed-api-and-mcp-convergence.md) both went on saying
+"D1 not started" for several PRs after it was true — see the "Implementation
+notes" section at the end for what each decision actually became, including
+the two places the implementation deliberately departs from what is proposed
+below. One piece of D1's *context* is deliberately still open rather than
+silently dropped: the two-resolution-path split (the CLI's own
+`cli_resolve._resolve_compare_snapshots`) — that choice is now recorded as a
+decision (option (b)) rather than left unanswered, see D1's own section.
+Written up after an external API-layer review of `abicheck`
 (CLI/Python/MCP/Actions/schemas) turned out to be largely stale against
 current `main` — G22/ADR-037 already landed the CLI consolidation and the
 `checker.compare`-vs-Tier-2 chokepoint the review flagged as missing — but
@@ -19,8 +27,9 @@ Re-checking that specific claim against `mcp_server.py` line-by-line
 (prompted by a second, independent review raising the same point with more
 detail) found it true only for the final snapshot-diffing step, not for the
 tool as a whole — see Gap 3 below, now folded in as D4 rather than left a
-Non-goal. This ADR proposes closing all four; it does not implement anything
-itself beyond D3.
+Non-goal. All four are now closed; the decisions below are kept in their
+original proposing voice, with each one's "As implemented" note recording
+where reality diverged.
 **Verified:** main@2e43d53 on 2026-08-04
 **Decision maker:** (pending)
 
@@ -187,6 +196,29 @@ extend `run_compare_request` to match `_resolve_compare_snapshots`'s
 capabilities in parallel, keeping two implementations in sync by hand. This
 ADR does not resolve that choice; it is scoped work for whoever picks up D1.
 
+**As implemented — and the choice above, now decided as (b).** D1 landed in
+PR #651: `InputSpec` gained `sources`/`build_info`/`dump_manifest`/`compile`/
+`public_header_dirs` and `CompareRequest` gained `depth`/`frontend_context`,
+with the resolution wiring split out into
+`abicheck/service_compare_evidence.py`. Its stated acceptance test holds —
+neither `service.py` comment this ADR quoted still exists.
+
+The open choice is now answered: **option (b)** — `run_compare_request` was
+extended in parallel, and the CLI `compare` command still resolves through
+`cli_resolve._resolve_compare_snapshots`. This is recorded as a decision, not
+as unfinished work, because the *capability* gap D1 set out to close is
+closed (a Python or MCP caller no longer has to drop to loose kwargs to reach
+`compare`'s depth/sources/build-info/manifest feature set), while option (a)
+would rewrite the CLI's single most heavily-tested resolution path to gain
+nothing a user can observe. What remains genuinely two-implementation is
+narrower than the framing above suggests, and is listed explicitly so nobody
+has to re-derive it: project-config `source.method` inference, the set-input
+evidence-flag rejection guard, and the per-side AST-frontend override live
+only in the CLI path. Migrating the CLI onto `run_compare_request` is a
+separate, independently-reviewable change — it needs its own before/after
+parity evidence over the CLI's full flag matrix, which is exactly the kind of
+work that goes wrong when bundled into a different decision's PR.
+
 ### D2. Typed `Result` wrappers for the existing typed-request verbs
 
 `run_compare`/`run_compare_request` return a bare
@@ -218,6 +250,25 @@ ADR-035 already applied to `ScanRequest`/`ScanResult`, generalized to
 `run_compare_request`'s tuple-returning callers are gone, a follow-up ADR can
 decide whether to rename `run_compare_request_v2` to something permanent —
 that rename is explicitly out of scope here.
+
+**As implemented — two deliberate departures.** `CompareResult` lives in
+`api_types.py` next to `CompareRequest`, not in `service.py` as the file
+sketch below says: that module is already "typed request/response structs",
+imports nothing from the service layer at runtime, and keeping the pair
+together lets a caller annotate a result without importing `service`'s much
+heavier graph. And it carries a **fourth** field, `suppression`, rather than
+the "exactly the tuple's three fields plus nothing else" this decision
+proposed. That field is not speculative growth — it is what D4 turned out to
+need: `run_compare_request` resolves the suppression list internally, but
+`appcompat.scope_diff_to_app(..., suppression=...)` needs the resolved object
+*after* classification, and `DiffResult` carries the resolved policy file but
+not the suppression list. Without it, the MCP server would have had to keep a
+`SuppressionList.load` call purely to re-derive a value the service had
+already loaded — the exact duplication D4 exists to remove, reintroduced by
+the shape chosen to enable removing it. `run_compare_request` was not
+duplicated to add the wrapper: it is now a one-line tuple view
+(`CompareResult.as_tuple()`) over the same implementation, since two copies
+of the resolution logic is the failure this whole ADR is about.
 
 ### D3. A minimal schema-version registry
 
@@ -251,6 +302,22 @@ that gap (wiring an actual generator to call `schemas.current()` instead of
 hand-copying) is separate follow-up work, not implied by the registry
 existing.
 
+**As implemented, including that follow-up.** `schemas.current(name)` covers
+all six artifact names, backed by each artifact's own constant through a
+function-local import (a module-level one is a real cycle: `run-plan` needs
+`buildsource.run_plan.RUN_PLAN_SCHEMA`, whose module already imports
+`abicheck.schemas` transitively). The consumer half is closed too, though not
+as a doc *generator*: `scripts/check_ai_readiness.py`'s existing
+`doc-count-sync` check now reads its expected snapshot and compare-report
+versions from `schemas.current()` and pins them against the pages that quote
+them. That fits better than generating the pages — these numbers sit inside
+hand-written prose and JSON examples, so a generator would have to own a
+whole page to own one number, whereas the check fails the build on exactly
+the drift D3 was written about. It caught two live instances the moment it
+was added (`docs/use/output-formats.md` claiming `report_schema_version`
+`"1.0"` and `docs/reference/check-target.md` claiming `"2.13"`, against a
+real `2.26`), which is the argument for it over trusting review.
+
 ### D4. Route `abi_compare` through `run_compare_request`
 
 Once D1 lands (so `CompareRequest`/`InputSpec` can express everything
@@ -274,6 +341,12 @@ Concretely, in terms of the current tool's parameters:
   suppression/policy-file field today, so this is new surface for
   `CompareRequest` itself, not something D1 already covers; scope it before
   starting D4, don't assume it falls out of D1 for free.
+  **Correction:** this bullet was wrong when written. `CompareRequest` has
+  carried `policy`, `policy_file_path`, and `suppress` since PR #611 (G30/
+  ADR-047), well before this ADR was drafted, so D4 needed no preceding
+  slice for them. Recorded rather than deleted because "check the struct
+  instead of trusting a neighbouring ADR's summary of it" is the same lesson
+  that produced this document's Gap 3 correction.
 
 What D4 deliberately does **not** try to fold into `CompareRequest`/
 `CompareResult`:
@@ -297,19 +370,57 @@ A parity test (comparing `abi_compare`'s output for a fixed input against
 the CLI `compare` command's output for the equivalent flags) is the
 regression guard against silent behavior drift during the rewrite.
 
-## Files & surfaces (sketch, for whoever picks this up)
+**As implemented.** `abi_compare` builds one `CompareRequest` and calls
+`run_compare_request_v2`; the module no longer imports `compare_snapshots` at
+all. Both acceptance tests exist in `tests/test_mcp_server_unit.py`
+(`TestAbiCompareCliParity`): the source-level gate is asserted directly
+(comments stripped first, since the function now *documents* what it stopped
+calling), and the parity tests compare `abi_compare`'s rendered report and
+exit code against the CLI's over a flag matrix — defaults, policy profile,
+policy file, suppression file, `--show-only`, `--report-mode`, and
+severity-aware gating. Three findings from doing it:
+
+1. **One MCP guard had to become request surface, not stay wrapper glue.**
+   `mcp_server._resolve_input` pinned `follow_linker_scripts=False`, because
+   the tool size-checks the *caller-supplied* path and a GNU ld script's
+   `INPUT()` target would never pass through that check. Routing through the
+   service would have silently dropped that, so `InputSpec` gained a
+   `follow_linker_scripts` field (default `True`, matching `resolve_input`'s
+   own default, so no pre-existing caller changes). The *path-containment*
+   and *file-size* guards stayed MCP-local, applied before the request is
+   built: those constrain untrusted input, which is genuinely the front end's
+   job, unlike resolve/load/classify.
+2. **The report is byte-identical to the CLI's**, modulo two keys the CLI's
+   renderer adds and this tool has never emitted (`old_evidence_depth`/
+   `new_evidence_depth`). Verified as a before/after diff of the tool's own
+   output across the flag matrix, not only against the CLI, so the rewrite is
+   shown not to have moved anything.
+3. **One intentional behaviour change:** an unsupported `language` (e.g.
+   `"rust"`) is now a structured validation error rather than a value passed
+   quietly down the resolver. That is `CompareRequest.validate()` doing what
+   the CLI's `--lang` choice already did — the front-end parity ADR-037 D9
+   asks for — so it is recorded here as intended, not tolerated as fallout.
+
+The parity tests deliberately do **not** cover `used_by`/`required_symbols`,
+consistent with the next paragraph: that scoping is applied after a result
+exists and has no CLI-comparable rendering path here. The sibling
+`TestAbiCompare` scoping tests continue to cover it.
+
+## Files & surfaces (as landed)
 
 | Module | Change |
 |---|---|
-| `abicheck/api_types.py` | New `InputSpec`/`CompareRequest` fields (D1); policy/suppression fields for D4 |
-| `abicheck/service.py` | `run_compare_request` reads the new fields instead of falling back to `resolve_input` kwargs; new `CompareResult` (D2) |
-| `abicheck/schemas/__init__.py` | `current(name)` registry (D3) — **implemented** |
-| `abicheck/mcp_server.py` | `abi_compare` rewritten to build a `CompareRequest` and call `run_compare_request` (D4) |
-| `docs/reference/python-api-reference.md` | Regenerate after D1/D2 (generated file) |
-| `docs/reference/mcp-tools-reference.md` | Regenerate after D4 (generated file) |
-| `tests/test_api_types.py` | New field defaults/round-trip tests |
-| `tests/test_service_unit.py` | Parity test: a `CompareRequest` built with the new fields set produces the same `DiffResult` as the equivalent `resolve_input`/kwargs call today |
-| `tests/test_mcp_server_unit.py` | Parity test: `abi_compare`'s output for a fixed input matches the CLI `compare` command's output for the equivalent flags, before and after the D4 rewrite |
+| `abicheck/api_types.py` | `InputSpec.sources`/`build_info`/`dump_manifest`/`compile`/`public_header_dirs` + `CompareRequest.depth`/`frontend_context` (D1); `InputSpec.follow_linker_scripts` (D4); `CompareResult` (D2 — here, not `service.py`, see its "As implemented" note) |
+| `abicheck/service_compare_evidence.py` | D1's resolution wiring, split out of `service.py` |
+| `abicheck/service.py` | `run_compare_request_v2` owns the implementation and returns `CompareResult`; `run_compare_request` is its tuple view (D2); per-side `follow_linker_scripts` forwarding (D4) |
+| `abicheck/schemas/__init__.py` | `current(name)` registry (D3) |
+| `scripts/check_ai_readiness.py` | `doc-count-sync` reads snapshot/compare versions from `schemas.current()` and pins the pages quoting them (D3's consumer half) |
+| `abicheck/mcp_server.py` | `abi_compare` builds a `CompareRequest` and calls `run_compare_request_v2`; no local resolve, no policy/suppression load, no `compare_snapshots` import (D4) |
+| `docs/reference/python-api-reference.md`, `docs/reference/mcp-tools-reference.md` | Regenerated (generated files) |
+| `tests/test_api_types.py` | Field defaults for D1/D4; `TestCompareResult` (D2) |
+| `tests/test_service_unit.py` | `TestCompareRequestAdr055Evidence` (D1); `TestRunCompareRequestV2` (D2, incl. per-side `follow_linker_scripts`) |
+| `tests/test_mcp_server_unit.py` | `TestAbiCompareCliParity`: the source-level D4 gate plus CLI-parity over a flag matrix |
+| `tests/test_mcp_server_coverage.py` | `TestAbiCompareTool` repointed to the service-layer names `abi_compare` now reaches |
 
 ## Alternatives considered
 
@@ -361,3 +472,33 @@ capability or force D4 to invent its own ad hoc `CompareRequest` extension
 outside this ADR's decision. See
 [G33](../plans/g33-typed-api-and-mcp-convergence.md) for the implementation
 plan and current per-phase status.
+
+That order held: D3 first, then D1 (PR #651), then D2 and D4 together — D4's
+need for the resolved suppression list is what gave `CompareResult` its
+fourth field, so splitting them would have meant landing a wrapper with no
+consumer and then changing its shape one PR later.
+
+## Implementation notes
+
+**How this ADR's own status went stale, since it is the second time.** D1
+landed inside PR #651 ("close dump/compare dependency-scoping asymmetry"),
+whose title says nothing about ADR-055 — so neither this document's status
+line nor G33's Phase 2 note was touched, and both kept saying "D1 not
+started" through several later PRs. The same shape as the Gap 3 correction
+above: a claim about the code that stayed true in the document long after it
+stopped being true in the code. The cheap mitigation is the one already used
+elsewhere in this repo — decisions carry an executable gate, not just a
+prose status. D1's and D4's both now do (the `service.py` comment-absence
+check by way of `TestCompareRequestAdr055Evidence`, and D4's source-level
+gate in `TestAbiCompareCliParity`).
+
+**Still open after this ADR, deliberately.** Two items, each needing its own
+scoped change rather than an extension of this one:
+
+- The CLI's separate `_resolve_compare_snapshots` path (option (b) above) —
+  see D1's "As implemented" note for the exact three capabilities that
+  remain CLI-only.
+- G33's Phase 5 (`abi_dump`/`abi_scan` reaching the same depth/sources/
+  build-info/manifest parity `abi_compare` now has). That plan gates it on
+  Phase 4, which this closes, so it is unblocked — but it is a change to two
+  other tools' parameter surfaces, not part of this decision.

--- a/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
+++ b/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
@@ -128,6 +128,10 @@ its top-priority finding. See D4 below.
   convention, or breaking any current caller. Every change below is
   additive: a new optional field with a default, or a new wrapper type that
   existing tuple-returning functions keep returning unchanged.
+  **No longer holds (0.6).** This non-goal assumed compatibility had to be
+  kept; it does not, pre-1.0. `run_compare`/`run_compare_request` now return
+  `CompareResult` instead of a tuple — see D2's superseding note. The rest of
+  this ADR's changes remain additive.
 
 ## Decision
 
@@ -268,6 +272,16 @@ ADR-035 already applied to `ScanRequest`/`ScanResult`, generalized to
 `run_compare_request`'s tuple-returning callers are gone, a follow-up ADR can
 decide whether to rename `run_compare_request_v2` to something permanent —
 that rename is explicitly out of scope here.
+
+**Superseded by the 0.6 API break — read this first.** The parallel-function
+decision below was correct only while compatibility had to hold. It does not:
+the project is pre-1.0 and does not yet keep API compatibility, so
+`run_compare_request` itself now returns `CompareResult`, `run_compare` (the
+kwargs shim) does too, and `run_compare_request_v2` **does not exist**. Two
+names for one operation are worth carrying only when removing one would break
+callers; here it would not. `CompareResult.as_tuple()` is the one-line
+migration for a positional caller. The reasoning below is kept as the record
+of why the seam existed, not as a description of today's API.
 
 **As implemented — two deliberate departures.** `CompareResult` lives in
 `api_types.py` next to `CompareRequest`, not in `service.py` as the file
@@ -416,7 +430,7 @@ the CLI `compare` command's output for the equivalent flags) is the
 regression guard against silent behavior drift during the rewrite.
 
 **As implemented.** `abi_compare` builds one `CompareRequest` and calls
-`run_compare_request_v2`; the module no longer imports `compare_snapshots` at
+`run_compare_request`; the module no longer imports `compare_snapshots` at
 all. Both acceptance tests exist in `tests/test_mcp_server_unit.py`
 (`TestAbiCompareCliParity`): the source-level gate is asserted directly
 (comments stripped first, since the function now *documents* what it stopped
@@ -457,10 +471,10 @@ exists and has no CLI-comparable rendering path here. The sibling
 |---|---|
 | `abicheck/api_types.py` | `InputSpec.sources`/`build_info`/`dump_manifest`/`compile`/`public_header_dirs` + `CompareRequest.depth`/`frontend_context` (D1); `InputSpec.follow_linker_scripts` (D4); `CompareResult` (D2 — here, not `service.py`, see its "As implemented" note) |
 | `abicheck/service_compare_evidence.py` | D1's resolution wiring, split out of `service.py` |
-| `abicheck/service.py` | `run_compare_request_v2` owns the implementation and returns `CompareResult`; `run_compare_request` is its tuple view (D2); per-side `follow_linker_scripts` forwarding (D4) |
+| `abicheck/service.py` | `run_compare_request` returns `CompareResult`, and so does the `run_compare` kwargs shim (D2, after the 0.6 API break — no `_v2` function exists); per-side `follow_linker_scripts` forwarding (D4) |
 | `abicheck/schemas/__init__.py` | `current(name)` registry (D3) |
 | `scripts/check_ai_readiness.py` | `doc-count-sync` reads snapshot/compare versions from `schemas.current()` and pins the pages quoting them (D3's consumer half) |
-| `abicheck/mcp_server.py` | `abi_compare` builds a `CompareRequest` and calls `run_compare_request_v2`; no local resolve, no policy/suppression load, no `compare_snapshots` import (D4) |
+| `abicheck/mcp_server.py` | `abi_compare` builds a `CompareRequest` and calls `run_compare_request`; no local resolve, no policy/suppression load, no `compare_snapshots` import (D4) |
 | `docs/reference/python-api-reference.md`, `docs/reference/mcp-tools-reference.md` | Regenerated (generated files) |
 | `tests/test_api_types.py` | Field defaults for D1/D4; `TestCompareResult` (D2) |
 | `tests/test_service_unit.py` | `TestCompareRequestAdr055Evidence` (D1); `TestRunCompareRequestV2` (D2, incl. per-side `follow_linker_scripts`) |
@@ -495,7 +509,9 @@ exists and has no CLI-comparable rendering path here. The sibling
   right — same class of thing this repo's own review process tends to flag
   elsewhere.
 - **D2's `CompareResult` entry point: a bare `compare()` function.** Rejected
-  in favor of `run_compare_request_v2` after checking this ADR's own claimed
+  in favor of `run_compare_request_v2` (since collapsed into
+  `run_compare_request` itself, see D2's superseding note) after checking this
+  ADR's own claimed
   precedent (ADR-035's `ScanRequest`/`ScanResult`) against the actual code:
   the real function there is `run_scan(req: ScanRequest) -> ScanResult`, not
   a bare `scan()` — it followed the existing `run_<verb>` naming family from

--- a/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
+++ b/docs/contribute/adr/055-typed-request-result-completeness-and-schema-registry.md
@@ -3,17 +3,10 @@
 **Date:** 2026-07-27 (D1–D3); Gap 3/D4 added 2026-07-27 after a second,
 more detailed external review of the same subject was checked line-by-line
 against `mcp_server.py` (see "Amendment" note below Gap 2)
-**Status:** Accepted — implemented (D1–D4). D3 (schema-version registry)
-landed first (`abicheck/schemas/__init__.py`'s `current()`); D1 landed inside
-PR #651, which is why this line and
-[G33](../plans/g33-typed-api-and-mcp-convergence.md) both went on saying
-"D1 not started" for several PRs after it was true — see the "Implementation
-notes" section at the end for what each decision actually became, including
-the two places the implementation deliberately departs from what is proposed
-below. One piece of D1's *context* is deliberately still open rather than
-silently dropped: the two-resolution-path split (the CLI's own
-`cli_resolve._resolve_compare_snapshots`) — that choice is now recorded as a
-decision (option (b)) rather than left unanswered, see D1's own section.
+**Status:** Accepted — implemented (D1–D4). Each decision below carries an
+"As implemented" note recording where the implementation departed from it;
+"Implementation notes" at the end covers what is still open and how this
+line itself went stale.
 Written up after an external API-layer review of `abicheck`
 (CLI/Python/MCP/Actions/schemas) turned out to be largely stale against
 current `main` — G22/ADR-037 already landed the CLI consolidation and the
@@ -306,17 +299,44 @@ existing.
 all six artifact names, backed by each artifact's own constant through a
 function-local import (a module-level one is a real cycle: `run-plan` needs
 `buildsource.run_plan.RUN_PLAN_SCHEMA`, whose module already imports
-`abicheck.schemas` transitively). The consumer half is closed too, though not
-as a doc *generator*: `scripts/check_ai_readiness.py`'s existing
-`doc-count-sync` check now reads its expected snapshot and compare-report
-versions from `schemas.current()` and pins them against the pages that quote
-them. That fits better than generating the pages — these numbers sit inside
-hand-written prose and JSON examples, so a generator would have to own a
-whole page to own one number, whereas the check fails the build on exactly
-the drift D3 was written about. It caught two live instances the moment it
-was added (`docs/use/output-formats.md` claiming `report_schema_version`
-`"1.0"` and `docs/reference/check-target.md` claiming `"2.13"`, against a
-real `2.26`), which is the argument for it over trusting review.
+`abicheck.schemas` transitively).
+
+The consumer half is closed in two layers, because a review round
+(chatgpt-codex-connector on PR #665) correctly pointed out that only one of
+them actually satisfies this repo's own rule:
+
+1. **Delete the copy where the number is incidental.** `docs/AGENTS.md`'s
+   rule is "don't hand-copy a version that has a fact owner — link to it."
+   Three sites were quoting a version whose *value* taught the reader
+   nothing: `docs/reference/check-target.md`'s "the starting shape is the
+   compare-report shape (`report_schema_version: "…"`)",
+   `docs/use/output-formats.md`'s `# e.g. "1.0"` import comment, and — the
+   one that proves the point — that same page's claim that a snapshot's
+   `schema_version` "is currently `8`". That is *the original D3 bug*, alive
+   on a second page: G33 Phase 0 fixed the identical sentence in
+   `docs/use/python-api.md` and nobody noticed the duplicate. All three now
+   link to the owning page instead of restating it.
+2. **Pin what must stay literal.** A JSON snippet showing real output can't
+   carry a link, and a fabricated version in it would misinform a reader
+   matching it against their own file. Those sites keep a real value, gated
+   by `scripts/check_ai_readiness.py`'s `doc-count-sync` check, which now
+   reads its expected values from `schemas.current()`. This is the
+   already-established pattern for `docs/reference/snapshot-format.md` (the
+   snapshot version's own fact owner), not a new exception invented here.
+
+The distinction between the two is *who owns the fact*, not how much effort
+each takes: layer 1 is for pages that were holding a second copy, layer 2 is
+for the owner page and for verbatim output samples. Generating these pages
+was considered and rejected — a generator would have to own a whole page of
+hand-written prose to own one number.
+
+Both mechanisms earned their place immediately. The check caught two live
+stale values on its first run (`report_schema_version` `"1.0"` and `"2.13"`
+against a real `2.26`), and the review that followed caught two *more* it
+structurally could not: a copy nobody had anchored (`snapshot-format.md`'s
+snapshot-vs-report comparison table, now anchored) and the `schema_version 8`
+sentence above. Pinning only catches the sites you thought to pin — which is
+the honest limitation of layer 2, and the reason layer 1 exists.
 
 ### D4. Route `abi_compare` through `run_compare_request`
 

--- a/docs/contribute/adr/index.md
+++ b/docs/contribute/adr/index.md
@@ -149,5 +149,5 @@ against the code as unverified, regardless of how confident it reads.
 | [052](052-unified-impact-assessment-model.md) | Unified Impact Assessment Model (G29 Phase 3, slices 1-9) | Accepted — slices 1-9 implemented |
 | [053](053-tu-link-unit-dso-attribution.md) | TU → Link-Unit → DSO Source-Evidence Attribution | Accepted — implemented (core algorithm + validator; CLI/Action pipeline wiring deferred, see D5) |
 | [054](054-cli-project-integration-surface-consolidation.md) | CLI Project-Integration Surface Consolidation | Accepted — implemented |
-| [055](055-typed-request-result-completeness-and-schema-registry.md) | Typed Request/Result Completeness and a Schema-Version Registry | Accepted — implemented (D1-D4); the CLI's own second resolution path stays, as a recorded decision |
+| [055](055-typed-request-result-completeness-and-schema-registry.md) | Typed Request/Result Completeness and a Schema-Version Registry | Accepted — implemented (D1-D4), including D1's structural half: the CLI, typed API, and MCP now share one input resolution |
 | [056](056-multi-artifact-library-set-scan.md) | Multi-Artifact / Library-Set `scan` | Proposed — partially implemented (Phases 1-4's engine/detector/CLI/Action slice shipped ahead of formal sign-off; MCP half, example catalog, and `--dry-run` estimator deferred); see [G35](../plans/g35-multi-artifact-scan.md) |

--- a/docs/contribute/adr/index.md
+++ b/docs/contribute/adr/index.md
@@ -149,5 +149,5 @@ against the code as unverified, regardless of how confident it reads.
 | [052](052-unified-impact-assessment-model.md) | Unified Impact Assessment Model (G29 Phase 3, slices 1-9) | Accepted — slices 1-9 implemented |
 | [053](053-tu-link-unit-dso-attribution.md) | TU → Link-Unit → DSO Source-Evidence Attribution | Accepted — implemented (core algorithm + validator; CLI/Action pipeline wiring deferred, see D5) |
 | [054](054-cli-project-integration-surface-consolidation.md) | CLI Project-Integration Surface Consolidation | Accepted — implemented |
-| [055](055-typed-request-result-completeness-and-schema-registry.md) | Typed Request/Result Completeness and a Schema-Version Registry | Proposed — D3 (schema registry) implemented; D1/D2/D4 not started |
+| [055](055-typed-request-result-completeness-and-schema-registry.md) | Typed Request/Result Completeness and a Schema-Version Registry | Accepted — implemented (D1-D4); the CLI's own second resolution path stays, as a recorded decision |
 | [056](056-multi-artifact-library-set-scan.md) | Multi-Artifact / Library-Set `scan` | Proposed — partially implemented (Phases 1-4's engine/detector/CLI/Action slice shipped ahead of formal sign-off; MCP half, example catalog, and `--dry-run` estimator deferred); see [G35](../plans/g35-multi-artifact-scan.md) |

--- a/docs/contribute/plans/g33-typed-api-and-mcp-convergence.md
+++ b/docs/contribute/plans/g33-typed-api-and-mcp-convergence.md
@@ -1,9 +1,10 @@
 # G33 — Typed API convergence: schema registry, Request/Result completeness, MCP dedup
 
-**Status:** Phase 0 (verification) and Phase 1 (schema-version registry,
-ADR-055 D3) done; Phases 2-6 not started — see per-phase status below
+**Status:** Phases 0-4 done (ADR-055 D1-D4 all implemented); Phase 5
+unblocked but not started; Phase 6 is a standing constraint, not work —
+see per-phase status below
 **Normative decision:** [ADR-055](../adr/055-typed-request-result-completeness-and-schema-registry.md)
-(Proposed — D3 implemented; D1/D2/D4 not started)
+(Accepted — implemented)
 **Related:** ADR-037 (G22, CLI consolidation — done), ADR-049 (contract relevance,
 see [public-contract-default.md](public-contract-default.md) for its own
 rollout), ADR-043 (`used_by`/`required_symbols` app scoping), ADR-050
@@ -86,10 +87,15 @@ CLI / Python / MCP / Action
 Invariant this plan exists to restore: **no front end (CLI, MCP, or an
 Action) resolves inputs, loads policy/suppression, or classifies a
 comparison on its own** — every front end builds the same typed request and
-reads the same typed result for that classification step. Today
-`abi_compare` is the one confirmed violation of that invariant (Phase 4/D4
-below); the other phases close gaps that make the invariant harder to reach
-even where it isn't yet violated. This deliberately does **not** cover every
+reads the same typed result for that classification step. `abi_compare` was
+the one confirmed violation (Phase 4/D4 below) and no longer is; the other
+phases closed gaps that made the invariant harder to reach even where it
+wasn't yet violated. One qualification the invariant needs, now that it
+holds: the CLI `compare` command builds the same *request* type and reads the
+same *result*, but still runs its own richer input resolution
+(`cli_resolve._resolve_compare_snapshots`) — a recorded decision, not an
+outstanding violation. See Phase 2's progress note for what that actually
+covers. This deliberately does **not** cover every
 downstream presentation concern: `used_by`/`required_symbols` app-scoping
 and severity/exit-code computation are explicitly kept as thin,
 front-end-specific glue applied *after* a typed result exists (Phase 4
@@ -153,7 +159,7 @@ or read the owning module's docstring for the live value.)
 generated from this registry (or a page that itself reads from it), not a
 hand-copied literal.
 
-**Progress:** the registry itself is done —
+**Progress:** done. The registry itself —
 `abicheck.schemas.current(name)` (`abicheck/schemas/__init__.py`) covers
 all six artifact names above, backed by each artifact's existing constant
 via a function-local import (a module-level import would create a real
@@ -161,12 +167,21 @@ cycle: `run-plan` needs `buildsource.run_plan.RUN_PLAN_SCHEMA`, but
 `buildsource/run_plan.py` imports `buildsource/check_report.py`, which
 already imports `abicheck.schemas` — confirmed by reading both modules
 before choosing the deferred-import shape). Covered by
-`tests/test_schemas_registry.py`. Still remaining: wiring an actual doc
-page or generator to *read from* `current()` instead of a hand-copied
-literal — `docs/reference/snapshot-format.md` (the designated fact-owner
-page for the snapshot version) still states "17" by hand, same as every
-other artifact's own doc page. That's a separate, larger follow-up (a real
-doc-generator change, reviewed on its own), not bundled into this slice.
+`tests/test_schemas_registry.py`.
+
+The gate above ("every version number quoted in docs is generated from this
+registry, not a hand-copied literal") is now met too, by a route this phase
+did not originally anticipate: rather than converting pages to generated
+ones, `scripts/check_ai_readiness.py`'s existing `doc-count-sync` check
+reads its expected snapshot and compare-report versions from
+`schemas.current()` and pins them against the pages that quote them. These
+numbers live inside hand-written prose and JSON examples, so a generator
+would have had to own a whole page to own one number, while the check fails
+the build on exactly the drift D3 was about — and caught two live instances
+on its first run (`docs/use/output-formats.md` and
+`docs/reference/check-target.md` both quoting long-superseded
+`report_schema_version` values). Extending it to the remaining four
+artifacts is mechanical: add an anchor when a doc page starts quoting one.
 
 ### Phase 2 — extend `InputSpec`/`CompareRequest` (ADR-055 D1)
 
@@ -183,37 +198,29 @@ today).
 has no explicit `--gcc-options` equivalent today"; "no lower-level
 'parse only, don't classify' mode") are no longer true.
 
-**Progress:** not started; a real complication found while scoping it,
-not yet reflected in ADR-055 itself. `run_compare_request` (the function
-`CompareRequest` feeds) is **not** what the CLI `compare` command actually
-calls for its full depth/sources/build-info/multi-TU-manifest feature set
-— reading `cli_compare_helpers.py` and `cli_resolve.py` shows the CLI's
-own resolution goes through `cli_resolve._resolve_compare_snapshots`, a
-CLI-layer function with a much richer parameter set (per-side
-`CompileContext`/`dump_manifest`/debug-root/debuginfod overrides, explicit
-old/new format detection, dependency-graph following) that itself calls
-`service.resolve_input`/`compare_snapshots` directly — not
-`run_compare_request`. So today there are genuinely **two** independent
-resolution paths: the CLI's rich one (`_resolve_compare_snapshots`) and
-the typed one (`run_compare_request`, what `CompareRequest` feeds, and
-what a future `abi_compare` rewrite in Phase 4 would use). Adding fields to
-`CompareRequest`/`InputSpec` without addressing this split would give the
-typed request a way to *carry* depth/sources/build-info in, but would not
-by itself make `CompareRequest` capable of everything the CLI supports —
-`_resolve_compare_snapshots`'s extra logic (dependency-graph following,
-per-side backend override, debug-root/debuginfod per side) would still
-need to either move into `run_compare_request` or be reconciled with it.
-Before writing code, whoever picks this up should decide: (a) migrate the
-CLI `compare` command onto an extended `run_compare_request` (higher risk,
-touches the CLI's own heavily-tested resolution path), or (b) extend
-`run_compare_request` to match `_resolve_compare_snapshots`'s capability
-set in parallel, keeping both paths but eliminating the *capability* gap
-between them (lower risk, but the two-path duplication ADR-055 D1 set out
-to close would persist one level down). The `DumpManifest`/`CompileContext`
-machinery itself is no longer a blocker either way — G32 (Phase 0 and
-Phases A–E) is now done, per that plan's own status — so this phase's
-only real blocker is the resolution-path decision above, not missing
-lower-level machinery.
+**Progress:** done, in [PR #651](https://github.com/abicheck/abicheck/pull/651)
+— whose title ("close dump/compare dependency-scoping asymmetry") is why this
+note went on saying "not started" for several PRs afterwards. `InputSpec`
+gained `sources`/`build_info`/`dump_manifest`/`compile`/`public_header_dirs`,
+`CompareRequest` gained `depth`/`frontend_context`, and the resolution wiring
+lives in the new `abicheck/service_compare_evidence.py`. The gate holds:
+neither `service.py` comment quoted above still exists. Tests:
+`TestCompareRequestAdr055Evidence` (`tests/test_service_unit.py`) and the
+ADR-055 D1 blocks in `tests/test_api_types.py`.
+
+The two-resolution-path question this note raised is now **decided as (b)**,
+recorded in ADR-055's D1 section rather than left open here:
+`run_compare_request` was extended in parallel and the CLI `compare` command
+still resolves through `cli_resolve._resolve_compare_snapshots`. The
+capability gap D1 existed to close is closed — no Python or MCP caller has to
+drop to loose kwargs any more — while option (a) would rewrite the CLI's
+most heavily-tested resolution path for no user-observable gain. What stays
+CLI-only is narrower than the framing above implies, and is worth not
+re-deriving: project-config `source.method` inference, the set-input
+evidence-flag rejection guard, and the per-side AST-frontend override.
+Migrating the CLI onto `run_compare_request` remains possible as its own
+change, gated on its own before/after parity evidence across the CLI's flag
+matrix.
 
 ### Phase 3 — `CompareResult` wrapper (ADR-055 D2)
 
@@ -226,9 +233,24 @@ caller.
 **Gate:** a new field (resolved depth, an `EvaluationReceipt`, a coverage
 summary) has somewhere to land without a second tuple-shape break.
 
-**Progress:** not started. Depends on Phase 2 landing first (ADR-055's own
-rollout order — the wrapper is only worth adding once the request side is
-worth wrapping too).
+**Progress:** done. `CompareResult` (`diff`/`old_snapshot`/`new_snapshot`)
+lives in `api_types.py` beside `CompareRequest`, and
+`service.run_compare_request_v2` returns it. `run_compare_request` keeps its
+exact tuple signature for every existing caller — it is now a one-line view
+(`CompareResult.as_tuple()`) over the same implementation, rather than a
+second copy of the resolution logic, which would have been this plan's own
+failure mode reproduced inside its fix.
+
+One departure from the decision as written: the struct carries a fourth
+field, `suppression`, not just the tuple's three. Phase 4 is why — the
+service resolves the suppression list internally, but `appcompat.
+scope_diff_to_app(..., suppression=...)` needs the resolved object *after*
+classification, and `DiffResult` carries the resolved policy file but not the
+suppression list. Without it the MCP server would have kept a
+`SuppressionList.load` call solely to re-derive what the service had already
+loaded — the duplication Phase 4 removes, reintroduced by the shape chosen to
+enable removing it. Tests: `TestCompareResult` (`tests/test_api_types.py`),
+`TestRunCompareRequestV2` (`tests/test_service_unit.py`).
 
 ### Phase 4 — route `abi_compare` through `run_compare_request` (ADR-055 D4)
 
@@ -247,10 +269,38 @@ avoid).
 identical output to the CLI `compare` command for equivalent flags, both
 before and after the rewrite.
 
-**Progress:** not started. Deliberately last and gated on Phase 2 — a
-rewrite before `CompareRequest` can express `abi_compare`'s full parameter
-set would either lose capability (dropping a parameter the tool currently
-accepts) or invent an ad hoc extension outside ADR-055's own decision.
+**Progress:** done. `abi_compare` builds one `CompareRequest` and calls
+`run_compare_request_v2`; `mcp_server.py` no longer imports
+`compare_snapshots` at all. Both halves of the gate are executable in
+`tests/test_mcp_server_unit.py`'s `TestAbiCompareCliParity`: the source-level
+absence check (comments stripped first — the function now *documents* what it
+stopped calling), and CLI-parity assertions over a flag matrix (defaults,
+policy profile, policy file, suppression file, `--show-only`,
+`--report-mode`, severity-aware gating) covering the rendered report and the
+exit code. Parity was additionally verified as a before/after diff of the
+tool's own output across that matrix, so the rewrite is shown not to have
+moved anything rather than only agreeing with the CLI.
+
+Three findings worth carrying forward:
+
+1. One MCP guard had to become *request* surface: `_resolve_input` pinned
+   `follow_linker_scripts=False` because the tool size-checks only the
+   caller-supplied path, and a GNU ld script's `INPUT()` target would bypass
+   that. `InputSpec.follow_linker_scripts` (default `True`, matching
+   `resolve_input`'s own default) carries it now. Path containment and file
+   size stayed MCP-local, applied before the request is built — those
+   constrain untrusted input, which really is the front end's job.
+2. The report matches the CLI's exactly, except for two keys the CLI's
+   renderer adds and this tool has never emitted (`old_evidence_depth`/
+   `new_evidence_depth`).
+3. One intentional behaviour change: an unsupported `language` is now a
+   structured validation error instead of a value passed quietly down the
+   resolver — `CompareRequest.validate()` doing what the CLI's `--lang`
+   choice already did (ADR-037 D9's front-end parity), so it is recorded as
+   intended rather than tolerated.
+
+`used_by`/`required_symbols` scoping and severity/exit-code computation
+stayed MCP glue over the returned `CompareResult`, exactly as scoped above.
 
 ### Phase 5 — extend the other MCP tools to the same parity (deferred)
 
@@ -265,7 +315,8 @@ this before Phase 4 is done.
 of `abi_compare`'s post-Phase-4 parameter set for every concept `dump`
 and `compare` share.
 
-**Progress:** not started; blocked on Phase 4.
+**Progress:** not started — but no longer blocked: Phase 4 is done, which
+was its only stated precondition.
 
 ### Phase 6 — ADR-049 sequencing constraint (no new work here)
 
@@ -294,14 +345,27 @@ actual progress in that plan's own "Work breakdown," not here.
 
 ## 6. Definition of done
 
-- All four ADR-055 decisions (D1–D4) implemented and tested per their
+All met:
+
+- [x] All four ADR-055 decisions (D1–D4) implemented and tested per their
   individual gates above.
-- `tests/test_mcp_server_unit.py`'s `abi_compare` parity test passes against
-  both the pre- and post-rewrite CLI `compare` output for a representative
-  input matrix (binary-only, headers, snapshot inputs, `used_by`-scoped,
-  severity-aware).
-- `docs/reference/python-api-reference.md` and
+- [x] `tests/test_mcp_server_unit.py`'s `abi_compare` parity test passes
+  against both the pre- and post-rewrite CLI `compare` output for a
+  representative input matrix. Two deliberate narrowings of the matrix this
+  line originally listed, each for a reason rather than for convenience:
+  *binary-only/headers* inputs need a real compiled library (the marker lanes
+  this fast-suite test can't require), and the JSON-snapshot inputs it does
+  use exercise the same request-building and classification path; and
+  *`used_by`-scoped* runs are deliberately excluded because that scoping is
+  applied after a result exists and has no CLI-comparable rendering here —
+  the sibling `TestAbiCompare` scoping tests own it. *Snapshot inputs* and
+  *severity-aware* are both covered.
+- [x] `docs/reference/python-api-reference.md` and
   `docs/reference/mcp-tools-reference.md` regenerated and committed.
-- ADR-055's status line updated from "Proposed" to "Accepted —
-  implemented" (or the individual D1–D4 statuses split out, if they land
-  in separate PRs on different schedules).
+- [x] ADR-055's status line updated from "Proposed" to "Accepted —
+  implemented".
+
+Remaining work tracked elsewhere, not reopening this plan: Phase 5
+(`abi_dump`/`abi_scan` parity) is unblocked and still open, and migrating the
+CLI onto `run_compare_request` is a possible future change under Phase 2's
+recorded decision (b).

--- a/docs/contribute/plans/g33-typed-api-and-mcp-convergence.md
+++ b/docs/contribute/plans/g33-typed-api-and-mcp-convergence.md
@@ -238,18 +238,21 @@ Introduce `CompareResult` (`diff`/`old_snapshot`/`new_snapshot`, a pure
 rename of the existing tuple shape) and a parallel typed entry point
 returning it, while `run_compare`/`run_compare_request`'s existing
 tuple-returning signatures stay exactly as they are for every current
-caller.
+caller. (The parallel-entry-point half was superseded before this phase
+closed — see the progress note.)
 
 **Gate:** a new field (resolved depth, an `EvaluationReceipt`, a coverage
 summary) has somewhere to land without a second tuple-shape break.
 
-**Progress:** done. `CompareResult` (`diff`/`old_snapshot`/`new_snapshot`)
-lives in `api_types.py` beside `CompareRequest`, and
-`service.run_compare_request_v2` returns it. `run_compare_request` keeps its
-exact tuple signature for every existing caller — it is now a one-line view
-(`CompareResult.as_tuple()`) over the same implementation, rather than a
-second copy of the resolution logic, which would have been this plan's own
-failure mode reproduced inside its fix.
+**Progress:** done, and then simplified past what the phase asked for.
+`CompareResult` (`diff`/`old_snapshot`/`new_snapshot`) lives in
+`api_types.py` beside `CompareRequest`. It first shipped behind a parallel
+`run_compare_request_v2` while `run_compare_request` kept its tuple; that
+seam is now gone. **`run_compare_request` returns `CompareResult` directly,
+`run_compare` does too, and no `_v2` function exists** — the only reason to
+carry two names was compatibility, which the project does not yet hold
+pre-1.0. `CompareResult.as_tuple()` is the one-line migration for a
+positional caller.
 
 One departure from the decision as written: the struct carries a fourth
 field, `suppression`, not just the tuple's three. Phase 4 is why — the
@@ -280,7 +283,7 @@ identical output to the CLI `compare` command for equivalent flags, both
 before and after the rewrite.
 
 **Progress:** done. `abi_compare` builds one `CompareRequest` and calls
-`run_compare_request_v2`; `mcp_server.py` no longer imports
+`run_compare_request`; `mcp_server.py` no longer imports
 `compare_snapshots` at all. Both halves of the gate are executable in
 `tests/test_mcp_server_unit.py`'s `TestAbiCompareCliParity`: the source-level
 absence check (comments stripped first — the function now *documents* what it

--- a/docs/contribute/plans/g33-typed-api-and-mcp-convergence.md
+++ b/docs/contribute/plans/g33-typed-api-and-mcp-convergence.md
@@ -92,11 +92,12 @@ reads the same typed result for that classification step. `abi_compare` was
 the one confirmed violation (Phase 4/D4 below) and no longer is; the other
 phases closed gaps that made the invariant harder to reach even where it
 wasn't yet violated. One qualification the invariant needs, now that it
-holds: the CLI `compare` command builds the same *request* type and reads the
-same *result*, but still runs its own richer input resolution
-(`cli_resolve._resolve_compare_snapshots`) — a recorded decision, not an
-outstanding violation. See Phase 2's progress note for what that actually
-covers. This deliberately does **not** cover every
+holds: the CLI `compare` command builds the same *request* type, runs the
+same *resolution*, and reads the same *result*. It carried its own richer
+input resolution (`cli_resolve._resolve_compare_snapshots`) until Phase 2's
+structural half landed; that helper now builds a `CompareRequest` and
+delegates to the shared `resolve_compare_request`. See Phase 2's progress
+note. This deliberately does **not** cover every
 downstream presentation concern: `used_by`/`required_symbols` app-scoping
 and severity/exit-code computation are explicitly kept as thin,
 front-end-specific glue applied *after* a typed result exists (Phase 4
@@ -209,11 +210,14 @@ neither `service.py` comment quoted above still exists. Tests:
 `TestCompareRequestAdr055Evidence` (`tests/test_service_unit.py`) and the
 ADR-055 D1 blocks in `tests/test_api_types.py`.
 
-The two-resolution-path question this note raised is now **decided as (b)**,
-recorded in ADR-055's D1 section: `run_compare_request` was extended in
-parallel and the CLI `compare` command still resolves through
-`cli_resolve._resolve_compare_snapshots`, because option (a) would rewrite
-the CLI's most heavily-tested resolution path for no user-observable gain.
+The two-resolution-path question this note raised was first **decided as
+(b)** — `run_compare_request` extended in parallel, the CLI still resolving
+through `cli_resolve._resolve_compare_snapshots`, on the grounds that option
+(a) would rewrite the CLI's most heavily-tested resolution path for no
+user-observable gain. **That decision has since been reversed to (a)**; see
+"Structural half" at the end of this phase's note for what changed and why
+the earlier reasoning missed the real obstacle. The two paragraphs below
+describe the capability slice that landed while (b) still held.
 
 A follow-up slice then closed the *capability* half properly. A first attempt
 at naming what stayed CLI-only listed three things and was wrong on all

--- a/docs/contribute/plans/g33-typed-api-and-mcp-convergence.md
+++ b/docs/contribute/plans/g33-typed-api-and-mcp-convergence.md
@@ -209,15 +209,25 @@ neither `service.py` comment quoted above still exists. Tests:
 ADR-055 D1 blocks in `tests/test_api_types.py`.
 
 The two-resolution-path question this note raised is now **decided as (b)**,
-recorded in ADR-055's D1 section rather than left open here:
-`run_compare_request` was extended in parallel and the CLI `compare` command
-still resolves through `cli_resolve._resolve_compare_snapshots`. The
-capability gap D1 existed to close is closed — no Python or MCP caller has to
-drop to loose kwargs any more — while option (a) would rewrite the CLI's
-most heavily-tested resolution path for no user-observable gain. What stays
-CLI-only is narrower than the framing above implies, and is worth not
-re-deriving: project-config `source.method` inference, the set-input
-evidence-flag rejection guard, and the per-side AST-frontend override.
+recorded in ADR-055's D1 section: `run_compare_request` was extended in
+parallel and the CLI `compare` command still resolves through
+`cli_resolve._resolve_compare_snapshots`, because option (a) would rewrite
+the CLI's most heavily-tested resolution path for no user-observable gain.
+
+A follow-up slice then closed the *capability* half properly. A first attempt
+at naming what stayed CLI-only listed three things and was wrong on all
+three: the per-side AST-frontend override already worked (`InputSpec.compile.
+frontend` reaches that side's `run_dump`, verified by spying on its
+arguments); `source.method` is expressible as `CompareRequest.depth`, and a
+Tier-2 API deliberately does not read `.abicheck.yml` from the cwd; and the
+set-input guard protects an input *kind* the typed path never accepts.
+Diffing the two parameter lists instead of reasoning about them found the
+real delta — `dwarf_only`, `debug_format`, ADR-050 D1's `include_labels`, and
+`--follow-deps` — all four now on `CompareRequest`, with `--follow-deps`'s
+implementation moved to the new leaf module `abicheck/dependency_info.py`
+that both layers depend on.
+
+So the two paths now differ in structure, not in what they can express.
 Migrating the CLI onto `run_compare_request` remains possible as its own
 change, gated on its own before/after parity evidence across the CLI's flag
 matrix.

--- a/docs/contribute/plans/g33-typed-api-and-mcp-convergence.md
+++ b/docs/contribute/plans/g33-typed-api-and-mcp-convergence.md
@@ -1,8 +1,9 @@
 # G33 — Typed API convergence: schema registry, Request/Result completeness, MCP dedup
 
-**Status:** Phases 0-4 done (ADR-055 D1-D4 all implemented); Phase 5
-unblocked but not started; Phase 6 is a standing constraint, not work —
-see per-phase status below
+**Status:** Phases 0-4 done (ADR-055 D1-D4 all implemented, including D1's
+deferred structural half — the CLI now shares one resolution with the typed
+and MCP paths); Phase 5 unblocked but not started; Phase 6 is a standing
+constraint, not work — see per-phase status below
 **Normative decision:** [ADR-055](../adr/055-typed-request-result-completeness-and-schema-registry.md)
 (Accepted — implemented)
 **Related:** ADR-037 (G22, CLI consolidation — done), ADR-049 (contract relevance,
@@ -227,10 +228,30 @@ real delta — `dwarf_only`, `debug_format`, ADR-050 D1's `include_labels`, and
 implementation moved to the new leaf module `abicheck/dependency_info.py`
 that both layers depend on.
 
-So the two paths now differ in structure, not in what they can express.
-Migrating the CLI onto `run_compare_request` remains possible as its own
-change, gated on its own before/after parity evidence across the CLI's flag
-matrix.
+So the two paths differed in structure, not in what they could express.
+
+**Structural half — now done, and the decision flipped to (a).** Doing the
+migration showed why (b) had looked inevitable: `run_compare_request` was one
+function that both resolved and classified, and the native `compare` CLI must
+run its Click-dependent ADR-049 `resolve_and_apply` between those two steps —
+it needs the Click context to answer "did the user type this?", and a `--pack`
+it selects can move the policy file and severity levels the classification is
+then scored under. With no seam, the CLI could reuse neither half.
+
+So the change was not "call `run_compare_request` from the CLI" but splitting
+it at its real joint into `abicheck/service_compare_pipeline.py`:
+`resolve_compare_request` (validate → evidence → both snapshots →
+`--follow-deps` → depth floor), `classify_compare_pair` (suppression/policy →
+embedded build-source diff → `compare_snapshots` → metrics), and
+`run_compare_request` as exactly their composition.
+`cli_resolve._resolve_compare_snapshots` now builds a `CompareRequest` and
+delegates; it resolves nothing itself. What stays CLI-specific is the
+`click.echo` notifier, the `ValidationError`/`SnapshotError` → `click`
+exception translation, and `allow_parallel=False` — the CLI's long-standing
+sequential resolution, kept deliberately rather than flipped as a side effect
+(see ADR-055 D1's "Structural half" note, which also records the
+`IMPORT_CYCLE_ALLOWLIST` sign-off and the stale-guard defect the unification
+surfaced on the typed path).
 
 ### Phase 3 — `CompareResult` wrapper (ADR-055 D2)
 
@@ -379,6 +400,6 @@ All met:
   implemented".
 
 Remaining work tracked elsewhere, not reopening this plan: Phase 5
-(`abi_dump`/`abi_scan` parity) is unblocked and still open, and migrating the
-CLI onto `run_compare_request` is a possible future change under Phase 2's
-recorded decision (b).
+(`abi_dump`/`abi_scan` parity) is unblocked and still open. Migrating the CLI
+onto the shared resolution — Phase 2's deferred structural half — is **done**;
+see that phase's "Structural half" note.

--- a/docs/reference/check-target.md
+++ b/docs/reference/check-target.md
@@ -155,7 +155,7 @@ flat directory), starting from whatever the
 underlying `compare`/`scan` run already produced and layering on the
 fields below. For a normal single-library `compare` (the common case),
 that starting shape is `abicheck/reporter.py`'s existing compare-report
-shape (`report_schema_version: "2.13"`). A `baseline-channel: none` audit
+shape (`report_schema_version: "2.26"`). A `baseline-channel: none` audit
 instead starts from a `scan` report (its own `scan_schema_version` shape),
 and a `kind: bundle` check starts from the CLI's per-library release
 fan-out summary (`libraries`/`old_dir`, no schema-version marker of its

--- a/docs/reference/check-target.md
+++ b/docs/reference/check-target.md
@@ -155,7 +155,10 @@ flat directory), starting from whatever the
 underlying `compare`/`scan` run already produced and layering on the
 fields below. For a normal single-library `compare` (the common case),
 that starting shape is `abicheck/reporter.py`'s existing compare-report
-shape (`report_schema_version: "2.26"`). A `baseline-channel: none` audit
+shape (the one carrying `report_schema_version` — see
+[Output formats](../use/output-formats.md#json-schema-and-stability-guarantees) for that contract and
+`abicheck.schemas.current("compare")` for the version this build emits).
+A `baseline-channel: none` audit
 instead starts from a `scan` report (its own `scan_schema_version` shape),
 and a `kind: bundle` check starts from the CLI's per-library release
 fan-out summary (`libraries`/`old_dir`, no schema-version marker of its

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -413,21 +413,11 @@ Compare two ABI inputs and return the classified diff result.
 | `include_dependencies` | `bool` | `True` |
 | `contract_mode` | `str \| None` | `None` |
 
-**Returns:** `tuple[DiffResult, AbiSnapshot, AbiSnapshot]`
+**Returns:** `CompareResult`
 
 ## `run_compare_request`
 
 Compare two ABI inputs described by a :class:`CompareRequest`.
-
-| Parameter | Type | Default |
-|---|---|---|
-| `request` | `CompareRequest` | *(required)* |
-
-**Returns:** `tuple[DiffResult, AbiSnapshot, AbiSnapshot]`
-
-## `run_compare_request_v2`
-
-Compare two ABI inputs and return a typed :class:`CompareResult`.
 
 | Parameter | Type | Default |
 |---|---|---|

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -46,6 +46,19 @@ A fully-specified comparison request — the single input to ``run_compare``.
 | `depth` | `str \| None` | `None` |
 | `frontend_context` | `str` | `'host'` |
 
+## `CompareResult`
+
+What one :class:`CompareRequest` produced — the typed result (ADR-055 D2).
+
+*Dataclass.*
+
+| Field | Type | Default |
+|---|---|---|
+| `diff` | `DiffResult` | *(required)* |
+| `old_snapshot` | `AbiSnapshot` | *(required)* |
+| `new_snapshot` | `AbiSnapshot` | *(required)* |
+| `suppression` | `SuppressionList \| None` | `None` |
+
 ## `CompileContext`
 
 L2 header-AST compile context — shared by ``dump`` and ``scan``.
@@ -98,6 +111,7 @@ One side of a comparison: a binary/snapshot path plus its build context.
 | `dump_manifest` | `DumpManifest \| None` | `None` |
 | `compile` | `CompileContext \| None` | `None` |
 | `public_header_dirs` | `tuple[Path, ...]` | `()` |
+| `follow_linker_scripts` | `bool` | `True` |
 
 ## `LayerResult`
 
@@ -404,6 +418,16 @@ Compare two ABI inputs described by a :class:`CompareRequest`.
 | `request` | `CompareRequest` | *(required)* |
 
 **Returns:** `tuple[DiffResult, AbiSnapshot, AbiSnapshot]`
+
+## `run_compare_request_v2`
+
+Compare two ABI inputs and return a typed :class:`CompareResult`.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `request` | `CompareRequest` | *(required)* |
+
+**Returns:** `CompareResult`
 
 ## `run_dump`
 

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -147,6 +147,21 @@ Where/how a result is rendered — the invocation-level output choice.
 | `fmt` | `str` | `'text'` |
 | `path` | `Path \| None` | `None` |
 
+## `ResolvedComparePair`
+
+Both sides of a comparison, resolved and ready to classify.
+
+*Dataclass.*
+
+| Field | Type | Default |
+|---|---|---|
+| `old` | `AbiSnapshot` | *(required)* |
+| `new` | `AbiSnapshot` | *(required)* |
+| `old_fmt` | `str \| None` | *(required)* |
+| `new_fmt` | `str \| None` | *(required)* |
+| `old_evidence` | `SideEvidence` | *(required)* |
+| `new_evidence` | `SideEvidence` | *(required)* |
+
 ## `ScanArtifactResult`
 
 One member's :class:`ScanResult`, with the identity that result alone doesn't carry (ADR-056 — neither `ScanResult` nor its nested report carries a binary path or library name anywhere).
@@ -231,6 +246,17 @@ Result of :func:`run_scan_set` — the ``--artifact-set`` sibling of :class:`Sca
 | `bundle_findings` | `list[Any]` | `[]` |
 | `bundle_verdict` | `str \| None` | `None` |
 | `bundle_incomplete` | `bool` | `False` |
+
+## `classify_compare_pair`
+
+Classify an already-resolved pair — the second half of ``run_compare_request``.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `request` | `CompareRequest` | *(required)* |
+| `pair` | `ResolvedComparePair` | *(required)* |
+
+**Returns:** `CompareResult`
 
 ## `collect_metadata`
 
@@ -335,6 +361,19 @@ Render comparison result in the requested output format.
 | `contract_evaluation` | `bool` | `False` |
 
 **Returns:** `str`
+
+## `resolve_compare_request`
+
+Resolve both sides of *request* into a classifiable pair.
+
+| Parameter | Type | Default |
+|---|---|---|
+| `request` | `CompareRequest` | *(required)* |
+| *(keyword-only below)* | | |
+| `notify` | `Callable[[str], None] \| None` | `None` |
+| `allow_parallel` | `bool` | `True` |
+
+**Returns:** `ResolvedComparePair`
 
 ## `resolve_input`
 

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -44,6 +44,12 @@ A fully-specified comparison request — the single input to ``run_compare``.
 | `contract_evaluation` | `bool` | `False` |
 | `contract_mode` | `str \| None` | `None` |
 | `depth` | `str \| None` | `None` |
+| `dwarf_only` | `bool` | `False` |
+| `debug_format` | `str \| None` | `None` |
+| `include_labels` | `tuple[tuple[Path, str], ...]` | `()` |
+| `follow_dependencies` | `bool` | `False` |
+| `dependency_search_paths` | `tuple[Path, ...]` | `()` |
+| `ld_library_path` | `str` | `''` |
 | `frontend_context` | `str` | `'host'` |
 
 ## `CompareResult`

--- a/docs/use/output-formats.md
+++ b/docs/use/output-formats.md
@@ -576,7 +576,7 @@ Every JSON report carries a top-level `report_schema_version` field
 
 ```json
 {
-  "report_schema_version": "1.0",
+  "report_schema_version": "2.26",
   "library": "libfoo.so.1",
   "verdict": "BREAKING"
 }

--- a/docs/use/output-formats.md
+++ b/docs/use/output-formats.md
@@ -544,7 +544,7 @@ It is described by a versioned [JSON Schema](https://json-schema.org/) (draft
 
 ```python
 from abicheck.schemas import (
-    REPORT_SCHEMA_VERSION,        # e.g. "1.0"
+    REPORT_SCHEMA_VERSION,        # the MAJOR.MINOR this build emits
     COMPARE_REPORT_SCHEMA_PATH,   # pathlib.Path to the .schema.json
     load_compare_report_schema,   # -> dict
 )
@@ -556,7 +556,9 @@ Every JSON report carries a top-level `report_schema_version` field
 > **Two version numbers, two contracts.** `report_schema_version` (above)
 > versions the **comparison report** emitted by `compare`. It is distinct from
 > the `schema_version` integer inside a **snapshot** (`.abi.json`) produced by
-> `dump` — that one versions the on-disk ABI surface and is currently `8`.
+> `dump` — that one versions the on-disk ABI surface, and its current value
+> lives on its own fact-owner page
+> ([Snapshot format](../reference/snapshot-format.md)), not here.
 > `abicheck dump --format json` writes a **snapshot** (carrying `schema_version`),
 > not a report, so it has no `report_schema_version`. A report and a snapshot can
 > carry different version numbers at the same time; consumers should read

--- a/docs/use/python-api.md
+++ b/docs/use/python-api.md
@@ -30,22 +30,34 @@ runs the comparison, and returns the classified result.
 from pathlib import Path
 from abicheck.service import run_compare
 
-result, old_snapshot, new_snapshot = run_compare(
+result = run_compare(
     old_input=Path("libfoo.so.1"),
     new_input=Path("libfoo.so.2"),
     old_headers=[Path("include/v1/foo.h")],
     new_headers=[Path("include/v2/foo.h")],
 )
 
-print(result.verdict)       # Verdict.BREAKING, Verdict.COMPATIBLE, ...
-print(len(result.changes))  # number of detected changes
-for change in result.changes:
+print(result.diff.verdict)       # Verdict.BREAKING, Verdict.COMPATIBLE, ...
+print(len(result.diff.changes))  # number of detected changes
+for change in result.diff.changes:
     print(change.kind, change.name)
 ```
 
-`run_compare` returns a `tuple[DiffResult, AbiSnapshot, AbiSnapshot]`. It raises
+`run_compare` returns a `CompareResult` — `diff` (the `DiffResult`),
+`old_snapshot`, `new_snapshot`, and the resolved `suppression` list. It raises
 `SnapshotError` if an input cannot be loaded and `ValidationError` for an
 unrecognised input format (both from `abicheck.errors`).
+
+!!! note "Changed in 0.6"
+    `run_compare` and `run_compare_request` returned a bare
+    `tuple[DiffResult, AbiSnapshot, AbiSnapshot]` before 0.6. A struct can gain
+    a field without breaking positional callers, which a tuple cannot — so the
+    typed result became the only shape rather than a second one alongside it
+    (ADR-055 D2). To migrate a positional caller in one line:
+
+    ```python
+    result, old_snapshot, new_snapshot = run_compare(...).as_tuple()
+    ```
 
 ### Common keyword arguments
 

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -642,13 +642,23 @@ def check_changekind_docs(f: Findings) -> None:
 def check_doc_count_sync(f: Findings) -> None:
     """Keep hand-written headline counts in sync with their source of truth.
 
-    Three numbers historically drifted across the docs: the number of `ChangeKind`
+    Four values historically drifted across the docs: the number of `ChangeKind`
     values ("N change types"), the size of the example catalog
-    (`examples/ground_truth.json`), and the snapshot `schema_version` (Codex
-    review — a doc page hand-copying a version number that already has a fact
-    owner, per AGENTS.md's "don't hand-copy a count/version that has a fact
-    owner elsewhere" rule, with nothing catching the next bump forgetting it).
-    Each anchor below pins a specific sentence to a computed value:
+    (`examples/ground_truth.json`), the snapshot `schema_version`, and the
+    compare report's `report_schema_version` (each a doc page hand-copying a
+    number that already has a fact owner, per AGENTS.md's "don't hand-copy a
+    count/version that has a fact owner elsewhere" rule, with nothing catching
+    the next bump forgetting it) — plus the CastXML policy's supported-version
+    range. Each anchor below pins a specific sentence to a computed value:
+
+    Pinning is the *second* line of defence, not the first: where a version is
+    incidental to what a sentence is saying, the page should link to the fact
+    owner and hold no copy at all (ADR-055 D3). An anchor here is for a value
+    that must appear literally — a JSON output sample, or the owner page's own
+    statement of the current value. It only guards the sites someone thought
+    to anchor, which is exactly how the fourth copy on `snapshot-format.md`
+    (its snapshot-vs-report comparison table) sat unchecked until review
+    caught it.
 
     - ERROR if the anchor sentence is present but the number is wrong (the real
       drift bug — forces docs to be updated when a ChangeKind or case is added).
@@ -663,9 +673,13 @@ def check_doc_count_sync(f: Findings) -> None:
             MIN_CASTXML_CLANG_MAJOR,
         )
         from abicheck.checker_policy import ChangeKind
-    except Exception:
+    except ModuleNotFoundError:
         # Package not importable (e.g. pre-install lane) — skip silently, like
-        # the other ChangeKind checks.
+        # the other ChangeKind checks. Deliberately *only* this: a broken
+        # `abicheck.schemas` (or any other import-time failure in an installed
+        # package) is a real defect, and swallowing it here would silently stop
+        # checking every version number below while still reporting success
+        # (CodeRabbit review).
         return
 
     # ADR-055 D3: read every persisted-artifact version through the registry
@@ -767,16 +781,16 @@ def check_doc_count_sync(f: Findings) -> None:
             r"Snapshot format version \(currently `(\d+)`\)",
         ),
         (
-            DOCS / "use/output-formats.md",
-            "compare report_schema_version (scan envelope JSON example)",
-            REPORT_SCHEMA_VERSION,
-            r'"report_schema_version":\s*"([0-9]+\.[0-9]+)"',
+            DOCS / "reference/snapshot-format.md",
+            "snapshot schema_version (snapshot-vs-report comparison table)",
+            SCHEMA_VERSION,
+            r"\*\*Type\*\* \| integer \(currently `(\d+)`\)",
         ),
         (
-            DOCS / "reference/check-target.md",
-            "compare report_schema_version (starting-shape sentence)",
+            DOCS / "use/output-formats.md",
+            "compare report_schema_version (compare report JSON example)",
             REPORT_SCHEMA_VERSION,
-            r'shape \(`report_schema_version: "([0-9]+\.[0-9]+)"`\)',
+            r'"report_schema_version":\s*"([0-9]+\.[0-9]+)"',
         ),
         (
             DOCS / "reference/environment.md",

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -656,17 +656,26 @@ def check_doc_count_sync(f: Findings) -> None:
       guard silently stopped covering that spot — update the regex here).
     """
     try:
+        from abicheck import schemas
         from abicheck.castxml_policy import (
             MAX_CASTXML,
             MIN_CASTXML,
             MIN_CASTXML_CLANG_MAJOR,
         )
         from abicheck.checker_policy import ChangeKind
-        from abicheck.serialization import SCHEMA_VERSION
     except Exception:
         # Package not importable (e.g. pre-install lane) — skip silently, like
         # the other ChangeKind checks.
         return
+
+    # ADR-055 D3: read every persisted-artifact version through the registry
+    # rather than importing each artifact's own constant here. That is what
+    # gives `schemas.current()` a consumer instead of leaving it a lookup
+    # nothing calls — the registry exists precisely because a version number
+    # with no single queryable owner is how `docs/use/python-api.md` came to
+    # claim schema_version 8 against a real 17.
+    SCHEMA_VERSION = schemas.current("snapshot")
+    REPORT_SCHEMA_VERSION = schemas.current("compare")
 
     n_kinds = len(list(ChangeKind))
 
@@ -756,6 +765,18 @@ def check_doc_count_sync(f: Findings) -> None:
             "snapshot schema_version (field table)",
             SCHEMA_VERSION,
             r"Snapshot format version \(currently `(\d+)`\)",
+        ),
+        (
+            DOCS / "use/output-formats.md",
+            "compare report_schema_version (scan envelope JSON example)",
+            REPORT_SCHEMA_VERSION,
+            r'"report_schema_version":\s*"([0-9]+\.[0-9]+)"',
+        ),
+        (
+            DOCS / "reference/check-target.md",
+            "compare report_schema_version (starting-shape sentence)",
+            REPORT_SCHEMA_VERSION,
+            r'shape \(`report_schema_version: "([0-9]+\.[0-9]+)"`\)',
         ),
         (
             DOCS / "reference/environment.md",

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -1168,6 +1168,24 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
         # through already-member modules, not a new dependency direction.
         # No init deadlock.
         #
+        # `service_compare_pipeline` joins the same SCC (ADR-055 D1), for the
+        # same reason `l0_export_delta` and `scan_engine` above do: it is a
+        # *split* of an existing member, not a new dependency direction.
+        # `run_compare_request`'s body was one function that both resolved and
+        # classified, which left the native `compare` CLI no seam to run its
+        # Click-dependent ADR-049 `resolve_and_apply` step in — so the CLI kept
+        # a second resolution implementation of its own. Splitting that body
+        # into `resolve_compare_request` / `classify_compare_pair` removed the
+        # reason for the copy. The extracted module reaches
+        # `cli_buildsource`/`cli_dump_helpers`/`cli_buildsource_helpers` and
+        # `service` itself function-locally — the *identical* set of edges
+        # `service.run_compare_request` already had before the split, moved
+        # rather than added — and `service` imports it back at its module-load
+        # tail. It imports only `api_types`/`errors` (both leaves) at module
+        # load, so the package still imports cleanly: no init deadlock. Net
+        # effect on the graph is a *reduction*, since `cli_resolve` no longer
+        # carries its own copy of the resolution this module now owns.
+        #
         # `cli_config`, `cli_doctor`, and `cli_graph` also join this same SCC —
         # each already had its own standalone `{"cli", "cli_X"}` entry above,
         # which covers the trivial two-node cycle from `cli`'s tail-of-module
@@ -1232,6 +1250,7 @@ IMPORT_CYCLE_ALLOWLIST: frozenset[frozenset[str]] = frozenset(
                 "l0_export_delta",
                 "scan_engine",
                 "service",
+                "service_compare_pipeline",
                 "service_scan",
             }
         ),

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -120,6 +120,17 @@ class TestCompareRequestDefaults:
         assert req.depth is None
         assert req.frontend_context == "host"
 
+    def test_adr055_resolution_parity_defaults(self):
+        # ADR-055 D1's second slice: additive, so an existing caller's
+        # behaviour is unchanged until it opts in.
+        req = CompareRequest(old=InputSpec.of("a"), new=InputSpec.of("b"))
+        assert req.dwarf_only is False
+        assert req.debug_format is None
+        assert req.include_labels == ()
+        assert req.follow_dependencies is False
+        assert req.dependency_search_paths == ()
+        assert req.ld_library_path == ""
+
     def test_is_frozen(self):
         req = CompareRequest(old=InputSpec.of("a"), new=InputSpec.of("b"))
         with pytest.raises(dataclasses.FrozenInstanceError):

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -416,3 +416,34 @@ class TestCompareResult:
         result, _diff, _old, new = self._result()
         with pytest.raises(dataclasses.FrozenInstanceError):
             result.old_snapshot = new  # type: ignore[misc]
+
+
+class TestDebugFormatValidation:
+    """ADR-055 D1 second slice (Codex review): the newly-exposed
+    ``debug_format`` must fail through this module's ``ValidationError``
+    contract, and accept the same spellings the CLI's case-insensitive
+    ``--debug-format`` choice does."""
+
+    def _request(self, debug_format):
+        return CompareRequest(
+            old=InputSpec.of("a"), new=InputSpec.of("b"), debug_format=debug_format
+        )
+
+    @pytest.mark.parametrize("value", ["auto", "dwarf", "btf", "ctf"])
+    def test_cli_choice_values_are_accepted(self, value):
+        assert self._request(value).validation_errors() == []
+
+    @pytest.mark.parametrize("value", ["DWARF", "Btf", "CTF"])
+    def test_accepted_case_insensitively_like_the_cli_choice(self, value):
+        # click.Choice(..., case_sensitive=False) — an API caller typing
+        # "DWARF" must not behave differently from the CLI caller who did.
+        assert self._request(value).validation_errors() == []
+
+    def test_a_typo_is_a_validation_error_not_a_raw_valueerror(self):
+        # Without this it reached dumper_debug._resolve_debug_metadata, whose
+        # comparisons are lowercase-only, and surfaced as a bare ValueError.
+        with pytest.raises(ValidationError, match="unsupported debug format"):
+            self._request("dwraf").validate()
+
+    def test_none_stays_valid(self):
+        assert self._request(None).validation_errors() == []

--- a/tests/test_api_types.py
+++ b/tests/test_api_types.py
@@ -22,7 +22,7 @@ from pathlib import Path
 
 import pytest
 
-from abicheck.api_types import CompareRequest, InputSpec, OutputSpec
+from abicheck.api_types import CompareRequest, CompareResult, InputSpec, OutputSpec
 from abicheck.errors import ValidationError
 
 
@@ -78,6 +78,18 @@ class TestInputSpec:
     def test_of_coerces_public_header_dirs(self):
         spec = InputSpec.of("lib.so", public_header_dirs=["a", "b"])
         assert spec.public_header_dirs == (Path("a"), Path("b"))
+
+    # ── ADR-055 D4: follow_linker_scripts ─────────────────────────────────────
+
+    def test_follow_linker_scripts_defaults_true(self):
+        # Matches `resolve_input`'s own default, so no pre-existing caller's
+        # behaviour changes just because the field appeared.
+        assert InputSpec.of("lib.so").follow_linker_scripts is True
+        assert InputSpec(path=Path("lib.so")).follow_linker_scripts is True
+
+    def test_of_passes_through_follow_linker_scripts(self):
+        spec = InputSpec.of("lib.so", follow_linker_scripts=False)
+        assert spec.follow_linker_scripts is False
 
     def test_of_passes_through_compile_and_dump_manifest(self):
         from abicheck.compile_context import CompileContext
@@ -352,3 +364,44 @@ class TestOutputSpec:
         out = OutputSpec(fmt="json")
         with pytest.raises(dataclasses.FrozenInstanceError):
             out.fmt = "sarif"  # type: ignore[misc]
+
+
+class TestCompareResult:
+    """ADR-055 D2: the typed result wrapper."""
+
+    def _result(self):
+        from abicheck.checker_types import DiffResult
+        from abicheck.model import AbiSnapshot
+
+        diff = DiffResult(old_version="1.0", new_version="2.0", library="lib")
+        old = AbiSnapshot(library="lib", version="1.0")
+        new = AbiSnapshot(library="lib", version="2.0")
+        return CompareResult(diff=diff, old_snapshot=old, new_snapshot=new), diff, old, new
+
+    def test_as_tuple_matches_the_legacy_return_shape(self):
+        # The whole point of the wrapper is that it is a *rename* of the tuple,
+        # not a reordering — a caller unpacking either must see the same three
+        # objects in the same order.
+        result, diff, old, new = self._result()
+        assert result.as_tuple() == (diff, old, new)
+
+    def test_suppression_defaults_to_none(self):
+        result, _diff, _old, _new = self._result()
+        assert result.suppression is None
+
+    def test_carries_the_resolved_suppression_list(self):
+        from abicheck.suppression import SuppressionList
+
+        _result, diff, old, new = self._result()
+        suppression = SuppressionList([])  # empty rule set is enough here
+        result = CompareResult(
+            diff=diff, old_snapshot=old, new_snapshot=new, suppression=suppression
+        )
+        assert result.suppression is suppression
+        # ...and it stays out of the tuple view, which is the legacy shape.
+        assert result.as_tuple() == (diff, old, new)
+
+    def test_is_frozen(self):
+        result, _diff, _old, new = self._result()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            result.old_snapshot = new  # type: ignore[misc]

--- a/tests/test_cli_contract.py
+++ b/tests/test_cli_contract.py
@@ -778,7 +778,7 @@ def test_compare_release_matches_service_run_compare(tmp_path: Path) -> None:
     old_p = _make_snap_file(tmp_path, "libfoo", "1.0", [_func("foo"), _func("bar")])
     new_p = _make_snap_file(tmp_path, "libfoo", "2.0", [_func("foo")])
 
-    svc_result, _, _ = service.run_compare(old_p, new_p, scope_to_public_surface=True)
+    svc_result, _, _ = service.run_compare(old_p, new_p, scope_to_public_surface=True).as_tuple()
     rel_result, _, _ = _run_compare_pair(
         old_p,
         new_p,
@@ -795,7 +795,7 @@ def test_compare_release_matches_service_run_compare(tmp_path: Path) -> None:
         old_pdb_path=None,
         new_pdb_path=None,
         scope_to_public_surface=True,
-    )
+    ).as_tuple()
 
     assert svc_result.verdict == rel_result.verdict
     assert sorted(c.kind for c in svc_result.breaking) == sorted(
@@ -817,9 +817,9 @@ def test_run_compare_request_equivalent_to_kwargs_shim(tmp_path: Path) -> None:
     old_p = _make_snap_file(tmp_path, "libbar", "1.0", [_func("a"), _func("b")])
     new_p = _make_snap_file(tmp_path, "libbar", "2.0", [_func("a")])
 
-    shim_result, _, _ = run_compare(old_p, new_p)
+    shim_result, _, _ = run_compare(old_p, new_p).as_tuple()
     req = CompareRequest(old=InputSpec.of(old_p), new=InputSpec.of(new_p))
-    req_result, _, _ = run_compare_request(req)
+    req_result, _, _ = run_compare_request(req).as_tuple()
 
     assert shim_result.verdict == req_result.verdict
     assert sorted(c.kind for c in shim_result.breaking) == sorted(

--- a/tests/test_cli_new_features.py
+++ b/tests/test_cli_new_features.py
@@ -231,17 +231,34 @@ class TestPerSideHeaderBackend:
         assert calls[1].get("header_backend") == "clang"
 
     def test_resolve_compare_snapshots_routes_backend_per_side(self, monkeypatch):
-        """Direct unit: _resolve_compare_snapshots derives per-side backend and
-        forwards it to each side's _resolve_input (None inherits the shared one)."""
-        from abicheck import cli_resolve
+        """Direct unit: ``_resolve_compare_snapshots`` gives each side its own
+        AST frontend, and a ``None`` override inherits the shared one.
 
-        seen: list[str] = []
+        ADR-055 D1 changed *how* it travels, not whether it does. That helper
+        now builds a ``CompareRequest`` and delegates to the shared
+        ``service.resolve_compare_request``, and a ``CompareRequest`` has one
+        request-level ``frontend`` — so a per-side override rides on that
+        side's own ``InputSpec.compile.frontend``, which
+        ``_run_dump_uncached`` documents as outranking the bare both-sides
+        ``header_backend``. The end-to-end tests above (which spy on
+        ``dumper.dump``, past that resolution) pin the effective backend each
+        side is really parsed with; this pins the transport.
+        """
+        from abicheck import cli_resolve, service
+
+        seen: list[tuple[str, str | None]] = []
 
         def fake_resolve_input(_input, _h, _inc, _ver, _lang, **kwargs):
-            seen.append(kwargs["header_backend"])
+            compile_ctx = kwargs.get("compile")
+            seen.append(
+                (
+                    kwargs["header_backend"],
+                    compile_ctx.frontend if compile_ctx is not None else None,
+                )
+            )
             return AbiSnapshot(library="libfoo.so", version=_ver)
 
-        monkeypatch.setattr(cli_resolve, "_resolve_input", fake_resolve_input)
+        monkeypatch.setattr(service, "resolve_input", fake_resolve_input)
         old, new = cli_resolve._resolve_compare_snapshots(
             Path("old.json"), Path("new.json"), None, None,
             [], [], [], [], "1.0", "2.0", "c++",
@@ -251,7 +268,10 @@ class TestPerSideHeaderBackend:
             old_header_backend=None,        # inherits castxml
             new_header_backend="clang",     # overrides
         )
-        assert seen == ["castxml", "clang"]
+        # Old side: no override, so nothing pins a per-side frontend and the
+        # shared "castxml" is what it parses with. New side: the override is
+        # carried on its own compile context and outranks the shared value.
+        assert seen == [("castxml", None), ("castxml", "clang")]
         assert old.version == "1.0" and new.version == "2.0"
 
 

--- a/tests/test_cli_split_modules.py
+++ b/tests/test_cli_split_modules.py
@@ -21,7 +21,13 @@ from unittest.mock import patch
 import pytest
 from click.testing import CliRunner
 
+from abicheck.api_types import CompareResult
 from abicheck.cli import main
+from abicheck.model import AbiSnapshot
+
+#: Placeholder snapshots for the CompareResult stubs below — these tests read
+#: only the diff, but the struct carries both sides.
+_SNAP = AbiSnapshot(library="stub", version="0")
 
 # ---------------------------------------------------------------------------
 # compare-release error paths
@@ -577,7 +583,7 @@ class TestCompareReleaseErrorPaths:
 
         monkeypatch.setattr(
             "abicheck.cli_compare_release._run_compare_pair",
-            lambda *a, **kw: (result, object(), None),
+            lambda *a, **kw: CompareResult(result, _SNAP, _SNAP),
         )
         monkeypatch.setattr(
             "abicheck.annotations.is_github_actions", lambda: True,
@@ -628,13 +634,13 @@ class TestCompareReleaseErrorPaths:
             # A fresh DiffResult each call, mirroring the real re-run —
             # asserts the suppression is applied per-call, not by mutating a
             # shared fixture.
-            return (
+            return CompareResult(
                 DiffResult(
                     old_version="1", new_version="2", library="libfoo.so",
                     changes=[c], verdict=Verdict.COMPATIBLE,
                 ),
-                object(),
-                None,
+                _SNAP,
+                _SNAP,
             )
 
         monkeypatch.setattr(

--- a/tests/test_compare_dispatch.py
+++ b/tests/test_compare_dispatch.py
@@ -30,10 +30,16 @@ import pytest
 from click.testing import CliRunner
 
 from abicheck import cli_compare_release
+from abicheck.api_types import CompareResult
 from abicheck.cli import main
 from abicheck.cli_resolve import _looks_like_application, classify_compare_operand
 from abicheck.model import AbiSnapshot, Function, Visibility
 from abicheck.serialization import snapshot_to_json
+
+#: Placeholder snapshots for CompareResult stubs — these tests only read
+#: the diff, but the struct requires both sides.
+_SNAP = AbiSnapshot(library="stub", version="0")
+
 
 
 class TestCompareHeaderMarksProvenance:
@@ -968,7 +974,7 @@ class TestCompareDispatch:
         )
         monkeypatch.setattr(
             "abicheck.cli_compare_release._run_compare_pair",
-            lambda *a, **kw: (api_break_diff, None, None),
+            lambda *a, **kw: CompareResult(api_break_diff, _SNAP, _SNAP),
         )
 
         code, out, _ = _invoke(

--- a/tests/test_compare_dispatch.py
+++ b/tests/test_compare_dispatch.py
@@ -55,7 +55,7 @@ class TestCompareHeaderMarksProvenance:
     def test_resolve_compare_snapshots_passes_header_as_public_header(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from abicheck import cli_resolve
+        from abicheck import cli_resolve, service
 
         calls: list[dict] = []
 
@@ -63,7 +63,11 @@ class TestCompareHeaderMarksProvenance:
             calls.append({"path": path, "headers": headers, "version": version, **kwargs})
             return _snap(version=version)
 
-        monkeypatch.setattr(cli_resolve, "_resolve_input", fake_resolve_input)
+        # ADR-055 D1: `_resolve_compare_snapshots` no longer resolves anything
+        # itself -- it builds a CompareRequest and delegates to the shared
+        # `service.resolve_compare_request`, so the spy belongs on the service
+        # function that shared pipeline actually calls.
+        monkeypatch.setattr(service, "resolve_input", fake_resolve_input)
 
         old_h = [tmp_path / "old.h"]
         new_h = [tmp_path / "new.h"]
@@ -92,7 +96,7 @@ class TestResolveCompareSnapshotsDependencyScope:
     def test_defaults_to_filtered_on_both_sides(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from abicheck import cli_resolve
+        from abicheck import cli_resolve, service
 
         calls: list[dict] = []
 
@@ -100,7 +104,7 @@ class TestResolveCompareSnapshotsDependencyScope:
             calls.append(kwargs)
             return _snap(version=version)
 
-        monkeypatch.setattr(cli_resolve, "_resolve_input", fake_resolve_input)
+        monkeypatch.setattr(service, "resolve_input", fake_resolve_input)
 
         cli_resolve._resolve_compare_snapshots(
             tmp_path / "old.so", tmp_path / "new.so",
@@ -118,7 +122,7 @@ class TestResolveCompareSnapshotsDependencyScope:
     def test_include_dependencies_true_reaches_both_sides(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        from abicheck import cli_resolve
+        from abicheck import cli_resolve, service
 
         calls: list[dict] = []
 
@@ -126,7 +130,7 @@ class TestResolveCompareSnapshotsDependencyScope:
             calls.append(kwargs)
             return _snap(version=version)
 
-        monkeypatch.setattr(cli_resolve, "_resolve_input", fake_resolve_input)
+        monkeypatch.setattr(service, "resolve_input", fake_resolve_input)
 
         cli_resolve._resolve_compare_snapshots(
             tmp_path / "old.so", tmp_path / "new.so",
@@ -150,22 +154,25 @@ def test_resolve_compare_snapshots_resolves_old_and_new_sequentially(
     ``_resolve_input`` for old, then new -- never concurrently.
 
     This is the specific path ADR-050 D6/G32 Phase E's "a manifest-driven
-    compare can launch two full-sized per-TU pools at once" concern is
-    actually about for the native CLI: unlike ``service.run_compare_request``
-    (which does resolve old/new concurrently via a ``ThreadPoolExecutor``, but
-    has no ``dump_manifest`` field on ``CompareRequest``/``InputSpec`` at all,
-    so it can never reach a manifest-driven dump), ``_resolve_compare_snapshots``
-    is what actually threads ``old_dump_manifest``/``new_dump_manifest``
-    through to ``resolve_input`` -- and it already resolves both sides with
-    two plain, sequential calls, so a manifest-driven compare here can never
-    size two per-TU pools off the same ``MemAvailable`` reading at once. A
-    regression back to concurrent resolution here (e.g. mirroring
-    ``run_compare_request``'s own ``ThreadPoolExecutor``) would reintroduce
-    exactly that double-pool-sizing risk, so this guards against it directly.
+    compare can launch two full-sized per-TU pools at once" concern is about:
+    a manifest-driven dump sizes its own per-TU pool from a live
+    ``MemAvailable`` reading, so two starting together size two full pools off
+    the same reading and jointly overcommit.
+
+    ADR-055 D1 moved the resolution itself into the shared
+    ``service_compare_pipeline``, which *can* resolve concurrently — so the
+    guard is now two things, and this asserts the CLI half. The CLI passes
+    ``allow_parallel=False``, which is unconditional and covers a plain
+    (manifest-free) compare like the one below; the shared
+    ``resolve_sides_sequentially`` covers the manifest case for every other
+    front end, including ``run_compare_request``, which reaches a
+    manifest-driven dump through ``InputSpec.dump_manifest`` and would
+    otherwise have had the very risk this test was written about
+    (``TestResolveSidesSequentially`` in ``tests/test_service_unit.py``).
     """
     import time
 
-    from abicheck import cli_resolve
+    from abicheck import cli_resolve, service
 
     calls: list[tuple[str, float, float]] = []
 
@@ -176,7 +183,7 @@ def test_resolve_compare_snapshots_resolves_old_and_new_sequentially(
         calls.append((version, start, end))
         return _snap(version=version)
 
-    monkeypatch.setattr(cli_resolve, "_resolve_input", fake_resolve_input)
+    monkeypatch.setattr(service, "resolve_input", fake_resolve_input)
 
     old_h = [tmp_path / "old.h"]
     new_h = [tmp_path / "new.h"]
@@ -1224,3 +1231,107 @@ class TestDirectoryComparison:
         # The standalone compare-release command was removed; no deprecation note.
         assert "deprecated" not in (result.stderr or "")
 
+
+
+class TestCompareCliSharesServiceResolution:
+    """ADR-055 D1: the native ``compare`` CLI no longer resolves inputs itself.
+
+    ``cli_resolve._resolve_compare_snapshots`` kept a second implementation of
+    what ``service.run_compare_request`` already did, because that function was
+    one unit with no seam for ``compare``'s Click-dependent ADR-049
+    ``resolve_and_apply`` step. Splitting it into
+    ``resolve_compare_request``/``classify_compare_pair`` removed the reason
+    for the copy, so this pins that the CLI really delegates rather than
+    merely producing a similar answer.
+    """
+
+    def test_delegates_to_the_shared_resolution(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from abicheck import cli_resolve, service
+
+        seen: list[object] = []
+
+        def _spy(request, **kwargs):
+            seen.append((request, kwargs))
+            from abicheck.service_compare_pipeline import ResolvedComparePair
+
+            # The CLI reads only the two snapshots off the pair; the evidence
+            # fields belong to the classification phase it runs on its own.
+            return ResolvedComparePair(
+                old=_snap(version="old"),
+                new=_snap(version="new"),
+                old_fmt="elf",
+                new_fmt="elf",
+                old_evidence=None,
+                new_evidence=None,
+            )
+
+        monkeypatch.setattr(service, "resolve_compare_request", _spy)
+        old, new = cli_resolve._resolve_compare_snapshots(
+            tmp_path / "old.so", tmp_path / "new.so",
+            "elf", "elf",
+            [tmp_path / "old.h"], [tmp_path / "new.h"],
+            [], [],
+            "1.0", "2.0",
+            "c++",
+            None, None, None,
+            True, "dwarf", True, (tmp_path / "libs",), "/opt/lib",
+        )
+        assert (old.version, new.version) == ("old", "new")
+        assert len(seen) == 1
+        request, kwargs = seen[0]
+        # The CLI's own concerns stay the CLI's: a click notifier, and the
+        # sequential resolution this path has always used.
+        assert kwargs["allow_parallel"] is False
+        assert kwargs["notify"] is cli_resolve._click_notify
+        # Every loose argument became request surface rather than a private
+        # resolution parameter.
+        assert request.old.path == tmp_path / "old.so"
+        assert request.old.headers == (tmp_path / "old.h",)
+        assert request.new.version == "2.0"
+        assert request.dwarf_only is True
+        assert request.debug_format == "dwarf"
+        assert request.follow_dependencies is True
+        assert request.dependency_search_paths == (tmp_path / "libs",)
+        assert request.ld_library_path == "/opt/lib"
+
+    def test_translates_service_errors_into_click_exceptions(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The contract ``_resolve_input`` documented survives the move.
+
+        ``ValidationError`` (unusable input) stays exit 64 via
+        ``click.UsageError``; ``SnapshotError`` (operational failure) stays a
+        plain ``click.ClickException``.
+        """
+        import click
+
+        from abicheck import cli_resolve, service
+        from abicheck.errors import SnapshotError, ValidationError
+
+        def _call() -> None:
+            cli_resolve._resolve_compare_snapshots(
+                tmp_path / "old.so", tmp_path / "new.so",
+                "elf", "elf", [], [], [], [], "1.0", "2.0", "c++",
+                None, None, None, False, None, False, (), "",
+            )
+
+        def _raise(exc):
+            def _inner(request, **kwargs):
+                raise exc
+
+            return _inner
+
+        monkeypatch.setattr(
+            service, "resolve_compare_request", _raise(ValidationError("bad input"))
+        )
+        with pytest.raises(click.UsageError, match="bad input"):
+            _call()
+
+        monkeypatch.setattr(
+            service, "resolve_compare_request", _raise(SnapshotError("cannot load"))
+        )
+        with pytest.raises(click.ClickException, match="cannot load") as excinfo:
+            _call()
+        assert not isinstance(excinfo.value, click.UsageError)

--- a/tests/test_dependency_info.py
+++ b/tests/test_dependency_info.py
@@ -194,6 +194,34 @@ class TestDependencySource:
         spec = InputSpec(path=script, follow_linker_scripts=False)
         assert _dependency_source(spec, None) is None
 
+    def test_a_chain_of_linker_scripts_is_followed_to_the_elf(self, tmp_path):
+        # resolve_input recurses through the whole chain, so a snapshot is
+        # produced fine; stopping at one hop here silently skipped the
+        # dependency scan for that side (Codex review).
+        elf = tmp_path / "libfoo.so.1.2"
+        elf.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        mid = tmp_path / "libfoo.so.1"
+        mid.write_text(f"INPUT({elf})\n", encoding="utf-8")
+        top = tmp_path / "libfoo.so"
+        top.write_text(f"INPUT({mid})\n", encoding="utf-8")
+
+        assert _dependency_source(InputSpec(path=top), None) == elf
+
+    def test_a_self_referencing_script_terminates(self, tmp_path):
+        script = tmp_path / "loop.so"
+        script.write_text(f"INPUT({script})\n", encoding="utf-8")
+        assert _dependency_source(InputSpec(path=script), None) is None
+
+    def test_a_two_script_cycle_terminates(self, tmp_path):
+        # resolve_input's own recursion guards only self-reference, so this
+        # shape would recurse there until the stack gives out; this function
+        # must not inherit that.
+        a = tmp_path / "a.so"
+        b = tmp_path / "b.so"
+        a.write_text(f"INPUT({b})\n", encoding="utf-8")
+        b.write_text(f"INPUT({a})\n", encoding="utf-8")
+        assert _dependency_source(InputSpec(path=a), None) is None
+
     def test_plain_non_elf_input_is_skipped(self, tmp_path):
         snapshot = tmp_path / "old.json"
         snapshot.write_text('{"library": "l"}', encoding="utf-8")

--- a/tests/test_dependency_info.py
+++ b/tests/test_dependency_info.py
@@ -1,0 +1,260 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for abicheck.dependency_info (ADR-055 D1's --follow-deps parity).
+
+The implementation moved here from ``cli_resolve`` when the typed request
+gained ``follow_dependencies``, so these cover it directly rather than only
+through a CLI path that needs a real ELF and a real dependency graph.
+"""
+
+from __future__ import annotations
+
+import types
+from pathlib import Path
+
+import pytest
+
+from abicheck.api_types import CompareRequest, InputSpec
+from abicheck.dependency_info import (
+    _dependency_source,
+    populate_dependency_info,
+    populate_pair_dependency_info,
+)
+from abicheck.model import AbiSnapshot
+
+
+class _FakeGraph:
+    """Minimal stand-in for resolver.resolve_dependencies' return value."""
+
+    def __init__(self):
+        self.nodes = {
+            "libb": types.SimpleNamespace(
+                path=Path("/usr/lib/libb.so.1"),
+                soname="libb.so.1",
+                needed=["libc.so.6"],
+                depth=1,
+                resolution_reason="needed",
+            ),
+            "liba": types.SimpleNamespace(
+                path=Path("/usr/lib/liba.so.1"),
+                soname="liba.so.1",
+                needed=[],
+                depth=0,
+                resolution_reason="root",
+            ),
+        }
+        self.edges = [("liba.so.1", "libb.so.1")]
+        self.unresolved = [("liba.so.1", "libmissing.so.2")]
+
+
+def _stub_resolution(monkeypatch, *, missing_symbol: bool = True):
+    from abicheck import binder, resolver
+
+    monkeypatch.setattr(resolver, "resolve_dependencies", lambda *a, **k: _FakeGraph())
+    bindings = [
+        types.SimpleNamespace(
+            consumer="liba.so.1",
+            symbol="ok",
+            version=None,
+            status=binder.BindingStatus.RESOLVED_OK,
+        )
+    ]
+    if missing_symbol:
+        bindings.append(
+            types.SimpleNamespace(
+                consumer="liba.so.1",
+                symbol="gone",
+                version="V1",
+                status=binder.BindingStatus.MISSING,
+            )
+        )
+    monkeypatch.setattr(binder, "compute_bindings", lambda graph: bindings)
+
+
+class TestPopulateDependencyInfo:
+    def test_builds_dependency_info_on_the_snapshot(self, monkeypatch):
+        _stub_resolution(monkeypatch)
+        snap = AbiSnapshot(library="liba.so.1", version="1.0")
+        populate_dependency_info(snap, Path("/usr/lib/liba.so.1"), [], None, "")
+
+        info = snap.dependency_info
+        assert info is not None
+        # Nodes are sorted by (depth, soname) so the record is stable across runs.
+        assert [n["soname"] for n in info.nodes] == ["liba.so.1", "libb.so.1"]
+        assert info.nodes[0]["depth"] == 0
+        assert info.edges == [{"consumer": "liba.so.1", "provider": "libb.so.1"}]
+        assert info.unresolved == [
+            {"consumer": "liba.so.1", "soname": "libmissing.so.2"}
+        ]
+
+    def test_missing_symbols_and_binding_summary(self, monkeypatch):
+        _stub_resolution(monkeypatch)
+        snap = AbiSnapshot(library="liba.so.1", version="1.0")
+        populate_dependency_info(snap, Path("/usr/lib/liba.so.1"), [], None, "")
+
+        info = snap.dependency_info
+        assert info.missing_symbols == [
+            {"consumer": "liba.so.1", "symbol": "gone", "version": "V1"}
+        ]
+        assert sum(info.bindings_summary.values()) == 2
+
+    def test_no_missing_symbols_yields_an_empty_list(self, monkeypatch):
+        _stub_resolution(monkeypatch, missing_symbol=False)
+        snap = AbiSnapshot(library="liba.so.1", version="1.0")
+        populate_dependency_info(snap, Path("/usr/lib/liba.so.1"), [], None, "")
+        assert snap.dependency_info.missing_symbols == []
+
+    def test_search_paths_and_ld_library_path_reach_the_resolver(self, monkeypatch):
+        from abicheck import binder, resolver
+
+        captured: dict[str, object] = {}
+
+        def _spy(so_path, *, search_paths=None, sysroot=None, ld_library_path=""):
+            captured.update(
+                {
+                    "search_paths": search_paths,
+                    "sysroot": sysroot,
+                    "ld_library_path": ld_library_path,
+                }
+            )
+            return _FakeGraph()
+
+        monkeypatch.setattr(resolver, "resolve_dependencies", _spy)
+        monkeypatch.setattr(binder, "compute_bindings", lambda graph: [])
+        populate_dependency_info(
+            AbiSnapshot(library="l", version="1"),
+            Path("/usr/lib/liba.so.1"),
+            [Path("/opt/lib")],
+            None,
+            "/usr/local/lib",
+        )
+        assert captured["search_paths"] == [Path("/opt/lib")]
+        assert captured["ld_library_path"] == "/usr/local/lib"
+
+    def test_empty_search_paths_pass_none_not_an_empty_list(self, monkeypatch):
+        # resolve_dependencies treats None as "use the default search order";
+        # an empty list would be a different, wrong instruction.
+        from abicheck import binder, resolver
+
+        captured: dict[str, object] = {}
+
+        def _spy(so_path, *, search_paths=None, **kwargs):
+            captured["search_paths"] = search_paths
+            return _FakeGraph()
+
+        monkeypatch.setattr(resolver, "resolve_dependencies", _spy)
+        monkeypatch.setattr(binder, "compute_bindings", lambda graph: [])
+        populate_dependency_info(
+            AbiSnapshot(library="l", version="1"), Path("/l.so"), [], None, ""
+        )
+        assert captured["search_paths"] is None
+
+
+class TestDependencySource:
+    """Which file the dependency graph is actually read from (Codex review)."""
+
+    def test_plain_elf_uses_its_own_path(self):
+        spec = InputSpec(path=Path("/usr/lib/liba.so.1"))
+        assert _dependency_source(spec, "elf") == Path("/usr/lib/liba.so.1")
+
+    def test_linker_script_resolves_to_its_elf_target(self, tmp_path):
+        target = tmp_path / "libfoo.so.1"
+        target.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        script = tmp_path / "libfoo.so"
+        script.write_text(f"/* GNU ld script */\nINPUT({target})\n", encoding="utf-8")
+
+        # This is the case the format check alone got wrong: a text linker
+        # script detects as no known format, so `fmt` is None even though
+        # resolve_input followed it and produced an ELF snapshot.
+        from abicheck.binary_utils import detect_binary_format
+
+        assert detect_binary_format(script) is None
+        assert _dependency_source(InputSpec(path=script), None) == target
+
+    def test_linker_script_is_not_followed_when_the_side_opted_out(self, tmp_path):
+        # The MCP server pins follow_linker_scripts=False to keep its size
+        # guard authoritative; that must hold here too, not just in resolving.
+        target = tmp_path / "libfoo.so.1"
+        target.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        script = tmp_path / "libfoo.so"
+        script.write_text(f"INPUT({target})\n", encoding="utf-8")
+        spec = InputSpec(path=script, follow_linker_scripts=False)
+        assert _dependency_source(spec, None) is None
+
+    def test_plain_non_elf_input_is_skipped(self, tmp_path):
+        snapshot = tmp_path / "old.json"
+        snapshot.write_text('{"library": "l"}', encoding="utf-8")
+        assert _dependency_source(InputSpec(path=snapshot), None) is None
+
+    def test_script_pointing_at_a_non_elf_target_is_skipped(self, tmp_path):
+        target = tmp_path / "notelf.so.1"
+        target.write_text("not a binary\n", encoding="utf-8")
+        script = tmp_path / "libfoo.so"
+        script.write_text(f"INPUT({target})\n", encoding="utf-8")
+        assert _dependency_source(InputSpec(path=script), None) is None
+
+
+class TestPopulatePairDependencyInfo:
+    def _request(self, old_path, new_path, **kwargs):
+        return CompareRequest(
+            old=InputSpec(path=old_path), new=InputSpec(path=new_path), **kwargs
+        )
+
+    def test_opt_out_is_a_no_op(self, monkeypatch):
+        calls: list = []
+        monkeypatch.setattr(
+            "abicheck.dependency_info.populate_dependency_info",
+            lambda *a: calls.append(a),
+        )
+        populate_pair_dependency_info(
+            self._request(Path("/a.so"), Path("/b.so")),
+            AbiSnapshot(library="a", version="1"),
+            AbiSnapshot(library="b", version="2"),
+            old_fmt="elf",
+            new_fmt="elf",
+        )
+        assert calls == []
+
+    def test_a_linker_script_side_is_no_longer_skipped(self, tmp_path, monkeypatch):
+        target = tmp_path / "libfoo.so.1"
+        target.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        script = tmp_path / "libfoo.so"
+        script.write_text(f"INPUT({target})\n", encoding="utf-8")
+        elf = tmp_path / "new.so"
+        elf.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+        seen: list[Path] = []
+        monkeypatch.setattr(
+            "abicheck.dependency_info.populate_dependency_info",
+            lambda snap, path, *a: seen.append(path),
+        )
+        populate_pair_dependency_info(
+            self._request(script, elf, follow_dependencies=True),
+            AbiSnapshot(library="a", version="1"),
+            AbiSnapshot(library="b", version="2"),
+            old_fmt=None,  # what detect_binary_format answers for the script
+            new_fmt="elf",
+        )
+        assert seen == [target, elf]
+
+
+@pytest.mark.parametrize("fmt", ["pe", "macho", None])
+def test_non_elf_formats_never_resolve_dependencies(fmt, tmp_path):
+    # resolve_dependencies reads ELF DT_NEEDED entries — there is nothing for
+    # it to do on a PE or Mach-O side.
+    other = tmp_path / "lib.bin"
+    other.write_bytes(b"MZ" + b"\x00" * 100)
+    assert _dependency_source(InputSpec(path=other), fmt) is None

--- a/tests/test_mcp_server_coverage.py
+++ b/tests/test_mcp_server_coverage.py
@@ -516,6 +516,14 @@ class TestAbiDumpTool:
 # ---------------------------------------------------------------------------
 
 class TestAbiCompareTool:
+    """These patch ``abicheck.service.resolve_input``/``compare_snapshots``,
+    not the ``abicheck.mcp_server`` names the sibling ``abi_dump`` tests still
+    patch. ADR-055 D4 routed ``abi_compare`` through the Tier-2 chokepoint
+    (``run_compare_request``), so the service-layer names are the ones this
+    tool now actually reaches; patching the MCP module's own would stub a
+    function ``abi_compare`` no longer calls.
+    """
+
     def _make_inputs(self, tmp_path):
         """Create two fake JSON snapshot files."""
         old = tmp_path / "old.json"
@@ -539,7 +547,7 @@ class TestAbiCompareTool:
         old, new = self._make_inputs(tmp_path)
         fake_snap = _empty_snapshot()
         monkeypatch.setattr(
-            "abicheck.mcp_server._resolve_input",
+            "abicheck.service.resolve_input",
             lambda *a, **kw: fake_snap,
         )
         # Mock ShowOnlyFilter.parse to raise
@@ -563,7 +571,7 @@ class TestAbiCompareTool:
 
         fake_snap = _empty_snapshot()
         monkeypatch.setattr(
-            "abicheck.mcp_server._resolve_input",
+            "abicheck.service.resolve_input",
             lambda *a, **kw: fake_snap,
         )
         mock_supp = MagicMock()
@@ -573,7 +581,7 @@ class TestAbiCompareTool:
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare_snapshots",
+            "abicheck.service.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(
@@ -595,7 +603,7 @@ class TestAbiCompareTool:
 
         fake_snap = _empty_snapshot()
         monkeypatch.setattr(
-            "abicheck.mcp_server._resolve_input",
+            "abicheck.service.resolve_input",
             lambda *a, **kw: fake_snap,
         )
         mock_pf = MagicMock()
@@ -605,7 +613,7 @@ class TestAbiCompareTool:
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare_snapshots",
+            "abicheck.service.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(
@@ -624,12 +632,12 @@ class TestAbiCompareTool:
         old, new = self._make_inputs(tmp_path)
         fake_snap = _empty_snapshot()
         monkeypatch.setattr(
-            "abicheck.mcp_server._resolve_input",
+            "abicheck.service.resolve_input",
             lambda *a, **kw: fake_snap,
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare_snapshots",
+            "abicheck.service.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(
@@ -647,12 +655,12 @@ class TestAbiCompareTool:
         old, new = self._make_inputs(tmp_path)
         fake_snap = _empty_snapshot()
         monkeypatch.setattr(
-            "abicheck.mcp_server._resolve_input",
+            "abicheck.service.resolve_input",
             lambda *a, **kw: fake_snap,
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare_snapshots",
+            "abicheck.service.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(
@@ -671,12 +679,12 @@ class TestAbiCompareTool:
         old, new = self._make_inputs(tmp_path)
         fake_snap = _empty_snapshot()
         monkeypatch.setattr(
-            "abicheck.mcp_server._resolve_input",
+            "abicheck.service.resolve_input",
             lambda *a, **kw: fake_snap,
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare_snapshots",
+            "abicheck.service.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(
@@ -695,12 +703,12 @@ class TestAbiCompareTool:
         old, new = self._make_inputs(tmp_path)
         fake_snap = _empty_snapshot()
         monkeypatch.setattr(
-            "abicheck.mcp_server._resolve_input",
+            "abicheck.service.resolve_input",
             lambda *a, **kw: fake_snap,
         )
         fake_result = _minimal_diff()
         monkeypatch.setattr(
-            "abicheck.mcp_server.compare_snapshots",
+            "abicheck.service.compare_snapshots",
             lambda old, new, **kw: fake_result,
         )
         monkeypatch.setattr(
@@ -719,7 +727,7 @@ class TestAbiCompareTool:
         old, new = self._make_inputs(tmp_path)
         fake_snap = _empty_snapshot()
         monkeypatch.setattr(
-            "abicheck.mcp_server._resolve_input",
+            "abicheck.service.resolve_input",
             lambda *a, **kw: fake_snap,
         )
         result_str = abi_compare(

--- a/tests/test_mcp_server_coverage_gaps.py
+++ b/tests/test_mcp_server_coverage_gaps.py
@@ -339,7 +339,10 @@ class TestToolTimeouts:
             time.sleep(1.0)
             return AbiSnapshot(library="x", version="1.0")
 
-        monkeypatch.setattr(ms, "_resolve_input", _slow)
+        # The slow work now lives behind the Tier-2 chokepoint (ADR-055 D4),
+        # so stubbing the MCP-local wrapper would no longer stall anything --
+        # the timeout would still be exercised, but against a fast call.
+        monkeypatch.setattr(service, "resolve_input", _slow)
         data = json.loads(abi_compare(str(old), str(new)))
         assert data["status"] == "error"
         assert "abi_compare timed out" in data["error"]
@@ -377,7 +380,9 @@ class TestToolTimeouts:
             time.sleep(2.0)
             return AbiSnapshot(library="x", version="1.0")
 
-        monkeypatch.setattr(ms, "_resolve_input", _slow)
+        # Stubbed at the service layer for the same reason as
+        # test_abi_compare_timeout above (ADR-055 D4).
+        monkeypatch.setattr(service, "resolve_input", _slow)
         started = time.monotonic()
         data = json.loads(abi_compare(str(old), str(new)))
         elapsed = time.monotonic() - started

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -883,8 +883,33 @@ class TestAbiDump:
 
 
 # ===================================================================
-# 11. abi_compare (with mocked _resolve_input)
+# 11. abi_compare (with mocked service.resolve_input)
 # ===================================================================
+
+
+def _stub_service_resolve(monkeypatch, old_snap: AbiSnapshot, new_snap: AbiSnapshot):
+    """Stub the resolver ``abi_compare`` reaches through the Tier-2 chokepoint.
+
+    ADR-055 D4 moved input resolution out of ``mcp_server._resolve_input`` and
+    into ``service.run_compare_request``, so a test feeding synthetic snapshots
+    for fake-ELF paths patches ``service.resolve_input`` — the function that
+    now actually runs — instead of the MCP-local wrapper that no longer does.
+
+    Dispatch is on ``version`` (``"old"``/``"new"``, exactly what
+    ``run_compare_request`` passes through from each ``InputSpec``), not on
+    call order: that function resolves both sides concurrently in a
+    ``ThreadPoolExecutor``, so an order-dependent ``side_effect=[old, new]``
+    list would hand the *old* snapshot to whichever side's thread happened to
+    start first.
+    """
+    import abicheck.service as service_mod
+
+    def _fake(
+        path, headers=None, includes=None, version="", lang="c++", **kwargs
+    ) -> AbiSnapshot:
+        return old_snap if version == "old" else new_snap
+
+    monkeypatch.setattr(service_mod, "resolve_input", _fake)
 
 
 class TestAbiCompare:
@@ -1173,7 +1198,6 @@ class TestAbiCompare:
         # code 0 (info-only preset). Picking the reported scoped verdict by
         # exit code (both apps tie at 0) let a later, merely-COMPATIBLE app
         # overwrite the first BREAKING app's verdict (Codex review).
-        from abicheck import mcp_server
         from abicheck.appcompat import AppCompatResult
 
         old = _make_snapshot("1.0", functions=[_pub_func("f", "_Zf")])
@@ -1184,9 +1208,7 @@ class TestAbiCompare:
         app2 = tmp_path / "app2"
         app2.write_bytes(b"\x7fELF" + b"\x00" * 100)
 
-        monkeypatch.setattr(
-            mcp_server, "_resolve_input", MagicMock(side_effect=[old, new]),
-        )
+        _stub_service_resolve(monkeypatch, old, new)
         breaking_scoped = AppCompatResult(
             app_path=str(app1), old_lib_path=str(old_p), new_lib_path=str(new_p),
             required_symbols={"_Zf"}, required_symbol_count=1,
@@ -1338,12 +1360,8 @@ class TestAbiCompare:
         """Stub snapshot resolution (fake ELF paths aren't real libraries) and
         appcompat.scope_diff_to_app so --used-by is exercised end to end
         without a real compiler/binary."""
-        from abicheck import mcp_server
 
-        monkeypatch.setattr(
-            mcp_server, "_resolve_input",
-            MagicMock(side_effect=[old_snap, new_snap]),
-        )
+        _stub_service_resolve(monkeypatch, old_snap, new_snap)
         import abicheck.appcompat as appcompat_mod
 
         monkeypatch.setattr(appcompat_mod, "scope_diff_to_app", lambda *a, **k: scoped)
@@ -1555,12 +1573,8 @@ class TestAbiCompare:
                 breaking_for_app=[scoped_only], verdict=Verdict.BREAKING,
             )
 
-        from abicheck import mcp_server
 
-        monkeypatch.setattr(
-            mcp_server, "_resolve_input",
-            MagicMock(side_effect=[old, new]),
-        )
+        _stub_service_resolve(monkeypatch, old, new)
         import abicheck.appcompat as appcompat_mod
 
         monkeypatch.setattr(appcompat_mod, "scope_diff_to_app", _scoped_for)
@@ -1882,12 +1896,8 @@ class TestAbiCompare:
                 breaking_for_app=[change], verdict=Verdict.BREAKING,
             )
 
-        from abicheck import mcp_server
 
-        monkeypatch.setattr(
-            mcp_server, "_resolve_input",
-            MagicMock(side_effect=[old, new]),
-        )
+        _stub_service_resolve(monkeypatch, old, new)
         import abicheck.appcompat as appcompat_mod
 
         monkeypatch.setattr(appcompat_mod, "scope_diff_to_app", _scoped_for)
@@ -1933,12 +1943,8 @@ class TestAbiCompare:
                 breaking_for_app=[scoped_only], verdict=Verdict.BREAKING,
             )
 
-        from abicheck import mcp_server
 
-        monkeypatch.setattr(
-            mcp_server, "_resolve_input",
-            MagicMock(side_effect=[old, new]),
-        )
+        _stub_service_resolve(monkeypatch, old, new)
         import abicheck.appcompat as appcompat_mod
 
         monkeypatch.setattr(appcompat_mod, "scope_diff_to_app", _scoped_for)
@@ -1983,12 +1989,8 @@ class TestAbiCompare:
                 breaking_for_app=[scoped_only], verdict=Verdict.BREAKING,
             )
 
-        from abicheck import mcp_server
 
-        monkeypatch.setattr(
-            mcp_server, "_resolve_input",
-            MagicMock(side_effect=[old, new]),
-        )
+        _stub_service_resolve(monkeypatch, old, new)
         import abicheck.appcompat as appcompat_mod
 
         monkeypatch.setattr(appcompat_mod, "scope_diff_to_app", _scoped_for)
@@ -2034,12 +2036,8 @@ class TestAbiCompare:
                 breaking_for_app=[scoped_only], verdict=Verdict.BREAKING,
             )
 
-        from abicheck import mcp_server
 
-        monkeypatch.setattr(
-            mcp_server, "_resolve_input",
-            MagicMock(side_effect=[old, new]),
-        )
+        _stub_service_resolve(monkeypatch, old, new)
         import abicheck.appcompat as appcompat_mod
 
         monkeypatch.setattr(appcompat_mod, "scope_diff_to_app", _scoped_for)
@@ -2068,15 +2066,11 @@ class TestAbiCompare:
         assert "real library binaries" in data["error"]
 
     def test_used_by_app_not_found(self, tmp_path: Path, monkeypatch):
-        from abicheck import mcp_server
 
         old = _make_snapshot("1.0")
         new = _make_snapshot("2.0")
         old_p, new_p = self._make_binary_pair(tmp_path)
-        monkeypatch.setattr(
-            mcp_server, "_resolve_input",
-            MagicMock(side_effect=[old, new]),
-        )
+        _stub_service_resolve(monkeypatch, old, new)
         raw = abi_compare(
             str(old_p), str(new_p), used_by=[str(tmp_path / "no_such_app")],
         )
@@ -2239,17 +2233,21 @@ class TestAbiCompare:
         assert data["status"] == "ok"
 
     def test_old_headers_overrides_shared(self, tmp_path: Path, monkeypatch):
-        """When old_headers=[] is given, it overrides shared headers."""
-        from abicheck import mcp_server
+        """When old_headers=[] is given, it overrides shared headers.
+
+        Spies on ``service.resolve_input`` for the same reason as
+        ``test_headers_are_passed_as_public_headers`` above (ADR-055 D4).
+        """
+        import abicheck.service as service_mod
 
         captured: list[tuple[str, list]] = []
-        original_resolve = mcp_server._resolve_input
+        original_resolve = service_mod.resolve_input
 
-        def _spy(path, headers, includes, version, lang, **kwargs):
-            captured.append((str(path), list(headers)))
+        def _spy(path, headers=None, includes=None, version="", lang="c++", **kwargs):
+            captured.append((str(path), list(headers or [])))
             return original_resolve(path, headers, includes, version, lang, **kwargs)
 
-        monkeypatch.setattr(mcp_server, "_resolve_input", _spy)
+        monkeypatch.setattr(service_mod, "resolve_input", _spy)
 
         shared_hdr = tmp_path / "shared.h"
         shared_hdr.write_text("// shared\n", encoding="utf-8")
@@ -2273,17 +2271,23 @@ class TestAbiCompare:
     def test_headers_are_passed_as_public_headers(self, tmp_path: Path, monkeypatch):
         """abi_compare's ``old_headers``/``new_headers`` are documented as
         header files just like the CLI's ``compare --header`` — both sides
-        must be threaded through as the public-header set for provenance."""
-        from abicheck import mcp_server
+        must be threaded through as the public-header set for provenance.
+
+        Spies on ``service.resolve_input`` rather than the MCP-local wrapper:
+        after ADR-055 D4 the provenance threading is ``run_compare_request``'s
+        own ``split_public_header_inputs`` step, so watching the wrapper would
+        assert nothing about what actually happens.
+        """
+        import abicheck.service as service_mod
 
         captured: list[tuple[str, object]] = []
-        original_resolve = mcp_server._resolve_input
+        original_resolve = service_mod.resolve_input
 
-        def _spy(path, headers, includes, version, lang, **kwargs):
+        def _spy(path, headers=None, includes=None, version="", lang="c++", **kwargs):
             captured.append((version, kwargs.get("public_headers")))
             return original_resolve(path, headers, includes, version, lang, **kwargs)
 
-        monkeypatch.setattr(mcp_server, "_resolve_input", _spy)
+        monkeypatch.setattr(service_mod, "resolve_input", _spy)
 
         snap = _make_snapshot("1.0")
         old_p, new_p = self._make_pair(tmp_path, snap, snap)
@@ -2708,3 +2712,204 @@ class TestAbiScanPublicHeaderDir:
         data = json.loads(raw)
         assert data["status"] == "ok"
         assert captured["public_header_dirs"] == [pub.resolve()]
+
+
+# ===================================================================
+# abi_compare ↔ CLI `compare` parity (ADR-055 D4)
+# ===================================================================
+
+
+class TestAbiCompareCliParity:
+    """``abi_compare`` and the CLI ``compare`` command must agree.
+
+    ADR-055 D4's regression guard. Before that decision, ``abi_compare``
+    resolved its own inputs, loaded its own policy/suppression, and only
+    borrowed ``compare_snapshots`` for the middle diffing step — a second
+    compare engine that could drift from the CLI's without anything failing.
+    Now both build one ``CompareRequest`` and go through
+    ``run_compare_request``, so this asserts the observable consequence:
+    identical findings, verdict, and exit code for equivalent flags.
+
+    Two keys are excluded rather than asserted equal: ``old_evidence_depth``/
+    ``new_evidence_depth``. Those are added by the CLI's own report-rendering
+    call, not by the comparison — this MCP tool has never emitted them, and
+    D4 explicitly keeps rendering/presentation as front-end glue rather than
+    folding it into the shared request/result. ``used_by``/
+    ``required_symbols`` scoping is likewise out of this test's scope for the
+    same reason (D4 keeps it MCP-local glue applied *after* a result exists);
+    the sibling ``TestAbiCompare`` scoping tests cover it.
+    """
+
+    #: Keys the CLI's renderer adds that the MCP tool has never emitted.
+    _RENDER_ONLY_KEYS = ("old_evidence_depth", "new_evidence_depth")
+
+    def _pair(self, tmp_path: Path):
+        """One removed symbol, one signature change, one addition."""
+        old = _make_snapshot(
+            "1.0",
+            functions=[_pub_func("a", "_Z1av"), _pub_func("b", "_Z1bv")],
+        )
+        new_a = _pub_func("a", "_Z1av")
+        new_a.return_type = "long"
+        new = _make_snapshot("2.0", functions=[new_a, _pub_func("c", "_Z1cv")])
+        old_p = tmp_path / "old.json"
+        new_p = tmp_path / "new.json"
+        _write_snapshot(old_p, old)
+        _write_snapshot(new_p, new)
+        return old_p, new_p
+
+    def _cli_report(self, argv: list[str]) -> tuple[dict, int]:
+        from click.testing import CliRunner
+
+        # Import `cli` (not a sibling helper) first: `cli_compare_helpers`
+        # imports `cli` at module scope while `cli`'s own tail re-imports it,
+        # so entering that cluster through the helper raises a partially-
+        # initialized ImportError. Pre-existing, unrelated to this test.
+        from abicheck.cli import main
+
+        result = CliRunner().invoke(main, argv)
+        assert result.exception is None or isinstance(
+            result.exception, SystemExit
+        ), result.output
+        report = json.loads(result.output)
+        for key in self._RENDER_ONLY_KEYS:
+            report.pop(key, None)
+        return report, result.exit_code
+
+    @pytest.mark.parametrize(
+        ("mcp_kwargs", "cli_flags"),
+        [
+            pytest.param({}, [], id="defaults"),
+            pytest.param(
+                {"policy": "sdk_vendor"},
+                ["--policy", "sdk_vendor"],
+                id="policy-profile",
+            ),
+            pytest.param(
+                {"show_only": "removed"}, ["--show-only", "removed"], id="show-only"
+            ),
+            pytest.param(
+                {"severity_abi_breaking": "error", "severity_addition": "warning"},
+                [
+                    "--severity-abi-breaking",
+                    "error",
+                    "--severity-addition",
+                    "warning",
+                ],
+                id="severity-aware",
+            ),
+            pytest.param(
+                {"report_mode": "leaf"}, ["--report-mode", "leaf"], id="report-mode"
+            ),
+        ],
+    )
+    def test_report_matches_cli(self, tmp_path: Path, mcp_kwargs, cli_flags):
+        old_p, new_p = self._pair(tmp_path)
+
+        cli_report, cli_exit = self._cli_report(
+            ["compare", str(old_p), str(new_p), "--format", "json", *cli_flags]
+        )
+        data = json.loads(
+            abi_compare(str(old_p), str(new_p), output_format="json", **mcp_kwargs)
+        )
+
+        assert data["status"] == "ok"
+        assert data["report"] == cli_report
+        assert data["exit_code"] == cli_exit
+
+    def test_suppression_file_matches_cli(self, tmp_path: Path):
+        old_p, new_p = self._pair(tmp_path)
+        supp = tmp_path / "suppress.yaml"
+        supp.write_text(
+            "version: 1\nsuppressions:\n  - symbol: _Z1bv\n    reason: parity\n",
+            encoding="utf-8",
+        )
+
+        cli_report, cli_exit = self._cli_report(
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--format",
+                "json",
+                "--suppress",
+                str(supp),
+            ]
+        )
+        data = json.loads(
+            abi_compare(
+                str(old_p),
+                str(new_p),
+                output_format="json",
+                suppression_file=str(supp),
+            )
+        )
+
+        assert data["status"] == "ok"
+        # The suppression actually took effect on both sides -- otherwise this
+        # would pass trivially by both ignoring the file identically.
+        assert cli_report["suppression"]["suppressed_count"] == 1
+        assert data["report"] == cli_report
+        assert data["exit_code"] == cli_exit
+
+    def test_policy_file_matches_cli(self, tmp_path: Path):
+        old_p, new_p = self._pair(tmp_path)
+        pol = tmp_path / "policy.yaml"
+        pol.write_text(
+            "base: strict_abi\noverrides:\n  func_removed: ignore\n", encoding="utf-8"
+        )
+
+        cli_report, cli_exit = self._cli_report(
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--format",
+                "json",
+                "--policy-file",
+                str(pol),
+            ]
+        )
+        data = json.loads(
+            abi_compare(
+                str(old_p), str(new_p), output_format="json", policy_file=str(pol)
+            )
+        )
+
+        assert data["status"] == "ok"
+        assert data["report"] == cli_report
+        assert data["exit_code"] == cli_exit
+
+    def test_unsupported_language_is_a_validation_error(self, tmp_path: Path):
+        """The typed request validates language the way the CLI's own
+        ``--lang`` choice does, instead of passing an unknown value down."""
+        old_p, new_p = self._pair(tmp_path)
+        data = json.loads(abi_compare(str(old_p), str(new_p), language="rust"))
+        assert data["status"] == "error"
+        assert "unsupported language" in data["error"]
+
+    def test_no_second_compare_engine_left_in_abi_compare(self):
+        """ADR-055 D4's acceptance test, executable.
+
+        The gate is stated as source-level absence because that is exactly
+        what regressed before: re-adding a local resolve or policy load would
+        still produce correct output today while silently recreating the
+        duplication -- no behavioural assertion can catch that.
+        """
+        import inspect
+
+        from abicheck import mcp_server
+
+        source = inspect.getsource(mcp_server.abi_compare)
+        # Strip comments: this function *documents* what it no longer calls,
+        # and a comment naming a removed call is the point, not a violation.
+        body = "\n".join(
+            line for line in source.splitlines() if not line.lstrip().startswith("#")
+        )
+        assert "_resolve_input(" not in body
+        assert "PolicyFile.load" not in body
+        assert "SuppressionList.load" not in body
+        assert "compare_snapshots(" not in body
+        assert "run_compare_request_v2(" in body
+        # ...and the module no longer imports the snapshot-diffing verb at all.
+        assert not hasattr(mcp_server, "compare_snapshots")

--- a/tests/test_mcp_server_unit.py
+++ b/tests/test_mcp_server_unit.py
@@ -2910,6 +2910,6 @@ class TestAbiCompareCliParity:
         assert "PolicyFile.load" not in body
         assert "SuppressionList.load" not in body
         assert "compare_snapshots(" not in body
-        assert "run_compare_request_v2(" in body
+        assert "run_compare_request(" in body
         # ...and the module no longer imports the snapshot-diffing verb at all.
         assert not hasattr(mcp_server, "compare_snapshots")

--- a/tests/test_python_api_reference.py
+++ b/tests/test_python_api_reference.py
@@ -60,7 +60,7 @@ def test_run_compare_return_annotation_appears_in_generated_reference():
     gen = _load_gen()
     content = gen.OUT_PATH.read_text(encoding="utf-8")
     section = content.split("## `run_compare`", 1)[1].split("## `run_compare_request`", 1)[0]
-    assert "**Returns:** `tuple[DiffResult, AbiSnapshot, AbiSnapshot]`" in section
+    assert "**Returns:** `CompareResult`" in section
 
 
 def test_keyword_only_parameters_are_marked_in_generated_reference():

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -4647,3 +4647,130 @@ class TestRunCompareRequestV2:
         assert captured["old"] is False
         # Unset stays the historical default rather than inheriting the other side.
         assert captured["new"] is True
+
+
+class TestRunCompareRequestResolutionParity:
+    """ADR-055 D1, second slice: the last concepts the CLI's own resolution
+    (``cli_resolve._resolve_compare_snapshots``) could express and the typed
+    request could not — ``--dwarf-only``, ``--debug-format``, ADR-050 D1's
+    include labels, and ``--follow-deps``."""
+
+    def _elf_pair(self, tmp_path):
+        old_p = tmp_path / "old.so"
+        new_p = tmp_path / "new.so"
+        for p in (old_p, new_p):
+            p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        return old_p, new_p
+
+    def _stub_dump(self, monkeypatch):
+        """Record resolve_input's debug kwargs per side, without a real parse."""
+        import abicheck.service as service_mod
+
+        seen: dict[str, dict] = {}
+
+        def _fake(path, headers=None, *args, **kwargs):
+            seen[Path(path).name] = {
+                k: kwargs.get(k)
+                for k in ("dwarf_only", "debug_format", "include_labels")
+            }
+            return AbiSnapshot(library=Path(path).name, version="x")
+
+        monkeypatch.setattr(service_mod, "run_dump", _fake)
+        return seen
+
+    def _request(self, tmp_path, **kwargs):
+        old_p, new_p = self._elf_pair(tmp_path)
+        return CompareRequest(
+            old=InputSpec(path=old_p, version="old"),
+            new=InputSpec(path=new_p, version="new"),
+            **kwargs,
+        )
+
+    def test_debug_parse_fields_reach_both_sides(self, tmp_path, monkeypatch):
+        seen = self._stub_dump(monkeypatch)
+        run_compare_request_v2(
+            self._request(tmp_path, dwarf_only=True, debug_format="dwarf")
+        )
+        assert set(seen) == {"old.so", "new.so"}
+        for side in seen.values():
+            assert side["dwarf_only"] is True
+            assert side["debug_format"] == "dwarf"
+
+    def test_include_labels_are_converted_back_to_a_mapping(
+        self, tmp_path, monkeypatch
+    ):
+        # Carried as a tuple of pairs so the request stays hashable, but
+        # `resolve_input` takes the mapping — the conversion must happen.
+        seen = self._stub_dump(monkeypatch)
+        run_compare_request_v2(
+            self._request(tmp_path, include_labels=((Path("/inc"), "proj"),))
+        )
+        assert seen["old.so"]["include_labels"] == {Path("/inc"): "proj"}
+
+    def test_include_labels_default_passes_none_not_an_empty_mapping(
+        self, tmp_path, monkeypatch
+    ):
+        seen = self._stub_dump(monkeypatch)
+        run_compare_request_v2(self._request(tmp_path))
+        assert seen["old.so"]["include_labels"] is None
+
+    def test_request_stays_hashable_with_include_labels_set(self, tmp_path):
+        # The property InputSpec's own docstring claims for the whole request.
+        request = self._request(tmp_path, include_labels=((Path("/inc"), "proj"),))
+        assert hash(request) == hash(request.replace())
+
+    def _stub_dependency_population(self, monkeypatch):
+        import abicheck.dependency_info as dep_mod
+
+        calls: list[tuple] = []
+        monkeypatch.setattr(
+            dep_mod,
+            "populate_dependency_info",
+            lambda snap, so_path, search_paths, sysroot, ld_library_path: calls.append(
+                (Path(so_path).name, list(search_paths), ld_library_path)
+            ),
+        )
+        return calls
+
+    def test_follow_dependencies_populates_both_elf_sides(
+        self, tmp_path, monkeypatch
+    ):
+        self._stub_dump(monkeypatch)
+        calls = self._stub_dependency_population(monkeypatch)
+        run_compare_request_v2(
+            self._request(
+                tmp_path,
+                follow_dependencies=True,
+                dependency_search_paths=(Path("/opt/lib"),),
+                ld_library_path="/usr/lib",
+            )
+        )
+        assert [c[0] for c in calls] == ["old.so", "new.so"]
+        assert calls[0][1] == [Path("/opt/lib")]
+        assert calls[0][2] == "/usr/lib"
+
+    def test_follow_dependencies_is_opt_in(self, tmp_path, monkeypatch):
+        # It costs a full dependency-graph resolution per side, so an
+        # unrelated caller must not start paying for it silently.
+        self._stub_dump(monkeypatch)
+        calls = self._stub_dependency_population(monkeypatch)
+        run_compare_request_v2(self._request(tmp_path))
+        assert calls == []
+
+    def test_non_elf_sides_are_skipped(self, tmp_path, monkeypatch):
+        # resolve_dependencies reads ELF DT_NEEDED entries; a PE/Mach-O side
+        # has nothing for it to do.
+        self._stub_dump(monkeypatch)
+        calls = self._stub_dependency_population(monkeypatch)
+        old_p = tmp_path / "old.json"
+        new_p = tmp_path / "new.json"
+        save_snapshot(AbiSnapshot(library="lib", version="1.0"), old_p)
+        save_snapshot(AbiSnapshot(library="lib", version="2.0"), new_p)
+        run_compare_request_v2(
+            CompareRequest(
+                old=InputSpec(path=old_p),
+                new=InputSpec(path=new_p),
+                follow_dependencies=True,
+            )
+        )
+        assert calls == []

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -4655,14 +4655,14 @@ class TestRunCompareRequestResolutionParity:
     request could not — ``--dwarf-only``, ``--debug-format``, ADR-050 D1's
     include labels, and ``--follow-deps``."""
 
-    def _elf_pair(self, tmp_path):
+    def _elf_pair(self, tmp_path) -> tuple[Path, Path]:
         old_p = tmp_path / "old.so"
         new_p = tmp_path / "new.so"
         for p in (old_p, new_p):
             p.write_bytes(b"\x7fELF" + b"\x00" * 200)
         return old_p, new_p
 
-    def _stub_dump(self, monkeypatch):
+    def _stub_dump(self, monkeypatch) -> dict[str, dict[str, object]]:
         """Record resolve_input's debug kwargs per side, without a real parse."""
         import abicheck.service as service_mod
 
@@ -4678,7 +4678,7 @@ class TestRunCompareRequestResolutionParity:
         monkeypatch.setattr(service_mod, "run_dump", _fake)
         return seen
 
-    def _request(self, tmp_path, **kwargs):
+    def _request(self, tmp_path, **kwargs) -> CompareRequest:
         old_p, new_p = self._elf_pair(tmp_path)
         return CompareRequest(
             old=InputSpec(path=old_p, version="old"),
@@ -4719,7 +4719,9 @@ class TestRunCompareRequestResolutionParity:
         request = self._request(tmp_path, include_labels=((Path("/inc"), "proj"),))
         assert hash(request) == hash(request.replace())
 
-    def _stub_dependency_population(self, monkeypatch):
+    def _stub_dependency_population(
+        self, monkeypatch
+    ) -> list[tuple[str, list[Path], str]]:
         import abicheck.dependency_info as dep_mod
 
         calls: list[tuple] = []

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -4942,6 +4942,42 @@ class TestComparePipelinePhases:
         assert pair.old_evidence.collect_mode == pair.new_evidence.collect_mode == "off"
 
 
+    def test_layer_coverage_rows_reach_the_result(self, tmp_path, monkeypatch):
+        """The one branch in `classify_compare_pair` nothing else exercises.
+
+        ``prepare_embedded_build_source`` only returns layer-coverage rows when
+        the snapshots actually carry embedded L3-L5 evidence, so a plain
+        snapshot pair leaves this assignment unexecuted. Stubbing that helper
+        checks the wiring itself: rows it produces are attached to the
+        ``DiffResult``, and the metrics call still receives the extra changes.
+        """
+        from abicheck import cli_buildsource
+        from abicheck.service import classify_compare_pair, resolve_compare_request
+
+        rows = [{"layer": "L3", "covered": 1}]
+        attached: list[object] = []
+
+        def _fake_prepare(*_args, **_kwargs):
+            return [], rows, {"elapsed": 0.0}, []
+
+        def _fake_attach(result, metrics, extra, **_kwargs):
+            attached.append((result, metrics, extra))
+
+        monkeypatch.setattr(
+            cli_buildsource, "prepare_embedded_build_source", _fake_prepare
+        )
+        monkeypatch.setattr(cli_buildsource, "attach_evidence_metrics", _fake_attach)
+
+        old_p = self._snap_file(tmp_path, "libtest", "1.0")
+        new_p = self._snap_file(tmp_path, "libtest", "2.0")
+        request = CompareRequest(old=InputSpec.of(old_p), new=InputSpec.of(new_p))
+        result = classify_compare_pair(request, resolve_compare_request(request))
+
+        assert result.diff.layer_coverage == rows
+        assert len(attached) == 1
+        assert attached[0][0] is result.diff
+
+
 class TestResolveSidesSequentially:
     """ADR-050 D6 / G32 Phase E, generalised by ADR-055 D1.
 

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -25,7 +25,6 @@ from abicheck.service import (
     resolve_input,
     run_compare,
     run_compare_request,
-    run_compare_request_v2,
     run_dump,
     sniff_text_format,
 )
@@ -1705,7 +1704,7 @@ class TestRunCompare:
     def test_compare_two_snapshots(self, tmp_path):
         old_p = self._make_snap_file(tmp_path, "libtest", "1.0")
         new_p = self._make_snap_file(tmp_path, "libtest", "2.0")
-        result, old, new = run_compare(old_p, new_p)
+        result, old, new = run_compare(old_p, new_p).as_tuple()
         assert isinstance(result, DiffResult)
         assert isinstance(old, AbiSnapshot)
         assert isinstance(new, AbiSnapshot)
@@ -1717,7 +1716,7 @@ class TestRunCompare:
         sf.write_text(
             "version: 1\nsuppressions:\n  - symbol: foo\n    change_kind: func_removed\n"
         )
-        result, _, _ = run_compare(old_p, new_p, suppress=sf)
+        result, _, _ = run_compare(old_p, new_p, suppress=sf).as_tuple()
         assert isinstance(result, DiffResult)
 
     def test_headers_passed_as_public_headers(self, tmp_path, monkeypatch):
@@ -2026,7 +2025,7 @@ class TestCompareRequestAdr055Evidence:
         request = CompareRequest(
             old=InputSpec.of(old_p, sources=src_dir), new=InputSpec.of(new_p)
         )
-        result, _, _ = run_compare_request(request)
+        result, _, _ = run_compare_request(request).as_tuple()
         assert captured["extra_changes"] == [sentinel_change]
         assert sentinel_change in result.changes
 
@@ -2313,7 +2312,7 @@ class TestCompareRequestAdr055Evidence:
             frontend="android",
             has_sources=True,
         )
-        result, _, _ = run_compare_request(request)
+        result, _, _ = run_compare_request(request).as_tuple()
         assert isinstance(result, DiffResult)
 
     def test_android_frontend_allowed_with_build_info_only(self, tmp_path, monkeypatch):
@@ -2338,7 +2337,7 @@ class TestCompareRequestAdr055Evidence:
             new=InputSpec.of(new_p),
             frontend="android",
         )
-        result, _, _ = run_compare_request(request)
+        result, _, _ = run_compare_request(request).as_tuple()
         assert isinstance(result, DiffResult)
 
     def test_hybrid_frontend_allowed_without_explicit_source_depth(
@@ -2368,7 +2367,7 @@ class TestCompareRequestAdr055Evidence:
             ),
             new=InputSpec.of(new_p),
         )
-        result, _, _ = run_compare_request(request)
+        result, _, _ = run_compare_request(request).as_tuple()
         assert isinstance(result, DiffResult)
 
     def test_manifest_forced_includes_feed_pair_wide_cxx20_detection(
@@ -2473,7 +2472,7 @@ class TestCompareRequestAdr055Evidence:
         request = CompareRequest(
             old=InputSpec.of(old_p), new=InputSpec.of(new_p), depth="BUILD"
         )
-        result, _, _ = run_compare_request(request)
+        result, _, _ = run_compare_request(request).as_tuple()
         assert isinstance(result, DiffResult)
 
     def test_pair_wide_dialect_merges_into_unrelated_side_compile(
@@ -2693,7 +2692,7 @@ class TestCompareRequestDepthSatisfaction:
         request = CompareRequest(
             old=InputSpec.of(old_p), new=InputSpec.of(new_p), depth="source"
         )
-        result, _, _ = run_compare_request(request)
+        result, _, _ = run_compare_request(request).as_tuple()
         assert isinstance(result, DiffResult)
 
     def test_reports_the_failing_side(self, tmp_path, monkeypatch):
@@ -2726,7 +2725,7 @@ class TestCompareRequestDepthSatisfaction:
         request = CompareRequest(
             old=InputSpec.of(old_p), new=InputSpec.of(new_p), depth="binary"
         )
-        result, _, _ = run_compare_request(request)
+        result, _, _ = run_compare_request(request).as_tuple()
         assert isinstance(result, DiffResult)
 
     def test_no_depth_skips_the_gate(self, tmp_path, monkeypatch):
@@ -2738,7 +2737,7 @@ class TestCompareRequestDepthSatisfaction:
         )
 
         request = CompareRequest(old=InputSpec.of(old_p), new=InputSpec.of(new_p))
-        result, _, _ = run_compare_request(request)
+        result, _, _ = run_compare_request(request).as_tuple()
         assert isinstance(result, DiffResult)
 
 
@@ -2818,7 +2817,7 @@ class TestDiagnosticComparisonThreading:
             new=InputSpec(path=new_p),
             diagnostic_comparison=True,
         )
-        result, _, _ = run_compare_request(request)
+        result, _, _ = run_compare_request(request).as_tuple()
         assert result.assurance == "none"
 
     def test_run_compare_shim_raises_by_default(self, tmp_path):
@@ -2828,7 +2827,7 @@ class TestDiagnosticComparisonThreading:
 
     def test_run_compare_shim_diagnostic_comparison_downgrades(self, tmp_path):
         old_p, new_p = self._mismatched_pair(tmp_path)
-        result, _, _ = run_compare(old_p, new_p, diagnostic_comparison=True)
+        result, _, _ = run_compare(old_p, new_p, diagnostic_comparison=True).as_tuple()
         assert result.assurance == "none"
 
     def test_diagnostic_comparison_appended_last_preserves_positional_order(self):
@@ -2904,13 +2903,13 @@ class TestContractEvaluationThreading:
             new=InputSpec(path=new_p),
             contract_evaluation=True,
         )
-        result, _, _ = run_compare_request(request)
+        result, _, _ = run_compare_request(request).as_tuple()
         assert result.changes
         assert any(c.contract_relevance is not None for c in result.changes)
 
     def test_run_compare_shim_contract_evaluation_stamps_relevance(self, tmp_path):
         old_p, new_p = self._changed_pair(tmp_path)
-        result, _, _ = run_compare(old_p, new_p, contract_evaluation=True)
+        result, _, _ = run_compare(old_p, new_p, contract_evaluation=True).as_tuple()
         assert result.changes
         assert any(c.contract_relevance is not None for c in result.changes)
 
@@ -2967,7 +2966,7 @@ class TestParallelOldNewExtraction:
 
         monkeypatch.setattr(service_mod, "resolve_input", _synced_resolve)
 
-        result, old, new = run_compare(old_p, new_p)
+        result, old, new = run_compare(old_p, new_p).as_tuple()
         assert isinstance(result, DiffResult)
 
     def test_exception_from_one_side_propagates(self, tmp_path, monkeypatch):
@@ -4561,8 +4560,13 @@ class TestMetadataAttachFailuresAreSwallowed:
         assert snap.numpy_capi is None
 
 
-class TestRunCompareRequestV2:
-    """ADR-055 D2: the typed entry point, and that it did not fork behaviour."""
+class TestRunCompareRequestTypedResult:
+    """ADR-055 D2: the one typed entry point and what it returns.
+
+    ``run_compare_request`` returned a bare 3-tuple until 0.6, briefly
+    alongside a ``run_compare_request_v2`` seam; both collapsed into this one
+    typed function once the pre-1.0 API break was on the table.
+    """
 
     def _pair(self, tmp_path):
         old = AbiSnapshot(library="libtest", version="1.0")
@@ -4574,30 +4578,30 @@ class TestRunCompareRequestV2:
         return CompareRequest(old=InputSpec.of(old_p), new=InputSpec.of(new_p))
 
     def test_returns_a_compare_result(self, tmp_path):
-        result = run_compare_request_v2(self._pair(tmp_path))
+        result = run_compare_request(self._pair(tmp_path))
         assert isinstance(result, CompareResult)
         assert isinstance(result.diff, DiffResult)
         assert result.old_snapshot.version == "1.0"
         assert result.new_snapshot.version == "2.0"
 
-    def test_tuple_entry_point_returns_the_same_three_objects(self, tmp_path):
-        """The legacy shape is a *view* of this one, not a second run.
+    def test_as_tuple_reproduces_the_pre_0_6_shape(self, tmp_path):
+        """The documented one-line migration for a positional caller."""
+        result = run_compare_request(self._pair(tmp_path))
+        diff, old, new = result.as_tuple()
+        assert diff is result.diff
+        assert old is result.old_snapshot
+        assert new is result.new_snapshot
 
-        Asserted on field values rather than identity: the two calls resolve
-        their own snapshots, so identity would only prove they both ran.
-        """
+    def test_the_kwargs_shim_returns_the_same_type(self, tmp_path):
+        # run_compare is the documented one-call entry point; it must not be
+        # the one place still handing back a tuple.
         request = self._pair(tmp_path)
-        diff, old, new = run_compare_request(request)
-        typed = run_compare_request_v2(request)
-        assert (old.version, new.version) == (
-            typed.old_snapshot.version,
-            typed.new_snapshot.version,
+        assert isinstance(
+            run_compare(request.old.path, request.new.path), CompareResult
         )
-        assert diff.verdict == typed.diff.verdict
-        assert len(diff.changes) == len(typed.diff.changes)
 
     def test_suppression_is_none_when_the_request_names_no_file(self, tmp_path):
-        assert run_compare_request_v2(self._pair(tmp_path)).suppression is None
+        assert run_compare_request(self._pair(tmp_path)).suppression is None
 
     def test_carries_the_resolved_suppression_list(self, tmp_path):
         """What ADR-055 D4 needs: the resolved list, without a second load.
@@ -4613,7 +4617,7 @@ class TestRunCompareRequestV2:
             encoding="utf-8",
         )
         request = self._pair(tmp_path).replace(suppress=supp)
-        result = run_compare_request_v2(request)
+        result = run_compare_request(request)
         assert result.suppression is not None
         assert len(result.suppression.rule_identities()) == 1
 
@@ -4636,7 +4640,7 @@ class TestRunCompareRequestV2:
         import dataclasses
 
         base = self._pair(tmp_path)
-        run_compare_request_v2(
+        run_compare_request(
             base.replace(
                 old=dataclasses.replace(
                     base.old, version="old", follow_linker_scripts=False
@@ -4688,7 +4692,7 @@ class TestRunCompareRequestResolutionParity:
 
     def test_debug_parse_fields_reach_both_sides(self, tmp_path, monkeypatch):
         seen = self._stub_dump(monkeypatch)
-        run_compare_request_v2(
+        run_compare_request(
             self._request(tmp_path, dwarf_only=True, debug_format="dwarf")
         )
         assert set(seen) == {"old.so", "new.so"}
@@ -4702,7 +4706,7 @@ class TestRunCompareRequestResolutionParity:
         # Carried as a tuple of pairs so the request stays hashable, but
         # `resolve_input` takes the mapping — the conversion must happen.
         seen = self._stub_dump(monkeypatch)
-        run_compare_request_v2(
+        run_compare_request(
             self._request(tmp_path, include_labels=((Path("/inc"), "proj"),))
         )
         assert seen["old.so"]["include_labels"] == {Path("/inc"): "proj"}
@@ -4711,7 +4715,7 @@ class TestRunCompareRequestResolutionParity:
         self, tmp_path, monkeypatch
     ):
         seen = self._stub_dump(monkeypatch)
-        run_compare_request_v2(self._request(tmp_path))
+        run_compare_request(self._request(tmp_path))
         assert seen["old.so"]["include_labels"] is None
 
     def test_request_stays_hashable_with_include_labels_set(self, tmp_path):
@@ -4739,7 +4743,7 @@ class TestRunCompareRequestResolutionParity:
     ):
         self._stub_dump(monkeypatch)
         calls = self._stub_dependency_population(monkeypatch)
-        run_compare_request_v2(
+        run_compare_request(
             self._request(
                 tmp_path,
                 follow_dependencies=True,
@@ -4756,7 +4760,7 @@ class TestRunCompareRequestResolutionParity:
         # unrelated caller must not start paying for it silently.
         self._stub_dump(monkeypatch)
         calls = self._stub_dependency_population(monkeypatch)
-        run_compare_request_v2(self._request(tmp_path))
+        run_compare_request(self._request(tmp_path))
         assert calls == []
 
     def test_non_elf_sides_are_skipped(self, tmp_path, monkeypatch):
@@ -4768,7 +4772,7 @@ class TestRunCompareRequestResolutionParity:
         new_p = tmp_path / "new.json"
         save_snapshot(AbiSnapshot(library="lib", version="1.0"), old_p)
         save_snapshot(AbiSnapshot(library="lib", version="2.0"), new_p)
-        run_compare_request_v2(
+        run_compare_request(
             CompareRequest(
                 old=InputSpec(path=old_p),
                 new=InputSpec(path=new_p),
@@ -4776,3 +4780,92 @@ class TestRunCompareRequestResolutionParity:
             )
         )
         assert calls == []
+
+
+class TestDebugFormatResolution:
+    """ADR-055 D1 second slice, Codex review round 2: what `debug_format`
+    actually reaches (and doesn't reach) the extraction layer as."""
+
+    def _request(self, tmp_path, **kwargs) -> CompareRequest:
+        old_p = tmp_path / "old.so"
+        new_p = tmp_path / "new.so"
+        for p in (old_p, new_p):
+            p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        return CompareRequest(
+            old=InputSpec(path=old_p), new=InputSpec(path=new_p), **kwargs
+        )
+
+    def _spy(self, monkeypatch) -> dict[str, object]:
+        import abicheck.service as service_mod
+
+        seen: dict[str, object] = {}
+
+        def _fake(path, headers=None, *args, **kwargs):
+            seen["debug_format"] = kwargs.get("debug_format")
+            return AbiSnapshot(library=Path(path).name, version="x")
+
+        monkeypatch.setattr(service_mod, "run_dump", _fake)
+        return seen
+
+    def test_auto_becomes_none_not_the_literal_string(self, tmp_path, monkeypatch):
+        # `_resolve_debug_metadata` raises ValueError for anything outside
+        # dwarf/btf/ctf and treats None as auto-detect, so forwarding the
+        # accepted "auto" verbatim crashed during extraction. The CLI does the
+        # same translation (cli_compare_helpers/cli_dump_helpers).
+        seen = self._spy(monkeypatch)
+        run_compare_request(self._request(tmp_path, debug_format="auto"))
+        assert seen["debug_format"] is None
+
+    def test_auto_is_case_insensitive_too(self, tmp_path, monkeypatch):
+        seen = self._spy(monkeypatch)
+        run_compare_request(self._request(tmp_path, debug_format="AUTO"))
+        assert seen["debug_format"] is None
+
+    def test_an_explicit_format_is_lowercased_and_forwarded(
+        self, tmp_path, monkeypatch
+    ):
+        seen = self._spy(monkeypatch)
+        run_compare_request(self._request(tmp_path, debug_format="BTF"))
+        assert seen["debug_format"] == "btf"
+
+    def test_forced_elf_format_is_rejected_for_a_non_elf_side(self, tmp_path):
+        # The PE/Mach-O dump paths take no debug-format argument, so it would
+        # be silently dropped and the run would report success having ignored
+        # what was asked. The CLI rejects this up front; so does this now.
+        old_p = tmp_path / "old.so"
+        old_p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        pe = tmp_path / "new.dll"
+        pe.write_bytes(b"MZ" + b"\x00" * 200)
+        request = CompareRequest(
+            old=InputSpec(path=old_p), new=InputSpec(path=pe), debug_format="dwarf"
+        )
+        with pytest.raises(ValidationError, match="only supported for ELF"):
+            run_compare_request(request)
+
+    def test_auto_is_not_rejected_for_a_non_elf_side(self, tmp_path, monkeypatch):
+        # "auto" forces nothing, so there is nothing for a PE side to ignore.
+        self._spy(monkeypatch)
+        old_p = tmp_path / "old.so"
+        old_p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        pe = tmp_path / "new.dll"
+        pe.write_bytes(b"MZ" + b"\x00" * 200)
+        run_compare_request(
+            CompareRequest(
+                old=InputSpec(path=old_p), new=InputSpec(path=pe), debug_format="auto"
+            )
+        )
+
+    def test_snapshot_inputs_are_unaffected(self, tmp_path, monkeypatch):
+        # A JSON snapshot has no detected binary format; same as the CLI, that
+        # is not a rejection case.
+        old_p = tmp_path / "old.json"
+        new_p = tmp_path / "new.json"
+        save_snapshot(AbiSnapshot(library="l", version="1"), old_p)
+        save_snapshot(AbiSnapshot(library="l", version="2"), new_p)
+        run_compare_request(
+            CompareRequest(
+                old=InputSpec(path=old_p),
+                new=InputSpec(path=new_p),
+                debug_format="dwarf",
+            )
+        )

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -2379,7 +2379,7 @@ class TestCompareRequestAdr055Evidence:
         signal goes undetected, letting the pair disagree on dialect."""
         from types import SimpleNamespace
 
-        from abicheck import service as service_mod
+        from abicheck import service_scan
 
         old_p = self._make_snap_file(tmp_path, "libtest", "1.0")
         new_p = self._make_snap_file(tmp_path, "libtest", "2.0")
@@ -2393,7 +2393,13 @@ class TestCompareRequestAdr055Evidence:
             captured["old_headers"] = list(old_headers)
             return None
 
-        monkeypatch.setattr(service_mod, "pair_wide_cxx20_std_override", _fake_override)
+        # ADR-055 D1: the pair-wide scan runs in the shared
+        # `service_compare_pipeline`, which imports this helper from the module
+        # that defines it rather than through `service`'s re-export -- so the
+        # spy belongs on `service_scan`, where it lives.
+        monkeypatch.setattr(
+            service_scan, "pair_wide_cxx20_std_override", _fake_override
+        )
 
         request = CompareRequest(
             old=InputSpec.of(old_p, dump_manifest=manifest), new=InputSpec.of(new_p)
@@ -2482,14 +2488,17 @@ class TestCompareRequestAdr055Evidence:
         dialect (e.g. only a sysroot) must not silently discard the pair-wide
         C++20 heuristic's override for that side -- it should be merged in
         unless the side already pins its own explicit standard."""
-        from abicheck import service as service_mod
+        from abicheck import service_scan
         from abicheck.compile_context import CompileContext
 
         old_p = self._make_snap_file(tmp_path, "libtest", "1.0")
         new_p = self._make_snap_file(tmp_path, "libtest", "2.0")
 
+        # ADR-055 D1: spied on `service_scan` (where it is defined) rather than
+        # `service` (which only re-exports it) -- the shared compare pipeline
+        # imports it from the defining module.
         monkeypatch.setattr(
-            service_mod,
+            service_scan,
             "pair_wide_cxx20_std_override",
             lambda *a, **k: ("-std=gnu++20",),
         )
@@ -4868,3 +4877,151 @@ class TestDebugFormatResolution:
                 debug_format="dwarf",
             )
         )
+
+
+class TestComparePipelinePhases:
+    """ADR-055 D1: ``run_compare_request`` is the composition of the two
+    phases in ``service_compare_pipeline``, and those phases are what the
+    native ``compare`` CLI now shares instead of its own resolution copy."""
+
+    def _snap_file(self, tmp_path, name, version):
+        from abicheck.serialization import save_snapshot
+
+        path = tmp_path / f"{name}-{version}.json"
+        save_snapshot(
+            AbiSnapshot(
+                library=name,
+                version=version,
+                functions=[
+                    Function(
+                        name="foo",
+                        mangled="foo",
+                        return_type="int",
+                        visibility=Visibility.PUBLIC,
+                        is_extern_c=True,
+                    )
+                ],
+            ),
+            path,
+        )
+        return path
+
+    def test_run_compare_request_equals_resolve_then_classify(self, tmp_path):
+        from abicheck.service import (
+            classify_compare_pair,
+            resolve_compare_request,
+            run_compare_request,
+        )
+
+        old_p = self._snap_file(tmp_path, "libtest", "1.0")
+        new_p = self._snap_file(tmp_path, "libtest", "2.0")
+        request = CompareRequest(old=InputSpec.of(old_p), new=InputSpec.of(new_p))
+
+        composed = classify_compare_pair(request, resolve_compare_request(request))
+        one_call = run_compare_request(request)
+
+        assert [c.kind for c in composed.diff.changes] == [
+            c.kind for c in one_call.diff.changes
+        ]
+        assert composed.diff.verdict == one_call.diff.verdict
+        assert composed.old_snapshot.version == one_call.old_snapshot.version
+        assert composed.new_snapshot.version == one_call.new_snapshot.version
+
+    def test_resolve_phase_returns_both_sides_and_their_evidence(self, tmp_path):
+        from abicheck.service import resolve_compare_request
+
+        old_p = self._snap_file(tmp_path, "libtest", "1.0")
+        new_p = self._snap_file(tmp_path, "libtest", "2.0")
+        pair = resolve_compare_request(
+            CompareRequest(old=InputSpec.of(old_p), new=InputSpec.of(new_p))
+        )
+        assert pair.old.version == "1.0"
+        assert pair.new.version == "2.0"
+        # A JSON snapshot has no detected binary format, same as on the CLI.
+        assert pair.old_fmt is None and pair.new_fmt is None
+        assert pair.old_evidence.collect_mode == pair.new_evidence.collect_mode == "off"
+
+
+class TestResolveSidesSequentially:
+    """ADR-050 D6 / G32 Phase E, generalised by ADR-055 D1.
+
+    A manifest-driven dump sizes its per-TU worker pool from a live
+    ``MemAvailable`` reading, so two starting concurrently size two full pools
+    off the same reading and jointly overcommit. That guard used to be
+    implicit — the native ``compare`` CLI simply resolved sequentially, and
+    ``run_compare_request`` was documented as unable to reach a manifest at
+    all. ``InputSpec.dump_manifest`` made that documentation stale: the typed
+    path could reach a manifest *and* resolved concurrently. Now that both
+    front ends share one resolution, the guard is explicit and lives with it.
+    """
+
+    def _request(self, tmp_path, *, old_manifest=None, new_manifest=None):
+        return CompareRequest(
+            old=InputSpec(path=tmp_path / "old.so", dump_manifest=old_manifest),
+            new=InputSpec(path=tmp_path / "new.so", dump_manifest=new_manifest),
+        )
+
+    def test_plain_pair_may_resolve_concurrently(self, tmp_path, monkeypatch):
+        from abicheck.service import resolve_sides_sequentially
+
+        monkeypatch.delenv("ABICHECK_PARALLEL_EXTRACTION", raising=False)
+        assert resolve_sides_sequentially(self._request(tmp_path)) is False
+
+    @pytest.mark.parametrize("side", ["old", "new"])
+    def test_a_dump_manifest_on_either_side_forces_sequential(
+        self, tmp_path, monkeypatch, side
+    ):
+        from types import SimpleNamespace
+
+        from abicheck.service import resolve_sides_sequentially
+
+        monkeypatch.delenv("ABICHECK_PARALLEL_EXTRACTION", raising=False)
+        manifest = SimpleNamespace(translation_units=[])
+        request = self._request(tmp_path, **{f"{side}_manifest": manifest})
+        assert resolve_sides_sequentially(request) is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "NO", " 0 "])
+    def test_env_opt_out_forces_sequential(self, tmp_path, monkeypatch, value):
+        from abicheck.service import resolve_sides_sequentially
+
+        monkeypatch.setenv("ABICHECK_PARALLEL_EXTRACTION", value)
+        assert resolve_sides_sequentially(self._request(tmp_path)) is True
+
+    def test_manifest_request_really_resolves_one_side_at_a_time(
+        self, tmp_path, monkeypatch
+    ):
+        """The behavioural half: not just the predicate, but the resolution.
+
+        Without the guard this is exactly the double-pool-sizing case — two
+        manifest dumps in a ``ThreadPoolExecutor``, overlapping in time.
+        """
+        import time
+        from types import SimpleNamespace
+
+        from abicheck import service as service_mod
+        from abicheck.service import resolve_compare_request
+
+        monkeypatch.delenv("ABICHECK_PARALLEL_EXTRACTION", raising=False)
+        spans: list[tuple[str, float, float]] = []
+
+        def _fake_resolve(path, headers, includes, version, lang, **kwargs):
+            start = time.monotonic()
+            time.sleep(0.05)
+            spans.append((version, start, time.monotonic()))
+            return AbiSnapshot(library="libtest", version=version)
+
+        monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve)
+        old_p = tmp_path / "old.so"
+        new_p = tmp_path / "new.so"
+        old_p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        new_p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        manifest = SimpleNamespace(translation_units=[])
+        resolve_compare_request(
+            CompareRequest(
+                old=InputSpec(path=old_p, version="old", dump_manifest=manifest),
+                new=InputSpec(path=new_p, version="new", dump_manifest=manifest),
+            )
+        )
+        assert len(spans) == 2
+        (_old_v, _old_start, old_end), (_new_v, new_start, _new_end) = spans
+        assert new_start >= old_end

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -4563,9 +4563,8 @@ class TestMetadataAttachFailuresAreSwallowed:
 class TestRunCompareRequestTypedResult:
     """ADR-055 D2: the one typed entry point and what it returns.
 
-    ``run_compare_request`` returned a bare 3-tuple until 0.6, briefly
-    alongside a ``run_compare_request_v2`` seam; both collapsed into this one
-    typed function once the pre-1.0 API break was on the table.
+    ``run_compare_request`` returned a bare 3-tuple until 0.6; it and the
+    ``run_compare`` shim both return the typed result now.
     """
 
     def _pair(self, tmp_path):

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from abicheck.api_types import CompareRequest, InputSpec
+from abicheck.api_types import CompareRequest, CompareResult, InputSpec
 from abicheck.checker_types import DiffResult
 from abicheck.comparability import compute_extraction_contract
 from abicheck.errors import ScopeMismatchError, SnapshotError, ValidationError
@@ -25,6 +25,7 @@ from abicheck.service import (
     resolve_input,
     run_compare,
     run_compare_request,
+    run_compare_request_v2,
     run_dump,
     sniff_text_format,
 )
@@ -4558,3 +4559,91 @@ class TestMetadataAttachFailuresAreSwallowed:
         snap = self._snap()
         _try_attach_numpy_capi_surface(snap, tmp_path / "libfoo.so")
         assert snap.numpy_capi is None
+
+
+class TestRunCompareRequestV2:
+    """ADR-055 D2: the typed entry point, and that it did not fork behaviour."""
+
+    def _pair(self, tmp_path):
+        old = AbiSnapshot(library="libtest", version="1.0")
+        new = AbiSnapshot(library="libtest", version="2.0")
+        old_p = tmp_path / "old.json"
+        new_p = tmp_path / "new.json"
+        save_snapshot(old, old_p)
+        save_snapshot(new, new_p)
+        return CompareRequest(old=InputSpec.of(old_p), new=InputSpec.of(new_p))
+
+    def test_returns_a_compare_result(self, tmp_path):
+        result = run_compare_request_v2(self._pair(tmp_path))
+        assert isinstance(result, CompareResult)
+        assert isinstance(result.diff, DiffResult)
+        assert result.old_snapshot.version == "1.0"
+        assert result.new_snapshot.version == "2.0"
+
+    def test_tuple_entry_point_returns_the_same_three_objects(self, tmp_path):
+        """The legacy shape is a *view* of this one, not a second run.
+
+        Asserted on field values rather than identity: the two calls resolve
+        their own snapshots, so identity would only prove they both ran.
+        """
+        request = self._pair(tmp_path)
+        diff, old, new = run_compare_request(request)
+        typed = run_compare_request_v2(request)
+        assert (old.version, new.version) == (
+            typed.old_snapshot.version,
+            typed.new_snapshot.version,
+        )
+        assert diff.verdict == typed.diff.verdict
+        assert len(diff.changes) == len(typed.diff.changes)
+
+    def test_suppression_is_none_when_the_request_names_no_file(self, tmp_path):
+        assert run_compare_request_v2(self._pair(tmp_path)).suppression is None
+
+    def test_carries_the_resolved_suppression_list(self, tmp_path):
+        """What ADR-055 D4 needs: the resolved list, without a second load.
+
+        ``DiffResult`` carries the resolved policy file but never the
+        suppression list, so before this a front end applying post-
+        classification scoping (``appcompat.scope_diff_to_app``) had to load
+        the same file again itself.
+        """
+        supp = tmp_path / "suppress.yaml"
+        supp.write_text(
+            "version: 1\nsuppressions:\n  - symbol: _Z1gone\n    reason: test\n",
+            encoding="utf-8",
+        )
+        request = self._pair(tmp_path).replace(suppress=supp)
+        result = run_compare_request_v2(request)
+        assert result.suppression is not None
+        assert len(result.suppression.rule_identities()) == 1
+
+    def test_follow_linker_scripts_is_forwarded_per_side(self, tmp_path, monkeypatch):
+        """ADR-055 D4: the MCP server's resource guard is request surface.
+
+        ``resolve_input`` follows a GNU ld linker script by default; the MCP
+        tools must not, because they size-check only the caller-supplied path.
+        """
+        import abicheck.service as service_mod
+
+        captured: dict[str, object] = {}
+        original = service_mod.resolve_input
+
+        def _spy(path, headers=None, includes=None, version="", lang="c++", **kwargs):
+            captured[version] = kwargs.get("follow_linker_scripts")
+            return original(path, headers, includes, version, lang, **kwargs)
+
+        monkeypatch.setattr(service_mod, "resolve_input", _spy)
+        import dataclasses
+
+        base = self._pair(tmp_path)
+        run_compare_request_v2(
+            base.replace(
+                old=dataclasses.replace(
+                    base.old, version="old", follow_linker_scripts=False
+                ),
+                new=dataclasses.replace(base.new, version="new"),
+            )
+        )
+        assert captured["old"] is False
+        # Unset stays the historical default rather than inheriting the other side.
+        assert captured["new"] is True


### PR DESCRIPTION
## Summary

Closes ADR-055's remaining decisions — D1 (both halves), D2, D4, and D3's consumer half — and corrects the ADR's own status, which had gone stale.

## Motivation

The question that started this was "what's done in ADR-055 and what remains?" — and checking the code against the documents turned up that the documents were wrong. **D1 was already implemented**, landed inside [PR #651](https://github.com/abicheck/abicheck/pull/651) ("close dump/compare dependency-scoping asymmetry"), whose title says nothing about ADR-055 — so neither the ADR's status line nor G33's Phase 2 note was touched, and both kept saying "D1 not started" through several later PRs. The same failure shape as this ADR's own Gap 3 correction: a claim about the code that stayed true in the document long after it stopped being true in the code.

Two smaller staleness items in the same document: its D4 section claimed `CompareRequest` had no policy/suppression fields and that D4 needed a preceding slice to add them — those fields have existed since PR #611, before this ADR was drafted.

## Changes

**D2 — a typed result, as the only shape.** `CompareResult` carries `diff`/`old_snapshot`/`new_snapshot` plus the resolved `suppression` list, and is what `run_compare_request` and the `run_compare` kwargs shim return.

**This is a pre-1.0 API break, taken deliberately.** An earlier revision of this PR added a parallel `run_compare_request_v2` beside the tuple-returning original, on the assumption that compatibility had to be kept. It does not, pre-1.0 — so the typed result became the only shape and the `_v2` name is gone. A positional caller migrates in one line: `result, old, new = run_compare(...).as_tuple()`. The alternative would have shipped two names for one operation and a third when `_v2` was eventually renamed.

Two departures from the ADR as written, both recorded there:
- The struct lives in `api_types.py` beside `CompareRequest`, not in `service.py`. That module is already "typed request/response structs", imports nothing from the service layer at runtime, and keeping the pair together lets a caller annotate a result without importing `service`'s much heavier graph.
- It carries a **fourth** field, not "exactly the tuple's three". That field is what D4 needed: the service resolves the suppression list internally, but `appcompat.scope_diff_to_app(..., suppression=...)` needs the resolved object *after* classification, and `DiffResult` carries the resolved policy file but not the suppression list. Without it the MCP server would have kept a `SuppressionList.load` call purely to re-derive what the service had already loaded — the exact duplication D4 removes, reintroduced by the shape chosen to enable removing it.

**D4 — `abi_compare` through the chokepoint.** It now builds one `CompareRequest` and calls the service, instead of resolving its own inputs, loading its own policy/suppression files, and borrowing `compare_snapshots` for the middle diffing step only. `mcp_server.py` no longer imports that verb at all. `used_by`/`required_symbols` scoping and severity/exit-code computation stay MCP glue over the returned result, exactly as the ADR scopes them.

Three findings from doing it:

1. **One MCP guard had to become request surface, not stay wrapper glue.** `_resolve_input` pinned `follow_linker_scripts=False` because the tool size-checks only the *caller-supplied* path, and a GNU ld script's `INPUT()` target would never pass through that check. Routing through the service would have silently dropped it, so `InputSpec.follow_linker_scripts` is new (default `True`, matching `resolve_input`'s own default, so no pre-existing caller changes). Path containment and file size stayed MCP-local, applied before the request is built — those constrain untrusted input, which genuinely is the front end's job, unlike resolve/load/classify.
2. **Output is unchanged**, verified two independent ways: parity against the CLI `compare` command, and a before/after diff of the tool's own output across a flag matrix. The report matches the CLI's exactly except for two keys the CLI's renderer adds and this tool has never emitted (`old_evidence_depth`/`new_evidence_depth`).
3. **One intentional behaviour change:** an unsupported `language` (e.g. `"rust"`) is now a structured validation error rather than a value passed quietly down the resolver — `CompareRequest.validate()` doing what the CLI's `--lang` choice already did (ADR-037 D9's front-end parity).

**D1, capability half.** An earlier revision of this description named three things as remaining CLI-only. **All three were wrong**, and checking them rather than repeating them is what found the real set:

- The **per-side AST-frontend override** already worked — `InputSpec.compile.frontend` reaches that side's `run_dump`, whose own precedence then beats the request-wide backend. Verified by spying on the per-side `run_dump` arguments.
- **`source.method` inference** is not a capability gap: the value is expressible as `CompareRequest.depth`, and a Tier-2 API deliberately does not discover `.abicheck.yml` from the working directory — which is exactly where ADR-049 D7's precedence model already puts `project_config`.
- The **set-input rejection guard** protects directory/package inputs, an input *kind* `CompareRequest` never accepts.

Diffing the two parameter lists found the real delta, now closed: `dwarf_only`, `debug_format`, ADR-050 D1's `include_labels`, and `--follow-deps` (`follow_dependencies` + `dependency_search_paths` + `ld_library_path`). All default to off. `include_labels` is a tuple of pairs rather than a dict, keeping the request hashable as `InputSpec`'s docstring claims. `--follow-deps`'s implementation moved out of `cli_resolve` into the new leaf module `abicheck/dependency_info.py`, which both layers depend on — the shape AGENTS.md prescribes when a CLI helper gains a service-layer caller.

**D1, structural half — and its open question, answered the other way.** The ADR left "migrate the CLI onto `run_compare_request`, or extend it in parallel?" unanswered, and an earlier revision of this PR recorded **option (b)**: keep both, because (a) would rewrite the CLI's most heavily-tested resolution path for nothing a user can observe.

Doing it showed why (b) had looked inevitable, and that the reasoning had the wrong obstacle. `run_compare_request` was one function that both resolved and classified — and the native `compare` CLI must run its Click-dependent ADR-049 `resolve_and_apply` **between** those two steps: it needs the Click context to answer "did the user type this?", and a `--pack` it selects can move the policy file and severity levels the classification is then scored under. With no seam there, the CLI could reuse neither half, so it kept a copy. The obstacle was never the CLI's test surface.

So the change is not "call `run_compare_request` from the CLI" but splitting it at its real joint, into `abicheck/service_compare_pipeline.py`:

| | |
|---|---|
| `resolve_compare_request(request, *, notify, allow_parallel)` | validate → per-side evidence → both snapshots → `--follow-deps` enrichment → enforce the requested depth |
| `classify_compare_pair(request, pair)` | suppression/policy → embedded build-source diff → `compare_snapshots` → coverage/metrics |
| `run_compare_request(request)` | exactly their composition |

`cli_resolve._resolve_compare_snapshots` now builds a `CompareRequest` and delegates; it resolves nothing itself. What stays CLI-specific is what genuinely is: the `click.echo` progress notifier, translating `ValidationError`/`SnapshotError` into `click.UsageError`/`click.ClickException` (the contract `_resolve_input` documented), and `allow_parallel=False`.

That last one is deliberate, not a leftover divergence. `allow_parallel` is the caller's **permission** to resolve both sides concurrently, not a demand — `resolve_sides_sequentially` can still veto it. The CLI declines it because it has always resolved sequentially and its two dumps write interleaving progress notes to one stderr; flipping that changes the memory and output profile of every existing `compare` invocation, which deserves its own evidence rather than riding along with the removal of a duplicate.

**A real defect the unification surfaced.** The sequential-resolution guard `tests/test_compare_dispatch.py` pinned for the CLI (ADR-050 D6 / G32 Phase E: a manifest-driven dump sizes its per-TU worker pool from a live `MemAvailable` reading, so two starting together size two full pools off the same reading and jointly overcommit) rested on a claim that had gone stale — that `run_compare_request` "has no `dump_manifest` field on `CompareRequest`/`InputSpec` at all, so it can never reach a manifest-driven dump". D1's own first slice added `InputSpec.dump_manifest`, so the typed path could reach a manifest *and* resolved concurrently: it had the exact risk the CLI test was written to prevent. `resolve_sides_sequentially` now states the rule once, for every front end.

**D3's consumer half — and, after review, deleting the copies rather than only pinning them.** `doc-count-sync` now reads its expected versions from `schemas.current()`. It caught two live stale values immediately (`report_schema_version` `"1.0"` and `"2.13"` against a real `2.26`). Codex then made the sharper point that pinning a copy only forces every future bump to update N duplicates instead of removing them — correct, and it led somewhere better: where the version is incidental to what a sentence says, the copy is now gone and the page links to the fact owner. One of those three sites was `output-formats.md` claiming a snapshot's `schema_version` "is currently `8`" — *the original ADR-055 D3 bug*, still alive on a second page after G33 Phase 0 fixed the identical sentence in `python-api.md`. Checking for more found a fourth copy no anchor covered. Pinning stays only for values that must appear literally (JSON output samples).

## Import-cycle allowlist — an explicit exception, per AGENTS.md

`service_compare_pipeline` is added to `IMPORT_CYCLE_ALLOWLIST`'s existing CLI-registration/service-routing SCC. This is the `l0_export_delta`/`scan_engine` precedent, not a new dependency direction: the module is a *split of an existing member*, reaching `cli_buildsource`/`cli_dump_helpers`/`cli_buildsource_helpers`/`service` function-locally — the identical edge set `service.run_compare_request` already had, relocated rather than added — and `service` imports it back at its module-load tail. It imports only `api_types`/`dependency_info`/`errors` (leaves) at module load, so the package still imports cleanly. The net effect on the graph is a **reduction**: `cli_resolve` no longer carries its own copy of this resolution. Sign-off is recorded in ADR-055 D1, which AGENTS.md requires for any allowlist extension.

## Tests

`TestAbiCompareCliParity` carries both halves of D4's acceptance test: the source-level absence gate (comments stripped first — the function now *documents* what it stopped calling) and CLI-parity over defaults, policy profile, policy file, suppression file, `--show-only`, `--report-mode`, and severity-aware gating. `TestCompareResult`/`TestRunCompareRequestTypedResult` for D2; `TestRunCompareRequestResolutionParity` for D1's capability half; `TestComparePipelinePhases`/`TestResolveSidesSequentially` (`tests/test_service_unit.py`) and `TestCompareCliSharesServiceResolution` (`tests/test_compare_dispatch.py`) for the structural half — including that the CLI still translates the service's errors into the `click` exceptions `_resolve_input` promised.

Existing tests that stubbed `mcp_server._resolve_input` or `cli_resolve._resolve_input` were repointed at `service.resolve_input`, the function both paths now actually reach; the order-dependent `side_effect=[old, new]` stubs became key-dispatched, since the typed path resolves both sides concurrently.

## Deliberately not done

- **Flipping the CLI to concurrent extraction.** Now a one-argument change (`allow_parallel=True`), but it alters the memory and stderr-interleaving profile of every existing `compare` run; it needs its own measurement.
- **G33's Phase 5** (`abi_dump`/`abi_scan` reaching the same parity) — unblocked by D4, but it changes two other tools' parameter surfaces and ADR-055 scopes it out.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) — including the `BREAKING (pre-1.0)` entry and its one-line migration
- [x] Docs updated — ADR-055 (D1's "Structural half" note, the superseded option-(b) paragraphs, the files table, the allowlist sign-off), its index row, the G33 plan, `AGENTS.md`'s module map, and the regenerated reference pages
- [ ] `pre-commit run --all-files` passes locally — ran the equivalent `verify.py` steps individually instead (see below)
- [x] No new `mypy` or `ruff` errors introduced

**Verification, on the rebased head:** full fast suite green (22913 passed, 17 skipped, 4 xfailed); `ruff check abicheck/ tests/ scripts/` clean; `mypy abicheck/` clean over 319 files on a cleared cache; `check_ai_readiness.py` exits 0; FP-rate gate 0 FP / 0 FN. `service.py` is 1835 lines, down from 1979 and no longer against the 2000-line cap.

The `fmt-check` step fails identically before and after this change — the ruff available in this environment (0.16.1) reformats 519 files repo-wide, and `verify.py` has no format step, so it carries no signal here. I did not run the `unit-pr` step's coverage floor or the golden lane.

Two `adr-status-sync` WARNs are expected on this branch and cannot be resolved here: the gate requires a `**Verified:**` receipt to name a commit reachable from the default branch, so a feature branch that is itself changing the modules an ADR's Status names has no honest sha to move the receipt to until merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1vhTBTBvfAX53XVgZuknJ)_