### PR TITLE
refactor: split the DWARF struct-layout detector and the stdlib spelling helper

### DIFF
--- a/abicheck/diff_platform.py
+++ b/abicheck/diff_platform.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .binary_utils import strip_vendor_hash
 from .checker_policy import ChangeKind
@@ -71,6 +71,11 @@ from .model import (
     stdlib_namespaces_excluded,
 )
 from .name_classification import RTTI_DATA_PREFIXES
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from collections.abc import Set as AbstractSet
+
+    from .dwarf_metadata import FieldInfo, StructLayout
 
 
 def _pe_export_id(e: Any) -> str:
@@ -1497,8 +1502,6 @@ def _normalize_type_name(name: str) -> str:
 
 
 def _diff_struct_layouts(o: object, n: object) -> list[Change]:
-    from .dwarf_metadata import FieldInfo, StructLayout
-
     old_structs: dict[str, StructLayout] = getattr(o, "structs", {})
     new_structs: dict[str, StructLayout] = getattr(n, "structs", {})
     changes: list[Change] = []
@@ -1506,223 +1509,247 @@ def _diff_struct_layouts(o: object, n: object) -> list[Change]:
     for name, old_s in old_structs.items():
         if name not in new_structs:
             continue  # struct removed — caught by header-layer (castxml)
-
         new_s = new_structs[name]
-
-        # 1. Total size
-        if old_s.byte_size != new_s.byte_size:
-            changes.append(
-                make_change(
-                    ChangeKind.STRUCT_SIZE_CHANGED,
-                    symbol=name,
-                    name=name,
-                    old=str(old_s.byte_size),
-                    new=str(new_s.byte_size),
-                )
-            )
-
-        # 2. Alignment (only when explicitly present in DWARF 5)
-        if old_s.alignment and new_s.alignment and old_s.alignment != new_s.alignment:
-            changes.append(
-                make_change(
-                    ChangeKind.STRUCT_ALIGNMENT_CHANGED,
-                    symbol=name,
-                    name=name,
-                    old=str(old_s.alignment),
-                    new=str(new_s.alignment),
-                )
-            )
-
-        # Build field maps
         old_fields = {f.name: f for f in old_s.fields}
         new_fields = {f.name: f for f in new_s.fields}
+        changes += _struct_size_and_alignment_changes(name, old_s, new_s)
+        changes += _removed_field_changes(name, old_fields, new_fields)
+        changes += _existing_field_changes(name, old_fields, new_fields)
+    return changes
 
