### PR TITLE
refactor: split the ADR-049 field resolver and the wheel-tag architecture check

### DIFF
--- a/abicheck/compatibility_evaluation_resolver.py
+++ b/abicheck/compatibility_evaluation_resolver.py
@@ -289,7 +289,36 @@ def resolve_field(
         )
 
     all_candidates = (*candidates, default)
+    _reject_unresolvable_candidates(
+        field_name, all_candidates, allow_run_profile=allow_run_profile
+    )
+    shadowed_legacy = _shadowed_legacy_candidate(
+        field_name,
+        all_candidates,
+        require_legacy_alias_agreement=require_legacy_alias_agreement,
+    )
+    winner = _winning_candidate(field_name, all_candidates)
+    provenance = winner.provenance
+    if shadowed_legacy is not None:
+        provenance = dataclasses.replace(
+            provenance, shadowed_legacy=shadowed_legacy.provenance
+        )
+    return winner.value, provenance
 
+
+def _reject_unresolvable_candidates(
+    field_name: str,
+    all_candidates: Sequence[FieldCandidate],
+    *,
+    allow_run_profile: bool,
+) -> None:
+    """Reject a candidate this resolver cannot place, before any tier runs.
+
+    Two distinct failures, both plain ``ValueError`` rather than a D7 usage
+    error: a layer no ``_PRECEDENCE_TIERS`` entry covers (a resolver/enum
+    mismatch that would otherwise silently drop the candidate), and a
+    ``RUN_PROFILE`` candidate for a field that did not opt in.
+    """
     for candidate in all_candidates:
         if candidate.layer not in _KNOWN_LAYERS:
             # `.name` assumes a real (or duck-typed enum-shaped) layer --
@@ -318,38 +347,66 @@ def resolve_field(
                 "pass allow_run_profile=True when resolving one of those"
             )
 
+
+def _shadowed_legacy_candidate(
+    field_name: str,
+    all_candidates: Sequence[FieldCandidate],
+    *,
+    require_legacy_alias_agreement: bool,
+) -> FieldCandidate | None:
+    """The legacy-alias candidate an explicit value overrides, if any.
+
+    Raises :class:`LegacyAliasConflictError` when an explicit CLI/API value
+    disagrees with a legacy-alias value for the same field, unless
+    *require_legacy_alias_agreement* is ``False`` (the documented
+    ``--policy``/``--policy-file`` exception, D7) -- in which case the
+    suppressed legacy candidate is returned so the winner's provenance can
+    record it for audit/replay.
+    """
     explicit_candidates = [c for c in all_candidates if c.layer in _EXPLICIT_LAYERS]
     legacy_candidates = [
         c for c in all_candidates if c.layer is SelectorLayer.LEGACY_ALIAS
     ]
