### PR TITLE
perf: bound DWARF DIE-cache memory on large binaries

### DIFF
--- a/abicheck/dwarf_snapshot.py
+++ b/abicheck/dwarf_snapshot.py
@@ -42,6 +42,8 @@ from .dwarf_utils import (
     attr_int as _attr_int,
     attr_str as _attr_str,
     decode_member_location as _decode_member_location,
+    dwarf_low_memory_mode,
+    free_cu_die_cache,
     has_real_dwarf_info,
     resolve_die_ref as _resolve_ref,
     resolve_type_die as _resolve_type_die,
@@ -398,7 +400,16 @@ class _DwarfSnapshotBuilder:
         """Walk every CU of *dwarf*, then filter to exported reachability.
 
         Shared by the open-here and reuse-session paths of :meth:`extract`.
+
+        On a large binary (``dwarf_low_memory_mode``), each CU's DIE cache
+        is freed as soon as this walk finishes with it -- this walk only
+        needs the plain functions/variables/types/enums/typedefs already
+        appended to ``self`` by ``_process_cu``, never the DIE objects
+        themselves afterwards, so retaining pyelftools' cache past that
+        point is pure waste on a binary large enough for it to matter (see
+        ``dwarf_utils.free_cu_die_cache``'s docstring).
         """
+        low_memory = dwarf_low_memory_mode(dwarf)
         # First pass: extract all functions, variables, types, enums, typedefs
         for CU in dwarf.iter_CUs():
             try:
@@ -409,6 +420,8 @@ class _DwarfSnapshotBuilder:
                     self._elf_path,
                     exc,
                 )
+            if low_memory:
+                free_cu_die_cache(CU)
 
         # Second pass: filter types to only those reachable from
         # exported symbols (transitive closure)

--- a/abicheck/dwarf_unified.py
+++ b/abicheck/dwarf_unified.py
@@ -63,7 +63,7 @@ from .dwarf_advanced import (
     _process_cu_impl as _adv_process_cu,
 )
 from .dwarf_metadata import DwarfMetadata, _process_cu_impl as _meta_process_cu
-from .dwarf_utils import has_real_dwarf_info
+from .dwarf_utils import dwarf_low_memory_mode, free_cu_die_cache, has_real_dwarf_info
 
 log = logging.getLogger(__name__)
 
