### PR TITLE
refactor: cut CodeFactor "Complex Method" complexity in buildsource/ (14 of 68)

### DIFF
--- a/abicheck/buildsource/check_report.py
+++ b/abicheck/buildsource/check_report.py
@@ -312,6 +312,105 @@ def _is_valid_coverage_contribution(raw: object) -> bool:
     return not isinstance(raw, bool) and isinstance(raw, int) and raw in (0, 1)
 
 
+def _stamp_schema_version(out: dict[str, Any], report: dict[str, Any]) -> None:
+    """Stamp the schema marker matching *report*'s actual shape.
+
+    A scan report (baseline-channel: none) has its own schema marker and shape
+    (level/risk/coverage/... -- no library/old_file/summary/changes/...) -- bump
+    it to the latest version for this envelope's new additive fields instead of
+    also stamping ``report_schema_version`` (the *compare*-report schema's
+    marker), which would make a downstream validator select
+    ``compare_report.schema.json`` for a report that structurally can never
+    satisfy it (Codex review).
+
+    A ``kind: bundle`` / directory-package compare report (the per-library
+    release fan-out's own summary shape: verdict/old_dir/new_dir/libraries/...)
+    has never had a schema of its own; it is left unversioned rather than
+    falsely claiming the single-pair compare schema (same rationale). ADR-047
+    §7's identity/policy-gate fields still apply regardless of report shape.
+    """
+    if "scan_schema_version" in report:
+        out["scan_schema_version"] = SCAN_SCHEMA_VERSION
+    elif not ("libraries" in report and "old_dir" in report):
+        out["report_schema_version"] = REPORT_SCHEMA_VERSION
+
+
+def _escalate_removed_library_severity(out: dict[str, Any]) -> None:
+    """Fold ``--fail-on-removed-library``'s exit 8 into the severity block.
+
+    Exit 8 is the *only* value ``cli_compare_release_helpers.
+    _exit_compare_release`` applies "in preference to the severity code" --
+    every other severity-aware exit path there emits ``severity_exit_code``
+    directly, so 8 is the sole case where the real outcome can diverge from
+    what is already persisted. Escalating ``policy_gate_decision``/
+    ``real_exit_code`` is not enough on its own: ``gate-mode: deferred`` relies
+    on ``check-project.yml``'s trailing aggregate job, and
+    ``abicheck.aggregate.GateInfo.from_report_data`` reads ONLY the persisted
+    ``severity.exit_code`` -- it cannot see ``policy_gate_decision`` or
+    ``analysis_exit_code`` at all. Without also updating severity here, a
+    removed-library gate on a deferred bundle check would still be silently
+    missed by aggregate even though the check's own local exit code is correct
+    (Codex review, second pass).
+
+    A whole library disappearing is unambiguously an ABI break, so it is
+    encoded as the ``abi_breaking`` tier (exit_code 4 -- the ceiling of
+    ``aggregate.py``'s ``_VALID_GATE_EXIT = {0, 1, 2, 4}``; 8 itself is not a
+    legal ``severity.exit_code`` and would raise ``_MalformedGate`` there).
+    Only escalates -- never downgrades an already->=4 severity block, though 4
+    is already that ceiling so there is nothing to downgrade from.
+    """
+    severity = out.get("severity")
+    if not isinstance(severity, dict) or severity.get("exit_code", 0) >= 4:
+        return
+    cats = list(severity.get("blocking_categories") or [])
+    if "abi_breaking" not in cats:
+        cats.append("abi_breaking")
+    out["severity"] = {
+        **severity,
+        "exit_code": 4,
+        "blocking": True,
+        "blocking_categories": cats,
+    }
+
+
+def _classify_verdict(
+    out: dict[str, Any], report: dict[str, Any], raw_verdict: Any
+) -> None:
+    """Split *raw_verdict* into a compatibility verdict or an operational error.
+
+    Any verdict string a scan run can produce that is neither a legacy
+    compatibility verdict nor the explicit operational-error sentinel (e.g.
+    ``"BUDGET_OVERFLOW"``/``"EVIDENCE_CONTRACT_ERROR"`` -- ``service_scan.py``'s
+    guard sentinels) is not a compatibility finding either: it is the scan
+    never completing its comparison at all, the same class of problem as an
+    analysis CLI error, not something ADR-047 §7's "deferred only defers the
+    *compatibility* verdict" rule was meant to cover. Treated as operational so
+    ``gate-mode: deferred``/``advisory`` cannot turn a guard failure into a
+    quiet pass (Codex review).
+    """
+    if raw_verdict in LEGACY_VERDICT_VALUES:
+        out["compatibility_verdict"] = raw_verdict
+        out.setdefault("operational_errors", [])
+        return
+    if raw_verdict == OPERATIONAL_ERROR_VERDICT:
+        out["operational_errors"] = [
+            {
+                "kind": "analysis_error",
+                "message": str(report.get("error") or "the analysis step failed"),
+            }
+        ]
+        return
+    out["operational_errors"] = [
+        {
+            "kind": "scan_guard_triggered",
+            "message": str(
+                report.get("error")
+                or f"the analysis reported a non-compatibility verdict: {raw_verdict!r}"
+            ),
+        }
+    ]
+
+
 def augment_report(
     report: dict[str, Any],
     *,
@@ -350,27 +449,7 @@ def augment_report(
     out = dict(report)
     check_id = build_check_id(name, profile_id, baseline_channel, requested_depth)
     effective_depth, coverage = derive_effective_depth(report, requested_depth)
-    if "scan_schema_version" in report:
-        # A scan report (baseline-channel: none) has its own schema marker
-        # and shape (level/risk/coverage/... -- no library/old_file/summary/
-        # changes/...) -- bump it to the latest version for this envelope's
-        # new additive fields instead of also stamping report_schema_version
-        # (the *compare*-report schema's marker), which would make a
-        # downstream validator select compare_report.schema.json for a
-        # report that structurally can never satisfy it (Codex review).
-        out["scan_schema_version"] = SCAN_SCHEMA_VERSION
-    elif "libraries" in report and "old_dir" in report:
-        # A kind: bundle / directory-package compare report (the per-library
-        # release fan-out's own summary shape: verdict/old_dir/new_dir/
-        # libraries/... -- no singular library/old_file/new_file/summary/
-        # changes/... either) has never had a schema of its own; leave it
-        # unversioned here too rather than falsely claiming the single-pair
-        # compare schema (same rationale as the scan case above, Codex
-        # review). ADR-047 §7's identity/policy-gate fields below still
-        # apply regardless of report shape.
-        pass
-    else:
-        out["report_schema_version"] = REPORT_SCHEMA_VERSION
+    _stamp_schema_version(out, report)
     out["check_id"] = check_id
     out["target_id"] = check_id
     out["profile_id"] = profile_id
@@ -391,67 +470,8 @@ def augment_report(
     real_exit_code = max(_real_exit_code(report), analysis_exit_code or 0)
     out["policy_gate_decision"] = "fail" if real_exit_code != 0 else "pass"
     if analysis_exit_code == _REMOVED_LIBRARY_EXIT_CODE:
-        # --fail-on-removed-library's exit 8 is the *only* value
-        # cli_compare_release_helpers._exit_compare_release applies "in
-        # preference to the severity code" -- every other severity-aware
-        # exit path there just emits severity_exit_code directly, so 8 is
-        # the sole case where the real outcome can diverge from what's
-        # already in the persisted severity block. Escalating
-        # policy_gate_decision/real_exit_code above isn't enough on its
-        # own: gate-mode: deferred relies on check-project.yml's trailing
-        # aggregate job, and abicheck.aggregate.GateInfo.from_report_data
-        # reads ONLY the persisted severity.exit_code -- it has no way to
-        # see policy_gate_decision or analysis_exit_code at all. Without
-        # also updating severity here, a removed-library gate on a
-        # deferred bundle check would still be silently missed by
-        # aggregate, even though this check's own local exit code is
-        # correct (Codex review, second pass). A whole library
-        # disappearing is unambiguously an ABI break, so it's encoded as
-        # the abi_breaking tier (exit_code 4 -- the ceiling of
-        # aggregate.py's _VALID_GATE_EXIT = {0, 1, 2, 4}; 8 itself isn't a
-        # legal severity.exit_code and would raise _MalformedGate there).
-        # Only escalates -- never downgrades an already-≥4 severity block,
-        # though 4 is already that ceiling so there's nothing to downgrade
-        # from in this scheme.
-        severity = out.get("severity")
-        if isinstance(severity, dict) and severity.get("exit_code", 0) < 4:
-            cats = list(severity.get("blocking_categories") or [])
-            if "abi_breaking" not in cats:
-                cats.append("abi_breaking")
-            out["severity"] = {
-                **severity,
-                "exit_code": 4,
-                "blocking": True,
-                "blocking_categories": cats,
-            }
-    if raw_verdict in LEGACY_VERDICT_VALUES:
-        out["compatibility_verdict"] = raw_verdict
-        out.setdefault("operational_errors", [])
-    elif raw_verdict == OPERATIONAL_ERROR_VERDICT:
-        out["operational_errors"] = [
-            {
-                "kind": "analysis_error",
-                "message": str(report.get("error") or "the analysis step failed"),
-            }
-        ]
-    else:
-        # Any other verdict string a scan run can produce (e.g. "BUDGET_OVERFLOW",
-        # "EVIDENCE_CONTRACT_ERROR" -- service_scan.py's guard sentinels) is not
-        # a compatibility finding either -- it's the scan never completing its
-        # comparison at all, the same class of problem as an analysis CLI error,
-        # not something ADR-047 §7's "deferred only defers the *compatibility*
-        # verdict" rule was ever meant to cover. Treated as operational so
-        # gate-mode: deferred/advisory can't turn a guard failure into a quiet
-        # pass (Codex review).
-        out["operational_errors"] = [
-            {
-                "kind": "scan_guard_triggered",
-                "message": str(
-                    report.get("error")
-                    or f"the analysis reported a non-compatibility verdict: {raw_verdict!r}"
-                ),
-            }
-        ]
+        _escalate_removed_library_severity(out)
+    _classify_verdict(out, report, raw_verdict)
     # check-target's own nested analysis step always disables add-job-summary/
     # pr-comment/upload-sarif (action.yml's "Run analysis" step), and the
     # finalize step itself only writes the report JSON to disk + sets

--- a/abicheck/buildsource/crosscheck_coherence.py
+++ b/abicheck/buildsource/crosscheck_coherence.py
@@ -82,6 +82,76 @@ def _effective_flag_mode(flags: list[str], pos: str, neg: str) -> str | None:
     return mode
 
 
+def _flag_family_conflicts(label: str, units: list[Any]) -> list[Change]:
+    """Conflicts where one target's units disagree on an ABI flag family.
+
+    Compares *effective, language-qualified* per-TU modes, not raw flag
+    membership. Each family is ON by default and C++-only, so the AC-008
+    umbrella case is: most C++ TUs default-on, one built ``-fno-rtti``. Two
+    false positives a raw membership test hits (Codex review): (1) a C TU (no
+    RTTI ABI at all) counted as "positive" and flagged against a C++
+    ``-fno-rtti`` TU; (2) a ``-fno-rtti -frtti`` override read as negative.
+    Both are avoided by taking each unit's last-wins effective mode and only
+    counting a unit that participates in the family — a C++ unit (default-on
+    when it names no token) or any unit carrying an explicit token for this
+    family (meaningful even if its language was not recorded).
+    """
+    findings: list[Change] = []
+    for pos, neg in _ABI_FLAG_FAMILIES:
+        pos_seen = neg_seen = False
+        for cu in units:
+            mode = _effective_flag_mode(cu.abi_relevant_flags, pos, neg)
+            if mode is None:
+                pos_seen = pos_seen or (cu.language or "").upper() in _CPP_LANGUAGES
+            elif mode == "pos":
+                pos_seen = True
+            else:
+                neg_seen = True
+        if pos_seen and neg_seen:
+            findings.append(
+                _change(
+                    ChangeKind.COMPILE_CONTEXT_CONFLICT,
+                    label,
+                    f"Build target {label} has compile units that disagree on "
+                    f"{pos}/{neg} (some built {neg}, others {pos} or the C++ "
+                    "language default); aggregating them into one build context "
+                    "silently picks one ABI. Scope the evidence to a single "
+                    "link unit or pass a compile-DB filter.",
+                    old_value=pos,
+                    new_value=neg,
+                    evidence_category="build_context",
+                )
+            )
+    return findings
+
+
+def _define_value_conflicts(label: str, units: list[Any]) -> list[Change]:
+    """Conflicts where one target's units bind a define to two values."""
+    define_values: dict[str, set[str]] = {}
+    for cu in units:
+        for k, v in cu.defines.items():
+            if v:  # a bare -DFOO (no value) carries no conflicting value
+                define_values.setdefault(k, set()).add(v)
+    findings: list[Change] = []
+    for key, values in sorted(define_values.items()):
+        if len(values) < 2:
+            continue
+        vs = ", ".join(sorted(values))
+        findings.append(
+            _change(
+                ChangeKind.COMPILE_CONTEXT_CONFLICT,
+                label,
+                f"Build target {label} binds define {key!r} to conflicting "
+                f"values ({vs}) across its compile units; the aggregated "
+                "context keeps only one. Scope to a single build variant.",
+                old_value=key,
+                new_value=vs,
+                evidence_category="build_context",
+            )
+        )
+    return findings
+
+
 def _check_compile_context_conflict(
     snapshot: AbiSnapshot, cfg: Any
 ) -> _CheckOutput:
@@ -113,63 +183,8 @@ def _check_compile_context_conflict(
         if len(units) < 2:
             continue
         label = target_id or "(unscoped compile units)"
-        for pos, neg in _ABI_FLAG_FAMILIES:
-            # Compare *effective, language-qualified* per-TU modes, not raw flag
-            # membership. Each of these families is ON by default and C++-only, so
-            # the AC-008 umbrella case is: most C++ TUs default-on, one built
-            # `-fno-rtti`. Two false positives a raw membership test hits (Codex
-            # review): (1) a C TU (no RTTI ABI at all) counted as "positive" and
-            # flagged against a C++ `-fno-rtti` TU; (2) a `-fno-rtti -frtti`
-            # override read as negative. Both are avoided by taking each unit's
-            # last-wins effective mode and only counting a unit that participates
-            # in the family — a C++ unit (default-on when it names no token) or any
-            # unit that carries an explicit token for this family (meaningful even
-            # if its language was not recorded).
-            pos_seen = neg_seen = False
-            for cu in units:
-                mode = _effective_flag_mode(cu.abi_relevant_flags, pos, neg)
-                if mode is None:
-                    if (cu.language or "").upper() in _CPP_LANGUAGES:
-                        pos_seen = True  # C++ default: family on
-                elif mode == "pos":
-                    pos_seen = True
-                else:
-                    neg_seen = True
-            if pos_seen and neg_seen:
-                findings.append(
-                    _change(
-                        ChangeKind.COMPILE_CONTEXT_CONFLICT,
-                        label,
-                        f"Build target {label} has compile units that disagree on "
-                        f"{pos}/{neg} (some built {neg}, others {pos} or the C++ "
-                        "language default); aggregating them into one build context "
-                        "silently picks one ABI. Scope the evidence to a single "
-                        "link unit or pass a compile-DB filter.",
-                        old_value=pos,
-                        new_value=neg,
-                        evidence_category="build_context",
-                    )
-                )
-        define_values: dict[str, set[str]] = {}
-        for cu in units:
-            for k, v in cu.defines.items():
-                if v:  # a bare -DFOO (no value) carries no conflicting value
-                    define_values.setdefault(k, set()).add(v)
-        for key, values in sorted(define_values.items()):
-            if len(values) > 1:
-                vs = ", ".join(sorted(values))
-                findings.append(
-                    _change(
-                        ChangeKind.COMPILE_CONTEXT_CONFLICT,
-                        label,
-                        f"Build target {label} binds define {key!r} to conflicting "
-                        f"values ({vs}) across its compile units; the aggregated "
-                        "context keeps only one. Scope to a single build variant.",
-                        old_value=key,
-                        new_value=vs,
-                        evidence_category="build_context",
-                    )
-                )
+        findings += _flag_family_conflicts(label, units)
+        findings += _define_value_conflicts(label, units)
     n_targets = len(by_target)
     detail = (
         f"L3 compile-context coherence across {n_targets} target(s): "

--- a/abicheck/buildsource/header_graph.py
+++ b/abicheck/buildsource/header_graph.py
@@ -320,6 +320,187 @@ def _flat_structural_type_edges(snapshot: AbiSnapshot) -> list[TypeEdge]:
     return edges
 
 
+def _seed_ast_type_nodes(
+    graph: SourceGraphSummary,
+    ast_root: dict[str, Any],
+    header_node: Callable[[str], str],
+    header_segs: Any,
+    dir_segs: Any,
+    have_public_set: bool,
+) -> None:
+    """Seed ``record_type`` nodes from the AST's own qualified-name index.
+
+    Deliberately not from ``snapshot.types``/``snapshot.enums``: the flat
+    snapshot model records a *bare*, unqualified type name (see
+    ``dumper_clang._ClangAstParser._build_record``), while the type graph's node
+    ids are the AST's *resolved qualified* name (``ns::Widget``) — two
+    representations that would silently fail to join on any namespaced type.
+    Deriving both the file (hence origin) and the node id from the same AST
+    index sidesteps that mismatch, and covers the ADR's headline case: a public
+    struct rarely has its own exported binary symbol, so it needs ``visibility``
+    set directly on the type node to act as a valid graph "entry"
+    (``is_public_dependency_node``).
+    """
+    for qname, file in index_declared_type_files(ast_root).items():
+        origin = classify_origin(
+            file, header_segs, dir_segs, have_public_set=have_public_set
+        )
+        if origin == ScopeOrigin.UNKNOWN:
+            continue
+        node_id = _type_node_id(qname)
+        # ``augment_graph_with_types`` defaults every AST-only type node to
+        # "record_type" uniformly (it cannot distinguish record/enum/typedef
+        # without an L4 surface) — matching that convention here keeps
+        # first-writer-wins joins consistent either way.
+        graph.add_node(
+            GraphNode(
+                id=node_id,
+                kind="record_type",
+                label=qname,
+                provenance=_PROVENANCE,
+                confidence=CONF_HIGH,
+                attrs={"visibility": origin.value},
+            )
+        )
+        graph.add_edge(
+            GraphEdge(
+                src=header_node(file),
+                dst=node_id,
+                kind="SOURCE_DECLARES",
+                provenance=_PROVENANCE,
+                confidence=CONF_HIGH,
+            )
+        )
+
+
+def _unseeded_decl_endpoints(
+    ast_root: dict[str, Any], type_edges: list[Any], call_edges: list[Any]
+) -> tuple[tuple[str, str], ...]:
+    """``(identity, file)`` for every edge endpoint the snapshot never seeded.
+
+    Annotates any AST-only decl target ``augment_graph_with_types``/
+    ``augment_graph_with_calls`` would otherwise create with no provenance at
+    all — a private declaration that is not a function or (namespace-scope)
+    variable, e.g. an ``EnumConstantDecl`` referenced by ``inline int f() {
+    return Color::RED; }``, is never seeded from
+    ``snapshot.functions``/``snapshot.variables``, since the flat AbiSnapshot
+    model has no equivalent per-enumerator entity to iterate. The
+    build-integrated path backfills this via ``augment_graph_with_types``'s
+    ``project_files`` parameter (matched against ``BuildEvidence``'s
+    compile-unit sources); a header-only world has no such set, but each edge
+    already carries its own target's declaring file
+    (``dst_file``/``callee_file``/``caller_file``), which is exactly what
+    ``classify_origin`` needs (Codex review).
+
+    A ``DECL_REFERENCES_DECL`` edge's *source* can be unseeded too — a field's
+    default member initializer (``struct Widget { int x = detail::k; };``)
+    makes ``Widget::x`` the edge's ``src``, and a field is never in
+    ``snapshot.functions``/``snapshot.variables`` either (Codex review). Unlike
+    the targets, ``TypeEdge`` carries no ``src_file``, so this falls back to
+    ``index_declared_entity_files`` (the unfiltered declaring-file index,
+    including fields) — computed once, lazily, only if there is at least one
+    such source to look up.
+    """
+    ref_srcs = {e.src for e in type_edges if e.kind == "DECL_REFERENCES_DECL"}
+    entity_files = index_declared_entity_files(ast_root) if ref_srcs else {}
+    return (
+        *((e.dst, e.dst_file) for e in type_edges if e.kind == "DECL_REFERENCES_DECL"),
+        *((src, entity_files.get(src, "")) for src in ref_srcs),
+        *((e.caller, e.caller_file) for e in call_edges),
+        *((e.callee, e.callee_file) for e in call_edges),
+    )
+
+
+def _seed_ast_graph(
+    graph: SourceGraphSummary,
+    ast_root: dict[str, Any],
+    header_node: Callable[[str], str],
+    header_segs: Any,
+    dir_segs: Any,
+    have_public_set: bool,
+) -> None:
+    """Seed type nodes and fold the clang type/call edges into *graph*."""
+    _seed_ast_type_nodes(
+        graph, ast_root, header_node, header_segs, dir_segs, have_public_set
+    )
+    type_edges = parse_clang_ast_types(ast_root)
+    call_edges = parse_clang_ast_calls(ast_root)
+    for identity, file in _unseeded_decl_endpoints(ast_root, type_edges, call_edges):
+        if not identity or not file:
+            continue
+        node_id = _decl_node_id(identity)
+        if graph.has_node(node_id):
+            # Already seeded as a real function/variable.
+            continue
+        origin = classify_origin(
+            file, header_segs, dir_segs, have_public_set=have_public_set
+        )
+        graph.add_node(
+            GraphNode(
+                id=node_id,
+                kind="source_decl",
+                label=identity,
+                provenance=_PROVENANCE,
+                confidence=CONF_HIGH,
+                attrs=(
+                    {"visibility": origin.value}
+                    if origin != ScopeOrigin.UNKNOWN
+                    else {}
+                ),
+            )
+        )
+    augment_graph_with_types(graph, type_edges)
+    augment_graph_with_calls(graph, call_edges)
+    # A header-only pass is a single parse over the whole header aggregate —
+    # never narrowed/scoped like a per-compile-unit build-integrated pass, and
+    # ``_clang_header_dump`` raises on a failed/empty parse rather than
+    # returning a degraded partial result (ADR-028 D3 "never abort collection"
+    # lives one layer up, in the caller's try/except around the clang
+    # invocation) — so reaching this line means the whole pass ran cleanly.
+    # Stamped unconditionally, regardless of edge count (ADR-041 P0 slice 2
+    # coverage-honesty convention: "ran, zero output" must be distinguishable
+    # from "never ran").
+    graph.extractor_passes[HEADER_CALL_GRAPH_PASS] = True
+    graph.extractor_passes[HEADER_TYPE_GRAPH_PASS] = True
+
+
+def _seed_flat_graph(
+    graph: SourceGraphSummary, snapshot: AbiSnapshot, header_node: Callable[[str], str]
+) -> None:
+    """Recover structural edges from the flat snapshot when no clang AST exists.
+
+    clang missing/unselected (the default L2 backend is castxml) — still
+    recover the three structural edge kinds directly from the flat snapshot
+    already parsed, rather than leaving the graph at declaration-visibility
+    nodes only. No second compiler invocation needed: every L2 backend
+    populates ``RecordType.bases``/``.fields``/``Function.return_type``/
+    ``.params``/``Variable.type`` identically (see
+    :func:`_flat_structural_type_edges`).
+    """
+    for rt in snapshot.types:
+        _seed_flat_type_node(
+            graph, header_node, rt.name, "record_type", rt.origin, rt.source_header
+        )
+    for en in snapshot.enums:
+        _seed_flat_type_node(
+            graph, header_node, en.name, "enum_type", en.origin, en.source_header
+        )
+    augment_graph_with_types(graph, _flat_structural_type_edges(snapshot))
+    # Only the structural pass ran — no bodies were ever visible to the flat
+    # model, in any circumstance, so ``HEADER_CALL_GRAPH_PASS`` must never be
+    # stamped here (that would falsely vouch for a project-wide zero on
+    # ``DECL_CALLS_DECL``/``DECL_REFERENCES_DECL``). Nor may
+    # ``HEADER_TYPE_GRAPH_PASS`` be stamped when the snapshot itself recorded a
+    # PE/Mach-O header-scope fallback (``scope_fallback`` — mangling mismatch or
+    # an unavailable header backend): that state's ``functions``/``types`` are
+    # placeholder export-table entries or a PDB-recovered approximation, not a
+    # genuine header parse, so this was never a real structural scan of the
+    # declared types at all (Codex review) — stamping it would let a later real
+    # header dump's first structural edge misread as newly added.
+    if not snapshot.scope_fallback:
+        graph.extractor_passes[HEADER_TYPE_GRAPH_PASS] = True
+
+
 def build_header_only_graph(
     snapshot: AbiSnapshot,
     ast_root: dict[str, Any] | None = None,
@@ -414,155 +595,11 @@ def build_header_only_graph(
         seed_decl(var)
 
     if ast_root is not None:
-        # Type nodes are seeded straight from the AST's own qualified-name
-        # index, not from ``snapshot.types``/``snapshot.enums``: the flat
-        # snapshot model records a *bare*, unqualified type name (see
-        # ``dumper_clang._ClangAstParser._build_record``), while the type
-        # graph's node ids are the AST's *resolved qualified* name
-        # (``ns::Widget``) — two representations that would silently fail to
-        # join on any namespaced type. Deriving both the file (hence origin)
-        # and the node id from the same AST index sidesteps that mismatch
-        # entirely, and covers the ADR's own headline case: a public struct
-        # rarely has its own exported binary symbol, so it needs its
-        # ``visibility`` set directly on the type node to act as a valid
-        # graph "entry" (``is_public_dependency_node``).
-        for qname, file in index_declared_type_files(ast_root).items():
-            origin = classify_origin(
-                file, header_segs, dir_segs, have_public_set=have_public_set
-            )
-            if origin == ScopeOrigin.UNKNOWN:
-                continue
-            node_id = _type_node_id(qname)
-            # ``augment_graph_with_types`` defaults every AST-only type node to
-            # "record_type" uniformly (it cannot distinguish record/enum/
-            # typedef without an L4 surface) — matching that convention here
-            # keeps first-writer-wins joins consistent either way.
-            graph.add_node(
-                GraphNode(
-                    id=node_id,
-                    kind="record_type",
-                    label=qname,
-                    provenance=_PROVENANCE,
-                    confidence=CONF_HIGH,
-                    attrs={"visibility": origin.value},
-                )
-            )
-            hid = header_node(file)
-            graph.add_edge(
-                GraphEdge(
-                    src=hid,
-                    dst=node_id,
-                    kind="SOURCE_DECLARES",
-                    provenance=_PROVENANCE,
-                    confidence=CONF_HIGH,
-                )
-            )
-
-        type_edges = parse_clang_ast_types(ast_root)
-        call_edges = parse_clang_ast_calls(ast_root)
-        # Annotate any AST-only decl target `augment_graph_with_types`/
-        # `augment_graph_with_calls` would otherwise create with no
-        # provenance at all — a private declaration that isn't a function or
-        # (namespace-scope) variable, e.g. an `EnumConstantDecl` referenced
-        # by `inline int f() { return Color::RED; }`, is never seeded by the
-        # `snapshot.functions`/`snapshot.variables` loop above, since the
-        # flat AbiSnapshot model has no equivalent per-enumerator entity to
-        # iterate. The build-integrated path backfills this via
-        # `augment_graph_with_types`'s `project_files` parameter (matched
-        # against `BuildEvidence`'s compile-unit sources); a header-only
-        # world has no such set, but each edge already carries its own
-        # target's declaring file (`dst_file`/`callee_file`/`caller_file`),
-        # which is exactly what `classify_origin` needs (Codex review).
-        #
-        # A `DECL_REFERENCES_DECL` edge's *source* can be unseeded too — a
-        # field's default member initializer (`struct Widget { int x =
-        # detail::k; };`) makes `Widget::x` the edge's `src`, and a field is
-        # never in `snapshot.functions`/`snapshot.variables` either (Codex
-        # review). Unlike the targets above, `TypeEdge` carries no
-        # `src_file`, so this falls back to `index_declared_entity_files`
-        # (the unfiltered declaring-file index, including fields) — computed
-        # once, lazily, only if there is at least one such source to look up.
-        # A source that was already seeded (a real function/variable) is
-        # simply skipped below by the existing `graph.has_node` check.
-        ref_srcs = {e.src for e in type_edges if e.kind == "DECL_REFERENCES_DECL"}
-        entity_files = index_declared_entity_files(ast_root) if ref_srcs else {}
-        for identity, file in (
-            *(
-                (e.dst, e.dst_file)
-                for e in type_edges
-                if e.kind == "DECL_REFERENCES_DECL"
-            ),
-            *((src, entity_files.get(src, "")) for src in ref_srcs),
-            *((e.caller, e.caller_file) for e in call_edges),
-            *((e.callee, e.callee_file) for e in call_edges),
-        ):
-            if not identity or not file:
-                continue
-            node_id = _decl_node_id(identity)
-            if graph.has_node(node_id):
-                continue
-            origin = classify_origin(
-                file, header_segs, dir_segs, have_public_set=have_public_set
-            )
-            attrs = (
-                {"visibility": origin.value} if origin != ScopeOrigin.UNKNOWN else {}
-            )
-            graph.add_node(
-                GraphNode(
-                    id=node_id,
-                    kind="source_decl",
-                    label=identity,
-                    provenance=_PROVENANCE,
-                    confidence=CONF_HIGH,
-                    attrs=attrs,
-                )
-            )
-
-        augment_graph_with_types(graph, type_edges)
-        augment_graph_with_calls(graph, call_edges)
-        # A header-only pass is a single parse over the whole header
-        # aggregate — never narrowed/scoped like a per-compile-unit
-        # build-integrated pass, and ``_clang_header_dump`` raises on a
-        # failed/empty parse rather than returning a degraded partial result
-        # (ADR-028 D3 "never abort collection" lives one layer up, in the
-        # caller's try/except around the clang invocation) — so reaching
-        # this line means the whole pass ran cleanly. Stamp unconditionally,
-        # regardless of edge count (ADR-041 P0 slice 2 coverage-honesty
-        # convention: "ran, zero output" must be distinguishable from
-        # "never ran").
-        graph.extractor_passes[HEADER_CALL_GRAPH_PASS] = True
-        graph.extractor_passes[HEADER_TYPE_GRAPH_PASS] = True
+        _seed_ast_graph(
+            graph, ast_root, header_node, header_segs, dir_segs, have_public_set
+        )
     else:
-        # No clang AST available (clang missing/unselected — the default L2
-        # backend is castxml) — still recover the three structural edge
-        # kinds directly from the flat snapshot already parsed, rather than
-        # leaving the graph at declaration-visibility nodes only. No second
-        # compiler invocation needed: every L2 backend populates
-        # ``RecordType.bases``/``.fields``/``Function.return_type``/``.params``/
-        # ``Variable.type`` identically (see :func:`_flat_structural_type_edges`).
-        for rt in snapshot.types:
-            _seed_flat_type_node(
-                graph, header_node, rt.name, "record_type", rt.origin, rt.source_header
-            )
-        for en in snapshot.enums:
-            _seed_flat_type_node(
-                graph, header_node, en.name, "enum_type", en.origin, en.source_header
-            )
-        augment_graph_with_types(graph, _flat_structural_type_edges(snapshot))
-        # Only the structural pass ran — no bodies were ever visible to the
-        # flat model, in any circumstance, so ``HEADER_CALL_GRAPH_PASS`` must
-        # never be stamped here (that would falsely vouch for a project-wide
-        # zero on ``DECL_CALLS_DECL``/``DECL_REFERENCES_DECL``). Nor may
-        # ``HEADER_TYPE_GRAPH_PASS`` be stamped when the snapshot itself
-        # recorded a PE/Mach-O header-scope fallback (``scope_fallback`` —
-        # mangling mismatch or an unavailable header backend): that state's
-        # ``functions``/``types`` are placeholder export-table entries or a
-        # PDB-recovered approximation, not a genuine header parse, so this
-        # was never a real structural scan of the declared types at all
-        # (Codex review) — stamping it would let a later real-header dump's
-        # first structural edge misread as newly added.
-        if not snapshot.scope_fallback:
-            graph.extractor_passes[HEADER_TYPE_GRAPH_PASS] = True
+        _seed_flat_graph(graph, snapshot, header_node)
 
     return graph.finalize()
 

--- a/abicheck/buildsource/include_graph.py
+++ b/abicheck/buildsource/include_graph.py
@@ -118,6 +118,101 @@ _DEPFILE_OUTPUT_PREFIXES = (
 )
 
 
+def _expand_argv_response_files(
+    args: list[str],
+    unwrapped: list[str],
+    directory: str | None,
+    trusted_root: str | None,
+) -> list[str]:
+    """Expand any remaining ``@response-file`` token in *args*, or leave it be.
+
+    Only expands when both *directory* (the compile unit's own working
+    directory, used to resolve a *relative* ``@file`` token) and *trusted_root*
+    (an independently-sourced, verified-real directory the expansion must stay
+    under) are given -- see :func:`depfile_args_from_argv`'s docstring for why
+    *trusted_root* must not simply be *directory*.
+    """
+    if (
+        directory is None
+        or trusted_root is None
+        or not any(a.startswith("@") and len(a) > 1 for a in args)
+    ):
+        return args
+
+    from pathlib import Path
+
+    from ..build_context import (
+        _expand_response_files,
+        _is_cl_style_driver,
+        _safe_resolve,
+    )
+    from .source_extractors._argv import unredact_home
+
+    # Response-file quoting depends on the driver actually invoked, not the
+    # host OS (Codex review) -- unwrapped[0] is still the compiler token here
+    # (the flags-only branch in the caller has not stripped it from *unwrapped*).
+    cl_style = (
+        bool(unwrapped)
+        and not unwrapped[0].startswith("-")
+        and _is_cl_style_driver(unredact_home(unwrapped[0]))
+    )
+
+    # unredact_home() first: a persisted CompileUnit.directory (and any
+    # individual @response-file argument, e.g. "@~/build/args.rsp") may carry
+    # RedactionPolicy's "~" home-dir placeholder, which bare Path() would treat
+    # as a literal, non-existent relative component (Path("~/build") stays
+    # under the process cwd and is never is_absolute(), so an absolute redacted
+    # @file token would even be wrongly joined onto cu_dir instead of resolved
+    # on its own) -- silently failing every response-file expansion for a
+    # redacted compile unit otherwise (Codex review, two rounds). Unredacting
+    # an already-real (non-redacted) token is a harmless no-op.
+    cu_dir = Path(unredact_home(directory))
+    root_dir = Path(unredact_home(trusted_root))
+    return _expand_response_files(
+        [unredact_home(a) for a in args],
+        cu_dir,
+        _safe_resolve(root_dir) or root_dir,
+        cl_style=cl_style,
+    )
+
+
+def _depfile_token_takes_value(tok: str) -> bool:
+    """True for a flag whose *next* argv token is its value and must go too."""
+    return tok == "--config" or tok in (
+        _DEPFILE_DROP_WITH_VALUE | _DEPFILE_UNSAFE_WITH_VALUE | _DEPFILE_OUTPUT_WITH_VALUE
+    )
+
+
+def _depfile_token_dropped(tok: str) -> bool:
+    """True for a standalone token that must not reach ``clang -MM``.
+
+    Covers unsafe/output flags and their prefixes, an unexpanded ``@file``, the
+    glued ``-oFOO``/``-MFfoo.d`` forms and the GCC long ``--output=foo.o``
+    spelling (clang ``-M`` with ``--output=`` writes the depfile to that file
+    and leaves stdout empty, losing the include entry -- Codex review), and
+    warning/diagnostic flags: those do not affect the include closure, but can
+    turn a harmless clang depfile-replay warning into a hard failure when the
+    original Bazel/GCC action recorded ``-Werror``.
+    """
+    if tok.startswith("@"):
+        return True
+    if tok in _DEPFILE_UNSAFE_FLAG or tok in _DEPFILE_OUTPUT_FLAG:
+        return True
+    if tok.startswith(_DEPFILE_UNSAFE_PREFIXES) or tok.startswith(
+        _DEPFILE_OUTPUT_PREFIXES
+    ):
+        return True
+    if tok.startswith("--output="):
+        return True
+    if any(tok.startswith(f) and tok != f for f in ("-o", "-MF", "-MT", "-MQ", "-MJ")):
+        return True
+    if tok in _DEPFILE_DROP_FLAG:
+        return True
+    return tok.startswith(_DEPFILE_DROP_PREFIXES) or (
+        tok.startswith("-W") and not tok.startswith("-Wp,")
+    )
+
+
 def depfile_args_from_argv(
     argv: list[str],
     directory: str | None = None,
@@ -177,91 +272,17 @@ def depfile_args_from_argv(
         if unwrapped and not unwrapped[0].startswith("-")
         else list(unwrapped)
     )
-    if (
-        directory is not None
-        and trusted_root is not None
-        and any(a.startswith("@") and len(a) > 1 for a in args)
-    ):
-        from pathlib import Path
-
-        from ..build_context import (
-            _expand_response_files,
-            _is_cl_style_driver,
-            _safe_resolve,
-        )
-        from .source_extractors._argv import unredact_home
-
-        # Response-file quoting depends on the driver actually invoked, not
-        # the host OS (Codex review) -- unwrapped[0] is still the compiler
-        # token here (the flags-only branch above hasn't stripped it yet).
-        cl_style = (
-            bool(unwrapped)
-            and not unwrapped[0].startswith("-")
-            and (_is_cl_style_driver(unredact_home(unwrapped[0])))
-        )
-
-        # The compile unit's own working directory is the base a relative
-        # @file resolves against; *trusted_root* (an independently-sourced,
-        # verified-real directory -- NOT `directory` itself, see the
-        # docstring) is the jail it must stay under. unredact_home() first:
-        # a persisted CompileUnit.directory (and any individual
-        # @response-file argument, e.g. "@~/build/args.rsp") may carry
-        # RedactionPolicy's "~" home-dir placeholder, which bare Path()
-        # would treat as a literal, non-existent relative component
-        # (Path("~/build") stays under the process cwd and is never
-        # is_absolute(), so an absolute redacted @file token would even be
-        # wrongly joined onto cu_dir instead of resolved on its own) --
-        # silently failing every response-file expansion for a redacted
-        # compile unit otherwise (Codex review, two rounds). Unredacting an
-        # already-real (non-redacted) token is a harmless no-op.
-        cu_dir = Path(unredact_home(directory))
-        root_dir = Path(unredact_home(trusted_root))
-        args = [unredact_home(a) for a in args]
-        args = _expand_response_files(
-            args, cu_dir, _safe_resolve(root_dir) or root_dir, cl_style=cl_style
-        )
+    args = _expand_argv_response_files(args, unwrapped, directory, trusted_root)
     out: list[str] = []
     skip_next = False
     for tok in args:
         if skip_next:
             skip_next = False
             continue
-        if (
-            tok in _DEPFILE_DROP_WITH_VALUE
-            or tok in _DEPFILE_UNSAFE_WITH_VALUE
-            or tok in _DEPFILE_OUTPUT_WITH_VALUE
-        ):
+        if _depfile_token_takes_value(tok):
             skip_next = True
             continue
-        if tok == "--config":
-            skip_next = True
-            continue
-        if tok.startswith("@"):
-            continue
-        if (
-            tok in _DEPFILE_UNSAFE_FLAG
-            or tok in _DEPFILE_OUTPUT_FLAG
-            or tok.startswith(_DEPFILE_UNSAFE_PREFIXES)
-            or tok.startswith(_DEPFILE_OUTPUT_PREFIXES)
-        ):
-            continue
-        # `-oFOO` / `-MFfoo.d` glued forms and the GCC long `--output=foo.o`
-        # spelling (clang -M with --output=… writes the depfile to that file and
-        # leaves stdout empty, losing the include entry — Codex review).
-        if tok.startswith("--output="):
-            continue
-        if any(
-            tok.startswith(f) and tok != f for f in ("-o", "-MF", "-MT", "-MQ", "-MJ")
-        ):
-            continue
-        if tok in _DEPFILE_DROP_FLAG:
-            continue
-        # Warning/diagnostic flags do not affect the include closure, but they
-        # can turn harmless clang depfile replay warnings into hard failures when
-        # the original Bazel/GCC action recorded `-Werror`.
-        if tok.startswith(_DEPFILE_DROP_PREFIXES) or (
-            tok.startswith("-W") and not tok.startswith("-Wp,")
-        ):
+        if _depfile_token_dropped(tok):
             continue
         out.append(tok)
     return out

--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -144,6 +144,72 @@ _TOP_LEVEL_STR_KEYS: frozenset[str] = frozenset({"exit_code_scheme"})
 _TOP_LEVEL_INT_KEYS: frozenset[str] = frozenset({"version"})
 
 
+
+def _block(data: dict[str, object], key: str) -> dict[str, object]:
+    """One top-level config block as a mapping (``{}`` when absent or wrong-typed).
+
+    A wrong type here is never silently accepted -- :meth:`BuildConfig.
+    _validate_structure` already rejected it -- so falling back to ``{}`` only
+    covers a caller that bypassed validation with a non-dict payload.
+    """
+    value = data.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _str(d: dict[str, object], key: str, default: str = "") -> str:
+    v = d.get(key)
+    return v if isinstance(v, str) else default
+
+
+def _opt_str(d: dict[str, object], key: str) -> str | None:
+    v = d.get(key)
+    return v if isinstance(v, str) else None
+
+
+def _opt_bool(d: dict[str, object], key: str) -> bool | None:
+    v = d.get(key)
+    return v if isinstance(v, bool) else None
+
+
+def _strs(d: dict[str, object], key: str) -> list[str]:
+    v = d.get(key)
+    if isinstance(v, list):
+        return [str(x) for x in v]
+    if isinstance(v, str):
+        return [v]
+    return []
+
+
+def _lowered(value: str | None) -> str | None:
+    """Case-normalize an optional enum-ish config scalar."""
+    return value.lower() if value is not None else None
+
+
+def _one_of(
+    value: str | None, allowed: tuple[str, ...] | frozenset[str], where: str
+) -> str | None:
+    """*value* if it is ``None`` or a member of *allowed*, else ``ValueError``."""
+    if value is not None and value not in allowed:
+        raise ValueError(f"{where} must be one of {allowed}, got {value!r}")
+    return value
+
+
+def _safe_compile_atom(key: str, value: str) -> str:
+    """One ``compile.*`` scalar, rejected unless it is a single argv atom.
+
+    Values from auto-discovered source-tree configs are later embedded in
+    individual compiler flags (``-std=<value>``/``-D<value>``) and flow through
+    legacy shlex-split ``gcc_options`` plumbing. Reject whitespace so one
+    config scalar cannot become multiple compiler arguments such as
+    ``-Xclang -load ./evil.so``.
+    """
+    if not value or any(ch.isspace() for ch in value):
+        raise ValueError(
+            f"compile.{key} must be a single compiler option atom, got {value!r}"
+        )
+    return value
+
+
 @dataclass
 class BuildConfig:
     """Parsed ``.abicheck.yml`` project config (ADR-028 amendment D4 + ADR-037 D4).
@@ -280,6 +346,70 @@ class BuildConfig:
     }
 
     @classmethod
+    def _scalar_findings(cls, key: str, value: object) -> list[str]:
+        """Type findings for a recognized top-level *scalar* key.
+
+        ``risk_rules``/``crosschecks`` are deliberately excluded:
+        :meth:`from_dict` never parses them at all (they are consumed by
+        ``risk.py``/``crosscheck.py`` instead), so there is no from_dict-level
+        type contract to enforce for them here.
+        """
+        if value is None:
+            return []
+        if key in _TOP_LEVEL_STR_KEYS and not isinstance(value, str):
+            return [f"{key} must be a string, got {type(value).__name__}: {value!r}"]
+        if key in _TOP_LEVEL_INT_KEYS and (
+            not isinstance(value, int) or isinstance(value, bool)
+        ):
+            return [f"{key} must be an integer, got {type(value).__name__}: {value!r}"]
+        return []
+
+    @classmethod
+    def _subkey_findings(cls, key: str, sub: str, sub_value: object) -> list[str]:
+        """Type findings for one ``<block>.<subkey>`` entry."""
+        if sub in _BOOL_SUBKEYS.get(key, ()) and not isinstance(sub_value, bool):
+            return [
+                f"{key}.{sub} must be a boolean, got "
+                f"{type(sub_value).__name__}: {sub_value!r}"
+            ]
+        if sub in _STR_SUBKEYS.get(key, ()) and not isinstance(sub_value, str):
+            return [
+                f"{key}.{sub} must be a string, got "
+                f"{type(sub_value).__name__}: {sub_value!r}"
+            ]
+        if sub not in _LIST_SUBKEYS.get(key, ()):
+            return []
+        if not isinstance(sub_value, (list, str)):
+            return [
+                f"{key}.{sub} must be a string or list of strings, "
+                f"got {type(sub_value).__name__}: {sub_value!r}"
+            ]
+        # `_strs()` accepts a list container but a non-string element must be
+        # rejected outright, not coerced via `str(x)`.
+        bad = [x for x in sub_value if not isinstance(x, str)] if isinstance(sub_value, list) else []
+        if bad:
+            return [
+                f"{key}.{sub} must be a list of strings, got "
+                f"non-string element(s): {bad!r}"
+            ]
+        return []
+
+    @classmethod
+    def _block_findings(cls, key: str, value: object, known_block: object) -> list[str]:
+        """Type findings for one recognized top-level *block* key."""
+        if value is None:
+            return []
+        if not isinstance(value, dict):
+            return [f"{key} must be a mapping, got {type(value).__name__}: {value!r}"]
+        findings: list[str] = []
+        for sub, sub_value in value.items():
+            if sub not in known_block:  # type: ignore[operator]
+                findings.append(f"unknown .abicheck.yml key {key}.{sub!r}")
+                continue
+            findings += cls._subkey_findings(key, sub, sub_value)
+        return findings
+
+    @classmethod
     def _validate_structure(cls, data: dict[str, object]) -> None:
         """Raise ``ValueError`` for every structural problem in a raw ``.abicheck.yml``.
 
@@ -299,194 +429,47 @@ class BuildConfig:
                 continue
             known_block = cls._KNOWN_BLOCK_KEYS.get(key)
             if known_block is None:
-                # A recognized top-level *scalar* (not a block key) — e.g.
-                # exit_code_scheme/version. risk_rules/crosschecks are
-                # deliberately excluded: from_dict never parses them at all
-                # (consumed by risk.py/crosscheck.py instead), so there is no
-                # from_dict-level type contract to enforce here.
-                if value is not None:
-                    if key in _TOP_LEVEL_STR_KEYS and not isinstance(value, str):
-                        findings.append(
-                            f"{key} must be a string, got "
-                            f"{type(value).__name__}: {value!r}"
-                        )
-                    elif key in _TOP_LEVEL_INT_KEYS and (
-                        not isinstance(value, int) or isinstance(value, bool)
-                    ):
-                        findings.append(
-                            f"{key} must be an integer, got "
-                            f"{type(value).__name__}: {value!r}"
-                        )
-                continue
-            if value is None:
-                continue
-            if not isinstance(value, dict):
-                findings.append(
-                    f"{key} must be a mapping, got {type(value).__name__}: {value!r}"
-                )
-                continue
-            for sub, sub_value in value.items():
-                if sub not in known_block:
-                    findings.append(f"unknown .abicheck.yml key {key}.{sub!r}")
-                    continue
-                if sub in _BOOL_SUBKEYS.get(key, ()) and not isinstance(
-                    sub_value, bool
-                ):
-                    findings.append(
-                        f"{key}.{sub} must be a boolean, got "
-                        f"{type(sub_value).__name__}: {sub_value!r}"
-                    )
-                elif sub in _STR_SUBKEYS.get(key, ()) and not isinstance(
-                    sub_value, str
-                ):
-                    findings.append(
-                        f"{key}.{sub} must be a string, got "
-                        f"{type(sub_value).__name__}: {sub_value!r}"
-                    )
-                elif sub in _LIST_SUBKEYS.get(key, ()):
-                    if not isinstance(sub_value, (list, str)):
-                        findings.append(
-                            f"{key}.{sub} must be a string or list of strings, "
-                            f"got {type(sub_value).__name__}: {sub_value!r}"
-                        )
-                    elif isinstance(sub_value, list):
-                        # `_strs()` accepts a list container but a non-string
-                        # element must be rejected outright, not coerced via
-                        # `str(x)`.
-                        bad = [x for x in sub_value if not isinstance(x, str)]
-                        if bad:
-                            findings.append(
-                                f"{key}.{sub} must be a list of strings, got "
-                                f"non-string element(s): {bad!r}"
-                            )
+                findings += cls._scalar_findings(key, value)
+            else:
+                findings += cls._block_findings(key, value, known_block)
         if findings:
             raise ValueError("; ".join(findings))
-
     @classmethod
     def from_dict(cls, data: dict[str, object]) -> BuildConfig:
         if isinstance(data, dict):
             cls._validate_structure(data)
-        build = data.get("build") if isinstance(data, dict) else None
-        build = build if isinstance(build, dict) else {}
-        sources = data.get("sources") if isinstance(data, dict) else None
-        sources = sources if isinstance(sources, dict) else {}
-        severity = data.get("severity") if isinstance(data, dict) else None
-        severity = severity if isinstance(severity, dict) else {}
-        scope = data.get("scope") if isinstance(data, dict) else None
-        scope = scope if isinstance(scope, dict) else {}
-        suppression = data.get("suppression") if isinstance(data, dict) else None
-        suppression = suppression if isinstance(suppression, dict) else {}
-        source = data.get("source") if isinstance(data, dict) else None
-        source = source if isinstance(source, dict) else {}
-        compile_blk = data.get("compile") if isinstance(data, dict) else None
-        compile_blk = compile_blk if isinstance(compile_blk, dict) else {}
-        debug = data.get("debug") if isinstance(data, dict) else None
-        debug = debug if isinstance(debug, dict) else {}
-
-        def _str(d: dict[str, object], key: str, default: str = "") -> str:
-            v = d.get(key)
-            return v if isinstance(v, str) else default
-
-        def _opt_str(d: dict[str, object], key: str) -> str | None:
-            v = d.get(key)
-            return v if isinstance(v, str) else None
-
-        def _opt_bool(d: dict[str, object], key: str) -> bool | None:
-            v = d.get(key)
-            return v if isinstance(v, bool) else None
-
-        def _strs(d: dict[str, object], key: str) -> list[str]:
-            v = d.get(key)
-            if isinstance(v, list):
-                return [str(x) for x in v]
-            if isinstance(v, str):
-                return [v]
-            return []
-
-        def _safe_compile_atom(key: str, value: str) -> str:
-            # Values from auto-discovered source-tree configs are later embedded
-            # in individual compiler flags (``-std=<value>``/``-D<value>``) and
-            # flow through legacy shlex-split ``gcc_options`` plumbing.  Reject
-            # whitespace so one config scalar cannot become multiple compiler
-            # arguments such as ``-Xclang -load ./evil.so``.
-            if not value or any(ch.isspace() for ch in value):
-                raise ValueError(
-                    f"compile.{key} must be a single compiler option atom, got {value!r}"
-                )
-            return value
+        top = data if isinstance(data, dict) else {}
+        build = _block(top, "build")
+        sources = _block(top, "sources")
+        severity = _block(top, "severity")
+        scope = _block(top, "scope")
+        suppression = _block(top, "suppression")
+        source = _block(top, "source")
+        compile_blk = _block(top, "compile")
+        debug = _block(top, "debug")
 
         def _safe_compile_atoms(key: str) -> list[str]:
             return [_safe_compile_atom(key, item) for item in _strs(compile_blk, key)]
 
         def _level(key: str) -> str | None:
-            raw = _opt_str(severity, key)
-            if raw is not None and raw not in _SEVERITY_LEVELS:
-                raise ValueError(
-                    f"severity.{key} must be one of {_SEVERITY_LEVELS}, got {raw!r}"
-                )
-            return raw
+            return _one_of(_opt_str(severity, key), _SEVERITY_LEVELS, f"severity.{key}")
 
-        graph_detail = _str(sources, "graph", "summary") or "summary"
-        if graph_detail not in ("summary", "full"):
-            raise ValueError(
-                f"sources.graph must be 'summary' or 'full', got {graph_detail!r}"
-            )
-
-        preset = _opt_str(severity, "preset")
-        if preset is not None and preset not in _SEVERITY_PRESETS:
-            raise ValueError(
-                f"severity.preset must be one of {_SEVERITY_PRESETS}, got {preset!r}"
-            )
-
-        scheme = (
-            _str(data if isinstance(data, dict) else {}, "exit_code_scheme", "auto")
-            or "auto"
-        )
-        if scheme not in _EXIT_CODE_SCHEMES:
-            raise ValueError(
-                f"exit_code_scheme must be one of {_EXIT_CODE_SCHEMES}, got {scheme!r}"
-            )
-
-        version_raw = data.get("version") if isinstance(data, dict) else None
-        version = (
-            version_raw
-            if isinstance(version_raw, int) and not isinstance(version_raw, bool)
-            else 0
-        )
-
-        debug_format = _opt_str(debug, "format")
-        if debug_format is not None:
-            debug_format = debug_format.lower()
-            if debug_format not in ("auto", "dwarf", "btf", "ctf"):
-                raise ValueError(
-                    "debug.format must be one of ('auto', 'dwarf', 'btf', 'ctf'), "
-                    f"got {debug_format!r}"
-                )
-
-        compile_frontend = _opt_str(compile_blk, "frontend")
-        if compile_frontend is not None:
-            # The CLI accepts the frontend case-insensitively (Click Choice
-            # case_sensitive=False); normalize the config value to match.
-            compile_frontend = compile_frontend.lower()
-        if compile_frontend is not None and compile_frontend not in (
-            "auto",
-            "castxml",
-            "clang",
-            "hybrid",
-        ):
-            raise ValueError(
-                "compile.frontend must be one of ('auto', 'castxml', 'clang', "
-                f"'hybrid'), got {compile_frontend!r}"
-            )
-
+        version_raw = top.get("version")
         return cls(
             system=_str(build, "system", "auto") or "auto",
             query=_str(build, "query"),
             compile_db=_str(build, "compile_db"),
             public_headers=_strs(sources, "public_headers"),
             exclude=_strs(sources, "exclude"),
-            graph_detail=graph_detail,
-            severity_preset=preset,
+            graph_detail=_one_of(
+                _str(sources, "graph", "summary") or "summary",
+                ("summary", "full"),
+                "sources.graph",
+            )
+            or "summary",
+            severity_preset=_one_of(
+                _opt_str(severity, "preset"), _SEVERITY_PRESETS, "severity.preset"
+            ),
             severity_abi_breaking=_level("abi_breaking"),
             severity_potential_breaking=_level("potential_breaking"),
             severity_quality_issues=_level("quality_issues"),
@@ -500,7 +483,13 @@ class BuildConfig:
                 suppression, "require_justification"
             ),
             source_method=_opt_str(source, "method"),
-            compile_frontend=compile_frontend,
+            # The CLI accepts the frontend case-insensitively (Click Choice
+            # case_sensitive=False); normalize the config value to match.
+            compile_frontend=_one_of(
+                _lowered(_opt_str(compile_blk, "frontend")),
+                ("auto", "castxml", "clang", "hybrid"),
+                "compile.frontend",
+            ),
             compile_std=(
                 _safe_compile_atom("std", std)
                 if (std := _opt_str(compile_blk, "std")) is not None
@@ -510,12 +499,25 @@ class BuildConfig:
             compile_defines=_safe_compile_atoms("defines"),
             compile_sysroot=_opt_str(compile_blk, "sysroot"),
             compile_nostdinc=_opt_bool(compile_blk, "nostdinc"),
-            debug_format=debug_format,
+            debug_format=_one_of(
+                _lowered(_opt_str(debug, "format")),
+                ("auto", "dwarf", "btf", "ctf"),
+                "debug.format",
+            ),
             debug_dwarf_only=_opt_bool(debug, "dwarf_only"),
             debug_debuginfod=_opt_bool(debug, "debuginfod"),
             debug_debuginfod_url=_opt_str(debug, "debuginfod_url"),
-            exit_code_scheme=scheme,
-            version=version,
+            exit_code_scheme=_one_of(
+                _str(top, "exit_code_scheme", "auto") or "auto",
+                _EXIT_CODE_SCHEMES,
+                "exit_code_scheme",
+            )
+            or "auto",
+            version=(
+                version_raw
+                if isinstance(version_raw, int) and not isinstance(version_raw, bool)
+                else 0
+            ),
         )
 
     def _build_block(self) -> dict[str, Any]:

--- a/abicheck/buildsource/inputs_emit.py
+++ b/abicheck/buildsource/inputs_emit.py
@@ -344,6 +344,174 @@ def _reject_escaping_filename(name: str) -> None:
         )
 
 
+def _normalize_compacted_filename(output_filename: str, compress: bool) -> tuple[str, bool]:
+    """``(filename, compress)`` with a scan-discoverable extension.
+
+    Compression is inferred from a caller-supplied ``.gz`` name too, same as
+    :func:`append_source_facts` (CodeRabbit review, P2). The default directory
+    scan :func:`_iter_source_fact_files` runs on every later read only
+    recognizes ``*.jsonl(.gz)`` and ``*.json(.gz)`` -- a caller-supplied
+    basename without one of those (e.g. ``--output-filename merged``) writes a
+    merged file that scan can never find. Compaction would then "succeed" with
+    zero diagnostics, delete the originals it merged, and the pack would
+    silently ingest as zero TUs from that point on (Codex review, P2,
+    reproduced empirically for both the compressed and uncompressed case).
+    """
+    compress = compress or output_filename.endswith(".gz")
+    base = (
+        output_filename[: -len(".gz")]
+        if output_filename.endswith(".gz")
+        else output_filename
+    )
+    if not (base.endswith(".jsonl") or base.endswith(".json")):
+        base = f"{base}.jsonl"
+    return (f"{base}.gz" if compress else base), compress
+
+
+def _last_record_wins(
+    files: list[Path], sink: list[str]
+) -> tuple[dict[str, SourceAbiTu], list[SourceAbiTu]]:
+    """Read *files* in (sorted, deterministic) order, keeping the last-seen
+    record per tu_id -- append order within/between files, never a timestamp
+    comparison. A no-tu_id record is never deduped ("" cannot be treated as a
+    real shared identity between otherwise-unrelated TUs, Codex review, P2).
+
+    A non-empty tu_id seen more than once *within this bucket* (as opposed to
+    a fresh record correctly superseding a stale prior-compaction record,
+    handled separately by the caller) is a genuine pack-integrity problem --
+    ``inputs_validate.py``'s own ``duplicate_tu_ids`` check already flags this
+    as an ERROR before compaction. Silently picking one via last-wins would
+    make compaction delete the losing record's file (*remove_originals*) and
+    erase the very duplicate the validator would otherwise catch, discarding
+    one TU's facts with no trace (Codex review, P2). So this counts as lossy
+    instead, same as any other malformed/ambiguous original.
+    """
+    by_id: dict[str, SourceAbiTu] = {}
+    no_id: list[SourceAbiTu] = []
+    for tu in read_source_fact_files(files, diagnostics=sink):
+        if not tu.tu_id:
+            no_id.append(tu)
+            continue
+        if tu.tu_id in by_id:
+            sink.append(
+                f"duplicate tu_id across source-fact files: {tu.tu_id!r} "
+                "(a race-free per-TU filename should make this impossible)"
+            )
+        by_id[tu.tu_id] = tu
+    return by_id, no_id
+
+
+def _recognized_prior_output(
+    root: Path, manifest: InputsManifest, originals: list[Path], sink: list[str]
+) -> tuple[Path | None, list[Path]]:
+    """``(prior_path, prior_files)`` for a previous compaction's own output.
+
+    Recognized via the explicit ``manifest.last_compacted`` pointer (written
+    after every successful compaction) rather than by matching *this* run's
+    output path or comparing file mtimes: a ``--compress`` toggle or a custom
+    ``--output-filename`` between two ``compact`` calls changes the output
+    path, defeating a path match, and a rebuild's freshly-rewritten per-TU
+    file can land in the same filesystem timestamp tick as the previous
+    compaction's write, which an mtime "which is newer" check cannot break
+    correctly (Codex review, P2 -- both findings, the second reproduced
+    empirically by a regression test on some filesystems).
+    """
+    if not manifest.last_compacted:
+        return None, []
+    candidate = _safe_pack_path(root, manifest.last_compacted, sink)
+    if candidate is None:
+        return None, []
+    candidate = candidate.resolve()
+    return candidate, [f for f in originals if f.resolve() == candidate]
+
+
+def _write_merged_facts(
+    facts_dir: Path, output_path: Path, tus: list[SourceAbiTu], compress: bool
+) -> None:
+    """Write *tus* to *output_path* via temp file + atomic rename.
+
+    Same discipline as ``_write_manifest``, so a concurrent reader never
+    observes a partially-written merge.
+    """
+    fd, tmp = tempfile.mkstemp(dir=str(facts_dir), prefix=".compact.", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "wb") as raw:
+            writer = gzip.GzipFile(fileobj=raw, mode="wb") if compress else raw
+            for tu in tus:
+                writer.write(
+                    (json.dumps(tu.to_dict(), sort_keys=True) + "\n").encode("utf-8")
+                )
+            if compress:
+                writer.close()
+        os.replace(tmp, output_path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
+
+
+def _repoint_manifest_entries(
+    root: Path, manifest: InputsManifest, facts_dir: Path, merged_ref: str
+) -> bool:
+    """Repoint an explicit-file manifest at the merged file. True if changed.
+
+    A manifest that names explicit individual files is repointed at the single
+    merged file (those originals are gone). But any entry that is itself a
+    *directory* reference (``SOURCE_FACTS_DIR`` itself — what the Clang facts
+    plugin's ``ensureManifest()`` always writes, and what a bare default
+    manifest effectively means too — or another sibling facts directory in a
+    hand-written mixed manifest) must NOT be dropped: ``ensureManifest()``
+    never rewrites an existing ``manifest.json``, so losing a directory
+    reference would permanently hide every per-TU file a later incremental
+    build writes into that directory from every subsequent
+    ingest/compact/validate (Codex review, P2 — both the single-entry case and
+    the generalization to a manifest listing a directory alongside other
+    entries, since the original single-entry check collapsed the *whole* list,
+    directory entries included, the moment there was more than one).
+
+    The merged file always physically lands directly inside
+    ``SOURCE_FACTS_DIR``, regardless of what the manifest's entries say -- so a
+    directory entry only "covers" it when the entry *resolves to that exact
+    directory*, not merely an ancestor of it. :func:`_iter_source_fact_files`'s
+    directory scan is non-recursive (one ``glob()``, no descent), so an
+    ancestor entry like ``source_facts=["."]`` can never actually discover a
+    file one level deeper no matter how the two paths relate on paper. A prior
+    version used ``Path(merged_ref).is_relative_to(Path(d))``, which answers
+    "is merged_ref a sub-path of d" -- true for essentially any ancestor --
+    not "would a non-recursive scan of d actually find merged_ref". That
+    silently deleted the very TUs compaction had just merged (review finding,
+    reproduced empirically). Likewise a directory-only manifest that does not
+    itself cover ``SOURCE_FACTS_DIR`` (e.g. ``source_facts=["extra_facts"]``)
+    still needs the merged file added explicitly, or it becomes permanently
+    undiscoverable the same way (Codex review, P2).
+
+    Directory-ness is checked against a scratch diagnostics list, not the
+    caller's: this classification pass re-resolves entries already validated
+    once during discovery, so it must not flip the already-decided lossy
+    outcome or duplicate diagnostics in the caller-visible result.
+    """
+    if not manifest.source_facts:
+        return False
+    facts_dir_resolved = facts_dir.resolve()
+    scratch: list[str] = []
+    directory_entries: list[str] = []
+    covered = False
+    for entry in manifest.source_facts:
+        target = _safe_pack_path(root, entry, scratch)
+        if target is None or not target.is_dir():
+            continue
+        directory_entries.append(entry)
+        if target.resolve() == facts_dir_resolved:
+            covered = True
+    new_source_facts = (
+        list(directory_entries) if covered else [*directory_entries, merged_ref]
+    )
+    if new_source_facts == manifest.source_facts:
+        return False
+    manifest.source_facts = new_source_facts
+    return True
+
+
 def compact_inputs_pack(
     root: Path | str,
     *,
@@ -368,69 +536,38 @@ def compact_inputs_pack(
     **Decoded facts an ingest sees are unchanged** (P1 #25 invariance) —
     compaction (and *compress*, gzipping the merged file) only changes file
     layout/size on disk, never the fact content ``ingest_inputs_pack`` folds.
-    One exception, both deliberate: a *rerun* of compaction (the pack already
-    has a prior compaction's output file, plus fresh per-TU files a later
-    incremental build emitted for since-rebuilt TUs) prefers each fresh
-    per-TU record over the prior output's now-stale record for the same
-    ``tu_id`` — the prior output's records for TUs *not* rebuilt since are
-    still carried forward, never dropped (Codex review, P2). "Prior" is
-    identified via the manifest's ``last_compacted`` pointer (this function
-    writes it after every successful run), not by matching *this* run's
-    output filename or comparing file mtimes: a rerun with a different
-    ``--output-filename``/``--compress`` setting than last time still
-    recognizes last run's output as stale, and a rebuild's freshly-rewritten
-    per-TU file landing in the same filesystem timestamp tick as the
-    previous compaction's write can no longer flip the outcome (Codex
-    review, P2 — both findings, the second reproduced empirically). And a
-    read that produces new diagnostics (a malformed/unreadable original)
+    One exception, deliberate: a *rerun* of compaction (the pack already has a
+    prior compaction's output file, plus fresh per-TU files a later
+    incremental build emitted for since-rebuilt TUs) prefers each fresh per-TU
+    record over the prior output's now-stale record for the same ``tu_id`` —
+    the prior output's records for TUs *not* rebuilt since are still carried
+    forward, never dropped (Codex review, P2). See
+    :func:`_recognized_prior_output` for how "prior" is identified.
+
+    A read that produces new diagnostics (a malformed/unreadable original)
     does **not** write or publish anything and returns ``None`` — check
     *diagnostics* to find out why. Publishing a best-effort merged file
     anyway, while leaving the lossy/malformed originals in place too (the
     previous behavior), let a single malformed sibling silently duplicate
-    every successfully-read TU on the next ingest: the default directory
-    scan sees both the untouched originals and their copies now baked into
-    the merged file (CodeRabbit review, P2 — reproduced empirically: a pack
-    with one malformed ``source_facts`` file reported ``tu_count == 2`` for
-    a single TU, and ``inputs validate`` flagged a duplicate ``tu_id``
-    error). A lossy compaction therefore leaves the pack byte-for-byte
-    unchanged — safe to retry once the offending file is fixed or removed.
+    every successfully-read TU on the next ingest: the default directory scan
+    sees both the untouched originals and their copies now baked into the
+    merged file (CodeRabbit review, P2 — reproduced empirically: a pack with
+    one malformed ``source_facts`` file reported ``tu_count == 2`` for a
+    single TU, and ``inputs validate`` flagged a duplicate ``tu_id`` error). A
+    lossy compaction therefore leaves the pack byte-for-byte unchanged — safe
+    to retry once the offending file is fixed or removed.
 
     *remove_originals* deletes the per-TU files that were merged once the
     merged file is written (skipped entirely on a lossy read, see above), so
     a later ingest cannot double-count TUs by reading both the merged file
-    and its stale sources. A manifest that names explicit ``source_facts``
-    entries is repointed at the single merged file; the default (auto-scan
-    of ``source_facts/``) needs no manifest change — the new file already
-    lives where the scan looks.
+    and its stale sources.
     """
     _reject_escaping_filename(output_filename)
     root = Path(root)
     manifest = load_inputs_manifest(root)
     sink = diagnostics if diagnostics is not None else []
 
-    # Infer compression from a caller-supplied ".gz" output_filename too, same
-    # as append_source_facts (CodeRabbit review, P2). Resolved before reading
-    # so the output path is known when partitioning discovered files below.
-    compress = compress or output_filename.endswith(".gz")
-    # The default directory scan _iter_source_fact_files() runs on every
-    # later read only recognizes *.jsonl(.gz) and *.json(.gz) -- a caller-
-    # supplied basename without one of those extensions (e.g.
-    # --output-filename merged, with or without --compress) writes a
-    # merged file that scan can never find. Compaction then "succeeds"
-    # with zero diagnostics, deletes the originals it just merged, and the
-    # pack silently ingests as zero TUs from that point on (Codex review,
-    # P2, reproduced empirically for both the compressed and uncompressed
-    # case). Normalize to the canonical .jsonl extension before the
-    # optional .gz suffix, matching every other producer in this codebase,
-    # unless the caller already used a recognized extension.
-    base = (
-        output_filename[: -len(".gz")]
-        if output_filename.endswith(".gz")
-        else output_filename
-    )
-    if not (base.endswith(".jsonl") or base.endswith(".json")):
-        base = f"{base}.jsonl"
-    output_filename = f"{base}.gz" if compress else base
+    output_filename, compress = _normalize_compacted_filename(output_filename, compress)
     facts_dir = root / SOURCE_FACTS_DIR
     facts_dir.mkdir(parents=True, exist_ok=True)
     output_path = facts_dir / output_filename
@@ -450,24 +587,9 @@ def compact_inputs_pack(
     # must never also be unlinked as a "leftover original".
     fresh_files = [f for f in originals if f.resolve() != output_path.resolve()]
 
-    # Recognize a stale prior compaction's output via an explicit manifest
-    # pointer (manifest.last_compacted, written below after every successful
-    # compaction) rather than matching *this* run's output path or comparing
-    # file mtimes: a --compress toggle or a custom --output-filename between
-    # two `compact` calls changes output_path, defeating a path match, and a
-    # rebuild's freshly-rewritten per-TU file can land in the same
-    # filesystem timestamp tick as the previous compaction's write, which an
-    # mtime "which is newer" check cannot break correctly (Codex review, P2
-    # -- both findings, the second reproduced empirically by a regression
-    # test on some filesystems).
-    prior_files: list[Path] = []
-    recognized_prior_path: Path | None = None
-    if manifest.last_compacted:
-        candidate = _safe_pack_path(root, manifest.last_compacted, sink)
-        if candidate is not None:
-            candidate = candidate.resolve()
-            recognized_prior_path = candidate
-            prior_files = [f for f in originals if f.resolve() == candidate]
+    recognized_prior_path, prior_files = _recognized_prior_output(
+        root, manifest, originals, sink
+    )
 
     # output_path already existing is legitimate ONLY when it IS the
     # recognized prior compaction's own file (a rerun reusing the same
@@ -497,47 +619,12 @@ def compact_inputs_pack(
             "or remove the conflicting file first."
         )
 
-    def _last_record_wins(
-        files: list[Path],
-    ) -> tuple[dict[str, SourceAbiTu], list[SourceAbiTu]]:
-        """Read *files* in (sorted, deterministic) order, keeping the last-seen
-        record per tu_id -- append order within/between files, never a
-        timestamp comparison. A no-tu_id record is never deduped ("" cannot
-        be treated as a real shared identity between otherwise-unrelated TUs,
-        Codex review, P2).
+    prior_by_id, prior_no_id = _last_record_wins(prior_files, sink)
+    fresh_by_id, fresh_no_id = _last_record_wins(
+        [f for f in originals if f not in prior_files], sink
+    )
 
-        A non-empty tu_id seen more than once *within this bucket* (as
-        opposed to a fresh record correctly superseding a stale prior-
-        compaction record, handled separately by the caller) is a genuine
-        pack-integrity problem -- inputs_validate.py's own duplicate_tu_ids
-        check already flags this as an ERROR before compaction. Silently
-        picking one via last-wins would make compaction delete the losing
-        record's file (remove_originals) and erase the very duplicate the
-        validator would otherwise catch, discarding one TU's facts with no
-        trace (Codex review, P2). So this counts as lossy instead, same as
-        any other malformed/ambiguous original.
-        """
-        by_id: dict[str, SourceAbiTu] = {}
-        no_id: list[SourceAbiTu] = []
-        for tu in read_source_fact_files(files, diagnostics=sink):
-            if tu.tu_id:
-                if tu.tu_id in by_id:
-                    sink.append(
-                        f"duplicate tu_id across source-fact files: {tu.tu_id!r} "
-                        "(a race-free per-TU filename should make this "
-                        "impossible)"
-                    )
-                by_id[tu.tu_id] = tu
-            else:
-                no_id.append(tu)
-        return by_id, no_id
-
-    prior_by_id, prior_no_id = _last_record_wins(prior_files)
-    fresh_only = [f for f in originals if f not in prior_files]
-    fresh_by_id, fresh_no_id = _last_record_wins(fresh_only)
-    lossy_read = len(sink) > before_diag_count
-
-    if lossy_read:
+    if len(sink) > before_diag_count:
         # Publishing a best-effort merge here (while leaving the malformed
         # original in place too, for inspection) would duplicate every
         # successfully-read TU on the next scan: the merged file now also
@@ -552,97 +639,23 @@ def compact_inputs_pack(
         )
         return None
 
-    tus = (
+    _write_merged_facts(
+        facts_dir,
+        output_path,
         [tu for tid, tu in prior_by_id.items() if tid not in fresh_by_id]
         + prior_no_id
         + list(fresh_by_id.values())
-        + fresh_no_id
+        + fresh_no_id,
+        compress,
     )
 
-    # Temp file + atomic rename so a concurrent reader never observes a
-    # partially-written merge (same discipline as _write_manifest).
-    fd, tmp = tempfile.mkstemp(dir=str(facts_dir), prefix=".compact.", suffix=".tmp")
-    try:
-        with os.fdopen(fd, "wb") as raw:
-            writer = gzip.GzipFile(fileobj=raw, mode="wb") if compress else raw
-            for tu in tus:
-                writer.write(
-                    (json.dumps(tu.to_dict(), sort_keys=True) + "\n").encode("utf-8")
-                )
-            if compress:
-                writer.close()
-        os.replace(tmp, output_path)
-    except BaseException:
-        with contextlib.suppress(OSError):
-            os.unlink(tmp)
-        raise
-
-    # A manifest that names explicit individual files is repointed at the
-    # single merged file (those originals are gone). But any entry that is
-    # itself a *directory* reference (SOURCE_FACTS_DIR itself — what the
-    # Clang facts plugin's ensureManifest() always writes, and what a bare
-    # default manifest effectively means too — or another sibling facts
-    # directory in a hand-written mixed manifest) must NOT be dropped:
-    # ensureManifest() never rewrites an existing manifest.json, so losing a
-    # directory reference would permanently hide every per-TU file a later
-    # incremental build writes into that directory from every subsequent
-    # ingest/compact/validate (Codex review, P2 — both the single-entry case
-    # and this generalization to a manifest that lists a directory alongside
-    # other entries, since the original single-entry check collapsed the
-    # *whole* list, directory entries included, the moment there was more
-    # than one).
-    #
-    # The merged file always physically lands directly inside SOURCE_FACTS_DIR
-    # (facts_dir above), regardless of what the manifest's entries say -- so a
-    # directory entry only "covers" it when the entry *resolves to that exact
-    # directory*, not merely an ancestor of it. _iter_source_fact_files()'s
-    # directory-scan is non-recursive (one glob() call, no descent), so an
-    # ancestor entry like source_facts=["."] can never actually discover a
-    # file one level deeper in source_facts/ no matter how the two paths
-    # relate on paper. A prior version of this check used
-    # Path(merged_ref).is_relative_to(Path(d)), which answers "is merged_ref a
-    # sub-path of d" -- true for essentially any ancestor directory, not
-    # "would a non-recursive scan of d actually find merged_ref". That
-    # silently deleted the very TUs compaction had just merged:
-    # source_facts=["."] with a root-level fact file compacted with zero
-    # diagnostics, deleted the original, and left the pack with zero readable
-    # TUs afterward (review finding, reproduced empirically). Likewise a
-    # directory-only manifest that does not itself cover SOURCE_FACTS_DIR
-    # (e.g. source_facts=["extra_facts"], no "source_facts" entry at all)
-    # still needs the merged file added explicitly, or it becomes permanently
-    # undiscoverable the same way (Codex review, P2). Directory-ness is
-    # checked against a scratch diagnostics list, not *sink*, so this
-    # classification pass — which re-resolves entries already validated once
-    # during discovery above — cannot itself flip the already-decided
-    # lossy_read outcome or duplicate diagnostics in the caller-visible
-    # result.
-    facts_dir_resolved = facts_dir.resolve()
-    _scratch: list[str] = []
-    directory_entries: list[str] = []
-    covered = False
-    for entry in manifest.source_facts:
-        target = _safe_pack_path(root, entry, _scratch)
-        if target is None or not target.is_dir():
-            continue
-        directory_entries.append(entry)
-        if target.resolve() == facts_dir_resolved:
-            covered = True
     merged_ref = f"{SOURCE_FACTS_DIR}/{output_filename}"
-    manifest_changed = False
-    if manifest.source_facts:
-        new_source_facts = (
-            list(directory_entries) if covered else [*directory_entries, merged_ref]
-        )
-        if new_source_facts != manifest.source_facts:
-            manifest.source_facts = new_source_facts
-            manifest_changed = True
-
+    manifest_changed = _repoint_manifest_entries(root, manifest, facts_dir, merged_ref)
     # Record this run's output as the pack's new "last compaction", so a
-    # later rerun recognizes it as stale (see prior_files above) regardless
-    # of what output filename/compression setting that rerun uses.
-    new_last_compacted = f"{SOURCE_FACTS_DIR}/{output_filename}"
-    if manifest.last_compacted != new_last_compacted:
-        manifest.last_compacted = new_last_compacted
+    # later rerun recognizes it as stale (see _recognized_prior_output)
+    # regardless of what output filename/compression setting that rerun uses.
+    if manifest.last_compacted != merged_ref:
+        manifest.last_compacted = merged_ref
         manifest_changed = True
 
     # Publish the manifest BEFORE destructively removing the originals it
@@ -652,28 +665,24 @@ def compact_inputs_pack(
     # failed write pointing an explicit-file manifest at now-deleted files
     # -- a later read finds neither the old originals nor a manifest that
     # knows to look at the merged output, discarding evidence the merge
-    # itself successfully captured. Publishing first means a manifest-write
-    # failure leaves the pack's *manifest* exactly as it was pre-compaction
-    # (still discoverable via its old entries/originals) (CodeRabbit
-    # review, P2).
+    # itself successfully captured (CodeRabbit review, P2).
     #
-    # But os.replace(tmp, output_path) above already published the merged
-    # file itself, inside SOURCE_FACTS_DIR where the default directory scan
-    # finds it unconditionally -- a manifest-write failure at this point
-    # would otherwise leave that stray, already-discoverable merged file
-    # sitting alongside the still-present (never-deleted, since
-    # remove_originals hasn't run yet) originals. A later read would then
-    # see BOTH copies of every TU compaction had just merged: not "less
-    # evidence than before" but silently *duplicated* evidence, and the
-    # stray file wedges every subsequent compact() attempt (Codex review,
-    # P2, reproduced empirically: tu_count doubled after a simulated
-    # manifest-write failure). Rolled back on failure, restoring the pack
-    # to its exact pre-compaction state -- but only when output_path did
-    # NOT already hold a prior successful compaction's result: a rerun
-    # reusing the same output_filename overwrites that file in place, and
-    # deleting it on this run's manifest-write failure would destroy the
-    # still-valid, still-published (per the old manifest) prior result too,
-    # not just this run's unpublished one.
+    # But _write_merged_facts already published the merged file itself,
+    # inside SOURCE_FACTS_DIR where the default directory scan finds it
+    # unconditionally -- a manifest-write failure at this point would
+    # otherwise leave that stray, already-discoverable merged file sitting
+    # alongside the still-present (never-deleted, since remove_originals
+    # hasn't run yet) originals. A later read would then see BOTH copies of
+    # every TU compaction had just merged: not "less evidence than before"
+    # but silently *duplicated* evidence, and the stray file wedges every
+    # subsequent compact() attempt (Codex review, P2, reproduced empirically:
+    # tu_count doubled after a simulated manifest-write failure). Rolled back
+    # on failure -- but only when output_path did NOT already hold a prior
+    # successful compaction's result: a rerun reusing the same output_filename
+    # overwrites that file in place, and deleting it on this run's
+    # manifest-write failure would destroy the still-valid, still-published
+    # (per the old manifest) prior result too, not just this run's unpublished
+    # one.
     if manifest_changed:
         try:
             _write_manifest(root, manifest)

--- a/abicheck/buildsource/inputs_validate.py
+++ b/abicheck/buildsource/inputs_validate.py
@@ -165,6 +165,89 @@ def _fact_set_recipe_issues(tus: list[SourceAbiTu]) -> list[str]:
     return issues
 
 
+def _resolve_pack_fact_set(
+    tus: list[SourceAbiTu], manifest: InputsManifest
+) -> tuple[dict[str, object], list[str]]:
+    """``(fact_set, warnings)`` — the identity this pack can actually claim.
+
+    Prefers the per-TU rollup over the manifest-declared ``fact_set``: a plugin
+    that stamps ``manifest.json`` up front cannot know whether every TU later
+    agreed with it, so a manifest-level ``fact_set`` must never mask a TU-level
+    inconsistency (Codex review). Falls back to the manifest only when there is
+    no TU-level signal to check it against (no TUs, or no TU ever stamped a
+    ``fact_set`` at all).
+    """
+    tu_fact_set = rollup_fact_set(tus)
+    stamped_tus_disagree = (
+        bool(tus) and any(tu.fact_set for tu in tus) and not tu_fact_set
+    )
+    if stamped_tus_disagree:
+        return {}, [
+            "TU records do not agree on a single fact_set identity (mixed "
+            "producers/versions, or some TUs missing fact_set entirely) — the "
+            "manifest-level fact_set cannot be trusted to describe every TU."
+        ]
+    fact_set = tu_fact_set or manifest.fact_set
+    if fact_set:
+        return fact_set, []
+    return {}, [
+        "no fact_set identity found (manifest nor any TU record) — this "
+        "pack predates ADR-038 C.8 coverage/fact-set reporting, or mixes "
+        "producers inconsistently."
+    ]
+
+
+def _fact_set_identity_errors(fact_set: dict[str, object]) -> list[str]:
+    """Errors for a fact_set naming a contract this build does not implement."""
+    if not fact_set:
+        return []
+    errors: list[str] = []
+    name = fact_set.get("name")
+    if name != SOURCE_ABI_FACT_SET_NAME:
+        errors.append(
+            f"pack fact_set name is {name!r}; this abicheck build expects "
+            f"{SOURCE_ABI_FACT_SET_NAME!r} — a different name is a different "
+            "canonical fact-set contract even if the version number matches, "
+            "so mandatory fact families may differ from what downstream "
+            "comparison assumes."
+        )
+    version = fact_set.get("version")
+    if version != SOURCE_ABI_FACT_SET_VERSION:
+        errors.append(
+            f"pack fact_set version is {version!r}; this abicheck build "
+            f"expects {SOURCE_ABI_FACT_SET_VERSION!r} — mandatory fact "
+            "families may differ from what downstream comparison assumes."
+        )
+    return errors
+
+
+def _empty_surface_warnings(
+    tus: list[SourceAbiTu], manifest: InputsManifest
+) -> list[str]:
+    """Warn when linking this pack's TUs yields no public surface at all.
+
+    Checks every reachable bucket (declarations/types/macros/templates/inline
+    bodies), not just declarations+types — a macro-only or header-only pack's
+    public evidence can land entirely in the other buckets, and checking only
+    two of the five would false-warn on a genuinely non-empty pack (Codex
+    review).
+    """
+    if not tus:
+        return []
+    surface = link_source_abi(
+        tus,
+        exported_symbols=sorted(set(manifest.exported_symbols)),
+        library=manifest.library,
+    )
+    if any(surface.reachable_buckets().values()):
+        return []
+    return [
+        "linked surface has an empty public surface (no reachable "
+        "declarations, types, macros, templates, or inline bodies) — "
+        "check public-header-roots scoping."
+    ]
+
+
 def validate_inputs_pack(root: Path | str) -> InputsValidationReport:
     """Validate one ``abicheck_inputs/`` pack directory; never raises for a
     structurally-readable pack — problems are reported, not thrown. Raises
@@ -214,50 +297,10 @@ def validate_inputs_pack(root: Path | str) -> InputsValidationReport:
     report.errors.extend(_target_id_issues(tus, manifest))
     report.errors.extend(_fact_set_recipe_issues(tus))
 
-    # Prefer the per-TU rollup over the manifest-declared fact_set: a plugin
-    # that stamps manifest.json up front cannot know whether every TU later
-    # agreed with it, so a manifest-level fact_set must never mask a TU-level
-    # inconsistency (Codex review). Only fall back to the manifest when there
-    # is no TU-level signal to check it against (no TUs, or no TU ever stamped
-    # a fact_set at all).
-    tu_fact_set = rollup_fact_set(tus)
-    stamped_tus_disagree = (
-        bool(tus) and any(tu.fact_set for tu in tus) and not tu_fact_set
-    )
-    if stamped_tus_disagree:
-        fact_set: dict[str, object] = {}
-        report.warnings.append(
-            "TU records do not agree on a single fact_set identity (mixed "
-            "producers/versions, or some TUs missing fact_set entirely) — the "
-            "manifest-level fact_set cannot be trusted to describe every TU."
-        )
-    else:
-        fact_set = tu_fact_set or manifest.fact_set
+    fact_set, fact_set_warnings = _resolve_pack_fact_set(tus, manifest)
     report.fact_set = fact_set
-    if not fact_set:
-        if not stamped_tus_disagree:
-            report.warnings.append(
-                "no fact_set identity found (manifest nor any TU record) — this "
-                "pack predates ADR-038 C.8 coverage/fact-set reporting, or mixes "
-                "producers inconsistently."
-            )
-    else:
-        name = fact_set.get("name")
-        if name != SOURCE_ABI_FACT_SET_NAME:
-            report.errors.append(
-                f"pack fact_set name is {name!r}; this abicheck build expects "
-                f"{SOURCE_ABI_FACT_SET_NAME!r} — a different name is a different "
-                "canonical fact-set contract even if the version number matches, "
-                "so mandatory fact families may differ from what downstream "
-                "comparison assumes."
-            )
-        version = fact_set.get("version")
-        if version != SOURCE_ABI_FACT_SET_VERSION:
-            report.errors.append(
-                f"pack fact_set version is {version!r}; this abicheck build "
-                f"expects {SOURCE_ABI_FACT_SET_VERSION!r} — mandatory fact "
-                "families may differ from what downstream comparison assumes."
-            )
+    report.warnings.extend(fact_set_warnings)
+    report.errors.extend(_fact_set_identity_errors(fact_set))
 
     coverage = rollup_coverage(tus)
     # A fact_set accepted above may have come entirely from the
@@ -284,21 +327,6 @@ def validate_inputs_pack(root: Path | str) -> InputsValidationReport:
             "absence from findings as proof nothing changed."
         )
 
-    if tus:
-        exports = sorted(set(manifest.exported_symbols))
-        surface = link_source_abi(
-            tus, exported_symbols=exports, library=manifest.library
-        )
-        # Every reachable bucket (declarations/types/macros/templates/inline
-        # bodies), not just declarations+types — a macro-only or header-only
-        # pack's public evidence can land entirely in the other buckets, and
-        # checking only two of the five would false-warn on a genuinely
-        # non-empty pack (Codex review).
-        if not any(surface.reachable_buckets().values()):
-            report.warnings.append(
-                "linked surface has an empty public surface (no reachable "
-                "declarations, types, macros, templates, or inline bodies) — "
-                "check public-header-roots scoping."
-            )
+    report.warnings.extend(_empty_surface_warnings(tus, manifest))
 
     return report

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -28,10 +28,12 @@ that would re-introduce an import cycle.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
+from typing import Any
 
 from .inline import (
     BuildConfig,
@@ -44,6 +46,121 @@ from .inline import (
 from .pack import BuildSourcePack
 
 logger = logging.getLogger(__name__)
+
+
+def _l2_seed_config(
+    build_config: Path | None,
+    sources: Path | None,
+    build_query: str | None,
+    build_compile_db: str | None,
+) -> BuildConfig | None:
+    """The effective ``BuildConfig`` for L2 seeding, or ``None`` to degrade.
+
+    Mirrors ``embed_build_source``'s config handling so a trusted ``--config``
+    ``build.compile_db``/``build.query`` is honored here too (and only an
+    explicit ``--config`` file is trusted for query execution; an
+    auto-discovered ``.abicheck.yml`` is loaded for its non-executable settings
+    but never run), then folds the CLI build-DB overrides in exactly as embed
+    does, so L2 seeding resolves the *same* DB L3 will.
+
+    A malformed/invalid config surfaces loudly elsewhere (``embed_build_source``,
+    the compile-context resolver); this is a best-effort include-dir hint, so it
+    degrades to "no seeded dirs" rather than raising through.
+    """
+    cfg_path = build_config or discover_build_config(sources)
+    try:
+        cfg = load_build_config(cfg_path) if cfg_path is not None else BuildConfig()
+    except ValueError:
+        return None
+    if build_query is None and build_compile_db is None:
+        return cfg
+    return dataclasses.replace(
+        cfg,
+        query=build_query if build_query is not None else cfg.query,
+        compile_db=(
+            build_compile_db if build_compile_db is not None else cfg.compile_db
+        ),
+    )
+
+
+def _l2_seed_pack_inputs(
+    build_info: Path | None, sources: Path | None
+) -> tuple[Any, Path | None, Path | None]:
+    """``(base_build, raw_build_info, raw_sources)`` with any pack pre-loaded.
+
+    A ``--sources`` pack carries its own L3 ``build_evidence``, which
+    ``embed_build_source``/``_combine_packs`` use for L3 when no ``--build-info``
+    does; mirror that so the pack's compile-unit include dirs seed L2 too
+    (Codex). Any explicit ``--build-info`` wins L3, so seed from the source pack
+    only when *no* ``--build-info`` was given (not merely no build-info *pack*):
+    a raw ``--build-info`` must still be resolved by ``collect_inline_pack``,
+    not skipped by folding the pack into ``base_build`` (Codex review).
+    """
+    base_build = None
+    raw_build_info = build_info
+    if build_info is not None and is_pack_dir(build_info):
+        base_build = BuildSourcePack.load(build_info).build_evidence
+        raw_build_info = None
+    raw_sources = sources
+    if sources is not None and is_pack_dir(sources):
+        if build_info is None:
+            base_build = BuildSourcePack.load(sources).build_evidence
+        raw_sources = None
+    return base_build, raw_build_info, raw_sources
+
+
+def _unit_include_dirs(cu: Any) -> list[str]:
+    """One compile unit's normal-priority include dirs, structured + argv.
+
+    The compile-DB adapter folds only ``-I``/``-isystem`` into the structured
+    ``include_paths``/``system_include_paths``; normal-priority include dirs
+    given via ``-iquote`` (GNU) or ``/I`` (MSVC) stay only in argv. The L4
+    replay honours those, so L2 must see them too or a build resolving
+    dependency headers via ``-iquote deps/include`` fails its header parse with
+    no manual ``-I`` (Codex review). Restricted to normal-priority buckets: the
+    callers re-emit every seeded dir as plain ``-I``, so promoting an
+    after-system dir (``-idirafter``) or a system dir (``-isystem``/``-imsvc``)
+    would shadow a system header the build would actually use (Codex review) —
+    ``-isystem`` dirs are already carried structurally anyway. Relative operands
+    resolve against the unit's ``directory`` (the compile command's cwd) and the
+    home-relative ``~`` the adapter stored is expanded.
+    """
+    from ..header_utils import _build_context_include_dirs
+
+    argv_dirs = (
+        _build_context_include_dirs(
+            list(cu.argv),
+            base_dir=cu.directory or None,
+            expand_user=True,
+            prefixes=("-I", "-iquote", "/I"),
+        )
+        if cu.argv
+        else set()
+    )
+    return [*cu.include_paths, *cu.system_include_paths, *sorted(argv_dirs)]
+
+
+def _existing_include_dirs(units: Iterable[Any]) -> list[str]:
+    """De-duplicated, existing include dirs across every compile unit.
+
+    ``CompileDbAdapter`` stores paths through ``DEFAULT_REDACTION``, which
+    rewrites the home prefix to a literal ``~`` (e.g. a CI runner's
+    ``/home/runner/work`` -> ``~/work``). This derivation is ephemeral and runs
+    on the same host as the build, so ``~`` is expanded back before the
+    existence check — otherwise every home-rooted include dir (the common CI
+    case this fallback targets) would be silently dropped.
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for cu in units:
+        for inc in _unit_include_dirs(cu):
+            if not inc:
+                continue
+            real = os.path.expanduser(inc)
+            if real not in seen and Path(real).is_dir():
+                seen.add(real)
+                out.append(real)
+    return out
 
 
 def derive_l2_include_dirs(
@@ -79,37 +196,16 @@ def derive_l2_include_dirs(
     """
     if sources is None and build_info is None:
         return [], []
-    # Mirror embed_build_source's config handling so a trusted --config
-    # build.compile_db / build.query is honored here too (and only an explicit
-    # --config file is trusted for query execution; an auto-discovered
-    # .abicheck.yml is loaded for its non-executable settings but never run).
-    cfg_path = build_config or discover_build_config(sources)
-    try:
-        cfg = load_build_config(cfg_path) if cfg_path is not None else BuildConfig()
-    except ValueError:
-        # A malformed/invalid config surfaces loudly elsewhere (embed_build_source,
-        # the compile-context resolver); this is a best-effort L2 include-dir hint,
-        # so degrade to "no seeded dirs" rather than raising through it.
+    cfg = _l2_seed_config(build_config, sources, build_query, build_compile_db)
+    if cfg is None:
         return [], []
-    # Fold the CLI build-DB overrides into cfg exactly as embed_build_source does,
-    # so the L2 seeding resolves the *same* DB L3 will (an explicit --build-compile-db
-    # / --build-query wins over an auto-discovered one). compile_db_explicit mirrors
-    # embed too: when the DB is explicitly configured, a missing glob must *stop*
-    # here rather than silently seed from an unrelated auto-discovered/inferred DB.
-    if build_query is not None or build_compile_db is not None:
-        import dataclasses
-
-        cfg = dataclasses.replace(
-            cfg,
-            query=build_query if build_query is not None else cfg.query,
-            compile_db=build_compile_db
-            if build_compile_db is not None
-            else cfg.compile_db,
-        )
     cfg_trusted_for_query = build_config is not None or build_query is not None
     compile_db_explicit = build_compile_db is not None or build_config is not None
     cleanups: list[Callable[[], None]] = []
     try:
+        base_build, raw_build_info, raw_sources = _l2_seed_pack_inputs(
+            build_info, sources
+        )
         # Reuse the same L3-collection path embed_build_source drives, restricted
         # to build context only (no L4/L5), so every supported build-info form —
         # a collected pack, a Bazel aquery/cquery, an explicit/auto-discovered/
@@ -117,23 +213,6 @@ def derive_l2_include_dirs(
         # the same CompileUnit include dirs the L4 replay would use. Re-deriving
         # this by hand kept missing input forms (packs, bazel); collect_inline_pack
         # owns them, plus the temp-build-dir cleanup lifecycle via defer_cleanup.
-        base_build = None
-        raw_build_info = build_info
-        if build_info is not None and is_pack_dir(build_info):
-            base_build = BuildSourcePack.load(build_info).build_evidence
-            raw_build_info = None
-        raw_sources = sources
-        if sources is not None and is_pack_dir(sources):
-            # A --sources pack carries its own L3 build_evidence, which
-            # embed_build_source/_combine_packs use for L3 when no --build-info does;
-            # mirror that so the pack's compile-unit include dirs seed L2 too (Codex).
-            # Any explicit --build-info wins L3, so seed from the source pack only
-            # when *no* --build-info was given (not merely no build-info *pack*): a
-            # raw --build-info must still be resolved by collect_inline_pack below,
-            # not skipped by folding the pack into base_build (Codex review).
-            if build_info is None:
-                base_build = BuildSourcePack.load(sources).build_evidence
-            raw_sources = None
         pack = collect_inline_pack(
             sources=raw_sources,
             build_info=raw_build_info,
@@ -150,46 +229,7 @@ def derive_l2_include_dirs(
             if pack is not None and pack.build_evidence is not None
             else []
         )
-        from ..header_utils import _build_context_include_dirs
-
-        seen: set[str] = set()
-        out: list[str] = []
-        for cu in units:
-            # The compile-DB adapter folds only -I/-isystem into the structured
-            # include_paths/system_include_paths; normal-priority include dirs given
-            # via -iquote (GNU) or /I (MSVC) stay only in argv. The L4 replay honours
-            # those, so L2 must see them too or a build resolving dependency headers
-            # via `-iquote deps/include` fails its header parse with no manual -I
-            # (Codex review). Restrict to normal-priority buckets: the callers re-emit
-            # every seeded dir as plain -I, so promoting an *after-system* dir
-            # (-idirafter) or a system dir (-isystem/-imsvc) would shadow a system
-            # header the build would actually use (Codex review) — -isystem dirs are
-            # already carried structurally anyway. Resolve relative operands against
-            # the unit's `directory` (the compile command's cwd) and un-redact the
-            # home-relative `~` the adapter stored. Union, deduped.
-            argv_dirs = (
-                _build_context_include_dirs(
-                    list(cu.argv),
-                    base_dir=cu.directory or None,
-                    expand_user=True,
-                    prefixes=("-I", "-iquote", "/I"),
-                )
-                if cu.argv
-                else set()
-            )
-            for inc in (*cu.include_paths, *cu.system_include_paths, *sorted(argv_dirs)):
-                if not inc:
-                    continue
-                # CompileDbAdapter stores paths through DEFAULT_REDACTION, which
-                # rewrites the home prefix to a literal ``~`` (e.g. a CI runner's
-                # /home/runner/work -> ~/work). This derivation is ephemeral and
-                # runs on the same host as the build, so expand ~ back before the
-                # existence check — otherwise every home-rooted include dir (the
-                # common CI case this fallback targets) would be silently dropped.
-                real = os.path.expanduser(inc)
-                if real not in seen and Path(real).is_dir():
-                    seen.add(real)
-                    out.append(real)
+        out = _existing_include_dirs(units)
         if not out:
             # Nothing to preserve — release any temp build dir now.
             _run_cleanups(cleanups)

--- a/abicheck/buildsource/project_targets.py
+++ b/abicheck/buildsource/project_targets.py
@@ -1252,40 +1252,72 @@ def _forbidden_field_issues(target: TargetSpec) -> list[str]:
     return issues
 
 
+def _library_target_issues(
+    config: ProjectTargetsConfig, target: TargetSpec
+) -> list[str]:
+    """Validate a ``kind: library`` target's own required/consistent fields."""
+    issues: list[str] = []
+    if not target.binary_pattern:
+        issues.append(f"target {target.id!r}: kind: library requires binary_pattern.")
+    if target.bundle_only and not target.bundle:
+        issues.append(f"target {target.id!r}: bundle_only requires bundle to be set.")
+    if target.bundle_only and target.checks:
+        issues.append(
+            f"target {target.id!r}: bundle_only: true target must not set "
+            "its own checks: — it is checked only as a bundle member, "
+            "never standalone, so a target-level check here would never "
+            "run; declare it under bundles:.checks instead."
+        )
+    if not target.bundle:
+        return issues
+    declared_bundle = config.bundles.get(target.bundle)
+    if declared_bundle is None:
+        issues.append(
+            f"target {target.id!r}: bundle {target.bundle!r} is not "
+            "declared under bundles:."
+        )
+    elif target.id not in declared_bundle.targets:
+        issues.append(
+            f"target {target.id!r}: declares bundle: {target.bundle!r} "
+            f"but bundles.{target.bundle}.targets does not list "
+            f"{target.id!r} back — a target's own bundle: field and its "
+            "membership in that bundle's targets: list must agree in "
+            "both directions."
+        )
+    return issues
+
+
+def _no_baseline_channel_issues(target: TargetSpec) -> list[str]:
+    """Reject ``channel: none`` on any target kind other than ``library``.
+
+    ``actions/check-target/validate-inputs.sh`` rejects ``baseline-channel:
+    none`` for any target kind other than library -- a no-baseline audit routes
+    to ``scan`` (a one-build check), which has no ``--used-by``/
+    ``--required-symbols`` equivalent to scope an app-consumer/plugin-contract
+    check against. Rejected at generation time rather than letting a
+    validated-looking config produce a run-plan cell that check-target refuses
+    with no per-cell report for aggregate to read.
+    """
+    if target.kind == TARGET_KIND_LIBRARY:
+        return []
+    return [
+        f"target {target.id!r}.checks[{i}]: channel: "
+        f"{NO_BASELINE_CHANNEL!r} is not supported for kind: "
+        f"{target.kind!r} -- a no-baseline audit check has no "
+        "--used-by/--required-symbols equivalent to scope an "
+        "app-consumer/plugin-contract check against "
+        "(actions/check-target/validate-inputs.sh). Use kind: "
+        "library for a no-baseline audit, or set a real channel."
+        for i, check in enumerate(target.checks)
+        if check.channel == NO_BASELINE_CHANNEL
+    ]
+
+
 def _target_issues(config: ProjectTargetsConfig, target: TargetSpec) -> list[str]:
     issues = _identifier_issues("target", target.id)
     issues.extend(_forbidden_field_issues(target))
     if target.kind == TARGET_KIND_LIBRARY:
-        if not target.binary_pattern:
-            issues.append(
-                f"target {target.id!r}: kind: library requires binary_pattern."
-            )
-        if target.bundle_only and not target.bundle:
-            issues.append(
-                f"target {target.id!r}: bundle_only requires bundle to be set."
-            )
-        if target.bundle_only and target.checks:
-            issues.append(
-                f"target {target.id!r}: bundle_only: true target must not set "
-                "its own checks: — it is checked only as a bundle member, "
-                "never standalone, so a target-level check here would never "
-                "run; declare it under bundles:.checks instead."
-            )
-        if target.bundle:
-            declared_bundle = config.bundles.get(target.bundle)
-            if declared_bundle is None:
-                issues.append(
-                    f"target {target.id!r}: bundle {target.bundle!r} is not "
-                    "declared under bundles:."
-                )
-            elif target.id not in declared_bundle.targets:
-                issues.append(
-                    f"target {target.id!r}: declares bundle: {target.bundle!r} "
-                    f"but bundles.{target.bundle}.targets does not list "
-                    f"{target.id!r} back — a target's own bundle: field and its "
-                    "membership in that bundle's targets: list must agree in "
-                    "both directions."
-                )
+        issues.extend(_library_target_issues(config, target))
     elif target.kind == TARGET_KIND_APP_CONSUMER:
         if not target.consumer_binary_pattern:
             issues.append(
@@ -1299,26 +1331,7 @@ def _target_issues(config: ProjectTargetsConfig, target: TargetSpec) -> list[str
                 f"target {target.id!r}: kind: plugin-contract requires contract_file."
             )
         issues.extend(_library_reference_issues(config, target))
-    if target.kind != TARGET_KIND_LIBRARY:
-        # actions/check-target/validate-inputs.sh rejects baseline-channel:
-        # none for any target-kind other than library -- a no-baseline audit
-        # routes to `scan` (a one-build check), which has no
-        # --used-by/--required-symbols equivalent to scope an app-consumer/
-        # plugin-contract check against. Reject at generation time rather
-        # than letting a validated-looking config produce a run-plan cell
-        # that check-target refuses with no per-cell report for aggregate
-        # to read.
-        for i, check in enumerate(target.checks):
-            if check.channel == NO_BASELINE_CHANNEL:
-                issues.append(
-                    f"target {target.id!r}.checks[{i}]: channel: "
-                    f"{NO_BASELINE_CHANNEL!r} is not supported for kind: "
-                    f"{target.kind!r} -- a no-baseline audit check has no "
-                    "--used-by/--required-symbols equivalent to scope an "
-                    "app-consumer/plugin-contract check against "
-                    "(actions/check-target/validate-inputs.sh). Use kind: "
-                    "library for a no-baseline audit, or set a real channel."
-                )
+    issues.extend(_no_baseline_channel_issues(target))
     for i, check in enumerate(target.checks):
         issues.extend(_check_issues(config, f"target {target.id!r}.checks[{i}]", check))
     return issues

--- a/abicheck/buildsource/source_link.py
+++ b/abicheck/buildsource/source_link.py
@@ -1122,6 +1122,111 @@ def _is_public(entity: SourceEntity) -> bool:
     return bool(loc and loc.origin in ("PUBLIC_HEADER", "GENERATED"))
 
 
+def _valid_source_edge(edge: Any) -> tuple[str, str, str] | None:
+    """``(edge, src, dst)`` for a well-formed source-edge record, else ``None``."""
+    if not isinstance(edge, dict):
+        return None
+    name, src, dst = edge.get("edge"), edge.get("src"), edge.get("dst")
+    if not (
+        isinstance(name, str)
+        and name
+        and isinstance(src, str)
+        and src
+        and isinstance(dst, str)
+        and dst
+    ):
+        return None
+    return (name, src, dst)
+
+
+def _merge_dst_file(existing: dict[str, Any], edge: dict[str, Any]) -> None:
+    """Fill a missing ``attrs.dst_file`` on the surviving duplicate edge.
+
+    A later TU's copy of the same logical ``(edge, src, dst)`` may resolve a
+    ``dst_file`` the first-seen copy couldn't (e.g. only this TU's AST carries
+    the callee/type's declaring file) -- fill it into the surviving row rather
+    than silently keeping the poorer one (Codex review): otherwise the
+    surviving row's missing ``dst_file`` means ``fold_source_edges()`` can
+    never mark that endpoint ``defined_in_project``, and
+    ``PUBLIC_API_INTERNAL_DEPENDENCY_ADDED`` is skipped for a dependency the
+    graph otherwise has full evidence for.
+    """
+    new_attrs = edge.get("attrs")
+    new_dst_file = new_attrs.get("dst_file") if isinstance(new_attrs, dict) else None
+    if not new_dst_file:
+        return
+    existing_attrs = existing.get("attrs")
+    if not isinstance(existing_attrs, dict):
+        existing_attrs = {}
+        existing["attrs"] = existing_attrs
+    if not existing_attrs.get("dst_file"):
+        existing_attrs["dst_file"] = new_dst_file
+
+
+def _fold_tu_source_edges(tus: list[SourceAbiTu]) -> list[dict[str, Any]]:
+    """Every TU's graph-edge facts, deduplicated on ``(edge, src, dst)``.
+
+    ADR-038 C.9 / PR1: folded up to the surface so ``build_source_graph()`` can
+    consume them directly instead of them being serialized-but-unused dead data.
+    TUs that share a public header re-emit the same edges, hence the dedup.
+    """
+    edge_by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
+    source_edges: list[dict[str, Any]] = []
+    for tu in tus:
+        for edge in tu.source_edges:
+            edge_key = _valid_source_edge(edge)
+            if edge_key is None:
+                continue
+            existing = edge_by_key.get(edge_key)
+            if existing is not None:
+                _merge_dst_file(existing, edge)
+                continue
+            edge_by_key[edge_key] = edge
+            source_edges.append(edge)
+    return source_edges
+
+
+def _is_duplicate_entity(entity: SourceEntity, state: _LinkState) -> bool:
+    """True for a byte-identical entity already routed from another TU.
+
+    Folds entities re-emitted by every TU that includes the same public header.
+    The key carries every identity- and hash-bearing field, so overloads (same
+    name, different mangled/sig), ODR variants (same name/id but a divergent
+    ``type_hash``/``body_hash`` -- the type id intentionally excludes the
+    content hash), and any other semantic difference still route and are
+    detected; only true duplicates are dropped. Shrinks the surface, its
+    content-hash ``json.dumps``, and the relink work proportionally.
+
+    A genuine ``identity_collision_detected`` pair (two distinct decls, proven
+    distinct by a differing USR) can still share every field in the key -- none
+    of them carry per-declaration provenance, so a bare, unmangled cross-scope
+    name/signature collision hashes identically. Only treat this as the
+    "byte-identical re-emission across TUs" case the dedup exists for when the
+    USRs agree (or are unknown, e.g. castxml/plain-clang extractors that never
+    stamp one) -- otherwise let the second entity through so
+    ``_route_declaration``'s USR-collision check actually sees it (Codex
+    review; ADR-041 P1 #5).
+    """
+    key = (
+        entity.kind,
+        entity.qualified_name,
+        entity.mangled_name,
+        entity.id,
+        entity.signature_hash,
+        entity.type_hash,
+        entity.body_hash,
+        entity.value,
+    )
+    usr = entity.names.get("usr", "")
+    prev_usr = state.seen_entity_usr.get(key, "")
+    if key in state.seen_entity_keys and (not usr or not prev_usr or usr == prev_usr):
+        return True
+    state.seen_entity_keys.add(key)
+    if usr and not prev_usr:
+        state.seen_entity_usr[key] = usr
+    return False
+
+
 def link_source_abi(
     tus: Iterable[SourceAbiTu],
     *,
@@ -1149,55 +1254,8 @@ def link_source_abi(
     state = _LinkState()
     state.export_index = _build_export_index(exported)
     state.exact_index = _build_exact_index(exported)
-    seen_edge_keys: set[tuple[str, str, str]] = set()
-    edge_by_key: dict[tuple[str, str, str], dict[str, Any]] = {}
-    source_edges: list[dict[str, Any]] = []
+    source_edges = _fold_tu_source_edges(tus)
     for tu in tus:
-        for edge in tu.source_edges:
-            if not isinstance(edge, dict):
-                continue
-            edge_name, edge_src, edge_dst = (
-                edge.get("edge"),
-                edge.get("src"),
-                edge.get("dst"),
-            )
-            if not (
-                isinstance(edge_name, str)
-                and edge_name
-                and isinstance(edge_src, str)
-                and edge_src
-                and isinstance(edge_dst, str)
-                and edge_dst
-            ):
-                continue
-            edge_key = (edge_name, edge_src, edge_dst)
-            if edge_key in seen_edge_keys:
-                # A later TU's copy of the same logical (edge, src, dst) may
-                # resolve a dst_file the first-seen copy couldn't (e.g. only
-                # this TU's AST carries the callee/type's declaring file) --
-                # fill it into the surviving row rather than silently
-                # keeping the poorer one (Codex review): otherwise the
-                # surviving row's missing dst_file means
-                # fold_source_edges() can never mark that endpoint
-                # defined_in_project, and PUBLIC_API_INTERNAL_DEPENDENCY_ADDED
-                # is skipped for a dependency the graph otherwise has full
-                # evidence for.
-                existing = edge_by_key.get(edge_key)
-                new_attrs = edge.get("attrs")
-                new_dst_file = (
-                    new_attrs.get("dst_file") if isinstance(new_attrs, dict) else None
-                )
-                if existing is not None and new_dst_file:
-                    existing_attrs = existing.get("attrs")
-                    if not isinstance(existing_attrs, dict):
-                        existing_attrs = {}
-                        existing["attrs"] = existing_attrs
-                    if not existing_attrs.get("dst_file"):
-                        existing_attrs["dst_file"] = new_dst_file
-                continue
-            seen_edge_keys.add(edge_key)
-            edge_by_key[edge_key] = edge
-            source_edges.append(edge)
         for header in tu.public_header_roots:
             surface.mappings["public_header_to_target"][header] = (
                 tu.target_id or target_id
@@ -1205,50 +1263,10 @@ def link_source_abi(
         for entity in tu.all_entities():
             if not (_is_public(entity) or entity.qualified_name in forced):
                 continue
-            # Fold byte-identical entities re-emitted by every TU that includes
-            # the same public header. The key carries every identity- and
-            # hash-bearing field, so overloads (same name, different mangled/sig),
-            # ODR variants (same name/id but a divergent type_hash/body_hash — the
-            # type id intentionally excludes the content hash), and any other
-            # semantic difference still route and are detected; only true
-            # duplicates are dropped. Shrinks the surface, its content-hash
-            # json.dumps, and the relink work proportionally.
-            key = (
-                entity.kind,
-                entity.qualified_name,
-                entity.mangled_name,
-                entity.id,
-                entity.signature_hash,
-                entity.type_hash,
-                entity.body_hash,
-                entity.value,
-            )
-            usr = entity.names.get("usr", "")
-            prev_usr = state.seen_entity_usr.get(key, "")
-            # A genuine identity_collision_detected pair (two distinct decls,
-            # proven distinct by a differing USR) can still share every field
-            # in `key` above -- none of them carry per-declaration provenance,
-            # so a bare, unmangled cross-scope name/signature collision hashes
-            # identically. Only treat this as the "byte-identical re-emission
-            # across TUs" case the dedup exists for when the USRs agree (or
-            # are unknown, e.g. castxml/plain-clang extractors that never
-            # stamp one) -- otherwise let the second entity through so
-            # `_route_declaration`'s USR-collision check actually sees it
-            # (Codex review; ADR-041 P1 #5).
-            if key in state.seen_entity_keys and (
-                not usr or not prev_usr or usr == prev_usr
-            ):
+            if _is_duplicate_entity(entity, state):
                 continue
-            state.seen_entity_keys.add(key)
-            if usr and not prev_usr:
-                state.seen_entity_usr[key] = usr
             state.public_decl_ids.append(entity.id)
             _route_entity(entity, surface, state, exported)
-
-    # ADR-038 C.9 / PR1: fold every TU's collected graph-edge facts up to the
-    # surface (deduplicated above by (edge, src, dst) across TUs that share a
-    # public header), so build_source_graph() can consume them directly instead
-    # of them being serialized-but-unused dead data.
     surface.source_edges = source_edges
     surface.roots["public_header_declarations"] = sorted(set(state.public_decl_ids))
     # Second-tier: rescue decls whose mangled name differs textually from the

--- a/abicheck/buildsource/toolchain_probe.py
+++ b/abicheck/buildsource/toolchain_probe.py
@@ -74,6 +74,7 @@ import os
 import re
 import subprocess
 from collections.abc import Mapping
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Protocol
@@ -620,46 +621,273 @@ class _HasCompileOverlays(Protocol):
     consumer_compile: Any
 
 
+def _family_errors(
+    where: str,
+    declared_family: str,
+    actual_family: str | None,
+    binding_id: str,
+    path: Any,
+) -> list[str]:
+    """Errors for a declared ``compiler_family`` against the probed one."""
+    if actual_family is None:
+        return [
+            f"{where}.compiler_family declares {declared_family!r} but the "
+            f"actual family of toolchain binding {binding_id!r} ({path!r}) "
+            f"could not be determined from its resolved path or --version "
+            f"output"
+        ]
+    wanted = _FAMILY_ALIASES.get(
+        declared_family.strip().lower(), declared_family.strip().lower()
+    )
+    if actual_family != wanted:
+        return [
+            f"{where}.compiler_family declares {declared_family!r} but "
+            f"toolchain binding {binding_id!r} ({path!r}) resolved to "
+            f"family {actual_family!r}"
+        ]
+    return []
+
+
+def _version_errors(
+    where: str,
+    declared: _OverlayDeclaration,
+    actual_family: str | None,
+    metadata: dict[str, Any],
+    binding_id: str,
+    path: Any,
+) -> list[str]:
+    """Errors for a declared ``compiler_version`` constraint."""
+    errors: list[str] = []
+    if not declared.family and not declared.target and actual_family is None:
+        # Only reported here when neither of the other two checks
+        # already covers it (both have their own actual_family-is-None
+        # error) -- a bare compiler_version: constraint is otherwise the one
+        # declaration shape with no family/target check to ever notice the
+        # resolved binding isn't recognizably a compiler at all (Codex
+        # review, fresh evidence).
+        errors.append(
+            f"{where}.compiler_version declares {declared.version!r} but the "
+            f"actual family of toolchain binding {binding_id!r} ({path!r}) "
+            f"could not be determined from its resolved path or --version "
+            f"output, so it cannot be verified to be a compiler at all"
+        )
+    try:
+        satisfied = version_satisfies(metadata.get("version", ""), declared.version)
+    except ToolchainProbeError as exc:
+        errors.append(f"{where}.compiler_version: {exc}")
+        return errors
+    if not satisfied:
+        errors.append(
+            f"{where}.compiler_version declares {declared.version!r} but "
+            f"toolchain binding {binding_id!r} ({path!r}) reported version "
+            f"output {metadata.get('version', '')!r}, which does not satisfy it"
+        )
+    return errors
+
+
+def _clang_target_errors(
+    where: str, declared_target: str, metadata: dict[str, Any], binding_id: str, path: Any
+) -> list[str]:
+    """Target errors for a Clang-family binding, probed with ``--target=``.
+
+    Clang is inherently multi-target: ``-dumpmachine`` (what ``target_triple``
+    comes from) reports only its host default, not a constraint -- the
+    profile's own compose logic passes the declared target explicitly via
+    ``--target=``, which a single Clang binary genuinely honors for
+    cross-compilation. Unlike GCC (a fixed single-target binary per install),
+    the bare dumpmachine probe has nothing to compare (Codex review, fresh
+    evidence: a real x86_64 Clang with ``target: aarch64-linux-gnu`` was
+    falsely rejected). But an entirely bogus/misspelled target must still be
+    rejected, so probe Clang directly with the declared ``--target=`` instead
+    (a second review round, fresh evidence: ``target: not-a-real-target``
+    previously passed unconditionally). Intel's oneAPI icx/icpx driver shares
+    this branch: it is a clang-based binary accepting the identical
+    ``--target=`` flag (``abicheck.dumper_clang`` already treats it as
+    clang-family for AST parsing), so the same exemption and real-probe
+    validation apply.
+    """
+    digest = metadata.get("sha256")
+    if not digest:
+        return []
+    accepted = _clang_accepts_target(path, digest, declared_target)
+    if accepted is False:
+        return [
+            f"{where}.target declares {declared_target!r} but "
+            f"toolchain binding {binding_id!r} ({path!r}) does not "
+            f"recognize it as a valid --target= triple"
+        ]
+    if accepted is None:
+        # _clang_accepts_target returns None only when the probe compile
+        # couldn't even run (timeout, OSError) -- e.g. a wrapper that answers
+        # --version fine but hangs on a real invocation. Silently accepting
+        # that leaves the declared target completely unverified, against the
+        # same "can't verify -> error, not a silent pass" principle this
+        # module applies everywhere else (Codex review, fresh evidence).
+        return [
+            f"{where}.target declares {declared_target!r} but "
+            f"toolchain binding {binding_id!r} ({path!r}) could "
+            f"not be probed for --target= support (the "
+            f"validation compile did not complete), so the "
+            f"declared target cannot be verified"
+        ]
+    return []
+
+
+def _triple_mismatches(declared_target: str, probed_triple: str) -> list[str]:
+    """Human-readable mismatches between a declared and a probed triple.
+
+    A mismatch is flagged whenever the two sides disagree, including when only
+    one side's OS/environment marker is recognized -- an unrecognized marker
+    on either side is itself unverifiable, not evidence of a match. Only "both
+    unrecognized" is a genuine skip. Previously this only fired when BOTH
+    sides were non-None, so an unrecognized declared OS/env (e.g.
+    ``x86_64-pc-solaris2.11``, ``arm-none-eabi``) silently passed against any
+    real probed triple (Codex review, fresh evidence).
+
+    The raw-suffix fallback covers the remaining hole: when NEITHER side's OS
+    nor environment marker is recognized, two triples that differ only after
+    the architecture (``arm-none-eabi`` vs ``arm-none-elf`` -- bare-metal EABI
+    vs ELF object-format spellings) previously passed as long as architecture
+    agreed. Every remaining ``-``-separated component is compared
+    case-insensitively after normalizing away an optional generic vendor
+    placeholder on either side (:func:`_strip_generic_vendor`) --
+    ``arm-none-eabi`` (vendor omitted) and ``arm-unknown-none-eabi`` (vendor
+    explicitly ``unknown``) name the same real target.
+    """
+    mismatches: list[str] = []
+    declared_arch = _normalize_arch(declared_target.split("-", 1)[0])
+    probed_arch = _normalize_arch(probed_triple.split("-", 1)[0])
+    if declared_arch and probed_arch and declared_arch != probed_arch:
+        mismatches.append(f"architecture {declared_arch!r} vs {probed_arch!r}")
+
+    declared_os = _os_family(declared_target)
+    probed_os = _os_family(probed_triple)
+    if (declared_os is not None or probed_os is not None) and declared_os != probed_os:
+        mismatches.append(f"OS {declared_os!r} vs {probed_os!r}")
+
+    declared_env = _env_family(declared_target)
+    probed_env = _env_family(probed_triple)
+    if (
+        declared_env is not None or probed_env is not None
+    ) and declared_env != probed_env:
+        mismatches.append(f"environment {declared_env!r} vs {probed_env!r}")
+
+    if declared_os is None and probed_os is None and declared_env is None and probed_env is None:
+        declared_rest = _strip_generic_vendor(
+            [p for p in declared_target.split("-")[1:] if p]
+        )
+        probed_rest = _strip_generic_vendor(
+            [p for p in probed_triple.split("-")[1:] if p]
+        )
+        if (
+            declared_rest
+            and probed_rest
+            and [p.lower() for p in declared_rest] != [p.lower() for p in probed_rest]
+        ):
+            mismatches.append(
+                "unrecognized target suffix "
+                f"{'-'.join(declared_rest)!r} vs {'-'.join(probed_rest)!r}"
+            )
+    return mismatches
+
+
+def _target_errors(
+    where: str,
+    declared_target: str,
+    actual_family: str | None,
+    metadata: dict[str, Any],
+    binding_id: str,
+    path: Any,
+) -> list[str]:
+    """Errors for a declared ``target`` triple."""
+    if actual_family is None:
+        return [
+            f"{where}.target declares {declared_target!r} but the actual "
+            f"family of toolchain binding {binding_id!r} ({path!r}) could "
+            f"not be determined, so its target cannot be verified"
+        ]
+    if actual_family in ("clang", "icx"):
+        return _clang_target_errors(where, declared_target, metadata, binding_id, path)
+
+    probed_triple = metadata.get("target_triple")
+    if not probed_triple:
+        return [
+            f"{where}.target declares {declared_target!r} but toolchain "
+            f"binding {binding_id!r} ({path!r}) has no probed target "
+            f"triple, so the declared target cannot be verified"
+        ]
+    mismatches = _triple_mismatches(declared_target, probed_triple)
+    if not mismatches:
+        return []
+    return [
+        f"{where}.target declares {declared_target!r} but "
+        f"toolchain binding {binding_id!r} ({path!r}) resolved to "
+        f"target triple {probed_triple!r} ({'; '.join(mismatches)})"
+    ]
+
+
+@dataclass(frozen=True)
+class _OverlayDeclaration:
+    """What one ``profiles.<id>.<overlay>.compile`` block declares about its tool."""
+
+    binding: str
+    family: str
+    version: str
+    target: str
+
+    @property
+    def declares_anything(self) -> bool:
+        return bool(self.family or self.version or self.target)
+
+
+def _overlay_declaration(compile_spec: Any) -> _OverlayDeclaration:
+    """Read the four declared identity fields off one compile overlay."""
+    if not compile_spec:
+        return _OverlayDeclaration("", "", "", "")
+    return _OverlayDeclaration(
+        getattr(compile_spec, "binding", ""),
+        getattr(compile_spec, "compiler_family", ""),
+        getattr(compile_spec, "compiler_version", ""),
+        getattr(compile_spec, "target", ""),
+    )
+
+
+def _is_unprobeable_msvc(path: Any, declared_family: str) -> bool:
+    """True for a binding that genuinely cannot be identity-checked here.
+
+    MSVC's ``cl.exe`` has no ``--version`` flag -- the fixed probe this module
+    reuses always runs exactly that flag -- so a binding that actually
+    resolves to ``cl.exe`` cannot be checked with the plumbing available here
+    (see module docstring), whether ``compiler_family: msvc`` was declared
+    explicitly or left unset.
+
+    Both conditions are required, not resolved-path-alone: an earlier revision
+    skipped whenever ``compiler_family: msvc`` was merely *declared*,
+    regardless of what the binding resolved to -- so a profile declaring
+    ``compiler_family: msvc`` whose binding resolves to a real, probeable
+    ``/usr/bin/gcc`` was also silently exempted (Codex review, fresh
+    evidence). A later revision keyed the skip on the resolved path alone
+    instead, which overcorrected: a profile explicitly declaring a genuinely
+    different, checkable family (``compiler_family: gcc``) against a binding
+    that resolves to a real ``cl.exe`` must still fall through to the probe
+    and be reported as unprobeable.
+    """
+    return Path(path).stem.lower() in _UNPROBED_FAMILIES and (
+        not declared_family or declared_family.strip().lower() in _UNPROBED_FAMILIES
+    )
+
+
 def _check_one_overlay(
     profile_id: str, overlay_key: str, compile_spec: Any, bindings_file: BindingsFile
 ) -> list[str]:
-    binding_id = getattr(compile_spec, "binding", "") if compile_spec else ""
-    declared_family = (
-        getattr(compile_spec, "compiler_family", "") if compile_spec else ""
-    )
-    declared_version = (
-        getattr(compile_spec, "compiler_version", "") if compile_spec else ""
-    )
-    declared_target = getattr(compile_spec, "target", "") if compile_spec else ""
-    if not binding_id or not (declared_family or declared_version or declared_target):
+    declared = _overlay_declaration(compile_spec)
+    if not declared.binding or not declared.declares_anything:
         return []
-    path = bindings_file.bindings.get(binding_id)
+    path = bindings_file.bindings.get(declared.binding)
     if path is None:
         # Already reported by check_profile_bindings_resolve; avoid duplicating.
         return []
-    if Path(path).stem.lower() in _UNPROBED_FAMILIES and (
-        not declared_family or declared_family.strip().lower() in _UNPROBED_FAMILIES
-    ):
-        # MSVC's cl.exe has no --version flag -- the fixed probe this
-        # module reuses always runs exactly that flag -- so a binding that
-        # actually resolves to cl.exe genuinely cannot be identity-checked
-        # with the plumbing available here (see module docstring), whether
-        # compiler_family: msvc was declared explicitly or left unset.
-        #
-        # Both conditions are required, not resolved-path-alone: an earlier
-        # revision of this guard skipped whenever `compiler_family: msvc`
-        # was merely *declared*, regardless of what the binding actually
-        # resolved to -- so a profile declaring `compiler_family: msvc`
-        # whose binding resolves to a real, probeable `/usr/bin/gcc` was
-        # also silently exempted (Codex review, fresh evidence). A later
-        # revision fixed that by keying the skip on the resolved path
-        # alone instead, but that overcorrected in the other direction:
-        # a profile explicitly declaring a genuinely different, checkable
-        # family (`compiler_family: gcc`) against a binding that resolves
-        # to a real `cl.exe` must still fall through to the probe below
-        # and be reported as unprobeable, not silently exempted just
-        # because the resolved binary happens to be MSVC -- exactly the
-        # regression the combined condition here restores.
+    if _is_unprobeable_msvc(path, declared.family):
         return []
 
     where = f"profiles.{profile_id}.{overlay_key}"
@@ -677,215 +905,35 @@ def _check_one_overlay(
         # all (Codex review, fresh evidence).
         reason = metadata.get("error") or version_text
         return [
-            f"{where}: toolchain binding {binding_id!r} (resolved to {path!r}) "
+            f"{where}: toolchain binding {declared.binding!r} (resolved to {path!r}) "
             f"could not be probed: {reason}"
         ]
 
-    errors: list[str] = []
-    # Resolved once, needed by the family check, the version check, and the
-    # target check (target's own semantics depend on whether the actual
-    # compiler is Clang -- see below). An indeterminate family is itself a
-    # failure whenever family, version, or target is declared: silently
-    # passing an unidentifiable executable defeats the point of a hard
-    # validation gate (Codex review, fresh evidence -- a family-only
+    # Resolved once, needed by all three checks (target's own semantics depend
+    # on whether the actual compiler is Clang). An indeterminate family is
+    # itself a failure whenever family, version, or target is declared:
+    # silently passing an unidentifiable executable defeats the point of a
+    # hard validation gate (Codex review, fresh evidence -- a family-only
     # profile previously accepted literally any unrecognized binary, and a
     # *version-only* profile skipped family detection entirely, so binding
-    # e.g. compiler_version: ">=3" to a real /usr/bin/cmake -- not a
-    # compiler at all -- passed unconditionally as long as its own
-    # --version banner happened to contain a matching dotted number).
-    actual_family = (
-        _probe_compiler_family(metadata)
-        if (declared_family or declared_version or declared_target)
-        else None
-    )
-    if declared_family:
-        if actual_family is None:
-            errors.append(
-                f"{where}.compiler_family declares {declared_family!r} but the "
-                f"actual family of toolchain binding {binding_id!r} ({path!r}) "
-                f"could not be determined from its resolved path or --version "
-                f"output"
-            )
-        else:
-            wanted_family = _FAMILY_ALIASES.get(
-                declared_family.strip().lower(), declared_family.strip().lower()
-            )
-            if actual_family != wanted_family:
-                errors.append(
-                    f"{where}.compiler_family declares {declared_family!r} but "
-                    f"toolchain binding {binding_id!r} ({path!r}) resolved to "
-                    f"family {actual_family!r}"
-                )
-    if declared_version:
-        if not declared_family and not declared_target and actual_family is None:
-            # Only reported here when neither of the other two checks
-            # already covers it (both have their own actual_family-is-None
-            # error above/below) -- a bare compiler_version: constraint is
-            # otherwise the one declaration shape with no family/target
-            # check to ever notice the resolved binding isn't recognizably
-            # a compiler at all (Codex review, fresh evidence).
-            errors.append(
-                f"{where}.compiler_version declares {declared_version!r} but the "
-                f"actual family of toolchain binding {binding_id!r} ({path!r}) "
-                f"could not be determined from its resolved path or --version "
-                f"output, so it cannot be verified to be a compiler at all"
-            )
-        try:
-            satisfied = version_satisfies(metadata.get("version", ""), declared_version)
-        except ToolchainProbeError as exc:
-            errors.append(f"{where}.compiler_version: {exc}")
-        else:
-            if not satisfied:
-                errors.append(
-                    f"{where}.compiler_version declares {declared_version!r} but "
-                    f"toolchain binding {binding_id!r} ({path!r}) reported version "
-                    f"output {metadata.get('version', '')!r}, which does not satisfy it"
-                )
-    if declared_target:
-        if actual_family is None:
-            errors.append(
-                f"{where}.target declares {declared_target!r} but the actual "
-                f"family of toolchain binding {binding_id!r} ({path!r}) could "
-                f"not be determined, so its target cannot be verified"
-            )
-        elif actual_family in ("clang", "icx"):
-            # Clang is inherently multi-target: -dumpmachine (what
-            # target_triple comes from) reports only its host default, not
-            # a constraint -- the profile's own compose logic passes the
-            # declared target explicitly via --target=, which a single
-            # Clang binary genuinely honors for cross-compilation. Unlike
-            # GCC (a fixed single-target binary per install), the bare
-            # dumpmachine probe has nothing to compare here (Codex review,
-            # fresh evidence: a real x86_64 Clang with target:
-            # aarch64-linux-gnu was falsely rejected). But an entirely
-            # bogus/misspelled target must still be rejected, so probe
-            # Clang directly with the declared --target= instead (a
-            # second review round, fresh evidence: target:
-            # not-a-real-target previously passed unconditionally).
-            # Intel's oneAPI icx/icpx driver shares this same branch: it is
-            # a clang-based binary accepting the identical --target= flag
-            # (abicheck.dumper_clang already treats it as clang-family for
-            # AST-parsing purposes), so the same multi-target exemption and
-            # real-probe validation apply.
-            digest = metadata.get("sha256")
-            if digest:
-                accepted = _clang_accepts_target(path, digest, declared_target)
-                if accepted is False:
-                    errors.append(
-                        f"{where}.target declares {declared_target!r} but "
-                        f"toolchain binding {binding_id!r} ({path!r}) does not "
-                        f"recognize it as a valid --target= triple"
-                    )
-                elif accepted is None:
-                    # _clang_accepts_target itself returns None only when
-                    # the probe compile couldn't even run (timeout, OSError)
-                    # -- e.g. a wrapper that answers --version fine but
-                    # hangs or fails on a real invocation. Silently
-                    # accepting that leaves the declared target completely
-                    # unverified, the same "can't verify -> error, not a
-                    # silent pass" principle this module applies to every
-                    # other unprobeable case (Codex review, fresh
-                    # evidence).
-                    errors.append(
-                        f"{where}.target declares {declared_target!r} but "
-                        f"toolchain binding {binding_id!r} ({path!r}) could "
-                        f"not be probed for --target= support (the "
-                        f"validation compile did not complete), so the "
-                        f"declared target cannot be verified"
-                    )
-        else:
-            probed_triple = metadata.get("target_triple")
-            if not probed_triple:
-                errors.append(
-                    f"{where}.target declares {declared_target!r} but toolchain "
-                    f"binding {binding_id!r} ({path!r}) has no probed target "
-                    f"triple, so the declared target cannot be verified"
-                )
-            else:
-                declared_arch = _normalize_arch(declared_target.split("-", 1)[0])
-                probed_arch = _normalize_arch(probed_triple.split("-", 1)[0])
-                arch_mismatch = bool(
-                    declared_arch and probed_arch and declared_arch != probed_arch
-                )
-                # A mismatch is flagged whenever the two sides disagree,
-                # including when only one side's OS/environment marker is
-                # recognized -- an unrecognized marker on either side is
-                # itself unverifiable, not evidence of a match. Only "both
-                # unrecognized" is a genuine skip (nothing to compare on
-                # either side). Previously this only fired when BOTH sides
-                # were non-None, so an unrecognized declared OS/env (e.g.
-                # `x86_64-pc-solaris2.11`, `arm-none-eabi`) silently passed
-                # against any real probed triple (Codex review, fresh
-                # evidence).
-                declared_os = _os_family(declared_target)
-                probed_os = _os_family(probed_triple)
-                os_mismatch = bool(
-                    (declared_os is not None or probed_os is not None)
-                    and declared_os != probed_os
-                )
-                declared_env = _env_family(declared_target)
-                probed_env = _env_family(probed_triple)
-                env_mismatch = bool(
-                    (declared_env is not None or probed_env is not None)
-                    and declared_env != probed_env
-                )
-                # Fall back to a raw suffix comparison when NEITHER the OS
-                # nor the environment marker table recognized anything on
-                # EITHER side: os_mismatch/env_mismatch above only fail
-                # closed when at least one side is recognized, so two
-                # triples that are both entirely unrecognized after the
-                # architecture (e.g. `arm-none-eabi` vs `arm-none-elf` --
-                # bare-metal EABI vs ELF object-format spellings, neither
-                # matching any OS/env marker) previously still passed
-                # silently as long as architecture agreed (Codex review,
-                # fresh evidence). Compares every remaining `-`-separated
-                # component (case-insensitive) after normalizing away an
-                # optional, generic vendor placeholder on either side
-                # (`_strip_generic_vendor`) -- `arm-none-eabi` (vendor
-                # omitted) and `arm-unknown-none-eabi` (vendor explicitly
-                # `unknown`) name the same real target, and comparing the
-                # raw component lists without that normalization rejected
-                # the equivalent spelling as a mismatch (Codex review,
-                # fresh evidence).
-                declared_rest = _strip_generic_vendor(
-                    [p for p in declared_target.split("-")[1:] if p]
-                )
-                probed_rest = _strip_generic_vendor(
-                    [p for p in probed_triple.split("-")[1:] if p]
-                )
-                suffix_mismatch = bool(
-                    declared_os is None
-                    and probed_os is None
-                    and declared_env is None
-                    and probed_env is None
-                    and declared_rest
-                    and probed_rest
-                    and [p.lower() for p in declared_rest]
-                    != [p.lower() for p in probed_rest]
-                )
-                if arch_mismatch or os_mismatch or env_mismatch or suffix_mismatch:
-                    mismatches = []
-                    if arch_mismatch:
-                        mismatches.append(
-                            f"architecture {declared_arch!r} vs {probed_arch!r}"
-                        )
-                    if os_mismatch:
-                        mismatches.append(f"OS {declared_os!r} vs {probed_os!r}")
-                    if env_mismatch:
-                        mismatches.append(
-                            f"environment {declared_env!r} vs {probed_env!r}"
-                        )
-                    if suffix_mismatch:
-                        mismatches.append(
-                            "unrecognized target suffix "
-                            f"{'-'.join(declared_rest)!r} vs "
-                            f"{'-'.join(probed_rest)!r}"
-                        )
-                    errors.append(
-                        f"{where}.target declares {declared_target!r} but "
-                        f"toolchain binding {binding_id!r} ({path!r}) resolved to "
-                        f"target triple {probed_triple!r} ({'; '.join(mismatches)})"
-                    )
+    # e.g. compiler_version: ">=3" to a real /usr/bin/cmake -- not a compiler
+    # at all -- passed unconditionally as long as its own --version banner
+    # happened to contain a matching dotted number).
+    actual_family = _probe_compiler_family(metadata)
+
+    errors: list[str] = []
+    if declared.family:
+        errors += _family_errors(
+            where, declared.family, actual_family, declared.binding, path
+        )
+    if declared.version:
+        errors += _version_errors(
+            where, declared, actual_family, metadata, declared.binding, path
+        )
+    if declared.target:
+        errors += _target_errors(
+            where, declared.target, actual_family, metadata, declared.binding, path
+        )
     return errors
 
 

--- a/abicheck/buildsource/type_graph.py
+++ b/abicheck/buildsource/type_graph.py
@@ -538,6 +538,31 @@ def _looks_like_record_definition(node: dict[str, Any]) -> bool:
 
 
 @dataclass(frozen=True)
+class _AstIndexes:
+    """The four whole-TU indexes both AST passes below read and populate.
+
+    Bundled so the two mutually recursive walks take one argument instead of
+    four. Every field is a mutable container filled in place and shared by
+    reference across the whole walk, so the dataclass itself is frozen: what
+    must not change is *which* dicts a walk writes into, not their contents.
+    """
+
+    #: bare type name -> every qualified name it can resolve to in this TU.
+    name_index: dict[str, list[str]]
+    #: entity identity -> the file it was declared in.
+    decl_file: dict[str, str]
+    #: bare var/enum-constant name -> every identity it can resolve to.
+    ref_name_index: dict[str, list[str]]
+    #: clang node id -> (identity, file), the unambiguous reference lookup.
+    id_index: dict[str, tuple[str, str]]
+
+
+def _new_ast_indexes() -> _AstIndexes:
+    """A fresh, empty :class:`_AstIndexes` for one AST walk."""
+    return _AstIndexes({}, {}, {}, {})
+
+
+@dataclass(frozen=True)
 class TypeEdge:
     """One type/reference edge extracted from a clang AST (ADR-041 P0)."""
 
@@ -578,14 +603,81 @@ class TypeEdge:
     resolution: str = field(default="", compare=False)
 
 
+def _index_type_target(
+    qname: str,
+    name: str,
+    cur_file: str,
+    idx: _AstIndexes,
+    *,
+    prefer_definition: bool,
+) -> None:
+    """Index one resolvable *type* target: its bare-name alias and its file.
+
+    ``prefer_definition`` is the records-only rule that a later, complete
+    definition overwrites a file recorded from an earlier forward declaration;
+    enums/typedefs keep the first file seen.
+    """
+    candidates = idx.name_index.setdefault(name, [])
+    if qname not in candidates:
+        candidates.append(qname)
+    if not cur_file:
+        return
+    if prefer_definition:
+        idx.decl_file[qname] = cur_file
+    else:
+        idx.decl_file.setdefault(qname, cur_file)
+
+
+def _index_reference_target(
+    node: Any, name: str, cur_file: str, idx: _AstIndexes
+) -> None:
+    """Index one var/enum-constant as a resolvable *reference* target.
+
+    Three lookups are populated, weakest last: the identity's declaring file,
+    the ambiguous bare-name alias, and clang's own per-node id. The id map is
+    the only unambiguous one — two same-named declarations in different scopes
+    collapse to one bare-name entry, so routing a stub's resolution through
+    ``decl_file``/``ref_name_index`` alone would pick whichever was indexed
+    first (Codex review). Mapping the id to *both* identity and file lets a
+    stub carrying only an ``id`` (no ``mangledName``) resolve its identity
+    precisely too — e.g. telling a reference to ``a::k`` from one to ``b::k``.
+    """
+    ident = _decl_identity(node)
+    if ident and cur_file:
+        idx.decl_file.setdefault(ident, cur_file)
+    if ident and name:
+        candidates = idx.ref_name_index.setdefault(name, [])
+        if ident not in candidates:
+            candidates.append(ident)
+    node_id = str(node.get("id") or "")
+    if node_id and ident:
+        idx.id_index.setdefault(node_id, (ident, cur_file))
+
+
+def _index_children(
+    node: Any,
+    scope: list[str],
+    cur_file: str,
+    idx: _AstIndexes,
+    in_body: bool,
+) -> str:
+    """Index every child of *node* in order, threading the sticky file state.
+
+    clang emits ``loc.file`` only on the *first* declaration in a file — later
+    siblings carry line/column only (Codex review) — so each sibling's return
+    value feeds the next call rather than every child re-receiving the parent's
+    value, which would lose the file for every sibling after the first.
+    """
+    for child in node.get("inner", []) or []:
+        cur_file = _index_declared_entities(child, scope, cur_file, idx, in_body)
+    return cur_file
+
+
 def _index_declared_entities(
     node: Any,
     scope: list[str],
     cur_file: str,
-    name_index: dict[str, list[str]],
-    decl_file: dict[str, str],
-    ref_name_index: dict[str, list[str]],
-    id_index: dict[str, tuple[str, str]],
+    idx: _AstIndexes,
     in_body: bool = False,
 ) -> str:
     """First pass: record every type declaration's qualified name (+declaring
@@ -600,12 +692,9 @@ def _index_declared_entities(
     targets (Codex review: a private enum/typedef used as a field/param type
     was previously left un-indexed, same gap as an un-indexed record).
 
-    Returns the last-seen file after visiting *node* and its whole subtree.
-    clang emits ``loc.file`` only on the *first* declaration in a file — later
-    siblings just carry line/column (Codex review) — so this sticky state
-    must be threaded from one sibling call to the next in every loop below,
-    not just passed down independently to each child from the parent's
-    value, or every sibling after the first loses its file.
+    Returns the last-seen file after visiting *node* and its whole subtree;
+    :func:`_index_children` documents why that state is threaded sibling to
+    sibling.
     """
     if not isinstance(node, dict):
         return cur_file
@@ -616,63 +705,26 @@ def _index_declared_entities(
     name = str(node.get("name") or "")
 
     if kind in _RECORD_DECL_KINDS and name:
-        qname = "::".join([*scope, name])
-        name_index.setdefault(name, [])
-        if qname not in name_index[name]:
-            name_index[name].append(qname)
-        if cur_file and (qname not in decl_file or _looks_like_record_definition(node)):
-            decl_file[qname] = cur_file
-        child_scope = [*scope, name]
-        for child in node.get("inner", []) or []:
-            cur_file = _index_declared_entities(
-                child,
-                child_scope,
-                cur_file,
-                name_index,
-                decl_file,
-                ref_name_index,
-                id_index,
-                in_body,
-            )
-        return cur_file
+        _index_type_target(
+            "::".join([*scope, name]),
+            name,
+            cur_file,
+            idx,
+            prefer_definition=_looks_like_record_definition(node),
+        )
+        return _index_children(node, [*scope, name], cur_file, idx, in_body)
 
     if kind in _OTHER_TYPE_DECL_KINDS and name:
-        qname = "::".join([*scope, name])
-        name_index.setdefault(name, [])
-        if qname not in name_index[name]:
-            name_index[name].append(qname)
-        if cur_file:
-            decl_file.setdefault(qname, cur_file)
+        _index_type_target(
+            "::".join([*scope, name]), name, cur_file, idx, prefer_definition=False
+        )
         # Enum constants (and any nested decls) still need indexing; no new
         # scope is opened — an unscoped/scoped enum's own name is not part of
         # its enumerators' spelling in clang's AST dump.
-        for child in node.get("inner", []) or []:
-            cur_file = _index_declared_entities(
-                child,
-                scope,
-                cur_file,
-                name_index,
-                decl_file,
-                ref_name_index,
-                id_index,
-                in_body,
-            )
-        return cur_file
+        return _index_children(node, scope, cur_file, idx, in_body)
 
     if kind == "NamespaceDecl" and name:
-        child_scope = [*scope, name]
-        for child in node.get("inner", []) or []:
-            cur_file = _index_declared_entities(
-                child,
-                child_scope,
-                cur_file,
-                name_index,
-                decl_file,
-                ref_name_index,
-                id_index,
-                in_body,
-            )
-        return cur_file
+        return _index_children(node, [*scope, name], cur_file, idx, in_body)
 
     if kind == "FieldDecl" and name and not in_body:
         # A field's own qualified identity (``Widget::x``), mirroring
@@ -686,21 +738,9 @@ def _index_declared_entities(
         # Deliberately NOT added to ``name_index``/``ref_name_index`` —
         # fields are not resolvable *type* targets or reference targets in
         # their own right, only entities with their own file to look up.
-        field_ident = "::".join([*scope, name])
         if cur_file:
-            decl_file.setdefault(field_ident, cur_file)
-        for child in node.get("inner", []) or []:
-            cur_file = _index_declared_entities(
-                child,
-                scope,
-                cur_file,
-                name_index,
-                decl_file,
-                ref_name_index,
-                id_index,
-                in_body,
-            )
-        return cur_file
+            idx.decl_file.setdefault("::".join([*scope, name]), cur_file)
+        return _index_children(node, scope, cur_file, idx, in_body)
 
     if kind in _FUNCTION_DECL_KINDS:
         # Everything declared inside a function/method body — including a
@@ -712,52 +752,12 @@ def _index_declared_entities(
         # local variables* get marked ``defined_in_project`` and reported by
         # ``public_to_internal_dependency`` as a hidden internal dependency
         # (Codex review).
-        for child in node.get("inner", []) or []:
-            cur_file = _index_declared_entities(
-                child,
-                scope,
-                cur_file,
-                name_index,
-                decl_file,
-                ref_name_index,
-                id_index,
-                True,
-            )
-        return cur_file
+        return _index_children(node, scope, cur_file, idx, True)
 
     if kind in _REFERENCE_DECL_KINDS and not in_body:
-        ident = _decl_identity(node)
-        if ident and cur_file:
-            decl_file.setdefault(ident, cur_file)
-        if ident and name:
-            candidates = ref_name_index.setdefault(name, [])
-            if ident not in candidates:
-                candidates.append(ident)
-        node_id = str(node.get("id") or "")
-        # Keyed by clang's own per-node id (unique, unlike the bare-name
-        # identity two same-named declarations in different scopes both
-        # collapse to) and mapped to *both* the full identity and the file —
-        # routing either through the shared identity->file `decl_file` dict,
-        # or through the ambiguous bare-name `ref_name_index`, would still
-        # pick whichever same-named declaration was indexed first (Codex
-        # review). A stub that only carries an ``id`` (no ``mangledName``)
-        # can then resolve its *identity* precisely too, not just its file —
-        # e.g. disambiguating a reference to ``a::k`` from one to ``b::k``.
-        if node_id and ident:
-            id_index.setdefault(node_id, (ident, cur_file))
+        _index_reference_target(node, name, cur_file, idx)
 
-    for child in node.get("inner", []) or []:
-        cur_file = _index_declared_entities(
-            child,
-            scope,
-            cur_file,
-            name_index,
-            decl_file,
-            ref_name_index,
-            id_index,
-            in_body,
-        )
-    return cur_file
+    return _index_children(node, scope, cur_file, idx, in_body)
 
 
 #: :func:`_resolve_type_name` resolution labels (ADR-041 richer-confidence
@@ -955,15 +955,208 @@ def _resolve_ref_identity(
     return ident, file, resolution
 
 
+def _walk_children(
+    node: Any,
+    scope: list[str],
+    enclosing_func: str,
+    edges: list[TypeEdge],
+    idx: _AstIndexes,
+) -> None:
+    """Recurse into every child of *node* with the given scope/function."""
+    for child in node.get("inner", []) or []:
+        _walk_types(child, scope, enclosing_func, edges, idx)
+
+
+def _emit_record_member_edges(
+    node: Any,
+    qname: str,
+    child_scope: list[str],
+    edges: list[TypeEdge],
+    idx: _AstIndexes,
+) -> None:
+    """Emit a record's own base and field type edges.
+
+    Base/field types resolve against the record's *own* scope
+    (``child_scope``), not just the enclosing one — a field or base naming a
+    type nested in this same record (``Outer::Inner`` referenced as bare
+    ``"Inner"`` from inside ``Outer``) must be looked up starting from the
+    record's own body outward, matching real C++ member lookup order (Codex
+    review). :func:`_resolve_type_name` still tries every shorter prefix down
+    to the enclosing scopes, so this is a strict superset of the previous
+    (enclosing-scope-only) lookup.
+    """
+    for base in node.get("bases", []) or []:
+        if not isinstance(base, dict):
+            continue
+        base_type = base.get("type")
+        raw_base = (
+            str(base_type.get("qualType", "")) if isinstance(base_type, dict) else ""
+        )
+        _emit_type_edges(
+            edges,
+            qname,
+            raw_base,
+            EDGE_TYPE_INHERITS,
+            "base",
+            child_scope,
+            idx.name_index,
+            idx.decl_file,
+        )
+    for child in node.get("inner", []) or []:
+        if isinstance(child, dict) and child.get("kind") == "FieldDecl":
+            _emit_type_edges(
+                edges,
+                qname,
+                _decl_type_name(child),
+                EDGE_TYPE_HAS_FIELD_TYPE,
+                "field",
+                child_scope,
+                idx.name_index,
+                idx.decl_file,
+            )
+
+
+def _emit_alias_edge(
+    node: Any, scope: list[str], name: str, edges: list[TypeEdge], idx: _AstIndexes
+) -> None:
+    """Emit the edge from a typedef/type-alias to its *underlying* type.
+
+    A public alias's underlying type was never emitted as a dependency at all
+    — only the alias's own name was indexed as a resolvable target (Codex
+    review: ``using Handle = detail::Impl *;`` produced no edge from
+    ``Handle`` to the private ``detail::Impl`` it wraps, so
+    ``public_to_internal_dependency`` had nothing to report for APIs that only
+    ever spell the public alias name).
+    """
+    _emit_type_edges(
+        edges,
+        "::".join([*scope, name]),
+        _decl_type_name(node),
+        EDGE_TYPE_HAS_FIELD_TYPE,
+        "alias",
+        scope,
+        idx.name_index,
+        idx.decl_file,
+    )
+
+
+def _emit_var_decl_edge(
+    node: Any, scope: list[str], name: str, edges: list[TypeEdge], idx: _AstIndexes
+) -> None:
+    """Emit a namespace/class-scope variable's own DECL_HAS_TYPE edge.
+
+    A public/exported data declaration's own type was never emitted either —
+    this module only ever read a VarDecl's type when it was the *target* of a
+    DeclRefExpr, never at its own declaration site (Codex review: ``extern
+    detail::Impl *g;`` or a public static data member produced no
+    DECL_HAS_TYPE edge for the private pointee).
+
+    Identity must be scope-qualified when unmangled (Codex review): a public
+    ``extern "C"`` variable inside a namespace (``namespace api { extern "C"
+    detail::Impl *g; }``) reports ``mangledName == name`` (no real Itanium
+    mangling), so ``SourceEntity.identity()`` falls back to the qualified name
+    ``"api::g"`` -- but the bare ``_decl_identity(node)`` gives just ``"g"``,
+    landing this edge's src on a different ``decl://`` node than the public
+    SOURCE_DECLARES node and breaking reachability from the public variable to
+    its private pointee. :func:`function_decl_identity` with an empty
+    ``type_qual`` falls through to the same bare-qualified-name case (a
+    variable's ``SourceEntity`` never sets ``signature_hash``, unlike a
+    function's), so it doubles as the right fallback here.
+    """
+    ident = function_decl_identity(
+        _normalize_mangled(str(node.get("mangledName") or "")),
+        name,
+        "::".join([*scope, name]) if scope else name,
+        "",
+    )
+    if not ident:
+        return
+    _emit_type_edges(
+        edges,
+        ident,
+        _decl_type_name(node),
+        EDGE_DECL_HAS_TYPE,
+        "var",
+        scope,
+        idx.name_index,
+        idx.decl_file,
+    )
+
+
+def _emit_function_signature_edges(
+    node: Any, ident: str, scope: list[str], edges: list[TypeEdge], idx: _AstIndexes
+) -> None:
+    """Emit a function's own return-type and parameter-type edges."""
+    raw_return = _decl_return_type_name(node)
+    if raw_return:
+        _emit_type_edges(
+            edges,
+            ident,
+            raw_return,
+            EDGE_DECL_HAS_TYPE,
+            "return",
+            scope,
+            idx.name_index,
+            idx.decl_file,
+        )
+    for child in node.get("inner", []) or []:
+        if isinstance(child, dict) and child.get("kind") == "ParmVarDecl":
+            _emit_type_edges(
+                edges,
+                ident,
+                _decl_type_name(child),
+                EDGE_DECL_HAS_TYPE,
+                "param",
+                scope,
+                idx.name_index,
+                idx.decl_file,
+            )
+
+
+def _function_decl_ident(node: Any, scope: list[str], name: str) -> str:
+    """The identity a function/method declaration contributes as an edge src."""
+    if not name:
+        return ""
+    type_obj = node.get("type")
+    return function_decl_identity(
+        _normalize_mangled(str(node.get("mangledName") or "")),
+        name,
+        "::".join([*scope, name]) if scope else name,
+        str(type_obj.get("qualType", "")) if isinstance(type_obj, dict) else "",
+    )
+
+
+def _emit_decl_ref_edge(
+    node: Any, enclosing_func: str, edges: list[TypeEdge], idx: _AstIndexes
+) -> None:
+    """Emit the DECL_REFERENCES_DECL edge for one ``DeclRefExpr``."""
+    ref = node.get("referencedDecl")
+    if not isinstance(ref, dict) or ref.get("kind") not in _REFERENCE_DECL_KINDS:
+        return
+    ref_ident, ref_file, ref_resolution = _resolve_ref_identity(
+        ref, idx.decl_file, idx.ref_name_index, idx.id_index
+    )
+    if not ref_ident or ref_ident == enclosing_func:
+        return
+    edges.append(
+        TypeEdge(
+            enclosing_func,
+            ref_ident,
+            EDGE_DECL_REFERENCES_DECL,
+            CONF_HIGH if ref_resolution == RESOLUTION_REF_EXACT else CONF_REDUCED,
+            "ref",
+            ref_file,
+            ref_resolution,
+        )
+    )
+
+
 def _walk_types(
     node: Any,
     scope: list[str],
     enclosing_func: str,
     edges: list[TypeEdge],
-    name_index: dict[str, list[str]],
-    decl_file: dict[str, str],
-    ref_name_index: dict[str, list[str]],
-    id_index: dict[str, tuple[str, str]],
+    idx: _AstIndexes,
 ) -> None:
     """Recursive AST walk tracking the qualified-name scope and enclosing function."""
     if not isinstance(node, dict):
@@ -972,191 +1165,40 @@ def _walk_types(
     name = str(node.get("name") or "")
 
     if kind in _RECORD_DECL_KINDS and name:
-        qname = "::".join([*scope, name])
-        # Resolve base/field types against the record's *own* scope
-        # (child_scope), not just the enclosing one — a field/base naming a
-        # type nested in this same record (``Outer::Inner`` referenced as
-        # bare "Inner" from inside ``Outer``) must be looked up starting from
-        # the record's own body outward, matching real C++ member lookup
-        # order (Codex review). ``_resolve_type_name`` still tries every
-        # shorter prefix down to the enclosing scopes, so this is a strict
-        # superset of the previous (enclosing-scope-only) lookup.
         child_scope = [*scope, name]
         # A ClassTemplateSpecializationDecl's own "name" is the *primary*
         # template's bare name (clang does not fold template arguments into
-        # it), so qname here collides with the generic template's node id.
-        # Emitting base/field edges from a specific *internal* instantiation
-        # (e.g. Holder<detail::Impl>) would misattribute that one
+        # it), so the qualified name here collides with the generic template's
+        # node id. Emitting base/field edges from a specific *internal*
+        # instantiation (e.g. Holder<detail::Impl>) would misattribute that one
         # instantiation's dependency to the public generic template itself
         # (Codex review) — skip edge emission for specializations, but still
-        # recurse into their children below (nested decls still resolve).
+        # recurse into their children (nested decls still resolve).
         if kind != "ClassTemplateSpecializationDecl":
-            for base in node.get("bases", []) or []:
-                if not isinstance(base, dict):
-                    continue
-                base_type = base.get("type")
-                raw_base = (
-                    str(base_type.get("qualType", ""))
-                    if isinstance(base_type, dict)
-                    else ""
-                )
-                _emit_type_edges(
-                    edges,
-                    qname,
-                    raw_base,
-                    EDGE_TYPE_INHERITS,
-                    "base",
-                    child_scope,
-                    name_index,
-                    decl_file,
-                )
-            for child in node.get("inner", []) or []:
-                if isinstance(child, dict) and child.get("kind") == "FieldDecl":
-                    raw_field = _decl_type_name(child)
-                    _emit_type_edges(
-                        edges,
-                        qname,
-                        raw_field,
-                        EDGE_TYPE_HAS_FIELD_TYPE,
-                        "field",
-                        child_scope,
-                        name_index,
-                        decl_file,
-                    )
-        for child in node.get("inner", []) or []:
-            _walk_types(
-                child,
-                child_scope,
-                enclosing_func,
-                edges,
-                name_index,
-                decl_file,
-                ref_name_index,
-                id_index,
+            _emit_record_member_edges(
+                node, "::".join([*scope, name]), child_scope, edges, idx
             )
+        _walk_children(node, child_scope, enclosing_func, edges, idx)
         return
 
     if kind == "NamespaceDecl" and name:
-        child_scope = [*scope, name]
-        for child in node.get("inner", []) or []:
-            _walk_types(
-                child,
-                child_scope,
-                enclosing_func,
-                edges,
-                name_index,
-                decl_file,
-                ref_name_index,
-                id_index,
-            )
+        _walk_children(node, [*scope, name], enclosing_func, edges, idx)
         return
 
     if kind in _OTHER_TYPE_DECL_KINDS and name:
-        # A public alias's *underlying* type was never emitted as a
-        # dependency at all — only the alias's own name was indexed as a
-        # resolvable target (Codex review: `using Handle = detail::Impl *;`
-        # produced no edge from `Handle` to the private `detail::Impl` it
-        # actually wraps, so `public_to_internal_dependency` had nothing to
-        # report for APIs that only ever spell the public alias name).
-        qname = "::".join([*scope, name])
-        raw_underlying = _decl_type_name(node)
-        _emit_type_edges(
-            edges,
-            qname,
-            raw_underlying,
-            EDGE_TYPE_HAS_FIELD_TYPE,
-            "alias",
-            scope,
-            name_index,
-            decl_file,
-        )
+        _emit_alias_edge(node, scope, name, edges, idx)
 
     if kind == "VarDecl" and name and not enclosing_func:
-        # A public/exported data declaration's *own* type was never emitted
-        # either — this module only ever read a VarDecl's type when it was
-        # the *target* of a DeclRefExpr, never at its own declaration site
-        # (Codex review: `extern detail::Impl *g;` or a public static data
-        # member produced no DECL_HAS_TYPE edge for the private pointee).
         # Block-scope locals are excluded the same way
         # `_index_declared_entities`'s `in_body` tracking excludes them from
         # provenance — `enclosing_func` is only truthy inside a function/
         # method body, never for a namespace- or class-scope declaration.
-        #
-        # Identity must be scope-qualified when unmangled (Codex review): a
-        # public `extern "C"` variable inside a namespace (`namespace api {
-        # extern "C" detail::Impl *g; }`) reports mangledName == name (no
-        # real Itanium mangling), so SourceEntity.identity() falls back to
-        # the qualified name "api::g" -- but the bare _decl_identity(node)
-        # used here gives just "g", landing this edge's src on a different
-        # decl:// node than the public SOURCE_DECLARES node, breaking
-        # reachability from the public variable to its private pointee.
-        # function_decl_identity() with an empty type_qual falls through to
-        # the same bare-qualified-name case (a variable's SourceEntity never
-        # sets signature_hash, unlike a function's), so it doubles as the
-        # right fallback here too.
-        qualified_name = "::".join([*scope, name]) if scope else name
-        ident = function_decl_identity(
-            _normalize_mangled(str(node.get("mangledName") or "")),
-            name,
-            qualified_name,
-            "",
-        )
-        if ident:
-            raw_var = _decl_type_name(node)
-            _emit_type_edges(
-                edges,
-                ident,
-                raw_var,
-                EDGE_DECL_HAS_TYPE,
-                "var",
-                scope,
-                name_index,
-                decl_file,
-            )
+        _emit_var_decl_edge(node, scope, name, edges, idx)
 
     if kind in _FUNCTION_DECL_KINDS:
-        qualified_name = "::".join([*scope, name]) if scope else name
-        type_obj = node.get("type")
-        type_qual = (
-            str(type_obj.get("qualType", "")) if isinstance(type_obj, dict) else ""
-        )
-        ident = (
-            function_decl_identity(
-                _normalize_mangled(str(node.get("mangledName") or "")),
-                name,
-                qualified_name,
-                type_qual,
-            )
-            if name
-            else ""
-        )
+        ident = _function_decl_ident(node, scope, name)
         if ident:
-            raw_return = _decl_return_type_name(node)
-            if raw_return:
-                _emit_type_edges(
-                    edges,
-                    ident,
-                    raw_return,
-                    EDGE_DECL_HAS_TYPE,
-                    "return",
-                    scope,
-                    name_index,
-                    decl_file,
-                )
-            for child in node.get("inner", []) or []:
-                if isinstance(child, dict) and child.get("kind") == "ParmVarDecl":
-                    raw_param = _decl_type_name(child)
-                    _emit_type_edges(
-                        edges,
-                        ident,
-                        raw_param,
-                        EDGE_DECL_HAS_TYPE,
-                        "param",
-                        scope,
-                        name_index,
-                        decl_file,
-                    )
-        next_func = ident or enclosing_func
+            _emit_function_signature_edges(node, ident, scope, edges, idx)
         # Recurse into every child, including a ParmVarDecl — its type was
         # already recorded as a "param" edge above, but a default-argument
         # expression (e.g. `int f(int x = detail::k)`) lives *under* the
@@ -1166,17 +1208,7 @@ def _walk_types(
         # default argument (Codex review). ParmVarDecl isn't a case this
         # walk special-cases, so recursing into it just walks its children
         # with the enclosing function scope — the same as every other node.
-        for child in node.get("inner", []) or []:
-            _walk_types(
-                child,
-                scope,
-                next_func,
-                edges,
-                name_index,
-                decl_file,
-                ref_name_index,
-                id_index,
-            )
+        _walk_children(node, scope, ident or enclosing_func, edges, idx)
         return
 
     if kind == "FieldDecl" and name:
@@ -1189,53 +1221,13 @@ def _walk_types(
         # review). Give it a scope-qualified identity, mirroring how a
         # function's own identity becomes the enclosing_func for its body.
         field_ident = "::".join([*scope, name])
-        for child in node.get("inner", []) or []:
-            _walk_types(
-                child,
-                scope,
-                field_ident or enclosing_func,
-                edges,
-                name_index,
-                decl_file,
-                ref_name_index,
-                id_index,
-            )
+        _walk_children(node, scope, field_ident or enclosing_func, edges, idx)
         return
 
     if kind == "DeclRefExpr" and enclosing_func:
-        ref = node.get("referencedDecl")
-        if isinstance(ref, dict) and ref.get("kind") in _REFERENCE_DECL_KINDS:
-            ref_ident, ref_file, ref_resolution = _resolve_ref_identity(
-                ref, decl_file, ref_name_index, id_index
-            )
-            if ref_ident and ref_ident != enclosing_func:
-                edges.append(
-                    TypeEdge(
-                        enclosing_func,
-                        ref_ident,
-                        EDGE_DECL_REFERENCES_DECL,
-                        CONF_HIGH
-                        if ref_resolution == RESOLUTION_REF_EXACT
-                        else CONF_REDUCED,
-                        "ref",
-                        ref_file,
-                        ref_resolution,
-                    )
-                )
+        _emit_decl_ref_edge(node, enclosing_func, edges, idx)
 
-    for child in node.get("inner", []) or []:
-        _walk_types(
-            child,
-            scope,
-            enclosing_func,
-            edges,
-            name_index,
-            decl_file,
-            ref_name_index,
-            id_index,
-        )
-
-
+    _walk_children(node, scope, enclosing_func, edges, idx)
 def _dedupe_edges(edges: list[TypeEdge]) -> list[TypeEdge]:
     """Dedup on ``(src, dst, kind, role)``, not just ``(src, dst, kind)``
     (Codex review, fresh evidence): a function that both returns and takes
@@ -1279,15 +1271,10 @@ def index_declared_type_files(ast: dict[str, Any]) -> dict[str, str]:
     declaration. Filtered here to exactly the qualified names
     ``name_index`` actually collected — the type-only subset.
     """
-    name_index: dict[str, list[str]] = {}
-    decl_file: dict[str, str] = {}
-    ref_name_index: dict[str, list[str]] = {}
-    id_index: dict[str, tuple[str, str]] = {}
-    _index_declared_entities(
-        ast, [], "", name_index, decl_file, ref_name_index, id_index
-    )
-    type_qnames = {qname for qnames in name_index.values() for qname in qnames}
-    return {qname: decl_file[qname] for qname in type_qnames if qname in decl_file}
+    idx = _new_ast_indexes()
+    _index_declared_entities(ast, [], "", idx)
+    type_qnames = {qname for qnames in idx.name_index.values() for qname in qnames}
+    return {q: idx.decl_file[q] for q in type_qnames if q in idx.decl_file}
 
 
 def index_declared_entity_files(ast: dict[str, Any]) -> dict[str, str]:
@@ -1310,14 +1297,9 @@ def index_declared_entity_files(ast: dict[str, Any]) -> dict[str, str]:
     per-edge ``dst_file``/``caller_file``/``callee_file`` backfill for each
     edge's *target* (Codex review).
     """
-    name_index: dict[str, list[str]] = {}
-    decl_file: dict[str, str] = {}
-    ref_name_index: dict[str, list[str]] = {}
-    id_index: dict[str, tuple[str, str]] = {}
-    _index_declared_entities(
-        ast, [], "", name_index, decl_file, ref_name_index, id_index
-    )
-    return decl_file
+    idx = _new_ast_indexes()
+    _index_declared_entities(ast, [], "", idx)
+    return idx.decl_file
 
 
 def parse_clang_ast_types(ast: dict[str, Any]) -> list[TypeEdge]:
@@ -1339,15 +1321,10 @@ def parse_clang_ast_types(ast: dict[str, Any]) -> list[TypeEdge]:
     types and non-call body references). Edges are de-duplicated by
     ``(src, dst, kind)``.
     """
-    name_index: dict[str, list[str]] = {}
-    decl_file: dict[str, str] = {}
-    ref_name_index: dict[str, list[str]] = {}
-    id_index: dict[str, tuple[str, str]] = {}
-    _index_declared_entities(
-        ast, [], "", name_index, decl_file, ref_name_index, id_index
-    )
+    idx = _new_ast_indexes()
+    _index_declared_entities(ast, [], "", idx)
     edges: list[TypeEdge] = []
-    _walk_types(ast, [], "", edges, name_index, decl_file, ref_name_index, id_index)
+    _walk_types(ast, [], "", edges, idx)
     return _dedupe_edges(edges)
 
 

--- a/changelog.d/20260810_000000_claude_codefactor_complexity_buildsource.md
+++ b/changelog.d/20260810_000000_claude_codefactor_complexity_buildsource.md
@@ -1,0 +1,11 @@
+### Changed
+
+- **The `buildsource/` AST and pack-handling internals were restructured to
+  cut cyclomatic complexity** — fourteen functions flagged by CodeFactor's
+  `Complex Method` check were split into named, individually-testable
+  helpers. The heaviest were `type_graph`'s two AST passes (`_walk_types`,
+  `_index_declared_entities`), which now share one `_AstIndexes` bundle
+  instead of threading four index dicts through every recursive call, and
+  `toolchain_probe._check_one_overlay`, whose compiler family/version/target
+  validations became three separate error producers. No behaviour, output,
+  or public signature changes.


### PR DESCRIPTION
## Summary

First batch of the CodeFactor **Complexity** cleanup: **14 of the board's 68** `Complex Method` findings — every one in `abicheck/buildsource/`. Behaviour-preserving extraction only; no logic changes.

Rebased onto `main` after #688 was squash-merged, so this now shows only its own two commits (12 files).

## Motivation

Reading the actual CodeFactor board changed the picture from what #688 assumed. Its 69 issues were:

| Category | Count | Severity | Engine |
|---|---|---|---|
| Complexity — `Complex Method` | 68 | Minor | CodeFactor's own metric (threshold ~16) |
| Security — unsafe yaml load | 1 | **Major** | bandit |

CodeFactor does **not** report pylint for this repo. The single Major (`abicheck/impact/use_cases.py:284`) went in with #688. Everything remaining is complexity, spread across 60 files.

The metric is not reproducible locally — I fitted candidate formulas against all 59 Python findings and the best fit matched only 8 — so `mccabe` is used as a proxy: it identifies the **same functions with the same line ranges**, running 0–9 points below CodeFactor's number. Targets below are quoted as mccabe.

## Changes

| Function | mccabe | CodeFactor (before) |
|---|---|---|
| `type_graph._walk_types` | 26 → **11** | 35 |
| `type_graph._index_declared_entities` | 24 → **10** | 33 |
| `toolchain_probe._check_one_overlay` | 24 → **8** | 33 |
| `inputs_emit.compact_inputs_pack` | 26 → **10** | 25 |
| `inline.BuildConfig.from_dict` | 20 → **<9** | 16 |
| `inline.BuildConfig._validate_structure` | 18 → **<9** | 22 |
| `source_link.link_source_abi` | 18 → **<12** | 21 |
| `header_graph.build_header_only_graph` | 17 → **9** | 16 |
| `crosscheck_coherence._check_compile_context_conflict` | 16 → **<9** | 18 |
| `project_targets._target_issues` | 16 → **<12** | 17 |
| `l2_seed.derive_l2_include_dirs` | 15 → **<9** | 17 |
| `inputs_validate.validate_inputs_pack` | 14 → **<9** | 16 |
| `check_report.augment_report` | 14 → **<9** | 17 |
| `include_graph.depfile_args_from_argv` | 13 → **<9** | 17 |

Shapes worth calling out:

- **`type_graph`** — the four whole-TU indexes both AST passes thread through (`name_index`/`decl_file`/`ref_name_index`/`id_index`) become one frozen `_AstIndexes` bundle, so the recursive calls take 5 arguments instead of 8. Each `kind` branch becomes its own emitter (`_emit_record_member_edges`, `_emit_alias_edge`, `_emit_var_decl_edge`, `_emit_function_signature_edges`, `_emit_decl_ref_edge`), with a shared `_walk_children`/`_index_children` sibling loop.
- **`header_graph.build_header_only_graph`** — the two mutually exclusive halves (clang AST available vs. not) split into `_seed_ast_graph` and `_seed_flat_graph`. They were one 150-line `if/else` whose branches stamp `extractor_passes` differently, and the reason each stamps what it does is load-bearing (a flat pass must never vouch for `HEADER_CALL_GRAPH_PASS`).
- **`toolchain_probe`** — family / version / target checks split into three error producers; `_triple_mismatches` isolates the arch/OS/env/raw-suffix comparison; the four declared identity fields become an `_OverlayDeclaration`.
- **`inline`** — the repeated `x = data.get(k) if isinstance(data, dict) else None; x = x if isinstance(x, dict) else {}` pair (eight copies) collapses to one `_block()` reader, and the four enum validations to one `_one_of()`.

Every reviewed comment explaining *why* a rule exists moves with the code it describes — none were dropped in the extraction.

## Checklist

- [x] Tests added / updated for new behaviour — n/a, behaviour-preserving; the existing suite covers every touched path
- [x] Changelog fragment added — no user-facing behaviour changes in this batch; #688 carries the series' fragment
- [x] Docs updated if user-visible behaviour changed — n/a
- [x] `pre-commit run --all-files` passes locally — `ruff check` over all five first-party trees; `python -m mypy abicheck/` clean (331 files); fast unit lane **23184 passed, 12 skipped, 4 xfailed**
- [x] No new `mypy` or `ruff` errors introduced

## Remaining

54 of 68 findings are still open, grouped for the next batches: dumper/AST (10), CLI (7), reporting (5), core compare/diff (23), scripts+validation+actions (6), and C++ (3, in `contrib/abicheck-clang-plugin` and `tools/clang-layout-tool`).
