### PR TITLE
refactor: cut CodeFactor "Complex Method" complexity in the dumper/AST layer (18 of 68)

### DIFF
--- a/abicheck/build_context.py
+++ b/abicheck/build_context.py
@@ -324,6 +324,127 @@ def _read_response_file(path: Path, root: Path) -> str | None:
 _ResponseFileCache = dict[tuple[str, bool], "list[str] | None"]
 
 
+def _read_and_tokenize_response_file(
+    path: Path,
+    root: Path,
+    *,
+    cl_style: bool,
+    read_budget: list[int],
+    cache_token_budget: list[int] | None,
+) -> list[str] | None:
+    """One response file's tokens, or ``None`` when it must not be expanded.
+
+    ``None`` is a *cacheable* rejection — unreadable/oversized/out-of-tree file,
+    unparsable contents, or a token count no entry could ever afford — so the
+    caller memoizes it and no later entry re-reads the same file to reach the
+    same answer.
+
+    Two of those rejections are size caps rather than errors:
+
+    * Over ``_MAX_RESPONSE_FILE_OUTPUT_TOKENS``: no entry's own output budget
+      ever starts above this constant (a fresh top-level call always defaults to
+      it), so a file this dense can never fit any entry regardless of how much
+      of that budget is left -- cache the rejection instead of the full token
+      list, or many distinct oversized files in one untrusted database would
+      each retain a huge, never-usable tokens list indefinitely (Codex review,
+      sixth round).
+    * Over the remaining *cache_token_budget*: a distinct file under the fixed
+      per-entry cap (so not caught above) can still be over THIS entry's own
+      remaining budget and be rejected for it -- but its full tokens list would
+      still be retained for possible reuse by a later entry with a fresh budget.
+      Many such distinct, never-actually-used files can accumulate unbounded
+      cached memory without ever charging the database-wide output budget (which
+      is only charged when tokens are actually spliced into some entry's
+      output). This separate, cache-population-time budget is charged instead,
+      regardless of whether the tokens end up used (Codex review, seventh round).
+    """
+    text = _read_response_file(path, root)
+    if text is None:
+        return None
+    read_budget[0] -= 1
+    try:
+        tokens = _split_command_line(text, cl_style=cl_style)
+    except ValueError:
+        return None
+    if len(tokens) > _MAX_RESPONSE_FILE_OUTPUT_TOKENS:
+        return None
+    if cache_token_budget is not None:
+        if len(tokens) > cache_token_budget[0]:
+            return None
+        cache_token_budget[0] -= len(tokens)
+    return tokens
+
+
+def _exceeds_output_budget(
+    tokens: list[str], output_budget: list[int], db_output_budget: list[int] | None
+) -> bool:
+    """True when splicing *tokens* would overrun a remaining output budget.
+
+    The pre-loop budget check only rejects a *subsequent* ``@file`` once the
+    budget has already gone negative, so a single response file at or near the
+    byte cap (tokenizable into hundreds of thousands of short tokens) could
+    otherwise still be expanded whole in one shot before that check ever fires
+    (Codex review, third round). The caller rejects the whole file rather than
+    partially truncating it -- a partial flag list is worse than none.
+    """
+    return len(tokens) > output_budget[0] or (
+        db_output_budget is not None and len(tokens) > db_output_budget[0]
+    )
+
+
+def _response_file_tokens_for_arg(
+    arg: str,
+    directory: Path,
+    root: Path,
+    *,
+    cl_style: bool,
+    read_budget: list[int],
+    output_budget: list[int],
+    db_output_budget: list[int] | None,
+    cache_token_budget: list[int] | None,
+    file_cache: _ResponseFileCache,
+) -> list[str] | None:
+    """Tokens for one ``@file`` argument, or ``None`` to keep the token as-is.
+
+    Resolves the path against *directory* (the compile action's own working
+    directory) unless already absolute, consults *file_cache*, and applies every
+    budget gate. ``None`` covers all four "do not expand" outcomes: an exhausted
+    output budget, an exhausted read budget, a cached-or-fresh rejection from
+    :func:`_read_and_tokenize_response_file`, and a token count that would
+    overrun the remaining output budget.
+    """
+    if output_budget[0] <= 0 or (
+        db_output_budget is not None and db_output_budget[0] <= 0
+    ):
+        return None
+    raw_path = Path(arg[1:])
+    path = raw_path if raw_path.is_absolute() else directory / raw_path
+    resolved = _safe_resolve(path)
+    cache_key = (str(resolved), cl_style) if resolved is not None else None
+    if cache_key is not None and cache_key in file_cache:
+        tokens = file_cache[cache_key]
+    elif read_budget[0] <= 0:
+        # No read budget left. Deliberately *not* cached: nothing was read, so
+        # there is no result to memoize -- a later call with its own budget must
+        # still get a real chance to read this file.
+        return None
+    else:
+        tokens = _read_and_tokenize_response_file(
+            path,
+            root,
+            cl_style=cl_style,
+            read_budget=read_budget,
+            cache_token_budget=cache_token_budget,
+        )
+        if cache_key is not None:
+            file_cache[cache_key] = tokens
+    if tokens is None or _exceeds_output_budget(
+        tokens, output_budget, db_output_budget
+    ):
+        return None
+    return tokens
+
+
 def _expand_response_files(
     arguments: list[str],
     directory: Path,
@@ -422,82 +543,18 @@ def _expand_response_files(
         if not arg.startswith("@") or len(arg) == 1:
             expanded.append(arg)
             continue
-        if _output_budget[0] <= 0 or (
-            _db_output_budget is not None and _db_output_budget[0] <= 0
-        ):
-            expanded.append(arg)
-            continue
-        raw_path = Path(arg[1:])
-        path = raw_path if raw_path.is_absolute() else directory / raw_path
-        resolved = _safe_resolve(path)
-        cache_key = (str(resolved), cl_style) if resolved is not None else None
-        if cache_key is not None and cache_key in _file_cache:
-            tokens = _file_cache[cache_key]
-        else:
-            if _budget[0] <= 0:
-                expanded.append(arg)
-                continue
-            text = _read_response_file(path, root)
-            if text is None:
-                tokens = None
-            else:
-                _budget[0] -= 1
-                try:
-                    tokens = _split_command_line(text, cl_style=cl_style)
-                except ValueError:
-                    tokens = None
-                if (
-                    tokens is not None
-                    and len(tokens) > _MAX_RESPONSE_FILE_OUTPUT_TOKENS
-                ):
-                    # No entry's own _output_budget ever starts above this
-                    # constant (a fresh top-level call always defaults to
-                    # it), so a file this dense can never fit any entry
-                    # regardless of how much of that budget is left --
-                    # cache the rejection instead of the full token list,
-                    # or many distinct oversized files in one untrusted
-                    # database would each retain a huge, never-usable
-                    # tokens list in _file_cache indefinitely (Codex
-                    # review, sixth round).
-                    tokens = None
-                if (
-                    tokens is not None
-                    and _cache_token_budget is not None
-                    and len(tokens) > _cache_token_budget[0]
-                ):
-                    # A distinct file under the fixed per-entry cap (so not
-                    # caught above) can still be over THIS entry's own
-                    # remaining budget and be rejected for it -- but its
-                    # full tokens list would still be retained in
-                    # _file_cache for possible reuse by a later entry with
-                    # a fresh budget. Many such distinct, never-actually-
-                    # used files can accumulate unbounded cached memory
-                    # without ever charging _db_output_budget (which is
-                    # only charged when tokens are actually spliced into
-                    # some entry's output). Charge this separate,
-                    # cache-population-time budget instead, regardless of
-                    # whether the tokens end up used (Codex review, seventh
-                    # round).
-                    tokens = None
-                elif tokens is not None and _cache_token_budget is not None:
-                    _cache_token_budget[0] -= len(tokens)
-            if cache_key is not None:
-                _file_cache[cache_key] = tokens
+        tokens = _response_file_tokens_for_arg(
+            arg,
+            directory,
+            root,
+            cl_style=cl_style,
+            read_budget=_budget,
+            output_budget=_output_budget,
+            db_output_budget=_db_output_budget,
+            cache_token_budget=_cache_token_budget,
+            file_cache=_file_cache,
+        )
         if tokens is None:
-            expanded.append(arg)
-            continue
-        if len(tokens) > _output_budget[0] or (
-            _db_output_budget is not None and len(tokens) > _db_output_budget[0]
-        ):
-            # This single file's own token count already exceeds the
-            # remaining output budget -- the pre-loop budget check above
-            # only rejects a *subsequent* @file once the budget has already
-            # gone negative, so a single response file at or near the byte
-            # cap (tokenizable into hundreds of thousands of short tokens)
-            # could otherwise still be expanded whole in one shot before
-            # that check ever fires (Codex review, third round). Reject the
-            # whole file rather than partially truncating it -- a partial
-            # flag list is worse than none.
             expanded.append(arg)
             continue
         _output_budget[0] -= len(tokens)

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import logging
 import os
-import shlex
 import shutil as shutil  # noqa: F401  # legacy test patch target
 import subprocess
 import tempfile
@@ -38,11 +37,12 @@ if TYPE_CHECKING:
 from defusedxml import ElementTree as DefusedET
 
 from . import deadline, dumper_cache
-from ._compiler_options import has_explicit_cpp_std, has_explicit_std
+from ._compiler_options import has_explicit_cpp_std
 from .castxml_policy import evaluate_castxml_version
 from .dumper_ast_config import (
     _CPP_ONLY_PATTERNS as _CPP_ONLY_PATTERNS,
     _build_castxml_command as _build_castxml_command,
+    _build_clang_header_command as _build_clang_header_command,
     _cache_key as _cache_key,
     _detect_cpp_headers as _detect_cpp_headers,
     _resolve_compiler_binary as _resolve_compiler_binary,
@@ -65,7 +65,7 @@ from .dumper_clang import (
     _clang_available as _clang_available,
     _ClangAstParser as _ClangAstParser,
     _is_dpcpp_family_binary as _is_dpcpp_family_binary,
-    _needs_sycl_host_only,
+    _needs_sycl_host_only as _needs_sycl_host_only,
     _resolve_clang_bin as _resolve_clang_bin,
     _resolve_dpcpp_multi_context,
 )
@@ -104,12 +104,19 @@ from .dumper_elf_fallback import (
 from .dumper_elf_symbols import (
     # ELF visibility/symbol-classification helpers live in the sibling module
     # (dumper.py is at the file-size cap); re-exported here so
-    # ``dumper._elf_classify_symbols``/``dumper._populate_elf_visibility``
-    # remain valid bare-name calls in ``_dump_elf``/``_try_dwarf_snapshot``/
-    # ``_build_symbol_only_snapshot`` and existing test patch targets.
+    # ``dumper._elf_classify_symbols``/``dumper._populate_elf_visibility``/
+    # ``dumper._pyelftools_exported_symbols`` remain valid bare-name calls in
+    # ``_dump_elf``/``_try_dwarf_snapshot``/``_build_symbol_only_snapshot``
+    # (and in the Mach-O/PE paths) and existing test patch targets. Because
+    # every caller still lives in ``dumper``, a bare-name call resolves through
+    # this module's namespace at call time, so ``monkeypatch.setattr(dumper,
+    # "_pyelftools_exported_symbols", ...)`` keeps taking effect.
     _ELF_VIS_MAP as _ELF_VIS_MAP,
+    _HIDDEN_VIS as _HIDDEN_VIS,
     _elf_classify_symbols as _elf_classify_symbols,
+    _is_abi_relevant_symbol as _is_abi_relevant_symbol,
     _populate_elf_visibility as _populate_elf_visibility,
+    _pyelftools_exported_symbols as _pyelftools_exported_symbols,
 )
 from .dumper_layout_backfill import (
     backfill_dwarf_layout,
@@ -142,7 +149,6 @@ from .dumper_toolchain import (
     _tool_identity as _tool_identity,
     _tool_identity_metadata as _tool_identity_metadata,
 )
-from .elf_symbol_filter import is_abi_relevant_elf_symbol
 from .errors import (
     AstContextMissingError,
     SnapshotError,
@@ -187,88 +193,6 @@ def _resolve_header_backend(backend: str | None) -> str:
     if env in ("castxml", "clang", "hybrid"):
         return env
     return "castxml"
-
-
-def _build_clang_header_command(
-    cc_bin: str,
-    cc_id: str,
-    extra_includes: list[Path],
-    agg_path: Path,
-    *,
-    sysroot: Path | None = None,
-    nostdinc: bool = False,
-    gcc_options: str | None = None,
-    gcc_option_tokens: tuple[str, ...] = (),
-    force_cpp: bool = False,
-    force_cpp20: bool = False,
-    system_includes: tuple[str, ...] = (),
-    dpcpp_multi_context: bool = False,
-) -> list[str]:
-    """Build the ``clang -ast-dump=json`` command for the aggregate header.
-
-    Mirrors :func:`_build_castxml_command`'s flag handling (includes, sysroot,
-    ``-nostdinc``, pass-through options, C-vs-C++ language mode and the C++20
-    bump) so the clang backend parses the same TU under the same context.
-    ``-fsyntax-only``/``-ferror-limit=0`` keeps parsing past recoverable
-    errors so a single bad decl does not blank the whole dump.
-
-    ``system_includes`` are host-compiler-probed system dirs (see
-    :func:`_probe_gnu_system_includes`) injected as ``-isystem`` so clang
-    finds the same libstdc++/libc headers castxml gets via
-    ``--castxml-cc-gnu``. Emitted **last** (after the user's ``-I`` and
-    pass-through ``--gcc-options``/``--gcc-option``) so a user-supplied
-    ``-isystem`` for a cross/hermetic SDK wins. Skipped under ``-nostdinc``.
-
-    On an Intel oneAPI driver, ``-fsycl-host-only`` is appended per
-    :func:`_needs_sycl_host_only` (PR #643) -- skipped when
-    ``dpcpp_multi_context`` is set, since that request wants both passes.
-
-    ``dpcpp_multi_context`` (ADR-050 D5, G32 Phase D) adds ``-fsycl -v``
-    when *cc_bin* is DPC++-capable (:func:`_is_dpcpp_family_binary`) --
-    ``-fsycl`` splits the driver into a host + one-or-more-device
-    compilation passes, and ``-v`` emits the ``-cc1 ... -triple <T> ...
-    -fsycl-is-(host|device)`` stderr lines :mod:`abicheck.sycl_context`
-    needs to correlate each stdout document back to a host/device ``kind``.
-    """
-    cmd = [cc_bin]
-    for inc in extra_includes:
-        cmd += ["-I", str(inc)]
-    if sysroot:
-        cmd += [f"--sysroot={sysroot.as_posix()}"]
-    if nostdinc:
-        cmd += ["-nostdinc"]
-    if gcc_options:
-        cmd += shlex.split(gcc_options, posix=os.name != "nt")
-    # Repeatable --gcc-option: one literal argument each (no shlex split).
-    cmd += list(gcc_option_tokens)
-    if not dpcpp_multi_context and _needs_sycl_host_only(cc_bin, cmd):
-        cmd.append("-fsycl-host-only")
-    # Auto-probed host system dirs go *after* the user's pass-through flags, so a
-    # user-supplied -isystem (cross/hermetic SDK) keeps higher priority (Codex review).
-    for sysinc in system_includes:
-        cmd += ["-isystem", sysinc]
-    explicit_std = has_explicit_std(gcc_options, gcc_option_tokens)
-    if not force_cpp:
-        if not explicit_std:
-            cmd += ["-x", "c", "-std=gnu11"]
-    elif not explicit_std:
-        # Select the C++ language explicitly (``-x c++``) rather than relying on
-        # the aggregate file's extension: the C→C++ retry reuses a ``.h`` aggregate
-        # that clang would otherwise parse as C. Only bump the standard to gnu++20
-        # when C++20 syntax was detected; otherwise leave clang's default dialect.
-        cmd += ["-x", "c++"]
-        if force_cpp20:
-            cmd += ["-std=gnu++20"]
-    if dpcpp_multi_context:
-        cmd += ["-fsycl", "-v"]
-    cmd += [
-        "-fsyntax-only",
-        "-ferror-limit=0",
-        "-Xclang",
-        "-ast-dump=json",
-        str(agg_path),
-    ]
-    return cmd
 
 
 def _resolve_force_cpp(
@@ -554,6 +478,160 @@ def _clang_header_dump(
             _p.unlink(missing_ok=True)
 
 
+def _resolve_single_ast_backend(backend: str, frontend_context: str) -> str:
+    """Resolve *backend* to the one L2 frontend that will actually run.
+
+    Rejects the two requests no single parser can satisfy: ``"hybrid"`` (which
+    only :func:`abicheck.dumper_hybrid.run_hybrid_dump` can resolve) and a
+    non-``"host"`` *frontend_context* under a deliberately-chosen castxml, which
+    has no SYCL/DPC++ host/device context concept. Split out of
+    :func:`_header_ast_parser` so that function reads as the three-way backend
+    dispatch it is.
+    """
+    resolved = _resolve_header_backend(backend)
+    if resolved == "hybrid":
+        # No single parser exists for "hybrid" — must be resolved by
+        # dumper_hybrid.run_hybrid_dump, not silently treated as castxml.
+        raise ValidationError(
+            '"hybrid" AST frontend has no single parser here '
+            "(see dumper_hybrid.run_hybrid_dump)."
+        )
+    # `resolved` alone can't tell explicit/env-pinned/defaulted castxml apart; an env pin counts as explicit (environment.md: "honoured verbatim").
+    _env_pinned_castxml = (backend or "auto").lower() == "auto" and (
+        os.environ.get("ABICHECK_AST_FRONTEND", "").strip().lower() == "castxml"
+    )
+    if (
+        resolved == "castxml"
+        and frontend_context != "host"
+        and ((backend or "auto").lower() == "castxml" or _env_pinned_castxml)
+    ):
+        raise AstContextMissingError(
+            f"--frontend-context {frontend_context!r} requires the clang "
+            "header backend (--ast-frontend clang); castxml has no SYCL/"
+            "DPC++ host/device context concept."
+        )
+    return resolved
+
+
+def _stamp_ast_parser(
+    parser: _CastxmlParser | _ClangAstParser,
+    *,
+    producer: str,
+    executable: str,
+    compiler: str,
+    gcc_path: str | None,
+    gcc_prefix: str | None,
+    fallback_reason: str | None = None,
+) -> _CastxmlParser | _ClangAstParser:
+    """Attach the frontend/compiler provenance attributes to a built parser.
+
+    Module-level (rather than a closure over :func:`_header_ast_parser`) so the
+    stamping rules are readable on their own; *compiler*/*gcc_path*/*gcc_prefix*
+    are the enclosing call's toolchain selection, needed only to probe the host
+    compiler behind a castxml dump.
+    """
+    metadata = {"producer": producer, **_tool_identity_metadata(executable)}
+    dialect: str | None
+    if producer == "clang":
+        compiler_meta = _tool_identity_metadata(executable)
+        # clang is both frontend and compiler here (mirrors
+        # _resolve_clang_langmode's own cc_id derivation for the same
+        # binary); same dialect test used there.
+        dialect = "msvc" if Path(executable).name.lower() in ("cl", "cl.exe") else "gnu"
+    else:
+        try:
+            host_cc, dialect = _resolve_compiler_binary(compiler, gcc_path, gcc_prefix)
+            compiler_meta = _tool_identity_metadata(host_cc)
+        except SnapshotError as exc:
+            metadata["compiler_error"] = str(exc)
+            compiler_meta = {}
+            dialect = None
+    metadata.update({f"compiler_{key}": value for key, value in compiler_meta.items()})
+    # ADR-050 D1: surface the ABI dialect (gnu/msvc) instead of
+    # discarding it -- compute_extraction_contract's abi_dialect field
+    # reads this key (Codex review, PR #624 follow-up).
+    if dialect is not None:
+        metadata["abi_dialect"] = dialect
+    setattr(parser, "_abicheck_ast_toolchain", metadata)
+    setattr(parser, "_abicheck_ast_fallback_reason", fallback_reason)
+    if producer == "castxml":
+        check = evaluate_castxml_version(metadata.get("version", ""))
+        setattr(parser, "_abicheck_ast_supported", check.supported)
+        setattr(parser, "_abicheck_ast_unsupported_reasons", check.reasons)
+        metadata.update(check.provenance_fields())
+    return parser
+
+
+def _castxml_fallback_reason(
+    exc: SnapshotError,
+    *,
+    auto_selected: bool,
+    compiler: str,
+    gcc_path: str | None,
+    gcc_prefix: str | None,
+) -> str | None:
+    """Decide whether a failed castxml dump may fall back to the clang backend.
+
+    Returns the ``fallback_reason`` to stamp on the clang parser, or ``None``
+    when the caller must re-raise *exc* unchanged. Raises an annotated copy of
+    *exc* when the failure *is* fallback-eligible but the opt-in is off, so the
+    user is told why the fallback did not happen rather than just seeing the raw
+    castxml error. Split out of :func:`_header_ast_parser`; the reasoning behind
+    each eligible signature is in the comments below.
+    """
+    # A proactive UnsupportedCastxmlVersionError (raised before castxml
+    # even runs) is exactly the same "this castxml can't be trusted"
+    # signal as the two string-matched stderr signatures below — it's
+    # just detected earlier and more precisely (an exact version
+    # comparison instead of a diagnostic-text guess). The opt-in
+    # fallback's whole purpose is letting a user accept the
+    # castxml/clang discrepancy risk to keep scanning on a host whose
+    # castxml can't be trusted; excluding this one reason a castxml is
+    # untrusted defeated that opt-in for exactly the case this PR's own
+    # new gate creates (Codex review).
+    is_version_gate_failure = isinstance(exc, UnsupportedCastxmlVersionError)
+    eligible = auto_selected and (
+        is_version_gate_failure
+        or _is_toolchain_version_failure(str(exc))
+        or _is_direct_include_guard_failure(str(exc))
+    )
+    if not eligible:
+        return None
+
+    # Probe the driver _run_clang() would actually invoke (honors
+    # --gcc-path/--gcc-prefix), not just a bare "clang" on PATH (Codex
+    # review).
+    def _clang_fallback_ready() -> bool:
+        try:
+            _resolve_clang_bin(compiler, gcc_path, gcc_prefix)
+            return True
+        except SnapshotError:
+            return False
+
+    if not _ast_fallback_enabled() or not _clang_fallback_ready():
+        message = (
+            f"{exc}\n\nAutomatic CastXML-to-Clang fallback is disabled because "
+            "the two frontends can produce materially different findings. "
+            "Install a compatible CastXML, select --ast-frontend clang "
+            "explicitly, or opt in with --allow-ast-frontend-fallback "
+            "(ABICHECK_ALLOW_AST_FALLBACK=1)."
+        )
+        raise type(exc)(message) from exc
+    log.warning(
+        "castxml could not parse the header(s) (toolchain mismatch, an "
+        "unsupported castxml version, or a header that refuses direct "
+        "inclusion); falling back to the clang header backend, which "
+        "parses against the host toolchain and can exclude direct-include "
+        "#error guard headers. Set --ast-frontend castxml to force castxml "
+        "and see the original error."
+    )
+    if is_version_gate_failure:
+        return "castxml-unsupported-version"
+    if _is_toolchain_version_failure(str(exc)):
+        return "castxml-toolchain-version-mismatch"
+    return "castxml-direct-include-guard"
+
+
 def _header_ast_parser(
     headers: list[Path],
     extra_includes: list[Path],
@@ -584,28 +662,7 @@ def _header_ast_parser(
     fails immediately rather than silently returning an ordinary castxml
     dump; under ``"auto"`` a non-``"host"`` request skips castxml entirely.
     """
-    resolved = _resolve_header_backend(backend)
-    if resolved == "hybrid":
-        # No single parser exists for "hybrid" — must be resolved by
-        # dumper_hybrid.run_hybrid_dump, not silently treated as castxml.
-        raise ValidationError(
-            '"hybrid" AST frontend has no single parser here '
-            "(see dumper_hybrid.run_hybrid_dump)."
-        )
-    # `resolved` alone can't tell explicit/env-pinned/defaulted castxml apart; an env pin counts as explicit (environment.md: "honoured verbatim").
-    _env_pinned_castxml = (backend or "auto").lower() == "auto" and (
-        os.environ.get("ABICHECK_AST_FRONTEND", "").strip().lower() == "castxml"
-    )
-    if (
-        resolved == "castxml"
-        and frontend_context != "host"
-        and ((backend or "auto").lower() == "castxml" or _env_pinned_castxml)
-    ):
-        raise AstContextMissingError(
-            f"--frontend-context {frontend_context!r} requires the clang "
-            "header backend (--ast-frontend clang); castxml has no SYCL/"
-            "DPC++ host/device context concept."
-        )
+    resolved = _resolve_single_ast_backend(backend, frontend_context)
 
     def _stamp_parser(
         parser: _CastxmlParser | _ClangAstParser,
@@ -614,42 +671,15 @@ def _header_ast_parser(
         executable: str,
         fallback_reason: str | None = None,
     ) -> _CastxmlParser | _ClangAstParser:
-        metadata = {"producer": producer, **_tool_identity_metadata(executable)}
-        dialect: str | None
-        if producer == "clang":
-            compiler_meta = _tool_identity_metadata(executable)
-            # clang is both frontend and compiler here (mirrors
-            # _resolve_clang_langmode's own cc_id derivation for the same
-            # binary); same dialect test used there.
-            dialect = (
-                "msvc" if Path(executable).name.lower() in ("cl", "cl.exe") else "gnu"
-            )
-        else:
-            try:
-                host_cc, dialect = _resolve_compiler_binary(
-                    compiler, gcc_path, gcc_prefix
-                )
-                compiler_meta = _tool_identity_metadata(host_cc)
-            except SnapshotError as exc:
-                metadata["compiler_error"] = str(exc)
-                compiler_meta = {}
-                dialect = None
-        metadata.update(
-            {f"compiler_{key}": value for key, value in compiler_meta.items()}
+        return _stamp_ast_parser(
+            parser,
+            producer=producer,
+            executable=executable,
+            compiler=compiler,
+            gcc_path=gcc_path,
+            gcc_prefix=gcc_prefix,
+            fallback_reason=fallback_reason,
         )
-        # ADR-050 D1: surface the ABI dialect (gnu/msvc) instead of
-        # discarding it -- compute_extraction_contract's abi_dialect field
-        # reads this key (Codex review, PR #624 follow-up).
-        if dialect is not None:
-            metadata["abi_dialect"] = dialect
-        setattr(parser, "_abicheck_ast_toolchain", metadata)
-        setattr(parser, "_abicheck_ast_fallback_reason", fallback_reason)
-        if producer == "castxml":
-            check = evaluate_castxml_version(metadata.get("version", ""))
-            setattr(parser, "_abicheck_ast_supported", check.supported)
-            setattr(parser, "_abicheck_ast_unsupported_reasons", check.reasons)
-            metadata.update(check.provenance_fields())
-        return parser
 
     def _run_clang(*, fallback_reason: str | None = None) -> _ClangAstParser:
         clang_bin = _resolve_clang_bin(compiler, gcc_path, gcc_prefix)
@@ -711,67 +741,16 @@ def _header_ast_parser(
             _selected_tool_out=selected_castxml,
         )
     except SnapshotError as exc:
-        # Probe the driver _run_clang() would actually invoke (honors
-        # --gcc-path/--gcc-prefix), not just a bare "clang" on PATH (Codex
-        # review).
-        def _clang_fallback_ready() -> bool:
-            try:
-                _resolve_clang_bin(compiler, gcc_path, gcc_prefix)
-                return True
-            except SnapshotError:
-                return False
-
-        # A proactive UnsupportedCastxmlVersionError (raised before castxml
-        # even runs) is exactly the same "this castxml can't be trusted"
-        # signal as the two string-matched stderr signatures below — it's
-        # just detected earlier and more precisely (an exact version
-        # comparison instead of a diagnostic-text guess). The opt-in
-        # fallback's whole purpose is letting a user accept the
-        # castxml/clang discrepancy risk to keep scanning on a host whose
-        # castxml can't be trusted; excluding this one reason a castxml is
-        # untrusted defeated that opt-in for exactly the case this PR's own
-        # new gate creates (Codex review).
-        is_version_gate_failure = isinstance(exc, UnsupportedCastxmlVersionError)
-        if (
-            auto_selected
-            and _ast_fallback_enabled()
-            and _clang_fallback_ready()
-            and (
-                is_version_gate_failure
-                or _is_toolchain_version_failure(str(exc))
-                or _is_direct_include_guard_failure(str(exc))
-            )
-        ):
-            log.warning(
-                "castxml could not parse the header(s) (toolchain mismatch, an "
-                "unsupported castxml version, or a header that refuses direct "
-                "inclusion); falling back to the clang header backend, which "
-                "parses against the host toolchain and can exclude direct-include "
-                "#error guard headers. Set --ast-frontend castxml to force castxml "
-                "and see the original error."
-            )
-            fallback_reason = (
-                "castxml-unsupported-version"
-                if is_version_gate_failure
-                else "castxml-toolchain-version-mismatch"
-                if _is_toolchain_version_failure(str(exc))
-                else "castxml-direct-include-guard"
-            )
-            return _run_clang(fallback_reason=fallback_reason)
-        if auto_selected and (
-            is_version_gate_failure
-            or _is_toolchain_version_failure(str(exc))
-            or _is_direct_include_guard_failure(str(exc))
-        ):
-            message = (
-                f"{exc}\n\nAutomatic CastXML-to-Clang fallback is disabled because "
-                "the two frontends can produce materially different findings. "
-                "Install a compatible CastXML, select --ast-frontend clang "
-                "explicitly, or opt in with --allow-ast-frontend-fallback "
-                "(ABICHECK_ALLOW_AST_FALLBACK=1)."
-            )
-            raise type(exc)(message) from exc
-        raise
+        fallback_reason = _castxml_fallback_reason(
+            exc,
+            auto_selected=auto_selected,
+            compiler=compiler,
+            gcc_path=gcc_path,
+            gcc_prefix=gcc_prefix,
+        )
+        if fallback_reason is None:
+            raise
+        return _run_clang(fallback_reason=fallback_reason)
     parser = _CastxmlParser(
         xml_root,
         exported_dynamic,
@@ -789,64 +768,106 @@ def _header_ast_parser(
     )
 
 
-_HIDDEN_VIS = frozenset({"STV_HIDDEN", "STV_INTERNAL"})
+def _resolve_gated_castxml_bin(castxml_bin: str | None) -> str:
+    """Resolve the castxml executable and fail closed on an out-of-policy build.
 
-
-def _is_abi_relevant_symbol(name: str) -> bool:
-    """Return False for symbols that are NOT part of the library's public ABI.
-
-    Filters out (in ELF-only mode):
-    1. GCC/compiler internal symbols (``ix86_*``, ``_ZGV*``, ``__svml_*`` …)
-       that leak into ``.dynsym`` through a statically-linked runtime.
-    2. Transitive C++ stdlib symbols (``_ZNSt*``, ``_ZTI*`` …) that appear
-       in ``.dynsym`` via weak linkage from libstdc++ / libc++.
-    3. Private C symbols that use ``__`` as a namespace separator
-       (e.g. ``H5C__flush``, ``MPI__send``).  These follow an internal
-       naming convention and are *not* part of the public API, even though
-       they may have global ELF visibility.
+    The version gate (``castxml_policy``) runs *before* any header is parsed. An
+    out-of-policy build (notably the legacy PyPI ``castxml`` distribution) is
+    rejected unless the caller explicitly opted in via
+    ``ABICHECK_ALLOW_UNSUPPORTED_CASTXML``. Skipped when the executable itself
+    could not even be resolved/probed (``"error"`` key) — that is a different,
+    pre-existing failure mode (missing/unreadable binary) that the actual castxml
+    invocation reports precisely; this gate only judges a version it could
+    actually observe.
     """
-    return is_abi_relevant_elf_symbol(name)
-
-
-def _pyelftools_exported_symbols(so_path: Path) -> tuple[set[str], set[str]]:
-    """Return (exported_dynamic, exported_static) sets of mangled symbol names.
-
-    Uses pyelftools (pure Python) instead of shelling out to readelf.
-    - exported_dynamic: symbols from .dynsym, truly exported via ELF
-    - exported_static: symbols from .symtab (all symbols including static)
-    """
-    from elftools.common.exceptions import ELFError
-    from elftools.elf.elffile import ELFFile
-    from elftools.elf.sections import SymbolTableSection
-
-    def _extract_symbols(elf: Any, section_name: str) -> set[str]:
-        syms: set[str] = set()
-        section = elf.get_section_by_name(section_name)
-        if section is None or not isinstance(section, SymbolTableSection):
-            return syms
-        for sym in section.iter_symbols():
-            shndx = sym.entry.st_shndx
-            if shndx in ("SHN_UNDEF", "SHN_ABS"):
-                continue
-            bind = sym.entry.st_info.bind
-            vis = sym.entry.st_other.visibility
-            if bind in ("STB_GLOBAL", "STB_WEAK") and vis not in _HIDDEN_VIS:
-                name = sym.name
-                if name and _is_abi_relevant_symbol(name):
-                    syms.add(name)
-        return syms
-
     try:
-        with open(so_path, "rb") as f:
-            elf: Any = ELFFile(f)  # type: ignore[no-untyped-call]
-            exported_dynamic = _extract_symbols(elf, ".dynsym")
-            try:
-                exported_static = _extract_symbols(elf, ".symtab")
-            except (ELFError, OSError):
-                exported_static = set(exported_dynamic)
-            return exported_dynamic, exported_static
-    except (ELFError, OSError) as exc:
-        raise SnapshotError(f"Failed to parse ELF file {so_path}: {exc}") from exc
+        resolved = castxml_bin or _resolve_selected_tool("castxml")
+    except OSError as exc:
+        raise SnapshotError(
+            "castxml not found in PATH. Install with: apt install castxml, "
+            "brew install castxml, conda install -c conda-forge castxml, "
+            "or choco install castxml (Windows); then ensure castxml is in PATH. "
+            "On a clang-only host, run with --ast-frontend clang (or "
+            "ABICHECK_AST_FRONTEND=clang) to use the clang JSON-AST backend "
+            "instead — note it does not carry record size/alignment/offset "
+            "layout, so layout-only breaks need castxml or debug info (L1)."
+        ) from exc
+    meta = _tool_identity_metadata(resolved)
+    if "error" not in meta:
+        check = evaluate_castxml_version(meta.get("version", ""))
+        if not check.supported and not _allow_unsupported_castxml_enabled():
+            raise UnsupportedCastxmlVersionError(check.message(found_at=resolved))
+    return resolved
+
+
+def _read_castxml_cache(cached: Path) -> Element | None:
+    """Parse a cached castxml XML tree, discarding the entry if it is unusable.
+
+    Returns ``None`` (having unlinked *cached*) when the file cannot be parsed,
+    so the caller falls through to a fresh run rather than failing on a
+    truncated or corrupt cache entry.
+    """
+    try:
+        root = DefusedET.parse(str(cached)).getroot()
+    except Exception:
+        root = None
+    if root is None:
+        cached.unlink(missing_ok=True)
+        return None
+    return cast(Element, root)
+
+
+def _castxml_cpp_retry_allowed(
+    primary: SnapshotError, *, force_cpp: bool, headers: list[Path]
+) -> bool:
+    """Whether a failed C-mode castxml run may be retried in C++ mode (G16/A3).
+
+    An explicit ``--lang c`` on a header that actually requires C++ (a stray
+    class/namespace/template, or C++20 concept/requires syntax — Codex review)
+    should degrade to a C++ retry rather than hard-fail. No retry when we are
+    already in C++ mode, when the failure is a frontend-too-old signature (a mode
+    switch won't help), or when the header has no *genuinely C++-only* construct
+    (``_CPP_ONLY_PATTERNS`` excludes ``extern "C"``: a guarded ``extern "C"``
+    header is valid C, so a C-mode failure there is real and must NOT be masked
+    by re-parsing as C++, which would skip the ``#ifndef __cplusplus`` branches —
+    Codex review).
+    """
+    if force_cpp or _is_toolchain_version_failure(str(primary)):
+        return False
+    return _detect_cpp_headers(headers, _CPP_ONLY_PATTERNS) or _detect_cpp20_headers(
+        headers
+    )
+
+
+def _write_castxml_cache(
+    cached: Path,
+    out_xml: Path,
+    *,
+    castxml_bin: str,
+    cc_bin: str,
+    frontend_identity: object,
+    compiler_identity: object,
+) -> None:
+    """Persist a fresh castxml XML dump, unless the toolchain moved underneath us.
+
+    The cache key encodes the frontend/compiler identities observed *before* the
+    run; if either changed while castxml was executing, the produced XML no
+    longer describes that key, so the write is skipped rather than poisoning the
+    cache. A cache write that fails on I/O is a warning, never an error — the
+    dump itself already succeeded.
+    """
+    if (
+        _tool_identity(castxml_bin) != frontend_identity
+        or _tool_identity(cc_bin) != compiler_identity
+    ):
+        log.warning(
+            "AST toolchain changed during CastXML execution; skipping cache write"
+        )
+        return
+    try:
+        _atomic_write(cached, out_xml.read_bytes())
+    except OSError as exc:
+        log.warning("Could not write castxml AST cache %s: %s", cached, exc)
 
 
 def _castxml_dump(
@@ -876,36 +897,9 @@ def _castxml_dump(
         nostdinc: If True, do not search standard system include paths.
         lang: Force language ("C" or "C++").  If "C", aggregated header uses .h extension.
     """
-    try:
-        castxml_bin = castxml_bin or _resolve_selected_tool("castxml")
-    except OSError as exc:
-        raise SnapshotError(
-            "castxml not found in PATH. Install with: apt install castxml, "
-            "brew install castxml, conda install -c conda-forge castxml, "
-            "or choco install castxml (Windows); then ensure castxml is in PATH. "
-            "On a clang-only host, run with --ast-frontend clang (or "
-            "ABICHECK_AST_FRONTEND=clang) to use the clang JSON-AST backend "
-            "instead — note it does not carry record size/alignment/offset "
-            "layout, so layout-only breaks need castxml or debug info (L1)."
-        ) from exc
+    castxml_bin = _resolve_gated_castxml_bin(castxml_bin)
     if _selected_tool_out is not None:
         _selected_tool_out.append(castxml_bin)
-
-    # CastXML version gate (castxml_policy) — fail closed *before* any header
-    # is parsed. An out-of-policy build (notably the legacy PyPI ``castxml``
-    # distribution) is rejected unless the caller explicitly opted in via
-    # ABICHECK_ALLOW_UNSUPPORTED_CASTXML. Skipped when the executable itself
-    # could not even be resolved/probed (``"error"`` key) — that is a
-    # different, pre-existing failure mode (missing/unreadable binary) that
-    # the actual castxml invocation below already reports precisely; this
-    # gate only judges a version it could actually observe.
-    _castxml_meta = _tool_identity_metadata(castxml_bin)
-    if "error" not in _castxml_meta:
-        _version_check = evaluate_castxml_version(_castxml_meta.get("version", ""))
-        if not _version_check.supported and not _allow_unsupported_castxml_enabled():
-            raise UnsupportedCastxmlVersionError(
-                _version_check.message(found_at=castxml_bin)
-            )
 
     # Determine language before selecting the emulated compiler: C mode uses
     # gcc/cc, not g++, and both cache identity and execution must describe the
@@ -951,15 +945,10 @@ def _castxml_dump(
     if cached.exists():
         # Same reasoning as the clang cache-hit path (_clang_header_dump, Codex review).
         deadline.check()
-        try:
-            _cached_root = DefusedET.parse(str(cached)).getroot()
-        except Exception:
-            _cached_root = None
-        if _cached_root is None:
-            cached.unlink(missing_ok=True)
-        else:
+        _cached_root = _read_castxml_cache(cached)
+        if _cached_root is not None:
             deadline.check()  # parsing a huge cached tree can eat the rest of the budget
-            return cast(Element, _cached_root)
+            return _cached_root
 
     with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as tmp:
         out_xml = Path(tmp.name)
@@ -980,23 +969,8 @@ def _castxml_dump(
                 castxml_bin=castxml_bin,
             )
         except SnapshotError as primary:
-            # G16/A3: an explicit ``--lang c`` on a header that actually requires
-            # C++ (a stray class/namespace/template, or C++20 concept/requires
-            # syntax — Codex review) should degrade to a C++ retry rather than
-            # hard-fail. Skip the retry when we are already in C++ mode, when
-            # the failure is a frontend-too-old signature (a mode switch won't
-            # help), or when the header has no *genuinely C++-only* construct
-            # (``_CPP_ONLY_PATTERNS`` excludes ``extern "C"``: a guarded
-            # ``extern "C"`` header is valid C, so a C-mode failure there is real
-            # and must NOT be masked by re-parsing as C++, which would skip the
-            # ``#ifndef __cplusplus`` branches — Codex review).
-            if (
-                force_cpp
-                or _is_toolchain_version_failure(str(primary))
-                or not (
-                    _detect_cpp_headers(headers, _CPP_ONLY_PATTERNS)
-                    or _detect_cpp20_headers(headers)
-                )
+            if not _castxml_cpp_retry_allowed(
+                primary, force_cpp=force_cpp, headers=headers
             ):
                 raise
             log.warning(
@@ -1024,18 +998,14 @@ def _castxml_dump(
                 # error (and its hint), not the fallback's, so the diagnostic
                 # matches what the user asked for.
                 raise primary from None
-        if (
-            _tool_identity(castxml_bin) != frontend_identity
-            or _tool_identity(cc_bin) != compiler_identity
-        ):
-            log.warning(
-                "AST toolchain changed during CastXML execution; skipping cache write"
-            )
-        else:
-            try:
-                _atomic_write(cached, out_xml.read_bytes())
-            except OSError as exc:
-                log.warning("Could not write castxml AST cache %s: %s", cached, exc)
+        _write_castxml_cache(
+            cached,
+            out_xml,
+            castxml_bin=castxml_bin,
+            cc_bin=cc_bin,
+            frontend_identity=frontend_identity,
+            compiler_identity=compiler_identity,
+        )
         # Re-reading/caching a huge fresh tree can itself consume real time;
         # re-check before returning (mirrors _validate_castxml_output's pre-cache-write check, Codex review).
         deadline.check()

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -530,13 +530,16 @@ def _stamp_ast_parser(
     are the enclosing call's toolchain selection, needed only to probe the host
     compiler behind a castxml dump.
     """
-    metadata = {"producer": producer, **_tool_identity_metadata(executable)}
+    executable_meta = _tool_identity_metadata(executable)
+    metadata = {"producer": producer, **executable_meta}
     dialect: str | None
     if producer == "clang":
-        compiler_meta = _tool_identity_metadata(executable)
         # clang is both frontend and compiler here (mirrors
         # _resolve_clang_langmode's own cc_id derivation for the same
-        # binary); same dialect test used there.
+        # binary); same dialect test used there -- and since it is the same
+        # binary, reuse the probe above rather than re-hashing and
+        # re-running --version on it (CodeRabbit review).
+        compiler_meta = executable_meta
         dialect = "msvc" if Path(executable).name.lower() in ("cl", "cl.exe") else "gnu"
     else:
         try:
@@ -845,8 +848,8 @@ def _write_castxml_cache(
     *,
     castxml_bin: str,
     cc_bin: str,
-    frontend_identity: object,
-    compiler_identity: object,
+    frontend_identity: str,
+    compiler_identity: str,
 ) -> None:
     """Persist a fresh castxml XML dump, unless the toolchain moved underneath us.
 

--- a/abicheck/dumper_ast_config.py
+++ b/abicheck/dumper_ast_config.py
@@ -1,7 +1,17 @@
 # Copyright 2026 Nikolay Petrov
 # SPDX-License-Identifier: Apache-2.0
 
-"""AST cache-key, language detection, and CastXML command helpers."""
+"""AST cache-key, language detection, and CastXML/Clang command helpers.
+
+``_build_castxml_command`` and ``_build_clang_header_command`` are deliberate
+neighbours: the two backends must parse the same TU under the same context, so
+their flag handling (includes, sysroot, ``-nostdinc``, pass-through options,
+C-vs-C++ mode, the C++20 bump) is meant to be read side by side. The clang
+builder previously lived in ``dumper.py``, which sits at the AI-readiness
+2000-line hard cap; it is pure argv construction with no dependency on the
+dumper pipeline, so it lives here and ``dumper`` re-exports it (several callers
+and tests import ``abicheck.dumper._build_clang_header_command``).
+"""
 
 from __future__ import annotations
 
@@ -13,6 +23,7 @@ from collections.abc import Sequence
 from pathlib import Path
 
 from ._compiler_options import has_explicit_std
+from .dumper_clang import _needs_sycl_host_only
 from .header_utils import iter_cache_header_files
 
 
@@ -267,4 +278,86 @@ def _build_castxml_command(
             cmd += ["-x", "c++", "-std=gnu++20"]
 
     cmd += ["-o", str(out_xml), str(agg_path)]
+    return cmd
+
+
+def _build_clang_header_command(
+    cc_bin: str,
+    cc_id: str,
+    extra_includes: list[Path],
+    agg_path: Path,
+    *,
+    sysroot: Path | None = None,
+    nostdinc: bool = False,
+    gcc_options: str | None = None,
+    gcc_option_tokens: tuple[str, ...] = (),
+    force_cpp: bool = False,
+    force_cpp20: bool = False,
+    system_includes: tuple[str, ...] = (),
+    dpcpp_multi_context: bool = False,
+) -> list[str]:
+    """Build the ``clang -ast-dump=json`` command for the aggregate header.
+
+    Mirrors :func:`_build_castxml_command`'s flag handling (includes, sysroot,
+    ``-nostdinc``, pass-through options, C-vs-C++ language mode and the C++20
+    bump) so the clang backend parses the same TU under the same context.
+    ``-fsyntax-only``/``-ferror-limit=0`` keeps parsing past recoverable
+    errors so a single bad decl does not blank the whole dump.
+
+    ``system_includes`` are host-compiler-probed system dirs (see
+    :func:`_probe_gnu_system_includes`) injected as ``-isystem`` so clang
+    finds the same libstdc++/libc headers castxml gets via
+    ``--castxml-cc-gnu``. Emitted **last** (after the user's ``-I`` and
+    pass-through ``--gcc-options``/``--gcc-option``) so a user-supplied
+    ``-isystem`` for a cross/hermetic SDK wins. Skipped under ``-nostdinc``.
+
+    On an Intel oneAPI driver, ``-fsycl-host-only`` is appended per
+    :func:`_needs_sycl_host_only` (PR #643) -- skipped when
+    ``dpcpp_multi_context`` is set, since that request wants both passes.
+
+    ``dpcpp_multi_context`` (ADR-050 D5, G32 Phase D) adds ``-fsycl -v``
+    when *cc_bin* is DPC++-capable (:func:`_is_dpcpp_family_binary`) --
+    ``-fsycl`` splits the driver into a host + one-or-more-device
+    compilation passes, and ``-v`` emits the ``-cc1 ... -triple <T> ...
+    -fsycl-is-(host|device)`` stderr lines :mod:`abicheck.sycl_context`
+    needs to correlate each stdout document back to a host/device ``kind``.
+    """
+    cmd = [cc_bin]
+    for inc in extra_includes:
+        cmd += ["-I", str(inc)]
+    if sysroot:
+        cmd += [f"--sysroot={sysroot.as_posix()}"]
+    if nostdinc:
+        cmd += ["-nostdinc"]
+    if gcc_options:
+        cmd += shlex.split(gcc_options, posix=os.name != "nt")
+    # Repeatable --gcc-option: one literal argument each (no shlex split).
+    cmd += list(gcc_option_tokens)
+    if not dpcpp_multi_context and _needs_sycl_host_only(cc_bin, cmd):
+        cmd.append("-fsycl-host-only")
+    # Auto-probed host system dirs go *after* the user's pass-through flags, so a
+    # user-supplied -isystem (cross/hermetic SDK) keeps higher priority (Codex review).
+    for sysinc in system_includes:
+        cmd += ["-isystem", sysinc]
+    explicit_std = has_explicit_std(gcc_options, gcc_option_tokens)
+    if not force_cpp:
+        if not explicit_std:
+            cmd += ["-x", "c", "-std=gnu11"]
+    elif not explicit_std:
+        # Select the C++ language explicitly (``-x c++``) rather than relying on
+        # the aggregate file's extension: the C→C++ retry reuses a ``.h`` aggregate
+        # that clang would otherwise parse as C. Only bump the standard to gnu++20
+        # when C++20 syntax was detected; otherwise leave clang's default dialect.
+        cmd += ["-x", "c++"]
+        if force_cpp20:
+            cmd += ["-std=gnu++20"]
+    if dpcpp_multi_context:
+        cmd += ["-fsycl", "-v"]
+    cmd += [
+        "-fsyntax-only",
+        "-ferror-limit=0",
+        "-Xclang",
+        "-ast-dump=json",
+        str(agg_path),
+    ]
     return cmd

--- a/abicheck/dumper_ast_config_cpp20.py
+++ b/abicheck/dumper_ast_config_cpp20.py
@@ -997,22 +997,26 @@ def _is_preprocessor_directive(line: bytes) -> bool:
     return re.match(rb"^\s*#", line) is not None
 
 
+#: The construct a :class:`Cpp20Requirement` names. Aliased so
+#: :func:`_requirement_kind`, which classifies a line into exactly one of
+#: these, is checked against the same closed set the dataclass accepts.
+Cpp20RequirementReason = Literal[
+    "concept-declaration",
+    "requires-expression",
+    "requires-clause",
+    "constrained-template-parameter",
+    "custom-constrained-auto-parameter",
+    "abbreviated-function-template-parameter",
+    "consteval-declaration",
+    "constinit-declaration",
+]
 
 
 @dataclass(frozen=True)
 class Cpp20Requirement:
     """A single structural C++20 construct found while scanning headers."""
 
-    reason: Literal[
-        "concept-declaration",
-        "requires-expression",
-        "requires-clause",
-        "constrained-template-parameter",
-        "custom-constrained-auto-parameter",
-        "abbreviated-function-template-parameter",
-        "consteval-declaration",
-        "constinit-declaration",
-    ]
+    reason: Cpp20RequirementReason
     path: str
     line: int
 
@@ -1138,6 +1142,207 @@ def _expand_with_quoted_includes(
     return expanded
 
 
+@dataclass(frozen=True)
+class _Cpp20ShadowFlags:
+    """Whether each C++20 keyword also names an ordinary type in the aggregate.
+
+    ORed across *every* header, not computed per file: *header_paths* is the
+    whole aggregate castxml/clang parses as a single translation unit, so a
+    pre-C++20 compatibility type shadowing one of these keywords can live in a
+    shared ``compat.hpp`` while the ambiguous bare use sits in ``api.hpp`` — a
+    per-file check would see only the latter and wrongly force C++20 mode on
+    the whole aggregate (Codex review, sixth round).
+    """
+
+    concept: bool = False
+    requires: bool = False
+    consteval: bool = False
+    constinit: bool = False
+
+
+def _preprocessed_header_content(
+    path: Path, *, for_language_mode_decision: bool
+) -> tuple[bytes, bytes] | None:
+    """``(scan_content, shadow_scan_content)`` for one header, or ``None``.
+
+    Raw string literals are blanked first — their body can contain arbitrary
+    quotes/backslashes that would otherwise confuse the ordinary string-literal
+    stripper. Then string/char literals, so a literal containing comment-like
+    text (``"/* not a comment */"``) is never mistaken for a real comment;
+    that pass is backslash-newline-continuation-tolerant (Codex review) so a
+    literal split across a continuation cannot leave its trapped text — e.g. a
+    fake ``struct concept {};`` inside an error message — visible to the shadow
+    scan. Block comments are replaced by their own newline count so
+    later-reported line numbers stay accurate (CodeRabbit review).
+
+    The two returned copies differ only in how dialect-fallback guards are
+    masked, and that difference is load-bearing (Codex review, nineteenth
+    round). The shadow scan asks "does ``concept`` name an ordinary type in
+    code still reachable *if C++20 were chosen*", so a ``struct concept {};``
+    shim confined to ``#if __cplusplus < 202002L`` — content that goes away
+    once C++20 is chosen — must not count; for the requirements scan that same
+    guarded arm is the unconditionally-relevant one.
+    """
+    try:
+        content = path.read_bytes()
+    except OSError:
+        return None
+    content = _strip_raw_strings(content)
+    content = _strip_literals_crossing_continuations(content)
+    content = re.sub(
+        rb"/\*.*?\*/",
+        lambda m: b"\n" * m.group(0).count(b"\n"),
+        content,
+        flags=re.DOTALL,
+    )
+    # A separate, additionally "//"-line-comment-stripped copy: raw
+    # strings/literals/block comments are already blanked above, but "//"
+    # comments are only stripped per-logical-line further down, and a
+    # "// struct concept {};" comment must never make a *real* concept
+    # declaration elsewhere look ambiguous (Codex review, fifth round).
+    # #if 0 / #if false regions go too — a disabled compatibility stub must not
+    # shadow a genuine keyword used elsewhere (Codex review).
+    no_double_slash = re.sub(rb"//[^\n]*", b"", content)
+    scan_content = _strip_inactive_if_zero_blocks(
+        no_double_slash, mask_cplusplus_defined_guards=for_language_mode_decision
+    )
+    shadow_content = _strip_inactive_if_zero_blocks(
+        no_double_slash, invert_dialect_fallback_guards=False
+    )
+    return scan_content, shadow_content
+
+
+def _preprocess_headers(
+    header_paths: list[Path], *, for_language_mode_decision: bool
+) -> tuple[list[tuple[Path, bytes]], _Cpp20ShadowFlags]:
+    """First pass: preprocess every header and OR the shadow flags across all.
+
+    The second pass reuses the returned content rather than re-reading, so the
+    per-line scan runs against aggregate-wide flags.
+    """
+    per_file: list[tuple[Path, bytes]] = []
+    concept = requires = consteval = constinit = False
+    for path in header_paths:
+        prepared = _preprocessed_header_content(
+            path, for_language_mode_decision=for_language_mode_decision
+        )
+        if prepared is None:
+            continue
+        scan_content, shadow_content = prepared
+        per_file.append((path, scan_content))
+        concept = concept or bool(
+            _CONCEPT_AS_TYPE_NAME_PATTERN.search(shadow_content)
+        )
+        requires = requires or bool(
+            _REQUIRES_AS_TYPE_NAME_PATTERN.search(shadow_content)
+        )
+        consteval = consteval or bool(
+            _CONSTEVAL_AS_TYPE_NAME_PATTERN.search(shadow_content)
+        )
+        constinit = constinit or bool(
+            _CONSTINIT_AS_TYPE_NAME_PATTERN.search(shadow_content)
+        )
+    return per_file, _Cpp20ShadowFlags(concept, requires, consteval, constinit)
+
+
+def _joined_lookahead(
+    logical_lines: list[tuple[int, bytes]], i: int, code: bytes
+) -> bytes:
+    """*code* plus any following lines a bare trailing keyword continues onto.
+
+    A bare ``requires``/``concept``/``consteval``/``constinit`` at end of line
+    (no parameter list/brace/name yet, or for consteval/constinit no declarator
+    at all) means the construct's continuation landed on a following physical
+    line with no backslash join — the per-line scan otherwise never sees the
+    two halves together (Codex review; the gap applies symmetrically to
+    ``concept`` split before its name, not just ``requires`` split before its
+    ``(``/``{``/constraint, and equally to consteval/constinit split before
+    their own declarator, e.g. ``consteval\nint f();`` — Codex review, second
+    round). Bounded, so a stray trailing keyword in unrelated code cannot scan
+    unboundedly.
+    """
+    lookahead = code
+    j = i
+    budget = 5
+    n = len(logical_lines)
+    while (
+        budget > 0
+        and re.search(
+            rb"\b(?:requires|concept|consteval|constinit)\s*$", lookahead.rstrip()
+        )
+        and j + 1 < n
+        and not _is_preprocessor_directive(logical_lines[j + 1][1])
+    ):
+        j += 1
+        nxt = _strip_literals_joined(logical_lines[j][1]).split(b"//")[0]
+        lookahead += b"\n" + nxt
+        budget -= 1
+    return lookahead
+
+
+def _requirement_kind(
+    lookahead: bytes, prev_nonblank_code: bytes, shadows: _Cpp20ShadowFlags
+) -> Cpp20RequirementReason | None:
+    """The C++20 construct this line requires, or ``None``. First match wins."""
+    concept_match = _CPP20_CONCEPT_PATTERN.search(lookahead)
+    if concept_match and _looks_like_genuine_concept(
+        lookahead, concept_match, prev_nonblank_code, shadows.concept
+    ):
+        return "concept-declaration"
+    requires_expr_match = _CPP20_REQUIRES_EXPR_PATTERN.search(lookahead)
+    if requires_expr_match and not _looks_like_requires_declarator(
+        lookahead, requires_expr_match, prev_nonblank_code
+    ):
+        return "requires-expression"
+    clause_match = _CPP20_REQUIRES_CLAUSE_PATTERN.search(lookahead)
+    if clause_match and _looks_like_genuine_requires_clause(
+        lookahead, clause_match.start(), prev_nonblank_code, shadows.requires
+    ):
+        return "requires-clause"
+    if _has_constrained_param_syntax(lookahead):
+        return "constrained-template-parameter"
+    if _has_custom_constrained_auto_param(lookahead, prev_nonblank_code):
+        return "custom-constrained-auto-parameter"
+    if _has_abbreviated_unconstrained_auto_param(lookahead):
+        return "abbreviated-function-template-parameter"
+    if not shadows.consteval and _CPP20_CONSTEVAL_PATTERN.search(lookahead):
+        return "consteval-declaration"
+    if not shadows.constinit and _CPP20_CONSTINIT_PATTERN.search(lookahead):
+        return "constinit-declaration"
+    return None
+
+
+def _scan_header_for_requirements(
+    path: Path, content: bytes, shadows: _Cpp20ShadowFlags
+) -> list[Cpp20Requirement]:
+    """Second pass: the per-logical-line scan of one already-preprocessed header.
+
+    Scans the same ``#if 0``-stripped content the shadow checks use — a genuine
+    consteval/constinit/concept/requires construct written only inside a
+    disabled ``#if 0`` block must not mark the header as needing C++20 (Codex
+    review): it is never actually compiled.
+    """
+    found: list[Cpp20Requirement] = []
+    logical_lines = _iter_logical_lines(content)
+    # Last non-blank line's own (un-extended) code, tracked across iterations --
+    # lets a concept-declaration candidate look backward for its template<...>
+    # header when "concept" itself starts a line (see
+    # _looks_like_genuine_concept).
+    prev_nonblank_code = b""
+    for i, (start_no, logical) in enumerate(logical_lines):
+        if _is_preprocessor_directive(logical):
+            continue
+        code = _strip_literals_joined(logical).split(b"//")[0]
+        kind = _requirement_kind(
+            _joined_lookahead(logical_lines, i, code), prev_nonblank_code, shadows
+        )
+        if kind is not None:
+            found.append(Cpp20Requirement(kind, str(path), start_no))
+        if code.strip():
+            prev_nonblank_code = code
+    return found
+
+
 def _find_cpp20_requirements(
     header_paths: list[Path], *, for_language_mode_decision: bool = False
 ) -> list[Cpp20Requirement]:
@@ -1182,193 +1387,15 @@ def _find_cpp20_requirements(
     unreachable under *this* decision's reasoning (e.g. ``#ifdef
     __cplusplus`` in a C-mode-decision scan) is not followed either.
     """
-    header_paths = _expand_with_quoted_includes(
-        header_paths, for_language_mode_decision=for_language_mode_decision
+    per_file, shadows = _preprocess_headers(
+        _expand_with_quoted_includes(
+            header_paths, for_language_mode_decision=for_language_mode_decision
+        ),
+        for_language_mode_decision=for_language_mode_decision,
     )
-    per_file: list[tuple[Path, bytes]] = []
-    concept_type_shadowed = False
-    requires_type_shadowed = False
-    consteval_type_shadowed = False
-    constinit_type_shadowed = False
-    for p in header_paths:
-        try:
-            content = p.read_bytes()
-        except OSError:
-            continue
-        # Blank raw string literals first — their body can contain arbitrary
-        # quotes/backslashes that would otherwise confuse the ordinary
-        # string-literal stripper below.
-        content = _strip_raw_strings(content)
-        # Blank string/char literals first so a literal containing comment-like
-        # text ("/* not a comment */") is never mistaken for a real comment.
-        # Backslash-newline-continuation-tolerant (Codex review): a literal
-        # split across a continuation must not leave its trapped text — e.g.
-        # a fake "struct concept {};" inside an error message — unblanked
-        # and visible to the shadow-name scan below.
-        content = _strip_literals_crossing_continuations(content)
-        # Strip real block comments, but preserve the embedded newline count so
-        # later-reported line numbers stay accurate for code following a
-        # multi-line comment (CodeRabbit review).
-        content = re.sub(
-            rb"/\*.*?\*/",
-            lambda m: b"\n" * m.group(0).count(b"\n"),
-            content,
-            flags=re.DOTALL,
-        )
-        # Whether this header defines "concept" as an ordinary type name
-        # anywhere (Codex review, fourth round) — a pre-C++20 header can
-        # declare a type literally named "concept" and initialize a
-        # variable template of that type via *any* expression convertible
-        # to it (not just a brace-init-list, which only covered the
-        # aggregate-init case), so no per-initializer-shape check can be
-        # complete. Once "concept" is confirmed to name a real type
-        # anywhere in the aggregate, every bare "concept NAME = ..." match
-        # in it is ambiguous and treated as non-genuine — see
-        # ``_looks_like_genuine_concept``. Checked against a *separate*,
-        # additionally "//"-line-comment-stripped copy of the content
-        # (raw strings/literals/block comments are already blanked in
-        # ``content`` itself at this point, but not "//" comments, which
-        # are only stripped per-logical-line further below) — a
-        # "// struct concept {};" comment must never make a *real*
-        # concept declaration elsewhere in the header look ambiguous
-        # (Codex review, fifth round).
-        # Also strip out #if 0/#if false regions before any of the three
-        # shadow scans below — a disabled compatibility stub must not shadow
-        # a genuine keyword used elsewhere in the header (Codex review).
-        content_no_double_slash_comments = re.sub(rb"//[^\n]*", b"", content)
-        content_no_line_comments = _strip_inactive_if_zero_blocks(
-            content_no_double_slash_comments,
-            mask_cplusplus_defined_guards=for_language_mode_decision,
-        )
-        per_file.append((p, content_no_line_comments))
-        # A *separate* masking pass, not the one above, feeds the shadow
-        # scans below: invert_dialect_fallback_guards=False (Codex review,
-        # nineteenth round) — the shadow scan asks "does 'concept' name an
-        # ordinary type in code still reachable if C++20 were chosen", so a
-        # ``struct concept {};`` compatibility shim confined to e.g.
-        # ``#if __cplusplus < 202002L`` (content that specifically goes
-        # away once C++20 is chosen) must not count, unlike for the
-        # requirements scan above where that same guarded arm is the
-        # unconditionally-relevant one. See the docstring of
-        # _strip_inactive_if_zero_blocks.
-        content_for_shadow_scan = _strip_inactive_if_zero_blocks(
-            content_no_double_slash_comments, invert_dialect_fallback_guards=False
-        )
-        concept_type_shadowed = concept_type_shadowed or bool(
-            _CONCEPT_AS_TYPE_NAME_PATTERN.search(content_for_shadow_scan)
-        )
-        # Same reasoning as concept_type_shadowed above, for "requires" used
-        # as an ordinary pre-C++20 type name (Codex review).
-        requires_type_shadowed = requires_type_shadowed or bool(
-            _REQUIRES_AS_TYPE_NAME_PATTERN.search(content_for_shadow_scan)
-        )
-        # Same reasoning and "//"-comment-stripped-copy caveat as
-        # concept_type_shadowed above, for "consteval"/"constinit" used as
-        # an ordinary pre-C++20 type name (Codex review, third round).
-        consteval_type_shadowed = consteval_type_shadowed or bool(
-            _CONSTEVAL_AS_TYPE_NAME_PATTERN.search(content_for_shadow_scan)
-        )
-        constinit_type_shadowed = constinit_type_shadowed or bool(
-            _CONSTINIT_AS_TYPE_NAME_PATTERN.search(content_for_shadow_scan)
-        )
-
     found: list[Cpp20Requirement] = []
-    for p, _content_no_line_comments in per_file:
-        # Scan the same #if-0-stripped content the shadow checks above use —
-        # a genuine consteval/constinit/concept/requires construct written
-        # only inside a disabled #if 0 block must not itself mark the header
-        # as needing C++20 (Codex review): it's never actually compiled.
-        logical_lines = _iter_logical_lines(_content_no_line_comments)
-        n = len(logical_lines)
-        # Last non-blank line's own (un-extended) code, tracked across
-        # iterations — lets a concept-declaration candidate look backward
-        # for its template<...> header when "concept" itself starts a line
-        # (see _looks_like_genuine_concept).
-        prev_nonblank_code = b""
-        for i, (start_no, logical) in enumerate(logical_lines):
-            if _is_preprocessor_directive(logical):
-                continue
-            code = _strip_literals_joined(logical)
-            code = code.split(b"//")[0]
-            # A bare "requires"/"concept"/"consteval"/"constinit" trailing at
-            # the end of a line (no parameter list/brace/name yet, or for
-            # consteval/constinit no declarator following at all) means the
-            # construct's continuation landed on a following physical line
-            # with no backslash join in between — the per-line scan
-            # otherwise never sees the two halves together (Codex review;
-            # the same gap applies symmetrically to "concept" split before
-            # its name, not just "requires" split before its "("/"{"/
-            # constraint, and equally to consteval/constinit split before
-            # their own declarator, e.g. ``consteval\nint f();`` — Codex
-            # review, second round). Pull in subsequent non-directive lines
-            # (bounded, so a stray trailing keyword in unrelated code can't
-            # scan unboundedly) until the bare-trailing condition no longer
-            # holds.
-            lookahead = code
-            j = i
-            lookahead_budget = 5
-            while (
-                lookahead_budget > 0
-                and re.search(
-                    rb"\b(?:requires|concept|consteval|constinit)\s*$",
-                    lookahead.rstrip(),
-                )
-                and j + 1 < n
-                and not _is_preprocessor_directive(logical_lines[j + 1][1])
-            ):
-                j += 1
-                nxt = _strip_literals_joined(logical_lines[j][1]).split(b"//")[0]
-                lookahead += b"\n" + nxt
-                lookahead_budget -= 1
-            concept_match = _CPP20_CONCEPT_PATTERN.search(lookahead)
-            requires_expr_match = _CPP20_REQUIRES_EXPR_PATTERN.search(lookahead)
-            if concept_match and _looks_like_genuine_concept(
-                lookahead, concept_match, prev_nonblank_code, concept_type_shadowed
-            ):
-                found.append(Cpp20Requirement("concept-declaration", str(p), start_no))
-            elif requires_expr_match and not _looks_like_requires_declarator(
-                lookahead, requires_expr_match, prev_nonblank_code
-            ):
-                found.append(Cpp20Requirement("requires-expression", str(p), start_no))
-            elif (
-                clause_match := _CPP20_REQUIRES_CLAUSE_PATTERN.search(lookahead)
-            ) and _looks_like_genuine_requires_clause(
-                lookahead,
-                clause_match.start(),
-                prev_nonblank_code,
-                requires_type_shadowed,
-            ):
-                found.append(Cpp20Requirement("requires-clause", str(p), start_no))
-            elif _has_constrained_param_syntax(lookahead):
-                found.append(
-                    Cpp20Requirement("constrained-template-parameter", str(p), start_no)
-                )
-            elif _has_custom_constrained_auto_param(lookahead, prev_nonblank_code):
-                found.append(
-                    Cpp20Requirement(
-                        "custom-constrained-auto-parameter", str(p), start_no
-                    )
-                )
-            elif _has_abbreviated_unconstrained_auto_param(lookahead):
-                found.append(
-                    Cpp20Requirement(
-                        "abbreviated-function-template-parameter", str(p), start_no
-                    )
-                )
-            elif not consteval_type_shadowed and _CPP20_CONSTEVAL_PATTERN.search(
-                lookahead
-            ):
-                found.append(
-                    Cpp20Requirement("consteval-declaration", str(p), start_no)
-                )
-            elif not constinit_type_shadowed and _CPP20_CONSTINIT_PATTERN.search(
-                lookahead
-            ):
-                found.append(
-                    Cpp20Requirement("constinit-declaration", str(p), start_no)
-                )
-            if code.strip():
-                prev_nonblank_code = code
+    for path, content in per_file:
+        found.extend(_scan_header_for_requirements(path, content, shadows))
     return found
 
 

--- a/abicheck/dumper_ast_config_cpp20.py
+++ b/abicheck/dumper_ast_config_cpp20.py
@@ -1212,9 +1212,10 @@ def _preprocessed_header_content(
         content,
         flags=re.DOTALL,
     )
-    # A separate, additionally "//"-line-comment-stripped copy: raw
+    # "//" line comments are removed once, up front, before *both* masking
+    # passes below (which then differ only in guard-masking polarity). Raw
     # strings/literals/block comments are already blanked above, but "//"
-    # comments are only stripped per-logical-line further down, and a
+    # comments are otherwise only stripped per-logical-line further down, and a
     # "// struct concept {};" comment must never make a *real* concept
     # declaration elsewhere look ambiguous (Codex review, fifth round).
     # #if 0 / #if false regions go too — a disabled compatibility stub must not

--- a/abicheck/dumper_ast_config_cpp20.py
+++ b/abicheck/dumper_ast_config_cpp20.py
@@ -405,6 +405,65 @@ def _has_abbreviated_unconstrained_auto_param(lookahead: bytes) -> bool:
 _QUALIFIED_IDENTIFIER_TAIL_PATTERN = re.compile(rb"(?:[A-Za-z_]\w*::)*[A-Za-z_]\w*\Z")
 
 
+def _strip_leading_decl_noise(before_ident: bytes) -> bytes:
+    """Strip trailing declarator specifiers, attributes and decl-specifier words.
+
+    Applied to a fixed point and in any order: ordinary leading decl-specifier
+    keywords (``inline``, ``static``, ``virtual``, ...) and attributes routinely
+    precede a return type (``inline MyConcept auto f();``, ``[[nodiscard]]
+    MyConcept auto f();`` — Codex review), so what remains is the real enclosing
+    punctuation the boundary check needs to see.
+    """
+    while True:
+        stripped = _strip_trailing_declarator_specifiers(before_ident)
+        stripped = _strip_trailing_attributes(stripped)
+        stripped = _strip_trailing_leading_decl_specifier_words(stripped)
+        if stripped == before_ident:
+            return before_ident
+        before_ident = stripped
+
+
+def _constrained_auto_at(
+    lookahead: bytes, auto_start: int, prev_nonblank_code: bytes
+) -> bool:
+    """True if the ``auto`` at *auto_start* is a concept-constrained placeholder.
+
+    Two accepted positions: inside a parameter list (the identifier is separated
+    from its enclosing ``(``/``,`` by nothing but cv-qualifiers/attributes), or a
+    declaration-start return type (nothing but whitespace separates the
+    identifier from a genuine statement boundary, or from a trailing-return-type
+    arrow directly following a function declarator's ``)`` -- the ``auto f() ->
+    MyConcept auto;`` shape, Codex review).
+
+    A ``decltype(`` open paren is excluded: it is not a parameter list.
+    """
+    prefix = _strip_trailing_declarator_specifiers(lookahead[:auto_start])
+    prefix = _strip_trailing_attributes(prefix)
+    ident_match = _QUALIFIED_IDENTIFIER_TAIL_PATTERN.search(prefix)
+    if not ident_match:
+        return False
+    before_ident = _strip_leading_decl_noise(prefix[: ident_match.start()].rstrip())
+    last = before_ident[-1:]
+
+    if last == b"(":
+        return not _is_decltype_open_paren(lookahead, len(before_ident) - 1)
+    if last == b",":
+        open_pos = _find_enclosing_open_paren(lookahead, len(before_ident))
+        if open_pos is None:
+            return False
+        return not _is_decltype_open_paren(lookahead, open_pos)
+
+    # Not inside a parameter list at all -- only a genuine statement boundary
+    # makes this a declaration-start return-type position rather than some
+    # other expression context.
+    if before_ident:
+        return last in _REQUIRES_STATEMENT_BOUNDARY_CHARS or (
+            last == b">" and _has_declarator_adjacent_trailing_arrow(before_ident)
+        )
+    prev = _strip_trailing_declarator_specifiers(prev_nonblank_code.rstrip())
+    return not prev or prev[-1:] in _REQUIRES_STATEMENT_BOUNDARY_CHARS
+
+
 def _has_custom_constrained_auto_param(
     lookahead: bytes, prev_nonblank_code: bytes = b""
 ) -> bool:
@@ -462,52 +521,10 @@ def _has_custom_constrained_auto_param(
     MyConcept auto f();``, ``[[nodiscard]] MyConcept auto f();`` — Codex
     review), so they're stripped in the same fixed-point loop, in any
     order, before the statement-boundary check runs."""
-    for m in re.finditer(rb"\bauto\b", lookahead):
-        prefix = _strip_trailing_declarator_specifiers(lookahead[: m.start()])
-        prefix = _strip_trailing_attributes(prefix)
-        ident_match = _QUALIFIED_IDENTIFIER_TAIL_PATTERN.search(prefix)
-        if not ident_match:
-            continue
-        before_ident = prefix[: ident_match.start()].rstrip()
-        while True:
-            stripped = _strip_trailing_declarator_specifiers(before_ident)
-            stripped = _strip_trailing_attributes(stripped)
-            stripped = _strip_trailing_leading_decl_specifier_words(stripped)
-            if stripped == before_ident:
-                break
-            before_ident = stripped
-        last = before_ident[-1:]
-        open_pos: int | None
-        if last == b"(":
-            open_pos = len(before_ident) - 1
-        elif last == b",":
-            open_pos = _find_enclosing_open_paren(lookahead, len(before_ident))
-            if open_pos is None:
-                continue
-        else:
-            open_pos = None
-        if open_pos is not None:
-            if not _is_decltype_open_paren(lookahead, open_pos):
-                return True
-            continue
-        # Not inside a parameter list at all — only a genuine statement
-        # boundary right before the identifier (on this line, or on the
-        # last preceding non-blank code when the identifier opens the
-        # line), or a trailing-return-type arrow directly following a
-        # function declarator's closing ")" (the ``auto f() -> MyConcept
-        # auto;`` shape, Codex review), makes this a declaration-start
-        # return-type position rather than some other expression context.
-        if before_ident:
-            if last not in _REQUIRES_STATEMENT_BOUNDARY_CHARS and not (
-                last == b">" and _has_declarator_adjacent_trailing_arrow(before_ident)
-            ):
-                continue
-        else:
-            prev = _strip_trailing_declarator_specifiers(prev_nonblank_code.rstrip())
-            if prev and prev[-1:] not in _REQUIRES_STATEMENT_BOUNDARY_CHARS:
-                continue
-        return True
-    return False
+    return any(
+        _constrained_auto_at(lookahead, m.start(), prev_nonblank_code)
+        for m in re.finditer(rb"\bauto\b", lookahead)
+    )
 
 
 # "requires" only became a reserved keyword in C++20 — any earlier standard

--- a/abicheck/dumper_ast_config_cpp20_chains.py
+++ b/abicheck/dumper_ast_config_cpp20_chains.py
@@ -439,16 +439,19 @@ _CHAIN_OPEN_RULES: tuple[tuple[_ChainMatcher, tuple[bool, bool, bool]], ...] = (
     (_opens_missing_cplusplus_fallback, _FRAME_LIVE_SETTLED),
     (_opens_unreachable_or_circular_guard, _FRAME_MASKED),
     (_opens_unconditionally_true, _FRAME_LIVE_SETTLED),
+    # The one inverted-polarity rule that does *not* precede the general mask
+    # rule, and safely so: the two are mutually exclusive by construction --
+    # `_opens_unreachable_or_circular_guard` only tests
+    # `_PP_IFNDEF_CPP_FEATURE_GUARD_PATTERN` when
+    # `invert_dialect_fallback_guards` is False, and this rule only fires when
+    # it is True, so neither can shadow the other whatever the order. Stated
+    # here so a later edit to that rule's gating cannot silently change this
+    # spelling's classification (CodeRabbit review).
     (_opens_ifndef_feature_fallback, _FRAME_LIVE_SETTLED),
 )
 
 
-def _frame_for_chain_open(
-    line: bytes,
-    *,
-    invert_dialect_fallback_guards: bool,
-    mask_cplusplus_defined_guards: bool,
-) -> list[bool]:
+def _frame_for_chain_open(line: bytes, policy: _ChainPolicy) -> list[bool]:
     """Classify a chain-opening ``#if``/``#ifdef``/``#ifndef`` directive.
 
     Returns the ``[recognized, masking, settled]`` stack frame this chain
@@ -459,7 +462,6 @@ def _frame_for_chain_open(
     conservative pass-through the top level always applied to an ``#if`` it
     can't evaluate.
     """
-    policy = _ChainPolicy(invert_dialect_fallback_guards, mask_cplusplus_defined_guards)
     for matches, frame in _CHAIN_OPEN_RULES:
         if matches(line, policy):
             return list(frame)
@@ -565,13 +567,7 @@ _OPEN_ARM_RULES: tuple[tuple[_ChainMatcher, Callable[[list[bool]], None]], ...] 
 )
 
 
-def _line_for_open_arm(
-    line: bytes,
-    frame: list[bool],
-    *,
-    invert_dialect_fallback_guards: bool,
-    mask_cplusplus_defined_guards: bool,
-) -> bytes:
+def _line_for_open_arm(line: bytes, frame: list[bool], policy: _ChainPolicy) -> bytes:
     """Advance the innermost open chain by one line; return what to emit.
 
     *frame* is mutated in place: an ``#elif``/``#else`` arm changes which of
@@ -585,7 +581,6 @@ def _line_for_open_arm(
         # exactly like the top level's unrecognized-chain
         # pass-through.
         return line
-    policy = _ChainPolicy(invert_dialect_fallback_guards, mask_cplusplus_defined_guards)
     for matches, advance in _OPEN_ARM_RULES:
         if matches(line, policy):
             advance(frame)
@@ -709,6 +704,10 @@ def _strip_inactive_if_zero_blocks(
     #   settled: an unconditionally-true arm already fired at this level,
     #     so every later sibling arm here is unconditionally unreachable.
     stack: list[list[bool]] = []
+    # Built once for the whole scan, not per line: both flags are constant for
+    # this call, and `_line_for_open_arm` runs once per line inside every chain
+    # of every scanned header (CodeRabbit review).
+    policy = _ChainPolicy(invert_dialect_fallback_guards, mask_cplusplus_defined_guards)
 
     def unreachable() -> bool:
         # Unreachable if this level or any ancestor is masking — a dead
@@ -733,11 +732,7 @@ def _strip_inactive_if_zero_blocks(
                 stack.append([False, True, True])
                 out.append(b"")
                 continue
-            frame = _frame_for_chain_open(
-                line,
-                invert_dialect_fallback_guards=invert_dialect_fallback_guards,
-                mask_cplusplus_defined_guards=mask_cplusplus_defined_guards,
-            )
+            frame = _frame_for_chain_open(line, policy)
             stack.append(frame)
             # Every recognized opener is itself blanked; only the
             # unrecognized pass-through frame keeps its own directive line.
@@ -756,12 +751,7 @@ def _strip_inactive_if_zero_blocks(
                 out.append(b"")
                 continue
             out.append(
-                _line_for_open_arm(
-                    line,
-                    stack[-1],
-                    invert_dialect_fallback_guards=invert_dialect_fallback_guards,
-                    mask_cplusplus_defined_guards=mask_cplusplus_defined_guards,
-                )
+                _line_for_open_arm(line, stack[-1], policy)
             )
             continue
 

--- a/abicheck/dumper_ast_config_cpp20_chains.py
+++ b/abicheck/dumper_ast_config_cpp20_chains.py
@@ -33,6 +33,8 @@ never the reverse (no new import cycle; CLAUDE.md "M1-3").
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
+from dataclasses import dataclass
 
 _PP_IF_OPEN_PATTERN = re.compile(rb"^[ \t]*#[ \t]*(?:if|ifdef|ifndef)\b")
 # A parenthesized literal (``#if (0)``, ``#elif (1)``) is the same
@@ -292,6 +294,155 @@ _PP_ELIF_NOT_DEFINED_CPP_FEATURE_GUARD_PATTERN = re.compile(
 )
 
 
+#: The three stack frames a chain can open with, as
+#: ``(recognized, masking, settled)`` — see :func:`_frame_for_chain_open`.
+_FRAME_LIVE_SETTLED = (True, False, True)
+_FRAME_MASKED = (True, True, False)
+_FRAME_UNRECOGNIZED = (False, False, False)
+
+
+@dataclass(frozen=True)
+class _ChainPolicy:
+    """The two masking-policy flags every chain-classifier rule consults.
+
+    Bundled into one object so the rule tables below can share a single
+    ``(line, policy)`` matcher signature; the flags themselves are documented
+    on :func:`_strip_inactive_if_zero_blocks`, the only caller that sets them.
+    """
+
+    invert_dialect_fallback_guards: bool
+    mask_cplusplus_defined_guards: bool
+
+
+_ChainMatcher = Callable[[bytes, _ChainPolicy], bool]
+
+
+def _opens_pre_cpp20_dialect_fallback(line: bytes, policy: _ChainPolicy) -> bool:
+    """``#if __cplusplus < N`` — the pre-C++20-safe fallback arm.
+
+    Opposite polarity from the general __cplusplus-guard rule: a less-than
+    comparison's guarded arm is the pre-C++20-safe fallback, so it's scanned
+    live and immediately settled so any #else (feature present, circular)
+    stays masked -- ordered ahead of the general rule since it would otherwise
+    also match. Skipped entirely when invert_dialect_fallback_guards is False
+    (shadow-scan callers), falling through to the general rule instead -- see
+    :func:`_strip_inactive_if_zero_blocks`.
+    """
+    return policy.invert_dialect_fallback_guards and bool(
+        _PP_IF_CPLUSPLUS_LESS_THAN_PATTERN.match(line)
+    )
+
+
+def _opens_missing_feature_fallback(line: bytes, policy: _ChainPolicy) -> bool:
+    """``#if !defined(__cpp_x)`` — the feature-absent fallback arm.
+
+    Same inverted polarity as ``#ifndef __cpp_x`` below -- ordered ahead of the
+    general rule since this spelling (unlike ``#ifndef``) starts with ``#if``
+    and would otherwise be caught there first. Same shadow-scan exception as
+    above.
+    """
+    return policy.invert_dialect_fallback_guards and bool(
+        _PP_IF_NOT_DEFINED_CPP_FEATURE_GUARD_PATTERN.match(line)
+    )
+
+
+def _opens_missing_cplusplus_fallback(line: bytes, policy: _ChainPolicy) -> bool:
+    """``#ifndef __cplusplus`` / ``#if !defined(__cplusplus)``, C-only arm.
+
+    Opposite polarity from the general rule's unconditional treatment of the
+    same spellings -- ordered ahead of it since it would otherwise also match.
+    See the docstring above ``_PP_NOT_DEFINED_CPLUSPLUS``.
+    """
+    return policy.mask_cplusplus_defined_guards and bool(
+        _PP_IFNDEF_CPLUSPLUS_PATTERN.match(line)
+        or _PP_IF_NOT_DEFINED_CPLUSPLUS_PATTERN.match(line)
+    )
+
+
+def _opens_unreachable_or_circular_guard(line: bytes, policy: _ChainPolicy) -> bool:
+    """``#if 0`` or a dialect/feature-test guard whose arm must not be scanned.
+
+    The general masking rule: permanently-unreachable literals plus the
+    circular guards (``__cplusplus``, ``__cpp_*``) whose own content must never
+    be allowed to decide the ``-std=`` this heuristic is picking.
+    """
+    return bool(
+        _PP_IF_ZERO_PATTERN.match(line)
+        or _PP_IFDEF_CPLUSPLUS_FEATURE_GUARD_PATTERN.match(line)
+        or _PP_IFNDEF_CPLUSPLUS_PATTERN.match(line)
+        or (
+            not policy.invert_dialect_fallback_guards
+            and _PP_IFNDEF_CPP_FEATURE_GUARD_PATTERN.match(line)
+        )
+        or (
+            policy.mask_cplusplus_defined_guards
+            and _PP_IFDEF_CPLUSPLUS_PATTERN.match(line)
+        )
+        or (
+            _PP_IF_CPLUSPLUS_GUARD_PATTERN.match(line)
+            and (
+                policy.mask_cplusplus_defined_guards
+                or not _PP_IF_CPLUSPLUS_ALWAYS_TRUE_PATTERN.match(line)
+            )
+        )
+    )
+
+
+def _opens_unconditionally_true(line: bytes, policy: _ChainPolicy) -> bool:
+    """``#if 1``/``#if true``, or ``#ifdef``/``#if defined(__cplusplus)``.
+
+    ``#if defined(__cplusplus)``/``#ifdef __cplusplus``/bare ``#if __cplusplus``
+    (Codex review, twenty-second round): tracked as *settled*-true here, the
+    same way ``#if 1``/``#if true`` already is, not left as an unrecognized
+    chain (whose #else/#elif arms then get scanned right along with this one,
+    unmasked). Without this, a dual C/C++ header's ``#else`` (C-only) fallback
+    -- e.g. a ``struct concept {};`` compatibility shim -- stayed visible to the
+    shadow-name scan alongside a genuine C++20 declaration in the *active*
+    ``#if`` arm, wrongly shadowing it. Elif-level already settles the equivalent
+    ``#elif`` spelling this same way; this closes the gap for it as the chain's
+    *opening* condition. The ``__cplusplus`` spellings are skipped when
+    mask_cplusplus_defined_guards is True (the caller already masked that
+    guard's own content in the general rule above, and never reaches here).
+    """
+    return bool(
+        _PP_IF_TRUE_PATTERN.match(line)
+        or (
+            not policy.mask_cplusplus_defined_guards
+            and (
+                _PP_IFDEF_CPLUSPLUS_PATTERN.match(line)
+                or _PP_IF_CPLUSPLUS_ALWAYS_TRUE_PATTERN.match(line)
+            )
+        )
+    )
+
+
+def _opens_ifndef_feature_fallback(line: bytes, policy: _ChainPolicy) -> bool:
+    """``#ifndef __cpp_x`` — the feature-absent fallback arm.
+
+    Opposite polarity from the general masking rule above: the
+    ``#ifndef``-guarded arm (feature absent) is the trustworthy one here, so
+    it's scanned live and immediately settled so any #else (feature present,
+    circular) stays masked. Skipped for a shadow-scan caller -- already folded
+    into the general mask rule above instead.
+    """
+    return policy.invert_dialect_fallback_guards and bool(
+        _PP_IFNDEF_CPP_FEATURE_GUARD_PATTERN.match(line)
+    )
+
+
+#: Ordered ``(matcher, frame)`` rules for a chain-opening directive. Order is
+#: load-bearing: every inverted-polarity spelling is tested ahead of the
+#: general guard rule that would otherwise also match it.
+_CHAIN_OPEN_RULES: tuple[tuple[_ChainMatcher, tuple[bool, bool, bool]], ...] = (
+    (_opens_pre_cpp20_dialect_fallback, _FRAME_LIVE_SETTLED),
+    (_opens_missing_feature_fallback, _FRAME_LIVE_SETTLED),
+    (_opens_missing_cplusplus_fallback, _FRAME_LIVE_SETTLED),
+    (_opens_unreachable_or_circular_guard, _FRAME_MASKED),
+    (_opens_unconditionally_true, _FRAME_LIVE_SETTLED),
+    (_opens_ifndef_feature_fallback, _FRAME_LIVE_SETTLED),
+)
+
+
 def _frame_for_chain_open(
     line: bytes,
     *,
@@ -303,98 +454,115 @@ def _frame_for_chain_open(
     Returns the ``[recognized, masking, settled]`` stack frame this chain
     opens with. The caller has already established the chain is not itself
     nested inside dead code, so this answers only what *this* condition
-    says. Branch order is load-bearing: every inverted-polarity spelling is
-    tested ahead of the general guard branch that would otherwise also
-    match it.
+    says. The rules are consulted in ``_CHAIN_OPEN_RULES`` order, which is
+    load-bearing; an unrecognized condition falls through to the same
+    conservative pass-through the top level always applied to an ``#if`` it
+    can't evaluate.
     """
-    if invert_dialect_fallback_guards and _PP_IF_CPLUSPLUS_LESS_THAN_PATTERN.match(
-        line
-    ):
-        # Opposite polarity from the general __cplusplus-guard
-        # branch below: a less-than comparison's guarded arm is
-        # the pre-C++20-safe fallback, so it's scanned live and
-        # immediately settled so any #else (feature present,
-        # circular) stays masked -- checked ahead of the general
-        # branch since it would otherwise also match. Skipped
-        # entirely when invert_dialect_fallback_guards is False
-        # (shadow-scan callers), falling through to the general
-        # branch below instead -- see the docstring.
-        return [True, False, True]
-    if (
-        invert_dialect_fallback_guards
-        and _PP_IF_NOT_DEFINED_CPP_FEATURE_GUARD_PATTERN.match(line)
-    ):
-        # Same inverted polarity as #ifndef __cpp_x below --
-        # checked ahead of the general branch since this spelling
-        # (unlike #ifndef) starts with "#if" and would otherwise
-        # be caught there first. Same shadow-scan exception as
-        # above.
-        return [True, False, True]
-    if mask_cplusplus_defined_guards and (
-        _PP_IFNDEF_CPLUSPLUS_PATTERN.match(line)
-        or _PP_IF_NOT_DEFINED_CPLUSPLUS_PATTERN.match(line)
-    ):
-        # Opposite polarity from the general branch below's
-        # unconditional #ifndef __cplusplus/!defined(__cplusplus)
-        # treatment -- checked ahead of it since it would
-        # otherwise also match. See the docstring above
-        # _PP_NOT_DEFINED_CPLUSPLUS.
-        return [True, False, True]
-    if (
-        _PP_IF_ZERO_PATTERN.match(line)
-        or _PP_IFDEF_CPLUSPLUS_FEATURE_GUARD_PATTERN.match(line)
-        or _PP_IFNDEF_CPLUSPLUS_PATTERN.match(line)
+    policy = _ChainPolicy(invert_dialect_fallback_guards, mask_cplusplus_defined_guards)
+    for matches, frame in _CHAIN_OPEN_RULES:
+        if matches(line, policy):
+            return list(frame)
+    return list(_FRAME_UNRECOGNIZED)
+
+
+def _arm_settle(frame: list[bool]) -> None:
+    """A decisive arm: flip which arm is masked, then settle the level.
+
+    Every later sibling in the chain is unconditionally unreachable once an
+    unconditionally-reachable arm has been seen, so masking resumes for them.
+    """
+    frame[1] = frame[2]
+    frame[2] = True
+
+
+def _arm_mask(frame: list[bool]) -> None:
+    """A provably-unreachable or circular arm (``#elif 0``, dialect guard)."""
+    frame[1] = True
+
+
+def _arm_flip(frame: list[bool]) -> None:
+    """A plain ``#elif``/``#else``: masked iff the level has already settled."""
+    frame[1] = frame[2]
+
+
+def _arm_is_pre_cpp20_dialect_fallback(line: bytes, policy: _ChainPolicy) -> bool:
+    """``#elif __cplusplus < N``.
+
+    Same inverted polarity as the ``#if``-opening case, ordered ahead of the
+    general rule below since it would otherwise also match. Same shadow-scan
+    exception as the ``#if``-opening case: falls through to the general rule
+    (mask) when invert_dialect_fallback_guards is False.
+    """
+    return policy.invert_dialect_fallback_guards and bool(
+        _PP_ELIF_CPLUSPLUS_LESS_THAN_PATTERN.match(line)
+    )
+
+
+def _arm_is_missing_feature_fallback(line: bytes, policy: _ChainPolicy) -> bool:
+    """``#elif !defined(__cpp_x)``.
+
+    Same inverted polarity as ``#if !defined(__cpp_x)``, ordered ahead of the
+    general rule since it would otherwise also match. Same shadow-scan
+    exception.
+    """
+    return policy.invert_dialect_fallback_guards and bool(
+        _PP_ELIF_NOT_DEFINED_CPP_FEATURE_GUARD_PATTERN.match(line)
+    )
+
+
+def _arm_is_missing_cplusplus_fallback(line: bytes, policy: _ChainPolicy) -> bool:
+    """``#elif !defined(__cplusplus)``.
+
+    Opposite polarity from the general rule's unconditional
+    ``!defined(__cplusplus)`` treatment, ordered ahead of it since it would
+    otherwise also match. Same reasoning as the ``#if``-opening case.
+    """
+    return policy.mask_cplusplus_defined_guards and bool(
+        _PP_ELIF_NOT_DEFINED_CPLUSPLUS_PATTERN.match(line)
+    )
+
+
+def _arm_is_unreachable_or_circular_guard(line: bytes, policy: _ChainPolicy) -> bool:
+    """``#elif 0``/``#elif false``, or a circular dialect/feature-test guard."""
+    return bool(
+        _PP_ELIF_ZERO_PATTERN.match(line)
         or (
-            not invert_dialect_fallback_guards
-            and _PP_IFNDEF_CPP_FEATURE_GUARD_PATTERN.match(line)
-        )
-        or (mask_cplusplus_defined_guards and _PP_IFDEF_CPLUSPLUS_PATTERN.match(line))
-        or (
-            _PP_IF_CPLUSPLUS_GUARD_PATTERN.match(line)
+            _PP_ELIF_CPLUSPLUS_GUARD_PATTERN.match(line)
             and (
-                mask_cplusplus_defined_guards
-                or not _PP_IF_CPLUSPLUS_ALWAYS_TRUE_PATTERN.match(line)
+                policy.mask_cplusplus_defined_guards
+                or not _PP_ELIF_CPLUSPLUS_ALWAYS_TRUE_PATTERN.match(line)
             )
         )
-    ):
-        return [True, True, False]
-    if _PP_IF_TRUE_PATTERN.match(line) or (
-        not mask_cplusplus_defined_guards
-        and (
-            _PP_IFDEF_CPLUSPLUS_PATTERN.match(line)
-            or _PP_IF_CPLUSPLUS_ALWAYS_TRUE_PATTERN.match(line)
+    )
+
+
+def _arm_is_unconditionally_true(line: bytes, policy: _ChainPolicy) -> bool:
+    """``#elif 1``/``#elif true``, or ``#elif defined(__cplusplus)``."""
+    return bool(
+        _PP_ELIF_TRUE_PATTERN.match(line)
+        or (
+            not policy.mask_cplusplus_defined_guards
+            and _PP_ELIF_CPLUSPLUS_ALWAYS_TRUE_PATTERN.match(line)
         )
-    ):
-        # ``#if defined(__cplusplus)``/``#ifdef __cplusplus``/bare
-        # ``#if __cplusplus`` (Codex review, twenty-second round):
-        # tracked as *settled*-true here, the same way ``#if 1``/
-        # ``#if true`` already is, not left as an unrecognized
-        # chain (whose #else/#elif arms then get scanned right
-        # along with this one, unmasked). Without this, a dual
-        # C/C++ header's ``#else`` (C-only) fallback -- e.g. a
-        # ``struct concept {};`` compatibility shim -- stayed
-        # visible to the shadow-name scan alongside a genuine
-        # C++20 declaration in the *active* ``#if`` arm, wrongly
-        # shadowing it. Elif-level already settles the equivalent
-        # ``#elif`` spelling this same way; this closes the gap
-        # for it as the chain's *opening* condition. Skipped when
-        # mask_cplusplus_defined_guards is True (the caller
-        # already masked this guard's own content in the general
-        # branch above instead, and never reaches this line).
-        return [True, False, True]
-    if invert_dialect_fallback_guards and _PP_IFNDEF_CPP_FEATURE_GUARD_PATTERN.match(
-        line
-    ):
-        # Opposite polarity from the branch above: the
-        # #ifndef-guarded arm (feature absent) is the trustworthy
-        # one here, so it's scanned live and immediately settled
-        # so any #else (feature present, circular) stays masked.
-        # Skipped for a shadow-scan caller -- already folded into
-        # the general mask branch above instead.
-        return [True, False, True]
-    # Unrecognized condition — same conservative pass-through the
-    # top level always applied to an #if it can't evaluate.
-    return [False, False, False]
+    )
+
+
+def _arm_is_plain_alternative(line: bytes, policy: _ChainPolicy) -> bool:
+    """Any other ``#elif``/``#else`` — a condition this heuristic can't read."""
+    return bool(_PP_ELIF_PATTERN.match(line) or _PP_ELSE_PATTERN.match(line))
+
+
+#: Ordered ``(matcher, mutator)`` rules for one arm of an already-open chain.
+#: Same load-bearing ordering rationale as ``_CHAIN_OPEN_RULES``.
+_OPEN_ARM_RULES: tuple[tuple[_ChainMatcher, Callable[[list[bool]], None]], ...] = (
+    (_arm_is_pre_cpp20_dialect_fallback, _arm_settle),
+    (_arm_is_missing_feature_fallback, _arm_settle),
+    (_arm_is_missing_cplusplus_fallback, _arm_settle),
+    (_arm_is_unreachable_or_circular_guard, _arm_mask),
+    (_arm_is_unconditionally_true, _arm_settle),
+    (_arm_is_plain_alternative, _arm_flip),
+)
 
 
 def _line_for_open_arm(
@@ -408,8 +576,8 @@ def _line_for_open_arm(
 
     *frame* is mutated in place: an ``#elif``/``#else`` arm changes which of
     this level's arms is currently masked, and may settle the level. A
-    non-directive line inside the chain is emitted or blanked purely by the
-    frame's current masking state.
+    non-directive line inside the chain matches no rule and is emitted or
+    blanked purely by the frame's current masking state.
     """
     if not frame[0]:
         # This level's own #if condition was unrecognized — its
@@ -417,56 +585,11 @@ def _line_for_open_arm(
         # exactly like the top level's unrecognized-chain
         # pass-through.
         return line
-    if invert_dialect_fallback_guards and _PP_ELIF_CPLUSPLUS_LESS_THAN_PATTERN.match(
-        line
-    ):
-        # Same inverted polarity as the #if-opening case, checked
-        # ahead of the general branch below since it would
-        # otherwise also match. Same shadow-scan exception as the
-        # #if-opening case: falls through to the general branch
-        # (mask) when invert_dialect_fallback_guards is False.
-        frame[1] = frame[2]
-        frame[2] = True
-        return b"" if frame[1] else line
-    if (
-        invert_dialect_fallback_guards
-        and _PP_ELIF_NOT_DEFINED_CPP_FEATURE_GUARD_PATTERN.match(line)
-    ):
-        # Same inverted polarity as #if !defined(__cpp_x) above,
-        # checked ahead of the general branch since it would
-        # otherwise also match. Same shadow-scan exception.
-        frame[1] = frame[2]
-        frame[2] = True
-        return b"" if frame[1] else line
-    if mask_cplusplus_defined_guards and _PP_ELIF_NOT_DEFINED_CPLUSPLUS_PATTERN.match(
-        line
-    ):
-        # Opposite polarity from the general branch below's
-        # unconditional !defined(__cplusplus) treatment, checked
-        # ahead of it since it would otherwise also match. Same
-        # reasoning as the #if-opening case above.
-        frame[1] = frame[2]
-        frame[2] = True
-        return b"" if frame[1] else line
-    if _PP_ELIF_ZERO_PATTERN.match(line) or (
-        _PP_ELIF_CPLUSPLUS_GUARD_PATTERN.match(line)
-        and (
-            mask_cplusplus_defined_guards
-            or not _PP_ELIF_CPLUSPLUS_ALWAYS_TRUE_PATTERN.match(line)
-        )
-    ):
-        frame[1] = True
-        return b""
-    if _PP_ELIF_TRUE_PATTERN.match(line) or (
-        not mask_cplusplus_defined_guards
-        and _PP_ELIF_CPLUSPLUS_ALWAYS_TRUE_PATTERN.match(line)
-    ):
-        frame[1] = frame[2]
-        frame[2] = True
-        return b"" if frame[1] else line
-    if _PP_ELIF_PATTERN.match(line) or _PP_ELSE_PATTERN.match(line):
-        frame[1] = frame[2]
-        return b"" if frame[1] else line
+    policy = _ChainPolicy(invert_dialect_fallback_guards, mask_cplusplus_defined_guards)
+    for matches, advance in _OPEN_ARM_RULES:
+        if matches(line, policy):
+            advance(frame)
+            break
     return b"" if frame[1] else line
 
 

--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -227,6 +227,22 @@ def is_synthetic_dtor_key(key: str) -> bool:
     return key.startswith(_SYNTHETIC_DTOR_KEY_PREFIX)
 
 
+def _virtual_method_mangled_name(method_el: Any) -> str:
+    """A virtual method's mangled name, with the destructor fallback.
+
+    castxml ``<Destructor>`` elements carry no ``mangled`` attribute. Without a
+    fallback every virtual destructor is silently dropped from the vtable,
+    which makes each polymorphic type look like it lacks a destructor slot
+    (false ``POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR``). The ``name`` attribute is the
+    class name, so ``"~Name"`` is a stable, per-class entry.
+    """
+    mangled_name: str = method_el.get("mangled", "")
+    if not mangled_name and method_el.tag == "Destructor":
+        name = method_el.get("name", "")
+        mangled_name = f"~{name}" if name else ""
+    return mangled_name
+
+
 class _CastxmlParser:
     """Parse castxml XML into ABI model objects."""
 
@@ -1733,108 +1749,13 @@ class _CastxmlParser:
         if class_el is None:
             return {}
 
-        slots: dict[int | str, tuple[int | None, str]] = {}
-        for base in class_el:
-            if base.tag != "Base":
-                continue
-            base_type_el = self._resolve(base.get("type", ""))
-            if base_type_el is not None:
-                slots.update(
-                    self._collect_virtual_methods(base_type_el.get("id", ""), seen)
-                )
-
+        slots = self._inherited_vtable_slots(class_el, seen)
         for method_el in self._virtual_methods_by_class.get(cid, []):
-            mangled_name = method_el.get("mangled", "")
-            if not mangled_name and method_el.tag == "Destructor":
-                # castxml <Destructor> elements carry no mangled attribute.
-                # Without a fallback every virtual destructor is silently
-                # dropped from the vtable, which makes each polymorphic type
-                # look like it lacks a destructor slot (false
-                # POLYMORPHIC_TYPE_NON_VIRTUAL_DTOR). The name attribute is
-                # the class name, so "~Name" is a stable, per-class entry.
-                name = method_el.get("name", "")
-                mangled_name = f"~{name}" if name else ""
+            mangled_name = _virtual_method_mangled_name(method_el)
             if not mangled_name:
                 continue
-            idx = _parse_vtable_index(method_el.get("vtable_index"))
             mid = method_el.get("id", "")
-            overrides_id = method_el.get("overrides")
-            key: int | str
-            extra_keys: list[int | str] = []
-            if overrides_id:
-                # An override always reuses whatever slot its base declaration
-                # landed under -- checked BEFORE falling back to this
-                # declaration's own vtable_index. Preferring a fresh idx here
-                # instead would miss the reverse mixed-index direction: a base
-                # that lacks vtable_index (so its slot is keyed by its own
-                # string id) but is overridden by a declaration that DOES
-                # carry an index would otherwise open a new int-keyed slot
-                # instead of collapsing onto the base's string-keyed one.
-                #
-                # castxml can list more than one overridden declaration as a
-                # whitespace-separated id list when a single override
-                # simultaneously covers more than one base-class branch (e.g.
-                # non-virtual multiple inheritance -- Derived : Base1, Base2 --
-                # where one final overrider satisfies both Base1::foo() and
-                # Base2::foo()). Each resolved id is a genuinely distinct
-                # position in the object's real vtable-group layout (typically
-                # an adjusting thunk for all but one) -- an exact lookup of the
-                # raw composite string never matches _vtable_slot_root, so
-                # resolve each id: the first resolved slot becomes this
-                # entry's own key, and every OTHER resolved slot keeps its own
-                # key and prior sort position (extra_keys, applied below)
-                # with only its content updated to this override, rather than
-                # collapsing them into one entry -- which would under-report
-                # the vtable's true size -- or leaving them with stale
-                # pre-override content.
-                #
-                # A resolved id can itself carry extra roots from an earlier
-                # multi-slot override (a further-derived override referencing
-                # an intermediate override's id by `overrides` must propagate
-                # to every slot that intermediate one touched, not just its
-                # primary) -- both _vtable_slot_root and
-                # _vtable_slot_extra_roots are consulted per id below.
-                resolved_keys: list[int | str] = []
-                for oid in overrides_id.split():
-                    candidates: list[int | str] = []
-                    primary = self._vtable_slot_root.get(oid)
-                    if primary is not None:
-                        candidates.append(primary)
-                    candidates.extend(self._vtable_slot_extra_roots.get(oid, ()))
-                    for candidate in candidates:
-                        if candidate not in resolved_keys:
-                            resolved_keys.append(candidate)
-                if resolved_keys:
-                    key = resolved_keys[0]
-                    extra_keys = resolved_keys[1:]
-                else:
-                    key = overrides_id
-                if isinstance(key, int):
-                    # Consistently-indexed lineage: adopt the resolved index
-                    # for sorting when this declaration has none of its own,
-                    # so _build_vtable's final _vt_sort_key sort places it at
-                    # the inherited position instead of the unindexed tail
-                    # (which would silently reorder it past any indexed
-                    # sibling slot declared after this one, an apparent
-                    # "vtable reordered" that never actually happened).
-                    if idx is None:
-                        idx = key
-                else:
-                    # Unindexed lineage (key is a string): a fresh
-                    # vtable_index on THIS declaration has no verified
-                    # relationship to sibling unindexed slots' true positions
-                    # (e.g. Base has unindexed foo then bar; Derived overrides
-                    # bar with its own vtable_index="1" -- that "1" doesn't
-                    # mean "after foo", it's not comparable to foo's unknown
-                    # position at all), so it must not be trusted for
-                    # cross-slot ordering. Discard it and let _vt_sort_key
-                    # treat this slot as unindexed, preserving its original
-                    # discovery-order position.
-                    idx = None
-            elif idx is not None:
-                key = idx
-            else:
-                key = mid or mangled_name
+            key, extra_keys, idx = self._vtable_slot_key(method_el, mid, mangled_name)
             if mid:
                 # Record the *actual* slot key (int index or str id) this method
                 # landed under, not just a self-reference -- a downstream override
@@ -1846,7 +1767,7 @@ class _CastxmlParser:
                 if extra_keys:
                     # This id itself touches more than one slot -- a further-
                     # derived override referencing it by `overrides` must
-                    # propagate to all of them (see the resolution loop above).
+                    # propagate to all of them.
                     self._vtable_slot_extra_roots[mid] = list(extra_keys)
             slots[key] = (idx, mangled_name)
             for extra_key in extra_keys:
@@ -1854,6 +1775,104 @@ class _CastxmlParser:
                 slots[extra_key] = (prev_idx, mangled_name)
 
         return slots
+
+    def _inherited_vtable_slots(
+        self, class_el: Any, seen: set[str]
+    ) -> dict[int | str, tuple[int | None, str]]:
+        """Every base class's slots, in base-declaration order."""
+        slots: dict[int | str, tuple[int | None, str]] = {}
+        for base in class_el:
+            if base.tag != "Base":
+                continue
+            base_type_el = self._resolve(base.get("type", ""))
+            if base_type_el is not None:
+                slots.update(
+                    self._collect_virtual_methods(base_type_el.get("id", ""), seen)
+                )
+        return slots
+
+    def _resolved_override_keys(self, overrides_id: str) -> list[int | str]:
+        """Every existing slot key the ``overrides`` attribute resolves to.
+
+        castxml can list more than one overridden declaration as a
+        whitespace-separated id list when a single override simultaneously
+        covers more than one base-class branch (e.g. non-virtual multiple
+        inheritance -- ``Derived : Base1, Base2`` -- where one final overrider
+        satisfies both ``Base1::foo()`` and ``Base2::foo()``). Each resolved id
+        is a genuinely distinct position in the object's real vtable-group
+        layout (typically an adjusting thunk for all but one), and an exact
+        lookup of the raw composite string never matches ``_vtable_slot_root``,
+        so every id is resolved separately.
+
+        A resolved id can itself carry extra roots from an earlier multi-slot
+        override (a further-derived override referencing an intermediate
+        override's id by ``overrides`` must propagate to every slot that
+        intermediate one touched, not just its primary), so both
+        ``_vtable_slot_root`` and ``_vtable_slot_extra_roots`` are consulted
+        per id.
+        """
+        resolved: list[int | str] = []
+        for oid in overrides_id.split():
+            candidates: list[int | str] = []
+            primary = self._vtable_slot_root.get(oid)
+            if primary is not None:
+                candidates.append(primary)
+            candidates.extend(self._vtable_slot_extra_roots.get(oid, ()))
+            for candidate in candidates:
+                if candidate not in resolved:
+                    resolved.append(candidate)
+        return resolved
+
+    def _vtable_slot_key(
+        self, method_el: Any, mid: str, mangled_name: str
+    ) -> tuple[int | str, list[int | str], int | None]:
+        """``(key, extra_keys, vtable_index)`` for one virtual method declaration.
+
+        An override always reuses whatever slot its base declaration landed
+        under -- checked BEFORE falling back to this declaration's own
+        ``vtable_index``. Preferring a fresh index would miss the reverse mixed-
+        index direction: a base that lacks ``vtable_index`` (so its slot is
+        keyed by its own string id) but is overridden by a declaration that DOES
+        carry an index would otherwise open a new int-keyed slot instead of
+        collapsing onto the base's string-keyed one.
+
+        The first resolved slot becomes this entry's own key; every OTHER
+        resolved slot keeps its own key and prior sort position (*extra_keys*)
+        with only its content updated to this override, rather than collapsing
+        them into one entry -- which would under-report the vtable's true size
+        -- or leaving them with stale pre-override content.
+        """
+        idx = _parse_vtable_index(method_el.get("vtable_index"))
+        overrides_id = method_el.get("overrides")
+        if not overrides_id:
+            return (idx if idx is not None else (mid or mangled_name)), [], idx
+
+        resolved_keys = self._resolved_override_keys(overrides_id)
+        if resolved_keys:
+            key: int | str = resolved_keys[0]
+            extra_keys = resolved_keys[1:]
+        else:
+            key, extra_keys = overrides_id, []
+        if isinstance(key, int):
+            # Consistently-indexed lineage: adopt the resolved index for
+            # sorting when this declaration has none of its own, so
+            # _build_vtable's final _vt_sort_key sort places it at the
+            # inherited position instead of the unindexed tail (which would
+            # silently reorder it past any indexed sibling slot declared after
+            # this one, an apparent "vtable reordered" that never happened).
+            if idx is None:
+                idx = key
+        else:
+            # Unindexed lineage (key is a string): a fresh vtable_index on THIS
+            # declaration has no verified relationship to sibling unindexed
+            # slots' true positions (e.g. Base has unindexed foo then bar;
+            # Derived overrides bar with its own vtable_index="1" -- that "1"
+            # doesn't mean "after foo", it's not comparable to foo's unknown
+            # position at all), so it must not be trusted for cross-slot
+            # ordering. Discard it and let _vt_sort_key treat this slot as
+            # unindexed, preserving its original discovery-order position.
+            idx = None
+        return key, extra_keys, idx
 
     def parse_enums(self) -> list[EnumType]:
         enums = []

--- a/abicheck/dumper_elf_symbols.py
+++ b/abicheck/dumper_elf_symbols.py
@@ -25,9 +25,11 @@ existing bare-name calls and test patches (``patch.object(dumper,
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from .elf_symbol_filter import is_abi_relevant_elf_symbol
+from .errors import SnapshotError
 from .model import AbiSnapshot, ElfVisibility, is_cxx_runtime_library
 
 if TYPE_CHECKING:
@@ -118,3 +120,63 @@ def _elf_classify_symbols(
         exported_dynamic_objects,
         exported_dynamic_tls,
     )
+
+
+_HIDDEN_VIS = frozenset({"STV_HIDDEN", "STV_INTERNAL"})
+
+
+def _is_abi_relevant_symbol(name: str) -> bool:
+    """Return False for symbols that are NOT part of the library's public ABI.
+
+    Filters out (in ELF-only mode):
+    1. GCC/compiler internal symbols (``ix86_*``, ``_ZGV*``, ``__svml_*`` …)
+       that leak into ``.dynsym`` through a statically-linked runtime.
+    2. Transitive C++ stdlib symbols (``_ZNSt*``, ``_ZTI*`` …) that appear
+       in ``.dynsym`` via weak linkage from libstdc++ / libc++.
+    3. Private C symbols that use ``__`` as a namespace separator
+       (e.g. ``H5C__flush``, ``MPI__send``).  These follow an internal
+       naming convention and are *not* part of the public API, even though
+       they may have global ELF visibility.
+    """
+    return is_abi_relevant_elf_symbol(name)
+
+
+def _pyelftools_exported_symbols(so_path: Path) -> tuple[set[str], set[str]]:
+    """Return (exported_dynamic, exported_static) sets of mangled symbol names.
+
+    Uses pyelftools (pure Python) instead of shelling out to readelf.
+    - exported_dynamic: symbols from .dynsym, truly exported via ELF
+    - exported_static: symbols from .symtab (all symbols including static)
+    """
+    from elftools.common.exceptions import ELFError
+    from elftools.elf.elffile import ELFFile
+    from elftools.elf.sections import SymbolTableSection
+
+    def _extract_symbols(elf: Any, section_name: str) -> set[str]:
+        syms: set[str] = set()
+        section = elf.get_section_by_name(section_name)
+        if section is None or not isinstance(section, SymbolTableSection):
+            return syms
+        for sym in section.iter_symbols():
+            shndx = sym.entry.st_shndx
+            if shndx in ("SHN_UNDEF", "SHN_ABS"):
+                continue
+            bind = sym.entry.st_info.bind
+            vis = sym.entry.st_other.visibility
+            if bind in ("STB_GLOBAL", "STB_WEAK") and vis not in _HIDDEN_VIS:
+                name = sym.name
+                if name and _is_abi_relevant_symbol(name):
+                    syms.add(name)
+        return syms
+
+    try:
+        with open(so_path, "rb") as f:
+            elf: Any = ELFFile(f)  # type: ignore[no-untyped-call]
+            exported_dynamic = _extract_symbols(elf, ".dynsym")
+            try:
+                exported_static = _extract_symbols(elf, ".symtab")
+            except (ELFError, OSError):
+                exported_static = set(exported_dynamic)
+            return exported_dynamic, exported_static
+    except (ELFError, OSError) as exc:
+        raise SnapshotError(f"Failed to parse ELF file {so_path}: {exc}") from exc

--- a/abicheck/dumper_layout_backfill.py
+++ b/abicheck/dumper_layout_backfill.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
-from .model import RecordType
+from .model import RecordType, TypeField
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -172,6 +172,181 @@ def _coherence_status(
     if unavailable_types or ambiguous:
         return "partial"
     return "matched"
+
+
+def _unique_dwarf_match(
+    dwarf_candidates: dict[str, list[RecordType]], name: str
+) -> RecordType | None:
+    """The single DWARF candidate for *name*, or ``None`` when ambiguous/absent."""
+    candidates = dwarf_candidates.get(name, [])
+    return candidates[0] if len(candidates) == 1 else None
+
+def _fields_corroborate(header: RecordType, dwarf: RecordType) -> bool:
+    if header.fields and dwarf.fields:
+        return bool(
+            {f.name for f in header.fields} & {f.name for f in dwarf.fields}
+        )
+    if not header.fields and dwarf.fields:
+        # An empty header type (tag type) can't corroborate against a
+        # DWARF candidate that DOES have fields — that's exactly the
+        # unrelated-internal-type risk this check exists to catch, not
+        # the anonymous-aggregate asymmetry handled below.
+        return False
+    # dwarf.fields is empty here — either both sides are genuinely
+    # fieldless, or the header side has real fields that DWARF's
+    # anonymous-aggregate asymmetry flattened away. Field names alone
+    # can't tell those apart from a coincidentally-fieldless unrelated
+    # type in either case, so fall back to base-class-name overlap as a
+    # second corroborating signal before trusting the match. Virtual
+    # bases are stored separately from ordinary bases on both the clang
+    # header parser and the DWARF builder (RecordType.virtual_bases,
+    # not .bases) — a virtual-inheritance-only class would otherwise
+    # leave both .bases sets empty and fall through unchallenged. Base
+    # names also need the same scope-suffix normalization record names
+    # get: the clang header parser stores each base's full `qualType`
+    # (e.g. "api::Base"), while the DWARF builder's base resolution
+    # only ever reads DW_AT_name (always bare, e.g. "Base", never
+    # scope-qualified) — comparing the raw strings would reject a
+    # namespaced base's own correct match (Codex review).
+    header_bases = {
+        _topmost_scope_suffix(b) for b in header.bases + header.virtual_bases
+    }
+    dwarf_bases = {
+        _topmost_scope_suffix(b) for b in dwarf.bases + dwarf.virtual_bases
+    }
+    if header_bases or dwarf_bases:
+        return bool(header_bases & dwarf_bases)
+    if header.name == dwarf.name:
+        # Exact match still needs the header's own fields to be real
+        # corroborating evidence, not just the match key itself (Codex
+        # review, fresh evidence): the clang header parser never
+        # namespace-qualifies RecordType.name at all (see above), so an
+        # exact match only shows this DWARF candidate has no scope of
+        # its own — not that it is the header's (possibly actually-
+        # namespaced) type. A *populated* header record (real,
+        # non-anonymous-aggregate fields) with an empty DWARF candidate
+        # reached only by that coincidence is exactly the unrelated-
+        # type risk the field-overlap check above exists to catch. A
+        # trivial fieldless match still needs ``not dwarf.vtable`` too
+        # (Codex review, fresh evidence): a genuinely empty header
+        # record can exact-match a unique, unrelated, fieldless-but-
+        # *polymorphic* DWARF candidate just as easily as the
+        # anonymous-aggregate case below can — "nothing to disagree
+        # with" isn't true once the DWARF side has a vtable the header
+        # side structurally can't (the clang header parser never
+        # populates ``RecordType.vtable`` itself).
+        return not dwarf.vtable and (
+            not header.fields or header.has_anonymous_aggregate_fields
+        )
+    # Suffix-only match with no field/base overlap left to corroborate.
+    # Trusting this on "header merely has some fields" would reopen the
+    # exact risk just closed above: an ordinary struct with real fields,
+    # whose actual DWARF counterpart is simply absent, matched instead
+    # to an unrelated, coincidentally-fieldless internal type via bare
+    # suffix (CodeRabbit review). Only trust it when the header's
+    # fields are *known* to come from an anonymous-aggregate flatten —
+    # a structural signal the clang parser sets itself, not a guess —
+    # since DWARF's own builder doesn't flatten the same way and a
+    # *namespaced* anonymous-aggregate record (clang emits the bare
+    # "Foo", DWARF emits "api::Foo") would otherwise be permanently
+    # layout-blind, defeating the point of that exception for exactly
+    # the common namespaced case it exists for (Codex review).
+    #
+    # That flag alone still doesn't vouch for *this particular* unique
+    # candidate, though (Codex review, fresh evidence): an unrelated
+    # ``impl::Foo`` that is fieldless and baseless but *polymorphic*
+    # (virtual methods only, no data) would pass every check so far and
+    # hand over its real vtable/size onto the public anonymous-aggregate
+    # type. Unlike the header side, DWARF's own builder does populate
+    # ``vtable`` for a genuinely polymorphic type, so requiring it to be
+    # empty here closes that specific over-trust: the only match this
+    # still can't rule out is a *fully* trivial unrelated type (no
+    # fields, no bases, no vtable), whose own layout is necessarily
+    # near-fixed and small regardless of identity — the same bounded,
+    # low-consequence residual risk already accepted for the plain
+    # fieldless-tag-type case above.
+    #
+    # A namespaced class with *only* virtual methods (no fields, no
+    # bases, no anonymous-aggregate flatten) is a deliberately accepted
+    # gap in this same vein, not an oversight (Codex review): it too is
+    # fieldless/baseless with a real, non-empty ``dwarf.vtable``, so by
+    # the reasoning just above it would need a structural signal on the
+    # *header* side analogous to ``has_anonymous_aggregate_fields`` —
+    # but "the class declares a virtual method" only demonstrates that
+    # *some* class does, not that this unique suffix-matched candidate
+    # is that same one; unlike anonymous-aggregate flattening (a fact
+    # about field provenance) or field/base-name overlap (specific
+    # identifiers), "has a vtable" is a coarse category shared by
+    # every polymorphic class in the binary. Trusting it here would
+    # reintroduce exactly the over-trust the ``not dwarf.vtable``
+    # guard above exists to prevent, just from the opposite class
+    # shape. Closing this safely would need to cross-reference actual
+    # member-function names/mangled symbols between the header and
+    # DWARF views — data this function doesn't have (only
+    # ``RecordType``s, not the snapshot's ``functions`` list) — so it's
+    # left unbackfilled (stays ``None``) rather than guessed.
+    return header.has_anonymous_aggregate_fields and not dwarf.vtable
+
+
+def _merged_fields(header: RecordType, dwarf: RecordType) -> list[TypeField]:
+    """*header*'s fields with offset/bitfield data filled in from *dwarf*.
+
+    A field that already carries an ``offset_bits``, or has no DWARF
+    counterpart by name, is kept exactly as the header parser produced it.
+    """
+    dwarf_fields_by_name = {f.name: f for f in dwarf.fields}
+    merged: list[TypeField] = []
+    for f in header.fields:
+        df = dwarf_fields_by_name.get(f.name)
+        if f.offset_bits is not None or df is None:
+            merged.append(f)
+            continue
+        merged.append(
+            replace(
+                f,
+                offset_bits=df.offset_bits,
+                is_bitfield=df.is_bitfield,
+                bitfield_bits=df.bitfield_bits,
+            )
+        )
+    return merged
+
+
+def _backfilled_record(header: RecordType, dwarf: RecordType) -> RecordType:
+    """*header* with every layout attribute it lacks taken from *dwarf*.
+
+    Purely additive: an attribute the header backend already computed always
+    wins, so this is a no-op for a layout-aware backend (castxml) and a fill-in
+    for a layout-blind one (clang).
+    """
+    return replace(
+        header,
+        size_bits=dwarf.size_bits,
+        alignment_bits=dwarf.alignment_bits,
+        fields=_merged_fields(header, dwarf),
+        vtable=header.vtable or dwarf.vtable,
+        vptr_offset_bits=(
+            header.vptr_offset_bits
+            if header.vptr_offset_bits is not None
+            else dwarf.vptr_offset_bits
+        ),
+        base_offsets=header.base_offsets or dwarf.base_offsets,
+        data_size_bits=(
+            header.data_size_bits
+            if header.data_size_bits is not None
+            else dwarf.data_size_bits
+        ),
+        is_standard_layout=(
+            header.is_standard_layout
+            if header.is_standard_layout is not None
+            else dwarf.is_standard_layout
+        ),
+        is_trivially_copyable=(
+            header.is_trivially_copyable
+            if header.is_trivially_copyable is not None
+            else dwarf.is_trivially_copyable
+        ),
+    )
 
 
 def backfill_dwarf_layout(
@@ -391,116 +566,6 @@ def backfill_dwarf_layout(
         for key in {t.name, _topmost_scope_suffix(t.name)}:  # pylint: disable=use-sequence-for-iteration
             dwarf_candidates.setdefault(key, []).append(t)
 
-    def _dwarf_match(name: str) -> RecordType | None:
-        candidates = dwarf_candidates.get(name, [])
-        return candidates[0] if len(candidates) == 1 else None
-
-    def _fields_corroborate(header: RecordType, dwarf: RecordType) -> bool:
-        if header.fields and dwarf.fields:
-            return bool(
-                {f.name for f in header.fields} & {f.name for f in dwarf.fields}
-            )
-        if not header.fields and dwarf.fields:
-            # An empty header type (tag type) can't corroborate against a
-            # DWARF candidate that DOES have fields — that's exactly the
-            # unrelated-internal-type risk this check exists to catch, not
-            # the anonymous-aggregate asymmetry handled below.
-            return False
-        # dwarf.fields is empty here — either both sides are genuinely
-        # fieldless, or the header side has real fields that DWARF's
-        # anonymous-aggregate asymmetry flattened away. Field names alone
-        # can't tell those apart from a coincidentally-fieldless unrelated
-        # type in either case, so fall back to base-class-name overlap as a
-        # second corroborating signal before trusting the match. Virtual
-        # bases are stored separately from ordinary bases on both the clang
-        # header parser and the DWARF builder (RecordType.virtual_bases,
-        # not .bases) — a virtual-inheritance-only class would otherwise
-        # leave both .bases sets empty and fall through unchallenged. Base
-        # names also need the same scope-suffix normalization record names
-        # get: the clang header parser stores each base's full `qualType`
-        # (e.g. "api::Base"), while the DWARF builder's base resolution
-        # only ever reads DW_AT_name (always bare, e.g. "Base", never
-        # scope-qualified) — comparing the raw strings would reject a
-        # namespaced base's own correct match (Codex review).
-        header_bases = {
-            _topmost_scope_suffix(b) for b in header.bases + header.virtual_bases
-        }
-        dwarf_bases = {
-            _topmost_scope_suffix(b) for b in dwarf.bases + dwarf.virtual_bases
-        }
-        if header_bases or dwarf_bases:
-            return bool(header_bases & dwarf_bases)
-        if header.name == dwarf.name:
-            # Exact match still needs the header's own fields to be real
-            # corroborating evidence, not just the match key itself (Codex
-            # review, fresh evidence): the clang header parser never
-            # namespace-qualifies RecordType.name at all (see above), so an
-            # exact match only shows this DWARF candidate has no scope of
-            # its own — not that it is the header's (possibly actually-
-            # namespaced) type. A *populated* header record (real,
-            # non-anonymous-aggregate fields) with an empty DWARF candidate
-            # reached only by that coincidence is exactly the unrelated-
-            # type risk the field-overlap check above exists to catch. A
-            # trivial fieldless match still needs ``not dwarf.vtable`` too
-            # (Codex review, fresh evidence): a genuinely empty header
-            # record can exact-match a unique, unrelated, fieldless-but-
-            # *polymorphic* DWARF candidate just as easily as the
-            # anonymous-aggregate case below can — "nothing to disagree
-            # with" isn't true once the DWARF side has a vtable the header
-            # side structurally can't (the clang header parser never
-            # populates ``RecordType.vtable`` itself).
-            return not dwarf.vtable and (
-                not header.fields or header.has_anonymous_aggregate_fields
-            )
-        # Suffix-only match with no field/base overlap left to corroborate.
-        # Trusting this on "header merely has some fields" would reopen the
-        # exact risk just closed above: an ordinary struct with real fields,
-        # whose actual DWARF counterpart is simply absent, matched instead
-        # to an unrelated, coincidentally-fieldless internal type via bare
-        # suffix (CodeRabbit review). Only trust it when the header's
-        # fields are *known* to come from an anonymous-aggregate flatten —
-        # a structural signal the clang parser sets itself, not a guess —
-        # since DWARF's own builder doesn't flatten the same way and a
-        # *namespaced* anonymous-aggregate record (clang emits the bare
-        # "Foo", DWARF emits "api::Foo") would otherwise be permanently
-        # layout-blind, defeating the point of that exception for exactly
-        # the common namespaced case it exists for (Codex review).
-        #
-        # That flag alone still doesn't vouch for *this particular* unique
-        # candidate, though (Codex review, fresh evidence): an unrelated
-        # ``impl::Foo`` that is fieldless and baseless but *polymorphic*
-        # (virtual methods only, no data) would pass every check so far and
-        # hand over its real vtable/size onto the public anonymous-aggregate
-        # type. Unlike the header side, DWARF's own builder does populate
-        # ``vtable`` for a genuinely polymorphic type, so requiring it to be
-        # empty here closes that specific over-trust: the only match this
-        # still can't rule out is a *fully* trivial unrelated type (no
-        # fields, no bases, no vtable), whose own layout is necessarily
-        # near-fixed and small regardless of identity — the same bounded,
-        # low-consequence residual risk already accepted for the plain
-        # fieldless-tag-type case above.
-        #
-        # A namespaced class with *only* virtual methods (no fields, no
-        # bases, no anonymous-aggregate flatten) is a deliberately accepted
-        # gap in this same vein, not an oversight (Codex review): it too is
-        # fieldless/baseless with a real, non-empty ``dwarf.vtable``, so by
-        # the reasoning just above it would need a structural signal on the
-        # *header* side analogous to ``has_anonymous_aggregate_fields`` —
-        # but "the class declares a virtual method" only demonstrates that
-        # *some* class does, not that this unique suffix-matched candidate
-        # is that same one; unlike anonymous-aggregate flattening (a fact
-        # about field provenance) or field/base-name overlap (specific
-        # identifiers), "has a vtable" is a coarse category shared by
-        # every polymorphic class in the binary. Trusting it here would
-        # reintroduce exactly the over-trust the ``not dwarf.vtable``
-        # guard above exists to prevent, just from the opposite class
-        # shape. Closing this safely would need to cross-reference actual
-        # member-function names/mangled symbols between the header and
-        # DWARF views — data this function doesn't have (only
-        # ``RecordType``s, not the snapshot's ``functions`` list) — so it's
-        # left unbackfilled (stays ``None``) rather than guessed.
-        return header.has_anonymous_aggregate_fields and not dwarf.vtable
-
     header_name_counts: dict[str, int] = {}
     for t in header_types:
         header_name_counts[t.name] = header_name_counts.get(t.name, 0) + 1
@@ -533,7 +598,7 @@ def backfill_dwarf_layout(
             out.append(t)
             ambiguous.append(t.name)
             continue
-        dwarf_t = _dwarf_match(t.name)
+        dwarf_t = _unique_dwarf_match(dwarf_candidates, t.name)
         if dwarf_t is None:
             out.append(t)
             unavailable_types.append(t.name)
@@ -543,49 +608,7 @@ def backfill_dwarf_layout(
             mismatched.append(t.name)
             continue
         matched.append(t.name)
-        dwarf_fields_by_name = {f.name: f for f in dwarf_t.fields}
-        new_fields = []
-        for f in t.fields:
-            df = dwarf_fields_by_name.get(f.name)
-            if f.offset_bits is not None or df is None:
-                new_fields.append(f)
-                continue
-            new_fields.append(
-                replace(
-                    f,
-                    offset_bits=df.offset_bits,
-                    is_bitfield=df.is_bitfield,
-                    bitfield_bits=df.bitfield_bits,
-                )
-            )
-        out.append(
-            replace(
-                t,
-                size_bits=dwarf_t.size_bits,
-                alignment_bits=dwarf_t.alignment_bits,
-                fields=new_fields,
-                vtable=t.vtable or dwarf_t.vtable,
-                vptr_offset_bits=(
-                    t.vptr_offset_bits
-                    if t.vptr_offset_bits is not None
-                    else dwarf_t.vptr_offset_bits
-                ),
-                base_offsets=t.base_offsets or dwarf_t.base_offsets,
-                data_size_bits=t.data_size_bits
-                if t.data_size_bits is not None
-                else dwarf_t.data_size_bits,
-                is_standard_layout=(
-                    t.is_standard_layout
-                    if t.is_standard_layout is not None
-                    else dwarf_t.is_standard_layout
-                ),
-                is_trivially_copyable=(
-                    t.is_trivially_copyable
-                    if t.is_trivially_copyable is not None
-                    else dwarf_t.is_trivially_copyable
-                ),
-            )
-        )
+        out.append(_backfilled_record(t, dwarf_t))
     coherence = DwarfLayoutCoherence(
         status=_coherence_status(
             mismatched=mismatched,

--- a/abicheck/dumper_scoping.py
+++ b/abicheck/dumper_scoping.py
@@ -95,7 +95,7 @@ import dataclasses
 import functools
 import inspect
 from collections import deque
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence, Set as AbstractSet
 from pathlib import Path
 from typing import Any
 
@@ -417,7 +417,7 @@ def _raw_candidate_spellings(candidate: RecordType | EnumType, identity: str) ->
 
 
 def _kept_touched_alias_names(
-    reachable_by_alias: dict[str, set[str]], kept_spellings: set[str]
+    reachable_by_alias: Mapping[str, AbstractSet[str]], kept_spellings: set[str]
 ) -> set[str]:
     """Alias names whose reachable set touches a kept type's/enum's spelling.
 
@@ -482,7 +482,8 @@ def _typedef_alias_name_spellings(typedefs: dict[str, str]) -> set[str]:
 
 
 def _alias_reach_identities(
-    reachable_by_alias: dict[str, set[str]], key_owners: dict[str, set[str]]
+    reachable_by_alias: Mapping[str, AbstractSet[str]],
+    key_owners: Mapping[str, set[str]],
 ) -> dict[str, set[str]]:
     """Per alias, the dependency-candidate identities its own reachability resolves to.
 

--- a/abicheck/dumper_scoping.py
+++ b/abicheck/dumper_scoping.py
@@ -409,9 +409,18 @@ def _raw_candidate_spellings(candidate: RecordType | EnumType, identity: str) ->
     if stripped:
         spellings.add(stripped)
     spellings.add(f"::{identity}")
-    tag_keywords = _elaborated_tag_keywords(candidate)
+    # Snapshot the un-elaborated spellings first: ``set.update`` consumes the
+    # generator incrementally, so an inline ``set(spellings)`` would be
+    # re-evaluated per keyword and the second keyword would see the first one's
+    # own output -- yielding double-tagged junk like ``class struct Foo``, and
+    # varying with ``_elaborated_tag_keywords``' frozenset iteration order
+    # (CodeRabbit review). A record with two legal keywords (``struct``/
+    # ``class``) is the common case, not an edge one.
+    base_spellings = set(spellings)
     spellings.update(
-        f"{keyword} {s}" for keyword in tag_keywords for s in set(spellings)
+        f"{keyword} {s}"
+        for keyword in _elaborated_tag_keywords(candidate)
+        for s in base_spellings
     )
     return spellings
 

--- a/abicheck/dumper_scoping.py
+++ b/abicheck/dumper_scoping.py
@@ -313,6 +313,340 @@ def _candidate_identity(candidate: RecordType | EnumType) -> str:
     return getattr(candidate, "qualified_name", None) or candidate.name
 
 
+def _kept_signature_haystack(
+    kept_functions: Sequence[Function],
+    kept_variables: Sequence[Variable],
+    kept_types: Sequence[RecordType],
+) -> str:
+    """The joined signature text of everything scoping is keeping anyway.
+
+    Deliberately single-hop: only the kept, already-retained declarations' own
+    return/parameter/variable types and field/base spellings, never a
+    *dependency* candidate's own fields/bases -- chasing further would re-admit
+    the transitive implementation closure (e.g. ``std::string``'s own
+    ``_Alloc_hider`` field) this scoping exists to drop.
+    """
+    texts: list[str] = []
+    for fn in kept_functions:
+        texts.append(fn.return_type)
+        texts.extend(p.type for p in fn.params)
+    for var in kept_variables:
+        texts.append(var.type)
+    for rec in kept_types:
+        texts.extend(f.type for f in rec.fields)
+        texts.extend(rec.bases)
+        texts.extend(rec.virtual_bases)
+    return "\n".join(t for t in texts if t)
+
+
+def _kept_type_spellings(
+    kept_types: Sequence[RecordType], kept_enums: Sequence[EnumType]
+) -> set[str]:
+    """Every spelling a *kept* type or enum could be named by.
+
+    Elaborated-type-specifier spellings (``struct Foo``, ``union Foo``, ``enum
+    Foo``) must collision-guard against a kept type's/enum's own spelling the
+    same way a dependency candidate's own elaborated spelling does (Codex
+    review, fresh evidence): a kept ``api::Foo`` and an unrelated
+    dependency-header global ``struct Foo`` share the bare tag name ``Foo``,
+    and a declaration inside ``api::`` can spell a reference to the kept type
+    as bare ``struct Foo *`` (the same namespace-dropping convention accounted
+    for everywhere else in this module) -- but only the bare ``Foo`` suffix was
+    ever added here, never its elaborated form, so ``struct Foo`` slipped past
+    this guard and let the unrelated dependency ``struct Foo`` be retained as
+    if the signature's elaborated reference named it.
+
+    Kept enums were missed entirely by an earlier version of the same guard
+    (it checked only *kept_types*); both are included here.
+    """
+    spellings: set[str] = set()
+    for rec in kept_types:
+        suffixes = _namespace_suffix_spellings(_candidate_identity(rec))
+        spellings.update(suffixes)
+        for keyword in _elaborated_tag_keywords(rec):
+            spellings.update(f"{keyword} {s}" for s in suffixes)
+    for enum in kept_enums:
+        suffixes = _namespace_suffix_spellings(_candidate_identity(enum))
+        spellings.update(suffixes)
+        spellings.update(f"enum {s}" for s in suffixes)
+    return spellings
+
+
+def _raw_candidate_spellings(candidate: RecordType | EnumType, identity: str) -> set[str]:
+    """Every spelling one dependency candidate could be named by, unguarded.
+
+    Full identity, namespace-suffix spellings, the stdlib-stripped form, the
+    globally-qualified form, and the elaborated tag forms of all of those. The
+    caller applies the collision guards.
+
+    The global-scope entry exists because direct-clang preserves a signature's
+    explicit global-scope qualifier in its printed ``qualType`` (``void
+    f(::dep::Thing *)`` keeps the leading ``::``, and this applies just as much
+    to an unnamespaced type -- ``void f(::Foo *)`` -- as to a namespaced one; an
+    earlier revision only handled the namespaced case, Codex review, fresh
+    evidence). The boundary-aware matcher's negative lookbehind treats ``:`` as
+    a non-boundary character (so a spelling can't accidentally match a *partial*
+    scope, e.g. ``Thing`` inside ``ns::Thing``), which also means it rejects the
+    bare-qualified spelling when immediately preceded by the extra ``:`` of a
+    leading ``::``. Registering the fully global-qualified spelling explicitly
+    lets it match on its own, without weakening the boundary check. Namespace-
+    suffix spellings are never meaningfully global-qualified this way
+    (``::Thing`` alone isn't how a backend spells a qualifier-dropped
+    reference), so only the full identity gets this treatment.
+
+    An elaborated-type-specifier spelling (``struct Handle``, ``union
+    Handle``, ``enum Handle``) is unambiguous in both C and C++ regardless of
+    any colliding typedef alias of the same bare name (Codex review, fresh
+    evidence): tag names and typedef names occupy separate namespaces, and the
+    elaborated keyword is exactly what disambiguates a signature writing
+    ``struct Handle *`` even when ``typedefs["Handle"] = "int"`` also exists.
+    These are added as distinct spellings (never equal to the bare
+    identity/suffix string a colliding typedef alias name could match), so they
+    naturally fall outside every typedef-alias veto without special-casing.
+    """
+    stripped = _stripped_signature_spelling(identity)
+    spellings = {identity, *_namespace_suffix_spellings(identity)}
+    if stripped:
+        spellings.add(stripped)
+    spellings.add(f"::{identity}")
+    tag_keywords = _elaborated_tag_keywords(candidate)
+    spellings.update(
+        f"{keyword} {s}" for keyword in tag_keywords for s in set(spellings)
+    )
+    return spellings
+
+
+def _kept_touched_alias_names(
+    reachable_by_alias: dict[str, set[str]], kept_spellings: set[str]
+) -> set[str]:
+    """Alias names whose reachable set touches a kept type's/enum's spelling.
+
+    Deliberately **not** folded into the shared *kept_spellings* set (Codex
+    review, fresh evidence): a compound alias like ``using Alias = Pair<api::Own,
+    dep::Thing>;`` reaches *both* a kept type and a real, distinct dependency
+    candidate in the same target; blanket-excluding the alias's own name via
+    *kept_spellings* -- which the final guard checks unconditionally for every
+    spelling -- would also erase the alias's legitimate use as ``dep::Thing``'s
+    own spelling, not just protect against a coincidental collision. Used
+    narrowly instead: only to keep a candidate's *own* bare-suffix spelling from
+    coincidentally matching an unrelated kept-pointing alias's name (an
+    unrelated ``dep::Handle`` deriving the same bare ``Handle`` as a typedef
+    alias pointing at a kept ``api::Own``).
+
+    The derived suffixes matter as much as the literal key (Codex review, fresh
+    evidence): a real backend's namespace-dropping convention makes a
+    kept-pointing alias's own bare-suffix spelling exactly as capable of
+    colliding as its qualified name, and an earlier guard excluded only the
+    literal key (``api::Handle``), never its derived suffix (``Handle``).
+    """
+    names: set[str] = set()
+    for alias, reached in reachable_by_alias.items():
+        if reached & kept_spellings:
+            names.add(alias)
+            names.update(_namespace_suffix_spellings(alias)[1:])
+    return names
+
+
+def _typedef_alias_name_spellings(typedefs: dict[str, str]) -> set[str]:
+    """Every spelling any typedef alias could be known by, resolving or not.
+
+    A typedef alias's own name is a collision claim on its spelling regardless
+    of what its target resolves to (Codex review, fresh evidence):
+    :func:`_kept_touched_alias_names` records only an alias whose target reaches
+    a kept type/enum, and :func:`_alias_spelling_owners` only one reaching a
+    dependency candidate -- an alias to a primitive (``typedefs["Handle"] =
+    "int"``) reaches neither, so it was never recorded anywhere, and an
+    unrelated ``dep::Handle`` deriving the identical bare suffix ``Handle`` was
+    retained as if the signature's ``Handle`` genuinely named it, even though it
+    unambiguously names the primitive alias instead. A typedef alias existing
+    under a given name at all means a signature spelling that name means *that
+    alias* first; only when the alias's own reachability separately resolves to
+    a candidate does that candidate still get credit for the spelling.
+
+    Applied only as a *final* veto on a candidate's weakest-tier (derived-only)
+    claim -- never folded into the per-candidate spellings upstream the way
+    :func:`_kept_touched_alias_names` is: a self-referential alias (``typedefs =
+    {"Foo0": "struct Foo0"}``) legitimately reaches its own matching candidate
+    via the alias-reach lookup, and that lookup keys off the candidate spelling
+    index -- blanket-stripping every typedef-alias-named spelling upstream would
+    remove the very key it needs to rediscover that legitimate self-reference,
+    silently losing the candidate entirely (confirmed empirically: doing so
+    broke the existing self-referential-typedef regression test).
+    """
+    names: set[str] = set()
+    for alias in typedefs:
+        names.add(alias)
+        names.add(f"::{alias}")
+        names.update(_namespace_suffix_spellings(alias)[1:])
+    return names
+
+
+def _alias_reach_identities(
+    reachable_by_alias: dict[str, set[str]], key_owners: dict[str, set[str]]
+) -> dict[str, set[str]]:
+    """Per alias, the dependency-candidate identities its own reachability resolves to.
+
+    Computed for *every* alias in ``typedefs``, not only ones already known to
+    reach something (Codex review, fresh evidence: an earlier revision built
+    this per-identity, from only the aliases that already resolved to one, which
+    made a *different*, colliding alias of the same spelling that reaches
+    nothing retainable at all -- an alias to a primitive, or one whose only
+    reached key is itself already ambiguous among dep_candidates -- invisible to
+    the ambiguity check; a genuinely ambiguous spelling was then retained as if
+    only the resolving alias existed).
+
+    A reached key that is itself already ambiguous among dep_candidates (more
+    than one owner -- e.g. a namespace-stripped target token ``Thing`` shared by
+    both ``dep1::Thing`` and ``dep2::Thing``) is excluded the same way the
+    candidate spelling sets already exclude a colliding key: the alias's target
+    contained one ambiguous token, not two distinct ones the way a genuine
+    compound alias (``Pair<dep::A, dep::B>``) does.
+    """
+    reach: dict[str, set[str]] = {}
+    for alias, reached in reachable_by_alias.items():
+        identities: set[str] = set()
+        for key in reached & key_owners.keys():
+            owners = key_owners[key]
+            if len(owners) == 1:
+                identities |= owners
+        reach[alias] = identities
+    return reach
+
+
+def _alias_spelling_owners(
+    typedefs: dict[str, str], alias_reach: dict[str, set[str]]
+) -> dict[str, set[str]]:
+    """Spelling -> identities every alias contributing that spelling agrees on.
+
+    A spelling maps back to *every* alias in ``typedefs`` that could produce it
+    -- literal name, namespace suffix, or globally-qualified form (direct-clang
+    preserves an explicit global-scope qualifier, ``void f(::Handle);``, the
+    same way it does for a direct type reference) -- regardless of whether that
+    alias resolves to anything, so a non-resolving alias's collision is never
+    invisible here.
+
+    The result is the *intersection* of each contributing alias's own reach
+    (Codex review, fresh evidence: an earlier revision required every
+    contributing alias's reach to be the *identical* set, which incorrectly
+    dropped merely *partial* agreement -- ``api::Handle -> Pair<dep::A,
+    dep::B>`` and ``vendor::Handle -> dep::A`` both, unambiguously, could mean
+    ``dep::A`` regardless of which alias ``Handle`` denotes, even though only
+    one also reaches ``dep::B``). Intersecting subsumes the single-alias case
+    (nothing to intersect against, so the alias's own reach passes through
+    unchanged -- exactly how a genuine compound alias still retains both) and
+    naturally empties out whenever any contributing alias reaches nothing at all
+    (a primitive, or an alias whose only reached key was itself ambiguous) --
+    the same conservative outcome a separate non-resolving-alias veto previously
+    enforced, now free.
+    """
+    sources: dict[str, set[str]] = {}
+    for alias in typedefs:
+        for spelling in {alias, f"::{alias}", *_namespace_suffix_spellings(alias)[1:]}:
+            sources.setdefault(spelling, set()).add(alias)
+    owners: dict[str, set[str]] = {}
+    for spelling, aliases in sources.items():
+        common = set.intersection(*(alias_reach[a] for a in aliases))
+        if common:
+            owners[spelling] = common
+    return owners
+
+
+def _resolve_spelling_index(
+    own_spelling_owners: dict[str, set[str]],
+    alias_spelling_owners: dict[str, set[str]],
+    kept_spellings: set[str],
+    typedef_alias_names: set[str],
+) -> dict[str, set[str]]:
+    """spelling -> the identities that spelling may be trusted to name.
+
+    A spelling that is some candidate's own identity/suffix is trusted only when
+    unambiguous among all owners of that same category, and not colliding with a
+    kept type's/enum's own spelling; a spelling reached via alias reachability
+    keeps every distinct owner the alias legitimately reaches.
+
+    A typedef alias existing under a given spelling **always** takes precedence
+    over any of a candidate's own claims on that spelling -- exact identity match
+    or merely derived -- never merged or compared against them (Codex review,
+    fresh evidence, generalizing an earlier, narrower rule that deferred only a
+    *derived* own-claim, not an *exact* one): in C, tag names (``struct
+    Handle``) and typedef names occupy separate namespaces, so a signature
+    spelling the bare, unqualified ``Handle`` can only mean an existing typedef
+    of that name -- a same-named tag is never reachable that way at all,
+    regardless of whether its own identity happens to be an exact or
+    merely-derived match for the same string. Concretely: ``typedef struct
+    Actual Handle;`` alongside an unrelated ``struct Handle`` must retain
+    ``Actual`` through the alias, and never conflate that with the unrelated
+    tag's own exact-identity claim on the same spelling. When the existing
+    typedef doesn't itself resolve to anything retainable (an alias to a
+    primitive, or one dropped as genuinely ambiguous among colliding aliases),
+    the spelling contributes nothing at all -- not even the runner-up
+    own-identity claim, unconditionally.
+
+    Only when *no* typedef exists under a spelling at all does this fall back to
+    plain own-identity resolution: a claim is trusted only when it is the
+    spelling's sole owner (two identities colliding is still genuine,
+    unresolvable ambiguity).
+    """
+    index: dict[str, set[str]] = {}
+    for spelling in own_spelling_owners.keys() | alias_spelling_owners.keys():
+        if spelling in kept_spellings:
+            continue
+        if spelling in typedef_alias_names:
+            alias_owners = alias_spelling_owners.get(spelling, set())
+            if alias_owners:
+                index[spelling] = set(alias_owners)
+            # else: the typedef exists but resolves to nothing retainable
+            # -- drop, no credit to any own-identity claim either.
+            continue
+        own_owners = own_spelling_owners.get(spelling, set())
+        if len(own_owners) == 1:
+            index[spelling] = set(own_owners)
+    return index
+
+
+def _referenced_from_haystack(
+    haystack: str, spelling_index: dict[str, set[str]]
+) -> set[str]:
+    """Scan *haystack* once and collect every identity its spellings name.
+
+    One compiled multi-spelling pattern
+    (:func:`abicheck.type_reachability._compile_spelling_pattern`) rather than
+    re-scanning once per candidate spelling (Codex review: the naive
+    per-spelling scan is O(candidate count x signature size), which becomes
+    seconds-to-minutes on the large transitive dependency surfaces --
+    SYCL/heavily-templated C++ headers -- this filter exists to make manageable
+    in the first place), turning the scan into one O(signature size) pass
+    regardless of candidate count.
+
+    A typedef alias (or any other bare spelling) nested strictly inside an
+    already-matched elaborated ``struct``/``union``/``enum <name>`` span must not
+    contribute its own resolution (Codex review, fresh evidence): ``typedef
+    struct Other Foo; void f(struct Foo *);`` means only the tag ``Foo``, never
+    the typedef -- in C/C++ an elaborated-type-specifier resolves exclusively
+    through the tag namespace, so the compiler never even considers a same-named
+    typedef there. Both ``"struct Foo"`` and the bare ``"Foo"`` can match the
+    identical text at once via nested matching, and without this filter the bare
+    match's alias resolution incorrectly pulled in the typedef's unrelated
+    target alongside the correctly-resolved tag.
+    """
+    pattern = _compile_spelling_pattern(spelling_index)
+    if pattern is None:
+        return set()
+    matches = _finditer_allow_nested(pattern, haystack)
+    elaborated_ends = {
+        m.end() for m in matches if m.group().partition(" ")[0] in _TAG_KEYWORDS
+    }
+    referenced: set[str] = set()
+    for match in matches:
+        if (
+            match.end() in elaborated_ends
+            and match.group().partition(" ")[0] not in _TAG_KEYWORDS
+        ):
+            continue
+        referenced.update(spelling_index[match.group()])
+    return referenced
+
+
 def _directly_referenced_dependency_names(
     kept_functions: Sequence[Function],
     kept_variables: Sequence[Variable],
@@ -465,342 +799,61 @@ def _directly_referenced_dependency_names(
     ``parse_typedefs()`` root cause, same declined fix, same blast radius
     as above.
     """
-    signature_texts: list[str] = []
-    for fn in kept_functions:
-        signature_texts.append(fn.return_type)
-        signature_texts.extend(p.type for p in fn.params)
-    for var in kept_variables:
-        signature_texts.append(var.type)
-    for rec in kept_types:
-        signature_texts.extend(f.type for f in rec.fields)
-        signature_texts.extend(rec.bases)
-        signature_texts.extend(rec.virtual_bases)
-    haystack = "\n".join(t for t in signature_texts if t)
-
+    haystack = _kept_signature_haystack(kept_functions, kept_variables, kept_types)
     typedefs = typedefs or {}
-
-    # Elaborated-type-specifier spellings (``struct Foo``, ``union Foo``,
-    # ``enum Foo``) must collision-guard against a kept type's/enum's own
-    # spelling the same way a dependency candidate's own elaborated
-    # spelling does (Codex review, fresh evidence): a kept ``api::Foo``
-    # and an unrelated dependency-header global ``struct Foo`` share the
-    # bare tag name ``Foo``, and a declaration inside ``api::`` can spell
-    # a reference to the kept type as bare ``struct Foo *`` (the same
-    # namespace-dropping convention already accounted for everywhere
-    # else in this module) -- but only the bare ``Foo`` suffix was ever
-    # added to *kept_spellings*, never its elaborated form, so ``struct
-    # Foo`` slipped past this guard and let the unrelated dependency
-    # ``struct Foo`` be retained as if the signature's elaborated
-    # reference named it.
-    kept_spellings = set()
-    for rec in kept_types:
-        suffixes = _namespace_suffix_spellings(_candidate_identity(rec))
-        kept_spellings.update(suffixes)
-        for keyword in _elaborated_tag_keywords(rec):
-            kept_spellings.update(f"{keyword} {s}" for s in suffixes)
-    for enum in kept_enums:
-        suffixes = _namespace_suffix_spellings(_candidate_identity(enum))
-        kept_spellings.update(suffixes)
-        kept_spellings.update(f"enum {s}" for s in suffixes)
+    kept_spellings = _kept_type_spellings(kept_types, kept_enums)
 
     identity_of: dict[int, str] = {}
     raw_own_spellings_of: dict[int, set[str]] = {}
-    # matching key (any of a candidate's own spellings -- full identity,
-    # namespace suffix, or stdlib-stripped form) -> every identity it could
-    # belong to -- built once so resolved typedef targets are scanned once
-    # in total (below), not once per dependency candidate (Codex review,
-    # fresh evidence: the naive per-candidate scan over every resolved
-    # target is O(dep_candidates x typedefs), confirmed empirically at
-    # ~5.6s for 3,000 candidates x 3,000 typedefs). Namespace-suffix
-    # spellings are included here, not just the full identity/stdlib-
-    # stripped form (Codex review, fresh evidence): castxml's own
-    # ``_underlying_type_name()`` stores a namespaced typedef target bare
-    # (``Thing`` for an underlying ``dep::Thing``), which only a suffix key
-    # can match -- the same bare-vs-qualified split already applied to a
-    # kept signature's own spelling of a candidate. This first pass excludes
-    # only keys colliding with the base *kept_spellings*; a second pass
-    # below additionally excludes keys colliding with a *kept-touched
-    # typedef alias name* once that's known (this preliminary key_owners
-    # only feeds the reachability computation).
+    # matching key (any of a candidate's own spellings) -> every identity it
+    # could belong to -- built once so resolved typedef targets are scanned once
+    # in total, not once per dependency candidate (Codex review, fresh evidence:
+    # the naive per-candidate scan over every resolved target is
+    # O(dep_candidates x typedefs), confirmed empirically at ~5.6s for 3,000
+    # candidates x 3,000 typedefs). This first pass excludes only keys colliding
+    # with the base *kept_spellings*; the second pass below additionally excludes
+    # keys colliding with a kept-touched typedef alias name once that is known
+    # (this preliminary map only feeds the reachability computation).
     prelim_key_owners: dict[str, set[str]] = {}
     for candidate in dep_candidates:
         identity = _candidate_identity(candidate)
         identity_of[id(candidate)] = identity
-        stripped = _stripped_signature_spelling(identity)
-        spellings = {identity, *_namespace_suffix_spellings(identity)}
-        if stripped:
-            spellings.add(stripped)
-        # direct-clang preserves a signature's explicit global-scope
-        # qualifier in its printed ``qualType`` (``void f(::dep::Thing *)``
-        # keeps the leading ``::``, and this applies just as much to an
-        # unnamespaced type -- ``void f(::Foo *)`` -- as to a namespaced
-        # one; an earlier revision of this fix only handled the namespaced
-        # case, Codex review, fresh evidence) -- but the boundary-aware
-        # matcher's negative lookbehind treats ``:`` as a non-boundary
-        # character (so a spelling can't accidentally match a *partial*
-        # scope, e.g. matching ``Thing`` inside ``ns::Thing``), which also
-        # means it rejects the bare-qualified spelling (``dep::Thing`` or
-        # bare ``Foo``) when it's immediately preceded by the extra ``:``
-        # of a leading ``::``. Registering the fully global-qualified
-        # spelling explicitly lets it match on its own, without weakening
-        # the boundary check itself. Namespace-suffix spellings are never
-        # meaningfully global-qualified this way (``::Thing`` alone isn't
-        # how a backend spells a qualifier-dropped reference), so only the
-        # full identity gets this treatment.
-        spellings.add(f"::{identity}")
-        # An elaborated-type-specifier spelling (``struct Handle``,
-        # ``union Handle``, ``enum Handle``) is unambiguous in both C and
-        # C++ regardless of any colliding typedef alias of the same bare
-        # name (Codex review, fresh evidence): tag names and typedef
-        # names occupy separate namespaces, and the elaborated keyword is
-        # exactly what disambiguates a signature that writes ``struct
-        # Handle *`` even when ``typedefs["Handle"] = "int"`` also
-        # exists. These are added as distinct spellings (never equal to
-        # the bare identity/suffix string a colliding typedef alias name
-        # could ever match), so they naturally fall outside every
-        # typedef-alias veto below without needing any special-casing
-        # there.
-        tag_keywords = _elaborated_tag_keywords(candidate)
-        spellings.update(
-            f"{keyword} {s}" for keyword in tag_keywords for s in set(spellings)
-        )
+        spellings = _raw_candidate_spellings(candidate, identity)
         raw_own_spellings_of[id(candidate)] = spellings
         for key in spellings:
-            if key in kept_spellings:
-                continue
-            prelim_key_owners.setdefault(key, set()).add(identity)
+            if key not in kept_spellings:
+                prelim_key_owners.setdefault(key, set()).add(identity)
 
     # Which of each typedef alias's transitively-reachable keys are
     # dependency-candidate keys vs. kept-type/enum spellings -- computed by
-    # reachability (see _typedef_alias_reachability), never by
-    # materializing expanded text.
+    # reachability (see _typedef_alias_reachability), never by materializing
+    # expanded text.
     reachable_by_alias = _typedef_alias_reachability(
         typedefs, set(prelim_key_owners) | kept_spellings
     )
-    # An alias whose reachable set touches any kept spelling is recorded
-    # here (not folded into the shared *kept_spellings* set -- Codex
-    # review, fresh evidence: a compound alias like ``using Alias =
-    # Pair<api::Own, dep::Thing>;`` reaches *both* a kept type and a real,
-    # distinct dependency candidate in the same target; blanket-excluding
-    # the alias's own name via *kept_spellings* -- which the final guard
-    # below checks unconditionally for every spelling -- would also erase
-    # the alias's legitimate use as ``dep::Thing``'s own spelling, not just
-    # protect against a coincidental collision). *kept_touched_aliases* is
-    # instead used narrowly: only to keep a candidate's *own* bare-suffix
-    # spelling from coincidentally matching an unrelated kept-pointing
-    # alias's name (the actual bug this guard exists for -- an unrelated
-    # ``dep::Handle`` deriving the same bare ``Handle`` as a typedef alias
-    # that points at a kept ``api::Own``) -- an alias's legitimate
-    # reachability-derived contribution to a genuinely-referenced
-    # candidate's spellings, below, is never subject to this exclusion.
-    kept_touched_aliases: set[str] = set()
-    for alias, reached in reachable_by_alias.items():
-        if reached & kept_spellings:
-            kept_touched_aliases.add(alias)
-            # A real backend's namespace-dropping convention means a
-            # kept-pointing alias's own bare-suffix spelling is exactly as
-            # capable of coincidentally colliding with an unrelated
-            # candidate's own bare-suffix spelling as its literal
-            # qualified name is (Codex review, fresh evidence): the
-            # earlier guard only ever excluded the literal alias key
-            # (``api::Handle``), never its derived suffix (``Handle``),
-            # so a signature spelling the bare-dropped form let an
-            # unrelated ``dep::Handle`` slip past this guard entirely.
-            kept_touched_aliases.update(_namespace_suffix_spellings(alias)[1:])
-
-    # Every typedef alias's own name is a collision claim on its spelling
-    # regardless of what its target resolves to (Codex review, fresh
-    # evidence): ``kept_touched_aliases`` above only recorded an alias
-    # whose target reaches a kept type/enum or a dependency candidate --
-    # an alias to a primitive (``typedefs["Handle"] = "int"`` or ``"void
-    # *"``) reaches neither, so it was never recorded anywhere, and an
-    # unrelated ``dep::Handle`` deriving the identical bare suffix
-    # ``Handle`` was retained as if the signature's ``Handle`` genuinely
-    # named it -- even though it unambiguously names the primitive alias
-    # instead. A typedef alias existing under a given name at all means a
-    # signature spelling that name means *that alias* first; only when
-    # the alias's own reachability separately, legitimately resolves to a
-    # candidate (via *alias_spelling_owners*, below) does that candidate
-    # still get credit for the spelling.
-    #
-    # This must be applied only as a *final* veto on a candidate's own
-    # weakest-tier (derived-only, no alias resolution) spelling claim
-    # below -- not folded into *own_spellings_of*/*key_owners* above the
-    # way *kept_touched_aliases* is: a self-referential alias (``typedefs
-    # = {"Foo0": "struct Foo0"}``) legitimately reaches its own matching
-    # candidate via *alias_reach*/*alias_spelling_owners* below, but that
-    # reachability lookup keys off ``key_owners`` -- blanket-stripping
-    # every typedef-alias-named spelling from ``own_spellings_of``
-    # upstream would remove the very key that lookup needs to rediscover
-    # that legitimate self-reference, silently losing the candidate
-    # entirely (confirmed empirically: doing so broke the existing
-    # self-referential-typedef regression test).
-    all_typedef_alias_names: set[str] = set()
-    for alias in typedefs:
-        all_typedef_alias_names.add(alias)
-        all_typedef_alias_names.add(f"::{alias}")
-        all_typedef_alias_names.update(_namespace_suffix_spellings(alias)[1:])
+    kept_touched_aliases = _kept_touched_alias_names(reachable_by_alias, kept_spellings)
+    typedef_alias_names = _typedef_alias_name_spellings(typedefs)
 
     key_owners: dict[str, set[str]] = {}
-    own_spellings_of: dict[int, set[str]] = {}
-    for candidate in dep_candidates:
-        identity = identity_of[id(candidate)]
-        kept_spellings_and_aliases = kept_spellings | kept_touched_aliases
-        spellings = {
-            s
-            for s in raw_own_spellings_of[id(candidate)]
-            if s not in kept_spellings_and_aliases
-        }
-        own_spellings_of[id(candidate)] = spellings
-        for key in spellings:
-            key_owners.setdefault(key, set()).add(identity)
-
-    # Every dependency-candidate identity a typedef alias's own
-    # reachability resolves to, computed directly per alias -- for *every*
-    # alias in ``typedefs``, not only ones already known to reach
-    # something (Codex review, fresh evidence: an earlier revision built
-    # this per-identity, from only the aliases that already resolved to
-    # one, which made a *different*, colliding alias of the same spelling
-    # that reaches nothing retainable at all -- an alias to a primitive,
-    # or one whose only reached key is itself already ambiguous among
-    # dep_candidates -- invisible to the ambiguity check below; a
-    # genuinely ambiguous spelling was then retained as if only the
-    # resolving alias existed). A reached key that is itself already
-    # ambiguous among dep_candidates (``key_owners[key]`` has more than
-    # one owner -- e.g. a namespace-stripped target token ``Thing``
-    # shared by both ``dep1::Thing`` and ``dep2::Thing``) is excluded the
-    # same way ``own_spellings_of``'s own construction already excludes a
-    # colliding key -- the alias's target contained one ambiguous token,
-    # not two distinct ones the way a genuine compound alias
-    # (``Pair<dep::A, dep::B>``) does.
-    alias_reach: dict[str, set[str]] = {}
-    for alias, reached in reachable_by_alias.items():
-        identities: set[str] = set()
-        for key in reached & key_owners.keys():
-            owners = key_owners[key]
-            if len(owners) == 1:
-                identities |= owners
-        alias_reach[alias] = identities
-
-    # Every spelling a typedef alias could be known by -- literal name,
-    # namespace suffix, or globally-qualified form (direct-clang preserves
-    # an explicit global-scope qualifier, ``void f(::Handle);``, the same
-    # way it does for a direct type reference) -- mapped back to *every*
-    # alias in ``typedefs`` that could produce it, regardless of whether
-    # that alias resolves to anything (built from ``typedefs`` directly,
-    # same universe as *alias_reach* above, so a non-resolving alias's
-    # collision is never invisible here).
-    alias_spelling_sources: dict[str, set[str]] = {}
-    for alias in typedefs:
-        spellings = {alias, f"::{alias}", *_namespace_suffix_spellings(alias)[1:]}
-        for spelling in spellings:
-            alias_spelling_sources.setdefault(spelling, set()).add(alias)
-
-    # spelling -> identities every contributing alias agrees the spelling
-    # could mean -- the *intersection* of each contributing alias's own
-    # reach (Codex review, fresh evidence: an earlier revision required
-    # every contributing alias's reach to be the *identical* set, which
-    # incorrectly dropped a merely *partial* agreement -- ``api::Handle ->
-    # Pair<dep::A, dep::B>`` and ``vendor::Handle -> dep::A`` both,
-    # unambiguously, could mean ``dep::A`` regardless of which alias
-    # ``Handle`` denotes, even though only one of them also reaches
-    # ``dep::B``). Intersecting also subsumes the single-alias case
-    # (nothing to intersect against, so the alias's own reach passes
-    # through unchanged -- this is exactly how a genuine compound alias
-    # like ``Pair<dep::A, dep::B>`` still retains both) and naturally
-    # empties out whenever any contributing alias reaches nothing at all
-    # (a primitive, or an alias whose only reached key was itself
-    # ambiguous) -- the same conservative outcome a separate
-    # non-resolving-alias veto previously existed to enforce, now free.
-    alias_spelling_owners: dict[str, set[str]] = {}
-    for spelling, aliases in alias_spelling_sources.items():
-        common = set.intersection(*(alias_reach[a] for a in aliases))
-        if common:
-            alias_spelling_owners[spelling] = common
-
     own_spelling_owners: dict[str, set[str]] = {}
+    kept_spellings_and_aliases = kept_spellings | kept_touched_aliases
     for candidate in dep_candidates:
         identity = identity_of[id(candidate)]
-        own = own_spellings_of[id(candidate)]
-        for spelling in own:
+        for spelling in raw_own_spellings_of[id(candidate)]:
+            if spelling in kept_spellings_and_aliases:
+                continue
+            key_owners.setdefault(spelling, set()).add(identity)
             own_spelling_owners.setdefault(spelling, set()).add(identity)
 
-    # spelling -> {identity, ...}: a spelling that is some candidate's own
-    # identity/suffix is trusted only when unambiguous among all owners of
-    # that same category, and not colliding with a kept type's/enum's own
-    # spelling; a spelling reached via alias reachability keeps every
-    # distinct owner the alias legitimately reaches.
-    #
-    # A typedef alias existing under a given spelling **always** takes
-    # precedence over any of a candidate's own claims on that spelling --
-    # exact identity match or merely derived (namespace-suffix/stdlib-
-    # stripped) -- never merged or compared against them (Codex review,
-    # fresh evidence, generalizing an earlier, narrower version of this
-    # rule that only deferred a *derived* own-claim, not an *exact* one):
-    # in C, tag names (``struct Handle``) and typedef names occupy
-    # separate namespaces, so a signature spelling the bare, unqualified
-    # ``Handle`` can only mean an existing typedef of that name -- a
-    # same-named tag is never reachable that way at all, regardless of
-    # whether its own identity happens to be an exact or merely-derived
-    # match for the same string. Concretely: ``typedef struct Actual
-    # Handle;`` alongside an unrelated ``struct Handle`` must retain
-    # ``Actual`` through the alias, and never conflate that with the
-    # unrelated tag's own exact-identity claim on the same spelling.
-    # When the existing typedef doesn't itself resolve to anything
-    # retainable (an alias to a primitive, or one dropped as genuinely
-    # ambiguous among colliding aliases), the spelling contributes
-    # nothing at all -- not even the runner-up own-identity claim,
-    # unconditionally.
-    #
-    # Only when *no* typedef exists under a spelling at all does this
-    # fall back to plain own-identity resolution: an exact-identity claim
-    # is trusted only when it is the spelling's sole owner (two exact
-    # identities colliding is still genuine, unresolvable ambiguity), and
-    # a purely-derived claim is trusted only when it, too, is the sole
-    # owner among dep_candidates.
-    spelling_index: dict[str, set[str]] = {}
-    for spelling in own_spelling_owners.keys() | alias_spelling_owners.keys():
-        if spelling in kept_spellings:
-            continue
-        if spelling in all_typedef_alias_names:
-            alias_owners = alias_spelling_owners.get(spelling, set())
-            if alias_owners:
-                spelling_index[spelling] = set(alias_owners)
-            # else: the typedef exists but resolves to nothing retainable
-            # -- drop, no credit to any own-identity claim either.
-            continue
-        own_owners = own_spelling_owners.get(spelling, set())
-        if len(own_owners) == 1:
-            spelling_index[spelling] = set(own_owners)
-
-    pattern = _compile_spelling_pattern(spelling_index)
-    if pattern is None:
-        return set()
-    matches = _finditer_allow_nested(pattern, haystack)
-    # A typedef alias (or any other bare spelling) nested strictly inside
-    # an already-matched elaborated ``struct``/``union``/``enum <name>``
-    # span must not contribute its own resolution (Codex review, fresh
-    # evidence): ``typedef struct Other Foo; void f(struct Foo *);`` means
-    # only the tag ``Foo``, never the typedef -- in C/C++, an elaborated-
-    # type-specifier resolves exclusively through the tag namespace, so
-    # the compiler never even considers a same-named typedef there. Both
-    # ``"struct Foo"`` (the elaborated spelling) and the bare ``"Foo"``
-    # (the typedef alias's own spelling) can match the identical text at
-    # once via nested matching, and without this filter the bare match's
-    # alias resolution incorrectly pulled in the typedef's unrelated
-    # target alongside the correctly-resolved tag.
-    elaborated_ends = {
-        m.end() for m in matches if m.group().partition(" ")[0] in _TAG_KEYWORDS
-    }
-    referenced: set[str] = set()
-    for match in matches:
-        if (
-            match.end() in elaborated_ends
-            and match.group().partition(" ")[0] not in _TAG_KEYWORDS
-        ):
-            continue
-        referenced.update(spelling_index[match.group()])
-    return referenced
+    spelling_index = _resolve_spelling_index(
+        own_spelling_owners,
+        _alias_spelling_owners(
+            typedefs, _alias_reach_identities(reachable_by_alias, key_owners)
+        ),
+        kept_spellings,
+        typedef_alias_names,
+    )
+    return _referenced_from_haystack(haystack, spelling_index)
 
 
 def _name_matches(name: str, kept_identifiers: set[str]) -> bool:

--- a/changelog.d/20260810_001000_claude_codefactor_complexity_dumper.md
+++ b/changelog.d/20260810_001000_claude_codefactor_complexity_dumper.md
@@ -1,10 +1,30 @@
 ### Changed
 
-- **The two heaviest dumper-side functions were restructured to cut
-  cyclomatic complexity** — `dumper_scoping._directly_referenced_dependency_names`
-  (the dependency-header direct-reference filter) and
-  `build_context._expand_response_files` (GNU `@response-file` inlining) were
-  each split into named helpers, one per phase. `_expand_response_files`
-  keeps its exact signature, budgets and cache semantics; the scoping filter
-  additionally folds two owner maps that were built in separate passes from
-  identical data into one. No behaviour, output, or public signature changes.
+- **The heaviest dumper-side functions were restructured to cut cyclomatic
+  complexity** — `dumper_scoping._directly_referenced_dependency_names` (the
+  dependency-header direct-reference filter), `build_context._expand_response_files`
+  (GNU `@response-file` inlining), and `dumper.py`'s own `_header_ast_parser`
+  and `_castxml_dump` were each split into named helpers, one per phase.
+  `_expand_response_files` keeps its exact signature, budgets and cache
+  semantics; the scoping filter additionally folds two owner maps that were
+  built in separate passes from identical data into one. No behaviour, output,
+  or public signature changes.
+- `dumper_ast_config_cpp20_chains`'s two preprocessor-chain classifiers
+  (`_frame_for_chain_open`, `_line_for_open_arm`) are now table-driven: each
+  arm of their long, order-sensitive `if`-chains became a named predicate
+  carrying its own review-derived rationale as a docstring, consulted through
+  an ordered rule tuple. The load-bearing ordering (every inverted-polarity
+  spelling tested ahead of the general guard rule that would otherwise also
+  match it) is now stated by the table rather than implied by statement order.
+  Verified behaviour-identical against the previous implementation across
+  every (directive spelling × policy flags × stack frame) combination.
+- Relocated `_build_clang_header_command` from `dumper.py` to
+  `dumper_ast_config.py` (next to its castxml counterpart, whose flag handling
+  it deliberately mirrors) and the ELF export-symbol readers
+  (`_HIDDEN_VIS`, `_is_abi_relevant_symbol`, `_pyelftools_exported_symbols`)
+  to `dumper_elf_symbols.py`, alongside the visibility helpers already living
+  there. Both are pure relocations with re-export shims: `dumper.py` sits at
+  the AI-readiness 2000-line hard cap, so splitting its two most complex
+  functions in place needed line budget first. Every caller stays in
+  `dumper`, so bare-name calls still resolve through `dumper`'s namespace and
+  existing `monkeypatch.setattr(dumper, ...)` targets keep working.

--- a/changelog.d/20260810_001000_claude_codefactor_complexity_dumper.md
+++ b/changelog.d/20260810_001000_claude_codefactor_complexity_dumper.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **The two heaviest dumper-side functions were restructured to cut
+  cyclomatic complexity** — `dumper_scoping._directly_referenced_dependency_names`
+  (the dependency-header direct-reference filter) and
+  `build_context._expand_response_files` (GNU `@response-file` inlining) were
+  each split into named helpers, one per phase. `_expand_response_files`
+  keeps its exact signature, budgets and cache semantics; the scoping filter
+  additionally folds two owner maps that were built in separate passes from
+  identical data into one. No behaviour, output, or public signature changes.

--- a/changelog.d/20260810_001000_claude_codefactor_complexity_dumper.md
+++ b/changelog.d/20260810_001000_claude_codefactor_complexity_dumper.md
@@ -28,3 +28,14 @@
   functions in place needed line budget first. Every caller stays in
   `dumper`, so bare-name calls still resolve through `dumper`'s namespace and
   existing `monkeypatch.setattr(dumper, ...)` targets keep working.
+
+### Fixed
+
+- `dumper_scoping._raw_candidate_spellings` emitted double-tagged
+  elaborated-type-specifier spellings (`class struct Foo`) for any
+  `struct`/`class` record. C++ lets either keyword refer to the same non-union
+  record, so the elaboration step iterates twice over the same spelling set —
+  and because `set.update` consumes its generator incrementally, re-evaluating
+  the base set inside that generator let the second keyword see the first
+  one's output. The junk spellings also varied with frozenset iteration order.
+  The base set is now snapshotted before elaboration (CodeRabbit review).

--- a/tests/test_dumper_scoping_dependency_retention.py
+++ b/tests/test_dumper_scoping_dependency_retention.py
@@ -19,9 +19,13 @@ for the full "direct-vs-transitive" design rationale.
 
 from __future__ import annotations
 
-from abicheck.dumper_scoping import scope_snapshot_excluding_dependencies
+from abicheck.dumper_scoping import (
+    _raw_candidate_spellings,
+    scope_snapshot_excluding_dependencies,
+)
 from abicheck.model import (
     AbiSnapshot,
+    EnumType,
     Function,
     Param,
     RecordType,
@@ -1527,3 +1531,59 @@ class TestDirectlyReferencedDependencyRetention:
         assert [t.name for t in scoped.types] == ["Own"]
 
 
+
+
+class TestRawCandidateSpellings:
+    """`_raw_candidate_spellings` must emit single-tag elaborated forms only.
+
+    A record whose kind is `struct`/`class` has two legal elaborated keywords
+    (C++ lets either refer to the same non-union record), so the elaboration
+    step iterates twice over the same spelling set. `set.update` consumes its
+    generator incrementally, so re-evaluating the base set inside that
+    generator let the second keyword see the first one's output and emit
+    double-tagged junk like `class struct Foo` -- varying with frozenset
+    iteration order (CodeRabbit review).
+    """
+
+    def test_struct_emits_each_keyword_once(self) -> None:
+        spellings = _raw_candidate_spellings(
+            RecordType(name="Foo", kind="struct"), "ns::Foo"
+        )
+        assert spellings == {
+            "ns::Foo",
+            "Foo",
+            "::ns::Foo",
+            "struct ns::Foo",
+            "struct Foo",
+            "struct ::ns::Foo",
+            "class ns::Foo",
+            "class Foo",
+            "class ::ns::Foo",
+        }
+
+    def test_no_spelling_carries_two_tag_keywords(self) -> None:
+        for candidate, identity in (
+            (RecordType(name="Foo", kind="struct"), "ns::Foo"),
+            (RecordType(name="Bar", kind="class"), "a::b::Bar"),
+            (RecordType(name="U", kind="union"), "U"),
+            (EnumType(name="E"), "ns::E"),
+        ):
+            for spelling in _raw_candidate_spellings(candidate, identity):
+                keyword, _, rest = spelling.partition(" ")
+                assert not rest.startswith(("struct ", "class ", "union ", "enum ")), (
+                    f"{identity}: double-tagged spelling {spelling!r}"
+                )
+
+    def test_single_keyword_kinds_tag_once(self) -> None:
+        assert _raw_candidate_spellings(RecordType(name="U", kind="union"), "U") == {
+            "U",
+            "::U",
+            "union U",
+            "union ::U",
+        }
+        assert _raw_candidate_spellings(EnumType(name="E"), "E") == {
+            "E",
+            "::E",
+            "enum E",
+            "enum ::E",
+        }


### PR DESCRIPTION
## Summary

Continues the CodeFactor **Complexity** cleanup started in #693. Two functions on the dumper/AST side — deliberately their own PR, because they are the two densest single functions left on the board and each carries an unusually large body of review-derived rationale that reviewers will want to check moved intact.

Independent of #693 (no file overlap: that one is `abicheck/buildsource/` only), so the two can land in either order.

## Motivation

CodeFactor's board is 68 `Complex Method` findings (its own metric, threshold ~16) plus one bandit Major that went in with #688 — see #693 for the full breakdown and why `mccabe` is used as the local proxy metric (same functions, same line ranges, runs 0–9 points below CodeFactor's number).

`dumper_scoping._directly_referenced_dependency_names` is the **second-heaviest finding on the whole board** (CodeFactor 33, behind only `type_graph._walk_types` at 35, fixed in #693).

## Changes

| Function | mccabe | CodeFactor (before) |
|---|---|---|
| `dumper_scoping._directly_referenced_dependency_names` | 33 → **<9** | 33 |
| `build_context._expand_response_files` | 20 → **9** | 29 |

**`_directly_referenced_dependency_names`** — eleven phases, each now a named function: the kept-signature haystack, the kept type/enum spelling set, one candidate's raw spellings, the kept-touched alias names, every typedef alias name, per-alias reach, alias spelling owners, the final spelling index, and the scan. One real simplification fell out: the two owner maps it built in separate passes (`key_owners` and `own_spelling_owners`) were populated from identical data, so they fold into a single loop.

**`_expand_response_files`** — reading and tokenizing one response file moves to `_read_and_tokenize_response_file`, the budget arithmetic to `_exceeds_output_budget`, and the whole per-`@file` decision to `_response_file_tokens_for_arg`, leaving the loop body as "expand it or keep the token". **The signature is unchanged** — every caller, budget and cache interaction is untouched, including the deliberate asymmetry that an exhausted *read* budget is not cached while a rejection is.

Both functions' comments record empirically-confirmed failure modes (the ~5.6s O(candidates × typedefs) scan, the cache-population budget, the elaborated-tag vs. typedef namespace split). Every one moved with the code it explains rather than being summarized away.

## Checklist

- [x] Tests added / updated for new behaviour — n/a, behaviour-preserving; existing coverage exercises both paths (832 passed across the two areas)
- [x] Changelog fragment added — no user-facing behaviour change
- [x] Docs updated if user-visible behaviour changed — n/a
- [x] `pre-commit run --all-files` passes locally — `ruff check` clean; `python -m mypy abicheck/` clean (331 files)
- [x] No new `mypy` or `ruff` errors introduced — one was caught and fixed in the second commit: `_typedef_alias_reachability` returns `dict[str, frozenset[str]]`, so the extracted helpers' parameters were widened to the read-only `Mapping`/`AbstractSet` they actually need

## Remaining

52 of 68 findings open after this. The rest of the dumper/AST group (8: `dumper_castxml._collect_virtual_methods`, `dumper_ast_config_cpp20` ×2, `dumper_layout_backfill.backfill_dwarf_layout`, `dumper.py` ×2, `dumper_ast_config_cpp20_chains` ×2) follows in a separate PR — `dumper.py` sits at exactly the 2000-line hard cap, so its two need extracting into a sibling module rather than in-place splitting, which is a different shape of change from everything here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of response files, including nested references and fallback behavior.
  * Increased reliability when parsing C/C++ headers, including C++20 features and CastXML compatibility.
  * Improved recovery from invalid cached data and unavailable symbol information.
  * Improved accuracy of exported symbol, inheritance, and type-layout detection.

* **Refactor**
  * Streamlined analysis workflows while preserving existing behavior and compatibility.
  * Improved support for complex conditional compilation and multi-inheritance scenarios.

* **Documentation**
  * Added changelog notes covering the latest reliability and maintainability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->