### PR TITLE
refactor: split the SYCL AST document scanner and the C++ cv-qualifier scanner

### DIFF
--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -47,6 +47,8 @@ checks and is left as a follow-up.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
+from typing import ClassVar
 
 __all__ = [
     "ITANIUM_RTTI_PREFIXES",
@@ -649,6 +651,192 @@ def _find_matching_close(name: str, open_idx: int) -> int:
     return len(name) - 1
 
 
+def _skip_spaces(name: str, i: int, end: int) -> int:
+    """First non-space index at or after *i*, bounded by *end*."""
+    while i < end and name[i].isspace():
+        i += 1
+    return i
+
+
+def _skip_trailing_cv_tokens(name: str, i: int, end: int) -> int:
+    """Skip past every cv token (and surrounding space) starting at *i*.
+
+    A cv qualifier immediately following a REAL parameter list's closing paren
+    is a member-function-POINTER's own cv-qualification (e.g.
+    ``"void (C::*)(int) const"`` -- the pointer points to a const member
+    function) -- a genuinely different, non-interchangeable type (confirmed
+    against real g++ mangling: two same-named overloads differing only in this
+    trailing const compile as distinct symbols, matching the existing
+    FUNC_CV_CHANGED precedent for a member function's own const/volatile).
+    Never neutral, regardless of strict/non-strict context or position relative
+    to any pointer sigil -- skipping past it leaves it completely untouched
+    rather than stripping it (permissive/non-strict mode) or treating it as a
+    stripping candidate (strict mode) (CodeRabbit review, PR #589).
+    """
+    i = _skip_spaces(name, i, end)
+    m = _CV_TOKEN_RE.match(name, i)
+    while m and m.end() <= end:
+        i = _skip_spaces(name, m.end(), end)
+        m = _CV_TOKEN_RE.match(name, i)
+    return i
+
+
+def _is_declarator_grouping_paren(name: str, close_idx: int, end: int) -> bool:
+    """Whether the paren closing at *close_idx* groups a declarator rather than
+    opening a parameter list.
+
+    A pointer/pointer-to-member DECLARATOR-GROUPING paren -- e.g. the
+    ``"(*)"``/``"(*const)"``/``"(C::*)"`` in ``"RetType (*)(Params)"``/
+    ``"RetType (C::*)(Params)"`` -- is recognized structurally by being
+    immediately followed by ANOTHER top-level paren/bracket (the real parameter
+    list or array dimensions), regardless of what's inside it (a bare sigil, or
+    a qualified pointer-to-member ``"Class::*"`` -- deliberately NOT restricted
+    to "only sigils/cv tokens inside", since that missed the class-qualified
+    case: Codex review, PR #589, round 2).
+    """
+    k = _skip_spaces(name, close_idx + 1, end)
+    return k < end and name[k] in "(["
+
+
+class _CvSegmentScan:
+    """One scan of ``name[start:end]``, blanking strippable cv tokens in
+    *chars*.
+
+    Split out of :func:`_strip_cv_in_segment` so each syntactic case is its own
+    named method rather than a branch in one long loop; the per-case rules
+    below are exactly the ones that function's docstring states, and each
+    method carries the evidence for its own rule.
+    """
+
+    #: Which method handles a given leading character (bound below, once the
+    #: methods exist). Every other character falls through to
+    #: :meth:`_at_other`, which is where a cv token is actually recognized.
+    _HANDLERS: ClassVar[dict[str, Callable[[_CvSegmentScan, int], int]]]
+
+    def __init__(self, name: str, chars: list[str], end: int, *, strict: bool):
+        self.name = name
+        self.chars = chars
+        self.end = end
+        self.strict = strict
+        self.last_ptr_pos: int | None = None
+        self.candidates: list[tuple[int, int]] = []
+
+    def run(self, start: int) -> None:
+        i = start
+        while i < self.end:
+            handler = self._HANDLERS.get(self.name[i], _CvSegmentScan._at_other)
+            i = handler(self, i)
+        self._flush()
+
+    def _flush(self) -> None:
+        """Blank every candidate not shadowed by a pointer sigil to its left.
+
+        In strict mode the pointee-vs-pointer-own position is resolved
+        independently PER comma-separated parameter within this paren (a
+        callback can itself take multiple parameters, e.g.
+        ``void (*)(int*, const int)`` -- the second parameter's own by-value cv
+        must not be judged against the FIRST parameter's unrelated pointer
+        sigil), which is why this runs at each comma as well as at the end.
+        """
+        for tok_start, tok_end in self.candidates:
+            if self.last_ptr_pos is None or tok_start > self.last_ptr_pos:
+                for k in range(tok_start, tok_end):
+                    self.chars[k] = " "
+        self.candidates.clear()
+
+    def _at_angle(self, i: int) -> int:
+        """``<...>`` is skipped whole: a cv qualifier inside a
+        template-argument list names a genuinely different type
+        (``Box<const int>`` vs. ``Box<int>``; Codex/CodeRabbit review, PR
+        #582)."""
+        return min(_find_matching_close(self.name, i), self.end - 1) + 1
+
+    def _at_bracket(self, i: int) -> int:
+        """``[...]`` is skipped whole, and may move the pointer boundary."""
+        j = min(_find_matching_close(self.name, i), self.end - 1)
+        if self.last_ptr_pos is None:
+            # An array-typed function PARAMETER (no preceding pointer sigil in
+            # this segment yet) decays to a pointer, so a cv qualifier before
+            # it is pointee-position, not by-value -- same non-strippable
+            # treatment as a real pointer sigil (confirmed against real
+            # clang/gcc mangling: void(*)(int[3]) and void(*)(const int[3])
+            # are different, non-interchangeable function pointer types, same
+            # as the int*/const int* case). Only matters in strict mode;
+            # harmless otherwise since non-strict stripping ignores
+            # last_ptr_pos entirely (Codex review, PR #589).
+            self.last_ptr_pos = i
+        # else: a "[...]" AFTER an already-seen pointer sigil is the POINTEE's
+        # array bound (e.g. "int (*)[3]" -- a pointer to an array, not a
+        # decaying array parameter), analogous to a callback's own parameter
+        # list: it doesn't move last_ptr_pos, so the declarator's own preceding
+        # qualifier (e.g. "int (* const)[3]") stays recognized as its own
+        # trailing cv, dropped for mangling (confirmed identical types by real
+        # g++: two same-named overloads differing only in that const are a hard
+        # redefinition error, not distinct overloads) -- treating this "[" the
+        # same as the decay case above wrongly moved the boundary past the
+        # declarator's own const, leaving it unstrippable (Codex review, PR
+        # #589, round 3).
+        return j + 1
+
+    def _at_paren(self, i: int) -> int:
+        """``(...)`` is either a declarator grouping (stepped into in place) or
+        a real parameter list (recursed into with ``strict=True``)."""
+        j = min(_find_matching_close(self.name, i), self.end - 1)
+        if _is_declarator_grouping_paren(self.name, j, self.end):
+            # NOT itself a nested parameter list, so don't open a fresh strict
+            # scope for it: its "*" is the CURRENT (possibly
+            # nested-callback-parameter's own) declarator's top-level sigil and
+            # must stay visible to it. Recursing here would hide that "*"
+            # inside an isolated scan whose own last_ptr_pos never reaches this
+            # scope's tracking, so a callback parameter that is itself a
+            # function pointer with a cv-qualified return type
+            # (``void(*)(int (*)())`` vs. ``void(*)(const int (*)())`` --
+            # confirmed distinct, non-interchangeable types by real g++
+            # mangling) had its return-type cv wrongly treated as the callback
+            # parameter's own neutral by-value qualifier instead. Just step
+            # past the "(" and let this same scan process the interior in
+            # place.
+            return i + 1
+        _strip_cv_in_segment(self.name, self.chars, i + 1, j, strict=True)
+        return _skip_trailing_cv_tokens(self.name, j + 1, self.end)
+
+    def _at_comma(self, i: int) -> int:
+        """A strict-mode comma closes one callback parameter's own scope."""
+        if not self.strict:
+            return self._at_other(i)
+        self._flush()
+        self.last_ptr_pos = None
+        return i + 1
+
+    def _at_sigil(self, i: int) -> int:
+        """``*``/``&`` moves the pointee/pointer-own boundary."""
+        self.last_ptr_pos = i
+        return i + 1
+
+    def _at_other(self, i: int) -> int:
+        """Anything else: a cv token here is recorded (strict) or blanked
+        outright (non-strict); any other character is just stepped over."""
+        m = _CV_TOKEN_RE.match(self.name, i)
+        if not (m and m.end() <= self.end):
+            return i + 1
+        if self.strict:
+            self.candidates.append((m.start(), m.end()))
+        else:
+            for k in range(m.start(), m.end()):
+                self.chars[k] = " "
+        return m.end()
+
+
+_CvSegmentScan._HANDLERS = {
+    "<": _CvSegmentScan._at_angle,
+    "[": _CvSegmentScan._at_bracket,
+    "(": _CvSegmentScan._at_paren,
+    ",": _CvSegmentScan._at_comma,
+    "*": _CvSegmentScan._at_sigil,
+    "&": _CvSegmentScan._at_sigil,
+}
+
+
 def _strip_cv_in_segment(
     name: str, chars: list[str], start: int, end: int, *, strict: bool
 ) -> None:
@@ -685,130 +873,7 @@ def _strip_cv_in_segment(
     (*)(int*, const int)`` — the second parameter's own by-value cv must
     not be judged against the FIRST parameter's unrelated pointer sigil).
     """
-    last_ptr_pos: int | None = None
-    candidates: list[tuple[int, int]] = []
-
-    def _flush() -> None:
-        for tok_start, tok_end in candidates:
-            if last_ptr_pos is None or tok_start > last_ptr_pos:
-                for k in range(tok_start, tok_end):
-                    chars[k] = " "
-        candidates.clear()
-
-    i = start
-    while i < end:
-        ch = name[i]
-        if ch == "<":
-            j = min(_find_matching_close(name, i), end - 1)
-            i = j + 1
-            continue
-        if ch == "[":
-            j = min(_find_matching_close(name, i), end - 1)
-            if last_ptr_pos is None:
-                # An array-typed function PARAMETER (no preceding pointer
-                # sigil in this segment yet) decays to a pointer, so a cv
-                # qualifier before it is pointee-position, not by-value —
-                # same non-strippable treatment as a real pointer sigil
-                # (confirmed against real clang/gcc mangling: void(*)(int[3])
-                # and void(*)(const int[3]) are different, non-
-                # interchangeable function pointer types, same as the
-                # int*/const int* case above). Only matters in strict mode;
-                # harmless otherwise since non-strict stripping ignores
-                # last_ptr_pos entirely (Codex review, PR #589).
-                last_ptr_pos = i
-            # else: a "[...]" AFTER an already-seen pointer sigil is the
-            # POINTEE's array bound (e.g. "int (*)[3]" — a pointer to an
-            # array, not a decaying array parameter), analogous to a
-            # callback's own parameter list: it doesn't move last_ptr_pos,
-            # so the declarator's own preceding qualifier (e.g. "int (*
-            # const)[3]") stays recognized as its own trailing cv, dropped
-            # for mangling (confirmed identical types by real g++: two
-            # same-named overloads differing only in that const are a
-            # hard redefinition error, not distinct overloads) — treating
-            # this "[" the same as the decay case above wrongly moved the
-            # boundary past the declarator's own const, leaving it
-            # unstrippable (Codex review, PR #589, round 3).
-            i = j + 1
-            continue
-        if ch == "(":
-            j = min(_find_matching_close(name, i), end - 1)
-            k = j + 1
-            while k < end and name[k].isspace():
-                k += 1
-            if k < end and name[k] in "([":
-                # A pointer/pointer-to-member DECLARATOR-GROUPING paren --
-                # e.g. the "(*)"/"(*const)"/"(C::*)" in "RetType
-                # (*)(Params)"/"RetType (C::*)(Params)" -- recognized
-                # structurally by being immediately followed by ANOTHER
-                # top-level paren/bracket (the real parameter list or array
-                # dimensions), regardless of what's inside it (a bare
-                # sigil, or a qualified pointer-to-member "Class::*" —
-                # deliberately NOT restricted to "only sigils/cv tokens
-                # inside", since that missed the class-qualified case:
-                # Codex review, PR #589, round 2). It is NOT itself a
-                # nested parameter list, so don't open a fresh strict scope
-                # for it: its "*" is the CURRENT (possibly
-                # nested-callback-parameter's own) declarator's top-level
-                # sigil and must stay visible to it. Recursing here would
-                # hide that "*" inside an isolated call whose own
-                # last_ptr_pos never reaches this scope's tracking, so a
-                # callback parameter that is itself a function pointer with
-                # a cv-qualified return type (``void(*)(int (*)())`` vs.
-                # ``void(*)(const int (*)())`` — confirmed distinct,
-                # non-interchangeable types by real g++ mangling) had its
-                # return-type cv wrongly treated as the callback
-                # parameter's own neutral by-value qualifier instead. Just
-                # step past the "(" and let this same scan process the
-                # interior in place.
-                i += 1
-                continue
-            _strip_cv_in_segment(name, chars, i + 1, j, strict=True)
-            i = j + 1
-            # A cv qualifier immediately following a REAL parameter list's
-            # closing paren is a member-function-POINTER's own
-            # cv-qualification (e.g. "void (C::*)(int) const" — the pointer
-            # points to a const member function) — a genuinely different,
-            # non-interchangeable type (confirmed against real g++
-            # mangling: two same-named overloads differing only in this
-            # trailing const compile as distinct symbols, matching the
-            # existing FUNC_CV_CHANGED precedent for a member function's
-            # own const/volatile). Never neutral, regardless of strict/
-            # non-strict context or position relative to any pointer
-            # sigil — leave it completely untouched rather than stripping
-            # it (permissive/non-strict mode) or treating it as a
-            # stripping candidate (strict mode) (CodeRabbit review, PR
-            # #589).
-            k = i
-            while k < end and name[k].isspace():
-                k += 1
-            m = _CV_TOKEN_RE.match(name, k)
-            while m and m.end() <= end:
-                k = m.end()
-                while k < end and name[k].isspace():
-                    k += 1
-                m = _CV_TOKEN_RE.match(name, k)
-            i = k
-            continue
-        if strict and ch == ",":
-            _flush()
-            last_ptr_pos = None
-            i += 1
-            continue
-        if ch in "*&":
-            last_ptr_pos = i
-            i += 1
-            continue
-        m = _CV_TOKEN_RE.match(name, i)
-        if m and m.end() <= end:
-            if strict:
-                candidates.append((m.start(), m.end()))
-            else:
-                for k in range(m.start(), m.end()):
-                    chars[k] = " "
-            i = m.end()
-            continue
-        i += 1
-    _flush()
+    _CvSegmentScan(name, chars, end, strict=strict).run(start)
 
 
 def _strip_cv_qualifiers(name: str) -> str:

--- a/abicheck/sycl_context.py
+++ b/abicheck/sycl_context.py
@@ -183,6 +183,160 @@ def _one_match_or_raise(
     return matches[0]
 
 
+class _BracketState:
+    """The bracket/string-escape state machine one JSON document is scanned
+    with.
+
+    A naive brace counter is wrong in general -- a JSON string value can itself
+    contain a literal ``{``/``}`` -- so string and escape state are tracked
+    alongside nesting depth. Fed one character at a time so the caller can
+    stream, never needing the document in memory to find its end.
+    """
+
+    __slots__ = ("depth", "escape", "in_string")
+
+    def __init__(self) -> None:
+        self.depth = 0
+        self.in_string = False
+        self.escape = False
+
+    def feed(self, c: str) -> bool:
+        """Consume one character; ``True`` when it closed the top-level
+        document."""
+        if self.in_string:
+            self._feed_in_string(c)
+            return False
+        return self._feed_structural(c)
+
+    def _feed_in_string(self, c: str) -> None:
+        if self.escape:
+            self.escape = False
+        elif c == "\\":
+            self.escape = True
+        elif c == '"':
+            self.in_string = False
+
+    def _feed_structural(self, c: str) -> bool:
+        if c == '"':
+            self.in_string = True
+        elif c in "{[":
+            self.depth += 1
+        elif c in "}]":
+            self.depth -= 1
+            return self.depth == 0
+        return False
+
+
+class _ChunkCursor:
+    """A one-chunk-at-a-time cursor over the text *read_more* feeds.
+
+    Holds exactly one chunk at a time: as ``pos`` runs off the end, ``cur`` is
+    replaced wholesale -- never appended to a list, never ``+=``'d onto a
+    growing ``str`` -- so the just-exhausted chunk becomes unreferenced and
+    eligible for GC immediately, unless a caller archived a piece of it first
+    (see :meth:`scan_document`).
+
+    This is what makes the scan linear. Repeatedly retrying
+    ``json.JSONDecoder.raw_decode`` from position 0 over an ever-growing
+    ``str`` was quadratic in a single document's size for any document
+    spanning more than one chunk (Codex review): each incomplete
+    ``raw_decode`` attempt re-parses the *entire* accumulated buffer, and
+    ``buf += chunk`` on an immutable ``str`` additionally re-copies the whole
+    accumulated buffer on every append. A hundreds-of-MB or multi-GB
+    single-pass AST -- this module's whole reason to exist -- made both costs
+    dominate. Here each byte is inspected exactly once across the whole
+    stream.
+    """
+
+    __slots__ = ("_read_more", "cur", "eof", "pos")
+
+    def __init__(self, read_more: Callable[[], str]) -> None:
+        self._read_more = read_more
+        self.cur = ""
+        self.pos = 0
+        self.eof = False
+
+    def ensure_char(self) -> bool:
+        """Make ``cur[pos]`` valid, pulling further chunks as needed. Returns
+        ``False`` only at genuine end of stream.
+
+        Calls :func:`abicheck.deadline.check` once per underlying *read_more*
+        call (P2, Codex review): a single document can take minutes to stream
+        through on a multi-GB DPC++ AST pass, and the only deadline checks
+        around this decode live in the caller (before/after the whole decode),
+        so a budget that expired early would otherwise still burn through the
+        rest of that time before the timeout is ever reported.
+        """
+        while self.pos >= len(self.cur):
+            if self.eof:  # pragma: no cover - defensive: every call site
+                # halts (return/raise) on this method's first False, so a
+                # second call after eof is already set never happens in
+                # practice; guarded anyway so a future call site that doesn't
+                # halt immediately can't call read_more() again past genuine
+                # end of stream.
+                return False
+            deadline.check()
+            chunk = self._read_more()
+            if not chunk:
+                self.eof = True
+                return False
+            self.cur = chunk
+            self.pos = 0
+        return True
+
+    def skip_whitespace(self) -> bool:
+        """Advance to the next non-whitespace character. Returns ``False`` at
+        genuine end of stream, with no partial document pending."""
+        if not self.ensure_char():
+            return False
+        while self.cur[self.pos].isspace():
+            self.pos += 1
+            if not self.ensure_char():
+                return False
+        return True
+
+    def scan_document(self, *, collect: bool) -> str | None:
+        """Scan from the current position past the end of one top-level JSON
+        document, returning its raw text when *collect* and ``None`` otherwise.
+
+        When not collecting, each chunk is dropped the moment it is fully
+        consumed rather than archived into *pieces*. Skipping only the final
+        join -- or only the caller's ``json.loads`` -- was not enough (P1,
+        Codex review, twice): the boundary scan itself must never accumulate
+        an unwanted document's chunks, or peak memory for a non-matching
+        multi-GB pass is still that pass's own full size, live at the same
+        time as an already-selected multi-GB match's dict.
+        """
+        pieces: list[str] = []
+        piece_start = self.pos
+        state = _BracketState()
+        while True:
+            if self.pos >= len(self.cur):
+                if collect:
+                    pieces.append(self.cur[piece_start:])
+                if not self.ensure_char():
+                    raise SnapshotError(
+                        "DPC++ frontend produced a truncated or malformed AST "
+                        "document stream: unexpected end of input"
+                    )
+                piece_start = self.pos  # == 0, freshly replaced `cur`
+                continue
+            closed = state.feed(self.cur[self.pos])
+            self.pos += 1
+            if closed:
+                break
+        if not collect:
+            return None
+        pieces.append(self.cur[piece_start : self.pos])
+        return _join_pieces(pieces)
+
+
+def _join_pieces(pieces: list[str]) -> str:
+    """One piece is the common case (a document wholly inside one chunk);
+    returning it directly avoids copying the whole document."""
+    return pieces[0] if len(pieces) == 1 else "".join(pieces)
+
+
 def _iter_json_documents(
     read_more: Callable[[], str], want_text: Callable[[int], bool] | None = None
 ) -> Iterator[str | None]:
@@ -200,19 +354,10 @@ def _iter_json_documents(
     Each document must be a top-level JSON **object or array** (``{...}``/
     ``[...]``) -- always true for a clang ``-ast-dump=json`` document, never
     a bare scalar. Boundary detection is a hand-rolled bracket/string-escape
-    scan over the CURRENT chunk only (never a growing list of chunks, never
-    an ever-growing single ``str``): repeatedly retrying
-    ``json.JSONDecoder.raw_decode`` from position 0 over an ever-growing
-    ``str`` was quadratic in a single document's size for any document
-    spanning more than one chunk (Codex review) -- each incomplete
-    ``raw_decode`` attempt re-parses the *entire* accumulated buffer, and
-    ``buf += chunk`` on an immutable ``str`` additionally re-copies the
-    whole accumulated buffer on every single append. A hundreds-of-MB or
-    multi-GB single-pass AST (this module's whole reason to exist) made
-    both costs dominate. Here, each byte is inspected exactly once across
-    the whole stream, and only ONE chunk is ever held onto beyond the
-    currently-scanned one (the collected pieces of a *wanted* document --
-    see *want_text* below).
+    scan over the CURRENT chunk only, never a growing list of chunks and
+    never an ever-growing single ``str`` -- see :class:`_ChunkCursor` for why
+    the obvious ``raw_decode``-over-a-growing-buffer approach was quadratic,
+    and :class:`_BracketState` for why a naive brace counter is wrong.
 
     *want_text*, if given, is called with each document's 0-based index
     BEFORE that document is scanned at all -- when it returns ``False``,
@@ -220,20 +365,14 @@ def _iter_json_documents(
     (so the boundary of the NEXT one can be found) but discards each chunk
     the moment it's fully consumed, never retaining more than the single
     chunk currently being scanned, and yields ``None`` for that document
-    instead of its text (P1, Codex review, twice: skipping ``json.loads``
-    for a definitely-non-matching document, as
-    :func:`_select_from_document_stream` already did, was not enough on its
-    own, and neither was skipping just the final join -- the boundary scan
-    itself must never accumulate an unwanted document's chunks into a list
-    at all, or peak memory for a non-matching multi-GB pass is still that
-    pass's full size, live at the same time as an already-selected
-    multi-GB match's dict. The *kind* of the pass that produced a document
-    is knowable from ``stderr`` alone, positionally, before this function's
-    ``read_more`` is ever called for that document's bytes at all, so a
-    definitely-non-matching multi-GB document now costs at most one
-    chunk's worth of memory to scan past, not its own full size).
-    ``want_text=None`` (the default) always collects and yields the text,
-    same as before this parameter existed.
+    instead of its text (P1, Codex review, twice; see
+    :meth:`_ChunkCursor.scan_document`). The *kind* of the pass that produced
+    a document is knowable from ``stderr`` alone, positionally, before this
+    function's ``read_more`` is ever called for that document's bytes at all,
+    so a definitely-non-matching multi-GB document costs at most one chunk's
+    worth of memory to scan past, not its own full size. ``want_text=None``
+    (the default) always collects and yields the text, same as before this
+    parameter existed.
 
     Deliberately does NOT call ``json.loads`` here -- that decision belongs
     to the caller (:func:`_select_from_document_stream`). Only a genuinely
@@ -243,105 +382,22 @@ def _iter_json_documents(
     when that surfaces as an error depends on whether the caller parses it.
 
     Calls :func:`abicheck.deadline.check` once per underlying *read_more*
-    call (P2, Codex review): a single document can take minutes to stream
-    through on a multi-GB DPC++ AST pass, and the only deadline checks
-    around this decode live in the caller (before/after the whole decode),
-    so a budget that expired early would otherwise still burn through the
-    rest of that time before the timeout is ever reported.
+    call (P2, Codex review; see :meth:`_ChunkCursor.ensure_char`).
     """
-    cur = ""
-    pos = 0
-    eof = False
-
-    def _ensure_char() -> bool:
-        """Ensure ``cur[pos]`` is valid, replacing ``cur`` wholesale (never
-        appending to a list) as it's exhausted -- the just-exhausted chunk
-        becomes unreferenced and eligible for GC immediately unless the
-        caller archived a piece of it first (see *pieces* below). Returns
-        ``False`` only at genuine end of stream."""
-        nonlocal cur, pos, eof
-        while pos >= len(cur):
-            if eof:  # pragma: no cover - defensive: every call site below
-                # halts (return/raise) on this function's first False,
-                # so a second call after eof is already set never happens
-                # in practice; guarded anyway so a future call site that
-                # doesn't halt immediately can't call read_more() again
-                # past genuine end of stream.
-                return False
-            deadline.check()
-            chunk = read_more()
-            if not chunk:
-                eof = True
-                return False
-            cur = chunk
-            pos = 0
-        return True
-
+    cursor = _ChunkCursor(read_more)
     doc_index = 0
-    while True:
-        if not _ensure_char():
-            return  # genuine end of stream, no partial document pending
-        while cur[pos].isspace():
-            pos += 1
-            if not _ensure_char():
-                return
-        c = cur[pos]
+    while cursor.skip_whitespace():
+        c = cursor.cur[cursor.pos]
         if c not in "{[":
             raise SnapshotError(
                 "DPC++ frontend produced a truncated or malformed AST "
                 f"document stream: expected an object/array, found {c!r}"
             )
-
         # Decided BEFORE scanning a single byte of this document -- purely
         # from *stderr*'s positional invocation list, never this document's
         # own content -- so an unwanted document never accumulates chunks
-        # below at all, not even transiently.
-        wants_this = want_text is None or want_text(doc_index)
-        pieces: list[str] = []
-        piece_start = pos
-
-        depth = 0
-        in_string = False
-        escape = False
-        end_pos: int | None = None
-        while end_pos is None:
-            if pos >= len(cur):
-                if wants_this:
-                    pieces.append(cur[piece_start:])
-                if not _ensure_char():
-                    raise SnapshotError(
-                        "DPC++ frontend produced a truncated or malformed AST "
-                        "document stream: unexpected end of input"
-                    )
-                piece_start = pos  # == 0, freshly replaced `cur`
-                continue
-            c = cur[pos]
-            if in_string:
-                if escape:
-                    escape = False
-                elif c == "\\":
-                    escape = True
-                elif c == '"':
-                    in_string = False
-            elif c == '"':
-                in_string = True
-            elif c in "{[":
-                depth += 1
-            elif c in "}]":
-                depth -= 1
-                if depth == 0:
-                    pos += 1
-                    end_pos = pos
-                    continue
-            pos += 1
-
-        doc_text: str | None
-        if wants_this:
-            pieces.append(cur[piece_start:end_pos])
-            doc_text = pieces[0] if len(pieces) == 1 else "".join(pieces)
-        else:
-            doc_text = None
-        yield doc_text
+        # inside scan_document at all, not even transiently.
+        yield cursor.scan_document(collect=want_text is None or want_text(doc_index))
         doc_index += 1
 
 

--- a/changelog.d/20260810_093000_claude_codefactor_complexity_diff2.md
+++ b/changelog.d/20260810_093000_claude_codefactor_complexity_diff2.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **Split two more CodeFactor "Complex Method" findings in the SYCL AST decoder
+  and the C++ name classifier.** `sycl_context._iter_json_documents`'s
+  document-boundary scanner is now a `_ChunkCursor` (the one-chunk-at-a-time
+  buffer) plus a `_BracketState` (the string- and escape-aware nesting counter),
+  leaving the generator as the per-document loop it describes.
+  `name_classification._strip_cv_in_segment`'s single loop over every C++
+  declarator case became `_CvSegmentScan`, one method per syntactic case reached
+  through a leading-character dispatch. Both behaviour-preserving and checked
+  differentially against their pre-refactor selves: 72,198 runs for the document
+  scanner (varying chunk sizes and document-selection policies, including
+  malformed and truncated input), and 98,463 type spellings plus all 1,283,689
+  ordered pairs through `cv_qualifiers_only_differ` for the cv scanner — no
+  differences in either.


### PR DESCRIPTION
## Summary

Batch 5b of the CodeFactor "Complex Method" series: the two hand-rolled character-level scanners, both behaviour-preserving and both verified differentially against their pre-refactor selves.

## Motivation

Continues #693 / #694 / #695 / #696 (merged) and #697 (open). These two are the highest-mccabe functions left on the board, and both are stateful parsers where the ordinary "read it and check the branches" review is weak — so each ships with an exhaustive differential check instead of an argument.

`name_classification._strip_cv_in_segment` in particular was **deferred earlier in this series** as too risky to touch. What changed is not the risk but the verification: the differential technique used on `_looks_like_itanium_encoding` in #697 applies directly, which turns the risk from assumed into measured.

## Changes

| Function | Score | mccabe before | after |
|---|---|---|---|
| `name_classification._strip_cv_in_segment` | 27 | 20 | <8 |
| `sycl_context._iter_json_documents` | 22 | 23 | <8 |

**`_iter_json_documents`** held the whole document-boundary scanner in one generator: a nested chunk-refill closure over three `nonlocal`s, the whitespace skip, the bracket/string/escape state machine and the piece collection, all sharing `cur`/`pos` directly. The state now has an owner — `_ChunkCursor` (`ensure_char`/`skip_whitespace`/`scan_document`) and `_BracketState`, fed one character at a time. The generator is left as what it always described: skip whitespace, check the document opens with an object/array, decide whether this one is wanted, scan, yield.

This also gives the two performance invariants a place next to the code implementing them rather than in one long docstring: why a growing buffer with `raw_decode` retries was quadratic (on `_ChunkCursor`), and why an unwanted document must not accumulate chunks even transiently (on `scan_document`).

**`_strip_cv_in_segment`** carried every syntactic case of C++ declarator parsing in one loop — template-argument skipping, array-decay pointer-boundary tracking, declarator-grouping vs. parameter-list parens, per-parameter comma scoping, sigil tracking and cv-token recording — over three variables shared with a nested closure. Each case is now a method on `_CvSegmentScan` reached through a leading-character dispatch table, so the rule for a case and the evidence for it (which real g++/clang mangling confirmed it, which review round found it) sit together instead of in one 130-line comment block. `_strip_cv_in_segment` stays as the entry point, so callers and the recursion are unchanged.

## Verification

Both were checked against their pre-refactor implementations, comparing outputs *and* raised exception types/messages:

- **`_iter_json_documents`** — 72,198 runs: 4,011 document streams (nested objects, brackets inside strings, escaped quotes and backslashes, malformed and truncated input) × chunk sizes 1/2/3/7/64/100000 × three `want_text` policies. **0 differences.**
- **`_strip_cv_qualifiers`** — 98,463 spellings: every combination of cv-qualifier × base type × pointer/reference/array suffix; function pointers across return type × declarator grouping × parameter list × trailing cv (including nested callbacks and cv-qualified callback return types); template arguments; pointer-to-array declarators; plus 120k random token-soup strings from the grammar's own alphabet. **0 differences.**
- **`cv_qualifiers_only_differ`** — the real public entry point — all **1,283,689** ordered pairs of the realistic subset. **0 differences.**

Plus the full fast suite (23334 passed), `ruff check`/`format`, `python -m mypy abicheck/` clean across 337 files, and `scripts/check_ai_readiness.py` at 0 errors.

## Checklist

- [x] Tests added / updated for new behaviour — n/a, refactor-only; the differential checks above plus the existing suites for each module are the regression check
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [x] Docs updated if user-visible behaviour changed — n/a, no user-visible change
- [x] `pre-commit run --all-files` passes locally — `ruff check`/`ruff format --check` and `scripts/check_ai_readiness.py` (0 errors) clean
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q)_