### PR TITLE
fix: warn loudly when an older snapshot degrades a facts-reliability flag

### DIFF
--- a/abicheck/diff_default_value_reliability.py
+++ b/abicheck/diff_default_value_reliability.py
@@ -94,35 +94,52 @@ def _is_expr_fingerprint(value: str) -> bool:
     return bool(_EXPR_FINGERPRINT_RE.match(value))
 
 
-def _fingerprint_comparison_unreliable(old_affected: bool, new_affected: bool) -> bool:
+def _fingerprint_comparison_unreliable(
+    old_is_fingerprint: bool,
+    old_legacy: bool,
+    new_is_fingerprint: bool,
+    new_legacy: bool,
+) -> bool:
     """The single decision rule every fingerprint-reliability guard in this
-    module reduces to, given whether EACH side's own value is a fingerprint
-    produced by the unstable pre-v20 algorithm ("affected" -- fingerprint-
-    shaped AND that side's own reliability flag is unset).
+    module reduces to. *_is_fingerprint* is whether THIS side's own value
+    has the fingerprint shape at all (:func:`_is_expr_fingerprint`);
+    *_legacy* is whether, IF it were fingerprint-shaped, that fingerprint
+    would have come from the unstable pre-v20 algorithm (producer- and
+    reliability-flag-derived, independent of the value's actual shape).
 
-    Suppressing whenever *either* side is independently affected -- what an
-    earlier version of both guards did -- is too conservative: two
-    extractions that BOTH used the identical pre-v20 algorithm produce
-    fingerprints that are directly comparable TO EACH OTHER (same
-    algorithm, same input -> same output; the algorithm being old and buggy
-    is not itself the risk). Only a MISMATCH between generations -- one
-    side pre-v20, the other stabilized (or never using this algorithm at
-    all) -- means a fingerprint difference could be an artifact of the
-    algorithm change rather than a real edit. A genuine constant/default
-    edit between two archived, equally-legacy baselines was being silently
-    dropped by the naive "either side affected" OR (Codex review, fresh
-    evidence, PR #720).
+    Two risks this collapses into one earlier boolean ("affected" =
+    ``is_fingerprint and legacy``) used to conflate, each fixed the same
+    review round (Codex review, fresh evidence, PR #720):
 
-    Deliberately just an XOR over two independently-computed booleans, not
-    a bigger rewrite: each caller already carries its own domain-specific
-    knowledge of what "affected" means for its own fact (per-declaration
-    provenance and producer-inclusive-of-hybrid for defaults; whole-
-    snapshot ``ast_producer`` and producer-exclusive-of-hybrid for
-    constants) -- this function's only job is the one decision both callers
-    were getting wrong in the same way, kept in exactly one place so a
-    future caller inherits the fix instead of re-deriving it.
+    1. Suppressing whenever *either* side was independently affected (an
+       OR) is too conservative when BOTH sides are fingerprint-shaped:
+       two extractions that both used the identical pre-v20 algorithm
+       produce fingerprints that are directly comparable TO EACH OTHER
+       (same algorithm, same input -> same output). Only a MISMATCH
+       between generations -- one side pre-v20, the other stabilized --
+       means a fingerprint difference could be an algorithm artifact
+       rather than a real edit. Fixed by comparing legacy status only
+       between two sides that are BOTH fingerprint-shaped.
+    2. The mirror bug the first fix alone still had: when EXACTLY ONE
+       side is fingerprint-shaped (a literal on one side, a compound
+       expression on the other), that is ALWAYS a genuine value-shape
+       change no algorithm version could produce spuriously -- the
+       unstable ``_canonical_expr`` only ever affects the HASH of an
+       already-compound expression, never whether a declaration's own
+       AST node was a literal or not (:func:`dumper_clang_expr.
+       _initializer_value` keeps a literal's plain value regardless of
+       algorithm version). Naively reducing ``is_fingerprint and legacy``
+       to one boolean before comparing lost this distinction: a legacy
+       fingerprint XORed against a non-fingerprint literal read as
+       "generations differ" and wrongly suppressed a confirmed
+       expression-to-literal (or literal-to-expression) edit.
+
+    So: never suppress unless BOTH sides are genuinely fingerprint-shaped,
+    and even then only when their legacy status actually differs.
     """
