### PR TITLE
refactor: split the aggregate text renderer and the ADR-049 contract evaluator

### DIFF
--- a/abicheck/aggregate.py
+++ b/abicheck/aggregate.py
@@ -953,19 +953,35 @@ class AggregateResult:
         lines.append("Compatibility:")
         lines.append("  " + self._render_compatibility_line())
 
+        lines.extend(self._render_contract_coverage_lines())
+        lines.extend(self._render_profile_matrix_lines())
+        lines.extend(render_finding_matrix_lines(self.finding_matrix))
+
+        lines.extend(self._render_coverage_and_gate_lines())
+
+        return "\n".join(lines)
+
+    def _render_contract_coverage_lines(self) -> list[str]:
+        """The ADR-049 contract-coverage block, empty when every domain closed.
+
+        Named separately from the required-target coverage line for the same
+        reason the JSON block is: a bare exit 1 with neither of them explained
+        is the failure this axis most easily causes.
+        """
+        out: list[str] = []
         # Named separately from the required-target coverage line above for
         # the same reason the JSON block is: a bare exit 1 with neither of
         # them explained is the failure this axis most easily causes.
         incomplete = self.contract_coverage_targets
         if incomplete:
-            lines.append("")
-            lines.append("Contract coverage:")
+            out.append("")
+            out.append("Contract coverage:")
             # The contribution is stated separately from the target list
             # rather than folded into one clause: with `contract.unresolved=
             # warn` a listed target contributes 0, so "incomplete on X —
             # contributes 0" would read as a contradiction rather than as the
             # acceptance it is.
