### PR TITLE
refactor: split the unnamed-type scan, the stack ABI-risk verdict and the baseline-floor check

### DIFF
--- a/abicheck/diff_unnamed_types.py
+++ b/abicheck/diff_unnamed_types.py
@@ -54,56 +54,83 @@ from .model import AbiSnapshot
 _UNNAMED_STRUCT_TOKEN = re.compile(r"Ut\d*_")
 
 
+def _skip_source_name(mangled: str, i: int, n: int) -> int | None:
+    """Index just past the ``<source-name> ::= <decimal length> <identifier>``
+    at *i*, or None when its length prefix is invalid.
+
+    Skipping the whole identifier is what keeps a token inside a user name from
+    ever being matched.
+    """
+    j = i
+    while j < n and mangled[j].isdigit():
+        j += 1
+    # Symbol names are untrusted input from ELF files/snapshots.
+    # Avoid feeding an unbounded digit run to int(): Python's
+    # integer-string guard can raise ValueError (and, if disabled, a
+    # huge conversion would waste CPU/memory). A source-name length
+    # larger than the whole mangled string cannot be valid anyway.
+    if j - i > len(str(n)):
+        return None
+    # The slice is non-empty, ASCII-decimal-only, and bounded above,
+    # so int() cannot raise ValueError here.
+    length = int(mangled[i:j])
+    if length == 0 or length > n - j:
+        return None
+    return j + length
+
+
+def _skip_substitution(mangled: str, i: int, n: int) -> int:
+    """Index just past the ``substitution ::= S <seq-id (base-36)> _ |
+    S <std abbrev> | S_`` at *i*."""
+    nxt = mangled[i + 1] if i + 1 < n else ""
+    if nxt in "abdiost":  # St/Sa/Sb/Ss/Si/So/Sd 2-char std abbreviations
+        return i + 2
+    j = i + 1
+    while j < n and (mangled[j].isdigit() or mangled[j].isupper()):
+        j += 1
+    return j + 1 if j < n and mangled[j] == "_" else i + 1
+
+
+def _skip_number_terminated(mangled: str, i: int, n: int) -> int:
+    """Index just past a ``template-param ::= T <number> _ | T_`` or
+    ``array-type ::= A <number> _ <type> | A _ <type>`` at *i*."""
+    j = i + 1
+    while j < n and mangled[j].isdigit():
+        j += 1
+    return j + 1 if j < n and mangled[j] == "_" else i + 1
+
+
+def _next_token_index(mangled: str, i: int, n: int) -> int | None:
+    """Index just past the length-or-bound-carrying production at *i*; *i*
+    itself when none starts here; None when the mangling is invalid.
+
+    Substitution / template-param / array productions embed a seq-id or bound
+    that must NOT be read as a <source-name> length prefix — their leading
+    letter would otherwise be stepped over and the *following* digit misread as
+    a length, skipping a real `Ut_`/`Ul…` token. (`Ut`/`Ul` start with `U`,
+    never `S`/`T`/`A`, so they are unaffected.)
+    """
+    ch = mangled[i]
+    if ch.isdigit():
+        return _skip_source_name(mangled, i, n)
+    if ch == "S":
+        return _skip_substitution(mangled, i, n)
+    if ch in "TA":
+        return _skip_number_terminated(mangled, i, n)
+    return i
+
+
 def _unnamed_kind(mangled: str) -> str | None:
     """Return a human label if *mangled* embeds an unnamed type at a real
     mangling-token boundary, else None."""
     i = 0
     n = len(mangled)
     while i < n:
