### PR TITLE
fix(snapshot-io): pass zstd max_window_size in bytes, not KiB

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -605,6 +605,20 @@ Several mechanisms guard test quality so coverage can't be "filled" without veri
   `ABICHECK_MIN_EXECUTED=<n>`; the session fails unless at least `<n>` tests actually ran,
   so a missing external tool can't turn a lane green with zero work done. Wired into the
   `abicc`, `libabigail`, and `integration` CI lanes.
+- **Third-party-boundary tests must exercise the real public API at realistic scale, not
+  just internal arithmetic.** Lesson from a real incident (ADR-059 §12: `snapshot_io.py`'s
+  zstd `max_window_size` was silently computed in the wrong unit for months): one test
+  asserted a value's own formula was self-consistent (a tautology against the bug's own
+  wrong formula), and a second used a toy-shaped fixture (small, highly-compressible input
+  at a large nominal parameter) whose *actual* required behavior collapsed to something
+  trivial — both passed identically before and after the regression. When a module's job is
+  "honor an external library's/format's contract," at least one test per algorithm must go
+  through the module's *actual public entry point*, at a *content scale realistic enough to
+  trigger the condition being defended against*, never only a hand-constructed shortcut into
+  the dependency's lower-level API. See `tests/test_snapshot_compression.py`'s
+  `test_zstd_round_trip_at_production_scale_and_level` for the pattern: real `AbiSnapshot` →
+  real `write_snapshot_bytes`/`read_snapshot_bytes` chokepoints → scaled past the threshold
+  where the defended-against condition actually reproduces.
 
 ## Line-coverage floor
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -612,13 +612,19 @@ Several mechanisms guard test quality so coverage can't be "filled" without veri
   wrong formula), and a second used a toy-shaped fixture (small, highly-compressible input
   at a large nominal parameter) whose *actual* required behavior collapsed to something
   trivial — both passed identically before and after the regression. When a module's job is
-  "honor an external library's/format's contract," at least one test per algorithm must go
-  through the module's *actual public entry point*, at a *content scale realistic enough to
-  trigger the condition being defended against*, never only a hand-constructed shortcut into
-  the dependency's lower-level API. See `tests/test_snapshot_compression.py`'s
-  `test_zstd_round_trip_at_production_scale_and_level` for the pattern: real `AbiSnapshot` →
-  real `write_snapshot_bytes`/`read_snapshot_bytes` chokepoints → scaled past the threshold
-  where the defended-against condition actually reproduces.
+  "honor an external library's/format's contract," **every** supported algorithm needs at
+  least one test that goes through the module's *actual public entry point*, at a *content
+  scale realistic enough to trigger the condition being defended against* where one is known
+  — never only a hand-constructed shortcut into the dependency's lower-level API. This
+  applies per algorithm even when only one of them has a known incident to defend against: a
+  principle that silently excludes the algorithm nobody has broken yet isn't a principle, and
+  a review round caught exactly that gap here (gzip had none). See
+  `tests/test_snapshot_compression.py`'s `test_zstd_round_trip_at_production_scale_and_level`
+  (real `AbiSnapshot` → real `write_snapshot_bytes`/`read_snapshot_bytes` chokepoints → scaled
+  past the threshold where the KiB/bytes regression actually reproduces) and its gzip sibling
+  `test_gzip_round_trip_at_production_scale` (same chokepoints/scale, no known incident to
+  reproduce, added purely to keep this bullet true for every supported algorithm) for the
+  pattern to follow for the next storage/serialization boundary.
 
 ## Line-coverage floor
 

--- a/abicheck/snapshot_io.py
+++ b/abicheck/snapshot_io.py
@@ -125,15 +125,28 @@ DEFAULT_MAX_STORED_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
 # empirically: decompressing a real frame with an 8 MiB window succeeds with
 # ``max_window_size=8 * 1024 * 1024`` and fails with
 # ``max_window_size=8 * 1024`` (the KiB-scaled value the docstring implies),
-# so the parameter is bytes in practice, not KiB. `_ZSTD_MAX_WINDOW_SIZE_BYTES`
-# is the value actually passed to the constructor; dividing it by 1024 (as an
+# so the parameter is bytes in practice, not KiB. Dividing it by 1024 (as an
 # earlier revision of this module did, reading the docstring at face value)
 # silently shrank the accepted window to 1/1024th of the intended ceiling,
 # making any snapshot the writer compressed with a larger window
 # undecodable. See ADR-059 §8, which already documents the ceiling in bytes
 # (`max_window_size = 1 << 31`).
-_ZSTD_MAX_WINDOW_LOG = 31  # 2 GiB window ceiling
-_ZSTD_MAX_WINDOW_SIZE_BYTES = 1 << _ZSTD_MAX_WINDOW_LOG
+_ZSTD_MAX_WINDOW_LOG = 31  # 2 GiB window ceiling, on a build that supports it
+
+
+# `ZSTD_DCtx_setMaxWindowSize()` bound-checks its argument against the
+# backend's own `[1 << windowLogMin, 1 << windowLogMax]` range and errors
+# out (not just declines the frame) if it's exceeded -- and `windowLogMax`
+# is only 31 (2 GiB) on a 64-bit libzstd build; a 32-bit build's
+# `ZSTD_WINDOWLOG_MAX_32` is 30 (1 GiB) (Codex review). Passing our fixed
+# 31 unconditionally would make `ZstdDecompressor(max_window_size=...)`
+# itself raise on such a build, rejecting every zstd snapshot outright
+# -- not just an oversized one. `zstandard.WINDOWLOG_MAX` reports the
+# *actual* backend ceiling at runtime, so clamp to whichever is smaller.
+def _zstd_max_window_size_bytes(zstandard: Any) -> int:
+    log = min(_ZSTD_MAX_WINDOW_LOG, int(zstandard.WINDOWLOG_MAX))
+    return 1 << log
+
 
 _MAX_DECODED_BYTES_ENV = "_ABICHECK_SNAPSHOT_MAX_DECODED_BYTES"
 _MAX_STORED_BYTES_ENV = "_ABICHECK_SNAPSHOT_MAX_STORED_BYTES"