-        # 3. Removed fields — check for reserved-field activations first
-        removed_names = sorted(old_fields.keys() - new_fields.keys())
-        added_names = new_fields.keys() - old_fields.keys()
-        # Build added-field index by byte_offset for reserved-field matching.
-        # A list per offset, not a single value: two renamed bit-fields can
-        # legitimately share a byte_offset (e.g. two 1-bit flags in the same
-        # storage byte), and a plain ``dict[int, FieldInfo]`` comprehension
-        # would silently keep only the last one, leaving every other
-        # same-byte bit-field with no candidate to match against and
-        # falling through to a false STRUCT_FIELD_REMOVED (caught in
-        # review).
-        added_by_offset: dict[int, list[FieldInfo]] = {}
-        for fn in added_names:
-            if _RESERVED_FIELD_RE.match(fn):
-                continue
-            added_by_offset.setdefault(new_fields[fn].byte_offset, []).append(
-                new_fields[fn]
+
+def _struct_size_and_alignment_changes(
+    name: str, old_s: StructLayout, new_s: StructLayout
+) -> list[Change]:
+    """Whole-struct size, and alignment when DWARF 5 recorded it on both
+    sides."""
+    changes: list[Change] = []
+    if old_s.byte_size != new_s.byte_size:
+        changes.append(
+            make_change(
+                ChangeKind.STRUCT_SIZE_CHANGED,
+                symbol=name,
+                name=name,
+                old=str(old_s.byte_size),
+                new=str(new_s.byte_size),
             )
-        reserved_matched: set[str] = set()
-        # Tracks candidates already consumed by a pure-rename match below, so
-        # a second removed field at the same offset (e.g. two overlapping
-        # anonymous-union members collapsing to one field) can't also claim
-        # it — without this, both would report FIELD_RENAMED to the same
-        # target and the fact that one of them was genuinely dropped would
-        # be silently hidden (caught in review).
-        rename_matched: set[str] = set()
+        )
 
-        for fname in removed_names:
-            old_f = old_fields[fname]
-            if _RESERVED_FIELD_RE.match(fname):
-                candidate = next(
-                    (
-                        c
-                        for c in added_by_offset.get(old_f.byte_offset, [])
-                        if c.name not in rename_matched
+    if old_s.alignment and new_s.alignment and old_s.alignment != new_s.alignment:
+        changes.append(
+            make_change(
+                ChangeKind.STRUCT_ALIGNMENT_CHANGED,
+                symbol=name,
+                name=name,
+                old=str(old_s.alignment),
+                new=str(new_s.alignment),
+            )
+        )
+    return changes
+
+
+def _added_fields_by_offset(
+    added_names: AbstractSet[str], new_fields: dict[str, FieldInfo]
+) -> dict[int, list[FieldInfo]]:
+    """Added, non-reserved fields indexed by ``byte_offset``.
+
+    A list per offset, not a single value: two renamed bit-fields can
+    legitimately share a byte_offset (e.g. two 1-bit flags in the same
+    storage byte), and a plain ``dict[int, FieldInfo]`` comprehension would
+    silently keep only the last one, leaving every other same-byte bit-field
+    with no candidate to match against and falling through to a false
+    STRUCT_FIELD_REMOVED (caught in review).
+    """
+    by_offset: dict[int, list[FieldInfo]] = {}
+    for fn in added_names:
+        if _RESERVED_FIELD_RE.match(fn):
+            continue
+        by_offset.setdefault(new_fields[fn].byte_offset, []).append(new_fields[fn])
+    return by_offset
+
+
+def _removed_field_changes(
+    name: str, old_fields: dict[str, FieldInfo], new_fields: dict[str, FieldInfo]
+) -> list[Change]:
+    """Fields gone from the new side: a reserved-field activation, a pure
+    rename, or a genuine removal."""
+    changes: list[Change] = []
+    removed_names = sorted(old_fields.keys() - new_fields.keys())
+    added_by_offset = _added_fields_by_offset(
+        new_fields.keys() - old_fields.keys(), new_fields
+    )
+    reserved_matched: set[str] = set()
+    # Tracks candidates already consumed by a pure-rename match below, so
+    # a second removed field at the same offset (e.g. two overlapping
+    # anonymous-union members collapsing to one field) can't also claim
+    # it — without this, both would report FIELD_RENAMED to the same
+    # target and the fact that one of them was genuinely dropped would
+    # be silently hidden (caught in review).
+    rename_matched: set[str] = set()
+
+    for fname in removed_names:
+        old_f = old_fields[fname]
+        if _RESERVED_FIELD_RE.match(fname):
+            candidate = next(
+                (
+                    c
+                    for c in added_by_offset.get(old_f.byte_offset, [])
+                    if c.name not in rename_matched and old_f.type_name == c.type_name
+                ),
+                None,
+            )
+            if candidate is not None:
+                changes.append(
+                    make_change(
+                        ChangeKind.USED_RESERVED_FIELD,
+                        symbol=name,
+                        name=name,
+                        old=fname,
+                        new=candidate.name,
+                    )
+                )
+                reserved_matched.add(candidate.name)
+                continue
+        else:
+            # Pure rename: same offset, identical type, different name.
+            # Report FIELD_RENAMED (API_BREAK) directly instead of a
+            # STRUCT_FIELD_REMOVED that would falsely claim the field no
+            # longer exists — mirrors the rename-skip already done for
+            # enum members below (ENUM_MEMBER_RENAMED). This does not
+            # depend on `_diff_field_renames` (over AbiSnapshot.types, a
+            # different model with its own type-name strings) also firing
+            # for the same pair — relying on that would silently drop the
+            # finding entirely whenever the two independent extractors
+            # spell the type differently (caught in review). Emitting the
+            # same FIELD_RENAMED shape here is safe either way: the
+            # post-processing dedup pass collapses an exact duplicate if
+            # `_diff_field_renames` also matches.
+            # _normalize_type_name is lossy by design (it also strips
+            # pointer/reference sigils to compare "struct Foo *" against
+            # "Foo" for the *tag-spelling* case), so it alone would equate
+            # "Foo *" with "Foo" and even a byte-size guard cannot save
+            # it: a same-size pointer-to-inline-value retype (e.g.
+            # "Handle *" (8B) -> an 8-byte-by-value "Handle") would still
+            # pass a size check while being a real layout/representation
+            # break (caught in review — twice). Require exact, non-lossy
+            # equality of the raw type spelling instead of any
+            # normalized comparison. Spelling alone is still not enough,
+            # though: the *same* typedef name can resolve to a different
+            # size/bit-layout across versions (e.g. "Word" widened
+            # 4B->8B elsewhere, or a bit-field at the same byte offset
+            # changing width) without the spelling changing at all, so
+            # also require byte_size and bit_offset/bit_size to match
+            # (caught in review — three times now). This is strictly
+            # narrower than a real rename check would ideally be (a
+            # harmless "struct Foo *" vs "Foo *" spelling difference now
+            # falls through to STRUCT_FIELD_REMOVED instead of
+            # FIELD_RENAMED) but never misclassifies a genuine type or
+            # layout change as a bare rename. Scanning the full
+            # same-offset candidate list (not just one arbitrary entry)
+            # also matters when two bit-fields share a byte_offset —
+            # each removed bit-field must find *its own* matching
+            # candidate by bit position/width, not whichever one a
+            # single-value dict happened to keep (caught in review —
+            # four times now). And a matched candidate must be excluded
+            # from further matches (`rename_matched`) — otherwise two
+            # removed fields with identical layout at the same offset
+            # (overlapping anonymous-union members collapsing to one
+            # field) would both claim the same new field as their
+            # rename target, hiding that one of them was genuinely
+            # dropped (caught in review — five times now).
+            candidate = next(
+                (
+                    c
+                    for c in added_by_offset.get(old_f.byte_offset, [])
+                    if (
+                        c.name not in reserved_matched
+                        and c.name not in rename_matched
                         and old_f.type_name == c.type_name
-                    ),
-                    None,
-                )
-                if candidate is not None:
-                    changes.append(
-                        make_change(
-                            ChangeKind.USED_RESERVED_FIELD,
-                            symbol=name,
-                            name=name,
-                            old=fname,
-                            new=candidate.name,
-                        )
+                        and old_f.byte_size == c.byte_size
+                        and old_f.bit_offset == c.bit_offset
+                        and old_f.bit_size == c.bit_size
                     )
-                    reserved_matched.add(candidate.name)
-                    continue
-            else:
-                # Pure rename: same offset, identical type, different name.
-                # Report FIELD_RENAMED (API_BREAK) directly instead of a
-                # STRUCT_FIELD_REMOVED that would falsely claim the field no
-                # longer exists — mirrors the rename-skip already done for
-                # enum members below (ENUM_MEMBER_RENAMED). This does not
-                # depend on `_diff_field_renames` (over AbiSnapshot.types, a
-                # different model with its own type-name strings) also firing
-                # for the same pair — relying on that would silently drop the
-                # finding entirely whenever the two independent extractors
-                # spell the type differently (caught in review). Emitting the
-                # same FIELD_RENAMED shape here is safe either way: the
-                # post-processing dedup pass collapses an exact duplicate if
-                # `_diff_field_renames` also matches.
-                # _normalize_type_name is lossy by design (it also strips
-                # pointer/reference sigils to compare "struct Foo *" against
-                # "Foo" for the *tag-spelling* case), so it alone would equate
-                # "Foo *" with "Foo" and even a byte-size guard cannot save
-                # it: a same-size pointer-to-inline-value retype (e.g.
-                # "Handle *" (8B) -> an 8-byte-by-value "Handle") would still
-                # pass a size check while being a real layout/representation
-                # break (caught in review — twice). Require exact, non-lossy
-                # equality of the raw type spelling instead of any
-                # normalized comparison. Spelling alone is still not enough,
-                # though: the *same* typedef name can resolve to a different
-                # size/bit-layout across versions (e.g. "Word" widened
-                # 4B->8B elsewhere, or a bit-field at the same byte offset
-                # changing width) without the spelling changing at all, so
-                # also require byte_size and bit_offset/bit_size to match
-                # (caught in review — three times now). This is strictly
-                # narrower than a real rename check would ideally be (a
-                # harmless "struct Foo *" vs "Foo *" spelling difference now
-                # falls through to STRUCT_FIELD_REMOVED instead of
-                # FIELD_RENAMED) but never misclassifies a genuine type or
-                # layout change as a bare rename. Scanning the full
-                # same-offset candidate list (not just one arbitrary entry)
-                # also matters when two bit-fields share a byte_offset —
-                # each removed bit-field must find *its own* matching
-                # candidate by bit position/width, not whichever one a
-                # single-value dict happened to keep (caught in review —
-                # four times now). And a matched candidate must be excluded
-                # from further matches (`rename_matched`) — otherwise two
-                # removed fields with identical layout at the same offset
-                # (overlapping anonymous-union members collapsing to one
-                # field) would both claim the same new field as their
-                # rename target, hiding that one of them was genuinely
-                # dropped (caught in review — five times now).
-                candidate = next(
-                    (
-                        c
-                        for c in added_by_offset.get(old_f.byte_offset, [])
-                        if (
-                            c.name not in reserved_matched
-                            and c.name not in rename_matched
-                            and old_f.type_name == c.type_name
-                            and old_f.byte_size == c.byte_size
-                            and old_f.bit_offset == c.bit_offset
-                            and old_f.bit_size == c.bit_size
-                        )
-                    ),
-                    None,
-                )
-                if candidate is not None:
-                    rename_matched.add(candidate.name)
-                    changes.append(
-                        make_change(
-                            ChangeKind.FIELD_RENAMED,
-                            symbol=name,
-                            name=name,
-                            old=fname,
-                            new=candidate.name,
-                        )
+                ),
+                None,
+            )
+            if candidate is not None:
+                rename_matched.add(candidate.name)
+                changes.append(
+                    make_change(
+                        ChangeKind.FIELD_RENAMED,
+                        symbol=name,
+                        name=name,
+                        old=fname,
+                        new=candidate.name,
                     )
-                    continue
+                )
+                continue
+        changes.append(
+            make_change(
+                ChangeKind.STRUCT_FIELD_REMOVED,
+                symbol=f"{name}::{fname}",
+                name=name,
+                detail=fname,
+                old_value=f"{old_fields[fname].type_name}",
+            )
+        )
+    return changes
+
+
+def _existing_field_changes(
+    name: str, old_fields: dict[str, FieldInfo], new_fields: dict[str, FieldInfo]
+) -> list[Change]:
+    """Offset and type drift for fields present on both sides."""
+    changes: list[Change] = []
+    for fname, old_f in old_fields.items():
+        if fname not in new_fields:
+            continue
+        new_f = new_fields[fname]
+
+        if old_f.byte_offset != new_f.byte_offset:
             changes.append(
                 make_change(
-                    ChangeKind.STRUCT_FIELD_REMOVED,
+                    ChangeKind.STRUCT_FIELD_OFFSET_CHANGED,
                     symbol=f"{name}::{fname}",
                     name=name,
                     detail=fname,
-                    old_value=f"{old_fields[fname].type_name}",
+                    old=str(old_f.byte_offset),
+                    new=str(new_f.byte_offset),
                 )
             )
 
-        # 4. Existing fields: offset and type changes
-        for fname, old_f in old_fields.items():
-            if fname not in new_fields:
-                continue
-            new_f = new_fields[fname]
-
-            if old_f.byte_offset != new_f.byte_offset:
-                changes.append(
-                    make_change(
-                        ChangeKind.STRUCT_FIELD_OFFSET_CHANGED,
-                        symbol=f"{name}::{fname}",
-                        name=name,
-                        detail=fname,
-                        old=str(old_f.byte_offset),
-                        new=str(new_f.byte_offset),
-                    )
+        # Field type drift:
+        # - catches same-size type substitutions (int→float, Foo*→Bar*)
+        # - strip "struct "/"class "/"union " prefixes for stable comparison
+        # - still includes explicit size drift when known on both sides
+        # A pointee/by-value cv-qualifier change (``char *`` ->
+        # ``const char *``) keeps the field's size and offset identical, so
+        # it is not a binary layout break (ISSUE-30/35/65: libuv
+        # ``uv_cpu_info_s::model`` const-pointer churn). A genuine size
+        # change is still reported via ``type_size_changed`` below.
+        type_name_changed = _normalize_type_name(
+            old_f.type_name
+        ) != _normalize_type_name(new_f.type_name) and not cv_qualifiers_only_differ(
+            old_f.type_name, new_f.type_name
+        )
+        type_size_changed = (
+            old_f.byte_size > 0
+            and new_f.byte_size > 0
+            and old_f.byte_size != new_f.byte_size
+        )
+        if type_name_changed or type_size_changed:
+            changes.append(
+                make_change(
+                    ChangeKind.STRUCT_FIELD_TYPE_CHANGED,
+                    symbol=f"{name}::{fname}",
+                    name=name,
+                    detail=fname,
+                    old=f"{old_f.type_name}({old_f.byte_size}B)",
+                    new=f"{new_f.type_name}({new_f.byte_size}B)",
+                    old_value=old_f.type_name,
+                    new_value=new_f.type_name,
                 )
-
-            # Field type drift:
-            # - catches same-size type substitutions (int→float, Foo*→Bar*)
-            # - strip "struct "/"class "/"union " prefixes for stable comparison
-            # - still includes explicit size drift when known on both sides
-            # A pointee/by-value cv-qualifier change (``char *`` ->
-            # ``const char *``) keeps the field's size and offset identical, so
-            # it is not a binary layout break (ISSUE-30/35/65: libuv
-            # ``uv_cpu_info_s::model`` const-pointer churn). A genuine size
-            # change is still reported via ``type_size_changed`` below.
-            type_name_changed = _normalize_type_name(
-                old_f.type_name
-            ) != _normalize_type_name(
-                new_f.type_name
-            ) and not cv_qualifiers_only_differ(old_f.type_name, new_f.type_name)
-            type_size_changed = (
-                old_f.byte_size > 0
-                and new_f.byte_size > 0
-                and old_f.byte_size != new_f.byte_size
             )
-            if type_name_changed or type_size_changed:
-                changes.append(
-                    make_change(
-                        ChangeKind.STRUCT_FIELD_TYPE_CHANGED,
-                        symbol=f"{name}::{fname}",
-                        name=name,
-                        detail=fname,
-                        old=f"{old_f.type_name}({old_f.byte_size}B)",
-                        new=f"{new_f.type_name}({new_f.byte_size}B)",
-                        old_value=old_f.type_name,
-                        new_value=new_f.type_name,
-                    )
-                )
-
     return changes
 
 

--- a/abicheck/type_reachability.py
+++ b/abicheck/type_reachability.py
@@ -89,6 +89,7 @@ default, never a false positive.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping
 from typing import TYPE_CHECKING
 
 from .diff_cxx_rules import owner_class_of
@@ -1105,6 +1106,156 @@ def directly_referenced_stdlib_types(
     return scan.referenced() if scan is not None else frozenset()
 
 
+def _alias_confirmed_identities(
+    base: Iterable[str],
+    alias_map: Mapping[str, frozenset[str]],
+    non_stdlib_spellings: frozenset[str],
+) -> frozenset[str]:
+    """*base*, plus every identity reached only through a typedef alias where
+    at least one producing alias is itself free of a collision against
+    *non_stdlib_spellings*.
+
+    A match found via a real declaration's own literal text is always
+    trustworthy. A match found only while recursively scanning a typedef's
+    *target* string is trustworthy too, but only under that condition -- the
+    scan itself cannot judge it, since only the caller computes that
+    vocabulary. One genuinely unambiguous route is real proof regardless of
+    how many other, separately ambiguous routes reached the same identity.
+
+    Shared by both the exact and the trusted set: the two differ only in
+    which scan collections they start from, never in this rule.
+    """
+    confirmed = set(base)
+    for identity, aliases in alias_map.items():
+        if aliases - non_stdlib_spellings:
+            confirmed.add(identity)
+    return frozenset(confirmed)
+
+
+def _stripped_spelling_index(
+    all_stdlib_identities: Iterable[str],
+    non_stdlib_spellings: frozenset[str],
+    non_stdlib_identities: frozenset[str],
+    typedef_candidate_spellings: frozenset[str],
+    typedef_spelling_targets: Mapping[str, str],
+) -> tuple[dict[str, str], dict[str, int]]:
+    """Each stdlib identity's own stripped spelling, and how many identities
+    share each such spelling.
+
+    Counts span EVERY stdlib identity the snapshot carries, not just the
+    referenced subset -- an unreferenced sibling sharing a referenced
+    identity's bare spelling still makes that spelling ambiguous for any
+    other finding's bare ``Change.symbol`` to match against.
+    """
+    stripped_by_identity: dict[str, str] = {}
+    stripped_counts: dict[str, int] = {}
+    for identity in set(all_stdlib_identities):
+        stripped = _stripped_signature_spelling(identity)
+        if not stripped or stripped in non_stdlib_spellings:
+            continue
+        if stripped in typedef_candidate_spellings:
+            typedef_target = typedef_spelling_targets.get(stripped)
+            # A typedef target naming this exact identity -- spelled fully
+            # qualified, or as one of its own *structural* namespace-suffix
+            # spellings (`_namespace_suffix_spellings`, which only ever
+            # drops a namespace/class-scope prefix `identity` itself
+            # already carries) -- genuinely refers to the same entity and
+            # is not a collision. An earlier revision instead compared via
+            # `_stripped_signature_spelling(typedef_target)` -- rejected
+            # (Codex review, fresh evidence): that normalization also
+            # strips inline ABI-tag namespaces (`__cxx11::`, `__1::`,
+            # `__ndk1::`), so a target naming a *different*, differently
+            # ABI-tagged stdlib sibling this snapshot never captured (e.g.
+            # a typedef targeting `std::__cxx11::basic_string<char>`
+            # against a captured pre-C++11-ABI `std::basic_string<char>`)
+            # stripped-collapses to the identical bare form as `identity`
+            # purely by coincidence, and was waved through here as "the
+            # same identity" when it actually names something else
+            # entirely -- confirmed empirically. `_namespace_suffix_
+            # spellings` cannot manufacture that coincidence, since it
+            # only derives suffixes from `identity`'s own scope chain.
+            # A suffix match is itself not safe unqualified: the target
+            # string can equal one of `identity`'s own structural suffixes
+            # while *also* being the real, distinct identity of an
+            # unrelated non-stdlib record/enum captured in this same
+            # snapshot (Codex review, fresh evidence -- e.g. a DWARF
+            # `std::chrono::duration` alongside an unrelated global
+            # `duration` record, with a typedef `chrono::duration ->
+            # duration`: the target textually matches `identity`'s own bare
+            # suffix, but a real, captured `duration` record is exactly
+            # what it actually names). Rejecting whenever the target is
+            # itself a captured non-stdlib identity closes this without
+            # reopening the ABI-tag coincidence above, since an *exact*
+            # match against `identity` is still accepted unconditionally.
+            suffix_match = (
+                typedef_target in _namespace_suffix_spellings(identity)
+                and typedef_target not in non_stdlib_identities
+            )
+            if typedef_target != identity and not suffix_match:
+                # A real, unrelated typedef alias whose key -- or one of
+                # its own derived namespace-suffix spellings -- happens to
+                # equal this identity's stripped spelling (bare key,
+                # namespace-qualified key, or an ambiguous one where
+                # `typedef_spelling_targets` itself drops the spelling
+                # rather than resolving it, leaving `typedef_target` as
+                # `None`, still correctly rejected here) -- the stripped
+                # spelling isn't this stdlib identity's own bare backend
+                # form at all, it's someone else's (possibly ambiguous)
+                # alias, so it can never safely stand in for the identity
+                # in a bare Change.symbol match.
+                continue
+        stripped_by_identity[identity] = stripped
+        stripped_counts[stripped] = stripped_counts.get(stripped, 0) + 1
+    return stripped_by_identity, stripped_counts
+
+
+def _assemble_spellings(
+    identities: Iterable[str],
+    stripped_by_identity: Mapping[str, str],
+    stripped_counts: Mapping[str, int],
+    exact: frozenset[str],
+    trusted: frozenset[str],
+) -> frozenset[str]:
+    """Which spellings each referenced identity may safely be matched by."""
+    spellings: set[str] = set()
+    for identity in identities:
+        stripped = stripped_by_identity.get(identity)
+        if stripped is None or stripped_counts[stripped] > 1:
+            # The derived spelling either collides with an unrelated
+            # non-stdlib record/enum (`stripped is None`, filtered out
+            # above) or with another stdlib identity in the snapshot --
+            # referenced or not (`stripped_counts[stripped] > 1`) -- either
+            # way, only an identity independently proven via its own
+            # literal spelling survives; the derived form itself is never
+            # added here.
+            if identity in exact:
+                spellings.add(identity)
+            continue
+        if identity not in trusted:
+            # The stripped form is unambiguous against everything else in
+            # the snapshot -- but that alone only says "nothing else could
+            # this spelling mean," not "the signature legitimately reaches
+            # this spelling at all." An identity whose own reachability was
+            # never proven trustworthy (e.g. found only inside a record
+            # that was itself reached solely through an ambiguous typedef
+            # alias) cannot be rescued by bare-spelling uniqueness alone.
+            # No fallback to `exact` here (unlike the ambiguous-stripped-
+            # form branch above): `exact` is always a subset of `trusted`
+            # by construction (every site that adds to `_referenced_exact`/
+            # `_exact_typedef_aliases` adds the identical identity/origin to
+            # `_referenced_trusted`/`_trusted_via_alias` first), so
+            # `identity not in trusted` already implies `identity not in
+            # exact` -- nothing would ever survive here.
+            continue
+        # Unambiguous against every stdlib identity in the snapshot *and*
+        # against every non-stdlib spelling in it, *and* independently
+        # proven trustworthy: keep both the identity and its derived bare
+        # form.
+        spellings.add(identity)
+        spellings.add(stripped)
+    return frozenset(spellings)
+
+
 def directly_referenced_stdlib_type_spellings(
     snapshot: AbiSnapshot,
     *,
@@ -1268,11 +1419,11 @@ def directly_referenced_stdlib_type_spellings(
     # that produced it is itself absent from this function's own
     # enum-aware `non_stdlib_spellings` collision set -- the scan itself
     # cannot judge that, since only this function computes that vocabulary.
-    exact_mut = set(scan.referenced_exact())
-    for identity, aliases in scan.referenced_exact_typedef_aliases().items():
-        if aliases - non_stdlib_spellings:
-            exact_mut.add(identity)
-    exact = frozenset(exact_mut)
+    exact = _alias_confirmed_identities(
+        scan.referenced_exact(),
+        scan.referenced_exact_typedef_aliases(),
+        non_stdlib_spellings,
+    )
     # Broader sibling of `exact` above, mirroring the same alias-ambiguity
     # check but for *any* spelling (self-key or derived) rather than only
     # the self-key one -- needed below for the "stripped form collides with
@@ -1283,11 +1434,11 @@ def directly_referenced_stdlib_type_spellings(
     # where the record itself was reached only through an ambiguous
     # typedef alias, was previously confirmed unconditionally through this
     # shortcut regardless of that ambiguity -- confirmed empirically).
-    trusted_mut = set(scan.referenced_trusted())
-    for identity, aliases in scan.trusted_via_alias().items():
-        if aliases - non_stdlib_spellings:
-            trusted_mut.add(identity)
-    trusted = frozenset(trusted_mut)
+    trusted = _alias_confirmed_identities(
+        scan.referenced_trusted(),
+        scan.trusted_via_alias(),
+        non_stdlib_spellings,
+    )
     # Every spelling a typedef could be reached by -- not just its literal
     # dict key -- via the same suffix-expansion _StdlibReferenceScan itself
     # already uses to resolve a typedef alias to its target: a raw
@@ -1313,99 +1464,13 @@ def directly_referenced_stdlib_type_spellings(
     # one identity (an ODR-duplicate/incomplete-declaration pair,
     # `_partition_snapshot_types`'s own list-per-identity reason) so a
     # duplicate doesn't inflate a count against itself.
-    stripped_by_identity: dict[str, str] = {}
-    stripped_counts: dict[str, int] = {}
-    for identity in set(all_stdlib_identities):
-        stripped = _stripped_signature_spelling(identity)
-        if not stripped or stripped in non_stdlib_spellings:
-            continue
-        if stripped in typedef_candidate_spellings:
-            typedef_target = typedef_spelling_targets.get(stripped)
-            # A typedef target naming this exact identity -- spelled fully
-            # qualified, or as one of its own *structural* namespace-suffix
-            # spellings (`_namespace_suffix_spellings`, which only ever
-            # drops a namespace/class-scope prefix `identity` itself
-            # already carries) -- genuinely refers to the same entity and
-            # is not a collision. An earlier revision instead compared via
-            # `_stripped_signature_spelling(typedef_target)` -- rejected
-            # (Codex review, fresh evidence): that normalization also
-            # strips inline ABI-tag namespaces (`__cxx11::`, `__1::`,
-            # `__ndk1::`), so a target naming a *different*, differently
-            # ABI-tagged stdlib sibling this snapshot never captured (e.g.
-            # a typedef targeting `std::__cxx11::basic_string<char>`
-            # against a captured pre-C++11-ABI `std::basic_string<char>`)
-            # stripped-collapses to the identical bare form as `identity`
-            # purely by coincidence, and was waved through here as "the
-            # same identity" when it actually names something else
-            # entirely -- confirmed empirically. `_namespace_suffix_
-            # spellings` cannot manufacture that coincidence, since it
-            # only derives suffixes from `identity`'s own scope chain.
-            # A suffix match is itself not safe unqualified: the target
-            # string can equal one of `identity`'s own structural suffixes
-            # while *also* being the real, distinct identity of an
-            # unrelated non-stdlib record/enum captured in this same
-            # snapshot (Codex review, fresh evidence -- e.g. a DWARF
-            # `std::chrono::duration` alongside an unrelated global
-            # `duration` record, with a typedef `chrono::duration ->
-            # duration`: the target textually matches `identity`'s own bare
-            # suffix, but a real, captured `duration` record is exactly
-            # what it actually names). Rejecting whenever the target is
-            # itself a captured non-stdlib identity closes this without
-            # reopening the ABI-tag coincidence above, since an *exact*
-            # match against `identity` is still accepted unconditionally.
-            suffix_match = (
-                typedef_target in _namespace_suffix_spellings(identity)
-                and typedef_target not in non_stdlib_identities
-            )
-            if typedef_target != identity and not suffix_match:
-                # A real, unrelated typedef alias whose key -- or one of
-                # its own derived namespace-suffix spellings -- happens to
-                # equal this identity's stripped spelling (bare key,
-                # namespace-qualified key, or an ambiguous one where
-                # `typedef_spelling_targets` itself drops the spelling
-                # rather than resolving it, leaving `typedef_target` as
-                # `None`, still correctly rejected here) -- the stripped
-                # spelling isn't this stdlib identity's own bare backend
-                # form at all, it's someone else's (possibly ambiguous)
-                # alias, so it can never safely stand in for the identity
-                # in a bare Change.symbol match.
-                continue
-        stripped_by_identity[identity] = stripped
-        stripped_counts[stripped] = stripped_counts.get(stripped, 0) + 1
-    spellings: set[str] = set()
-    for identity in identities:
-        stripped = stripped_by_identity.get(identity)
-        if stripped is None or stripped_counts[stripped] > 1:
-            # The derived spelling either collides with an unrelated
-            # non-stdlib record/enum (`stripped is None`, filtered out
-            # above) or with another stdlib identity in the snapshot --
-            # referenced or not (`stripped_counts[stripped] > 1`) -- either
-            # way, only an identity independently proven via its own
-            # literal spelling survives; the derived form itself is never
-            # added here.
-            if identity in exact:
-                spellings.add(identity)
-            continue
-        if identity not in trusted:
-            # The stripped form is unambiguous against everything else in
-            # the snapshot -- but that alone only says "nothing else could
-            # this spelling mean," not "the signature legitimately reaches
-            # this spelling at all." An identity whose own reachability was
-            # never proven trustworthy (e.g. found only inside a record
-            # that was itself reached solely through an ambiguous typedef
-            # alias) cannot be rescued by bare-spelling uniqueness alone.
-            # No fallback to `exact` here (unlike the ambiguous-stripped-
-            # form branch above): `exact` is always a subset of `trusted`
-            # by construction (every site that adds to `_referenced_exact`/
-            # `_exact_typedef_aliases` adds the identical identity/origin to
-            # `_referenced_trusted`/`_trusted_via_alias` first), so
-            # `identity not in trusted` already implies `identity not in
-            # exact` -- nothing would ever survive here.
-            continue
-        # Unambiguous against every stdlib identity in the snapshot *and*
-        # against every non-stdlib spelling in it, *and* independently
-        # proven trustworthy: keep both the identity and its derived bare
-        # form.
-        spellings.add(identity)
-        spellings.add(stripped)
-    return frozenset(spellings)
+    stripped_by_identity, stripped_counts = _stripped_spelling_index(
+        all_stdlib_identities,
+        non_stdlib_spellings,
+        non_stdlib_identities,
+        typedef_candidate_spellings,
+        typedef_spelling_targets,
+    )
+    return _assemble_spellings(
+        identities, stripped_by_identity, stripped_counts, exact, trusted
+    )

--- a/changelog.d/20260810_112000_claude_codefactor_complexity_diff4.md
+++ b/changelog.d/20260810_112000_claude_codefactor_complexity_diff4.md
@@ -1,0 +1,16 @@
+### Changed
+
+- **Split two more CodeFactor "Complex Method" findings in the DWARF struct-layout
+  detector and the stdlib type-reachability spelling helper.**
+  `diff_platform._diff_struct_layouts`'s four numbered sections each become their
+  own function (`_struct_size_and_alignment_changes`, `_added_fields_by_offset`,
+  `_removed_field_changes`, `_existing_field_changes`), so the reserved-field,
+  rename and removal rules sit with the matching they constrain.
+  `type_reachability.directly_referenced_stdlib_type_spellings` splits its four
+  passes similarly, and its exact and trusted passes — structurally identical,
+  differing only in which scan collections they start from — now share one
+  `_alias_confirmed_identities`. Both behaviour-preserving and checked
+  differentially against their pre-refactor selves: 40,002 runs over randomized
+  field sets for the struct detector, and 12,000 runs over snapshots built to
+  exercise every documented spelling-collision hazard for the reachability
+  helper — no differences in either.


### PR DESCRIPTION
## Summary

Batch 5e of the CodeFactor "Complex Method" series: two findings, both in dense, heavily review-hardened code, so both ship with a differential check rather than an argument.

## Motivation

Continues #693 / #694 / #695 / #696 / #697 / #701 / #702 (merged) and #703 (open). Touches no file the open PR does.

## Changes

| Function | Score | mccabe before | after |
|---|---|---|---|
| `diff_platform._diff_struct_layouts` | 17 | 15 | <8 |
| `type_reachability.directly_referenced_stdlib_type_spellings` | 17 | 15 | <8 |

**`_diff_struct_layouts`** held four numbered sections inside one per-struct loop: whole-struct size and alignment, the added-field-by-offset index, the removed-field matching (reserved-field activation → pure rename → genuine removal), and existing-field offset/type drift. Each is now its own function, so the five rounds of review fixes recorded in the removed-field matching comments sit next to the matching they constrain rather than in the middle of an unrelated loop.

`FieldInfo`/`StructLayout` move to a `TYPE_CHECKING` import — the runtime function-local import existed only to annotate locals, and the helpers need the names in signatures.

**`directly_referenced_stdlib_type_spellings`** ran four distinct passes in one body: resolving the exact set, resolving the trusted set, counting stripped-spelling collisions across every stdlib identity in the snapshot, and assembling the answer.

The exact and trusted passes were *structurally identical* — differing only in which scan collections they start from, never in the rule — so they now share `_alias_confirmed_identities`. The "one genuinely unambiguous route is real proof" rule is stated once instead of twice. `_stripped_spelling_index` and `_assemble_spellings` take the other two passes.

## Verification

Both checked differentially against their pre-refactor implementations, comparing full outputs:

- **`_diff_struct_layouts`** — 40,002 runs: randomized field sets over overlapping names (including reserved-prefixed ones), byte offsets, type spellings, byte sizes and bit offsets/widths, so the reserved-activation, rename and removal paths all fire; plus the struct-missing and empty-struct cases. **0 differences.**
- **`directly_referenced_stdlib_type_spellings`** — 12,000 runs: randomized snapshots over identities chosen to exercise every hazard the function's own comments document — a user `api::vector<int>` whose bare spelling collides with `std::vector<int>`, an inline-ABI-tagged `__cxx11::basic_string`, a global `duration` alongside `std::chrono::duration`, resolved and ambiguous typedef aliases, and qualified typedef keys whose *derived* suffix is what collides — across both `exclude_export_only_roots` values. **0 differences.**

The second check was also confirmed non-vacuous: **34% of sampled inputs returned non-empty results** (both the qualified identity and its derived bare form), so it compared real output rather than empty sets on both sides.

Plus the full fast suite (23468 passed), `ruff check`/`format`, `python -m mypy abicheck/` clean across 340 files, and `scripts/check_ai_readiness.py` at 0 errors.

## Checklist

- [x] Tests added / updated for new behaviour — n/a, refactor-only; the differential checks above plus the existing suites are the regression check
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [x] Docs updated if user-visible behaviour changed — n/a, no user-visible change
- [x] `pre-commit run --all-files` passes locally — `ruff check`/`ruff format --check` and `scripts/check_ai_readiness.py` (0 errors) clean
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q)_