### PR TITLE
refactor: cut CodeFactor complexity across all seven CLI entry points

### DIFF
--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -38,10 +38,18 @@ except ImportError:  # pragma: no cover - rich-click is a declared dependency
 from . import deadline
 from .checker import DiffResult, LibraryMetadata
 from .cli_audit import echo_filtered_surface, echo_reconciled
+from .cli_buildsource import (
+    # The snapshot write path lives there (cli.py is at the file-size cap);
+    # re-exported so ``abicheck.cli._write_snapshot_output`` and its two
+    # evidence-layer helpers keep resolving for dump_cmd, cli_buildsource's
+    # own caller, and the tests that import them from here.
+    _classify_missing_layers as _classify_missing_layers,
+    _layer_payload_empty as _layer_payload_empty,
+    _missing_requested_evidence_layers as _missing_requested_evidence_layers,
+    _write_snapshot_output as _write_snapshot_output,
+)
 from .cli_dump_helpers import (
     _dump_will_attempt_hybrid_l4_extraction,
-    check_requested_depth_satisfied,
-    fold_dump_provenance_into_json,
     handle_non_elf_dump,
     has_other_l3_source,
     perform_elf_dump,
@@ -114,10 +122,8 @@ from .cli_resolve import (
     classify_compare_operand,
 )
 from .compat.cli import compat_group
-from .serialization import snapshot_to_json
 
 if TYPE_CHECKING:
-    from .buildsource.pack import BuildSourcePack
     from .checker_types import Change
     from .debug_resolver import DebugArtifact
     from .service_scan import CompileContext
@@ -204,215 +210,6 @@ def _stamp_provenance(
                 snap.git_commit = result.stdout.strip()
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass  # git not available or not a repo — leave as None
-
-
-def _layer_payload_empty(pack: BuildSourcePack, key: str) -> bool:
-    """True when *key*'s embedded payload carries no facts.
-
-    A coverage row can read ``PARTIAL``/``PRESENT`` while the payload is empty —
-    e.g. ``_run_inline_source_abi`` returns an empty ``SourceAbiSurface()`` when
-    clang is unavailable after L3 was found. The status alone then hides the
-    miss, so we inspect the actual payload (Codex review, PR #422).
-    """
-    if key == "L3":
-        be = pack.build_evidence
-        return be is None or (not be.targets and not be.compile_units)
-    if key == "L4":
-        sa = pack.source_abi
-        return sa is None or not any(sa.reachable_buckets().values())
-    if key == "L5":
-        sg = pack.source_graph
-        return sg is None or not sg.nodes
-    return False
-
-
-def _missing_requested_evidence_layers(
-    pack: BuildSourcePack | None, collect_mode: str
-) -> list[str]:
-    """Layers the *collect_mode* asked for but that came back empty.
-
-    Maps the ADR-033 evidence mode to its expected L3/L4/L5 layers and checks the
-    embedded pack. A layer is reported missing when its coverage row is
-    ``NOT_COLLECTED`` (or absent) **or** when its embedded payload carries no
-    facts despite a ``PARTIAL``/``PRESENT`` status — the latter catches a
-    requested extractor that ran but produced nothing (e.g. clang unavailable).
-    Returns [] when nothing was requested or every requested layer has facts.
-    """
-    if pack is None:
-        return []
-    from .buildsource.model import CoverageStatus, DataLayer
-    from .buildsource.source_replay import collection_for_ci_mode
-
-    _layer_for = {
-        "L3": DataLayer.L3_BUILD,
-        "L4": DataLayer.L4_SOURCE_ABI,
-        "L5": DataLayer.L5_SOURCE_GRAPH,
-    }
-    _, layers = collection_for_ci_mode(collect_mode)
-    missing: list[str] = []
-    for key in layers:
-        layer = _layer_for.get(key)
-        if layer is None:
-            continue
-        cov = pack.manifest.coverage_for(layer)
-        if (
-            cov is None
-            or cov.status == CoverageStatus.NOT_COLLECTED
-            or _layer_payload_empty(pack, key)
-        ):
-            missing.append(layer.value)
-    return missing
-
-
-def _classify_missing_layers(
-    pack: BuildSourcePack | None, missing: list[str]
-) -> tuple[list[str], list[str]]:
-    """Split *missing* layer values into (absent, ran_but_empty).
-
-    ``absent`` — the layer never ran (no coverage row, or NOT_COLLECTED): the
-    actionable fix is a compile DB / an installed frontend. ``ran_but_empty`` —
-    a coverage row exists (PARTIAL/PRESENT) but the payload linked no facts: the
-    fix is scoping/roots, not installing tools. Distinguishing the two stops the
-    warning from telling users to install clang/castxml when those already ran.
-    With no pack (or an unknown layer), default to ``absent`` so the legacy
-    "not collected" wording still appears.
-    """
-    if pack is None:
-        return list(missing), []
-    from .buildsource.model import CoverageStatus, DataLayer
-
-    by_value = {layer.value: layer for layer in DataLayer}
-    absent: list[str] = []
-    ran_empty: list[str] = []
-    for value in missing:
-        layer = by_value.get(value)
-        cov = pack.manifest.coverage_for(layer) if layer is not None else None
-        if cov is not None and cov.status != CoverageStatus.NOT_COLLECTED:
-            ran_empty.append(value)
-        else:
-            absent.append(value)
-    return absent, ran_empty
-
-
-def _write_snapshot_output(
-    snap: AbiSnapshot,
-    output: Path | None,
-    build_info: Path | None = None,
-    sources: Path | None = None,
-    build_config: Path | None = None,
-    allow_build_query: bool = False,
-    collect_mode: str = "source-target",
-    build_query: str | None = None,
-    build_compile_db: str | None = None,
-    extractor: str = "auto",
-    inputs_pack: Path | None = None,
-    depth: str | None = None,
-    include_dependencies: bool = False,
-    header_roots: tuple[Path, ...] = (),
-    clang_bin: str = "clang",
-) -> None:
-    """Serialize snapshot and write to file or stdout.
-
-    When *build_info* and/or *sources* are given, their normalized L3/L4/L5 facts
-    are collected (inline from a source tree / build dir, or loaded from a pack
-    directory) and embedded in the snapshot first (single-artifact UX) so a later
-    ``compare old.json new.json`` needs no out-of-band packs. *collect_mode* (the
-    ADR-033 D2 CI evidence mode) selects which layers and replay scope to collect:
-    ``build`` captures L3 build context only, ``off`` collects nothing.
-    *build_query* / *build_compile_db* are the CLI equivalents of the ``.abicheck.yml``
-    ``build.query`` / ``build.compile_db`` keys. *extractor* is the L4 source-ABI
-    frontend — the same ``--ast-frontend`` knob that drives the L2 header AST
-    (ADR-037 D8): one frontend choice across both pipeline stages. *clang_bin* is
-    the caller-resolved L4 replay compiler (forwarded to ``embed_build_source``).
-    *depth* is the raw ``--depth`` CLI value (``None`` when not passed); when given,
-    ``check_requested_depth_satisfied`` raises if the snapshot did not actually reach
-    it. Unless *include_dependencies* is set (``dump --include-dependencies``),
-    toolchain/system-header declarations are excluded from the snapshot right before
-    serialization by default, once every embed step above has had its chance to fill
-    in the snapshot — see ``dumper_scoping.py`` for what "dependency" means here.
-    *header_roots* is the actual ``-H``/``--header`` input the dump was invoked with,
-    forwarded to ``scope_snapshot_excluding_dependencies`` so a header that IS one of
-    those roots (or lives under one) is never treated as a dependency just because it
-    happens to sit under a system prefix (e.g. an installed library dumped via its real
-    ``/usr/include`` path).
-    """
-    if build_info is not None or sources is not None:
-        from .cli_buildsource import embed_build_source
-        embed_build_source(
-            snap, build_info, sources,
-            build_config=build_config, allow_build_query=allow_build_query,
-            collect_mode=collect_mode,
-            build_query=build_query, build_compile_db=build_compile_db,
-            extractor=extractor, clang_bin=clang_bin,
-        )
-        # G21.7: fail loud — if a requested evidence layer came back empty, say so
-        # prominently instead of leaving it buried in the coverage rows. Permissive
-        # by design (a warning, not an error): --collection-mode strict on
-        # `collect` remains the hard-fail path (ADR-028 D3).
-        missing = _missing_requested_evidence_layers(snap.build_source, collect_mode)
-        if missing:
-            absent, ran_empty = _classify_missing_layers(snap.build_source, missing)
-            parts: list[str] = []
-            if absent:
-                # Genuinely absent: no extractor / no compile DB / layer never ran.
-                parts.append(
-                    f"not collected: {', '.join(absent)} — supply "
-                    "--build-info/--compile-db (a compile_commands.json, e.g. from "
-                    "`bear -- make`), or install the clang/castxml source frontend"
-                )
-            if ran_empty:
-                # Ran but produced/linked nothing — do NOT tell the user to install
-                # tools they already have; point at the real cause in the coverage
-                # rows (usually a public-header-roots or snapshot/source mismatch).
-                parts.append(
-                    f"collected but linked no facts: {', '.join(ran_empty)} — the "
-                    "extractor ran but matched nothing; see the coverage rows for "
-                    "the reason (commonly a public-header-roots mismatch, an "
-                    "unseeded `--depth source` that selected 0 TUs — use "
-                    "--changed-path/--since to seed a changed scope — or the "
-                    "snapshot binary not matching --sources; a '0/N symbols "
-                    "matched' means source decls did not link to the binary's "
-                    "exports)"
-                )
-            click.echo(
-                "Warning: requested evidence layer(s) " + "; ".join(parts) + ".",
-                err=True,
-            )
-    # A build-emitted Flow-2 pack (--inputs) folds straight into the dump — the
-    # plugin/wrapper flow in one command, no separate `merge` (after any inline
-    # --sources/--build-info embed, so both fact sources combine).
-    if inputs_pack is not None:
-        from .cli_buildsource_merge import embed_inputs_pack
-        embed_inputs_pack(snap, inputs_pack, output)
-    # CLI-audit P1: an *explicitly* requested --depth that was not actually
-    # reached is a hard failure, not a warning — see
-    # check_requested_depth_satisfied's docstring. Checked last, after every
-    # embed step above has had its chance to fill in build_source.
-    check_requested_depth_satisfied(depth, snap)
-    from .dumper_scoping import resolve_dependency_scope
-    snap = resolve_dependency_scope(snap, include_dependencies, header_roots)
-    result = snapshot_to_json(snap)
-    # Audit finding: dump/baseline provenance didn't record requested vs.
-    # effective depth anywhere a later reader could inspect -- fold it into
-    # the written JSON now that the strict gate above has had its say.
-    result, resolved_depth_label = fold_dump_provenance_into_json(result, depth, snap)
-    if output:
-        _safe_write_output(output, result)
-        click.echo(f"Snapshot written to {output}", err=True)
-        # Self-describing output (CLI-audit P2): report the evidence depth
-        # this snapshot actually reached -- computed from what it carries,
-        # not the requested --depth, so an explicit --depth source that
-        # collected nothing usable is never silently reported as if it had
-        # succeeded. Only alongside the file-write notice above (never for
-        # bare stdout output, which callers may pipe/parse as pure JSON).
-        # Reuses fold_dump_provenance_into_json's own returned label (the
-        # strict _gated_source_label, not the plain evidence_depth_label)
-        # so this line can never disagree with the JSON's effective_depth
-        # for the same dump -- they previously could, on the documented
-        # zero-match-source-only case (external review).
-        click.echo(f"Resolved evidence depth: {resolved_depth_label}", err=True)
-    else:
-        click.echo(result)
 
 
 def _collect_metadata(path: Path) -> LibraryMetadata | None:
@@ -506,6 +303,81 @@ def main() -> None:
     # detached clang/castxml process group started by deadline.run_bounded
     # (Codex review, PR #591).
     deadline.install_sigterm_cleanup()
+
+
+def _load_dump_manifest_or_reject(
+    dump_manifest_path: Path | None,
+    headers: tuple[Path, ...],
+    public_headers: tuple[Path, ...],
+    public_header_dirs: tuple[Path, ...],
+) -> Any:
+    """Parse ``--dump-manifest``, rejecting the flags it is exclusive with.
+
+    A manifest's own ``roots`` field and base profile declare the public
+    surface, so ``-H``/``--public-header``/``--public-header-dir`` would be a
+    second, conflicting declaration. Returns the parsed manifest, or ``None``
+    when no ``--dump-manifest`` was given.
+    """
+    if dump_manifest_path is None:
+        return None
+    if headers:
+        raise click.UsageError(
+            "--dump-manifest and -H/--header are mutually exclusive -- the "
+            "manifest's own 'roots' field declares the public surface instead."
+        )
+    if public_headers or public_header_dirs:
+        raise click.UsageError(
+            "--dump-manifest and --public-header/--public-header-dir are "
+            "mutually exclusive -- declare them in the manifest's own base "
+            "profile instead."
+        )
+    from .dump_manifest import load_manifest
+    from .errors import ManifestValidationError
+
+    try:
+        parsed_dump_manifest = load_manifest(dump_manifest_path)
+    except ManifestValidationError as exc:
+        raise click.UsageError(str(exc)) from exc
+    return parsed_dump_manifest
+
+
+def _resolve_and_check_dump_debug_format(
+    so_path: Path | None,
+    debug_format_opt: str | None,
+    debug_format: str | None,
+    compile_db_path: Path | None,
+    compile_db_path_alt: Path | None,
+    headers: tuple[Path, ...],
+) -> str | None:
+    """Resolve the effective debug format and reject the usage errors it implies.
+
+    Both checks are genuine usage errors in the real run (exit 64), raised here
+    -- before the ``--dry-run`` branch -- so the dry run and the real run agree
+    on them rather than the dry run downgrading either into an evidence
+    blocker. Returns ``None`` for a source-only dump, which has no binary to
+    resolve a debug format against.
+    """
+    if so_path is None:
+        return None
+    from .binary_utils import normalize_binary_input as _peek_binary_format
+    from .cli_dump_helpers import (
+        check_dump_compile_db_error,
+        check_dump_debug_format_error,
+    )
+
+    effective_debug_format = resolve_dump_debug_format(debug_format_opt, debug_format)
+    compile_db_error = check_dump_compile_db_error(
+        compile_db_path, compile_db_path_alt, headers
+    )
+    if compile_db_error is not None:
+        raise click.UsageError(compile_db_error)
+    _, dry_run_binary_fmt = _peek_binary_format(so_path)
+    debug_format_error = check_dump_debug_format_error(
+        effective_debug_format, dry_run_binary_fmt
+    )
+    if debug_format_error is not None:
+        raise click.BadParameter(debug_format_error)
+    return effective_debug_format
 
 
 @main.command("dump")
@@ -653,25 +525,9 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
     # a bad manifest fails fast, and validated against the *raw* CLI values
     # (headers/public_headers/public_header_dirs haven't been reassigned yet).
     parsed_dump_manifest = None
-    if dump_manifest_path is not None:
-        if headers:
-            raise click.UsageError(
-                "--dump-manifest and -H/--header are mutually exclusive -- the "
-                "manifest's own 'roots' field declares the public surface instead."
-            )
-        if public_headers or public_header_dirs:
-            raise click.UsageError(
-                "--dump-manifest and --public-header/--public-header-dir are "
-                "mutually exclusive -- declare them in the manifest's own base "
-                "profile instead."
-            )
-        from .dump_manifest import load_manifest
-        from .errors import ManifestValidationError
-
-        try:
-            parsed_dump_manifest = load_manifest(dump_manifest_path)
-        except ManifestValidationError as exc:
-            raise click.UsageError(str(exc)) from exc
+    parsed_dump_manifest = _load_dump_manifest_or_reject(
+        dump_manifest_path, headers, public_headers, public_header_dirs
+    )
 
     # Resolve the evidence-depth preset into the collect mode, apply --depth binary
     # suppression, and warn on an explicitly-requested deep depth without sources.
@@ -771,26 +627,10 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
     # the real path below still calls _normalize_binary_input itself for
     # that echo and the so_path reassignment (a no-op re-validation once
     # this has already passed).
-    effective_debug_format: str | None = None
-    if so_path is not None:
-        from .binary_utils import normalize_binary_input as _peek_binary_format
-        from .cli_dump_helpers import (
-            check_dump_compile_db_error,
-            check_dump_debug_format_error,
-        )
-
-        effective_debug_format = resolve_dump_debug_format(debug_format_opt, debug_format)
-        compile_db_error = check_dump_compile_db_error(
-            compile_db_path, compile_db_path_alt, headers
-        )
-        if compile_db_error is not None:
-            raise click.UsageError(compile_db_error)
-        _, dry_run_binary_fmt = _peek_binary_format(so_path)
-        debug_format_error = check_dump_debug_format_error(
-            effective_debug_format, dry_run_binary_fmt
-        )
-        if debug_format_error is not None:
-            raise click.BadParameter(debug_format_error)
+    effective_debug_format = _resolve_and_check_dump_debug_format(
+        so_path, debug_format_opt, debug_format,
+        compile_db_path, compile_db_path_alt, headers,
+    )
 
     if dry_run:
         from .buildsource.inline import is_pack_dir

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1779,6 +1779,32 @@ from .compat.cli import (  # noqa: E402,F401
 main.add_command(compat_group)
 
 
+# The snapshot write path moved to `cli_buildsource` (this module sits near the
+# AI-readiness file-size cap; see that module's own "Snapshot output" section).
+# These names are kept resolvable at their historical `abicheck.cli` path for
+# tests and for `cli_dump_helpers`' `cli._layer_payload_empty` /
+# `cli._missing_requested_evidence_layers` lookups. A module-level `__getattr__`
+# (PEP 562) resolves them lazily via `importlib.import_module` -- a runtime
+# call, not a static import edge -- so `cli` never grows a top-level dependency
+# on `cli_buildsource`, which imports back into `cli` (AGENTS.md, "Moving
+# helpers out of a module that re-exports them"). New code should import from
+# `cli_buildsource` directly.
+_SNAPSHOT_OUTPUT_REEXPORTS = frozenset({
+    "_classify_missing_layers",
+    "_layer_payload_empty",
+    "_missing_requested_evidence_layers",
+    "_write_snapshot_output",
+})
+
+
+def __getattr__(name: str) -> Any:
+    if name in _SNAPSHOT_OUTPUT_REEXPORTS:
+        import importlib
+
+        return getattr(importlib.import_module("abicheck.cli_buildsource"), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 # ---------------------------------------------------------------------------
 # Sub-command modules. Imported for side-effect so their @main.command(...)
 # decorators register the commands on the Click group above. They sit in
@@ -1812,29 +1838,3 @@ from . import (  # noqa: E402  — must run after `main` and helpers are defined
 
 if __name__ == "__main__":
     main()
-
-
-# The snapshot write path moved to `cli_buildsource` (this module sits near the
-# AI-readiness file-size cap; see that module's own "Snapshot output" section).
-# These names are kept resolvable at their historical `abicheck.cli` path for
-# tests and for `cli_dump_helpers`' `cli._layer_payload_empty` /
-# `cli._missing_requested_evidence_layers` lookups. A module-level `__getattr__`
-# (PEP 562) resolves them lazily via `importlib.import_module` -- a runtime
-# call, not a static import edge -- so `cli` never grows a top-level dependency
-# on `cli_buildsource`, which imports back into `cli` (AGENTS.md, "Moving
-# helpers out of a module that re-exports them"). New code should import from
-# `cli_buildsource` directly.
-_SNAPSHOT_OUTPUT_REEXPORTS = frozenset({
-    "_classify_missing_layers",
-    "_layer_payload_empty",
-    "_missing_requested_evidence_layers",
-    "_write_snapshot_output",
-})
-
-
-def __getattr__(name: str) -> Any:
-    if name in _SNAPSHOT_OUTPUT_REEXPORTS:
-        import importlib
-
-        return getattr(importlib.import_module("abicheck.cli_buildsource"), name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -38,16 +38,6 @@ except ImportError:  # pragma: no cover - rich-click is a declared dependency
 from . import deadline
 from .checker import DiffResult, LibraryMetadata
 from .cli_audit import echo_filtered_surface, echo_reconciled
-from .cli_buildsource import (
-    # The snapshot write path lives there (cli.py is at the file-size cap);
-    # re-exported so ``abicheck.cli._write_snapshot_output`` and its two
-    # evidence-layer helpers keep resolving for dump_cmd, cli_buildsource's
-    # own caller, and the tests that import them from here.
-    _classify_missing_layers as _classify_missing_layers,
-    _layer_payload_empty as _layer_payload_empty,
-    _missing_requested_evidence_layers as _missing_requested_evidence_layers,
-    _write_snapshot_output as _write_snapshot_output,
-)
 from .cli_dump_helpers import (
     _dump_will_attempt_hybrid_l4_extraction,
     handle_non_elf_dump,
@@ -511,6 +501,14 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
       abicheck dump libfoo.so.1 -H include/foo.h --version 1.2.3 -o snap.json
       abicheck dump --sources ./libfoo-src/ -o libfoo.src.json  # source-only (no binary)
     """
+    # Imported here, not at module level: the snapshot write path lives in
+    # `cli_buildsource`, which reaches back into this module, so a static
+    # top-level import would be the very edge the lazy `__getattr__` shim at
+    # the tail of this file exists to avoid (AGENTS.md, "Moving helpers out of
+    # a module that re-exports them"). That shim only serves *attribute*
+    # access on the module (`cli._write_snapshot_output`); a bare name inside
+    # this module needs a real import.
+    from .cli_buildsource import _write_snapshot_output as _write_snapshot_output_fn
     from .cli_options import warn_deprecated_header_graph_flags
     from .dry_run import emit_dry_run, reject_dry_run_with_output
 
@@ -741,7 +739,7 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
         handle_non_elf_dump(
             so_path, binary_fmt, headers, includes, version, lang, pdb_path,
             follow_deps, git_tag, build_id, no_git, output,
-            _dump_native_binary, _stamp_provenance, _write_snapshot_output,
+            _dump_native_binary, _stamp_provenance, _write_snapshot_output_fn,
             public_headers, public_header_dirs, build_info, sources, build_config,
             allow_build_query, collect_mode, build_query, build_compile_db,
             header_backend=header_backend, compile_context=native_cc,
@@ -800,7 +798,7 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
         expand_header_inputs=_expand_header_inputs,
         populate_dependency_info=_populate_dependency_info,
         stamp_provenance=_stamp_provenance,
-        write_snapshot_output=_write_snapshot_output,
+        write_snapshot_output=_write_snapshot_output_fn,
         build_query=build_query,
         build_compile_db=build_compile_db,
         compile_context=_cc,
@@ -1814,3 +1812,29 @@ from . import (  # noqa: E402  — must run after `main` and helpers are defined
 
 if __name__ == "__main__":
     main()
+
+
+# The snapshot write path moved to `cli_buildsource` (this module sits near the
+# AI-readiness file-size cap; see that module's own "Snapshot output" section).
+# These names are kept resolvable at their historical `abicheck.cli` path for
+# tests and for `cli_dump_helpers`' `cli._layer_payload_empty` /
+# `cli._missing_requested_evidence_layers` lookups. A module-level `__getattr__`
+# (PEP 562) resolves them lazily via `importlib.import_module` -- a runtime
+# call, not a static import edge -- so `cli` never grows a top-level dependency
+# on `cli_buildsource`, which imports back into `cli` (AGENTS.md, "Moving
+# helpers out of a module that re-exports them"). New code should import from
+# `cli_buildsource` directly.
+_SNAPSHOT_OUTPUT_REEXPORTS = frozenset({
+    "_classify_missing_layers",
+    "_layer_payload_empty",
+    "_missing_requested_evidence_layers",
+    "_write_snapshot_output",
+})
+
+
+def __getattr__(name: str) -> Any:
+    if name in _SNAPSHOT_OUTPUT_REEXPORTS:
+        import importlib
+
+        return getattr(importlib.import_module("abicheck.cli_buildsource"), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/abicheck/cli_buildsource.py
+++ b/abicheck/cli_buildsource.py
@@ -402,28 +402,6 @@ def dump_source_only(
     )
 
 
-# ── Back-compat re-export shim (lazy, to avoid an import cycle) ───────────────
-# `_load_source_graph` / `_resolve_symbol_from_report` historically lived here
-# (re-exported from `cli_buildsource_helpers`, like the block above). They moved
-# to `cli_graph` when the `graph` command group was extracted. A *static*
-# `from .cli_graph import ...` would form a `cli_buildsource → cli_graph → cli →
-# … → cli_buildsource` import cycle (the AI-readiness gate rejects it), so this
-# module-level `__getattr__` (PEP 562) resolves them lazily via
-# `importlib.import_module` — a runtime call, not a static import edge. It
-# preserves the historical path `from abicheck.cli_buildsource import
-# _load_source_graph` without coupling the two modules. New code should import
-# from `cli_graph` directly.
-_GRAPH_REEXPORTS = frozenset({"_load_source_graph", "_resolve_symbol_from_report"})
-
-
-def __getattr__(name: str) -> Any:
-    if name in _GRAPH_REEXPORTS:
-        import importlib
-
-        return getattr(importlib.import_module("abicheck.cli_graph"), name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
 # ---------------------------------------------------------------------------
 # Snapshot output (dump's write path)
 #
@@ -665,3 +643,25 @@ def _write_snapshot_output(
         click.echo(f"Resolved evidence depth: {resolved_depth_label}", err=True)
     else:
         click.echo(result)
+
+
+# ── Back-compat re-export shim (lazy, to avoid an import cycle) ───────────────
+# `_load_source_graph` / `_resolve_symbol_from_report` historically lived here
+# (re-exported from `cli_buildsource_helpers`, like the block above). They moved
+# to `cli_graph` when the `graph` command group was extracted. A *static*
+# `from .cli_graph import ...` would form a `cli_buildsource → cli_graph → cli →
+# … → cli_buildsource` import cycle (the AI-readiness gate rejects it), so this
+# module-level `__getattr__` (PEP 562) resolves them lazily via
+# `importlib.import_module` — a runtime call, not a static import edge. It
+# preserves the historical path `from abicheck.cli_buildsource import
+# _load_source_graph` without coupling the two modules. New code should import
+# from `cli_graph` directly.
+_GRAPH_REEXPORTS = frozenset({"_load_source_graph", "_resolve_symbol_from_report"})
+
+
+def __getattr__(name: str) -> Any:
+    if name in _GRAPH_REEXPORTS:
+        import importlib
+
+        return getattr(importlib.import_module("abicheck.cli_graph"), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/abicheck/cli_buildsource.py
+++ b/abicheck/cli_buildsource.py
@@ -422,3 +422,246 @@ def __getattr__(name: str) -> Any:
 
         return getattr(importlib.import_module("abicheck.cli_graph"), name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+# ---------------------------------------------------------------------------
+# Snapshot output (dump's write path)
+#
+# Relocated here from ``cli.py`` (which sits within a handful of lines of the
+# AI-readiness 2000-line hard cap) as one cohesive cluster: writing a snapshot
+# *is* the step that folds this module's own ``embed_build_source`` /
+# ``embed_inputs_pack`` payloads in and then enforces the requested evidence
+# depth, and ``embed_build_source``'s caller here already imported
+# ``_write_snapshot_output`` back out of ``cli``. ``cli`` re-exports all three
+# names, so ``abicheck.cli._write_snapshot_output`` -- which several tests and
+# ``dump_cmd`` itself use -- keeps resolving unchanged. This module, not a new
+# one: a *new* module reaching ``service``/``buildsource`` would join the
+# allowlisted CLI import-cycle SCC, which CLAUDE.md "M1-3" forbids extending.
+# ---------------------------------------------------------------------------
+
+
+def _layer_payload_empty(pack: BuildSourcePack, key: str) -> bool:
+    """True when *key*'s embedded payload carries no facts.
+
+    A coverage row can read ``PARTIAL``/``PRESENT`` while the payload is empty —
+    e.g. ``_run_inline_source_abi`` returns an empty ``SourceAbiSurface()`` when
+    clang is unavailable after L3 was found. The status alone then hides the
+    miss, so we inspect the actual payload (Codex review, PR #422).
+    """
+    if key == "L3":
+        be = pack.build_evidence
+        return be is None or (not be.targets and not be.compile_units)
+    if key == "L4":
+        sa = pack.source_abi
+        return sa is None or not any(sa.reachable_buckets().values())
+    if key == "L5":
+        sg = pack.source_graph
+        return sg is None or not sg.nodes
+    return False
+
+
+def _missing_requested_evidence_layers(
+    pack: BuildSourcePack | None, collect_mode: str
+) -> list[str]:
+    """Layers the *collect_mode* asked for but that came back empty.
+
+    Maps the ADR-033 evidence mode to its expected L3/L4/L5 layers and checks the
+    embedded pack. A layer is reported missing when its coverage row is
+    ``NOT_COLLECTED`` (or absent) **or** when its embedded payload carries no
+    facts despite a ``PARTIAL``/``PRESENT`` status — the latter catches a
+    requested extractor that ran but produced nothing (e.g. clang unavailable).
+    Returns [] when nothing was requested or every requested layer has facts.
+    """
+    if pack is None:
+        return []
+    from .buildsource.model import CoverageStatus, DataLayer
+    from .buildsource.source_replay import collection_for_ci_mode
+
+    _layer_for = {
+        "L3": DataLayer.L3_BUILD,
+        "L4": DataLayer.L4_SOURCE_ABI,
+        "L5": DataLayer.L5_SOURCE_GRAPH,
+    }
+    _, layers = collection_for_ci_mode(collect_mode)
+    missing: list[str] = []
+    for key in layers:
+        layer = _layer_for.get(key)
+        if layer is None:
+            continue
+        cov = pack.manifest.coverage_for(layer)
+        if (
+            cov is None
+            or cov.status == CoverageStatus.NOT_COLLECTED
+            or _layer_payload_empty(pack, key)
+        ):
+            missing.append(layer.value)
+    return missing
+
+
+def _classify_missing_layers(
+    pack: BuildSourcePack | None, missing: list[str]
+) -> tuple[list[str], list[str]]:
+    """Split *missing* layer values into (absent, ran_but_empty).
+
+    ``absent`` — the layer never ran (no coverage row, or NOT_COLLECTED): the
+    actionable fix is a compile DB / an installed frontend. ``ran_but_empty`` —
+    a coverage row exists (PARTIAL/PRESENT) but the payload linked no facts: the
+    fix is scoping/roots, not installing tools. Distinguishing the two stops the
+    warning from telling users to install clang/castxml when those already ran.
+    With no pack (or an unknown layer), default to ``absent`` so the legacy
+    "not collected" wording still appears.
+    """
+    if pack is None:
+        return list(missing), []
+    from .buildsource.model import CoverageStatus, DataLayer
+
+    by_value = {layer.value: layer for layer in DataLayer}
+    absent: list[str] = []
+    ran_empty: list[str] = []
+    for value in missing:
+        layer = by_value.get(value)
+        cov = pack.manifest.coverage_for(layer) if layer is not None else None
+        if cov is not None and cov.status != CoverageStatus.NOT_COLLECTED:
+            ran_empty.append(value)
+        else:
+            absent.append(value)
+    return absent, ran_empty
+
+
+def _write_snapshot_output(
+    snap: AbiSnapshot,
+    output: Path | None,
+    build_info: Path | None = None,
+    sources: Path | None = None,
+    build_config: Path | None = None,
+    allow_build_query: bool = False,
+    collect_mode: str = "source-target",
+    build_query: str | None = None,
+    build_compile_db: str | None = None,
+    extractor: str = "auto",
+    inputs_pack: Path | None = None,
+    depth: str | None = None,
+    include_dependencies: bool = False,
+    header_roots: tuple[Path, ...] = (),
+    clang_bin: str = "clang",
+) -> None:
+    """Serialize snapshot and write to file or stdout.
+
+    When *build_info* and/or *sources* are given, their normalized L3/L4/L5 facts
+    are collected (inline from a source tree / build dir, or loaded from a pack
+    directory) and embedded in the snapshot first (single-artifact UX) so a later
+    ``compare old.json new.json`` needs no out-of-band packs. *collect_mode* (the
+    ADR-033 D2 CI evidence mode) selects which layers and replay scope to collect:
+    ``build`` captures L3 build context only, ``off`` collects nothing.
+    *build_query* / *build_compile_db* are the CLI equivalents of the ``.abicheck.yml``
+    ``build.query`` / ``build.compile_db`` keys. *extractor* is the L4 source-ABI
+    frontend — the same ``--ast-frontend`` knob that drives the L2 header AST
+    (ADR-037 D8): one frontend choice across both pipeline stages. *clang_bin* is
+    the caller-resolved L4 replay compiler (forwarded to ``embed_build_source``).
+    *depth* is the raw ``--depth`` CLI value (``None`` when not passed); when given,
+    ``check_requested_depth_satisfied`` raises if the snapshot did not actually reach
+    it. Unless *include_dependencies* is set (``dump --include-dependencies``),
+    toolchain/system-header declarations are excluded from the snapshot right before
+    serialization by default, once every embed step above has had its chance to fill
+    in the snapshot — see ``dumper_scoping.py`` for what "dependency" means here.
+    *header_roots* is the actual ``-H``/``--header`` input the dump was invoked with,
+    forwarded to ``scope_snapshot_excluding_dependencies`` so a header that IS one of
+    those roots (or lives under one) is never treated as a dependency just because it
+    happens to sit under a system prefix (e.g. an installed library dumped via its real
+    ``/usr/include`` path).
+    """
+    from .cli import _safe_write_output
+    from .cli_dump_helpers import (
+        check_requested_depth_satisfied,
+        fold_dump_provenance_into_json,
+    )
+    from .serialization import snapshot_to_json
+
+    if build_info is not None or sources is not None:
+        from .cli_buildsource import embed_build_source
+        embed_build_source(
+            snap, build_info, sources,
+            build_config=build_config, allow_build_query=allow_build_query,
+            collect_mode=collect_mode,
+            build_query=build_query, build_compile_db=build_compile_db,
+            extractor=extractor, clang_bin=clang_bin,
+        )
+        # G21.7: fail loud — if a requested evidence layer came back empty, say so
+        # prominently instead of leaving it buried in the coverage rows. Permissive
+        # by design (a warning, not an error): --collection-mode strict on
+        # `collect` remains the hard-fail path (ADR-028 D3).
+        # Through the ``cli`` module (which re-exports both) so a monkeypatch on
+        # ``abicheck.cli._missing_requested_evidence_layers`` /
+        # ``._classify_missing_layers`` is still honoured after the relocation --
+        # the same resolution the neighbouring ``cli._normalize_binary_input``
+        # calls use, and what several existing tests patch.
+        from . import cli as _cli
+
+        missing = _cli._missing_requested_evidence_layers(
+            snap.build_source, collect_mode
+        )
+        if missing:
+            absent, ran_empty = _cli._classify_missing_layers(
+                snap.build_source, missing
+            )
+            parts: list[str] = []
+            if absent:
+                # Genuinely absent: no extractor / no compile DB / layer never ran.
+                parts.append(
+                    f"not collected: {', '.join(absent)} — supply "
+                    "--build-info/--compile-db (a compile_commands.json, e.g. from "
+                    "`bear -- make`), or install the clang/castxml source frontend"
+                )
+            if ran_empty:
+                # Ran but produced/linked nothing — do NOT tell the user to install
+                # tools they already have; point at the real cause in the coverage
+                # rows (usually a public-header-roots or snapshot/source mismatch).
+                parts.append(
+                    f"collected but linked no facts: {', '.join(ran_empty)} — the "
+                    "extractor ran but matched nothing; see the coverage rows for "
+                    "the reason (commonly a public-header-roots mismatch, an "
+                    "unseeded `--depth source` that selected 0 TUs — use "
+                    "--changed-path/--since to seed a changed scope — or the "
+                    "snapshot binary not matching --sources; a '0/N symbols "
+                    "matched' means source decls did not link to the binary's "
+                    "exports)"
+                )
+            click.echo(
+                "Warning: requested evidence layer(s) " + "; ".join(parts) + ".",
+                err=True,
+            )
+    # A build-emitted Flow-2 pack (--inputs) folds straight into the dump — the
+    # plugin/wrapper flow in one command, no separate `merge` (after any inline
+    # --sources/--build-info embed, so both fact sources combine).
+    if inputs_pack is not None:
+        from .cli_buildsource_merge import embed_inputs_pack
+        embed_inputs_pack(snap, inputs_pack, output)
+    # CLI-audit P1: an *explicitly* requested --depth that was not actually
+    # reached is a hard failure, not a warning — see
+    # check_requested_depth_satisfied's docstring. Checked last, after every
+    # embed step above has had its chance to fill in build_source.
+    check_requested_depth_satisfied(depth, snap)
+    from .dumper_scoping import resolve_dependency_scope
+    snap = resolve_dependency_scope(snap, include_dependencies, header_roots)
+    result = snapshot_to_json(snap)
+    # Audit finding: dump/baseline provenance didn't record requested vs.
+    # effective depth anywhere a later reader could inspect -- fold it into
+    # the written JSON now that the strict gate above has had its say.
+    result, resolved_depth_label = fold_dump_provenance_into_json(result, depth, snap)
+    if output:
+        _safe_write_output(output, result)
+        click.echo(f"Snapshot written to {output}", err=True)
+        # Self-describing output (CLI-audit P2): report the evidence depth
+        # this snapshot actually reached -- computed from what it carries,
+        # not the requested --depth, so an explicit --depth source that
+        # collected nothing usable is never silently reported as if it had
+        # succeeded. Only alongside the file-write notice above (never for
+        # bare stdout output, which callers may pipe/parse as pure JSON).
+        # Reuses fold_dump_provenance_into_json's own returned label (the
+        # strict _gated_source_label, not the plain evidence_depth_label)
+        # so this line can never disagree with the JSON's effective_depth
+        # for the same dump -- they previously could, on the documented
+        # zero-match-source-only case (external review).
+        click.echo(f"Resolved evidence depth: {resolved_depth_label}", err=True)
+    else:
+        click.echo(result)

--- a/abicheck/cli_compare_fold.py
+++ b/abicheck/cli_compare_fold.py
@@ -514,6 +514,165 @@ class _ScopedFold:
 
     # ── markdown / text / review ───────────────────────────
 
+    def _scoped_verdict_header(self) -> list[str]:
+        """The "scoped verdict disagrees with the headline" note, or ``[]``.
+
+        The exit code is computed from the *scoped* result (ADR-043
+        worst-wins), which can disagree with the full-library verdict this
+        report's own headline already rendered above -- state which one is
+        authoritative for CI instead of leaving the two to silently disagree
+        (Codex review). Under a severity scheme the exit code is NOT a fixed
+        BREAKING->4/API_BREAK->2 mapping of scoped_verdict -- e.g.
+        ``--severity-preset info-only`` can floor it at 0 even for a BREAKING
+        scoped verdict -- so state the actual computed value/scheme instead of
+        asserting the exit code "reflects" the scoped verdict, which would be
+        false in that case (Codex review follow-up).
+        """
+        scoped_verdict_value = self.scoped_verdict_value
+        full_verdict_value = getattr(
+            getattr(self.result, "verdict", None), "value", None
+        )
+        if (
+            scoped_verdict_value is None
+            or full_verdict_value is None
+            or scoped_verdict_value == full_verdict_value
+        ):
+            return []
+        scoped_exit_code = getattr(self.result, "scoped_exit_code", None)
+        scoped_exit_code_scheme = getattr(self.result, "scoped_exit_code_scheme", None)
+        exit_note = (
+            f"the CLI process exits {scoped_exit_code} under the "
+            f"{scoped_exit_code_scheme} exit-code scheme for this run"
+            if scoped_exit_code is not None
+            else "this is what the exit code reflects"
+        )
+        return [
+            f"**Scoped verdict: {scoped_verdict_value}** "
+            f"({exit_note}; the full library verdict above is "
+            f"{full_verdict_value}).",
+            "",
+        ]
+
+    def _used_by_lines(self) -> list[str]:
+        """Per-application ``--used-by`` summaries, naming the missing symbols.
+
+        Names the actual missing symbols/versions, not just their count (Codex
+        review) -- a human reading the default text report otherwise has no way
+        to tell *which* symbol broke this app without re-running with
+        ``--format json``.
+        """
+        if self.used_by is None:
+            return []
+        lines = ["## Scoped to --used-by applications"]
+        for summary in self.used_by:
+            lines.append(
+                f"- {summary['app']}: {summary['verdict']} "
+                f"(missing {len(summary['missing_symbols'])} symbol(s), "
+                f"{len(summary['missing_versions'])} version(s), "
+                f"{summary['relevant_change_count']} relevant change(s))"
+            )
+            lines.extend(
+                f"  - missing symbol: `{sym}`" for sym in summary["missing_symbols"]
+            )
+            lines.extend(
+                f"  - missing version: `{ver}`" for ver in summary["missing_versions"]
+            )
+        return lines
+
+    def _required_symbols_lines(self) -> list[str]:
+        """The ``--required-symbol(s)`` entrypoint-contract summary."""
+        required_symbols = self.required_symbols
+        if required_symbols is None:
+            return []
+        lines = [
+            "## Scoped to --required-symbol(s) contract",
+            f"- verdict: {required_symbols['verdict']} "
+            f"(missing {len(required_symbols['missing_entrypoints'])} of "
+            f"{len(required_symbols['required_entrypoints'])} required "
+            f"entrypoint(s))",
+        ]
+        lines.extend(
+            f"  - missing entrypoint: `{entrypoint}`"
+            for entrypoint in required_symbols["missing_entrypoints"]
+        )
+        return lines
+
+    def _missing_label_line(self, label: str, severity_tag: str) -> str:
+        """One "required but missing" contract-label line.
+
+        ADR-049 Phase 3 (Codex review, fresh evidence): a missing-contract
+        label is a bare string here, not the stamped dict entry the JSON branch
+        builds -- without the contract suffix, the default
+        markdown/text/review report (unlike JSON) silently dropped the contract
+        decision for this exact finding shape.
+        """
+        line = (
+            f"- `{label}` is required but missing from the new library ({severity_tag})"
+        )
+        if not self.contract_evaluation:
+            return line
+        from .contract_scoped_promotion import (
+            stamp_explicit_scope_contract_evaluation,
+        )
+
+        label_decision: dict[str, object] = {}
+        stamp_explicit_scope_contract_evaluation(label_decision)
+        return line + (
+            f" [contract: {label_decision['contract_relevance']} "
+            f"({label_decision['contract_reason_code']}), "
+            f"assurance: {label_decision['contract_assurance']}]"
+        )
+
+    @staticmethod
+    def _scoped_only_line(c: Any) -> str:
+        """One scoped-only ``Change`` line, rendering any contract stamp it has.
+
+        ``scoped_only`` changes are already stamped by
+        ``stamp_scoped_result_findings`` upstream when ``contract_evaluation``
+        was requested -- render what's already there instead of re-deriving it.
+        """
+        line = f"- {c.kind.value}: {c.description}"
+        relevance = getattr(c, "contract_relevance", None)
+        if relevance is None:
+            return line
+        assurance = getattr(c, "contract_assurance", None)
+        line += (
+            f" [contract: {relevance.value} "
+            f"({getattr(c, 'contract_reason_code', None)})"
+        )
+        if assurance is not None:
+            line += f", assurance: {assurance.value}"
+        return line + "]"
+
+    def _scoped_gate_finding_lines(self, fmt: str) -> list[str]:
+        """Scoped-only changes and uncovered missing-contract labels.
+
+        These are relevant to the scoped gate but never land in
+        ``result.changes`` -- name them here too, mirroring the
+        JSON/SARIF/JUnit fold-in, so a text/markdown/review reader sees the
+        same actionable findings a JSON consumer would (Codex review). Skipped
+        for markdown/text root-cause mode: ``_to_markdown_root_cause`` already
+        merged these into its own root-cause groups, so appending them again
+        here would duplicate every scoped finding that correlates with an
+        existing group (Codex review follow-up).
+        """
+        if self.report_mode == "root-cause" and fmt in ("markdown", "text"):
+            return []
+        scoped_only, missing_labels, blocks, _missing_kind = (
+            self._scoped_gate_findings()
+        )
+        if not scoped_only and not missing_labels:
+            return []
+        severity_tag = "breaking" if blocks else "compatible"
+        return [
+            "## Additional scoped-gate findings",
+            *(
+                self._missing_label_line(label, severity_tag)
+                for label in missing_labels
+            ),
+            *(self._scoped_only_line(c) for c in scoped_only),
+        ]
+
     def into_text(self, text: str, fmt: str) -> str:
         """Append the scoped-gate sections to a markdown/text/review report.
 
@@ -521,128 +680,16 @@ class _ScopedFold:
         scoped-verdict header (only when the two verdicts disagree), the
         per-consumer summaries, and the scoped gate's own findings.
         """
-        result = self.result
-        used_by = self.used_by
-        required_symbols = self.required_symbols
-        scoped_verdict_value = self.scoped_verdict_value
-        full_verdict_value = getattr(getattr(result, "verdict", None), "value", None)
-        header: list[str] = []
-        if (
-            scoped_verdict_value is not None
-            and full_verdict_value is not None
-            and scoped_verdict_value != full_verdict_value
-        ):
-            # The exit code is computed from the *scoped* result (ADR-043
-            # worst-wins), which can disagree with the full-library verdict
-            # this report's own headline already rendered above -- state
-            # which one is authoritative for CI instead of leaving the two to
-            # silently disagree (Codex review). Under a severity scheme the
-            # exit code is NOT a fixed BREAKING->4/API_BREAK->2 mapping of
-            # scoped_verdict -- e.g. --severity-preset info-only can floor it
-            # at 0 even for a BREAKING scoped verdict -- so state the actual
-            # computed value/scheme instead of asserting the exit code
-            # "reflects" the scoped verdict, which would be false in that
-            # case (Codex review follow-up).
-            scoped_exit_code = getattr(result, "scoped_exit_code", None)
-            scoped_exit_code_scheme = getattr(result, "scoped_exit_code_scheme", None)
-            exit_note = (
-                f"the CLI process exits {scoped_exit_code} under the "
-                f"{scoped_exit_code_scheme} exit-code scheme for this run"
-                if scoped_exit_code is not None
-                else "this is what the exit code reflects"
-            )
-            header = [
-                f"**Scoped verdict: {scoped_verdict_value}** "
-                f"({exit_note}; the full library verdict above is "
-                f"{full_verdict_value}).",
+        return "\n".join(
+            [
+                *self._scoped_verdict_header(),
+                text,
                 "",
+                *self._used_by_lines(),
+                *self._required_symbols_lines(),
+                *self._scoped_gate_finding_lines(fmt),
             ]
-        lines = [*header, text, ""]
-        if used_by is not None:
-            lines.append("## Scoped to --used-by applications")
-            for summary in used_by:
-                lines.append(
-                    f"- {summary['app']}: {summary['verdict']} "
-                    f"(missing {len(summary['missing_symbols'])} symbol(s), "
-                    f"{len(summary['missing_versions'])} version(s), "
-                    f"{summary['relevant_change_count']} relevant change(s))"
-                )
-                # Name the actual missing symbols/versions, not just their
-                # count (Codex review) -- a human reading the default text
-                # report otherwise has no way to tell *which* symbol broke
-                # this app without re-running with --format json.
-                for sym in summary["missing_symbols"]:
-                    lines.append(f"  - missing symbol: `{sym}`")
-                for ver in summary["missing_versions"]:
-                    lines.append(f"  - missing version: `{ver}`")
-        if required_symbols is not None:
-            lines.append("## Scoped to --required-symbol(s) contract")
-            lines.append(
-                f"- verdict: {required_symbols['verdict']} "
-                f"(missing {len(required_symbols['missing_entrypoints'])} of "
-                f"{len(required_symbols['required_entrypoints'])} required "
-                f"entrypoint(s))"
-            )
-            for entrypoint in required_symbols["missing_entrypoints"]:
-                lines.append(f"  - missing entrypoint: `{entrypoint}`")
-        # Scoped-only changes (e.g. PE_ORDINAL_RETARGETED) and uncovered
-        # missing-contract labels are relevant to the scoped gate but never
-        # land in `result.changes` -- name them here too, mirroring the
-        # JSON/SARIF/JUnit fold-in, so a text/markdown/review reader sees the
-        # same actionable findings a JSON consumer would (Codex review).
-        # Skipped for markdown/text root-cause mode: _to_markdown_root_cause
-        # already merged these into its own root-cause groups, so appending
-        # them again here would duplicate every scoped finding that
-        # correlates with an existing group (Codex review follow-up).
-        if not (self.report_mode == "root-cause" and fmt in ("markdown", "text")):
-            scoped_only, missing_labels, blocks, _missing_kind = (
-                self._scoped_gate_findings()
-            )
-            if scoped_only or missing_labels:
-                lines.append("## Additional scoped-gate findings")
-                severity_tag = "breaking" if blocks else "compatible"
-                for label in missing_labels:
-                    line = (
-                        f"- `{label}` is required but missing from the new "
-                        f"library ({severity_tag})"
-                    )
-                    # ADR-049 Phase 3 (Codex review, fresh evidence): a
-                    # missing-contract label is a bare string here, not the
-                    # stamped dict entry the JSON branch above builds --
-                    # without this, the default markdown/text/review report
-                    # (unlike JSON) silently dropped the contract decision
-                    # for this exact finding shape.
-                    if self.contract_evaluation:
-                        from .contract_scoped_promotion import (
-                            stamp_explicit_scope_contract_evaluation,
-                        )
-
-                        label_decision: dict[str, object] = {}
-                        stamp_explicit_scope_contract_evaluation(label_decision)
-                        line += (
-                            f" [contract: {label_decision['contract_relevance']} "
-                            f"({label_decision['contract_reason_code']}), "
-                            f"assurance: {label_decision['contract_assurance']}]"
-                        )
-                    lines.append(line)
-                for c in scoped_only:
-                    line = f"- {c.kind.value}: {c.description}"
-                    # scoped_only Change objects are already stamped by
-                    # stamp_scoped_result_findings upstream when
-                    # contract_evaluation was requested -- render what's
-                    # already there instead of re-deriving it.
-                    relevance = getattr(c, "contract_relevance", None)
-                    if relevance is not None:
-                        assurance = getattr(c, "contract_assurance", None)
-                        line += (
-                            f" [contract: {relevance.value} "
-                            f"({getattr(c, 'contract_reason_code', None)})"
-                        )
-                        if assurance is not None:
-                            line += f", assurance: {assurance.value}"
-                        line += "]"
-                    lines.append(line)
-        return "\n".join(lines)
+        )
 
 
 def _suppression_rule_label(rule: Any, index: int) -> str:

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import json
 import sys
-from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -70,8 +69,22 @@ from .cli_compare_options import (
 )
 from .cli_dump_helpers import resolve_dump_depth
 from .cli_helpers_compare import (
+    # The ADR-043 scoped-gating family lives there (this module is at the
+    # file-size cap); re-exported so ``cli_compare_helpers._verdict_exit_code``
+    # -- which cli_scan_baseline imports -- and the existing test patch targets
+    # keep resolving unchanged.
+    _app_compat_summary as _app_compat_summary,
+    _apply_required_symbol_scoping as _apply_required_symbol_scoping,
+    _apply_runtime_probe as _apply_runtime_probe,
+    _apply_used_by_scoping as _apply_used_by_scoping,
     _pair_wide_dialect_override,
+    _plugin_contract_summary as _plugin_contract_summary,
+    _require_used_by_binary_evidence as _require_used_by_binary_evidence,
     _resolve_per_side_options,
+    _scoped_exit_code as _scoped_exit_code,
+    _scoped_severity_summary as _scoped_severity_summary,
+    _verdict_exit_code as _verdict_exit_code,
+    _verdict_severity_rank as _verdict_severity_rank,
     _warn_ignored_flags,
     fold_l0_hard_removals,
     load_required_symbols,
@@ -360,449 +373,6 @@ def _classify_and_reject_operands(
 
 
 
-def _app_compat_summary(result: object) -> dict[str, Any]:
-    """Project an :class:`appcompat.AppCompatResult` into a small JSON-safe dict."""
-    return {
-        "app": result.app_path,  # type: ignore[attr-defined]
-        "verdict": result.verdict.value,  # type: ignore[attr-defined]
-        "required_symbol_count": result.required_symbol_count,  # type: ignore[attr-defined]
-        "missing_symbols": result.missing_symbols,  # type: ignore[attr-defined]
-        "missing_versions": result.missing_versions,  # type: ignore[attr-defined]
-        "relevant_change_count": len(result.breaking_for_app),  # type: ignore[attr-defined]
-        "symbol_coverage": round(result.symbol_coverage, 1),  # type: ignore[attr-defined]
-    }
-
-
-def _plugin_contract_summary(result: object) -> dict[str, Any]:
-    """Project a :class:`appcompat.PluginHostContractResult` into a small dict."""
-    return {
-        "verdict": result.verdict.value,  # type: ignore[attr-defined]
-        "required_entrypoints": sorted(result.required_entrypoints),  # type: ignore[attr-defined]
-        "missing_entrypoints": result.missing_entrypoints,  # type: ignore[attr-defined]
-        "relevant_change_count": len(result.breaking_for_host),  # type: ignore[attr-defined]
-        "coverage": round(result.coverage, 1),  # type: ignore[attr-defined]
-    }
-
-
-def _verdict_exit_code(verdict: object) -> int:
-    """Map a scoped-comparison Verdict to its floor exit code (ADR-043)."""
-    value = getattr(verdict, "value", verdict)
-    if value == "BREAKING":
-        return 4
-    if value == "API_BREAK":
-        return 2
-    return 0
-
-
-_VERDICT_SEVERITY_RANK = {
-    "BREAKING": 3, "API_BREAK": 2, "COMPATIBLE_WITH_RISK": 1,
-    "COMPATIBLE": 0, "NO_CHANGE": 0,
-}
-
-
-def _verdict_severity_rank(verdict: object) -> int:
-    """Rank a Verdict by severity, independent of any exit-code scheme.
-
-    Under a severity scheme, a BREAKING app can carry exit code 0 (e.g.
-    ``--severity-preset info-only``) -- ranking "worst app" by exit code
-    would then let a later COMPATIBLE app (also exit code 0) overwrite the
-    reported scoped verdict, so JSON/HTML/SARIF could claim COMPATIBLE while
-    an earlier --used-by summary is still BREAKING (Codex review). Verdict
-    selection for reporting must stay keyed on verdict severity, not on the
-    (independently correct) max-exit-code computation used for gating.
-    """
-    value = getattr(verdict, "value", verdict)
-    return _VERDICT_SEVERITY_RANK.get(value, 0) if isinstance(value, str) else 0
-
-
-def _scoped_exit_code(
-    scoped: Any, relevant_changes: list[Any],
-    result: Any, exit_code_scheme: str, sev_config: Any,
-    policy: str, policy_file: PolicyFile | None,
-    *, has_missing_contract: bool = False,
-) -> int:
-    """Compute a scoped result's exit code under the active exit-code scheme.
-
-    ADR-043's --used-by/--required-symbol(s) floor the exit code on the
-    *scoped* verdict rather than the full library's -- but that floor must
-    still respect ``--exit-code-scheme severity``/``--severity-*``: without
-    this, a scoped compare silently reverted to the legacy 0/2/4 mapping no
-    matter what severity configuration the caller passed, because the scoped
-    branch returned straight to ``sys.exit`` before the severity-aware exit
-    handler ever ran.
-
-    *has_missing_contract* (a required symbol/version/entrypoint absent from
-    the new library) floors the severity-scheme exit code separately from
-    *relevant_changes*: a missing contract symbol is BREAKING but is not a
-    diff ``Change``, so ``compute_exit_code`` never sees it and would
-    otherwise return 0 (Codex review).
-    """
-    if exit_code_scheme == "severity":
-        from .severity import compute_exit_code, missing_contract_exit_code
-
-        code = compute_exit_code(
-            relevant_changes, sev_config,
-            policy=policy,
-            kind_sets=result._effective_kind_sets(),
-            policy_file=policy_file,
-        )
-        if has_missing_contract:
-            code = max(code, missing_contract_exit_code(sev_config))
-        return code
-    return _verdict_exit_code(scoped.verdict)
-
-
-def _scoped_severity_summary(
-    relevant_changes: list[Any], missing: Iterable[str],
-    result: Any, sev_config: Any, policy: str, policy_file: PolicyFile | None,
-) -> tuple[tuple[str, ...], dict[str, int]]:
-    """(blocking_categories, per-category counts) for one scoped result.
-
-    Mirrors ``_scoped_exit_code``'s missing-contract floor: a missing
-    symbol/version/entrypoint with no matching diff Change is folded into
-    ``abi_breaking`` directly here -- both into the blocking-categories set
-    (when abi_breaking is severity-configured as error, matching the exit
-    -code floor) and into the count (always, since a count is a factual
-    tally, not a gate decision) -- otherwise a missing-contract-only scoped
-    BREAKING would report an empty ``blocking_categories`` alongside a
-    nonzero exit code, or a ``categories.abi_breaking.count`` of 0 alongside
-    a blocking ``abi_breaking`` category (Codex review). A *missing* entry
-    that already has a matching Change in *relevant_changes* (e.g. a removed
-    symbol is both "missing" from the new export table and a ``FUNC_REMOVED``
-    Change) is excluded via ``uncovered_missing_symbols`` -- otherwise that
-    single ABI break would be counted twice (Codex review follow-up).
-    """
-    from .appcompat import uncovered_missing_symbols
-    from .severity import (
-        IssueCategory,
-        SeverityLevel,
-        categorize_changes,
-        compute_gate_decision,
-    )
-
-    categorized = categorize_changes(
-        relevant_changes, policy=policy,
-        kind_sets=result._effective_kind_sets(), policy_file=policy_file,
-    )
-    counts = {
-        "abi_breaking": len(categorized.abi_breaking),
-        "potential_breaking": len(categorized.potential_breaking),
-        "quality_issues": len(categorized.quality_issues),
-        "addition": len(categorized.addition),
-    }
-    gate = compute_gate_decision(
-        relevant_changes, sev_config,
-        policy=policy, kind_sets=result._effective_kind_sets(), policy_file=policy_file,
-    )
-    categories = list(gate.blocking_categories)
-    uncovered = uncovered_missing_symbols(missing, relevant_changes)
-    if uncovered:
-        counts["abi_breaking"] += len(uncovered)
-        if (
-            sev_config.abi_breaking == SeverityLevel.ERROR
-            and IssueCategory.ABI_BREAKING.value not in categories
-        ):
-            categories.append(IssueCategory.ABI_BREAKING.value)
-    return tuple(categories), counts
-
-
-def _require_used_by_binary_evidence(
-    old_lib: Any, new_lib: Any, old_input: Path, new_input: Path,
-) -> None:
-    """Reject a ``--used-by`` run whose OLD/NEW side carries no binary evidence.
-
-    A real library path always qualifies; a JSON snapshot qualifies only when it
-    carries an ``elf``/``pe``/``macho`` block (i.e. it is a ``dump`` of a real
-    library, not a headers-only one) -- that is what supplies the SONAME/export
-    table/version list/PE ordinal table the scoping needs.
-    """
-    for lib, path, label in (
-        (old_lib, old_input, "OLD"), (new_lib, new_input, "NEW"),
-    ):
-        has_binary_evidence = isinstance(lib, Path) or any(
-            getattr(lib, field, None) is not None for field in ("elf", "pe", "macho")
-        )
-        if not has_binary_evidence:
-            raise click.UsageError(
-                f"--used-by requires OLD/NEW to be real library binaries, or "
-                f"JSON snapshots carrying binary evidence (a `dump` of a real "
-                f"library, not headers-only); {label} ({path}) is neither."
-            )
-
-
-def _apply_runtime_probe(
-    scoped: Any, app: Path, old_lib: Path, new_lib: Path,
-    suppression: Any, policy: str, policy_file: PolicyFile | None,
-) -> None:
-    """Run *app* against both libraries and fold a load regression into *scoped*.
-
-    ADR-044 P2 item 2. Mutates *scoped* in place: appends a
-    ``CONSUMER_RUNTIME_LOAD_FAILED`` finding (unless a suppression rule removes
-    it) and recomputes the app verdict, since ``scope_diff_to_app`` computed it
-    before this RISK-tier finding existed.
-    """
-    from .checker_policy import ChangeKind, ReachabilityState
-    from .diff_helpers import make_change
-    from .runtime_probe import run_runtime_probe
-
-    probe = run_runtime_probe(app, old_lib, new_lib)
-    regressed_symbol = probe.regressed_symbol
-    if not regressed_symbol:
-        return
-    # public_reachable=True (Codex review, fresh evidence, mirrors
-    # appcompat.scope_diff_to_app's identical fix for
-    # CONSUMER_REQUIRED_SYMBOL_REMOVED): this finding only exists
-    # because the dynamic linker itself failed to resolve a
-    # symbol for a real, executed --used-by consumer binary --
-    # left at the dataclass default (False), a broad
-    # namespace/source_location suppression rule's default
-    # "unreachable-only" reachability would read it as
-    # unreachable and silently suppress a runtime regression that
-    # is, by construction, always consumer-proven real.
-    runtime_change = make_change(
-        ChangeKind.CONSUMER_RUNTIME_LOAD_FAILED,
-        symbol=regressed_symbol,
-        name=app.name,
-        public_reachable=True,
-        reachability_kind="consumer_proven",
-        reachability_state=ReachabilityState.PROVEN_REACHABLE,
-    )
-    add_finding = suppression is None
-    if suppression is not None:
-        outcome = suppression.evaluate(runtime_change)
-        add_finding = not outcome.suppressed
-        # outcome.withheld_unknown_rule is never set here:
-        # runtime_change is always constructed with
-        # reachability_state=PROVEN_REACHABLE above (it is by
-        # construction consumer-proven), and
-        # would_withhold_unknown_reachability only ever fires on
-        # UNKNOWN.
-        if add_finding and outcome.withheld_rule is not None:
-            from .post_processing import _build_suppression_overreach_change
-
-            scoped.breaking_for_app.append(
-                _build_suppression_overreach_change(
-                    runtime_change, outcome.withheld_rule
-                )
-            )
-    if not add_finding:
-        return
-    scoped.breaking_for_app.append(runtime_change)
-    # scope_diff_to_app already computed scoped.verdict before
-    # this RISK-tier finding existed -- recompute so a clean
-    # static scope plus a runtime regression reports
-    # COMPATIBLE_WITH_RISK instead of a stale COMPATIBLE
-    # (Codex review).
-    from .appcompat import _compute_appcompat_verdict
-
-    scoped.verdict = _compute_appcompat_verdict(
-        scoped.missing_symbols, scoped.missing_versions,
-        scoped.breaking_for_app, scoped.required_symbol_count,
-        policy, policy_file,
-    )
-
-
-def _apply_used_by_scoping(
-    result: Any, used_by_apps: tuple[Path, ...],
-    old_input: Path, new_input: Path,
-    old_snapshot: Any, new_snapshot: Any,
-    policy: str, policy_file: PolicyFile | None,
-    exit_code_scheme: str = "legacy", sev_config: Any = None,
-    verify_runtime: bool = False,
-    suppression: Any = None,
-) -> int:
-    """Scope *result* to each ``--used-by`` app; worst-wins (ADR-043).
-
-    OLD/NEW may be real library binaries or JSON snapshots (e.g. a saved
-    ``dump`` output): a recognized binary is parsed directly; otherwise the
-    already-loaded snapshot (``old_snapshot``/``new_snapshot``, from
-    ``compare``'s own pipeline) is used instead, since a snapshot's
-    ``elf``/``pe``/``macho`` fields already carry the SONAME/export table/
-    version list/PE ordinal table :func:`~abicheck.appcompat.scope_diff_to_app`
-    needs. Attaches a JSON-safe summary to ``result.used_by`` for the
-    renderer and returns the worst app's exit code, computed under
-    *exit_code_scheme* (legacy verdict floor, or severity-aware over each
-    app's relevant changes when the caller passed --severity-*).
-
-    *verify_runtime* (ADR-044 P2 item 2) additionally runs each app once
-    against the old library and once against the new one
-    (:func:`~abicheck.runtime_probe.run_runtime_probe`) when both are real
-    binaries — a JSON-snapshot side has no file to execute against, so the
-    probe is silently skipped for that app, same as the static check's own
-    snapshot fallback degrades gracefully.
-
-    *suppression* (ADR-044 P2, Codex review) is forwarded to
-    :func:`~abicheck.appcompat.scope_diff_to_app` and also consulted here
-    directly for the ``CONSUMER_RUNTIME_LOAD_FAILED`` overlay: both findings
-    are synthesized *after* the pipeline's own suppression pass already ran
-    over ``result.changes``, so without this they would be unsuppressible
-    even by an exact rule.
-    """
-    from .appcompat import scope_diff_to_app
-    from .service import detect_binary_format
-
-    old_lib = old_input if detect_binary_format(old_input) is not None else old_snapshot
-    new_lib = new_input if detect_binary_format(new_input) is not None else new_snapshot
-
-    _require_used_by_binary_evidence(old_lib, new_lib, old_input, new_input)
-
-    from .appcompat import uncovered_missing_symbols
-    from .reporter import _finding_id
-
-    summaries = []
-    worst_exit = 0
-    worst_verdict = None
-    worst_verdict_rank = -1
-    # Keyed by the change's semantic identity (kind/symbol/old/new/location/
-    # description, via `_finding_id`) -- not id(change) -- so a Change or
-    # missing symbol shared by two tied apps (e.g. both import the same
-    # removed symbol) collapses to one entry instead of being tallied once
-    # per app (Codex review) -- `_scoped_severity_summary` runs once at the
-    # end over this deduplicated union, not per app summed together.
-    # `id()` alone under-deduplicates PE_ORDINAL_RETARGETED findings:
-    # `scope_diff_to_app` synthesizes a fresh `Change` object per app (via
-    # `_check_pe_ordinal_imports`), so two apps hitting the same ordinal
-    # retarget produce structurally-identical but object-distinct `Change`s
-    # that `id()` would double-count in the severity summary.
-    worst_changes: dict[str, Any] = {}
-    worst_missing: set[str] = set()
-    # Union across ALL apps (not just the worst-exit-code one) of which
-    # findings this --used-by gate actually cares about -- SARIF/JUnit
-    # consult this to make their own result levels/failure counts follow
-    # the scoped gate instead of the full, unscoped library diff (CLI-audit
-    # P1: "SARIF/JUnit computing pass/fail from the full library diff").
-    relevant_finding_ids: set[str] = set()
-    # Union across ALL apps of relevant Change objects, keyed by finding id --
-    # not just their ids -- so scoped-only changes (e.g. PE_ORDINAL_RETARGETED,
-    # which scope_diff_to_app synthesizes fresh per app and never adds to
-    # result.changes) can still be rendered by SARIF/JUnit instead of only
-    # contributing to the gate's exit code with nothing to explain it (Codex
-    # review).
-    relevant_changes_by_id: dict[str, Any] = {}
-    missing_labels: set[str] = set()
-    for app in used_by_apps:
-        scoped = scope_diff_to_app(
-            result, app, old_lib, new_lib,
-            policy=policy, policy_file=policy_file, suppression=suppression,
-            # ADR-057: old_lib above is the *path* whenever OLD is a real
-            # binary, and a path carries no L5 graph -- pass the snapshot
-            # compare's own pipeline already resolved so the consumer-impact
-            # join can explain why a consumer required a removed symbol.
-            # Graph lookup only; old_lib still owns every export/version read.
-            old_snapshot=old_snapshot,
-        )
-        if verify_runtime and isinstance(old_lib, Path) and isinstance(new_lib, Path):
-            _apply_runtime_probe(
-                scoped, app, old_lib, new_lib, suppression, policy, policy_file,
-            )
-        summaries.append(_app_compat_summary(scoped))
-        relevant_finding_ids.update(_finding_id(c) for c in scoped.breaking_for_app)
-        relevant_changes_by_id.update(
-            {_finding_id(c): c for c in scoped.breaking_for_app}
-        )
-        # A missing symbol/version already covered by a relevant Change (e.g.
-        # FUNC_REMOVED) must not also become a synthetic missing-contract
-        # finding -- that would double-report the same ABI break (Codex
-        # review, mirrors _scoped_severity_summary's own dedup below).
-        missing_labels.update(
-            uncovered_missing_symbols(
-                list(scoped.missing_symbols) + list(scoped.missing_versions),
-                scoped.breaking_for_app,
-            )
-        )
-        exit_code = _scoped_exit_code(
-            scoped, scoped.breaking_for_app, result, exit_code_scheme, sev_config,
-            policy, policy_file,
-            has_missing_contract=bool(scoped.missing_symbols or scoped.missing_versions),
-        )
-        # exit code (gating) and verdict (reporting) are maxed/ranked
-        # independently: under a severity scheme the two can disagree (a
-        # BREAKING app can carry exit code 0 under e.g. `--severity-preset
-        # info-only`), so picking the reported scoped_verdict by exit code
-        # could let a later, less-severe app overwrite an earlier BREAKING
-        # one merely because their exit codes tied at 0 (Codex review).
-        if exit_code_scheme == "severity":
-            if exit_code > worst_exit:
-                worst_changes = {_finding_id(c): c for c in scoped.breaking_for_app}
-                worst_missing = set(scoped.missing_symbols) | set(scoped.missing_versions)
-            elif exit_code == worst_exit:
-                worst_changes.update({_finding_id(c): c for c in scoped.breaking_for_app})
-                worst_missing |= set(scoped.missing_symbols) | set(scoped.missing_versions)
-        worst_exit = max(worst_exit, exit_code)
-        rank = _verdict_severity_rank(scoped.verdict)
-        if worst_verdict is None or rank >= worst_verdict_rank:
-            worst_verdict_rank = rank
-            worst_verdict = scoped.verdict
-    result.used_by = summaries  # type: ignore[attr-defined]
-    result.scoped_verdict = worst_verdict  # type: ignore[attr-defined]
-    result.scoped_exit_code = worst_exit  # type: ignore[attr-defined]
-    result.scoped_exit_code_scheme = exit_code_scheme  # type: ignore[attr-defined]
-    result.gate_scope = "used_by"  # type: ignore[attr-defined]
-    result.scoped_relevant_finding_ids = frozenset(relevant_finding_ids)  # type: ignore[attr-defined]
-    result.scoped_missing_labels = tuple(sorted(missing_labels))  # type: ignore[attr-defined]
-    _existing_ids = {_finding_id(c) for c in result.changes}
-    result.scoped_only_changes = tuple(  # type: ignore[attr-defined]
-        c for fid, c in relevant_changes_by_id.items() if fid not in _existing_ids
-    )
-    if exit_code_scheme == "severity":
-        categories, counts = _scoped_severity_summary(
-            list(worst_changes.values()), worst_missing,
-            result, sev_config, policy, policy_file,
-        )
-        result.scoped_blocking_categories = categories  # type: ignore[attr-defined]
-        result.scoped_severity_counts = counts  # type: ignore[attr-defined]
-    return worst_exit
-
-
-def _apply_required_symbol_scoping(
-    result: Any, required_symbols: tuple[str, ...],
-    old: Any, new: Any,
-    policy: str, policy_file: PolicyFile | None,
-    exit_code_scheme: str = "legacy", sev_config: Any = None,
-) -> int:
-    """Scope *result* to an explicit ``--required-symbol(s)`` contract (ADR-043)."""
-    from .appcompat import scope_diff_to_required_symbols, uncovered_missing_symbols
-    from .reporter import _finding_id
-
-    scoped = scope_diff_to_required_symbols(
-        result, old, new, required_symbols,
-        policy=policy, policy_file=policy_file,
-    )
-    result.required_symbols = _plugin_contract_summary(scoped)  # type: ignore[attr-defined]
-    result.scoped_verdict = scoped.verdict  # type: ignore[attr-defined]
-    result.gate_scope = "required_symbol"  # type: ignore[attr-defined]
-    result.scoped_relevant_finding_ids = frozenset(  # type: ignore[attr-defined]
-        _finding_id(c) for c in scoped.breaking_for_host
-    )
-    # An entrypoint already covered by a relevant Change must not also
-    # become a synthetic missing-contract finding (Codex review, mirrors
-    # _apply_used_by_scoping's identical dedup).
-    result.scoped_missing_labels = tuple(sorted(  # type: ignore[attr-defined]
-        uncovered_missing_symbols(scoped.missing_entrypoints, scoped.breaking_for_host)
-    ))
-    # Scoped-only changes: relevant to the host contract but never added to
-    # result.changes (mirrors _apply_used_by_scoping's identical handling).
-    _existing_ids = {_finding_id(c) for c in result.changes}
-    result.scoped_only_changes = tuple(  # type: ignore[attr-defined]
-        c for c in scoped.breaking_for_host if _finding_id(c) not in _existing_ids
-    )
-    exit_code = _scoped_exit_code(
-        scoped, scoped.breaking_for_host, result, exit_code_scheme, sev_config,
-        policy, policy_file,
-        has_missing_contract=bool(scoped.missing_entrypoints),
-    )
-    result.scoped_exit_code = exit_code  # type: ignore[attr-defined]
-    result.scoped_exit_code_scheme = exit_code_scheme  # type: ignore[attr-defined]
-    if exit_code_scheme == "severity":
-        categories, counts = _scoped_severity_summary(
-            scoped.breaking_for_host, scoped.missing_entrypoints,
-            result, sev_config, policy, policy_file,
-        )
-        result.scoped_blocking_categories = categories  # type: ignore[attr-defined]
-        result.scoped_severity_counts = counts  # type: ignore[attr-defined]
-    return exit_code
-
-
 def _render_compare_dry_run(
     *,
     old_input: Path, new_input: Path,
@@ -1072,6 +642,539 @@ def _preflight_manifests_and_audit(
     return old_manifest_obj, new_manifest_obj
 
 
+def _resolve_required_symbol_policy(
+    ctx: click.Context, policy: str, required_symbols: tuple[str, ...],
+    required_symbols_from_file: tuple[str, ...],
+    required_symbols_file: Path | None, required_symbols_sha: str | None,
+) -> tuple[str, str | None, Path | None, str | None]:
+    """Pick ``policy`` for a ``--required-symbol`` contract, and say what picked it.
+
+    Required-symbol contracts default to the plugin-oriented policy unless the
+    user explicitly picked one -- an explicit ``--policy`` always wins (ADR-043).
+    Recorded, not just applied: the ADR-049 receipt has to name whatever really
+    selected ``policy.base``, and this value was chosen by a typed
+    ``--required-symbol`` rather than by ``--policy`` or a built-in default
+    (Codex review, fresh evidence -- the receipt claimed ``strict_abi`` for a run
+    that used ``plugin_abi``).
+
+    Which spelling actually *contributed* decides what the receipt names -- not
+    merely which was passed. A ``--required-symbols FILE`` run never passed
+    ``--required-symbol``, so naming the inline flag fabricates a selector; but a
+    file that parsed to nothing selected nothing either, so naming it for a
+    ``--required-symbol api_b --required-symbols empty.txt`` run omits the option
+    that really made the contract non-empty (Codex review, two rounds). The file
+    form wins when it contributed, since it is then both true and the one
+    carrying a path and digest to audit.
+
+    Returns ``(policy, selected_by, selected_path, selected_sha)``.
+    """
+    if not required_symbols or (
+        ctx.get_parameter_source("policy") == click.core.ParameterSource.COMMANDLINE
+    ):
+        return policy, None, None, None
+    if required_symbols_from_file:
+        return (
+            "plugin_abi", "--required-symbols",
+            required_symbols_file, required_symbols_sha,
+        )
+    return "plugin_abi", "--required-symbol", None, None
+
+
+def _reject_manifest_header_conflicts(
+    old_manifest_obj: Any, new_manifest_obj: Any, old_h: Any, new_h: Any,
+) -> None:
+    """``--dump-manifest <side>=`` and that side's ``-H`` are mutually exclusive."""
+    for manifest, side_headers, side in (
+        (old_manifest_obj, old_h, "old"), (new_manifest_obj, new_h, "new"),
+    ):
+        if manifest is not None and side_headers:
+            raise click.UsageError(
+                f"--dump-manifest {side}=... and a header for the {side} side "
+                "(-H/--header) are mutually exclusive -- declare the "
+                f"{side} side's public surface in the manifest's own base "
+                "profile instead."
+            )
+
+
+def _reject_manifest_non_elf(
+    old_manifest_obj: Any, new_manifest_obj: Any,
+    old_fmt: str | None, new_fmt: str | None,
+) -> None:
+    """``--dump-manifest`` extraction is wired for ELF only (ADR-050 D3)."""
+    for manifest, fmt, side in (
+        (old_manifest_obj, old_fmt, "old"), (new_manifest_obj, new_fmt, "new"),
+    ):
+        if manifest is not None and fmt != "elf":
+            raise click.UsageError(
+                f"--dump-manifest {side}=... requires the {side} input to be an "
+                f"ELF binary (ADR-050 D3); got {fmt or 'a non-binary input'}."
+            )
+
+
+def _apply_scoped_gating(
+    result: Any, old: Any, new: Any, policy: str, pf: PolicyFile | None,
+    *,
+    used_by_apps: tuple[Path, ...], required_symbols: tuple[str, ...],
+    used_by_old_input: Path, used_by_new_input: Path,
+    exit_code_scheme: str, sev_config: Any,
+    verify_runtime: bool, suppression: Any,
+) -> int | None:
+    """Apply whichever ADR-043 scoped gate this run selected, if any.
+
+    ``--used-by`` and ``--required-symbol`` are mutually exclusive (rejected
+    earlier), so at most one applies. Returns the scoped exit code, or ``None``
+    when the run is unscoped and the full-library verdict gates instead.
+    """
+    if used_by_apps:
+        return _apply_used_by_scoping(
+            result, used_by_apps, used_by_old_input, used_by_new_input, old, new,
+            policy, pf,
+            exit_code_scheme=exit_code_scheme, sev_config=sev_config,
+            verify_runtime=verify_runtime, suppression=suppression,
+        )
+    if required_symbols:
+        return _apply_required_symbol_scoping(
+            result, required_symbols, old, new, policy, pf,
+            exit_code_scheme=exit_code_scheme, sev_config=sev_config,
+        )
+    return None
+
+
+def _embed_inline_source_sides(
+    ctx: click.Context, *,
+    old_input: Path, new_input: Path,
+    old_sources: Path | None, new_sources: Path | None,
+    old_build_info: Path | None, new_build_info: Path | None,
+    old_h: Any, new_h: Any, old_inc: Any, new_inc: Any,
+    old_version: str, new_version: str, lang: str,
+    header_backend: str,
+    old_header_backend: str | None, new_header_backend: str | None,
+    compile_context: Any,
+    follow_deps: bool, search_paths: tuple[Path, ...], ld_library_path: str,
+    dwarf_only: bool, effective_debug_format: str | None,
+    pdb_path: Path | None, old_pdb_path: Path | None, new_pdb_path: Path | None,
+    resolved_old_debug: Any, resolved_new_debug: Any,
+    debuginfod: bool, debuginfod_url: str | None,
+    collect_mode: str, depth: str | None,
+    include_labels: dict[Path, str] | None,
+    include_dependencies: bool,
+) -> tuple[Path, Path | None, Path | None, Path, Path | None, Path | None]:
+    """Dump each raw source/build-dir side inline, returning the rewritten inputs.
+
+    Inline source-tree collection (deep-compare folded into compare): when a
+    side's ``--old/new-sources`` points at a raw checkout, or
+    ``--old/new-build-info`` at a raw build dir / ``compile_commands.json`` (not
+    a ``collect`` pack), dump that side at ``--depth`` so its L3-L5 facts ride
+    embedded in the snapshot, the way the standalone deep-compare command used
+    to. Pre-built packs fall through unchanged to
+    ``prepare_embedded_build_source``.
+
+    Returns ``(old_input, old_sources, old_build_info, new_input, new_sources,
+    new_build_info)`` -- an embedded side has its input rewritten to a temporary
+    JSON snapshot.
+    """
+    # G29 Phase A: the L2 header-only semantic graph is no longer a flag
+    # a user can request here, so there is nothing to reject loudly. The
+    # inline dump below runs through `dump_cmd` (which has no L2-graph
+    # attach step of its own — that only lives on compare's own
+    # resolve_input calls / dump's own perform_elf_dump/
+    # handle_non_elf_dump path), and the rewritten old_input/new_input
+    # become a temporary JSON snapshot that _resolve_compare_snapshots
+    # below loads via resolve_input's JSON branch, which never attaches
+    # a graph either. So a raw --old/new-sources tree or raw
+    # --old/new-build-info combination structurally skips the L2 graph
+    # (silent, not_collected) — same behavior as before this change,
+    # just without a flag to have explicitly asked for it. See
+    # docs/contribute/plans/g31-header-graph-default-on-followup.md for
+    # extending graph coverage to this path.
+    import shutil
+    import tempfile
+
+    # CLI-over-config explicitness read from compare's *real* ctx (where
+    # --ast-frontend/--nostdinc are genuine COMMANDLINE params); the inline
+    # dump runs under ctx.invoke where that signal is lost, so we compute it
+    # here and thread it through (Codex review). A per-side --old/new-ast-frontend
+    # is itself an explicit frontend for that side.
+    _nostdinc_explicit = (
+        ctx.get_parameter_source("nostdinc")
+        == click.core.ParameterSource.COMMANDLINE
+    )
+    _frontend_explicit = (
+        ctx.get_parameter_source("header_backend")
+        == click.core.ParameterSource.COMMANDLINE
+    )
+
+    _src_tmp = tempfile.mkdtemp(prefix="abicheck-compare-src-")
+    # Cleanup on context teardown so the temp dir never leaks, even if an
+    # inline dump or _resolve_compare_snapshots raises before we return.
+    ctx.call_on_close(lambda: shutil.rmtree(_src_tmp, ignore_errors=True))
+    old_input, old_sources, old_build_info = _embed_inline_source_side(
+        ctx, input_path=old_input, sources=old_sources,
+        headers=old_h, includes=old_inc, version=old_version, lang=lang,
+        header_backend=old_header_backend or header_backend,
+        compile_context=compile_context,
+        frontend_explicit=_frontend_explicit or old_header_backend is not None,
+        # A nostdinc already resolved True (from --config) must survive the
+        # tree-config merge even when the tree omits it (Codex review); False
+        # is the default and indistinguishable from "unset", so only True needs
+        # preserving.
+        nostdinc_explicit=_nostdinc_explicit or compile_context.nostdinc,
+        build_info=old_build_info,
+        follow_deps=follow_deps, search_paths=search_paths,
+        ld_library_path=ld_library_path,
+        dwarf_only=dwarf_only, debug_format=effective_debug_format,
+        pdb_path=old_pdb_path or pdb_path,
+        debug_roots=tuple(resolved_old_debug),
+        debuginfod=debuginfod, debuginfod_url=debuginfod_url,
+        collect_mode=collect_mode, out_dir=Path(_src_tmp), label="old",
+        depth=depth, include_labels=include_labels,
+        include_dependencies=include_dependencies,
+    )
+    new_input, new_sources, new_build_info = _embed_inline_source_side(
+        ctx, input_path=new_input, sources=new_sources,
+        headers=new_h, includes=new_inc, version=new_version, lang=lang,
+        header_backend=new_header_backend or header_backend,
+        compile_context=compile_context,
+        frontend_explicit=_frontend_explicit or new_header_backend is not None,
+        nostdinc_explicit=_nostdinc_explicit or compile_context.nostdinc,
+        build_info=new_build_info,
+        follow_deps=follow_deps, search_paths=search_paths,
+        debug_roots=tuple(resolved_new_debug),
+        debuginfod=debuginfod, debuginfod_url=debuginfod_url,
+        ld_library_path=ld_library_path,
+        dwarf_only=dwarf_only, debug_format=effective_debug_format,
+        pdb_path=new_pdb_path or pdb_path,
+        collect_mode=collect_mode, out_dir=Path(_src_tmp), label="new",
+        depth=depth, include_labels=include_labels,
+        include_dependencies=include_dependencies,
+    )
+    return (
+        old_input, old_sources, old_build_info,
+        new_input, new_sources, new_build_info,
+    )
+
+
+def _resolve_evaluation_config(
+    ctx: click.Context, *,
+    resolved_cfg: Any, project_cfg: Any, cfg_path: Path | None, cfg_sha: str | None,
+    policy: str, policy_file_path: Path | None, policy_file: PolicyFile | None,
+    suppression: Any, suppress: Path | None, symbols_list: Any,
+    contract_mode: str | None, contract_evaluation: bool,
+    scope_public_headers: bool,
+    public_symbols: tuple[str, ...], public_symbols_list: Path | None,
+    require_justification: bool,
+    exit_code_scheme: str | None, severity_preset: str | None,
+    severity_abi_breaking: str | None, severity_potential_breaking: str | None,
+    severity_quality_issues: str | None, severity_addition: str | None,
+    pack_paths: tuple[Path, ...],
+    policy_selected_by: str | None, policy_selected_path: Path | None,
+    policy_selected_sha: str | None,
+) -> tuple[Any, PolicyFile | None, Any]:
+    """Resolve this invocation's ADR-049 configuration and apply its packs.
+
+    Returns ``(evaluation_config, policy_file, resolved_cfg)``. A D7 same-tier
+    conflict, a D8 pack conflict, or an inapplicable manifest is a usage error
+    -- the exit code the resolver leaves to its front end.
+    """
+    pf = policy_file
+    # ADR-049: one resolved configuration for this invocation -- the receipt
+    # the report carries *and*, since D8's `--pack` landed, the thing that
+    # configures the run (hence: before the comparison). Built from the raw
+    # CLI values, not the already-merged locals several of these were
+    # overwritten with above -- the resolver merges them itself, and a
+    # pre-merged value would look CLI-stated.
+    from .cli_compare_receipt import resolve_and_apply, typed_parameter_names
+    from .cli_options import RUN_PROFILE_META_KEY as _RUN_PROFILE_META_KEY
+    from .compatibility_evaluation_resolver import (
+        FieldResolutionError,
+        PackConflictError,
+    )
+    from .errors import PackManifestError
+
+    try:
+        evaluation_config, pf, resolved_cfg = resolve_and_apply(
+            {
+                "contract_mode": contract_mode,
+                "scope_public_headers": scope_public_headers,
+                "policy": policy,
+                "policy_file_path": policy_file_path,
+                "public_symbols": public_symbols,
+                "public_symbols_list": public_symbols_list,
+                "suppress": suppress,
+                "require_justification": require_justification,
+                "exit_code_scheme": exit_code_scheme,
+                "severity_preset": severity_preset,
+                "severity_abi_breaking": severity_abi_breaking,
+                "severity_potential_breaking": severity_potential_breaking,
+                "severity_quality_issues": severity_quality_issues,
+                "severity_addition": severity_addition,
+                "pack_paths": pack_paths,
+            },
+            resolved_cfg=resolved_cfg,
+            policy=policy,
+            contract_evaluation=contract_evaluation,
+            # Only this module holds the Click context, so it answers "did the
+            # user type this?" and hands the answers over as data -- which is
+            # what keeps `cli_compare_receipt` a leaf.
+            typed={n for n in typed_parameter_names() if _param_from_cli(n)},
+            project_cfg=project_cfg,
+            project_path=cfg_path,
+            # Both already loaded for the comparison itself; re-reading them
+            # here could pair one content's digest with another's rules.
+            policy_file=pf,
+            suppression=suppression,
+            suppress_path=suppress,
+            run_profile=ctx.meta.get(_RUN_PROFILE_META_KEY),
+            policy_option=policy_selected_by,
+            policy_path=policy_selected_path,
+            policy_sha256=policy_selected_sha,
+            project_sha256=cfg_sha,
+            symbols_list=symbols_list,
+        )
+    except (FieldResolutionError, PackConflictError, PackManifestError) as exc:
+        # A D7 same-tier conflict / D8 pack conflict / inapplicable manifest
+        # is a usage error, the exit code the resolver leaves to its front end.
+        raise click.UsageError(str(exc)) from exc
+    return evaluation_config, pf, resolved_cfg
+
+
+def _render_compare_report(
+    result: Any, old: Any, new: Any, *,
+    fmt: str, follow_deps: bool, show_only: str | None, report_mode: str,
+    show_impact: bool, stat: bool, severity_config: Any,
+    recommend: bool, demangle: bool, contract_evaluation: bool,
+    old_build_info: Path | None, new_build_info: Path | None,
+    old_sources: Path | None, new_sources: Path | None,
+) -> str:
+    """Render one compare report and fold every post-render section into it.
+
+    The primary (``--format``) and secondary (``--secondary-format``) renders
+    run the identical four-step pipeline and differ only in their arguments, so
+    they share this one function rather than keeping two copies that can drift.
+    """
+    text = _render_output(
+        fmt, result, old, new,
+        follow_deps=follow_deps,
+        show_only=show_only, report_mode=report_mode,
+        show_impact=show_impact, stat=stat,
+        severity_config=severity_config,
+        show_recommendation=recommend,
+        demangle=demangle,
+        contract_evaluation=contract_evaluation,
+    )
+    text = _fold_scoped_compat_into_text(
+        text, fmt, result,
+        severity_config=severity_config,
+        show_only=show_only, report_mode=report_mode,
+        contract_evaluation=contract_evaluation,
+    )
+    text = _fold_suppression_audit_into_text(
+        text, fmt, getattr(result, "suppression_audit", None)
+    )
+    return _fold_evidence_depth_into_json(
+        text, fmt, old, new,
+        old_build_info=old_build_info, new_build_info=new_build_info,
+        old_sources=old_sources, new_sources=new_sources,
+    )
+
+
+def _attach_suppression_audit(result: Any, suppression: Any) -> None:
+    """Attach the ``--audit-suppressions`` audit trail to *result*.
+
+    Guarded above: audit_suppressions=True implies suppression is not
+    None. Audited against the full pre-suppression change set (kept +
+    suppressed) plus any --used-by/--required-symbol scoped_only_changes
+    (Codex review, fresh evidence: run *after* scoping, not before, so a
+    rule matching only a scoping-synthesized finding like
+    CONSUMER_REQUIRED_SYMBOL_REMOVED isn't misreported as stale). Not a
+    complete fix: scope_diff_to_app/scope_diff_to_required_symbols apply
+    suppression internally to their own candidates before this ever
+    sees them, so a rule matching only a scoping candidate suppression
+    itself already dropped (never reaching scoped_only_changes at all)
+    is still invisible here -- closing that needs those functions to
+    expose their own pre-suppression candidate list, a separate,
+    larger change to appcompat.py this fix does not attempt.
+    """
+    assert suppression is not None
+    # Codex review, fresh evidence: pass the *effective*, policy-override-
+    # applied breaking set (not the static BREAKING_KINDS default) so a
+    # rule's "high risk" classification matches the verdict this run's
+    # own --policy-file would actually produce, e.g. a rule suppressing
+    # a kind the policy promoted to BREAKING is reported as high-risk
+    # even though it isn't in the built-in BREAKING_KINDS.
+    effective_breaking_kinds, _, _, _ = result._effective_kind_sets()
+    result.suppression_audit = suppression.audit(  # type: ignore[attr-defined]
+        list(result.changes)
+        + list(result.suppressed_changes)
+        + list(getattr(result, "scoped_only_changes", ()) or ()),
+        breaking_kinds=effective_breaking_kinds,
+    )
+
+
+def _reject_flags_unsupported_for_set_inputs(
+    ctx: click.Context, project_cfg: Any, *,
+    exit_code_scheme: str | None, reconcile_build_context: bool,
+    env_matrix_path: Path | None, secondary_fmt: str | None,
+    used_by_apps: tuple[Path, ...], required_symbols: tuple[str, ...],
+    diagnostic_comparison: bool, audit_suppressions: bool,
+    pack_paths: tuple[Path, ...], include_labels: dict[Path, str] | None,
+) -> None:
+    """Reject the single-pair-only flags on a directory/package compare.
+
+    The per-library fan-out (``compare-release`` backend) consumes the
+    resolved scheme from config but has no public CLI support for these
+    flags on set inputs -- reject them loudly (ADR-037 D12). Validated ahead
+    of the ``--dry-run`` emit (not just before the real dispatch) so a dry
+    run can't report "ok" for a flag combination the real run would then
+    reject (Codex review).
+    """
+    # The per-library fan-out (`compare-release` backend) consumes the
+    # resolved scheme from config but has no public CLI support for these
+    # single-pair-only flags on set inputs — reject them loudly (ADR-037 D12).
+    # Validated ahead of the --dry-run emit below (not just before the real
+    # dispatch) so a dry run can't report "ok" for a flag combination the
+    # real run would then reject (Codex review).
+    _reject_set_input_flags(
+        exit_code_scheme, reconcile_build_context, env_matrix_path, secondary_fmt,
+        used_by_apps=used_by_apps, required_symbols=required_symbols,
+        diagnostic_comparison=diagnostic_comparison,
+        audit_suppressions=audit_suppressions,
+        pack_paths=pack_paths,
+        include_labels=include_labels,
+    )
+    _reject_compile_context_for_set_inputs(ctx, project_cfg)
+    _reject_evidence_flags_for_set_inputs(ctx)
+
+
+def _report_compare_result(
+    ctx: click.Context, result: Any, old: Any, new: Any, *,
+    old_input: Path, new_input: Path,
+    resolved_cfg: Any, evaluation_config: Any,
+    sev_config: Any, report_severity: Any,
+    layer_coverage_rows: Any, evidence_metrics: Any, extra_changes: Any,
+    explain_patterns: bool,
+    show_redundant: bool, show_filtered: bool,
+    annotate: bool, annotate_additions: bool,
+    contract_evaluation: bool,
+    policy: str, pf: PolicyFile | None,
+    used_by_apps: tuple[Path, ...], required_symbols: tuple[str, ...],
+    used_by_old_input: Path, used_by_new_input: Path,
+    verify_runtime: bool, suppression: Any, audit_suppressions: bool,
+    fmt: str, output: Path | None, show_only: str | None, report_mode: str,
+    show_impact: bool, stat: bool, recommend: bool,
+    demangle: bool, demangle_explicit: bool | None, follow_deps: bool,
+    secondary_fmt: str | None, secondary_output: Path | None,
+    old_build_info: Path | None, new_build_info: Path | None,
+    old_sources: Path | None, new_sources: Path | None,
+) -> None:
+    """Everything after the comparison: annotate, scope, render, exit.
+
+    ``run_compare``'s third phase (resolve -> compare -> report), split out so
+    each reads as one job. Terminal: ends in
+    :func:`_exit_with_severity_or_verdict`, which never returns.
+    """
+    from .cli_buildsource import attach_evidence_metrics
+    from .cli_compare_receipt import record_resolved_config
+
+    record_resolved_config(result, resolved_cfg, evaluation_config)
+    if layer_coverage_rows:
+        result.layer_coverage = layer_coverage_rows
+    # Pass all injected findings (probe-matrix + evidence) so artifact-backed
+    # excludes them — none come from L0-L2 diffing.
+    attach_evidence_metrics(result, evidence_metrics, extra_changes or [])
+
+    if explain_patterns:
+        echo_pattern_modulations(result)
+
+    _finalize_compare_result(
+        result, old_input, new_input,
+        show_redundant=show_redundant, show_filtered=show_filtered,
+        annotate=annotate, annotate_additions=annotate_additions,
+        severity_config=report_severity,
+        contract_evaluation=contract_evaluation,
+    )
+
+    scoped_exit_code = _apply_scoped_gating(
+        result, old, new, policy, pf,
+        used_by_apps=used_by_apps, required_symbols=required_symbols,
+        used_by_old_input=used_by_old_input, used_by_new_input=used_by_new_input,
+        exit_code_scheme=resolved_cfg.exit_code_scheme, sev_config=sev_config,
+        verify_runtime=verify_runtime, suppression=suppression,
+    )
+
+    if audit_suppressions:
+        _attach_suppression_audit(result, suppression)
+
+    # ADR-049 Phase 3 (Codex review, fresh evidence): --used-by/
+    # --required-symbol scoping above can add scoped_only_changes (fresh
+    # Change objects scope_diff_to_app/scope_diff_to_required_symbols
+    # synthesize, e.g. PE_ORDINAL_RETARGETED) and mark existing
+    # result.changes entries as relevant to the scoped contract -- neither
+    # ever passes through checker._apply_contract_evaluation_shadow, so
+    # both stayed permanently unstamped even when --contract-evaluation was
+    # given. This must run before _render_output below serializes
+    # result.changes, and mirrors the identical fix already applied to the
+    # MCP abi_compare tool (mcp_server.py) -- both share the same traversal
+    # (CodeRabbit review: hand-copying it here previously let one call site
+    # drift out of sync with the other).
+    if contract_evaluation:
+        from .reporter import _finding_id
+
+        stamp_scoped_result_findings(result, finding_id=_finding_id)
+
+    _write_or_echo(
+        output,
+        _render_compare_report(
+            result, old, new, fmt=fmt,
+            follow_deps=follow_deps, show_only=show_only, report_mode=report_mode,
+            show_impact=show_impact, stat=stat, severity_config=report_severity,
+            recommend=recommend, demangle=demangle,
+            contract_evaluation=contract_evaluation,
+            old_build_info=old_build_info, new_build_info=new_build_info,
+            old_sources=old_sources, new_sources=new_sources,
+        ),
+    )
+
+    if secondary_fmt is not None:
+        # Always the full, unfiltered report — ignores --show-only/--stat
+        # (which describe the *primary* format's display) and forces
+        # report_mode="full" (not the primary's --report-mode leaf) so a
+        # --secondary-* consumer (e.g. a CI action rendering a PR-comment
+        # JSON from a markdown-format primary run) sees the complete change
+        # set the gate actually acted on, not whatever the primary format
+        # chose to filter or group down to. Reuses the same already-computed
+        # `result` — no second comparison run.
+        # Resolve demangle against secondary_fmt, not the primary-resolved
+        # value above — otherwise a machine primary format (e.g. json) paired
+        # with a markdown/review secondary format would wrongly inherit
+        # demangle=False into the secondary render (Codex review, PR #557).
+        _write_or_echo(
+            secondary_output,
+            _render_compare_report(
+                result, old, new, fmt=secondary_fmt,
+                follow_deps=follow_deps, show_only=None, report_mode="full",
+                show_impact=show_impact, stat=False,
+                severity_config=report_severity,
+                recommend=recommend,
+                demangle=_resolve_demangle(secondary_fmt, demangle_explicit),
+                contract_evaluation=contract_evaluation,
+                old_build_info=old_build_info, new_build_info=new_build_info,
+                old_sources=old_sources, new_sources=new_sources,
+            ),
+        )
+
+    if scoped_exit_code is not None:
+        # ADR-043: --used-by / --required-symbol(s) scope the primary verdict
+        # to the application/plugin-host contract, floored at the worst
+        # scoped result -- the full library verdict stays informational only.
+        # ADR-049 §7's coverage axis is orthogonal to that scoping.
+        announce_coverage_floor(result, base_exit=scoped_exit_code, fmt=fmt, stat=stat, secondary_fmt=secondary_fmt)
+        sys.exit(fold_coverage_exit(scoped_exit_code, result))
+
+    _announce_exit_scheme(resolved_cfg.exit_code_scheme, fmt=fmt, stat=stat)
+    _exit_with_severity_or_verdict(result, sev_config, resolved_cfg.exit_code_scheme, fmt, stat, secondary_fmt)
+
+
 def run_compare(
     ctx: click.Context,
     *,
@@ -1171,33 +1274,12 @@ def run_compare(
             "exclusive: scope the comparison to either application imports or "
             "an explicit required-symbol contract, not both."
         )
-    # Required-symbol contracts default to the plugin-oriented policy unless the
-    # user explicitly picked one -- an explicit --policy always wins (ADR-043).
-    # Recorded, not just applied: the ADR-049 receipt has to name whatever
-    # really selected `policy.base`, and this value was chosen by a typed
-    # `--required-symbol` rather than by `--policy` or a built-in default
-    # (Codex review, fresh evidence -- the receipt claimed `strict_abi` for a
-    # run that used `plugin_abi`).
-    # Which spelling actually *contributed* decides what the receipt names --
-    # not merely which was passed. A `--required-symbols FILE` run never
-    # passed `--required-symbol`, so naming the inline flag fabricates a
-    # selector; but a file that parsed to nothing selected nothing either, so
-    # naming it for a `--required-symbol api_b --required-symbols empty.txt`
-    # run omits the option that really made the contract non-empty (Codex
-    # review, two rounds). The file form wins when it contributed, since it is
-    # then both true and the one carrying a path and digest to audit.
-    policy_selected_by: str | None = None
-    policy_selected_path: Path | None = None
-    policy_selected_sha: str | None = None
-    if required_symbols and ctx.get_parameter_source("policy") != click.core.ParameterSource.COMMANDLINE:
-        policy = "plugin_abi"
-        if required_symbols_from_file:
-            policy_selected_by = "--required-symbols"
-            policy_selected_path = required_symbols_file
-            policy_selected_sha = required_symbols_sha
-        else:
-            policy_selected_by = "--required-symbol"
-
+    policy, policy_selected_by, policy_selected_path, policy_selected_sha = (
+        _resolve_required_symbol_policy(
+            ctx, policy, required_symbols,
+            required_symbols_from_file, required_symbols_file, required_symbols_sha,
+        )
+    )
     # ADR-037 D4: load the project config and merge CLI flags over it
     # (precedence CLI > config > built-in default) *before* dispatch, so both the
     # single-file and the directory/package fan-out paths share one resolution.
@@ -1250,22 +1332,17 @@ def run_compare(
     old_kind, new_kind = _classify_and_reject_operands(old_input, new_input)
 
     if {old_kind, new_kind} & {"directory", "package"}:
-        # The per-library fan-out (`compare-release` backend) consumes the
-        # resolved scheme from config but has no public CLI support for these
-        # single-pair-only flags on set inputs — reject them loudly (ADR-037 D12).
-        # Validated ahead of the --dry-run emit below (not just before the real
-        # dispatch) so a dry run can't report "ok" for a flag combination the
-        # real run would then reject (Codex review).
-        _reject_set_input_flags(
-            exit_code_scheme, reconcile_build_context, env_matrix_path, secondary_fmt,
+        _reject_flags_unsupported_for_set_inputs(
+            ctx, project_cfg,
+            exit_code_scheme=exit_code_scheme,
+            reconcile_build_context=reconcile_build_context,
+            env_matrix_path=env_matrix_path, secondary_fmt=secondary_fmt,
             used_by_apps=used_by_apps, required_symbols=required_symbols,
             diagnostic_comparison=diagnostic_comparison,
             audit_suppressions=audit_suppressions,
             pack_paths=pack_paths,
             include_labels=include_labels,
         )
-        _reject_compile_context_for_set_inputs(ctx, project_cfg)
-        _reject_evidence_flags_for_set_inputs(ctx)
 
     # Parsed after the directory/package rejection above (not before, like an
     # earlier revision of this function did): a malformed --dump-manifest on
@@ -1402,18 +1479,7 @@ def run_compare(
         headers, includes, old_headers_only, new_headers_only,
         old_includes_only, new_includes_only,
     )
-    if old_manifest_obj is not None and old_h:
-        raise click.UsageError(
-            "--dump-manifest old=... and a header for the old side "
-            "(-H/--header) are mutually exclusive -- declare the old side's "
-            "public surface in the manifest's own base profile instead."
-        )
-    if new_manifest_obj is not None and new_h:
-        raise click.UsageError(
-            "--dump-manifest new=... and a header for the new side "
-            "(-H/--header) are mutually exclusive -- declare the new side's "
-            "public surface in the manifest's own base profile instead."
-        )
+    _reject_manifest_header_conflicts(old_manifest_obj, new_manifest_obj, old_h, new_h)
     if config_includes:
         old_inc = list(old_inc) + list(config_includes)
         new_inc = list(new_inc) + list(config_includes)
@@ -1439,79 +1505,29 @@ def run_compare(
     # the standalone deep-compare command used to. Pre-built packs fall through
     # unchanged to prepare_embedded_build_source below.
     if _needs_inline_embed(old_sources, new_sources, old_build_info, new_build_info):
-        # G29 Phase A: the L2 header-only semantic graph is no longer a flag
-        # a user can request here, so there is nothing to reject loudly. The
-        # inline dump below runs through `dump_cmd` (which has no L2-graph
-        # attach step of its own — that only lives on compare's own
-        # resolve_input calls / dump's own perform_elf_dump/
-        # handle_non_elf_dump path), and the rewritten old_input/new_input
-        # become a temporary JSON snapshot that _resolve_compare_snapshots
-        # below loads via resolve_input's JSON branch, which never attaches
-        # a graph either. So a raw --old/new-sources tree or raw
-        # --old/new-build-info combination structurally skips the L2 graph
-        # (silent, not_collected) — same behavior as before this change,
-        # just without a flag to have explicitly asked for it. See
-        # docs/contribute/plans/g31-header-graph-default-on-followup.md for
-        # extending graph coverage to this path.
-        import shutil
-        import tempfile
-
-        # CLI-over-config explicitness read from compare's *real* ctx (where
-        # --ast-frontend/--nostdinc are genuine COMMANDLINE params); the inline
-        # dump runs under ctx.invoke where that signal is lost, so we compute it
-        # here and thread it through (Codex review). A per-side --old/new-ast-frontend
-        # is itself an explicit frontend for that side.
-        _nostdinc_explicit = (
-            ctx.get_parameter_source("nostdinc")
-            == click.core.ParameterSource.COMMANDLINE
-        )
-        _frontend_explicit = (
-            ctx.get_parameter_source("header_backend")
-            == click.core.ParameterSource.COMMANDLINE
-        )
-
-        _src_tmp = tempfile.mkdtemp(prefix="abicheck-compare-src-")
-        # Cleanup on context teardown so the temp dir never leaks, even if an
-        # inline dump or _resolve_compare_snapshots raises before we return.
-        ctx.call_on_close(lambda: shutil.rmtree(_src_tmp, ignore_errors=True))
-        old_input, old_sources, old_build_info = _embed_inline_source_side(
-            ctx, input_path=old_input, sources=old_sources,
-            headers=old_h, includes=old_inc, version=old_version, lang=lang,
-            header_backend=old_header_backend or header_backend,
+        (
+            old_input, old_sources, old_build_info,
+            new_input, new_sources, new_build_info,
+        ) = _embed_inline_source_sides(
+            ctx,
+            old_input=old_input, new_input=new_input,
+            old_sources=old_sources, new_sources=new_sources,
+            old_build_info=old_build_info, new_build_info=new_build_info,
+            old_h=old_h, new_h=new_h, old_inc=old_inc, new_inc=new_inc,
+            old_version=old_version, new_version=new_version, lang=lang,
+            header_backend=header_backend,
+            old_header_backend=old_header_backend,
+            new_header_backend=new_header_backend,
             compile_context=compile_context,
-            frontend_explicit=_frontend_explicit or old_header_backend is not None,
-            # A nostdinc already resolved True (from --config) must survive the
-            # tree-config merge even when the tree omits it (Codex review); False
-            # is the default and indistinguishable from "unset", so only True needs
-            # preserving.
-            nostdinc_explicit=_nostdinc_explicit or compile_context.nostdinc,
-            build_info=old_build_info,
             follow_deps=follow_deps, search_paths=search_paths,
             ld_library_path=ld_library_path,
-            dwarf_only=dwarf_only, debug_format=effective_debug_format,
-            pdb_path=old_pdb_path or pdb_path,
-            debug_roots=tuple(resolved_old_debug),
+            dwarf_only=dwarf_only, effective_debug_format=effective_debug_format,
+            pdb_path=pdb_path, old_pdb_path=old_pdb_path, new_pdb_path=new_pdb_path,
+            resolved_old_debug=resolved_old_debug,
+            resolved_new_debug=resolved_new_debug,
             debuginfod=debuginfod, debuginfod_url=debuginfod_url,
-            collect_mode=collect_mode, out_dir=Path(_src_tmp), label="old",
-            depth=depth, include_labels=include_labels,
-            include_dependencies=include_dependencies,
-        )
-        new_input, new_sources, new_build_info = _embed_inline_source_side(
-            ctx, input_path=new_input, sources=new_sources,
-            headers=new_h, includes=new_inc, version=new_version, lang=lang,
-            header_backend=new_header_backend or header_backend,
-            compile_context=compile_context,
-            frontend_explicit=_frontend_explicit or new_header_backend is not None,
-            nostdinc_explicit=_nostdinc_explicit or compile_context.nostdinc,
-            build_info=new_build_info,
-            follow_deps=follow_deps, search_paths=search_paths,
-            debug_roots=tuple(resolved_new_debug),
-            debuginfod=debuginfod, debuginfod_url=debuginfod_url,
-            ld_library_path=ld_library_path,
-            dwarf_only=dwarf_only, debug_format=effective_debug_format,
-            pdb_path=new_pdb_path or pdb_path,
-            collect_mode=collect_mode, out_dir=Path(_src_tmp), label="new",
-            depth=depth, include_labels=include_labels,
+            collect_mode=collect_mode, depth=depth,
+            include_labels=include_labels,
             include_dependencies=include_dependencies,
         )
 
@@ -1528,16 +1544,7 @@ def run_compare(
     # new_input (which, in that case, no longer point at the original library).
     used_by_old_input, _ = cli._normalize_binary_input(used_by_old_input)
     used_by_new_input, _ = cli._normalize_binary_input(used_by_new_input)
-    if old_manifest_obj is not None and old_fmt != "elf":
-        raise click.UsageError(
-            "--dump-manifest old=... requires the old input to be an ELF "
-            f"binary (ADR-050 D3); got {old_fmt or 'a non-binary input'}."
-        )
-    if new_manifest_obj is not None and new_fmt != "elf":
-        raise click.UsageError(
-            "--dump-manifest new=... requires the new input to be an ELF "
-            f"binary (ADR-050 D3); got {new_fmt or 'a non-binary input'}."
-        )
+    _reject_manifest_non_elf(old_manifest_obj, new_manifest_obj, old_fmt, new_fmt)
     _reject_debug_format_for_non_elf(effective_debug_format, old_fmt, new_fmt)
     _warn_ignored_flags(
         old_fmt is not None, new_fmt is not None,
@@ -1590,64 +1597,26 @@ def run_compare(
     )
     _warn_force_public_ignored(force_public, scope_public_headers)
 
-    # ADR-049: one resolved configuration for this invocation -- the receipt
-    # the report carries *and*, since D8's `--pack` landed, the thing that
-    # configures the run (hence: before the comparison). Built from the raw
-    # CLI values, not the already-merged locals several of these were
-    # overwritten with above -- the resolver merges them itself, and a
-    # pre-merged value would look CLI-stated.
-    from .cli_compare_receipt import resolve_and_apply, typed_parameter_names
-    from .cli_options import RUN_PROFILE_META_KEY as _RUN_PROFILE_META_KEY
-    from .compatibility_evaluation_resolver import (
-        FieldResolutionError,
-        PackConflictError,
+    evaluation_config, pf, resolved_cfg = _resolve_evaluation_config(
+        ctx,
+        resolved_cfg=resolved_cfg, project_cfg=project_cfg, cfg_path=cfg_path,
+        cfg_sha=cfg_sha, policy=policy, policy_file_path=policy_file_path,
+        policy_file=pf, suppression=suppression, suppress=suppress,
+        symbols_list=symbols_list,
+        contract_mode=contract_mode, contract_evaluation=contract_evaluation,
+        scope_public_headers=scope_public_headers,
+        public_symbols=public_symbols, public_symbols_list=public_symbols_list,
+        require_justification=require_justification,
+        exit_code_scheme=exit_code_scheme, severity_preset=severity_preset,
+        severity_abi_breaking=severity_abi_breaking,
+        severity_potential_breaking=severity_potential_breaking,
+        severity_quality_issues=severity_quality_issues,
+        severity_addition=severity_addition,
+        pack_paths=pack_paths,
+        policy_selected_by=policy_selected_by,
+        policy_selected_path=policy_selected_path,
+        policy_selected_sha=policy_selected_sha,
     )
-    from .errors import PackManifestError
-
-    try:
-        evaluation_config, pf, resolved_cfg = resolve_and_apply(
-            {
-                "contract_mode": contract_mode,
-                "scope_public_headers": scope_public_headers,
-                "policy": policy,
-                "policy_file_path": policy_file_path,
-                "public_symbols": public_symbols,
-                "public_symbols_list": public_symbols_list,
-                "suppress": suppress,
-                "require_justification": require_justification,
-                "exit_code_scheme": exit_code_scheme,
-                "severity_preset": severity_preset,
-                "severity_abi_breaking": severity_abi_breaking,
-                "severity_potential_breaking": severity_potential_breaking,
-                "severity_quality_issues": severity_quality_issues,
-                "severity_addition": severity_addition,
-                "pack_paths": pack_paths,
-            },
-            resolved_cfg=resolved_cfg,
-            policy=policy,
-            contract_evaluation=contract_evaluation,
-            # Only this module holds the Click context, so it answers "did the
-            # user type this?" and hands the answers over as data -- which is
-            # what keeps `cli_compare_receipt` a leaf.
-            typed={n for n in typed_parameter_names() if _param_from_cli(n)},
-            project_cfg=project_cfg,
-            project_path=cfg_path,
-            # Both already loaded for the comparison itself; re-reading them
-            # here could pair one content's digest with another's rules.
-            policy_file=pf,
-            suppression=suppression,
-            suppress_path=suppress,
-            run_profile=ctx.meta.get(_RUN_PROFILE_META_KEY),
-            policy_option=policy_selected_by,
-            policy_path=policy_selected_path,
-            policy_sha256=policy_selected_sha,
-            project_sha256=cfg_sha,
-            symbols_list=symbols_list,
-        )
-    except (FieldResolutionError, PackConflictError, PackManifestError) as exc:
-        # A D7 same-tier conflict / D8 pack conflict / inapplicable manifest
-        # is a usage error, the exit code the resolver leaves to its front end.
-        raise click.UsageError(str(exc)) from exc
     # A gate pack may have moved a severity level; later consumers read it
     # off here, so re-derive rather than keep the pre-pack value.
     sev_config = resolved_cfg.severity
@@ -1667,7 +1636,7 @@ def run_compare(
 
     # Build-info + source facts (ADR-028/033): the helper times inline diffing
     # for the D6/D9 metrics and returns coverage/metrics to attach post-compare.
-    from .cli_buildsource import attach_evidence_metrics, prepare_embedded_build_source
+    from .cli_buildsource import prepare_embedded_build_source
     extra_changes, layer_coverage_rows, evidence_metrics, _ev_changes = (
         prepare_embedded_build_source(
             old, new, collect_mode, extra_changes,
@@ -1683,6 +1652,9 @@ def run_compare(
     )
 
     apply_patterns = pattern_verdicts or explain_patterns  # --explain implies on
+    # Reporting reads the severity config only under the severity exit scheme;
+    # resolved once here rather than re-spelled at each of the five consumers.
+    report_severity = sev_config if resolved_cfg.exit_code_scheme == "severity" else None
     from .service import compare_snapshots, load_env_matrix
     try:
         env_matrix = load_env_matrix(env_matrix_path)
@@ -1707,162 +1679,30 @@ def run_compare(
     except (ProfileMismatchError, ScopeMismatchError) as exc:
         _report_not_comparable(exc, old, new, fmt=fmt, output=output)
         sys.exit(_EXIT_NOT_COMPARABLE)
-    from .cli_compare_receipt import record_resolved_config
-
-    record_resolved_config(result, resolved_cfg, evaluation_config)
-    if layer_coverage_rows:
-        result.layer_coverage = layer_coverage_rows
-    # Pass all injected findings (probe-matrix + evidence) so artifact-backed
-    # excludes them — none come from L0-L2 diffing.
-    attach_evidence_metrics(result, evidence_metrics, extra_changes or [])
-
-    if explain_patterns:
-        echo_pattern_modulations(result)
-
-    _finalize_compare_result(
-        result, old_input, new_input,
+    _report_compare_result(
+        ctx, result, old, new,
+        old_input=old_input, new_input=new_input,
+        resolved_cfg=resolved_cfg, evaluation_config=evaluation_config,
+        sev_config=sev_config, report_severity=report_severity,
+        layer_coverage_rows=layer_coverage_rows,
+        evidence_metrics=evidence_metrics, extra_changes=extra_changes,
+        explain_patterns=explain_patterns,
         show_redundant=show_redundant, show_filtered=show_filtered,
         annotate=annotate, annotate_additions=annotate_additions,
-        severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
         contract_evaluation=contract_evaluation,
-    )
-
-    scoped_exit_code: int | None = None
-    if used_by_apps:
-        scoped_exit_code = _apply_used_by_scoping(
-            result, used_by_apps, used_by_old_input, used_by_new_input, old, new,
-            policy, pf,
-            exit_code_scheme=resolved_cfg.exit_code_scheme, sev_config=sev_config,
-            verify_runtime=verify_runtime, suppression=suppression,
-        )
-    elif required_symbols:
-        scoped_exit_code = _apply_required_symbol_scoping(
-            result, required_symbols, old, new, policy, pf,
-            exit_code_scheme=resolved_cfg.exit_code_scheme, sev_config=sev_config,
-        )
-
-    if audit_suppressions:
-        # Guarded above: audit_suppressions=True implies suppression is not
-        # None. Audited against the full pre-suppression change set (kept +
-        # suppressed) plus any --used-by/--required-symbol scoped_only_changes
-        # (Codex review, fresh evidence: run *after* scoping, not before, so a
-        # rule matching only a scoping-synthesized finding like
-        # CONSUMER_REQUIRED_SYMBOL_REMOVED isn't misreported as stale). Not a
-        # complete fix: scope_diff_to_app/scope_diff_to_required_symbols apply
-        # suppression internally to their own candidates before this ever
-        # sees them, so a rule matching only a scoping candidate suppression
-        # itself already dropped (never reaching scoped_only_changes at all)
-        # is still invisible here -- closing that needs those functions to
-        # expose their own pre-suppression candidate list, a separate,
-        # larger change to appcompat.py this fix does not attempt.
-        assert suppression is not None
-        # Codex review, fresh evidence: pass the *effective*, policy-override-
-        # applied breaking set (not the static BREAKING_KINDS default) so a
-        # rule's "high risk" classification matches the verdict this run's
-        # own --policy-file would actually produce, e.g. a rule suppressing
-        # a kind the policy promoted to BREAKING is reported as high-risk
-        # even though it isn't in the built-in BREAKING_KINDS.
-        effective_breaking_kinds, _, _, _ = result._effective_kind_sets()
-        result.suppression_audit = suppression.audit(  # type: ignore[attr-defined]
-            list(result.changes)
-            + list(result.suppressed_changes)
-            + list(getattr(result, "scoped_only_changes", ()) or ()),
-            breaking_kinds=effective_breaking_kinds,
-        )
-
-    # ADR-049 Phase 3 (Codex review, fresh evidence): --used-by/
-    # --required-symbol scoping above can add scoped_only_changes (fresh
-    # Change objects scope_diff_to_app/scope_diff_to_required_symbols
-    # synthesize, e.g. PE_ORDINAL_RETARGETED) and mark existing
-    # result.changes entries as relevant to the scoped contract -- neither
-    # ever passes through checker._apply_contract_evaluation_shadow, so
-    # both stayed permanently unstamped even when --contract-evaluation was
-    # given. This must run before _render_output below serializes
-    # result.changes, and mirrors the identical fix already applied to the
-    # MCP abi_compare tool (mcp_server.py) -- both share the same traversal
-    # (CodeRabbit review: hand-copying it here previously let one call site
-    # drift out of sync with the other).
-    if contract_evaluation:
-        from .reporter import _finding_id
-
-        stamp_scoped_result_findings(result, finding_id=_finding_id)
-
-    text = _render_output(
-        fmt, result, old, new,
+        policy=policy, pf=pf,
+        used_by_apps=used_by_apps, required_symbols=required_symbols,
+        used_by_old_input=used_by_old_input, used_by_new_input=used_by_new_input,
+        verify_runtime=verify_runtime, suppression=suppression,
+        audit_suppressions=audit_suppressions,
+        fmt=fmt, output=output, show_only=show_only, report_mode=report_mode,
+        show_impact=show_impact, stat=stat, recommend=recommend,
+        demangle=demangle, demangle_explicit=demangle_explicit,
         follow_deps=follow_deps,
-        show_only=show_only, report_mode=report_mode,
-        show_impact=show_impact, stat=stat,
-        severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
-        show_recommendation=recommend,
-        demangle=demangle,
-        contract_evaluation=contract_evaluation,
-    )
-    text = _fold_scoped_compat_into_text(
-        text, fmt, result,
-        severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
-        show_only=show_only, report_mode=report_mode,
-        contract_evaluation=contract_evaluation,
-    )
-    text = _fold_suppression_audit_into_text(
-        text, fmt, getattr(result, "suppression_audit", None)
-    )
-    text = _fold_evidence_depth_into_json(
-        text, fmt, old, new,
+        secondary_fmt=secondary_fmt, secondary_output=secondary_output,
         old_build_info=old_build_info, new_build_info=new_build_info,
         old_sources=old_sources, new_sources=new_sources,
     )
-
-    _write_or_echo(output, text)
-
-    if secondary_fmt is not None:
-        # Always the full, unfiltered report — ignores --show-only/--stat
-        # (which describe the *primary* format's display) and forces
-        # report_mode="full" (not the primary's --report-mode leaf) so a
-        # --secondary-* consumer (e.g. a CI action rendering a PR-comment
-        # JSON from a markdown-format primary run) sees the complete change
-        # set the gate actually acted on, not whatever the primary format
-        # chose to filter or group down to. Reuses the same already-computed
-        # `result` — no second comparison run.
-        # Resolve demangle against secondary_fmt, not the primary-resolved
-        # value above — otherwise a machine primary format (e.g. json) paired
-        # with a markdown/review secondary format would wrongly inherit
-        # demangle=False into the secondary render (Codex review, PR #557).
-        secondary_demangle = _resolve_demangle(secondary_fmt, demangle_explicit)
-        secondary_text = _render_output(
-            secondary_fmt, result, old, new,
-            follow_deps=follow_deps,
-            show_only=None, report_mode="full",
-            show_impact=show_impact, stat=False,
-            severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
-            show_recommendation=recommend,
-            demangle=secondary_demangle,
-            contract_evaluation=contract_evaluation,
-        )
-        secondary_text = _fold_scoped_compat_into_text(
-            secondary_text, secondary_fmt, result,
-            severity_config=sev_config if resolved_cfg.exit_code_scheme == "severity" else None,
-            contract_evaluation=contract_evaluation,
-        )
-        secondary_text = _fold_suppression_audit_into_text(
-            secondary_text, secondary_fmt, getattr(result, "suppression_audit", None)
-        )
-        secondary_text = _fold_evidence_depth_into_json(
-            secondary_text, secondary_fmt, old, new,
-            old_build_info=old_build_info, new_build_info=new_build_info,
-            old_sources=old_sources, new_sources=new_sources,
-        )
-        _write_or_echo(secondary_output, secondary_text)
-
-    if scoped_exit_code is not None:
-        # ADR-043: --used-by / --required-symbol(s) scope the primary verdict
-        # to the application/plugin-host contract, floored at the worst
-        # scoped result -- the full library verdict stays informational only.
-        # ADR-049 §7's coverage axis is orthogonal to that scoping.
-        announce_coverage_floor(result, base_exit=scoped_exit_code, fmt=fmt, stat=stat, secondary_fmt=secondary_fmt)
-        sys.exit(fold_coverage_exit(scoped_exit_code, result))
-
-    _announce_exit_scheme(resolved_cfg.exit_code_scheme, fmt=fmt, stat=stat)
-    _exit_with_severity_or_verdict(result, sev_config, resolved_cfg.exit_code_scheme, fmt, stat, secondary_fmt)
 
 
 def _fold_evidence_depth_into_json(

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -506,6 +506,102 @@ def _scoped_severity_summary(
     return tuple(categories), counts
 
 
+def _require_used_by_binary_evidence(
+    old_lib: Any, new_lib: Any, old_input: Path, new_input: Path,
+) -> None:
+    """Reject a ``--used-by`` run whose OLD/NEW side carries no binary evidence.
+
+    A real library path always qualifies; a JSON snapshot qualifies only when it
+    carries an ``elf``/``pe``/``macho`` block (i.e. it is a ``dump`` of a real
+    library, not a headers-only one) -- that is what supplies the SONAME/export
+    table/version list/PE ordinal table the scoping needs.
+    """
+    for lib, path, label in (
+        (old_lib, old_input, "OLD"), (new_lib, new_input, "NEW"),
+    ):
+        has_binary_evidence = isinstance(lib, Path) or any(
+            getattr(lib, field, None) is not None for field in ("elf", "pe", "macho")
+        )
+        if not has_binary_evidence:
+            raise click.UsageError(
+                f"--used-by requires OLD/NEW to be real library binaries, or "
+                f"JSON snapshots carrying binary evidence (a `dump` of a real "
+                f"library, not headers-only); {label} ({path}) is neither."
+            )
+
+
+def _apply_runtime_probe(
+    scoped: Any, app: Path, old_lib: Path, new_lib: Path,
+    suppression: Any, policy: str, policy_file: PolicyFile | None,
+) -> None:
+    """Run *app* against both libraries and fold a load regression into *scoped*.
+
+    ADR-044 P2 item 2. Mutates *scoped* in place: appends a
+    ``CONSUMER_RUNTIME_LOAD_FAILED`` finding (unless a suppression rule removes
+    it) and recomputes the app verdict, since ``scope_diff_to_app`` computed it
+    before this RISK-tier finding existed.
+    """
+    from .checker_policy import ChangeKind, ReachabilityState
+    from .diff_helpers import make_change
+    from .runtime_probe import run_runtime_probe
+
+    probe = run_runtime_probe(app, old_lib, new_lib)
+    regressed_symbol = probe.regressed_symbol
+    if not regressed_symbol:
+        return
+    # public_reachable=True (Codex review, fresh evidence, mirrors
+    # appcompat.scope_diff_to_app's identical fix for
+    # CONSUMER_REQUIRED_SYMBOL_REMOVED): this finding only exists
+    # because the dynamic linker itself failed to resolve a
+    # symbol for a real, executed --used-by consumer binary --
+    # left at the dataclass default (False), a broad
+    # namespace/source_location suppression rule's default
+    # "unreachable-only" reachability would read it as
+    # unreachable and silently suppress a runtime regression that
+    # is, by construction, always consumer-proven real.
+    runtime_change = make_change(
+        ChangeKind.CONSUMER_RUNTIME_LOAD_FAILED,
+        symbol=regressed_symbol,
+        name=app.name,
+        public_reachable=True,
+        reachability_kind="consumer_proven",
+        reachability_state=ReachabilityState.PROVEN_REACHABLE,
+    )
+    add_finding = suppression is None
+    if suppression is not None:
+        outcome = suppression.evaluate(runtime_change)
+        add_finding = not outcome.suppressed
+        # outcome.withheld_unknown_rule is never set here:
+        # runtime_change is always constructed with
+        # reachability_state=PROVEN_REACHABLE above (it is by
+        # construction consumer-proven), and
+        # would_withhold_unknown_reachability only ever fires on
+        # UNKNOWN.
+        if add_finding and outcome.withheld_rule is not None:
+            from .post_processing import _build_suppression_overreach_change
+
+            scoped.breaking_for_app.append(
+                _build_suppression_overreach_change(
+                    runtime_change, outcome.withheld_rule
+                )
+            )
+    if not add_finding:
+        return
+    scoped.breaking_for_app.append(runtime_change)
+    # scope_diff_to_app already computed scoped.verdict before
+    # this RISK-tier finding existed -- recompute so a clean
+    # static scope plus a runtime regression reports
+    # COMPATIBLE_WITH_RISK instead of a stale COMPATIBLE
+    # (Codex review).
+    from .appcompat import _compute_appcompat_verdict
+
+    scoped.verdict = _compute_appcompat_verdict(
+        scoped.missing_symbols, scoped.missing_versions,
+        scoped.breaking_for_app, scoped.required_symbol_count,
+        policy, policy_file,
+    )
+
+
 def _apply_used_by_scoping(
     result: Any, used_by_apps: tuple[Path, ...],
     old_input: Path, new_input: Path,
@@ -548,18 +644,7 @@ def _apply_used_by_scoping(
     old_lib = old_input if detect_binary_format(old_input) is not None else old_snapshot
     new_lib = new_input if detect_binary_format(new_input) is not None else new_snapshot
 
-    for lib, path, label in (
-        (old_lib, old_input, "OLD"), (new_lib, new_input, "NEW"),
-    ):
-        has_binary_evidence = isinstance(lib, Path) or any(
-            getattr(lib, field, None) is not None for field in ("elf", "pe", "macho")
-        )
-        if not has_binary_evidence:
-            raise click.UsageError(
-                f"--used-by requires OLD/NEW to be real library binaries, or "
-                f"JSON snapshots carrying binary evidence (a `dump` of a real "
-                f"library, not headers-only); {label} ({path}) is neither."
-            )
+    _require_used_by_binary_evidence(old_lib, new_lib, old_input, new_input)
 
     from .appcompat import uncovered_missing_symbols
     from .reporter import _finding_id
@@ -607,63 +692,9 @@ def _apply_used_by_scoping(
             old_snapshot=old_snapshot,
         )
         if verify_runtime and isinstance(old_lib, Path) and isinstance(new_lib, Path):
-            from .checker_policy import ChangeKind, ReachabilityState
-            from .diff_helpers import make_change
-            from .runtime_probe import run_runtime_probe
-
-            probe = run_runtime_probe(app, old_lib, new_lib)
-            regressed_symbol = probe.regressed_symbol
-            if regressed_symbol:
-                # public_reachable=True (Codex review, fresh evidence, mirrors
-                # appcompat.scope_diff_to_app's identical fix for
-                # CONSUMER_REQUIRED_SYMBOL_REMOVED): this finding only exists
-                # because the dynamic linker itself failed to resolve a
-                # symbol for a real, executed --used-by consumer binary --
-                # left at the dataclass default (False), a broad
-                # namespace/source_location suppression rule's default
-                # "unreachable-only" reachability would read it as
-                # unreachable and silently suppress a runtime regression that
-                # is, by construction, always consumer-proven real.
-                runtime_change = make_change(
-                    ChangeKind.CONSUMER_RUNTIME_LOAD_FAILED,
-                    symbol=regressed_symbol,
-                    name=app.name,
-                    public_reachable=True,
-                    reachability_kind="consumer_proven",
-                    reachability_state=ReachabilityState.PROVEN_REACHABLE,
-                )
-                add_finding = suppression is None
-                if suppression is not None:
-                    outcome = suppression.evaluate(runtime_change)
-                    add_finding = not outcome.suppressed
-                    # outcome.withheld_unknown_rule is never set here:
-                    # runtime_change is always constructed with
-                    # reachability_state=PROVEN_REACHABLE above (it is by
-                    # construction consumer-proven), and
-                    # would_withhold_unknown_reachability only ever fires on
-                    # UNKNOWN.
-                    if add_finding and outcome.withheld_rule is not None:
-                        from .post_processing import _build_suppression_overreach_change
-
-                        scoped.breaking_for_app.append(
-                            _build_suppression_overreach_change(
-                                runtime_change, outcome.withheld_rule
-                            )
-                        )
-                if add_finding:
-                    scoped.breaking_for_app.append(runtime_change)
-                    # scope_diff_to_app already computed scoped.verdict before
-                    # this RISK-tier finding existed -- recompute so a clean
-                    # static scope plus a runtime regression reports
-                    # COMPATIBLE_WITH_RISK instead of a stale COMPATIBLE
-                    # (Codex review).
-                    from .appcompat import _compute_appcompat_verdict
-
-                    scoped.verdict = _compute_appcompat_verdict(
-                        scoped.missing_symbols, scoped.missing_versions,
-                        scoped.breaking_for_app, scoped.required_symbol_count,
-                        policy, policy_file,
-                    )
+            _apply_runtime_probe(
+                scoped, app, old_lib, new_lib, suppression, policy, policy_file,
+            )
         summaries.append(_app_compat_summary(scoped))
         relevant_finding_ids.update(_finding_id(c) for c in scoped.breaking_for_app)
         relevant_changes_by_id.update(

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -591,226 +591,123 @@ def _l4_source_abi_frontend(snap: AbiSnapshot) -> str | None:
     return None
 
 
-def render_dump_dry_run(
+def _add_dump_manifest_section(result: Any, dump_manifest: Any) -> None:
+    """Report a ``--dump-manifest`` document's TUs and ``scope_fingerprint``.
+
+    Everything here is derived from the manifest document alone -- no compiler
+    invocation -- which is what lets a dry run report the same
+    ``scope_fingerprint`` (ADR-050 D1) the real extraction computes. It never
+    computes a ``profile_fingerprint``: that fingerprint's ``-I`` component is a
+    ``-MD``-depfile digest that only exists once a real L2 extraction runs.
+    """
+    from .comparability import compute_extraction_contract, manifest_tu_scope_field
+    from .dumper_contract import _manifest_declared_includes
+
+    contract = compute_extraction_contract(
+        declared_headers=list(dump_manifest.roots),
+        # Purely manifest-document-derived (no compiler invocation),
+        # exactly like manifest_tu_scope below -- the real (non-dry) path
+        # folds both into scope_fingerprint via this same helper (Codex
+        # review: the legacy field set either omission would otherwise
+        # fall back to omits every TU's own includes/structure), so
+        # without them the dry-run's printed fingerprint could never
+        # match what the real extraction actually computes.
+        declared_includes=_manifest_declared_includes(dump_manifest),
+        public_header_paths=list(dump_manifest.public_header_paths),
+        public_header_dirs=list(dump_manifest.public_header_dirs),
+        l2_frontend_ran=False,
+        manifest_tu_scope=manifest_tu_scope_field(dump_manifest),
+    )
+    scope_fingerprint = contract.scope_fingerprint if contract is not None else None
+    manifest_lines = [
+        f"compiler: {dump_manifest.compiler}",
+        f"target: {dump_manifest.target or '(none)'}",
+        f"frontend_context: {dump_manifest.frontend_context}",
+        f"roots: {', '.join(str(p) for p in dump_manifest.roots)}",
+    ]
+    if dump_manifest.public_header_paths:
+        manifest_lines.append(
+            "public_header_paths: "
+            + ", ".join(str(p) for p in dump_manifest.public_header_paths)
+        )
+    if dump_manifest.public_header_dirs:
+        manifest_lines.append(
+            "public_header_dirs: "
+            + ", ".join(str(p) for p in dump_manifest.public_header_dirs)
+        )
+    for tu in dump_manifest.translation_units:
+        manifest_lines.append(
+            f"  tu: {tu.name} (required={tu.required}, "
+            f"contributes_to_abi={tu.contributes_to_abi})"
+        )
+        if tu.forced_includes:
+            manifest_lines.append(
+                "      forced_includes: "
+                + ", ".join(str(p) for p in tu.forced_includes)
+            )
+        if tu.includes:
+            inc_repr = ", ".join(
+                f"{inc.path}{' [project_owned]' if inc.project_owned else ''}"
+                for inc in tu.includes
+            )
+            manifest_lines.append(f"      includes: {inc_repr}")
+    manifest_lines.append(f"scope_fingerprint: {scope_fingerprint or '(none)'}")
+    manifest_lines.append(
+        "profile_fingerprint: (not computed -- requires a real L2 "
+        "extraction; run without --dry-run)"
+    )
+    result.add("Multi-TU manifest (--dump-manifest)", *manifest_lines)
+
+
+def _add_dump_data_layers(result: Any, so_path: Path, headers: tuple[Path, ...]) -> None:
+    """Report which L0-L2 data layers the artifact actually carries.
+
+    Best-effort: a diagnostic section, so any parse failure is downgraded to a
+    warning rather than failing the dry run.
+    """
+    try:
+        from .binary_utils import detect_binary_format, normalize_binary_input
+        from .dwarf_snapshot import show_data_sources
+
+        normalized_path, binary_fmt = normalize_binary_input(so_path)
+        if binary_fmt is None:
+            binary_fmt = detect_binary_format(normalized_path)
+        elf_meta = None
+        dwarf_meta = None
+        if binary_fmt == "elf":
+            from .dwarf_unified import parse_dwarf
+            from .elf_metadata import parse_elf_metadata
+
+            elf_meta = parse_elf_metadata(normalized_path)
+            dwarf_meta, _ = parse_dwarf(normalized_path)
+        report = show_data_sources(
+            normalized_path, elf_meta, dwarf_meta, bool(headers), None
+        )
+        result.add("Available data layers", *report.splitlines())
+    except Exception as exc:  # pragma: no cover - best-effort diagnostic
+        result.warn(f"could not inspect available data layers: {exc}")
+
+
+def _add_dump_depth_feasibility(
+    result: Any,
     *,
     so_path: Path | None,
-    headers: tuple[Path, ...],
     sources: Path | None,
     build_info: Path | None,
-    build_config: Path | None,
     depth: str | None,
-    collect_mode: str,
-    header_backend: str,
-    output: Path | None,
-    has_compile_db: bool = False,
-    compile_db_matched: bool | None = None,
-    build_info_is_pack: bool = False,
-    compile_db_reused_as_l3: bool = False,
-    dump_manifest: Any | None = None,
-) -> Any:
-    """Build the ``dump --dry-run`` report (ADR-043 D4): resolve, never execute.
+    has_compile_db: bool,
+    compile_db_matched: bool | None,
+    build_info_is_pack: bool,
+    dump_manifest: Any | None,
+) -> None:
+    """Decide whether the requested ``--depth`` is reachable from these inputs.
 
-    Cheap, read-only resolution only: classifies the inputs, discovers config,
-    shows the resolved depth/collect-mode and available data layers, and
-    checks tool availability on PATH. Never runs castxml/clang, a build query,
-    or any I/O beyond stat()/PATH lookups.
-
-    ``has_compile_db`` (Codex review): whether ``-p``/``--compile-db`` was
-    given at all -- a bare presence flag, kept for the "nothing was given at
-    all" case below, distinct from whether it actually matches.
-
-    ``compile_db_matched`` (external review): the *real* result of loading
-    ``-p``/``--compile-db`` and checking it against the resolved headers --
-    ``cli.dump_cmd`` computes this the same way the real run does
-    (``cli_helpers_compare._resolve_build_context_flags``, the same JSON
-    load + path match the real run performs before castxml even runs) and
-    passes the outcome in, rather than this function loading it itself.
-    Loading and matching a compile database is cheap, deterministic,
-    read-only resolution (no compiler/frontend invocation) -- an earlier
-    version of this function treated it as "real work out of scope for a
-    dry run" and only checked bare presence, so a ``--depth build`` backed
-    by an empty/non-matching compile database dry-ran as merely a soft
-    warning even though the real run's strict depth gate would definitely
-    reject it. ``None`` when no compile database was given at all (the
-    "nothing was given" case is handled separately, below); ``True``/
-    ``False`` is now a definite verdict, not a "possibly satisfiable" guess.
-
-    ``build_info_is_pack`` (Codex review): whether ``--build-info`` names a
-    prebuilt ``BuildSourcePack`` *or* a Flow-2 ``abicheck_inputs/`` directory
-    rather than a raw compile DB / build dir -- the caller ORs
-    ``buildsource.inline.is_pack_dir`` and ``cli_buildsource_helpers.
-    _is_inputs_pack_dir`` (each a manifest-shape stat + small JSON read, not
-    a full pack load), the same two directory kinds ``cli_buildsource.
-    embed_build_source`` itself recognizes as pack-shaped (``bi_is_pack``/
-    ``bi_is_inputs``). Either one's ``_combine_packs`` fallback lets a
-    pack-shaped ``build_info``'s own ``source_abi`` (L4) satisfy ``--depth
-    source`` with no ``--sources`` pack given, unlike a raw compile
-    database, which never carries L4 facts of its own. Checking only
-    ``is_pack_dir`` missed the ``abicheck_inputs/`` case (Codex review,
-    second finding on this signal): that combination was wrongly treated as
-    "--depth source has no path without --sources" and blocked even though
-    the real (non-dry) run writes a valid source-depth snapshot from it.
-
-    ``dump_manifest`` (ADR-050 D3, folded from the former standalone ``plan
-    --dump-manifest`` diagnostic, ADR-054): a parsed
-    :class:`~abicheck.dump_manifest.DumpManifest` when ``--dump-manifest``
-    was given (mutually exclusive with ``headers``, enforced by the caller
-    before this function is reached). When present, this function reports
-    the manifest's translation units and its ``scope_fingerprint`` (ADR-050
-    D1) — computed from the manifest document alone, no compiler invocation
-    — the same information ``dump --dump-manifest FILE --dry-run`` now
-    covers standalone, without running castxml/clang. It never computes a
-    ``profile_fingerprint``: that fingerprint's ``-I`` component is a
-    ``-MD``-depfile digest that only exists once a real L2 extraction
-    actually runs. Text-only, like every other dry-run (ADR-043 D9,
-    ``--format`` is inert against ``--dry-run`` everywhere, not just here) —
-    the former standalone command's ``--format json``/``-o`` machine-readable
-    output has no CLI replacement; see ADR-054's D4 for the accepted
-    trade-off and the equivalent two-line Python snippet (calling
-    ``dump_manifest.load_manifest`` + ``comparability.compute_extraction_contract``
-    directly, the same two functions this branch itself calls below).
-
-    A ``-p`` compile DB with no ``-H``, or a ``--debug-format``/``--dwarf``/
-    ``--btf``/``--ctf`` selection against a PE/Mach-O binary, are genuine
-    usage errors in the real run (``click.UsageError``/``BadParameter``,
-    exit 64) -- ``cli.dump_cmd`` checks both, via
-    :func:`check_dump_compile_db_error`/:func:`check_dump_debug_format_error`,
-    and raises directly *before* branching on ``dry_run`` at all, so this
-    function is never even reached for that input on either path. Do not
-    re-encode either as a :meth:`DryRunResult.block` (exit 1) here -- that
-    would silently downgrade a usage error into an evidence blocker and
-    disagree with the real run's actual exit code for the identical input
-    (CodeRabbit review).
+    Emits the blockers and warnings that predict the real run's strict
+    ``check_requested_depth_satisfied`` gate. A blocker means the real run would
+    certainly exit 1; a warning means "possibly satisfiable" -- the distinction
+    is load-bearing, and the reasoning behind each case is kept with the case
+    itself below.
     """
-    from .cli_helpers_compare import discover_project_config
-    from .dry_run import DryRunResult, tool_status
-
-    result = DryRunResult(command="dump")
-    result.add(
-        "Inputs",
-        f"artifact: {so_path}" if so_path else "artifact: (none -- source-only dump)",
-        f"headers: {', '.join(str(h) for h in headers)}" if headers else None,
-    )
-    if dump_manifest is not None:
-        from .comparability import compute_extraction_contract, manifest_tu_scope_field
-        from .dumper_contract import _manifest_declared_includes
-
-        contract = compute_extraction_contract(
-            declared_headers=list(dump_manifest.roots),
-            # Purely manifest-document-derived (no compiler invocation),
-            # exactly like manifest_tu_scope below -- the real (non-dry) path
-            # folds both into scope_fingerprint via this same helper (Codex
-            # review: the legacy field set either omission would otherwise
-            # fall back to omits every TU's own includes/structure), so
-            # without them the dry-run's printed fingerprint could never
-            # match what the real extraction actually computes.
-            declared_includes=_manifest_declared_includes(dump_manifest),
-            public_header_paths=list(dump_manifest.public_header_paths),
-            public_header_dirs=list(dump_manifest.public_header_dirs),
-            l2_frontend_ran=False,
-            manifest_tu_scope=manifest_tu_scope_field(dump_manifest),
-        )
-        scope_fingerprint = contract.scope_fingerprint if contract is not None else None
-        manifest_lines = [
-            f"compiler: {dump_manifest.compiler}",
-            f"target: {dump_manifest.target or '(none)'}",
-            f"frontend_context: {dump_manifest.frontend_context}",
-            f"roots: {', '.join(str(p) for p in dump_manifest.roots)}",
-        ]
-        if dump_manifest.public_header_paths:
-            manifest_lines.append(
-                "public_header_paths: "
-                + ", ".join(str(p) for p in dump_manifest.public_header_paths)
-            )
-        if dump_manifest.public_header_dirs:
-            manifest_lines.append(
-                "public_header_dirs: "
-                + ", ".join(str(p) for p in dump_manifest.public_header_dirs)
-            )
-        for tu in dump_manifest.translation_units:
-            manifest_lines.append(
-                f"  tu: {tu.name} (required={tu.required}, "
-                f"contributes_to_abi={tu.contributes_to_abi})"
-            )
-            if tu.forced_includes:
-                manifest_lines.append(
-                    "      forced_includes: "
-                    + ", ".join(str(p) for p in tu.forced_includes)
-                )
-            if tu.includes:
-                inc_repr = ", ".join(
-                    f"{inc.path}{' [project_owned]' if inc.project_owned else ''}"
-                    for inc in tu.includes
-                )
-                manifest_lines.append(f"      includes: {inc_repr}")
-        manifest_lines.append(f"scope_fingerprint: {scope_fingerprint or '(none)'}")
-        manifest_lines.append(
-            "profile_fingerprint: (not computed -- requires a real L2 "
-            "extraction; run without --dry-run)"
-        )
-        result.add("Multi-TU manifest (--dump-manifest)", *manifest_lines)
-    result.add(
-        "Resolved depth and source scope",
-        f"requested depth: {depth or '(auto)'}",
-        f"effective collect mode: {collect_mode}",
-        "source scope: target (dump always analyzes the resolved library target)"
-        if collect_mode in ("source-target", "source-changed", "graph-full")
-        else None,
-    )
-    result.add(
-        "Headers and compile context",
-        f"ast-frontend: {header_backend}",
-    )
-    result.add(
-        "Build/source inputs",
-        f"--sources: {sources}" if sources else None,
-        f"--build-info: {build_info}" if build_info else None,
-        # AC-007: the real run reuses a matched -p/--compile-db as the L3 build
-        # source when no --build-info is given, so report that here and do not
-        # also claim "L0-L2 only" (Codex review).
-        "L3 build source: reused from -p/--compile-db (no --build-info needed)"
-        if compile_db_reused_as_l3
-        else None,
-        "no --sources/--build-info given -- L0-L2 only"
-        if sources is None
-        and build_info is None
-        and not compile_db_reused_as_l3
-        and collect_mode != "off"
-        else None,
-    )
-    result.add("Tools and frontends", *tool_status("castxml", "clang", "gcc", "g++"))
-    if so_path is not None:
-        try:
-            from .binary_utils import detect_binary_format, normalize_binary_input
-            from .dwarf_snapshot import show_data_sources
-
-            normalized_path, binary_fmt = normalize_binary_input(so_path)
-            if binary_fmt is None:
-                binary_fmt = detect_binary_format(normalized_path)
-            elf_meta = None
-            dwarf_meta = None
-            if binary_fmt == "elf":
-                from .dwarf_unified import parse_dwarf
-                from .elf_metadata import parse_elf_metadata
-
-                elf_meta = parse_elf_metadata(normalized_path)
-                dwarf_meta, _ = parse_dwarf(normalized_path)
-            report = show_data_sources(
-                normalized_path, elf_meta, dwarf_meta, bool(headers), None
-            )
-            result.add("Available data layers", *report.splitlines())
-        except Exception as exc:  # pragma: no cover - best-effort diagnostic
-            result.warn(f"could not inspect available data layers: {exc}")
-    cfg_path = build_config or discover_project_config(sources)
-    result.add(
-        "Configuration and value origins",
-        f".abicheck.yml: {cfg_path if cfg_path else '(none found)'}",
-    )
-    result.add(
-        "Output and exit-code behavior",
-        f"output: {output if output else 'stdout'}",
-        "exit codes: 0 valid, 1 requested depth not satisfiable, 64 usage error",
-    )
     if so_path is None and sources is None and build_info is None:
         if dump_manifest is not None:
             # A --dump-manifest-only dry run is a legitimate narrower
@@ -930,6 +827,163 @@ def render_dump_dry_run(
             "resolved evidence depth check_requested_depth_satisfied would "
             "raise on this: the real run would exit 1."
         )
+
+
+def render_dump_dry_run(
+    *,
+    so_path: Path | None,
+    headers: tuple[Path, ...],
+    sources: Path | None,
+    build_info: Path | None,
+    build_config: Path | None,
+    depth: str | None,
+    collect_mode: str,
+    header_backend: str,
+    output: Path | None,
+    has_compile_db: bool = False,
+    compile_db_matched: bool | None = None,
+    build_info_is_pack: bool = False,
+    compile_db_reused_as_l3: bool = False,
+    dump_manifest: Any | None = None,
+) -> Any:
+    """Build the ``dump --dry-run`` report (ADR-043 D4): resolve, never execute.
+
+    Cheap, read-only resolution only: classifies the inputs, discovers config,
+    shows the resolved depth/collect-mode and available data layers, and
+    checks tool availability on PATH. Never runs castxml/clang, a build query,
+    or any I/O beyond stat()/PATH lookups.
+
+    ``has_compile_db`` (Codex review): whether ``-p``/``--compile-db`` was
+    given at all -- a bare presence flag, kept for the "nothing was given at
+    all" case below, distinct from whether it actually matches.
+
+    ``compile_db_matched`` (external review): the *real* result of loading
+    ``-p``/``--compile-db`` and checking it against the resolved headers --
+    ``cli.dump_cmd`` computes this the same way the real run does
+    (``cli_helpers_compare._resolve_build_context_flags``, the same JSON
+    load + path match the real run performs before castxml even runs) and
+    passes the outcome in, rather than this function loading it itself.
+    Loading and matching a compile database is cheap, deterministic,
+    read-only resolution (no compiler/frontend invocation) -- an earlier
+    version of this function treated it as "real work out of scope for a
+    dry run" and only checked bare presence, so a ``--depth build`` backed
+    by an empty/non-matching compile database dry-ran as merely a soft
+    warning even though the real run's strict depth gate would definitely
+    reject it. ``None`` when no compile database was given at all (the
+    "nothing was given" case is handled separately, below); ``True``/
+    ``False`` is now a definite verdict, not a "possibly satisfiable" guess.
+
+    ``build_info_is_pack`` (Codex review): whether ``--build-info`` names a
+    prebuilt ``BuildSourcePack`` *or* a Flow-2 ``abicheck_inputs/`` directory
+    rather than a raw compile DB / build dir -- the caller ORs
+    ``buildsource.inline.is_pack_dir`` and ``cli_buildsource_helpers.
+    _is_inputs_pack_dir`` (each a manifest-shape stat + small JSON read, not
+    a full pack load), the same two directory kinds ``cli_buildsource.
+    embed_build_source`` itself recognizes as pack-shaped (``bi_is_pack``/
+    ``bi_is_inputs``). Either one's ``_combine_packs`` fallback lets a
+    pack-shaped ``build_info``'s own ``source_abi`` (L4) satisfy ``--depth
+    source`` with no ``--sources`` pack given, unlike a raw compile
+    database, which never carries L4 facts of its own. Checking only
+    ``is_pack_dir`` missed the ``abicheck_inputs/`` case (Codex review,
+    second finding on this signal): that combination was wrongly treated as
+    "--depth source has no path without --sources" and blocked even though
+    the real (non-dry) run writes a valid source-depth snapshot from it.
+
+    ``dump_manifest`` (ADR-050 D3, folded from the former standalone ``plan
+    --dump-manifest`` diagnostic, ADR-054): a parsed
+    :class:`~abicheck.dump_manifest.DumpManifest` when ``--dump-manifest``
+    was given (mutually exclusive with ``headers``, enforced by the caller
+    before this function is reached). When present, this function reports
+    the manifest's translation units and its ``scope_fingerprint`` (ADR-050
+    D1) — computed from the manifest document alone, no compiler invocation
+    — the same information ``dump --dump-manifest FILE --dry-run`` now
+    covers standalone, without running castxml/clang. It never computes a
+    ``profile_fingerprint``: that fingerprint's ``-I`` component is a
+    ``-MD``-depfile digest that only exists once a real L2 extraction
+    actually runs. Text-only, like every other dry-run (ADR-043 D9,
+    ``--format`` is inert against ``--dry-run`` everywhere, not just here) —
+    the former standalone command's ``--format json``/``-o`` machine-readable
+    output has no CLI replacement; see ADR-054's D4 for the accepted
+    trade-off and the equivalent two-line Python snippet (calling
+    ``dump_manifest.load_manifest`` + ``comparability.compute_extraction_contract``
+    directly, the same two functions this branch itself calls below).
+
+    A ``-p`` compile DB with no ``-H``, or a ``--debug-format``/``--dwarf``/
+    ``--btf``/``--ctf`` selection against a PE/Mach-O binary, are genuine
+    usage errors in the real run (``click.UsageError``/``BadParameter``,
+    exit 64) -- ``cli.dump_cmd`` checks both, via
+    :func:`check_dump_compile_db_error`/:func:`check_dump_debug_format_error`,
+    and raises directly *before* branching on ``dry_run`` at all, so this
+    function is never even reached for that input on either path. Do not
+    re-encode either as a :meth:`DryRunResult.block` (exit 1) here -- that
+    would silently downgrade a usage error into an evidence blocker and
+    disagree with the real run's actual exit code for the identical input
+    (CodeRabbit review).
+    """
+    from .cli_helpers_compare import discover_project_config
+    from .dry_run import DryRunResult, tool_status
+
+    result = DryRunResult(command="dump")
+    result.add(
+        "Inputs",
+        f"artifact: {so_path}" if so_path else "artifact: (none -- source-only dump)",
+        f"headers: {', '.join(str(h) for h in headers)}" if headers else None,
+    )
+    if dump_manifest is not None:
+        _add_dump_manifest_section(result, dump_manifest)
+    result.add(
+        "Resolved depth and source scope",
+        f"requested depth: {depth or '(auto)'}",
+        f"effective collect mode: {collect_mode}",
+        "source scope: target (dump always analyzes the resolved library target)"
+        if collect_mode in ("source-target", "source-changed", "graph-full")
+        else None,
+    )
+    result.add(
+        "Headers and compile context",
+        f"ast-frontend: {header_backend}",
+    )
+    result.add(
+        "Build/source inputs",
+        f"--sources: {sources}" if sources else None,
+        f"--build-info: {build_info}" if build_info else None,
+        # AC-007: the real run reuses a matched -p/--compile-db as the L3 build
+        # source when no --build-info is given, so report that here and do not
+        # also claim "L0-L2 only" (Codex review).
+        "L3 build source: reused from -p/--compile-db (no --build-info needed)"
+        if compile_db_reused_as_l3
+        else None,
+        "no --sources/--build-info given -- L0-L2 only"
+        if sources is None
+        and build_info is None
+        and not compile_db_reused_as_l3
+        and collect_mode != "off"
+        else None,
+    )
+    result.add("Tools and frontends", *tool_status("castxml", "clang", "gcc", "g++"))
+    if so_path is not None:
+        _add_dump_data_layers(result, so_path, headers)
+    cfg_path = build_config or discover_project_config(sources)
+    result.add(
+        "Configuration and value origins",
+        f".abicheck.yml: {cfg_path if cfg_path else '(none found)'}",
+    )
+    result.add(
+        "Output and exit-code behavior",
+        f"output: {output if output else 'stdout'}",
+        "exit codes: 0 valid, 1 requested depth not satisfiable, 64 usage error",
+    )
+    _add_dump_depth_feasibility(
+        result,
+        so_path=so_path,
+        sources=sources,
+        build_info=build_info,
+        depth=depth,
+        has_compile_db=has_compile_db,
+        compile_db_matched=compile_db_matched,
+        build_info_is_pack=build_info_is_pack,
+        dump_manifest=dump_manifest,
+    )
     return result
 
 

--- a/abicheck/cli_helpers_compare.py
+++ b/abicheck/cli_helpers_compare.py
@@ -28,10 +28,11 @@ from __future__ import annotations
 
 import dataclasses
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -44,6 +45,7 @@ if TYPE_CHECKING:
     from .checker_types import Change, DiffResult
     from .compatibility_evaluation_frontend import PublicSymbolsList
     from .model import AbiSnapshot
+    from .policy_file import PolicyFile
     from .service_scan import CompileContext
     from .severity import SeverityConfig
 
@@ -803,3 +805,464 @@ def fold_l0_hard_removals(
 
     l0_hard_removals = collect_l0_export_delta(Path(old_path), Path(new_path), lang)
     return [*(extra_changes or []), *l0_hard_removals]
+
+
+# ---------------------------------------------------------------------------
+# ADR-043 scoped gating (--used-by / --required-symbol(s))
+#
+# Relocated here from ``cli_compare_helpers`` (which sits at the AI-readiness
+# 2000-line hard cap) as one self-contained family: the per-app/per-contract
+# scoping passes, the runtime-probe overlay, the worst-wins exit-code and
+# verdict ranking, and the JSON-safe summaries the renderer reads back off
+# ``result``. A pure relocation -- ``cli_compare_helpers`` re-exports every name
+# below, so ``cli_compare_helpers._verdict_exit_code`` (which
+# ``cli_scan_baseline`` imports) and the existing test patch targets keep
+# resolving unchanged, and a bare-name call there still goes through that
+# module's namespace. This module, not a new one, because a *new* module
+# reaching ``service``/``appcompat`` would join the allowlisted CLI
+# import-cycle SCC, which CLAUDE.md "M1-3" forbids extending; this one is
+# already a member.
+# ---------------------------------------------------------------------------
+
+
+def _app_compat_summary(result: object) -> dict[str, Any]:
+    """Project an :class:`appcompat.AppCompatResult` into a small JSON-safe dict."""
+    return {
+        "app": result.app_path,  # type: ignore[attr-defined]
+        "verdict": result.verdict.value,  # type: ignore[attr-defined]
+        "required_symbol_count": result.required_symbol_count,  # type: ignore[attr-defined]
+        "missing_symbols": result.missing_symbols,  # type: ignore[attr-defined]
+        "missing_versions": result.missing_versions,  # type: ignore[attr-defined]
+        "relevant_change_count": len(result.breaking_for_app),  # type: ignore[attr-defined]
+        "symbol_coverage": round(result.symbol_coverage, 1),  # type: ignore[attr-defined]
+    }
+
+
+def _plugin_contract_summary(result: object) -> dict[str, Any]:
+    """Project a :class:`appcompat.PluginHostContractResult` into a small dict."""
+    return {
+        "verdict": result.verdict.value,  # type: ignore[attr-defined]
+        "required_entrypoints": sorted(result.required_entrypoints),  # type: ignore[attr-defined]
+        "missing_entrypoints": result.missing_entrypoints,  # type: ignore[attr-defined]
+        "relevant_change_count": len(result.breaking_for_host),  # type: ignore[attr-defined]
+        "coverage": round(result.coverage, 1),  # type: ignore[attr-defined]
+    }
+
+
+def _verdict_exit_code(verdict: object) -> int:
+    """Map a scoped-comparison Verdict to its floor exit code (ADR-043)."""
+    value = getattr(verdict, "value", verdict)
+    if value == "BREAKING":
+        return 4
+    if value == "API_BREAK":
+        return 2
+    return 0
+
+
+_VERDICT_SEVERITY_RANK = {
+    "BREAKING": 3, "API_BREAK": 2, "COMPATIBLE_WITH_RISK": 1,
+    "COMPATIBLE": 0, "NO_CHANGE": 0,
+}
+
+
+def _verdict_severity_rank(verdict: object) -> int:
+    """Rank a Verdict by severity, independent of any exit-code scheme.
+
+    Under a severity scheme, a BREAKING app can carry exit code 0 (e.g.
+    ``--severity-preset info-only``) -- ranking "worst app" by exit code
+    would then let a later COMPATIBLE app (also exit code 0) overwrite the
+    reported scoped verdict, so JSON/HTML/SARIF could claim COMPATIBLE while
+    an earlier --used-by summary is still BREAKING (Codex review). Verdict
+    selection for reporting must stay keyed on verdict severity, not on the
+    (independently correct) max-exit-code computation used for gating.
+    """
+    value = getattr(verdict, "value", verdict)
+    return _VERDICT_SEVERITY_RANK.get(value, 0) if isinstance(value, str) else 0
+
+
+def _scoped_exit_code(
+    scoped: Any, relevant_changes: list[Any],
+    result: Any, exit_code_scheme: str, sev_config: Any,
+    policy: str, policy_file: PolicyFile | None,
+    *, has_missing_contract: bool = False,
+) -> int:
+    """Compute a scoped result's exit code under the active exit-code scheme.
+
+    ADR-043's --used-by/--required-symbol(s) floor the exit code on the
+    *scoped* verdict rather than the full library's -- but that floor must
+    still respect ``--exit-code-scheme severity``/``--severity-*``: without
+    this, a scoped compare silently reverted to the legacy 0/2/4 mapping no
+    matter what severity configuration the caller passed, because the scoped
+    branch returned straight to ``sys.exit`` before the severity-aware exit
+    handler ever ran.
+
+    *has_missing_contract* (a required symbol/version/entrypoint absent from
+    the new library) floors the severity-scheme exit code separately from
+    *relevant_changes*: a missing contract symbol is BREAKING but is not a
+    diff ``Change``, so ``compute_exit_code`` never sees it and would
+    otherwise return 0 (Codex review).
+    """
+    if exit_code_scheme == "severity":
+        from .severity import compute_exit_code, missing_contract_exit_code
+
+        code = compute_exit_code(
+            relevant_changes, sev_config,
+            policy=policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=policy_file,
+        )
+        if has_missing_contract:
+            code = max(code, missing_contract_exit_code(sev_config))
+        return code
+    return _verdict_exit_code(scoped.verdict)
+
+
+def _scoped_severity_summary(
+    relevant_changes: list[Any], missing: Iterable[str],
+    result: Any, sev_config: Any, policy: str, policy_file: PolicyFile | None,
+) -> tuple[tuple[str, ...], dict[str, int]]:
+    """(blocking_categories, per-category counts) for one scoped result.
+
+    Mirrors ``_scoped_exit_code``'s missing-contract floor: a missing
+    symbol/version/entrypoint with no matching diff Change is folded into
+    ``abi_breaking`` directly here -- both into the blocking-categories set
+    (when abi_breaking is severity-configured as error, matching the exit
+    -code floor) and into the count (always, since a count is a factual
+    tally, not a gate decision) -- otherwise a missing-contract-only scoped
+    BREAKING would report an empty ``blocking_categories`` alongside a
+    nonzero exit code, or a ``categories.abi_breaking.count`` of 0 alongside
+    a blocking ``abi_breaking`` category (Codex review). A *missing* entry
+    that already has a matching Change in *relevant_changes* (e.g. a removed
+    symbol is both "missing" from the new export table and a ``FUNC_REMOVED``
+    Change) is excluded via ``uncovered_missing_symbols`` -- otherwise that
+    single ABI break would be counted twice (Codex review follow-up).
+    """
+    from .appcompat import uncovered_missing_symbols
+    from .severity import (
+        IssueCategory,
+        SeverityLevel,
+        categorize_changes,
+        compute_gate_decision,
+    )
+
+    categorized = categorize_changes(
+        relevant_changes, policy=policy,
+        kind_sets=result._effective_kind_sets(), policy_file=policy_file,
+    )
+    counts = {
+        "abi_breaking": len(categorized.abi_breaking),
+        "potential_breaking": len(categorized.potential_breaking),
+        "quality_issues": len(categorized.quality_issues),
+        "addition": len(categorized.addition),
+    }
+    gate = compute_gate_decision(
+        relevant_changes, sev_config,
+        policy=policy, kind_sets=result._effective_kind_sets(), policy_file=policy_file,
+    )
+    categories = list(gate.blocking_categories)
+    uncovered = uncovered_missing_symbols(missing, relevant_changes)
+    if uncovered:
+        counts["abi_breaking"] += len(uncovered)
+        if (
+            sev_config.abi_breaking == SeverityLevel.ERROR
+            and IssueCategory.ABI_BREAKING.value not in categories
+        ):
+            categories.append(IssueCategory.ABI_BREAKING.value)
+    return tuple(categories), counts
+
+
+def _require_used_by_binary_evidence(
+    old_lib: Any, new_lib: Any, old_input: Path, new_input: Path,
+) -> None:
+    """Reject a ``--used-by`` run whose OLD/NEW side carries no binary evidence.
+
+    A real library path always qualifies; a JSON snapshot qualifies only when it
+    carries an ``elf``/``pe``/``macho`` block (i.e. it is a ``dump`` of a real
+    library, not a headers-only one) -- that is what supplies the SONAME/export
+    table/version list/PE ordinal table the scoping needs.
+    """
+    for lib, path, label in (
+        (old_lib, old_input, "OLD"), (new_lib, new_input, "NEW"),
+    ):
+        has_binary_evidence = isinstance(lib, Path) or any(
+            getattr(lib, field, None) is not None for field in ("elf", "pe", "macho")
+        )
+        if not has_binary_evidence:
+            raise click.UsageError(
+                f"--used-by requires OLD/NEW to be real library binaries, or "
+                f"JSON snapshots carrying binary evidence (a `dump` of a real "
+                f"library, not headers-only); {label} ({path}) is neither."
+            )
+
+
+def _apply_runtime_probe(
+    scoped: Any, app: Path, old_lib: Path, new_lib: Path,
+    suppression: Any, policy: str, policy_file: PolicyFile | None,
+) -> None:
+    """Run *app* against both libraries and fold a load regression into *scoped*.
+
+    ADR-044 P2 item 2. Mutates *scoped* in place: appends a
+    ``CONSUMER_RUNTIME_LOAD_FAILED`` finding (unless a suppression rule removes
+    it) and recomputes the app verdict, since ``scope_diff_to_app`` computed it
+    before this RISK-tier finding existed.
+    """
+    from .checker_policy import ChangeKind, ReachabilityState
+    from .diff_helpers import make_change
+    from .runtime_probe import run_runtime_probe
+
+    probe = run_runtime_probe(app, old_lib, new_lib)
+    regressed_symbol = probe.regressed_symbol
+    if not regressed_symbol:
+        return
+    # public_reachable=True (Codex review, fresh evidence, mirrors
+    # appcompat.scope_diff_to_app's identical fix for
+    # CONSUMER_REQUIRED_SYMBOL_REMOVED): this finding only exists
+    # because the dynamic linker itself failed to resolve a
+    # symbol for a real, executed --used-by consumer binary --
+    # left at the dataclass default (False), a broad
+    # namespace/source_location suppression rule's default
+    # "unreachable-only" reachability would read it as
+    # unreachable and silently suppress a runtime regression that
+    # is, by construction, always consumer-proven real.
+    runtime_change = make_change(
+        ChangeKind.CONSUMER_RUNTIME_LOAD_FAILED,
+        symbol=regressed_symbol,
+        name=app.name,
+        public_reachable=True,
+        reachability_kind="consumer_proven",
+        reachability_state=ReachabilityState.PROVEN_REACHABLE,
+    )
+    add_finding = suppression is None
+    if suppression is not None:
+        outcome = suppression.evaluate(runtime_change)
+        add_finding = not outcome.suppressed
+        # outcome.withheld_unknown_rule is never set here:
+        # runtime_change is always constructed with
+        # reachability_state=PROVEN_REACHABLE above (it is by
+        # construction consumer-proven), and
+        # would_withhold_unknown_reachability only ever fires on
+        # UNKNOWN.
+        if add_finding and outcome.withheld_rule is not None:
+            from .post_processing import _build_suppression_overreach_change
+
+            scoped.breaking_for_app.append(
+                _build_suppression_overreach_change(
+                    runtime_change, outcome.withheld_rule
+                )
+            )
+    if not add_finding:
+        return
+    scoped.breaking_for_app.append(runtime_change)
+    # scope_diff_to_app already computed scoped.verdict before
+    # this RISK-tier finding existed -- recompute so a clean
+    # static scope plus a runtime regression reports
+    # COMPATIBLE_WITH_RISK instead of a stale COMPATIBLE
+    # (Codex review).
+    from .appcompat import _compute_appcompat_verdict
+
+    scoped.verdict = _compute_appcompat_verdict(
+        scoped.missing_symbols, scoped.missing_versions,
+        scoped.breaking_for_app, scoped.required_symbol_count,
+        policy, policy_file,
+    )
+
+
+def _apply_used_by_scoping(
+    result: Any, used_by_apps: tuple[Path, ...],
+    old_input: Path, new_input: Path,
+    old_snapshot: Any, new_snapshot: Any,
+    policy: str, policy_file: PolicyFile | None,
+    exit_code_scheme: str = "legacy", sev_config: Any = None,
+    verify_runtime: bool = False,
+    suppression: Any = None,
+) -> int:
+    """Scope *result* to each ``--used-by`` app; worst-wins (ADR-043).
+
+    OLD/NEW may be real library binaries or JSON snapshots (e.g. a saved
+    ``dump`` output): a recognized binary is parsed directly; otherwise the
+    already-loaded snapshot (``old_snapshot``/``new_snapshot``, from
+    ``compare``'s own pipeline) is used instead, since a snapshot's
+    ``elf``/``pe``/``macho`` fields already carry the SONAME/export table/
+    version list/PE ordinal table :func:`~abicheck.appcompat.scope_diff_to_app`
+    needs. Attaches a JSON-safe summary to ``result.used_by`` for the
+    renderer and returns the worst app's exit code, computed under
+    *exit_code_scheme* (legacy verdict floor, or severity-aware over each
+    app's relevant changes when the caller passed --severity-*).
+
+    *verify_runtime* (ADR-044 P2 item 2) additionally runs each app once
+    against the old library and once against the new one
+    (:func:`~abicheck.runtime_probe.run_runtime_probe`) when both are real
+    binaries — a JSON-snapshot side has no file to execute against, so the
+    probe is silently skipped for that app, same as the static check's own
+    snapshot fallback degrades gracefully.
+
+    *suppression* (ADR-044 P2, Codex review) is forwarded to
+    :func:`~abicheck.appcompat.scope_diff_to_app` and also consulted here
+    directly for the ``CONSUMER_RUNTIME_LOAD_FAILED`` overlay: both findings
+    are synthesized *after* the pipeline's own suppression pass already ran
+    over ``result.changes``, so without this they would be unsuppressible
+    even by an exact rule.
+    """
+    from .appcompat import scope_diff_to_app
+    from .service import detect_binary_format
+
+    old_lib = old_input if detect_binary_format(old_input) is not None else old_snapshot
+    new_lib = new_input if detect_binary_format(new_input) is not None else new_snapshot
+
+    _require_used_by_binary_evidence(old_lib, new_lib, old_input, new_input)
+
+    from .appcompat import uncovered_missing_symbols
+    from .reporter import _finding_id
+
+    summaries = []
+    worst_exit = 0
+    worst_verdict = None
+    worst_verdict_rank = -1
+    # Keyed by the change's semantic identity (kind/symbol/old/new/location/
+    # description, via `_finding_id`) -- not id(change) -- so a Change or
+    # missing symbol shared by two tied apps (e.g. both import the same
+    # removed symbol) collapses to one entry instead of being tallied once
+    # per app (Codex review) -- `_scoped_severity_summary` runs once at the
+    # end over this deduplicated union, not per app summed together.
+    # `id()` alone under-deduplicates PE_ORDINAL_RETARGETED findings:
+    # `scope_diff_to_app` synthesizes a fresh `Change` object per app (via
+    # `_check_pe_ordinal_imports`), so two apps hitting the same ordinal
+    # retarget produce structurally-identical but object-distinct `Change`s
+    # that `id()` would double-count in the severity summary.
+    worst_changes: dict[str, Any] = {}
+    worst_missing: set[str] = set()
+    # Union across ALL apps (not just the worst-exit-code one) of which
+    # findings this --used-by gate actually cares about -- SARIF/JUnit
+    # consult this to make their own result levels/failure counts follow
+    # the scoped gate instead of the full, unscoped library diff (CLI-audit
+    # P1: "SARIF/JUnit computing pass/fail from the full library diff").
+    relevant_finding_ids: set[str] = set()
+    # Union across ALL apps of relevant Change objects, keyed by finding id --
+    # not just their ids -- so scoped-only changes (e.g. PE_ORDINAL_RETARGETED,
+    # which scope_diff_to_app synthesizes fresh per app and never adds to
+    # result.changes) can still be rendered by SARIF/JUnit instead of only
+    # contributing to the gate's exit code with nothing to explain it (Codex
+    # review).
+    relevant_changes_by_id: dict[str, Any] = {}
+    missing_labels: set[str] = set()
+    for app in used_by_apps:
+        scoped = scope_diff_to_app(
+            result, app, old_lib, new_lib,
+            policy=policy, policy_file=policy_file, suppression=suppression,
+            # ADR-057: old_lib above is the *path* whenever OLD is a real
+            # binary, and a path carries no L5 graph -- pass the snapshot
+            # compare's own pipeline already resolved so the consumer-impact
+            # join can explain why a consumer required a removed symbol.
+            # Graph lookup only; old_lib still owns every export/version read.
+            old_snapshot=old_snapshot,
+        )
+        if verify_runtime and isinstance(old_lib, Path) and isinstance(new_lib, Path):
+            _apply_runtime_probe(
+                scoped, app, old_lib, new_lib, suppression, policy, policy_file,
+            )
+        summaries.append(_app_compat_summary(scoped))
+        relevant_finding_ids.update(_finding_id(c) for c in scoped.breaking_for_app)
+        relevant_changes_by_id.update(
+            {_finding_id(c): c for c in scoped.breaking_for_app}
+        )
+        # A missing symbol/version already covered by a relevant Change (e.g.
+        # FUNC_REMOVED) must not also become a synthetic missing-contract
+        # finding -- that would double-report the same ABI break (Codex
+        # review, mirrors _scoped_severity_summary's own dedup below).
+        missing_labels.update(
+            uncovered_missing_symbols(
+                list(scoped.missing_symbols) + list(scoped.missing_versions),
+                scoped.breaking_for_app,
+            )
+        )
+        exit_code = _scoped_exit_code(
+            scoped, scoped.breaking_for_app, result, exit_code_scheme, sev_config,
+            policy, policy_file,
+            has_missing_contract=bool(scoped.missing_symbols or scoped.missing_versions),
+        )
+        # exit code (gating) and verdict (reporting) are maxed/ranked
+        # independently: under a severity scheme the two can disagree (a
+        # BREAKING app can carry exit code 0 under e.g. `--severity-preset
+        # info-only`), so picking the reported scoped_verdict by exit code
+        # could let a later, less-severe app overwrite an earlier BREAKING
+        # one merely because their exit codes tied at 0 (Codex review).
+        if exit_code_scheme == "severity":
+            if exit_code > worst_exit:
+                worst_changes = {_finding_id(c): c for c in scoped.breaking_for_app}
+                worst_missing = set(scoped.missing_symbols) | set(scoped.missing_versions)
+            elif exit_code == worst_exit:
+                worst_changes.update({_finding_id(c): c for c in scoped.breaking_for_app})
+                worst_missing |= set(scoped.missing_symbols) | set(scoped.missing_versions)
+        worst_exit = max(worst_exit, exit_code)
+        rank = _verdict_severity_rank(scoped.verdict)
+        if worst_verdict is None or rank >= worst_verdict_rank:
+            worst_verdict_rank = rank
+            worst_verdict = scoped.verdict
+    result.used_by = summaries  # type: ignore[attr-defined]
+    result.scoped_verdict = worst_verdict  # type: ignore[attr-defined]
+    result.scoped_exit_code = worst_exit  # type: ignore[attr-defined]
+    result.scoped_exit_code_scheme = exit_code_scheme  # type: ignore[attr-defined]
+    result.gate_scope = "used_by"  # type: ignore[attr-defined]
+    result.scoped_relevant_finding_ids = frozenset(relevant_finding_ids)  # type: ignore[attr-defined]
+    result.scoped_missing_labels = tuple(sorted(missing_labels))  # type: ignore[attr-defined]
+    _existing_ids = {_finding_id(c) for c in result.changes}
+    result.scoped_only_changes = tuple(  # type: ignore[attr-defined]
+        c for fid, c in relevant_changes_by_id.items() if fid not in _existing_ids
+    )
+    if exit_code_scheme == "severity":
+        categories, counts = _scoped_severity_summary(
+            list(worst_changes.values()), worst_missing,
+            result, sev_config, policy, policy_file,
+        )
+        result.scoped_blocking_categories = categories  # type: ignore[attr-defined]
+        result.scoped_severity_counts = counts  # type: ignore[attr-defined]
+    return worst_exit
+
+
+def _apply_required_symbol_scoping(
+    result: Any, required_symbols: tuple[str, ...],
+    old: Any, new: Any,
+    policy: str, policy_file: PolicyFile | None,
+    exit_code_scheme: str = "legacy", sev_config: Any = None,
+) -> int:
+    """Scope *result* to an explicit ``--required-symbol(s)`` contract (ADR-043)."""
+    from .appcompat import scope_diff_to_required_symbols, uncovered_missing_symbols
+    from .reporter import _finding_id
+
+    scoped = scope_diff_to_required_symbols(
+        result, old, new, required_symbols,
+        policy=policy, policy_file=policy_file,
+    )
+    result.required_symbols = _plugin_contract_summary(scoped)  # type: ignore[attr-defined]
+    result.scoped_verdict = scoped.verdict  # type: ignore[attr-defined]
+    result.gate_scope = "required_symbol"  # type: ignore[attr-defined]
+    result.scoped_relevant_finding_ids = frozenset(  # type: ignore[attr-defined]
+        _finding_id(c) for c in scoped.breaking_for_host
+    )
+    # An entrypoint already covered by a relevant Change must not also
+    # become a synthetic missing-contract finding (Codex review, mirrors
+    # _apply_used_by_scoping's identical dedup).
+    result.scoped_missing_labels = tuple(sorted(  # type: ignore[attr-defined]
+        uncovered_missing_symbols(scoped.missing_entrypoints, scoped.breaking_for_host)
+    ))
+    # Scoped-only changes: relevant to the host contract but never added to
+    # result.changes (mirrors _apply_used_by_scoping's identical handling).
+    _existing_ids = {_finding_id(c) for c in result.changes}
+    result.scoped_only_changes = tuple(  # type: ignore[attr-defined]
+        c for c in scoped.breaking_for_host if _finding_id(c) not in _existing_ids
+    )
+    exit_code = _scoped_exit_code(
+        scoped, scoped.breaking_for_host, result, exit_code_scheme, sev_config,
+        policy, policy_file,
+        has_missing_contract=bool(scoped.missing_entrypoints),
+    )
+    result.scoped_exit_code = exit_code  # type: ignore[attr-defined]
+    result.scoped_exit_code_scheme = exit_code_scheme  # type: ignore[attr-defined]
+    if exit_code_scheme == "severity":
+        categories, counts = _scoped_severity_summary(
+            scoped.breaking_for_host, scoped.missing_entrypoints,
+            result, sev_config, policy, policy_file,
+        )
+        result.scoped_blocking_categories = categories  # type: ignore[attr-defined]
+        result.scoped_severity_counts = counts  # type: ignore[attr-defined]
+    return exit_code

--- a/abicheck/cli_scan.py
+++ b/abicheck/cli_scan.py
@@ -816,6 +816,199 @@ def _run_artifact_set(
         sys.exit(result.exit_code)
 
 
+def _resolve_scan_evaluation_config(
+    *,
+    against: Path | None, contract_evaluation: bool, pack_paths: tuple[Path, ...],
+    policy: str, policy_file: Any,
+    project_cfg: Any, cfg_path: Path | None, project_sha256: str | None,
+    suppression: Any, suppress: Path | None, symbols_list: Any,
+) -> tuple[Any, Any]:
+    """Resolve this scan's ADR-049 configuration and fold in any ``--pack``.
+
+    Returns ``(resolved_config, policy_file)`` -- ``(None, policy_file)`` when
+    there is nothing to resolve, i.e. no ``--against`` to compare against or
+    neither ``--contract-evaluation`` nor ``--pack`` given.
+
+    ADR-049 Phase 5's "same typed config", for the third and last front end.
+    ``checker.compare`` can only claim ``API_REQUEST`` for arguments it was
+    handed, so without this the scan's persisted ``evaluation_context`` carried
+    the core verb's reconstruction rather than real D7 provenance -- the same
+    defect already fixed for ``compare``. Resolved here because this is where
+    the Click context is: which flags the user actually typed is a question
+    only the front end can answer.
+    """
+    if against is None or not (contract_evaluation or pack_paths):
+        return None, policy_file
+    resolved_config = None
+    from .cli_scan_receipt import SCAN_CONFIG_PARAMS, resolve_scan_config
+    from .compatibility_evaluation_resolver import (
+        FieldResolutionError,
+        PackConflictError,
+    )
+    from .errors import PackManifestError
+
+    _ctx = click.get_current_context()
+    _params = {name: _ctx.params.get(name) for name in SCAN_CONFIG_PARAMS}
+    _typed = {
+        name
+        for name in SCAN_CONFIG_PARAMS
+        if _ctx.get_parameter_source(name) == click.core.ParameterSource.COMMANDLINE
+    }
+    try:
+        resolved_config = resolve_scan_config(
+            _params,
+            typed=_typed,
+            project_cfg=project_cfg,
+            project_path=cfg_path,
+            project_sha256=project_sha256,
+            policy_file=policy_file,
+            suppression=suppression,
+            suppress_path=suppress,
+            symbols_list=symbols_list,
+        )
+        if pack_paths:
+            # ADR-049 D8: a pack that reached the receipt and not the
+            # engine is exactly what got the flag reverted once before, so
+            # its contributions are folded into the policy file the
+            # baseline comparison runs with. `gate_supported=False`
+            # because a scan's exit code follows its verdict directly --
+            # the same reason `cli_scan_receipt._without_gate_settings`
+            # blanks the gate rather than reporting one it never used.
+            from .pack_application import (
+                check_resolved_config_applies_packs,
+                pack_application,
+                policy_file_with_packs,
+            )
+
+            # Emptiness is not asked here: it is a property of the file,
+            # and `load_selected_packs` -- which the resolution above
+            # already went through -- rejects an empty manifest on the
+            # very revision that configured this run. Asking it again
+            # from a second read would only move that window, not close
+            # it (Codex review).
+            #
+            # Everything else is asked of the resolution, not a second
+            # read of the files -- same reasoning as the compare path:
+            # the resolver already loaded its own copy, so re-reading
+            # would validate a revision that is not the one configuring
+            # the run (Codex review, raised for compare and then here).
+            check_resolved_config_applies_packs(
+                resolved_config,
+                gate_supported=False,
+                gate_reason=(
+                    "a scan's exit code follows its compatibility verdict "
+                    "directly, so it has no severity or exit-code scheme "
+                    "for a gate pack to move (compare does)"
+                ),
+                contract_evaluation=contract_evaluation,
+            )
+            policy_file = policy_file_with_packs(
+                policy_file,
+                pack_application(resolved_config, policy_file=policy_file),
+                base_policy=policy,
+            )
+    except (FieldResolutionError, PackConflictError, PackManifestError) as exc:
+        # A D7 same-tier conflict or a D8 pack conflict is a usage error,
+        # exactly as it is for `compare` -- not a traceback out of a
+        # command that had already validated its own flags.
+        #
+        # Narrower than `service_scan._scan_request_config`'s
+        # `except (ValueError, PackManifestError)` on purpose, not by
+        # oversight: the extra case that catch covers is an unknown base
+        # policy, which reaches the resolver only as a free string on a
+        # typed `ScanRequest`. Here `--policy` is a `click.Choice`, so
+        # Click rejects an unknown base before this call. If either front
+        # end gains a new failure mode, change both.
+        raise click.UsageError(str(exc)) from exc
+    return resolved_config, policy_file
+
+
+def _reject_incoherent_scan_operands(
+    *,
+    artifact: Path | None,
+    artifact_set: str | None,
+    against: Path | None,
+    dry_run: bool,
+    bundle_system_providers: str,
+) -> None:
+    """Reject operand/flag combinations ``scan`` cannot serve.
+
+    An empty ``--artifact-set`` is rejected explicitly rather than left to
+    collapse to ``Path("") == Path(".")`` and audit the whole CWD (CodeRabbit
+    review). ``--artifact-set`` is audit-only -- there is no old side for a set
+    -- so ``--against`` is rejected with it, and ``--dry-run`` is not wired for
+    it yet. ``--bundle-system-providers`` is the mirror case: it only means
+    something *for* a set.
+    """
+    if artifact_set is not None and not artifact_set.strip():
+        raise click.UsageError("--artifact-set must not be empty.")
+    if (artifact is not None) == (artifact_set is not None):
+        raise click.UsageError(
+            "scan requires exactly one of ARTIFACT or --artifact-set."
+        )
+    if artifact_set is not None:
+        if against is not None:
+            raise click.UsageError(
+                "--against is not supported with --artifact-set "
+                "(audit-only -- no old side for a set)."
+            )
+        if dry_run:
+            raise click.UsageError(
+                "--dry-run is not yet supported with --artifact-set."
+            )
+    elif bundle_system_providers:
+        raise click.UsageError("--bundle-system-providers requires --artifact-set.")
+
+
+def _discover_scan_project_config(
+    build_config: Path | None, sources: Path | None, against: Path | None,
+) -> tuple[Path | None, Any, str | None]:
+    """Resolve the project config for this scan, with the digest that parsed it.
+
+    Returns ``(cfg_path, project_cfg, sha256)``. An explicitly-bound
+    ``--build-config`` that cannot be parsed is a usage error; an
+    auto-discovered one is best-effort and degrades to a warning with
+    ``cfg_path`` cleared, matching ``merge_compile_config``'s own convention --
+    a config the user never explicitly bound to shouldn't fail a run it wasn't
+    asked to affect.
+    """
+    from .buildsource.inline import discover_build_config
+
+    explicit_config = build_config is not None
+    cfg_path = build_config if explicit_config else discover_build_config(sources)
+    if cfg_path is None and not explicit_config and against is not None:
+        from .cli_helpers_compare import discover_project_config
+
+        cfg_path = discover_project_config()
+    project_cfg = None
+    # ADR-049 D6: a project-derived receipt entry must name the path *and*
+    # prove which revision supplied the value, from the same read that
+    # parsed it -- so the digest comes from `load_build_config_with_digest`
+    # rather than a second read at receipt time.
+    _project_sha256: str | None = None
+    if cfg_path is not None:
+        try:
+            from .buildsource.build_config_io import load_build_config_with_digest
+
+            project_cfg, _project_sha256 = load_build_config_with_digest(cfg_path)
+        except ValueError as exc:
+            if explicit_config:
+                raise click.UsageError(
+                    f"cannot parse build config {cfg_path}: {exc}"
+                ) from exc
+            # Auto-discovered (--sources root or cwd-upward): best-effort,
+            # matching `merge_compile_config`'s own identical convention --
+            # a config the user never explicitly bound to shouldn't fail a
+            # run it wasn't asked to affect.
+            click.echo(
+                f"warning: could not parse auto-discovered {cfg_path}; "
+                f"using CLI compile/comparison settings only ({exc}).",
+                err=True,
+            )
+            cfg_path = None
+    return cfg_path, project_cfg, _project_sha256
+
+
 @main.command("scan")
 @click.argument(
     "artifact", type=click.Path(exists=True, path_type=Path), required=False
@@ -1149,22 +1342,11 @@ def scan_cmd(
     # check and then silently ignored ARTIFACT, resolving the empty string
     # to Path("") == Path(".") and auditing the whole CWD instead of
     # erroring (CodeRabbit review).
-    if artifact_set is not None and not artifact_set.strip():
-        raise click.UsageError("--artifact-set must not be empty.")
-    if (artifact is not None) == (artifact_set is not None):
-        raise click.UsageError(
-            "scan requires exactly one of ARTIFACT or --artifact-set."
-        )
+    _reject_incoherent_scan_operands(
+        artifact=artifact, artifact_set=artifact_set, against=against,
+        dry_run=dry_run, bundle_system_providers=bundle_system_providers,
+    )
     if artifact_set is not None:
-        if against is not None:
-            raise click.UsageError(
-                "--against is not supported with --artifact-set "
-                "(audit-only -- no old side for a set)."
-            )
-        if dry_run:
-            raise click.UsageError(
-                "--dry-run is not yet supported with --artifact-set."
-            )
         _reject_comparison_only_flags(no_baseline_reason="drop --artifact-set")
         _run_artifact_set(
             artifact_set=artifact_set,
@@ -1197,8 +1379,6 @@ def scan_cmd(
             frontend_context=frontend_context,
         )
         return
-    if bundle_system_providers:
-        raise click.UsageError("--bundle-system-providers requires --artifact-set.")
     # The mutual-exclusion check above already guarantees exactly one of
     # ARTIFACT/--artifact-set is set, and the --artifact-set branch always
     # returns -- so `artifact` is non-None on every path reaching here.
@@ -1251,40 +1431,9 @@ def scan_cmd(
     # only flags without --against" guard above, only attempted for an
     # actual `--against` comparison -- a plain one-build audit never needs
     # any of this, so it must not even try the cwd-upward walk.
-    from .buildsource.inline import discover_build_config
-
-    explicit_config = build_config is not None
-    cfg_path = build_config if explicit_config else discover_build_config(sources)
-    if cfg_path is None and not explicit_config and against is not None:
-        from .cli_helpers_compare import discover_project_config
-
-        cfg_path = discover_project_config()
-    project_cfg = None
-    # ADR-049 D6: a project-derived receipt entry must name the path *and*
-    # prove which revision supplied the value, from the same read that
-    # parsed it -- so the digest comes from `load_build_config_with_digest`
-    # rather than a second read at receipt time.
-    _project_sha256: str | None = None
-    if cfg_path is not None:
-        try:
-            from .buildsource.build_config_io import load_build_config_with_digest
-
-            project_cfg, _project_sha256 = load_build_config_with_digest(cfg_path)
-        except ValueError as exc:
-            if explicit_config:
-                raise click.UsageError(
-                    f"cannot parse build config {cfg_path}: {exc}"
-                ) from exc
-            # Auto-discovered (--sources root or cwd-upward): best-effort,
-            # matching `merge_compile_config`'s own identical convention --
-            # a config the user never explicitly bound to shouldn't fail a
-            # run it wasn't asked to affect.
-            click.echo(
-                f"warning: could not parse auto-discovered {cfg_path}; "
-                f"using CLI compile/comparison settings only ({exc}).",
-                err=True,
-            )
-            cfg_path = None
+    cfg_path, project_cfg, _project_sha256 = _discover_scan_project_config(
+        build_config, sources, against
+    )
 
     # L2 header compile context (compare↔dump↔scan parity, ADR-037 D3): the one
     # shared resolver bundles the cross-toolchain + frontend flags and folds the
@@ -1425,88 +1574,13 @@ def scan_cmd(
     # -- the same defect already fixed for `compare` and the MCP tool.
     # Resolved here because this is where the Click context is: which flags
     # the user actually typed is a question only the front end can answer.
-    resolved_config = None
-    if against is not None and (contract_evaluation or pack_paths):
-        from .cli_scan_receipt import SCAN_CONFIG_PARAMS, resolve_scan_config
-        from .compatibility_evaluation_resolver import (
-            FieldResolutionError,
-            PackConflictError,
-        )
-        from .errors import PackManifestError
-
-        _ctx = click.get_current_context()
-        _params = {name: _ctx.params.get(name) for name in SCAN_CONFIG_PARAMS}
-        _typed = {
-            name
-            for name in SCAN_CONFIG_PARAMS
-            if _ctx.get_parameter_source(name) == click.core.ParameterSource.COMMANDLINE
-        }
-        try:
-            resolved_config = resolve_scan_config(
-                _params,
-                typed=_typed,
-                project_cfg=project_cfg,
-                project_path=cfg_path,
-                project_sha256=_project_sha256,
-                policy_file=policy_file,
-                suppression=suppression,
-                suppress_path=suppress,
-                symbols_list=_symbols_list,
-            )
-            if pack_paths:
-                # ADR-049 D8: a pack that reached the receipt and not the
-                # engine is exactly what got the flag reverted once before, so
-                # its contributions are folded into the policy file the
-                # baseline comparison runs with. `gate_supported=False`
-                # because a scan's exit code follows its verdict directly --
-                # the same reason `cli_scan_receipt._without_gate_settings`
-                # blanks the gate rather than reporting one it never used.
-                from .pack_application import (
-                    check_resolved_config_applies_packs,
-                    pack_application,
-                    policy_file_with_packs,
-                )
-
-                # Emptiness is not asked here: it is a property of the file,
-                # and `load_selected_packs` -- which the resolution above
-                # already went through -- rejects an empty manifest on the
-                # very revision that configured this run. Asking it again
-                # from a second read would only move that window, not close
-                # it (Codex review).
-                #
-                # Everything else is asked of the resolution, not a second
-                # read of the files -- same reasoning as the compare path:
-                # the resolver already loaded its own copy, so re-reading
-                # would validate a revision that is not the one configuring
-                # the run (Codex review, raised for compare and then here).
-                check_resolved_config_applies_packs(
-                    resolved_config,
-                    gate_supported=False,
-                    gate_reason=(
-                        "a scan's exit code follows its compatibility verdict "
-                        "directly, so it has no severity or exit-code scheme "
-                        "for a gate pack to move (compare does)"
-                    ),
-                    contract_evaluation=contract_evaluation,
-                )
-                policy_file = policy_file_with_packs(
-                    policy_file,
-                    pack_application(resolved_config, policy_file=policy_file),
-                    base_policy=policy,
-                )
-        except (FieldResolutionError, PackConflictError, PackManifestError) as exc:
-            # A D7 same-tier conflict or a D8 pack conflict is a usage error,
-            # exactly as it is for `compare` -- not a traceback out of a
-            # command that had already validated its own flags.
-            #
-            # Narrower than `service_scan._scan_request_config`'s
-            # `except (ValueError, PackManifestError)` on purpose, not by
-            # oversight: the extra case that catch covers is an unknown base
-            # policy, which reaches the resolver only as a free string on a
-            # typed `ScanRequest`. Here `--policy` is a `click.Choice`, so
-            # Click rejects an unknown base before this call. If either front
-            # end gains a new failure mode, change both.
-            raise click.UsageError(str(exc)) from exc
+    resolved_config, policy_file = _resolve_scan_evaluation_config(
+        against=against, contract_evaluation=contract_evaluation,
+        pack_paths=pack_paths, policy=policy, policy_file=policy_file,
+        project_cfg=project_cfg, cfg_path=cfg_path,
+        project_sha256=_project_sha256,
+        suppression=suppression, suppress=suppress, symbols_list=_symbols_list,
+    )
 
     budget_s = _parse_budget(budget)
     enabled_checks, severities = _parse_crosschecks(crosschecks)

--- a/abicheck/cli_scan_baseline.py
+++ b/abicheck/cli_scan_baseline.py
@@ -327,90 +327,25 @@ def _baseline_is_native_library(path: Path) -> bool:
     return ".so" in name or name.endswith((".dll", ".dylib"))
 
 
-def _run_baseline_compare(
+def _resolve_baseline_header_scope(
     baseline: Path,
-    binary: Path,
-    new_snap: Any,
-    extra_changes: list[Any],
-    lang: str,
-    collect_mode: str,
     headers: list[Path],
     includes: list[Path],
     public_headers: list[Path],
     public_header_dirs: list[Path],
-    compile_context: CompileContext | None = None,
-    baseline_headers: list[Path] | None = None,
-    baseline_includes: list[Path] | None = None,
-    symbols_only: bool = False,
-    debug_presence_only: bool = False,
-    suppression: SuppressionList | None = None,
-    policy: str = "strict_abi",
-    policy_file: PolicyFile | None = None,
-    scope_to_public_surface: bool = True,
-    force_public_symbols: set[str] | None = None,
-    pattern_verdicts: bool = False,
-    env_matrix: EnvironmentMatrix | None = None,
-    collapse_versioned_symbols: bool = False,
-    contract_evaluation: bool = False,
-    contract_mode: str | None = None,
-    resolved_config: Any = None,
-) -> tuple[str, int, dict[str, Any]]:
-    """Compare *new_snap* against *baseline*, preserving scan authority.
+    baseline_headers: list[Path] | None,
+    baseline_includes: list[Path] | None,
+) -> tuple[list[Path], list[Path], list[Path], list[Path]]:
+    """Pick the old side's ``(headers, includes, public_headers, public_dirs)``.
 
-    Single-version cross-source findings are reported in the scan's dedicated
-    ``crosscheck`` block and stay advisory for baseline comparisons unless the
-    maintainer explicitly promotes one with ``--crosscheck KEY=error``. They are
-    not folded into ``extra_changes`` by default: doing so lets a candidate-side
-    evidence hygiene finding such as ``header_build_context_mismatch`` turn a
-    clean old/new artifact diff into an ``API_BREAK`` false positive. Real
-    old/new embedded build/source drift is still diffed below via
-    ``prepare_embedded_build_source``.
-
-    *headers*/*includes* are the same scan header inputs used to build the
-    candidate, threaded into the baseline parse so a native ``--baseline``
-    library is header-scoped symmetrically — else the old side stays
-    symbol/DWARF-only and the compare drops old type evidence or invents spurious
-    API diffs (Codex review). They are inert for a JSON-snapshot baseline.
-
-    The embedded L3/L4/L5 build/source packs on either snapshot are diffed via
-    :func:`prepare_embedded_build_source` — the same path ``abicheck compare``
-    uses — so source-only / graph findings the collected evidence reveals are
-    folded into the verdict too (``checker.compare`` itself does not read
-    ``build_source``).
+    Each side is parsed with its *own* headers. ``scan`` has a single ``-H``
+    (built for the candidate); for a native ``--against`` library whose public
+    headers differ, ``-H old=PATH``/``-I old=PATH`` (side-aware, ADR-043 D5)
+    select the old side's headers. Without them we reuse the candidate
+    ``-H``/``-I`` — correct only when the headers did not change — so warn
+    rather than silently read the old side through the new headers (Codex).
     """
-    from .cli_buildsource import prepare_embedded_build_source
-    from .errors import AbicheckError
-    from .service import compare_snapshots, resolve_input
-
-    # Each side is parsed with its *own* headers. `scan` has a single -H (built for
-    # the candidate); for a native --against library whose public headers differ,
-    # `-H old=PATH`/`-I old=PATH` (side-aware, ADR-043 D5) select the old side's
-    # headers. Without them we reuse the candidate -H/-I — correct only when the
-    # headers did not change — so warn rather than silently read the old side
-    # through the new headers (Codex).
-    if baseline_headers:
-        bl_headers = list(baseline_headers)
-        bl_includes = list(baseline_includes) if baseline_includes else includes
-        # The old-side public boundary comes ONLY from `-H old=`: dirs in
-        # it are public-header dirs, files opt in just themselves. Do NOT fall back
-        # to the new side's public dirs — a relative dir like `include/` would
-        # (segment-based provenance) re-mark old private headers as PUBLIC and skew
-        # the public-surface scoping (Codex review).
-        #
-        # Split by file-vs-dir the same way the candidate side's
-        # `_public_provenance_set` already does (Codex review, PR #624
-        # follow-up): a lone `-H old=<dir>` umbrella must feed its directory
-        # into `bl_public_dirs` ONLY, not also into `bl_public_headers` as a
-        # raw directory "path" -- doing both fed the ADR-050 comparability
-        # gate an old side whose declared scope was represented differently
-        # from the new side's (a directory counted twice vs. once), a false
-        # scope_fingerprint mismatch on an ordinary --against comparison
-        # that never touched the actual public surface.
-        bl_public_headers = [p for p in bl_headers if not p.is_dir()]
-        bl_public_dirs = [p for p in bl_headers if p.is_dir()]
-    else:
-        bl_headers, bl_includes = headers, includes
-        bl_public_headers, bl_public_dirs = public_headers, public_header_dirs
+    if not baseline_headers:
         if headers and _baseline_is_native_library(baseline):
             click.echo(
                 f"warning: --against {baseline.name} is a native library parsed "
@@ -420,85 +355,38 @@ def _run_baseline_compare(
                 f"wrong/noisy).",
                 err=True,
             )
+        return headers, includes, public_headers, public_header_dirs
 
-    try:
-        old_snap = resolve_input(
-            baseline,
-            bl_headers,
-            bl_includes,
-            version="",
-            lang=lang,
-            public_headers=bl_public_headers,
-            public_header_dirs=bl_public_dirs,
-            compile=compile_context,
-            symbols_only=symbols_only,
-            debug_presence_only=debug_presence_only,
-            # Matches the candidate's own resolve_input() default in
-            # scan_engine.py's run_scan_core -- a no-op for a JSON snapshot
-            # baseline (already-serialized, no dumping happens), but keeps a
-            # *native* --baseline library filtered consistently with the
-            # candidate (Codex review).
-            include_dependencies=False,
-        )
-    except AbicheckError as exc:
-        raise click.ClickException(
-            f"Failed to load --baseline {baseline}: {exc}"
-        ) from exc
-
-    # Preserve hard L0 removals even when the richer header/source view cannot
-    # prove public-header ownership for the removed entity.  A source/full scan
-    # may parse both sides' headers through different consumer macro contexts;
-    # in fixtures such as case97 the old library exported a function that the
-    # old header exposes only under a consumer macro, so the final public-surface
-    # comparison can otherwise filter the old-only ELF fact away.  Re-reading the
-    # already-loaded snapshots without public-surface scoping and carrying only
-    # the hard ELF-only removal kind keeps the L0 authority while avoiding the
-    # older false-positive class where advisory cross-check findings were folded
-    # into the verdict wholesale.
+    bl_headers = list(baseline_headers)
+    bl_includes = list(baseline_includes) if baseline_includes else includes
+    # The old-side public boundary comes ONLY from `-H old=`: dirs in
+    # it are public-header dirs, files opt in just themselves. Do NOT fall back
+    # to the new side's public dirs — a relative dir like `include/` would
+    # (segment-based provenance) re-mark old private headers as PUBLIC and skew
+    # the public-surface scoping (Codex review).
     #
-    # Shares abicheck.l0_export_delta.collect_l0_export_delta with
-    # cli_helpers_compare.fold_l0_hard_removals (direct `compare`) -- ADR-049
-    # Phase 5 §6.3 -- rather than each hand-copying the same
-    # resolve-symbols-only-and-diff-unscoped extraction.
-    l0_hard_removals: tuple[Any, ...] = ()
-    if not symbols_only:
-        from .l0_export_delta import collect_l0_export_delta
+    # Split by file-vs-dir the same way the candidate side's
+    # `_public_provenance_set` already does (Codex review, PR #624
+    # follow-up): a lone `-H old=<dir>` umbrella must feed its directory
+    # into `bl_public_dirs` ONLY, not also into `bl_public_headers` as a
+    # raw directory "path" -- doing both fed the ADR-050 comparability
+    # gate an old side whose declared scope was represented differently
+    # from the new side's (a directory counted twice vs. once), a false
+    # scope_fingerprint mismatch on an ordinary --against comparison
+    # that never touched the actual public surface.
+    bl_public_headers = [p for p in bl_headers if not p.is_dir()]
+    bl_public_dirs = [p for p in bl_headers if p.is_dir()]
+    return bl_headers, bl_includes, bl_public_headers, bl_public_dirs
 
-        l0_hard_removals = collect_l0_export_delta(baseline, binary, lang)
-    # Fold embedded build-info/source (L3/L4/L5) diff findings into extra_changes
-    # before comparing — mirrors the compare command (Codex review). Only engage
-    # when a snapshot actually carries an embedded pack; otherwise pass
-    # ``collect_mode="off"`` so the pipeline stays inert (no spurious collection
-    # attempt / output noise on a plain artifact-only baseline compare).
-    has_embedded = (
-        old_snap.build_source is not None or new_snap.build_source is not None
-    )
-    merged_extra, _coverage_rows, _metrics, _ev = prepare_embedded_build_source(
-        old_snap,
-        new_snap,
-        collect_mode if has_embedded else "off",
-        [*extra_changes, *l0_hard_removals],
-        None,
-        None,
-        None,
-        None,
-        policy_file=policy_file,
-    )
-    diff = compare_snapshots(
-        old_snap,
-        new_snap,
-        suppression,
-        policy=policy,
-        policy_file=policy_file,
-        extra_changes=merged_extra,
-        scope_to_public_surface=scope_to_public_surface,
-        force_public_symbols=force_public_symbols,
-        pattern_verdicts=pattern_verdicts,
-        env_matrix=env_matrix,
-        collapse_versioned_symbols=collapse_versioned_symbols,
-        contract_evaluation=contract_evaluation,
-        contract_mode=contract_mode,
-    )
+
+def _baseline_summary(diff: Any) -> dict[str, Any]:
+    """Build the always-on ``scan --against`` summary block from *diff*.
+
+    Counts, detector provenance, the capped gating findings and the
+    suppression audit trail — everything except the contract-context block,
+    which :func:`_baseline_contract_block` adds separately because it also
+    installs the front end's resolved configuration onto *diff*.
+    """
     summary: dict[str, Any] = {
         "breaking": len(diff.breaking),
         "api_break": len(diff.source_breaks),
@@ -591,7 +479,181 @@ def _run_baseline_compare(
         )
         if len(suppressed_changes) > _MAX_BASELINE_FINDINGS:
             summary["suppressed_truncated"] = True
+    return summary
 
+
+def _baseline_contract_block(diff: Any, resolved_config: Any) -> dict[str, Any]:
+    """The ADR-049 contract-context fields for the summary, or ``{}``.
+
+    Installs this front end's own resolved configuration over the narrower
+    object ``checker.compare`` reconstructs from its arguments, then emits the
+    whole persisted context -- which ``scan --against --contract-evaluation``
+    computed and then dropped, so the receipt its per-finding decisions rest on
+    was unobservable. Same encoder ``reporter._add_contract_context`` uses, so
+    the block is byte-for-byte the one ``compare`` writes and
+    ``replay_original_decisions`` reads back.
+    """
+    from .cli_scan_receipt import context_block, record_resolved_config
+
+    if resolved_config is not None:
+        record_resolved_config(diff, resolved_config)
+    context = context_block(diff)
+    if context is None:
+        return {}
+    from .contract_coverage_exit import coverage_exit_for_context
+    from .contract_coverage_ledger import coverage_failures_for_context
+
+    # The sibling unsuppressible ledger, on the same terms `compare`
+    # reports it (plan Section 6.1) -- a coverage failure is not a
+    # finding, so it belongs beside the diff's findings, not among them.
+    failures = coverage_failures_for_context(diff.contract_context)
+    return {
+        "contract_context": context,
+        "contract_coverage_failures": [f.to_dict() for f in failures],
+        "contract_coverage_exit_contribution": coverage_exit_for_context(
+            diff.contract_context
+        ),
+    }
+
+
+def _run_baseline_compare(
+    baseline: Path,
+    binary: Path,
+    new_snap: Any,
+    extra_changes: list[Any],
+    lang: str,
+    collect_mode: str,
+    headers: list[Path],
+    includes: list[Path],
+    public_headers: list[Path],
+    public_header_dirs: list[Path],
+    compile_context: CompileContext | None = None,
+    baseline_headers: list[Path] | None = None,
+    baseline_includes: list[Path] | None = None,
+    symbols_only: bool = False,
+    debug_presence_only: bool = False,
+    suppression: SuppressionList | None = None,
+    policy: str = "strict_abi",
+    policy_file: PolicyFile | None = None,
+    scope_to_public_surface: bool = True,
+    force_public_symbols: set[str] | None = None,
+    pattern_verdicts: bool = False,
+    env_matrix: EnvironmentMatrix | None = None,
+    collapse_versioned_symbols: bool = False,
+    contract_evaluation: bool = False,
+    contract_mode: str | None = None,
+    resolved_config: Any = None,
+) -> tuple[str, int, dict[str, Any]]:
+    """Compare *new_snap* against *baseline*, preserving scan authority.
+
+    Single-version cross-source findings are reported in the scan's dedicated
+    ``crosscheck`` block and stay advisory for baseline comparisons unless the
+    maintainer explicitly promotes one with ``--crosscheck KEY=error``. They are
+    not folded into ``extra_changes`` by default: doing so lets a candidate-side
+    evidence hygiene finding such as ``header_build_context_mismatch`` turn a
+    clean old/new artifact diff into an ``API_BREAK`` false positive. Real
+    old/new embedded build/source drift is still diffed below via
+    ``prepare_embedded_build_source``.
+
+    *headers*/*includes* are the same scan header inputs used to build the
+    candidate, threaded into the baseline parse so a native ``--baseline``
+    library is header-scoped symmetrically — else the old side stays
+    symbol/DWARF-only and the compare drops old type evidence or invents spurious
+    API diffs (Codex review). They are inert for a JSON-snapshot baseline.
+
+    The embedded L3/L4/L5 build/source packs on either snapshot are diffed via
+    :func:`prepare_embedded_build_source` — the same path ``abicheck compare``
+    uses — so source-only / graph findings the collected evidence reveals are
+    folded into the verdict too (``checker.compare`` itself does not read
+    ``build_source``).
+    """
+    from .cli_buildsource import prepare_embedded_build_source
+    from .errors import AbicheckError
+    from .service import compare_snapshots, resolve_input
+
+    bl_headers, bl_includes, bl_public_headers, bl_public_dirs = _resolve_baseline_header_scope(
+        baseline, headers, includes, public_headers, public_header_dirs,
+        baseline_headers, baseline_includes,
+    )
+    try:
+        old_snap = resolve_input(
+            baseline,
+            bl_headers,
+            bl_includes,
+            version="",
+            lang=lang,
+            public_headers=bl_public_headers,
+            public_header_dirs=bl_public_dirs,
+            compile=compile_context,
+            symbols_only=symbols_only,
+            debug_presence_only=debug_presence_only,
+            # Matches the candidate's own resolve_input() default in
+            # scan_engine.py's run_scan_core -- a no-op for a JSON snapshot
+            # baseline (already-serialized, no dumping happens), but keeps a
+            # *native* --baseline library filtered consistently with the
+            # candidate (Codex review).
+            include_dependencies=False,
+        )
+    except AbicheckError as exc:
+        raise click.ClickException(
+            f"Failed to load --baseline {baseline}: {exc}"
+        ) from exc
+
+    # Preserve hard L0 removals even when the richer header/source view cannot
+    # prove public-header ownership for the removed entity.  A source/full scan
+    # may parse both sides' headers through different consumer macro contexts;
+    # in fixtures such as case97 the old library exported a function that the
+    # old header exposes only under a consumer macro, so the final public-surface
+    # comparison can otherwise filter the old-only ELF fact away.  Re-reading the
+    # already-loaded snapshots without public-surface scoping and carrying only
+    # the hard ELF-only removal kind keeps the L0 authority while avoiding the
+    # older false-positive class where advisory cross-check findings were folded
+    # into the verdict wholesale.
+    #
+    # Shares abicheck.l0_export_delta.collect_l0_export_delta with
+    # cli_helpers_compare.fold_l0_hard_removals (direct `compare`) -- ADR-049
+    # Phase 5 §6.3 -- rather than each hand-copying the same
+    # resolve-symbols-only-and-diff-unscoped extraction.
+    l0_hard_removals: tuple[Any, ...] = ()
+    if not symbols_only:
+        from .l0_export_delta import collect_l0_export_delta
+
+        l0_hard_removals = collect_l0_export_delta(baseline, binary, lang)
+    # Fold embedded build-info/source (L3/L4/L5) diff findings into extra_changes
+    # before comparing — mirrors the compare command (Codex review). Only engage
+    # when a snapshot actually carries an embedded pack; otherwise pass
+    # ``collect_mode="off"`` so the pipeline stays inert (no spurious collection
+    # attempt / output noise on a plain artifact-only baseline compare).
+    has_embedded = (
+        old_snap.build_source is not None or new_snap.build_source is not None
+    )
+    merged_extra, _coverage_rows, _metrics, _ev = prepare_embedded_build_source(
+        old_snap,
+        new_snap,
+        collect_mode if has_embedded else "off",
+        [*extra_changes, *l0_hard_removals],
+        None,
+        None,
+        None,
+        None,
+        policy_file=policy_file,
+    )
+    diff = compare_snapshots(
+        old_snap,
+        new_snap,
+        suppression,
+        policy=policy,
+        policy_file=policy_file,
+        extra_changes=merged_extra,
+        scope_to_public_surface=scope_to_public_surface,
+        force_public_symbols=force_public_symbols,
+        pattern_verdicts=pattern_verdicts,
+        env_matrix=env_matrix,
+        collapse_versioned_symbols=collapse_versioned_symbols,
+        contract_evaluation=contract_evaluation,
+        contract_mode=contract_mode,
+    )
+    summary = _baseline_summary(diff)
     # ADR-049 Phase 5: install this front end's own resolved configuration
     # over the narrower object `checker.compare` reconstructs from its
     # arguments, then emit the whole persisted context -- which `scan
@@ -600,24 +662,7 @@ def _run_baseline_compare(
     # encoder `reporter._add_contract_context` uses, so the block is
     # byte-for-byte the one `compare` writes and `replay_original_decisions`
     # reads back.
-    from .cli_scan_receipt import context_block, record_resolved_config
-
-    if resolved_config is not None:
-        record_resolved_config(diff, resolved_config)
-    context = context_block(diff)
-    if context is not None:
-        summary["contract_context"] = context
-        from .contract_coverage_exit import coverage_exit_for_context
-        from .contract_coverage_ledger import coverage_failures_for_context
-
-        # The sibling unsuppressible ledger, on the same terms `compare`
-        # reports it (plan Section 6.1) -- a coverage failure is not a
-        # finding, so it belongs beside the diff's findings, not among them.
-        failures = coverage_failures_for_context(diff.contract_context)
-        summary["contract_coverage_failures"] = [f.to_dict() for f in failures]
-        summary["contract_coverage_exit_contribution"] = coverage_exit_for_context(
-            diff.contract_context
-        )
+    summary.update(_baseline_contract_block(diff, resolved_config))
 
     from .cli_compare_helpers import _verdict_exit_code
     from .contract_coverage_exit import fold_coverage_exit

--- a/changelog.d/20260810_030000_claude_codefactor_complexity_cli.md
+++ b/changelog.d/20260810_030000_claude_codefactor_complexity_cli.md
@@ -1,0 +1,42 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Changed
+
+- **Five CLI entry points were restructured to cut cyclomatic complexity**, with
+  no behaviour, output, or exit-code changes:
+  - `cli_compare_helpers.run_compare` — the heaviest function on the board — is
+    now an explicit three-phase pipeline (resolve → compare → report). The
+    post-comparison half moved wholesale into `_report_compare_result`, and
+    eight resolution steps each became their own helper
+    (`_resolve_required_symbol_policy`, `_reject_manifest_header_conflicts`,
+    `_reject_manifest_non_elf`, `_reject_flags_unsupported_for_set_inputs`,
+    `_embed_inline_source_sides`, `_resolve_evaluation_config`,
+    `_apply_scoped_gating`, `_attach_suppression_audit`).
+  - The primary (`--format`) and secondary (`--secondary-format`) reports ran
+    two byte-identical copies of the same four-step render/fold pipeline; they
+    now share one `_render_compare_report`, so the two cannot drift. The
+    secondary keeps its deliberate differences — always the full unfiltered
+    report, and `demangle` resolved against its own format.
+  - `cli_compare_helpers._apply_used_by_scoping` — the OLD/NEW binary-evidence
+    precondition and the ADR-044 runtime-probe overlay each became a helper.
+  - `cli_scan_baseline._run_baseline_compare` — the old-side header-scope
+    resolution, the summary block, and the ADR-049 contract block each became a
+    helper.
+  - `cli_compare_fold._ScopedFold.into_text` — one method per report section,
+    assembled by a single join.
+  - `cli_dump_helpers.render_dump_dry_run` — the manifest section, the
+    data-layer probe, and the depth-feasibility chain each became a helper.
+- Relocated the ADR-043 scoped-gating family (`_apply_used_by_scoping`,
+  `_apply_required_symbol_scoping`, the runtime-probe overlay, the worst-wins
+  exit-code/verdict ranking and the JSON-safe summaries) from
+  `cli_compare_helpers.py` to `cli_helpers_compare.py`. A pure relocation
+  behind a re-export shim, needed because `cli_compare_helpers` sits at the
+  AI-readiness 2000-line hard cap. It lands in that existing module rather
+  than a new one deliberately: the family reaches `service`/`appcompat`
+  (through function-local imports, which the cycle check also counts), so a
+  *new* module would join the allowlisted CLI import-cycle SCC — the growth
+  CLAUDE.md "M1-3" forbids — while `cli_helpers_compare` is already a member.
+  `cli_compare_helpers._verdict_exit_code` (which `cli_scan_baseline` imports)
+  and the existing test patch targets keep resolving unchanged.

--- a/changelog.d/20260810_030000_claude_codefactor_complexity_cli.md
+++ b/changelog.d/20260810_030000_claude_codefactor_complexity_cli.md
@@ -54,7 +54,13 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   `cli_buildsource`'s own `embed_build_source`/`embed_inputs_pack` payloads in
   and then enforces the requested evidence depth, and that module already
   imported `_write_snapshot_output` back out of `cli`. `cli` re-exports all
-  four names. The two evidence-layer helpers are additionally called back
+  four names through a lazy module-level `__getattr__` shim (AGENTS.md's
+  required pattern for a relocated helper kept at its old path, modelled on
+  the one at the tail of `cli_buildsource.py`), so `cli` never grows a
+  top-level import of a module that reaches back into it. `dump_cmd`'s own
+  two bare-name uses take a function-local import instead — PEP 562's module
+  `__getattr__` serves attribute access on the module, never a global lookup
+  inside it. The two evidence-layer helpers are additionally called back
   *through* the `cli` module rather than by bare name, so the existing
   `monkeypatch.setattr(cli, "_missing_requested_evidence_layers", ...)` targets
   keep taking effect — the same resolution the neighbouring

--- a/changelog.d/20260810_030000_claude_codefactor_complexity_cli.md
+++ b/changelog.d/20260810_030000_claude_codefactor_complexity_cli.md
@@ -4,8 +4,11 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
 
 ### Changed
 
-- **Six CLI entry points were restructured to cut cyclomatic complexity**, with
-  no behaviour, output, or exit-code changes:
+- **All seven CLI entry points were restructured to cut cyclomatic
+  complexity**, with no behaviour, output, or exit-code changes:
+  - `cli.dump_cmd` — the `--dump-manifest` load (with the flags it is
+    mutually exclusive with) and the debug-format resolution plus its two
+    usage-error checks each became their own helper.
   - `cli_scan.scan_cmd` — the operand/flag mutual-exclusion checks, the project
     config discovery (with the digest that parsed it), and the ADR-049
     evaluation-config resolution each became their own helper.
@@ -43,3 +46,16 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   CLAUDE.md "M1-3" forbids — while `cli_helpers_compare` is already a member.
   `cli_compare_helpers._verdict_exit_code` (which `cli_scan_baseline` imports)
   and the existing test patch targets keep resolving unchanged.
+- Relocated the snapshot write path (`_write_snapshot_output`,
+  `_missing_requested_evidence_layers`, `_classify_missing_layers`,
+  `_layer_payload_empty`) from `cli.py` to `cli_buildsource.py`. `cli.py` was
+  within a handful of lines of the 2000-line hard cap, and this cluster is
+  cohesive with its new home: writing a snapshot *is* the step that folds
+  `cli_buildsource`'s own `embed_build_source`/`embed_inputs_pack` payloads in
+  and then enforces the requested evidence depth, and that module already
+  imported `_write_snapshot_output` back out of `cli`. `cli` re-exports all
+  four names. The two evidence-layer helpers are additionally called back
+  *through* the `cli` module rather than by bare name, so the existing
+  `monkeypatch.setattr(cli, "_missing_requested_evidence_layers", ...)` targets
+  keep taking effect — the same resolution the neighbouring
+  `cli._normalize_binary_input` calls already use.

--- a/changelog.d/20260810_030000_claude_codefactor_complexity_cli.md
+++ b/changelog.d/20260810_030000_claude_codefactor_complexity_cli.md
@@ -4,8 +4,11 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
 
 ### Changed
 
-- **Five CLI entry points were restructured to cut cyclomatic complexity**, with
+- **Six CLI entry points were restructured to cut cyclomatic complexity**, with
   no behaviour, output, or exit-code changes:
+  - `cli_scan.scan_cmd` — the operand/flag mutual-exclusion checks, the project
+    config discovery (with the digest that parsed it), and the ADR-049
+    evaluation-config resolution each became their own helper.
   - `cli_compare_helpers.run_compare` — the heaviest function on the board — is
     now an explicit three-phase pipeline (resolve → compare → report). The
     post-comparison half moved wholesale into `_report_compare_result`, and

--- a/tests/test_cli_coverage_extra2.py
+++ b/tests/test_cli_coverage_extra2.py
@@ -471,3 +471,34 @@ class TestClassifyMissingLayers:
         # L4 (PARTIAL) → the ran-but-empty branch, NOT "install clang/castxml".
         assert "collected but linked no facts" in err
         assert "L4_source_abi" in err
+
+
+def test_relocated_snapshot_helpers_resolve_under_direct_module_execution(
+    tmp_path: Path,
+) -> None:
+    """`python -m abicheck.cli` must reach the relocated snapshot-write helpers.
+
+    Regression guard (Codex review): the lazy `__getattr__` shim that keeps
+    `_write_snapshot_output` and friends at their historical `abicheck.cli`
+    path was first appended *after* the module's `if __name__ == "__main__":
+    main()` block. Under direct-module execution that block runs during module
+    execution, before the shim is bound, so `cli_buildsource.dump_source_only`'s
+    `from .cli import _write_snapshot_output` raised `ImportError` — which every
+    CI job shelling out to `python -m abicheck.cli` hit. The unit suite never
+    caught it because in-process imports always see the fully-executed module.
+    """
+    import subprocess
+    import sys
+
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "foo.h").write_text("int foo(void);\n")
+    proc = subprocess.run(
+        [sys.executable, "-m", "abicheck.cli", "dump", "--sources", str(src),
+         "-o", str(tmp_path / "out.json")],
+        capture_output=True,
+        text=True,
+    )
+    combined = proc.stdout + proc.stderr
+    assert "ImportError" not in combined, combined
+    assert "_write_snapshot_output" not in combined, combined


### PR DESCRIPTION
Batch 3 of the CodeFactor "Complex Method" series (68 findings total; batch 1 is #693, batch 2 is #694). **All seven** CLI findings, no behaviour, output, or exit-code changes.

## Findings addressed

| Function | mccabe | radon |
|---|---|---|
| `cli_compare_helpers.run_compare` | 28 → **12** | 44 → **16** |
| `cli_scan.scan_cmd` | 26 → **12** | 26 → **18** |
| `cli.dump_cmd` | 20 → **12** | — |
| `cli_dump_helpers.render_dump_dry_run` | 19 → **<4** | — |
| `cli_scan_baseline._run_baseline_compare` | 16 → **<8** | — |
| `cli_compare_helpers._apply_used_by_scoping` | 14 → **8** | — |
| `cli_compare_fold._ScopedFold.into_text` | 15 → **<10** | — |

## `run_compare`

Now an explicit three-phase pipeline — resolve → compare → report. The whole post-comparison half moved into `_report_compare_result`, and eight resolution steps each became a named helper.

Two of these are deduplication rather than decomposition:

- The primary (`--format`) and secondary (`--secondary-format`) reports ran two byte-identical copies of the same four-step render/fold pipeline. They now share one `_render_compare_report`, so the two cannot drift. The secondary keeps its deliberate differences: always the full unfiltered report (`show_only=None`, `report_mode="full"`, `stat=False`) and `demangle` resolved against its own format.
- The severity config was selected by re-spelling `sev_config if scheme == "severity" else None` at five call sites; it is resolved once now.

## `scan_cmd` and `dump_cmd`

- `scan_cmd` — the operand/flag mutual-exclusion checks, the project config discovery (returning the digest from the same read that parsed it, per ADR-049 D6), and the ADR-049 evaluation-config resolution each became a helper. The `--bundle-system-providers` check folds in as the `elif` branch it always effectively was, since the `--artifact-set` path returns before reaching it.
- `dump_cmd` — the `--dump-manifest` load (with the flags it is mutually exclusive with) and the debug-format resolution plus its two usage-error checks each became a helper.

## Two relocations, both forced by the 2000-line hard cap

`cli_compare_helpers` and `cli.py` were both at the cap, so the extractions above needed line budget first.

- The ADR-043 scoped-gating family moved from `cli_compare_helpers` → `cli_helpers_compare`.
- The snapshot write path (`_write_snapshot_output` + its three evidence-layer helpers) moved from `cli.py` → `cli_buildsource.py`, which already imported `_write_snapshot_output` back out of `cli`.

Both land in **existing** modules rather than new siblings, deliberately. Each family reaches `service`/`appcompat`/`buildsource` through function-local imports — which `check_ai_readiness.py`'s cycle check also counts — so a *new* module would join the allowlisted CLI import-cycle SCC. That is exactly the growth CLAUDE.md "M1-3" forbids, and extending the allowlist would need an ADR.

Every moved name is re-exported. One monkeypatch target genuinely broke on the second move and is fixed in the source rather than worked around in the test: `_write_snapshot_output` now calls the two evidence-layer helpers back *through* the `cli` module, so `monkeypatch.setattr(cli, "_missing_requested_evidence_layers", ...)` still takes effect — the same resolution the neighbouring `cli._normalize_binary_input` calls already use. A failing test is what caught it.

## Verification

- Full fast suite: **23213 passed**, 12 skipped, 4 xfailed
- `mypy abicheck/` clean; `ruff check abicheck/ tests/` clean — mypy caught two real annotation slips in extracted code (`required_symbols_from_file` is a tuple, `bundle_system_providers` is a `str`)
- `python scripts/check_ai_readiness.py`: **0 errors** — file-size cap and import-cycle-growth both pass. `cli.py` 1976 → 1816; `cli_compare_helpers.py` 2178 → 1748.

Note: `ruff format` was deliberately not run on these files. Several were not format-clean on `main` (pre-existing `ruff` version drift), so formatting them would have buried the change in unrelated reformatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)