@@ -156,10 +156,19 @@ def parse_dwarf_from_session(
     Behaviourally identical to the DWARF branch of :func:`parse_dwarf`; split
     out so the snapshot build can reuse the same session (and its warm DIE
     cache) instead of opening the ELF a second time.
+
+    On a large binary (``dwarf_low_memory_mode`` -- see ``dwarf_utils.py``),
+    each CU's DIE cache is freed as soon as this pass finishes with it,
+    trading that reuse for bounded peak memory: a later pass over the same
+    session (the snapshot build, the layout backfill) simply re-parses the
+    CU's DIEs from the stream on its own first touch, rather than finding
+    the whole binary's DIE tree still resident from this one. Output is
+    unaffected either way -- see ``free_cu_die_cache``'s docstring.
     """
     meta = DwarfMetadata(has_dwarf=True)
     adv = AdvancedDwarfMetadata(has_dwarf=True)
     adv.target_arch = session.arch
+    low_memory = dwarf_low_memory_mode(session.dwarf)
 
     # Per-binary type-resolution cache: (cu_offset, die_offset) → (type_name, byte_size).
     # DIE offsets are only unique within one ELF file — do not share across binaries.
@@ -174,6 +183,8 @@ def parse_dwarf_from_session(
             _adv_process_cu(CU, adv)
         except (ELFError, OSError, ValueError, KeyError) as exc:
             log.warning("parse_dwarf: adv CU skipped in %s: %s", session.path, exc)
+        if low_memory:
+            free_cu_die_cache(CU)
 
     return meta, adv
 

--- a/abicheck/dwarf_utils.py
+++ b/abicheck/dwarf_utils.py
@@ -319,8 +319,9 @@ def resolve_type_die(die: Any, CU: Any) -> Any | None:
 #: Default ``.debug_info`` size (MiB) above which DWARF walks free each
 #: CompileUnit's DIE cache as soon as they finish with it, instead of
 #: leaving it cached for the rest of the process (see module docstring
-#: above). Override with ``ABICHECK_DWARF_LOW_MEMORY_MB`` (set to a very
-#: large number, or a negative one, to disable low-memory mode entirely).
+#: above). Override with ``ABICHECK_DWARF_LOW_MEMORY_MB`` (a negative value
+#: disables low-memory mode entirely -- every ``.debug_info`` size is >= 0,
+#: so it can never exceed a negative threshold).
 DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB = 32
 
 
@@ -334,8 +335,11 @@ def dwarf_low_memory_mode(dwarf_info: Any) -> bool:
     (default :data:`DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB`), compared
     against the raw ``.debug_info`` section size in MiB -- the same section
     whose in-memory DIE representation is what actually drives peak RSS on
-    a large binary (see module docstring). An unparsable override falls
-    back to the default rather than raising.
+    a large binary (see module docstring). A negative override always
+    returns False (documented disable switch -- a plain ``>`` comparison
+    alone would do the opposite, since every real size is >= 0 and so
+    would compare greater than any negative threshold). An unparsable
+    override falls back to the default rather than raising.
     """
     threshold_mb: float = DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB
     env = os.environ.get("ABICHECK_DWARF_LOW_MEMORY_MB")
@@ -350,6 +354,8 @@ def dwarf_low_memory_mode(dwarf_info: Any) -> bool:
                 DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB,
             )
             threshold_mb = DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB
+    if threshold_mb < 0:
+        return False
     debug_info_sec = getattr(dwarf_info, "debug_info_sec", None)
     try:
         size = int(getattr(debug_info_sec, "size", 0) or 0)
@@ -364,21 +370,26 @@ def dwarf_low_memory_mode(dwarf_info: Any) -> bool:
 def free_cu_die_cache(CU: Any) -> None:
     """Drop a CompileUnit's cached DIE objects so the GC can reclaim them.
 
-    Clearing the two parallel lists pyelftools uses to represent "no DIEs
-    parsed yet" (matching ``CompileUnit.__init__``'s own initial state) is
-    safe: every DIE accessor (``get_top_DIE``, ``iter_DIEs``,
-    ``_get_cached_DIE``, ``get_DIE_from_refaddr``) re-parses transparently
-    from the underlying stream on a cache miss, so a caller that revisits
-    this CU later gets a byte-for-byte identical (if freshly allocated) DIE
-    tree -- the cost is pure CPU (re-decoding), never a correctness change.
-    See the module docstring above for why this trade is worth making on a
-    large binary.
+    Clears (rather than reassigns) the two pyelftools cache containers in
+    place, so this works regardless of the exact container type a given
+    pyelftools release uses internally (parallel lists as of the versions
+    this project has checked, but ``.clear()`` degrades safely instead of
+    raising ``AttributeError``/type-mismatches if that ever changes) --
+    every DIE accessor (``get_top_DIE``, ``iter_DIEs``, ``_get_cached_DIE``,
+    ``get_DIE_from_refaddr``) re-parses transparently from the underlying
+    stream on a cache miss once cleared, so a caller that revisits this CU
+    later gets a byte-for-byte identical (if freshly allocated) DIE tree --
+    the cost is pure CPU (re-decoding), never a correctness change. See the
+    module docstring above for why this trade is worth making on a large
+    binary.
 
     No-ops if *CU* doesn't carry the private pyelftools cache attributes (a
     version mismatch, or a CU that hasn't cached anything yet) rather than
     raising -- freeing is always best-effort.
     """
-    if hasattr(CU, "_dielist"):
-        CU._dielist = []
-    if hasattr(CU, "_diemap"):
-        CU._diemap = []
+    dielist = getattr(CU, "_dielist", None)
+    if dielist is not None:
+        dielist.clear()
+    diemap = getattr(CU, "_diemap", None)
+    if diemap is not None:
+        diemap.clear()

