### PR TITLE
fix(buildsource): unredact override graph replay cwd

### DIFF
--- a/abicheck/buildsource/override_graph.py
+++ b/abicheck/buildsource/override_graph.py
@@ -746,10 +746,10 @@ class ClangOverrideGraphExtractor:
     def _extract_from_compile_unit(
         self, cu: BuildEvidenceCompileUnit
     ) -> list[OverrideEdge]:
-        from .call_graph import _safe_clang_args_from_compile_unit
+        from .call_graph import _replay_cwd, _safe_clang_args_from_compile_unit
 
         argv = _safe_clang_args_from_compile_unit(cu)
-        return self._extract_from_safe_args(argv, cwd=cu.directory or None)
+        return self._extract_from_safe_args(argv, cwd=_replay_cwd(cu))
 
     def extract_from_build(self, build: BuildEvidence) -> list[OverrideEdge]:
         """Extract override edges across every compile unit in *build*

--- a/changelog.d/20260810_143300_openclaw_override_graph_cwd.md
+++ b/changelog.d/20260810_143300_openclaw_override_graph_cwd.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Windows source-graph override extraction now replays its working directory correctly.** The Clang override-graph pass expands the redacted home-directory placeholder before setting its subprocess `cwd`, so home-rooted compile databases no longer degrade `override_graph` and the dependent virtual-dispatch graph.

--- a/tests/test_override_graph.py
+++ b/tests/test_override_graph.py
@@ -902,6 +902,46 @@ def test_extractor_missing_clang_returns_empty() -> None:
     assert ext.diagnostics
 
 
+def test_extract_from_build_unredacts_home_placeholder_in_cwd(monkeypatch) -> None:
+    """Override extraction must replay the redacted compile-db cwd as a path.
+
+    ``BuildEvidence`` redacts home prefixes to ``~``; subprocess does not
+    expand that placeholder, so passing ``cu.directory`` directly makes every
+    home-rooted Windows CI TU fail before Clang can emit its AST.
+    """
+    import os
+
+    import abicheck.buildsource.override_graph as og
+
+    home = os.path.expanduser("~")
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(og.shutil, "which", lambda _b: "/usr/bin/clang++")
+
+    def fake_dump(clang_bin, argv, *, cwd, diagnostics):
+        captured["argv"] = argv
+        captured["cwd"] = cwd
+        return {"kind": "TranslationUnitDecl", "inner": []}
+
+    monkeypatch.setattr(og, "run_clang_ast_dump", fake_dump)
+    ClangOverrideGraphExtractor().extract_from_build(
+        BuildEvidence(
+            compile_units=[
+                CompileUnit(
+                    id="cu://x",
+                    source="~/AppData/Local/Temp/t.cpp",
+                    directory="~/AppData/Local/Temp",
+                    argv=["/usr/bin/g++", "victim.cpp"],
+                    language="CXX",
+                    standard="c++17",
+                )
+            ]
+        )
+    )
+
+    assert captured["argv"][-2:] == ["--", f"{home}/AppData/Local/Temp/t.cpp"]
+    assert captured["cwd"] == f"{home}/AppData/Local/Temp"
+
+
 def test_extract_from_build_dedupes_across_compile_units(monkeypatch) -> None:
     ext = ClangOverrideGraphExtractor(clang_bin="clang++")
     monkeypatch.setattr(ext, "available", lambda: True)


### PR DESCRIPTION
## Summary
- expand the redacted home placeholder before using the override-graph Clang replay working directory
- add regression coverage for a home-rooted compile database

## Validation
- uv run --extra dev ruff check abicheck/buildsource/override_graph.py tests/test_override_graph.py
- uv run --extra dev pytest tests/test_override_graph.py tests/test_build_source_cli.py -q (165 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Windows override-graph extraction when home-directory paths are redacted.
  - Clang now runs from the correct expanded working directory, preserving override-graph and virtual-dispatch graph generation.

- **Tests**
  - Added regression coverage for expanding home-directory placeholders in source and working-directory paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->