### PR TITLE
refactor: cut CodeFactor complexity across the five reporting entry points

### DIFF
--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import html
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from .checker_policy import HasKind
 
@@ -671,6 +671,102 @@ def _build_impact_html(
     )
 
 
+def _gate_card_html(
+    result: DiffResult,
+    all_changes: list[Any],
+    severity_config: Any,
+    *,
+    h: Any,
+) -> str:
+    """Render the CI-gate card, or ``""`` when no severity gate is configured.
+
+    Split out of :func:`generate_html_report`; the reasoning behind the
+    scoped-vs-full gate split and the blocking-category naming is kept with the
+    code below.
+    """
+    if severity_config is None:
+        return ""
+    from .severity import compute_gate_decision
+
+    _eff_kind_sets_fn2 = getattr(result, "_effective_kind_sets", None)
+    full_gate = compute_gate_decision(
+        cast(list[HasKind], all_changes),
+        severity_config,
+        policy=getattr(result, "policy", None),
+        kind_sets=_eff_kind_sets_fn2() if callable(_eff_kind_sets_fn2) else None,
+        policy_file=getattr(result, "policy_file", None),
+    )
+    # `--used-by`/`--required-symbol(s)` scoping (ADR-043): the CLI
+    # process actually exits on the *scoped* gate, not this full-library
+    # one -- without this, the card could say "CI Gate: FAIL (exit 4)"
+    # for a run that just exited 0 because the scoped contract was
+    # compatible (CodeRabbit review). Mirrors the JSON severity block's
+    # full_severity/severity split.
+    scoped_exit_code = getattr(result, "scoped_exit_code", None)
+    scoped_exit_code_scheme = getattr(result, "scoped_exit_code_scheme", None)
+    gate_exit_code: int
+    # blocking_categories only corresponds 1:1 to full_gate in the
+    # non-scoped branch below (gate_passed derives directly from
+    # full_gate.blocking there); the scoped exit code can fail for a
+    # reason full_gate's categories don't describe at all (e.g. a
+    # missing --required-symbol entrypoint), so it's left blank there
+    # rather than risk naming the wrong cause.
+    gate_blocking_categories: tuple[str, ...] = ()
+    if scoped_exit_code is not None and scoped_exit_code_scheme == "severity":
+        gate_passed = scoped_exit_code == 0
+        gate_exit_code = scoped_exit_code
+        gate_title = "CI Gate (scoped)"
+        full_gate_label = (
+            "PASS" if not full_gate.blocking else f"FAIL (exit {full_gate.exit_code})"
+        )
+        gate_note = (
+            f"Reflects the scoped --used-by/--required-symbol severity gate "
+            f"the CLI process actually exits on (full-library gate: "
+            f"{h(full_gate_label)})."
+        )
+    else:
+        gate_passed = not full_gate.blocking
+        gate_exit_code = full_gate.exit_code
+        gate_title = "CI Gate"
+        gate_note = (
+            "Reflects the configured severity gate — may differ from the "
+            "Compatibility verdict above (e.g. an addition promoted to "
+            "<code>error</code> still fails CI)."
+        )
+        gate_blocking_categories = full_gate.blocking_categories
+    gate_fg, gate_bg = (
+        ("#1b5e20", "#e8f5e9") if gate_passed else ("#b71c1c", "#ffebee")
+    )
+    gate_label = "PASS" if gate_passed else f"FAIL (exit {gate_exit_code})"
+    gate_icon = "✅" if gate_passed else "🛑"
+    # Names which severity category(ies) actually gated CI — without
+    # this, "FAIL" reads as an undifferentiated red box even when the
+    # cause is a policy-blocked COMPATIBLE addition rather than a
+    # genuine ABI/API break (same category-naming this PR already
+    # added to the sticky PR comment and the Action's Job Summary).
+    gate_categories_html = ""
+    if not gate_passed and gate_blocking_categories:
+        cats = ", ".join(
+            f"<code>{h(c)}</code>" for c in sorted(gate_blocking_categories)
+        )
+        gate_categories_html = (
+            f"<div class='bc-metric' style='font-size:0.85em; opacity:0.85;'>"
+            f"Blocked by: {cats}</div>"
+        )
+    gate_html = (
+        f"<div class='verdict-box' "
+        f"style='background:{gate_bg}; color:{gate_fg}; "
+        f"border-left:6px solid {gate_fg};'>"
+        f"<h2>{gate_icon} {h(gate_title)}: {h(gate_label)}</h2>"
+        f"<div class='bc-metric' style='font-size:0.85em; opacity:0.85;'>"
+        f"{gate_note}"
+        f"</div>"
+        f"{gate_categories_html}"
+        f"</div>"
+    )
+    return gate_html
+
+
 def generate_html_report(
     result: DiffResult,
     lib_name: str = "",
@@ -823,86 +919,9 @@ def generate_html_report(
 
     verdict_icon = _verdict_icon(verdict)
 
-    gate_html = ""
-    if severity_config is not None:
-        from .severity import compute_gate_decision
-
-        _eff_kind_sets_fn2 = getattr(result, "_effective_kind_sets", None)
-        full_gate = compute_gate_decision(
-            cast(list[HasKind], all_changes),
-            severity_config,
-            policy=getattr(result, "policy", None),
-            kind_sets=_eff_kind_sets_fn2() if callable(_eff_kind_sets_fn2) else None,
-            policy_file=getattr(result, "policy_file", None),
-        )
-        # `--used-by`/`--required-symbol(s)` scoping (ADR-043): the CLI
-        # process actually exits on the *scoped* gate, not this full-library
-        # one -- without this, the card could say "CI Gate: FAIL (exit 4)"
-        # for a run that just exited 0 because the scoped contract was
-        # compatible (CodeRabbit review). Mirrors the JSON severity block's
-        # full_severity/severity split.
-        scoped_exit_code = getattr(result, "scoped_exit_code", None)
-        scoped_exit_code_scheme = getattr(result, "scoped_exit_code_scheme", None)
-        gate_exit_code: int
-        # blocking_categories only corresponds 1:1 to full_gate in the
-        # non-scoped branch below (gate_passed derives directly from
-        # full_gate.blocking there); the scoped exit code can fail for a
-        # reason full_gate's categories don't describe at all (e.g. a
-        # missing --required-symbol entrypoint), so it's left blank there
-        # rather than risk naming the wrong cause.
-        gate_blocking_categories: tuple[str, ...] = ()
-        if scoped_exit_code is not None and scoped_exit_code_scheme == "severity":
-            gate_passed = scoped_exit_code == 0
-            gate_exit_code = scoped_exit_code
-            gate_title = "CI Gate (scoped)"
-            full_gate_label = (
-                "PASS" if not full_gate.blocking else f"FAIL (exit {full_gate.exit_code})"
-            )
-            gate_note = (
-                f"Reflects the scoped --used-by/--required-symbol severity gate "
-                f"the CLI process actually exits on (full-library gate: "
-                f"{h(full_gate_label)})."
-            )
-        else:
-            gate_passed = not full_gate.blocking
-            gate_exit_code = full_gate.exit_code
-            gate_title = "CI Gate"
-            gate_note = (
-                "Reflects the configured severity gate — may differ from the "
-                "Compatibility verdict above (e.g. an addition promoted to "
-                "<code>error</code> still fails CI)."
-            )
-            gate_blocking_categories = full_gate.blocking_categories
-        gate_fg, gate_bg = (
-            ("#1b5e20", "#e8f5e9") if gate_passed else ("#b71c1c", "#ffebee")
-        )
-        gate_label = "PASS" if gate_passed else f"FAIL (exit {gate_exit_code})"
-        gate_icon = "✅" if gate_passed else "🛑"
-        # Names which severity category(ies) actually gated CI — without
-        # this, "FAIL" reads as an undifferentiated red box even when the
-        # cause is a policy-blocked COMPATIBLE addition rather than a
-        # genuine ABI/API break (same category-naming this PR already
-        # added to the sticky PR comment and the Action's Job Summary).
-        gate_categories_html = ""
-        if not gate_passed and gate_blocking_categories:
-            cats = ", ".join(
-                f"<code>{h(c)}</code>" for c in sorted(gate_blocking_categories)
-            )
-            gate_categories_html = (
-                f"<div class='bc-metric' style='font-size:0.85em; opacity:0.85;'>"
-                f"Blocked by: {cats}</div>"
-            )
-        gate_html = (
-            f"<div class='verdict-box' "
-            f"style='background:{gate_bg}; color:{gate_fg}; "
-            f"border-left:6px solid {gate_fg};'>"
-            f"<h2>{gate_icon} {h(gate_title)}: {h(gate_label)}</h2>"
-            f"<div class='bc-metric' style='font-size:0.85em; opacity:0.85;'>"
-            f"{gate_note}"
-            f"</div>"
-            f"{gate_categories_html}"
-            f"</div>"
-        )
+    gate_html = _gate_card_html(
+        result, all_changes, severity_config, h=h
+    )
 
     scoped_verdict = getattr(result, "scoped_verdict", None)
     scoped_html = ""

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from .severity import KindSets, SeverityConfig
@@ -1306,6 +1306,83 @@ def _add_contract_evaluation_fields(
         d["finding_id"] = report_finding_id(c)
 
 
+def _change_annotation_fields(c: Any) -> dict[str, Any]:
+    """Optional per-change attribution/annotation fields for the JSON report.
+
+    Each is omitted rather than emitted as ``null`` when it carries nothing, so
+    a consumer can tell "not applicable" from "empty". The reasoning behind the
+    individual entries is kept with them below.
+    """
+    out: dict[str, Any] = {}
+    # Source location
+    loc = getattr(c, "source_location", None)
+    if loc:
+        out["source_location"] = loc
+    # Affected symbols
+    affected = getattr(c, "affected_symbols", None)
+    if affected:
+        out["affected_symbols"] = affected
+    # Redundancy annotation
+    caused_by = getattr(c, "caused_by_type", None)
+    if caused_by:
+        out["caused_by_type"] = caused_by
+    caused_count = getattr(c, "caused_count", 0)
+    if caused_count > 0:
+        out["caused_count"] = caused_count
+    # ADR-027 A4 — disclose a pattern-aware modulation on the finding itself.
+    mod_reason = getattr(c, "modulation_reason", None)
+    if mod_reason:
+        out["modulation_reason"] = mod_reason
+        out["modulation_rule"] = getattr(c, "modulation_rule", None)
+        eff = getattr(c, "effective_verdict", None)
+        if isinstance(eff, Verdict):
+            out["effective_verdict"] = eff.value
+    # ADR-041 P0 roadmap item 2 — this finding correlates with another
+    # finding (currently: PUBLIC_API_INTERNAL_DEPENDENCY_ADDED correlating
+    # with the same entry's own body/type-hash change), named by ChangeKind
+    # value so a machine consumer can act on it without parsing description.
+    correlated = getattr(c, "correlated_change_kind", None)
+    if correlated:
+        out["correlated_change_kind"] = correlated
+    return out
+
+
+def _change_reachability_fields(c: Any) -> dict[str, Any]:
+    """Structured reachability evidence and graph-impact data for one change.
+
+    Machine-readable counterparts to what used to be description prose only --
+    see the per-entry comments for which ADR each came from.
+    """
+    out: dict[str, Any] = {}
+    # ADR-044 P1 item 4 — structured reachability evidence (previously
+    # description-text-only): whether a suppression rule's reachability gate
+    # tagged this change public-reachable, how (layout/call-graph/direct),
+    # and the shortest proof path, so a machine consumer doesn't need to
+    # parse the suppression_would_hide_public_break diagnostic's prose.
+    if getattr(c, "public_reachable", False):
+        out["public_reachable"] = True
+        reach_kind = getattr(c, "reachability_kind", None)
+        if reach_kind:
+            out["reachability_kind"] = reach_kind
+        proof_path = getattr(c, "reachability_proof_path", None)
+        if proof_path:
+            out["reachability_proof_path"] = proof_path
+    # G31 Phase B B3 (ADR-048) — structured graph impact/proof-path data:
+    # the machine-readable counterpart of reachability_proof_path's prose,
+    # as a list of node/edge reference dicts, plus which public root(s) it
+    # traces back to and whether the dependency is direct or transitive.
+    affected_roots = getattr(c, "affected_public_roots", None)
+    if affected_roots:
+        out["affected_public_roots"] = affected_roots
+    impact_path = getattr(c, "impact_proof_path", None)
+    if impact_path:
+        out["impact_proof_path"] = impact_path
+    impact_direct = getattr(c, "impact_is_direct", None)
+    if impact_direct is not None:
+        out["impact_is_direct"] = impact_direct
+    return out
+
+
 def _change_to_dict(
     c: object,
     *,
@@ -1401,62 +1478,8 @@ def _change_to_dict(
         impact = impact_for(kind)
         if impact:
             d["impact"] = impact
-    # Source location
-    loc = getattr(c, "source_location", None)
-    if loc:
-        d["source_location"] = loc
-    # Affected symbols
-    affected = getattr(c, "affected_symbols", None)
-    if affected:
-        d["affected_symbols"] = affected
-    # Redundancy annotation
-    caused_by = getattr(c, "caused_by_type", None)
-    if caused_by:
-        d["caused_by_type"] = caused_by
-    caused_count = getattr(c, "caused_count", 0)
-    if caused_count > 0:
-        d["caused_count"] = caused_count
-    # ADR-027 A4 — disclose a pattern-aware modulation on the finding itself.
-    mod_reason = getattr(c, "modulation_reason", None)
-    if mod_reason:
-        d["modulation_reason"] = mod_reason
-        d["modulation_rule"] = getattr(c, "modulation_rule", None)
-        eff = getattr(c, "effective_verdict", None)
-        if isinstance(eff, Verdict):
-            d["effective_verdict"] = eff.value
-    # ADR-041 P0 roadmap item 2 — this finding correlates with another
-    # finding (currently: PUBLIC_API_INTERNAL_DEPENDENCY_ADDED correlating
-    # with the same entry's own body/type-hash change), named by ChangeKind
-    # value so a machine consumer can act on it without parsing description.
-    correlated = getattr(c, "correlated_change_kind", None)
-    if correlated:
-        d["correlated_change_kind"] = correlated
-    # ADR-044 P1 item 4 — structured reachability evidence (previously
-    # description-text-only): whether a suppression rule's reachability gate
-    # tagged this change public-reachable, how (layout/call-graph/direct),
-    # and the shortest proof path, so a machine consumer doesn't need to
-    # parse the suppression_would_hide_public_break diagnostic's prose.
-    if getattr(c, "public_reachable", False):
-        d["public_reachable"] = True
-        reach_kind = getattr(c, "reachability_kind", None)
-        if reach_kind:
-            d["reachability_kind"] = reach_kind
-        proof_path = getattr(c, "reachability_proof_path", None)
-        if proof_path:
-            d["reachability_proof_path"] = proof_path
-    # G31 Phase B B3 (ADR-048) — structured graph impact/proof-path data:
-    # the machine-readable counterpart of reachability_proof_path's prose,
-    # as a list of node/edge reference dicts, plus which public root(s) it
-    # traces back to and whether the dependency is direct or transitive.
-    affected_roots = getattr(c, "affected_public_roots", None)
-    if affected_roots:
-        d["affected_public_roots"] = affected_roots
-    impact_path = getattr(c, "impact_proof_path", None)
-    if impact_path:
-        d["impact_proof_path"] = impact_path
-    impact_direct = getattr(c, "impact_is_direct", None)
-    if impact_direct is not None:
-        d["impact_is_direct"] = impact_direct
+    d.update(_change_annotation_fields(c))
+    d.update(_change_reachability_fields(c))
     # G29 Phase 3 slice 1 (ADR-052): reachability_state has existed on Change
     # since PR #607 but was never serialized -- without it, a JSON consumer
     # cannot tell a PROVEN_UNREACHABLE finding apart from one the graph walk

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -1528,6 +1528,77 @@ def _build_internal_rtti_note(breaking: list[Change]) -> list[str]:
     ]
 
 
+def _markdown_alternate_rendering(
+    result: DiffResult,
+    *,
+    stat: bool,
+    report_mode: str,
+    show_impact: bool,
+    show_only: str | None,
+    show_recommendation: bool,
+    severity_config: Any,
+    contract_evaluation: bool,
+) -> str | None:
+    """Render one of the non-default markdown views, or ``None`` for the default.
+
+    ``--stat`` and the ``leaf`` / ``root-cause`` report modes each produce a
+    complete document of their own; the caller returns it as-is (after its own
+    demangling pass) rather than continuing into the full report.
+    """
+    if stat:
+        return to_stat(result, severity_config=severity_config)
+    if report_mode == "leaf":
+        return _to_markdown_leaf(
+            result,
+            show_impact=show_impact,
+            show_only=show_only,
+            show_recommendation=show_recommendation,
+            severity_config=severity_config,
+        )
+    if report_mode == "root-cause":
+        return _to_markdown_root_cause(
+            result,
+            show_only=show_only,
+            show_recommendation=show_recommendation,
+            show_impact=show_impact,
+            severity_config=severity_config,
+            contract_evaluation=contract_evaluation,
+        )
+    return None
+
+
+def _markdown_headline_table(
+    result: DiffResult, emoji: str, label: str
+) -> list[str]:
+    """The report's headline summary table.
+
+    ADR-049 D1/D11: when contract evaluation excluded findings from the
+    compatibility axis, say so in the headline table. The four counts above
+    are now over the *evaluated* findings only, so a reader who sees a
+    `NO_CHANGE` verdict beside a populated "Not Evaluated" section has the
+    count that reconciles them rather than an apparent contradiction. The
+    row is absent for every run that did not opt in, where it is always 0.
+    """
+    lines: list[str] = [
+        f"# ABI Report: {result.library}",
+        "",
+        "| | |",
+        "|---|---|",
+        f"| **Old version** | `{result.old_version}` |",
+        f"| **New version** | `{result.new_version}` |",
+        f"| **Verdict** | {emoji} `{label}` |",
+        f"| Breaking changes | {len(result.breaking)} |",
+        f"| Source-level breaks | {len(result.source_breaks)} |",
+        f"| Deployment risk changes | {len(result.risk)} |",
+        f"| Compatible changes | {len(result.compatible)} |",
+    ]
+    not_evaluated_total = len(result.not_evaluated)
+    if not_evaluated_total:
+        lines.append(f"| Not evaluated (contract) | {not_evaluated_total} |")
+    lines.append("")
+    return lines
+
+
 def to_markdown(
     result: DiffResult,
     *,
@@ -1549,31 +1620,18 @@ def to_markdown(
 
         return demangle_text(text)
 
-    if stat:
-        return _out(to_stat(result, severity_config=severity_config))
-
-    if report_mode == "leaf":
-        return _out(
-            _to_markdown_leaf(
-                result,
-                show_impact=show_impact,
-                show_only=show_only,
-                show_recommendation=show_recommendation,
-                severity_config=severity_config,
-            )
-        )
-
-    if report_mode == "root-cause":
-        return _out(
-            _to_markdown_root_cause(
-                result,
-                show_only=show_only,
-                show_recommendation=show_recommendation,
-                show_impact=show_impact,
-                severity_config=severity_config,
-                contract_evaluation=contract_evaluation,
-            )
-        )
+    alternate = _markdown_alternate_rendering(
+        result,
+        stat=stat,
+        report_mode=report_mode,
+        show_impact=show_impact,
+        show_only=show_only,
+        show_recommendation=show_recommendation,
+        severity_config=severity_config,
+        contract_evaluation=contract_evaluation,
+    )
+    if alternate is not None:
+        return _out(alternate)
 
     v = result.verdict
     emoji = _VERDICT_EMOJI[v]
@@ -1605,30 +1663,7 @@ def to_markdown(
         model.compatible,
     )
 
-    lines: list[str] = [
-        f"# ABI Report: {result.library}",
-        "",
-        "| | |",
-        "|---|---|",
-        f"| **Old version** | `{result.old_version}` |",
-        f"| **New version** | `{result.new_version}` |",
-        f"| **Verdict** | {emoji} `{label}` |",
-        f"| Breaking changes | {len(result.breaking)} |",
-        f"| Source-level breaks | {len(result.source_breaks)} |",
-        f"| Deployment risk changes | {len(result.risk)} |",
-        f"| Compatible changes | {len(result.compatible)} |",
-    ]
-    # ADR-049 D1/D11: when contract evaluation excluded findings from the
-    # compatibility axis, say so in the headline table. The four counts above
-    # are now over the *evaluated* findings only, so a reader who sees a
-    # `NO_CHANGE` verdict beside a populated "Not Evaluated" section has the
-    # count that reconciles them rather than an apparent contradiction. The
-    # row is absent for every run that did not opt in, where it is always 0.
-    not_evaluated_total = len(result.not_evaluated)
-    if not_evaluated_total:
-        lines.append(f"| Not evaluated (contract) | {not_evaluated_total} |")
-    lines.append("")
-
+    lines = _markdown_headline_table(result, emoji, label)
     # When most of the breaking count is RTTI / internal-namespace churn, say so
     # up front — otherwise a huge count from a library lacking -fvisibility=hidden
     # buries the handful of genuine public-API breaks.

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -221,6 +221,105 @@ def _missing_contract_rule(rule_id: str) -> dict[str, Any]:
     }
 
 
+def _change_detail_properties(change: Change) -> dict[str, Any]:
+    """The optional per-change value/attribution entries of the properties bag.
+
+    Each is omitted rather than emitted as ``null`` when it carries nothing, so
+    a SARIF consumer can tell "not applicable" from "empty".
+    """
+    props: dict[str, Any] = {}
+    if change.old_value is not None:
+        props["oldValue"] = change.old_value
+    if change.new_value is not None:
+        props["newValue"] = change.new_value
+    if change.affected_symbols:
+        props["affectedSymbols"] = change.affected_symbols
+    if change.caused_by_type:
+        props["causedByType"] = change.caused_by_type
+    if change.caused_count > 0:
+        props["causedCount"] = change.caused_count
+    if change.correlated_change_kind:
+        props["correlatedChangeKind"] = change.correlated_change_kind
+    return props
+
+
+def _reachability_and_impact_properties(change: Change) -> dict[str, Any]:
+    """Structured reachability evidence and graph-impact data.
+
+    ADR-044 P1 item 4 — structured reachability evidence (previously
+    description-text-only, e.g. inside the suppression_would_hide_public_break
+    diagnostic's prose): whether this change is public-reachable, how, and
+    the shortest proof path.
+
+    G31 Phase B B3 (ADR-048) — structured graph impact data. SARIF's own
+    relatedLocations/codeFlows model source-file locations, not abstract
+    graph node/edge references, so surfacing this as typed `properties`
+    (matching every other graph-derived field on this object) is the
+    pragmatic fit here rather than forcing an artificial codeFlow —
+    documented as a deliberate scope decision in ADR-048.
+    """
+    props: dict[str, Any] = {}
+    if change.public_reachable:
+        props["publicReachable"] = True
+        if change.reachability_kind:
+            props["reachabilityKind"] = change.reachability_kind
+        if change.reachability_proof_path:
+            props["reachabilityProofPath"] = change.reachability_proof_path
+    if change.affected_public_roots:
+        props["affectedPublicRoots"] = change.affected_public_roots
+    if change.impact_proof_path:
+        props["impactProofPath"] = change.impact_proof_path
+    if change.impact_is_direct is not None:
+        props["impactIsDirect"] = change.impact_is_direct
+    return props
+
+
+def _contract_properties(
+    change: Change,
+    relevance: Any,
+    result: DiffResult,
+    severity_config: Any,
+) -> dict[str, Any]:
+    """The per-finding ADR-049 contract fields, in reporter.py's canonical shape.
+
+    ``contract_relevance_of`` returns ``None`` for a run that never opted into
+    ``--contract-evaluation``, which is what keeps this inert for every
+    pre-existing SARIF report. Before this shape was unified, only the
+    ``NOT_EVALUATED`` case set any of these, so an ``IN_CONTRACT`` /
+    ``NOT_APPLICABLE`` finding under ``--contract-evaluation`` carried no
+    contract properties at all even though it has a real, stamped decision
+    (CLI-audit P1).
+    """
+    if relevance is None:
+        return {}
+    props: dict[str, Any] = {}
+    props["contractRelevance"] = relevance.value
+    if change.contract_reason_code:
+        props["contractReasonCode"] = change.contract_reason_code
+    if change.contract_assurance is not None:
+        props["contractAssurance"] = change.contract_assurance.value
+    # evaluation_status_of always resolves to a real status once
+    # `relevance` is known non-None (it falls back to deriving one from
+    # the relevance itself -- see its own docstring), so there is no
+    # reachable `None` branch to guard here -- `cast` tells mypy that
+    # without adding one.
+    status = cast(CompatibilityEvaluationStatus, evaluation_status_of(change))
+    props["compatibilityEvaluationStatus"] = status.value
+    decision = getattr(change, "compatibility_decision", None)
+    props["compatibilityDecision"] = getattr(decision, "value", None)
+    from abicheck.severity import gate_contribution_for_change
+
+    props["gateContribution"] = gate_contribution_for_change(
+        change,
+        severity_config,
+        policy=result.policy,
+        policy_file=result.policy_file,
+    )
+    if change.contract_evidence_refs is not None:
+        props["contractEvidenceRefs"] = list(change.contract_evidence_refs)
+    return props
+
+
 def _result_for(
     change: Change,
     result: DiffResult,
@@ -295,40 +394,8 @@ def _result_for(
         "oldVersion": old_version,
         "newVersion": new_version,
     }
-    if change.old_value is not None:
-        properties["oldValue"] = change.old_value
-    if change.new_value is not None:
-        properties["newValue"] = change.new_value
-    if change.affected_symbols:
-        properties["affectedSymbols"] = change.affected_symbols
-    if change.caused_by_type:
-        properties["causedByType"] = change.caused_by_type
-    if change.caused_count > 0:
-        properties["causedCount"] = change.caused_count
-    if change.correlated_change_kind:
-        properties["correlatedChangeKind"] = change.correlated_change_kind
-    # ADR-044 P1 item 4 — structured reachability evidence (previously
-    # description-text-only, e.g. inside the suppression_would_hide_public_break
-    # diagnostic's prose): whether this change is public-reachable, how, and
-    # the shortest proof path.
-    if change.public_reachable:
-        properties["publicReachable"] = True
-        if change.reachability_kind:
-            properties["reachabilityKind"] = change.reachability_kind
-        if change.reachability_proof_path:
-            properties["reachabilityProofPath"] = change.reachability_proof_path
-    # G31 Phase B B3 (ADR-048) — structured graph impact data. SARIF's own
-    # relatedLocations/codeFlows model source-file locations, not abstract
-    # graph node/edge references, so surfacing this as typed `properties`
-    # (matching every other graph-derived field on this object) is the
-    # pragmatic fit here rather than forcing an artificial codeFlow —
-    # documented as a deliberate scope decision in ADR-048.
-    if change.affected_public_roots:
-        properties["affectedPublicRoots"] = change.affected_public_roots
-    if change.impact_proof_path:
-        properties["impactProofPath"] = change.impact_proof_path
-    if change.impact_is_direct is not None:
-        properties["impactIsDirect"] = change.impact_is_direct
+    properties.update(_change_detail_properties(change))
+    properties.update(_reachability_and_impact_properties(change))
     # G29 Phase 3 slice 1 (ADR-052): same unified read view reporter.py's
     # JSON output gained -- reachabilityState always present (the tri-state
     # signal from PR #607, never surfaced in SARIF before this), and the
@@ -358,31 +425,9 @@ def _result_for(
     # never opted into --contract-evaluation, which is what keeps this
     # unconditional call inert for every pre-existing SARIF report.
     relevance = contract_relevance_of(change)
-    if relevance is not None:
-        properties["contractRelevance"] = relevance.value
-        if change.contract_reason_code:
-            properties["contractReasonCode"] = change.contract_reason_code
-        if change.contract_assurance is not None:
-            properties["contractAssurance"] = change.contract_assurance.value
-        # evaluation_status_of always resolves to a real status once
-        # `relevance` is known non-None (it falls back to deriving one from
-        # the relevance itself -- see its own docstring), so there is no
-        # reachable `None` branch to guard here -- `cast` tells mypy that
-        # without adding one.
-        status = cast(CompatibilityEvaluationStatus, evaluation_status_of(change))
-        properties["compatibilityEvaluationStatus"] = status.value
-        decision = getattr(change, "compatibility_decision", None)
-        properties["compatibilityDecision"] = getattr(decision, "value", None)
-        from abicheck.severity import gate_contribution_for_change
-
-        properties["gateContribution"] = gate_contribution_for_change(
-            change,
-            severity_config,
-            policy=result.policy,
-            policy_file=result.policy_file,
-        )
-        if change.contract_evidence_refs is not None:
-            properties["contractEvidenceRefs"] = list(change.contract_evidence_refs)
+    properties.update(
+        _contract_properties(change, relevance, result, severity_config)
+    )
 
     level = _severity(change, result, severity_config)
     # ADR-049 D1/D9: compatibility policy did not score this finding, so it

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -17,9 +17,10 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import asdict
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeVar
 
 if TYPE_CHECKING:
     from .build_mode import BuildMode
@@ -684,6 +685,22 @@ def _python_api_from_dict(d: dict[str, Any]) -> Any:
     )
 
 
+_T = TypeVar("_T")
+
+
+def _sub_block(
+    parser: Callable[[dict[str, Any]], _T], raw: Any
+) -> _T | None:
+    """Parse one optional sub-block of a serialized snapshot, or ``None``.
+
+    Every ``elf``/``pe``/``macho``/``dwarf``/... section of a snapshot document
+    is optional and, per this module's forward-compatibility convention, is
+    ignored rather than fatal when it is present but not an object. Sharing the
+    one guard keeps a dozen call sites from each spelling it out.
+    """
+    return parser(raw) if isinstance(raw, dict) else None
+
+
 def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
     # Inspect schema version for future migration hooks.
     # Snapshots without schema_version are treated as v1 (pre-versioning format).
@@ -862,33 +879,21 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
     dwarf_data = d.get("dwarf")
     dwarf_adv_data = d.get("dwarf_advanced")
 
-    elf = _elf_from_dict(elf_data) if isinstance(elf_data, dict) else None
-    pe = _pe_from_dict(pe_data) if isinstance(pe_data, dict) else None
-    macho = _macho_from_dict(macho_data) if isinstance(macho_data, dict) else None
-    dwarf = _dwarf_from_dict(dwarf_data) if isinstance(dwarf_data, dict) else None
-    dwarf_advanced = (
-        _dwarf_advanced_from_dict(dwarf_adv_data)
-        if isinstance(dwarf_adv_data, dict)
-        else None
-    )
+    elf = _sub_block(_elf_from_dict, elf_data)
+    pe = _sub_block(_pe_from_dict, pe_data)
+    macho = _sub_block(_macho_from_dict, macho_data)
+    dwarf = _sub_block(_dwarf_from_dict, dwarf_data)
+    dwarf_advanced = _sub_block(_dwarf_advanced_from_dict, dwarf_adv_data)
 
     sycl_data = d.get("sycl")
-    sycl = _sycl_from_dict(sycl_data) if isinstance(sycl_data, dict) else None
+    sycl = _sub_block(_sycl_from_dict, sycl_data)
 
     kabi_data = d.get("kabi")
-    kabi = _kabi_from_dict(kabi_data) if isinstance(kabi_data, dict) else None
+    kabi = _sub_block(_kabi_from_dict, kabi_data)
     numpy_capi_data = d.get("numpy_capi")
-    numpy_capi = (
-        _numpy_capi_from_dict(numpy_capi_data)
-        if isinstance(numpy_capi_data, dict)
-        else None
-    )
+    numpy_capi = _sub_block(_numpy_capi_from_dict, numpy_capi_data)
     python_ext_data = d.get("python_ext")
-    python_ext = (
-        _python_ext_from_dict(python_ext_data)
-        if isinstance(python_ext_data, dict)
-        else None
-    )
+    python_ext = _sub_block(_python_ext_from_dict, python_ext_data)
     # A snapshot dumped without the G14 key (older abicheck, or a `dump` writer
     # path that didn't attach it) has no serialized ``python_ext``. Derive it on
     # load from the already-parsed binary metadata so `dump` → `compare` never
@@ -899,11 +904,7 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
     _python_ext_key_absent = "python_ext" not in d
 
     python_api_data = d.get("python_api")
-    python_api = (
-        _python_api_from_dict(python_api_data)
-        if isinstance(python_api_data, dict)
-        else None
-    )
+    python_api = _sub_block(_python_api_from_dict, python_api_data)
 
     dep_data = d.get("dependency_info")
     dep_info = (

--- a/changelog.d/20260810_060000_claude_codefactor_complexity_reporting.md
+++ b/changelog.d/20260810_060000_claude_codefactor_complexity_reporting.md
@@ -1,0 +1,31 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Changed
+
+- **The five reporting-side CodeFactor "Complex Method" findings were
+  restructured**, with no behaviour or output changes:
+  - `sarif._result_for` (27 → 11) — the properties bag was one long run of
+    `if x: properties[...] = x`. The change-detail entries, the
+    reachability/graph-impact evidence, and the ADR-049 contract block each
+    became their own builder returning a dict the caller merges.
+  - `reporter._change_to_dict` (23 → 10) — same shape, same treatment: the
+    optional attribution/annotation fields and the reachability/graph-impact
+    evidence each became their own builder.
+  - `reporter_markdown.to_markdown` (15 → 12) — the `--stat` / `leaf` /
+    `root-cause` early dispatch became `_markdown_alternate_rendering`
+    (returning `None` for the default view), and the headline summary table
+    became `_markdown_headline_table`.
+  - `html_report.generate_html_report` (13 → 10) — the CI-gate card, including
+    the scoped-vs-full gate split and the blocking-category naming, became
+    `_gate_card_html`.
+  - `serialization.snapshot_from_dict` — eleven hand-written
+    `parser(x) if isinstance(x, dict) else None` ternaries collapse onto one
+    shared `_sub_block` helper, which states the forward-compatibility rule (a
+    present-but-non-object section is ignored, not fatal) once instead of
+    eleven times. This is a deduplication rather than a decomposition: the
+    function's branch count was already low (mccabe 12, unchanged) and its
+    CodeFactor score comes from operator density, so the score improves
+    (radon 66 → 56) without the function being split. Splitting the 530-line
+    deserializer into phases is left as its own scoped change.


### PR DESCRIPTION
Batch 4 of the CodeFactor "Complex Method" series (68 findings total; batch 1 is #693, batch 2 #694, batch 3 #695). All five reporting findings, no behaviour or output changes.

## Findings addressed

| Function | mccabe | radon |
|---|---|---|
| `sarif._result_for` | 27 → **11** | — |
| `reporter._change_to_dict` | 23 → **10** | — |
| `reporter_markdown.to_markdown` | 15 → **12** | 12 |
| `html_report.generate_html_report` | 13 → **10** | — |
| `serialization.snapshot_from_dict` | 12 (unchanged) | 66 → **56** |

## The four decompositions

`_result_for` and `_change_to_dict` had the same shape — one long run of `if x: bag[...] = x` building an output dict. Both now delegate to focused builders that return a dict the caller merges: change-detail entries, reachability/graph-impact evidence, and (for SARIF) the ADR-049 contract block.

`to_markdown` gained `_markdown_alternate_rendering` (the `--stat` / `leaf` / `root-cause` early dispatch, returning `None` for the default view) and `_markdown_headline_table`.

`generate_html_report` gained `_gate_card_html`, which carries the scoped-vs-full gate split and the blocking-category naming with it.

## `snapshot_from_dict` is different, deliberately

This one is **not** decomposed, and the table above says so. Its branch count was already low — mccabe 12, unchanged by this PR — and its CodeFactor score comes from operator density across a 530-line linear deserializer, not from branching.

What it had instead was eleven hand-written copies of the same guard:

```python
elf = _elf_from_dict(elf_data) if isinstance(elf_data, dict) else None
pe = _pe_from_dict(pe_data) if isinstance(pe_data, dict) else None
...
```

Those collapse onto one shared `_sub_block` helper, which states the forward-compatibility rule — a present-but-non-object section is ignored rather than fatal — once instead of eleven times. That is a genuine deduplication and moves radon 66 → 56, but I want to be straight that **it may still sit near the CodeFactor threshold**. Splitting the deserializer into phases (binary metadata / Python metadata / build-source / scope+contract) is the real fix and deserves its own scoped change rather than being tacked on here.

## Verification

- Full fast suite: **23213 passed**, 12 skipped, 4 xfailed
- `mypy abicheck/` clean; `ruff check abicheck/ tests/` clean
- `python scripts/check_ai_readiness.py`: **0 errors**

One run of the suite showed a single failure in `tests/test_type_reachability.py::…::test_many_unreferenced_stdlib_candidates_scan_efficiently`. That is a flake, not a regression: it is a wall-clock performance guard, it passes 3/3 in isolation (0.59s–4.56s spread on a loaded machine), and this branch touches neither `abicheck/type_reachability.py` nor its test. A clean re-run was fully green.

Note: `html_report.py` is one of the files that is **not** `ruff format`-clean on `main`, so its import line was hand-corrected rather than formatted — running the formatter there would have buried the change in unrelated reformatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q)_