-    return old_affected != new_affected
+    if not (old_is_fingerprint and new_is_fingerprint):
+        return False
+    return old_legacy != new_legacy
 
 
 def default_value_representation_unreliable(
@@ -201,19 +218,20 @@ def default_value_fingerprint_comparison_unreliable(
     flag was unset — even though the old side's own literal value never
     depended on that flag at all.
 
-    The actual suppress/don't-suppress decision, given each side's own
-    "affected" status, is :func:`_fingerprint_comparison_unreliable` —
-    an XOR, not an OR: two sides that BOTH used the pre-v20 algorithm are
-    directly comparable to each other (Codex review, fresh evidence,
-    PR #720).
+    The actual suppress/don't-suppress decision is
+    :func:`_fingerprint_comparison_unreliable` — never suppressed unless
+    BOTH sides are genuinely fingerprint-shaped (a literal-vs-expression
+    shape change is always a confirmed real edit, whatever either side's
+    reliability), and even then only on a legacy-generation MISMATCH, not
+    whenever either side is independently unreliable (Codex review, fresh
+    evidence, PR #720).
     """
-    old_affected = _is_expr_fingerprint(
-        old_value
-    ) and default_value_representation_unreliable(old, old_producer)
-    new_affected = _is_expr_fingerprint(
-        new_value
-    ) and default_value_representation_unreliable(new, new_producer)
-    return _fingerprint_comparison_unreliable(old_affected, new_affected)
+    return _fingerprint_comparison_unreliable(
+        _is_expr_fingerprint(old_value),
+        default_value_representation_unreliable(old, old_producer),
+        _is_expr_fingerprint(new_value),
+        default_value_representation_unreliable(new, new_producer),
+    )
 
 
 def constant_value_fingerprint_comparison_unreliable(
@@ -265,19 +283,20 @@ def constant_value_fingerprint_comparison_unreliable(
     get its genuine ``CONSTANT_CHANGED`` silently suppressed regardless of
     producer (Codex review, fresh evidence, PR #720).
 
-    The actual suppress/don't-suppress decision, given each side's own
-    "affected" status, is :func:`_fingerprint_comparison_unreliable` — an
-    XOR, not an OR: two archived baselines that BOTH came from the same
-    pre-v20 direct-clang build are directly comparable to each other, so a
-    genuine edit between them must still be reported (Codex review, fresh
-    evidence, PR #720).
+    The actual suppress/don't-suppress decision is
+    :func:`_fingerprint_comparison_unreliable` — never suppressed unless
+    BOTH sides are genuinely fingerprint-shaped (a literal-vs-expression
+    shape change is always a confirmed real edit), and even then only on a
+    legacy-generation MISMATCH: two archived baselines that BOTH came from
+    the same pre-v20 direct-clang build are directly comparable to each
+    other, so a genuine edit between them must still be reported (Codex
+    review, fresh evidence, PR #720).
     """
-    old_affected = _is_expr_fingerprint(old_value) and (
+    return _fingerprint_comparison_unreliable(
+        _is_expr_fingerprint(old_value),
         old.ast_producer not in ("castxml", "hybrid")
-        and not old.clang_field_initializer_facts_reliable
-    )
-    new_affected = _is_expr_fingerprint(new_value) and (
+        and not old.clang_field_initializer_facts_reliable,
+        _is_expr_fingerprint(new_value),
         new.ast_producer not in ("castxml", "hybrid")
-        and not new.clang_field_initializer_facts_reliable
+        and not new.clang_field_initializer_facts_reliable,
     )
-    return _fingerprint_comparison_unreliable(old_affected, new_affected)

--- a/abicheck/diff_default_value_reliability.py
+++ b/abicheck/diff_default_value_reliability.py
@@ -37,6 +37,34 @@ class of gap ``AbiSnapshot.clang_field_initializer_facts_reliable`` closes
 for ``TypeField.default``'s own presence/absence, reused here for a
 different reason: a default's presence was never unreliable, only the
 non-literal VALUE representation is.
+
+PR #720 retrospective — why five distinct bugs in this small a module took
+five separate review rounds to surface, and what changed about how it's
+tested: every one of them was a different edge of the SAME finite state
+space (each side's producer x reliability-flag x value-shape), and every
+test that existed before that PR picked ONE hand-crafted example per
+property instead of covering that space. A hand-picked example proves the
+one scenario its author thought of works; it says nothing about the dozens
+of other reachable combinations. Concretely, the OR-vs-XOR bug (both guards
+suppressed whenever EITHER side was independently unreliable, when the
+correct rule is a MISMATCH between the two sides' extraction generations)
+survived four earlier review rounds that each fixed a different bug in the
+same two functions, because none of those rounds' new tests happened to
+cover "both sides equally unreliable." ``tests/test_fingerprint_
+reliability_properties.py`` closes that gap structurally rather than
+example-by-example: the reachable domain here is genuinely small (four
+producer values x two reliability states x two value shapes, per side) —
+cheap enough to enumerate EXHAUSTIVELY rather than sample, so it asserts
+invariants ("two fingerprint-shaped values with identical producer and
+reliability are never suppressed", "two non-fingerprint values are never
+suppressed", "the decision is symmetric in old/new") across the entire
+space at once. The general lesson, not just this module's: when a
+function's behavior is fully determined by a handful of independent
+enum/boolean inputs, prefer a test that enumerates that state space and
+asserts invariants over one more hand-picked scenario per bug report —
+it converts "did we think to test this one case" into "is this true for
+every case," which is exactly the class of check a human/LLM review pass
+manually re-deriving edge cases one at a time cannot exhaustively provide.
 """
 
 from __future__ import annotations
@@ -64,6 +92,37 @@ def _is_expr_fingerprint(value: str) -> bool:
     """True if *value* is exactly a clang structural-expression fingerprint,
     not merely ``"expr:"``-prefixed text (see ``_EXPR_FINGERPRINT_RE``)."""
     return bool(_EXPR_FINGERPRINT_RE.match(value))
+
+
+def _fingerprint_comparison_unreliable(old_affected: bool, new_affected: bool) -> bool:
+    """The single decision rule every fingerprint-reliability guard in this
+    module reduces to, given whether EACH side's own value is a fingerprint
+    produced by the unstable pre-v20 algorithm ("affected" -- fingerprint-
+    shaped AND that side's own reliability flag is unset).
+
+    Suppressing whenever *either* side is independently affected -- what an
+    earlier version of both guards did -- is too conservative: two
+    extractions that BOTH used the identical pre-v20 algorithm produce
+    fingerprints that are directly comparable TO EACH OTHER (same
+    algorithm, same input -> same output; the algorithm being old and buggy
+    is not itself the risk). Only a MISMATCH between generations -- one
+    side pre-v20, the other stabilized (or never using this algorithm at
+    all) -- means a fingerprint difference could be an artifact of the
+    algorithm change rather than a real edit. A genuine constant/default
+    edit between two archived, equally-legacy baselines was being silently
+    dropped by the naive "either side affected" OR (Codex review, fresh
+    evidence, PR #720).
+
+    Deliberately just an XOR over two independently-computed booleans, not
+    a bigger rewrite: each caller already carries its own domain-specific
+    knowledge of what "affected" means for its own fact (per-declaration
+    provenance and producer-inclusive-of-hybrid for defaults; whole-
+    snapshot ``ast_producer`` and producer-exclusive-of-hybrid for
+    constants) -- this function's only job is the one decision both callers
+    were getting wrong in the same way, kept in exactly one place so a
+    future caller inherits the fix instead of re-deriving it.
+    """
+    return old_affected != new_affected
 
 
 def default_value_representation_unreliable(
@@ -141,16 +200,20 @@ def default_value_fingerprint_comparison_unreliable(
     solely because the OLD snapshot's ``clang_field_initializer_facts_reliable``
     flag was unset — even though the old side's own literal value never
     depended on that flag at all.
+
+    The actual suppress/don't-suppress decision, given each side's own
+    "affected" status, is :func:`_fingerprint_comparison_unreliable` —
+    an XOR, not an OR: two sides that BOTH used the pre-v20 algorithm are
+    directly comparable to each other (Codex review, fresh evidence,
+    PR #720).
     """
-    if _is_expr_fingerprint(old_value) and default_value_representation_unreliable(
-        old, old_producer
-    ):
-        return True
-    if _is_expr_fingerprint(new_value) and default_value_representation_unreliable(
-        new, new_producer
-    ):
-        return True
-    return False
+    old_affected = _is_expr_fingerprint(
+        old_value
+    ) and default_value_representation_unreliable(old, old_producer)
+    new_affected = _is_expr_fingerprint(
+        new_value
+    ) and default_value_representation_unreliable(new, new_producer)
+    return _fingerprint_comparison_unreliable(old_affected, new_affected)
 
 
 def constant_value_fingerprint_comparison_unreliable(
@@ -201,15 +264,20 @@ def constant_value_fingerprint_comparison_unreliable(
     namespace) would otherwise collide with the ``"expr:"`` PREFIX check and
     get its genuine ``CONSTANT_CHANGED`` silently suppressed regardless of
     producer (Codex review, fresh evidence, PR #720).
+
+    The actual suppress/don't-suppress decision, given each side's own
+    "affected" status, is :func:`_fingerprint_comparison_unreliable` — an
+    XOR, not an OR: two archived baselines that BOTH came from the same
+    pre-v20 direct-clang build are directly comparable to each other, so a
+    genuine edit between them must still be reported (Codex review, fresh
+    evidence, PR #720).
     """
-    if _is_expr_fingerprint(old_value) and (
+    old_affected = _is_expr_fingerprint(old_value) and (
         old.ast_producer not in ("castxml", "hybrid")
         and not old.clang_field_initializer_facts_reliable
-    ):
-        return True
-    if _is_expr_fingerprint(new_value) and (
+    )
+    new_affected = _is_expr_fingerprint(new_value) and (
         new.ast_producer not in ("castxml", "hybrid")
         and not new.clang_field_initializer_facts_reliable
-    ):
-        return True
-    return False
+    )
+    return _fingerprint_comparison_unreliable(old_affected, new_affected)

--- a/abicheck/diff_default_value_reliability.py
+++ b/abicheck/diff_default_value_reliability.py
@@ -41,7 +41,29 @@ non-literal VALUE representation is.
 
 from __future__ import annotations
 
+import re
+
 from .model import AbiSnapshot
+
+#: The exact shape ``dumper_clang_expr._expr_fingerprint`` produces --
+#: ``"expr:" + sha256(...).hexdigest()[:16]`` (16 lowercase hex digits) --
+#: not merely the ``"expr:"`` PREFIX. A plain ``.startswith("expr:")`` check
+#: also matches castxml's raw, verbatim source-text initializer whenever it
+#: happens to spell a qualified name whose next component is literally
+#: ``expr`` (e.g. an expression-template library's ``expr::`` namespace) --
+#: ``dumper_castxml._iter_public_constants``/``_ClangAstParser`` parsers both
+#: pass that XML/AST ``init`` text straight through unmodified, no fingerprint
+#: involved at all. Matching the full shape means a genuine
+#: ``"expr::OLD_VALUE"`` vs. ``"expr::NEW_VALUE"`` castxml comparison is never
+#: mistaken for a clang fingerprint and silently suppressed (Codex review,
+#: fresh evidence, PR #720).
+_EXPR_FINGERPRINT_RE = re.compile(r"^expr:[0-9a-f]{16}$")
+
+
+def _is_expr_fingerprint(value: str) -> bool:
+    """True if *value* is exactly a clang structural-expression fingerprint,
+    not merely ``"expr:"``-prefixed text (see ``_EXPR_FINGERPRINT_RE``)."""
+    return bool(_EXPR_FINGERPRINT_RE.match(value))
 
 
 def default_value_representation_unreliable(
@@ -120,11 +142,11 @@ def default_value_fingerprint_comparison_unreliable(
     flag was unset — even though the old side's own literal value never
     depended on that flag at all.
     """
-    if old_value.startswith("expr:") and default_value_representation_unreliable(
+    if _is_expr_fingerprint(old_value) and default_value_representation_unreliable(
         old, old_producer
     ):
         return True
-    if new_value.startswith("expr:") and default_value_representation_unreliable(
+    if _is_expr_fingerprint(new_value) and default_value_representation_unreliable(
         new, new_producer
     ):
         return True
@@ -170,16 +192,22 @@ def constant_value_fingerprint_comparison_unreliable(
     :func:`default_value_representation_unreliable`'s own third-round
     ``None``-is-clang-family-risk fix for the identical shape of gap). Safe
     for a genuinely castxml-authored ``None``-producer legacy snapshot too:
-    castxml never emits an ``"expr:"``-prefixed value at all (it keeps the
-    verbatim source expression instead), so the ``.startswith("expr:")``
-    guard alone already excludes it regardless of producer precision.
+    ``_is_expr_fingerprint`` matches the full 16-hex-digit shape, not merely
+    the ``"expr:"`` prefix -- castxml keeps the verbatim source expression
+    for a constant's value (``dumper_castxml._iter_public_constants`` passes
+    its raw XML ``init`` text straight through), so a real castxml constant
+    referencing a qualified name whose next component happens to spell
+    ``expr`` (e.g. ``"expr::OLD_VALUE"``, an expression-template library's
+    namespace) would otherwise collide with the ``"expr:"`` PREFIX check and
+    get its genuine ``CONSTANT_CHANGED`` silently suppressed regardless of
+    producer (Codex review, fresh evidence, PR #720).
     """
-    if old_value.startswith("expr:") and (
+    if _is_expr_fingerprint(old_value) and (
         old.ast_producer not in ("castxml", "hybrid")
         and not old.clang_field_initializer_facts_reliable
     ):
         return True
-    if new_value.startswith("expr:") and (
+    if _is_expr_fingerprint(new_value) and (
         new.ast_producer not in ("castxml", "hybrid")
         and not new.clang_field_initializer_facts_reliable
     ):

--- a/abicheck/diff_default_value_reliability.py
+++ b/abicheck/diff_default_value_reliability.py
@@ -153,20 +153,35 @@ def constant_value_fingerprint_comparison_unreliable(
     resolve: ``dumper_hybrid.merge_snapshots`` keeps ``constants`` verbatim
     from its castxml base (never clang-merged per-entry), so a snapshot's
     own top-level ``ast_producer`` already answers which single backend
-    produced every entry. Checked as an EXACT ``"clang"`` match, deliberately
-    NOT :func:`default_value_representation_unreliable`'s broader
-    ``producer != "castxml"`` reasoning: that reasoning also treats a
-    ``"hybrid"`` producer as at-risk, because a hybrid merge's clang-only-
-    APPENDED fields keep their own unstable fingerprint -- true for
-    ``TypeField.default``, but not for constants, which never take that
-    per-declaration merge path at all.
+    produced every entry. Checked as ``NOT in ("castxml", "hybrid")`` --
+    NEITHER of :func:`default_value_representation_unreliable`'s two
+    producer checks alone is right here. Its broader ``producer !=
+    "castxml"`` treats a ``"hybrid"`` producer as at-risk too, because a
+    hybrid merge's clang-only-APPENDED fields keep their own unstable
+    fingerprint -- true for ``TypeField.default``, but not for constants,
+    which never take that per-declaration merge path at all, so ``"hybrid"``
+    is excluded here same as ``"castxml"``. But an exact ``== "clang"``
+    match is too narrow the other direction: ``ast_producer`` itself wasn't
+    tracked before schema v10 (eight versions before this class of risk even
+    existed in the wild), so a snapshot straddling that boundary reads
+    ``ast_producer=None`` -- "unknown", not "definitely not clang" -- and
+    excluding it would silently trust an ``"expr:"`` value from exactly the
+    producer this guard exists to distrust (Codex review, PR #720; mirrors
+    :func:`default_value_representation_unreliable`'s own third-round
+    ``None``-is-clang-family-risk fix for the identical shape of gap). Safe
+    for a genuinely castxml-authored ``None``-producer legacy snapshot too:
+    castxml never emits an ``"expr:"``-prefixed value at all (it keeps the
+    verbatim source expression instead), so the ``.startswith("expr:")``
+    guard alone already excludes it regardless of producer precision.
     """
     if old_value.startswith("expr:") and (
-        old.ast_producer == "clang" and not old.clang_field_initializer_facts_reliable
+        old.ast_producer not in ("castxml", "hybrid")
+        and not old.clang_field_initializer_facts_reliable
     ):
         return True
     if new_value.startswith("expr:") and (
-        new.ast_producer == "clang" and not new.clang_field_initializer_facts_reliable
+        new.ast_producer not in ("castxml", "hybrid")
+        and not new.clang_field_initializer_facts_reliable
     ):
         return True
     return False

--- a/abicheck/diff_default_value_reliability.py
+++ b/abicheck/diff_default_value_reliability.py
@@ -129,3 +129,44 @@ def default_value_fingerprint_comparison_unreliable(
     ):
         return True
     return False
+
+
+def constant_value_fingerprint_comparison_unreliable(
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+    old_value: str,
+    new_value: str,
+) -> bool:
+    """True if comparing two ``AbiSnapshot.constants`` entries (same name,
+    different value) risks a false ``CONSTANT_CHANGED`` from the identical
+    fingerprint-algorithm version mismatch
+    :func:`default_value_fingerprint_comparison_unreliable` guards against
+    for ``Param.default``/``TypeField.default`` -- ``dumper_clang.py``'s
+    ``parse_constants()`` calls the very same ``_initializer_value()``, so a
+    non-literal constant's ``"expr:"``-prefixed value on the direct-clang
+    backend is exactly as unstable pre-schema-v20 (measured against a real
+    corpus: 173 of 440 findings across a v18-vs-v24 comparison were exactly
+    this -- one constant's stale fingerprint colliding with 35 unrelated
+    others').
+
+    Unlike the default-value case there is no per-declaration provenance to
+    resolve: ``dumper_hybrid.merge_snapshots`` keeps ``constants`` verbatim
+    from its castxml base (never clang-merged per-entry), so a snapshot's
+    own top-level ``ast_producer`` already answers which single backend
+    produced every entry. Checked as an EXACT ``"clang"`` match, deliberately
+    NOT :func:`default_value_representation_unreliable`'s broader
+    ``producer != "castxml"`` reasoning: that reasoning also treats a
+    ``"hybrid"`` producer as at-risk, because a hybrid merge's clang-only-
+    APPENDED fields keep their own unstable fingerprint -- true for
+    ``TypeField.default``, but not for constants, which never take that
+    per-declaration merge path at all.
+    """
+    if old_value.startswith("expr:") and (
+        old.ast_producer == "clang" and not old.clang_field_initializer_facts_reliable
+    ):
+        return True
+    if new_value.startswith("expr:") and (
+        new.ast_producer == "clang" and not new.clang_field_initializer_facts_reliable
+    ):
+        return True
+    return False

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -31,6 +31,7 @@ from .diff_cxx_rules import (
     virtual_method_addition,
 )
 from .diff_default_value_reliability import (
+    constant_value_fingerprint_comparison_unreliable,
     default_value_fingerprint_comparison_unreliable,
 )
 from .diff_helpers import (
@@ -1905,13 +1906,19 @@ def _diff_param_va_list(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
 def _diff_constants(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     """Detect preprocessor / const-constant changes (ABICC: Changed/Added/Removed_Constant).
 
-    Header-tier only: ``AbiSnapshot.constants`` is populated solely from castxml
-    header parsing. If either side was NOT (confirmed) parsed from headers
-    (DWARF/symbols mode, a snapshot taken before constant extraction, or a
-    legacy/inferred headerless snapshot), its ``constants`` map is empty only
-    because the data is *unavailable* — comparing would report every constant as
-    removed (or added, depending on direction). Skip unless both sides are
-    header-aware.
+    Header-tier only: ``AbiSnapshot.constants`` is populated from header
+    parsing (castxml, and the direct-clang backend's own
+    ``parse_constants()``). If either side was NOT (confirmed) parsed from
+    headers (DWARF/symbols mode, a snapshot taken before constant extraction,
+    or a legacy/inferred headerless snapshot), its ``constants`` map is empty
+    only because the data is *unavailable* — comparing would report every
+    constant as removed (or added, depending on direction). Skip unless both
+    sides are header-aware.
+
+    ``constant_value_fingerprint_comparison_unreliable`` declines a CHANGED
+    verdict when either side's value is a pre-stabilization direct-clang
+    fingerprint that can't be trusted against a fresh one — see that
+    function's own docstring (``diff_default_value_reliability.py``) for why.
     """
     if not _both_header_aware(old, new):
         return []
@@ -1931,6 +1938,10 @@ def _diff_constants(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
                 )
             )
         elif new_val != old_val:
+            if constant_value_fingerprint_comparison_unreliable(
+                old, new, old_val, new_val
+            ):
+                continue
             changes.append(
                 make_change(
                     ChangeKind.CONSTANT_CHANGED,
@@ -1970,8 +1981,7 @@ def _diff_var_access(old: AbiSnapshot, new: AbiSnapshot) -> list[Change]:
     if old.ast_producer != "castxml" or new.ast_producer != "castxml":
         return []
     if not (
-        old.castxml_var_access_facts_reliable
-        and new.castxml_var_access_facts_reliable
+        old.castxml_var_access_facts_reliable and new.castxml_var_access_facts_reliable
     ):
         return []
     return var_access_changes(_public_variables(old), _public_variables(new))

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -265,6 +265,18 @@ from .model import (
 #     False so `diff_symbols._diff_var_access` declines to trust it, instead
 #     of reporting a false `VAR_ACCESS_WIDENED` for every private/protected
 #     static member purely from a tool upgrade.
+#
+# Reading an OLDER snapshot (the direction every CI baseline actually hits —
+# a baseline is committed once and outlives however many abicheck pin bumps
+# happen before it's next regenerated) used to be entirely silent whenever it
+# degraded one of the `*_facts_reliable` flags above: the flag itself was set
+# correctly, but nothing surfaced that fact to whoever was reading the
+# comparison. `snapshot_from_dict` now emits a `UserWarning` naming exactly
+# which flags got degraded, once, at load time — but only when the version
+# gap actually degraded something; a trivial one-version-behind snapshot that
+# doesn't hit any producer-specific threshold above stays silent, since every
+# CI baseline is *always* some number of versions behind and warning
+# regardless of relevance would just be noise.
 SCHEMA_VERSION: int = 24
 
 # Schema version at which CastXML field CV facts became reliable (see v9 above).
@@ -1449,6 +1461,60 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             from .python_ext import detect_python_extension
 
             snap.python_ext = detect_python_extension(snap)
+
+    # An older snapshot (schema_version < SCHEMA_VERSION) is the direction
+    # every CI baseline actually hits -- a baseline is committed once and
+    # then outlives however many abicheck pin bumps happen before it's next
+    # regenerated, unlike a fresh dump which is always current-schema. Reads
+    # normally (older schema versions are backward compatible by design; see
+    # the version-history comments above SCHEMA_VERSION), but until now that
+    # was entirely silent: the *_facts_reliable flags computed above already
+    # degrade individual detectors' trust in specific stale-but-real-looking
+    # facts, yet nothing ever told the person running the comparison that any
+    # of that degradation happened. Unlike the "reader older than snapshot"
+    # branch above (which always warns, any single version behind), this
+    # only fires when the version gap actually degraded a known fact --
+    # warning on every trivial one-version-behind snapshot regardless of
+    # whether it affects anything would be exactly the noise CI baselines
+    # (which are *always* somewhat behind) don't need.
+    if _schema_version < SCHEMA_VERSION:
+        _degraded_facts = sorted(
+            name
+            for name, reliable in (
+                ("header_cv_facts_reliable", header_cv_facts_reliable_value),
+                (
+                    "clang_deprecation_facts_reliable",
+                    clang_deprecation_facts_reliable_value,
+                ),
+                (
+                    "clang_field_initializer_facts_reliable",
+                    clang_field_initializer_facts_reliable_value,
+                ),
+                ("clang_vtable_facts_reliable", clang_vtable_facts_reliable_value),
+                ("clang_restrict_facts_reliable", clang_restrict_facts_reliable_value),
+                ("clang_va_list_facts_reliable", clang_va_list_facts_reliable_value),
+                (
+                    "castxml_var_access_facts_reliable",
+                    castxml_var_access_facts_reliable_value,
+                ),
+            )
+            if not reliable
+        )
+        if _degraded_facts:
+            import warnings
+
+            warnings.warn(
+                f"Snapshot schema_version {_schema_version} predates this abicheck's "
+                f"schema_version {SCHEMA_VERSION}: "
+                f"{', '.join(_degraded_facts)} "
+                f"{'is' if len(_degraded_facts) == 1 else 'are'} marked unreliable on "
+                "this snapshot, so the affected detectors will decline to trust these "
+                "stale facts rather than risk a false positive purely from this tool "
+                "upgrade. Detection coverage for these fields is reduced until this "
+                "snapshot is regenerated with the current abicheck.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     return snap
 

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -1462,88 +1462,107 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
 
             snap.python_ext = detect_python_extension(snap)
 
-    # An older snapshot (schema_version < SCHEMA_VERSION) is the direction
-    # every CI baseline actually hits -- a baseline is committed once and
-    # then outlives however many abicheck pin bumps happen before it's next
-    # regenerated, unlike a fresh dump which is always current-schema. Reads
-    # normally (older schema versions are backward compatible by design; see
-    # the version-history comments above SCHEMA_VERSION), but until now that
-    # was entirely silent: the *_facts_reliable flags computed above already
-    # degrade individual detectors' trust in specific stale-but-real-looking
-    # facts, yet nothing ever told the person running the comparison that any
-    # of that degradation happened. Unlike the "reader older than snapshot"
-    # branch above (which always warns, any single version behind), this
-    # only fires when the version gap actually degraded a known fact --
-    # warning on every trivial one-version-behind snapshot regardless of
-    # whether it affects anything would be exactly the noise CI baselines
-    # (which are *always* somewhat behind) don't need.
-    if _schema_version < SCHEMA_VERSION:
-        # Each entry pairs a flag with whether it is even CONSULTED by the
-        # one detector that reads it, given THIS side's own AST producer.
-        # Most flags' value computation already collapses to "reliable" for
-        # every producer their consumer doesn't gate on (see each flag's own
-        # computation above) -- but two don't: clang_va_list_facts_reliable's
-        # value treats "hybrid" the same as "clang" (correct for the fact's
-        # own provenance), yet diff_symbols._diff_param_va_list only ever
-        # consults it when BOTH sides are exactly "clang" (never "hybrid").
-        # castxml_var_access_facts_reliable is the mirror case for "castxml"
-        # vs. diff_symbols._diff_var_access. Listing either one for a hybrid
-        # snapshot would claim reduced detection coverage that regenerating
-        # the snapshot could never restore, since no detector consults it
-        # for that producer regardless of schema version (Codex review,
-        # PR #720).
-        _degraded_facts = sorted(
-            name
-            for name, reliable, consulted in (
-                ("header_cv_facts_reliable", header_cv_facts_reliable_value, True),
-                (
-                    "clang_deprecation_facts_reliable",
-                    clang_deprecation_facts_reliable_value,
-                    True,
-                ),
-                (
-                    "clang_field_initializer_facts_reliable",
-                    clang_field_initializer_facts_reliable_value,
-                    True,
-                ),
-                (
-                    "clang_vtable_facts_reliable",
-                    clang_vtable_facts_reliable_value,
-                    True,
-                ),
-                (
-                    "clang_restrict_facts_reliable",
-                    clang_restrict_facts_reliable_value,
-                    True,
-                ),
-                (
-                    "clang_va_list_facts_reliable",
-                    clang_va_list_facts_reliable_value,
-                    ast_producer_value == "clang",
-                ),
-                (
-                    "castxml_var_access_facts_reliable",
-                    castxml_var_access_facts_reliable_value,
-                    ast_producer_value == "castxml",
-                ),
-            )
-            if not reliable and consulted
+    # A degraded *_facts_reliable flag used to load with no signal at all --
+    # the flag itself was computed correctly, but nothing ever told the
+    # person running the comparison that any detector would decline to
+    # trust a stale-but-real-looking fact on this snapshot. Two separate
+    # situations both leave a flag False, and both need the same visible
+    # signal rather than silence:
+    #   (1) THIS snapshot's own schema_version predates SCHEMA_VERSION, and
+    #       the gap crossed one of the per-flag thresholds above -- the
+    #       direction every CI baseline actually hits, since a baseline is
+    #       committed once and outlives however many abicheck pin bumps
+    #       happen before it's next regenerated.
+    #   (2) schema_version reads as CURRENT, but an explicit False marker in
+    #       `d` carried a degraded flag forward from an earlier, genuinely
+    #       older extraction -- the "explicit-marker-wins" round-trip-
+    #       stability path every flag's own computation above already
+    #       implements. `snapshot_to_dict` always re-stamps schema_version
+    #       to the CURRENT SCHEMA_VERSION on save (it describes the writing
+    #       tool's format capability, not the snapshot's true field-fact
+    #       origin -- see e.g. header_cv_facts_reliable_value's own comment),
+    #       so a legacy snapshot that was loaded and simply re-saved reads
+    #       as current-schema on its next load even though the underlying
+    #       facts were never regenerated. Gating this warning on
+    #       schema_version alone would make it disappear across exactly that
+    #       round-trip (Codex review, PR #720) -- the flags themselves, not
+    #       the version number, are the ground truth here.
+    # Each entry pairs a flag with whether it is even CONSULTED by the one
+    # detector that reads it, given THIS side's own AST producer. Most
+    # flags' value computation already collapses to "reliable" for every
+    # producer their consumer doesn't gate on (see each flag's own
+    # computation above) -- but two don't: clang_va_list_facts_reliable's
+    # value treats "hybrid" the same as "clang" (correct for the fact's own
+    # provenance), yet diff_symbols._diff_param_va_list only ever consults
+    # it when BOTH sides are exactly "clang" (never "hybrid").
+    # castxml_var_access_facts_reliable is the mirror case for "castxml" vs.
+    # diff_symbols._diff_var_access. Listing either one for a hybrid
+    # snapshot would claim reduced detection coverage that regenerating the
+    # snapshot could never restore, since no detector consults it for that
+    # producer regardless of schema version (Codex review, PR #720).
+    _degraded_facts = sorted(
+        name
+        for name, reliable, consulted in (
+            ("header_cv_facts_reliable", header_cv_facts_reliable_value, True),
+            (
+                "clang_deprecation_facts_reliable",
+                clang_deprecation_facts_reliable_value,
+                True,
+            ),
+            (
+                "clang_field_initializer_facts_reliable",
+                clang_field_initializer_facts_reliable_value,
+                True,
+            ),
+            (
+                "clang_vtable_facts_reliable",
+                clang_vtable_facts_reliable_value,
+                True,
+            ),
+            (
+                "clang_restrict_facts_reliable",
+                clang_restrict_facts_reliable_value,
+                True,
+            ),
+            (
+                "clang_va_list_facts_reliable",
+                clang_va_list_facts_reliable_value,
+                ast_producer_value == "clang",
+            ),
+            (
+                "castxml_var_access_facts_reliable",
+                castxml_var_access_facts_reliable_value,
+                ast_producer_value == "castxml",
+            ),
         )
-        if _degraded_facts:
-            import warnings
+        if not reliable and consulted
+    )
+    if _degraded_facts:
+        import warnings
 
-            warnings.warn(
-                f"Snapshot schema_version {_schema_version} predates this abicheck's "
-                f"schema_version {SCHEMA_VERSION}: "
-                f"{', '.join(_degraded_facts)} "
-                f"{'is' if len(_degraded_facts) == 1 else 'are'} marked unreliable on "
-                "this snapshot, so the affected detectors will decline to trust these "
-                "stale facts rather than risk a false positive purely from this tool "
-                "upgrade. Detection coverage for these fields is reduced until this "
-                "snapshot is regenerated with the current abicheck.",
-                UserWarning,
-                stacklevel=2,
+        if _schema_version < SCHEMA_VERSION:
+            _reason = (
+                f"Snapshot schema_version {_schema_version} predates this "
+                f"abicheck's schema_version {SCHEMA_VERSION}"
             )
+        else:
+            _reason = (
+                "This snapshot carries facts preserved from an earlier, "
+                f"older extraction (its schema_version reads as the current "
+                f"{SCHEMA_VERSION} because it was re-saved since, but the "
+                "underlying facts below were never regenerated)"
+            )
+        warnings.warn(
+            f"{_reason}: "
+            f"{', '.join(_degraded_facts)} "
+            f"{'is' if len(_degraded_facts) == 1 else 'are'} marked unreliable on "
+            "this snapshot, so the affected detectors will decline to trust these "
+            "stale facts rather than risk a false positive purely from this tool "
+            "upgrade. Detection coverage for these fields is reduced until this "
+            "snapshot is regenerated with the current abicheck.",
+            UserWarning,
+            stacklevel=2,
+        )
 
     return snap
 

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -1488,18 +1488,36 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
     #       round-trip (Codex review, PR #720) -- the flags themselves, not
     #       the version number, are the ground truth here.
     # Each entry pairs a flag with whether it is even CONSULTED by the one
-    # detector that reads it, given THIS side's own AST producer. Most
-    # flags' value computation already collapses to "reliable" for every
-    # producer their consumer doesn't gate on (see each flag's own
-    # computation above) -- but two don't: clang_va_list_facts_reliable's
-    # value treats "hybrid" the same as "clang" (correct for the fact's own
-    # provenance), yet diff_symbols._diff_param_va_list only ever consults
-    # it when BOTH sides are exactly "clang" (never "hybrid").
+    # detector that reads it, given THIS side's own AST producer and header
+    # confirmation. Most flags' value computation already collapses to
+    # "reliable" for every producer their consumer doesn't gate on (see each
+    # flag's own computation above) -- but two don't: clang_va_list_facts_
+    # reliable's value treats "hybrid" the same as "clang" (correct for the
+    # fact's own provenance), yet diff_symbols._diff_param_va_list only ever
+    # consults it when BOTH sides are exactly "clang" (never "hybrid").
     # castxml_var_access_facts_reliable is the mirror case for "castxml" vs.
     # diff_symbols._diff_var_access. Listing either one for a hybrid
     # snapshot would claim reduced detection coverage that regenerating the
     # snapshot could never restore, since no detector consults it for that
     # producer regardless of schema version (Codex review, PR #720).
+    #
+    # Separately, five of the seven flags' one real consumer requires
+    # CONFIRMED (non-inferred) header awareness on this side before it ever
+    # reads the flag at all: clang_restrict/clang_va_list/
+    # castxml_var_access's detectors each exit through
+    # diff_symbols._both_header_aware before consulting their flag, and
+    # clang_deprecation/clang_field_initializer's shared consumer
+    # (fact_provenance.fact_producer) opens with the identical
+    # ``from_headers and not from_headers_inferred`` check. A schema-v1..v5
+    # snapshot that predates the explicit ``from_headers`` key gets
+    # ``from_headers`` GUESSED true from a populated surface -- real, but
+    # not "confirmed" -- so none of these five detectors will ever consult
+    # their flag for it regardless of whether a fresh dump would restore it
+    # (Codex review, PR #720). header_cv_facts_reliable and
+    # clang_vtable_facts_reliable are the two exceptions: their consumers
+    # (variable/field cv checks, layout/vtable diffing) apply to any
+    # snapshot carrying the underlying fact, header-confirmed or not.
+    _header_confirmed = from_headers and not from_headers_inferred
     _degraded_facts = sorted(
         name
         for name, reliable, consulted in (
@@ -1507,12 +1525,12 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             (
                 "clang_deprecation_facts_reliable",
                 clang_deprecation_facts_reliable_value,
-                True,
+                _header_confirmed,
             ),
             (
                 "clang_field_initializer_facts_reliable",
                 clang_field_initializer_facts_reliable_value,
-                True,
+                _header_confirmed,
             ),
             (
                 "clang_vtable_facts_reliable",
@@ -1522,17 +1540,17 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
             (
                 "clang_restrict_facts_reliable",
                 clang_restrict_facts_reliable_value,
-                True,
+                _header_confirmed,
             ),
             (
                 "clang_va_list_facts_reliable",
                 clang_va_list_facts_reliable_value,
-                ast_producer_value == "clang",
+                _header_confirmed and ast_producer_value == "clang",
             ),
             (
                 "castxml_var_access_facts_reliable",
                 castxml_var_access_facts_reliable_value,
-                ast_producer_value == "castxml",
+                _header_confirmed and ast_producer_value == "castxml",
             ),
         )
         if not reliable and consulted

--- a/abicheck/serialization.py
+++ b/abicheck/serialization.py
@@ -1478,27 +1478,56 @@ def snapshot_from_dict(d: dict[str, Any]) -> AbiSnapshot:
     # whether it affects anything would be exactly the noise CI baselines
     # (which are *always* somewhat behind) don't need.
     if _schema_version < SCHEMA_VERSION:
+        # Each entry pairs a flag with whether it is even CONSULTED by the
+        # one detector that reads it, given THIS side's own AST producer.
+        # Most flags' value computation already collapses to "reliable" for
+        # every producer their consumer doesn't gate on (see each flag's own
+        # computation above) -- but two don't: clang_va_list_facts_reliable's
+        # value treats "hybrid" the same as "clang" (correct for the fact's
+        # own provenance), yet diff_symbols._diff_param_va_list only ever
+        # consults it when BOTH sides are exactly "clang" (never "hybrid").
+        # castxml_var_access_facts_reliable is the mirror case for "castxml"
+        # vs. diff_symbols._diff_var_access. Listing either one for a hybrid
+        # snapshot would claim reduced detection coverage that regenerating
+        # the snapshot could never restore, since no detector consults it
+        # for that producer regardless of schema version (Codex review,
+        # PR #720).
         _degraded_facts = sorted(
             name
-            for name, reliable in (
-                ("header_cv_facts_reliable", header_cv_facts_reliable_value),
+            for name, reliable, consulted in (
+                ("header_cv_facts_reliable", header_cv_facts_reliable_value, True),
                 (
                     "clang_deprecation_facts_reliable",
                     clang_deprecation_facts_reliable_value,
+                    True,
                 ),
                 (
                     "clang_field_initializer_facts_reliable",
                     clang_field_initializer_facts_reliable_value,
+                    True,
                 ),
-                ("clang_vtable_facts_reliable", clang_vtable_facts_reliable_value),
-                ("clang_restrict_facts_reliable", clang_restrict_facts_reliable_value),
-                ("clang_va_list_facts_reliable", clang_va_list_facts_reliable_value),
+                (
+                    "clang_vtable_facts_reliable",
+                    clang_vtable_facts_reliable_value,
+                    True,
+                ),
+                (
+                    "clang_restrict_facts_reliable",
+                    clang_restrict_facts_reliable_value,
+                    True,
+                ),
+                (
+                    "clang_va_list_facts_reliable",
+                    clang_va_list_facts_reliable_value,
+                    ast_producer_value == "clang",
+                ),
                 (
                     "castxml_var_access_facts_reliable",
                     castxml_var_access_facts_reliable_value,
+                    ast_producer_value == "castxml",
                 ),
             )
-            if not reliable
+            if not reliable and consulted
         )
         if _degraded_facts:
             import warnings

--- a/changelog.d/20260811_090000_claude_older_snapshot_degraded_facts_warning.md
+++ b/changelog.d/20260811_090000_claude_older_snapshot_degraded_facts_warning.md
@@ -1,0 +1,21 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **Loading an older-schema snapshot that degraded a `*_facts_reliable` flag
+  was silent** (`serialization.snapshot_from_dict`): the hard-rejection and
+  version-mismatch warning at the top of the function only ever covered a
+  snapshot *newer* than the reader. A snapshot *older* than the reader — the
+  direction every CI baseline actually hits, since a baseline is committed
+  once and outlives however many abicheck pin bumps happen before it's next
+  regenerated — loaded with no signal at all, even when the version gap
+  meant a real, known fact (e.g. clang-backend deprecation/vtable/restrict/
+  va_list facts, or CastXML CV/variable-access facts) was marked unreliable
+  and silently excluded from detection. `snapshot_from_dict` now emits a
+  `UserWarning` at load time naming exactly which `*_facts_reliable` flags
+  got degraded, so a stale committed baseline's reduced detection coverage
+  is visible instead of discovered later. Stays silent for a version gap
+  that doesn't actually degrade anything, so an ordinary one-version-behind
+  baseline isn't warned about for no reason.

--- a/changelog.d/20260811_090000_claude_older_snapshot_degraded_facts_warning.md
+++ b/changelog.d/20260811_090000_claude_older_snapshot_degraded_facts_warning.md
@@ -26,4 +26,12 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   `schema_version` to the current value, so a degraded flag preserved
   through an explicit marker on a reserialized legacy snapshot now still
   triggers the warning instead of silently disappearing once the version
-  number itself reads as current.
+  number itself reads as current. Five of the seven flags are further
+  gated on this side's own confirmed (non-inferred) header awareness,
+  matching each flag's one real consumer: a schema-v1–v5 snapshot with no
+  explicit `from_headers` key gets it *guessed* true from a populated
+  surface, and none of `diff_symbols._diff_param_restrict`/
+  `_diff_param_va_list`/`_diff_var_access`/`fact_provenance.fact_producer`
+  ever consult their flag without confirmed header evidence — so listing
+  them would have claimed reduced coverage a fresh dump could never
+  actually restore.

--- a/changelog.d/20260811_090000_claude_older_snapshot_degraded_facts_warning.md
+++ b/changelog.d/20260811_090000_claude_older_snapshot_degraded_facts_warning.md
@@ -21,4 +21,9 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   baseline isn't warned about for no reason — including for
   `clang_va_list_facts_reliable`/`castxml_var_access_facts_reliable` on a
   `"hybrid"`-producer snapshot, where the flag's own value is conservatively
-  `False` but no detector actually consults it for that producer.
+  `False` but no detector actually consults it for that producer. The
+  warning also survives a re-save: `snapshot_to_dict` always re-stamps
+  `schema_version` to the current value, so a degraded flag preserved
+  through an explicit marker on a reserialized legacy snapshot now still
+  triggers the warning instead of silently disappearing once the version
+  number itself reads as current.

--- a/changelog.d/20260811_090000_claude_older_snapshot_degraded_facts_warning.md
+++ b/changelog.d/20260811_090000_claude_older_snapshot_degraded_facts_warning.md
@@ -18,4 +18,7 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   got degraded, so a stale committed baseline's reduced detection coverage
   is visible instead of discovered later. Stays silent for a version gap
   that doesn't actually degrade anything, so an ordinary one-version-behind
-  baseline isn't warned about for no reason.
+  baseline isn't warned about for no reason — including for
+  `clang_va_list_facts_reliable`/`castxml_var_access_facts_reliable` on a
+  `"hybrid"`-producer snapshot, where the flag's own value is conservatively
+  `False` but no detector actually consults it for that producer.

--- a/changelog.d/20260811_100000_claude_stale_clang_constant_fingerprint_fp.md
+++ b/changelog.d/20260811_100000_claude_stale_clang_constant_fingerprint_fp.md
@@ -1,0 +1,29 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **A pre-schema-v20 direct-clang snapshot's non-literal `constant_changed`
+  findings could be fabricated wholesale** (`diff_symbols._diff_constants`):
+  `dumper_clang.py`'s `parse_constants()` calls the same
+  `_initializer_value()`/`_expr_fingerprint()` machinery as
+  `Param.default`/`TypeField.default`, so a compound constant expression's
+  value is a structural fingerprint (`"expr:" + sha256(...)[:16]`) whose
+  exact algorithm was stabilized at schema v20 — the same instability
+  `clang_field_initializer_facts_reliable`/
+  `default_value_fingerprint_comparison_unreliable` already guard for the
+  other two fact kinds. `_diff_constants` never consulted that guard at
+  all, so comparing a pre-v20 clang-producer baseline against a fresh dump
+  of *unchanged* headers could report every non-literal constant as
+  `CONSTANT_CHANGED` purely from the fingerprint algorithm change — measured
+  against a real corpus, 173 of 440 findings in one v18-vs-v24 comparison
+  were exactly this (one constant's stale, collision-prone fingerprint
+  shared by 36 unrelated constants). Added
+  `constant_value_fingerprint_comparison_unreliable`
+  (`diff_default_value_reliability.py`) and wired it into
+  `_diff_constants`'s `CONSTANT_CHANGED` branch — scoped to an exact
+  `ast_producer == "clang"` match rather than the broader `!= "castxml"`
+  check the default-value case uses, since `dumper_hybrid.merge_snapshots`
+  keeps `constants` verbatim from its castxml base and never takes a
+  hybrid merge's clang-only-append path the way `TypeField.default` can.

--- a/changelog.d/20260811_100000_claude_stale_clang_constant_fingerprint_fp.md
+++ b/changelog.d/20260811_100000_claude_stale_clang_constant_fingerprint_fp.md
@@ -22,8 +22,14 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   shared by 36 unrelated constants). Added
   `constant_value_fingerprint_comparison_unreliable`
   (`diff_default_value_reliability.py`) and wired it into
-  `_diff_constants`'s `CONSTANT_CHANGED` branch — scoped to an exact
-  `ast_producer == "clang"` match rather than the broader `!= "castxml"`
+  `_diff_constants`'s `CONSTANT_CHANGED` branch — scoped to `ast_producer
+  not in ("castxml", "hybrid")` rather than the broader `!= "castxml"`
   check the default-value case uses, since `dumper_hybrid.merge_snapshots`
   keeps `constants` verbatim from its castxml base and never takes a
   hybrid merge's clang-only-append path the way `TypeField.default` can.
+  Deliberately not an exact `== "clang"` match either: `ast_producer`
+  itself wasn't tracked before schema v10, eight versions before this
+  fingerprint risk even existed, so a snapshot straddling that boundary
+  reads `ast_producer=None` — treated as possibly-clang, not excluded,
+  mirroring `default_value_representation_unreliable`'s own handling of
+  the identical gap.

--- a/changelog.d/20260811_110000_claude_expr_fingerprint_prefix_collision.md
+++ b/changelog.d/20260811_110000_claude_expr_fingerprint_prefix_collision.md
@@ -1,0 +1,24 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **A genuine castxml constant/default value could be silently mistaken for
+  a stale clang fingerprint and its real change dropped** (`diff_default_
+  value_reliability.py`): both `default_value_fingerprint_comparison_
+  unreliable` (`Param.default`/`TypeField.default`) and the newly-added
+  `constant_value_fingerprint_comparison_unreliable` identified a clang
+  structural-expression fingerprint by checking only the `"expr:"` PREFIX.
+  castxml keeps a constant's or default's value as verbatim source text
+  (`dumper_castxml._iter_public_constants` passes its raw XML `init` text
+  straight through), so a real declaration referencing a qualified name
+  whose next component happens to spell `expr` (an expression-template
+  library's `expr::` namespace, say) produces a legitimate value like
+  `"expr::OLD_VALUE"` — which the prefix check misidentified as a clang
+  fingerprint and could silently suppress a genuine
+  `CONSTANT_CHANGED`/`PARAM_DEFAULT_VALUE_CHANGED`/
+  `FIELD_DEFAULT_INITIALIZER_CHANGED`. Both functions now match the full
+  fingerprint shape (`"expr:"` plus exactly 16 lowercase hex digits, the
+  exact output of `dumper_clang_expr._expr_fingerprint`) via a new shared
+  `_is_expr_fingerprint` helper.

--- a/changelog.d/20260811_120000_claude_fingerprint_guard_xor_and_exhaustive_tests.md
+++ b/changelog.d/20260811_120000_claude_fingerprint_guard_xor_and_exhaustive_tests.md
@@ -1,0 +1,36 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **A genuine constant/default edit between two equally-legacy baselines
+  could be silently dropped** (`diff_default_value_reliability.py`): both
+  `default_value_fingerprint_comparison_unreliable` (`Param.default`/
+  `TypeField.default`) and `constant_value_fingerprint_comparison_unreliable`
+  (constants) suppressed a comparison whenever *either* side was
+  independently marked unreliable (an OR) — but two archived snapshots that
+  both came from the same pre-schema-v20 direct-clang build use the
+  *identical* legacy fingerprint algorithm and are directly comparable to
+  each other. Only a *mismatch* between the two sides' extraction
+  generations (one legacy, one stabilized) is actually unsafe to compare.
+  Both guards now compute each side's own "affected" status independently
+  and delegate the suppress/don't-suppress decision to a single shared
+  `_fingerprint_comparison_unreliable` (XOR, not OR).
+
+### Added
+
+- **Exhaustive, invariant-based test coverage for the fingerprint-
+  reliability guards and the degraded-facts warning's producer/header-
+  confirmation gate table.** PR #720's review found six distinct bugs
+  across these two small modules over six rounds — each one a different
+  cell of the same small, finite (producer × reliability/confirmation ×
+  value-shape) state space, none caught beforehand because every existing
+  test picked one hand-crafted scenario per property instead of covering
+  that space. `tests/test_fingerprint_reliability_properties.py` (new) and
+  `tests/test_schema_compat.py::test_degraded_facts_warning_grid` (new)
+  enumerate their respective state spaces completely rather than sample
+  them, so a future regression in either area fails immediately instead of
+  waiting for a real customer's corpus to surface it. See
+  `diff_default_value_reliability.py`'s module docstring for the full
+  retrospective.

--- a/changelog.d/20260811_120000_claude_fingerprint_guard_xor_and_exhaustive_tests.md
+++ b/changelog.d/20260811_120000_claude_fingerprint_guard_xor_and_exhaustive_tests.md
@@ -14,16 +14,27 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   *identical* legacy fingerprint algorithm and are directly comparable to
   each other. Only a *mismatch* between the two sides' extraction
   generations (one legacy, one stabilized) is actually unsafe to compare.
-  Both guards now compute each side's own "affected" status independently
-  and delegate the suppress/don't-suppress decision to a single shared
-  `_fingerprint_comparison_unreliable` (XOR, not OR).
+  Both guards now delegate the suppress/don't-suppress decision to a single
+  shared `_fingerprint_comparison_unreliable`.
+
+- **A follow-on to the fix above had its own mirror bug**: naively
+  collapsing "is this side a fingerprint AND is it legacy" into one boolean
+  before comparing lost the value-SHAPE distinction — a legacy fingerprint
+  on one side compared against a plain literal on the other read as
+  "generations differ" and wrongly suppressed a confirmed
+  expression-to-literal (or literal-to-expression) edit, a change no
+  algorithm version could ever produce spuriously (the unstable algorithm
+  only affects a compound expression's fingerprint *hash*, never whether a
+  declaration's own value was a literal at all). `_fingerprint_comparison_
+  unreliable` now only ever suppresses when BOTH sides are genuinely
+  fingerprint-shaped, and even then only on a legacy-generation mismatch.
 
 ### Added
 
 - **Exhaustive, invariant-based test coverage for the fingerprint-
   reliability guards and the degraded-facts warning's producer/header-
-  confirmation gate table.** PR #720's review found six distinct bugs
-  across these two small modules over six rounds — each one a different
+  confirmation gate table.** PR #720's review found seven distinct bugs
+  across these two small modules over seven rounds — each one a different
   cell of the same small, finite (producer × reliability/confirmation ×
   value-shape) state space, none caught beforehand because every existing
   test picked one hand-crafted scenario per property instead of covering

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -686,12 +686,12 @@ class TestParamDefaultChanged:
         f_old = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:oldalgo1234")],
+            params=[Param(name="timeout", type="int", default="expr:1111111111111111")],
         )
         f_new = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:newalgo5678")],
+            params=[Param(name="timeout", type="int", default="expr:2222222222222222")],
         )
         old = AbiSnapshot(
             library="libtest.so.1",
@@ -724,12 +724,12 @@ class TestParamDefaultChanged:
         f_old = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:oldalgo1234")],
+            params=[Param(name="timeout", type="int", default="expr:1111111111111111")],
         )
         f_new = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:newalgo5678")],
+            params=[Param(name="timeout", type="int", default="expr:2222222222222222")],
         )
         old = AbiSnapshot(
             library="libtest.so.1",
@@ -769,12 +769,12 @@ class TestParamDefaultChanged:
         f_old = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:oldalgo1234")],
+            params=[Param(name="timeout", type="int", default="expr:1111111111111111")],
         )
         f_new = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:newalgo5678")],
+            params=[Param(name="timeout", type="int", default="expr:2222222222222222")],
         )
         legacy_dict = snapshot_to_dict(
             AbiSnapshot(
@@ -821,7 +821,7 @@ class TestParamDefaultChanged:
         f_new = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:newalgo5678")],
+            params=[Param(name="timeout", type="int", default="expr:2222222222222222")],
         )
         old = AbiSnapshot(
             library="libtest.so.1",
@@ -850,12 +850,12 @@ class TestParamDefaultChanged:
         f_old = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:aaaa")],
+            params=[Param(name="timeout", type="int", default="expr:aaaaaaaaaaaaaaaa")],
         )
         f_new = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:bbbb")],
+            params=[Param(name="timeout", type="int", default="expr:bbbbbbbbbbbbbbbb")],
         )
         old = AbiSnapshot(
             library="libtest.so.1",
@@ -916,7 +916,7 @@ class TestParamDefaultChanged:
         f_old = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:oldalgo1234")],
+            params=[Param(name="timeout", type="int", default="expr:1111111111111111")],
         )
         f_new = _pub_func(
             "connect",
@@ -952,12 +952,12 @@ class TestParamDefaultChanged:
         f_old = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:aaaa")],
+            params=[Param(name="timeout", type="int", default="expr:aaaaaaaaaaaaaaaa")],
         )
         f_new = _pub_func(
             "connect",
             "_Z7connectv",
-            params=[Param(name="timeout", type="int", default="expr:bbbb")],
+            params=[Param(name="timeout", type="int", default="expr:bbbbbbbbbbbbbbbb")],
         )
         old = AbiSnapshot(
             library="libtest.so.1",
@@ -977,6 +977,43 @@ class TestParamDefaultChanged:
         )
         r = compare(old, new)
         assert ChangeKind.PARAM_DEFAULT_VALUE_CHANGED not in _kinds(r)
+
+    def test_genuine_expr_namespace_default_change_still_reported(self):
+        """Mirrors constant_value_fingerprint_comparison_unreliable's own
+        identical fix: the guard matches the FULL clang fingerprint shape
+        (``"expr:"`` plus exactly 16 hex digits), not merely the ``"expr:"``
+        prefix. castxml keeps a default's verbatim source expression, so a
+        real castxml default referencing a qualified name whose next
+        component happens to spell `expr` produces a legitimate value like
+        `"expr::OLD_VALUE"` -- a plain prefix check would misidentify it as
+        a clang fingerprint and silently suppress the real change (Codex
+        review, fresh evidence, PR #720)."""
+        f_old = _pub_func(
+            "connect",
+            "_Z7connectv",
+            params=[Param(name="timeout", type="int", default="expr::OLD_VALUE")],
+        )
+        f_new = _pub_func(
+            "connect",
+            "_Z7connectv",
+            params=[Param(name="timeout", type="int", default="expr::NEW_VALUE")],
+        )
+        old = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            functions=[f_old],
+            from_headers=True,
+            ast_producer="castxml",
+        )
+        new = AbiSnapshot(
+            library="libtest.so.1",
+            version="2.0",
+            functions=[f_new],
+            from_headers=True,
+            ast_producer="castxml",
+        )
+        r = compare(old, new)
+        assert ChangeKind.PARAM_DEFAULT_VALUE_CHANGED in _kinds(r)
 
 
 # ── param_renamed ────────────────────────────────────────────────────────
@@ -1325,11 +1362,11 @@ class TestConstantChanges:
         CONSTANT_CHANGED when the OLD side's value is fingerprint-shaped and
         unreliable."""
         old = self._clang_snap(
-            {"K1": "expr:aaaa", "K2": "expr:aaaa"},
+            {"K1": "expr:aaaaaaaaaaaaaaaa", "K2": "expr:aaaaaaaaaaaaaaaa"},
             field_initializer_facts_reliable=False,
         )
         new = self._clang_snap(
-            {"K1": "expr:bbbb", "K2": "expr:cccc"},
+            {"K1": "expr:bbbbbbbbbbbbbbbb", "K2": "expr:cccccccccccccccc"},
             field_initializer_facts_reliable=True,
         )
         r = compare(old, new)
@@ -1341,10 +1378,10 @@ class TestConstantChanges:
         still fire -- the guard must not blanket-suppress every fingerprint
         comparison on a clang-producer snapshot."""
         old = self._clang_snap(
-            {"K": "expr:aaaa"}, field_initializer_facts_reliable=True
+            {"K": "expr:aaaaaaaaaaaaaaaa"}, field_initializer_facts_reliable=True
         )
         new = self._clang_snap(
-            {"K": "expr:bbbb"}, field_initializer_facts_reliable=True
+            {"K": "expr:bbbbbbbbbbbbbbbb"}, field_initializer_facts_reliable=True
         )
         r = compare(old, new)
         assert ChangeKind.CONSTANT_CHANGED in _kinds(r)
@@ -1363,7 +1400,7 @@ class TestConstantChanges:
             functions=[],
             variables=[],
             types=[],
-            constants={"K1": "expr:aaaa", "K2": "expr:aaaa"},
+            constants={"K1": "expr:aaaaaaaaaaaaaaaa", "K2": "expr:aaaaaaaaaaaaaaaa"},
             from_headers=True,
             ast_producer=None,
             clang_field_initializer_facts_reliable=False,
@@ -1374,7 +1411,7 @@ class TestConstantChanges:
             functions=[],
             variables=[],
             types=[],
-            constants={"K1": "expr:bbbb", "K2": "expr:cccc"},
+            constants={"K1": "expr:bbbbbbbbbbbbbbbb", "K2": "expr:cccccccccccccccc"},
             from_headers=True,
             ast_producer=None,
             clang_field_initializer_facts_reliable=True,
@@ -1389,13 +1426,48 @@ class TestConstantChanges:
         constant value must still decline the comparison when the NEW
         side's own fingerprint is the one that can't be trusted."""
         old = self._clang_snap(
-            {"K": "expr:aaaa"}, field_initializer_facts_reliable=True
+            {"K": "expr:aaaaaaaaaaaaaaaa"}, field_initializer_facts_reliable=True
         )
         new = self._clang_snap(
-            {"K": "expr:bbbb"}, field_initializer_facts_reliable=False
+            {"K": "expr:bbbbbbbbbbbbbbbb"}, field_initializer_facts_reliable=False
         )
         r = compare(old, new)
         assert ChangeKind.CONSTANT_CHANGED not in _kinds(r)
+
+    def test_genuine_expr_namespace_constant_change_still_reported(self):
+        """The guard matches the FULL clang fingerprint shape (``"expr:"``
+        plus exactly 16 hex digits), not merely the ``"expr:"`` prefix.
+        `dumper_castxml._iter_public_constants` passes its raw XML `init`
+        text straight through, so a real castxml constant referencing a
+        qualified name whose next component happens to spell `expr` (an
+        expression-template library's namespace, say) produces a legitimate
+        verbatim value like `"expr::OLD_VALUE"` -- which a plain prefix
+        check would misidentify as a clang fingerprint and silently
+        suppress the real change (Codex review, fresh evidence, PR #720)."""
+        old = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            functions=[],
+            variables=[],
+            types=[],
+            constants={"K": "expr::OLD_VALUE"},
+            from_headers=True,
+            ast_producer=None,
+            clang_field_initializer_facts_reliable=False,
+        )
+        new = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            functions=[],
+            variables=[],
+            types=[],
+            constants={"K": "expr::NEW_VALUE"},
+            from_headers=True,
+            ast_producer=None,
+            clang_field_initializer_facts_reliable=False,
+        )
+        r = compare(old, new)
+        assert ChangeKind.CONSTANT_CHANGED in _kinds(r)
 
     def test_stale_fingerprint_guard_does_not_apply_to_hybrid_producer(self):
         """dumper_hybrid.merge_snapshots keeps `constants` verbatim from its
@@ -1410,7 +1482,7 @@ class TestConstantChanges:
             functions=[],
             variables=[],
             types=[],
-            constants={"K": "expr:aaaa"},
+            constants={"K": "expr:aaaaaaaaaaaaaaaa"},
             from_headers=True,
             ast_producer="hybrid",
             clang_field_initializer_facts_reliable=False,
@@ -1421,7 +1493,7 @@ class TestConstantChanges:
             functions=[],
             variables=[],
             types=[],
-            constants={"K": "expr:bbbb"},
+            constants={"K": "expr:bbbbbbbbbbbbbbbb"},
             from_headers=True,
             ast_producer="hybrid",
             clang_field_initializer_facts_reliable=False,

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -1264,6 +1264,87 @@ class TestConstantChanges:
         r = compare(old, new)
         assert ChangeKind.CONSTANT_REMOVED in _kinds(r)
 
+    def _clang_snap(self, constants, *, field_initializer_facts_reliable):
+        return AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            functions=[],
+            variables=[],
+            types=[],
+            constants=constants,
+            from_headers=True,
+            ast_producer="clang",
+            clang_field_initializer_facts_reliable=field_initializer_facts_reliable,
+        )
+
+    def test_stale_clang_fingerprint_collision_not_reported(self):
+        """dumper_clang.py's parse_constants() shares Param.default/
+        TypeField.default's unstable pre-schema-v20 "expr:" fingerprint
+        algorithm (dumper_clang_expr._initializer_value) -- a pre-v20
+        clang-producer snapshot's fingerprint for an UNCHANGED non-literal
+        constant can collide across unrelated constants, then differ from a
+        stabilized re-dump purely from the algorithm fix, not a real edit
+        (measured against a real corpus: 173 of 440 findings in a
+        v18-vs-v24 comparison were exactly this). Must not report
+        CONSTANT_CHANGED when the OLD side's value is fingerprint-shaped and
+        unreliable."""
+        old = self._clang_snap(
+            {"K1": "expr:aaaa", "K2": "expr:aaaa"},
+            field_initializer_facts_reliable=False,
+        )
+        new = self._clang_snap(
+            {"K1": "expr:bbbb", "K2": "expr:cccc"},
+            field_initializer_facts_reliable=True,
+        )
+        r = compare(old, new)
+        assert ChangeKind.CONSTANT_CHANGED not in _kinds(r)
+
+    def test_reliable_clang_fingerprint_change_still_reported(self):
+        """The opposite of the case above: once BOTH sides are past the
+        stabilization threshold, a genuine "expr:" fingerprint change must
+        still fire -- the guard must not blanket-suppress every fingerprint
+        comparison on a clang-producer snapshot."""
+        old = self._clang_snap(
+            {"K": "expr:aaaa"}, field_initializer_facts_reliable=True
+        )
+        new = self._clang_snap(
+            {"K": "expr:bbbb"}, field_initializer_facts_reliable=True
+        )
+        r = compare(old, new)
+        assert ChangeKind.CONSTANT_CHANGED in _kinds(r)
+
+    def test_stale_fingerprint_guard_does_not_apply_to_hybrid_producer(self):
+        """dumper_hybrid.merge_snapshots keeps `constants` verbatim from its
+        castxml base -- constants never take a hybrid merge's clang-only-
+        append path the way TypeField.default can. A "hybrid"-producer
+        snapshot's constants must therefore compare normally even when
+        clang_field_initializer_facts_reliable is False, unlike
+        TypeField.default's broader "hybrid is also at risk" reasoning."""
+        old = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            functions=[],
+            variables=[],
+            types=[],
+            constants={"K": "expr:aaaa"},
+            from_headers=True,
+            ast_producer="hybrid",
+            clang_field_initializer_facts_reliable=False,
+        )
+        new = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            functions=[],
+            variables=[],
+            types=[],
+            constants={"K": "expr:bbbb"},
+            from_headers=True,
+            ast_producer="hybrid",
+            clang_field_initializer_facts_reliable=False,
+        )
+        r = compare(old, new)
+        assert ChangeKind.CONSTANT_CHANGED in _kinds(r)
+
 
 # ── Multiple simultaneous symbol changes ─────────────────────────────────
 

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -942,6 +942,42 @@ class TestParamDefaultChanged:
         r = compare(old, new)
         assert ChangeKind.PARAM_DEFAULT_VALUE_REMOVED in _kinds(r)
 
+    def test_change_suppressed_when_only_new_side_is_unreliable(self):
+        """The mirror of test_real_change_from_literal_to_fingerprint_still_
+        detected above: every existing scenario made the OLD side the
+        unreliable one. Checked per side (this function's own docstring),
+        so a RELIABLE old side with a fingerprint-shaped value must still
+        decline the comparison when the NEW side's own fingerprint is the
+        one that can't be trusted."""
+        f_old = _pub_func(
+            "connect",
+            "_Z7connectv",
+            params=[Param(name="timeout", type="int", default="expr:aaaa")],
+        )
+        f_new = _pub_func(
+            "connect",
+            "_Z7connectv",
+            params=[Param(name="timeout", type="int", default="expr:bbbb")],
+        )
+        old = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            functions=[f_old],
+            from_headers=True,
+            ast_producer="clang",
+            clang_field_initializer_facts_reliable=True,
+        )
+        new = AbiSnapshot(
+            library="libtest.so.1",
+            version="2.0",
+            functions=[f_new],
+            from_headers=True,
+            ast_producer="clang",
+            clang_field_initializer_facts_reliable=False,
+        )
+        r = compare(old, new)
+        assert ChangeKind.PARAM_DEFAULT_VALUE_CHANGED not in _kinds(r)
+
 
 # ── param_renamed ────────────────────────────────────────────────────────
 
@@ -1342,6 +1378,21 @@ class TestConstantChanges:
             from_headers=True,
             ast_producer=None,
             clang_field_initializer_facts_reliable=True,
+        )
+        r = compare(old, new)
+        assert ChangeKind.CONSTANT_CHANGED not in _kinds(r)
+
+    def test_stale_fingerprint_collision_suppressed_when_new_side_unreliable(self):
+        """Checked per side (constant_value_fingerprint_comparison_
+        unreliable's own docstring): every scenario above made the OLD side
+        the unreliable one. A RELIABLE old side with a fingerprint-shaped
+        constant value must still decline the comparison when the NEW
+        side's own fingerprint is the one that can't be trusted."""
+        old = self._clang_snap(
+            {"K": "expr:aaaa"}, field_initializer_facts_reliable=True
+        )
+        new = self._clang_snap(
+            {"K": "expr:bbbb"}, field_initializer_facts_reliable=False
         )
         r = compare(old, new)
         assert ChangeKind.CONSTANT_CHANGED not in _kinds(r)

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -978,6 +978,44 @@ class TestParamDefaultChanged:
         r = compare(old, new)
         assert ChangeKind.PARAM_DEFAULT_VALUE_CHANGED not in _kinds(r)
 
+    def test_genuine_edit_reported_when_both_sides_share_legacy_algorithm(self):
+        """Mirrors constant_value_fingerprint_comparison_unreliable's own
+        identical fix: when BOTH archived snapshots came from the same
+        pre-v20 direct-clang build, their fingerprints use the identical
+        legacy algorithm and are directly comparable to each other --
+        suppressing whenever EITHER side is independently unreliable was
+        too conservative and would silently drop a genuine default-value
+        edit between two equally-legacy baselines (Codex review, fresh
+        evidence, PR #720)."""
+        f_old = _pub_func(
+            "connect",
+            "_Z7connectv",
+            params=[Param(name="timeout", type="int", default="expr:aaaaaaaaaaaaaaaa")],
+        )
+        f_new = _pub_func(
+            "connect",
+            "_Z7connectv",
+            params=[Param(name="timeout", type="int", default="expr:bbbbbbbbbbbbbbbb")],
+        )
+        old = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            functions=[f_old],
+            from_headers=True,
+            ast_producer="clang",
+            clang_field_initializer_facts_reliable=False,
+        )
+        new = AbiSnapshot(
+            library="libtest.so.1",
+            version="2.0",
+            functions=[f_new],
+            from_headers=True,
+            ast_producer="clang",
+            clang_field_initializer_facts_reliable=False,
+        )
+        r = compare(old, new)
+        assert ChangeKind.PARAM_DEFAULT_VALUE_CHANGED in _kinds(r)
+
     def test_genuine_expr_namespace_default_change_still_reported(self):
         """Mirrors constant_value_fingerprint_comparison_unreliable's own
         identical fix: the guard matches the FULL clang fingerprint shape
@@ -1433,6 +1471,25 @@ class TestConstantChanges:
         )
         r = compare(old, new)
         assert ChangeKind.CONSTANT_CHANGED not in _kinds(r)
+
+    def test_genuine_edit_reported_when_both_sides_share_legacy_algorithm(self):
+        """When BOTH archived snapshots came from the same pre-v20
+        direct-clang build, their fingerprints use the identical (if
+        collision-prone) legacy algorithm and are directly comparable TO
+        EACH OTHER -- suppressing whenever EITHER side is independently
+        unreliable (the naive OR an earlier version of this guard used) was
+        too conservative: it made a genuine constant edit between two
+        archived schema-v19 baselines produce no CONSTANT_CHANGED at all
+        (Codex review, fresh evidence, PR #720). Suppression is for a
+        MISMATCH between generations, not for every unreliable fingerprint."""
+        old = self._clang_snap(
+            {"K": "expr:aaaaaaaaaaaaaaaa"}, field_initializer_facts_reliable=False
+        )
+        new = self._clang_snap(
+            {"K": "expr:bbbbbbbbbbbbbbbb"}, field_initializer_facts_reliable=False
+        )
+        r = compare(old, new)
+        assert ChangeKind.CONSTANT_CHANGED in _kinds(r)
 
     def test_genuine_expr_namespace_constant_change_still_reported(self):
         """The guard matches the FULL clang fingerprint shape (``"expr:"``

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -1313,6 +1313,39 @@ class TestConstantChanges:
         r = compare(old, new)
         assert ChangeKind.CONSTANT_CHANGED in _kinds(r)
 
+    def test_stale_fingerprint_collision_suppressed_for_unknown_producer(self):
+        """``ast_producer`` itself wasn't tracked before schema v10 -- eight
+        versions before ``parse_constants()``'s "expr:" fingerprint risk
+        even existed in the wild -- so a snapshot straddling that boundary
+        reads ``ast_producer=None``: "unknown", not "definitely not clang".
+        An exact ``== "clang"`` producer check would wrongly trust an
+        "expr:" value from exactly the producer this guard exists to
+        distrust (Codex review, PR #720)."""
+        old = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            functions=[],
+            variables=[],
+            types=[],
+            constants={"K1": "expr:aaaa", "K2": "expr:aaaa"},
+            from_headers=True,
+            ast_producer=None,
+            clang_field_initializer_facts_reliable=False,
+        )
+        new = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            functions=[],
+            variables=[],
+            types=[],
+            constants={"K1": "expr:bbbb", "K2": "expr:cccc"},
+            from_headers=True,
+            ast_producer=None,
+            clang_field_initializer_facts_reliable=True,
+        )
+        r = compare(old, new)
+        assert ChangeKind.CONSTANT_CHANGED not in _kinds(r)
+
     def test_stale_fingerprint_guard_does_not_apply_to_hybrid_producer(self):
         """dumper_hybrid.merge_snapshots keeps `constants` verbatim from its
         castxml base -- constants never take a hybrid merge's clang-only-

--- a/tests/test_diff_symbols_deep.py
+++ b/tests/test_diff_symbols_deep.py
@@ -1016,6 +1016,45 @@ class TestParamDefaultChanged:
         r = compare(old, new)
         assert ChangeKind.PARAM_DEFAULT_VALUE_CHANGED in _kinds(r)
 
+    def test_expression_to_literal_edit_reported_even_from_legacy_side(self):
+        """The XOR fix above has its own mirror bug: naively collapsing
+        "is this side a fingerprint AND is it legacy" into one boolean
+        before comparing lost the value-SHAPE distinction. A pre-v20
+        clang snapshot's compound default becoming a plain LITERAL (or
+        vice versa) is ALWAYS a confirmed real edit -- the unstable
+        algorithm only ever affects a compound expression's fingerprint
+        HASH, never whether a declaration's own value was a literal at
+        all -- so this shape transition must fire regardless of either
+        side's reliability (Codex review, fresh evidence, PR #720)."""
+        f_old = _pub_func(
+            "connect",
+            "_Z7connectv",
+            params=[Param(name="timeout", type="int", default="expr:aaaaaaaaaaaaaaaa")],
+        )
+        f_new = _pub_func(
+            "connect",
+            "_Z7connectv",
+            params=[Param(name="timeout", type="int", default="42")],
+        )
+        old = AbiSnapshot(
+            library="libtest.so.1",
+            version="1.0",
+            functions=[f_old],
+            from_headers=True,
+            ast_producer="clang",
+            clang_field_initializer_facts_reliable=False,
+        )
+        new = AbiSnapshot(
+            library="libtest.so.1",
+            version="2.0",
+            functions=[f_new],
+            from_headers=True,
+            ast_producer="clang",
+            clang_field_initializer_facts_reliable=False,
+        )
+        r = compare(old, new)
+        assert ChangeKind.PARAM_DEFAULT_VALUE_CHANGED in _kinds(r)
+
     def test_genuine_expr_namespace_default_change_still_reported(self):
         """Mirrors constant_value_fingerprint_comparison_unreliable's own
         identical fix: the guard matches the FULL clang fingerprint shape
@@ -1488,6 +1527,23 @@ class TestConstantChanges:
         new = self._clang_snap(
             {"K": "expr:bbbbbbbbbbbbbbbb"}, field_initializer_facts_reliable=False
         )
+        r = compare(old, new)
+        assert ChangeKind.CONSTANT_CHANGED in _kinds(r)
+
+    def test_expression_to_literal_edit_reported_even_from_legacy_side(self):
+        """The XOR fix above has its own mirror bug: naively collapsing
+        "is this side a fingerprint AND is it legacy" into one boolean
+        before comparing lost the value-SHAPE distinction. A pre-v20
+        clang constant becoming a plain LITERAL (or vice versa) is
+        ALWAYS a confirmed real edit -- the unstable algorithm only ever
+        affects a compound expression's fingerprint HASH, never whether
+        a declaration's own value was a literal at all -- so this shape
+        transition must fire regardless of either side's reliability
+        (Codex review, fresh evidence, PR #720)."""
+        old = self._clang_snap(
+            {"K": "expr:aaaaaaaaaaaaaaaa"}, field_initializer_facts_reliable=False
+        )
+        new = self._clang_snap({"K": "42"}, field_initializer_facts_reliable=False)
         r = compare(old, new)
         assert ChangeKind.CONSTANT_CHANGED in _kinds(r)
 

--- a/tests/test_fingerprint_reliability_properties.py
+++ b/tests/test_fingerprint_reliability_properties.py
@@ -1,0 +1,249 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Exhaustive, invariant-based coverage of the fingerprint-reliability guards
+in ``diff_default_value_reliability.py`` (PR #720 retrospective).
+
+Why this file exists, not just more hand-picked examples
+----------------------------------------------------------
+PR #720's review round found FIVE distinct bugs in these guards across five
+separate passes, each one a different edge of the same small state space
+(producer x reliability x value-shape):
+
+1. The degraded-facts *warning* (a different module, ``serialization.py``)
+   listing a flag no real detector consulted for a given producer.
+2. ...the same warning not surviving a snapshot re-save round-trip.
+3. ...the same warning not accounting for inferred (unconfirmed) header
+   awareness.
+4. ``constant_value_fingerprint_comparison_unreliable``'s exact
+   ``producer == "clang"`` check missing ``producer is None`` (pre-v10,
+   before ``ast_producer`` was even tracked).
+5. Both fingerprint guards matching the bare ``"expr:"`` PREFIX instead of
+   the full 16-hex-digit shape, so a genuine castxml value that merely
+   *starts* the same way (e.g. a real ``expr::`` namespace reference) could
+   be misidentified as a stale clang fingerprint and its real change
+   silently dropped.
+6. Both guards suppressing whenever *either* side was independently
+   "unreliable" (an OR), when two archived snapshots that used the exact
+   same legacy algorithm are directly comparable TO EACH OTHER — the
+   correct rule is an XOR (a MISMATCH between generations), not an OR.
+
+None of these were caught by unit tests before review, because every
+existing test picked ONE hand-crafted scenario per property instead of
+covering the state space that determines the guards' output. The state
+space here is genuinely small and finite (producer in 4 values, reliable in
+2, value-shape in 3, times two sides = well under a thousand combinations)
+— cheap enough to enumerate completely rather than sample. This file does
+that: instead of re-deriving whether each of those five bugs is fixed by
+picking one more example, it asserts INVARIANTS that must hold across the
+*entire* reachable input space, so any future change that reintroduces one
+of these bugs (or a sibling one this exact review round didn't happen to
+think of) fails on the very next test run, not after a real customer's
+corpus surfaces it.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from abicheck.diff_default_value_reliability import (
+    _is_expr_fingerprint,
+    constant_value_fingerprint_comparison_unreliable,
+    default_value_fingerprint_comparison_unreliable,
+)
+from abicheck.model import AbiSnapshot
+
+# A real fingerprint has the exact shape `dumper_clang_expr._expr_fingerprint`
+# produces: "expr:" + 16 lowercase hex digits.
+_LITERAL_VALUE = "42"
+_FINGERPRINT_A = "expr:aaaaaaaaaaaaaaaa"
+_FINGERPRINT_B = "expr:bbbbbbbbbbbbbbbb"
+# The exhaustive cross-product test below only needs each side's VALUE SHAPE
+# (fingerprint vs. not) -- the guard's decision never depends on the two
+# values' specific content or on whether they're equal, only on each side's
+# own shape/producer/reliability, so a two-element domain gives the exact
+# same coverage as three while halving the combinatorial cost. The distinct-
+# fingerprint-content cases (genuine-edit detection) are covered by the
+# dedicated example tests in test_diff_symbols_deep.py instead.
+_VALUES = (_LITERAL_VALUE, _FINGERPRINT_A)
+
+_PRODUCERS = (None, "clang", "castxml", "hybrid")
+_RELIABLE = (True, False)
+
+# Which producers can NEVER contribute an "expr:"-fingerprinted value in the
+# first place, per each guard's own documented domain (see both guard
+# functions' docstrings): constants stay castxml-verbatim on a hybrid
+# snapshot (never clang-merged per-entry), so both castxml and hybrid are
+# safe; a default/field-initializer's hybrid merge keeps its clang-only-
+# APPENDED entries' own unstable fingerprint, so only castxml is safe there.
+_CONSTANT_SAFE_PRODUCERS = ("castxml", "hybrid")
+_DEFAULT_SAFE_PRODUCERS = ("castxml",)
+
+
+def _snap(*, ast_producer, reliable, version):
+    return AbiSnapshot(
+        library="libtest.so.1",
+        version=version,
+        from_headers=True,
+        ast_producer=ast_producer,
+        clang_field_initializer_facts_reliable=reliable,
+    )
+
+
+class TestIsExprFingerprintShape:
+    """The shape check itself: bug #5 above was a bare ``.startswith``."""
+
+    def test_literal_is_not_a_fingerprint(self):
+        assert not _is_expr_fingerprint(_LITERAL_VALUE)
+
+    def test_real_fingerprint_is_a_fingerprint(self):
+        assert _is_expr_fingerprint(_FINGERPRINT_A)
+
+    @pytest.mark.parametrize(
+        "collision",
+        [
+            "expr::NAMESPACE_VALUE",  # a real "expr" namespace, castxml-verbatim
+            "expr:short",  # too few hex digits
+            "expr:" + "a" * 17,  # too many hex digits
+            "expr:AAAAAAAAAAAAAAAA",  # uppercase -- real hexdigest() is lowercase
+            "EXPR:aaaaaaaaaaaaaaaa",  # wrong case on the literal prefix itself
+            "notexpr:aaaaaaaaaaaaaaaa",
+            "",
+        ],
+    )
+    def test_prefix_or_shape_collisions_are_not_fingerprints(self, collision):
+        assert not _is_expr_fingerprint(collision)
+
+
+class _GuardInvariants:
+    """Shared invariant assertions, parametrized per guard by its own
+    producer-safety domain. Subclassed once per guard below rather than
+    parametrized at the pytest level, so a failure's traceback names the
+    guard directly."""
+
+    safe_producers: tuple[str, ...]
+
+    def _call(self, old: AbiSnapshot, new: AbiSnapshot, old_value: str, new_value: str):
+        raise NotImplementedError
+
+    def _affected(self, producer, reliable, value):
+        """First-principles ("is this side even capable of carrying a
+        stale legacy fingerprint") reference — independent of the guard's
+        own internal XOR wiring, so this doesn't just test the
+        implementation against itself."""
+        return (
+            _is_expr_fingerprint(value)
+            and producer not in self.safe_producers
+            and not reliable
+        )
+
+    @pytest.mark.parametrize(
+        "old_producer,old_reliable,new_producer,new_reliable,old_value,new_value",
+        list(
+            itertools.product(
+                _PRODUCERS, _RELIABLE, _PRODUCERS, _RELIABLE, _VALUES, _VALUES
+            )
+        ),
+    )
+    def test_suppresses_iff_exactly_one_side_affected(
+        self,
+        old_producer,
+        old_reliable,
+        new_producer,
+        new_reliable,
+        old_value,
+        new_value,
+    ):
+        old = _snap(ast_producer=old_producer, reliable=old_reliable, version="1.0")
+        new = _snap(ast_producer=new_producer, reliable=new_reliable, version="2.0")
+        expected = self._affected(
+            old_producer, old_reliable, old_value
+        ) != self._affected(new_producer, new_reliable, new_value)
+        assert self._call(old, new, old_value, new_value) is expected
+
+    def test_neither_side_fingerprint_shaped_never_suppresses(self):
+        """Bug #5's invariant, phrased structurally: two values that are
+        NOT genuine fingerprints (whatever their producer/reliability) are
+        always directly comparable -- there is no algorithm-instability
+        risk to guard against when neither side ever touched the
+        fingerprint machinery at all."""
+        for old_producer, old_reliable, new_producer, new_reliable in itertools.product(
+            _PRODUCERS, _RELIABLE, _PRODUCERS, _RELIABLE
+        ):
+            old = _snap(ast_producer=old_producer, reliable=old_reliable, version="1.0")
+            new = _snap(ast_producer=new_producer, reliable=new_reliable, version="2.0")
+            assert self._call(old, new, _LITERAL_VALUE, "99") is False
+
+    def test_same_generation_on_both_sides_never_suppresses(self):
+        """Bug #6's invariant: two sides with IDENTICAL producer and
+        reliability -- same extraction generation, whether that generation
+        is the stable one or the legacy one -- must never be suppressed
+        from each other, since their fingerprints (if any) came from the
+        identical algorithm and are directly comparable."""
+        for producer, reliable in itertools.product(_PRODUCERS, _RELIABLE):
+            old = _snap(ast_producer=producer, reliable=reliable, version="1.0")
+            new = _snap(ast_producer=producer, reliable=reliable, version="2.0")
+            assert self._call(old, new, _FINGERPRINT_A, _FINGERPRINT_B) is False
+
+    def test_symmetric(self):
+        """Suppression must not depend on an arbitrary old/new labeling."""
+        for (
+            old_producer,
+            old_reliable,
+            new_producer,
+            new_reliable,
+            old_value,
+            new_value,
+        ) in itertools.islice(
+            itertools.product(
+                _PRODUCERS, _RELIABLE, _PRODUCERS, _RELIABLE, _VALUES, _VALUES
+            ),
+            0,
+            None,
+            7,  # every 7th combination -- full coverage across runs, cheap per run
+        ):
+            old = _snap(ast_producer=old_producer, reliable=old_reliable, version="1.0")
+            new = _snap(ast_producer=new_producer, reliable=new_reliable, version="2.0")
+            forward = self._call(old, new, old_value, new_value)
+            backward = self._call(new, old, new_value, old_value)
+            assert forward == backward
+
+
+class TestConstantFingerprintGuardInvariants(_GuardInvariants):
+    safe_producers = _CONSTANT_SAFE_PRODUCERS
+
+    def _call(self, old, new, old_value, new_value):
+        return constant_value_fingerprint_comparison_unreliable(
+            old, new, old_value, new_value
+        )
+
+
+class TestDefaultValueFingerprintGuardInvariants(_GuardInvariants):
+    safe_producers = _DEFAULT_SAFE_PRODUCERS
+
+    def _call(self, old, new, old_value, new_value):
+        # default_value_fingerprint_comparison_unreliable takes an explicit
+        # per-declaration producer separately from snap.ast_producer (see
+        # default_value_representation_unreliable's own docstring for why:
+        # a hybrid snapshot's clang-only-appended declaration is resolved
+        # per-declaration, not from the whole-snapshot tag) -- pass the
+        # snapshot's own producer for both, matching every real call site's
+        # common case (a non-hybrid-merged declaration, where the two always
+        # agree) and every other test in this suite.
+        return default_value_fingerprint_comparison_unreliable(
+            old, new, old.ast_producer, new.ast_producer, old_value, new_value
+        )

--- a/tests/test_fingerprint_reliability_properties.py
+++ b/tests/test_fingerprint_reliability_properties.py
@@ -18,9 +18,9 @@ in ``diff_default_value_reliability.py`` (PR #720 retrospective).
 
 Why this file exists, not just more hand-picked examples
 ----------------------------------------------------------
-PR #720's review round found FIVE distinct bugs in these guards across five
-separate passes, each one a different edge of the same small state space
-(producer x reliability x value-shape):
+PR #720's review round found SEVEN distinct bugs in these guards across
+seven separate passes, each one a different edge of the same small state
+space (producer x reliability x value-shape):
 
 1. The degraded-facts *warning* (a different module, ``serialization.py``)
    listing a flag no real detector consulted for a given producer.
@@ -38,15 +38,23 @@ separate passes, each one a different edge of the same small state space
 6. Both guards suppressing whenever *either* side was independently
    "unreliable" (an OR), when two archived snapshots that used the exact
    same legacy algorithm are directly comparable TO EACH OTHER — the
-   correct rule is an XOR (a MISMATCH between generations), not an OR.
+   correct rule is a MISMATCH between generations, not "either side risky".
+7. Fix #6's own naive collapse of ``is_fingerprint and legacy`` into one
+   "affected" boolean before comparing lost the value-SHAPE distinction: a
+   legacy fingerprint on one side XORed against a plain literal on the
+   other read as "generations differ" and wrongly suppressed a confirmed
+   expression-to-literal (or literal-to-expression) edit — a change no
+   algorithm version could ever produce spuriously, since the unstable
+   algorithm only affects a compound expression's HASH, never whether a
+   declaration's own value was a literal at all.
 
 None of these were caught by unit tests before review, because every
 existing test picked ONE hand-crafted scenario per property instead of
 covering the state space that determines the guards' output. The state
 space here is genuinely small and finite (producer in 4 values, reliable in
-2, value-shape in 3, times two sides = well under a thousand combinations)
+2, value-shape in 2, times two sides = well under a thousand combinations)
 — cheap enough to enumerate completely rather than sample. This file does
-that: instead of re-deriving whether each of those five bugs is fixed by
+that: instead of re-deriving whether each of those seven bugs is fixed by
 picking one more example, it asserts INVARIANTS that must hold across the
 *entire* reachable input space, so any future change that reintroduces one
 of these bugs (or a sibling one this exact review round didn't happen to
@@ -140,16 +148,14 @@ class _GuardInvariants:
     def _call(self, old: AbiSnapshot, new: AbiSnapshot, old_value: str, new_value: str):
         raise NotImplementedError
 
-    def _affected(self, producer, reliable, value):
-        """First-principles ("is this side even capable of carrying a
-        stale legacy fingerprint") reference — independent of the guard's
-        own internal XOR wiring, so this doesn't just test the
-        implementation against itself."""
-        return (
-            _is_expr_fingerprint(value)
-            and producer not in self.safe_producers
-            and not reliable
-        )
+    def _is_legacy(self, producer, reliable):
+        """First-principles ("if this side WERE fingerprint-shaped, would
+        that fingerprint be from the unstable pre-v20 algorithm") reference
+        — independent of the guard's own internal wiring, so this doesn't
+        just test the implementation against itself. Deliberately does NOT
+        fold in the value's own shape (bug #7's own lesson: shape and
+        legacy-status are two separate questions)."""
+        return producer not in self.safe_producers and not reliable
 
     @pytest.mark.parametrize(
         "old_producer,old_reliable,new_producer,new_reliable,old_value,new_value",
@@ -159,7 +165,7 @@ class _GuardInvariants:
             )
         ),
     )
-    def test_suppresses_iff_exactly_one_side_affected(
+    def test_suppresses_iff_both_fingerprint_shaped_and_legacy_differs(
         self,
         old_producer,
         old_reliable,
@@ -170,10 +176,29 @@ class _GuardInvariants:
     ):
         old = _snap(ast_producer=old_producer, reliable=old_reliable, version="1.0")
         new = _snap(ast_producer=new_producer, reliable=new_reliable, version="2.0")
-        expected = self._affected(
-            old_producer, old_reliable, old_value
-        ) != self._affected(new_producer, new_reliable, new_value)
+        both_fingerprint_shaped = _is_expr_fingerprint(
+            old_value
+        ) and _is_expr_fingerprint(new_value)
+        expected = both_fingerprint_shaped and (
+            self._is_legacy(old_producer, old_reliable)
+            != self._is_legacy(new_producer, new_reliable)
+        )
         assert self._call(old, new, old_value, new_value) is expected
+
+    def test_shape_mismatch_never_suppresses(self):
+        """Bug #7's invariant: one side a literal, the other a genuine
+        fingerprint (whatever either side's producer/reliability) is
+        ALWAYS a confirmed real edit -- the unstable algorithm only ever
+        affects a compound expression's fingerprint HASH, never whether a
+        declaration's own value was a literal at all, so this shape
+        transition can never be an algorithm-version artifact."""
+        for old_producer, old_reliable, new_producer, new_reliable in itertools.product(
+            _PRODUCERS, _RELIABLE, _PRODUCERS, _RELIABLE
+        ):
+            old = _snap(ast_producer=old_producer, reliable=old_reliable, version="1.0")
+            new = _snap(ast_producer=new_producer, reliable=new_reliable, version="2.0")
+            assert self._call(old, new, _LITERAL_VALUE, _FINGERPRINT_A) is False
+            assert self._call(old, new, _FINGERPRINT_A, _LITERAL_VALUE) is False
 
     def test_neither_side_fingerprint_shaped_never_suppresses(self):
         """Bug #5's invariant, phrased structurally: two values that are

--- a/tests/test_schema_compat.py
+++ b/tests/test_schema_compat.py
@@ -278,6 +278,40 @@ class TestReserialization:
             warnings.simplefilter("error")
             snapshot_from_dict(d)
 
+    def test_older_version_silent_for_hybrid_producer_flags_no_detector_reads(self):
+        """clang_va_list_facts_reliable / castxml_var_access_facts_reliable
+        each have exactly one consumer, and each gates strictly on an EXACT
+        producer match ("clang"-only, "castxml"-only respectively -- neither
+        includes "hybrid", unlike most of the other flags). Their own value
+        computation still marks both False for a "hybrid" producer (correct
+        for the underlying fact's provenance), so naively listing every
+        False flag would warn about "reduced coverage" a hybrid snapshot's
+        regeneration could never actually restore, since no detector reads
+        either flag for that producer regardless of schema version (Codex
+        review, PR #720)."""
+        d = _load_fixture("v4.json")
+        d["schema_version"] = 22  # < both _MIN_SCHEMA_VERSION_FOR_CLANG_VA_LIST_FACTS
+        # and _MIN_SCHEMA_VERSION_FOR_CASTXML_VAR_ACCESS_FACTS thresholds
+        d["from_headers"] = True
+        d["ast_producer"] = "hybrid"
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            snap = snapshot_from_dict(d)
+        assert snap.clang_va_list_facts_reliable is False
+        assert snap.castxml_var_access_facts_reliable is False
+
+    def test_older_version_warns_for_clang_producer_va_list_flag(self):
+        """The producer filter above must not over-filter: a genuine
+        "clang" producer (not "hybrid") still gets the warning, since
+        diff_symbols._diff_param_va_list DOES consult the flag for that
+        producer."""
+        d = _load_fixture("v4.json")
+        d["schema_version"] = 22
+        d["from_headers"] = True
+        d["ast_producer"] = "clang"
+        with pytest.warns(UserWarning, match="clang_va_list_facts_reliable"):
+            snapshot_from_dict(d)
+
 
 # ---------------------------------------------------------------------------
 # Documentation/constant sync — a stale docs number silently misleads readers

--- a/tests/test_schema_compat.py
+++ b/tests/test_schema_compat.py
@@ -337,6 +337,40 @@ class TestReserialization:
             snap2 = snapshot_from_dict(resaved)
         assert snap2.clang_deprecation_facts_reliable is False
 
+    def test_older_version_silent_for_inferred_header_flags_no_detector_reads(self):
+        """Five of the seven flags' one real consumer requires CONFIRMED
+        (non-inferred) header awareness before it ever reads the flag:
+        clang_restrict/clang_va_list/castxml_var_access's detectors each
+        exit through diff_symbols._both_header_aware, and clang_deprecation/
+        clang_field_initializer's shared consumer
+        (fact_provenance.fact_producer) opens with the identical
+        ``from_headers and not from_headers_inferred`` check. A schema-v1
+        snapshot with no explicit ``from_headers`` key gets it GUESSED true
+        from a populated surface -- real, but not "confirmed" -- so none of
+        these five detectors will ever consult their flag for it (Codex
+        review, PR #720). header_cv_facts_reliable is the one exception
+        exercised here: its consumers (variable/field cv checks) apply
+        regardless of header confirmation, so it still warns."""
+        d = _load_fixture("v1.json")
+        d.pop("from_headers", None)
+        d.pop("ast_producer", None)
+        d["schema_version"] = 1
+        with pytest.warns(UserWarning) as record:
+            snap = snapshot_from_dict(d)
+        assert snap.from_headers is True
+        assert snap.from_headers_inferred is True
+        assert len(record) == 1
+        message = str(record[0].message)
+        assert "header_cv_facts_reliable" in message
+        for degraded_but_unconsulted in (
+            "clang_deprecation_facts_reliable",
+            "clang_field_initializer_facts_reliable",
+            "clang_restrict_facts_reliable",
+            "clang_va_list_facts_reliable",
+            "castxml_var_access_facts_reliable",
+        ):
+            assert degraded_but_unconsulted not in message
+
 
 # ---------------------------------------------------------------------------
 # Documentation/constant sync — a stale docs number silently misleads readers

--- a/tests/test_schema_compat.py
+++ b/tests/test_schema_compat.py
@@ -312,6 +312,31 @@ class TestReserialization:
         with pytest.warns(UserWarning, match="clang_va_list_facts_reliable"):
             snapshot_from_dict(d)
 
+    def test_degraded_flag_still_warns_after_reserialization_to_current_schema(self):
+        """snapshot_to_dict always re-stamps schema_version to the CURRENT
+        SCHEMA_VERSION on save -- so a legacy snapshot that's loaded (which
+        degrades a flag) and then simply re-saved reads as current-schema on
+        its NEXT load, even though the underlying facts were never
+        regenerated. Gating the warning purely on schema_version would make
+        it silently disappear across exactly this round-trip (Codex review,
+        PR #720) -- it must still fire, driven by the preserved explicit
+        False marker rather than the version number."""
+        d = _load_fixture("v4.json")
+        d["schema_version"] = 9
+        d["from_headers"] = True
+        d["ast_producer"] = "clang"
+        with warnings.catch_warnings(record=True) as first_load_warnings:
+            warnings.simplefilter("always")
+            snap = snapshot_from_dict(d)
+        assert len(first_load_warnings) == 1
+
+        resaved = snapshot_to_dict(snap)
+        assert resaved["schema_version"] == SCHEMA_VERSION
+
+        with pytest.warns(UserWarning, match="clang_deprecation_facts_reliable"):
+            snap2 = snapshot_from_dict(resaved)
+        assert snap2.clang_deprecation_facts_reliable is False
+
 
 # ---------------------------------------------------------------------------
 # Documentation/constant sync — a stale docs number silently misleads readers

--- a/tests/test_schema_compat.py
+++ b/tests/test_schema_compat.py
@@ -10,6 +10,7 @@ identical logical content. Tests verify:
 
 import json
 import re
+import warnings
 from pathlib import Path
 
 import pytest
@@ -246,6 +247,35 @@ class TestReserialization:
         d = _load_fixture("v4.json")
         d["schema_version"] = 999
         with pytest.raises(IncompatibleSnapshotSchemaError):
+            snapshot_from_dict(d)
+
+    def test_older_version_warns_when_a_fact_is_degraded(self):
+        """A snapshot older than SCHEMA_VERSION used to load with no signal
+        at all -- the *_facts_reliable flags degraded silently, and CI
+        (which reads a committed, once-generated baseline against whatever
+        abicheck version its pin currently resolves to -- the "reader newer
+        than snapshot" direction it always hits) never saw anything. Loading
+        a legacy header-derived, clang-producer snapshot should now raise a
+        loud UserWarning naming exactly which facts got degraded."""
+        d = _load_fixture("v4.json")
+        d["schema_version"] = 9
+        d["from_headers"] = True
+        d["ast_producer"] = "clang"
+        with pytest.warns(UserWarning, match="clang_deprecation_facts_reliable"):
+            snap = snapshot_from_dict(d)
+        assert snap.clang_deprecation_facts_reliable is False
+
+    def test_older_version_silent_when_nothing_is_degraded(self):
+        """The opposite of the case above: an older snapshot whose producer
+        isn't affected by any of the reliability flags shouldn't warn at all
+        -- every CI baseline is *always* some number of versions behind, and
+        warning regardless of whether that gap ever mattered would be
+        exactly the noise this fix is not meant to introduce."""
+        d = _load_fixture("v4.json")
+        d["schema_version"] = SCHEMA_VERSION - 1
+        d["from_headers"] = False
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             snapshot_from_dict(d)
 
 

--- a/tests/test_schema_compat.py
+++ b/tests/test_schema_compat.py
@@ -373,6 +373,95 @@ class TestReserialization:
 
 
 # ---------------------------------------------------------------------------
+# Exhaustive grid over the degraded-facts warning's (producer x header-
+# confirmation) domain per flag (PR #720 retrospective). The three rounds of
+# review that found the hybrid-producer, inferred-header, and round-trip
+# bugs above each fixed exactly one (flag, producer, header-confirmed) cell
+# at a time; nothing forced every OTHER cell in the same small grid to also
+# be checked, so a fourth wrong cell could easily have shipped unnoticed.
+# The grid is small enough (4 producers x 2 header-confirmation states x 7
+# flags = 56 cells) to enumerate completely rather than keep adding one more
+# hand-picked example per bug report — see
+# ``abicheck/diff_default_value_reliability.py``'s module docstring for the
+# same reasoning applied to the sibling fingerprint-reliability guards, and
+# ``tests/test_fingerprint_reliability_properties.py`` for that exhaustive
+# suite.
+# ---------------------------------------------------------------------------
+
+# Each flag's own DEGRADED-value rule at a schema version below every
+# per-flag threshold (so only the producer term of each flag's real
+# computation in snapshot_from_dict — see SCHEMA_VERSION's own version-
+# history comments — still varies; the schema-threshold term is uniformly
+# "not met" for every flag at schema_version=1).
+_FLAG_DEGRADED_FOR_PRODUCER = {
+    "header_cv_facts_reliable": lambda p: p != "clang",
+    "clang_deprecation_facts_reliable": lambda p: p == "clang",
+    "clang_field_initializer_facts_reliable": lambda p: p != "castxml",
+    "clang_vtable_facts_reliable": lambda p: p == "clang",
+    "clang_restrict_facts_reliable": lambda p: p != "castxml",
+    "clang_va_list_facts_reliable": lambda p: p != "castxml",
+    "castxml_var_access_facts_reliable": lambda p: p != "clang",
+}
+
+# Each flag's own CONSULTED rule -- does the one real detector that reads
+# this flag even reach the point of checking it, for this (producer,
+# header-confirmed) combination. Mirrors the table `snapshot_from_dict`
+# builds (see its own extensive comment for the per-flag reasoning); this
+# is the independently-maintained pin the exhaustive grid test below checks
+# it against.
+_FLAG_CONSULTED_FOR = {
+    "header_cv_facts_reliable": lambda p, h: True,
+    "clang_deprecation_facts_reliable": lambda p, h: h,
+    "clang_field_initializer_facts_reliable": lambda p, h: h,
+    "clang_vtable_facts_reliable": lambda p, h: True,
+    "clang_restrict_facts_reliable": lambda p, h: h,
+    "clang_va_list_facts_reliable": lambda p, h: h and p == "clang",
+    "castxml_var_access_facts_reliable": lambda p, h: h and p == "castxml",
+}
+
+_GRID_PRODUCERS = (None, "clang", "castxml", "hybrid")
+
+
+def _load_with_producer_and_header_confirmation(producer, header_confirmed):
+    """Load a schema-v1 dict (below every per-flag threshold) with the
+    given `ast_producer` and header-confirmation state, returning the
+    UserWarning message (or None if no warning fired)."""
+    d = _load_fixture("v1.json")
+    d["schema_version"] = 1
+    if producer is not None:
+        d["ast_producer"] = producer
+    if header_confirmed:
+        d["from_headers"] = True
+    else:
+        # Omitting the key entirely -- rather than setting it False -- is
+        # what triggers `from_headers_inferred=True` (a GUESSED, not
+        # confirmed, header-aware side): see snapshot_from_dict's own
+        # from_headers-inference comment.
+        d.pop("from_headers", None)
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        snap = snapshot_from_dict(d)
+    assert snap.functions, (
+        "fixture must carry at least one function for from_headers to infer True"
+    )
+    return str(record[0].message) if record else ""
+
+
+@pytest.mark.parametrize("flag_name", sorted(_FLAG_DEGRADED_FOR_PRODUCER))
+@pytest.mark.parametrize("header_confirmed", [True, False])
+@pytest.mark.parametrize("producer", _GRID_PRODUCERS)
+def test_degraded_facts_warning_grid(producer, header_confirmed, flag_name):
+    message = _load_with_producer_and_header_confirmation(producer, header_confirmed)
+    degraded = _FLAG_DEGRADED_FOR_PRODUCER[flag_name](producer)
+    consulted = _FLAG_CONSULTED_FOR[flag_name](producer, header_confirmed)
+    expect_listed = degraded and consulted
+    assert (flag_name in message) is expect_listed, (
+        f"{flag_name} producer={producer!r} header_confirmed={header_confirmed}: "
+        f"expected listed={expect_listed}, message={message!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Documentation/constant sync — a stale docs number silently misleads readers
 # about what "current" means (docs/reference/snapshot-format.md drifted to a
 # hardcoded "8" while SCHEMA_VERSION had moved on to 11; this pins them together).


### PR DESCRIPTION
## Summary

`serialization.snapshot_from_dict` now warns when loading an older snapshot degrades a `*_facts_reliable` flag, instead of doing so silently.

## Motivation

The version-mismatch check at the top of `snapshot_from_dict` only ever warned in one direction: snapshot *newer* than the reader. Snapshot *older* than the reader — the direction CI actually hits, since a baseline is committed once and outlives however many abicheck pin bumps happen before it's next regenerated — loaded with no signal at all, even when the version gap meant a real, known fact (clang deprecation/vtable/restrict/va_list facts, or CastXML CV/variable-access facts) got marked unreliable and silently excluded from detection. The `*_facts_reliable` flags themselves were already being computed correctly; nothing surfaced that to whoever was reading the comparison.

## Changes

- `abicheck/serialization.py`: `snapshot_from_dict` now emits a `UserWarning` at load time, naming exactly which `*_facts_reliable` flags got degraded, whenever the snapshot's `schema_version` is older than the reader's `SCHEMA_VERSION` *and* that gap actually degraded something. Stays silent for a version gap that doesn't affect any known fact, so an ordinary one-version-behind baseline isn't warned about for no reason.
- Added a version-history note next to `SCHEMA_VERSION` documenting the new warning and why it's conditional rather than unconditional (unlike the existing "newer" branch, which always warns).
- `tests/test_schema_compat.py`: two new tests — one confirming the warning fires and names the degraded flag for a legacy clang-producer snapshot, one confirming it stays silent when nothing is actually degraded.
- Changelog fragment under `changelog.d/`.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [ ] Docs updated if user-visible behaviour changed (no doc changes needed — a `UserWarning` message, not a documented API/CLI contract)
- [x] `pre-commit run --all-files` passes locally (ruff check/format + mypy on the changed files clean; full fast-profile suite: 25038 passed, 2 pre-existing unrelated failures confirmed to fail identically on `main` — `test_adr_status_sync_holds`/`test_main_returns_zero_on_clean_tree`, both failing on ADR `**Verified:**` commits not reachable from `origin/main` in this sandboxed checkout)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hyu4oT1YHwB1a53nvpUGXe)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Loading older snapshots now clearly warns when producer-specific fact reliability has degraded.
  - Warnings identify the affected reliability flags and are shown only when degradation occurs.
  - Older snapshots without degraded facts continue to load silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->