--- a/abicheck/dwarf_utils.py
+++ b/abicheck/dwarf_utils.py
@@ -20,7 +20,11 @@ duplicating low-level DIE attribute extraction logic.
 # pylint: disable=invalid-name  # CU is the standard DWARF term (Compilation Unit)
 from __future__ import annotations
 
+import logging
+import os
 from typing import Any
+
+log = logging.getLogger(__name__)
 
 
 def has_real_dwarf_info(elf: Any) -> bool:
@@ -288,3 +292,93 @@ def resolve_type_die(die: Any, CU: Any) -> Any | None:
         return resolve_die_ref(die, "DW_AT_type", CU)
     except Exception:  # noqa: BLE001
         return None
+
+
+# ---------------------------------------------------------------------------
+# Low-memory DIE-cache management
+#
+# pyelftools permanently caches every DIE object it has ever parsed inside
+# ``CompileUnit._dielist``/``_diemap`` (see ``compileunit.py``'s
+# ``_get_cached_DIE``/``iter_DIEs``) for as long as the ``CU``/``DWARFInfo``
+# objects stay alive — there is no built-in eviction. A single full-tree
+# walk of one CU therefore leaves every DIE it visited resident afterwards,
+# and abicheck's ``DwarfSession`` (dwarf_unified.py) deliberately shares one
+# ``DWARFInfo`` across up to three separate full-tree walks (basic metadata,
+# advanced metadata, snapshot build/layout backfill) specifically so later
+# walks hit that cache instead of re-parsing. For a small binary this is a
+# clear win; for a template-heavy C++ library with millions of DIEs, the
+# per-DIE Python object overhead (each DIE holds an attributes dict of
+# ``AttributeValue`` records, plus CU/offset/parent bookkeeping) inflates the
+# resident set to 50-100x the raw ``.debug_info``/``.debug_loc`` section
+# bytes — a real dump measured 108 MB of ``.debug_info`` peaking above 12 GB
+# of RSS purely from this. ``free_cu_die_cache``/``dwarf_low_memory_mode``
+# let a walk trade the session-cache reuse's "zero re-parse" benefit for
+# bounded peak memory on binaries large enough that the trade is worth it.
+# ---------------------------------------------------------------------------
+
+#: Default ``.debug_info`` size (MiB) above which DWARF walks free each
+#: CompileUnit's DIE cache as soon as they finish with it, instead of
+#: leaving it cached for the rest of the process (see module docstring
+#: above). Override with ``ABICHECK_DWARF_LOW_MEMORY_MB`` (set to a very
+#: large number, or a negative one, to disable low-memory mode entirely).
+DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB = 32
+
+
+def dwarf_low_memory_mode(dwarf_info: Any) -> bool:
+    """Return True when *dwarf_info*'s ``.debug_info`` is large enough that
+    DWARF walks over it should free each CU's DIE cache as they finish with
+    it (see :func:`free_cu_die_cache`), rather than retaining the whole
+    binary's DIE tree simultaneously for the F5b cross-pass cache reuse.
+
+    Threshold is ``ABICHECK_DWARF_LOW_MEMORY_MB``
+    (default :data:`DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB`), compared
+    against the raw ``.debug_info`` section size in MiB -- the same section
+    whose in-memory DIE representation is what actually drives peak RSS on
+    a large binary (see module docstring). An unparsable override falls
+    back to the default rather than raising.
+    """
+    threshold_mb: float = DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB
+    env = os.environ.get("ABICHECK_DWARF_LOW_MEMORY_MB")
+    if env:
+        try:
+            threshold_mb = float(env)
+        except ValueError:
+            log.warning(
+                "ABICHECK_DWARF_LOW_MEMORY_MB=%r is not a valid number; "
+                "falling back to the default (%s MiB).",
+                env,
+                DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB,
+            )
+            threshold_mb = DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB
+    debug_info_sec = getattr(dwarf_info, "debug_info_sec", None)
+    try:
+        size = int(getattr(debug_info_sec, "size", 0) or 0)
+    except (TypeError, ValueError):
+        # A test double (e.g. MagicMock) or otherwise non-numeric ``.size``
+        # carries no real size signal — treat as unknown/small rather than
+        # raise, matching every other "never raise" DWARF helper here.
+        size = 0
+    return (size / (1024 * 1024)) > threshold_mb
+
+
+def free_cu_die_cache(CU: Any) -> None:
+    """Drop a CompileUnit's cached DIE objects so the GC can reclaim them.
+
+    Clearing the two parallel lists pyelftools uses to represent "no DIEs
+    parsed yet" (matching ``CompileUnit.__init__``'s own initial state) is
+    safe: every DIE accessor (``get_top_DIE``, ``iter_DIEs``,
+    ``_get_cached_DIE``, ``get_DIE_from_refaddr``) re-parses transparently
+    from the underlying stream on a cache miss, so a caller that revisits
+    this CU later gets a byte-for-byte identical (if freshly allocated) DIE
+    tree -- the cost is pure CPU (re-decoding), never a correctness change.
+    See the module docstring above for why this trade is worth making on a
+    large binary.
+
+    No-ops if *CU* doesn't carry the private pyelftools cache attributes (a
+    version mismatch, or a CU that hasn't cached anything yet) rather than
+    raising -- freeing is always best-effort.
+    """
+    if hasattr(CU, "_dielist"):
+        CU._dielist = []
+    if hasattr(CU, "_diemap"):
+        CU._diemap = []