-            lines.append(f"  incomplete on {', '.join(incomplete)}")
+            out.append(f"  incomplete on {', '.join(incomplete)}")
             accepted = tuple(
                 t.target_id
                 for t in list(self.analyzed) + list(self._gated_unexpected)
@@ -981,91 +997,104 @@ class AggregateResult:
                 # _neutralize_gate`), and this side cannot tell them apart --
                 # both look like "declared 0 with failures listed". Naming
                 # one of them was wrong for the other (Codex review).
-                lines.append(
+                out.append(
                     f"  not gated on {', '.join(sorted(accepted))} "
                     "(that run contributed 0; listed, not gated)"
                 )
-            lines.append(
+            out.append(
                 f"  contributes {self.contract_coverage_exit} to the exit code "
                 "(ADR-049 contract-coverage axis)"
             )
 
+        return out
+
+    def _render_profile_matrix_lines(self) -> list[str]:
+        """The per-base-target profile matrix, empty when no profiles ran."""
+        out: list[str] = []
         matrix = self.profile_matrix
         if matrix:
-            lines.append("")
-            lines.append("Profile matrix:")
+            out.append("")
+            out.append("Profile matrix:")
             for entry in matrix:
-                unanalyzed = entry.unanalyzed_profiles
-                if entry.affected_profiles:
-                    line = (
-                        f"  {entry.base_target}: affected on "
-                        f"{', '.join(entry.affected_profiles)} "
-                        f"(checked on {', '.join(entry.profiles)})"
-                    )
-                    if unanalyzed:
-                        # An affected profile and an unanalyzed one can
-                        # coexist on the same target -- don't let "checked
-                        # on" imply the unanalyzed one produced a result too
-                        # (Codex review).
-                        line += f"; no analyzed result on {', '.join(unanalyzed)}"
-                elif not unanalyzed:
-                    line = (
-                        f"  {entry.base_target}: clean on all checked profiles "
-                        f"({', '.join(entry.profiles)})"
-                    )
-                elif len(unanalyzed) < len(entry.profiles):
-                    # Some profiles are clean, others never produced an
-                    # analyzed result at all -- never call the latter
-                    # "clean" (Codex review).
-                    clean = [p for p in entry.profiles if p not in unanalyzed]
-                    line = (
-                        f"  {entry.base_target}: clean on {', '.join(clean)} "
-                        f"(checked on {', '.join(entry.profiles)}); "
-                        f"no analyzed result on {', '.join(unanalyzed)}"
-                    )
-                else:
-                    line = (
-                        f"  {entry.base_target}: no analyzed result on any "
-                        f"checked profile ({', '.join(entry.profiles)})"
-                    )
-                if entry.incomplete_profiles:
-                    line += (
-                        f" [incomplete coverage on "
-                        f"{', '.join(entry.incomplete_profiles)}]"
-                    )
-                if entry.contract_incomplete_profiles:
-                    # Qualifies whatever precedes it, exactly as the
-                    # incomplete-coverage suffix above does -- including a
-                    # "clean" line, which stays accurate: clean is a
-                    # statement about compatibility, and this is the
-                    # orthogonal evidence axis saying the domain never
-                    # closed. Without it a profile that raised the exit to 1
-                    # on contract coverage alone read as flatly clean.
-                    line += (
-                        f" [contract evidence incomplete on "
-                        f"{', '.join(entry.contract_incomplete_profiles)}]"
-                    )
-                lines.append(line)
+                out.append(self._render_profile_entry_line(entry))
 
-        lines.extend(render_finding_matrix_lines(self.finding_matrix))
+        return out
 
-        lines.append("Coverage:")
+    def _render_profile_entry_line(self, entry: ProfileMatrixEntry) -> str:
+        """One base target's row in the profile matrix.
+
+        Four mutually exclusive shapes -- affected, clean everywhere, partly
+        clean with some profile never producing an analyzed result, and
+        nothing analyzed at all -- then two independent suffixes that qualify
+        whichever shape was chosen.
+        """
+        unanalyzed = entry.unanalyzed_profiles
+        if entry.affected_profiles:
+            line = (
+                f"  {entry.base_target}: affected on "
+                f"{', '.join(entry.affected_profiles)} "
+                f"(checked on {', '.join(entry.profiles)})"
+            )
+            if unanalyzed:
+                # An affected profile and an unanalyzed one can
+                # coexist on the same target -- don't let "checked
+                # on" imply the unanalyzed one produced a result too
+                # (Codex review).
+                line += f"; no analyzed result on {', '.join(unanalyzed)}"
+        elif not unanalyzed:
+            line = (
+                f"  {entry.base_target}: clean on all checked profiles "
+                f"({', '.join(entry.profiles)})"
+            )
+        elif len(unanalyzed) < len(entry.profiles):
+            # Some profiles are clean, others never produced an
+            # analyzed result at all -- never call the latter
+            # "clean" (Codex review).
+            clean = [p for p in entry.profiles if p not in unanalyzed]
+            line = (
+                f"  {entry.base_target}: clean on {', '.join(clean)} "
+                f"(checked on {', '.join(entry.profiles)}); "
+                f"no analyzed result on {', '.join(unanalyzed)}"
+            )
+        else:
+            line = (
+                f"  {entry.base_target}: no analyzed result on any "
+                f"checked profile ({', '.join(entry.profiles)})"
+            )
+        if entry.incomplete_profiles:
+            line += f" [incomplete coverage on {', '.join(entry.incomplete_profiles)}]"
+        if entry.contract_incomplete_profiles:
+            # Qualifies whatever precedes it, exactly as the
+            # incomplete-coverage suffix above does -- including a
+            # "clean" line, which stays accurate: clean is a
+            # statement about compatibility, and this is the
+            # orthogonal evidence axis saying the domain never
+            # closed. Without it a profile that raised the exit to 1
+            # on contract coverage alone read as flatly clean.
+            line += (
+                f" [contract evidence incomplete on "
+                f"{', '.join(entry.contract_incomplete_profiles)}]"
+            )
+        return line
+
+    def _render_coverage_and_gate_lines(self) -> list[str]:
+        """The closing Coverage: and Gate: blocks."""
+        out: list[str] = []
+        out.append("Coverage:")
         if self.coverage is CoverageStatus.COMPLETE:
-            lines.append("  Complete — every required target was analyzed.")
+            out.append("  Complete — every required target was analyzed.")
         else:
             missing = ", ".join(self.missing_required) or "(none)"
             gated = "" if self.coverage_blocking else " (advisory)"
-            lines.append(
-                f"  Incomplete — required target(s) unknown: {missing}.{gated}"
-            )
+            out.append(f"  Incomplete — required target(s) unknown: {missing}.{gated}")
 
-        lines.append("Gate:")
+        out.append("Gate:")
         if self.passed:
             # Deliberately does NOT claim "coverage complete": under
             # --on-missing-required warn a required gap is reported above but
             # does not fail the gate, so a passing result can still have an
             # (advisory) coverage gap.
-            lines.append(
+            out.append(
                 "  Passed — no gate-blocking findings under the configured policies."
             )
         else:
@@ -1081,9 +1110,9 @@ class AggregateResult:
             ):
                 ids = ", ".join(t.target_id for t in self.unexpected_targets)
                 parts.append(f"unexpected target(s) present: {ids}")
-            lines.append("  Failed — " + "; ".join(parts) + ".")
+            out.append("  Failed — " + "; ".join(parts) + ".")
 
-        return "\n".join(lines)
+        return out
 
     def _render_target_line(self, t: TargetReport) -> str:
         tag = "" if t.required else " (optional)"

--- a/abicheck/contract_evaluation.py
+++ b/abicheck/contract_evaluation.py
@@ -1287,74 +1287,18 @@ def _exports_mode_decision(
     )
 
 
-def evaluate_change_contract_relevance(
+def _mode_dispatch_decision(
     change: Change,
+    mode: ContractMode,
     surf_old: PublicSurface,
     surf_new: PublicSurface,
-    *,
-    mode: ContractMode = ContractMode.PUBLIC,
-    unions: SurfaceUnions | None = None,
-    force_public_symbols: frozenset[str] | None = None,
-    public_surface_allowlist: frozenset[str] | None = None,
-    exports_old: ExportSurface | None = None,
-    exports_new: ExportSurface | None = None,
-    directly_referenced_stdlib_old: frozenset[str] | None = None,
-    directly_referenced_stdlib_new: frozenset[str] | None = None,
-) -> ContractEvaluationDecision:
-    """Compute *change*'s shadow contract-relevance decision.
-
-    ``mode`` selects the declared contract (all three ADR-049 D2 values are
-    implemented). ``surf_old``/``surf_new`` are
-    the same :class:`~abicheck.surface.PublicSurface` pair
-    ``FilterNonPublicSurface`` already computes; pass a precomputed
-    ``unions`` (:func:`~abicheck.surface.surface_unions`) when evaluating many
-    changes against the same pair, mirroring
-    :func:`~abicheck.surface.classify_change_surface`'s own guidance.
-    ``exports_old``/``exports_new`` are the corresponding
-    :class:`~abicheck.export_surface.ExportSurface` pair
-    (:func:`~abicheck.export_surface.compute_export_surface`), required when
-    and only when ``mode`` is ``EXPORTS`` -- that domain's roots are the
-    binary's own export table, evidence a ``PublicSurface`` does not carry.
-    Omitting them under ``EXPORTS`` is a caller error (``ValueError``), not a
-    silent degradation to a header-derived answer for a domain that is not
-    header-derived.
-    ``directly_referenced_stdlib_old``/``directly_referenced_stdlib_new``
-    are each side's
-    :func:`~abicheck.type_reachability.directly_referenced_stdlib_type_spellings`
-    -- see :func:`_in_surface_result_is_confirmed`'s docstring for why this
-    is a second confirmation source, independent of ``public_types``. Omit
-    them (the default) for a caller with no snapshot in scope; a `PUBLIC`
-    evaluation degrades to exactly its pre-existing behaviour, never raising.
-    ``force_public_symbols`` mirrors ``PipelineContext.force_public_symbols``
-    (ADR-024 D6's widening overlay, ``FilterNonPublicSurface``'s
-    ``_run_scope``/``_run_allowlist``) -- omit it (the default) when the
-    caller has no such overlay configured for this run. ``public_surface_allowlist``
-    mirrors ``PipelineContext.public_surface_allowlist`` (the ``--post-manifest``
-    committed-export set consulted by ``FilterNonPublicSurface._run_allowlist``)
-    -- omit it (the default) for a run with no POST manifest configured.
-
-    Never raises for a *finding* it cannot confidently classify -- every such
-    case degrades to ``UNKNOWN_UNRESOLVED`` (see the module docstring's
-    ``UNKNOWN_UNPROVEN`` rule). It raises for an entirely invalid ``mode``
-    value, and for ``EXPORTS`` without an ``ExportSurface`` pair (both
-    ``ValueError``).
+    exports_old: ExportSurface | None,
+    exports_new: ExportSurface | None,
+) -> ContractEvaluationDecision | None:
+    """The decisions settled by the finding's kind and the selected contract
+    domain alone, before any header-surface evidence is consulted. ``None``
+    when none applies and the PUBLIC path continues.
     """
-    # `ContractMode` is a `str` Enum, so an untyped caller passing the bare
-    # serialized value (e.g. `"all"` from a config/API adapter) would compare
-    # equal to a member (equality/hash) but then silently fail the
-    # `is ContractMode.ALL` identity check below, falling through to the
-    # PUBLIC path for a caller that actually asked for ALL (Codex review).
-    # Coercing through the enum constructor first (a no-op for an
-    # already-real member) means every later `is` comparison is safe.
-    mode = coerce_contract_mode(mode)
-    if mode is ContractMode.EXPORTS and (exports_old is None or exports_new is None):
-        raise ValueError(
-            "contract mode 'exports' requires an ExportSurface pair "
-            "(exports_old/exports_new, from "
-            "abicheck.export_surface.compute_export_surface) -- its roots are "
-            "the binary's own export table, which a PublicSurface does not carry"
-        )
-
     if change.kind.value in _NOT_APPLICABLE_KIND_SLUGS:
         return _not_applicable_decision()
 
@@ -1392,8 +1336,21 @@ def evaluate_change_contract_relevance(
 
     if mode is ContractMode.ALL:
         return _all_mode_decision()
+    return None
 
-    # mode is ContractMode.PUBLIC from here on.
+
+def _pipeline_authority_decision(
+    change: Change,
+    surf_old: PublicSurface,
+    surf_new: PublicSurface,
+    *,
+    force_public_symbols: frozenset[str] | None,
+    public_surface_allowlist: frozenset[str] | None,
+) -> ContractEvaluationDecision | None:
+    """Decisions an earlier pipeline step already made authoritatively, which a
+    from-scratch ``classify_change_surface`` recomputation here cannot see and
+    could contradict. ``None`` when none applies.
+    """
     # A finding already demoted to the audit ledger by an earlier pipeline
     # step (FilterNonPublicSurface / DemoteOffPythonSurface /
     # DemoteUnreachableInternalChurn, post_processing.py) already carries
@@ -1493,28 +1450,22 @@ def evaluate_change_contract_relevance(
             reason_code="public_root_membership",
             assurance=ContractAssurance.COMPLETE,
         )
+    return None
 
-    # ADR-049 D4: "If the authoritative side is unresolved, evidence from
-    # the other side cannot manufacture confidence." Checking the
-    # *authoritative* side specifically (not "either side" -- a prior
-    # version of this gate used `surf_old.resolvable or surf_new.resolvable`,
-    # which let an unrelated resolvable *non*-authoritative side substitute
-    # for the authoritative one) -- e.g. a `FUNC_REMOVED` finding is proven
-    # by the *old* side alone (the function existed and was public there;
-    # the new side's own header availability is irrelevant to that fact),
-    # so only the old side's resolvability matters for it; a `FUNC_ADDED`
-    # finding is the mirror image, judged by the new side alone (Codex
-    # review, fresh evidence).
-    auth = _authoritative_surface(change, surf_old, surf_new)
-    if not auth.resolvable:
-        return _unresolved_decision(
-            "required_evidence_incomplete", ContractAssurance.UNAVAILABLE
-        )
 
-    identity = resolve_change_identity(change)
-    if identity.tier == IDENTITY_TIER_REDUCED:
-        return _unresolved_decision("identity_ambiguous", ContractAssurance.PARTIAL)
-
+def _surface_classification_decision(
+    change: Change,
+    surf_old: PublicSurface,
+    surf_new: PublicSurface,
+    *,
+    unions: SurfaceUnions | None,
+    directly_referenced_stdlib_old: frozenset[str] | None,
+    directly_referenced_stdlib_new: frozenset[str] | None,
+) -> ContractEvaluationDecision:
+    """The from-scratch header-surface classification, reached only once every
+    earlier authority has declined to settle the finding and both the
+    authoritative surface and the finding's identity have resolved.
+    """
     if unions is None:
         unions = surface_unions(surf_old, surf_new)
     in_surface, reason = classify_change_surface(
@@ -1546,6 +1497,122 @@ def evaluate_change_contract_relevance(
     # still be unresolvable and fall through to here, in which case
     # `classify_change_surface`'s own gate keeps it at `in_surface=True`).
     return _decision_for_surface_reason(reason or "", change, surf_old, surf_new)
+
+
+def evaluate_change_contract_relevance(
+    change: Change,
+    surf_old: PublicSurface,
+    surf_new: PublicSurface,
+    *,
+    mode: ContractMode = ContractMode.PUBLIC,
+    unions: SurfaceUnions | None = None,
+    force_public_symbols: frozenset[str] | None = None,
+    public_surface_allowlist: frozenset[str] | None = None,
+    exports_old: ExportSurface | None = None,
+    exports_new: ExportSurface | None = None,
+    directly_referenced_stdlib_old: frozenset[str] | None = None,
+    directly_referenced_stdlib_new: frozenset[str] | None = None,
+) -> ContractEvaluationDecision:
+    """Compute *change*'s shadow contract-relevance decision.
+
+    ``mode`` selects the declared contract (all three ADR-049 D2 values are
+    implemented). ``surf_old``/``surf_new`` are
+    the same :class:`~abicheck.surface.PublicSurface` pair
+    ``FilterNonPublicSurface`` already computes; pass a precomputed
+    ``unions`` (:func:`~abicheck.surface.surface_unions`) when evaluating many
+    changes against the same pair, mirroring
+    :func:`~abicheck.surface.classify_change_surface`'s own guidance.
+    ``exports_old``/``exports_new`` are the corresponding
+    :class:`~abicheck.export_surface.ExportSurface` pair
+    (:func:`~abicheck.export_surface.compute_export_surface`), required when
+    and only when ``mode`` is ``EXPORTS`` -- that domain's roots are the
+    binary's own export table, evidence a ``PublicSurface`` does not carry.
+    Omitting them under ``EXPORTS`` is a caller error (``ValueError``), not a
+    silent degradation to a header-derived answer for a domain that is not
+    header-derived.
+    ``directly_referenced_stdlib_old``/``directly_referenced_stdlib_new``
+    are each side's
+    :func:`~abicheck.type_reachability.directly_referenced_stdlib_type_spellings`
+    -- see :func:`_in_surface_result_is_confirmed`'s docstring for why this
+    is a second confirmation source, independent of ``public_types``. Omit
+    them (the default) for a caller with no snapshot in scope; a `PUBLIC`
+    evaluation degrades to exactly its pre-existing behaviour, never raising.
+    ``force_public_symbols`` mirrors ``PipelineContext.force_public_symbols``
+    (ADR-024 D6's widening overlay, ``FilterNonPublicSurface``'s
+    ``_run_scope``/``_run_allowlist``) -- omit it (the default) when the
+    caller has no such overlay configured for this run. ``public_surface_allowlist``
+    mirrors ``PipelineContext.public_surface_allowlist`` (the ``--post-manifest``
+    committed-export set consulted by ``FilterNonPublicSurface._run_allowlist``)
+    -- omit it (the default) for a run with no POST manifest configured.
+
+    Never raises for a *finding* it cannot confidently classify -- every such
+    case degrades to ``UNKNOWN_UNRESOLVED`` (see the module docstring's
+    ``UNKNOWN_UNPROVEN`` rule). It raises for an entirely invalid ``mode``
+    value, and for ``EXPORTS`` without an ``ExportSurface`` pair (both
+    ``ValueError``).
+    """
+    # `ContractMode` is a `str` Enum, so an untyped caller passing the bare
+    # serialized value (e.g. `"all"` from a config/API adapter) would compare
+    # equal to a member (equality/hash) but then silently fail the
+    # `is ContractMode.ALL` identity check below, falling through to the
+    # PUBLIC path for a caller that actually asked for ALL (Codex review).
+    # Coercing through the enum constructor first (a no-op for an
+    # already-real member) means every later `is` comparison is safe.
+    mode = coerce_contract_mode(mode)
+    if mode is ContractMode.EXPORTS and (exports_old is None or exports_new is None):
+        raise ValueError(
+            "contract mode 'exports' requires an ExportSurface pair "
+            "(exports_old/exports_new, from "
+            "abicheck.export_surface.compute_export_surface) -- its roots are "
+            "the binary's own export table, which a PublicSurface does not carry"
+        )
+
+    mode_decision = _mode_dispatch_decision(
+        change, mode, surf_old, surf_new, exports_old, exports_new
+    )
+    if mode_decision is not None:
+        return mode_decision
+
+    # mode is ContractMode.PUBLIC from here on.
+    pipeline_decision = _pipeline_authority_decision(
+        change,
+        surf_old,
+        surf_new,
+        force_public_symbols=force_public_symbols,
+        public_surface_allowlist=public_surface_allowlist,
+    )
+    if pipeline_decision is not None:
+        return pipeline_decision
+
+    # ADR-049 D4: "If the authoritative side is unresolved, evidence from
+    # the other side cannot manufacture confidence." Checking the
+    # *authoritative* side specifically (not "either side" -- a prior
+    # version of this gate used `surf_old.resolvable or surf_new.resolvable`,
+    # which let an unrelated resolvable *non*-authoritative side substitute
+    # for the authoritative one) -- e.g. a `FUNC_REMOVED` finding is proven
+    # by the *old* side alone (the function existed and was public there;
+    # the new side's own header availability is irrelevant to that fact),
+    # so only the old side's resolvability matters for it; a `FUNC_ADDED`
+    # finding is the mirror image, judged by the new side alone (Codex
+    # review, fresh evidence).
+    auth = _authoritative_surface(change, surf_old, surf_new)
+    if not auth.resolvable:
+        return _unresolved_decision(
+            "required_evidence_incomplete", ContractAssurance.UNAVAILABLE
+        )
+
+    identity = resolve_change_identity(change)
+    if identity.tier == IDENTITY_TIER_REDUCED:
+        return _unresolved_decision("identity_ambiguous", ContractAssurance.PARTIAL)
+
+    return _surface_classification_decision(
+        change,
+        surf_old,
+        surf_new,
+        unions=unions,
+        directly_referenced_stdlib_old=directly_referenced_stdlib_old,
+        directly_referenced_stdlib_new=directly_referenced_stdlib_new,
+    )
 
 
 def evidence_refs_for_change(

--- a/changelog.d/20260810_104500_claude_codefactor_complexity_diff3.md
+++ b/changelog.d/20260810_104500_claude_codefactor_complexity_diff3.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **Split two more CodeFactor "Complex Method" findings in the aggregate text
+  report and the ADR-049 contract evaluator.**
+  `aggregate.AggregateResult.render_text` now delegates each block that can be
+  absent or take several shapes to its own renderer
+  (`_render_contract_coverage_lines`, `_render_profile_matrix_lines`,
+  `_render_profile_entry_line`, `_render_coverage_and_gate_lines`), leaving the
+  entry point as the section order it describes.
+  `contract_evaluation.evaluate_change_contract_relevance` splits its chain of
+  early-return authorities into `_mode_dispatch_decision`,
+  `_pipeline_authority_decision` and `_surface_classification_decision` — one per
+  kind of authority, applied in the same order as before. Both
+  behaviour-preserving.


### PR DESCRIPTION
## Summary

Batch 5d of the CodeFactor "Complex Method" series: two findings, both pure extractions with no reordering.

## Motivation

Continues #693 / #694 / #695 / #696 / #697 / #701 (merged) and #702 (open). Touches no file the open PR does, so it lands independently.

## Changes

| Function | Score | mccabe before | after |
|---|---|---|---|
| `aggregate.AggregateResult.render_text` | 22 | 19 | <8 |
| `contract_evaluation.evaluate_change_contract_relevance` | 18 | 15 | <8 |

**`render_text`** rendered the whole aggregate text report — header, per-target lines, compatibility, contract coverage, the profile matrix, and the closing `Coverage:`/`Gate:` blocks — appending to one `lines` list throughout, so every section's branching counted against the same function. Each block that can be absent or take several shapes now returns its own lines: `_render_contract_coverage_lines`, `_render_profile_matrix_lines`, `_render_coverage_and_gate_lines`, with `_render_profile_entry_line` taking the four mutually exclusive per-target shapes and their two qualifying suffixes.

**`evaluate_change_contract_relevance`** is a chain of early-return authorities — kind, contract domain, decisions an earlier pipeline step already made, then a from-scratch header-surface classification. Each carries the review round that established it, so the guards had grown a long way from the code they guard. Three helpers, one per kind of authority:

- `_mode_dispatch_decision` — what the finding's kind and the selected `--contract` domain settle on their own;
- `_pipeline_authority_decision` — what `FilterNonPublicSurface` and friends already decided unconditionally, which a recomputation here cannot see and could contradict;
- `_surface_classification_decision` — the from-scratch classification, reached only once every earlier authority has declined.

The entry point is left as the order those authorities apply in.

## Verification

Both are extractions with no reordering, and both have strong direct coverage, so neither needed the differential treatment the hand-rolled parsers in #697/#701 got:

- `render_text`'s output is asserted directly in **27 places** across `tests/test_aggregate.py`, `tests/test_aggregate_findings.py` and `tests/test_cli_scan_helpers_coverage.py`.
- `evaluate_change_contract_relevance` is covered by **1,639** contract tests.

Plus the full fast suite (23340 passed), `ruff check`/`format`, `python -m mypy abicheck/` clean across 338 files, and `scripts/check_ai_readiness.py` at 0 errors.

## Checklist

- [x] Tests added / updated for new behaviour — n/a, refactor-only; the existing direct coverage above is the regression check
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [x] Docs updated if user-visible behaviour changed — n/a, no user-visible change
- [x] `pre-commit run --all-files` passes locally — `ruff check`/`ruff format --check` and `scripts/check_ai_readiness.py` (0 errors) clean
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q)_