### PR TITLE
fix: prevent baseline action row injection

### DIFF
--- a/actions/baseline/run.sh
+++ b/actions/baseline/run.sh
@@ -56,6 +56,15 @@ for i, e in enumerate(entries):
     if "stage_binary" in e and not isinstance(e["stage_binary"], bool):
         bad_stage_binary = e["stage_binary"]
         sys.exit(f"entry {i} has an invalid \"stage_binary\" {bad_stage_binary!r} -- must be a boolean")
+    # These strings are serialized below as newline-separated records whose
+    # fields use ASCII Unit Separator. Reject either delimiter before
+    # serialization so one field cannot inject a synthetic, unvalidated row.
+    for field in ("artifact", "header", "include"):
+        value = e.get(field, "")
+        if not isinstance(value, str):
+            sys.exit(f"entry {i} has an invalid \"{field}\" {value!r} -- must be a string")
+        if "\n" in value or "\r" in value or "\x1f" in value:
+            sys.exit(f"entry {i} has an invalid \"{field}\" {value!r} -- must not contain record delimiters")
     # Both run.sh ("$OUTPUT_DIR/$name.abicheck.json", bash string concat)
     # and build_manifest.py (output_dir / f"{name}.abicheck.json", pathlib)
     # build the per-library snapshot path directly from this string, so a

--- a/changelog.d/20260725_150000_aardvark_baseline_row_injection.md
+++ b/changelog.d/20260725_150000_aardvark_baseline_row_injection.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Reject record delimiters in baseline action artifact, header, and include
+  fields so crafted library metadata cannot inject an unvalidated output row
+  or escape the baseline output directory.

--- a/tests/test_action_baseline.py
+++ b/tests/test_action_baseline.py
@@ -172,6 +172,27 @@ class TestLibrariesJsonValidation:
         assert result.returncode == 1
         assert "entry 1" in result.stdout
 
+    @pytest.mark.parametrize("field", ["artifact", "header", "include"])
+    @pytest.mark.parametrize("delimiter", ["\n", "\r", "\x1f"])
+    def test_record_delimiter_in_field_fails(
+        self, tmp_path: Path, field: str, delimiter: str
+    ) -> None:
+        entry = {"name": "safe", "artifact": "libsafe.so"}
+        entry[field] = f"safe{delimiter}../../injected\x1fpayload.so\x1f\x1f\x1f1"
+        result, _ = _run_action({"INPUT_LIBRARIES": json.dumps([entry])}, tmp_path)
+        assert result.returncode == 1
+        assert f'invalid "{field}"' in result.stdout
+        assert "must not contain record delimiters" in result.stdout
+        assert not (tmp_path.parent / "injected.abicheck.json").exists()
+
+    @pytest.mark.parametrize("field", ["artifact", "header", "include"])
+    def test_non_string_field_fails(self, tmp_path: Path, field: str) -> None:
+        entry = {"name": "safe", "artifact": "libsafe.so", field: ["unsafe"]}
+        result, _ = _run_action({"INPUT_LIBRARIES": json.dumps([entry])}, tmp_path)
+        assert result.returncode == 1
+        assert f'invalid "{field}"' in result.stdout
+        assert "must be a string" in result.stdout
+
     def test_duplicate_library_name_fails(self, tmp_path: Path) -> None:
         # A generated matrix producing two entries with the same name would
         # otherwise have the second dump silently overwrite the first's


### PR DESCRIPTION
### Motivation

- The baseline publishing flow serialized `artifact`/`header`/`include` fields into a newline + ASCII Unit Separator (\x1f) line protocol without escaping, allowing crafted values to inject extra records and bypass the `name` path validation.
- An injected row could set `stage_binary` and cause `cp`/snapshot writes outside the intended `$OUTPUT_DIR`, creating an integrity/availability issue for CI runs consuming untrusted build-output artifacts.

### Description

- Add validation to the `actions/baseline/run.sh` upfront JSON check to require `artifact`, `header`, and `include` be strings and reject values containing newline (`\n`), carriage-return (`\r`), or ASCII Unit Separator (`\x1f`) before serialization.
- Keep existing `name` validation and duplicate-name guards; the new checks prevent field-level row injection while preserving prior semantics.
- Add parameterized regression tests in `tests/test_action_baseline.py` that cover each affected field (`artifact`, `header`, `include`), each delimiter (`\n`, `\r`, `\x1f`), and non-string field cases to ensure invalid inputs are rejected.
- Add a changelog fragment documenting the security fix.

### Testing

- Ran `pytest tests/test_action_baseline.py -q` which passed (39 passed, 5 skipped).
- Checked the modified shell script syntax with `bash -n actions/baseline/run.sh` and ran `ruff check` / `ruff format --check` on the modified test file; those checks succeeded for the touched files.
- Ran the repository `pr` profile verifier `python scripts/verify.py --profile pr`; runnable gates (lint, mypy/typecheck, AI-readiness, FP-rate, tier-accuracy, docs-contract, repo-facts, schema-sync, and use-case sync) passed, but the full `pr` profile run was incomplete in this environment due to missing optional tools and existing unrelated format drift across many files (reported by the verifier). All local tests and validations exercised for this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a64acdf9d64832bab20083ee22177d2)