--- a/changelog.d/20260809_225129_noreply_dump_memory_analysis_w2bx7j.md
+++ b/changelog.d/20260809_225129_noreply_dump_memory_analysis_w2bx7j.md
@@ -1,0 +1,21 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Performance
+
+- **Bounded DWARF parse memory on large binaries** — pyelftools permanently
+  caches every DIE it parses for the lifetime of the `CompileUnit`/
+  `DWARFInfo` objects, and `dump`'s DWARF passes (basic metadata, advanced
+  metadata, snapshot build, layout backfill) share one such session across
+  up to three full-tree walks so later passes hit that cache instead of
+  re-parsing. On a template-heavy C++ library (millions of DIEs from a
+  ~100 MB `.debug_info`), the per-DIE Python object overhead inflated that
+  cache to 50-100x the raw section bytes, peaking above 12 GB of RSS for a
+  single `dump`. Each DWARF walk now frees a `CompileUnit`'s DIE cache as
+  soon as it finishes with it whenever `.debug_info` exceeds
+  `ABICHECK_DWARF_LOW_MEMORY_MB` (default 32 MiB) — trading the cross-pass
+  cache-reuse CPU savings for bounded peak memory on binaries large enough
+  for that trade to matter. Output is unaffected; small binaries (the
+  common case) keep the existing cache-reuse behavior unchanged.
+

--- a/tests/test_dwarf_low_memory.py
+++ b/tests/test_dwarf_low_memory.py
@@ -158,6 +158,16 @@ class TestDwarfLowMemoryMode:
         huge = _FakeDwarfInfo(500 * 1024 * 1024)  # 500 MiB
         assert dwarf_low_memory_mode(huge) is False
 
+    def test_negative_env_override_disables_low_memory_mode(self, monkeypatch) -> None:
+        # A negative threshold is the documented disable switch. A naive
+        # ``size_mb > threshold_mb`` alone would do the *opposite* here,
+        # since every real (non-negative) size compares greater than a
+        # negative threshold -- this must return False regardless of size.
+        monkeypatch.setenv("ABICHECK_DWARF_LOW_MEMORY_MB", "-1")
+        huge = _FakeDwarfInfo(500 * 1024 * 1024)  # 500 MiB
+        assert dwarf_low_memory_mode(huge) is False
+        assert dwarf_low_memory_mode(_FakeDwarfInfo(0)) is False
+
     def test_invalid_env_override_falls_back_to_default(self, monkeypatch) -> None:
         monkeypatch.setenv("ABICHECK_DWARF_LOW_MEMORY_MB", "not-a-number")
         small = _FakeDwarfInfo(1024 * 1024)  # 1 MiB, below default threshold