-    shadowed_legacy: FieldCandidate | None = None
-    if explicit_candidates and legacy_candidates:
-        # Same runtime-type-blind collision _value_identity_key documents
-        # for the same-tier/pack-conflict checks: if the explicit candidate
-        # itself carries an unnormalized raw value equal to a typed legacy
-        # candidate (e.g. explicit="public" vs. legacy=ContractMode.PUBLIC),
-        # plain equality treated that as agreement, and the winner-selection
-        # loop below then returns the explicit tier's own value verbatim --
-        # the malformed raw string -- since EXPLICIT_CLI always wins
-        # precedence regardless of this check. Comparing type-aware here
-        # instead surfaces that malformed explicit input as the intended
-        # LegacyAliasConflictError (Codex review, fresh evidence: this
-        # module's front ends are documented to construct FieldCandidate
-        # from already-normalized values, so a raw spelling reaching here
-        # is itself the adapter bug this check exists to catch).
-        explicit_values = {_value_identity_key(c.value) for c in explicit_candidates}
-        legacy_values = {_value_identity_key(c.value) for c in legacy_candidates}
-        if (
-            len(explicit_values) == 1
-            and len(legacy_values) == 1
-            and explicit_values != legacy_values
-        ):
-            if require_legacy_alias_agreement:
-                raise LegacyAliasConflictError(
-                    field_name, explicit_candidates[0], legacy_candidates[0]
-                )
-            shadowed_legacy = legacy_candidates[0]
+    if not (explicit_candidates and legacy_candidates):
+        return None
+    # Same runtime-type-blind collision _value_identity_key documents
+    # for the same-tier/pack-conflict checks: if the explicit candidate
+    # itself carries an unnormalized raw value equal to a typed legacy
+    # candidate (e.g. explicit="public" vs. legacy=ContractMode.PUBLIC),
+    # plain equality treated that as agreement, and the winner-selection
+    # loop below then returns the explicit tier's own value verbatim --
+    # the malformed raw string -- since EXPLICIT_CLI always wins
+    # precedence regardless of this check. Comparing type-aware here
+    # instead surfaces that malformed explicit input as the intended
+    # LegacyAliasConflictError (Codex review, fresh evidence: this
+    # module's front ends are documented to construct FieldCandidate
+    # from already-normalized values, so a raw spelling reaching here
+    # is itself the adapter bug this check exists to catch).
+    explicit_values = {_value_identity_key(c.value) for c in explicit_candidates}
+    legacy_values = {_value_identity_key(c.value) for c in legacy_candidates}
+    if (
+        len(explicit_values) == 1
+        and len(legacy_values) == 1
+        and explicit_values != legacy_values
+    ):
+        if require_legacy_alias_agreement:
+            raise LegacyAliasConflictError(
+                field_name, explicit_candidates[0], legacy_candidates[0]
+            )
+        return legacy_candidates[0]
+    return None
 
+
+def _winning_candidate(
+    field_name: str, all_candidates: Sequence[FieldCandidate]
+) -> FieldCandidate:
+    """The highest-precedence candidate, after checking every populated tier.
+
+    ADR-049 D7's "contradictory values at the same selector layer are usage
+    errors" is not scoped to only the winning tier: a shadowed layer's
+    internal conflict must still be caught now, not silently exposed later if
+    the higher-precedence override is ever removed.
+    """
     winner: FieldCandidate | None = None
     for tier in _PRECEDENCE_TIERS:
         tier_candidates = [c for c in all_candidates if c.layer in tier]
