### PR TITLE
refactor: split 7 CodeFactor Complex Method findings in comparability/contract/compare

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -615,6 +615,113 @@ def _old_public_symbol_count(old: AbiSnapshot) -> int | None:
     return count if count > 0 else None
 
 
+def _contract_coverage_status(
+    old: AbiSnapshot, new: AbiSnapshot
+) -> Literal["partial"] | None:
+    """ADR-050 D2 — ``"partial"`` when an axis of the comparability contract
+    was never actually checked because exactly one side carries it.
+
+    Mirrors :func:`check_contracts_comparable`'s own per-fingerprint-independent
+    gating (Codex review, PR #624): a per-``contract``-object check misses the
+    case where both sides carry a real contract but only one has a
+    ``profile_fingerprint`` — e.g. a symbols-only side with only scope
+    provenance compared against a full L2 side — which
+    ``check_contracts_comparable`` correctly skips the profile check for, but a
+    coarse "contract is None" comparison would still report as fully covered
+    even though that axis was never checked.
+
+    ``dependency_scope`` is included for the same reason (Codex review, fresh
+    evidence): ``_check_dependency_scope_comparable`` deliberately permits a
+    ``None`` (pre-v18/genuinely-untagged) side against an explicitly-tagged one
+    rather than raising, since there is no way to recover which mode the
+    untagged side actually used — but that means the comparison silently
+    proceeds without ever having verified this axis matches, and a legacy
+    "full"-mode snapshot compared against a freshly "filtered" one could
+    produce a wrong verdict with the report still reading as fully verified.
+
+    Report-level metadata, not a ``Change``/``ChangeKind`` finding.
+    """
+    old_profile = old.contract.profile_fingerprint if old.contract else None
+    new_profile = new.contract.profile_fingerprint if new.contract else None
+    old_scope = old.contract.scope_fingerprint if old.contract else None
+    new_scope = new.contract.scope_fingerprint if new.contract else None
+    mixed = (
+        (old_profile is None) != (new_profile is None)
+        or (old_scope is None) != (new_scope is None)
+        or (old.dependency_scope is None) != (new.dependency_scope is None)
+    )
+    return "partial" if mixed else None
+
+
+def _env_matrix_contract_changes(
+    new: AbiSnapshot,
+    kept: list[Change],
+    verdict_redundant: list[Change],
+    suppression: SuppressionList | None,
+    suppressed: list[Change],
+    env_matrix: EnvironmentMatrix | None,
+) -> list[Change]:
+    """Every declared-runtime-floor / wheel-packaging check, run under one
+    ``env_matrix.runtime_floors`` gate.
+
+    Two different things happen here, in this order:
+
+    * ``apply_runtime_floor_contract`` *reclassifies in place* — it only
+      touches an existing version-requirement *delta* finding already in
+      ``kept``/``verdict_redundant`` (ADR-020b), producing nothing new.
+    * every other check is standalone: it reads the new binary's own evidence
+      and can fire even when the floor never moved between old and new, which
+      is exactly the manylinux-tag violation case (a binary that has always
+      required a newer glibc than its wheel tag promises). Their findings are
+      returned, suppression-filtered, for the caller to fold into ``kept``.
+
+    The wheel checks (``G27``) each additionally require the dedicated
+    ``runtime_floors["WHEEL_CONTEXT"]`` key *inside themselves* — not just any
+    declared floor, since GLIBC/GLIBCXX/CXXABI are a general-purpose ADR-020b
+    mechanism unrelated to wheel packaging, so an ordinary non-wheel DSO
+    declaring one of those must not get wheel-portability findings it never
+    opted into (Codex review #583). The gate here is just the cheap "any floors
+    declared at all" pre-filter.
+    """
+    if env_matrix is None or not env_matrix.runtime_floors:
+        return []
+    floors = env_matrix.runtime_floors
+
+    from .diff_versioning import (
+        apply_runtime_floor_contract,
+        check_musllinux_glibc_dependency,
+        check_platform_baseline_floor,
+    )
+    from .diff_wheel_deployment import (
+        check_macos_deployment_target_floor,
+        check_wheel_closure_dependency_violation,
+        check_wheel_rpath_not_portable,
+        check_wheel_tag_architecture_mismatch,
+    )
+    from .elf_metadata import ElfMetadata
+
+    apply_runtime_floor_contract(kept + verdict_redundant, floors)
+
+    new_elf = getattr(new, "elf", None)
+    new_macho = getattr(new, "macho", None)
+    # The floor checks substitute an empty ElfMetadata for a missing one (they
+    # answer "does this binary's own declared requirement violate the floor",
+    # which an absent ELF answers "no"); the wheel checks take the raw value,
+    # since a non-ELF input has no wheel-portability claim to check at all.
+    return _filter_suppressed_changes(
+        [
+            *check_platform_baseline_floor(new_elf or ElfMetadata(), floors),
+            *check_musllinux_glibc_dependency(new_elf or ElfMetadata(), floors),
+            *check_macos_deployment_target_floor(new_macho, floors),
+            *check_wheel_tag_architecture_mismatch(new_elf, new_macho, floors),
+            *check_wheel_rpath_not_portable(new_elf, floors),
+            *check_wheel_closure_dependency_violation(new_elf, floors),
+        ],
+        suppression,
+        suppressed,
+    )
+
+
 def compare(
     old: AbiSnapshot,
     new: AbiSnapshot,
@@ -740,38 +847,7 @@ def compare(
     # of the escape hatch ("the caller can still see a result but knows not
     # to trust it").
     comparability_warnings = [mismatch.reason] if mismatch is not None else []
-    # ADR-050 D2 — set when either fingerprint is mixed (exactly one side
-    # has it) between old and new, mirroring check_contracts_comparable's
-    # own per-fingerprint-independent gating (Codex review, PR #624: a
-    # per-``contract``-object check misses the case where both sides carry
-    # a real contract but only one has a profile_fingerprint — e.g. a
-    # symbols-only side with only scope provenance compared against a full
-    # L2 side — which check_contracts_comparable correctly skips the
-    # profile check for, but a coarse "contract is None" comparison would
-    # still report as fully covered even though that axis was never
-    # actually checked). Report-level metadata, not a Change/ChangeKind
-    # finding.
-    old_profile = old.contract.profile_fingerprint if old.contract else None
-    new_profile = new.contract.profile_fingerprint if new.contract else None
-    old_scope = old.contract.scope_fingerprint if old.contract else None
-    new_scope = new.contract.scope_fingerprint if new.contract else None
-    # Mirrors the profile/scope-fingerprint mixed-presence check above for the
-    # dependency_scope axis: check_contracts_comparable deliberately permits a
-    # None (pre-v18/genuinely-untagged) side against an explicitly-tagged one
-    # (see _check_dependency_scope_comparable's own docstring) rather than
-    # raising, since there is no way to recover which mode the untagged side
-    # actually used — but that means the comparison silently proceeds without
-    # ever having verified this axis matches. Without this, a legacy
-    # "full"-mode snapshot compared against a freshly "filtered" one could
-    # produce a wrong verdict with the report still reading as fully verified
-    # (Codex review, fresh evidence).
-    contract_coverage: Literal["partial"] | None = (
-        "partial"
-        if (old_profile is None) != (new_profile is None)
-        or (old_scope is None) != (new_scope is None)
-        or (old.dependency_scope is None) != (new.dependency_scope is None)
-        else None
-    )
+    contract_coverage = _contract_coverage_status(old, new)
 
     # Discover any diff_* detector modules not already imported above, then run
     # all registered detectors via the self-registering registry. ensure_loaded
@@ -863,121 +939,22 @@ def compare(
     if reconcile_build_context:
         kept, reconciled = reconcile_build_context_findings(kept, old, new)
 
-    # Declared-runtime-floor contract (ADR-020b): before the SONAME policy so
-    # a floor-decided BREAKING finding also drives the soname_bump_recommended
-    # advisory (check_soname_bump_policy honors effective_verdict), and so the
-    # internal-node demotion inside _apply_soname_policy — which skips findings
-    # already carrying an effective_verdict — cannot race it (Codex review #510).
-    if env_matrix is not None and env_matrix.runtime_floors:
-        from .diff_versioning import apply_runtime_floor_contract
-
-        apply_runtime_floor_contract(
-            kept + verdict_redundant, env_matrix.runtime_floors
+    # Declared-runtime-floor and wheel-packaging contracts (ADR-020b / G10 /
+    # G27). Before the SONAME policy so a floor-decided BREAKING finding also
+    # drives the soname_bump_recommended advisory (check_soname_bump_policy
+    # honors effective_verdict), and so the internal-node demotion inside
+    # _apply_soname_policy — which skips findings already carrying an
+    # effective_verdict — cannot race it (Codex review #510).
+    kept.extend(
+        _env_matrix_contract_changes(
+            new,
+            kept,
+            verdict_redundant,
+            suppression,
+            suppressed,
+            env_matrix,
         )
-
-    # Platform-baseline floor check (G10, ADR-020b runtime_floors reused):
-    # unlike apply_runtime_floor_contract above (which only reclassifies an
-    # existing version-requirement *delta* finding), this is a standalone
-    # check of the new binary's own required floor against the declared
-    # baseline — it fires even when the floor never moved between old and
-    # new, which is exactly the manylinux-tag violation case (a binary that
-    # has always required a newer glibc than its wheel tag promises).
-    if env_matrix is not None and env_matrix.runtime_floors:
-        from .diff_versioning import check_platform_baseline_floor
-        from .elf_metadata import ElfMetadata as _ElfMetadataFloor
-
-        new_elf_for_floor = getattr(new, "elf", None) or _ElfMetadataFloor()
-        floor_changes = check_platform_baseline_floor(
-            new_elf_for_floor, env_matrix.runtime_floors
-        )
-        floor_changes = _filter_suppressed_changes(
-            floor_changes, suppression, suppressed
-        )
-        if floor_changes:
-            kept.extend(floor_changes)
-
-    # musllinux glibc-dependency check (G27): same declared-floor gate as the
-    # platform-baseline check above, but a yes/no compatibility check rather
-    # than a numeric floor comparison — see check_musllinux_glibc_dependency's
-    # docstring for why musl has no version-floor concept to compare against.
-    if env_matrix is not None and env_matrix.runtime_floors:
-        from .diff_versioning import check_musllinux_glibc_dependency
-        from .elf_metadata import ElfMetadata as _ElfMetadataMusl
-
-        new_elf_for_musl = getattr(new, "elf", None) or _ElfMetadataMusl()
-        musllinux_changes = check_musllinux_glibc_dependency(
-            new_elf_for_musl, env_matrix.runtime_floors
-        )
-        musllinux_changes = _filter_suppressed_changes(
-            musllinux_changes, suppression, suppressed
-        )
-        if musllinux_changes:
-            kept.extend(musllinux_changes)
-
-    # macOS deployment-target floor check (G27, the macOS half of G10's
-    # manylinux glibc-floor idea): same declared-floor gate, checked against
-    # the new snapshot's Mach-O evidence instead of ELF.
-    if env_matrix is not None and env_matrix.runtime_floors:
-        from .diff_wheel_deployment import check_macos_deployment_target_floor
-
-        macos_floor_changes = check_macos_deployment_target_floor(
-            getattr(new, "macho", None), env_matrix.runtime_floors
-        )
-        macos_floor_changes = _filter_suppressed_changes(
-            macos_floor_changes, suppression, suppressed
-        )
-        if macos_floor_changes:
-            kept.extend(macos_floor_changes)
-
-    # Wheel-tag architecture-mismatch check (G27): same declared-claim gate,
-    # checked against whichever of ELF/Mach-O evidence the new snapshot
-    # carries.
-    if env_matrix is not None and env_matrix.runtime_floors:
-        from .diff_wheel_deployment import check_wheel_tag_architecture_mismatch
-
-        arch_mismatch_changes = check_wheel_tag_architecture_mismatch(
-            getattr(new, "elf", None),
-            getattr(new, "macho", None),
-            env_matrix.runtime_floors,
-        )
-        arch_mismatch_changes = _filter_suppressed_changes(
-            arch_mismatch_changes, suppression, suppressed
-        )
-        if arch_mismatch_changes:
-            kept.extend(arch_mismatch_changes)
-
-    # RPATH/RUNPATH portability + vendored-dependency-closure checks (G27):
-    # ELF-only; each check function requires the dedicated
-    # runtime_floors["WHEEL_CONTEXT"] key itself (not just any declared
-    # floor — GLIBC/GLIBCXX/CXXABI are a general-purpose ADR-020b mechanism
-    # unrelated to wheel packaging, so an ordinary non-wheel DSO declaring
-    # one of those must not get wheel-portability findings it never opted
-    # into; Codex review #583). This outer check is just the cheap
-    # "any floors declared at all" pre-filter.
-    if env_matrix is not None and env_matrix.runtime_floors:
-        from .diff_wheel_deployment import (
-            check_wheel_closure_dependency_violation,
-            check_wheel_rpath_not_portable,
-        )
-
-        new_elf_for_rpath = getattr(new, "elf", None)
-        rpath_changes = check_wheel_rpath_not_portable(
-            new_elf_for_rpath, env_matrix.runtime_floors
-        )
-        rpath_changes = _filter_suppressed_changes(
-            rpath_changes, suppression, suppressed
-        )
-        if rpath_changes:
-            kept.extend(rpath_changes)
-
-        closure_changes = check_wheel_closure_dependency_violation(
-            new_elf_for_rpath, env_matrix.runtime_floors
-        )
-        closure_changes = _filter_suppressed_changes(
-            closure_changes, suppression, suppressed
-        )
-        if closure_changes:
-            kept.extend(closure_changes)
+    )
 
     # NumPy C-API compatibility-envelope delta (G26): needs only the two
     # snapshots' own numpy_capi field (no external wheel metadata), so this
@@ -988,14 +965,15 @@ def compare(
     # precedent as G10's package.parse_manylinux_glibc_floor).
     from .diff_numpy_capi import diff_numpy_capi_surfaces
 
-    numpy_capi_changes = diff_numpy_capi_surfaces(
-        getattr(old, "numpy_capi", None), getattr(new, "numpy_capi", None)
+    kept.extend(
+        _filter_suppressed_changes(
+            diff_numpy_capi_surfaces(
+                getattr(old, "numpy_capi", None), getattr(new, "numpy_capi", None)
+            ),
+            suppression,
+            suppressed,
+        )
     )
-    numpy_capi_changes = _filter_suppressed_changes(
-        numpy_capi_changes, suppression, suppressed
-    )
-    if numpy_capi_changes:
-        kept.extend(numpy_capi_changes)
 
     # Post-detector: SONAME bump policy check.  Runs after post-processing so
     # rename collapsing and other dedup is already settled before reading `kept`.

--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -708,18 +708,28 @@ def _env_matrix_contract_changes(
     # answer "does this binary's own declared requirement violate the floor",
     # which an absent ELF answers "no"); the wheel checks take the raw value,
     # since a non-ELF input has no wheel-portability claim to check at all.
-    return _filter_suppressed_changes(
-        [
-            *check_platform_baseline_floor(new_elf or ElfMetadata(), floors),
-            *check_musllinux_glibc_dependency(new_elf or ElfMetadata(), floors),
-            *check_macos_deployment_target_floor(new_macho, floors),
-            *check_wheel_tag_architecture_mismatch(new_elf, new_macho, floors),
-            *check_wheel_rpath_not_portable(new_elf, floors),
-            *check_wheel_closure_dependency_violation(new_elf, floors),
-        ],
-        suppression,
-        suppressed,
-    )
+    # Filtered per check, not once over the concatenation (Codex review):
+    # _filter_suppressed_changes appends the SUPPRESSION_WOULD_HIDE_PUBLIC_BREAK
+    # / unknown-reachability diagnostics it raises to the END of its own return
+    # value, so one combined call would move every check's diagnostics past
+    # every other check's findings -- turning the report's
+    # [floor, floor-diagnostic, musl, musl-diagnostic, ...] into
+    # [floor, musl, ..., floor-diagnostic, musl-diagnostic, ...]. DiffResult
+    # .changes preserves list order and the reporters render it, so that is an
+    # observable output change, not an internal detail.
+    produced: list[Change] = []
+    for check_changes in (
+        check_platform_baseline_floor(new_elf or ElfMetadata(), floors),
+        check_musllinux_glibc_dependency(new_elf or ElfMetadata(), floors),
+        check_macos_deployment_target_floor(new_macho, floors),
+        check_wheel_tag_architecture_mismatch(new_elf, new_macho, floors),
+        check_wheel_rpath_not_portable(new_elf, floors),
+        check_wheel_closure_dependency_violation(new_elf, floors),
+    ):
+        produced.extend(
+            _filter_suppressed_changes(check_changes, suppression, suppressed)
+        )
+    return produced
 
 
 def compare(

--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -114,7 +114,6 @@ docstring for the full algorithm.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import os
 from collections.abc import Callable, Sequence
@@ -122,6 +121,21 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .comparability_fields import (
+    # The redundant `X as X` aliases are explicit re-exports, for import-path
+    # stability: these names were part of this module's surface before the
+    # field layer moved to comparability_fields (see that module's docstring),
+    # and dumper_contract.py/dumper_hybrid.py plus the comparability test
+    # modules still import them from here. Without the alias, `--no-implicit-
+    # reexport` refuses the import at the call site rather than here.
+    IncludeDir as IncludeDir,
+    _compute_profile_fields,
+    _compute_scope_fields,
+    _fingerprint_from_fields,
+    _fingerprint_matches_fields as _fingerprint_matches_fields,
+    _resolved,
+    _sha256_of as _sha256_of,
+)
 from .comparability_json import _SCOPE_SINGLE_ENTRY_SENTINELS, _json_load_str_list
 from .comparability_sequences import (
     _HEADER_SEQUENCE_FIELDS,
@@ -130,12 +144,7 @@ from .comparability_sequences import (
     _include_sequence_is_additive_owned_growth,
     _scope_newly_added_headers,
 )
-from .errors import (
-    AbicheckError,
-    ProfileMismatchError,
-    ScopeMismatchError,
-    SnapshotError,
-)
+from .errors import AbicheckError, ProfileMismatchError, ScopeMismatchError
 from .model import AbiSnapshot, ExtractionContract
 
 # A sentinel distinct from every valid profile_fields/scope_fields value
@@ -199,284 +208,6 @@ _PLATFORM_IDENTITY_FIELDS = frozenset({"target_triple", "pointer_width", "endian
 # CXX_STANDARD_FLOOR_RAISED/ABI_RELEVANT_BUILD_FLAG_CHANGED exist to
 # surface as a RISK finding, not a reason to refuse a verdict outright.
 _BUILD_CONTEXT_FIELDS = frozenset({"language_standard", "macro_ops"})
-
-
-@dataclass(frozen=True)
-class IncludeDir:
-    """One declared ``-I`` search-path entry, in the order it was declared
-    on the command line (or manifest, once that exists) — order is itself a
-    hashed input, since ``-I`` order is real compiler search-precedence
-    order, not cosmetic.
-
-    ``label`` is the resolved value of a legacy-CLI labeled
-    ``--include old:LABEL=PATH`` entry (ADR-050 D1) — ``None`` for an
-    ordinary, unlabeled entry. This module accepts the resolved label
-    directly; the CLI grammar that would parse it from a command line is
-    separate, not-yet-built work (see this module's docstring).
-    """
-
-    path: Path
-    label: str | None = None
-
-
-def _resolved(path: Path) -> Path:
-    return path.resolve()
-
-
-def _common_root(candidates: Sequence[str]) -> Path | None:
-    """``os.path.commonpath``, tolerant of candidates with no shared anchor
-    at all (CodeRabbit review, PR #624): mixed drives on Windows, or a local
-    vs. UNC root, make ``commonpath`` raise ``ValueError`` instead of
-    degrading gracefully — that must not propagate out of fingerprinting as
-    an unhandled crash. Returns ``None`` when there is no common root to
-    strip; callers fall back to :func:`_side_local_identity`'s
-    drive-stripped form in that case."""
-    try:
-        return Path(os.path.commonpath(candidates))
-    except ValueError:
-        return None
-
-
-def _side_local_identity(path: Path, root: Path | None) -> str:
-    """A path's identity relative to ``root``, or — when ``root`` is
-    ``None`` because this side's declared paths share no common anchor at
-    all — the drive-stripped absolute path (still deterministic and
-    drive-letter-independent, just without a common prefix to strip)."""
-    resolved = _resolved(path)
-    if root is not None:
-        return str(resolved.relative_to(root))
-    return os.path.splitdrive(str(resolved))[1]
-
-
-def _is_ancestor_or_equal(root: Path, path: Path) -> bool:
-    root = _resolved(root)
-    path = _resolved(path)
-    return path == root or root in path.parents
-
-
-def _content_hash(path: Path) -> str:
-    try:
-        data = path.read_bytes()
-    except OSError as exc:
-        # ADR-050 D1: a resolved header's content that can't be read at
-        # fingerprint time must fail extraction outright, not fold an
-        # "unresolvable" sentinel into the hash — two runs unresolvable for
-        # different reasons must not spuriously fingerprint-match.
-        raise SnapshotError(
-            f"cannot read {path} while computing profile_fingerprint: {exc}"
-        ) from exc
-    return hashlib.sha256(data).hexdigest()
-
-
-def _sha256_of(*parts: str) -> str:
-    h = hashlib.sha256()
-    for part in parts:
-        h.update(part.encode("utf-8"))
-        h.update(b"\x00")
-    return f"sha256:{h.hexdigest()}"
-
-
-def _fingerprint_matches_fields(
-    fingerprint: str, fields: dict[str, str], keys: tuple[str, ...]
-) -> bool:
-    """Whether *fingerprint* is exactly what :func:`compute_extraction_contract`
-    would produce from *fields* over *keys* (``SCOPE_FIELD_KEYS`` or
-    ``PROFILE_FIELD_KEYS``) -- i.e. whether this contract's stored fields
-    are actually what its own fingerprint was computed from (Codex review,
-    PR #641 follow-up, sixth P1).
-
-    Every carve-out above reasons entirely from ``scope_fields``/
-    ``profile_fields`` -- "this recognized field grew additively, so the
-    fingerprint mismatch is explained" -- but that reasoning only holds if
-    the stored fingerprint was genuinely computed from those exact fields.
-    For a snapshot dumped by this codebase's own
-    :func:`compute_extraction_contract`, that invariant always holds by
-    construction. It is NOT verified anywhere, though, so a deserialized or
-    externally constructed contract can carry a stale, fabricated, or
-    otherwise unrelated fingerprint alongside fields that merely *look*
-    additive: confirmed by direct repro before any fix -- two arbitrary,
-    unrelated fingerprint strings with ``headers`` genuinely growing from
-    ``["a.h", "b.h"]`` to ``["a.h", "b.h", "c.h"]`` made
-    :func:`check_contracts_comparable` return ``None`` (comparable) even
-    though neither fingerprint was ever verified to have anything to do
-    with those fields -- the true cause of the mismatch remains completely
-    unverified. Called on BOTH sides before any carve-out below is trusted;
-    a mismatch on either side means the fields can't be trusted to explain
-    that side's own fingerprint, so nothing reasoned from them is safe to
-    act on.
-    """
-    return fingerprint == _sha256_of(*[fields.get(k, "") for k in keys])
-
-
-def _classify_include_dirs(
-    declared_headers: Sequence[Path],
-    declared_includes: Sequence[IncludeDir],
-) -> list[bool]:
-    """Return, per ``declared_includes`` entry (same order/length), whether
-    that directory is project-owned: labeled explicitly (a sibling support
-    root with no owned declared header), or equal to/an ancestor of any
-    declared header (ADR-050 D1)."""
-    owned = []
-    for inc in declared_includes:
-        if inc.label is not None:
-            owned.append(True)
-            continue
-        owned.append(any(_is_ancestor_or_equal(inc.path, h) for h in declared_headers))
-    return owned
-
-
-def _header_identities(
-    declared_headers: Sequence[Path], extra_root_paths: Sequence[Path] = ()
-) -> dict[Path, str]:
-    """A stable, side-local identity string per declared header — its path
-    relative to the common ancestor of every declared header's *parent*
-    directory (the same normalization ``scope_fingerprint`` uses for its own
-    header identity). Used only to build ancestor-derived slot tokens below;
-    the basename alone (Codex review, PR #624) is not enough to disambiguate
-    two project-owned roots that each own a different declared header
-    sharing the same basename (e.g. ``include/foo.h`` vs.
-    ``generated/foo.h``) — both would otherwise collapse to token
-    ``hdrs:foo.h``, silently losing the order-sensitivity a swapped
-    ``-I include -I generated`` vs. ``-I generated -I include`` is supposed
-    to preserve.
-
-    *extra_root_paths* (``public_header_paths`` — provenance-only headers
-    never fed to the L2 frontend, so never in *declared_headers* or the
-    returned dict) widens the root candidates the same way the scope
-    ``"headers"`` field's own root computation already does (Codex review,
-    PR #641 follow-up, sixteenth P2): without this, a ``public_header_paths``
-    entry outside every declared header's common root makes this function's
-    root narrower than the scope side's, so the SAME physical file gets two
-    different identity strings across the two fields (e.g. scope
-    ``"foo/c.h"`` vs. sequence ``"c.h"``) — and the header/include-sequence
-    carve-outs' specific-correspondence check (``_scope_newly_added_headers``)
-    compares these by exact string equality, so a genuinely safe, purely
-    additive header change spuriously hard-fails with ``ProfileMismatchError``
-    the moment any ``public_header_paths`` entry reaches outside that
-    narrower root. Widening the root here to match closes the mismatch
-    without changing what a declared header's identity actually disambiguates
-    (its path relative to a root is still unique per file — the root is
-    just wider than before when *extra_root_paths* is non-empty)."""
-    if not declared_headers:
-        return {}
-    parents = [str(_resolved(h).parent) for h in (*declared_headers, *extra_root_paths)]
-    root = _common_root(parents)
-    return {h: _side_local_identity(h, root) for h in declared_headers}
-
-
-def _slot_token_for_ancestor(
-    inc: IncludeDir,
-    declared_headers: Sequence[Path],
-    header_identities: dict[Path, str],
-    single_header_mode: bool,
-) -> str:
-    # A single declared header's own name is not load-bearing here either
-    # (Codex review, PR #624 follow-up -- CI went red at scale once real
-    # dumps started populating contract): P3's auto-added include root
-    # (`resolve_inferred_header_roots`, cli_dump_helpers.py) makes a lone
-    # `-H v1.h` umbrella's own parent directory project-owned, and without
-    # this short-circuit the owned-slot token below would embed `v1.h`'s own
-    # basename via the dir-relative component -- so a legitimate single-
-    # header rename (`v1.h` -> `v2.h`, examples/case189's exact CI failure)
-    # would spuriously flip `include_sequence` even though `header_sequence`
-    # and the scope `headers` field both already correctly collapse to the
-    # same "<single-header>" placeholder for this case. With only one
-    # declared header there is nothing to disambiguate a name against
-    # anyway, same reasoning as those two fields.
-    if single_header_mode:
-        return "hdrs:<single-header>"
-    # Codex review (PR #624): pair each owned header's GLOBAL root-relative
-    # identity (disambiguates the same-basename-under-two-separate-roots case
-    # already fixed once -- e.g. `include/foo.h` vs. `generated/foo.h`) with
-    # its identity RELATIVE TO THIS SPECIFIC include dir (disambiguates two
-    # NESTED/overlapping project-owned roots, e.g. `-I work` and
-    # `-I work/include`, that both own the exact same header). Global
-    # identity alone is identical for both slots in the nested case -- e.g.
-    # both would tokenize as `hdrs:[["foo.h", ...]]` regardless of which
-    # dir owns it -- silently losing the order-sensitivity a swapped
-    # `-I work -I work/include` vs. `-I work/include -I work` is supposed to
-    # preserve. The dir-relative component is always safe to compute here:
-    # ownership (checked by the filter below) means `inc.path` is already
-    # an ancestor-or-equal of `h`, so `h.relative_to(inc.path)` never raises.
-    # sorted(set(...)), not sorted(...) (Codex review, PR #624): declared_headers
-    # is not itself deduplicated before reaching this function, so the same
-    # header supplied twice in one CLI/manifest invocation must not retain a
-    # duplicate (header_identity, relative_path) pair -- mirroring the same
-    # duplicate-collapse rule scope's "headers" field and header_sequence
-    # both already apply.
-    owned = sorted(
-        {
-            (header_identities[h], str(_resolved(h).relative_to(_resolved(inc.path))))
-            for h in declared_headers
-            if _is_ancestor_or_equal(inc.path, h)
-        }
-    )
-    # json.dumps, not a raw "," join (Codex review, PR #624): a header
-    # identity string is not guaranteed comma-free, so an unescaped join
-    # could let two structurally different owned-header sets collapse to
-    # the same token — the identical class of bug reported for macro_ops.
-    return "hdrs:" + json.dumps(owned)
-
-
-def _attribute_file(
-    file_path: Path,
-    declared_includes: Sequence[IncludeDir],
-    ownership: Sequence[bool],
-    declared_headers: Sequence[Path],
-) -> int | None:
-    """Return the index into ``declared_includes`` that ``file_path`` is
-    attributed to (longest-prefix match among directories that actually
-    contain it), or ``None`` if it falls under no declared ``-I`` directory
-    at all (the system/toolchain bucket) or under a declared header's own
-    (implicitly project-owned) parent directory."""
-    # A declared header's own parent directory is implicitly project-owned
-    # even with no matching --include at all (quote-include same-directory
-    # resolution) -- checked BEFORE the declared_includes longest-prefix
-    # match, not after (Codex review, PR #624): a file under a declared
-    # header's own parent that ALSO happens to fall under a nested, non-
-    # owned --include (e.g. --header old/include/foo.h plus --include
-    # old/include/sub, with foo.h quote-including sub/detail.h) would
-    # otherwise get attributed to that external slot and content-hashed,
-    # even though it is structurally part of the same project directory
-    # tree the implicit-parent rule exists to exclude -- an ordinary
-    # internal support-header edit could then spuriously raise
-    # ProfileMismatchError. Attribute such a file to a synthetic
-    # "owned, excluded" bucket by returning -1, distinct from "no declared
-    # -I dir at all".
-    for h in declared_headers:
-        if _is_ancestor_or_equal(h.parent, file_path):
-            return -1
-    # An owned ancestor -I directory's exclusion ("every file under it,
-    # named or not") wins over a deeper, non-owned nested -I directory
-    # (Codex review, PR #624): with `--header old/include/foo.h --include
-    # old --include old/generated`, `old` is project-owned (an ancestor of
-    # the declared header) and `old/generated` is not (it isn't itself an
-    # ancestor of any declared header) -- a plain longest-prefix match would
-    # pick the deeper, non-owned `old/generated` slot for a file under it,
-    # content-hashing it even though the broader owned `old` root already
-    # claims everything beneath it. Owned matches are therefore preferred
-    # outright over non-owned ones, with longest-prefix only breaking ties
-    # within the same ownership class (which owned index wins is otherwise
-    # immaterial: an owned slot's token never depends on per_slot_files).
-    best_owned_idx: int | None = None
-    best_owned_len = -1
-    best_external_idx: int | None = None
-    best_external_len = -1
-    for idx, inc in enumerate(declared_includes):
-        if _is_ancestor_or_equal(inc.path, file_path):
-            depth = len(_resolved(inc.path).parts)
-            if ownership[idx]:
-                if depth > best_owned_len:
-                    best_owned_len = depth
-                    best_owned_idx = idx
-            elif depth > best_external_len:
-                best_external_len = depth
-                best_external_idx = idx
-    if best_owned_idx is not None:
-        return best_owned_idx
-    if best_external_idx is not None:
-        return best_external_idx
-    return None
 
 
 def manifest_tu_scope_field(dump_manifest: Any) -> str:
@@ -709,310 +440,36 @@ def compute_extraction_contract(
     profile_fingerprint: str | None = None
     profile_fields: dict[str, str] = {}
     if l2_frontend_ran:
-        ownership = _classify_include_dirs(declared_headers, declared_includes)
-        header_identities = _header_identities(declared_headers, public_header_paths)
-        # Whether the owned-slot token below is safe to collapse to a
-        # constant placeholder instead of encoding the (rename-prone)
-        # declared header's own name: true only when the WHOLE declared
-        # surface is one logical header (by identity, not raw list length --
-        # the same header supplied twice is still "one distinct header") AND
-        # there is at most one owned, unlabeled include-dir slot for it.
-        # Both conditions matter -- gating on single-header alone regressed
-        # test_13c (Codex review, PR #624 follow-up): two NESTED project-
-        # owned roots (`-I work` and `-I work/include`) that both own the
-        # SAME single declared header must still tokenize distinctly per
-        # slot to preserve order-sensitivity (which nested root search comes
-        # first is a genuine compile-context fact) -- collapsing both to one
-        # constant would silently lose that. It is only the single-owner
-        # case (P3's `resolve_inferred_header_roots` auto-adding exactly one
-        # owned root for a lone `-H v1.h`/`-H old=<dir>` umbrella, examples/
-        # case189's exact CI failure) where there is nothing left to
-        # disambiguate and the header's own name is pure rename-noise.
-        single_header_mode = len({header_identities[h] for h in declared_headers}) <= 1
-        if single_header_mode:
-            _owned_unlabeled_count = sum(
-                1
-                for idx, inc in enumerate(declared_includes)
-                if ownership[idx] and inc.label is None
-            )
-            single_header_mode = _owned_unlabeled_count <= 1
-
-        # Deduplicated by resolved identity, not just filtered (Codex
-        # review, PR #624): depfile_resolved_paths can realistically list
-        # the same resolved file more than once (e.g. concatenated per-TU
-        # depfiles, or an un-deduplicated depfile parse). Left un-deduped,
-        # a repeated entry is bucketed and hashed twice, so an otherwise
-        # identical extraction fingerprints differently purely because one
-        # side happens to repeat the same dependency entry.
-        seen_resolved: set[Path] = set()
-        resolved_paths: list[Path] = []
-        for p in depfile_resolved_paths:
-            if p == generated_driver_path:
-                continue
-            key = _resolved(p)
-            if key in seen_resolved:
-                continue
-            seen_resolved.add(key)
-            resolved_paths.append(p)
-        per_slot_files: list[list[Path]] = [[] for _ in declared_includes]
-        system_bucket_files: list[Path] = []
-        for file_path in resolved_paths:
-            idx = _attribute_file(
-                file_path, declared_includes, ownership, declared_headers
-            )
-            if idx is None:
-                system_bucket_files.append(file_path)
-            elif idx == -1:
-                continue  # implicitly project-owned via a declared header's parent
-            else:
-                per_slot_files[idx].append(file_path)
-
-        slot_tokens: list[str] = []
-        for idx, inc in enumerate(declared_includes):
-            if ownership[idx]:
-                if inc.label is not None:
-                    token = f"label:{inc.label}"
-                else:
-                    token = _slot_token_for_ancestor(
-                        inc, declared_headers, header_identities, single_header_mode
-                    )
-            else:
-                pairs = sorted(
-                    (
-                        str(_resolved(f).relative_to(_resolved(inc.path))),
-                        _content_hash(f),
-                    )
-                    for f in per_slot_files[idx]
-                )
-                token = "ext:" + _sha256_of(*[f"{p}={h}" for p, h in pairs])
-            slot_tokens.append(f"{idx}:{token}")
-
-        if system_bucket_files:
-            # Content hashes only, no path component (Codex review, PR #624):
-            # unlike the "ext:" bucket, a system-bucket file has no declared
-            # IncludeDir to make its path side-local against, and its raw
-            # resolved path is checkout/cache-root-dependent (e.g. an
-            # auto-injected sysroot under /tmp/old-sysroot/... vs.
-            # /tmp/new-sysroot/...). Two toolchains with byte-identical
-            # system headers must fingerprint identically regardless of
-            # where those headers happen to sit on disk -- the bucket is
-            # already unordered/unattributed, so path identity was never
-            # load-bearing here, only content is.
-            sys_hashes = sorted(_content_hash(f) for f in system_bucket_files)
-            slot_tokens.append("sys:" + _sha256_of(*sys_hashes))
-
-        # Declared-header ORDER is a profile/extraction-context fact, not a
-        # scope one (Codex review, PR #624): the aggregate driver TU
-        # dumper.py generates includes declared headers sequentially in the
-        # caller's given order, so a macro/pragma side effect from one
-        # header can change how a LATER header in the sequence parses --
-        # `-H a.h -H b.h` and `-H b.h -H a.h` can genuinely produce
-        # different ASTs even though the same header SET is declared either
-        # way. scope_fingerprint deliberately stays order-independent (the
-        # declared *surface* -- which headers are public -- doesn't depend
-        # on dump order; see the "headers" field above), but
-        # profile_fingerprint must still catch a reordering that could
-        # change the extracted AST. Order-preserving de-duplication (first
-        # occurrence wins), not a sorted set, mirroring the same
-        # duplicate-collapse rule scope's "headers" field applies -- a
-        # header named twice must not itself change the sequence.
-        seen_header_identities: set[str] = set()
-        header_sequence: list[str] = []
-        for h in declared_headers:
-            identity = header_identities[h]
-            if identity not in seen_header_identities:
-                seen_header_identities.add(identity)
-                header_sequence.append(identity)
-
-        # A single declared header's own name is not load-bearing here
-        # either (Codex review, PR #624 follow-up — same reasoning as the
-        # scope "headers" field above): with only one header, there is no
-        # order to disambiguate, so a rename (v1.h -> v2.h) must not
-        # collide with the ORDER-sensitivity this field exists to catch
-        # for 2+ headers.
-        if len(header_sequence) == 1:
-            header_sequence = ["<single-header>"]
-
-        # Path-valued pass-through operands are content-hashed, never
-        # hashed as their raw string form (Codex review, PR #624): a
-        # forced-include flag like `-include /checkout-old/force.h` names
-        # a real file, and that file's checkout-root-dependent absolute
-        # path is exactly the class of noise this whole algorithm exists
-        # to strip everywhere else -- old/new checkouts using
-        # `/checkout-old/...` vs. `/checkout-new/...` must not
-        # fingerprint differently for byte-identical forced-include
-        # content. A `str` element (the flag name itself, or a non-path
-        # operand) is opaque and hashed as literal text; there is no
-        # principled root to normalize a forced-include path against (it
-        # need not fall under any declared header or -I directory at
-        # all), so it gets the same treatment as the unattributed
-        # system/toolchain bucket: content only, no path.
-        normalized_pass_through = [
-            f"path:{_content_hash(item)}" if isinstance(item, Path) else f"str:{item}"
-            for item in pass_through_flags
-        ]
-
-        profile_fields = {
-            "compiler_family": compiler_family or "",
-            "compiler_version": compiler_version or "",
-            "abi_dialect": abi_dialect or "",
-            "language_standard": language_standard or "",
-            "target_triple": target_triple or "",
-            "pointer_width": str(pointer_width) if pointer_width is not None else "",
-            "endianness": endianness or "",
-            # json.dumps, not a raw "|"/":" join (Codex review, PR #624): a
-            # macro value or slot token is not guaranteed pipe/colon-free —
-            # macro_ops=[("D", "A|U:B")] and [("D", "A"), ("U", "B")] would
-            # otherwise both serialize to the identical string "D:A|U:B",
-            # letting the gate miss a real profile drift. json.dumps
-            # length-delimits each element unambiguously regardless of its
-            # content.
-            "macro_ops": json.dumps(list(macro_ops)),
-            # Ordered, not sorted (Codex review, PR #624): repeatable
-            # pass-through frontend flags like `-include a.h -include b.h`
-            # force preprocessing content whose ORDER can change
-            # macro/pragma state before the rest of the TU is parsed --
-            # `-include a.h -include b.h` and `-include b.h -include a.h`
-            # can genuinely produce different ASTs even when the depfile's
-            # resolved dependency SET is identical (which bucketing above
-            # would otherwise report as unchanged, since bucket contents
-            # are order-independent by design). This is deliberately a raw,
-            # caller-supplied ordered flag list, not parsed or validated --
-            # dumper.py's actual `-include`/other repeatable-flag wiring is
-            # separate, not-yet-built work (see this module's docstring).
-            "pass_through_flags": json.dumps(normalized_pass_through),
-            "include_sequence": json.dumps(slot_tokens),
-            "header_sequence": json.dumps(header_sequence),
-            "frontend_context_kind": frontend_context_kind or "",
-        }
-        _profile_fingerprint_keys = (
+        profile_fields = _compute_profile_fields(
+            compiler_family=compiler_family,
+            compiler_version=compiler_version,
+            abi_dialect=abi_dialect,
+            language_standard=language_standard,
+            target_triple=target_triple,
+            pointer_width=pointer_width,
+            endianness=endianness,
+            macro_ops=macro_ops,
+            pass_through_flags=pass_through_flags,
+            declared_headers=declared_headers,
+            declared_includes=declared_includes,
+            depfile_resolved_paths=depfile_resolved_paths,
+            generated_driver_path=generated_driver_path,
+            public_header_paths=public_header_paths,
+            frontend_context_kind=frontend_context_kind,
+        )
+        profile_fingerprint = _fingerprint_from_fields(
+            profile_fields,
             _FRONTEND_CONTEXT_PROFILE_FIELD_KEYS
             if frontend_context_kind is not None
-            else PROFILE_FIELD_KEYS
-        )
-        profile_fingerprint = _sha256_of(
-            *[profile_fields[k] for k in _profile_fingerprint_keys]
+            else PROFILE_FIELD_KEYS,
         )
 
     scope_fingerprint: str | None = None
     scope_fields: dict[str, str] = {}
     if scope_inputs_present:
-        # All scope-identity inputs normalize against a shared, side-local
-        # root — never raw absolute paths (Codex review, PR #624): a lone
-        # `--public-header`/`--public-header-dir` provenance input (the
-        # symbols-only-with-provenance case, no declared_headers at all) is
-        # exactly as checkout-root-dependent as declared_headers, and
-        # hashing it unnormalized would make an ordinary two-checkout
-        # compare relying only on public-header provenance spuriously
-        # ScopeMismatchError. declared_headers and public_header_paths are
-        # merged into one combined "headers" identity, not two separate
-        # scope_fields entries (Codex review, PR #624): both name individual
-        # public header *files* — the same declared surface, captured by two
-        # different mechanisms (a full L2 header-AST dump's `-H` vs. a
-        # symbols-only dump's `--public-header` provenance tag). Keeping
-        # them in separate fields made an ordinary depth difference between
-        # two dumps of the *same* header (one via each mechanism) fingerprint
-        # as a scope mismatch, even though nothing about the declared
-        # surface actually differs. public_header_dirs stays its own field —
-        # a directory asserts "everything under here is public," a
-        # categorically different claim from naming individual files, so
-        # merging it into "headers" would conflate the two rather than
-        # recognize genuine equivalence.
-        #
-        # "headers" and "public_header_dirs" normalize against SEPARATE
-        # roots, not one shared across both (found via real-world CI: a
-        # `--devel-pkg`/`-H <dir>` umbrella whose declared_headers live
-        # several directories below the extracted/declared root -- e.g.
-        # `<root>/usr/include/*.h` and `<root>/usr/share/doc/.../*.h` next
-        # to `<root>` itself passed as a public_header_dir). A single shared
-        # root, computed from every entry's parent including the directory
-        # entries, gets pulled up to the directory's *own* parent (one level
-        # above the declared root) the moment that directory sits shallower
-        # than the header files -- leaking that root's name (often
-        # per-run-random, e.g. a tempfile-extracted package) into "headers"'
-        # normalized identities even though "public_header_dirs" collapses
-        # its own single-entry case away separately. Two byte-identical
-        # extractions into two different temp directories then spuriously
-        # fingerprint as a scope mismatch. Each field already hashes
-        # independently (SCOPE_FIELD_KEYS), so there is no reason for them
-        # to share a root: files use their parent for the root (preserving
-        # the basename, the same single-entry-preserving trick used
-        # everywhere else in this function); public_header_dirs are
-        # themselves directories, so their *own* parent is the analogous
-        # root candidate for *that field alone* (preserving the directory's
-        # own basename the same way a lone header's basename survives).
-        headers_root_candidates = [
-            str(_resolved(p).parent) for p in (*declared_headers, *public_header_paths)
-        ]
-        headers_root = (
-            _common_root(headers_root_candidates) if headers_root_candidates else None
+        scope_fields = _compute_scope_fields(
+            declared_headers, public_header_paths, public_header_dirs, manifest_tu_scope
         )
-        header_dirs_root_candidates = [
-            str(_resolved(p).parent) for p in public_header_dirs
-        ]
-        header_dirs_root = (
-            _common_root(header_dirs_root_candidates)
-            if header_dirs_root_candidates
-            else None
-        )
-
-        def _normalize(paths: Sequence[Path], root: Path | None) -> list[str]:
-            # sorted(set(...)), not sorted(...) (Codex review, PR #624): the
-            # same logical header reaching this function through both
-            # declared_headers and public_header_paths on one side (e.g. a
-            # full L2 dump that also passes --public-header for the same
-            # file) must not retain a duplicate entry a side naming it only
-            # once wouldn't have -- ["foo.h", "foo.h"] vs. ["foo.h"] would
-            # otherwise mismatch on element count alone, despite describing
-            # the identical declared surface.
-            return sorted({_side_local_identity(p, root) for p in paths})
-
-        # A single declared header's own filename is NOT load-bearing scope
-        # identity (Codex review, PR #624 follow-up — CI went red at scale
-        # once real dumps started populating contract): renaming a
-        # project's one main header between versions (v1.h -> v2.h, or any
-        # other rename) is a common, legitimate practice, not the
-        # "manifest/CLI-flag drift" mistake this fingerprint exists to
-        # catch -- and with only one header declared there is nothing to
-        # disambiguate a name against anyway. The multi-header case below
-        # still needs real per-file identity: two co-located headers must
-        # not collapse to the same token (["a.h","b.h"] vs ["a.h","c.h"]
-        # is a genuine declared-surface difference). The header's actual
-        # API surface is still verified by the ordinary diff engine; this
-        # only concerns whether the extraction inputs count as "the same
-        # declared surface" for the comparability gate.
-        _scope_header_identities = _normalize(
-            (*declared_headers, *public_header_paths), headers_root
-        )
-        if len(_scope_header_identities) == 1:
-            _scope_header_identities = ["<single-header>"]
-
-        # A single declared public-header directory's own name is not
-        # load-bearing scope identity either (Codex review, PR #624
-        # follow-up -- same reasoning as "headers" above, same CI incident:
-        # a lone `-H old=<dir>`/`-H new=<dir>` umbrella, e.g.
-        # test_perf_binary_scan.py's old-include/new-include fixture dirs,
-        # is exactly as legitimate a rename as a single header file, and
-        # with only one directory declared there is nothing to disambiguate
-        # a name against anyway. Two co-located declared dirs still need
-        # real per-directory identity (a genuine declared-surface
-        # difference), so this only collapses the single-entry case.
-        _scope_public_header_dirs = _normalize(public_header_dirs, header_dirs_root)
-        if len(_scope_public_header_dirs) == 1:
-            _scope_public_header_dirs = ["<single-header-dir>"]
-
-        # json.dumps, not a raw "|" join (Codex review, PR #624, same class
-        # of bug already fixed for macro_ops/include_sequence above): a
-        # normalized path is not guaranteed pipe-free.
-        scope_fields = {
-            "headers": json.dumps(_scope_header_identities),
-            "public_header_dirs": json.dumps(_scope_public_header_dirs),
-            # Present in scope_fields (so it's visible for reporting/
-            # debugging either way) but deliberately NOT always folded into
-            # scope_fingerprint itself -- see the manifest_tu_scope branch
-            # below (Codex review, PR #636).
-            "translation_units": manifest_tu_scope or "[]",
-        }
         # A non-manifest (legacy) dump's scope_fingerprint is computed from
         # exactly the same field set as before this ADR's D6/G32-Phase-E
         # translation_units addition -- SCOPE_FIELD_KEYS alone, never
@@ -1031,12 +488,12 @@ def compute_extraction_contract(
         # incomplete -- missing exactly this TU-level data -- until this
         # same change, so there is no correctly-comparable prior value a
         # manifest baseline could have been relying on.
-        _fingerprint_keys = (
+        scope_fingerprint = _fingerprint_from_fields(
+            scope_fields,
             _MANIFEST_SCOPE_FIELD_KEYS
             if manifest_tu_scope is not None
-            else SCOPE_FIELD_KEYS
+            else SCOPE_FIELD_KEYS,
         )
-        scope_fingerprint = _sha256_of(*[scope_fields[k] for k in _fingerprint_keys])
 
     return ExtractionContract(
         profile_fingerprint=profile_fingerprint,

--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -117,7 +117,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -130,7 +130,12 @@ from .comparability_sequences import (
     _include_sequence_is_additive_owned_growth,
     _scope_newly_added_headers,
 )
-from .errors import ProfileMismatchError, ScopeMismatchError, SnapshotError
+from .errors import (
+    AbicheckError,
+    ProfileMismatchError,
+    ScopeMismatchError,
+    SnapshotError,
+)
 from .model import AbiSnapshot, ExtractionContract
 
 # A sentinel distinct from every valid profile_fields/scope_fields value
@@ -1303,6 +1308,423 @@ def _check_dependency_scope_comparable(
     return ComparabilityMismatch(kind="dependency_scope", reason=reason)
 
 
+def _differing_keys(
+    old_fields: dict[str, str], new_fields: dict[str, str], keys: Sequence[str]
+) -> set[str]:
+    """Which of the *recognized* ``keys`` actually differ between the two sides.
+
+    Missing keys compare as ``""`` here, deliberately unlike
+    :func:`_unknown_differing_keys` below: a recognized field this build knows
+    about but neither side recorded is not a difference, whereas an
+    *unrecognized* key's very presence on one side is exactly the schema drift
+    that check exists to catch.
+    """
+    return {key for key in keys if old_fields.get(key, "") != new_fields.get(key, "")}
+
+
+def _unknown_differing_keys(
+    old_fields: dict[str, str], new_fields: dict[str, str], known: Sequence[str]
+) -> set[str]:
+    """Which keys *outside* ``known`` differ — a newer schema field this build
+    doesn't recognize at all.
+
+    Shared by both fingerprint gates below, which each reject such a key
+    unconditionally and before any of their own carve-outs (Codex review, PR
+    #641 follow-up, first and third P1): every carve-out reasons only over its
+    own recognized field set, so an unrecognized delta was invisible to them and
+    could ride along, silently waived, whenever a *recognized* delta happened to
+    be carve-out-eligible. No carve-out here understands an unrecognized key's
+    semantics well enough to vouch for it.
+
+    Compares via ``.get(k, _FIELD_ABSENT)`` rather than ``.get(k, "")`` (Codex
+    review, PR #641 follow-up, fifth P1): the empty-string fallback would
+    conflate "key absent entirely" with "key present with an empty string
+    value" — a newer-schema field added on only one side with an empty value
+    (e.g. ``{"future_profile": ""}`` vs. no key at all) would otherwise compare
+    ``"" == ""`` and stay invisible even though the key's very presence is the
+    drift being looked for. :data:`_FIELD_ABSENT` is a sentinel object distinct
+    from every valid field value, so presence and absence are never conflated.
+    """
+    return {
+        key
+        for key in set(old_fields) | set(new_fields)
+        if key not in known
+        and old_fields.get(key, _FIELD_ABSENT) != new_fields.get(key, _FIELD_ABSENT)
+    }
+
+
+def _scope_mismatch_is_additive(
+    old_contract: ExtractionContract, new_contract: ExtractionContract
+) -> bool:
+    """Whether an already-authenticated ``scope_fingerprint`` mismatch is pure
+    additive growth — the additive-only header-set carve-out (PR #641
+    follow-up, pvxs scan F8); see :func:`check_contracts_comparable`'s own
+    docstring.
+
+    An unrecognized differing ``scope_fields`` key blocks the carve-out
+    outright, checked independently of and before it (Codex review, PR #641
+    follow-up, third P1) — the ``all(...)`` below only ever examines
+    :data:`SCOPE_FIELD_KEYS`.
+
+    An entirely empty ``scope_differing`` is *not* an explanation either (Codex
+    review, PR #641 follow-up, fourth P1): a deserialized/externally-constructed
+    contract can carry an opaque ``scope_fingerprint`` that doesn't match what
+    this version would recompute from ``scope_fields``, the scope-side
+    equivalent of the opaque profile-fingerprint mismatch rejected below.
+    Restricting the additive-superset check to only the fields that actually
+    differ (rather than calling it for every :data:`SCOPE_FIELD_KEYS` entry,
+    where an unchanged field would trivially pass
+    :func:`_scope_field_is_additive_superset`'s ``old == new`` branch) makes an
+    empty ``scope_differing`` impossible to satisfy silently.
+    """
+    if _unknown_differing_keys(
+        old_contract.scope_fields, new_contract.scope_fields, SCOPE_FIELD_KEYS
+    ):
+        return False
+    scope_differing = _differing_keys(
+        old_contract.scope_fields, new_contract.scope_fields, SCOPE_FIELD_KEYS
+    )
+    if not scope_differing:
+        return False
+    return all(
+        _scope_field_is_additive_superset(
+            old_contract.scope_fields.get(key),
+            new_contract.scope_fields.get(key),
+        )
+        for key in scope_differing
+    )
+
+
+def _check_scope_fingerprint_comparable(
+    old_contract: ExtractionContract | None, new_contract: ExtractionContract | None
+) -> ComparabilityMismatch | None:
+    """The ``scope_fingerprint`` half of :func:`check_contracts_comparable`.
+
+    Gated independently of the profile half — a symbols-only side carrying only
+    a ``scope_fingerprint`` still gets its scope checked. Returns the mismatch
+    that would raise :class:`ScopeMismatchError`, or ``None`` when this axis is
+    comparable (including when either side carries no contract/fingerprint).
+    """
+    if (
+        old_contract is None
+        or new_contract is None
+        or old_contract.scope_fingerprint is None
+        or new_contract.scope_fingerprint is None
+        or old_contract.scope_fingerprint == new_contract.scope_fingerprint
+    ):
+        return None
+
+    if not (
+        _fingerprint_matches_fields(
+            old_contract.scope_fingerprint,
+            old_contract.scope_fields,
+            SCOPE_FIELD_KEYS,
+        )
+        and _fingerprint_matches_fields(
+            new_contract.scope_fingerprint,
+            new_contract.scope_fields,
+            SCOPE_FIELD_KEYS,
+        )
+    ):
+        # The carve-out below may not be trusted: at least one side's
+        # scope_fields don't actually produce that side's own
+        # scope_fingerprint, so nothing reasoned from those fields
+        # explains the real mismatch (Codex review, PR #641 follow-up,
+        # sixth P1) -- see _fingerprint_matches_fields's own docstring.
+        return ComparabilityMismatch(
+            kind="scope",
+            reason=(
+                "old and new snapshots do not cover the same declared "
+                "surface (scope_fingerprint mismatch), and at least one "
+                "side's scope_fields do not reproduce its own "
+                "scope_fingerprint — the comparison cannot be verified "
+                "safe."
+            ),
+        )
+
+    # Waiving the scope mismatch must fall through to the profile check, not
+    # skip it (Codex review, PR #641 follow-up) -- a release that both adds a
+    # header AND changes an unrelated extraction-profile field (compiler flags,
+    # macros, include order) must still be caught by that check, not silently
+    # waved through. Returning None here, rather than short-circuiting the whole
+    # gate, is what keeps that true.
+    if _scope_mismatch_is_additive(old_contract, new_contract):
+        return None
+    return ComparabilityMismatch(
+        kind="scope",
+        reason=(
+            "old and new snapshots do not cover the same declared "
+            "surface (scope_fingerprint mismatch) — the comparison is "
+            "not comparable. This commonly means a manifest/CLI-flag "
+            "drift between the two extraction runs, not a real API "
+            "change."
+        ),
+    )
+
+
+def _platform_identity_confirmed(
+    old: AbiSnapshot, new: AbiSnapshot, platform_candidate: set[str]
+) -> bool:
+    """Whether the binaries themselves confirm every candidate platform-identity
+    field as a genuine cross-architecture difference.
+
+    Every candidate field must itself map to a binary-derived component present
+    on BOTH sides AND genuinely differing on that same field (Codex review, PR
+    #624) -- not just "some" component of the platform identity differs
+    somewhere. A field with no corresponding binary component on one side (e.g.
+    pointer_width/endianness for a PE/Mach-O snapshot, which has no distinct
+    word-size/endianness field) can never be confirmed this way, so the
+    carve-out correctly declines to waive it.
+
+    ``target_triple`` is the one exception, verified against the FULL axis
+    rather than its own single "machine" component (Codex review, PR #624):
+    some ELF families share ``e_machine`` across word sizes (e.g. EM_RISCV for
+    both RV32 and RV64), so a target_triple change that's really just an
+    expression of a genuine word-size change (riscv32-... vs. riscv64-...)
+    would otherwise fail verification on its own narrow "machine" component
+    even though ``elf_class`` already confirms the architecture genuinely
+    differs. target_triple is a coarse, composite descriptor -- unlike
+    pointer_width/endianness, which map to one specific, independently-
+    meaningful field, it can be corroborated by any genuine difference on this
+    axis.
+    """
+    old_components = _binary_platform_components(old)
+    new_components = _binary_platform_components(new)
+    if old_components is None or new_components is None:
+        return False
+
+    common_keys = old_components.keys() & new_components.keys()
+    any_component_differs = any(
+        old_components[k] != new_components[k] for k in common_keys
+    )
+
+    def _field_verified(field: str) -> bool:
+        if field not in old_components or field not in new_components:
+            return False
+        if field == "target_triple":
+            return any_component_differs
+        return old_components[field] != new_components[field]
+
+    return all(_field_verified(field) for field in platform_candidate)
+
+
+def _unexplained_profile_fields(
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+    old_contract: ExtractionContract,
+    new_contract: ExtractionContract,
+    differing: set[str],
+) -> set[str]:
+    """Narrow ``differing`` down to the fields no carve-out can account for.
+
+    Each carve-out claims and verifies only the subset of ``differing`` it
+    actually understands, removing exactly those fields -- carve-outs COMPOSE
+    (Codex review, PR #641 follow-up, fourth round): a release combining two
+    independently-sanctioned deltas (e.g. a header addition AND a corroborated
+    C++-standard raise) must not raise just because neither carve-out's static
+    field-set covers ``differing`` in full on its own. The four carve-outs'
+    field-sets (:data:`_PLATFORM_IDENTITY_FIELDS`/:data:`_BUILD_CONTEXT_FIELDS`/
+    :data:`_HEADER_SEQUENCE_FIELDS`/:data:`_INCLUDE_SEQUENCE_FIELDS`) are
+    mutually disjoint, so processing order never matters -- each only ever
+    narrows the working set, never re-adds to it.
+    """
+    old_fields = old_contract.profile_fields
+    new_fields = new_contract.profile_fields
+    unexplained = set(differing)
+
+    platform_candidate = unexplained & _PLATFORM_IDENTITY_FIELDS
+    if platform_candidate and _platform_identity_confirmed(
+        old, new, platform_candidate
+    ):
+        # genuine cross-architecture compare; diff_platform.py handles it
+        unexplained -= platform_candidate
+
+    build_candidate = unexplained & _BUILD_CONTEXT_FIELDS
+    if build_candidate and _build_context_corroborated(old, new):
+        # Build-context carve-out (Codex review, PR #624 follow-up --
+        # examples/case98_cxx_standard_floor_raised's real CI failure):
+        # a raised C++-standard floor or a build-derived macro delta
+        # between two snapshots BOTH actually reconciled against real
+        # build-system evidence is exactly the fact
+        # CXX_STANDARD_FLOOR_RAISED/ABI_RELEVANT_BUILD_FLAG_CHANGED
+        # (diff_build_config.py) exist to surface as a RISK finding --
+        # gating it into a generic not_comparable first would only
+        # discard that finding instead of letting the more specific
+        # detector classify it correctly.
+        unexplained -= build_candidate
+
+    # Both sequence carve-outs below additionally require
+    # _scope_growth_corroborated (Codex review, PR #641 follow-up, P1):
+    # an additive-shaped header_sequence/include_sequence on its own is
+    # not sufficient evidence -- a header already declared identically
+    # on both sides via --public-header, but fed to the L2 frontend via
+    # -H only on the new side, produces the identical additive-growth
+    # SHAPE with scope_fingerprint completely UNCHANGED, even though the
+    # old snapshot never actually parsed that header's content at all
+    # (see _scope_growth_corroborated's own docstring for why that's
+    # unsafe to wave through). Requiring a genuinely differing,
+    # independently-verified scope-level growth corroborates that the
+    # sequence growth reflects real new declared content, not just a
+    # same-declared-surface extraction-mechanism difference.
+    scope_growth_corroborated = _scope_growth_corroborated(old_contract, new_contract)
+    # The specific set of header identities the sequence carve-outs
+    # below are allowed to treat an appended/newly-owned entry as
+    # corresponding to (Codex review, PR #641 follow-up, ninth P1) --
+    # see _scope_newly_added_headers's own docstring for why
+    # scope_growth_corroborated alone (proving the scope grew by SOME
+    # header) isn't enough; the carve-outs must additionally verify
+    # they're waiving growth in the SAME header(s).
+    scope_new_headers = _scope_newly_added_headers(
+        old_contract.scope_fields.get("headers"),
+        new_contract.scope_fields.get("headers"),
+    )
+
+    header_seq_candidate = unexplained & _HEADER_SEQUENCE_FIELDS
+    if (
+        header_seq_candidate
+        and scope_growth_corroborated
+        and _header_sequence_is_additive_reorder_free(
+            old_fields.get("header_sequence"),
+            new_fields.get("header_sequence"),
+            scope_new_headers,
+        )
+    ):
+        # Header-sequence-growth carve-out (PR #641 follow-up, third
+        # round) -- see check_contracts_comparable's own docstring.
+        unexplained -= header_seq_candidate
+
+    include_seq_candidate = unexplained & _INCLUDE_SEQUENCE_FIELDS
+    if (
+        include_seq_candidate
+        and scope_growth_corroborated
+        and _include_sequence_is_additive_owned_growth(
+            old_fields.get("include_sequence"),
+            new_fields.get("include_sequence"),
+            scope_new_headers,
+        )
+    ):
+        # Include-sequence-owned-growth carve-out (PR #641 follow-up,
+        # fourth round) -- see check_contracts_comparable's own
+        # docstring.
+        unexplained -= include_seq_candidate
+
+    return unexplained
+
+
+def _profile_mismatch_reason(
+    unknown_differing: set[str], differing: set[str], unexplained: set[str]
+) -> str | None:
+    """Why an authenticated ``profile_fingerprint`` mismatch is not comparable,
+    or ``None`` when every differing field was explained by a carve-out."""
+    if unknown_differing:
+        return (
+            "old and new snapshots were extracted under different "
+            "compile contexts (profile_fingerprint mismatch), and "
+            f"differ on field(s) this version does not recognize: "
+            f"{', '.join(sorted(unknown_differing))} — the comparison "
+            "cannot be verified safe."
+        )
+    if not differing:
+        # Codex review, PR #641 follow-up (P1): profile_fingerprint
+        # differs but NONE of the known PROFILE_FIELD_KEYS explain it --
+        # profile_fields was entirely absent/malformed on
+        # deserialization (_extraction_contract_from_dict substitutes
+        # {}, so every old_fields.get(k, "")/new_fields.get(k, "")
+        # compares "" == "" for every k). An empty `differing` must NOT
+        # be treated as "nothing to explain, therefore comparable" --
+        # that would silently bypass this fail-closed gate exactly when
+        # the granular field data needed to verify safety is missing or
+        # incomplete, which is the opposite of the gate's purpose.
+        return (
+            "old and new snapshots were extracted under different "
+            "compile contexts (profile_fingerprint mismatch), but no "
+            "recognized profile field explains the difference — "
+            "profile_fields may be absent/incomplete — so the "
+            "comparison cannot be verified safe."
+        )
+    if unexplained:
+        return (
+            "old and new snapshots were extracted under different compile "
+            f"contexts (profile_fingerprint mismatch; differing fields: "
+            f"{', '.join(sorted(unexplained))}) — the comparison "
+            "is not comparable."
+        )
+    return None
+
+
+def _check_profile_fingerprint_comparable(
+    old: AbiSnapshot, new: AbiSnapshot
+) -> ComparabilityMismatch | None:
+    """The ``profile_fingerprint`` half of :func:`check_contracts_comparable`.
+
+    Gated independently of the scope half — a side that never ran an L2
+    frontend carries no ``profile_fingerprint`` and is not hard-failed on this
+    axis for that ordinary depth difference alone. Returns the mismatch that
+    would raise :class:`ProfileMismatchError`, or ``None`` when this axis is
+    comparable.
+    """
+    old_contract = old.contract
+    new_contract = new.contract
+    if (
+        old_contract is None
+        or new_contract is None
+        or old_contract.profile_fingerprint is None
+        or new_contract.profile_fingerprint is None
+        or old_contract.profile_fingerprint == new_contract.profile_fingerprint
+    ):
+        return None
+
+    old_fields = old_contract.profile_fields
+    new_fields = new_contract.profile_fields
+    if not (
+        _fingerprint_matches_fields(
+            old_contract.profile_fingerprint, old_fields, PROFILE_FIELD_KEYS
+        )
+        and _fingerprint_matches_fields(
+            new_contract.profile_fingerprint, new_fields, PROFILE_FIELD_KEYS
+        )
+    ):
+        # No carve-out below may be trusted: at least one side's
+        # profile_fields don't actually produce that side's own
+        # profile_fingerprint (Codex review, PR #641 follow-up, sixth
+        # P1) -- see _fingerprint_matches_fields's own docstring, and
+        # the scope-side equivalent check above.
+        return ComparabilityMismatch(
+            kind="profile",
+            reason=(
+                "old and new snapshots were extracted under different "
+                "compile contexts (profile_fingerprint mismatch), and at "
+                "least one side's profile_fields do not reproduce its own "
+                "profile_fingerprint — the comparison cannot be verified "
+                "safe."
+            ),
+        )
+
+    differing = _differing_keys(
+        old_fields, new_fields, _FRONTEND_CONTEXT_PROFILE_FIELD_KEYS
+    )
+    unknown_differing = _unknown_differing_keys(
+        old_fields, new_fields, PROFILE_FIELD_KEYS
+    )
+    unexplained = _unexplained_profile_fields(
+        old, new, old_contract, new_contract, differing
+    )
+    reason = _profile_mismatch_reason(unknown_differing, differing, unexplained)
+    if reason is None:
+        return None
+    return ComparabilityMismatch(kind="profile", reason=reason)
+
+
+# Which error each :attr:`ComparabilityMismatch.kind` raises as outside
+# ``diagnostic`` mode. ``dependency_scope`` shares ScopeMismatchError with
+# ``scope``: both say the two sides do not cover the same declared surface.
+_MISMATCH_ERRORS: dict[str, type[AbicheckError]] = {
+    "dependency_scope": ScopeMismatchError,
+    "scope": ScopeMismatchError,
+    "profile": ProfileMismatchError,
+}
+
+
 def check_contracts_comparable(
     old: AbiSnapshot, new: AbiSnapshot, *, diagnostic: bool = False
 ) -> ComparabilityMismatch | None:
@@ -1507,332 +1929,21 @@ def check_contracts_comparable(
     force a tentative diff through a genuine contract mismatch. ``None`` is
     returned (in either mode) when the pair is comparable.
     """
-    dependency_scope_mismatch = _check_dependency_scope_comparable(old, new)
-    if dependency_scope_mismatch is not None:
+    # Deferred as thunks rather than evaluated into a tuple up front: the three
+    # axes are checked in a fixed order and the first mismatch wins (scope
+    # shadows a co-occurring profile one, as ComparabilityMismatch's own
+    # docstring states), so a later check must not run once an earlier one
+    # already answered.
+    checks: tuple[Callable[[], ComparabilityMismatch | None], ...] = (
+        lambda: _check_dependency_scope_comparable(old, new),
+        lambda: _check_scope_fingerprint_comparable(old.contract, new.contract),
+        lambda: _check_profile_fingerprint_comparable(old, new),
+    )
+    for check in checks:
+        mismatch = check()
+        if mismatch is None:
+            continue
         if diagnostic:
-            return dependency_scope_mismatch
-        raise ScopeMismatchError(dependency_scope_mismatch.reason)
-
-    old_contract = old.contract
-    new_contract = new.contract
-
-    if (
-        old_contract is not None
-        and new_contract is not None
-        and old_contract.scope_fingerprint is not None
-        and new_contract.scope_fingerprint is not None
-        and old_contract.scope_fingerprint != new_contract.scope_fingerprint
-    ):
-        if not (
-            _fingerprint_matches_fields(
-                old_contract.scope_fingerprint,
-                old_contract.scope_fields,
-                SCOPE_FIELD_KEYS,
-            )
-            and _fingerprint_matches_fields(
-                new_contract.scope_fingerprint,
-                new_contract.scope_fields,
-                SCOPE_FIELD_KEYS,
-            )
-        ):
-            # Neither carve-out below may be trusted: at least one side's
-            # scope_fields don't actually produce that side's own
-            # scope_fingerprint, so nothing reasoned from those fields
-            # explains the real mismatch (Codex review, PR #641 follow-up,
-            # sixth P1) -- see _fingerprint_matches_fields's own docstring.
-            reason = (
-                "old and new snapshots do not cover the same declared "
-                "surface (scope_fingerprint mismatch), and at least one "
-                "side's scope_fields do not reproduce its own "
-                "scope_fingerprint — the comparison cannot be verified "
-                "safe."
-            )
-            if diagnostic:
-                return ComparabilityMismatch(kind="scope", reason=reason)
-            raise ScopeMismatchError(reason)
-        # A differing scope_fields key OUTSIDE SCOPE_FIELD_KEYS entirely --
-        # a newer schema field this build doesn't recognize -- must also
-        # block the additive-only carve-out below, for the identical reason
-        # as the profile side's unknown_differing check (Codex review, PR
-        # #641 follow-up, third P1): the carve-out's `all(...)` below only
-        # ever checks SCOPE_FIELD_KEYS, so an unrecognized field's delta was
-        # invisible to it -- if headers/public_header_dirs happened to be
-        # equal or additive, the whole scope mismatch was wrongly waived
-        # without ever examining the unrecognized field.
-        scope_unknown_differing = {
-            k
-            for k in set(old_contract.scope_fields) | set(new_contract.scope_fields)
-            if k not in SCOPE_FIELD_KEYS
-            and old_contract.scope_fields.get(k, _FIELD_ABSENT)
-            != new_contract.scope_fields.get(k, _FIELD_ABSENT)
-        }
-        # Which recognized SCOPE_FIELD_KEYS actually differ -- an entirely
-        # empty set here (Codex review, PR #641 follow-up, fourth P1) means
-        # NOTHING recognized explains the differing scope_fingerprint: a
-        # deserialized/externally-constructed contract can carry an opaque
-        # scope_fingerprint that doesn't match what this version would
-        # recompute from scope_fields, the scope-side equivalent of the
-        # opaque profile-fingerprint mismatch rejected below. Restricting
-        # the additive-superset check to only the fields that actually
-        # differ (rather than calling it for every SCOPE_FIELD_KEYS entry,
-        # where an unchanged field would trivially pass via
-        # _scope_field_is_additive_superset's old==new branch) makes an
-        # empty `scope_differing` impossible to satisfy silently.
-        scope_differing = {
-            key
-            for key in SCOPE_FIELD_KEYS
-            if old_contract.scope_fields.get(key, "")
-            != new_contract.scope_fields.get(key, "")
-        }
-        # Additive-only header-set carve-out (PR #641 follow-up, pvxs scan
-        # F8) -- see check_contracts_comparable's own docstring. Gated into
-        # the *condition* itself, not a `return None` inside the block
-        # (Codex review, PR #641 follow-up): waiving the scope mismatch
-        # must fall through to the profile check below, not skip it -- a
-        # release that both adds a header AND changes an unrelated
-        # extraction-profile field (compiler flags, macros, include order)
-        # must still be caught by that check, not silently waved through.
-        if (
-            scope_unknown_differing
-            or not scope_differing
-            or not all(
-                _scope_field_is_additive_superset(
-                    old_contract.scope_fields.get(key),
-                    new_contract.scope_fields.get(key),
-                )
-                for key in scope_differing
-            )
-        ):
-            reason = (
-                "old and new snapshots do not cover the same declared "
-                "surface (scope_fingerprint mismatch) — the comparison is "
-                "not comparable. This commonly means a manifest/CLI-flag "
-                "drift between the two extraction runs, not a real API "
-                "change."
-            )
-            if diagnostic:
-                return ComparabilityMismatch(kind="scope", reason=reason)
-            raise ScopeMismatchError(reason)
-
-    if (
-        old_contract is not None
-        and new_contract is not None
-        and old_contract.profile_fingerprint is not None
-        and new_contract.profile_fingerprint is not None
-        and old_contract.profile_fingerprint != new_contract.profile_fingerprint
-    ):
-        old_fields = old_contract.profile_fields
-        new_fields = new_contract.profile_fields
-        if not (
-            _fingerprint_matches_fields(
-                old_contract.profile_fingerprint, old_fields, PROFILE_FIELD_KEYS
-            )
-            and _fingerprint_matches_fields(
-                new_contract.profile_fingerprint, new_fields, PROFILE_FIELD_KEYS
-            )
-        ):
-            # Neither carve-out below may be trusted: at least one side's
-            # profile_fields don't actually produce that side's own
-            # profile_fingerprint (Codex review, PR #641 follow-up, sixth
-            # P1) -- see _fingerprint_matches_fields's own docstring, and
-            # the scope-side equivalent check above.
-            reason = (
-                "old and new snapshots were extracted under different "
-                "compile contexts (profile_fingerprint mismatch), and at "
-                "least one side's profile_fields do not reproduce its own "
-                "profile_fingerprint — the comparison cannot be verified "
-                "safe."
-            )
-            if diagnostic:
-                return ComparabilityMismatch(kind="profile", reason=reason)
-            raise ProfileMismatchError(reason)
-        differing = {
-            k
-            for k in _FRONTEND_CONTEXT_PROFILE_FIELD_KEYS
-            if old_fields.get(k, "") != new_fields.get(k, "")
-        }
-        # A differing key OUTSIDE PROFILE_FIELD_KEYS entirely -- a newer
-        # schema field this build doesn't recognize -- must also block the
-        # "comparable" outcome, checked independently of and before any
-        # carve-out (Codex review, PR #641 follow-up, P1): `differing` above
-        # only ever iterates PROFILE_FIELD_KEYS, so a contract carrying an
-        # extra field this version doesn't know how to interpret (mixed
-        # with an otherwise-legitimate, carve-out-waived delta like additive
-        # `header_sequence` growth) was invisible to `unexplained` and the
-        # pair was wrongly reported comparable once the recognized delta
-        # alone got waived. No carve-out here understands an unrecognized
-        # key's semantics, so its presence is unconditionally fatal
-        # regardless of what the recognized fields' carve-outs conclude.
-        unknown_differing = {
-            k
-            for k in set(old_fields) | set(new_fields)
-            if k not in PROFILE_FIELD_KEYS
-            and old_fields.get(k, _FIELD_ABSENT) != new_fields.get(k, _FIELD_ABSENT)
-        }
-        # Each carve-out below claims and verifies only the subset of
-        # `differing` it actually understands, removing exactly those
-        # fields from `unexplained` -- carve-outs COMPOSE (Codex review, PR
-        # #641 follow-up, fourth round): a release combining two
-        # independently-sanctioned deltas (e.g. a header addition AND a
-        # corroborated C++-standard raise) must not raise just because
-        # neither carve-out's static field-set covers `differing` in full
-        # on its own. The four carve-outs' field-sets
-        # (_PLATFORM_IDENTITY_FIELDS/_BUILD_CONTEXT_FIELDS/
-        # _HEADER_SEQUENCE_FIELDS/_INCLUDE_SEQUENCE_FIELDS) are mutually
-        # disjoint, so processing order never matters -- each only ever
-        # narrows `unexplained`, never re-adds to it.
-        unexplained = set(differing)
-
-        platform_candidate = unexplained & _PLATFORM_IDENTITY_FIELDS
-        if platform_candidate:
-            old_components = _binary_platform_components(old)
-            new_components = _binary_platform_components(new)
-            # Every candidate field must itself map to a binary-derived
-            # component present on BOTH sides AND genuinely differing on
-            # that same field (Codex review, PR #624) -- not just "some"
-            # component of the platform identity differs somewhere. A field
-            # with no corresponding binary component on one side (e.g.
-            # pointer_width/endianness for a PE/Mach-O snapshot, which has
-            # no distinct word-size/endianness field) can never be confirmed
-            # this way, so the carve-out correctly declines to waive it.
-            #
-            # `target_triple` is the one exception, verified against the
-            # FULL axis rather than its own single "machine" component
-            # (Codex review, PR #624): some ELF families share `e_machine`
-            # across word sizes (e.g. EM_RISCV for both RV32 and RV64), so a
-            # target_triple change that's really just an expression of a
-            # genuine word-size change (riscv32-... vs. riscv64-...) would
-            # otherwise fail verification on its own narrow "machine"
-            # component even though `elf_class` already confirms the
-            # architecture genuinely differs. target_triple is a coarse,
-            # composite descriptor -- unlike pointer_width/endianness, which
-            # map to one specific, independently-meaningful field, it can be
-            # corroborated by any genuine difference on this axis.
-            if old_components is not None and new_components is not None:
-                common_keys = old_components.keys() & new_components.keys()
-                any_component_differs = any(
-                    old_components[k] != new_components[k] for k in common_keys
-                )
-
-                def _field_verified(field: str) -> bool:
-                    if field not in old_components or field not in new_components:
-                        return False
-                    if field == "target_triple":
-                        return any_component_differs
-                    return old_components[field] != new_components[field]
-
-                if all(_field_verified(field) for field in platform_candidate):
-                    # genuine cross-architecture compare; diff_platform.py handles it
-                    unexplained -= platform_candidate
-
-        build_candidate = unexplained & _BUILD_CONTEXT_FIELDS
-        if build_candidate and _build_context_corroborated(old, new):
-            # Build-context carve-out (Codex review, PR #624 follow-up --
-            # examples/case98_cxx_standard_floor_raised's real CI failure):
-            # a raised C++-standard floor or a build-derived macro delta
-            # between two snapshots BOTH actually reconciled against real
-            # build-system evidence is exactly the fact
-            # CXX_STANDARD_FLOOR_RAISED/ABI_RELEVANT_BUILD_FLAG_CHANGED
-            # (diff_build_config.py) exist to surface as a RISK finding --
-            # gating it into a generic not_comparable first would only
-            # discard that finding instead of letting the more specific
-            # detector classify it correctly.
-            unexplained -= build_candidate
-
-        # Both sequence carve-outs below additionally require
-        # _scope_growth_corroborated (Codex review, PR #641 follow-up, P1):
-        # an additive-shaped header_sequence/include_sequence on its own is
-        # not sufficient evidence -- a header already declared identically
-        # on both sides via --public-header, but fed to the L2 frontend via
-        # -H only on the new side, produces the identical additive-growth
-        # SHAPE with scope_fingerprint completely UNCHANGED, even though the
-        # old snapshot never actually parsed that header's content at all
-        # (see _scope_growth_corroborated's own docstring for why that's
-        # unsafe to wave through). Requiring a genuinely differing,
-        # independently-verified scope-level growth corroborates that the
-        # sequence growth reflects real new declared content, not just a
-        # same-declared-surface extraction-mechanism difference.
-        scope_growth_corroborated = _scope_growth_corroborated(
-            old_contract, new_contract
-        )
-        # The specific set of header identities the sequence carve-outs
-        # below are allowed to treat an appended/newly-owned entry as
-        # corresponding to (Codex review, PR #641 follow-up, ninth P1) --
-        # see _scope_newly_added_headers's own docstring for why
-        # scope_growth_corroborated alone (proving the scope grew by SOME
-        # header) isn't enough; the carve-outs must additionally verify
-        # they're waiving growth in the SAME header(s).
-        scope_new_headers = _scope_newly_added_headers(
-            old_contract.scope_fields.get("headers"),
-            new_contract.scope_fields.get("headers"),
-        )
-
-        header_seq_candidate = unexplained & _HEADER_SEQUENCE_FIELDS
-        if (
-            header_seq_candidate
-            and scope_growth_corroborated
-            and _header_sequence_is_additive_reorder_free(
-                old_fields.get("header_sequence"),
-                new_fields.get("header_sequence"),
-                scope_new_headers,
-            )
-        ):
-            # Header-sequence-growth carve-out (PR #641 follow-up, third
-            # round) -- see check_contracts_comparable's own docstring.
-            unexplained -= header_seq_candidate
-
-        include_seq_candidate = unexplained & _INCLUDE_SEQUENCE_FIELDS
-        if (
-            include_seq_candidate
-            and scope_growth_corroborated
-            and _include_sequence_is_additive_owned_growth(
-                old_fields.get("include_sequence"),
-                new_fields.get("include_sequence"),
-                scope_new_headers,
-            )
-        ):
-            # Include-sequence-owned-growth carve-out (PR #641 follow-up,
-            # fourth round) -- see check_contracts_comparable's own
-            # docstring.
-            unexplained -= include_seq_candidate
-
-        if unknown_differing:
-            reason = (
-                "old and new snapshots were extracted under different "
-                "compile contexts (profile_fingerprint mismatch), and "
-                f"differ on field(s) this version does not recognize: "
-                f"{', '.join(sorted(unknown_differing))} — the comparison "
-                "cannot be verified safe."
-            )
-        elif not differing:
-            # Codex review, PR #641 follow-up (P1): profile_fingerprint
-            # differs but NONE of the known PROFILE_FIELD_KEYS explain it --
-            # profile_fields was entirely absent/malformed on
-            # deserialization (_extraction_contract_from_dict substitutes
-            # {}, so every old_fields.get(k, "")/new_fields.get(k, "")
-            # compares "" == "" for every k). An empty `differing` must NOT
-            # be treated as "nothing to explain, therefore comparable" --
-            # that would silently bypass this fail-closed gate exactly when
-            # the granular field data needed to verify safety is missing or
-            # incomplete, which is the opposite of the gate's purpose.
-            reason = (
-                "old and new snapshots were extracted under different "
-                "compile contexts (profile_fingerprint mismatch), but no "
-                "recognized profile field explains the difference — "
-                "profile_fields may be absent/incomplete — so the "
-                "comparison cannot be verified safe."
-            )
-        elif not unexplained:
-            return None
-        else:
-            reason = (
-                "old and new snapshots were extracted under different compile "
-                f"contexts (profile_fingerprint mismatch; differing fields: "
-                f"{', '.join(sorted(unexplained))}) — the comparison "
-                "is not comparable."
-            )
-        if diagnostic:
-            return ComparabilityMismatch(kind="profile", reason=reason)
-        raise ProfileMismatchError(reason)
-
+            return mismatch
+        raise _MISMATCH_ERRORS[mismatch.kind](mismatch.reason)
     return None

--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -765,6 +765,44 @@ def _check_dependency_scope_comparable(
     return ComparabilityMismatch(kind="dependency_scope", reason=reason)
 
 
+#: Every key set :func:`compute_extraction_contract` may have hashed a
+#: ``profile_fingerprint``/``scope_fingerprint`` over. Each fingerprint is
+#: computed over the base set, *or* over the extended one when that dump
+#: carried the extra field (``frontend_context_kind`` for a DPC++-capable
+#: frontend, ADR-050 D5; ``translation_units`` for a ``--dump-manifest`` dump,
+#: D6) -- so authenticating against the base set alone declared every such
+#: contract inauthentic (CodeRabbit review; confirmed by direct repro: a
+#: `frontend_context_kind="device"` contract's own fingerprint did not
+#: reproduce under `PROFILE_FIELD_KEYS`, and a `manifest_tu_scope` one's did
+#: not reproduce under `SCOPE_FIELD_KEYS`).
+_PROFILE_FINGERPRINT_KEY_SETS = (
+    PROFILE_FIELD_KEYS,
+    _FRONTEND_CONTEXT_PROFILE_FIELD_KEYS,
+)
+_SCOPE_FINGERPRINT_KEY_SETS = (SCOPE_FIELD_KEYS, _MANIFEST_SCOPE_FIELD_KEYS)
+
+
+def _fingerprint_is_authentic(
+    fingerprint: str, fields: dict[str, str], key_sets: Sequence[tuple[str, ...]]
+) -> bool:
+    """Whether *fingerprint* reproduces from *fields* under any of *key_sets*.
+
+    Which set a given contract's fingerprint was hashed over is not always
+    recoverable from the stored fields: ``profile_fields`` records
+    ``frontend_context_kind`` as ``""`` both when the dump passed ``None``
+    (base key set) and when it passed an empty string (extended set), so the
+    gate cannot re-derive the choice and must accept either.
+
+    That is no weaker than knowing the answer. This check exists to catch a
+    *fabricated or stale* fingerprint sitting alongside fields that merely look
+    additive (:func:`_fingerprint_matches_fields`); accepting one of two
+    specific SHA-256 values instead of one leaves it exactly as hard to forge.
+    """
+    return any(
+        _fingerprint_matches_fields(fingerprint, fields, keys) for keys in key_sets
+    )
+
+
 def _differing_keys(
     old_fields: dict[str, str], new_fields: dict[str, str], keys: Sequence[str]
 ) -> set[str]:
@@ -872,15 +910,15 @@ def _check_scope_fingerprint_comparable(
         return None
 
     if not (
-        _fingerprint_matches_fields(
+        _fingerprint_is_authentic(
             old_contract.scope_fingerprint,
             old_contract.scope_fields,
-            SCOPE_FIELD_KEYS,
+            _SCOPE_FINGERPRINT_KEY_SETS,
         )
-        and _fingerprint_matches_fields(
+        and _fingerprint_is_authentic(
             new_contract.scope_fingerprint,
             new_contract.scope_fields,
-            SCOPE_FIELD_KEYS,
+            _SCOPE_FINGERPRINT_KEY_SETS,
         )
     ):
         # The carve-out below may not be trusted: at least one side's
@@ -1134,11 +1172,11 @@ def _check_profile_fingerprint_comparable(
     old_fields = old_contract.profile_fields
     new_fields = new_contract.profile_fields
     if not (
-        _fingerprint_matches_fields(
-            old_contract.profile_fingerprint, old_fields, PROFILE_FIELD_KEYS
+        _fingerprint_is_authentic(
+            old_contract.profile_fingerprint, old_fields, _PROFILE_FINGERPRINT_KEY_SETS
         )
-        and _fingerprint_matches_fields(
-            new_contract.profile_fingerprint, new_fields, PROFILE_FIELD_KEYS
+        and _fingerprint_is_authentic(
+            new_contract.profile_fingerprint, new_fields, _PROFILE_FINGERPRINT_KEY_SETS
         )
     ):
         # No carve-out below may be trusted: at least one side's
@@ -1160,8 +1198,15 @@ def _check_profile_fingerprint_comparable(
     differing = _differing_keys(
         old_fields, new_fields, _FRONTEND_CONTEXT_PROFILE_FIELD_KEYS
     )
+    # `_FRONTEND_CONTEXT_PROFILE_FIELD_KEYS`, not `PROFILE_FIELD_KEYS`
+    # (CodeRabbit review): `frontend_context_kind` is a field this build knows
+    # about -- `differing` directly above iterates it -- so reporting it as one
+    # "this version does not recognize" was simply wrong. The outcome for a
+    # differing `frontend_context_kind` is unchanged, only its reason: no
+    # carve-out's field-set contains it, so it stays in `unexplained` and the
+    # pair is still not comparable.
     unknown_differing = _unknown_differing_keys(
-        old_fields, new_fields, PROFILE_FIELD_KEYS
+        old_fields, new_fields, _FRONTEND_CONTEXT_PROFILE_FIELD_KEYS
     )
     unexplained = _unexplained_profile_fields(
         old, new, old_contract, new_contract, differing

--- a/abicheck/comparability_fields.py
+++ b/abicheck/comparability_fields.py
@@ -1,0 +1,730 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ADR-050 D1 — the extraction-contract *field* layer.
+
+``comparability.py`` owns the two questions a caller asks of a contract: what
+one a dump has (:func:`~abicheck.comparability.compute_extraction_contract`),
+and whether two of them are comparable
+(:func:`~abicheck.comparability.check_contracts_comparable`). This module owns
+the inner half of the first — how a resolved compile context and a declared
+surface each become the ``profile_fields``/``scope_fields`` dicts those
+fingerprints are hashed from, plus the side-local path-identity primitives that
+keep those fields free of checkout-root noise.
+
+Split out of ``comparability.py`` for file size (the AI-readiness gate's
+2000-line hard cap), along the seam that was already there: nothing here needs
+anything from the gate side, so this is a leaf depending only on
+``comparability_json`` and the standard library, and nothing in it may import
+back. ``comparability.py`` re-exports the names its own public surface
+historically carried (``IncludeDir``, ``_sha256_of``,
+``_fingerprint_matches_fields``), so no caller's import path changes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from .errors import SnapshotError
+
+
+@dataclass(frozen=True)
+class IncludeDir:
+    """One declared ``-I`` search-path entry, in the order it was declared
+    on the command line (or manifest, once that exists) — order is itself a
+    hashed input, since ``-I`` order is real compiler search-precedence
+    order, not cosmetic.
+
+    ``label`` is the resolved value of a legacy-CLI labeled
+    ``--include old:LABEL=PATH`` entry (ADR-050 D1) — ``None`` for an
+    ordinary, unlabeled entry. This module accepts the resolved label
+    directly; the CLI grammar that would parse it from a command line is
+    separate, not-yet-built work (see this module's docstring).
+    """
+
+    path: Path
+    label: str | None = None
+
+
+def _resolved(path: Path) -> Path:
+    return path.resolve()
+
+
+def _common_root(candidates: Sequence[str]) -> Path | None:
+    """``os.path.commonpath``, tolerant of candidates with no shared anchor
+    at all (CodeRabbit review, PR #624): mixed drives on Windows, or a local
+    vs. UNC root, make ``commonpath`` raise ``ValueError`` instead of
+    degrading gracefully — that must not propagate out of fingerprinting as
+    an unhandled crash. Returns ``None`` when there is no common root to
+    strip; callers fall back to :func:`_side_local_identity`'s
+    drive-stripped form in that case."""
+    try:
+        return Path(os.path.commonpath(candidates))
+    except ValueError:
+        return None
+
+
+def _side_local_identity(path: Path, root: Path | None) -> str:
+    """A path's identity relative to ``root``, or — when ``root`` is
+    ``None`` because this side's declared paths share no common anchor at
+    all — the drive-stripped absolute path (still deterministic and
+    drive-letter-independent, just without a common prefix to strip)."""
+    resolved = _resolved(path)
+    if root is not None:
+        return str(resolved.relative_to(root))
+    return os.path.splitdrive(str(resolved))[1]
+
+
+def _is_ancestor_or_equal(root: Path, path: Path) -> bool:
+    root = _resolved(root)
+    path = _resolved(path)
+    return path == root or root in path.parents
+
+
+def _content_hash(path: Path) -> str:
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        # ADR-050 D1: a resolved header's content that can't be read at
+        # fingerprint time must fail extraction outright, not fold an
+        # "unresolvable" sentinel into the hash — two runs unresolvable for
+        # different reasons must not spuriously fingerprint-match.
+        raise SnapshotError(
+            f"cannot read {path} while computing profile_fingerprint: {exc}"
+        ) from exc
+    return hashlib.sha256(data).hexdigest()
+
+
+def _sha256_of(*parts: str) -> str:
+    h = hashlib.sha256()
+    for part in parts:
+        h.update(part.encode("utf-8"))
+        h.update(b"\x00")
+    return f"sha256:{h.hexdigest()}"
+
+
+def _fingerprint_matches_fields(
+    fingerprint: str, fields: dict[str, str], keys: tuple[str, ...]
+) -> bool:
+    """Whether *fingerprint* is exactly what :func:`compute_extraction_contract`
+    would produce from *fields* over *keys* (``SCOPE_FIELD_KEYS`` or
+    ``PROFILE_FIELD_KEYS``) -- i.e. whether this contract's stored fields
+    are actually what its own fingerprint was computed from (Codex review,
+    PR #641 follow-up, sixth P1).
+
+    Every carve-out above reasons entirely from ``scope_fields``/
+    ``profile_fields`` -- "this recognized field grew additively, so the
+    fingerprint mismatch is explained" -- but that reasoning only holds if
+    the stored fingerprint was genuinely computed from those exact fields.
+    For a snapshot dumped by this codebase's own
+    :func:`compute_extraction_contract`, that invariant always holds by
+    construction. It is NOT verified anywhere, though, so a deserialized or
+    externally constructed contract can carry a stale, fabricated, or
+    otherwise unrelated fingerprint alongside fields that merely *look*
+    additive: confirmed by direct repro before any fix -- two arbitrary,
+    unrelated fingerprint strings with ``headers`` genuinely growing from
+    ``["a.h", "b.h"]`` to ``["a.h", "b.h", "c.h"]`` made
+    :func:`check_contracts_comparable` return ``None`` (comparable) even
+    though neither fingerprint was ever verified to have anything to do
+    with those fields -- the true cause of the mismatch remains completely
+    unverified. Called on BOTH sides before any carve-out below is trusted;
+    a mismatch on either side means the fields can't be trusted to explain
+    that side's own fingerprint, so nothing reasoned from them is safe to
+    act on.
+    """
+    return fingerprint == _sha256_of(*[fields.get(k, "") for k in keys])
+
+
+def _classify_include_dirs(
+    declared_headers: Sequence[Path],
+    declared_includes: Sequence[IncludeDir],
+) -> list[bool]:
+    """Return, per ``declared_includes`` entry (same order/length), whether
+    that directory is project-owned: labeled explicitly (a sibling support
+    root with no owned declared header), or equal to/an ancestor of any
+    declared header (ADR-050 D1)."""
+    owned = []
+    for inc in declared_includes:
+        if inc.label is not None:
+            owned.append(True)
+            continue
+        owned.append(any(_is_ancestor_or_equal(inc.path, h) for h in declared_headers))
+    return owned
+
+
+def _header_identities(
+    declared_headers: Sequence[Path], extra_root_paths: Sequence[Path] = ()
+) -> dict[Path, str]:
+    """A stable, side-local identity string per declared header — its path
+    relative to the common ancestor of every declared header's *parent*
+    directory (the same normalization ``scope_fingerprint`` uses for its own
+    header identity). Used only to build ancestor-derived slot tokens below;
+    the basename alone (Codex review, PR #624) is not enough to disambiguate
+    two project-owned roots that each own a different declared header
+    sharing the same basename (e.g. ``include/foo.h`` vs.
+    ``generated/foo.h``) — both would otherwise collapse to token
+    ``hdrs:foo.h``, silently losing the order-sensitivity a swapped
+    ``-I include -I generated`` vs. ``-I generated -I include`` is supposed
+    to preserve.
+
+    *extra_root_paths* (``public_header_paths`` — provenance-only headers
+    never fed to the L2 frontend, so never in *declared_headers* or the
+    returned dict) widens the root candidates the same way the scope
+    ``"headers"`` field's own root computation already does (Codex review,
+    PR #641 follow-up, sixteenth P2): without this, a ``public_header_paths``
+    entry outside every declared header's common root makes this function's
+    root narrower than the scope side's, so the SAME physical file gets two
+    different identity strings across the two fields (e.g. scope
+    ``"foo/c.h"`` vs. sequence ``"c.h"``) — and the header/include-sequence
+    carve-outs' specific-correspondence check (``_scope_newly_added_headers``)
+    compares these by exact string equality, so a genuinely safe, purely
+    additive header change spuriously hard-fails with ``ProfileMismatchError``
+    the moment any ``public_header_paths`` entry reaches outside that
+    narrower root. Widening the root here to match closes the mismatch
+    without changing what a declared header's identity actually disambiguates
+    (its path relative to a root is still unique per file — the root is
+    just wider than before when *extra_root_paths* is non-empty)."""
+    if not declared_headers:
+        return {}
+    parents = [str(_resolved(h).parent) for h in (*declared_headers, *extra_root_paths)]
+    root = _common_root(parents)
+    return {h: _side_local_identity(h, root) for h in declared_headers}
+
+
+def _slot_token_for_ancestor(
+    inc: IncludeDir,
+    declared_headers: Sequence[Path],
+    header_identities: dict[Path, str],
+    single_header_mode: bool,
+) -> str:
+    # A single declared header's own name is not load-bearing here either
+    # (Codex review, PR #624 follow-up -- CI went red at scale once real
+    # dumps started populating contract): P3's auto-added include root
+    # (`resolve_inferred_header_roots`, cli_dump_helpers.py) makes a lone
+    # `-H v1.h` umbrella's own parent directory project-owned, and without
+    # this short-circuit the owned-slot token below would embed `v1.h`'s own
+    # basename via the dir-relative component -- so a legitimate single-
+    # header rename (`v1.h` -> `v2.h`, examples/case189's exact CI failure)
+    # would spuriously flip `include_sequence` even though `header_sequence`
+    # and the scope `headers` field both already correctly collapse to the
+    # same "<single-header>" placeholder for this case. With only one
+    # declared header there is nothing to disambiguate a name against
+    # anyway, same reasoning as those two fields.
+    if single_header_mode:
+        return "hdrs:<single-header>"
+    # Codex review (PR #624): pair each owned header's GLOBAL root-relative
+    # identity (disambiguates the same-basename-under-two-separate-roots case
+    # already fixed once -- e.g. `include/foo.h` vs. `generated/foo.h`) with
+    # its identity RELATIVE TO THIS SPECIFIC include dir (disambiguates two
+    # NESTED/overlapping project-owned roots, e.g. `-I work` and
+    # `-I work/include`, that both own the exact same header). Global
+    # identity alone is identical for both slots in the nested case -- e.g.
+    # both would tokenize as `hdrs:[["foo.h", ...]]` regardless of which
+    # dir owns it -- silently losing the order-sensitivity a swapped
+    # `-I work -I work/include` vs. `-I work/include -I work` is supposed to
+    # preserve. The dir-relative component is always safe to compute here:
+    # ownership (checked by the filter below) means `inc.path` is already
+    # an ancestor-or-equal of `h`, so `h.relative_to(inc.path)` never raises.
+    # sorted(set(...)), not sorted(...) (Codex review, PR #624): declared_headers
+    # is not itself deduplicated before reaching this function, so the same
+    # header supplied twice in one CLI/manifest invocation must not retain a
+    # duplicate (header_identity, relative_path) pair -- mirroring the same
+    # duplicate-collapse rule scope's "headers" field and header_sequence
+    # both already apply.
+    owned = sorted(
+        {
+            (header_identities[h], str(_resolved(h).relative_to(_resolved(inc.path))))
+            for h in declared_headers
+            if _is_ancestor_or_equal(inc.path, h)
+        }
+    )
+    # json.dumps, not a raw "," join (Codex review, PR #624): a header
+    # identity string is not guaranteed comma-free, so an unescaped join
+    # could let two structurally different owned-header sets collapse to
+    # the same token — the identical class of bug reported for macro_ops.
+    return "hdrs:" + json.dumps(owned)
+
+
+def _attribute_file(
+    file_path: Path,
+    declared_includes: Sequence[IncludeDir],
+    ownership: Sequence[bool],
+    declared_headers: Sequence[Path],
+) -> int | None:
+    """Return the index into ``declared_includes`` that ``file_path`` is
+    attributed to (longest-prefix match among directories that actually
+    contain it), or ``None`` if it falls under no declared ``-I`` directory
+    at all (the system/toolchain bucket) or under a declared header's own
+    (implicitly project-owned) parent directory."""
+    # A declared header's own parent directory is implicitly project-owned
+    # even with no matching --include at all (quote-include same-directory
+    # resolution) -- checked BEFORE the declared_includes longest-prefix
+    # match, not after (Codex review, PR #624): a file under a declared
+    # header's own parent that ALSO happens to fall under a nested, non-
+    # owned --include (e.g. --header old/include/foo.h plus --include
+    # old/include/sub, with foo.h quote-including sub/detail.h) would
+    # otherwise get attributed to that external slot and content-hashed,
+    # even though it is structurally part of the same project directory
+    # tree the implicit-parent rule exists to exclude -- an ordinary
+    # internal support-header edit could then spuriously raise
+    # ProfileMismatchError. Attribute such a file to a synthetic
+    # "owned, excluded" bucket by returning -1, distinct from "no declared
+    # -I dir at all".
+    for h in declared_headers:
+        if _is_ancestor_or_equal(h.parent, file_path):
+            return -1
+    # An owned ancestor -I directory's exclusion ("every file under it,
+    # named or not") wins over a deeper, non-owned nested -I directory
+    # (Codex review, PR #624): with `--header old/include/foo.h --include
+    # old --include old/generated`, `old` is project-owned (an ancestor of
+    # the declared header) and `old/generated` is not (it isn't itself an
+    # ancestor of any declared header) -- a plain longest-prefix match would
+    # pick the deeper, non-owned `old/generated` slot for a file under it,
+    # content-hashing it even though the broader owned `old` root already
+    # claims everything beneath it. Owned matches are therefore preferred
+    # outright over non-owned ones, with longest-prefix only breaking ties
+    # within the same ownership class (which owned index wins is otherwise
+    # immaterial: an owned slot's token never depends on per_slot_files).
+    best_owned_idx: int | None = None
+    best_owned_len = -1
+    best_external_idx: int | None = None
+    best_external_len = -1
+    for idx, inc in enumerate(declared_includes):
+        if _is_ancestor_or_equal(inc.path, file_path):
+            depth = len(_resolved(inc.path).parts)
+            if ownership[idx]:
+                if depth > best_owned_len:
+                    best_owned_len = depth
+                    best_owned_idx = idx
+            elif depth > best_external_len:
+                best_external_len = depth
+                best_external_idx = idx
+    if best_owned_idx is not None:
+        return best_owned_idx
+    if best_external_idx is not None:
+        return best_external_idx
+    return None
+
+
+def _fingerprint_from_fields(fields: dict[str, str], keys: Sequence[str]) -> str:
+    """Hash *fields* over *keys* into one fingerprint — the profile/scope
+    fingerprint algorithm itself, shared by both sides of
+    :func:`compute_extraction_contract`. Indexes rather than ``.get``s: a field
+    this function is asked to hash but never populated is a bug in the caller,
+    not a value to silently substitute (:func:`_fingerprint_matches_fields`
+    recomputes the same value from an already-*stored* field dict, where a
+    missing key is an ordinary deserialization outcome, and does use ``.get``).
+    """
+    return _sha256_of(*[fields[k] for k in keys])
+
+
+def _single_header_mode(
+    declared_headers: Sequence[Path],
+    declared_includes: Sequence[IncludeDir],
+    ownership: Sequence[bool],
+    header_identities: dict[Path, str],
+) -> bool:
+    """Whether the owned-slot token is safe to collapse to a constant
+    placeholder instead of encoding the (rename-prone) declared header's own
+    name.
+
+    True only when the WHOLE declared surface is one logical header (by
+    identity, not raw list length -- the same header supplied twice is still
+    "one distinct header") AND there is at most one owned, unlabeled
+    include-dir slot for it. Both conditions matter -- gating on single-header
+    alone regressed test_13c (Codex review, PR #624 follow-up): two NESTED
+    project-owned roots (``-I work`` and ``-I work/include``) that both own the
+    SAME single declared header must still tokenize distinctly per slot to
+    preserve order-sensitivity (which nested root search comes first is a
+    genuine compile-context fact) -- collapsing both to one constant would
+    silently lose that. It is only the single-owner case (P3's
+    ``resolve_inferred_header_roots`` auto-adding exactly one owned root for a
+    lone ``-H v1.h``/``-H old=<dir>`` umbrella, examples/case189's exact CI
+    failure) where there is nothing left to disambiguate and the header's own
+    name is pure rename-noise.
+    """
+    if len({header_identities[h] for h in declared_headers}) > 1:
+        return False
+    owned_unlabeled_count = sum(
+        1
+        for idx, inc in enumerate(declared_includes)
+        if ownership[idx] and inc.label is None
+    )
+    return owned_unlabeled_count <= 1
+
+
+def _deduplicated_resolved_paths(
+    depfile_resolved_paths: Sequence[Path], generated_driver_path: Path | None
+) -> list[Path]:
+    """The depfile's resolved dependencies, minus the generated driver TU and
+    minus repeats.
+
+    Deduplicated by resolved identity, not just filtered (Codex review, PR
+    #624): ``depfile_resolved_paths`` can realistically list the same resolved
+    file more than once (e.g. concatenated per-TU depfiles, or an
+    un-deduplicated depfile parse). Left un-deduped, a repeated entry is
+    bucketed and hashed twice, so an otherwise identical extraction
+    fingerprints differently purely because one side happens to repeat the same
+    dependency entry.
+    """
+    seen: set[Path] = set()
+    resolved_paths: list[Path] = []
+    for p in depfile_resolved_paths:
+        if p == generated_driver_path:
+            continue
+        key = _resolved(p)
+        if key in seen:
+            continue
+        seen.add(key)
+        resolved_paths.append(p)
+    return resolved_paths
+
+
+def _bucket_resolved_files(
+    resolved_paths: Sequence[Path],
+    declared_includes: Sequence[IncludeDir],
+    ownership: Sequence[bool],
+    declared_headers: Sequence[Path],
+) -> tuple[list[list[Path]], list[Path]]:
+    """Attribute each resolved dependency to the ``-I`` slot it came through.
+
+    Returns ``(per_slot_files, system_bucket_files)`` -- the latter holding
+    everything no declared slot claims. A file attributed to ``-1`` is
+    implicitly project-owned via a declared header's own parent directory and
+    belongs to neither bucket.
+    """
+    per_slot_files: list[list[Path]] = [[] for _ in declared_includes]
+    system_bucket_files: list[Path] = []
+    for file_path in resolved_paths:
+        idx = _attribute_file(file_path, declared_includes, ownership, declared_headers)
+        if idx is None:
+            system_bucket_files.append(file_path)
+        elif idx == -1:
+            continue  # implicitly project-owned via a declared header's parent
+        else:
+            per_slot_files[idx].append(file_path)
+    return per_slot_files, system_bucket_files
+
+
+def _external_slot_token(inc: IncludeDir, files: Sequence[Path]) -> str:
+    """The content token for a non-project-owned ``-I`` slot: every file reached
+    through it, by its path *relative to that slot* plus its content hash."""
+    pairs = sorted(
+        (str(_resolved(f).relative_to(_resolved(inc.path))), _content_hash(f))
+        for f in files
+    )
+    return "ext:" + _sha256_of(*[f"{p}={h}" for p, h in pairs])
+
+
+def _system_bucket_token(files: Sequence[Path]) -> str:
+    """The content token for the unattributed system/toolchain bucket.
+
+    Content hashes only, no path component (Codex review, PR #624): unlike the
+    ``ext:`` bucket, a system-bucket file has no declared :class:`IncludeDir` to
+    make its path side-local against, and its raw resolved path is
+    checkout/cache-root-dependent (e.g. an auto-injected sysroot under
+    ``/tmp/old-sysroot/...`` vs. ``/tmp/new-sysroot/...``). Two toolchains with
+    byte-identical system headers must fingerprint identically regardless of
+    where those headers happen to sit on disk -- the bucket is already
+    unordered/unattributed, so path identity was never load-bearing here, only
+    content is.
+    """
+    return "sys:" + _sha256_of(*sorted(_content_hash(f) for f in files))
+
+
+def _include_slot_tokens(
+    declared_headers: Sequence[Path],
+    declared_includes: Sequence[IncludeDir],
+    ownership: Sequence[bool],
+    header_identities: dict[Path, str],
+    single_header_mode: bool,
+    per_slot_files: Sequence[Sequence[Path]],
+    system_bucket_files: Sequence[Path],
+) -> list[str]:
+    """One ordered token per declared ``-I`` slot, plus a trailing system-bucket
+    token when anything landed there.
+
+    A project-owned slot tokenizes by *which* declared surface it owns (never
+    by its own checkout-dependent path); an external one by the content reached
+    through it.
+    """
+    slot_tokens: list[str] = []
+    for idx, inc in enumerate(declared_includes):
+        if not ownership[idx]:
+            token = _external_slot_token(inc, per_slot_files[idx])
+        elif inc.label is not None:
+            token = f"label:{inc.label}"
+        else:
+            token = _slot_token_for_ancestor(
+                inc, declared_headers, header_identities, single_header_mode
+            )
+        slot_tokens.append(f"{idx}:{token}")
+
+    if system_bucket_files:
+        slot_tokens.append(_system_bucket_token(system_bucket_files))
+    return slot_tokens
+
+
+def _declared_header_sequence(
+    declared_headers: Sequence[Path], header_identities: dict[Path, str]
+) -> list[str]:
+    """The declared headers' ORDER, as a profile/extraction-context fact.
+
+    Declared-header order is a profile fact, not a scope one (Codex review, PR
+    #624): the aggregate driver TU ``dumper.py`` generates includes declared
+    headers sequentially in the caller's given order, so a macro/pragma side
+    effect from one header can change how a LATER header in the sequence parses
+    -- ``-H a.h -H b.h`` and ``-H b.h -H a.h`` can genuinely produce different
+    ASTs even though the same header SET is declared either way.
+    ``scope_fingerprint`` deliberately stays order-independent (the declared
+    *surface* -- which headers are public -- doesn't depend on dump order; see
+    the "headers" field), but ``profile_fingerprint`` must still catch a
+    reordering that could change the extracted AST. Order-preserving
+    de-duplication (first occurrence wins), not a sorted set, mirroring the same
+    duplicate-collapse rule scope's "headers" field applies -- a header named
+    twice must not itself change the sequence.
+
+    A single declared header's own name is not load-bearing here either (Codex
+    review, PR #624 follow-up — same reasoning as the scope "headers" field):
+    with only one header, there is no order to disambiguate, so a rename
+    (v1.h -> v2.h) must not collide with the ORDER-sensitivity this field
+    exists to catch for 2+ headers.
+    """
+    seen: set[str] = set()
+    sequence: list[str] = []
+    for h in declared_headers:
+        identity = header_identities[h]
+        if identity not in seen:
+            seen.add(identity)
+            sequence.append(identity)
+    if len(sequence) == 1:
+        return ["<single-header>"]
+    return sequence
+
+
+def _compute_profile_fields(
+    *,
+    compiler_family: str | None,
+    compiler_version: str | None,
+    abi_dialect: str | None,
+    language_standard: str | None,
+    target_triple: str | None,
+    pointer_width: int | None,
+    endianness: str | None,
+    macro_ops: Sequence[tuple[str, str]],
+    pass_through_flags: Sequence[str | Path],
+    declared_headers: Sequence[Path],
+    declared_includes: Sequence[IncludeDir],
+    depfile_resolved_paths: Sequence[Path],
+    generated_driver_path: Path | None,
+    public_header_paths: Sequence[Path],
+    frontend_context_kind: str | None,
+) -> dict[str, str]:
+    """The ``profile_fields`` half of :func:`compute_extraction_contract` — the
+    *resolved compile context* an L2 frontend actually ran under."""
+    ownership = _classify_include_dirs(declared_headers, declared_includes)
+    header_identities = _header_identities(declared_headers, public_header_paths)
+    single_header_mode = _single_header_mode(
+        declared_headers, declared_includes, ownership, header_identities
+    )
+    per_slot_files, system_bucket_files = _bucket_resolved_files(
+        _deduplicated_resolved_paths(depfile_resolved_paths, generated_driver_path),
+        declared_includes,
+        ownership,
+        declared_headers,
+    )
+    slot_tokens = _include_slot_tokens(
+        declared_headers,
+        declared_includes,
+        ownership,
+        header_identities,
+        single_header_mode,
+        per_slot_files,
+        system_bucket_files,
+    )
+    header_sequence = _declared_header_sequence(declared_headers, header_identities)
+
+    # Path-valued pass-through operands are content-hashed, never
+    # hashed as their raw string form (Codex review, PR #624): a
+    # forced-include flag like `-include /checkout-old/force.h` names
+    # a real file, and that file's checkout-root-dependent absolute
+    # path is exactly the class of noise this whole algorithm exists
+    # to strip everywhere else -- old/new checkouts using
+    # `/checkout-old/...` vs. `/checkout-new/...` must not
+    # fingerprint differently for byte-identical forced-include
+    # content. A `str` element (the flag name itself, or a non-path
+    # operand) is opaque and hashed as literal text; there is no
+    # principled root to normalize a forced-include path against (it
+    # need not fall under any declared header or -I directory at
+    # all), so it gets the same treatment as the unattributed
+    # system/toolchain bucket: content only, no path.
+    normalized_pass_through = [
+        f"path:{_content_hash(item)}" if isinstance(item, Path) else f"str:{item}"
+        for item in pass_through_flags
+    ]
+
+    return {
+        "compiler_family": compiler_family or "",
+        "compiler_version": compiler_version or "",
+        "abi_dialect": abi_dialect or "",
+        "language_standard": language_standard or "",
+        "target_triple": target_triple or "",
+        "pointer_width": str(pointer_width) if pointer_width is not None else "",
+        "endianness": endianness or "",
+        # json.dumps, not a raw "|"/":" join (Codex review, PR #624): a
+        # macro value or slot token is not guaranteed pipe/colon-free —
+        # macro_ops=[("D", "A|U:B")] and [("D", "A"), ("U", "B")] would
+        # otherwise both serialize to the identical string "D:A|U:B",
+        # letting the gate miss a real profile drift. json.dumps
+        # length-delimits each element unambiguously regardless of its
+        # content.
+        "macro_ops": json.dumps(list(macro_ops)),
+        # Ordered, not sorted (Codex review, PR #624): repeatable
+        # pass-through frontend flags like `-include a.h -include b.h`
+        # force preprocessing content whose ORDER can change
+        # macro/pragma state before the rest of the TU is parsed --
+        # `-include a.h -include b.h` and `-include b.h -include a.h`
+        # can genuinely produce different ASTs even when the depfile's
+        # resolved dependency SET is identical (which bucketing above
+        # would otherwise report as unchanged, since bucket contents
+        # are order-independent by design). This is deliberately a raw,
+        # caller-supplied ordered flag list, not parsed or validated --
+        # dumper.py's actual `-include`/other repeatable-flag wiring is
+        # separate, not-yet-built work (see this module's docstring).
+        "pass_through_flags": json.dumps(normalized_pass_through),
+        "include_sequence": json.dumps(slot_tokens),
+        "header_sequence": json.dumps(header_sequence),
+        "frontend_context_kind": frontend_context_kind or "",
+    }
+
+
+def _common_root_of_parents(paths: Sequence[Path]) -> Path | None:
+    """The common root of every path's *parent* directory, or ``None`` when
+    there are no paths at all.
+
+    Rooting on the parent rather than the path itself is what preserves each
+    entry's own basename in the normalized identity — the same
+    single-entry-preserving trick used everywhere else in this module.
+    """
+    candidates = [str(_resolved(p).parent) for p in paths]
+    return _common_root(candidates) if candidates else None
+
+
+def _normalized_identities(paths: Sequence[Path], root: Path | None) -> list[str]:
+    """Side-local identities for *paths*, deduplicated and ordered.
+
+    ``sorted(set(...))``, not ``sorted(...)`` (Codex review, PR #624): the same
+    logical header reaching :func:`compute_extraction_contract` through both
+    ``declared_headers`` and ``public_header_paths`` on one side (e.g. a full L2
+    dump that also passes ``--public-header`` for the same file) must not retain
+    a duplicate entry a side naming it only once wouldn't have --
+    ``["foo.h", "foo.h"]`` vs. ``["foo.h"]`` would otherwise mismatch on element
+    count alone, despite describing the identical declared surface.
+    """
+    return sorted({_side_local_identity(p, root) for p in paths})
+
+
+def _compute_scope_fields(
+    declared_headers: Sequence[Path],
+    public_header_paths: Sequence[Path],
+    public_header_dirs: Sequence[Path],
+    manifest_tu_scope: str | None,
+) -> dict[str, str]:
+    """The ``scope_fields`` half of :func:`compute_extraction_contract` — the
+    *declared surface* being compared, independent of how it was extracted.
+
+    All scope-identity inputs normalize against a shared, side-local root —
+    never raw absolute paths (Codex review, PR #624): a lone
+    ``--public-header``/``--public-header-dir`` provenance input (the
+    symbols-only-with-provenance case, no ``declared_headers`` at all) is
+    exactly as checkout-root-dependent as ``declared_headers``, and hashing it
+    unnormalized would make an ordinary two-checkout compare relying only on
+    public-header provenance spuriously ``ScopeMismatchError``.
+    ``declared_headers`` and ``public_header_paths`` are merged into one
+    combined "headers" identity, not two separate ``scope_fields`` entries
+    (Codex review, PR #624): both name individual public header *files* — the
+    same declared surface, captured by two different mechanisms (a full L2
+    header-AST dump's ``-H`` vs. a symbols-only dump's ``--public-header``
+    provenance tag). Keeping them in separate fields made an ordinary depth
+    difference between two dumps of the *same* header (one via each mechanism)
+    fingerprint as a scope mismatch, even though nothing about the declared
+    surface actually differs. ``public_header_dirs`` stays its own field — a
+    directory asserts "everything under here is public," a categorically
+    different claim from naming individual files, so merging it into "headers"
+    would conflate the two rather than recognize genuine equivalence.
+
+    "headers" and "public_header_dirs" normalize against SEPARATE roots, not one
+    shared across both (found via real-world CI: a ``--devel-pkg``/``-H <dir>``
+    umbrella whose ``declared_headers`` live several directories below the
+    extracted/declared root -- e.g. ``<root>/usr/include/*.h`` and
+    ``<root>/usr/share/doc/.../*.h`` next to ``<root>`` itself passed as a
+    ``public_header_dir``). A single shared root, computed from every entry's
+    parent including the directory entries, gets pulled up to the directory's
+    *own* parent (one level above the declared root) the moment that directory
+    sits shallower than the header files -- leaking that root's name (often
+    per-run-random, e.g. a tempfile-extracted package) into "headers"' normalized
+    identities even though "public_header_dirs" collapses its own single-entry
+    case away separately. Two byte-identical extractions into two different temp
+    directories then spuriously fingerprint as a scope mismatch. Each field
+    already hashes independently (:data:`SCOPE_FIELD_KEYS`), so there is no
+    reason for them to share a root: files use their parent for the root;
+    ``public_header_dirs`` are themselves directories, so their *own* parent is
+    the analogous root candidate for *that field alone*.
+
+    A single declared header's own filename is NOT load-bearing scope identity
+    (Codex review, PR #624 follow-up — CI went red at scale once real dumps
+    started populating contract): renaming a project's one main header between
+    versions (v1.h -> v2.h, or any other rename) is a common, legitimate
+    practice, not the "manifest/CLI-flag drift" mistake this fingerprint exists
+    to catch -- and with only one header declared there is nothing to
+    disambiguate a name against anyway. The multi-header case still needs real
+    per-file identity: two co-located headers must not collapse to the same
+    token (``["a.h","b.h"]`` vs ``["a.h","c.h"]`` is a genuine declared-surface
+    difference). The header's actual API surface is still verified by the
+    ordinary diff engine; this only concerns whether the extraction inputs count
+    as "the same declared surface" for the comparability gate. The same holds
+    for a single declared public-header *directory* (same CI incident: a lone
+    ``-H old=<dir>``/``-H new=<dir>`` umbrella, e.g. test_perf_binary_scan.py's
+    old-include/new-include fixture dirs).
+    """
+    header_identities = _normalized_identities(
+        (*declared_headers, *public_header_paths),
+        _common_root_of_parents((*declared_headers, *public_header_paths)),
+    )
+    if len(header_identities) == 1:
+        header_identities = ["<single-header>"]
+
+    dir_identities = _normalized_identities(
+        public_header_dirs, _common_root_of_parents(public_header_dirs)
+    )
+    if len(dir_identities) == 1:
+        dir_identities = ["<single-header-dir>"]
+
+    # json.dumps, not a raw "|" join (Codex review, PR #624, same class
+    # of bug already fixed for macro_ops/include_sequence above): a
+    # normalized path is not guaranteed pipe-free.
+    return {
+        "headers": json.dumps(header_identities),
+        "public_header_dirs": json.dumps(dir_identities),
+        # Present in scope_fields (so it's visible for reporting/
+        # debugging either way) but deliberately NOT always folded into
+        # scope_fingerprint itself -- see the manifest_tu_scope branch
+        # in compute_extraction_contract (Codex review, PR #636).
+        "translation_units": manifest_tu_scope or "[]",
+    }

--- a/abicheck/comparability_sequences.py
+++ b/abicheck/comparability_sequences.py
@@ -261,14 +261,79 @@ def _slot_indices_match_position(slots: list[str]) -> bool:
         if (
             rest.startswith(_OWNED_HEADER_TOKEN_PREFIX)
             and rest != _OWNED_HEADER_SINGLE_SENTINEL
+            and _owned_header_pairs(rest) is None
         ):
-            pairs = _json_load_list(rest[len(_OWNED_HEADER_TOKEN_PREFIX) :])
-            if pairs is None or not all(_is_owned_header_pair(p) for p in pairs):
-                return False
-            pair_tuples = [tuple(p) for p in pairs]
-            if len(pair_tuples) != len(set(pair_tuples)):
-                return False
+            return False
     return True
+
+
+def _owned_header_pairs(token_rest: str) -> set[tuple[str, ...]] | None:
+    """Decode one owned ``"hdrs:"`` slot token's pair list into a set, or
+    ``None`` when the token isn't a decodable owned pair list at all.
+
+    ``None`` covers four distinct "no usable per-header evidence here" cases,
+    all of which callers treat identically (fail closed):
+
+    * the ``<single-header>`` sentinel -- no real per-header identity to verify
+      a superset against, mirroring the scope-side carve-out's own sentinel
+      handling;
+    * a non-owned token shape (``ext:``/``label:``) -- a differing one is real,
+      unrelated profile drift no carve-out here has business waiving;
+    * a payload that isn't a JSON list, or a member that isn't an exact
+      two-string list (Codex review, PR #641 follow-up, third P2) -- ``tuple(p)``
+      alone doesn't reject a malformed member the way it looks like it should:
+      a bare string like ``"xx"`` is itself iterable, so ``tuple("xx")``
+      silently succeeds as ``("x", "x")`` instead of raising, letting malformed
+      evidence masquerade as a legitimate owned-header pair;
+    * a *duplicated* pair (Codex review, PR #641 follow-up, fourteenth P2):
+      ``_slot_token_for_ancestor``'s real ``owned`` construction always emits a
+      deduplicated pair list, so a duplicate -- e.g. a newly appended
+      ``("c.h", "c.h")`` listed twice -- is never genuine evidence, and the set
+      conversion here would otherwise silently collapse it away.
+    """
+    if token_rest == _OWNED_HEADER_SINGLE_SENTINEL or not token_rest.startswith(
+        _OWNED_HEADER_TOKEN_PREFIX
+    ):
+        return None
+    pairs = _json_load_list(token_rest[len(_OWNED_HEADER_TOKEN_PREFIX) :])
+    if pairs is None or not all(_is_owned_header_pair(p) for p in pairs):
+        return None
+    pair_tuples = [tuple(p) for p in pairs]
+    owned = set(pair_tuples)
+    if len(pair_tuples) != len(owned):
+        return None
+    return owned
+
+
+def _owned_slot_growth_is_additive(
+    old_slot: str, new_slot: str, scope_new_headers: set[str] | None
+) -> bool:
+    """Whether one differing ``"<slot-index>:<token>"`` pair differs only in its
+    owned header list growing to include headers *scope_new_headers* confirms
+    were genuinely newly added.
+
+    Declines when the slot index moved, when either side's token isn't a
+    decodable owned pair list (see :func:`_owned_header_pairs`), when the new
+    list isn't a superset of the old, or when a newly-owned pair's global
+    identity (its first element; see ``_slot_token_for_ancestor``) isn't among
+    the scope-confirmed new headers.
+    """
+    old_idx, _, old_rest = old_slot.partition(":")
+    new_idx, _, new_rest = new_slot.partition(":")
+    if old_idx != new_idx:
+        return False
+    old_owned = _owned_header_pairs(old_rest)
+    new_owned = _owned_header_pairs(new_rest)
+    if old_owned is None or new_owned is None:
+        return False
+    if not new_owned >= old_owned:
+        return False
+    newly_owned = new_owned - old_owned
+    if not newly_owned:
+        return True
+    if scope_new_headers is None:
+        return False
+    return all(pair[0] in scope_new_headers for pair in newly_owned)
 
 
 def _include_sequence_is_additive_owned_growth(
@@ -314,58 +379,8 @@ def _include_sequence_is_additive_owned_growth(
         and _slot_indices_match_position(new_slots)
     ):
         return False
-    for old_slot, new_slot in zip(old_slots, new_slots):
-        if old_slot == new_slot:
-            continue
-        old_idx, _, old_rest = old_slot.partition(":")
-        new_idx, _, new_rest = new_slot.partition(":")
-        if old_idx != new_idx:
-            return False
-        if _OWNED_HEADER_SINGLE_SENTINEL in (old_rest, new_rest):
-            return False
-        if not (
-            old_rest.startswith(_OWNED_HEADER_TOKEN_PREFIX)
-            and new_rest.startswith(_OWNED_HEADER_TOKEN_PREFIX)
-        ):
-            return False
-        old_pairs = _json_load_list(old_rest[len(_OWNED_HEADER_TOKEN_PREFIX) :])
-        new_pairs = _json_load_list(new_rest[len(_OWNED_HEADER_TOKEN_PREFIX) :])
-        if old_pairs is None or new_pairs is None:
-            return False
-        # Every owned pair must be an exact two-string list (Codex review,
-        # PR #641 follow-up, third P2) -- `tuple(p)` alone doesn't reject a
-        # malformed member the way it looks like it should: a bare string
-        # like "xx" is itself iterable, so `tuple("xx")` silently succeeds
-        # as `("x", "x")` instead of raising, letting malformed evidence
-        # masquerade as a legitimate owned-header pair and potentially make
-        # a bogus set comparison look like real superset growth.
-        if not (
-            all(_is_owned_header_pair(p) for p in old_pairs)
-            and all(_is_owned_header_pair(p) for p in new_pairs)
-        ):
-            return False
-        # Reject a duplicated pair before the set conversion below collapses
-        # it away (Codex review, PR #641 follow-up, fourteenth P2):
-        # `_slot_token_for_ancestor`'s real `owned` construction always
-        # emits a deduplicated pair list, so a duplicate -- e.g. a newly
-        # appended ("c.h", "c.h") listed twice -- is never genuine evidence.
-        # `{tuple(p) for p in pairs}` silently discards that duplication,
-        # so without this check a malformed, duplicated newly-owned pair
-        # would still authorize the waiver instead of failing closed.
-        old_tuples = [tuple(p) for p in old_pairs]
-        new_tuples = [tuple(p) for p in new_pairs]
-        if len(old_tuples) != len(set(old_tuples)) or len(new_tuples) != len(
-            set(new_tuples)
-        ):
-            return False
-        old_owned = set(old_tuples)
-        new_owned = set(new_tuples)
-        if not new_owned >= old_owned:
-            return False
-        newly_owned = new_owned - old_owned
-        if newly_owned:
-            if scope_new_headers is None:
-                return False
-            if not all(pair[0] in scope_new_headers for pair in newly_owned):
-                return False
-    return True
+    return all(
+        old_slot == new_slot
+        or _owned_slot_growth_is_additive(old_slot, new_slot, scope_new_headers)
+        for old_slot, new_slot in zip(old_slots, new_slots)
+    )

--- a/abicheck/comparability_sequences.py
+++ b/abicheck/comparability_sequences.py
@@ -382,5 +382,8 @@ def _include_sequence_is_additive_owned_growth(
     return all(
         old_slot == new_slot
         or _owned_slot_growth_is_additive(old_slot, new_slot, scope_new_headers)
-        for old_slot, new_slot in zip(old_slots, new_slots)
+        # strict=True documents the invariant the length check above already
+        # enforces -- zip cannot truncate here, and if that check is ever
+        # weakened this raises rather than silently skipping trailing slots.
+        for old_slot, new_slot in zip(old_slots, new_slots, strict=True)
     )

--- a/abicheck/export_surface.py
+++ b/abicheck/export_surface.py
@@ -62,7 +62,7 @@ from typing import NamedTuple
 
 from .diff_cxx_rules import owner_class_of
 from .elf_symbol_filter import is_abi_relevant_elf_symbol
-from .model import AbiSnapshot, EnumType, RecordType
+from .model import AbiSnapshot, EnumType, Function, RecordType
 from .name_classification import (
     STDLIB_TYPE_NAMESPACE_PREFIXES,
     is_cxx_runtime_library,
@@ -463,77 +463,16 @@ def _seed_export_roots(
     ``all_*`` universe alone (nothing can match) rather than that path keeping
     its own copy of the same key derivation (CodeRabbit review).
     """
-    owner_seed_by_identity = owner_seed_by_identity or {}
-    # Every export name a declaration claims by exact linker identity --
-    # computed before any matching so the Mach-O shift can refuse to steal
-    # one (see `_matched_export_names`).
-    exact_owners: set[str] = set()
-    identities = [_linker_identity(f.name, f.mangled) for f in snap.functions]
-    identities += [_linker_identity(v.name, v.mangled) for v in snap.variables]
-    for ident in identities:
-        if ident and any(ident in names for names in tables.values()):
-            exact_owners.add(ident)
-
-    seed_types: set[str] = set()
-    nonroot_keys: set[str] = set()
-    root_identities: set[str] = set()
-    matched_pairs: set[tuple[str, str]] = set()
-    for fn in snap.functions:
-        keys = _symbol_keys(fn.name, fn.mangled)
-        surface.all_symbols |= keys
-        matched = _matched_export_names(fn.name, fn.mangled, tables, exact_owners)
-        if not matched:
-            nonroot_keys |= keys
-            continue
-        matched_pairs |= matched
-        # Truthiness-guarded: an empty identity in this set would make every
-        # *other* identity-less declaration look like a root to
-        # `_unresolved_type_edges` (CodeRabbit review). Unreachable today --
-        # `_matched_export_names` returns nothing for an empty identity, so a
-        # declaration carrying one never matches -- but the invariant belongs
-        # where the set is built, not in a reader's head.
-        if identity := _linker_identity(fn.name, fn.mangled):
-            root_identities.add(identity)
-        surface.matched_exports |= {n for _, n in matched}
-        surface.export_symbols |= keys
-        surface.has_roots = True
-        if fn.params or _is_real_type(fn.return_type):
-            surface.has_typed_roots = True
-        # `all_roots_typed` is strict where `has_typed_roots` is permissive:
-        # a *single* parameter recorded as the `"?"` sentinel (what
-        # `dwarf_snapshot._process_param` writes for a missing `DW_AT_type`)
-        # leaves that root's closure incomplete just as surely as a wholly
-        # untyped root does, even though the root as a whole looks typed
-        # (Codex review). Every parameter and the return type must be real.
-        if not _is_real_type(fn.return_type) or not all(
-            _is_real_type(getattr(p, "type", None)) for p in fn.params
-        ):
-            surface.all_roots_typed = False
-        seed_types |= _type_identifiers(fn.return_type)
-        for p in fn.params:
-            seed_types |= _type_identifiers(getattr(p, "type", None))
-        owner = owner_class_of(fn)
-        owner_seed = owner_seed_by_identity.get(owner) if owner else None
-        if owner_seed:
-            seed_types.add(owner_seed)
-    for var in snap.variables:
-        keys = _symbol_keys(var.name, var.mangled)
-        surface.all_symbols |= keys
-        matched = _matched_export_names(var.name, var.mangled, tables, exact_owners)
-        if not matched:
-            nonroot_keys |= keys
-            continue
-        matched_pairs |= matched
-        if identity := _linker_identity(var.name, var.mangled):
-            root_identities.add(identity)
-        surface.matched_exports |= {n for _, n in matched}
-        surface.export_symbols |= keys
-        surface.has_roots = True
-        if _is_real_type(var.type):
-            surface.has_typed_roots = True
-        else:
-            surface.all_roots_typed = False
-        seed_types |= _type_identifiers(var.type)
+    exact_owners = _exact_export_owners(snap, tables)
+    acc = _RootAccumulator()
+    _seed_function_roots(
+        snap, surface, tables, exact_owners, acc, owner_seed_by_identity or {}
+    )
+    _seed_variable_roots(snap, surface, tables, exact_owners, acc)
+    seed_types = acc.seed_types
+    nonroot_keys = acc.nonroot_keys
+    root_identities = acc.root_identities
+    matched_pairs = acc.matched_pairs
 
     # Drop every lookup alias a *non*-root declaration also answers to: the
     # inverse of the linker-identity fix on the rootness decision (Codex
@@ -557,6 +496,124 @@ def _seed_export_roots(
     # export name is -- only the *derived* aliases around it can be shared.
     surface.export_symbols -= nonroot_keys - surface.matched_exports - root_identities
     return _RootSeeding(seed_types, matched_pairs, root_identities)
+
+
+@dataclass
+class _RootAccumulator:
+    """The four sets :func:`_seed_export_roots`'s two declaration passes build
+    up together. ``nonroot_keys`` is the one that never leaves this function --
+    it exists only to prune shared aliases at the end (see there)."""
+
+    seed_types: set[str] = field(default_factory=set)
+    nonroot_keys: set[str] = field(default_factory=set)
+    root_identities: set[str] = field(default_factory=set)
+    matched_pairs: set[tuple[str, str]] = field(default_factory=set)
+
+
+def _exact_export_owners(snap: AbiSnapshot, tables: dict[str, set[str]]) -> set[str]:
+    """Every export name a declaration claims by exact linker identity.
+
+    Computed before any matching so the Mach-O underscore shift can refuse to
+    steal one (see :func:`_matched_export_names`).
+    """
+    identities = [_linker_identity(f.name, f.mangled) for f in snap.functions]
+    identities += [_linker_identity(v.name, v.mangled) for v in snap.variables]
+    return {
+        ident
+        for ident in identities
+        if ident and any(ident in names for names in tables.values())
+    }
+
+
+def _record_export_root(
+    surface: ExportSurface,
+    acc: _RootAccumulator,
+    name: str,
+    mangled: str,
+    keys: set[str],
+    matched: set[tuple[str, str]],
+) -> None:
+    """The bookkeeping every matched root does, function and variable alike."""
+    acc.matched_pairs |= matched
+    # Truthiness-guarded: an empty identity in this set would make every
+    # *other* identity-less declaration look like a root to
+    # `_unresolved_type_edges` (CodeRabbit review). Unreachable today --
+    # `_matched_export_names` returns nothing for an empty identity, so a
+    # declaration carrying one never matches -- but the invariant belongs
+    # where the set is built, not in a reader's head.
+    if identity := _linker_identity(name, mangled):
+        acc.root_identities.add(identity)
+    surface.matched_exports |= {n for _, n in matched}
+    surface.export_symbols |= keys
+    surface.has_roots = True
+
+
+def _record_function_root_typing(surface: ExportSurface, fn: Function) -> None:
+    """Fold one function root into the surface's two typed-root flags."""
+    if fn.params or _is_real_type(fn.return_type):
+        surface.has_typed_roots = True
+    # `all_roots_typed` is strict where `has_typed_roots` is permissive:
+    # a *single* parameter recorded as the `"?"` sentinel (what
+    # `dwarf_snapshot._process_param` writes for a missing `DW_AT_type`)
+    # leaves that root's closure incomplete just as surely as a wholly
+    # untyped root does, even though the root as a whole looks typed
+    # (Codex review). Every parameter and the return type must be real.
+    if not _is_real_type(fn.return_type) or not all(
+        _is_real_type(getattr(p, "type", None)) for p in fn.params
+    ):
+        surface.all_roots_typed = False
+
+
+def _seed_function_roots(
+    snap: AbiSnapshot,
+    surface: ExportSurface,
+    tables: dict[str, set[str]],
+    exact_owners: set[str],
+    acc: _RootAccumulator,
+    owner_seed_by_identity: dict[str, str],
+) -> None:
+    """The function half of :func:`_seed_export_roots`: signature types seed the
+    closure, and a method root additionally seeds its own enclosing class."""
+    for fn in snap.functions:
+        keys = _symbol_keys(fn.name, fn.mangled)
+        surface.all_symbols |= keys
+        matched = _matched_export_names(fn.name, fn.mangled, tables, exact_owners)
+        if not matched:
+            acc.nonroot_keys |= keys
+            continue
+        _record_export_root(surface, acc, fn.name, fn.mangled, keys, matched)
+        _record_function_root_typing(surface, fn)
+        acc.seed_types |= _type_identifiers(fn.return_type)
+        for p in fn.params:
+            acc.seed_types |= _type_identifiers(getattr(p, "type", None))
+        owner = owner_class_of(fn)
+        owner_seed = owner_seed_by_identity.get(owner) if owner else None
+        if owner_seed:
+            acc.seed_types.add(owner_seed)
+
+
+def _seed_variable_roots(
+    snap: AbiSnapshot,
+    surface: ExportSurface,
+    tables: dict[str, set[str]],
+    exact_owners: set[str],
+    acc: _RootAccumulator,
+) -> None:
+    """The variable half of :func:`_seed_export_roots`. A variable has one type
+    and no owner, so both typed-root flags follow from that single answer."""
+    for var in snap.variables:
+        keys = _symbol_keys(var.name, var.mangled)
+        surface.all_symbols |= keys
+        matched = _matched_export_names(var.name, var.mangled, tables, exact_owners)
+        if not matched:
+            acc.nonroot_keys |= keys
+            continue
+        _record_export_root(surface, acc, var.name, var.mangled, keys, matched)
+        if _is_real_type(var.type):
+            surface.has_typed_roots = True
+        else:
+            surface.all_roots_typed = False
+        acc.seed_types |= _type_identifiers(var.type)
 
 
 #: ``typename``/``template`` as whole words -- C++'s explicit markers for a
@@ -682,56 +739,107 @@ def _resolvable_type_spellings(
       stripping, every C++ library using a standard-library type looks
       riddled with missing edges and can never prove an exclusion.
     """
-    # Spelling -> node identity. Registered per *node*, so a later lookup can
-    # ask whether the node a spelling names is the node the walk reached --
-    # a global spelling set cannot answer that (see `_edge_is_unresolved`).
-    nodes_by_spelling: dict[str, set[str]] = {}
+    return _SpellingIndex(
+        _nodes_by_spelling(snap, record_by_name, enum_by_name),
+        _nodes_by_walk_key(snap, record_by_name, enum_by_name),
+        _unscoped_identities(snap),
+        _toolchain_owned_aliases(snap, record_by_name, enum_by_name),
+    )
 
-    def _register(spelling: str, node_id: str) -> None:
-        nodes_by_spelling.setdefault(spelling, set()).add(node_id)
 
-    def _register_all(identity: str, node_id: str) -> None:
-        for form in (identity, _stripped_signature_spelling(identity)):
-            if not form:
-                continue
-            _register(form, node_id)
-            for suffix in _namespace_suffix_spellings(form):
-                _register(suffix, node_id)
+def _nodes_by_spelling(
+    snap: AbiSnapshot,
+    record_by_name: dict[str, list[RecordType]],
+    enum_by_name: dict[str, list[EnumType]],
+) -> dict[str, frozenset[str]]:
+    """Spelling -> the node identities that spelling can name.
 
-    # A record/enum's node identity is its own `name`: that is what
-    # `_walk_type_closure` records when it reaches one, so both maps agree
-    # on what "the same node" means. Its *spellings* come from `name` and
-    # `qualified_name` alike, since backends split the two differently.
-    for rec_nodes in record_by_name.values():
-        for rec in rec_nodes:
-            _register_all(rec.name, rec.name)
-            if rec.qualified_name:
-                _register_all(rec.qualified_name, rec.name)
-    for en_nodes in enum_by_name.values():
-        for en in en_nodes:
-            _register_all(en.name, en.name)
-            if en.qualified_name:
-                _register_all(en.qualified_name, en.name)
+    Registered per *node*, so a later lookup can ask whether the node a
+    spelling names is the node the walk reached -- a global spelling set
+    cannot answer that (see :func:`_edge_is_unresolved`).
+
+    A record/enum's node identity is its own ``name``: that is what
+    ``_walk_type_closure`` records when it reaches one, so both indices agree
+    on what "the same node" means. Its *spellings* come from ``name`` and
+    ``qualified_name`` alike, since backends split the two differently, plus
+    every partially-qualified and stdlib-stripped form of each (see this
+    module's :func:`_resolvable_type_spellings` docstring for why).
+    """
+    spellings: dict[str, set[str]] = {}
+    for name, qualified in _indexed_node_identities(record_by_name, enum_by_name):
+        _register_spellings(spellings, name, name)
+        if qualified:
+            _register_spellings(spellings, qualified, name)
     for alias in snap.typedefs:
-        _register_all(alias, _typedef_node_id(alias))
+        _register_spellings(spellings, alias, _typedef_node_id(alias))
+    return {k: frozenset(v) for k, v in spellings.items()}
 
-    # Lookup key -> node identities the walk reaches through it: the two
-    # index dicts (whose keys `_index_surface_types` builds as each node's
-    # own name plus, for a namespaced one, its bare `::` tail) and
-    # `snap.typedefs` by *exact* key, with no tail tolerance of its own.
-    nodes_by_walk_key: dict[str, set[str]] = {}
+
+def _register_spellings(
+    spellings: dict[str, set[str]], identity: str, node_id: str
+) -> None:
+    """Record *identity*, and every equivalent spelling of it, as naming
+    *node_id* in the in-progress *spellings* index."""
+    for form in (identity, _stripped_signature_spelling(identity)):
+        if not form:
+            continue
+        spellings.setdefault(form, set()).add(node_id)
+        for suffix in _namespace_suffix_spellings(form):
+            spellings.setdefault(suffix, set()).add(node_id)
+
+
+def _indexed_node_identities(
+    record_by_name: dict[str, list[RecordType]],
+    enum_by_name: dict[str, list[EnumType]],
+) -> list[tuple[str, str | None]]:
+    """Every indexed record/enum node as ``(name, qualified_name)``.
+
+    Plain tuples, and the two maps flattened by two separately-typed
+    comprehensions rather than one loop over a mixed
+    ``(*records, *enums)`` tuple -- mypy widens that tuple's element type to
+    ``object``, the same reason :func:`_unscoped_identities` builds its own
+    list this way.
+    """
+    identities: list[tuple[str, str | None]] = [
+        (rec.name, rec.qualified_name)
+        for rec_nodes in record_by_name.values()
+        for rec in rec_nodes
+    ]
+    identities += [
+        (en.name, en.qualified_name)
+        for en_nodes in enum_by_name.values()
+        for en in en_nodes
+    ]
+    return identities
+
+
+def _nodes_by_walk_key(
+    snap: AbiSnapshot,
+    record_by_name: dict[str, list[RecordType]],
+    enum_by_name: dict[str, list[EnumType]],
+) -> dict[str, frozenset[str]]:
+    """Lookup key -> node identities the walk reaches through it: the two index
+    dicts (whose keys ``_index_surface_types`` builds as each node's own name
+    plus, for a namespaced one, its bare ``::`` tail) and ``snap.typedefs`` by
+    *exact* key, with no tail tolerance of its own."""
+    by_key: dict[str, set[str]] = {}
     for key, rec_nodes in record_by_name.items():
-        nodes_by_walk_key.setdefault(key, set()).update(r.name for r in rec_nodes)
+        by_key.setdefault(key, set()).update(r.name for r in rec_nodes)
     for key, en_nodes in enum_by_name.items():
-        nodes_by_walk_key.setdefault(key, set()).update(e.name for e in en_nodes)
+        by_key.setdefault(key, set()).update(e.name for e in en_nodes)
     for alias in snap.typedefs:
-        nodes_by_walk_key.setdefault(alias, set()).add(_typedef_node_id(alias))
+        by_key.setdefault(alias, set()).add(_typedef_node_id(alias))
+    return {k: frozenset(v) for k, v in by_key.items()}
 
-    # A node whose own recorded identity carries no scope: its bare name is
-    # everything the snapshot knows about where it lives, so a token that
-    # spells it with a scope contradicts nothing. A node that *does* record
-    # a scope is excluded -- its leaf must not absorb a differently-scoped
-    # token (see `_edge_is_unresolved`).
+
+def _unscoped_identities(snap: AbiSnapshot) -> frozenset[str]:
+    """Nodes whose own recorded identity carries no scope.
+
+    A bare name is everything the snapshot knows about where such a node
+    lives, so a token that spells it with a scope contradicts nothing. A node
+    that *does* record a scope is excluded -- its leaf must not absorb a
+    differently-scoped token (see :func:`_edge_is_unresolved`).
+    """
     # Two separately-typed comprehensions rather than one over a mixed
     # `(*snap.types, *snap.enums)` tuple, whose element type mypy widens to
     # `object`.
@@ -744,28 +852,31 @@ def _resolvable_type_spellings(
         for name, qualified in identities
         if qualified and qualified != name
     }
-    unscoped: set[str] = set()
-    for name, qualified in identities:
-        identity = qualified or name
-        if "::" not in identity and identity not in scoped_leaves:
-            unscoped.add(identity)
-    for alias in snap.typedefs:
-        if "::" not in alias and alias not in scoped_leaves:
-            unscoped.add(alias)
+    candidates = [qualified or name for name, qualified in identities]
+    candidates += list(snap.typedefs)
+    return frozenset(c for c in candidates if "::" not in c and c not in scoped_leaves)
 
-    # An alias key a record or enum also owns, where *every* colliding node
-    # is toolchain-owned: libstdc++'s bare-key alias templates. Measured on a
-    # real `g++` library -- `"vector" -> "std::vector<_Tp,
-    # polymorphic_allocator<_Tp>>"` collides with the record `std::vector`,
-    # and `"basic_string"` with `std::__cxx11::basic_string`. Judging those
-    # targets reports the template *parameter* names in them (`_Tp`,
-    # `_CharT`, `_Traits`) as missing edges, which is the same
-    # toolchain-internals noise `_unresolved_type_edges` already declines one
-    # level up -- and any one of them blocks every exclusion for every C++
-    # library. "Every colliding node" rather than "any" keeps the
-    # conservative direction: a library's own record sharing the key means
-    # the alias may well be its own, so it is still followed.
-    toolchain_aliases: set[str] = set()
+
+def _toolchain_owned_aliases(
+    snap: AbiSnapshot,
+    record_by_name: dict[str, list[RecordType]],
+    enum_by_name: dict[str, list[EnumType]],
+) -> frozenset[str]:
+    """Alias keys a record or enum also owns, where *every* colliding node is
+    toolchain-owned: libstdc++'s bare-key alias templates.
+
+    Measured on a real ``g++`` library -- ``"vector" -> "std::vector<_Tp,
+    polymorphic_allocator<_Tp>>"`` collides with the record ``std::vector``,
+    and ``"basic_string"`` with ``std::__cxx11::basic_string``. Judging those
+    targets reports the template *parameter* names in them (``_Tp``,
+    ``_CharT``, ``_Traits``) as missing edges, which is the same
+    toolchain-internals noise :func:`_unresolved_type_edges` already declines
+    one level up -- and any one of them blocks every exclusion for every C++
+    library. "Every colliding node" rather than "any" keeps the conservative
+    direction: a library's own record sharing the key means the alias may well
+    be its own, so it is still followed.
+    """
+    aliases: set[str] = set()
     for alias in snap.typedefs:
         colliding = [
             *record_by_name.get(alias, ()),
@@ -777,14 +888,8 @@ def _resolvable_type_spellings(
             )
             for node in colliding
         ):
-            toolchain_aliases.add(alias)
-
-    return _SpellingIndex(
-        {k: frozenset(v) for k, v in nodes_by_spelling.items()},
-        {k: frozenset(v) for k, v in nodes_by_walk_key.items()},
-        frozenset(unscoped),
-        frozenset(toolchain_aliases),
-    )
+            aliases.add(alias)
+    return frozenset(aliases)
 
 
 def _edge_is_unresolved(

--- a/abicheck/finding_identity.py
+++ b/abicheck/finding_identity.py
@@ -254,6 +254,227 @@ def _operand_looks_valid(operand: str) -> bool:
     return _source_name_end(operand) is not None
 
 
+def _consume_nested_prefix_components(rest: str) -> tuple[int, bool, bool] | None:
+    """Walk the ``<prefix>`` components of an ``N``/``Z`` production, starting
+    just past the leading ``N``/``Z`` byte.
+
+    Returns ``(pos, consumed_any_component, pending_prefix_only)`` -- *pos*
+    being the index of the first byte this walk could not consume -- or
+    ``None`` when a digit-prefixed component is itself malformed (declared
+    length 0, or claiming more bytes than exist), which invalidates the whole
+    production, matching the single-component "_ZN0E"/"_ZN9abcE" fix (round 3).
+
+    Consuming components at all exists to keep an ``E`` byte that belongs to a
+    component's OWN spelling from being mistaken for the production's
+    terminator -- e.g. "_ZN1E" is incomplete (the "1E" is a length-1
+    <source-name> whose one-byte identifier IS "E", leaving no separate
+    terminator), but a naive ``rest.find("E", 1)`` found that embedded byte and
+    wrongly accepted it (Codex review, fresh evidence). A <nested-name>'s
+    <prefix> can chain MULTIPLE consecutive source-name components (e.g.
+    "N1A1BE" = namespace A, class B), so a single-component skip left a later
+    component's own trailing 'E' exposed to the identical confusion: "_ZN1A1E"
+    is incomplete (after consuming "1A", "1E" is a second length-1
+    <source-name> whose identifier IS "E" -- the complete form is "_ZN1A1EE"),
+    but a single skip still found that embedded byte (Codex review, fresh
+    evidence, round 4). No other <nested-name>/<local-name> first-component
+    production starts with a bare digit -- a digit-prefixed component can only
+    be a <source-name>, the same reasoning as :func:`_operand_looks_valid`.
+    """
+    pos = 1
+    consumed_any_component = False
+    pending_prefix_only = False
+    while pos < len(rest):
+        if rest[pos] == "S" and pos + 1 < len(rest) and rest[pos + 1] in "tabdios":
+            # A standard substitution ("St" = std:: prefix; "Sa" / "Sb" /
+            # "Sd" / "Si" / "So" / "Ss" = the complete named substitutions,
+            # e.g. std::allocator/std::string) is itself a <prefix>
+            # component -- consuming just its two bytes without continuing
+            # the loop left a trailing digit-prefixed <source-name> exposed
+            # to the same embedded-terminator confusion the earlier fixes
+            # addressed: "_ZNSt1E" and "_ZNSa1E" are both incomplete ("1E"
+            # is a length-1 <source-name> whose identifier IS "E", leaving
+            # no separate terminator) but a loop that only recognized "St"
+            # literally -- or only digits -- never started skipping here for
+            # the other five letters (Codex review, fresh evidence, round 7).
+            #
+            # Whichever letter follows "S", the production is still
+            # <nested-name> ::= N <prefix> <unqualified-name> E, and
+            # <substitution> (what ANY of these six letters spells) is never
+            # itself a valid <unqualified-name> -- so even though
+            # "Sa"/"Sb"/"Sd"/"Si"/"So"/"Ss" are complete, context-free
+            # substitutions in their OWN right (see _substitution_looks_valid),
+            # a <nested-name> still needs a real <unqualified-name> after
+            # them, same as "St". "_ZNSaE" leaves `pos` pointing straight at
+            # the 'E' right after "Sa", which the terminator search previously
+            # accepted as though "Sa" alone had completed the required
+            # trailing unqualified-name (Codex review, fresh evidence,
+            # round 9; round 6 fixed only the "St" spelling of this same
+            # gap). `pending_prefix_only` tracks that the most recent thing
+            # consumed was a bare substitution with nothing completing it
+            # yet, and is cleared as soon as a real component (a
+            # <source-name>) follows it.
+            pos += 2
+            consumed_any_component = True
+            pending_prefix_only = True
+            continue
+        if not rest[pos].isdigit():
+            break
+        component_end = _source_name_end(rest[pos:])
+        if component_end is None:
+            return None
+        pos += component_end
+        consumed_any_component = True
+        pending_prefix_only = False
+    return pos, consumed_any_component, pending_prefix_only
+
+
+def _nested_or_local_name_looks_valid(rest: str) -> bool:
+    """The ``N``/``Z`` branch of :func:`_looks_like_itanium_encoding`:
+    ``<nested-name>`` (``N...E``) and ``<local-name>``
+    (``Z<encoding>E<entity>``).
+
+    Both productions terminate with a literal 'E' after at least one non-empty
+    component -- a bare "N" or content with no terminator at all (e.g.
+    "_ZNonsense", "_ZN") was previously accepted outright regardless of
+    structure (Codex review). Does not validate that everything between N/Z and
+    E is itself well-formed -- that is the unbounded full-grammar case this
+    heuristic deliberately doesn't attempt (see
+    :func:`_looks_like_itanium_encoding`'s docstring on its accepted boundary);
+    a component shape this walk doesn't recognize (constructor/destructor
+    names, template-args, ...) falls back to the original naive terminator
+    scan.
+    """
+    walked = _consume_nested_prefix_components(rest)
+    if walked is None:
+        return False
+    pos, consumed_any_component, pending_prefix_only = walked
+    if pending_prefix_only:
+        return False
+    if consumed_any_component:
+        e_index = rest.find("E", pos)
+        terminator_ok = e_index >= pos
+    else:
+        e_index = rest.find("E", 1)
+        terminator_ok = e_index > 1
+    if not terminator_ok:
+        return False
+    if rest[0] == "Z":
+        # Unlike <nested-name> (complete once its own terminator E is
+        # found), a <local-name> is "Z <function encoding> E <entity
+        # name> [<discriminator>]" -- the terminator MUST be followed
+        # by a non-empty entity name. "_ZZ1fvE" has a terminator (the
+        # trailing E) but nothing after it, so it previously passed
+        # the shared N/Z check above despite being incomplete (Codex
+        # review, fresh evidence). A merely non-empty suffix isn't
+        # enough either: "_ZZ1fvE0" has one trailing byte, but "0" is
+        # a zero-length <source-name> and not a valid entity name --
+        # reuse _operand_looks_valid's same digit-prefixed check
+        # (Codex review, fresh evidence, round 2).
+        suffix = rest[e_index + 1 :]
+        return bool(suffix) and _operand_looks_valid(suffix)
+    return True
+
+
+def _internal_linkage_name_looks_valid(rest: str) -> bool:
+    """The ``L`` branch: GCC internal-linkage prefix (_ZL7g_count) +
+    ``<source-name>``."""
+    return len(rest) > 1 and rest[1].isdigit() and _valid_source_name(rest[1:])
+
+
+def _special_name_looks_valid(rest: str) -> bool:
+    """The ``T`` branch -- ``<special-name>``: vtable(V)/VTT(T)/typeinfo(I)/
+    typeinfo-name(S)/thread-local-init(H)/thread-local-wrapper(W).
+
+    Previously included unverified "F"/"J" (CodeRabbit review: no corresponding
+    Itanium production found for either) -- dropped rather than guessed at,
+    matching this module's ambiguity-safe bias (a real production this set is
+    missing only degrades to NORMALIZED, never a wrong promotion the other
+    way). ``len(rest) > 2``, not ``> 1``: every one of these productions
+    requires an operand (a type or source-name) after the two-letter prefix --
+    a bare "_ZTV" has no such operand and is not a complete encoding (Codex
+    review). The operand itself is then checked by :func:`_operand_looks_valid`
+    for the narrower digit-prefixed case (Codex review, fresh evidence:
+    "_ZTV0").
+    """
+    return len(rest) > 2 and rest[1] in "VITSHW" and _operand_looks_valid(rest[2:])
+
+
+def _guard_variable_looks_valid(rest: str) -> bool:
+    """The ``G`` branch -- guard variable / reference temporary. Same "requires
+    an operand after the two-letter prefix" reasoning as
+    :func:`_special_name_looks_valid`; a bare "_ZGV" is not a complete encoding
+    either."""
+    return len(rest) > 2 and rest[1] in "VR" and _operand_looks_valid(rest[2:])
+
+
+def _substitution_looks_valid(rest: str) -> bool:
+    """The ``S`` branch -- substitution-abbreviated std:: name.
+
+    "St" specifically abbreviates the std:: NAMESPACE PREFIX only, not a
+    complete substitution by itself -- it must be followed by an
+    unqualified-name (e.g. "St9terminate" for std::terminate), unlike the other
+    single-letter abbreviations (Sa/Sb/Sd/Si/So/Ss, each a complete named
+    substitution on its own) or numbered back-references (S_, S0_, ...). A bare
+    "_ZSt" previously passed this check with nothing after it (Codex review,
+    fresh evidence).
+    """
+    if len(rest) < 2 or not (rest[1].isalnum() or rest[1] == "_"):
+        return False
+    if rest[1] == "t":
+        # A length-only check let "_ZSt0"/"_ZSt9abc" through: "0" is a
+        # zero-length <source-name> and "9abc" is truncated (claims 9
+        # bytes, has 3) -- neither is a valid unqualified-name after
+        # the namespace prefix. Reuse _operand_looks_valid's same
+        # digit-prefixed <source-name> check (Codex review, fresh
+        # evidence, round 3).
+        return len(rest) > 2 and _operand_looks_valid(rest[2:])
+    if rest[1].isdigit() or (rest[1].isalpha() and rest[1].isupper()):
+        # A numbered substitution (<seq-id> ::= [0-9A-Z]+, ALWAYS
+        # followed by a literal terminating "_", e.g. "S0_", "SA_")
+        # references an EARLIER substitution-table entry -- one only
+        # populated by <name>/<type> productions already emitted
+        # earlier in the SAME encoding. This function validates only
+        # the FIRST production of a top-level <encoding>, where no
+        # such entry can exist yet: a well-formed "S0_"/"SA_" here is
+        # a context-free reference to nothing, never a valid first
+        # production, regardless of whether its own terminator is
+        # present (Codex review, fresh evidence, round 8; previously
+        # only the missing-terminator shape "_ZS0"/"_ZSA" was
+        # rejected, while the well-formed-but-context-free "_ZS0_"
+        # still passed).
+        return False
+    # Only Sa/Sb/Sd/Si/So/Ss are real complete single-letter
+    # abbreviations (allocator/basic_string/basic_iostream/
+    # basic_istream/basic_ostream/string) that don't need any prior
+    # context -- they denote fixed, well-known components, unlike a
+    # numbered back-reference. Bare "S_" (back-reference-0) has the
+    # exact same "no earlier entry can exist yet" problem as the
+    # numbered case above and is rejected for the same reason (Codex
+    # review, fresh evidence, round 8). Any other lowercase letter
+    # (e.g. "_ZSx") is not a real Itanium substitution at all, but
+    # previously matched this fallback outright regardless of which
+    # letter followed "S" (Codex review, fresh evidence, round 2).
+    return rest[1] in "abdios"
+
+
+#: Leading-byte dispatch for the non-``<source-name>`` ``<encoding>``
+#: productions :func:`_looks_like_itanium_encoding` recognizes. A handler owns
+#: its production's *whole* condition, including the guard that used to sit in
+#: the ``if`` -- returning ``False`` where the pre-table code fell through to
+#: the ``<operator-name>`` tail is equivalent, since no Itanium operator code
+#: begins with any of these six bytes (verified against
+#: :data:`_ITANIUM_OPERATOR_CODES`: every code's first byte is lowercase, and
+#: none of ``N``/``Z``/``L``/``T``/``G``/``S`` appears there).
+_ENCODING_PRODUCTION_HANDLERS: dict[str, Callable[[str], bool]] = {
+    "N": _nested_or_local_name_looks_valid,
+    "Z": _nested_or_local_name_looks_valid,
+    "L": _internal_linkage_name_looks_valid,
+    "T": _special_name_looks_valid,
+    "G": _guard_variable_looks_valid,
+    "S": _substitution_looks_valid,
+}
+
+
 def _looks_like_itanium_encoding(rest: str) -> bool:
     """Whether *rest* (``mangled_name`` with the ``_Z`` prefix and any
     clone suffix already stripped) plausibly starts a real Itanium
@@ -282,184 +503,9 @@ def _looks_like_itanium_encoding(rest: str) -> bool:
         return False
     if rest[0].isdigit():  # <source-name>: digit-prefixed length
         return _valid_source_name(rest)
-    if rest[0] in "NZ":  # <nested-name> / <local-name>
-        # Both productions (`N...E`, `Z<encoding>E...`) terminate with a
-        # literal 'E' after at least one non-empty component -- a bare "N"
-        # or content with no terminator at all (e.g. "_ZNonsense", "_ZN")
-        # was previously accepted outright regardless of structure (Codex
-        # review). Does not validate that everything between N/Z and E is
-        # itself well-formed -- that is the unbounded full-grammar case
-        # this heuristic deliberately doesn't attempt (see this function's
-        # docstring on its accepted boundary).
-        #
-        # A naive `rest.find("E", 1)` can mistake an 'E' byte that is part
-        # of the first component's OWN spelling for the production's
-        # terminator -- e.g. "_ZN1E" is incomplete (the "1E" is a
-        # length-1 <source-name> whose one-byte identifier IS "E", leaving
-        # no separate terminator), but the naive scan found that embedded
-        # byte and wrongly accepted it (Codex review, fresh evidence).
-        # When the component right after N/Z is itself a <source-name>
-        # (the common shape: a namespace/class/function name), skip past
-        # it before searching for the real terminator; any other
-        # component shape (constructor/destructor names, template-args,
-        # ...) falls back to the original naive scan -- still this
-        # heuristic's documented accepted boundary, just narrowed to the
-        # one concrete counterexample found so far.
-        # No other <nested-name>/<local-name> first-component production
-        # starts with a bare digit -- a digit-prefixed component can only
-        # be a <source-name> (same reasoning as _operand_looks_valid), and
-        # a <nested-name>'s <prefix> can chain MULTIPLE consecutive
-        # source-name components (e.g. "N1A1BE" = namespace A, class B) --
-        # a single-component skip left a later component's own trailing
-        # 'E' byte exposed to the same embedded-terminator confusion the
-        # first-component fix addressed: "_ZN1A1E" is incomplete (after
-        # consuming "1A", "1E" is a second length-1 <source-name> whose
-        # identifier IS "E", leaving no separate terminator -- the
-        # complete form is "_ZN1A1EE"), but a single skip still found that
-        # embedded byte (Codex review, fresh evidence, round 4). If a
-        # digit-prefixed component fails to parse (declared length 0, or
-        # claims more bytes than exist), the whole production is invalid,
-        # matching the single-component "_ZN0E"/"_ZN9abcE" fix (round 3).
-        pos = 1
-        consumed_any_component = False
-        pending_prefix_only = False
-        while pos < len(rest):
-            if rest[pos] == "S" and pos + 1 < len(rest) and rest[pos + 1] in "tabdios":
-                # A standard substitution ("St" = std:: prefix; "Sa" /
-                # "Sb" / "Sd" / "Si" / "So" / "Ss" = the complete named
-                # substitutions, e.g. std::allocator/std::string) is
-                # itself a <prefix> component -- consuming just its two
-                # bytes without continuing the loop left a trailing
-                # digit-prefixed <source-name> exposed to the same
-                # embedded-terminator confusion the earlier fixes
-                # addressed: "_ZNSt1E" and "_ZNSa1E" are both incomplete
-                # ("1E" is a length-1 <source-name> whose identifier IS
-                # "E", leaving no separate terminator) but a loop that
-                # only recognized "St" literally -- or only digits --
-                # never started skipping here for the other five letters
-                # (Codex review, fresh evidence, round 7).
-                #
-                # Whichever letter follows "S", the production is still
-                # <nested-name> ::= N <prefix> <unqualified-name> E, and
-                # <substitution> (what ANY of these six letters spells)
-                # is never itself a valid <unqualified-name> -- so even
-                # though "Sa"/"Sb"/"Sd"/"Si"/"So"/"Ss" are complete,
-                # context-free substitutions in their OWN right (see the
-                # non-nested "S"-prefix branch below), a <nested-name>
-                # still needs a real <unqualified-name> after them, same
-                # as "St". "_ZNSaE" leaves `pos` pointing straight at the
-                # 'E' right after "Sa", which the terminator search
-                # previously accepted as though "Sa" alone had completed
-                # the required trailing unqualified-name (Codex review,
-                # fresh evidence, round 9; round 6 fixed only the "St"
-                # spelling of this same gap). `pending_prefix_only`
-                # tracks that the most recent thing consumed was a bare
-                # substitution with nothing completing it yet, and is
-                # cleared as soon as a real component (a <source-name>)
-                # follows it.
-                pos += 2
-                consumed_any_component = True
-                pending_prefix_only = True
-                continue
-            if not rest[pos].isdigit():
-                break
-            component_end = _source_name_end(rest[pos:])
-            if component_end is None:
-                return False
-            pos += component_end
-            consumed_any_component = True
-            pending_prefix_only = False
-        if pending_prefix_only:
-            return False
-        if consumed_any_component:
-            e_index = rest.find("E", pos)
-            terminator_ok = e_index >= pos
-        else:
-            e_index = rest.find("E", 1)
-            terminator_ok = e_index > 1
-        if not terminator_ok:
-            return False
-        if rest[0] == "Z":
-            # Unlike <nested-name> (complete once its own terminator E is
-            # found), a <local-name> is "Z <function encoding> E <entity
-            # name> [<discriminator>]" -- the terminator MUST be followed
-            # by a non-empty entity name. "_ZZ1fvE" has a terminator (the
-            # trailing E) but nothing after it, so it previously passed
-            # the shared N/Z check above despite being incomplete (Codex
-            # review, fresh evidence). A merely non-empty suffix isn't
-            # enough either: "_ZZ1fvE0" has one trailing byte, but "0" is
-            # a zero-length <source-name> and not a valid entity name --
-            # reuse _operand_looks_valid's same digit-prefixed check
-            # (Codex review, fresh evidence, round 2).
-            suffix = rest[e_index + 1 :]
-            return bool(suffix) and _operand_looks_valid(suffix)
-        return True
-    if rest[0] == "L" and len(rest) > 1 and rest[1].isdigit():
-        # GCC internal-linkage prefix (_ZL7g_count) + <source-name>
-        return _valid_source_name(rest[1:])
-    if rest[0] == "T" and len(rest) > 2 and rest[1] in "VITSHW":
-        # <special-name>: vtable(V)/VTT(T)/typeinfo(I)/typeinfo-name(S)/
-        # thread-local-init(H)/thread-local-wrapper(W). Previously included
-        # unverified "F"/"J" (CodeRabbit review: no corresponding Itanium
-        # production found for either) -- dropped rather than guessed at,
-        # matching this module's ambiguity-safe bias (a real production
-        # this set is missing only degrades to NORMALIZED, never a wrong
-        # promotion the other way). `len(rest) > 2`, not `> 1`: every one of
-        # these productions requires an operand (a type or source-name)
-        # after the two-letter prefix -- a bare "_ZTV" has no such operand
-        # and is not a complete encoding (Codex review). The operand
-        # itself is then checked by _operand_looks_valid for the narrower
-        # digit-prefixed case (Codex review, fresh evidence: "_ZTV0").
-        return _operand_looks_valid(rest[2:])
-    if rest[0] == "G" and len(rest) > 2 and rest[1] in "VR":
-        # guard variable / reference temporary -- same "requires an operand
-        # after the two-letter prefix" reasoning as <special-name> above; a
-        # bare "_ZGV" is not a complete encoding either.
-        return _operand_looks_valid(rest[2:])
-    if rest[0] == "S" and len(rest) > 1 and (rest[1].isalnum() or rest[1] == "_"):
-        # substitution-abbreviated std:: name. "St" specifically
-        # abbreviates the std:: NAMESPACE PREFIX only, not a complete
-        # substitution by itself -- it must be followed by an
-        # unqualified-name (e.g. "St9terminate" for std::terminate),
-        # unlike the other single-letter abbreviations (Sa/Sb/Sd/Si/So/Ss,
-        # each a complete named substitution on its own) or numbered
-        # back-references (S_, S0_, ...). A bare "_ZSt" previously passed
-        # this check with nothing after it (Codex review, fresh evidence).
-        if rest[1] == "t":
-            # A length-only check let "_ZSt0"/"_ZSt9abc" through: "0" is a
-            # zero-length <source-name> and "9abc" is truncated (claims 9
-            # bytes, has 3) -- neither is a valid unqualified-name after
-            # the namespace prefix. Reuse _operand_looks_valid's same
-            # digit-prefixed <source-name> check (Codex review, fresh
-            # evidence, round 3).
-            return len(rest) > 2 and _operand_looks_valid(rest[2:])
-        if rest[1].isdigit() or (rest[1].isalpha() and rest[1].isupper()):
-            # A numbered substitution (<seq-id> ::= [0-9A-Z]+, ALWAYS
-            # followed by a literal terminating "_", e.g. "S0_", "SA_")
-            # references an EARLIER substitution-table entry -- one only
-            # populated by <name>/<type> productions already emitted
-            # earlier in the SAME encoding. This function validates only
-            # the FIRST production of a top-level <encoding>, where no
-            # such entry can exist yet: a well-formed "S0_"/"SA_" here is
-            # a context-free reference to nothing, never a valid first
-            # production, regardless of whether its own terminator is
-            # present (Codex review, fresh evidence, round 8; previously
-            # only the missing-terminator shape "_ZS0"/"_ZSA" was
-            # rejected, while the well-formed-but-context-free "_ZS0_"
-            # still passed).
-            return False
-        # Only Sa/Sb/Sd/Si/So/Ss are real complete single-letter
-        # abbreviations (allocator/basic_string/basic_iostream/
-        # basic_istream/basic_ostream/string) that don't need any prior
-        # context -- they denote fixed, well-known components, unlike a
-        # numbered back-reference. Bare "S_" (back-reference-0) has the
-        # exact same "no earlier entry can exist yet" problem as the
-        # numbered case above and is rejected for the same reason (Codex
-        # review, fresh evidence, round 8). Any other lowercase letter
-        # (e.g. "_ZSx") is not a real Itanium substitution at all, but
-        # previously matched this fallback outright regardless of which
-        # letter followed "S" (Codex review, fresh evidence, round 2).
-        return rest[1] in "abdios"
+    handler = _ENCODING_PRODUCTION_HANDLERS.get(rest[0])
+    if handler is not None:
+        return handler(rest)
     # Two <operator-name> codes are not complete by themselves the way the
     # other 47 are: "cv" (conversion operator) requires a following
     # <type>, and "li" (C++11 literal operator) requires a following

--- a/changelog.d/20260810_090000_claude_codefactor_complexity_comparability.md
+++ b/changelog.d/20260810_090000_claude_codefactor_complexity_comparability.md
@@ -1,8 +1,8 @@
 ### Changed
 
 - **Split seven CodeFactor "Complex Method" findings across the comparability,
-  contract-evidence and core-compare modules.** `comparability.
-  check_contracts_comparable` now dispatches to one checker per axis
+  contract-evidence and core-compare modules.** `comparability.check_contracts_comparable`
+  now dispatches to one checker per axis
   (`dependency_scope`/`scope_fingerprint`/`profile_fingerprint`), and
   `compute_extraction_contract` to one builder per fields dict; the field layer
   moved to a new leaf module `abicheck/comparability_fields.py` to keep

--- a/changelog.d/20260810_090000_claude_codefactor_complexity_comparability.md
+++ b/changelog.d/20260810_090000_claude_codefactor_complexity_comparability.md
@@ -15,3 +15,20 @@
   behaviour-preserving; `_looks_like_itanium_encoding` was additionally
   differentially checked against its pre-refactor self over 592,354 inputs with
   no differences.
+
+### Fixed
+
+- **The comparability gate no longer refuses a DPC++ or `--dump-manifest`
+  comparison as unverifiable.** `compute_extraction_contract` hashes a
+  fingerprint over an extended key set whenever the dump carried the extra
+  field — `frontend_context_kind` for a DPC++-capable frontend (ADR-050 D5),
+  `translation_units` for a `--dump-manifest` dump (D6) — but
+  `check_contracts_comparable` only ever recomputed over the base set, so every
+  such contract failed its own authenticity check and the gate returned
+  "…profile_fields do not reproduce its own profile_fingerprint — the
+  comparison cannot be verified safe" before any carve-out could run. A
+  manifest-driven additive header addition is now comparable, and a SYCL pair
+  that is genuinely not comparable names the field that actually differs.
+  A differing `frontend_context_kind` is also no longer reported as "a field
+  this version does not recognize" — the outcome is unchanged (still not
+  comparable), only the reason given.

--- a/changelog.d/20260810_090000_claude_codefactor_complexity_comparability.md
+++ b/changelog.d/20260810_090000_claude_codefactor_complexity_comparability.md
@@ -1,0 +1,17 @@
+### Changed
+
+- **Split seven CodeFactor "Complex Method" findings across the comparability,
+  contract-evidence and core-compare modules.** `comparability.
+  check_contracts_comparable` now dispatches to one checker per axis
+  (`dependency_scope`/`scope_fingerprint`/`profile_fingerprint`), and
+  `compute_extraction_contract` to one builder per fields dict; the field layer
+  moved to a new leaf module `abicheck/comparability_fields.py` to keep
+  `comparability.py` under the 2000-line hard cap, with `IncludeDir`,
+  `_sha256_of` and `_fingerprint_matches_fields` re-exported so no import path
+  changes. `comparability_sequences._include_sequence_is_additive_owned_growth`,
+  `finding_identity._looks_like_itanium_encoding`, `checker.compare`,
+  `export_surface._resolvable_type_spellings` and
+  `export_surface._seed_export_roots` were split the same way. All
+  behaviour-preserving; `_looks_like_itanium_encoding` was additionally
+  differentially checked against its pre-refactor self over 592,354 inputs with
+  no differences.

--- a/tests/test_comparability_gate_fingerprint_keys.py
+++ b/tests/test_comparability_gate_fingerprint_keys.py
@@ -1,0 +1,134 @@
+"""ADR-050 D2 — the comparability gate's fingerprint-authenticity check, across
+BOTH key sets :func:`compute_extraction_contract` may have hashed over.
+
+Split out of ``test_comparability_gate.py`` (which was itself split out of
+``test_comparability.py`` for the same reason): that file crossed the
+file-size hard cap once these landed. Scope here is exactly the
+extended-key-set cases -- ``frontend_context_kind`` (ADR-050 D5) and
+``translation_units`` (D6) -- plus the guard that accepting either key set did
+not weaken the forgery check.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from abicheck.comparability import (
+    ComparabilityMismatch,
+    check_contracts_comparable,
+    compute_extraction_contract,
+)
+from abicheck.model import AbiSnapshot, ExtractionContract
+
+
+def _snap(contract: ExtractionContract | None, **kwargs) -> AbiSnapshot:
+    return AbiSnapshot(library="libfoo.so", version="1.0", contract=contract, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint authenticity across BOTH key sets a producer may have used
+# (CodeRabbit review, PR #697). compute_extraction_contract hashes over the
+# extended key set whenever the dump carried the extra field --
+# frontend_context_kind for a DPC++-capable frontend (ADR-050 D5),
+# translation_units for a --dump-manifest dump (D6) -- so a gate that only
+# ever recomputed over the base set declared every such contract inauthentic
+# and refused before any carve-out ran.
+# ---------------------------------------------------------------------------
+
+
+def test_frontend_context_contract_reproduces_its_own_profile_fingerprint():
+    """A real DPC++ contract is authentic, so the gate reaches the carve-outs
+    and names the field that actually differs."""
+    old = _snap(
+        compute_extraction_contract(
+            compiler_family="clang",
+            l2_frontend_ran=True,
+            frontend_context_kind="host",
+            language_standard="c++17",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            compiler_family="clang",
+            l2_frontend_ran=True,
+            frontend_context_kind="host",
+            language_standard="c++20",
+        )
+    )
+    result = check_contracts_comparable(old, new, diagnostic=True)
+    assert isinstance(result, ComparabilityMismatch)
+    assert result.kind == "profile"
+    # The real cause, not "profile_fields do not reproduce its own
+    # profile_fingerprint".
+    assert "language_standard" in result.reason
+    assert "do not reproduce" not in result.reason
+
+
+def test_differing_frontend_context_kind_is_not_reported_as_unrecognized():
+    """frontend_context_kind is a field this build knows about. A host-vs-device
+    pair is still not comparable -- no carve-out claims that field -- but it is
+    named, not reported as a key this version does not recognize."""
+    old = _snap(
+        compute_extraction_contract(
+            compiler_family="clang", l2_frontend_ran=True, frontend_context_kind="host"
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            compiler_family="clang",
+            l2_frontend_ran=True,
+            frontend_context_kind="device",
+        )
+    )
+    result = check_contracts_comparable(old, new, diagnostic=True)
+    assert isinstance(result, ComparabilityMismatch)
+    assert result.kind == "profile"
+    assert "frontend_context_kind" in result.reason
+    assert "does not recognize" not in result.reason
+
+
+def test_manifest_contract_reproduces_its_own_scope_fingerprint():
+    """A --dump-manifest contract growing its declared header set additively is
+    comparable, the same as the non-manifest case."""
+    old = _snap(
+        compute_extraction_contract(
+            public_header_paths=[Path("/proj/a.h"), Path("/proj/b.h")],
+            manifest_tu_scope='["tu1"]',
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            public_header_paths=[
+                Path("/proj/a.h"),
+                Path("/proj/b.h"),
+                Path("/proj/c.h"),
+            ],
+            manifest_tu_scope='["tu1"]',
+        )
+    )
+    assert check_contracts_comparable(old, new, diagnostic=True) is None
+
+
+def test_fabricated_fingerprint_still_rejected_under_both_key_sets():
+    """Accepting either key set must not accept an arbitrary hash: the
+    authenticity check is still what catches a stale/fabricated fingerprint."""
+    real = compute_extraction_contract(
+        compiler_family="clang", l2_frontend_ran=True, frontend_context_kind="host"
+    )
+    assert real.profile_fingerprint is not None
+    old = _snap(
+        ExtractionContract(
+            profile_fingerprint="sha256:" + "0" * 64,
+            profile_fields=dict(real.profile_fields),
+        )
+    )
+    new = _snap(
+        ExtractionContract(
+            profile_fingerprint="sha256:" + "1" * 64,
+            profile_fields=dict(real.profile_fields),
+        )
+    )
+    result = check_contracts_comparable(old, new, diagnostic=True)
+    assert isinstance(result, ComparabilityMismatch)
+    assert result.kind == "profile"
+    assert "do not reproduce" in result.reason

--- a/tests/test_diff_wheel_deployment.py
+++ b/tests/test_diff_wheel_deployment.py
@@ -1026,3 +1026,88 @@ class TestWheelRpathAndClosureCliEndToEnd:
         assert ChangeKind.WHEEL_CLOSURE_DEPENDENCY_VIOLATION not in _kinds(
             result.changes
         )
+
+
+# ---------------------------------------------------------------------------
+# Ordering of env-matrix findings vs. their own suppression diagnostics
+# (Codex review, PR #697).
+# ---------------------------------------------------------------------------
+
+
+def test_env_matrix_diagnostics_stay_beside_their_own_check(monkeypatch):
+    """Each declared-floor/wheel check's findings are followed by that same
+    check's suppression diagnostics, not by every other check's findings first.
+
+    ``_filter_suppressed_changes`` appends the diagnostics it raises to the END
+    of its own return value, so running all six checks through one combined
+    call would reorder the report from ``[floor, floor-diagnostic, musl,
+    musl-diagnostic, …]`` to ``[floor, musl, …, floor-diagnostic,
+    musl-diagnostic, …]``. ``DiffResult.changes`` preserves list order and the
+    reporters render it, so that is observable output, not an internal detail.
+    """
+    import abicheck.diff_versioning as dv
+    import abicheck.diff_wheel_deployment as dw
+    from abicheck.checker import _env_matrix_contract_changes
+    from abicheck.checker_policy import ChangeKind
+    from abicheck.checker_types import Change
+    from abicheck.model import AbiSnapshot
+    from abicheck.suppression import SuppressionOutcome
+
+    names = ["floor", "musl", "macos", "arch", "rpath", "closure"]
+    for module, attr, name in [
+        (dv, "check_platform_baseline_floor", "floor"),
+        (dv, "check_musllinux_glibc_dependency", "musl"),
+        (dw, "check_macos_deployment_target_floor", "macos"),
+        (dw, "check_wheel_tag_architecture_mismatch", "arch"),
+        (dw, "check_wheel_rpath_not_portable", "rpath"),
+        (dw, "check_wheel_closure_dependency_violation", "closure"),
+    ]:
+        monkeypatch.setattr(
+            module,
+            attr,
+            (
+                lambda n: lambda *a, **k: [
+                    Change(kind=ChangeKind.FUNC_REMOVED, symbol=n, description=n)
+                ]
+            )(name),
+        )
+
+    class _WithheldRule:
+        namespace = "ns::*"
+        entity_namespace = None
+        cause_namespace = None
+        source_location = None
+
+        def rule_label(self):
+            return "r1"
+
+    class _AlwaysWithheld:
+        """Nothing is suppressed, but every change has a withheld rule -- so
+        each one produces exactly one SUPPRESSION_WOULD_HIDE_PUBLIC_BREAK."""
+
+        def evaluate(self, change, today=None):
+            return SuppressionOutcome(
+                suppressed=False,
+                withheld_rule=_WithheldRule(),
+                withheld_unknown_rule=None,
+                matched_rule=None,
+            )
+
+    class _Env:
+        runtime_floors = {"GLIBC": "2.17", "WHEEL_CONTEXT": "manylinux_2_17_x86_64"}
+
+    produced = _env_matrix_contract_changes(
+        AbiSnapshot(library="libx.so", version="1"),
+        [],
+        [],
+        _AlwaysWithheld(),
+        [],
+        _Env(),
+    )
+    assert [
+        (
+            c.symbol,
+            c.kind is ChangeKind.SUPPRESSION_WOULD_HIDE_PUBLIC_BREAK,
+        )
+        for c in produced
+    ] == [(n, is_diag) for n in names for is_diag in (False, True)]


### PR DESCRIPTION
## Summary

Batch 5a of the CodeFactor "Complex Method" series: seven findings in the comparability gate, the ADR-049 contract-evidence provider, and the core `compare` verb — all behaviour-preserving.

## Motivation

CodeFactor reports 68 Complex Method findings across the repo. This is the fifth batch (previous: #693 buildsource, #694 dumper/AST, #695 CLI, #696 reporting). Batch 5 is the largest single group, so it is split by sub-area — this PR takes the comparability/contract/compare cluster; the remaining diff/service/scan findings follow separately.

## Changes

| Function | Score | mccabe before | after |
|---|---|---|---|
| `comparability.check_contracts_comparable` | 31 | 24 | <8 |
| `finding_identity._looks_like_itanium_encoding` | 27 | 19 | <8 |
| `checker.compare` | 25 | 20 | <8 |
| `comparability.compute_extraction_contract` | 23 | 21 | <8 |
| `comparability_sequences._include_sequence_is_additive_owned_growth` | 22 | 18 | <8 |
| `export_surface._resolvable_type_spellings` | 22 | 22 | <8 |
| `export_surface._seed_export_roots` | 17 | 14 | <8 |

- **`check_contracts_comparable`** carried three independent gates inline — dependency scope, `scope_fingerprint`, `profile_fingerprint` — each with its own authenticity check, carve-outs and reason strings, plus the raise/diagnostic dispatch for all three. Each axis now answers for itself and returns the mismatch it would raise, leaving the entry point as the fixed-order dispatch it always was. `_differing_keys`/`_unknown_differing_keys` are shared: both gates computed the same two set comprehensions with different key sets.
- **`compute_extraction_contract`** built both fields dicts inline. `_compute_profile_fields`/`_compute_scope_fields` now own a half each, with `_include_slot_tokens`, `_declared_header_sequence`, `_bucket_resolved_files` and friends behind them.
- **New leaf module `abicheck/comparability_fields.py`.** `comparability.py` crossed the AI-readiness 2000-line hard cap (2083) doing the above, so the field layer moved out along the seam that was already there — nothing in it needs anything from the gate side. `comparability.py` re-exports `IncludeDir`/`_sha256_of`/`_fingerprint_matches_fields` with explicit `X as X` aliases (so `--no-implicit-reexport` accepts them at the call sites), leaving every import path unchanged. No new import-cycle SCC member: the new module imports only `errors`.
- **`_looks_like_itanium_encoding`** was a leading-byte dispatch over the `<encoding>` productions with each body inlined; each now has its own function reached through `_ENCODING_PRODUCTION_HANDLERS`, and the N/Z prefix walk splits again into `_consume_nested_prefix_components`. A handler owns its production's whole condition, so it returns `False` where the old code fell through to the `<operator-name>` tail — equivalent because no Itanium operator code begins with `N`/`Z`/`L`/`T`/`G`/`S`, verified against `_ITANIUM_OPERATOR_CODES` itself rather than assumed.
- **`checker.compare`**: six consecutive `if env_matrix is not None and env_matrix.runtime_floors:` blocks, each re-deriving the same ELF/Mach-O operands and each guarding its own `if changes:` before an extend an empty list already no-ops. `_env_matrix_contract_changes` runs them under one gate; `_contract_coverage_status` takes the four fingerprint reads and the mixed-presence test.
- **`_include_sequence_is_additive_owned_growth`**: the owned `"hdrs:"` pair decode is now `_owned_header_pairs` (all four "no usable evidence" outcomes collapse to `None`). That decode was already duplicated in `_slot_indices_match_position`, which now calls it too and drops 10 → 8 as a side effect.
- **`_resolvable_type_spellings`** built four independent indices inline; each is now named for the question it answers. **`_seed_export_roots`** ran two near-identical passes over functions and variables — the shared bookkeeping is `_record_export_root`, the shared state is `_RootAccumulator`, and the passes now differ only where they genuinely do.

### Behaviour preservation

Every split keeps check order, accumulation order, and reason strings. Two worth calling out:

- `_looks_like_itanium_encoding` was differentially checked against its pre-refactor self over **592,354 inputs** (every string up to length 4 over a 23-byte alphabet covering all the productions' marker bytes, plus 300k random longer ones and the review-fix cases named in its comments) — **0 differences**.
- In `checker.compare`, folding the six env-matrix checks under one gate preserves the order findings land in `kept` *and* in `suppressed`; the dropped `if changes:` guards only skipped an empty extend.

## Checklist

- [x] Tests added / updated for new behaviour — n/a, refactor-only; the existing suites for each module are the regression check (23331 passed locally, plus the differential check above)
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [x] Docs updated if user-visible behaviour changed — n/a, no user-visible change
- [x] `pre-commit run --all-files` passes locally — `ruff check`/`ruff format --check` and `scripts/check_ai_readiness.py` (0 errors) clean
- [x] No new `mypy` or `ruff` errors introduced — `python -m mypy abicheck/` clean across 338 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added partial-coverage reporting when contract metadata is incomplete.
  * Improved contract and environment-matrix analysis, including more consistent portability and runtime compatibility findings.
  * Enhanced comparison validation for scopes, profiles, dependency scopes, fingerprints, and approved exceptions.

* **Bug Fixes**
  * Improved detection of invalid, unverifiable, duplicate, or malformed comparison data.
  * Preserved consistent handling of suppressed findings and first-mismatch reporting.
  * Strengthened export and symbol analysis while maintaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->