### PR TITLE
feat: G29 Phase 4 — use-case manifest and the use_case/test_case graph join (ADR-057)

### DIFF
--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -1125,26 +1125,41 @@ def _merge_consumer_impact_paths(
     instead of silently keeping only the first and discarding the rest
     (Codex review, fresh evidence).
 
-    ``consumer``/``symbol`` keep the first match's values — display-only
-    fields a single merged explanation can only ever name one of.
-    ``public_entries``/``declarations`` are the order-preserving deduped
-    union across every match, so a finding covering several requirements
-    reports every public root/declaration that explains it, not just the
-    first. ``entry_path`` stays the first non-empty (indirect) match's own
-    path; every *other* match's ``entry_path``/``alternative_entry_paths``
+    All of ``consumer``/``symbol``/``entry_path``/the primary (first)
+    ``public_entries`` entry come from the **same** match — the one
+    :func:`_choose_primary_match` picks — never from independently-chosen
+    fields (Codex review, fresh evidence): an earlier version picked
+    ``symbol``/``public_entries`` from ``matches[0]`` but ``entry_path``
+    from the first match that happened to carry a non-empty (indirect)
+    path, which are not necessarily the same match when the first match is
+    itself *direct* (``entry_path == []``) and a later one is indirect.
+    ``_format_consumer_impact`` reads ``explained.symbol``/
+    ``explained.public_entries[0]`` together with ``explained.entry_path``
+    as one coherent story ("*symbol* is reachable from public entry
+    *entry*: *chain*"); mixing fields from two different matches produced
+    an internally contradictory sentence — symbol A "reachable from" A's
+    own entry, followed by a chain that actually starts at (and explains)
+    a completely different symbol B's entry and target.
+
+    ``public_entries``/``declarations`` are still the order-preserving
+    deduped union across every match (so a finding covering several
+    requirements reports every public root/declaration that explains it,
+    not just the primary's), just with the primary's own values ordered
+    first. Every *other* match's ``entry_path``/``alternative_entry_paths``
     is folded into the merged ``alternative_entry_paths`` instead of
-    dropped outright, so no explanation is lost even though only one path
+    dropped outright, so no explanation is lost even though only one match
     can be primary (``attach_impact_metadata`` caps how many of these are
     actually kept).
     """
     if len(matches) == 1:
         return matches[0]
-    primary = matches[0]
+    primary = _choose_primary_match(matches)
+    ordered = [primary, *(m for m in matches if m is not primary)]
     entries: list[str] = []
     seen_entries: set[str] = set()
     declarations: list[str] = []
     seen_decls: set[str] = set()
-    for m in matches:
+    for m in ordered:
         for e in m.public_entries:
             if e not in seen_entries:
                 seen_entries.add(e)
@@ -1153,12 +1168,14 @@ def _merge_consumer_impact_paths(
             if d not in seen_decls:
                 seen_decls.add(d)
                 declarations.append(d)
-    entry_path = next((m.entry_path for m in matches if m.entry_path), [])
     alternatives = []
     for m in matches:
-        if m.entry_path and m.entry_path != entry_path:
+        if m is primary:
+            continue
+        if m.entry_path:
             alternatives.append(m.entry_path)
         alternatives.extend(m.alternative_entry_paths)
+    alternatives.extend(primary.alternative_entry_paths)
     from .impact.consumer_graph import ConsumerImpactPath as _ConsumerImpactPath
 
     return _ConsumerImpactPath(
@@ -1166,9 +1183,27 @@ def _merge_consumer_impact_paths(
         symbol=primary.symbol,
         declarations=tuple(declarations),
         public_entries=tuple(entries),
-        entry_path=entry_path,
+        entry_path=primary.entry_path,
         alternative_entry_paths=alternatives,
     )
+
+
+def _choose_primary_match(
+    matches: list[ConsumerImpactPath],
+) -> ConsumerImpactPath:
+    """The one match :func:`_merge_consumer_impact_paths` derives
+    ``consumer``/``symbol``/``entry_path``/the primary public entry from.
+
+    Prefers the first match that carries an actual walked ``entry_path``
+    (an indirect, graph-proven chain) over a direct one — a direct match's
+    own ``entry_path`` is ``[]`` by construction (its "path" is the trivial
+    zero-hop declaration-is-the-entry case), so preferring it as primary
+    when a genuinely indirect match also exists would silently discard the
+    only real path this merged explanation could have shown. Falls back to
+    the first match when every match is direct — there is no path to
+    prefer among them, so display order is the only remaining tiebreaker.
+    """
+    return next((m for m in matches if m.entry_path), matches[0])
 
 
 def _attach_consumer_impact(

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -1145,11 +1145,18 @@ def _merge_consumer_impact_paths(
     deduped union across every match (so a finding covering several
     requirements reports every public root/declaration that explains it,
     not just the primary's), just with the primary's own values ordered
-    first. Every *other* match's ``entry_path``/``alternative_entry_paths``
-    is folded into the merged ``alternative_entry_paths`` instead of
-    dropped outright, so no explanation is lost even though only one match
-    can be primary (``attach_impact_metadata`` caps how many of these are
-    actually kept).
+    first. A *same-rooted* other match's ``entry_path``/
+    ``alternative_entry_paths`` is folded into the merged
+    ``alternative_entry_paths`` instead of dropped outright, so no
+    explanation is lost even though only one match can be primary
+    (``attach_impact_metadata`` caps how many of these are actually kept).
+    A *differently-rooted* other match's own path is deliberately left out
+    (Codex review, fresh evidence) — ``impact.engine._build_alternative_path``
+    stamps every merged ``GraphProofPath`` with the SAME single primary
+    root, so including a path that actually starts at a different public
+    entry would misrepresent it in JSON/SARIF as a variant of the primary's
+    own root; that entry is still reported via ``public_entries``, just not
+    smuggled in as a same-rooted alternative.
     """
     if len(matches) == 1:
         return matches[0]
@@ -1168,13 +1175,28 @@ def _merge_consumer_impact_paths(
             if d not in seen_decls:
                 seen_decls.add(d)
                 declarations.append(d)
+    # A non-primary match's own entry_path/alternative_entry_paths is only
+    # folded in when it shares the primary's own root (Codex review, fresh
+    # evidence): impact.engine._build_alternative_path stamps every merged
+    # GraphProofPath.root from the SAME single primary root
+    # (impact.engine._build_proof_path's affected_roots[0]) -- it has no
+    # per-alternative root field at all. Including a differently-rooted
+    # match's own path here would have it serialized in JSON/SARIF as
+    # though it started at the primary's entry, when it actually starts at
+    # (and explains) a different public entry entirely -- the exact
+    # "confident but wrong" shape this module otherwise never allows, so a
+    # differently-rooted match's own path is left out of the merged
+    # alternatives rather than mislabeled.
+    primary_root = primary.public_entries[0] if primary.public_entries else None
     alternatives = []
     for m in matches:
         if m is primary:
             continue
-        if m.entry_path:
+        same_root = bool(m.public_entries) and m.public_entries[0] == primary_root
+        if m.entry_path and same_root:
             alternatives.append(m.entry_path)
-        alternatives.extend(m.alternative_entry_paths)
+        if same_root:
+            alternatives.extend(m.alternative_entry_paths)
     alternatives.extend(primary.alternative_entry_paths)
     from .impact.consumer_graph import ConsumerImpactPath as _ConsumerImpactPath
 
@@ -1244,6 +1266,20 @@ def _attach_consumer_impact(
     )
     change.public_reachable = True
     change.reachability_kind = "consumer_proven"
+    # Unconditionally overrides whatever reachability_state MarkReachability
+    # (or nothing) already left here, including a prior PROVEN_UNREACHABLE
+    # from its own layout/type-graph closure walk (CodeRabbit review): that
+    # walk reasons about *potential* reachability from the public API
+    # surface as the library's own source declares it, while this evidence
+    # is a real --used-by consumer binary's own undefined-symbol resolution
+    # -- an empirically stronger, more direct signal than a structural
+    # closure inference, and this function only ever runs when that real
+    # requirement was found. Deliberately not treated as a recorded
+    # conflict between two disagreeing verdicts: an actual observed
+    # dependency is not "in tension" with an inference about the surface
+    # that dependency turned out to route around (an alias, a compiler
+    # intrinsic call, or any other path the closure walk doesn't model) --
+    # it settles the question the walk could only approximate.
     change.reachability_state = ReachabilityState.PROVEN_REACHABLE
 
 

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -1072,6 +1072,25 @@ def _enrich_covered_changes(
     prose written here is deliberately consumer-neutral (see
     :func:`_format_consumer_impact`) and only findings with no evidence of
     their own are touched.
+
+    Refreshes ``change.impact_assessment`` after attaching (Codex review,
+    fresh evidence): a change reaching this point with a *cached but
+    pathless* assessment (``MarkReachability``'s blanket Slice 10 cache —
+    the case :func:`_has_impact_evidence` now lets through) still has that
+    stale, path-less object sitting on ``change.impact_assessment`` after
+    :func:`_attach_consumer_impact` sets the flat proof-path fields —
+    ``impact.engine.assess_change`` prefers any non-``None`` cached
+    assessment over re-deriving from those flat fields, so without this
+    refresh the newly attached consumer explanation would never actually
+    reach a JSON/SARIF render. Mirrors the overlay-change path a few lines
+    below (``overlay_change.impact_assessment = assess_change(overlay_change)``),
+    which already does this correctly for the *uncovered*-symbol case
+    because that ``Change`` is always freshly constructed with no
+    pre-existing cache to go stale — this shared-``Change`` counterpart
+    must clear the stale cache *first*: ``assess_change`` reads
+    ``change.impact_assessment`` as its own cache, so recomputing while the
+    old object is still assigned would just hand back that same stale
+    object unchanged.
     """
     for change in changes:
         if _has_impact_evidence(change):
@@ -1087,6 +1106,8 @@ def _enrich_covered_changes(
         if explained is None:
             continue
         _attach_consumer_impact(change, explained, graph, name_consumer=False)
+        change.impact_assessment = None
+        change.impact_assessment = assess_change(change)
 
 
 def _attach_consumer_impact(

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -1157,9 +1157,22 @@ def _merge_consumer_impact_paths(
     entry would misrepresent it in JSON/SARIF as a variant of the primary's
     own root; that entry is still reported via ``public_entries``, just not
     smuggled in as a same-rooted alternative.
+
+    Deliberately does **not** early-return ``matches[0]`` unchanged when
+    ``len(matches) == 1`` (Codex review, fresh evidence): the single-symbol
+    case is the *ordinary* one, not a degenerate special case that can skip
+    the root filter below.
+    :func:`~abicheck.impact.consumer_graph.explain_required_symbols` can
+    itself return one ``ConsumerImpactPath`` whose own
+    ``alternative_entry_paths`` already mixes candidates from more than one
+    consumer-compiled entry (every entry that reaches the target
+    declaration, not just the ``select_preferred_graph_path``-chosen one) —
+    so a lone match can carry a differently-rooted alternative exactly like
+    the primary-match case below, and skipping this function's filtering
+    for it would let ``impact.engine._build_proof_path``'s single
+    ``affected_public_roots[0]`` mislabel that alternative's root the same
+    way an unfiltered multi-match merge would.
     """
-    if len(matches) == 1:
-        return matches[0]
     primary = _choose_primary_match(matches)
     ordered = [primary, *(m for m in matches if m is not primary)]
     entries: list[str] = []

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -1028,9 +1028,27 @@ def _has_impact_evidence(change: Change) -> bool:
     unconditionally (``None`` included). It also makes the multi-``--used-by``
     case first-writer-wins and therefore deterministic in app order, rather
     than silently last-writer-wins.
+
+    ``impact_assessment.proof_path is not None`` (a *cached assessment that
+    actually carries a proof path*), not merely "a cached assessment
+    exists" (Codex review, fresh evidence): since ADR-052 Slice 10,
+    ``post_processing.MarkReachability`` caches an ``ImpactAssessment`` on
+    *every* change it tags -- including a change it leaves
+    ``ReachabilityState.UNKNOWN`` with no proof path at all (an ordinary,
+    otherwise-unexplained ``FUNC_REMOVED``), and one it tags
+    ``PROVEN_REACHABLE`` via a direct-symbol/public-source-ABI-surface match
+    with no walked path either (see that step's own two early-continue
+    branches). Treating either of those as "evidence of its own" would skip
+    :func:`_enrich_covered_changes` for the exact common case this join
+    exists to explain, silently dropping ``affected_public_roots``/
+    ``impact_proof_path``/the consumer-neutral prose for a covered removed
+    export. Reading ``.proof_path`` instead makes this check equivalent to
+    the two flat-field checks below regardless of whether the evidence
+    reached this change via the cache or directly.
     """
+    assessment = getattr(change, "impact_assessment", None)
     return (
-        getattr(change, "impact_assessment", None) is not None
+        (assessment is not None and assessment.proof_path is not None)
         or getattr(change, "impact_proof_path", None) is not None
         or getattr(change, "reachability_proof_path", None) is not None
     )

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -1217,6 +1217,22 @@ def _merge_consumer_impact_paths(
             return m.entry_path[0].src == primary.entry_path[0].src
         return bool(m.public_entries) and m.public_entries[0] == primary_root
 
+    # A non-primary match's OWN alternative_entry_paths need the identical
+    # per-alt filter the primary's own alternatives get below (Codex
+    # review, fresh evidence): _same_root(m) only proves m's PREFERRED
+    # entry_path shares the primary's root -- explain_required_symbols
+    # builds m.alternative_entry_paths from every candidate path across
+    # every consumer-compiled entry that reached the target, not just the
+    # entry m's own preferred path happens to start at, so one of m's own
+    # alternatives can start at yet another, third entry. Bulk-extending
+    # all of them once m's preferred path passes the root check would
+    # still let a differently-rooted path through and have it serialized
+    # under the primary's single root. Filtered against m's own verified
+    # entry_path[0].src (equal to primary's by construction once same_root
+    # is True) rather than re-deriving it from primary directly, so the
+    # comparison reads as "does this alt start where m's OWN already-
+    # verified path starts" -- the same question the primary-side filter
+    # answers about primary's own alternatives.
     alternatives = []
     for m in matches:
         if m is primary:
@@ -1224,8 +1240,10 @@ def _merge_consumer_impact_paths(
         same_root = _same_root(m)
         if m.entry_path and same_root:
             alternatives.append(m.entry_path)
-        if same_root:
-            alternatives.extend(m.alternative_entry_paths)
+            m_start = m.entry_path[0].src
+            alternatives.extend(
+                alt for alt in m.alternative_entry_paths if alt and alt[0].src == m_start
+            )
     # primary's OWN alternative_entry_paths need the identical guard (Codex
     # review, fresh evidence): explain_required_symbols builds these from
     # every candidate path across every consumer-compiled entry the walk

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -1200,12 +1200,28 @@ def _merge_consumer_impact_paths(
     # "confident but wrong" shape this module otherwise never allows, so a
     # differently-rooted match's own path is left out of the merged
     # alternatives rather than mislabeled.
+    #
+    # Compares by the actual graph node id (entry_path[0].src) whenever BOTH
+    # sides have a walked path, not by display label (Codex review, fresh
+    # evidence): distinct public-entry nodes can share one display label --
+    # C++ overloads are the common case -- so a label match alone does not
+    # prove m's path starts at the SAME node primary's does. Falls back to
+    # the label comparison only when one side has no entry_path at all (a
+    # *direct* match, whose declaration-is-the-entry "path" has no edge to
+    # read a node id from) -- the label is the only signal available then,
+    # same as before this fix.
     primary_root = primary.public_entries[0] if primary.public_entries else None
+
+    def _same_root(m: ConsumerImpactPath) -> bool:
+        if m.entry_path and primary.entry_path:
+            return m.entry_path[0].src == primary.entry_path[0].src
+        return bool(m.public_entries) and m.public_entries[0] == primary_root
+
     alternatives = []
     for m in matches:
         if m is primary:
             continue
-        same_root = bool(m.public_entries) and m.public_entries[0] == primary_root
+        same_root = _same_root(m)
         if m.entry_path and same_root:
             alternatives.append(m.entry_path)
         if same_root:

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -1091,23 +1091,84 @@ def _enrich_covered_changes(
     ``change.impact_assessment`` as its own cache, so recomputing while the
     old object is still assigned would just hand back that same stale
     object unchanged.
+
+    Aggregates *every* matching explanation, not just the first
+    (:func:`_merge_consumer_impact_paths`) — a single shared ``Change`` can
+    cover more than one missing export at once via ``affected_symbols``
+    (e.g. one type-size change breaking several removed functions), and
+    :func:`_change_covers_symbol` treats all of them as covered. Keeping
+    only the first match's ``next(...)`` pick (Codex review, fresh
+    evidence) silently discarded every other symbol's own public root and
+    proof path, reporting a narrower explanation than the same logic
+    already claims this finding accounts for.
     """
     for change in changes:
         if _has_impact_evidence(change):
             continue
-        explained = next(
-            (
-                e
-                for sym, e in explanations.items()
-                if _change_covers_symbol(change, sym)
-            ),
-            None,
-        )
-        if explained is None:
+        matches = [
+            e for sym, e in explanations.items() if _change_covers_symbol(change, sym)
+        ]
+        if not matches:
             continue
+        explained = _merge_consumer_impact_paths(matches)
         _attach_consumer_impact(change, explained, graph, name_consumer=False)
         change.impact_assessment = None
         change.impact_assessment = assess_change(change)
+
+
+def _merge_consumer_impact_paths(
+    matches: list[ConsumerImpactPath],
+) -> ConsumerImpactPath:
+    """Combine every symbol-level explanation one shared ``Change`` covers
+    (via ``affected_symbols`` naming more than one missing export) into a
+    single :class:`~abicheck.impact.consumer_graph.ConsumerImpactPath`,
+    instead of silently keeping only the first and discarding the rest
+    (Codex review, fresh evidence).
+
+    ``consumer``/``symbol`` keep the first match's values — display-only
+    fields a single merged explanation can only ever name one of.
+    ``public_entries``/``declarations`` are the order-preserving deduped
+    union across every match, so a finding covering several requirements
+    reports every public root/declaration that explains it, not just the
+    first. ``entry_path`` stays the first non-empty (indirect) match's own
+    path; every *other* match's ``entry_path``/``alternative_entry_paths``
+    is folded into the merged ``alternative_entry_paths`` instead of
+    dropped outright, so no explanation is lost even though only one path
+    can be primary (``attach_impact_metadata`` caps how many of these are
+    actually kept).
+    """
+    if len(matches) == 1:
+        return matches[0]
+    primary = matches[0]
+    entries: list[str] = []
+    seen_entries: set[str] = set()
+    declarations: list[str] = []
+    seen_decls: set[str] = set()
+    for m in matches:
+        for e in m.public_entries:
+            if e not in seen_entries:
+                seen_entries.add(e)
+                entries.append(e)
+        for d in m.declarations:
+            if d not in seen_decls:
+                seen_decls.add(d)
+                declarations.append(d)
+    entry_path = next((m.entry_path for m in matches if m.entry_path), [])
+    alternatives = []
+    for m in matches:
+        if m.entry_path and m.entry_path != entry_path:
+            alternatives.append(m.entry_path)
+        alternatives.extend(m.alternative_entry_paths)
+    from .impact.consumer_graph import ConsumerImpactPath as _ConsumerImpactPath
+
+    return _ConsumerImpactPath(
+        consumer=primary.consumer,
+        symbol=primary.symbol,
+        declarations=tuple(declarations),
+        public_entries=tuple(entries),
+        entry_path=entry_path,
+        alternative_entry_paths=alternatives,
+    )
 
 
 def _attach_consumer_impact(
@@ -1120,8 +1181,19 @@ def _attach_consumer_impact(
     """Attach one :class:`ConsumerImpactPath` to *change* in place.
 
     Enrichment only — never constructs a finding, never changes a verdict or
-    a severity. The overlay was already ``PROVEN_REACHABLE``/
-    ``consumer_proven`` before this ran; all this adds is *why*.
+    a severity. The overlay call site already stamps ``PROVEN_REACHABLE``/
+    ``consumer_proven`` on its freshly-built ``Change`` before calling this
+    (see its own comment) — this function stamps the identical three fields
+    itself too (Codex review, fresh evidence), a no-op there, but load-bearing
+    for :func:`_enrich_covered_changes`'s *shared*-``Change`` caller: that
+    change's ``reachability_state``/``public_reachable`` are whatever
+    ``MarkReachability`` left them (``UNKNOWN``/``False`` by default when no
+    reachability-aware suppression rule is even configured, so that step never
+    ran at all) — attaching a concrete proof path here without also raising
+    those fields would otherwise leave the *same* internal contradiction the
+    overlay's own comment already reasons its way out of: a real consumer
+    requirement resolving to a real, walked call chain is not a "maybe
+    internal, maybe not" ambiguity, by construction, for either caller.
     """
     from .buildsource.graph_impact import attach_impact_metadata
 
@@ -1135,6 +1207,9 @@ def _attach_consumer_impact(
     change.reachability_proof_path = _format_consumer_impact(
         explained, graph, name_consumer=name_consumer
     )
+    change.public_reachable = True
+    change.reachability_kind = "consumer_proven"
+    change.reachability_state = ReachabilityState.PROVEN_REACHABLE
 
 
 def scope_diff_to_app(

--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -1197,7 +1197,25 @@ def _merge_consumer_impact_paths(
             alternatives.append(m.entry_path)
         if same_root:
             alternatives.extend(m.alternative_entry_paths)
-    alternatives.extend(primary.alternative_entry_paths)
+    # primary's OWN alternative_entry_paths need the identical guard (Codex
+    # review, fresh evidence): explain_required_symbols builds these from
+    # every candidate path across every consumer-compiled entry the walk
+    # reached, not just ones starting at the SAME entry select_preferred_graph_path
+    # chose as primary -- so an entry in here can legitimately start at a
+    # different node than primary.entry_path's own first hop. There is no
+    # per-alternative root field to compare by label (unlike the
+    # cross-match case above), so this compares each alternative's actual
+    # first-edge source node against primary.entry_path's own first-edge
+    # source directly -- the same underlying question ("does this
+    # alternative start where the primary path starts"), answered without
+    # needing graph/label access this function doesn't have.
+    if primary.entry_path:
+        primary_start = primary.entry_path[0].src
+        alternatives.extend(
+            alt
+            for alt in primary.alternative_entry_paths
+            if alt and alt[0].src == primary_start
+        )
     from .impact.consumer_graph import ConsumerImpactPath as _ConsumerImpactPath
 
     return _ConsumerImpactPath(

--- a/abicheck/buildsource/graph_facts.py
+++ b/abicheck/buildsource/graph_facts.py
@@ -84,6 +84,41 @@ CONSUMER_EDGE_KINDS: frozenset[str] = frozenset(
     }
 )
 
+#: The use-case half of the graph vocabulary (G29 Phase 4 slice 2, ADR-057
+#: amendment) — ``source_graph.NODE_KINDS``/``EDGE_KINDS`` union these in the
+#: same way ``CONSUMER_NODE_KINDS``/``CONSUMER_EDGE_KINDS`` above are unioned
+#: in, and ``abicheck.impact.use_cases`` (which populates them) re-exports
+#: them. Same two reasons for living in this leaf module rather than beside
+#: the rest of the vocabulary: ``source_graph.py`` is at its 2000-line hard
+#: cap, and the producer imports ``source_graph`` (function-local, to avoid a
+#: cycle), so ``source_graph`` cannot import the producer back.
+#:
+#: A ``use_case``/``test_case`` node is declared by an optional, hand-authored
+#: ``impact-use-cases.yaml`` manifest — deliberately a **separate** schema
+#: from ``docs/contribute/usecase-registry.yaml`` (which tracks abicheck's own
+#: feature coverage, not a consumer project's business use cases; conflating
+#: the two would read "abicheck supports header-only analysis" and "the DAL
+#: training workflow uses ``train()``" as the same kind of fact).
+#:
+#: Only ``USE_CASE_USES_ENTRY`` and ``TEST_COVERS_USE_CASE`` are populated in
+#: this slice, both from the manifest alone. ``TRACE_OBSERVED_ENTRY``/
+#: ``TRACE_OBSERVED_EDGE`` are **reserved** — same "registered so a hand-built
+#: or newer graph naming one is never rejected, but no normalized data source
+#: yet" pattern ``CONSUMER_INSTANTIATES_DECL`` etc. use above: runtime-trace
+#: ingestion is explicitly out of scope for this slice (ADR-057's
+#: "Deliberately not implemented this slice" — absence of a trace must never
+#: read as "not used", a semantics decision with no data to validate against
+#: yet).
+USE_CASE_NODE_KINDS: frozenset[str] = frozenset({"use_case", "test_case"})
+USE_CASE_EDGE_KINDS: frozenset[str] = frozenset(
+    {
+        "USE_CASE_USES_ENTRY",
+        "TEST_COVERS_USE_CASE",
+        "TRACE_OBSERVED_ENTRY",
+        "TRACE_OBSERVED_EDGE",
+    }
+)
+
 
 def _precedence_key(fact: GraphFact) -> tuple[int, str, str]:
     """Deterministic total order over facts: highest confidence first, tie

--- a/abicheck/buildsource/source_graph.py
+++ b/abicheck/buildsource/source_graph.py
@@ -59,6 +59,8 @@ from .graph_facts import (
     CONF_UNKNOWN as CONF_UNKNOWN,
     CONSUMER_EDGE_KINDS,  # G29 Phase 4 (ADR-057)
     CONSUMER_NODE_KINDS,
+    USE_CASE_EDGE_KINDS,  # G29 Phase 4 slice 2 (ADR-057 amendment)
+    USE_CASE_NODE_KINDS,
     FactConflict as FactConflict,
     GraphEdge as GraphEdge,
     GraphFact as GraphFact,
@@ -112,16 +114,9 @@ NODE_KINDS: frozenset[str] = frozenset(
         "toolchain",
         "generated_file",
         "external_dependency",
-        # ADR-041 P1 #2: object/link provenance (a symbol change attributed
-        # to "which object/archive member/link step", not only "which
-        # target"). object_file/static_library/version_script are populated
-        # from BuildEvidence.compile_units/link_units below;
-        # archive_member/linker_script/export_map/comdat_group are reserved
-        # for a future archive/linker-artifact introspection extractor (no
-        # normalized data source yet — same "reserved, not yet populated"
-        # pattern this ADR's own P0 slice 1 used for the edge kinds it later
-        # filled in), so an inputs-pack/hand-built graph naming one is never
-        # rejected.
+        # ADR-041 P1 #2: object/link provenance (a symbol change attributed to "which object/archive member/link step", not only "which target"). object_file/static_library/version_script are populated
+        # from BuildEvidence.compile_units/link_units below; archive_member/linker_script/export_map/comdat_group are reserved for a future archive/linker-artifact introspection extractor (no normalized
+        # data source yet — same "reserved, not yet populated" pattern this ADR's own P0 slice 1 used for the edge kinds it later filled in), so an inputs-pack/hand-built graph naming one is never rejected.
         "object_file",
         "archive_member",
         "static_library",
@@ -129,7 +124,9 @@ NODE_KINDS: frozenset[str] = frozenset(
         "version_script",
         "export_map",
         "comdat_group",
-    } | CONSUMER_NODE_KINDS
+    }
+    | CONSUMER_NODE_KINDS
+    | USE_CASE_NODE_KINDS
 )
 
 #: Edge kinds the graph schema understands (ADR-031 D2).
@@ -168,7 +165,9 @@ EDGE_KINDS: frozenset[str] = frozenset(
         # already creates.
         "ARCHIVE_CONTAINS_OBJECT",
         "OBJECT_DEFINES_SYMBOL",
-    } | CONSUMER_EDGE_KINDS
+    }
+    | CONSUMER_EDGE_KINDS
+    | USE_CASE_EDGE_KINDS
 )
 
 #: L5 edge kinds that express a decl/type dependency (ADR-041 P0): a call, a

--- a/abicheck/buildsource/source_graph_findings.py
+++ b/abicheck/buildsource/source_graph_findings.py
@@ -766,6 +766,31 @@ def _mapping_drift_findings(
         if old_sym != new_sym:
             label = new_labels.get(decl, decl)
             findings.append(
+                # ADR-052 D2 follow-up (G29 Phase 3 slice 10 audit): NOT
+                # cached with `change.impact_assessment = assess_change(change)`
+                # here, unlike Slice 8/9's `internal_leak.py`/`appcompat.py`
+                # sites. Those builders run as (or after) a
+                # `post_processing.DEFAULT_PIPELINE` *step*, downstream of
+                # `MarkReachability`, so their own Change objects are never
+                # touched by it. This module's findings are different: their
+                # caller (`cli_buildsource_helpers.prepare_embedded_build_source`)
+                # folds them into `checker.compare`'s `extra_changes`, which
+                # `compare()` merges into `changes` *before* calling
+                # `_run_post_processing` (checker.py) — i.e. before
+                # `DEFAULT_PIPELINE.run()`, where `MarkReachability` (the
+                # only step that mutates `public_reachable`/
+                # `reachability_state`/`reachability_kind`/
+                # `reachability_proof_path` on an existing Change) still runs
+                # on every one of these findings when suppression needs
+                # reachability evidence. None of the ten `Change(...)` sites
+                # in this module set those four fields themselves — caching
+                # here would freeze them at their unset defaults, which
+                # `MarkReachability` would then silently make stale.
+                # `MarkReachability` itself now caches
+                # `impact_assessment` right after it finalizes those fields
+                # (`post_processing_reachability.py`), so every finding here
+                # still ends up with a correctly cached assessment once it
+                # reaches that step — just not from this construction site.
                 Change(
                     kind=ChangeKind.SOURCE_TO_BINARY_MAPPING_CHANGED,
                     symbol=label,
@@ -816,6 +841,10 @@ def _public_reachability_findings(
                 continue
             label = new_labels.get(decl, decl)
             findings.append(
+                # ADR-052 D2 follow-up: not cached here -- see
+                # _mapping_drift_findings's comment above for the full audit
+                # (MarkReachability runs downstream of this module and would
+                # make an eagerly-cached assessment stale).
                 Change(
                     kind=ChangeKind.PUBLIC_REACHABILITY_CHANGED,
                     symbol=label,
@@ -834,6 +863,8 @@ def _public_reachability_findings(
                 continue
             label = old_labels.get(decl, decl)
             findings.append(
+                # ADR-052 D2 follow-up: not cached -- see
+                # _mapping_drift_findings's comment above.
                 Change(
                     kind=ChangeKind.PUBLIC_REACHABILITY_CHANGED,
                     symbol=label,
@@ -867,6 +898,8 @@ def _generated_public_closure_findings(
     for gen in sorted(newly_generated):
         label = new_labels.get(gen, gen)
         findings.append(
+            # ADR-052 D2 follow-up: not cached -- see
+            # _mapping_drift_findings's comment above.
             Change(
                 kind=ChangeKind.GENERATED_HEADER_REACHES_PUBLIC_API,
                 symbol=label,
@@ -918,6 +951,8 @@ def _call_reachability_findings(
                     example = f" Example newly-reachable path: {_format_dependency_path(new, path)}."
                     break
             findings.append(
+                # ADR-052 D2 follow-up: not cached -- see
+                # _mapping_drift_findings's comment above.
                 Change(
                     kind=ChangeKind.CALL_GRAPH_PUBLIC_ENTRY_REACHABILITY_CHANGED,
                     symbol=label,
@@ -1062,6 +1097,8 @@ def _include_graph_drift_findings(
         is_entered = hdr in new_inc
         label = (new_labels if is_entered else old_labels).get(hdr, hdr)
         findings.append(
+            # ADR-052 D2 follow-up: not cached -- see
+            # _mapping_drift_findings's comment above.
             Change(
                 kind=ChangeKind.INCLUDE_GRAPH_PUBLIC_HEADER_DRIFT,
                 symbol=label,
@@ -1106,6 +1143,8 @@ def _build_option_reach_findings(
         label = new_labels.get(opt, opt)
         n_syms = len(reached_by_option[opt])
         findings.append(
+            # ADR-052 D2 follow-up: not cached -- see
+            # _mapping_drift_findings's comment above.
             Change(
                 kind=ChangeKind.BUILD_OPTION_REACHES_PUBLIC_SYMBOL,
                 symbol=label,
@@ -1246,6 +1285,17 @@ def _internal_dependency_findings(
             if own_change is not None
             else ""
         )
+        # ADR-052 D2 follow-up: not cached immediately after construction --
+        # see _mapping_drift_findings's comment above. Unlike the other
+        # eight sites, this one also calls attach_impact_metadata below,
+        # which sets impact_proof_path/affected_public_roots/impact_is_direct/
+        # impact_alternative_paths -- but those fields are never touched by
+        # MarkReachability (confirmed: it only mutates public_reachable/
+        # reachability_state/reachability_kind/reachability_proof_path), so
+        # they are already stable by the time MarkReachability runs and
+        # caches this change's assessment; only the reachability fields
+        # this site leaves unset are the reason caching here (before
+        # attach_impact_metadata even runs) would be unsafe.
         change = Change(
             kind=ChangeKind.PUBLIC_API_INTERNAL_DEPENDENCY_ADDED,
             symbol=label,
@@ -1310,6 +1360,8 @@ def _target_dependency_findings(
         tlabel = new_labels.get(target, target)
         dlabel = new_labels.get(dep, dep)
         findings.append(
+            # ADR-052 D2 follow-up: not cached -- see
+            # _mapping_drift_findings's comment above.
             Change(
                 kind=ChangeKind.TARGET_DEPENDENCY_ADDED,
                 symbol=tlabel,
@@ -1431,6 +1483,8 @@ def _symbol_owner_findings(
             # "[L5_SOURCE_GRAPH]" placeholder when the real one is on hand).
             new_owner_label = new_labels.get(new_owner[symbol], new_owner[symbol])
             findings.append(
+                # ADR-052 D2 follow-up: not cached -- see
+                # _mapping_drift_findings's comment above.
                 Change(
                     kind=ChangeKind.EXPORTED_SYMBOL_SOURCE_OWNER_CHANGED,
                     symbol=label,

--- a/abicheck/errors.py
+++ b/abicheck/errors.py
@@ -243,6 +243,27 @@ class PackManifestError(AbicheckError, ValueError):
     """
 
 
+class UseCaseManifestError(AbicheckError, ValueError):
+    """Raised by :func:`abicheck.impact.use_cases.load_use_case_manifest` for
+    a structurally malformed ``impact-use-cases.yaml`` document (G29 Phase 4
+    slice 2, ADR-057 amendment): not a YAML list at the top level, an entry
+    that isn't a mapping, or an entry with a missing/blank ``use_case`` name.
+
+    Inherits ValueError for the same backward-compatibility reason
+    :class:`PolicyError`/:class:`ManifestValidationError` do. Deliberately a
+    sibling of those, not a subclass: an ``impact-use-cases.yaml`` document is
+    a distinct, unrelated configuration artifact (declared consumer use
+    cases, not verdict policy or a dump manifest).
+
+    A single manifest entry naming an ``entrypoints`` symbol the library
+    graph cannot resolve is **not** this error — that degrades silently to
+    "no node/edge for this entry", per the same "absence, never a wrong
+    answer" discipline :mod:`abicheck.impact.consumer_graph` already follows
+    (ADR-057). This error is only for the manifest document itself being
+    unreadable as the schema it claims to be.
+    """
+
+
 class ReportError(AbicheckError):
     """Error during report generation."""
 

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -569,6 +569,31 @@ def join_use_case_graph(
     test check) is untouched, only the single summary ``provenance``/
     ``confidence`` fields are reset to what the library graph already
     resolved before this join ran.
+
+    **Known residual gap** (Codex review, fresh evidence): this restoration
+    only patches the *already-resolved* ``provenance``/``confidence``
+    fields on the graph this function returns — the risky
+    ``declared_use_case``/``CONF_UNKNOWN`` fact itself is still sitting in
+    ``node.facts`` (deliberately; that is the join's whole point). Nothing
+    in the current codebase re-runs ``ensure_facts_and_resolve`` on this
+    specific returned graph afterward (confirmed: :func:`join_use_case_graph`
+    has no other caller today — this module isn't wired into any real
+    ``compare``/report pipeline yet, per this file's own module docstring),
+    so this fix is correct for every real code path that exists right now.
+    But a *future* caller that merges this joined graph's nodes into another
+    graph via :meth:`~abicheck.buildsource.source_graph.SourceGraphSummary.add_node`
+    again, or round-trips it through ``to_dict()``/``from_dict()``, would
+    re-trigger the same tied-confidence provenance risk this function just
+    fixed, since both recompute ``provenance``/``confidence`` fresh from the
+    unchanged ``facts`` list. Closing that residual gap for real needs a
+    change to the shared merge precedence itself (a way to mark a
+    :class:`~abicheck.buildsource.graph_facts.GraphFact` as never eligible
+    to win the "top" pick in ``graph_facts._precedence_key``/
+    ``ensure_facts_and_resolve``) — every graph producer in the codebase
+    shares that one precedence function, so this is a scoped design
+    decision of its own, not a drive-by fix bundled into this module's join.
+    Whoever wires :func:`join_use_case_graph`'s result into a real pipeline
+    that might re-merge or re-serialize it must close this gap first.
     """
     original = {n.id: (n.provenance, n.confidence) for n in library_graph.nodes}
     joined = copy.deepcopy(library_graph)

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -78,6 +78,44 @@ if TYPE_CHECKING:
 USE_CASE_PROVENANCE = "declared_use_case"
 
 
+class _DuplicateKeyCheckingLoader(yaml.SafeLoader):
+    """``yaml.SafeLoader`` with one behavior change: a mapping that repeats a
+    key is a load error instead of the PyYAML default of silently keeping
+    only the last value.
+
+    A manifest author who accidentally repeats a field (two ``entrypoints:``
+    lines in one use-case entry, most plausibly from a copy-paste) would
+    otherwise have part of their declared coverage silently dropped with no
+    signal at all — exactly the "coverage quietly disappears" failure mode
+    :func:`load_use_case_manifest`'s docstring already promises this module
+    never allows. Scoped to this loader class alone (not a process-wide
+    ``yaml`` monkeypatch), so it affects nothing outside this module.
+    """
+
+
+def _construct_mapping_rejecting_duplicates(
+    loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[Any, Any]:
+    mapping: dict[Any, Any] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found duplicate key: {key!r}",
+                key_node.start_mark,
+            )
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_DuplicateKeyCheckingLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    _construct_mapping_rejecting_duplicates,
+)
+
+
 def use_case_node_id(name: str) -> str:
     """Node id for a declared use case. Mirrors the ``<scheme>://<name>``
     convention every other id helper in this package/``source_graph.py``
@@ -175,14 +213,16 @@ def load_use_case_manifest(path: str | Path) -> list[UseCaseDefinition]:
 
     Raises :class:`~abicheck.errors.UseCaseManifestError` for a structurally
     malformed document (not a list, a non-mapping entry, a missing/blank
-    ``use_case`` name) — the same hard-load-error discipline
-    ``policy_file.py``/``suppression.py`` already use for user-supplied YAML,
-    since silently skipping a malformed entry could make a use case's
-    declared coverage quietly disappear.
+    ``use_case`` name), a syntactically invalid one, or one that repeats a
+    mapping key (:class:`_DuplicateKeyCheckingLoader`) — the same
+    hard-load-error discipline ``policy_file.py``/``suppression.py`` already
+    use for user-supplied YAML, since silently skipping or overwriting a
+    malformed entry could make a use case's declared coverage quietly
+    disappear.
     """
     text = Path(path).read_text(encoding="utf-8")
     try:
-        raw = yaml.safe_load(text)
+        raw = yaml.load(text, Loader=_DuplicateKeyCheckingLoader)
     except yaml.YAMLError as exc:
         raise UseCaseManifestError(
             f"impact-use-cases.yaml: {path}: invalid YAML syntax: {exc}"

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -278,9 +278,20 @@ def _public_entry_index(library_graph: SourceGraphSummary) -> dict[str, str]:
     A "public entry" here is either an exported ``binary_symbol`` node (a
     library's export table names a real, consumer-visible entry point even
     when no source graph exists to walk from it — e.g. a binary-only or
-    header-only graph) or a ``source_decl``/other node whose own declared
+    header-only graph) or a ``source_decl`` node whose own declared
     ``visibility`` is public (``PUBLIC_VISIBILITIES`` — the same set
     :mod:`abicheck.impact.consumer_graph`'s direct-requirement check reads).
+
+    Deliberately restricted to these two kinds, not any public-visibility
+    node (Codex review, fresh evidence): a public ``record_type``/
+    ``enum_type``/``typedef`` can share ``PUBLIC_VISIBILITIES`` too, but a
+    type is never something a use case "exercises" — it has no outgoing
+    ``DECL_CALLS_DECL`` edge for a consumer-impact walk to follow, and a
+    manifest entry naming one by label is far more likely to be an author's
+    mistake than a genuine business/runtime entrypoint. Accepting it would
+    emit a ``USE_CASE_USES_ENTRY`` edge to a node the graph's own
+    entry-domain predicates (``is_consumer_compiled_public_entry`` and
+    friends) never treat as a real call-graph starting point.
 
     A node's own id is always registered (exact-id lookups can never be
     ambiguous — two distinct nodes never share one id). A node's ``label``
@@ -314,8 +325,12 @@ def _public_entry_index(library_graph: SourceGraphSummary) -> dict[str, str]:
     from ..buildsource.source_graph import PUBLIC_VISIBILITIES
 
     def is_public(node: GraphNode) -> bool:
+        if node.kind == "binary_symbol":
+            return True
+        if node.kind != "source_decl":
+            return False
         visibility = str((node.resolved or node.attrs).get("visibility", ""))
-        return node.kind == "binary_symbol" or visibility in PUBLIC_VISIBILITIES
+        return visibility in PUBLIC_VISIBILITIES
 
     public_nodes = [n for n in library_graph.nodes if is_public(n)]
     public_ids = {n.id for n in public_nodes}

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -162,11 +162,27 @@ class UseCaseDefinition:
     tests: tuple[str, ...] = ()
 
 
+#: The only keys a manifest entry may declare (Codex review, fresh evidence):
+#: an unrecognized key (e.g. a misspelled ``entrypoint``/``test`` instead of
+#: ``entrypoints``/``tests``) must be a hard error, not silently ignored --
+#: ``mapping.get(...)`` treats an unknown key as absent and would otherwise
+#: load successfully while quietly dropping the coverage the author actually
+#: declared, exactly the failure mode this module's docstring already
+#: promises never happens.
+_MANIFEST_ENTRY_KEYS = frozenset({"use_case", "entrypoints", "tests"})
+
+
 def _require_mapping(entry: Any, index: int) -> dict[str, Any]:
     if not isinstance(entry, dict):
         raise UseCaseManifestError(
             f"impact-use-cases.yaml: entry {index} must be a mapping, got "
             f"{type(entry).__name__}"
+        )
+    unknown = sorted(set(entry) - _MANIFEST_ENTRY_KEYS)
+    if unknown:
+        raise UseCaseManifestError(
+            f"impact-use-cases.yaml: entry {index} has unknown field(s) "
+            f"{unknown} — expected only {sorted(_MANIFEST_ENTRY_KEYS)}"
         )
     return entry
 

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -337,20 +337,36 @@ def _public_entry_index(library_graph: SourceGraphSummary) -> dict[str, str]:
 
     index: dict[str, str] = {n.id: n.id for n in public_nodes}
 
-    # A public decl's mapped-to public symbol id, when one exists — the
-    # coalescing key. Restricted to edges between two *public* nodes so a
-    # mapping onto an internal/unresolved target can't smuggle a non-public
-    # id into the label index.
-    mapped_symbol: dict[str, str] = {
-        e.src: e.dst
-        for e in library_graph.edges
-        if e.kind == "SOURCE_DECL_MAPS_TO_SYMBOL"
-        and e.src in public_ids
-        and e.dst in public_ids
-    }
+    # A public decl's mapped-to public symbol id, when *exactly one* exists
+    # — the coalescing key. Restricted to edges between two *public* nodes
+    # so a mapping onto an internal/unresolved target can't smuggle a
+    # non-public id into the label index.
+    #
+    # Collected as a set per src, not a plain {src: dst} dict comprehension
+    # (Codex review, fresh evidence): a decl legitimately mapped to more
+    # than one symbol (versioned exports, aliases, or facts merged from more
+    # than one graph producer under ADR-046 D2's evidence-preserving merge —
+    # add_edge dedups only on the full (src, dst, kind, role) relation key,
+    # so two such edges coexist rather than collapsing) would otherwise have
+    # a plain dict comprehension silently keep whichever destination came
+    # last in ``library_graph.edges`` iteration order — an
+    # order-dependent, wrong-but-confident coalescing target instead of the
+    # "degrade to no answer" this whole function otherwise guarantees for a
+    # genuine ambiguity.
+    mapped_symbols: dict[str, set[str]] = {}
+    for e in library_graph.edges:
+        if (
+            e.kind == "SOURCE_DECL_MAPS_TO_SYMBOL"
+            and e.src in public_ids
+            and e.dst in public_ids
+        ):
+            mapped_symbols.setdefault(e.src, set()).add(e.dst)
 
     def coalesced(node_id: str) -> str:
-        return mapped_symbol.get(node_id, node_id)
+        targets = mapped_symbols.get(node_id)
+        if targets is not None and len(targets) == 1:
+            return next(iter(targets))
+        return node_id
 
     label_targets: dict[str, set[str]] = {}
     for node in public_nodes:

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -254,16 +254,29 @@ def load_use_case_manifest(path: str | Path) -> list[UseCaseDefinition]:
 
     Raises :class:`~abicheck.errors.UseCaseManifestError` for a structurally
     malformed document (not a list, a non-mapping entry, a missing/blank
-    ``use_case`` name), a syntactically invalid one, or one that repeats a
-    mapping key (:class:`_DuplicateKeyCheckingLoader`) — the same
-    hard-load-error discipline ``policy_file.py``/``suppression.py`` already
-    use for user-supplied YAML, since silently skipping or overwriting a
-    malformed entry could make a use case's declared coverage quietly
-    disappear.
+    ``use_case`` name), a syntactically invalid one, one that repeats a
+    mapping key (:class:`_DuplicateKeyCheckingLoader`), or one that isn't
+    valid UTF-8 — the same hard-load-error discipline
+    ``policy_file.py``/``suppression.py`` already use for user-supplied
+    YAML, since silently skipping or overwriting a malformed entry could
+    make a use case's declared coverage quietly disappear.
+
+    A missing/unreadable *path* itself (``OSError`` — no such file, a
+    directory, a permissions error) is deliberately left as-is, not wrapped
+    — that is an ordinary filesystem error a caller already knows how to
+    handle, distinct from "the file exists but its contents are malformed"
+    (Codex review, fresh evidence: the read used to happen *outside* this
+    function's guarded block at all, so a real-world non-UTF-8 manifest
+    raised a bare ``UnicodeDecodeError`` instead of the documented
+    exception type).
     """
-    text = Path(path).read_text(encoding="utf-8")
     try:
+        text = Path(path).read_text(encoding="utf-8")
         raw = yaml.load(text, Loader=_DuplicateKeyCheckingLoader)
+    except UnicodeError as exc:
+        raise UseCaseManifestError(
+            f"impact-use-cases.yaml: {path}: not valid UTF-8: {exc}"
+        ) from exc
     except yaml.YAMLError as exc:
         raise UseCaseManifestError(
             f"impact-use-cases.yaml: {path}: invalid YAML syntax: {exc}"

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -56,6 +56,7 @@ import yaml
 
 from ..buildsource.graph_facts import (
     CONF_HIGH,
+    CONF_UNKNOWN,
     USE_CASE_EDGE_KINDS as USE_CASE_EDGE_KINDS,
     USE_CASE_NODE_KINDS as USE_CASE_NODE_KINDS,
     GraphEdge,
@@ -178,11 +179,18 @@ def _require_mapping(entry: Any, index: int) -> dict[str, Any]:
             f"impact-use-cases.yaml: entry {index} must be a mapping, got "
             f"{type(entry).__name__}"
         )
-    unknown = sorted(set(entry) - _MANIFEST_ENTRY_KEYS)
+    # Sorted by repr, not the bare keys (Codex review, fresh evidence): a
+    # syntactically valid YAML mapping may use heterogeneous key types (an
+    # integer key alongside a string one, e.g. `1: foo`) -- sorted() on the
+    # raw values would raise a bare TypeError comparing int to str *before*
+    # UseCaseManifestError could even be constructed, breaking this
+    # function's own single-exception contract for exactly the malformed
+    # input it exists to reject cleanly.
+    unknown = sorted((set(entry) - _MANIFEST_ENTRY_KEYS), key=repr)
     if unknown:
         raise UseCaseManifestError(
             f"impact-use-cases.yaml: entry {index} has unknown field(s) "
-            f"{unknown} — expected only {sorted(_MANIFEST_ENTRY_KEYS)}"
+            f"{unknown!r} — expected only {sorted(_MANIFEST_ENTRY_KEYS)}"
         )
     return entry
 
@@ -324,15 +332,39 @@ def build_use_case_graph(
     resolution) — only the ``USE_CASE_USES_ENTRY`` edges are conditional.
 
     A resolved entrypoint also gets a same-id placeholder node registered
-    alongside its edge (kind copied from the real library node, so
-    ``add_node``'s "first registration wins" rule never overrides it) —
-    mirroring :func:`abicheck.impact.consumer_graph.build_consumer_graph`'s
-    identical pattern for its ``binary_symbol`` targets. Without it, only an
-    *edge* would point at the library node and the join
-    (:func:`join_use_case_graph`) would never actually deposit a
-    ``USE_CASE_PROVENANCE`` fact onto the shared node — the merge (ADR-046
-    D2) only happens on a node/edge registration, not implicitly because an
-    edge names an id.
+    alongside its edge (kind copied from the real library node) — mirroring
+    :func:`abicheck.impact.consumer_graph.build_consumer_graph`'s identical
+    pattern for its ``binary_symbol`` targets. Without it, only an *edge*
+    would point at the library node and the join (:func:`join_use_case_graph`)
+    would never actually deposit a ``USE_CASE_PROVENANCE`` fact onto the
+    shared node — the merge (ADR-046 D2) only happens on a node/edge
+    registration, not implicitly because an edge names an id.
+
+    Deliberately registered at ``CONF_UNKNOWN``, not ``CONF_HIGH`` (Codex
+    review, fresh evidence): ``SourceGraphSummary.add_node``'s ADR-046 D2
+    merge doesn't keep ``attrs``/``provenance``/``confidence`` per-producer —
+    ``provenance``/``confidence`` are each set from the single
+    highest-*precedence* fact across every producer that ever registered the
+    node (``ensure_facts_and_resolve``'s ``top = min(entity.facts, key=
+    _precedence_key)``), and precedence ranks confidence first. A
+    ``kythe``/``codeql``-sourced or indirectly-resolved ``call_graph``
+    fallback node carries no ``consumer_compiled_body`` attr and is exactly
+    ``CONF_REDUCED`` — lower than this module's placeholder would be at
+    ``CONF_HIGH`` — which would let a use-case reference *win* that node's
+    ``provenance`` outright. `source_graph.is_consumer_compiled_node`` falls
+    back to reading ``provenance`` exactly when no ``consumer_compiled_body``
+    attr is present, so a provenance flip from a real "unproven body" signal
+    to ``declared_use_case`` (not itself one of the three provenances that
+    signal excludes) would flip that predicate from correctly conservative
+    (``False``) to wrongly permissive (``True``) — letting a later
+    consumer-impact call-graph traversal walk straight through an out-of-line
+    body it was never proven to reach, and report a false impact path.
+    ``CONF_UNKNOWN`` is the lowest rank (:data:`~abicheck.buildsource.
+    graph_facts._CONFIDENCE_RANK`), so this placeholder can never outrank
+    *any* real evidence the target node already carries — it only ever wins
+    when the target has no competing fact at all, which cannot happen here
+    (:func:`_public_entry_index` only ever resolves an id/label already
+    present in *library_graph*).
 
     Every ``test_case`` named in ``tests`` gets its own node and a
     ``TEST_COVERS_USE_CASE`` edge onto its use case, unconditionally: unlike
@@ -366,7 +398,7 @@ def build_use_case_graph(
                     id=target,
                     kind=target_kind,
                     provenance=USE_CASE_PROVENANCE,
-                    confidence=CONF_HIGH,
+                    confidence=CONF_UNKNOWN,
                 )
             )
             graph.add_edge(

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -285,13 +285,31 @@ def _public_entry_index(library_graph: SourceGraphSummary) -> dict[str, str]:
     A node's own id is always registered (exact-id lookups can never be
     ambiguous — two distinct nodes never share one id). A node's ``label``
     (when set) is registered only when it resolves *uniquely* across every
-    public node in the graph: overloaded C++ entry points routinely share
-    one display label, and silently picking an arbitrary one of them would
-    hand a manifest's ``entrypoints: [foo]`` a wrong-but-confident answer
-    instead of the "degrade to no answer" this module otherwise guarantees
+    public node in the graph, **after** coalescing a declaration onto the
+    binary symbol it maps to (below) — overloaded C++ entry points routinely
+    share one display label with no such mapping between them, and silently
+    picking an arbitrary one of them would hand a manifest's
+    ``entrypoints: [foo]`` a wrong-but-confident answer instead of the
+    "degrade to no answer" this module otherwise guarantees
     (:func:`build_use_case_graph`). An id also always wins over a label —
     built as a separate pass, an ambiguous or colliding label can never
     shadow an exact id already registered.
+
+    Coalescing (Codex review, fresh evidence): an ordinary exported C
+    function like ``train`` produces **two** public nodes sharing the exact
+    label ``"train"`` — the ``source_decl`` (``build_source_graph``'s
+    ``label=ent.qualified_name or ent.identity()``) and the ``binary_symbol``
+    it maps to (``label=symbol``, joined by a ``SOURCE_DECL_MAPS_TO_SYMBOL``
+    edge) — since a plain C function's declared name, qualified name, and
+    linker symbol are all the identical string. Without coalescing, this is
+    exactly the common case a manifest's plain-label ``entrypoints: [train]``
+    is meant to name, yet it would read as a genuine two-way ambiguity and be
+    silently dropped. A declaration and the export it maps to are one public
+    entry represented twice in the graph, not two candidates competing for
+    one label — collapsed onto the mapped symbol id before the
+    ambiguity/uniqueness check runs, so only a *real* overload collision
+    (two distinct declarations sharing a label with no mapping edge joining
+    them) is still treated as ambiguous.
     """
     from ..buildsource.source_graph import PUBLIC_VISIBILITIES
 
@@ -300,13 +318,29 @@ def _public_entry_index(library_graph: SourceGraphSummary) -> dict[str, str]:
         return node.kind == "binary_symbol" or visibility in PUBLIC_VISIBILITIES
 
     public_nodes = [n for n in library_graph.nodes if is_public(n)]
+    public_ids = {n.id for n in public_nodes}
 
     index: dict[str, str] = {n.id: n.id for n in public_nodes}
+
+    # A public decl's mapped-to public symbol id, when one exists — the
+    # coalescing key. Restricted to edges between two *public* nodes so a
+    # mapping onto an internal/unresolved target can't smuggle a non-public
+    # id into the label index.
+    mapped_symbol: dict[str, str] = {
+        e.src: e.dst
+        for e in library_graph.edges
+        if e.kind == "SOURCE_DECL_MAPS_TO_SYMBOL"
+        and e.src in public_ids
+        and e.dst in public_ids
+    }
+
+    def coalesced(node_id: str) -> str:
+        return mapped_symbol.get(node_id, node_id)
 
     label_targets: dict[str, set[str]] = {}
     for node in public_nodes:
         if node.label:
-            label_targets.setdefault(node.label, set()).add(node.id)
+            label_targets.setdefault(node.label, set()).add(coalesced(node.id))
     for label, targets in label_targets.items():
         if label in index:
             continue  # an exact id already claims this string; it wins

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -181,7 +181,12 @@ def load_use_case_manifest(path: str | Path) -> list[UseCaseDefinition]:
     declared coverage quietly disappear.
     """
     text = Path(path).read_text(encoding="utf-8")
-    raw = yaml.safe_load(text)
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise UseCaseManifestError(
+            f"impact-use-cases.yaml: {path}: invalid YAML syntax: {exc}"
+        ) from exc
     return parse_use_case_manifest(raw)
 
 
@@ -195,26 +200,38 @@ def _public_entry_index(library_graph: SourceGraphSummary) -> dict[str, str]:
     header-only graph) or a ``source_decl``/other node whose own declared
     ``visibility`` is public (``PUBLIC_VISIBILITIES`` — the same set
     :mod:`abicheck.impact.consumer_graph`'s direct-requirement check reads).
-    Both a node's own id and its ``label`` (when set) are registered, so a
-    manifest can name either the graph's internal id spelling or the
-    human-readable label.
 
-    Later registrations never overwrite an earlier one for the same string
-    (``setdefault``) — an ambiguous label two different nodes share resolves
-    to whichever public entry was iterated first, deterministically (graph
-    node order), rather than flipping between runs.
+    A node's own id is always registered (exact-id lookups can never be
+    ambiguous — two distinct nodes never share one id). A node's ``label``
+    (when set) is registered only when it resolves *uniquely* across every
+    public node in the graph: overloaded C++ entry points routinely share
+    one display label, and silently picking an arbitrary one of them would
+    hand a manifest's ``entrypoints: [foo]`` a wrong-but-confident answer
+    instead of the "degrade to no answer" this module otherwise guarantees
+    (:func:`build_use_case_graph`). An id also always wins over a label —
+    built as a separate pass, an ambiguous or colliding label can never
+    shadow an exact id already registered.
     """
     from ..buildsource.source_graph import PUBLIC_VISIBILITIES
 
-    index: dict[str, str] = {}
-    for node in library_graph.nodes:
+    def is_public(node: GraphNode) -> bool:
         visibility = str((node.resolved or node.attrs).get("visibility", ""))
-        is_public = node.kind == "binary_symbol" or visibility in PUBLIC_VISIBILITIES
-        if not is_public:
-            continue
-        index.setdefault(node.id, node.id)
+        return node.kind == "binary_symbol" or visibility in PUBLIC_VISIBILITIES
+
+    public_nodes = [n for n in library_graph.nodes if is_public(n)]
+
+    index: dict[str, str] = {n.id: n.id for n in public_nodes}
+
+    label_targets: dict[str, set[str]] = {}
+    for node in public_nodes:
         if node.label:
-            index.setdefault(node.label, node.id)
+            label_targets.setdefault(node.label, set()).add(node.id)
+    for label, targets in label_targets.items():
+        if label in index:
+            continue  # an exact id already claims this string; it wins
+        if len(targets) == 1:
+            index[label] = next(iter(targets))
+        # else: label is ambiguous across >1 public node — left unresolved
     return index
 
 

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -544,10 +544,40 @@ def join_use_case_graph(
     the library's own coverage honesty describe a pass that never ran.
     Deliberately not :meth:`~abicheck.buildsource.source_graph.SourceGraphSummary.finalize`\\ d
     either, for the same transient-graph reason.
+
+    Restores every already-existing node's own ``provenance``/``confidence``
+    to their pre-join value afterward (Codex review, fresh evidence — a
+    residual gap in the earlier ``CONF_UNKNOWN`` placeholder-confidence fix):
+    ``ensure_facts_and_resolve``'s ADR-046 D2 merge picks **one** globally
+    winning fact for a node's ``provenance``/``confidence`` via a full
+    precedence order (confidence rank first, then producer name as a
+    tiebreak) — there is no way to mark a fact as "never eligible to win",
+    so no confidence level :func:`build_use_case_graph`'s coalescing
+    placeholder could choose is safe against *every* real producer's own
+    confidence/name combination. ``CONF_UNKNOWN`` (the lowest rank) stops a
+    higher-confidence real fact from ever losing to it, but a real fact that
+    is *also* ``CONF_UNKNOWN`` (e.g. a loaded or hand-built graph whose node
+    omitted a confidence) ties on rank, and the producer-name tiebreak alone
+    can still pick ``"declared_use_case"`` over a real producer whose name
+    sorts later (``"kythe"``, ``"codeql"``, …) — the same
+    ``is_consumer_compiled_node()`` provenance-fallback risk the earlier fix
+    closed for the confidence-ordering case, reopened for the tied case.
+    Restoring the pre-join value afterward is correct regardless of
+    ordering, rather than attempting to out-rank every possible producer
+    name — this module's own ``facts`` contribution (what
+    :func:`join_use_case_graph`'s own docstring above and its regression
+    test check) is untouched, only the single summary ``provenance``/
+    ``confidence`` fields are reset to what the library graph already
+    resolved before this join ran.
     """
+    original = {n.id: (n.provenance, n.confidence) for n in library_graph.nodes}
     joined = copy.deepcopy(library_graph)
     for node in use_cases.nodes:
         joined.add_node(copy.deepcopy(node))
     for edge in use_cases.edges:
         joined.add_edge(copy.deepcopy(edge))
+    for node in joined.nodes:
+        restore = original.get(node.id)
+        if restore is not None:
+            node.provenance, node.confidence = restore
     return joined

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -269,6 +269,15 @@ def load_use_case_manifest(path: str | Path) -> list[UseCaseDefinition]:
     function's guarded block at all, so a real-world non-UTF-8 manifest
     raised a bare ``UnicodeDecodeError`` instead of the documented
     exception type).
+
+    Also wraps a bare ``ValueError`` from PyYAML's own implicit-resolver
+    scalar constructors (Codex review, fresh evidence): a value that looks
+    like a YAML timestamp but has an invalid component (``2023-99-99`` —
+    no such month) is resolved to the timestamp tag by PyYAML's *resolver*
+    before construction even reaches this loader's own overrides, and its
+    built-in timestamp constructor raises a plain ``ValueError`` (not a
+    ``yaml.YAMLError`` subclass) for an out-of-range date/time part — a
+    document shape neither the syntax nor the UTF-8 guard above catches.
     """
     try:
         text = Path(path).read_text(encoding="utf-8")
@@ -280,6 +289,10 @@ def load_use_case_manifest(path: str | Path) -> list[UseCaseDefinition]:
     except yaml.YAMLError as exc:
         raise UseCaseManifestError(
             f"impact-use-cases.yaml: {path}: invalid YAML syntax: {exc}"
+        ) from exc
+    except ValueError as exc:
+        raise UseCaseManifestError(
+            f"impact-use-cases.yaml: {path}: invalid scalar value: {exc}"
         ) from exc
     return parse_use_case_manifest(raw)
 

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -96,9 +96,26 @@ class _DuplicateKeyCheckingLoader(yaml.SafeLoader):
 def _construct_mapping_rejecting_duplicates(
     loader: yaml.SafeLoader, node: yaml.MappingNode, deep: bool = False
 ) -> dict[Any, Any]:
+    """PyYAML's own ``SafeConstructor.construct_mapping`` already rejects an
+    unhashable key (e.g. ``- {[a, b]: x}``, a YAML sequence used as a
+    mapping key) with a ``ConstructorError`` — a check this override must
+    keep, not just the duplicate-key check it adds, or a syntactically
+    valid-but-unhashable-keyed document raises a bare ``TypeError`` that
+    escapes ``load_use_case_manifest``'s ``except yaml.YAMLError`` and the
+    documented :class:`~abicheck.errors.UseCaseManifestError` contract
+    entirely (Codex review, fresh evidence)."""
     mapping: dict[Any, Any] = {}
     for key_node, value_node in node.value:
         key = loader.construct_object(key_node, deep=deep)
+        try:
+            hash(key)
+        except TypeError as exc:
+            raise yaml.constructor.ConstructorError(
+                "while constructing a mapping",
+                node.start_mark,
+                f"found unhashable key: {key!r}",
+                key_node.start_mark,
+            ) from exc
         if key in mapping:
             raise yaml.constructor.ConstructorError(
                 "while constructing a mapping",

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -607,6 +607,27 @@ def join_use_case_graph(
     decision of its own, not a drive-by fix bundled into this module's join.
     Whoever wires :func:`join_use_case_graph`'s result into a real pipeline
     that might re-merge or re-serialize it must close this gap first.
+
+    Clears the copied ``graph_id`` before returning (Codex review, fresh
+    evidence): unlike :func:`~abicheck.impact.consumer_graph.join_consumer_graph`
+    — whose result never leaves ``appcompat.py``'s own in-memory analysis —
+    this function is the module's *documented public Python API* (see
+    ``docs/use/use-case-impact.md``), so a caller following that doc and
+    calling ``joined.to_dict()`` on the result is a real, reachable path,
+    not a hypothetical future pipeline. ``library_graph`` may already carry
+    a non-empty ``graph_id`` from its own :meth:`~abicheck.buildsource.source_graph.SourceGraphSummary.finalize`;
+    left untouched, the deep copy would inherit that same id even though the
+    node/edge content just changed, and ``to_dict()`` only recomputes an id
+    when the stored value is empty — silently describing this join's
+    different content under the library graph's own unrelated id, which
+    could corrupt a content-addressed cache or an identity comparison keyed
+    on it. Clearing (rather than eagerly recomputing via
+    :meth:`~abicheck.buildsource.source_graph.SourceGraphSummary.compute_graph_id`)
+    matches this function's own choice to leave the rest of ``finalize()``'s
+    output (``coverage``/etc.) untouched — the join result is still not
+    :meth:`~abicheck.buildsource.source_graph.SourceGraphSummary.finalize`\\ d,
+    so an empty id is the honest "not finalized" signal a caller who does
+    want one can resolve via ``compute_graph_id()``/``finalize()`` itself.
     """
     original = {n.id: (n.provenance, n.confidence) for n in library_graph.nodes}
     joined = copy.deepcopy(library_graph)
@@ -618,4 +639,5 @@ def join_use_case_graph(
         restore = original.get(node.id)
         if restore is not None:
             node.provenance, node.confidence = restore
+    joined.graph_id = ""
     return joined

--- a/abicheck/impact/use_cases.py
+++ b/abicheck/impact/use_cases.py
@@ -1,0 +1,353 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Declared business/runtime use cases, promoted to graph facts (G29 Phase 4
+slice 2, an amendment to ADR-057).
+
+``abicheck.impact.consumer_graph`` (slice 1) joins a real ``--used-by``
+binary's *symbol-level* requirements onto the library's own graph. This
+module is the declared, human-authored counterpart: an optional
+``impact-use-cases.yaml`` manifest names a project's own business/runtime
+use cases (e.g. "the DAL training workflow") and which public entry points
+and tests exercise each one, so a finding can eventually be scoped not just
+to "some consumer requires this symbol" but to "the training workflow does".
+
+**Deliberately a separate schema from
+``docs/contribute/usecase-registry.yaml``** — that registry tracks
+abicheck's *own* feature coverage (does abicheck support header-only
+analysis?), a completely different, tool-internal concept. Reusing it here
+would conflate two unrelated meanings of "use case" under one file format.
+
+Same discipline as :mod:`abicheck.impact.consumer_graph` throughout:
+everything degrades to "no answer" rather than to a wrong one. A manifest
+entry naming an entrypoint the library graph cannot resolve is silently
+skipped — not an error, and not evidence the entrypoint doesn't exist; only
+a structurally malformed manifest *document* (not a YAML list, an entry
+that's not a mapping, a missing/blank ``use_case`` name) raises
+:class:`~abicheck.errors.UseCaseManifestError`.
+
+**Not implemented in this slice** (see ADR-057's "Deliberately not
+implemented this slice", G29 Phase 4): runtime-trace ingestion
+(``TRACE_OBSERVED_ENTRY``/``TRACE_OBSERVED_EDGE`` stay reserved vocabulary,
+same as :mod:`abicheck.impact.consumer_graph`'s reserved consumer kinds) and
+any report-level ``affected_use_cases``/``USE_CASE_IMPACT_CONFIRMED``
+surface (G29 Phase 6). This module only builds and joins the graph facts.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from ..buildsource.graph_facts import (
+    CONF_HIGH,
+    USE_CASE_EDGE_KINDS as USE_CASE_EDGE_KINDS,
+    USE_CASE_NODE_KINDS as USE_CASE_NODE_KINDS,
+    GraphEdge,
+    GraphNode,
+)
+from ..errors import UseCaseManifestError
+
+if TYPE_CHECKING:
+    from ..buildsource.source_graph import SourceGraphSummary
+
+# USE_CASE_NODE_KINDS/USE_CASE_EDGE_KINDS are re-exported (imported above)
+# from buildsource.graph_facts, the leaf that owns the whole graph vocabulary
+# — see the comment there for why they live in a leaf rather than beside this
+# producer.
+
+#: ``provenance`` tag every node/edge this module creates carries, so a
+#: declared-use-case fact is distinguishable from a build-evidence,
+#: replay, or consumer (ADR-057 slice 1) one in the ADR-046 D2 merge
+#: (``GraphFact.producer``).
+USE_CASE_PROVENANCE = "declared_use_case"
+
+
+def use_case_node_id(name: str) -> str:
+    """Node id for a declared use case. Mirrors the ``<scheme>://<name>``
+    convention every other id helper in this package/``source_graph.py``
+    uses."""
+    return f"use_case://{name}"
+
+
+def test_case_node_id(name: str) -> str:
+    """Node id for a declared test case."""
+    return f"test_case://{name}"
+
+
+@dataclass(frozen=True)
+class UseCaseDefinition:
+    """One ``impact-use-cases.yaml`` entry, already validated.
+
+    ``entrypoints``/``tests`` are free-form labels from the manifest author's
+    own vocabulary — a symbol name, a qualified declaration name, or any
+    other string a human chose to write there. Only ``entrypoints`` is ever
+    matched against the library graph (:func:`build_use_case_graph`);
+    ``tests`` are recorded as-is, since there is no graph node kind for an
+    external test identifier to resolve against.
+    """
+
+    use_case: str
+    entrypoints: tuple[str, ...] = ()
+    tests: tuple[str, ...] = ()
+
+
+def _require_mapping(entry: Any, index: int) -> dict[str, Any]:
+    if not isinstance(entry, dict):
+        raise UseCaseManifestError(
+            f"impact-use-cases.yaml: entry {index} must be a mapping, got "
+            f"{type(entry).__name__}"
+        )
+    return entry
+
+
+def _string_list(value: Any, *, field_name: str, use_case: str) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if not isinstance(value, list) or not all(isinstance(v, str) for v in value):
+        raise UseCaseManifestError(
+            f"impact-use-cases.yaml: use case {use_case!r}'s {field_name!r} "
+            "must be a YAML list of strings"
+        )
+    return tuple(value)
+
+
+def parse_use_case_manifest(raw: Any) -> list[UseCaseDefinition]:
+    """Parse an already-``yaml.safe_load``-ed document into
+    :class:`UseCaseDefinition`\\ s.
+
+    Split from :func:`load_use_case_manifest` so a caller that already has
+    the parsed YAML (e.g. folded into a larger project-config document) does
+    not need a real file on disk to validate it — the same split
+    ``policy_file.py``'s own parser/loader pair uses.
+
+    A missing manifest is not this function's concern: an *empty* document
+    (``raw is None``, an empty file) is a valid, empty manifest — no use
+    cases declared — not an error.
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise UseCaseManifestError(
+            "impact-use-cases.yaml: top-level document must be a YAML list "
+            f"of use cases, got {type(raw).__name__}"
+        )
+    definitions: list[UseCaseDefinition] = []
+    for index, entry in enumerate(raw):
+        mapping = _require_mapping(entry, index)
+        name = mapping.get("use_case")
+        if not isinstance(name, str) or not name.strip():
+            raise UseCaseManifestError(
+                f"impact-use-cases.yaml: entry {index} is missing a non-empty "
+                "'use_case' name"
+            )
+        definitions.append(
+            UseCaseDefinition(
+                use_case=name,
+                entrypoints=_string_list(
+                    mapping.get("entrypoints"), field_name="entrypoints", use_case=name
+                ),
+                tests=_string_list(
+                    mapping.get("tests"), field_name="tests", use_case=name
+                ),
+            )
+        )
+    return definitions
+
+
+def load_use_case_manifest(path: str | Path) -> list[UseCaseDefinition]:
+    """Load and parse an ``impact-use-cases.yaml`` manifest from disk.
+
+    Raises :class:`~abicheck.errors.UseCaseManifestError` for a structurally
+    malformed document (not a list, a non-mapping entry, a missing/blank
+    ``use_case`` name) — the same hard-load-error discipline
+    ``policy_file.py``/``suppression.py`` already use for user-supplied YAML,
+    since silently skipping a malformed entry could make a use case's
+    declared coverage quietly disappear.
+    """
+    text = Path(path).read_text(encoding="utf-8")
+    raw = yaml.safe_load(text)
+    return parse_use_case_manifest(raw)
+
+
+def _public_entry_index(library_graph: SourceGraphSummary) -> dict[str, str]:
+    """Every string a manifest ``entrypoints`` value might name -> the node
+    id it resolves to in *library_graph*.
+
+    A "public entry" here is either an exported ``binary_symbol`` node (a
+    library's export table names a real, consumer-visible entry point even
+    when no source graph exists to walk from it — e.g. a binary-only or
+    header-only graph) or a ``source_decl``/other node whose own declared
+    ``visibility`` is public (``PUBLIC_VISIBILITIES`` — the same set
+    :mod:`abicheck.impact.consumer_graph`'s direct-requirement check reads).
+    Both a node's own id and its ``label`` (when set) are registered, so a
+    manifest can name either the graph's internal id spelling or the
+    human-readable label.
+
+    Later registrations never overwrite an earlier one for the same string
+    (``setdefault``) — an ambiguous label two different nodes share resolves
+    to whichever public entry was iterated first, deterministically (graph
+    node order), rather than flipping between runs.
+    """
+    from ..buildsource.source_graph import PUBLIC_VISIBILITIES
+
+    index: dict[str, str] = {}
+    for node in library_graph.nodes:
+        visibility = str((node.resolved or node.attrs).get("visibility", ""))
+        is_public = node.kind == "binary_symbol" or visibility in PUBLIC_VISIBILITIES
+        if not is_public:
+            continue
+        index.setdefault(node.id, node.id)
+        if node.label:
+            index.setdefault(node.label, node.id)
+    return index
+
+
+def build_use_case_graph(
+    definitions: list[UseCaseDefinition], library_graph: SourceGraphSummary
+) -> SourceGraphSummary:
+    """Promote *definitions* to ``use_case``/``test_case`` graph facts,
+    joined onto *library_graph*'s own public-entry nodes.
+
+    An ``entrypoints`` value that cannot be resolved against
+    *library_graph* (see :func:`_public_entry_index`) is silently skipped —
+    no node, no edge, no error — the same "absence, never a wrong answer"
+    discipline :mod:`abicheck.impact.consumer_graph` already follows for an
+    unresolvable required symbol. A use case with none of its declared
+    entrypoints resolved still gets its own ``use_case`` node (and its
+    ``test_case`` nodes/edges, which never depend on entrypoint
+    resolution) — only the ``USE_CASE_USES_ENTRY`` edges are conditional.
+
+    A resolved entrypoint also gets a same-id placeholder node registered
+    alongside its edge (kind copied from the real library node, so
+    ``add_node``'s "first registration wins" rule never overrides it) —
+    mirroring :func:`abicheck.impact.consumer_graph.build_consumer_graph`'s
+    identical pattern for its ``binary_symbol`` targets. Without it, only an
+    *edge* would point at the library node and the join
+    (:func:`join_use_case_graph`) would never actually deposit a
+    ``USE_CASE_PROVENANCE`` fact onto the shared node — the merge (ADR-046
+    D2) only happens on a node/edge registration, not implicitly because an
+    edge names an id.
+
+    Every ``test_case`` named in ``tests`` gets its own node and a
+    ``TEST_COVERS_USE_CASE`` edge onto its use case, unconditionally: unlike
+    an entrypoint, a test identifier has no corresponding node kind in the
+    library graph to resolve against, so there is nothing to fail to
+    resolve.
+    """
+    from ..buildsource.source_graph import SourceGraphSummary
+
+    entries = _public_entry_index(library_graph)
+    node_by_id = {n.id: n for n in library_graph.nodes}
+    graph = SourceGraphSummary()
+    for definition in definitions:
+        uc_id = use_case_node_id(definition.use_case)
+        graph.add_node(
+            GraphNode(
+                id=uc_id,
+                kind="use_case",
+                label=definition.use_case,
+                provenance=USE_CASE_PROVENANCE,
+                confidence=CONF_HIGH,
+            )
+        )
+        for entry_name in definition.entrypoints:
+            target = entries.get(entry_name)
+            if target is None:
+                continue
+            target_kind = node_by_id[target].kind
+            graph.add_node(
+                GraphNode(
+                    id=target,
+                    kind=target_kind,
+                    provenance=USE_CASE_PROVENANCE,
+                    confidence=CONF_HIGH,
+                )
+            )
+            graph.add_edge(
+                GraphEdge(
+                    src=uc_id,
+                    dst=target,
+                    kind="USE_CASE_USES_ENTRY",
+                    provenance=USE_CASE_PROVENANCE,
+                    confidence=CONF_HIGH,
+                )
+            )
+        for test_name in definition.tests:
+            test_id = test_case_node_id(test_name)
+            graph.add_node(
+                GraphNode(
+                    id=test_id,
+                    kind="test_case",
+                    label=test_name,
+                    provenance=USE_CASE_PROVENANCE,
+                    confidence=CONF_HIGH,
+                )
+            )
+            graph.add_edge(
+                GraphEdge(
+                    src=test_id,
+                    dst=uc_id,
+                    kind="TEST_COVERS_USE_CASE",
+                    provenance=USE_CASE_PROVENANCE,
+                    confidence=CONF_HIGH,
+                )
+            )
+    return graph
+
+
+def join_use_case_graph(
+    library_graph: SourceGraphSummary, use_cases: SourceGraphSummary
+) -> SourceGraphSummary:
+    """Fold *use_cases*'s nodes/edges into a **deep copy** of *library_graph*.
+
+    Mirrors :func:`abicheck.impact.consumer_graph.join_consumer_graph`
+    exactly, including the reasoning: a shallow re-registration of the
+    library graph's own :class:`~abicheck.buildsource.graph_facts.GraphNode`
+    objects would work today (nothing here mutates a node's `attrs`
+    directly), but ``SourceGraphSummary.add_node`` merges into the *stored*
+    object in place (ADR-046 D2) — the library graph is read off an
+    ``AbiSnapshot``'s embedded pack and is shared with every other consumer
+    of that snapshot (``internal_leak``'s walks, ``source_graph_findings``'
+    diff, and now also :mod:`abicheck.impact.consumer_graph`'s own join). A
+    shallow fold would leak one project's declared-use-case facts onto the
+    library graph's own public-entry nodes, corrupting every unrelated
+    analysis of the same run — exactly the failure mode the consumer-graph
+    join's own regression test guards against. Deep-copying first keeps this
+    join's blast radius confined to its own returned graph.
+
+    Within the copy, that same ADR-046 D2 merge performs the join itself: a
+    node the library graph already has (a ``binary_symbol`` or public
+    ``source_decl``) and this module's edge also names ends up as **one**
+    node/edge carrying both producers' facts — there is nothing else to
+    "join" beyond registering into the same store.
+
+    ``coverage``/``extractor_passes``/``narrowed_passes``/``degraded_passes``
+    are carried over from *library_graph* unchanged, for the identical
+    reason ``join_consumer_graph`` keeps them unchanged: a declared use case
+    is not a source-extraction pass, and rewriting those flags would make
+    the library's own coverage honesty describe a pass that never ran.
+    Deliberately not :meth:`~abicheck.buildsource.source_graph.SourceGraphSummary.finalize`\\ d
+    either, for the same transient-graph reason.
+    """
+    joined = copy.deepcopy(library_graph)
+    for node in use_cases.nodes:
+        joined.add_node(copy.deepcopy(node))
+    for edge in use_cases.edges:
+        joined.add_edge(copy.deepcopy(edge))
+    return joined

--- a/abicheck/post_processing_reachability.py
+++ b/abicheck/post_processing_reachability.py
@@ -109,6 +109,24 @@ class MarkReachability:
     review) — :meth:`SuppressionList.needs_reachability_evidence` proves
     such a file's rules can never actually consult the tag either, which is
     the common case (a handful of exact ``symbol:`` waivers).
+
+    ADR-052 D2 follow-up (G29 Phase 3 slice 10): once this step actually
+    tags a change (the branch above did *not* early-return), it also caches
+    that change's :class:`~abicheck.impact.model.ImpactAssessment` via
+    :func:`impact.engine.assess_change` right at the point its own
+    reachability/evidence fields become final -- see the ``_cache_assessment``
+    closure below for the specific per-field safety audit. This is the
+    resolution of ADR-052's own open measurement question ("is
+    ``assess_change`` ever called more than once for the same ``Change``
+    within one ``compare`` run"): measured directly (not assumed) via
+    ``compare --format json --secondary-format sarif``, which renders the
+    identical ``DiffResult``/``Change`` objects twice in one process --
+    ``reporter.py``'s JSON path and ``sarif.py``'s SARIF path each call
+    ``assess_change`` independently. A one-off instrumented run over a
+    genuinely breaking two-snapshot pair confirmed a real, non-hypothetical
+    repeat call on the same ``Change`` object (2 calls recorded for 1
+    finding) -- caching here avoids rebuilding ``proof_path``/``GraphProofPath``
+    formatting from scratch on the second and later renders.
     """
 
     name = "mark_reachability"
@@ -132,6 +150,63 @@ class MarkReachability:
     def run(self, changes: list[Change], ctx: PipelineContext) -> list[Change]:
         if ctx.suppression is None or not ctx.suppression.needs_reachability_evidence():
             return changes
+
+        from .impact.engine import assess_change
+
+        def _cache_assessment(c: Change) -> None:
+            """ADR-052 D2 follow-up (G29 Phase 3 slice 10): cache *c*'s
+            :class:`~abicheck.impact.model.ImpactAssessment` right after this
+            step finalizes its reachability/evidence fields.
+
+            Verified safe, not assumed, per the same discipline Slice 8/9 used
+            for ``internal_leak.py``/``appcompat.py``: this is the *only* place
+            in the codebase that mutates ``public_reachable``/
+            ``reachability_state``/``reachability_kind``/
+            ``reachability_proof_path`` on an already-constructed ``Change``
+            (confirmed by a repo-wide grep, not assumed) -- so once this
+            function returns for *c*, nothing later in
+            ``post_processing.DEFAULT_PIPELINE`` (``ApplySuppression``,
+            ``SuppressRenamedPairs``, ``FilterRedundant``,
+            ``EnrichAffectedSymbols``, ``AttributeStdlibEmbedding``,
+            ``DetectCppPatterns``, ``DetectTemplatePatterns``,
+            ``DetectNamespacePatterns``, ``DetectInternalLeaks``,
+            ``DemoteUnreachableInternalChurn``, ``DetectVersionedSymbolScheme``,
+            ``EscalateFrozenNamespaceViolations``) touches them again.
+            ``confidence``/``impact_proof_path``/``affected_public_roots``/
+            ``impact_is_direct``/``impact_alternative_paths``/
+            ``impact_discarded_path_count``/``impact_occurrence_id`` are all
+            set (if at all) at ``Change`` construction time, before this step
+            ever sees the change, so they are equally stable by this point.
+
+            One residual field checked and found *not* to break this, rather
+            than overlooked: ``Change.evidence_category`` has exactly one
+            other post-construction mutator, ``diff_reconcile.
+            reconcile_build_context_findings`` (``checker.py``, gated on
+            ``--reconcile-build-context``) -- but it runs *after*
+            ``_run_post_processing`` (this step included) and only ever sets
+            ``evidence_category`` on a change it is simultaneously moving out
+            of ``kept`` into ``DiffResult.reconciled_changes``.
+            ``reporter._add_reconciled`` renders that list from its own
+            hand-built dict and never reads ``Change.impact_assessment`` for
+            it (confirmed by reading ``reporter.py``), so a change that ends
+            up reconciled never has its (by-then-stale) cached
+            ``evidence_category`` read through ``impact_assessment`` by any
+            current report path -- the mutation is real but has no reachable
+            consumer to observe it going stale.
+
+            This also gives every source-graph finding
+            (``buildsource/source_graph_findings.py``'s nine ``Change(...)``
+            sites) a correctly cached assessment once its finding reaches
+            this step: those builders run *before* ``_run_post_processing``
+            (their output is merged into ``checker.compare``'s ``changes``
+            list as ``extra_changes``, ahead of the whole pipeline -- unlike
+            ``internal_leak.py``'s builders, which are themselves a
+            *later* pipeline step), so caching directly at their own
+            construction time would capture default/unset evidence fields
+            this step hasn't tagged yet -- see the comment at each of those
+            nine sites for the negative half of this same audit.
+            """
+            c.impact_assessment = assess_change(c)
 
         from .internal_leak import (
             _IDENTITY_VTABLE_KINDS,
@@ -366,11 +441,13 @@ class MarkReachability:
                 c.public_reachable = True
                 c.reachability_kind = "direct_public_symbol"
                 c.reachability_state = ReachabilityState.PROVEN_REACHABLE
+                _cache_assessment(c)
                 continue
             if c.kind in _PUBLIC_SOURCE_ABI_KINDS:
                 c.public_reachable = True
                 c.reachability_kind = "public_source_abi_surface"
                 c.reachability_state = ReachabilityState.PROVEN_REACHABLE
+                _cache_assessment(c)
                 continue
             tagged = False
             # An enum-member finding's root still carries the "::member"
@@ -530,4 +607,5 @@ class MarkReachability:
                     c.reachability_state = ReachabilityState.PROVEN_UNREACHABLE
                 else:
                     c.reachability_state = ReachabilityState.UNKNOWN
+            _cache_assessment(c)
         return changes

--- a/changelog.d/20260809_120000_claude_g29_phase4_use_cases.md
+++ b/changelog.d/20260809_120000_claude_g29_phase4_use_cases.md
@@ -1,0 +1,25 @@
+### Added
+
+- **An optional `impact-use-cases.yaml` manifest declares a project's own
+  business/runtime use cases and joins them onto the library's own graph.**
+  `abicheck.impact.use_cases` parses a top-level YAML list of
+  `use_case`/`entrypoints`/`tests` entries into `UseCaseDefinition`s,
+  promotes each to a `use_case` graph node (and each `tests` entry to a
+  `test_case` node with a `TEST_COVERS_USE_CASE` edge onto it), and resolves
+  each `entrypoints` name against the library graph's own exported
+  `binary_symbol`/public `source_decl` nodes to emit a `USE_CASE_USES_ENTRY`
+  edge — matched by either the node's own id or its label. An entrypoint
+  the library graph cannot resolve is silently skipped, never an error;
+  only a structurally malformed manifest document (not a YAML list, a
+  non-mapping entry, a missing/blank `use_case` name) raises the new
+  `UseCaseManifestError`. `join_use_case_graph` folds the declared facts
+  into a **deep copy** of the library graph, mirroring
+  `consumer_graph.join_consumer_graph`'s identical mutation-safety
+  discipline. Deliberately a separate schema from
+  `docs/contribute/usecase-registry.yaml` (abicheck's own feature-coverage
+  registry — an unrelated concept). G29 Phase 4 slice 2, amending
+  [ADR-057](docs/contribute/adr/057-consumer-graph-and-impact-join.md).
+  Runtime-trace ingestion (`TRACE_OBSERVED_ENTRY`/`TRACE_OBSERVED_EDGE`) and
+  any report-level `affected_use_cases`/`USE_CASE_IMPACT_CONFIRMED` surface
+  remain out of scope for this slice — see
+  [Use-Case Impact](docs/use/use-case-impact.md).

--- a/changelog.d/20260809_130000_claude_g29_phase3_slice10_mark_reachability_cache.md
+++ b/changelog.d/20260809_130000_claude_g29_phase3_slice10_mark_reachability_cache.md
@@ -1,0 +1,29 @@
+### Added
+
+- **`Change.impact_assessment` — `MarkReachability` now caches it, closing
+  the D2 producer sweep** (ADR-052 D2 follow-up, Slice 10):
+  `post_processing.MarkReachability` — the only pipeline step that mutates
+  `public_reachable`/`reachability_state`/`reachability_kind`/
+  `reachability_proof_path` on an already-constructed `Change` — now calls
+  `impact.engine.assess_change(change)` right after it finalizes those
+  fields and attaches the result to `Change.impact_assessment`, the same
+  cache-and-reuse pattern `internal_leak.py`/`appcompat.py` used in Slices
+  8-9. This was previously an open, unmeasured question; it is now measured:
+  a `compare --format json --secondary-format sarif` invocation genuinely
+  calls `assess_change()` twice for the same `Change` object in one process
+  (`reporter.py`'s JSON path and `sarif.py`'s SARIF path each read the same
+  already-computed `DiffResult` independently), confirmed by an instrumented
+  test rather than assumed.
+  `abicheck/buildsource/source_graph_findings.py`'s ten `Change(...)`
+  construction sites (across nine finding functions) were re-audited and
+  found *not* individually safe to cache at construction time — unlike
+  `internal_leak.py`'s builder, they run **before**
+  `post_processing.DEFAULT_PIPELINE` (their findings are merged into
+  `checker.compare`'s `changes` ahead of the whole pipeline), so
+  `MarkReachability` still runs downstream of them and would invalidate an
+  eagerly-cached assessment. None of the ten sites were changed to cache
+  directly; `MarkReachability`'s own new caching reaches every one of these
+  findings anyway, once tagged. `suppression.py`'s own named role in D2
+  remains the one unresolved item (it constructs no `Change` of its own) —
+  see ADR-052's "Slice 10" and "Deliberately not implemented this slice"
+  sections for the full per-site detail and the measurement methodology.

--- a/changelog.d/20260809_140000_claude_g29_impact_evidence_review_fixes.md
+++ b/changelog.d/20260809_140000_claude_g29_impact_evidence_review_fixes.md
@@ -60,3 +60,15 @@
   root. Now compares `entry_path[0].src` node ids whenever both sides have
   a walked path, falling back to the label comparison only when one side
   is a direct match with no path to read a node id from.
+- **A non-primary match's own `alternative_entry_paths` are now filtered
+  per-alternative, not bulk-folded in once its preferred `entry_path`
+  passes the root check** (Codex review, fresh evidence):
+  `impact.consumer_graph.explain_required_symbols` builds
+  `alternative_entry_paths` from every candidate path across every
+  consumer-compiled entry that reached the target, not just the one entry
+  the match's own preferred path happens to start at — so one of a
+  same-rooted non-primary match's own alternatives could still start at a
+  *third*, unrelated entry and get folded in and serialized under the
+  primary's single root. Now filters each alternative against the
+  non-primary match's own verified `entry_path[0].src`, mirroring the
+  identical filter the primary's own alternatives already got.

--- a/changelog.d/20260809_140000_claude_g29_impact_evidence_review_fixes.md
+++ b/changelog.d/20260809_140000_claude_g29_impact_evidence_review_fixes.md
@@ -50,3 +50,13 @@
   recomputes an id when the stored value is empty — silently describing
   the join's different content under an unrelated, stale id. Fixed by
   clearing `joined.graph_id` before returning.
+- **`appcompat._merge_consumer_impact_paths`'s non-primary same-root check
+  now compares graph node ids, not display labels** (Codex review, fresh
+  evidence): distinct public-entry nodes can share one display label (C++
+  overloads are the common case), so `m.public_entries[0] ==
+  primary_root` alone did not prove a non-primary match's walked path
+  actually started at the same node as the primary's — it could fold in
+  an unrelated overload's path and have it serialized under the primary's
+  root. Now compares `entry_path[0].src` node ids whenever both sides have
+  a walked path, falling back to the label comparison only when one side
+  is a direct match with no path to read a node id from.

--- a/changelog.d/20260809_140000_claude_g29_impact_evidence_review_fixes.md
+++ b/changelog.d/20260809_140000_claude_g29_impact_evidence_review_fixes.md
@@ -38,3 +38,15 @@
   single-symbol case, letting a differently-rooted alternative be
   serialized in JSON/SARIF under the primary's own root
   (`impact.engine._build_proof_path`'s single `affected_public_roots[0]`).
+- **`impact.use_cases.join_use_case_graph` no longer leaves a stale,
+  inherited `graph_id` on its returned graph** (Codex review, fresh
+  evidence): unlike `impact.consumer_graph.join_consumer_graph` — whose
+  result never leaves `appcompat.py`'s own in-memory analysis —
+  `join_use_case_graph` is this module's documented public Python API, so a
+  caller following `docs/use/use-case-impact.md` and calling
+  `joined.to_dict()` is a real, reachable path. Left un-cleared, the deep
+  copy inherited `library_graph`'s own already-finalized `graph_id` even
+  though the joined node/edge content had changed, and `to_dict()` only
+  recomputes an id when the stored value is empty — silently describing
+  the join's different content under an unrelated, stale id. Fixed by
+  clearing `joined.graph_id` before returning.

--- a/changelog.d/20260809_140000_claude_g29_impact_evidence_review_fixes.md
+++ b/changelog.d/20260809_140000_claude_g29_impact_evidence_review_fixes.md
@@ -1,0 +1,28 @@
+### Fixed
+
+- **Consumer-graph impact evidence no longer silently dropped by
+  `MarkReachability`'s Slice 10 cache** (ADR-052/ADR-057 follow-up, review
+  fixes): `appcompat._has_impact_evidence` treated *any* cached
+  `Change.impact_assessment` as "this change already has evidence of its
+  own", but `post_processing.MarkReachability` now caches an
+  `ImpactAssessment` on *every* change it tags — including one left
+  `UNKNOWN` with no proof path, or tagged `PROVEN_REACHABLE` via a
+  direct-symbol/public-source-ABI match with no walked path either. That
+  made `appcompat._enrich_covered_changes` skip the consumer-graph join for
+  the ordinary, common case it exists to explain (a covered `FUNC_REMOVED`
+  never got its `affected_public_roots`/`impact_proof_path`/consumer-neutral
+  prose). Fixed by keying the check on
+  `impact_assessment.proof_path is not None` instead. A second, related gap:
+  once enrichment was allowed through, it attached the flat proof-path
+  fields but left the *stale, pathless* cached `impact_assessment` object in
+  place — `impact.engine.assess_change()` prefers any non-`None` cached
+  assessment over re-deriving from flat fields, so a JSON/SARIF render would
+  still have returned the old `proof_path=None`. Fixed by clearing
+  `Change.impact_assessment` before recomputing it via `assess_change()`.
+- **`impact-use-cases.yaml` manifest loading now rejects a duplicate or
+  unhashable mapping key** instead of silently keeping only the last value
+  (PyYAML's default) or raising a bare `TypeError` outside the documented
+  `UseCaseManifestError` contract — both closed a real "declared coverage
+  quietly disappears" gap in `abicheck.impact.use_cases.load_use_case_manifest`,
+  and a syntactically invalid manifest document is now also wrapped in
+  `UseCaseManifestError` rather than letting a bare `yaml.YAMLError` escape.

--- a/changelog.d/20260809_140000_claude_g29_impact_evidence_review_fixes.md
+++ b/changelog.d/20260809_140000_claude_g29_impact_evidence_review_fixes.md
@@ -26,3 +26,15 @@
   quietly disappears" gap in `abicheck.impact.use_cases.load_use_case_manifest`,
   and a syntactically invalid manifest document is now also wrapped in
   `UseCaseManifestError` rather than letting a bare `yaml.YAMLError` escape.
+  A bare `ValueError` from PyYAML's implicit-timestamp scalar constructor
+  (e.g. `use_case: 2023-99-99`) is now wrapped the same way.
+- **`appcompat._merge_consumer_impact_paths`'s same-root alternative-path
+  filter now also applies to the single-match case** (review fixes):
+  `impact.consumer_graph.explain_required_symbols` can itself return one
+  `ConsumerImpactPath` whose own `alternative_entry_paths` already mixes
+  candidates from more than one consumer-compiled entry — not just a
+  multi-symbol merge — so the previous `len(matches) == 1: return
+  matches[0]` early return skipped the root filter for the *ordinary*
+  single-symbol case, letting a differently-rooted alternative be
+  serialized in JSON/SARIF under the primary's own root
+  (`impact.engine._build_proof_path`'s single `affected_public_roots[0]`).

--- a/docs/_meta/topics.yaml
+++ b/docs/_meta/topics.yaml
@@ -135,11 +135,13 @@ topics:
     fact_sources:
       - abicheck/impact/model.py
       - abicheck/impact/engine.py
+      - abicheck/impact/use_cases.py
       - abicheck/buildsource/graph_impact.py
       - abicheck/junit_report.py
     reference_page: reference/source-graph-schema.md
     task_pages:
       - contribute/detector-impact-contract.md
+      - use/use-case-impact.md
 
   policies:
     canonical_page: use/policies.md

--- a/docs/contribute/adr/052-unified-impact-assessment-model.md
+++ b/docs/contribute/adr/052-unified-impact-assessment-model.md
@@ -1,7 +1,7 @@
-# ADR-052: Unified Impact Assessment Model (G29 Phase 3, slices 1-9)
+# ADR-052: Unified Impact Assessment Model (G29 Phase 3, slices 1-10)
 
 **Date:** 2026-07-22
-**Status:** Accepted — slices 1-9 implemented. Slice 6 (G29 Phase 3
+**Status:** Accepted — slices 1-10 implemented. Slice 6 (G29 Phase 3
 follow-up) closed two items this ADR originally left open: `--format junit`
 now renders `--report-mode root-cause` (additive `rootCauseId`/`rootCause`
 attributes on each `<failure>`, not a restructured `<testcase>` tree — see
@@ -17,16 +17,32 @@ direction flip as a deliberately *scoped* subset — two producers
 (`internal_leak.py`'s two leak-finding builders, Slice 8; `appcompat.py`'s
 one consumer-overlay builder, Slice 9) construct `ImpactAssessment` directly
 and `assess_change` reuses their evidence fields, each verified safe by its
-own pipeline-ordering/purity audit; the remaining two producer sites named
-in D2's original decision (`post_processing.MarkReachability` especially,
-the suppression-safety-critical one; and
-`abicheck/buildsource/source_graph_findings.py`'s nine
-construction sites) are **not** migrated, and `suppression.py` — D2's
+own pipeline-ordering/purity audit. Slice 10 (G29 Phase 3 follow-up) closes
+the `post_processing.MarkReachability` half of D2's remaining scope: a
+real measurement (not an assumption) confirmed `assess_change` is called
+more than once for the same `Change` within a single `compare` invocation
+(`--secondary-format`, e.g. `--format json --secondary-format sarif`,
+renders the identical `DiffResult` twice in one process), so
+`MarkReachability` now caches `impact_assessment` right after it finalizes
+each change's reachability/evidence fields — the *only* place in the
+codebase that mutates those fields on an existing `Change`, verified by the
+same repo-wide-grep discipline Slice 8 used.
+`abicheck/buildsource/source_graph_findings.py`'s ten construction sites
+(across its nine per-family helpers) were re-audited in the same slice and
+found *not* individually cacheable at construction time — unlike
+`internal_leak.py`'s builders, they run **before**
+`post_processing.DEFAULT_PIPELINE` (their output is merged into
+`checker.compare`'s `changes` as `extra_changes`, ahead of the whole
+pipeline), so `MarkReachability` still runs downstream of them and would
+make an eagerly-cached assessment stale. They are not left uncovered,
+though: `MarkReachability`'s own new caching (above) reaches every one of
+these findings too, once each is tagged, closing the practical gap without
+needing nine/ten independent construction-site edits. `suppression.py` — D2's
 original decision text also named it, but it turns out to construct no
-`Change` of its own — has an unresolved role that needs a documentation
-clarification pass rather than a migration (see "Deliberately not
-implemented this slice") — see "Slice 8"/"Slice 9" below for the full
-scoping rationale.
+`Change` of its own — still has an unresolved role that needs a
+documentation clarification pass rather than a migration (see "Deliberately
+not implemented this slice") — see "Slice 8"/"Slice 9"/"Slice 10" below for
+the full scoping rationale.
 **Verified:** main@2e43d53 on 2026-08-04
 **Decision maker:** (pending — recorded per repository convention;
 implemented under [G29](../plans/g29-impact-analysis-layer.md) Phase 3's own
@@ -822,6 +838,127 @@ implemented this slice" below for why that one stays open).
   `suppression.py`'s still-unclear D2 role (see below) is a separate,
   unresolved documentation question, not a third producer to migrate.
 
+## Slice 10 — `MarkReachability` measurement + caching, and the `source_graph_findings.py` audit (G29 Phase 3 follow-up, 2026-08-09)
+
+Closes the two remaining items "Deliberately not implemented this slice"
+(below, pre-Slice-10 text) left open: the unmeasured `MarkReachability`
+question, and the nine-site `source_graph_findings.py` sweep. Both turned
+out to have one answer, not two independent ones — see "How the two connect"
+below.
+
+### The `MarkReachability` measurement
+
+The open question was whether a single `compare` invocation ever calls
+`assess_change()` more than once for the same `Change` object — the ADR text
+speculated `reporter.py` alone has three call sites (`_leaf_entry`, the
+suppressed-changes entry builder, the main JSON entry builder) "though
+normally each `Change` only ever passes through one of the three." That
+speculation about `reporter.py`'s own three call sites is correct (they
+render disjoint change-list memberships) — but it was the wrong place to
+look. `sarif.py` has its own, independent `assess_change` call site, and
+`compare --format <fmt1> --secondary-format <fmt2> --secondary-output <path>`
+(a real, existing CLI feature, `cli_compare_helpers.py`) renders the
+*identical* `DiffResult`/`Change` objects through two different formats in
+one process — the code comment there says so explicitly ("Reuses the same
+already-computed `result` — no second comparison run").
+
+**Measured, not assumed**: `tests/test_cli_unit.py::TestCompareSecondaryFormat::
+test_json_then_sarif_secondary_calls_assess_change_twice_per_change`
+monkeypatches `assess_change` in `impact.engine`/`reporter`/`sarif` to count
+calls keyed by `id(change)`, then runs `compare --format json
+--secondary-format sarif` (via `CliRunner`) over a two-snapshot pair with one
+removed function. Result: **the same `Change` object was assessed twice** —
+once by `reporter.py`'s JSON render, once by `sarif.py`'s SARIF render, in
+the same process. This is the real, non-hypothetical repeat-call scenario
+the ADR asked to be measured before deciding.
+
+### The `MarkReachability` caching implementation
+
+`post_processing_reachability.py`'s `MarkReachability.run()` now sets
+`c.impact_assessment = assess_change(c)` at the point it finalizes each
+change's reachability fields (all three per-change exit paths: the two early
+`continue`s and the natural loop fallthrough for the
+tagged/`PROVEN_UNREACHABLE`/`UNKNOWN` branches) — right where Slice 8's own
+comment already knew this step is "the *only* step anywhere in the codebase
+that mutates `public_reachable`/`reachability_state`/`reachability_kind`/
+`reachability_proof_path` on an existing `Change`" (re-confirmed by a fresh
+repo-wide grep for this slice, not carried forward on faith).
+
+**Verified safe, not assumed**, per the same discipline Slice 8/9 used:
+
+- `confidence` and the `attach_impact_metadata` proof-path fields
+  (`impact_proof_path`/`affected_public_roots`/`impact_is_direct`/
+  `impact_alternative_paths`/`impact_discarded_path_count`/
+  `impact_occurrence_id`) are always set (if at all) at `Change` construction
+  time, before this step ever runs — stable by the time it caches.
+- One residual field checked and found *not* to break this, rather than
+  overlooked: `Change.evidence_category` has exactly one other
+  post-construction mutator, `diff_reconcile.reconcile_build_context_findings`
+  (`checker.py`, gated on `--reconcile-build-context`) — but it runs *after*
+  `_run_post_processing` (this step included) and only ever sets
+  `evidence_category` on a change it is simultaneously moving out of `kept`
+  into `DiffResult.reconciled_changes`. `reporter._add_reconciled` renders
+  that list from its own hand-built dict and never reads
+  `Change.impact_assessment` (confirmed by reading `reporter.py`), so a
+  reconciled change's by-then-stale cached `evidence_category` is never read
+  through `impact_assessment` by any current report path.
+- `decision`/`root_cause_id`/`root_cause_display`/`impact_group_id` are —
+  exactly as Slice 8/9 established — never read from the cache; they are
+  always recomputed fresh on every `assess_change()` call from the `Change`'s
+  *current* state, so a later suppression/pattern-modulation pass changing
+  `suppression_rule`/`modulation_reason`/`effective_verdict` is still
+  reflected correctly even though the cached evidence predates it.
+
+### How the two connect: `source_graph_findings.py` re-audited
+
+Re-auditing `abicheck/buildsource/source_graph_findings.py`'s nine
+per-family helpers (ten `Change(...)` construction sites —
+`_public_reachability_findings` has two) found they are **not** individually
+safe to cache the way `internal_leak.py`'s builders were in Slice 8, for the
+opposite pipeline-position reason: `internal_leak.py`'s `DetectInternalLeaks`
+is itself a `DEFAULT_PIPELINE` *step*, registered after `MarkReachability`,
+so its `Change` objects don't exist yet when `MarkReachability` runs.
+`source_graph_findings.py`'s findings are different — their caller
+(`cli_buildsource_helpers.prepare_embedded_build_source`) folds them into
+`checker.compare`'s `extra_changes`, which `checker.compare` merges into
+`changes` **before** calling `_run_post_processing` (i.e. before
+`DEFAULT_PIPELINE.run()`, `MarkReachability` included). None of the ten
+sites set `public_reachable`/`reachability_state`/`reachability_kind`/
+`reachability_proof_path` themselves (confirmed by reading the whole file),
+so caching at construction time would freeze those fields at their unset
+defaults — exactly the fields `MarkReachability` still goes on to tag for
+every one of these findings whenever a suppression file needs reachability
+evidence.
+
+Rather than force a mismatched "cache at construction" edit onto nine sites
+whose own pipeline position makes it wrong, each of the ten sites got a
+short code comment recording this finding (one detailed audit comment at
+the first site, `_mapping_drift_findings`, and a pointer comment at the
+other nine) — **and no site was migrated to cache directly**. This is not a
+gap: `MarkReachability`'s own new caching (this slice) already reaches every
+`source_graph_findings.py` finding once it's merged into the pipeline and
+tagged, giving all nine families a correctly cached `impact_assessment`
+exactly the way Slice 8 gave `internal_leak.py`'s findings one — just from a
+different, but safe, cache-write point. `tests/test_source_graph_findings_impact.py`
+covers both halves: `test_findings_are_not_eagerly_cached_with_impact_assessment`
+(construction-time state) and
+`test_source_graph_finding_gets_cached_assessment_once_it_reaches_mark_reachability`
+(the pipeline-ordering regression test — the cache reflects the *post*-tag
+value, not the pre-tag default a naive construction-time cache would have
+captured). `tests/test_reachability_state.py::TestMarkReachabilityImpactAssessmentCache`
+covers the `MarkReachability` step itself directly (both early-`continue`
+branches, the fallthrough branch, and the no-op gate leaving
+`impact_assessment` at `None` when no suppression needs reachability
+evidence, unchanged from before this slice).
+
+- **Zero producer sites now remain unmigrated as "not yet looked at"** —
+  `post_processing.MarkReachability` is migrated;
+  `source_graph_findings.py`'s ten sites are covered transitively through
+  it, each with a recorded reason for not caching directly.
+  `suppression.py`'s still-unclear D2 role (Slice 9's note, unchanged) is
+  the one remaining open item, and it was never a producer to migrate in
+  the first place — see "Deliberately not implemented this slice" below.
+
 ## Deliberately not implemented this slice
 
 Per the "ship each phase independently" mitigation this initiative committed
@@ -842,59 +979,25 @@ remaining four tiers):
   rather than added as permanently-`None` fields.
 - **The full D2 direction flip** (every flat `Change` field becoming a
   derived view over `ImpactAssessment`, across all five producer modules
-  D2's decision text names) — still not attempted in full; Slices 8-9
-  (above) deliver a verifiably safe, two-producer subset instead of forcing
-  the whole flip through in one pass. Attempting all five in one pass would
-  still be exactly the kind of rushed, high-blast-radius change the "needs
-  its own ADR/scoped design pass" bar (this ADR's own header, ADR-046 D4,
-  and CLAUDE.md "M1-3") exists to prevent — a real regression to either of
-  the two remaining producer sites would risk suppression correctness, not
-  just this reporting layer. Each remaining producer site is its own
-  follow-up slice, migrated only once the same kind of pipeline-ordering
-  safety audit Slice 8 did for `internal_leak.py` has been done for it
-  specifically — a real audit, not an assumption carried over from a
-  different module's safety proof. Status below, refined by direct code
-  inspection rather than carried forward from the original decision text
-  unchanged: two are genuine remaining producer sites
-  (`source_graph_findings.py`, `post_processing.MarkReachability`); the
-  third entry the original decision text named, `suppression.py`, turns out
-  not to be a producer at all (no `Change(...)` construction site exists in
-  it) — its own D2 role is a separate, unresolved documentation question,
-  not a third migration:
-  - **`source_graph_findings.py`** — not one construction site like
-    `internal_leak.py`/`appcompat.py`, but **nine**:
-    `_mapping_drift_findings`, `_public_reachability_findings` (two),
-    `_generated_public_closure_findings`, `_call_reachability_findings`,
-    `_include_graph_drift_findings`, `_build_option_reach_findings`,
-    `_internal_dependency_findings`, `_target_dependency_findings`,
-    `_symbol_owner_findings`. Each needs its own check for whether anything
-    downstream of `diff_source_graph_findings()` (in particular, whether its
-    output changes flow through `post_processing.DEFAULT_PIPELINE` before
-    reaching a report) still mutates evidence fields after construction,
-    before caching is safe — a bigger audit than Slice 8/9's single-site
-    ones, plausibly worth a shared `_finalize_finding(change)` helper
-    invoked at the end of all nine instead of nine independent edits.
-  - **`post_processing.MarkReachability`** — mutates existing `Change`
-    objects in place (not a constructor site), via four separate graph
-    walks (`compute_leak_paths`/`compute_call_graph_leak_paths` on old and
-    new) plus `ScopeOrigin.PUBLIC_HEADER` logic, and only runs at all when
-    `ctx.suppression.needs_reachability_evidence()`. **Open question,
-    unresolved**: `impact.engine.assess_change` is already a pure read view
-    that performs no graph traversal of its own (module docstring) — the
-    expensive walks this step performs are not duplicated by
-    `assess_change`, cached or not. What caching here would actually save
-    is re-building the `ImpactAssessment`/`GraphProofPath` object (proof-path
-    formatting in particular) on every `assess_change()` call for the same
-    `Change` — worth doing only if a single `compare` run actually calls
-    `assess_change` more than once per `Change` (e.g. rendering JSON and
-    SARIF from the same `DiffResult` in one process; `reporter.py` alone has
-    three separate call sites — `_leaf_entry`, a suppressed-changes entry
-    builder, and the main JSON entry builder — though normally each
-    `Change` only ever passes through one of the three, since they render
-    disjoint change-list memberships). This needs to be measured before
-    deciding whether `MarkReachability` caching is worth its
-    suppression-safety risk at all, not assumed the way Slice 8's
-    performance rationale was for `internal_leak.py`.
+  D2's decision text names) — still not attempted in the *literal* sense of
+  five independent construction-site migrations; Slices 8-10 instead deliver
+  a verifiably safe subset chosen by real pipeline-ordering audits rather
+  than forcing the whole flip through in one pass — see "Slice 10" above for
+  why `MarkReachability` caching (rather than nine/ten independent
+  `source_graph_findings.py` edits) turned out to be the correct shape for
+  the remaining scope. Status below, refined by direct code inspection
+  rather than carried forward from the original decision text unchanged:
+  `suppression.py`, the third module the original decision text named,
+  turns out not to be a producer at all (no `Change(...)` construction site
+  exists in it) — its own D2 role is a separate, unresolved documentation
+  question, not a fourth migration:
+  - **`source_graph_findings.py`** and **`post_processing.MarkReachability`**
+    — both closed by Slice 10 (above): the former is not individually
+    cacheable at construction time (audited, ten sites, all found unsafe for
+    the same reason — see Slice 10), but every finding it produces still
+    ends up correctly cached once `MarkReachability` tags it, which Slice 10
+    also implemented after measuring (not assuming) that doing so is worth
+    it.
   - **`suppression.py`** — direct inspection found **no** `Change(...)`
     construction inside this module at all; it only *reads*
     `public_reachable`/`reachability_state` for rule matching. The one
@@ -903,13 +1006,14 @@ remaining four tiers):
     actually lives in `post_processing.py`, not `suppression.py`, and sets
     no reachability fields to cache in the first place (see Slice 9 above).
     **This ADR's own D2 decision text naming `suppression.py` as a producer
-    needs a follow-up clarification pass** — either it meant this
+    still needs a follow-up clarification pass** — either it meant this
     `post_processing.py` diagnostic function, or it meant the Slice 2 audit-
     trail (`FindingDecision`/`SuppressionAudit`) surface instead of
     `impact_assessment` caching at all, or the original text was simply
     imprecise about which module owns the construction site. Resolve this
     with a documentation-only pass through the original decision text before
-    scheduling any code change here.
+    scheduling any code change here — this is the one item from D2's
+    original five-producer scope still genuinely open after Slice 10.
 - **The full `RootCauseCorrelator` correlation across consumer-overlay
   findings that don't share a `caused_by_type` today** — Slices 3-5 shipped
   the `caused_by_type`-based first cut (JSON, markdown/text, and SARIF

--- a/docs/contribute/adr/057-consumer-graph-and-impact-join.md
+++ b/docs/contribute/adr/057-consumer-graph-and-impact-join.md
@@ -6,13 +6,23 @@ the `CONSUMER_*` graph vocabulary in
 `abicheck/buildsource/graph_facts.py`, ADR-046 D6's tier-1 "consumer-proven"
 selector in `abicheck/buildsource/graph_impact.py`, and the
 `abicheck/appcompat.py` wiring that puts the answer on the
-`CONSUMER_REQUIRED_SYMBOL_REMOVED` overlay). The rest of
-[G29](../plans/g29-impact-analysis-layer.md) Phase 4 — the
-`impact-use-cases.yaml` manifest, `use_case`/`test_case` nodes, and
-runtime-trace ingestion — is **not implemented**; the three reserved edge
-kinds this ADR registers (`CONSUMER_INSTANTIATES_DECL`,
-`CONSUMER_COMPILED_FROM_HEADER`, `RUNTIME_FAILED_TO_RESOLVE_SYMBOL`) mark
-where that work attaches. See "Deliberately not implemented this slice".
+`CONSUMER_REQUIRED_SYMBOL_REMOVED` overlay). **Slice 2 (2026-08-09) also
+implemented**: the declared-use-case half of Phase 4 —
+`abicheck/impact/use_cases.py`, the `USE_CASE_*`/`test_case` graph
+vocabulary (`USE_CASE_NODE_KINDS`/`USE_CASE_EDGE_KINDS` in
+`abicheck/buildsource/graph_facts.py`), and an optional
+`impact-use-cases.yaml` manifest (`use_case`/`entrypoints`/`tests`) that
+`build_use_case_graph`/`join_use_case_graph` promote to graph facts and join
+onto the library graph, mirroring slice 1's build/join API and mutation-safety
+discipline exactly. See "Slice 2: declared use cases" below. Still **not
+implemented**: runtime-trace ingestion, and any report-level
+`affected_use_cases`/`USE_CASE_IMPACT_CONFIRMED` surface reading the joined
+graph — the two remaining reserved use-case edge kinds this slice registers
+(`TRACE_OBSERVED_ENTRY`, `TRACE_OBSERVED_EDGE`) mark where trace ingestion
+attaches. The three `CONSUMER_*` reserved edge kinds from slice 1
+(`CONSUMER_INSTANTIATES_DECL`, `CONSUMER_COMPILED_FROM_HEADER`,
+`RUNTIME_FAILED_TO_RESOLVE_SYMBOL`) also remain unimplemented. See
+"Deliberately not implemented this slice".
 **Decision maker:** (pending — recorded per repository convention;
 implemented under [G29](../plans/g29-impact-analysis-layer.md) Phase 2's own
 "needs its own ADR before implementation starts" gate, which
@@ -286,6 +296,49 @@ all — collides with `_apply_used_by_scoping`'s `_finding_id`-based
 `scoped_only_changes` dedup (an enriched copy shares its original's id and
 would be dropped) and needs its own design across all three front ends.
 
+### Slice 2 — declared use cases (2026-08-09 amendment)
+
+Slice 1 joins a real, observed consumer's requirements onto the library
+graph. Slice 2 adds the declared, human-authored counterpart the original
+plan sketch named but this ADR deferred: an optional
+`impact-use-cases.yaml` manifest naming a project's own business/runtime use
+cases (`use_case`/`entrypoints`/`tests`), promoted to `use_case`/`test_case`
+graph nodes and `USE_CASE_USES_ENTRY`/`TEST_COVERS_USE_CASE` edges.
+
+The shape mirrors slice 1's D1/D3/D6 decisions directly, without needing new
+decisions of its own:
+
+- **An entrypoint is an edge onto the library's own existing node**, not a
+  parallel node kind — the same D1 reasoning: a `use_case` node names its
+  entry points by pointing at the library graph's real `binary_symbol`/
+  `source_decl` nodes (matched by id or label), so the join is again one
+  shared node id, not a second disconnected graph needing a name-matching
+  pass to reunite.
+- **The join is a deep copy** (`join_use_case_graph`), for the identical D3
+  reason `join_consumer_graph` is: the library graph is shared with every
+  other analysis of the same snapshot, and a shallow fold would leak one
+  project's declared use cases onto the library graph's own nodes.
+- **Degrade to no answer, never a wrong one** (D6): an `entrypoints` name
+  the library graph cannot resolve is silently skipped — no node, no edge,
+  no error. Only the manifest *document* being structurally malformed (not
+  a YAML list, a non-mapping entry, a missing/blank `use_case` name) is a
+  hard error (`UseCaseManifestError`), matching `PolicyError`'s "an
+  unknown/malformed rule must never be silently skipped" precedent for
+  user-supplied YAML, not `consumer_graph`'s degrade-on-absence rule — the
+  two are different failure classes (a malformed document vs. one
+  unresolvable entry within an otherwise-valid one).
+
+`TRACE_OBSERVED_ENTRY`/`TRACE_OBSERVED_EDGE` remain reserved, unpopulated
+vocabulary — runtime-trace ingestion is still out of scope, for the same
+reason the original "Deliberately not implemented this slice" section gives:
+absence of a trace must never read as "not used", a semantics decision with
+no data yet to validate against. This slice adds no CLI flag reading the
+manifest, no report field, and no finding enrichment — it is graph-building
+only, the same position slice 1 was in before its own D5/D8 wiring. See
+[Use-Case Impact](../../use/use-case-impact.md) for the user-facing manifest
+format and the declared-vs-observed distinction, and
+`tests/test_use_cases.py` for the test coverage.
+
 ## Consequences
 
 - The top of ADR-046 D6's preference order is reachable for the first time.
@@ -306,17 +359,18 @@ would be dropped) and needs its own design across all three front ends.
 
 ## Deliberately not implemented this slice
 
-- **`impact-use-cases.yaml` and the use-case graph** (`use_case`/`test_case`
-  nodes, `USE_CASE_USES_ENTRY`/`TEST_COVERS_USE_CASE`/`TRACE_OBSERVED_ENTRY`/
-  `TRACE_OBSERVED_EDGE`, `docs/use/use-case-impact.md`). A declared-vs-observed
-  manifest format is a user-facing schema with its own compatibility
-  obligations, and G29's own plan is emphatic that it must **not** reuse
-  `docs/contribute/usecase-registry.yaml` (which tracks abicheck's own feature
-  coverage). It needs its own design pass, not an appendix to this one.
+- **`impact-use-cases.yaml` and the use-case graph** — **implemented in
+  slice 2** (2026-08-09 amendment, above): `use_case`/`test_case` nodes and
+  `USE_CASE_USES_ENTRY`/`TEST_COVERS_USE_CASE` edges, in
+  `abicheck/impact/use_cases.py`; see
+  [Use-Case Impact](../../use/use-case-impact.md). `TRACE_OBSERVED_ENTRY`/
+  `TRACE_OBSERVED_EDGE` remain reserved, unpopulated — see the next bullet.
 - **Runtime-trace ingestion** (`RUNTIME_FAILED_TO_RESOLVE_SYMBOL`,
-  `runtime_probe`). Registered as vocabulary; no producer. The hard part is
-  not the edges — it is that absence of a trace must never read as "not used",
-  which is a semantics decision this slice has no data to validate against.
+  `runtime_probe`, and — as of slice 2 — `TRACE_OBSERVED_ENTRY`/
+  `TRACE_OBSERVED_EDGE` too). Registered as vocabulary; no producer. The hard
+  part is not the edges — it is that absence of a trace must never read as
+  "not used", which is a semantics decision this slice has no data to
+  validate against.
 - **`consumer_object` / `CONSUMER_COMPILED_FROM_HEADER` /
   `CONSUMER_INSTANTIATES_DECL`.** These need *consumer-side* build evidence
   (which TU of the consumer compiled which header, which template it

--- a/docs/contribute/detector-impact-contract.md
+++ b/docs/contribute/detector-impact-contract.md
@@ -107,7 +107,7 @@ A new detector should:
 ## 5. What this contract does *not* require (yet)
 
 - **Consumer-proven evidence** (`select_preferred_graph_path`'s tier 1). This
-  now exists — [G29 Phase 4 slice 1](plans/g29-impact-analysis-layer.md#phase-4-consumer-use-case-join-slice-1-implemented-adr-057)
+  now exists — [G29 Phase 4 slice 1](plans/g29-impact-analysis-layer.md#phase-4-consumer-use-case-join-slices-1-2-implemented-adr-057)
   ([ADR-057](adr/057-consumer-graph-and-impact-join.md)) folds a real
   `--used-by` consumer's requirements into the graph — but it is still not
   something a *detector* claims. The tier is derived from

--- a/docs/contribute/plans/g29-impact-analysis-layer.md
+++ b/docs/contribute/plans/g29-impact-analysis-layer.md
@@ -105,18 +105,18 @@ model:
     fields — confirmed (fresh repo-wide grep, not carried over from Slice 8's
     claim) to be the only step that mutates those fields on an existing
     `Change`, so nothing downstream invalidates the cache.
-  - `source_graph_findings.py` — re-audited with ten `Change(...)`
-    construction sites (not nine; `_public_reachability_findings` alone has
-    two). None are individually cacheable at construction time: unlike
-    `internal_leak.py`'s builder (itself a later `DEFAULT_PIPELINE` step),
-    these builders' output is merged into `checker.compare`'s `changes`
-    *before* `_run_post_processing`/`DEFAULT_PIPELINE.run()`, so
+  - `source_graph_findings.py` — re-audited: none of its `Change(...)`
+    construction sites are individually cacheable at construction time,
+    unlike `internal_leak.py`'s builder (itself a later `DEFAULT_PIPELINE`
+    step) — these builders' output is merged into `checker.compare`'s
+    `changes` *before* `_run_post_processing`/`DEFAULT_PIPELINE.run()`, so
     `MarkReachability` still runs downstream of them and would invalidate an
-    eagerly-cached assessment. Each of the ten sites got a short comment
-    documenting this instead of a (would-be-wrong) construction-time cache
-    write — but the practical gap is closed anyway: `MarkReachability`'s own
-    new caching (above) reaches every `source_graph_findings.py` finding too,
-    once it's tagged.
+    eagerly-cached assessment. Each site got a brief comment documenting
+    this instead of a (would-be-wrong) construction-time cache write — but
+    the practical gap is closed anyway: `MarkReachability`'s own new caching
+    (above) reaches every `source_graph_findings.py` finding too, once it's
+    tagged. See the Phase 3 section below ("Slice 10") for the exact
+    per-function site count and breakdown.
 
   A third entry D2's original decision text named, `suppression.py`, still
   contains **no** `Change(...)` construction at all (confirmed by direct
@@ -461,7 +461,7 @@ sites, each resolved by a real audit rather than an assumption:
   these builders' findings are merged into `checker.compare`'s `changes`
   *before* `_run_post_processing`/`DEFAULT_PIPELINE.run()`, so
   `MarkReachability` still runs downstream and would invalidate an
-  eagerly-cached assessment. Each site got a short comment recording this
+  eagerly-cached assessment. Each site got a brief comment recording this
   instead of a construction-time cache write; `MarkReachability`'s own new
   caching reaches every one of these findings anyway, once tagged.
 

--- a/docs/contribute/plans/g29-impact-analysis-layer.md
+++ b/docs/contribute/plans/g29-impact-analysis-layer.md
@@ -77,46 +77,56 @@ model:
   `UNKNOWN` unless `allow_unknown_reachability: true` is set explicitly. See
   [PR #607](https://github.com/abicheck/abicheck/pull/607) and
   `docs/learn/graph-coverage.md`.
-- **G29.2** (Phase 3, **slices 1-9 done, ADR-052**) — A single
+- **G29.2** (Phase 3, **slices 1-10 done, ADR-052**) — A single
   `abicheck/impact/` package with `ImpactAssessment`, `GraphProofPath`, and
   `FindingDecision` dataclasses. **Slices 1-7 implement the read-view
   direction only**: the dataclasses exist and `reporter.py`/`sarif.py`/
   `junit_report.py` (Slice 6) surface them (including the suppression audit
   trail, slice 2, and `--report-mode root-cause` grouping in JSON,
   markdown/text, SARIF properties, and — Slice 6 — additive JUnit `<failure>`
-  attributes). **Slices 8-9 deliver the D2 direction flip for two
-  producers**: `internal_leak.py` (Slice 8) and `appcompat.py` (Slice 9) now
-  populate `Change.impact_assessment` directly for their single-purpose
-  finding builders (each verified safe by its own audit — a pipeline-ordering
-  audit for `internal_leak.py`, confirmation that `suppression.evaluate()` is
-  a pure read for `appcompat.py`), with `assess_change` reusing that cached
-  evidence while always recomputing `decision`/`root_cause_id` fresh.
-  **Two producer sites remain unmigrated, each for a documented reason**
-  (see ADR-052's "Deliberately not implemented this slice" for the full
-  detail, refined by direct code inspection rather than the original
-  decision text's assumption that all five named entries were comparably
-  scoped producers):
-  - `source_graph_findings.py` has **nine** separate `Change(...)`
-    construction sites (not one), each needing its own downstream-mutation
-    check before caching is safe there — a materially bigger audit than
-    Slices 8-9's single-site ones.
-  - `post_processing.MarkReachability` mutates existing `Change` objects via
-    four graph walks rather than constructing new ones; whether caching
-    there is even worth the suppression-safety risk is an **open, unmeasured
-    question** — `assess_change()` is already a pure read view with no graph
-    traversal of its own, so the walks aren't duplicated regardless; caching
-    would only save re-building the `ImpactAssessment` object itself on a
-    second `assess_change()` call for the same `Change`, which needs
-    confirming actually happens (e.g. one `compare` run rendering both JSON
-    and SARIF) before it's worth the risk.
+  attributes). **Slices 8-10 deliver the D2 direction flip**:
+  `internal_leak.py` (Slice 8) and `appcompat.py` (Slice 9) populate
+  `Change.impact_assessment` directly for their single-purpose finding
+  builders (each verified safe by its own audit — a pipeline-ordering audit
+  for `internal_leak.py`, confirmation that `suppression.evaluate()` is a
+  pure read for `appcompat.py`); Slice 10 closes the remaining two named
+  producer sites, each for a documented, code-inspected reason (see ADR-052's
+  "Slice 10" and "Deliberately not implemented this slice" sections for the
+  full detail):
+  - `post_processing.MarkReachability` — the open measurement question is
+    **resolved, migrated**: a real instrumented `compare --format json
+    --secondary-format sarif` run (`tests/test_cli_unit.py::
+    TestCompareSecondaryFormat::test_json_then_sarif_secondary_calls_assess_change_twice_per_change`)
+    confirmed `assess_change()` is genuinely called more than once for the
+    same `Change` object within one process (`reporter.py`'s JSON path and
+    `sarif.py`'s SARIF path each call it independently over the identical,
+    already-computed `DiffResult`). `MarkReachability` now caches
+    `impact_assessment` right after it finalizes each change's reachability
+    fields — confirmed (fresh repo-wide grep, not carried over from Slice 8's
+    claim) to be the only step that mutates those fields on an existing
+    `Change`, so nothing downstream invalidates the cache.
+  - `source_graph_findings.py` — re-audited with ten `Change(...)`
+    construction sites (not nine; `_public_reachability_findings` alone has
+    two). None are individually cacheable at construction time: unlike
+    `internal_leak.py`'s builder (itself a later `DEFAULT_PIPELINE` step),
+    these builders' output is merged into `checker.compare`'s `changes`
+    *before* `_run_post_processing`/`DEFAULT_PIPELINE.run()`, so
+    `MarkReachability` still runs downstream of them and would invalidate an
+    eagerly-cached assessment. Each of the ten sites got a short comment
+    documenting this instead of a (would-be-wrong) construction-time cache
+    write — but the practical gap is closed anyway: `MarkReachability`'s own
+    new caching (above) reaches every `source_graph_findings.py` finding too,
+    once it's tagged.
 
-  A third entry D2's original decision text named, `suppression.py`, turns
-  out to contain **no** `Change(...)` construction at all (confirmed by
-  direct search) — the diagnostic construction near it
-  (`SUPPRESSION_WOULD_HIDE_PUBLIC_BREAK`) actually lives in
+  A third entry D2's original decision text named, `suppression.py`, still
+  contains **no** `Change(...)` construction at all (confirmed by direct
+  search, unchanged from Slice 8/9's finding) — the diagnostic construction
+  near it (`SUPPRESSION_WOULD_HIDE_PUBLIC_BREAK`) actually lives in
   `post_processing.py` and carries no reachability evidence to cache. This
-  is a separate, unresolved documentation question (what `suppression.py`'s
-  named D2 role was actually meant to be), not a third producer to migrate.
+  is the one item from D2's original scope still genuinely open after
+  Slice 10 — a separate, unresolved documentation question (what
+  `suppression.py`'s named D2 role was actually meant to be), not a
+  producer to migrate.
 - **G29.3** (Phase 2, **D1-D6 all done, ADR-046**) — Graph core v2:
   relation/occurrence identity split (**done**), an evidence-preserving
   (order-independent) node/edge merge (**done**), a per-kind/per-role
@@ -351,7 +361,7 @@ current per-decision status (D1-D6 all implemented, D4 as a deliberately
 scoped subset); this paragraph originally described the pre-implementation
 "needs a recorded decision" gate (ADR-044's own bar) before the ADR existed.
 
-### Phase 3 — Reporting & root causes — **slices 1-9 implemented (ADR-052)**
+### Phase 3 — Reporting & root causes — **slices 1-10 implemented (ADR-052)**
 
 [ADR-052](../adr/052-unified-impact-assessment-model.md) records the slice 1
 decisions: `abicheck/impact/model.py`'s `ImpactAssessment`/`GraphProofPath`/
@@ -426,32 +436,43 @@ consumer-overlay builder (Slice 9), verified safe by confirming
 `suppression.evaluate()`/`matches()`/`would_withhold()` are pure reads of the
 `Change` passed in — with `impact.engine.assess_change` reusing the cached
 evidence for both while always recomputing `decision`/`root_cause_id` fresh.
-**Two producer sites still open under this same ADR, now scoped by direct
-code inspection rather than the original decision text's
-five-symmetric-producers assumption**:
-- `source_graph_findings.py` — not one site, **nine** separate
-  `Change(...)` construction sites across as many finding functions
+Slice 10 (G29 Phase 3 follow-up) then closed both remaining named producer
+sites, each resolved by a real audit rather than an assumption:
+- `post_processing.MarkReachability` — the open measurement question is
+  **resolved, migrated**. `tests/test_cli_unit.py::
+  TestCompareSecondaryFormat::test_json_then_sarif_secondary_calls_assess_change_twice_per_change`
+  instruments `assess_change` and runs a real `compare --format json
+  --secondary-format sarif` invocation, confirming the same `Change` object
+  is assessed twice in one process (`reporter.py`'s JSON path, `sarif.py`'s
+  SARIF path — both read the identical, already-computed `DiffResult`).
+  `post_processing_reachability.py`'s `MarkReachability.run()` now caches
+  `impact_assessment` right after finalizing each change's reachability
+  fields (all three per-change exit paths), re-confirming via a fresh
+  repo-wide grep (not carried over from Slice 8's own claim) that it is
+  still the only step that mutates those fields on an existing `Change`.
+- `source_graph_findings.py` — re-audited: **ten** separate `Change(...)`
+  construction sites across nine finding functions
   (`_mapping_drift_findings`, `_public_reachability_findings` ×2,
   `_generated_public_closure_findings`, `_call_reachability_findings`,
   `_include_graph_drift_findings`, `_build_option_reach_findings`,
   `_internal_dependency_findings`, `_target_dependency_findings`,
-  `_symbol_owner_findings`) — each needs its own downstream-mutation check.
-- `post_processing.MarkReachability` — mutates existing `Change`s via four
-  graph walks rather than constructing new ones; **open, unmeasured
-  question** whether caching is worth the suppression-safety risk at all,
-  since `assess_change()` already performs no graph traversal of its own —
-  see ADR-052's "Deliberately not implemented this slice" for the
-  reasoning that needs a measurement, not an assumption, before this is
-  scheduled.
+  `_symbol_owner_findings`). None are safe to cache at construction time —
+  unlike `internal_leak.py`'s builder (a later `DEFAULT_PIPELINE` step),
+  these builders' findings are merged into `checker.compare`'s `changes`
+  *before* `_run_post_processing`/`DEFAULT_PIPELINE.run()`, so
+  `MarkReachability` still runs downstream and would invalidate an
+  eagerly-cached assessment. Each site got a short comment recording this
+  instead of a construction-time cache write; `MarkReachability`'s own new
+  caching reaches every one of these findings anyway, once tagged.
 
-A third entry the original decision text named, `suppression.py`, is a
-separate, unresolved documentation question rather than a third producer
-site: direct search found no `Change(...)` construction in this module at
-all; the nearby diagnostic (`SUPPRESSION_WOULD_HIDE_PUBLIC_BREAK`) actually
-lives in `post_processing.py` and carries no reachability evidence. What
-D2's original text meant by naming `suppression.py` needs a
-documentation-only clarification pass before any code work is scheduled
-against it.
+A third entry the original decision text named, `suppression.py`, is still a
+separate, unresolved documentation question rather than a producer site:
+direct search found no `Change(...)` construction in this module at all; the
+nearby diagnostic (`SUPPRESSION_WOULD_HIDE_PUBLIC_BREAK`) actually lives in
+`post_processing.py` and carries no reachability evidence. What D2's
+original text meant by naming `suppression.py` needs a documentation-only
+clarification pass before any code work is scheduled against it — this is
+the one item from D2's original scope still genuinely open after Slice 10.
 
 Also still open: the full `RootCauseCorrelator`-based correlation across
 consumer-overlay findings with no `caused_by_type` link (Phase 6) — which is
@@ -475,20 +496,23 @@ section describes, most of it still open:
   `contract_effect`/`changed_entities`/`public_entries`/`affected_consumers`/
   `affected_use_cases`/`coverage` — no data source yet (Phase 4/5), left out
   entirely rather than added as permanently-`None` placeholders.
-- `source_graph_findings.py`, `internal_leak.py`, `suppression.py`,
+- `source_graph_findings.py`, `internal_leak.py`, `post_processing.py`,
   `appcompat.py` populate `ImpactAssessment` instead of independently setting
   overlapping `Change` fields; the existing `public_reachable`/
   `reachability_kind`/`reachability_proof_path`/`reachability_state` fields
   become **derived, backward-compatible views** over it (no JSON/SARIF
-  breaking change). **Partially done (Slices 8-9)**: `internal_leak.py` and
+  breaking change). **Partially done (Slices 8-10)**: `internal_leak.py` and
   `appcompat.py` construct `Change.impact_assessment` directly for their
-  finding builders; the flat fields stay as real fields (not converted to
-  derived properties) rather than the originally-described full flip, since
-  that conversion touches every existing `Change(...)` construction site
+  finding builders (Slices 8-9); `post_processing.MarkReachability` now
+  caches it for every change it tags (Slice 10), which transitively covers
+  `source_graph_findings.py`'s findings too, without any of its own ten
+  construction sites caching directly (found unsafe by Slice 10's audit —
+  see above). The flat fields stay as real fields (not converted to derived
+  properties) rather than the originally-described full flip, since that
+  conversion touches every existing `Change(...)` construction site
   repo-wide and was judged out of scope for a verifiably-safe slice. **Still
-  open**: `source_graph_findings.py` (nine construction sites),
-  `post_processing.MarkReachability` (caching value unmeasured — see above),
-  and `suppression.py` (its D2 role needs clarification — see above).
+  open**: `suppression.py` (its D2 role needs a documentation clarification
+  pass — see above) — the one remaining item from D2's original scope.
 - `reporter.py`/`sarif.py`: structured `impact` object in JSON (**done**,
   `impact_assessment`), `codeFlows`/`threadFlows` in SARIF (**not done** —
   SARIF's root-cause mode is additive `properties.rootCauseId`/`rootCause`

--- a/docs/contribute/plans/g29-impact-analysis-layer.md
+++ b/docs/contribute/plans/g29-impact-analysis-layer.md
@@ -155,7 +155,7 @@ model:
   `impact_group_id` is currently always an alias of `root_cause_id`;
   making it independently meaningful still needs Phase 6's
   `RootCauseCorrelator`.
-- **G29.5** (Phase 4, **slice 1 done, ADR-057**) — A consumer graph
+- **G29.5** (Phase 4, **slices 1-2 done, ADR-057**) — A consumer graph
   (`CONSUMER_REQUIRES_SYMBOL`, `CONSUMER_REQUIRES_VERSION`, …) that joins
   with the source graph so a `CONSUMER_REQUIRED_SYMBOL_REMOVED` finding can
   name the public entry point that produced the dependency — **done**
@@ -163,12 +163,18 @@ model:
   `binary_symbol://` node id, not a parallel node kind, and the walk reuses
   ADR-046 D5's `CALL_GRAPH_TRAVERSAL_POLICY` rather than a fresh BFS). This
   also closed ADR-046 D6's tier 1 ("consumer-proven"), which had been
-  unreachable since it was written. Still open: the optional
+  unreachable since it was written. **Slice 2 also done**: the optional
   `impact-use-cases.yaml` manifest (declared entrypoints/tests, explicitly
-  **not** a reuse of `usecase-registry.yaml`) and best-effort runtime-trace
-  ingestion — the three reserved edge kinds ADR-057 registers
+  **not** a reuse of `usecase-registry.yaml`) — `abicheck/impact/use_cases.py`
+  parses the manifest and builds/joins `use_case`/`test_case` nodes and
+  `USE_CASE_USES_ENTRY`/`TEST_COVERS_USE_CASE` edges onto the library graph,
+  mirroring slice 1's build/join API and mutation-safety discipline. Still
+  open: best-effort runtime-trace ingestion, and any report-level
+  `affected_use_cases`/`USE_CASE_IMPACT_CONFIRMED` surface reading the joined
+  use-case graph (G29 Phase 6) — the reserved edge kinds ADR-057 registers
   (`CONSUMER_INSTANTIATES_DECL`/`CONSUMER_COMPILED_FROM_HEADER`/
-  `RUNTIME_FAILED_TO_RESOLVE_SYMBOL`) mark where that work attaches.
+  `RUNTIME_FAILED_TO_RESOLVE_SYMBOL`/`TRACE_OBSERVED_ENTRY`/
+  `TRACE_OBSERVED_EDGE`) mark where that work attaches.
 - **G29.6** — The five open graph families (template instantiation, virtual
   dispatch, macro/config, callback/function-pointer, object/archive link
   provenance) implemented behind the same coverage-honesty discipline as the
@@ -512,7 +518,7 @@ section describes, most of it still open:
   `attach_impact_metadata`) for the contract to point at working code rather
   than aspirational surface.
 
-### Phase 4 — Consumer / use-case join — **slice 1 implemented (ADR-057)**
+### Phase 4 — Consumer / use-case join — **slices 1-2 implemented (ADR-057)**
 
 [ADR-057](../adr/057-consumer-graph-and-impact-join.md) records the slice 1
 decisions.
@@ -558,11 +564,21 @@ decisions.
   `docs/contribute/usecase-registry.yaml` (that registry tracks abicheck's
   *own* feature coverage — reusing it for a project's business use cases would
   conflate "abicheck supports header-only analysis" with "the DAL training
-  workflow uses `train()`", per the review's own caution).
-- `docs/use/use-case-impact.md` (new): manifest format, entrypoint
-  mapping, test association, trace ingestion, declared-vs-observed use,
-  full-library-vs-consumer-scoped verdict semantics (absence of a trace must
-  never read as "not used").
+  workflow uses `train()`", per the review's own caution). **Done** (slice
+  2): `load_use_case_manifest`/`parse_use_case_manifest` (hard-error on a
+  malformed document via `UseCaseManifestError`, silent skip on one
+  unresolvable entrypoint), `build_use_case_graph`/`join_use_case_graph`
+  (deep-copy join, mirroring `consumer_graph`'s slice 1 API/discipline
+  exactly). Only `USE_CASE_USES_ENTRY`/`TEST_COVERS_USE_CASE` are populated;
+  `TRACE_OBSERVED_ENTRY`/`TRACE_OBSERVED_EDGE` stay reserved — **runtime-trace
+  ingestion itself is still not implemented**, and neither is any CLI flag
+  reading the manifest or report-level field/finding consuming the joined
+  graph (that's G29 Phase 6's `USE_CASE_IMPACT_CONFIRMED`).
+- `docs/use/use-case-impact.md` (new, **done**): manifest format, entrypoint
+  mapping, test association, declared-vs-observed use (**trace ingestion
+  itself remains unimplemented** — documented honestly as not-yet-built, not
+  described as working), full-library-vs-consumer-scoped verdict semantics
+  (absence of a trace must never read as "not used").
 
 ### Phase 5 — New semantic graph families
 
@@ -654,11 +670,11 @@ abicheck/impact/
     correlation.py       # RootCauseCorrelator (Phase 6, not started)
     root_causes.py
     consumer_graph.py    # Phase 4 slice 1, DONE — ADR-057 (consumer graph + the source join)
-    use_cases.py         # Phase 4, not started
+    use_cases.py         # Phase 4 slice 2, DONE — ADR-057 amendment (manifest + use_case/test_case graph join; trace ingestion still not started)
 docs/learn/impact-analysis.md          # Phase 3 slices 1/6/7 + Phase 4's consumer join (ADR-057), DONE
 docs/reference/source-graph-schema.md     # Phase 2 D1-D6 identity/merge/traversal-policy schema, DONE
 docs/learn/graph-coverage.md           # Phase 1, DONE
-docs/use/use-case-impact.md        # Phase 4, not started (needs the manifest design first)
+docs/use/use-case-impact.md        # Phase 4 slice 2, DONE (manifest format, entrypoint mapping, test association, declared-vs-observed; trace ingestion documented as not-yet-built)
 docs/contribute/detector-impact-contract.md  # DONE, ahead of Phase 5/6 themselves — see Phase 3 section above
 examples/case194.../case205.../           # Phase 6
 ```
@@ -704,9 +720,17 @@ Modified (recurring across phases): `abicheck/buildsource/source_graph.py`,
   overapprox-still-wins rule, and an end-to-end `scope_diff_to_app` class
   covering both the enriched overlay and the byte-for-byte-unchanged
   no-graph run.
-- New per remaining phase: `tests/test_use_cases.py` (Phase 4), one
-  `test_diff_<family>.py` per
-  Phase 5 graph family, `tests/test_root_cause_correlator.py` (Phase 6).
+- `tests/test_use_cases.py` — Phase 4 slice 2 (ADR-057 amendment), done:
+  schema registration, manifest parsing (valid, empty, and each malformed
+  shape), `build_use_case_graph`'s entrypoint resolution by id and by label,
+  the unresolvable-entrypoint silent-skip path, `test_case` node/edge
+  emission independent of entrypoint resolution, `join_use_case_graph`'s
+  fold-onto-one-shared-node and its deep-copy/no-mutation guarantee
+  (asserted on object identity and fact membership, mirroring
+  `test_consumer_graph.py`'s own pattern), and an end-to-end scenario joining
+  a `use_case` node onto a library graph's public entry node.
+- New per remaining phase: one `test_diff_<family>.py` per Phase 5 graph
+  family, `tests/test_root_cause_correlator.py` (Phase 6).
 - `tests/test_abi_examples.py` picks up `case194`-`case205` automatically once
   `ground_truth.json` is updated (existing harness, no new test file needed).
 

--- a/docs/learn/impact-analysis.md
+++ b/docs/learn/impact-analysis.md
@@ -205,10 +205,13 @@ no report field — it fills in fields the schema already had.
 `impact_assessment` does not (yet) include a list of affected consumers or
 use cases, or a coverage summary. The consumer *graph* exists (above), but as
 evidence a finding is enriched from — not as its own
-`affected_consumers`/`affected_use_cases` fields; declared use cases
-(`impact-use-cases.yaml`) and runtime-trace ingestion are the remainder of
-G29 Phase 4, and the per-role coverage matrix is not wired through the impact
-layer. `root_cause_id`/`impact_group_id` (documented above) are implemented,
+`affected_consumers`/`affected_use_cases` fields. Declared use cases
+(an optional `impact-use-cases.yaml` manifest, `abicheck.impact.use_cases`)
+are now also graph-buildable and joinable the same way — see
+[Use-Case Impact](../use/use-case-impact.md) — but, same as the consumer
+graph, only as evidence, with no report field or finding reading it yet.
+Runtime-trace ingestion (for either graph) and the per-role coverage matrix
+being wired through the impact layer are the remainder of G29 Phase 4. `root_cause_id`/`impact_group_id` (documented above) are implemented,
 but `impact_group_id` is currently only ever an alias of `root_cause_id` —
 distinguishing them (e.g. bucketing several distinct root causes that share
 one broader consumer-visible event under one group while keeping their own

--- a/docs/use/use-case-impact.md
+++ b/docs/use/use-case-impact.md
@@ -66,7 +66,12 @@ sketches, nothing more:
   `source_decl` (or other) node whose own declared visibility is public. A
   name can be spelled either as the graph's internal node id
   (`binary_symbol://_ZN6detail4evalEv`) or as the node's plain label
-  (`_ZN6detail4evalEv`, `train`) — both resolve to the same node.
+  (`_ZN6detail4evalEv`, `train`). An exact node id always resolves and
+  always takes precedence over a label. A plain label resolves **only**
+  when exactly one public node in the graph carries that label — a label
+  two or more public nodes share (a common shape for overloaded C++
+  entries) is genuinely ambiguous and is treated the same as an
+  unresolvable name (below), never guessed at.
 - **`tests`** (optional list of strings) — free-form test identifiers that
   cover this use case. Recorded as `test_case` nodes with no resolution
   step, since there is no graph node kind an external test identifier could
@@ -82,12 +87,26 @@ far more likely explanation than a genuinely broken manifest entry, and
 treating the two the same way would make an ordinary coverage gap look like
 a manifest bug.
 
-Only the document shape itself is validated as a hard error: the top-level
-document must be a YAML list, each entry a mapping, and each entry's
-`use_case` a non-empty string. A malformed manifest raises
-`abicheck.errors.UseCaseManifestError` rather than silently dropping the bad
-entry — silently skipping a malformed entry could make a use case's declared
-coverage quietly disappear from every future run with no indication why.
+The document's own shape is validated as a hard error, raising
+`abicheck.errors.UseCaseManifestError` rather than silently dropping or
+misreading the bad entry — silently accepting a malformed manifest could
+make a use case's declared coverage quietly disappear or misresolve from
+every future run with no indication why. Rejected:
+
+- invalid YAML syntax, or a mapping that repeats a key (e.g. two
+  `entrypoints:` lines pasted into one entry — YAML's own default keeps
+  only the last value) or uses an unhashable key (a YAML sequence used as a
+  mapping key);
+- a top-level document that isn't a YAML list, or a list entry that isn't a
+  mapping;
+- an entry with an unrecognized field — only `use_case`/`entrypoints`/
+  `tests` are accepted, so a misspelling (`entrypoint` instead of
+  `entrypoints`) fails loudly instead of silently contributing nothing;
+- a missing or blank `use_case` name;
+- an `entrypoints`/`tests` value that isn't a YAML list of strings.
+
+An empty document (no file content at all) is a valid, empty manifest —
+no use cases declared, not an error.
 
 ## Entrypoint mapping and test association
 

--- a/docs/use/use-case-impact.md
+++ b/docs/use/use-case-impact.md
@@ -63,7 +63,10 @@ sketches, nothing more:
 - **`entrypoints`** (optional list of strings) — public-entry symbol or
   declaration names/labels this use case exercises. Each name is matched
   against the library's own graph: an exported `binary_symbol` node, or a
-  `source_decl` (or other) node whose own declared visibility is public. A
+  `source_decl` node whose own declared visibility is public. Deliberately
+  restricted to these two kinds — a public type (`record_type`/`enum_type`/
+  `typedef`) is never a valid entrypoint target, since it has no outgoing
+  call-graph edge for a consumer-impact walk to follow. A
   name can be spelled either as the graph's internal node id
   (`binary_symbol://_ZN6detail4evalEv`) or as the node's plain label
   (`_ZN6detail4evalEv`, `train`). An exact node id always resolves and

--- a/docs/use/use-case-impact.md
+++ b/docs/use/use-case-impact.md
@@ -1,0 +1,177 @@
+---
+doc_type: how-to
+audience:
+  - library-maintainer
+level: intermediate
+summarizes:
+  - impact-analysis
+lifecycle: active
+generated: false
+---
+
+# Use-Case Impact
+
+An optional `impact-use-cases.yaml` manifest lets you declare a project's own
+business/runtime use cases — "the training workflow", "the batch export
+job" — and which public entry points and tests exercise each one. abicheck
+promotes the manifest to graph facts and joins them onto the library's own
+[unified impact-assessment graph](../learn/impact-analysis.md), the same way
+[`--used-by` promotes a real consumer binary's requirements](../use/appcompat.md).
+
+This is [G29 Phase 4 slice 2](../contribute/plans/g29-impact-analysis-layer.md),
+amending [ADR-057](../contribute/adr/057-consumer-graph-and-impact-join.md).
+It is a **graph-building** feature only: `abicheck.impact.use_cases` parses
+the manifest and builds/joins the graph facts. There is no CLI flag reading
+this manifest yet, no `affected_use_cases` report field, and no
+`USE_CASE_IMPACT_CONFIRMED` finding — see "What this does not cover yet"
+below.
+
+## Why a separate manifest from `usecase-registry.yaml`
+
+`docs/contribute/usecase-registry.yaml` tracks **abicheck's own** feature
+coverage — whether abicheck itself supports header-only analysis, for
+example. `impact-use-cases.yaml` tracks **your project's** business/runtime
+use cases — whether *your* training workflow calls `train()`. These are
+unrelated concepts that happen to share the English phrase "use case";
+conflating them into one schema would make "abicheck supports X" and "our
+workflow uses Y" read as the same kind of fact. They are deliberately kept
+as two separate, unrelated files.
+
+## Manifest format
+
+```yaml
+# impact-use-cases.yaml
+- use_case: training-workflow
+  entrypoints:
+    - train
+    - _ZN6detail4evalEv
+  tests:
+    - test_train_end_to_end
+
+- use_case: batch-export
+  entrypoints:
+    - export_batch
+  tests: []
+```
+
+Three fields per entry, deliberately minimal — matching exactly what
+[the plan](../contribute/plans/g29-impact-analysis-layer.md#phase-4-consumer-use-case-join-slices-1-2-implemented-adr-057)
+sketches, nothing more:
+
+- **`use_case`** (required, non-empty string) — the use case's name. Becomes
+  the label of a `use_case` graph node.
+- **`entrypoints`** (optional list of strings) — public-entry symbol or
+  declaration names/labels this use case exercises. Each name is matched
+  against the library's own graph: an exported `binary_symbol` node, or a
+  `source_decl` (or other) node whose own declared visibility is public. A
+  name can be spelled either as the graph's internal node id
+  (`binary_symbol://_ZN6detail4evalEv`) or as the node's plain label
+  (`_ZN6detail4evalEv`, `train`) — both resolve to the same node.
+- **`tests`** (optional list of strings) — free-form test identifiers that
+  cover this use case. Recorded as `test_case` nodes with no resolution
+  step, since there is no graph node kind an external test identifier could
+  fail to resolve against.
+
+An entrypoint name the library graph cannot resolve is **silently skipped**
+— no node, no edge, no error, and no signal that the entrypoint is somehow
+wrong. This is the same "absence, never a wrong answer" discipline
+`abicheck.impact.consumer_graph` (ADR-057 slice 1) already follows for an
+unresolvable required symbol: a library graph that's incomplete (header-only,
+partial `--sources` coverage, or simply missing that one declaration) is a
+far more likely explanation than a genuinely broken manifest entry, and
+treating the two the same way would make an ordinary coverage gap look like
+a manifest bug.
+
+Only the document shape itself is validated as a hard error: the top-level
+document must be a YAML list, each entry a mapping, and each entry's
+`use_case` a non-empty string. A malformed manifest raises
+`abicheck.errors.UseCaseManifestError` rather than silently dropping the bad
+entry — silently skipping a malformed entry could make a use case's declared
+coverage quietly disappear from every future run with no indication why.
+
+## Entrypoint mapping and test association
+
+```python
+from abicheck.impact.use_cases import (
+    build_use_case_graph,
+    join_use_case_graph,
+    load_use_case_manifest,
+)
+
+definitions = load_use_case_manifest("impact-use-cases.yaml")
+use_case_graph = build_use_case_graph(definitions, library_graph)
+joined = join_use_case_graph(library_graph, use_case_graph)
+```
+
+`build_use_case_graph` resolves every `entrypoints` name against
+*`library_graph`* — the library's own L5 source graph or header-only graph
+(see [Build Info & Sources](../learn/build-source-data.md) for how that
+graph gets built in the first place) — and returns a small, standalone
+graph of `use_case`/`test_case` nodes and their edges. `join_use_case_graph`
+then folds that graph into a **deep copy** of the library graph, mirroring
+`consumer_graph.join_consumer_graph`'s identical reasoning: the library
+graph is shared with every other analysis of the same snapshot (internal-leak
+walks, the source-graph diff, a `--used-by` consumer join), so a shallow
+fold would leak one project's declared use cases onto the library's own
+public-entry nodes and corrupt every unrelated analysis of the same run.
+The join itself is nothing more than registering into the same evidence
+store: a node the library graph already has and a use case's edge also
+names ends up as one node carrying both producers' facts (ADR-046 D2).
+
+## Declared vs. observed use — and what "no trace" does *not* mean
+
+This slice only ever adds **declared** evidence: a human wrote
+`impact-use-cases.yaml` and asserted that a use case exercises certain
+entry points. There is no **observed** counterpart yet — no runtime trace
+confirms or contradicts a declaration. Two edge kinds are already reserved
+in the graph schema for that future work, `TRACE_OBSERVED_ENTRY` and
+`TRACE_OBSERVED_EDGE`, but nothing populates them today.
+
+This distinction matters for how you read the graph: the **absence** of a
+`use_case` node naming some entry point is not evidence that no use case
+depends on it — it only means nobody has written a manifest entry for it
+yet (or the manifest doesn't exist at all). Likewise, once trace ingestion
+exists, the absence of an observed trace edge will not mean "this use case
+doesn't really use this entry" — a trace only ever *positively* confirms
+what it happened to observe during one run; it can never prove a codepath
+is unused. Runtime-trace ingestion is explicitly deferred (see ADR-057's
+"Deliberately not implemented this slice") precisely because getting this
+distinction wrong — reading a missing trace as "not used" — is a real
+correctness risk with no data yet to validate the right semantics against.
+
+## Full-library vs. consumer/use-case-scoped verdict semantics
+
+Nothing in this slice changes any verdict, finding set, or exit code. The
+same rule that governs `--used-by` scoping applies here in advance of any
+consumer of this graph existing: a **full-library** `compare` verdict
+reflects every change to every declared symbol, regardless of whether any
+use case (declared or observed) reaches it. A **use-case-scoped** verdict —
+not implemented yet, tracked as G29 Phase 6's `USE_CASE_IMPACT_CONFIRMED`
+report-level overlay — would answer a narrower question: does *this*
+declared use case's own entry points and their call-graph closure reach the
+change at all. The two are not in tension and neither ever silently
+replaces the other, the same additive-evidence principle every other
+optional L3–L5 layer in abicheck already follows (see
+[Build Info & Sources](../learn/build-source-data.md)'s "one rule that
+governs everything").
+
+## What this does not cover yet
+
+- **No CLI wiring.** There is no `dump`/`compare` flag that reads
+  `impact-use-cases.yaml` today. The Python API above is the only way to
+  build and join a use-case graph in this slice.
+- **No report field.** `impact_assessment` (see
+  [Unified Impact Assessment](../learn/impact-analysis.md)) has no
+  `affected_use_cases` field yet — the use-case graph exists as evidence a
+  future finding could be enriched from, the same position the consumer
+  graph was in before ADR-057's D5/D8 wiring enriched
+  `CONSUMER_REQUIRED_SYMBOL_REMOVED` and shared `FUNC_REMOVED`/`SYMBOL_REMOVED`
+  findings with it.
+- **No new `ChangeKind` or verdict.** `USE_CASE_IMPACT_CONFIRMED` (G29 Phase
+  6) is a planned report-level overlay, not a raw break — matching how
+  `CONSUMER_IMPACT_PATH_CONFIRMED` is scoped for the consumer side.
+- **Runtime-trace ingestion.** As above — `TRACE_OBSERVED_ENTRY`/
+  `TRACE_OBSERVED_EDGE` are reserved vocabulary with no producer.
+- **Multiple use-case manifests, or a manifest embedded in `.abicheck.yml`.**
+  Only a single, standalone YAML file loaded explicitly via
+  `load_use_case_manifest` is supported.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,7 @@ nav:
       - Applications & Consumers:
         - Application Compatibility: use/appcompat.md
         - API Surface Intelligence: use/api-surface-intelligence.md
+        - Use-Case Impact: use/use-case-impact.md
       - Plugins & Dynamic Loading:
         - Plugin Systems: use/plugin-systems.md
       - Python Extensions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,7 +222,6 @@ module = [
     "abicheck.buildsource.inline",
     "abicheck.buildsource.project_targets",
     "abicheck.buildsource.toolchain_bindings",
-    "abicheck.impact.use_cases",
 ]
 disable_error_code = ["import-untyped"]
 
@@ -232,8 +231,15 @@ disable_error_code = ["import-untyped"]
 # rejection) — without stubs ``yaml.SafeLoader`` types as ``Any``, so
 # subclassing it also trips ``misc`` ("cannot subclass Any").
 # ``compatibility_evaluation_packs`` (ADR-049 D8 pack-manifest loader) adds
-# its own, independent ``_StrictLoader`` for the identical reason.
-module = ["abicheck.dump_manifest", "abicheck.compatibility_evaluation_packs"]
+# its own, independent ``_StrictLoader`` for the identical reason;
+# ``abicheck.impact.use_cases``'s ``_DuplicateKeyCheckingLoader`` (Codex
+# review, G29 Phase 4 slice 2) is a fourth, independent instance of the
+# identical pattern.
+module = [
+    "abicheck.dump_manifest",
+    "abicheck.compatibility_evaluation_packs",
+    "abicheck.impact.use_cases",
+]
 disable_error_code = ["import-untyped", "misc"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,6 +222,7 @@ module = [
     "abicheck.buildsource.inline",
     "abicheck.buildsource.project_targets",
     "abicheck.buildsource.toolchain_bindings",
+    "abicheck.impact.use_cases",
 ]
 disable_error_code = ["import-untyped"]
 

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -2454,6 +2454,40 @@ class TestMergeConsumerImpactPaths:
         assert merged.entry_path == [edge_a]
         assert [edge_b] in merged.alternative_entry_paths
 
+    def test_symbol_entry_and_path_come_from_the_same_match(self):
+        """The exact contradiction Codex flagged: the first match is
+        direct (entry_path=[]) and the second is indirect. symbol,
+        entry_path, and the primary public entry must all come from the
+        SAME match (the indirect one, since only it has a real path to
+        show) -- not symbol/entries from the first match glued onto a
+        path from a different one, which would read as 'A is reachable
+        from entry A' followed by a chain that actually starts at and
+        explains B."""
+        from abicheck.appcompat import _merge_consumer_impact_paths
+        from abicheck.buildsource.graph_facts import GraphEdge
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+
+        direct_first = ConsumerImpactPath(
+            consumer="app",
+            symbol="A",
+            public_entries=("entry_A",),
+            entry_path=[],  # direct: declaration IS the public entry
+        )
+        indirect_second = ConsumerImpactPath(
+            consumer="app",
+            symbol="B",
+            public_entries=("entry_B",),
+            entry_path=[GraphEdge(src="entry_B", dst="B", kind="DECL_CALLS_DECL")],
+        )
+        merged = _merge_consumer_impact_paths([direct_first, indirect_second])
+        # entry_path came from indirect_second -- symbol and the primary
+        # public entry must agree with it, not with direct_first.
+        assert merged.entry_path == indirect_second.entry_path
+        assert merged.symbol == "B"
+        assert merged.public_entries[0] == "entry_B"
+        # The direct match's own entry is still reported, just not first.
+        assert "entry_A" in merged.public_entries
+
     def test_enrichment_uses_the_merged_explanation_end_to_end(self):
         """_enrich_covered_changes' own next(...)-vs-merge regression: a
         single shared Change whose affected_symbols names two missing

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -2280,3 +2280,50 @@ class TestHasImpactEvidence:
         change = self._change(reachability_proof_path="Foo -> Bar -> _Z9dispatchv")
         assert change.impact_assessment is None
         assert _has_impact_evidence(change) is True
+
+
+class TestEnrichCoveredChangesRefreshesCache:
+    """:func:`abicheck.appcompat._enrich_covered_changes` must refresh
+    ``change.impact_assessment`` after attaching consumer evidence, not just
+    the flat proof-path fields (Codex review, fresh evidence): a change
+    reaching this function with a cached-but-pathless ``ImpactAssessment``
+    (``MarkReachability``'s blanket Slice 10 cache) still has that stale
+    object sitting on ``change.impact_assessment`` after enrichment --
+    ``impact.engine.assess_change`` prefers any non-``None`` cached
+    assessment, so a later JSON/SARIF render would keep returning
+    ``proof_path=None`` and silently drop the newly attached explanation."""
+
+    def test_stale_pathless_cache_is_refreshed_after_enrichment(self):
+        from abicheck.appcompat import _enrich_covered_changes
+        from abicheck.buildsource.source_graph import GraphNode, SourceGraphSummary
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+        from abicheck.impact.engine import assess_change
+
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol="_Z9dispatchv",
+            description="Function removed: _Z9dispatchv",
+            reachability_state=ReachabilityState.UNKNOWN,
+        )
+        # Simulate MarkReachability's Slice 10 blanket cache: a real
+        # ImpactAssessment object with no proof path.
+        change.impact_assessment = assess_change(change)
+        assert change.impact_assessment.proof_path is None
+
+        graph = SourceGraphSummary()
+        graph.add_node(GraphNode(id="decl://run", kind="source_decl", label="run"))
+        explained = ConsumerImpactPath(
+            consumer="training-service",
+            symbol="_Z9dispatchv",
+            declarations=("_Z9dispatchv",),
+            public_entries=("run",),
+        )
+        assert explained.is_direct()
+
+        _enrich_covered_changes([change], {"_Z9dispatchv": explained}, graph)
+
+        assert change.affected_public_roots == ["run"]
+        assert change.impact_assessment.proof_path is not None
+        # The refreshed cache must agree with a fresh, uncached derivation.
+        fresh = assess_change(change)
+        assert change.impact_assessment.proof_path == fresh.proof_path

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -2393,14 +2393,52 @@ class TestMergeConsumerImpactPaths:
     removed functions), and _change_covers_symbol treats every one of them
     as covered."""
 
-    def test_single_match_is_returned_unchanged(self):
+    def test_single_match_with_no_alternatives_is_equivalent(self):
+        """A lone match with nothing to filter comes back with the same
+        content -- but not necessarily the same object (Codex review, fresh
+        evidence): the single-match case is no longer a special-cased
+        early return, since a lone match can itself carry a
+        differently-rooted alternative that needs the same filtering as
+        the multi-match case (see the class below)."""
         from abicheck.appcompat import _merge_consumer_impact_paths
         from abicheck.impact.consumer_graph import ConsumerImpactPath
 
         only = ConsumerImpactPath(
             consumer="app", symbol="foo", public_entries=("run",)
         )
-        assert _merge_consumer_impact_paths([only]) is only
+        merged = _merge_consumer_impact_paths([only])
+        assert merged.consumer == only.consumer
+        assert merged.symbol == only.symbol
+        assert merged.public_entries == only.public_entries
+        assert merged.entry_path == only.entry_path
+        assert merged.alternative_entry_paths == only.alternative_entry_paths
+
+    def test_single_matchs_own_differently_rooted_alternative_is_excluded(self):
+        """The exact bug Codex flagged: explain_required_symbols can return
+        one ConsumerImpactPath (the ordinary single-symbol case) whose own
+        alternative_entry_paths already mixes candidates from more than one
+        consumer-compiled entry -- not just multi-match merges. Without
+        routing this through the same root filter, impact.engine's single
+        affected_public_roots[0] would mislabel a differently-rooted
+        alternative as though it started at the primary's own root."""
+        from abicheck.appcompat import _merge_consumer_impact_paths
+        from abicheck.buildsource.graph_facts import GraphEdge
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+
+        primary_edge = GraphEdge(src="entry_A", dst="foo", kind="DECL_CALLS_DECL")
+        same_root_alt = GraphEdge(src="entry_A", dst="foo2", kind="DECL_CALLS_DECL")
+        other_root_alt = GraphEdge(src="entry_C", dst="foo3", kind="DECL_CALLS_DECL")
+        only = ConsumerImpactPath(
+            consumer="app",
+            symbol="foo",
+            public_entries=("entry_A",),
+            entry_path=[primary_edge],
+            alternative_entry_paths=[[same_root_alt], [other_root_alt]],
+        )
+        merged = _merge_consumer_impact_paths([only])
+        assert merged.entry_path == [primary_edge]
+        assert [same_root_alt] in merged.alternative_entry_paths
+        assert [other_root_alt] not in merged.alternative_entry_paths
 
     def test_multiple_matches_union_public_entries_and_declarations(self):
         from abicheck.appcompat import _merge_consumer_impact_paths

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -2323,7 +2323,12 @@ class TestEnrichCoveredChangesRefreshesCache:
         _enrich_covered_changes([change], {"_Z9dispatchv": explained}, graph)
 
         assert change.affected_public_roots == ["run"]
-        assert change.impact_assessment.proof_path is not None
-        # The refreshed cache must agree with a fresh, uncached derivation.
+        refreshed = change.impact_assessment
+        assert refreshed.proof_path is not None
+        # The refreshed cache must agree with a genuinely uncached
+        # derivation -- assess_change() prefers change.impact_assessment
+        # when it's non-None, so clear it first or this comparison would
+        # just read the very cache under test.
+        change.impact_assessment = None
         fresh = assess_change(change)
-        assert change.impact_assessment.proof_path == fresh.proof_path
+        assert refreshed.proof_path == fresh.proof_path

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -2432,6 +2432,8 @@ class TestMergeConsumerImpactPaths:
         assert merged.declarations == ("foo", "bar")
 
     def test_non_primary_entry_paths_become_alternatives(self):
+        """Two matches that share the SAME root: the non-primary's own
+        path is a valid alternative for that root, so it is folded in."""
         from abicheck.appcompat import _merge_consumer_impact_paths
         from abicheck.buildsource.graph_facts import GraphEdge
         from abicheck.impact.consumer_graph import ConsumerImpactPath
@@ -2447,12 +2449,45 @@ class TestMergeConsumerImpactPaths:
         second = ConsumerImpactPath(
             consumer="app",
             symbol="bar",
-            public_entries=("train",),
+            public_entries=("run",),
             entry_path=[edge_b],
         )
         merged = _merge_consumer_impact_paths([first, second])
         assert merged.entry_path == [edge_a]
         assert [edge_b] in merged.alternative_entry_paths
+
+    def test_differently_rooted_paths_are_not_folded_into_alternatives(self):
+        """A non-primary match whose own root differs from the primary's
+        must NOT be folded into alternative_entry_paths (Codex review,
+        fresh evidence): impact.engine._build_alternative_path stamps
+        every merged alternative with the SAME single primary root, so
+        including a differently-rooted path would serialize it in
+        JSON/SARIF as though it started at the primary's own entry, when
+        it actually starts at (and explains) an entirely different one."""
+        from abicheck.appcompat import _merge_consumer_impact_paths
+        from abicheck.buildsource.graph_facts import GraphEdge
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+
+        edge_a = GraphEdge(src="a", dst="foo", kind="DECL_CALLS_DECL")
+        edge_b = GraphEdge(src="b", dst="bar", kind="DECL_CALLS_DECL")
+        first = ConsumerImpactPath(
+            consumer="app",
+            symbol="foo",
+            public_entries=("run",),
+            entry_path=[edge_a],
+        )
+        second = ConsumerImpactPath(
+            consumer="app",
+            symbol="bar",
+            public_entries=("train",),  # a different root than "run"
+            entry_path=[edge_b],
+        )
+        merged = _merge_consumer_impact_paths([first, second])
+        assert merged.entry_path == [edge_a]
+        assert [edge_b] not in merged.alternative_entry_paths
+        # The differently-rooted entry is still reported in public_entries
+        # (the union), just not smuggled in as a same-rooted alternative.
+        assert "train" in merged.public_entries
 
     def test_symbol_entry_and_path_come_from_the_same_match(self):
         """The exact contradiction Codex flagged: the first match is

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -2489,6 +2489,38 @@ class TestMergeConsumerImpactPaths:
         # (the union), just not smuggled in as a same-rooted alternative.
         assert "train" in merged.public_entries
 
+    def test_primarys_own_differently_rooted_alternative_is_excluded_too(self):
+        """The identical guard applies to the PRIMARY match's own
+        alternative_entry_paths, not just non-primary matches (Codex
+        review, fresh evidence): explain_required_symbols can attach an
+        alternative that started at a different consumer-compiled entry
+        than the one select_preferred_graph_path chose as primary -- that
+        alternative must not be folded in either, since
+        assess_change()/GraphProofPath has no per-alternative root field
+        and would serialize it as though it shared the primary's own
+        start."""
+        from abicheck.appcompat import _merge_consumer_impact_paths
+        from abicheck.buildsource.graph_facts import GraphEdge
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+
+        primary_edge = GraphEdge(src="entry_A", dst="foo", kind="DECL_CALLS_DECL")
+        same_root_alt = GraphEdge(src="entry_A", dst="foo2", kind="DECL_CALLS_DECL")
+        other_root_alt = GraphEdge(src="entry_C", dst="foo3", kind="DECL_CALLS_DECL")
+        first = ConsumerImpactPath(
+            consumer="app",
+            symbol="foo",
+            public_entries=("entry_A",),
+            entry_path=[primary_edge],
+            alternative_entry_paths=[[same_root_alt], [other_root_alt]],
+        )
+        second = ConsumerImpactPath(
+            consumer="app", symbol="bar", public_entries=("entry_A",)
+        )
+        merged = _merge_consumer_impact_paths([first, second])
+        assert merged.entry_path == [primary_edge]
+        assert [same_root_alt] in merged.alternative_entry_paths
+        assert [other_root_alt] not in merged.alternative_entry_paths
+
     def test_symbol_entry_and_path_come_from_the_same_match(self):
         """The exact contradiction Codex flagged: the first match is
         direct (entry_path=[]) and the second is indirect. symbol,

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -2332,3 +2332,157 @@ class TestEnrichCoveredChangesRefreshesCache:
         change.impact_assessment = None
         fresh = assess_change(change)
         assert refreshed.proof_path == fresh.proof_path
+
+
+class TestAttachConsumerImpactStampsReachability:
+    """:func:`abicheck.appcompat._attach_consumer_impact` must stamp
+    ``public_reachable``/``reachability_kind``/``reachability_state`` on the
+    change it enriches, not just the proof-path fields (Codex review, fresh
+    evidence): a shared ``Change`` reaching ``_enrich_covered_changes`` with
+    no reachability-aware suppression configured at all never had
+    ``MarkReachability`` run on it, so it still carries the dataclass
+    defaults (``UNKNOWN``/``False``) -- attaching a concrete consumer-proven
+    proof path without also raising those fields left an internally
+    contradictory finding (a real proof path, but 'unknown'/'unreachable'
+    status)."""
+
+    def test_enrichment_marks_the_change_consumer_proven(self):
+        from abicheck.appcompat import _enrich_covered_changes
+        from abicheck.buildsource.source_graph import GraphNode, SourceGraphSummary
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol="_Z9dispatchv",
+            description="Function removed: _Z9dispatchv",
+            # Left at the dataclass defaults, same as a real Change that
+            # never went through MarkReachability (no suppression file, or
+            # one whose rules never need reachability evidence).
+        )
+        assert change.reachability_state == ReachabilityState.UNKNOWN
+        assert change.public_reachable is False
+
+        graph = SourceGraphSummary()
+        graph.add_node(GraphNode(id="decl://run", kind="source_decl", label="run"))
+        explained = ConsumerImpactPath(
+            consumer="training-service",
+            symbol="_Z9dispatchv",
+            declarations=("_Z9dispatchv",),
+            public_entries=("run",),
+        )
+
+        _enrich_covered_changes([change], {"_Z9dispatchv": explained}, graph)
+
+        assert change.public_reachable is True
+        assert change.reachability_kind == "consumer_proven"
+        assert change.reachability_state == ReachabilityState.PROVEN_REACHABLE
+        # The cached assessment must agree -- assess_change() derives these
+        # fields straight from the flat ones this stamps.
+        assert change.impact_assessment.public_reachable is True
+        assert change.impact_assessment.reachability_state == (
+            ReachabilityState.PROVEN_REACHABLE
+        )
+
+
+class TestMergeConsumerImpactPaths:
+    """:func:`abicheck.appcompat._merge_consumer_impact_paths` must combine
+    every matching symbol-level explanation for a shared Change, not keep
+    only the first and silently discard the rest (Codex review, fresh
+    evidence): a single Change can cover more than one missing export via
+    ``affected_symbols`` (e.g. one type-size change breaking several
+    removed functions), and _change_covers_symbol treats every one of them
+    as covered."""
+
+    def test_single_match_is_returned_unchanged(self):
+        from abicheck.appcompat import _merge_consumer_impact_paths
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+
+        only = ConsumerImpactPath(
+            consumer="app", symbol="foo", public_entries=("run",)
+        )
+        assert _merge_consumer_impact_paths([only]) is only
+
+    def test_multiple_matches_union_public_entries_and_declarations(self):
+        from abicheck.appcompat import _merge_consumer_impact_paths
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+
+        first = ConsumerImpactPath(
+            consumer="app",
+            symbol="foo",
+            declarations=("foo",),
+            public_entries=("run",),
+        )
+        second = ConsumerImpactPath(
+            consumer="app",
+            symbol="bar",
+            declarations=("bar",),
+            public_entries=("train",),
+        )
+        # A duplicate entry across matches must not appear twice.
+        third = ConsumerImpactPath(
+            consumer="app",
+            symbol="baz",
+            declarations=("bar",),
+            public_entries=("run",),
+        )
+        merged = _merge_consumer_impact_paths([first, second, third])
+        assert merged.consumer == "app"
+        assert merged.symbol == "foo"  # display-only, first match's value
+        assert merged.public_entries == ("run", "train")
+        assert merged.declarations == ("foo", "bar")
+
+    def test_non_primary_entry_paths_become_alternatives(self):
+        from abicheck.appcompat import _merge_consumer_impact_paths
+        from abicheck.buildsource.graph_facts import GraphEdge
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+
+        edge_a = GraphEdge(src="a", dst="foo", kind="DECL_CALLS_DECL")
+        edge_b = GraphEdge(src="b", dst="bar", kind="DECL_CALLS_DECL")
+        first = ConsumerImpactPath(
+            consumer="app",
+            symbol="foo",
+            public_entries=("run",),
+            entry_path=[edge_a],
+        )
+        second = ConsumerImpactPath(
+            consumer="app",
+            symbol="bar",
+            public_entries=("train",),
+            entry_path=[edge_b],
+        )
+        merged = _merge_consumer_impact_paths([first, second])
+        assert merged.entry_path == [edge_a]
+        assert [edge_b] in merged.alternative_entry_paths
+
+    def test_enrichment_uses_the_merged_explanation_end_to_end(self):
+        """_enrich_covered_changes' own next(...)-vs-merge regression: a
+        single shared Change whose affected_symbols names two missing
+        exports must report both public roots, not just the first
+        explanation found."""
+        from abicheck.appcompat import _enrich_covered_changes
+        from abicheck.buildsource.source_graph import GraphNode, SourceGraphSummary
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+
+        change = Change(
+            kind=ChangeKind.TYPE_SIZE_CHANGED,
+            symbol="Config",
+            description="Type size changed: Config",
+            affected_symbols=["_Z3foov", "_Z3barv"],
+        )
+        graph = SourceGraphSummary()
+        graph.add_node(GraphNode(id="decl://run", kind="source_decl", label="run"))
+        graph.add_node(GraphNode(id="decl://train", kind="source_decl", label="train"))
+        explanations = {
+            "_Z3foov": ConsumerImpactPath(
+                consumer="app", symbol="_Z3foov", public_entries=("run",)
+            ),
+            "_Z3barv": ConsumerImpactPath(
+                consumer="app", symbol="_Z3barv", public_entries=("train",)
+            ),
+        }
+
+        _enrich_covered_changes([change], explanations, graph)
+
+        # Both symbols' public entries must be represented, not just the
+        # first one found in dict iteration order.
+        assert set(change.affected_public_roots) == {"run", "train"}

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -2471,13 +2471,20 @@ class TestMergeConsumerImpactPaths:
 
     def test_non_primary_entry_paths_become_alternatives(self):
         """Two matches that share the SAME root: the non-primary's own
-        path is a valid alternative for that root, so it is folded in."""
+        path is a valid alternative for that root, so it is folded in.
+
+        Both edges start at the SAME node id ("a") -- not just the same
+        display label (Codex review, fresh evidence: an earlier version of
+        this test used two DIFFERENT node ids ("a"/"b") sharing one label
+        to model "same root", which is exactly the label-vs-node-identity
+        conflation _merge_consumer_impact_paths must not make, since
+        distinct nodes commonly share a label for C++ overloads)."""
         from abicheck.appcompat import _merge_consumer_impact_paths
         from abicheck.buildsource.graph_facts import GraphEdge
         from abicheck.impact.consumer_graph import ConsumerImpactPath
 
         edge_a = GraphEdge(src="a", dst="foo", kind="DECL_CALLS_DECL")
-        edge_b = GraphEdge(src="b", dst="bar", kind="DECL_CALLS_DECL")
+        edge_b = GraphEdge(src="a", dst="bar", kind="DECL_CALLS_DECL")
         first = ConsumerImpactPath(
             consumer="app",
             symbol="foo",
@@ -2558,6 +2565,39 @@ class TestMergeConsumerImpactPaths:
         assert merged.entry_path == [primary_edge]
         assert [same_root_alt] in merged.alternative_entry_paths
         assert [other_root_alt] not in merged.alternative_entry_paths
+
+    def test_non_primary_root_comparison_uses_node_id_not_label(self):
+        """Codex review, fresh evidence: distinct public-entry nodes can
+        share one display label -- C++ overloads are the common case -- so
+        comparing m.public_entries[0] (a label) against the primary's own
+        label is not proof m's path starts at the SAME graph node. Two
+        matches here share the label "run" but their entry_path edges
+        start at genuinely different node ids (entry_A vs entry_B); the
+        non-primary match must NOT be folded in as a same-rooted
+        alternative just because the labels collide."""
+        from abicheck.appcompat import _merge_consumer_impact_paths
+        from abicheck.buildsource.graph_facts import GraphEdge
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+
+        primary_edge = GraphEdge(src="entry_A", dst="foo", kind="DECL_CALLS_DECL")
+        overload_edge = GraphEdge(src="entry_B", dst="bar", kind="DECL_CALLS_DECL")
+        primary = ConsumerImpactPath(
+            consumer="app",
+            symbol="foo",
+            public_entries=("run",),
+            entry_path=[primary_edge],
+        )
+        # Same label "run", but a DIFFERENT graph node (entry_B, an
+        # overload of "run" sharing its display name with entry_A).
+        overload = ConsumerImpactPath(
+            consumer="app",
+            symbol="bar",
+            public_entries=("run",),
+            entry_path=[overload_edge],
+        )
+        merged = _merge_consumer_impact_paths([primary, overload])
+        assert merged.entry_path == [primary_edge]
+        assert [overload_edge] not in merged.alternative_entry_paths
 
     def test_symbol_entry_and_path_come_from_the_same_match(self):
         """The exact contradiction Codex flagged: the first match is

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -2599,6 +2599,51 @@ class TestMergeConsumerImpactPaths:
         assert merged.entry_path == [primary_edge]
         assert [overload_edge] not in merged.alternative_entry_paths
 
+    def test_non_primarys_own_differently_rooted_alternative_is_excluded(self):
+        """Codex review, fresh evidence: a non-primary match's OWN
+        alternative_entry_paths must be filtered per-alt too, not bulk
+        folded in once the match's PREFERRED entry_path passes the
+        same-root check. explain_required_symbols can attach a non-primary
+        match's own alternative that started at a THIRD entry -- neither
+        the primary's root nor the non-primary match's own preferred
+        entry -- and that third-rooted path must not be smuggled in as
+        though it shared the primary's root."""
+        from abicheck.appcompat import _merge_consumer_impact_paths
+        from abicheck.buildsource.graph_facts import GraphEdge
+        from abicheck.impact.consumer_graph import ConsumerImpactPath
+
+        primary_edge = GraphEdge(src="entry_A", dst="foo", kind="DECL_CALLS_DECL")
+        # second's own preferred path shares the primary's root (entry_A).
+        second_preferred = GraphEdge(src="entry_A", dst="bar2", kind="DECL_CALLS_DECL")
+        # But one of second's OWN alternatives starts at a THIRD entry.
+        second_own_alt_same_root = GraphEdge(
+            src="entry_A", dst="bar3", kind="DECL_CALLS_DECL"
+        )
+        second_own_alt_third_root = GraphEdge(
+            src="entry_C", dst="bar4", kind="DECL_CALLS_DECL"
+        )
+        primary = ConsumerImpactPath(
+            consumer="app",
+            symbol="foo",
+            public_entries=("entry_A",),
+            entry_path=[primary_edge],
+        )
+        second = ConsumerImpactPath(
+            consumer="app",
+            symbol="bar",
+            public_entries=("entry_A",),
+            entry_path=[second_preferred],
+            alternative_entry_paths=[
+                [second_own_alt_same_root],
+                [second_own_alt_third_root],
+            ],
+        )
+        merged = _merge_consumer_impact_paths([primary, second])
+        assert merged.entry_path == [primary_edge]
+        assert [second_preferred] in merged.alternative_entry_paths
+        assert [second_own_alt_same_root] in merged.alternative_entry_paths
+        assert [second_own_alt_third_root] not in merged.alternative_entry_paths
+
     def test_symbol_entry_and_path_come_from_the_same_match(self):
         """The exact contradiction Codex flagged: the first match is
         direct (entry_path=[]) and the second is indirect. symbol,

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -2205,3 +2205,78 @@ class TestCheckPeOrdinalImportsWithSnapshots:
                 old_snap, new_snap, app_reqs,
             )
         assert (resolved, retargeted, names) == (set(), [], set())
+
+
+class TestHasImpactEvidence:
+    """``_has_impact_evidence`` must key off a *meaningful* proof path, not
+    merely "an ``impact_assessment`` object exists on the change" (Codex
+    review, fresh evidence). Since ADR-052 Slice 10,
+    ``post_processing.MarkReachability`` caches an ``ImpactAssessment`` on
+    *every* change it tags — including a change it leaves ``UNKNOWN`` with
+    no proof path and one it tags ``PROVEN_REACHABLE`` via a direct-symbol/
+    public-source-ABI match with no walked path either. Treating either as
+    "evidence of its own" would wrongly block
+    :func:`abicheck.appcompat._enrich_covered_changes` from attaching the
+    consumer-graph explanation for the ordinary, common case this join
+    exists to serve."""
+
+    def _change(self, **kwargs):
+        return Change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol="_Z9dispatchv",
+            description="Function removed: _Z9dispatchv",
+            **kwargs,
+        )
+
+    def test_no_evidence_at_all_is_false(self):
+        from abicheck.appcompat import _has_impact_evidence
+
+        assert _has_impact_evidence(self._change()) is False
+
+    def test_a_cached_assessment_with_no_proof_path_is_false(self):
+        """The exact regression shape: MarkReachability's blanket cache on
+        an UNKNOWN, unproven change must not read as evidence."""
+        from abicheck.appcompat import _has_impact_evidence
+        from abicheck.impact.engine import assess_change
+
+        change = self._change(reachability_state=ReachabilityState.UNKNOWN)
+        change.impact_assessment = assess_change(change)
+        assert change.impact_assessment.proof_path is None
+        assert _has_impact_evidence(change) is False
+
+    def test_a_cached_assessment_tagged_reachable_with_no_path_is_false(self):
+        """The direct-symbol/public-source-ABI-surface tag branches set
+        ``public_reachable``/``reachability_state`` but no proof path —
+        still not "evidence of its own" for this check's purpose."""
+        from abicheck.appcompat import _has_impact_evidence
+        from abicheck.impact.engine import assess_change
+
+        change = self._change(
+            public_reachable=True,
+            reachability_kind="direct_public_symbol",
+            reachability_state=ReachabilityState.PROVEN_REACHABLE,
+        )
+        change.impact_assessment = assess_change(change)
+        assert change.impact_assessment.proof_path is None
+        assert _has_impact_evidence(change) is False
+
+    def test_a_cached_assessment_with_a_real_proof_path_is_true(self):
+        from abicheck.appcompat import _has_impact_evidence
+        from abicheck.impact.engine import assess_change
+
+        change = self._change(
+            public_reachable=True,
+            reachability_kind="value_embedding",
+            reachability_state=ReachabilityState.PROVEN_REACHABLE,
+            reachability_proof_path="Foo -> Bar -> _Z9dispatchv",
+        )
+        change.impact_assessment = assess_change(change)
+        assert change.impact_assessment.proof_path is not None
+        assert _has_impact_evidence(change) is True
+
+    def test_a_flat_reachability_proof_path_with_no_cached_assessment_is_true(self):
+        from abicheck.appcompat import _has_impact_evidence
+
+        change = self._change(reachability_proof_path="Foo -> Bar -> _Z9dispatchv")
+        assert change.impact_assessment is None
+        assert _has_impact_evidence(change) is True

--- a/tests/test_cli_unit.py
+++ b/tests/test_cli_unit.py
@@ -314,6 +314,60 @@ class TestCompareSecondaryFormat:
         assert "_Z3barv" not in secondary_text
         assert "bar" in secondary_text
 
+    def test_json_then_sarif_secondary_calls_assess_change_twice_per_change(
+        self, tmp_path
+    ):
+        """ADR-052 D2 follow-up (G29 Phase 3 slice 10): the measurement this
+        slice's ``MarkReachability`` caching decision rests on.
+        ``--format json --secondary-format sarif`` renders the *same*
+        ``DiffResult``/``Change`` objects twice in one process — the module
+        docstring of ``impact.engine`` says as much, but this asserts it
+        directly by counting real ``assess_change`` calls keyed by
+        ``id(change)``, instead of trusting that claim un-measured."""
+        import abicheck.impact.engine as engine_mod
+        import abicheck.reporter as reporter_mod
+        import abicheck.sarif as sarif_mod
+
+        calls: list[int] = []
+        orig = engine_mod.assess_change
+
+        def _counting(change, **kw):
+            calls.append(id(change))
+            return orig(change, **kw)
+
+        monkeypatch_targets = [
+            (engine_mod, "assess_change"),
+            (reporter_mod, "assess_change"),
+            (sarif_mod, "assess_change"),
+        ]
+        originals = [(mod, name, getattr(mod, name)) for mod, name in monkeypatch_targets]
+        for mod, name in monkeypatch_targets:
+            setattr(mod, name, _counting)
+        try:
+            old_p, new_p = _breaking_snapshots(tmp_path)
+            primary_out = tmp_path / "primary.json"
+            secondary_out = tmp_path / "secondary.sarif"
+            runner = CliRunner()
+            result = runner.invoke(main, [
+                "compare", str(old_p), str(new_p),
+                "--format", "json", "--output", str(primary_out),
+                "--secondary-format", "sarif", "--secondary-output", str(secondary_out),
+            ])
+        finally:
+            for mod, name, orig_fn in originals:
+                setattr(mod, name, orig_fn)
+
+        assert result.exit_code == 4
+        from collections import Counter
+
+        per_change_counts = Counter(calls)
+        assert per_change_counts, "assess_change was never called"
+        # At least one Change (the removed 'bar' function) was assessed by
+        # both the JSON and the SARIF render in this single process — the
+        # real, non-hypothetical repeat-call scenario ADR-052's open
+        # question needed measured, not assumed.
+        assert any(n > 1 for n in per_change_counts.values())
+
     def test_secondary_format_requires_secondary_output(self, tmp_path):
         old_p, new_p = _write_snapshots(tmp_path)
         runner = CliRunner()

--- a/tests/test_reachability_state.py
+++ b/tests/test_reachability_state.py
@@ -568,6 +568,118 @@ class TestMarkReachabilityTriState:
         assert found[0].reachability_state == ReachabilityState.UNKNOWN
 
 
+class TestMarkReachabilityImpactAssessmentCache:
+    """ADR-052 D2 follow-up (G29 Phase 3 slice 10): ``MarkReachability`` now
+    caches ``Change.impact_assessment`` right after it finalizes a change's
+    reachability/evidence fields. The measurement/decision behind doing this
+    at all is recorded in ADR-052's Slice 10 section; these are the
+    regression tests for the caching itself and for the pipeline-ordering
+    safety property the audit relies on (the cache must reflect the
+    *post*-tag value, never a stale pre-tag default).
+    """
+
+    def test_reachable_change_gets_cached_assessment_matching_fresh_call(self) -> None:
+        from abicheck.impact.engine import assess_change
+
+        old = _snap(
+            functions=[_public_fn("make", "ns::Widget*")],
+            types=[
+                RecordType(name="ns::Widget", kind="class", bases=["ns::detail::Base"]),
+                RecordType(name="ns::detail::Base", kind="class", size_bits=64),
+            ],
+        )
+        new = _snap(
+            functions=[_public_fn("make", "ns::Widget*")],
+            types=[
+                RecordType(name="ns::Widget", kind="class", bases=["ns::detail::Base"]),
+                RecordType(name="ns::detail::Base", kind="class", size_bits=128),
+            ],
+        )
+        raw_change = Change(
+            kind=ChangeKind.TYPE_SIZE_CHANGED,
+            symbol="ns::detail::Base",
+            description="size changed",
+        )
+        ctx = DEFAULT_PIPELINE.run(
+            [raw_change], old, new, suppression=_needs_evidence_suppression()
+        )
+        found = [c for c in ctx.kept if c.kind == ChangeKind.TYPE_SIZE_CHANGED][0]
+        assert found.reachability_state == ReachabilityState.PROVEN_REACHABLE
+        assert found.impact_assessment is not None
+        # The cached object must be the same evidence a fresh, uncached
+        # derivation would produce from the *current* (post-tag) flat
+        # fields -- proving the two paths never disagree, same discipline
+        # Slice 8/9's own tests use.
+        fresh = assess_change(found)
+        assert found.impact_assessment.reachability_state == fresh.reachability_state
+        assert found.impact_assessment.public_reachable == fresh.public_reachable
+        assert found.impact_assessment.reachability_kind == fresh.reachability_kind
+        assert found.impact_assessment.proof_path == fresh.proof_path
+
+    def test_unreachable_change_also_gets_cached_assessment(self) -> None:
+        """The ``else``/fallthrough tagging path (PROVEN_UNREACHABLE/UNKNOWN,
+        no early ``continue``) must cache too -- not just the two early-exit
+        branches."""
+        from abicheck.model import Param
+
+        old = _snap(
+            functions=[Function(
+                name="use", mangled="use", return_type="void",
+                params=[Param(name="h", type="ns::detail::Hidden*", pointer_depth=1)],
+                visibility=Visibility.PUBLIC,
+            )],
+            types=[RecordType(name="ns::detail::Hidden", kind="struct", size_bits=32)],
+        )
+        new = _snap(
+            functions=[Function(
+                name="use", mangled="use", return_type="void",
+                params=[Param(name="h", type="ns::detail::Hidden*", pointer_depth=1)],
+                visibility=Visibility.PUBLIC,
+            )],
+            types=[RecordType(name="ns::detail::Hidden", kind="struct", size_bits=64)],
+        )
+        raw_change = Change(
+            kind=ChangeKind.TYPE_SIZE_CHANGED,
+            symbol="ns::detail::Hidden",
+            description="size changed",
+        )
+        DEFAULT_PIPELINE.run(
+            [raw_change], old, new, suppression=_needs_evidence_suppression()
+        )
+        assert raw_change.reachability_state == ReachabilityState.PROVEN_UNREACHABLE
+        assert raw_change.impact_assessment is not None
+        # The critical pipeline-ordering safety property: the cache reflects
+        # the value MarkReachability actually settled on (PROVEN_UNREACHABLE),
+        # never the pre-tag UNKNOWN default a naive "cache at construction"
+        # approach would have captured.
+        assert (
+            raw_change.impact_assessment.reachability_state
+            == ReachabilityState.PROVEN_UNREACHABLE
+        )
+
+    def test_not_cached_when_mark_reachability_is_a_no_op(self) -> None:
+        """No suppression configured at all -- MarkReachability returns
+        immediately and never tags anything, so nothing gets cached either
+        (unchanged pre-slice-10 behavior: ``impact_assessment`` stays
+        ``None`` and ``assess_change`` derives on demand from the flat
+        defaults, same result either way)."""
+        # A non-internal-namespaced symbol (Codex review: an internal-looking
+        # one is dropped by the unrelated DemoteUnreachableInternalChurn step
+        # later in the pipeline when nothing ever proved it reachable --
+        # this test is about mark_reachability's own no-op gate, not that
+        # step, so it must survive to `ctx.kept` regardless).
+        old = _snap(functions=[_public_fn("make", "PublicWidget*")])
+        new = _snap(functions=[_public_fn("make", "PublicWidget*")])
+        raw_change = Change(
+            kind=ChangeKind.TYPE_SIZE_CHANGED,
+            symbol="PublicWidget",
+            description="size changed",
+        )
+        ctx = DEFAULT_PIPELINE.run([raw_change], old, new, suppression=None)
+        found = [c for c in ctx.kept if c.kind == ChangeKind.TYPE_SIZE_CHANGED][0]
+        assert found.impact_assessment is None
+
+
 class TestProvenUnreachableOnlySuppressionGate:
     def test_matches_proven_unreachable(self) -> None:
         change = Change(

--- a/tests/test_reachability_state.py
+++ b/tests/test_reachability_state.py
@@ -603,18 +603,22 @@ class TestMarkReachabilityImpactAssessmentCache:
         ctx = DEFAULT_PIPELINE.run(
             [raw_change], old, new, suppression=_needs_evidence_suppression()
         )
-        found = [c for c in ctx.kept if c.kind == ChangeKind.TYPE_SIZE_CHANGED][0]
+        found = next(c for c in ctx.kept if c.kind == ChangeKind.TYPE_SIZE_CHANGED)
         assert found.reachability_state == ReachabilityState.PROVEN_REACHABLE
         assert found.impact_assessment is not None
-        # The cached object must be the same evidence a fresh, uncached
+        cached = found.impact_assessment
+        # The cached object must be the same evidence a genuinely uncached
         # derivation would produce from the *current* (post-tag) flat
         # fields -- proving the two paths never disagree, same discipline
-        # Slice 8/9's own tests use.
+        # Slice 8/9's own tests use. assess_change() prefers
+        # found.impact_assessment when it's non-None, so clear it first or
+        # this comparison would just read the cache under test.
+        found.impact_assessment = None
         fresh = assess_change(found)
-        assert found.impact_assessment.reachability_state == fresh.reachability_state
-        assert found.impact_assessment.public_reachable == fresh.public_reachable
-        assert found.impact_assessment.reachability_kind == fresh.reachability_kind
-        assert found.impact_assessment.proof_path == fresh.proof_path
+        assert cached.reachability_state == fresh.reachability_state
+        assert cached.public_reachable == fresh.public_reachable
+        assert cached.reachability_kind == fresh.reachability_kind
+        assert cached.proof_path == fresh.proof_path
 
     def test_unreachable_change_also_gets_cached_assessment(self) -> None:
         """The ``else``/fallthrough tagging path (PROVEN_UNREACHABLE/UNKNOWN,
@@ -676,7 +680,7 @@ class TestMarkReachabilityImpactAssessmentCache:
             description="size changed",
         )
         ctx = DEFAULT_PIPELINE.run([raw_change], old, new, suppression=None)
-        found = [c for c in ctx.kept if c.kind == ChangeKind.TYPE_SIZE_CHANGED][0]
+        found = next(c for c in ctx.kept if c.kind == ChangeKind.TYPE_SIZE_CHANGED)
         assert found.impact_assessment is None
 
 

--- a/tests/test_source_graph_findings_impact.py
+++ b/tests/test_source_graph_findings_impact.py
@@ -140,15 +140,16 @@ def test_source_graph_finding_gets_cached_assessment_once_it_reaches_mark_reacha
     assert change.public_reachable is True
     assert change.reachability_state == ReachabilityState.PROVEN_REACHABLE
     assert change.impact_assessment is not None
-    assert (
-        change.impact_assessment.reachability_state
-        == ReachabilityState.PROVEN_REACHABLE
-    )
-    # Matches a fresh, uncached derivation from the same (now post-tag) flat
-    # fields -- the two paths never disagree.
+    cached = change.impact_assessment
+    assert cached.reachability_state == ReachabilityState.PROVEN_REACHABLE
+    # Matches a genuinely uncached derivation from the same (now post-tag)
+    # flat fields -- the two paths never disagree. assess_change() prefers
+    # change.impact_assessment when it's non-None, so clear it first or
+    # this comparison would just read the cache under test.
+    change.impact_assessment = None
     fresh = assess_change(change)
-    assert change.impact_assessment.reachability_state == fresh.reachability_state
-    assert change.impact_assessment.public_reachable == fresh.public_reachable
+    assert cached.reachability_state == fresh.reachability_state
+    assert cached.public_reachable == fresh.public_reachable
 
 
 def test_no_suppression_leaves_findings_uncached_same_as_before() -> None:

--- a/tests/test_source_graph_findings_impact.py
+++ b/tests/test_source_graph_findings_impact.py
@@ -1,0 +1,165 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-052 D2 follow-up (G29 Phase 3 slice 10): impact_assessment caching
+audit for ``buildsource/source_graph_findings.py``.
+
+Split out of ``test_source_graph.py`` rather than appended there (it was
+already at the 2000-line hard cap; see ``scripts/check_ai_readiness.py``'s
+``file-size`` check) -- mirrors the existing convention of a small,
+topic-scoped sibling test file rather than growing an already-large one.
+
+``diff_source_graph_findings()``'s ten ``Change(...)`` construction sites
+(across its nine per-family helpers) do **not** eagerly cache
+``impact_assessment`` the way ``internal_leak.py``/``appcompat.py``'s
+builders do (Slice 8/9) -- the pipeline-ordering audit in
+``source_graph_findings.py``'s own comments (see ``_mapping_drift_findings``)
+found ``post_processing.MarkReachability`` runs *downstream* of these
+builders (their output is merged into ``checker.compare()``'s ``changes``
+before ``_run_post_processing``/``DEFAULT_PIPELINE.run()``, unlike
+``internal_leak.py``'s builders, which are themselves a *later* pipeline
+step), so caching at construction time would freeze a stale, unset default.
+``MarkReachability`` itself now caches the assessment once it finalizes
+those fields (``post_processing_reachability.py``), so these findings still
+end up correctly cached once they reach that step -- these tests cover both
+halves of that finding.
+"""
+
+from __future__ import annotations
+
+from abicheck.buildsource.build_evidence import BuildEvidence, Confidence, Target
+from abicheck.buildsource.source_abi import (
+    SourceAbiSurface,
+    SourceEntity,
+    SourceLocation,
+)
+from abicheck.buildsource.source_graph import build_source_graph
+from abicheck.buildsource.source_graph_findings import diff_source_graph_findings
+from abicheck.checker_policy import ChangeKind, ReachabilityState
+from abicheck.impact.engine import assess_change
+from abicheck.model import AbiSnapshot
+from abicheck.post_processing import DEFAULT_PIPELINE
+from abicheck.suppression import Suppression, SuppressionList
+
+
+def _surface_with(decls, mapping, *, target="target://libfoo") -> SourceAbiSurface:
+    s = SourceAbiSurface(library="libfoo.so", target_id=target)
+    for qn, path in decls:
+        s.reachable_declarations.append(
+            SourceEntity(
+                id=qn,
+                kind="function",
+                qualified_name=qn,
+                source_location=SourceLocation(
+                    path=path, line=1, origin="PUBLIC_HEADER"
+                ),
+                visibility="public_header",
+                confidence=Confidence.HIGH,
+            )
+        )
+    s.mappings["source_decl_to_binary_symbol"] = dict(mapping)
+    return s
+
+
+def _build_with_public_header(headers=("inc/foo.h",)) -> BuildEvidence:
+    b = BuildEvidence()
+    b.targets.append(
+        Target(
+            id="target://libfoo",
+            public_headers=list(headers),
+            confidence=Confidence.HIGH,
+        )
+    )
+    return b
+
+
+def _mapping_drift_findings():
+    b = _build_with_public_header()
+    old = build_source_graph(
+        b, source_abi=_surface_with([("foo::b", "inc/foo.h")], {"foo::b": "_Zb"})
+    )
+    new = build_source_graph(
+        b, source_abi=_surface_with([("foo::b", "inc/foo.h")], {"foo::b": "_Zb2"})
+    )
+    return diff_source_graph_findings(old, new)
+
+
+def _needs_evidence_suppression() -> SuppressionList:
+    return SuppressionList(
+        [Suppression(namespace="__never_matches__::*", reason="evidence trigger only")]
+    )
+
+
+def test_findings_are_not_eagerly_cached_with_impact_assessment() -> None:
+    """Right after diff_source_graph_findings() returns, none of its findings
+    carry a cached impact_assessment -- confirming the audit above rather
+    than assuming it."""
+    findings = _mapping_drift_findings()
+    assert findings
+    assert all(c.impact_assessment is None for c in findings)
+
+
+def test_source_graph_finding_gets_cached_assessment_once_it_reaches_mark_reachability() -> (
+    None
+):
+    """The regression test for the pipeline-ordering safety property: once a
+    source_graph_findings.py Change is merged into an ordinary compare()-style
+    changes list and run through post_processing.DEFAULT_PIPELINE (with a
+    suppression that needs reachability evidence, mirroring how a real
+    `compare` invocation feeds `extra_changes` in before post-processing),
+    MarkReachability tags it AND caches a matching impact_assessment -- and
+    that cached assessment reflects the *post*-tag value
+    (SOURCE_TO_BINARY_MAPPING_CHANGED is in _PUBLIC_SOURCE_ABI_KINDS, so it is
+    always tagged PROVEN_REACHABLE), never a pre-tag default.
+    """
+    findings = _mapping_drift_findings()
+    assert findings
+    assert findings[0].kind == ChangeKind.SOURCE_TO_BINARY_MAPPING_CHANGED
+
+    old_snap = AbiSnapshot(library="libtest.so", version="1.0")
+    new_snap = AbiSnapshot(library="libtest.so", version="2.0")
+    ctx = DEFAULT_PIPELINE.run(
+        list(findings), old_snap, new_snap, suppression=_needs_evidence_suppression()
+    )
+    found = [
+        c for c in ctx.kept if c.kind == ChangeKind.SOURCE_TO_BINARY_MAPPING_CHANGED
+    ]
+    assert len(found) == 1
+    change = found[0]
+    assert change.public_reachable is True
+    assert change.reachability_state == ReachabilityState.PROVEN_REACHABLE
+    assert change.impact_assessment is not None
+    assert (
+        change.impact_assessment.reachability_state
+        == ReachabilityState.PROVEN_REACHABLE
+    )
+    # Matches a fresh, uncached derivation from the same (now post-tag) flat
+    # fields -- the two paths never disagree.
+    fresh = assess_change(change)
+    assert change.impact_assessment.reachability_state == fresh.reachability_state
+    assert change.impact_assessment.public_reachable == fresh.public_reachable
+
+
+def test_no_suppression_leaves_findings_uncached_same_as_before() -> None:
+    """MarkReachability's own no-op gate (no suppression configured) means
+    these findings stay uncached -- unchanged pre-slice-10 behavior."""
+    findings = _mapping_drift_findings()
+    old_snap = AbiSnapshot(library="libtest.so", version="1.0")
+    new_snap = AbiSnapshot(library="libtest.so", version="2.0")
+    ctx = DEFAULT_PIPELINE.run(list(findings), old_snap, new_snap, suppression=None)
+    found = [
+        c for c in ctx.kept if c.kind == ChangeKind.SOURCE_TO_BINARY_MAPPING_CHANGED
+    ]
+    assert len(found) == 1
+    assert found[0].impact_assessment is None

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -595,6 +595,46 @@ def test_join_never_flips_an_unproven_node_to_consumer_compiled() -> None:
     ), "a use-case reference must never make an unproven node look consumer-compiled"
 
 
+def test_join_never_flips_a_tied_unknown_confidence_node_either() -> None:
+    """The residual gap the earlier CONF_UNKNOWN placeholder fix didn't
+    close (Codex review, fresh evidence): when the *real* fact backing a
+    public entry is ALSO CONF_UNKNOWN (e.g. a loaded/hand-built graph node
+    with no confidence recorded), the placeholder's confidence rank ties
+    rather than loses, and the producer-name tiebreak alone
+    ("declared_use_case" < "kythe") would let it win provenance anyway.
+    join_use_case_graph's provenance/confidence restoration must close
+    this regardless of the tiebreak outcome."""
+    from abicheck.buildsource.graph_facts import CONF_UNKNOWN
+    from abicheck.buildsource.source_graph import is_consumer_compiled_node
+
+    library = SourceGraphSummary()
+    library.add_node(
+        GraphNode(
+            id="decl://dispatch",
+            kind="source_decl",
+            label="dispatch",
+            attrs={"visibility": "public_header"},
+            provenance="kythe",
+            confidence=CONF_UNKNOWN,
+        )
+    )
+    node_by_id = {n.id: n for n in library.nodes}
+    assert is_consumer_compiled_node("decl://dispatch", node_by_id) is False
+
+    use_cases = build_use_case_graph(
+        [UseCaseDefinition(use_case="training-workflow", entrypoints=("dispatch",))],
+        library,
+    )
+    joined = join_use_case_graph(library, use_cases)
+    joined_node_by_id = {n.id: n for n in joined.nodes}
+    entry = joined_node_by_id["decl://dispatch"]
+    assert {f.producer for f in entry.facts} >= {USE_CASE_PROVENANCE, "kythe"}
+    assert entry.provenance == "kythe"
+    assert (
+        is_consumer_compiled_node("decl://dispatch", joined_node_by_id) is False
+    ), "a tied-confidence use-case placeholder must never win the provenance tiebreak"
+
+
 def test_join_does_not_mutate_the_library_graph() -> None:
     library = _library_graph()
     nodes, edges = len(library.nodes), len(library.edges)

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -390,6 +390,39 @@ def test_build_use_case_graph_does_not_resolve_an_internal_declaration() -> None
     assert [e for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"] == []
 
 
+def test_build_use_case_graph_does_not_resolve_a_public_type() -> None:
+    """A public record_type/enum_type/typedef is never a valid entrypoint
+    target, even though it can share PUBLIC_VISIBILITIES with a real decl --
+    a type is never something a use case 'exercises', and has no outgoing
+    call-graph edge for a consumer-impact walk to follow (Codex review,
+    fresh evidence)."""
+    library = _library_graph()
+    library.add_node(
+        GraphNode(
+            id="record_type://Config",
+            kind="record_type",
+            label="Config",
+            attrs={"visibility": "public_header"},
+        )
+    )
+    graph = build_use_case_graph(
+        [UseCaseDefinition(use_case="training-workflow", entrypoints=("Config",))],
+        library,
+    )
+    assert [e for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"] == []
+    # The exact node id is rejected the same way -- a type is never public
+    # in this module's sense, regardless of how it's spelled.
+    graph2 = build_use_case_graph(
+        [
+            UseCaseDefinition(
+                use_case="training-workflow", entrypoints=("record_type://Config",)
+            )
+        ],
+        library,
+    )
+    assert [e for e in graph2.edges if e.kind == "USE_CASE_USES_ENTRY"] == []
+
+
 def test_build_use_case_graph_emits_test_case_nodes_and_edges() -> None:
     library = _library_graph()
     graph = build_use_case_graph(

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -689,6 +689,31 @@ def test_join_of_an_empty_use_case_graph_is_a_pure_copy() -> None:
     assert joined is not library
 
 
+def test_join_clears_the_inherited_graph_id(tmp_path) -> None:
+    """Codex review, fresh evidence: join_use_case_graph is this module's
+    documented public Python API (docs/use/use-case-impact.md), so a caller
+    following that doc and calling joined.to_dict() on the result is a real,
+    reachable path -- not join_consumer_graph's situation, whose result
+    never leaves appcompat.py's own in-memory analysis. Left un-cleared, the
+    deep copy inherits the library graph's own finalized graph_id even
+    though the node/edge content just changed, and to_dict() only
+    recomputes an id when the stored value is empty -- silently describing
+    this join's different content under the library graph's own unrelated,
+    now-stale id."""
+    library = _library_graph()
+    library.finalize()
+    assert library.graph_id  # sanity: the library graph really is finalized
+    use_cases = build_use_case_graph(
+        [UseCaseDefinition(use_case="training-workflow", entrypoints=("train",))],
+        library,
+    )
+    joined = join_use_case_graph(library, use_cases)
+    assert joined.graph_id == ""
+    # A caller who does want an id for the joined graph gets one that
+    # actually reflects the new content, not the stale inherited one.
+    assert joined.to_dict()["graph_id"] != library.graph_id
+
+
 # ── end-to-end: a use_case node joined onto a public entry ────────────────
 
 

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -178,6 +178,17 @@ def test_load_use_case_manifest_rejects_a_malformed_file(tmp_path: Path) -> None
         load_use_case_manifest(manifest)
 
 
+def test_load_use_case_manifest_wraps_a_yaml_syntax_error(tmp_path: Path) -> None:
+    """A syntactically invalid document (not merely a structurally wrong
+    one) must still surface through the public UseCaseManifestError
+    contract, not a bare yaml.YAMLError -- so every caller can catch one
+    exception type for any invalid manifest."""
+    manifest = tmp_path / "impact-use-cases.yaml"
+    manifest.write_text("- use_case: [unterminated flow sequence\n")
+    with pytest.raises(UseCaseManifestError, match="invalid YAML syntax"):
+        load_use_case_manifest(manifest)
+
+
 def test_load_use_case_manifest_of_an_empty_file_is_empty(tmp_path: Path) -> None:
     manifest = tmp_path / "impact-use-cases.yaml"
     manifest.write_text("")
@@ -235,6 +246,53 @@ def test_build_use_case_graph_skips_an_unresolvable_entrypoint_silently() -> Non
     assert [e for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"] == []
     # The use_case node itself is still emitted.
     assert graph.has_node(use_case_node_id("training-workflow"))
+
+
+def test_build_use_case_graph_skips_an_ambiguous_label_silently() -> None:
+    """Two public entries sharing one label (a common shape for C++
+    overloads) must never resolve a bare-label entrypoint to an arbitrary
+    one of them -- ambiguous is exactly the 'no answer' case, not a
+    coin-flip pick."""
+    library = _library_graph()
+    library.add_node(
+        GraphNode(
+            id="decl://train_overload_2",
+            kind="source_decl",
+            label="train",
+            attrs={"visibility": "public_header"},
+        )
+    )
+    graph = build_use_case_graph(
+        [UseCaseDefinition(use_case="training-workflow", entrypoints=("train",))],
+        library,
+    )
+    assert [e for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"] == []
+
+
+def test_build_use_case_graph_an_exact_id_wins_over_a_colliding_label() -> None:
+    """A manifest naming a node's exact id must resolve to that node even
+    when some *other* public node's own label happens to collide with that
+    id string -- an id lookup is never shadowed by an ambiguous or
+    unrelated label registration."""
+    library = _library_graph()
+    library.add_node(
+        GraphNode(
+            id="decl://other",
+            kind="source_decl",
+            label="decl://train",  # collides with train's own id
+            attrs={"visibility": "public_header"},
+        )
+    )
+    graph = build_use_case_graph(
+        [
+            UseCaseDefinition(
+                use_case="training-workflow", entrypoints=("decl://train",)
+            )
+        ],
+        library,
+    )
+    edges = {e.dst for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"}
+    assert edges == {"decl://train"}
 
 
 def test_build_use_case_graph_does_not_resolve_an_internal_declaration() -> None:

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -216,6 +216,27 @@ def test_load_use_case_manifest_wraps_a_yaml_syntax_error(tmp_path: Path) -> Non
         load_use_case_manifest(manifest)
 
 
+def test_load_use_case_manifest_wraps_a_utf8_decoding_error(tmp_path: Path) -> None:
+    """A manifest file that isn't valid UTF-8 must still surface through the
+    public UseCaseManifestError contract, not a bare UnicodeDecodeError --
+    the read used to happen outside this function's guarded block entirely
+    (Codex review, fresh evidence)."""
+    manifest = tmp_path / "impact-use-cases.yaml"
+    manifest.write_bytes(b"- use_case: \xff\xfe not valid utf-8\n")
+    with pytest.raises(UseCaseManifestError, match="not valid UTF-8"):
+        load_use_case_manifest(manifest)
+
+
+def test_load_use_case_manifest_missing_file_is_a_plain_oserror(
+    tmp_path: Path,
+) -> None:
+    """A missing/unreadable path is an ordinary filesystem error, left
+    as-is rather than wrapped -- distinct from 'the file exists but its
+    contents are malformed'."""
+    with pytest.raises(OSError):
+        load_use_case_manifest(tmp_path / "does-not-exist.yaml")
+
+
 def test_load_use_case_manifest_rejects_a_duplicate_key(tmp_path: Path) -> None:
     """A repeated mapping key (e.g. two 'entrypoints:' lines pasted into one
     entry) must be a hard error, not PyYAML's default of silently keeping

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -189,6 +189,19 @@ def test_load_use_case_manifest_wraps_a_yaml_syntax_error(tmp_path: Path) -> Non
         load_use_case_manifest(manifest)
 
 
+def test_load_use_case_manifest_rejects_a_duplicate_key(tmp_path: Path) -> None:
+    """A repeated mapping key (e.g. two 'entrypoints:' lines pasted into one
+    entry) must be a hard error, not PyYAML's default of silently keeping
+    only the last value -- the latter would drop declared coverage with no
+    signal at all."""
+    manifest = tmp_path / "impact-use-cases.yaml"
+    manifest.write_text(
+        "- use_case: training-workflow\n  entrypoints: [train]\n  entrypoints: [eval]\n"
+    )
+    with pytest.raises(UseCaseManifestError, match="duplicate key"):
+        load_use_case_manifest(manifest)
+
+
 def test_load_use_case_manifest_of_an_empty_file_is_empty(tmp_path: Path) -> None:
     manifest = tmp_path / "impact-use-cases.yaml"
     manifest.write_text("")

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -227,6 +227,20 @@ def test_load_use_case_manifest_wraps_a_utf8_decoding_error(tmp_path: Path) -> N
         load_use_case_manifest(manifest)
 
 
+def test_load_use_case_manifest_wraps_an_invalid_timestamp_scalar(
+    tmp_path: Path,
+) -> None:
+    """A value PyYAML's implicit resolver recognizes as a timestamp but
+    with an invalid component (no such month) makes PyYAML's own
+    timestamp constructor raise a bare ValueError, not a yaml.YAMLError --
+    a document shape neither the syntax nor the UTF-8 guard catches
+    (Codex review, fresh evidence)."""
+    manifest = tmp_path / "impact-use-cases.yaml"
+    manifest.write_text("- use_case: 2023-99-99\n")
+    with pytest.raises(UseCaseManifestError, match="invalid scalar value"):
+        load_use_case_manifest(manifest)
+
+
 def test_load_use_case_manifest_missing_file_is_a_plain_oserror(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -148,6 +148,15 @@ def test_parse_rejects_an_unknown_field(raw_entry: dict) -> None:
         parse_use_case_manifest([raw_entry])
 
 
+def test_parse_rejects_unknown_fields_with_heterogeneous_key_types() -> None:
+    """A syntactically valid entry may mix key types (e.g. an integer key
+    alongside a string one) -- the unknown-field check must not raise a
+    bare TypeError comparing incomparable types while sorting them for the
+    error message."""
+    with pytest.raises(UseCaseManifestError, match="unknown field"):
+        parse_use_case_manifest([{"use_case": "x", 1: "a", "z": "b"}])
+
+
 @pytest.mark.parametrize(
     "raw_entry", [{}, {"use_case": ""}, {"use_case": "   "}, {"use_case": 5}]
 )
@@ -415,6 +424,44 @@ def test_join_folds_the_use_case_node_onto_the_shared_entry_node() -> None:
     assert len(joined.nodes) == before_nodes + 1
     entry = next(n for n in joined.nodes if n.id == "decl://train")
     assert {f.producer for f in entry.facts} >= {USE_CASE_PROVENANCE}
+
+
+def test_join_never_flips_an_unproven_node_to_consumer_compiled() -> None:
+    """A public entry that is only an unproven call-graph fallback node
+    (no ``consumer_compiled_body`` attr, ``provenance="call_graph"``,
+    ``CONF_REDUCED``) must still read as NOT consumer-compiled
+    (``is_consumer_compiled_node`` False) after a use case references it --
+    the use-case placeholder registration must never outrank real
+    reachability-provenance evidence and let a later call-graph traversal
+    wrongly walk through an unproven body (Codex review, fresh evidence)."""
+    from abicheck.buildsource.graph_facts import CONF_REDUCED
+    from abicheck.buildsource.source_graph import is_consumer_compiled_node
+
+    library = SourceGraphSummary()
+    library.add_node(
+        GraphNode(
+            id="decl://dispatch",
+            kind="source_decl",
+            label="dispatch",
+            attrs={"visibility": "public_header"},
+            provenance="call_graph",
+            confidence=CONF_REDUCED,
+        )
+    )
+    node_by_id = {n.id: n for n in library.nodes}
+    assert is_consumer_compiled_node("decl://dispatch", node_by_id) is False
+
+    use_cases = build_use_case_graph(
+        [UseCaseDefinition(use_case="training-workflow", entrypoints=("dispatch",))],
+        library,
+    )
+    joined = join_use_case_graph(library, use_cases)
+    joined_node_by_id = {n.id: n for n in joined.nodes}
+    entry = joined_node_by_id["decl://dispatch"]
+    assert {f.producer for f in entry.facts} >= {USE_CASE_PROVENANCE, "call_graph"}
+    assert (
+        is_consumer_compiled_node("decl://dispatch", joined_node_by_id) is False
+    ), "a use-case reference must never make an unproven node look consumer-compiled"
 
 
 def test_join_does_not_mutate_the_library_graph() -> None:

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -202,6 +202,18 @@ def test_load_use_case_manifest_rejects_a_duplicate_key(tmp_path: Path) -> None:
         load_use_case_manifest(manifest)
 
 
+def test_load_use_case_manifest_wraps_an_unhashable_key(tmp_path: Path) -> None:
+    """A syntactically valid document with an unhashable mapping key (a YAML
+    sequence used as a key) must still surface through the public
+    UseCaseManifestError contract, not a bare TypeError -- the duplicate-key
+    override must keep the hashability check PyYAML's own default
+    constructor already performs."""
+    manifest = tmp_path / "impact-use-cases.yaml"
+    manifest.write_text("- {[a, b]: x}\n")
+    with pytest.raises(UseCaseManifestError, match="unhashable key"):
+        load_use_case_manifest(manifest)
+
+
 def test_load_use_case_manifest_of_an_empty_file_is_empty(tmp_path: Path) -> None:
     manifest = tmp_path / "impact-use-cases.yaml"
     manifest.write_text("")

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -1,0 +1,392 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the declared use-case manifest and graph join (G29 Phase 4
+slice 2, ADR-057 amendment)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.buildsource.source_graph import (
+    EDGE_KINDS,
+    NODE_KINDS,
+    GraphNode,
+    SourceGraphSummary,
+)
+from abicheck.errors import UseCaseManifestError
+from abicheck.impact.use_cases import (
+    USE_CASE_EDGE_KINDS,
+    USE_CASE_NODE_KINDS,
+    USE_CASE_PROVENANCE,
+    UseCaseDefinition,
+    build_use_case_graph,
+    join_use_case_graph,
+    load_use_case_manifest,
+    parse_use_case_manifest,
+    test_case_node_id as make_test_case_node_id,
+    use_case_node_id,
+)
+
+
+def _library_graph() -> SourceGraphSummary:
+    """A minimal library graph: one public entry (`train`), one exported
+    symbol with no declaration (`_Z5evalv`), and one internal-only decl
+    (`detail::helper`, never resolvable as an entrypoint)."""
+    g = SourceGraphSummary()
+    g.add_node(
+        GraphNode(
+            id="decl://train",
+            kind="source_decl",
+            label="train",
+            attrs={"visibility": "public_header"},
+        )
+    )
+    g.add_node(
+        GraphNode(
+            id="decl://helper",
+            kind="source_decl",
+            label="detail::helper",
+            attrs={"visibility": "source"},
+        )
+    )
+    g.add_node(
+        GraphNode(id="binary_symbol://_Z5evalv", kind="binary_symbol", label="_Z5evalv")
+    )
+    return g
+
+
+# ── schema registration ───────────────────────────────────────────────────
+
+
+def test_use_case_kinds_are_registered_in_the_graph_schema() -> None:
+    assert USE_CASE_NODE_KINDS <= NODE_KINDS
+    assert USE_CASE_EDGE_KINDS <= EDGE_KINDS
+    assert USE_CASE_NODE_KINDS == {"use_case", "test_case"}
+    assert USE_CASE_EDGE_KINDS == {
+        "USE_CASE_USES_ENTRY",
+        "TEST_COVERS_USE_CASE",
+        "TRACE_OBSERVED_ENTRY",
+        "TRACE_OBSERVED_EDGE",
+    }
+
+
+# ── manifest parsing ──────────────────────────────────────────────────────
+
+
+def test_parse_empty_document_is_a_valid_empty_manifest() -> None:
+    assert parse_use_case_manifest(None) == []
+    assert parse_use_case_manifest([]) == []
+
+
+def test_parse_a_valid_manifest() -> None:
+    raw = [
+        {
+            "use_case": "training-workflow",
+            "entrypoints": ["train", "_Z5evalv"],
+            "tests": ["test_train_e2e"],
+        },
+        {"use_case": "no-entrypoints-declared"},
+    ]
+    defs = parse_use_case_manifest(raw)
+    assert defs == [
+        UseCaseDefinition(
+            use_case="training-workflow",
+            entrypoints=("train", "_Z5evalv"),
+            tests=("test_train_e2e",),
+        ),
+        UseCaseDefinition(use_case="no-entrypoints-declared"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"use_case": "not-a-list"},
+        "also not a list",
+        42,
+    ],
+)
+def test_parse_rejects_a_non_list_top_level_document(raw: object) -> None:
+    with pytest.raises(UseCaseManifestError, match="top-level document"):
+        parse_use_case_manifest(raw)
+
+
+def test_parse_rejects_a_non_mapping_entry() -> None:
+    with pytest.raises(UseCaseManifestError, match="entry 0 must be a mapping"):
+        parse_use_case_manifest(["just a string"])
+
+
+@pytest.mark.parametrize(
+    "raw_entry", [{}, {"use_case": ""}, {"use_case": "   "}, {"use_case": 5}]
+)
+def test_parse_rejects_a_missing_or_blank_use_case_name(raw_entry: dict) -> None:
+    with pytest.raises(UseCaseManifestError, match="use_case"):
+        parse_use_case_manifest([raw_entry])
+
+
+def test_parse_rejects_a_non_list_entrypoints_field() -> None:
+    with pytest.raises(UseCaseManifestError, match="entrypoints"):
+        parse_use_case_manifest([{"use_case": "x", "entrypoints": "train"}])
+
+
+def test_parse_rejects_a_non_string_entrypoints_element() -> None:
+    with pytest.raises(UseCaseManifestError, match="entrypoints"):
+        parse_use_case_manifest([{"use_case": "x", "entrypoints": ["train", 5]}])
+
+
+def test_parse_rejects_a_non_list_tests_field() -> None:
+    with pytest.raises(UseCaseManifestError, match="tests"):
+        parse_use_case_manifest([{"use_case": "x", "tests": "test_train"}])
+
+
+def test_load_use_case_manifest_from_disk(tmp_path: Path) -> None:
+    manifest = tmp_path / "impact-use-cases.yaml"
+    manifest.write_text(
+        "- use_case: training-workflow\n"
+        "  entrypoints: [train]\n"
+        "  tests: [test_train_e2e]\n"
+    )
+    defs = load_use_case_manifest(manifest)
+    assert defs == [
+        UseCaseDefinition(
+            use_case="training-workflow",
+            entrypoints=("train",),
+            tests=("test_train_e2e",),
+        )
+    ]
+
+
+def test_load_use_case_manifest_rejects_a_malformed_file(tmp_path: Path) -> None:
+    manifest = tmp_path / "impact-use-cases.yaml"
+    manifest.write_text("not_a_list: true\n")
+    with pytest.raises(UseCaseManifestError, match="top-level document"):
+        load_use_case_manifest(manifest)
+
+
+def test_load_use_case_manifest_of_an_empty_file_is_empty(tmp_path: Path) -> None:
+    manifest = tmp_path / "impact-use-cases.yaml"
+    manifest.write_text("")
+    assert load_use_case_manifest(manifest) == []
+
+
+# ── build_use_case_graph ──────────────────────────────────────────────────
+
+
+def test_build_use_case_graph_emits_the_use_case_node() -> None:
+    library = _library_graph()
+    graph = build_use_case_graph(
+        [UseCaseDefinition(use_case="training-workflow")], library
+    )
+    assert graph.has_node(use_case_node_id("training-workflow"))
+    node = next(n for n in graph.nodes if n.id == use_case_node_id("training-workflow"))
+    assert node.kind == "use_case"
+    assert node.label == "training-workflow"
+    assert node.provenance == USE_CASE_PROVENANCE
+
+
+def test_build_use_case_graph_resolves_entrypoints_by_id_and_label() -> None:
+    library = _library_graph()
+    graph = build_use_case_graph(
+        [
+            UseCaseDefinition(
+                use_case="training-workflow",
+                entrypoints=("train", "binary_symbol://_Z5evalv"),
+            )
+        ],
+        library,
+    )
+    edges = {e.dst for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"}
+    assert edges == {"decl://train", "binary_symbol://_Z5evalv"}
+    assert all(
+        e.src == use_case_node_id("training-workflow")
+        for e in graph.edges
+        if e.kind == "USE_CASE_USES_ENTRY"
+    )
+
+
+def test_build_use_case_graph_skips_an_unresolvable_entrypoint_silently() -> None:
+    """An entrypoint the library graph cannot resolve is dropped, not an
+    error -- the same 'absence, never a wrong answer' discipline
+    consumer_graph.py already follows."""
+    library = _library_graph()
+    graph = build_use_case_graph(
+        [
+            UseCaseDefinition(
+                use_case="training-workflow", entrypoints=("does_not_exist",)
+            )
+        ],
+        library,
+    )
+    assert [e for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"] == []
+    # The use_case node itself is still emitted.
+    assert graph.has_node(use_case_node_id("training-workflow"))
+
+
+def test_build_use_case_graph_does_not_resolve_an_internal_declaration() -> None:
+    """A non-public decl is never a valid entrypoint target, even if a
+    manifest names it by label."""
+    library = _library_graph()
+    graph = build_use_case_graph(
+        [
+            UseCaseDefinition(
+                use_case="training-workflow", entrypoints=("detail::helper",)
+            )
+        ],
+        library,
+    )
+    assert [e for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"] == []
+
+
+def test_build_use_case_graph_emits_test_case_nodes_and_edges() -> None:
+    library = _library_graph()
+    graph = build_use_case_graph(
+        [UseCaseDefinition(use_case="training-workflow", tests=("test_train_e2e",))],
+        library,
+    )
+    assert graph.has_node(make_test_case_node_id("test_train_e2e"))
+    (edge,) = [e for e in graph.edges if e.kind == "TEST_COVERS_USE_CASE"]
+    assert edge.src == make_test_case_node_id("test_train_e2e")
+    assert edge.dst == use_case_node_id("training-workflow")
+
+
+def test_build_use_case_graph_emits_a_test_case_regardless_of_entrypoint_resolution() -> (
+    None
+):
+    """Unlike an entrypoint, a test identifier has no graph node kind to
+    fail to resolve against."""
+    library = _library_graph()
+    graph = build_use_case_graph(
+        [
+            UseCaseDefinition(
+                use_case="training-workflow",
+                entrypoints=("does_not_exist",),
+                tests=("test_train_e2e",),
+            )
+        ],
+        library,
+    )
+    assert [e for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"] == []
+    assert [e for e in graph.edges if e.kind == "TEST_COVERS_USE_CASE"] != []
+
+
+def test_build_use_case_graph_handles_several_use_cases_independently() -> None:
+    library = _library_graph()
+    graph = build_use_case_graph(
+        [
+            UseCaseDefinition(use_case="uc1", entrypoints=("train",)),
+            UseCaseDefinition(use_case="uc2", entrypoints=("does_not_exist",)),
+        ],
+        library,
+    )
+    assert graph.has_node(use_case_node_id("uc1"))
+    assert graph.has_node(use_case_node_id("uc2"))
+    edges = [e for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"]
+    assert [e.src for e in edges] == [use_case_node_id("uc1")]
+
+
+# ── join_use_case_graph ───────────────────────────────────────────────────
+
+
+def test_join_folds_the_use_case_node_onto_the_shared_entry_node() -> None:
+    library = _library_graph()
+    before_nodes = len(library.nodes)
+    use_cases = build_use_case_graph(
+        [UseCaseDefinition(use_case="training-workflow", entrypoints=("train",))],
+        library,
+    )
+    joined = join_use_case_graph(library, use_cases)
+    # The use-case graph contributes exactly one *new* node (the use_case
+    # itself); its entry edge folds onto the library's existing decl node.
+    assert len(joined.nodes) == before_nodes + 1
+    entry = next(n for n in joined.nodes if n.id == "decl://train")
+    assert {f.producer for f in entry.facts} >= {USE_CASE_PROVENANCE}
+
+
+def test_join_does_not_mutate_the_library_graph() -> None:
+    library = _library_graph()
+    nodes, edges = len(library.nodes), len(library.edges)
+    lib_entry = next(n for n in library.nodes if n.id == "decl://train")
+    use_cases = build_use_case_graph(
+        [UseCaseDefinition(use_case="training-workflow", entrypoints=("train",))],
+        library,
+    )
+    joined = join_use_case_graph(library, use_cases)
+    assert (len(library.nodes), len(library.edges)) == (nodes, edges)
+    # Membership counts alone don't prove non-mutation: add_node's ADR-046
+    # D2 merge mutates the *stored* node in place, so a shallow
+    # re-registration would leave the library's own node carrying the
+    # use-case fact while every count stayed identical.
+    assert USE_CASE_PROVENANCE not in {f.producer for f in lib_entry.facts}
+    joined_entry = next(n for n in joined.nodes if n.id == "decl://train")
+    assert joined_entry is not lib_entry
+
+
+def test_join_carries_over_coverage_honesty_flags() -> None:
+    library = _library_graph()
+    library.extractor_passes = {"call_graph": True}
+    library.narrowed_passes = {"type_graph": True}
+    library.degraded_passes = {"include_graph": True}
+    library.coverage = {"source_decls": 3}
+    joined = join_use_case_graph(library, build_use_case_graph([], library))
+    assert joined.extractor_passes == {"call_graph": True}
+    assert joined.narrowed_passes == {"type_graph": True}
+    assert joined.degraded_passes == {"include_graph": True}
+    assert joined.coverage == {"source_decls": 3}
+
+
+def test_join_of_an_empty_use_case_graph_is_a_pure_copy() -> None:
+    library = _library_graph()
+    joined = join_use_case_graph(library, SourceGraphSummary())
+    assert len(joined.nodes) == len(library.nodes)
+    assert len(joined.edges) == len(library.edges)
+    assert joined is not library
+
+
+# ── end-to-end: a use_case node joined onto a public entry ────────────────
+
+
+def test_end_to_end_use_case_joins_onto_the_public_entry_node() -> None:
+    library = _library_graph()
+    defs = parse_use_case_manifest(
+        [
+            {
+                "use_case": "training-workflow",
+                "entrypoints": ["train"],
+                "tests": ["test_train_e2e"],
+            }
+        ]
+    )
+    use_cases = build_use_case_graph(defs, library)
+    joined = join_use_case_graph(library, use_cases)
+
+    uc = next(n for n in joined.nodes if n.id == use_case_node_id("training-workflow"))
+    assert uc.kind == "use_case"
+    entry_edges = [
+        e for e in joined.edges if e.kind == "USE_CASE_USES_ENTRY" and e.src == uc.id
+    ]
+    assert [e.dst for e in entry_edges] == ["decl://train"]
+
+    test_edges = [e for e in joined.edges if e.kind == "TEST_COVERS_USE_CASE"]
+    assert [e.src for e in test_edges] == [make_test_case_node_id("test_train_e2e")]
+    assert [e.dst for e in test_edges] == [uc.id]
+
+    # The public entry node itself is unchanged in kind/identity -- the join
+    # only adds an incoming edge and a fact, never rewrites it.
+    entry_node = next(n for n in joined.nodes if n.id == "decl://train")
+    assert entry_node.kind == "source_decl"
+    assert entry_node.label == "train"

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -25,6 +25,7 @@ import pytest
 from abicheck.buildsource.source_graph import (
     EDGE_KINDS,
     NODE_KINDS,
+    GraphEdge,
     GraphNode,
     SourceGraphSummary,
 )
@@ -318,6 +319,34 @@ def test_build_use_case_graph_skips_an_ambiguous_label_silently() -> None:
         library,
     )
     assert [e for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"] == []
+
+
+def test_build_use_case_graph_coalesces_a_mapped_decl_and_symbol_pair() -> None:
+    """An ordinary exported C function's decl and the binary_symbol it maps
+    to (via SOURCE_DECL_MAPS_TO_SYMBOL) share the exact same label -- this
+    must resolve as ONE public entry, not a two-way ambiguity, or the most
+    common real-world entrypoint shape (a plain C function's label matching
+    its own linker symbol) would silently fail to resolve at all (Codex
+    review, fresh evidence)."""
+    library = _library_graph()
+    library.add_node(
+        GraphNode(id="binary_symbol://train", kind="binary_symbol", label="train")
+    )
+    library.add_edge(
+        GraphEdge(
+            src="decl://train",
+            dst="binary_symbol://train",
+            kind="SOURCE_DECL_MAPS_TO_SYMBOL",
+        )
+    )
+    graph = build_use_case_graph(
+        [UseCaseDefinition(use_case="training-workflow", entrypoints=("train",))],
+        library,
+    )
+    edges = {e.dst for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"}
+    # Coalesced onto the mapped binary_symbol node, matching
+    # consumer_graph.py's own preference for the exported representation.
+    assert edges == {"binary_symbol://train"}
 
 
 def test_build_use_case_graph_an_exact_id_wins_over_a_colliding_label() -> None:

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -349,6 +349,54 @@ def test_build_use_case_graph_coalesces_a_mapped_decl_and_symbol_pair() -> None:
     assert edges == {"binary_symbol://train"}
 
 
+def test_build_use_case_graph_does_not_coalesce_a_decl_mapped_to_two_symbols() -> None:
+    """A decl mapped to more than one public symbol (versioned exports,
+    aliases, or facts merged from multiple graph producers) must not
+    coalesce onto whichever destination happens to iterate last -- an
+    order-dependent, wrong-but-confident pick instead of the 'degrade to
+    no answer' this module otherwise guarantees for a genuine ambiguity
+    (Codex review, fresh evidence).
+
+    Resolved by the decl's own LABEL ("train"), not its exact id -- an
+    exact-id lookup would trivially resolve to itself regardless of
+    coalescing and never exercise the buggy code path at all (own review
+    finding, caught before landing: the id always resolves via `index`,
+    built before coalescing ever runs). The label is unique among this
+    fixture's public nodes, so it is coalescing -- not label-ambiguity --
+    that decides the outcome here: the buggy last-write-wins dict
+    comprehension resolved it to whichever symbol was registered last
+    (an ``in {binary_symbol://train@v1, binary_symbol://train@v2}``
+    silent, order-dependent pick); the fix must resolve it to the decl's
+    own id instead, uncoalesced."""
+    library = _library_graph()
+    library.add_node(
+        GraphNode(id="binary_symbol://train@v1", kind="binary_symbol", label="train_v1")
+    )
+    library.add_node(
+        GraphNode(id="binary_symbol://train@v2", kind="binary_symbol", label="train_v2")
+    )
+    library.add_edge(
+        GraphEdge(
+            src="decl://train",
+            dst="binary_symbol://train@v1",
+            kind="SOURCE_DECL_MAPS_TO_SYMBOL",
+        )
+    )
+    library.add_edge(
+        GraphEdge(
+            src="decl://train",
+            dst="binary_symbol://train@v2",
+            kind="SOURCE_DECL_MAPS_TO_SYMBOL",
+        )
+    )
+    graph = build_use_case_graph(
+        [UseCaseDefinition(use_case="training-workflow", entrypoints=("train",))],
+        library,
+    )
+    edges = {e.dst for e in graph.edges if e.kind == "USE_CASE_USES_ENTRY"}
+    assert edges == {"decl://train"}
+
+
 def test_build_use_case_graph_an_exact_id_wins_over_a_colliding_label() -> None:
     """A manifest naming a node's exact id must resolve to that node even
     when some *other* public node's own label happens to collide with that

--- a/tests/test_use_cases.py
+++ b/tests/test_use_cases.py
@@ -132,6 +132,23 @@ def test_parse_rejects_a_non_mapping_entry() -> None:
 
 
 @pytest.mark.parametrize(
+    "raw_entry",
+    [
+        {"use_case": "x", "entrypoint": ["train"]},  # misspelled entrypoints
+        {"use_case": "x", "test": ["t"]},  # misspelled tests
+        {"use_case": "x", "extra_field": 1},
+    ],
+)
+def test_parse_rejects_an_unknown_field(raw_entry: dict) -> None:
+    """A misspelled/unknown field must be a hard error, not silently
+    ignored -- mapping.get(...) treats an unknown key as absent, which
+    would otherwise load successfully while quietly dropping the coverage
+    the author actually declared."""
+    with pytest.raises(UseCaseManifestError, match="unknown field"):
+        parse_use_case_manifest([raw_entry])
+
+
+@pytest.mark.parametrize(
     "raw_entry", [{}, {"use_case": ""}, {"use_case": "   "}, {"use_case": 5}]
 )
 def test_parse_rejects_a_missing_or_blank_use_case_name(raw_entry: dict) -> None:


### PR DESCRIPTION
## Summary

Implements the remaining half of [G29](docs/contribute/plans/g29-impact-analysis-layer.md) Phase 4 (the consumer/use-case join): the optional `impact-use-cases.yaml` manifest and the `use_case`/`test_case` graph join onto the L5 source graph, following the same pattern as Phase 4 slice 1 (the consumer graph, ADR-057, PR #672).

## Motivation

ADR-057 shipped the consumer-graph half of Phase 4 but explicitly left "the `impact-use-cases.yaml` manifest, `use_case`/`test_case` nodes, and runtime-trace ingestion" as **not implemented**, reserving `CONSUMER_INSTANTIATES_DECL`/`CONSUMER_COMPILED_FROM_HEADER`/`RUNTIME_FAILED_TO_RESOLVE_SYMBOL` as attachment points. This PR closes the manifest/graph-join part of that gap; runtime-trace ingestion stays reserved and out of scope, as documented.

## Changes

- `abicheck/impact/use_cases.py` (new): `UseCaseDefinition` dataclass, `load_use_case_manifest`/`parse_use_case_manifest` (hard error only on structurally malformed YAML), `build_use_case_graph` (resolves manifest `entrypoints` against the library graph's own public nodes, silently skipping anything unresolvable — never a wrong answer), and `join_use_case_graph` (deep-copy join, mirroring `consumer_graph.join_consumer_graph`'s mutation-safety discipline).
- `abicheck/buildsource/graph_facts.py` / `source_graph.py`: new `USE_CASE_NODE_KINDS` (`use_case`, `test_case`) / `USE_CASE_EDGE_KINDS` (`USE_CASE_USES_ENTRY`, `TEST_COVERS_USE_CASE` populated; `TRACE_OBSERVED_ENTRY`/`TRACE_OBSERVED_EDGE` reserved for future runtime-trace work), unioned into the graph schema.
- `abicheck/errors.py`: new `UseCaseManifestError`.
- `tests/test_use_cases.py` (new, 40 tests): manifest parsing, entrypoint resolution/silent-skip, join deep-copy/no-mutation guarantee, end-to-end join scenario.
- `docs/use/use-case-impact.md` (new): manifest format, entrypoint mapping, test association, and honest documentation of what's implemented vs. still reserved (trace ingestion). Wired into `mkdocs.yml` nav and `docs/_meta/topics.yaml`.
- `docs/contribute/adr/057-consumer-graph-and-impact-join.md`: amended in place with a "Slice 2" section.
- `docs/contribute/plans/g29-impact-analysis-layer.md`: G29.5/Phase 4 status updated to reflect what shipped vs. what's still open.
- `changelog.d/20260809_120000_claude_g29_phase4_use_cases.md`.

**Explicitly out of scope** (consistent with ADR-057): runtime-trace ingestion, a CLI flag reading the manifest, and any report-level `affected_use_cases`/`USE_CASE_IMPACT_CONFIRMED` finding (that's G29 Phase 6).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added
- [x] Docs updated (new page + ADR/plan amendments)
- [x] `ruff check`, `ruff format --check` (touched files), `mypy abicheck/` all clean
- [x] `python scripts/check_ai_readiness.py` — 0 errors
- [x] `python scripts/check_docs_contract.py` — 0 errors
- [x] `python -m mkdocs build --strict` — passes
- [x] `python scripts/adr_status_sync.py` — clean
- [ ] Full `python scripts/verify.py --profile pr` (golden tests + 95% coverage floor) not run in this session — recommended before merge


---
_Generated by [Claude Code](https://claude.ai/code/session_01M7tg53cYxpoMSBKgxDwcSb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `impact-use-cases.yaml` support for declaring use cases, entrypoints, and tests.
  * Use cases and test cases can now be represented in impact-analysis graphs with resolved relationships and provenance metadata.
  * Unresolved entrypoints are skipped without interrupting processing.

* **Bug Fixes**
  * Improved impact evidence detection and refreshed stale assessments after consumer-impact enrichment.
  * Improved validation and error reporting for malformed manifests and duplicate YAML keys.
  * Cached finalized impact assessments to avoid repeated calculations.

* **Documentation**
  * Added guidance for configuring and using use-case impact analysis, including current limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->