-        ch = mangled[i]
-        if ch.isdigit():
-            # <source-name> ::= <decimal length> <identifier>. Skip the whole
-            # identifier so tokens inside a user name are never matched.
-            j = i
-            while j < n and mangled[j].isdigit():
-                j += 1
-            # Symbol names are untrusted input from ELF files/snapshots.
-            # Avoid feeding an unbounded digit run to int(): Python's
-            # integer-string guard can raise ValueError (and, if disabled, a
-            # huge conversion would waste CPU/memory). A source-name length
-            # larger than the whole mangled string cannot be valid anyway.
-            if j - i > len(str(n)):
-                return None
-            # The slice is non-empty, ASCII-decimal-only, and bounded above,
-            # so int() cannot raise ValueError here.
-            length = int(mangled[i:j])
-            if length == 0 or length > n - j:
-                return None
-            i = j + length
-            continue
-        # Substitution / template-param / array productions embed a seq-id or
-        # bound that must NOT be read as a <source-name> length prefix — their
-        # leading letter would otherwise be stepped over and the *following*
-        # digit misread as a length, skipping a real `Ut_`/`Ul…` token:
-        #   substitution   ::= S <seq-id (base-36)> _ | S <std abbrev> | S_
-        #   template-param ::= T <number> _ | T_
-        #   array-type     ::= A <number> _ <type> | A _ <type>
-        # (`Ut`/`Ul` start with `U`, never `S`/`T`/`A`, so they are unaffected.)
-        if ch == "S":
-            nxt = mangled[i + 1] if i + 1 < n else ""
-            if nxt in "abdiost":  # St/Sa/Sb/Ss/Si/So/Sd 2-char std abbreviations
-                i += 2
-                continue
-            j = i + 1
-            while j < n and (mangled[j].isdigit() or mangled[j].isupper()):
-                j += 1
-            i = j + 1 if j < n and mangled[j] == "_" else i + 1
-            continue
-        if ch in "TA":
-            j = i + 1
-            while j < n and mangled[j].isdigit():
-                j += 1
-            i = j + 1 if j < n and mangled[j] == "_" else i + 1
+        nxt = _next_token_index(mangled, i, n)
+        if nxt is None:
+            return None
+        if nxt != i:
+            i = nxt
             continue
         # Structural position: `Ut[<n>]_` / `Ul…E[<n>]_` are the productions.
         if mangled.startswith("Ul", i):