@@ -364,17 +421,11 @@ def resolve_field(
         if winner is None:
             winner = tier_candidates[0]
 
-    if winner is not None:
-        provenance = winner.provenance
-        if shadowed_legacy is not None:
-            provenance = dataclasses.replace(
-                provenance, shadowed_legacy=shadowed_legacy.provenance
-            )
-        return winner.value, provenance
-
-    raise AssertionError(  # pragma: no cover - default always matches a tier
-        f"{field_name}: no candidate matched any precedence tier"
-    )
+    if winner is None:
+        raise AssertionError(  # pragma: no cover - default always matches a tier
+            f"{field_name}: no candidate matched any precedence tier"
+        )
+    return winner
 
 
 class PackConflictError(ValueError):
@@ -432,6 +483,37 @@ def detect_pack_conflicts(
     conflict is detected first never depends on ``pack_assignments`` input
     order ("pack order never decides semantics").
     """
+    _validate_explicit_overrides(explicit_overrides)
+    by_field = _collect_pack_assignments(pack_assignments)
+
+    for field_name in sorted(by_field):
+        if field_name in explicit_overrides:
+            continue
+        contributors = by_field[field_name]
+        # Same runtime-type-blind collision _value_identity_key documents
+        # for resolve_field's tier/legacy-alias comparisons: a plain
+        # `{value for _, value in contributors}` would treat
+        # ContractMode.PUBLIC and the raw string "public" as one value
+        # (ContractMode subclasses str, so they hash/compare equal),
+        # silently picking whichever pack happened to be sorted first
+        # instead of flagging the genuine pack-vs-pack disagreement.
+        if len({_value_identity_key(value) for _, value in contributors}) > 1:
+            raise PackConflictError(field_name, contributors)
+
+
+def _validate_explicit_overrides(
+    explicit_overrides: Mapping[str, Hashable],
+) -> None:
+    """Reject an ``explicit_overrides`` mapping this function cannot trust.
+
+    Three separate annotation-isn't-runtime-enforced gaps, each found
+    independently (Codex review): the collection shape, its key types, and
+    its value hashability. All three matter because the only use downstream
+    is a key-only ``field_name in explicit_overrides`` membership test, which
+    silently succeeds on a list, on non-``str`` keys, and on an unhashable
+    value -- each of which would exempt a field from conflict detection
+    without any real override ever having been supplied.
+    """
     # The `Mapping[str, Hashable]` annotation isn't runtime-enforced -- an
     # untyped pack adapter passing a plain collection (e.g.
     # explicit_overrides=["exit_code_scheme"]) was previously accepted
@@ -478,6 +560,20 @@ def detect_pack_conflicts(
                 f"{override_field_name!r} must be hashable, not "
                 f"{override_value!r} ({exc})."
             ) from exc
+
+
+def _collect_pack_assignments(
+    pack_assignments: Sequence[tuple[ImmutableIdentity, Mapping[str, Hashable]]],
+) -> dict[str, list[tuple[ImmutableIdentity, Hashable]]]:
+    """Group every selected pack's assignments by field name, validating each.
+
+    Same class of guard as :func:`_validate_explicit_overrides`, applied to the
+    pack side: an untyped pack-manifest adapter supplying a bare identity, a
+    non-mapping assignment block, a non-``str`` field key, or an unhashable
+    value would otherwise crash later with an uncontextualized ``AttributeError``
+    / ``TypeError`` instead of the deliberate configuration error naming the
+    pack and field responsible (Codex review, four rounds).
+    """
     by_field: dict[str, list[tuple[ImmutableIdentity, Hashable]]] = {}
     for identity, assignments in pack_assignments:
         # A future untyped pack-manifest adapter supplying a bare/decoded
@@ -505,47 +601,41 @@ def detect_pack_conflicts(
                 f"{identity!r})."
             )
         for field_name, value in assignments.items():
-            # A non-str field/ChangeKind-slug key (e.g. an untyped pack
-            # adapter supplying {2: "legacy"}) previously reached
-            # sorted(by_field) unvalidated below, crashing with "TypeError:
-            # '<' not supported between instances of 'int' and 'str'"
-            # instead of the deliberate PackConflictError this function
-            # exists to raise (Codex review).
-            if not isinstance(field_name, str):
-                raise TypeError(
-                    "detect_pack_conflicts: every assignment key must be a "
-                    f"str, not {field_name!r} (from pack {identity!r})."
-                )
-            # An untyped pack adapter supplying a decoded collection-valued
-            # assignment (e.g. {"contract.overlays": ["api"]}) previously
-            # reached the `{value for _, value in contributors}` set
-            # comprehension below unvalidated, crashing with an
-            # uncontextualized "TypeError: unhashable type: 'list'" instead
-            # of a message identifying which pack/field caused it --
-            # FieldCandidate.__post_init__ guards this same
-            # annotation-isn't-runtime-enforced gap for individual
-            # candidates, but this separate pack-conflict path wasn't
-            # covered (Codex review).
-            try:
-                hash(value)
-            except TypeError as exc:
-                raise TypeError(
-                    "detect_pack_conflicts: assignment value for field "
-                    f"{field_name!r} from pack {identity!r} must be "
-                    f"hashable, not {value!r} ({exc})."
-                ) from exc
+            _reject_invalid_assignment(identity, field_name, value)
             by_field.setdefault(field_name, []).append((identity, value))
+    return by_field
 
-    for field_name in sorted(by_field):
-        if field_name in explicit_overrides:
-            continue
-        contributors = by_field[field_name]
-        # Same runtime-type-blind collision _value_identity_key documents
-        # for resolve_field's tier/legacy-alias comparisons: a plain
-        # `{value for _, value in contributors}` would treat
-        # ContractMode.PUBLIC and the raw string "public" as one value
-        # (ContractMode subclasses str, so they hash/compare equal),
-        # silently picking whichever pack happened to be sorted first
-        # instead of flagging the genuine pack-vs-pack disagreement.
-        if len({_value_identity_key(value) for _, value in contributors}) > 1:
-            raise PackConflictError(field_name, contributors)
+
+def _reject_invalid_assignment(
+    identity: ImmutableIdentity, field_name: object, value: object
+) -> None:
+    """Reject one pack assignment entry this function cannot group or compare."""
+    # A non-str field/ChangeKind-slug key (e.g. an untyped pack
+    # adapter supplying {2: "legacy"}) previously reached
+    # sorted(by_field) unvalidated below, crashing with "TypeError:
+    # '<' not supported between instances of 'int' and 'str'"
+    # instead of the deliberate PackConflictError this function
+    # exists to raise (Codex review).
+    if not isinstance(field_name, str):
+        raise TypeError(
+            "detect_pack_conflicts: every assignment key must be a "
+            f"str, not {field_name!r} (from pack {identity!r})."
+        )
+    # An untyped pack adapter supplying a decoded collection-valued
+    # assignment (e.g. {"contract.overlays": ["api"]}) previously
+    # reached the `{value for _, value in contributors}` set
+    # comprehension below unvalidated, crashing with an
+    # uncontextualized "TypeError: unhashable type: 'list'" instead
+    # of a message identifying which pack/field caused it --
+    # FieldCandidate.__post_init__ guards this same
+    # annotation-isn't-runtime-enforced gap for individual
+    # candidates, but this separate pack-conflict path wasn't
+    # covered (Codex review).
+    try:
+        hash(value)
+    except TypeError as exc:
+        raise TypeError(
+            "detect_pack_conflicts: assignment value for field "
+            f"{field_name!r} from pack {identity!r} must be "
+            f"hashable, not {value!r} ({exc})."
+        ) from exc

--- a/abicheck/diff_wheel_deployment.py
+++ b/abicheck/diff_wheel_deployment.py
@@ -328,128 +328,140 @@ def check_wheel_tag_architecture_mismatch(
         return []
     claimed = claimed.lower()
     if elf is not None:
-        elf_machine = getattr(elf, "machine", "")
-        if elf_machine:
-            expected = _ARCH_CLAIM_TO_ELF_MACHINE.get(claimed)
-            if expected is None:
-                return []
-            if elf_machine not in expected:
-                return [
-                    make_change(
-                        ChangeKind.WHEEL_TAG_ARCHITECTURE_MISMATCH,
-                        symbol="<platform-baseline>",
-                        name=getattr(elf, "soname", "") or "<binary>",
-                        detail="architecture",
-                        old=claimed,
-                        new=elf_machine,
-                    )
-                ]
-            expected_ei_data = _ARCH_CLAIM_TO_ELF_EI_DATA.get(claimed)
-            elf_ei_data = getattr(elf, "ei_data", "")
-            if (
-                expected_ei_data is not None
-                and elf_ei_data
-                and elf_ei_data != expected_ei_data
-            ):
-                return [
-                    make_change(
-                        ChangeKind.WHEEL_TAG_ARCHITECTURE_MISMATCH,
-                        symbol="<platform-baseline>",
-                        name=getattr(elf, "soname", "") or "<binary>",
-                        detail="architecture",
-                        old=claimed,
-                        new=f"{elf_machine} ({elf_ei_data})",
-                    )
-                ]
-            expected_class = _ARCH_CLAIM_TO_ELF_CLASS.get(claimed)
-            elf_class = getattr(elf, "elf_class", 64)
-            if expected_class is not None and elf_class != expected_class:
-                # riscv64/loongarch64/s390x share one e_machine value across
-                # both word sizes (RV32/RV64, LoongArch32/64, 31/32-bit
-                # S/390 vs. 64-bit s390x) — a 32-bit ELF would otherwise
-                # pass a "*64" claim purely because e_machine matched
-                # (Codex review #583).
-                return [
-                    make_change(
-                        ChangeKind.WHEEL_TAG_ARCHITECTURE_MISMATCH,
-                        symbol="<platform-baseline>",
-                        name=getattr(elf, "soname", "") or "<binary>",
-                        detail="architecture",
-                        old=claimed,
-                        new=f"{elf_machine} ({elf_class}-bit)",
-                    )
-                ]
-            if claimed == "armv7l":
-                # manylinux's armv7l tag specifically means the hard-float
-                # armhf ABI: EABI version 5 AND EF_ARM_ABI_FLOAT_HARD
-                # (packaging._manylinux._is_linux_armhf) — a soft-float
-                # binary, a binary with neither float-ABI e_flags bit set,
-                # or a hard-float binary built against an older EABI (e.g.
-                # eabi4) all share the same e_machine/EI_DATA but cannot
-                # satisfy an armv7l-tagged wheel's runtime expectations.
-                # _decode_abi_flags always evaluates both the float e_flags
-                # bits AND the EABI-version field for EM_ARM, so once
-                # abi_flags is non-empty at all (decode actually ran), a
-                # missing "float-hard" token, or a missing "eabiN" token
-                # (which means the real e_flags EABI-version field is
-                # exactly 0 — GNU/"bare" EABI, not 5), is definitive
-                # contradicting evidence, not merely an absence of
-                # confirming evidence — only a fully empty abi_flags (no
-                # decode ran at all, e.g. a legacy/undecoded snapshot)
-                # degrades safely and skips the check entirely (Codex
-                # review #583, four rounds).
-                abi_flags: frozenset[str] = getattr(elf, "abi_flags", frozenset())
-                violation: str | None = None
-                if abi_flags:
-                    if "float-hard" in abi_flags:
-                        eabi_tokens = sorted(
-                            t for t in abi_flags if t.startswith("eabi")
-                        )
-                        if "eabi5" not in eabi_tokens:
-                            violation = eabi_tokens[0] if eabi_tokens else "eabi0"
-                    elif "float-soft" in abi_flags:
-                        violation = "soft-float"
-                    else:
-                        violation = "no hard-float ABI marker"
-                if violation is not None:
-                    return [
-                        make_change(
-                            ChangeKind.WHEEL_TAG_ARCHITECTURE_MISMATCH,
-                            symbol="<platform-baseline>",
-                            name=getattr(elf, "soname", "") or "<binary>",
-                            detail="architecture",
-                            old=claimed,
-                            new=f"{elf_machine} ({violation})",
-                        )
-                    ]
-            return []
+        elf_result = _elf_arch_mismatch(elf, claimed)
+        if elf_result is not None:
+            return elf_result
     if macho is not None:
-        cpu_type = getattr(macho, "cpu_type", "")
-        # cpu_types (all slices) is the primary evidence; cpu_type (the
-        # single host-selected slice) is only a fallback for a snapshot
-        # predating that field. Checking `cpu_type` truthiness first would
-        # bypass a snapshot that has `cpu_types` populated but an empty
-        # `cpu_type` (Codex review #583).
-        slices: list[str] = getattr(macho, "cpu_types", None) or (
-            [cpu_type] if cpu_type else []
-        )
-        if slices:
-            expected = _ARCH_CLAIM_TO_MACHO_CPU_TYPE.get(claimed)
-            if expected is None:
-                return []
-            if any(s.upper() in expected for s in slices):
-                return []
-            return [
-                make_change(
-                    ChangeKind.WHEEL_TAG_ARCHITECTURE_MISMATCH,
-                    symbol="<platform-baseline>",
-                    name=macho.install_name or "<binary>",
-                    detail="architecture",
-                    old=claimed,
-                    new=", ".join(slices),
-                )
-            ]
+        return _macho_arch_mismatch(macho, claimed)
     return []
+
+
+def _arch_mismatch(name: str, claimed: str, observed: str) -> list[Change]:
+    """The one finding every architecture check here produces, differing only
+    in what it observed."""
+    return [
+        make_change(
+            ChangeKind.WHEEL_TAG_ARCHITECTURE_MISMATCH,
+            symbol="<platform-baseline>",
+            name=name,
+            detail="architecture",
+            old=claimed,
+            new=observed,
+        )
+    ]
+
+
+def _armv7l_abi_violation(abi_flags: frozenset[str]) -> str | None:
+    """Why *abi_flags* fails manylinux's ``armv7l`` (armhf) tag, or ``None``.
+
+    That tag specifically means the hard-float armhf ABI: EABI version 5 AND
+    EF_ARM_ABI_FLOAT_HARD (``packaging._manylinux._is_linux_armhf``). A
+    soft-float binary, one with neither float-ABI e_flags bit set, or a
+    hard-float binary built against an older EABI (e.g. eabi4) all share the
+    same e_machine/EI_DATA but cannot satisfy an armv7l-tagged wheel's runtime
+    expectations.
+
+    ``_decode_abi_flags`` always evaluates both the float e_flags bits AND the
+    EABI-version field for EM_ARM, so once *abi_flags* is non-empty at all
+    (decode actually ran) a missing ``"float-hard"`` token, or a missing
+    ``"eabiN"`` token (meaning the real EABI-version field is exactly 0 --
+    GNU/"bare" EABI, not 5), is definitive contradicting evidence, not merely
+    an absence of confirming evidence. Only a fully empty *abi_flags* (no
+    decode ran at all, e.g. a legacy/undecoded snapshot) degrades safely and
+    skips the check entirely (Codex review #583, four rounds).
+    """
+    if not abi_flags:
+        return None
+    if "float-hard" not in abi_flags:
+        return "soft-float" if "float-soft" in abi_flags else "no hard-float ABI marker"
+    eabi_tokens = sorted(t for t in abi_flags if t.startswith("eabi"))
+    if "eabi5" in eabi_tokens:
+        return None
+    return eabi_tokens[0] if eabi_tokens else "eabi0"
+
+
+def _elf_arch_mismatch(elf: ElfMetadata, claimed: str) -> list[Change] | None:
+    """The ELF half: ``e_machine``, then byte order, word size and armhf ABI.
+
+    Returns ``None`` -- distinct from ``[]`` -- when this ELF records no
+    machine at all, so the caller falls through to the Mach-O evidence rather
+    than concluding the claim is satisfied.
+    """
+    elf_machine = getattr(elf, "machine", "")
+    if not elf_machine:
+        return None
+    name = getattr(elf, "soname", "") or "<binary>"
+    expected = _ARCH_CLAIM_TO_ELF_MACHINE.get(claimed)
+    if expected is None:
+        return []
+    if elf_machine not in expected:
+        return _arch_mismatch(name, claimed, elf_machine)
+
+    observed = _elf_byte_order_or_word_size_violation(elf, claimed, elf_machine)
+    if observed is not None:
+        return _arch_mismatch(name, claimed, observed)
+
+    if claimed == "armv7l":
+        violation = _armv7l_abi_violation(getattr(elf, "abi_flags", frozenset()))
+        if violation is not None:
+            return _arch_mismatch(name, claimed, f"{elf_machine} ({violation})")
+    return []
+
+
+def _elf_byte_order_or_word_size_violation(
+    elf: ElfMetadata, claimed: str, elf_machine: str
+) -> str | None:
+    """What contradicts *claimed* beyond ``e_machine``, spelled for the finding.
+
+    A matching ``e_machine`` alone proves neither byte order nor word size.
+    ``ppc64``/``ppc64le`` share one ``e_machine`` value, and even an
+    unambiguous one (``x86_64``, always little-endian) could pass a claim it
+    does not satisfy if the captured evidence carries the opposite endianness
+    -- a strong signal of a corrupted or misidentified snapshot. Likewise
+    ``riscv64``/``loongarch64``/``s390x`` each share one ``e_machine`` across a
+    32- and a 64-bit variant, as do ``x86_64``/``aarch64`` via the x86-64 x32
+    and AArch64 ILP32 ABIs -- distinct, non-interchangeable ABIs a plain
+    64-bit claim must reject, distinguished only by ``elf_class`` (Codex review
+    #583). ``i686``/``armv7l`` are deliberately absent from
+    :data:`_ARCH_CLAIM_TO_ELF_CLASS`, where the field's 64 default would
+    false-positive an unset-``elf_class`` legacy snapshot.
+    """
+    expected_ei_data = _ARCH_CLAIM_TO_ELF_EI_DATA.get(claimed)
+    elf_ei_data = getattr(elf, "ei_data", "")
+    if expected_ei_data is not None and elf_ei_data and elf_ei_data != expected_ei_data:
+        return f"{elf_machine} ({elf_ei_data})"
+    expected_class = _ARCH_CLAIM_TO_ELF_CLASS.get(claimed)
+    elf_class = getattr(elf, "elf_class", 64)
+    if expected_class is not None and elf_class != expected_class:
+        return f"{elf_machine} ({elf_class}-bit)"
+    return None
+
+
+def _macho_arch_mismatch(macho: MachoMetadata, claimed: str) -> list[Change]:
+    """The Mach-O half, checked against EVERY slice a fat binary carries.
+
+    :attr:`MachoMetadata.cpu_type` is only the one slice
+    ``parse_macho_metadata`` selected for the host running abicheck (arm64
+    preferred on Apple Silicon, x86_64 otherwise) -- not necessarily the slice
+    the wheel tag claims, so a single-arch tag on a still-fat binary would
+    false-positive purely on which host ran the parse. ``cpu_types`` (all
+    slices) is the primary evidence and ``cpu_type`` only a fallback for a
+    snapshot predating that field; checking ``cpu_type`` truthiness first would
+    bypass a snapshot with ``cpu_types`` populated but an empty ``cpu_type``
+    (Codex review #583).
+    """
+    cpu_type = getattr(macho, "cpu_type", "")
+    slices: list[str] = getattr(macho, "cpu_types", None) or (
+        [cpu_type] if cpu_type else []
+    )
+    if not slices:
+        return []
+    expected = _ARCH_CLAIM_TO_MACHO_CPU_TYPE.get(claimed)
+    if expected is None:
+        return []
+    if any(s.upper() in expected for s in slices):
+        return []
+    return _arch_mismatch(macho.install_name or "<binary>", claimed, ", ".join(slices))
 
 
 def _elf_rpath_entries(elf: ElfMetadata) -> list[str]:

--- a/changelog.d/20260810_100000_claude_codefactor_complexity_resolver.md
+++ b/changelog.d/20260810_100000_claude_codefactor_complexity_resolver.md
@@ -1,0 +1,12 @@
+### Changed
+
+- **Split the two CodeFactor "Complex Method" findings in the ADR-049 field
+  resolver.** `compatibility_evaluation_resolver.resolve_field` now delegates to
+  `_reject_unresolvable_candidates`, `_shadowed_legacy_candidate` and
+  `_winning_candidate` — one per D7 rule it enforces — leaving the entry point as
+  the resolve-then-record-provenance shape it describes.
+  `detect_pack_conflicts` splits its three layers of
+  annotation-isn't-runtime-enforced input validation into
+  `_validate_explicit_overrides`, `_collect_pack_assignments` and
+  `_reject_invalid_assignment`, so D8's actual conflict rule is no longer buried
+  under them. Behaviour-preserving.

--- a/changelog.d/20260810_100000_claude_codefactor_complexity_resolver.md
+++ b/changelog.d/20260810_100000_claude_codefactor_complexity_resolver.md
@@ -10,3 +10,12 @@
   `_validate_explicit_overrides`, `_collect_pack_assignments` and
   `_reject_invalid_assignment`, so D8's actual conflict rule is no longer buried
   under them. Behaviour-preserving.
+- **Split `diff_wheel_deployment.check_wheel_tag_architecture_mismatch`.** The
+  ELF and Mach-O halves are now `_elf_arch_mismatch` / `_macho_arch_mismatch`,
+  with the byte-order/word-size evidence and the armhf ABI rule as their own
+  named checks and the five identical finding constructions folded into one
+  `_arch_mismatch`. Behaviour-preserving, checked differentially against the
+  pre-refactor implementation over 94,083 runs (every architecture claim x
+  e_machine x byte order x word size x ARM ABI-flag set x Mach-O slice shape) —
+  no differences.
+


### PR DESCRIPTION
## Summary

Batch 5c of the CodeFactor "Complex Method" series: three findings across the ADR-049 field resolver and the G27 wheel-tag architecture check. All behaviour-preserving.

## Motivation

Continues #693 / #694 / #695 / #696 (merged), #697 and #701 (open). These three are self-contained and touch no file the other open PRs do, so they land independently.

## Changes

| Function | Score | mccabe before | after |
|---|---|---|---|
| `diff_wheel_deployment.check_wheel_tag_architecture_mismatch` | 21 | 19 | <8 |
| `compatibility_evaluation_resolver.resolve_field` | 16 | 14 | <8 |
| `compatibility_evaluation_resolver.detect_pack_conflicts` | 16 | 16 | <8 |

**`resolve_field`** enforced four separate D7 rules in one body — layer validity, run-profile scoping, the explicit-vs-legacy-alias conflict, and the per-tier winner search that must check *every* populated tier rather than only the winning one. Each is now its own function (`_reject_unresolvable_candidates`, `_shadowed_legacy_candidate`, `_winning_candidate`), leaving the entry point as the resolve-then-record-provenance shape its docstring describes.

**`detect_pack_conflicts`** had D8's actual rule — two packs assigning different values to one field — buried under three layers of annotation-isn't-runtime-enforced input validation, each added by its own review round. Those move to `_validate_explicit_overrides`, `_collect_pack_assignments` and `_reject_invalid_assignment`, so the conflict check is what the function reads as again.

**`check_wheel_tag_architecture_mismatch`** held the ELF evidence chain (`e_machine`, then byte order, word size and the armhf ABI rule), the Mach-O fat-slice check, and five separate constructions of the same finding differing only in what they observed. `_elf_arch_mismatch` / `_macho_arch_mismatch` take a half each; `_elf_byte_order_or_word_size_violation` and `_armv7l_abi_violation` take the two evidence rules `e_machine` alone cannot decide; `_arch_mismatch` is the finding all five sites were spelling out.

One detail worth a reviewer's eye: `_elf_arch_mismatch` returns `None` — distinct from `[]` — when the ELF records no machine at all. That is what keeps the caller falling through to the Mach-O evidence instead of concluding the claim was satisfied, matching the original's control flow exactly.

## Verification

`check_wheel_tag_architecture_mismatch` has intricate branching, so it was checked differentially against its pre-refactor implementation over **94,083 runs** — 10 architecture claims × 8 `e_machine` values × 3 `EI_DATA` values × 2 ELF classes × 7 ARM ABI-flag sets × 7 Mach-O slice shapes × 4 elf/macho presence combinations, plus the no-floors cases — comparing full finding tuples. **0 differences.**

The two resolver functions are straight extractions with no reordering; the module's 1,622 existing tests cover them.

Plus the full fast suite (23335 passed), `ruff check`/`format`, `python -m mypy abicheck/` clean across 337 files, and `scripts/check_ai_readiness.py` at 0 errors.

## Checklist

- [x] Tests added / updated for new behaviour — n/a, refactor-only; the differential check above plus the existing suites are the regression check
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [x] Docs updated if user-visible behaviour changed — n/a, no user-visible change
- [x] `pre-commit run --all-files` passes locally — `ruff check`/`ruff format --check` and `scripts/check_ai_readiness.py` (0 errors) clean
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q)_