### PR TITLE
fix: isolate baseline workflow Python imports

### DIFF
--- a/.github/workflows/publish-baseline.yml
+++ b/.github/workflows/publish-baseline.yml
@@ -212,7 +212,7 @@ jobs:
           # build-output.json) still falls through to that block's "was not
           # produced" branch instead of aborting this step with a bare
           # traceback.
-          python3 -c "
+          python3 -I -c "
           import json
           import os
           from pathlib import Path
@@ -228,7 +228,7 @@ jobs:
           report = derive_baseline_libraries(build_output, directory)
           Path('baseline-libraries.json').write_text(json.dumps(report.to_dict()))
           " || true
-          python3 -c "
+          python3 -I -c "
           import json, sys
 
           try:

--- a/.github/workflows/update-main-baseline.yml
+++ b/.github/workflows/update-main-baseline.yml
@@ -235,7 +235,7 @@ jobs:
           # directly, same as publish-baseline.yml's identical step
           # (including the trailing `|| true`, matching the former CLI
           # call's own blanket tolerance for any unexpected failure here).
-          python3 -c "
+          python3 -I -c "
           import json
           import os
           from pathlib import Path
@@ -251,7 +251,7 @@ jobs:
           report = derive_baseline_libraries(build_output, directory)
           Path('baseline-libraries.json').write_text(json.dumps(report.to_dict()))
           " || true
-          python3 -c "
+          python3 -I -c "
           import json, sys
 
           try:

--- a/tests/test_publish_baseline_workflows.py
+++ b/tests/test_publish_baseline_workflows.py
@@ -358,7 +358,7 @@ class TestBaselineLibrariesDerivation:
     docstring). Not a CLI command (ADR-054): `build-output baseline-libraries`
     was a wire-format adapter for exactly this call site, not general
     project-integration CLI surface, so both workflows call
-    `derive_baseline_libraries()` directly via `python3 -c`."""
+    `derive_baseline_libraries()` directly via isolated `python3 -I -c`."""
 
     def test_publish_baseline_calls_the_library_function(self) -> None:
         data = _load(PUBLISH_BASELINE)
@@ -381,6 +381,22 @@ class TestBaselineLibrariesDerivation:
         )
         assert "derive_baseline_libraries" in step["run"]
         assert "abicheck build-output" not in step["run"]
+
+    def test_library_imports_use_isolated_python(self) -> None:
+        """The caller checkout must not shadow the installed abicheck package."""
+        for path, job_name in (
+            (PUBLISH_BASELINE, "publish"),
+            (UPDATE_MAIN_BASELINE, "refresh"),
+        ):
+            data = _load(path)
+            steps = _steps(data["jobs"][job_name])
+            step = next(
+                s
+                for s in steps
+                if s.get("name") == "Derive baseline libraries from build-output.json"
+            )
+            assert step["run"].count('python3 -I -c "') == 2
+            assert 'python3 -c "' not in step["run"]
 
     def test_libraries_output_feeds_the_baseline_action_input(self) -> None:
         for path, job_name in (


### PR DESCRIPTION
### Motivation
- The baseline reusable workflows ran inline Python with `python3 -c`, which lets the checked-out caller repository appear first on `sys.path` and thereby shadow the installed `abicheck` package, enabling import-time code execution from an attacker-controlled workspace.
- These workflows have elevated permissions (including `contents: write`) and produce/publish baseline artifacts, so import-shadowing is a high-integrity risk that must be mitigated.

### Description
- Use isolated Python mode for inline snippets by replacing `python3 -c` with `python3 -I -c` in both `/.github/workflows/publish-baseline.yml` and `/.github/workflows/update-main-baseline.yml` so the workspace is not placed first on `sys.path` during those invocations.
- Add a structural regression test in `tests/test_publish_baseline_workflows.py` that asserts the workflows invoke `derive_baseline_libraries()` via the isolated form (`python3 -I -c`) and that the vulnerable `python3 -c` form does not appear in the step text.
- Update the test docstring to reflect that the workflows call the library via isolated `python3 -I -c`.

### Testing
- Ran `pytest tests/test_publish_baseline_workflows.py -q` and all tests in that module passed (`38 passed`).
- Ran `ruff check` and `ruff format --check` on the modified test file and fixed formatting; `ruff check` passed for the test file and `ruff format` left the tree consistent after formatting.
- Ran `python scripts/check_ai_readiness.py` which passed its checks relevant to these changes.
- Attempted `python scripts/verify.py --profile pr` in the local environment; the run was incomplete due to missing tools/modules in this environment (e.g. `jsonschema`, `mkdocs`, `build`, `twine`, and pytest coverage/xdist tooling), and the profile reported other repository-wide formatting differences; the change-specific tests and linters above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a65fce0af94832bac567bb456889ee6)