--- a/abicheck/diff_versioning.py
+++ b/abicheck/diff_versioning.py
@@ -382,6 +382,55 @@ def check_platform_baseline_floor(
     return changes
 
 
+class _FloorScan:
+    """The highest observed version for one prefix, the tag that carried it,
+    and which libraries provide a version above the declared floor."""
+
+    def __init__(self, floor_tuple: tuple[int, ...]) -> None:
+        self.best: tuple[int, ...] = (0,)
+        self.best_tag = ""
+        self.providers: set[str] = set()
+        self._floor = floor_tuple
+        self._relr = _parse_abi_version_tag(_DT_RELR_GLIBC_FLOOR_TAG)
+
+    def observe(self, version: tuple[int, ...], tag: str, provider: str) -> None:
+        """Fold one observed version tag in. The two comparisons are
+        independent: a tag can raise the observed maximum without exceeding the
+        declared floor, and vice versa."""
+        if _version_gt(version, self.best):
+            self.best, self.best_tag = version, tag
+        if _version_gt(version, self._floor):
+            self.providers.add(provider)
+
+    def observe_dt_relr(self, provider: str) -> None:
+        """Fold in the floor implied by DT_RELR support, however it was
+        observed -- the dedicated ``has_dt_relr`` flag, or the synthetic
+        ``GLIBC_ABI_DT_RELR`` verneed marker a legacy snapshot carries
+        instead."""
+        self.observe(self._relr, _DT_RELR_GLIBC_FLOOR_TAG, provider)
+
+
+def _scan_verneed_tags(elf: ElfMetadata, prefix: str, scan: _FloorScan) -> None:
+    """Fold every ``prefix``-matching verneed tag on *elf* into *scan*."""
+    tag_prefix = f"{prefix}_"
+    for lib, tags in (getattr(elf, "versions_required", None) or {}).items():
+        for tag in tags:
+            if prefix == "GLIBC" and tag == "GLIBC_ABI_DT_RELR":
+                # Legacy snapshots predating the has_dt_relr field may still
+                # carry this synthetic verneed marker directly — treat it as
+                # implying the same floor the has_dt_relr fallback applies,
+                # so an older snapshot isn't under-called just because the
+                # dedicated flag wasn't captured (Codex review).
+                scan.observe_dt_relr(lib)
+                continue
+            if not tag.startswith(tag_prefix):
+                continue
+            parsed = _parse_abi_version_tag(tag)
+            if parsed == _UNPARSEABLE_VERSION:
+                continue
+            scan.observe(parsed, tag, lib)
+
+
 def _check_baseline_floor_for_prefix(
     elf: ElfMetadata, prefix: str, floor_raw: str
 ) -> Change | None:
@@ -389,47 +438,19 @@ def _check_baseline_floor_for_prefix(
     floor_tuple = _parse_dotted_numeric_version(floor_raw)
     if floor_tuple is None:
         return None
-    best: tuple[int, ...] = (0,)
-    best_tag = ""
-    providers: set[str] = set()
-    relr_tuple = _parse_abi_version_tag(_DT_RELR_GLIBC_FLOOR_TAG)
-    tag_prefix = f"{prefix}_"
-    for lib, tags in (getattr(elf, "versions_required", None) or {}).items():
-        for tag in tags:
-            if prefix == "GLIBC" and tag == "GLIBC_ABI_DT_RELR":
-                # Legacy snapshots predating the has_dt_relr field may still
-                # carry this synthetic verneed marker directly — treat it as
-                # implying the same floor the has_dt_relr fallback below
-                # applies, so an older snapshot isn't under-called just
-                # because the dedicated flag wasn't captured (Codex review).
-                if _version_gt(relr_tuple, best):
-                    best, best_tag = relr_tuple, _DT_RELR_GLIBC_FLOOR_TAG
-                if _version_gt(relr_tuple, floor_tuple):
-                    providers.add(lib)
-                continue
-            if not tag.startswith(tag_prefix):
-                continue
-            parsed = _parse_abi_version_tag(tag)
-            if parsed == _UNPARSEABLE_VERSION:
-                continue
-            if _version_gt(parsed, best):
-                best, best_tag = parsed, tag
-            if _version_gt(parsed, floor_tuple):
-                providers.add(lib)
+    scan = _FloorScan(floor_tuple)
+    _scan_verneed_tags(elf, prefix, scan)
     if prefix == "GLIBC" and getattr(elf, "has_dt_relr", False):
-        if _version_gt(relr_tuple, best):
-            best, best_tag = relr_tuple, _DT_RELR_GLIBC_FLOOR_TAG
-        if _version_gt(relr_tuple, floor_tuple):
-            providers.add(getattr(elf, "soname", "") or "<binary>")
-    if best == (0,) or _version_le(best, floor_tuple):
+        scan.observe_dt_relr(getattr(elf, "soname", "") or "<binary>")
+    if scan.best == (0,) or _version_le(scan.best, floor_tuple):
         return None
     return make_change(
         ChangeKind.PLATFORM_BASELINE_FLOOR_RAISED,
         symbol="<platform-baseline>",
-        name=", ".join(sorted(providers)) or "(no provider evidence captured)",
+        name=", ".join(sorted(scan.providers)) or "(no provider evidence captured)",
         detail=prefix,
         old=f"{prefix}_{floor_raw}",
-        new=best_tag,
+        new=scan.best_tag,
     )
 
 

--- a/abicheck/stack_checker.py
+++ b/abicheck/stack_checker.py
@@ -141,6 +141,37 @@ def _breaking_change_touches_imports(change: StackChange) -> bool:
     return bool(imported_symbols & breaking_symbols)
 
 
+def _abi_diff_risk(change: StackChange) -> tuple[bool, bool]:
+    """``(breaking, risk)`` for a change whose ABI diff actually resolved.
+
+    Whether the root *imports* anything the break touches is what separates a
+    confirmed impact from an environment observation.
+    """
+    assert change.abi_diff is not None  # narrowed by the caller
+    verdict = change.abi_diff.verdict.value
+    if not change.impacted_imports:
+        return False, verdict == "BREAKING"
+    if verdict == "BREAKING":
+        if _breaking_change_touches_imports(change):
+            return True, False
+        # The DSO is broken, but not by anything this root
+        # imports — real "environment contains a broken DSO"
+        # signal, but not a confirmed impact on this root.
+        return False, True
+    return False, verdict in ("API_BREAK", "COMPATIBLE_WITH_RISK")
+
+
+def _stack_change_risk(change: StackChange) -> tuple[bool, bool]:
+    """``(breaking, risk)`` contributed by one stack change."""
+    if change.change_type == "removed":
+        return True, False
+    if change.abi_diff is None:
+        # ABI diff failed (unreadable file or diff error) — treat as risk
+        # since we can't confirm compatibility.
+        return False, change.change_type == "content_changed"
+    return _abi_diff_risk(change)
+
+
 def _compute_abi_risk(
     stack_changes: list[StackChange],
     binding_changes: list[Change] | None = None,
@@ -150,26 +181,9 @@ def _compute_abi_risk(
     has_risk = False
 
     for change in stack_changes:
-        if change.change_type == "removed":
-            has_breaking = True
-        elif change.abi_diff is None and change.change_type == "content_changed":
-            # ABI diff failed (unreadable file or diff error) — treat as risk
-            # since we can't confirm compatibility.
-            has_risk = True
-        elif change.abi_diff is not None and change.impacted_imports:
-            if change.abi_diff.verdict.value == "BREAKING":
-                if _breaking_change_touches_imports(change):
-                    has_breaking = True
-                else:
-                    # The DSO is broken, but not by anything this root
-                    # imports — real "environment contains a broken DSO"
-                    # signal, but not a confirmed impact on this root.
-                    has_risk = True
-            elif change.abi_diff.verdict.value in ("API_BREAK", "COMPATIBLE_WITH_RISK"):
-                has_risk = True
-        elif change.abi_diff is not None and not change.impacted_imports:
-            if change.abi_diff.verdict.value == "BREAKING":
-                has_risk = True
+        breaking, risk = _stack_change_risk(change)
+        has_breaking = has_breaking or breaking
+        has_risk = has_risk or risk
 
     for bchange in binding_changes or []:
         if bchange.kind in BREAKING_KINDS:

--- a/changelog.d/20260810_120000_claude_codefactor_complexity_diff5.md
+++ b/changelog.d/20260810_120000_claude_codefactor_complexity_diff5.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **Split three more CodeFactor "Complex Method" findings, in the unnamed-type
+  detector, the stack ABI-risk verdict and the platform-baseline floor check.**
+  `diff_unnamed_types._unnamed_kind`'s Itanium token-boundary scan becomes one
+  skip function per production behind `_next_token_index`;
+  `stack_checker._compute_abi_risk` moves its per-change classification into
+  `_stack_change_risk`/`_abi_diff_risk`, leaving the fold and the verdict;
+  `diff_versioning._check_baseline_floor_for_prefix` gains a `_FloorScan`
+  accumulator, so the DT_RELR floor — previously folded in by two hand-written
+  copies, one per way it can be observed — is stated once. All three
+  behaviour-preserving and verified against their pre-refactor selves: 671,465
+  inputs for the token scan, and exhaustive branch coverage for the other two
+  (all 360 stack-change combinations, all 840 baseline-floor combinations) — no
+  differences.

--- a/tests/test_g23_phase_d.py
+++ b/tests/test_g23_phase_d.py
@@ -138,6 +138,30 @@ class TestUnnamedTypeLeak:
 
         assert _unnamed_kind("_Z" + "9" * 5000) is None
         assert _unnamed_kind("_Z9abc") is None
+
+    def test_seq_id_digit_not_misread_as_source_name_length(self):
+        # A substitution's seq-id and an array-type's bound are digits that must
+        # NOT be read as a <source-name> length prefix. Without the dedicated
+        # skips, `S`/`A` is stepped over, the following `3` is taken as a
+        # length-3 identifier, and the real `Ut_` token right after it is
+        # consumed as part of that phantom name -- so the leak goes unreported.
+        # These two inputs are exactly that case: they only resolve when the
+        # seq-id/bound is skipped as its own production.
+        from abicheck.diff_unnamed_types import _unnamed_kind
+
+        assert _unnamed_kind("_Z1fS3_Ut_E") == "unnamed struct/enum"
+        assert _unnamed_kind("_Z1fA3_Ut_E") == "unnamed struct/enum"
+
+    def test_substitution_and_template_param_shapes_skipped(self):
+        # The remaining production shapes the scanner must step over before it
+        # can see a structural `Ut_`: a 2-char std abbreviation (`St`), a bare
+        # back-reference (`S_`), and a template-param with and without a number.
+        from abicheck.diff_unnamed_types import _unnamed_kind
+
+        assert _unnamed_kind("_Z1fSt3barUt_E") == "unnamed struct/enum"
+        assert _unnamed_kind("_Z1fS_Ut_E") == "unnamed struct/enum"
+        assert _unnamed_kind("_Z1fT1_Ut_E") == "unnamed struct/enum"
+        assert _unnamed_kind("_Z1fT_Ut_E") == "unnamed struct/enum"
         assert _unnamed_kind("_Z0Ut_") is None
 
     def test_malformed_huge_source_name_length_not_flagged_end_to_end(self):


### PR DESCRIPTION
## Summary

Batch 5f of the CodeFactor "Complex Method" series: three findings, all in files that are **not** `ruff format`-clean on `main`.

## Motivation

Continues #693–#697, #701, #702, #703 (merged) and #707 (open). Touches no file the open PR does.

Every remaining target in this series is either format-dirty or needs a line-budget move first — the format-clean ones are done. These three are the self-contained dirty ones, so they land as a group.

## Changes

| Function | Score | mccabe before | after |
|---|---|---|---|
| `diff_unnamed_types._unnamed_kind` | 18 | 13 | <8 |
| `stack_checker._compute_abi_risk` | 18 | 14 | <8 |
| `diff_versioning._check_baseline_floor_for_prefix` | 17 | 15 | <8 |

**`_unnamed_kind`** carried the whole Itanium token-boundary scan in one loop: the `<source-name>` length prefix with its untrusted-input guard, the three-shape substitution production, the number-terminated template-param/array productions, and the `Ut`/`Ul` match the scan exists to find. Each production is now its own skip function returning the index just past it, reached through `_next_token_index` — which also carries the "why `S`/`T`/`A` must not be read as a length prefix" reasoning, next to the dispatch it explains.

**`_compute_abi_risk`** mixed per-change classification with accumulation and the final verdict. `_stack_change_risk`/`_abi_diff_risk` return the `(breaking, risk)` pair one change contributes. The distinction carrying the reasoning — a confirmed impact on this root vs. an environment observation about a broken DSO — now sits on the function that makes it.

**`_check_baseline_floor_for_prefix`** accumulated three locals in parallel across a nested walk, then applied the DT_RELR fallback with a **duplicate copy of that same accumulation**. `_FloorScan` owns it, and `observe_dt_relr` states the DT_RELR floor once for both ways it can be observed (the synthetic `GLIBC_ABI_DT_RELR` verneed marker a legacy snapshot carries, and the `has_dt_relr` flag). That duplication also obscured something worth naming: the two comparisons inside `observe()` are independent — a tag can raise the observed maximum without exceeding the declared floor, and vice versa.

## Formatting

All three files are not `ruff format`-clean on `main` (pre-existing formatter drift), so **the formatter was deliberately not run** and the changes are hand-matched to the surrounding style. The diffs are 71/44, 34/20 and 50/29 insertions/deletions — no unrelated reformatting buried in them.

## Verification

Each checked against its pre-refactor implementation, comparing outputs *and* exception types/messages. Two had small enough branch spaces to enumerate **exhaustively** rather than sample:

- **`_unnamed_kind`** — 671,465 inputs: every string up to length 5 over the productions' own marker alphabet, 400k random longer ones, and the hand-written cases the comments describe (unbounded digit runs, zero and overlong length prefixes, std abbreviations, seq-ids, lambda and unnamed-struct tokens sitting behind each skip). **0 differences**, with 7,640 producing a non-`None` label — so the matching paths were exercised, not only the rejections.
- **`_compute_abi_risk`** — all **360** single-change combinations (change_type × verdict-or-absent × impacted-imports × breaking-symbol shape, including the DSO-wide sentinel and the `affected_symbols` indirection), plus 20,000 random pairs to confirm accumulation across changes. **0 differences**, all three `StackVerdict` outcomes reached.
- **`_check_baseline_floor_for_prefix`** — all **840** combinations (verneed tag set: empty, absent, multi-library, unparseable, non-matching prefix, both DT_RELR shapes × prefix × declared floor including unparseable and empty × `has_dt_relr` × soname-present), compared field-by-field. **0 differences**, 96 producing an actual finding.

Plus the full fast suite (23807 passed), `ruff check`, `python -m mypy abicheck/` clean across 340 files, and `scripts/check_ai_readiness.py` at 0 errors.

## Checklist

- [x] Tests added / updated for new behaviour — n/a, refactor-only; the verification above plus the existing suites are the regression check
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [x] Docs updated if user-visible behaviour changed — n/a, no user-visible change
- [x] `pre-commit run --all-files` passes locally — `ruff check` and `scripts/check_ai_readiness.py` (0 errors) clean; `ruff format` deliberately not run on these pre-existing-dirty files
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q


---
_Generated by [Claude Code](https://claude.ai/code/session_01WjgkdwQ6FHYescEokur66q)_