@@ -351,7 +364,9 @@ def _decompress_gzip(data: bytes, *, max_decoded_bytes: int, source: str) -> byt
 
 def _decompress_zstd(data: bytes, *, max_decoded_bytes: int, source: str) -> bytes:
     zstandard = _zstd_module()
-    dctx = zstandard.ZstdDecompressor(max_window_size=_ZSTD_MAX_WINDOW_SIZE_BYTES)
+    dctx = zstandard.ZstdDecompressor(
+        max_window_size=_zstd_max_window_size_bytes(zstandard)
+    )
     out = io.BytesIO()
     try:
         with dctx.stream_reader(io.BytesIO(data)) as reader:
@@ -601,7 +616,9 @@ def _try_decode_prefix(
             with gzip.GzipFile(fileobj=io.BytesIO(head), mode="rb") as gz:
                 return bytes(gz.read(n))
         zstandard = _zstd_module()
-        dctx = zstandard.ZstdDecompressor(max_window_size=_ZSTD_MAX_WINDOW_SIZE_BYTES)
+        dctx = zstandard.ZstdDecompressor(
+            max_window_size=_zstd_max_window_size_bytes(zstandard)
+        )
         with dctx.stream_reader(io.BytesIO(head)) as reader:
             return bytes(reader.read(n))
     except Exception:

--- a/abicheck/snapshot_io.py
+++ b/abicheck/snapshot_io.py
@@ -117,15 +117,23 @@ DEFAULT_MAX_STORED_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB
 # zstd window-size bound, independent of the decoded-size limit above: caps
 # how much memory a hostile frame can force the decompressor to allocate for
 # its sliding window, regardless of how much data it claims/produces.
-# ``python-zstandard``'s ``ZstdDecompressor(max_window_size=...)`` takes this
-# value in *kibibytes*, not bytes (confirmed against its own docstring: "an
-# upper limit on the window size for decompression operations in kibibytes")
-# -- passing a raw byte count here would silently permit a window 1024x
-# larger than intended. `_ZSTD_MAX_WINDOW_SIZE_KIB` is the value actually
-# passed to the constructor; the bit-shift below only sizes the byte ceiling
-# this comment/the ADR describe.
+# ``python-zstandard``'s ``ZstdDecompressor(max_window_size=...)`` docstring
+# claims this value is in *kibibytes*, but the underlying implementation
+# (``backend_cffi.py``'s ``_ensure_dctx``, and the C extension alike) passes
+# it straight through to ``ZSTD_DCtx_setMaxWindowSize()`` with no `* 1024`
+# anywhere -- and that libzstd API takes a raw *byte* count. Confirmed
+# empirically: decompressing a real frame with an 8 MiB window succeeds with
+# ``max_window_size=8 * 1024 * 1024`` and fails with
+# ``max_window_size=8 * 1024`` (the KiB-scaled value the docstring implies),
+# so the parameter is bytes in practice, not KiB. `_ZSTD_MAX_WINDOW_SIZE_BYTES`
+# is the value actually passed to the constructor; dividing it by 1024 (as an
+# earlier revision of this module did, reading the docstring at face value)
+# silently shrank the accepted window to 1/1024th of the intended ceiling,
+# making any snapshot the writer compressed with a larger window
+# undecodable. See ADR-059 §8, which already documents the ceiling in bytes
+# (`max_window_size = 1 << 31`).
 _ZSTD_MAX_WINDOW_LOG = 31  # 2 GiB window ceiling
-_ZSTD_MAX_WINDOW_SIZE_KIB = (1 << _ZSTD_MAX_WINDOW_LOG) // 1024
+_ZSTD_MAX_WINDOW_SIZE_BYTES = 1 << _ZSTD_MAX_WINDOW_LOG
 
 _MAX_DECODED_BYTES_ENV = "_ABICHECK_SNAPSHOT_MAX_DECODED_BYTES"
 _MAX_STORED_BYTES_ENV = "_ABICHECK_SNAPSHOT_MAX_STORED_BYTES"
@@ -343,7 +351,7 @@ def _decompress_gzip(data: bytes, *, max_decoded_bytes: int, source: str) -> byt
 
 def _decompress_zstd(data: bytes, *, max_decoded_bytes: int, source: str) -> bytes:
     zstandard = _zstd_module()
-    dctx = zstandard.ZstdDecompressor(max_window_size=_ZSTD_MAX_WINDOW_SIZE_KIB)
+    dctx = zstandard.ZstdDecompressor(max_window_size=_ZSTD_MAX_WINDOW_SIZE_BYTES)
     out = io.BytesIO()
     try:
         with dctx.stream_reader(io.BytesIO(data)) as reader:
@@ -593,7 +601,7 @@ def _try_decode_prefix(
             with gzip.GzipFile(fileobj=io.BytesIO(head), mode="rb") as gz:
                 return bytes(gz.read(n))
         zstandard = _zstd_module()
-        dctx = zstandard.ZstdDecompressor(max_window_size=_ZSTD_MAX_WINDOW_SIZE_KIB)
+        dctx = zstandard.ZstdDecompressor(max_window_size=_ZSTD_MAX_WINDOW_SIZE_BYTES)
         with dctx.stream_reader(io.BytesIO(head)) as reader:
             return bytes(reader.read(n))
     except Exception:

--- a/changelog.d/20260811_220056_noreply_zstd_window_size_units_wc9o9y.md
+++ b/changelog.d/20260811_220056_noreply_zstd_window_size_units_wc9o9y.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **zstd-compressed snapshots (`.json.zst`) written at a realistic window
+  size could not be read back.** `snapshot_io.py`'s zstd decompressor
+  passed its window-size ceiling to `python-zstandard`'s
+  `ZstdDecompressor(max_window_size=...)` after dividing it by 1024 — that
+  parameter's own docstring claims kibibytes, but the underlying
+  implementation passes the value straight through to
+  `ZSTD_DCtx_setMaxWindowSize()`, which takes raw bytes. The effective
+  accepted window shrank to ~2 MiB instead of the intended 2 GiB, so any
+  `.json.zst` snapshot the writer compressed with a larger window (e.g. its
+  8 MiB baseline compression level) failed to decode with
+  `ZstdError: Frame requires too much memory for decoding` — surfaced to
+  users as a misleading `Cannot detect format of '...'` error, since format
+  sniffing swallows the underlying decompression failure.

--- a/docs/contribute/adr/059-compressed-snapshot-storage.md
+++ b/docs/contribute/adr/059-compressed-snapshot-storage.md
@@ -354,6 +354,80 @@ None of the above blocks what *is* implemented: `dump`, `compare`, `scan
 already transparently read/write plain, gzip, and zstd snapshots today —
 see the acceptance table in the PR/CHANGELOG entry for this ADR.
 
+### 12. Postmortem: the `max_window_size` unit bug (and what it changed about this ADR's tests)
+
+A real-world `.json.zst` baseline (window_size 8 MiB, content_size ~150 MB —
+exactly the scale this ADR's own "Real-world audit" table above cites)
+could not be read back after this ADR shipped: `ZstdDecompressor(
+max_window_size=...)` was being called with an intended-byte value silently
+divided by 1024 (a docstring-literal reading of `python-zstandard`'s
+`max_window_size` parameter, which claims kibibytes; the underlying
+implementation — both backends — passes the value straight through to
+`ZSTD_DCtx_setMaxWindowSize()`, and that libzstd API takes raw bytes). The
+effective accepted window shrank to ~2 MiB against an intended 2 GiB, so any
+snapshot compressed with a real multi-megabyte window failed to decode with
+`ZstdError: Frame requires too much memory for decoding` — surfaced to users
+as a misleading `Cannot detect format of '...'`, since the sniffing path
+(`bounded_decoded_prefix`/`_try_decode_prefix`) swallows the underlying
+decompression exception into "unrecognized format" by design (see
+"Detection" above).
+
+**Root cause, generalized beyond this one bug:** every existing test
+validated *shape*, not *the actual external-library contract*:
+
+1. A unit test asserted the fixed ceiling's own internal arithmetic
+   (`_ZSTD_MAX_WINDOW_SIZE_KIB * 1024 == intended_byte_ceiling`) — a
+   tautology against the bug's own (wrong) formula, not a check against
+   `python-zstandard`'s actual runtime behavior.
+2. A second test *did* attempt to exercise a real "at the ceiling" frame
+   (`window_log=31`), but with a small, highly-compressible fixture
+   (`b"a" * (1 << 20)`). zstd's single-segment framing collapses a frame's
+   *recorded* `window_size` down to its `content_size` whenever content
+   fits inside the nominal window — so that fixture's real required window
+   was ~1 MiB, comfortably under the *buggy* ~2 MiB effective ceiling too.
+   The test exercised none of the failure mode it was written to catch,
+   and passed identically before and after the bug.
+3. No test exercised the storage layer's actual public contract — write
+   through the real production path (`ZSTD_LEVEL_BASELINE`, no manual
+   `CompressionParameters` override) at a large-enough scale to force zstd's
+   real auto-selected window, then read it back. Every zstd test either
+   compressed a tiny in-memory fixture or hand-built a `CompressionParameters`
+   object, none of which is what `write_snapshot`/`dump` actually do.
+
+**The general lesson, not specific to zstd:** a test that only checks a
+value's internal arithmetic, or that exercises a *toy-shaped* boundary
+condition (small/no-op input at a small-number-but-large-magnitude nominal
+parameter), can pass on both sides of a real regression. When a module's
+job is "honor an external library's storage contract" (this ADR's whole
+premise), at least one test per algorithm must go through the *actual
+public write path*, at a *content scale realistic enough to trigger the
+condition being defended against* (here: content large enough that zstd's
+auto window-sizing stops collapsing to a toy value) — never only a
+hand-constructed shortcut into the library's lower-level API. `snapshot_io.py`'s
+test suite (`tests/test_snapshot_compression.py`) now has three such tests
+built around a payload sized to force a real 8 MiB window (matching the
+`ZSTD_LEVEL_BASELINE` auto-selection observed against a real ~150 MB
+snapshot): one exercising `_decompress_zstd` directly, one exercising
+`bounded_decoded_prefix`'s sniffing path, and one exercising
+`sniff_text_format` end to end — plus a full production-write-path
+round-trip test (`test_zstd_round_trip_at_production_scale_and_level`) that
+never constructs a `CompressionParameters` at all, only calls
+`write_snapshot_bytes`/`read_snapshot_bytes` the way `dump`/`compare`
+actually do. All four fail against the pre-fix code with the same
+`Frame requires too much memory for decoding` symptom the field report hit,
+and pass with it.
+
+A related, independently-found gap in the same fix (Codex review): the
+ceiling itself (`1 << 31`) is only valid on a 64-bit libzstd build —
+`ZSTD_DCtx_setMaxWindowSize()` bound-checks its argument against the
+backend's own reported `[windowLogMin, windowLogMax]` range and *errors*
+(not just declines an oversized frame) if exceeded, and a 32-bit build's
+`ZSTD_WINDOWLOG_MAX_32` is 30. `_zstd_max_window_size_bytes()` now clamps
+to `min(31, zstandard.WINDOWLOG_MAX)` — the backend's own runtime-reported
+ceiling — rather than a value this module asserts unconditionally, with a
+unit test simulating a lower `WINDOWLOG_MAX` to pin the clamp directly
+rather than relying on access to an actual 32-bit build.
+
 ## Non-goals (explicit)
 
 - **DWARF/scan extraction memory (RSS)** is out of scope. This ADR touches

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -74,6 +74,31 @@ class TestSniffTextFormat:
         p.write_text("   \n  {}")
         assert sniff_text_format(p) == "json"
 
+    def test_zstd_compressed_json_with_realistic_window(self, tmp_path):
+        """End-to-end repro of the reported bug: a `.json.zst` baseline
+        whose frame records a realistic multi-megabyte window (matching the
+        writer's real baseline level -- content large enough to keep zstd
+        out of the single-segment mode that would otherwise collapse the
+        recorded window down to the content size) must still sniff as
+        `json` rather than falling through to `unknown` -- which is what
+        surfaced as the user-facing "Cannot detect format" error when
+        `snapshot_io._ZSTD_MAX_WINDOW_SIZE_BYTES` was computed in KiB
+        instead of bytes."""
+        zstandard = pytest.importorskip("zstandard")
+
+        blob = "a" * (9 * 1024 * 1024)
+        text = json.dumps({"library": "x", "version": "1", "blob": blob})
+
+        params = zstandard.ZstdCompressionParameters.from_level(19, window_log=23)
+        cctx = zstandard.ZstdCompressor(compression_params=params)
+        compressed = cctx.compress(text.encode())
+        frame = zstandard.get_frame_parameters(compressed)
+        assert frame.window_size == 8 * 1024 * 1024
+
+        p = tmp_path / "baseline.json.zst"
+        p.write_bytes(compressed)
+        assert sniff_text_format(p) == "json"
+
 
 # ── expand_header_inputs() ──────────────────────────────────────────────────
 
@@ -1335,9 +1360,7 @@ class TestHeaderScopedInferredRoots:
                     "macho", tmp_path / "x.dylib", [umb], [], "1.0", "c++"
                 )
 
-    def test_explicit_device_context_failure_propagates_not_swallowed(
-        self, tmp_path
-    ):
+    def test_explicit_device_context_failure_propagates_not_swallowed(self, tmp_path):
         # Codex review: AstContextMissingError/AstContextAmbiguousError only
         # ever come from a NON-"host" --frontend-context request (ADR-050
         # D5) -- there is no "device" default, so seeing either here always
@@ -1864,7 +1887,9 @@ class TestCompareRequestAdr055Evidence:
         calls_by_path = {c["path"]: c for c in calls}
         assert calls_by_path[old_p]["dump_manifest"] is None
 
-    def test_per_side_compile_override_wins_over_pair_compile(self, tmp_path, monkeypatch):
+    def test_per_side_compile_override_wins_over_pair_compile(
+        self, tmp_path, monkeypatch
+    ):
         from abicheck.compile_context import CompileContext
 
         old_p = self._make_snap_file(tmp_path, "libtest", "1.0")
@@ -1985,7 +2010,9 @@ class TestCompareRequestAdr055Evidence:
         run_compare_request(request)
         assert embed_calls == []
 
-    def test_embedded_evidence_is_diffed_into_extra_changes(self, tmp_path, monkeypatch):
+    def test_embedded_evidence_is_diffed_into_extra_changes(
+        self, tmp_path, monkeypatch
+    ):
         """Codex review (P1): embed_build_source alone only writes
         snap.build_source -- the checker never reads it directly, so it must
         also be diffed (prepare_embedded_build_source) and forwarded to
@@ -2125,7 +2152,9 @@ class TestCompareRequestAdr055Evidence:
         run_compare_request(request)
         assert embed_calls[0]["extractor"] == "castxml"
 
-    def test_public_headers_forwarded_to_embed_build_source(self, tmp_path, monkeypatch):
+    def test_public_headers_forwarded_to_embed_build_source(
+        self, tmp_path, monkeypatch
+    ):
         """Codex review (P1): omitting the side's public-header roots from
         embed_build_source leaves source replay's own public-header set
         empty, so the L4 extractor can classify every declaration as non-API
@@ -2221,7 +2250,10 @@ class TestCompareRequestAdr055Evidence:
         private_inc = SimpleNamespace(path="/proj/private_support", project_owned=True)
         tu = SimpleNamespace(includes=[private_inc], forced_includes=())
         manifest = SimpleNamespace(
-            roots=[], public_header_paths=[], public_header_dirs=[], translation_units=[tu]
+            roots=[],
+            public_header_paths=[],
+            public_header_dirs=[],
+            translation_units=[tu],
         )
 
         embed_calls: list[dict] = []
@@ -3502,7 +3534,9 @@ class TestRunDumpHeaderGraph:
         ast = {"kind": "TranslationUnitDecl", "inner": []}
         with (
             patch("abicheck.service._dump_pe", return_value=snap),
-            patch("abicheck.dumper._clang_header_dump", return_value=(ast, None)) as mock_ast,
+            patch(
+                "abicheck.dumper._clang_header_dump", return_value=(ast, None)
+            ) as mock_ast,
         ):
             result = run_dump(p, "pe", [header], [], "1.0", "c++")
         mock_ast.assert_called_once()
@@ -3551,7 +3585,9 @@ class TestRunDumpHeaderGraph:
         cc = CompileContext(frontend_context="device")
         with (
             patch("abicheck.service._dump_pe", return_value=snap),
-            patch("abicheck.dumper._clang_header_dump", return_value=(ast, None)) as mock_ast,
+            patch(
+                "abicheck.dumper._clang_header_dump", return_value=(ast, None)
+            ) as mock_ast,
         ):
             run_dump(p, "pe", [header], [], "1.0", "c++", compile=cc)
         mock_ast.assert_called_once()
@@ -3595,7 +3631,9 @@ class TestRunDumpHeaderGraph:
         ast = {"kind": "TranslationUnitDecl", "inner": []}
         with (
             patch("abicheck.service._dump_pe", return_value=snap),
-            patch("abicheck.dumper._clang_header_dump", return_value=(ast, None)) as mock_ast,
+            patch(
+                "abicheck.dumper._clang_header_dump", return_value=(ast, None)
+            ) as mock_ast,
         ):
             result = run_dump(p, "pe", [hdr_dir], [], "1.0", "c++")
         mock_ast.assert_called_once()
@@ -4746,9 +4784,7 @@ class TestRunCompareRequestResolutionParity:
         )
         return calls
 
-    def test_follow_dependencies_populates_both_elf_sides(
-        self, tmp_path, monkeypatch
-    ):
+    def test_follow_dependencies_populates_both_elf_sides(self, tmp_path, monkeypatch):
         self._stub_dump(monkeypatch)
         calls = self._stub_dependency_population(monkeypatch)
         run_compare_request(
@@ -4940,7 +4976,6 @@ class TestComparePipelinePhases:
         # A JSON snapshot has no detected binary format, same as on the CLI.
         assert pair.old_fmt is None and pair.new_fmt is None
         assert pair.old_evidence.collect_mode == pair.new_evidence.collect_mode == "off"
-
 
     def test_layer_coverage_rows_reach_the_result(self, tmp_path, monkeypatch):
         """The one branch in `classify_compare_pair` nothing else exercises.

--- a/tests/test_snapshot_compression.py
+++ b/tests/test_snapshot_compression.py
@@ -626,6 +626,38 @@ def test_zstd_round_trip_at_production_scale_and_level(tmp_path):
     )
 
 
+def test_gzip_round_trip_at_production_scale(tmp_path):
+    """gzip counterpart to `test_zstd_round_trip_at_production_scale_and_level`
+    above -- added per the AGENTS.md Test-quality-gates principle that
+    prompted that test ("at least one test per algorithm must go through
+    the module's actual public entry point, at a realistic content scale"),
+    which a review round correctly flagged as unfulfilled for gzip: every
+    existing gzip test used either a tiny (`_sample_snapshot`) fixture or a
+    hand-built low-level fixture, never the real `write_snapshot_bytes`/
+    `read_snapshot_bytes` chokepoint at production scale. Unlike zstd, gzip
+    (`zlib` under the hood) has no window-size *parameter* a caller can get
+    a unit wrong on -- this test exists to keep the stated principle
+    actually true for every supported algorithm, not because a gzip-specific
+    bug is already known. Cheap to run (gzip compresses this size in well
+    under a second, unlike zstd level 19), so no `slow` marker needed."""
+    snap = _graph_heavy_snapshot(n=8600)
+    original_bytes = json.dumps(snapshot_to_dict(snap)).encode()
+    assert (
+        len(original_bytes) > 8 * 1024 * 1024
+    )  # same realistic scale as the zstd test
+
+    p = tmp_path / "production_scale.abicheck.json.gz"
+    result = write_snapshot_bytes(
+        original_bytes, p, compression=SnapshotCompression.GZIP
+    )
+    assert result.compression is SnapshotCompression.GZIP
+
+    assert (
+        read_snapshot_bytes(p, max_decoded_bytes=len(original_bytes) + 10)
+        == original_bytes
+    )
+
+
 def test_oversized_stored_file_rejected_before_full_read(tmp_path, monkeypatch):
     """CodeRabbit review, refined by two later Codex rounds: the stored-
     file-size check (via fstat(), before a full read) must reject a file

--- a/tests/test_snapshot_compression.py
+++ b/tests/test_snapshot_compression.py
@@ -432,17 +432,24 @@ def test_plain_snapshot_overflow(tmp_path):
         read_snapshot_bytes(p, max_decoded_bytes=100)
 
 
-def test_zstd_max_window_size_is_kibibytes_not_bytes():
-    """Codex review, PR #699: python-zstandard's ``ZstdDecompressor(
-    max_window_size=...)`` takes its argument in *kibibytes*, confirmed
-    against its own docstring -- passing a raw byte count (as an earlier
-    version of this module did) silently permitted a window 1024x larger
-    than the documented "2 GiB window ceiling" (effectively ~2 TiB)."""
-    from abicheck.snapshot_io import _ZSTD_MAX_WINDOW_LOG, _ZSTD_MAX_WINDOW_SIZE_KIB
+def test_zstd_max_window_size_is_bytes_not_kibibytes():
+    """python-zstandard's ``ZstdDecompressor(max_window_size=...)`` docstring
+    *claims* kibibytes, but the underlying implementation (both the C
+    extension and ``backend_cffi.py``'s ``_ensure_dctx``) passes the value
+    straight through to ``ZSTD_DCtx_setMaxWindowSize()`` with no ``* 1024``
+    -- and that libzstd API takes a raw byte count. An earlier revision of
+    this module divided the intended byte ceiling by 1024 (reading the
+    docstring at face value), which shrank the accepted window to
+    1/1024th of the intended 2 GiB and made any snapshot compressed with a
+    real multi-megabyte window (e.g. the writer's 8 MiB baseline level)
+    undecodable. See ``test_zstd_decoder_rejects_realistic_writer_window``
+    below for the end-to-end repro of that failure mode."""
+    from abicheck.snapshot_io import _ZSTD_MAX_WINDOW_LOG, _ZSTD_MAX_WINDOW_SIZE_BYTES
 
-    intended_byte_ceiling = 1 << _ZSTD_MAX_WINDOW_LOG
-    assert _ZSTD_MAX_WINDOW_SIZE_KIB * 1024 == intended_byte_ceiling
-    assert intended_byte_ceiling == 2 * 1024 * 1024 * 1024  # 2 GiB, per the comment
+    assert _ZSTD_MAX_WINDOW_SIZE_BYTES == 1 << _ZSTD_MAX_WINDOW_LOG
+    assert (
+        _ZSTD_MAX_WINDOW_SIZE_BYTES == 2 * 1024 * 1024 * 1024
+    )  # 2 GiB, per the comment
 
 
 def test_zstd_decoder_rejects_window_above_ceiling(tmp_path):
@@ -451,7 +458,7 @@ def test_zstd_decoder_rejects_window_above_ceiling(tmp_path):
     not silently allow an oversized one because of a unit-conversion bug.
     zstd's own ZSTD_WINDOWLOG_MAX is 31 (2 GiB) on a 64-bit build, i.e.
     exactly this module's ceiling, so a legitimate max-size frame (window_log
-    31) must still decode successfully with the fixed KiB-denominated value
+    31) must still decode successfully with the fixed byte-denominated value
     -- if the conversion silently permitted a *smaller* effective window than
     intended, this would fail instead."""
     zstandard = pytest.importorskip("zstandard")
@@ -466,6 +473,38 @@ def test_zstd_decoder_rejects_window_above_ceiling(tmp_path):
     # succeed rather than raising "too much memory" for a legitimate,
     # at-the-ceiling window.
     assert read_snapshot_bytes(p) == b"a" * (1 << 20)
+
+
+def test_zstd_decoder_rejects_realistic_writer_window(tmp_path):
+    """End-to-end repro of the KiB/bytes unit bug: a frame whose *actually
+    required* window (not just its nominal window_log ceiling -- see the
+    highly-compressible fixture in `test_zstd_decoder_rejects_window_above_
+    ceiling` above, whose real required window collapses to far less than
+    its window_log) is a realistic multi-megabyte size, matching what the
+    writer picks at its baseline compression level. Low-entropy data lets
+    the *frame's own recorded window_size* stay large despite compressing
+    well, so this exercises the real ceiling instead of coincidentally
+    fitting under the pre-fix (1/1024th) ceiling too. Confirmed the old,
+    KiB-denominated ceiling (2097152, interpreted as raw bytes by
+    python-zstandard) rejects this frame with "Frame requires too much
+    memory for decoding", while the fixed byte ceiling decodes it."""
+    zstandard = pytest.importorskip("zstandard")
+    import random
+
+    random.seed(2026)
+    # An 8 MiB window (window_log=23), with enough genuinely incompressible
+    # payload that the frame's recorded window_size stays at the full 8 MiB
+    # rather than collapsing to the (smaller) content size.
+    payload = bytes(random.randrange(256) for _ in range(9 * 1024 * 1024))
+    params = zstandard.ZstdCompressionParameters.from_level(19, window_log=23)
+    cctx = zstandard.ZstdCompressor(compression_params=params)
+    compressed = cctx.compress(payload)
+    frame = zstandard.get_frame_parameters(compressed)
+    assert frame.window_size == 8 * 1024 * 1024
+
+    p = tmp_path / "realistic_window.abicheck.json.zst"
+    p.write_bytes(compressed)
+    assert read_snapshot_bytes(p, max_decoded_bytes=len(payload) + 10) == payload
 
 
 def test_oversized_stored_file_rejected_before_full_read(tmp_path, monkeypatch):

--- a/tests/test_snapshot_compression.py
+++ b/tests/test_snapshot_compression.py
@@ -478,12 +478,35 @@ def test_zstd_max_window_size_is_bytes_not_kibibytes():
     real multi-megabyte window (e.g. the writer's 8 MiB baseline level)
     undecodable. See ``test_zstd_decoder_rejects_realistic_writer_window``
     below for the end-to-end repro of that failure mode."""
-    from abicheck.snapshot_io import _ZSTD_MAX_WINDOW_LOG, _ZSTD_MAX_WINDOW_SIZE_BYTES
+    import zstandard
 
-    assert _ZSTD_MAX_WINDOW_SIZE_BYTES == 1 << _ZSTD_MAX_WINDOW_LOG
-    assert (
-        _ZSTD_MAX_WINDOW_SIZE_BYTES == 2 * 1024 * 1024 * 1024
-    )  # 2 GiB, per the comment
+    from abicheck.snapshot_io import _ZSTD_MAX_WINDOW_LOG, _zstd_max_window_size_bytes
+
+    result = _zstd_max_window_size_bytes(zstandard)
+    assert result == 1 << min(_ZSTD_MAX_WINDOW_LOG, zstandard.WINDOWLOG_MAX)
+    # On any real (64-bit) build this is the documented 2 GiB ceiling; a
+    # 32-bit build would clamp lower (see _zstd_max_window_size_bytes's own
+    # docstring) rather than asserting this exact value everywhere.
+    if zstandard.WINDOWLOG_MAX >= _ZSTD_MAX_WINDOW_LOG:
+        assert result == 2 * 1024 * 1024 * 1024  # 2 GiB, per the comment
+
+
+def test_zstd_max_window_size_clamps_to_backend_windowlog_max():
+    """Codex review: ``ZSTD_DCtx_setMaxWindowSize()`` bound-checks its
+    argument against the backend's own reported ``windowLogMax`` and
+    *errors* (not just declines the frame) if exceeded -- and a 32-bit
+    libzstd build's ``ZSTD_WINDOWLOG_MAX_32`` is 30, not this module's
+    fixed 31. Passing the fixed value unconditionally would make
+    ``ZstdDecompressor(max_window_size=...)`` itself raise on such a
+    build, rejecting every zstd snapshot outright. Simulate that build
+    with a stand-in exposing a lower ``WINDOWLOG_MAX`` and confirm the
+    computed ceiling clamps down to it rather than using the fixed 31."""
+    from abicheck.snapshot_io import _zstd_max_window_size_bytes
+
+    class _Fake32BitBuild:
+        WINDOWLOG_MAX = 30  # ZSTD_WINDOWLOG_MAX_32
+
+    assert _zstd_max_window_size_bytes(_Fake32BitBuild) == 1 << 30
 
 
 def test_zstd_decoder_rejects_window_above_ceiling(tmp_path):

--- a/tests/test_snapshot_compression.py
+++ b/tests/test_snapshot_compression.py
@@ -564,6 +564,60 @@ def test_zstd_decoder_rejects_realistic_writer_window(tmp_path):
     assert read_snapshot_bytes(p, max_decoded_bytes=len(payload) + 10) == payload
 
 
+@pytest.mark.slow
+def test_zstd_round_trip_at_production_scale_and_level(tmp_path):
+    """The postmortem regression test for the KiB/bytes unit bug (ADR-059
+    §12): every test above hand-builds a `zstandard.CompressionParameters`
+    object to force a specific window -- useful for pinning the exact
+    mechanism, but none of them go through the *actual* production write
+    path, which never sets an explicit window and instead lets zstd
+    auto-select one from `ZSTD_LEVEL_BASELINE` and the input size. This test
+    calls only the same public functions `dump`/`write_snapshot` call
+    (`write_snapshot_bytes`/`read_snapshot_bytes`, no manual compression
+    params) against a real, large-enough `AbiSnapshot` (`_graph_heavy_
+    snapshot`, scaled up past the point its serialized JSON exceeds 8 MiB --
+    the threshold where zstd stops collapsing its recorded window down to
+    the content size) so the frame really does carry the same 8 MiB window
+    a real oneDAL-scale baseline does (confirmed below), then asserts a full
+    round trip. Would have caught the original bug directly: it fails with
+    the same "Frame requires too much memory for decoding" against the
+    pre-fix ceiling and passes with the fix, with no knowledge of zstd's
+    internal APIs required to write or understand it. `slow`-marked (not in
+    the fast default suite): real level-19 compression of an 8+ MiB payload
+    takes several seconds, unlike every other test in this file -- still
+    covered by CI's dedicated `-m slow` lane (`ci.yml`)."""
+    zstandard = pytest.importorskip("zstandard")
+
+    snap = _graph_heavy_snapshot(n=8600)
+    original_bytes = json.dumps(snapshot_to_dict(snap)).encode()
+    assert (
+        len(original_bytes) > 8 * 1024 * 1024
+    )  # past the single-segment collapse point
+
+    # The real production chokepoint: no manual CompressionParameters, no
+    # explicit window -- exactly what `dump`/`write_snapshot` call.
+    p = tmp_path / "production_scale.abicheck.json.zst"
+    result = write_snapshot_bytes(
+        original_bytes, p, compression=SnapshotCompression.ZSTD
+    )
+    assert result.compression is SnapshotCompression.ZSTD
+
+    # Sanity-check the premise before trusting the round trip below: the
+    # real writer (level=ZSTD_LEVEL_BASELINE, no explicit window) must
+    # actually produce the realistic 8 MiB window this test exists to catch
+    # a regression against -- if a future zstandard/libzstd upgrade changed
+    # that auto-selection, this assertion (not a silent pass) is what would
+    # tell us the fixture needs revisiting.
+    frame = zstandard.get_frame_parameters(p.read_bytes())
+    assert frame.window_size == 8 * 1024 * 1024
+    assert frame.content_size == len(original_bytes)
+
+    assert (
+        read_snapshot_bytes(p, max_decoded_bytes=len(original_bytes) + 10)
+        == original_bytes
+    )
+
+
 def test_oversized_stored_file_rejected_before_full_read(tmp_path, monkeypatch):
     """CodeRabbit review, refined by two later Codex rounds: the stored-
     file-size check (via fstat(), before a full read) must reject a file

--- a/tests/test_snapshot_compression.py
+++ b/tests/test_snapshot_compression.py
@@ -199,6 +199,40 @@ def test_bounded_decoded_prefix_escalates_for_low_compression_content(tmp_path):
     assert prefix.startswith(b'{"library"')
 
 
+def test_bounded_decoded_prefix_zstd_with_realistic_window(tmp_path):
+    """zstd counterpart to the gzip test above -- also the direct regression
+    test for the KiB/bytes unit bug in `_try_decode_prefix`'s own
+    ``max_window_size=`` call (the sniffing path `sniff_text_format`/
+    `service.resolve_input` uses to classify a `.json.zst` baseline before
+    ever reaching `_decompress_zstd`'s full-read path). Mirrors a real
+    written baseline: highly-compressible JSON content large enough that its
+    *frame* records the full 8 MiB window (content exceeding the window
+    keeps zstd out of the single-segment mode that otherwise collapses
+    `window_size` down to the content size -- see
+    `test_zstd_decoder_rejects_realistic_writer_window` below for that
+    mechanism spelled out) while the *stored* bytes stay tiny, same as real
+    ABI snapshot JSON."""
+    zstandard = pytest.importorskip("zstandard")
+
+    from abicheck.snapshot_io import bounded_decoded_prefix
+
+    blob = "a" * (9 * 1024 * 1024)
+    text = json.dumps({"library": "x", "version": "1", "blob": blob})
+
+    params = zstandard.ZstdCompressionParameters.from_level(19, window_log=23)
+    cctx = zstandard.ZstdCompressor(compression_params=params)
+    compressed = cctx.compress(text.encode())
+    frame = zstandard.get_frame_parameters(compressed)
+    assert frame.window_size == 8 * 1024 * 1024
+
+    zst_path = tmp_path / "realistic_window.abicheck.json.zst"
+    zst_path.write_bytes(compressed)
+
+    prefix = bounded_decoded_prefix(zst_path, n=100)
+    assert prefix is not None
+    assert prefix.startswith(b'{"library"')
+
+
 def test_detect_compression_from_bytes_plain():
     assert detect_compression_from_bytes(b"{not compressed") == SnapshotCompression.NONE
 

--- a/tests/test_snapshot_compression.py
+++ b/tests/test_snapshot_compression.py
@@ -538,21 +538,29 @@ def test_zstd_decoder_rejects_realistic_writer_window(tmp_path):
     highly-compressible fixture in `test_zstd_decoder_rejects_window_above_
     ceiling` above, whose real required window collapses to far less than
     its window_log) is a realistic multi-megabyte size, matching what the
-    writer picks at its baseline compression level. Low-entropy data lets
-    the *frame's own recorded window_size* stay large despite compressing
-    well, so this exercises the real ceiling instead of coincidentally
-    fitting under the pre-fix (1/1024th) ceiling too. Confirmed the old,
+    writer picks at its baseline compression level. Confirmed the old,
     KiB-denominated ceiling (2097152, interpreted as raw bytes by
     python-zstandard) rejects this frame with "Frame requires too much
-    memory for decoding", while the fixed byte ceiling decodes it."""
-    zstandard = pytest.importorskip("zstandard")
-    import random
+    memory for decoding", while the fixed byte ceiling decodes it.
 
-    random.seed(2026)
-    # An 8 MiB window (window_log=23), with enough genuinely incompressible
-    # payload that the frame's recorded window_size stays at the full 8 MiB
-    # rather than collapsing to the (smaller) content size.
-    payload = bytes(random.randrange(256) for _ in range(9 * 1024 * 1024))
+    Codex review: an earlier revision of this test compressed 9 MiB of
+    genuinely incompressible (`random.randrange(256)`) data to force the
+    window -- correct, but real zstd level-19 compression of incompressible
+    input is slow (~5-8s by itself), leaving this in the *default fast*
+    lane despite costing about as much as the dedicated `slow`-marked test
+    two below it. Content only needs to *exceed* the 8 MiB window for zstd
+    to stop collapsing the frame's recorded `window_size` down to
+    `content_size` (confirmed empirically, and exercised the same way by
+    `test_zstd_round_trip_at_production_scale_and_level`'s real snapshot
+    fixture below) -- highly-compressible content works identically for
+    that purpose and compresses in milliseconds, so no `slow` marker is
+    needed at all."""
+    zstandard = pytest.importorskip("zstandard")
+
+    # An 8 MiB window (window_log=23); content merely needs to exceed the
+    # window for the frame to record the full 8 MiB rather than collapsing
+    # to its own (smaller) content size -- compressibility doesn't matter.
+    payload = b"a" * (9 * 1024 * 1024)
     params = zstandard.ZstdCompressionParameters.from_level(19, window_log=23)
     cctx = zstandard.ZstdCompressor(compression_params=params)
     compressed = cctx.compress(payload)


### PR DESCRIPTION
## Summary

Fixes a blocker where `abicheck` cannot read back its own zstd-compressed (`.json.zst`) snapshot baselines.

## Motivation

`snapshot_io.py` computed its zstd decompression window-size ceiling in KiB (`_ZSTD_MAX_WINDOW_LOG = 31; _ZSTD_MAX_WINDOW_SIZE_KIB = (1 << 31) // 1024 = 2097152`) and passed that value to `zstandard.ZstdDecompressor(max_window_size=...)`. That parameter's own docstring claims kibibytes, but the underlying implementation (confirmed in both `backend_cffi.py`'s `_ensure_dctx` and the C extension) passes the value straight through to `ZSTD_DCtx_setMaxWindowSize()`, which takes a raw **byte** count.

Net effect: the effective accepted window was ~2 MiB instead of the intended 2 GiB ceiling documented in ADR-059 §8. The writer picks an 8 MiB window at its baseline compression level (`ZSTD_LEVEL_BASELINE = 19`), so every `.json.zst` baseline it wrote became undecodable — failing with `ZstdError: Frame requires too much memory for decoding`. That error is swallowed by format sniffing in `service.sniff_text_format`/`bounded_decoded_prefix`, so the user-facing symptom was a misleading:

```
Error: Failed to load --baseline ...json.zst: Cannot detect format of '...json.zst'.
Expected: ELF (.so), PE (.dll), Mach-O (.dylib), JSON snapshot, or ABICC Perl dump.
```

Confirmed the failure mode empirically (real zstd frames with realistic window sizes, not just the nominal `window_log` ceiling — see the test docstrings) and confirmed the fix resolves it.

## Changes

- `abicheck/snapshot_io.py`: renamed `_ZSTD_MAX_WINDOW_SIZE_KIB` → `_ZSTD_MAX_WINDOW_SIZE_BYTES`, dropped the erroneous `// 1024`, and corrected the surrounding comment to document why the docstring's "kibibytes" claim doesn't match the library's actual behavior.
- `tests/test_snapshot_compression.py`: fixed the existing test that had codified the wrong (KiB) assumption — it passed only because its highly-compressible fixture's *actual required* window collapsed to well under the buggy ceiling, so it never exercised the real bug. Added `test_zstd_decoder_rejects_realistic_writer_window`, an end-to-end repro using a realistic multi-megabyte incompressible payload (matching the writer's real baseline window) that fails against the pre-fix code and passes with the fix.
- `changelog.d/`: added a `Fixed` fragment via `scriv create`.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed — no user-facing docs describe this internal constant/behavior
- [x] `ruff check` / `ruff format --check` / `mypy abicheck/snapshot_io.py` pass locally on the changed files
- [x] No new `mypy` or `ruff` errors introduced

## Notes / follow-up (not done in this PR)

The report also suggested that format sniffing should surface the underlying decompression error rather than reporting "cannot detect format" for a file whose magic it clearly detected. That's a separate, smaller UX improvement independent of this fix (which resolves the root cause for any legitimately-written snapshot) — leaving it for a follow-up rather than scope-creeping this fix.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_018pk1KRFwvqgZWZXYvpDG5R)_