--- a/tests/test_dwarf_low_memory.py
+++ b/tests/test_dwarf_low_memory.py
@@ -1,0 +1,267 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""tests/test_dwarf_low_memory.py — DWARF low-memory DIE-cache freeing.
+
+Covers ``dwarf_utils.free_cu_die_cache``/``dwarf_low_memory_mode`` (the unit
+mechanics) and, on Linux with a real compiler, that forcing low-memory mode
+on for a real compiled binary produces byte-for-byte identical
+DwarfMetadata/AdvancedDwarfMetadata/AbiSnapshot output to the default
+(cache-reusing) path -- freeing a CU's DIE cache mid-walk must change only
+peak memory / CPU cost, never a single field of the result.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from abicheck.dwarf_utils import (
+    DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB,
+    dwarf_low_memory_mode,
+    free_cu_die_cache,
+)
+
+
+def _require_tool(name: str) -> None:
+    import shutil
+    if shutil.which(name) is None:
+        pytest.skip(f"{name} not found in PATH")
+
+
+def _compile_so(tmp_path: Path, name: str, src: str, lang: str = "cpp") -> Path:
+    ext = ".c" if lang == "c" else ".cpp"
+    compiler = "gcc" if lang == "c" else "g++"
+    src_file = tmp_path / f"{name}{ext}"
+    so_file = tmp_path / f"{name}.so"
+    src_file.write_text(textwrap.dedent(src).strip(), encoding="utf-8")
+    r = subprocess.run(
+        [compiler, "-shared", "-fPIC", "-g", "-fvisibility=default",
+         "-o", str(so_file), str(src_file)],
+        capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        pytest.skip(f"Compilation failed: {r.stderr[:200]}")
+    with open(so_file, "rb") as f:
+        if f.read(4) != b"\x7fELF":
+            pytest.skip("Compiled binary is not ELF (non-Linux platform)")
+    return so_file
+
+
+_SRC = """
+    namespace demo {
+    struct Point { int x; int y; double weight; };
+    class Base {
+    public:
+        virtual ~Base() {}
+        virtual int value() const { return 0; }
+    };
+    class Derived : public Base {
+    public:
+        int value() const override { return 42; }
+        Point p;
+    };
+    enum class Color { Red, Green, Blue };
+    }
+    extern "C" int demo_add(int a, int b) { return a + b; }
+    demo::Derived make_derived() { return demo::Derived(); }
+    extern demo::Point demo_origin;
+    demo::Point demo_origin = {0, 0, 0.0};
+"""
+
+
+# ---------------------------------------------------------------------------
+# free_cu_die_cache — unit mechanics
+# ---------------------------------------------------------------------------
+
+class _FakeCU:
+    """Minimal stand-in for pyelftools' CompileUnit cache attributes."""
+
+    def __init__(self, with_cache: bool = True):
+        if with_cache:
+            self._dielist = ["die0", "die1", "die2"]
+            self._diemap = [0, 10, 20]
+
+
+class TestFreeCuDieCache:
+    def test_clears_populated_cache(self) -> None:
+        cu = _FakeCU(with_cache=True)
+        assert cu._dielist and cu._diemap
+        free_cu_die_cache(cu)
+        assert cu._dielist == []
+        assert cu._diemap == []
+
+    def test_noop_on_cu_without_cache_attrs(self) -> None:
+        cu = object()  # no _dielist/_diemap at all
+        assert free_cu_die_cache(cu) is None  # must not raise
+
+    def test_idempotent(self) -> None:
+        cu = _FakeCU(with_cache=True)
+        free_cu_die_cache(cu)
+        free_cu_die_cache(cu)  # second call on an already-empty cache
+        assert cu._dielist == []
+        assert cu._diemap == []
+
+
+# ---------------------------------------------------------------------------
+# dwarf_low_memory_mode — threshold decision
+# ---------------------------------------------------------------------------
+
+class _FakeSection:
+    def __init__(self, size: int):
+        self.size = size
+
+
+class _FakeDwarfInfo:
+    def __init__(self, debug_info_size: int | None):
+        self.debug_info_sec = None if debug_info_size is None else _FakeSection(debug_info_size)
+
+
+class TestDwarfLowMemoryMode:
+    def test_small_binary_below_default_threshold(self, monkeypatch) -> None:
+        monkeypatch.delenv("ABICHECK_DWARF_LOW_MEMORY_MB", raising=False)
+        small = _FakeDwarfInfo(1024 * 1024)  # 1 MiB
+        assert dwarf_low_memory_mode(small) is False
+
+    def test_large_binary_above_default_threshold(self, monkeypatch) -> None:
+        monkeypatch.delenv("ABICHECK_DWARF_LOW_MEMORY_MB", raising=False)
+        big_mb = DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB + 10
+        big = _FakeDwarfInfo(int(big_mb * 1024 * 1024))
+        assert dwarf_low_memory_mode(big) is True
+
+    def test_missing_debug_info_sec_is_never_low_memory(self, monkeypatch) -> None:
+        monkeypatch.delenv("ABICHECK_DWARF_LOW_MEMORY_MB", raising=False)
+        assert dwarf_low_memory_mode(_FakeDwarfInfo(None)) is False
+
+    def test_env_override_lowers_threshold(self, monkeypatch) -> None:
+        monkeypatch.setenv("ABICHECK_DWARF_LOW_MEMORY_MB", "0")
+        tiny = _FakeDwarfInfo(1024)  # 1 KiB — above a 0 MiB threshold
+        assert dwarf_low_memory_mode(tiny) is True
+
+    def test_env_override_raises_threshold_effectively_disabling(self, monkeypatch) -> None:
+        monkeypatch.setenv("ABICHECK_DWARF_LOW_MEMORY_MB", "1000000")
+        huge = _FakeDwarfInfo(500 * 1024 * 1024)  # 500 MiB
+        assert dwarf_low_memory_mode(huge) is False
+
+    def test_invalid_env_override_falls_back_to_default(self, monkeypatch) -> None:
+        monkeypatch.setenv("ABICHECK_DWARF_LOW_MEMORY_MB", "not-a-number")
+        small = _FakeDwarfInfo(1024 * 1024)  # 1 MiB, below default threshold
+        assert dwarf_low_memory_mode(small) is False
+        big_mb = DEFAULT_DWARF_LOW_MEMORY_THRESHOLD_MB + 10
+        big = _FakeDwarfInfo(int(big_mb * 1024 * 1024))
+        assert dwarf_low_memory_mode(big) is True
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: low-memory mode must not change any parsed output
+# ---------------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="ELF DWARF tests require Linux (macOS/Windows compilers produce Mach-O/PE)",
+)
+class TestLowMemoryModeIsOutputNeutral:
+    def test_parse_dwarf_identical_with_low_memory_forced_on(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        _require_tool("g++")
+        from abicheck.dwarf_unified import parse_dwarf
+
+        so = _compile_so(tmp_path, "liblowmem1", _SRC)
+
+        monkeypatch.delenv("ABICHECK_DWARF_LOW_MEMORY_MB", raising=False)
+        meta_normal, adv_normal = parse_dwarf(so)
+
+        monkeypatch.setenv("ABICHECK_DWARF_LOW_MEMORY_MB", "0")
+        meta_low, adv_low = parse_dwarf(so)
+
+        assert meta_normal.structs == meta_low.structs
+        assert meta_normal.enums == meta_low.enums
+        assert meta_normal.base_types == meta_low.base_types
+        assert adv_normal.target_arch == adv_low.target_arch
+        assert adv_normal.calling_conventions == adv_low.calling_conventions
+        assert adv_normal.packed_structs == adv_low.packed_structs
+        # And the walk genuinely exercised the struct/class paths.
+        assert meta_normal.structs
+
+    def test_snapshot_via_session_identical_with_low_memory_forced_on(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        _require_tool("g++")
+        from abicheck.dwarf_snapshot import build_snapshot_from_dwarf
+        from abicheck.dwarf_unified import open_dwarf_session, parse_dwarf_from_session
+        from abicheck.elf_metadata import parse_elf_metadata
+        from abicheck.serialization import snapshot_to_json
+
+        so = _compile_so(tmp_path, "liblowmem2", _SRC)
+        elf_meta = parse_elf_metadata(so)
+
+        monkeypatch.delenv("ABICHECK_DWARF_LOW_MEMORY_MB", raising=False)
+        sess_a = open_dwarf_session(so)
+        assert sess_a is not None
+        try:
+            meta_a, adv_a = parse_dwarf_from_session(sess_a)
+            snap_a = build_snapshot_from_dwarf(
+                so, elf_meta, meta_a, adv_a, version="t", session=sess_a
+            )
+        finally:
+            sess_a.close()
+
+        monkeypatch.setenv("ABICHECK_DWARF_LOW_MEMORY_MB", "0")
+        sess_b = open_dwarf_session(so)
+        assert sess_b is not None
+        try:
+            meta_b, adv_b = parse_dwarf_from_session(sess_b)
+            # Sanity: the CU cache was actually freed by the low-memory pass.
+            for CU in sess_b.dwarf.iter_CUs():
+                assert CU._dielist == []
+                assert CU._diemap == []
+            snap_b = build_snapshot_from_dwarf(
+                so, elf_meta, meta_b, adv_b, version="t", session=sess_b
+            )
+        finally:
+            sess_b.close()
+
+        assert snapshot_to_json(snap_a) == snapshot_to_json(snap_b)
+        assert snap_b.types
+        assert snap_b.functions
+
+    def test_low_memory_snapshot_matches_non_low_memory_direct_open(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        """Same check without session reuse -- the DWARF-only ``dump``
+        (``--depth binary``) code path opens fresh rather than sharing a
+        session when none is supplied."""
+        _require_tool("g++")
+        from abicheck.dwarf_snapshot import build_snapshot_from_dwarf
+        from abicheck.dwarf_unified import parse_dwarf
+        from abicheck.elf_metadata import parse_elf_metadata
+        from abicheck.serialization import snapshot_to_json
+
+        so = _compile_so(tmp_path, "liblowmem3", _SRC)
+        elf_meta = parse_elf_metadata(so)
+
+        monkeypatch.delenv("ABICHECK_DWARF_LOW_MEMORY_MB", raising=False)
+        meta_a, adv_a = parse_dwarf(so)
+        snap_a = build_snapshot_from_dwarf(so, elf_meta, meta_a, adv_a, version="t")
+
+        monkeypatch.setenv("ABICHECK_DWARF_LOW_MEMORY_MB", "0")
+        meta_b, adv_b = parse_dwarf(so)
+        snap_b = build_snapshot_from_dwarf(so, elf_meta, meta_b, adv_b, version="t")
+
+        assert snapshot_to_json(snap_a) == snapshot_to_json(snap_b)

--- a/tests/test_dwarf_low_memory.py
+++ b/tests/test_dwarf_low_memory.py
@@ -168,6 +168,16 @@ class TestDwarfLowMemoryMode:
         assert dwarf_low_memory_mode(huge) is False
         assert dwarf_low_memory_mode(_FakeDwarfInfo(0)) is False
 
+    def test_non_numeric_debug_info_size_treated_as_unknown(self, monkeypatch) -> None:
+        # A test double (or any pyelftools object whose .size isn't a plain
+        # number) must degrade to "unknown/small" rather than raise --
+        # exercises the int()-cast except branch directly. A plain
+        # ``str`` .size is used rather than MagicMock: MagicMock defines
+        # ``__int__`` itself (returning 1), so ``int(MagicMock())``
+        # succeeds and would never reach the except clause.
+        monkeypatch.delenv("ABICHECK_DWARF_LOW_MEMORY_MB", raising=False)
+        assert dwarf_low_memory_mode(_FakeDwarfInfo("not-a-size")) is False  # type: ignore[arg-type]
+
     def test_invalid_env_override_falls_back_to_default(self, monkeypatch) -> None:
         monkeypatch.setenv("ABICHECK_DWARF_LOW_MEMORY_MB", "not-a-number")
         small = _FakeDwarfInfo(1024 * 1024)  # 1 MiB, below default threshold


### PR DESCRIPTION
## Summary

`dump` on a large template-heavy C++ library (e.g. oneAPI DAAL, ~108 MB `.debug_info`) was measured peaking above 12-16 GB of RSS and taking minutes, close to/over a 16 GB CI runner's headroom.

## Motivation

pyelftools permanently caches every DIE it parses inside a `CompileUnit`, for the lifetime of the `DWARFInfo` object — there's no eviction. abicheck's `DwarfSession` (`dwarf_unified.py`) deliberately shares one `DWARFInfo` across up to three full-tree DWARF walks (basic metadata + advanced metadata, snapshot build, layout backfill) so later passes hit that cache instead of re-parsing (an intentional prior optimization). For a small library this is a clear win. For a binary with millions of DIEs, the per-DIE Python object overhead (each DIE holds an attributes dict of `AttributeValue` records plus bookkeeping) inflates that permanently-cached tree to roughly 50-100x the raw `.debug_info`/`.debug_loc` section bytes, which matches the observed multi-GB RSS from ~150 MB of raw DWARF sections.

## Changes

- `abicheck/dwarf_utils.py`: new `free_cu_die_cache()` (drops a `CompileUnit`'s cached DIE objects — safe, since pyelftools transparently re-parses from the stream on the next access) and `dwarf_low_memory_mode()` (decides from `.debug_info` section size vs. a threshold, default 32 MiB, overridable via `ABICHECK_DWARF_LOW_MEMORY_MB`, whether a walk should free eagerly).
- Wired into the two production DWARF walkers: `dwarf_unified.parse_dwarf_from_session` (basic + advanced metadata pass) and `dwarf_snapshot._DwarfSnapshotBuilder._walk_dwarf` (the snapshot-build walk, which also backs the layout-backfill path via `dumper_layout_backfill.py`). Each frees a CU's DIE cache immediately after finishing with it when in low-memory mode, bounding peak memory to roughly one CU's tree instead of the whole binary's, trading the cross-pass cache-reuse CPU savings for bounded peak memory on binaries large enough for that trade to matter.
- Small binaries (the common case) are unaffected — the default threshold keeps the existing fast cache-reuse behavior unchanged.
- `changelog.d/`: performance fragment.

## Tests

- `tests/test_dwarf_low_memory.py`: unit tests for the cache-freeing/threshold mechanics (including env-var override and non-numeric/mocked-size edge cases), plus Linux/gcc integration tests proving low-memory mode is byte-for-byte output-neutral against `parse_dwarf`/`build_snapshot_from_dwarf` in both the session-reuse and direct-open code paths.
- Full fast suite: `23210 passed, 13 skipped, 4 xfailed` (0 failures).
- `mypy abicheck/`: clean. `ruff check`: clean on touched files.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed — no user-facing CLI/API surface changed; the new `ABICHECK_DWARF_LOW_MEMORY_MB` env var is an internal tuning knob mirroring existing ones (`ABICHECK_TU_JOBS`, etc.)
- [x] No new `mypy` or `ruff` errors introduced


---
_Generated by [Claude Code](https://claude.ai/code/session_01EPw9kJTsSV2TCNTjkdxXWY)_