### PR TITLE
feat: wire RootCauseCorrelator's evidence into JSON/SARIF (G29 Phase 6 follow-up)

### DIFF
--- a/abicheck/cli_compare_fold.py
+++ b/abicheck/cli_compare_fold.py
@@ -265,12 +265,38 @@ class _ScopedFold:
             _root_cause_key_and_display,
             root_cause_for_change,
         )
+        from .reporter_markdown import (
+            apply_show_only,
+            root_cause_evidence_lookup_for_changes,
+        )
 
         result = self.result
         severity_config = self.severity_config
         contract_evaluation = self.contract_evaluation
         eff_sets = result._effective_kind_sets()
         scoped_only, missing_labels, blocks, missing_kind = self._scoped_gate_findings()
+        # G29 Phase 6 follow-up (Codex review): the scoped-only entries built
+        # below never routed through _add_changes_block's own evidence
+        # lookup (that ran earlier, over `changes` alone, before this
+        # fold-in even has `scoped_only` in hand) -- correlate over the same
+        # combined set sarif.to_sarif uses (`result.changes` filtered by
+        # --show-only, plus `scoped_only`), so a scoped-only finding that is
+        # itself a RootCauseCorrelator group member (e.g. a
+        # CONSUMER_REQUIRED_SYMBOL_REMOVED sibling of a regular
+        # FUNC_REMOVED) carries the same root_cause_evidence JSON's regular
+        # `changes[]` entries do.
+        primary_changes = list(result.changes)
+        if self.show_only:
+            primary_changes = apply_show_only(
+                primary_changes,
+                self.show_only,
+                policy=result.policy,
+                kind_sets=eff_sets,
+                policy_file=result.policy_file,
+            )
+        rc_evidence = root_cause_evidence_lookup_for_changes(
+            primary_changes + scoped_only
+        )
         # ADR-049 D1: `gate_contribution` is defined as the number that
         # *actually* gated, and under --used-by/--required-symbol the
         # scoped gate is what the run exits on -- this fold is where it
@@ -330,6 +356,7 @@ class _ScopedFold:
                 root_cause=root_cause_for_change(
                     c, referenced_causes=referenced_causes
                 ),
+                root_cause_evidence=rc_evidence.get(_finding_id(c)),
             )
             changes_list.append(entry)
             key, root_display = _root_cause_key_and_display(

--- a/abicheck/impact/__init__.py
+++ b/abicheck/impact/__init__.py
@@ -30,3 +30,14 @@ __all__ = [
     "ProofStep",
     "assess_change",
 ]
+
+# `correlate_root_causes`/`RootCauseGroup` (impact.correlation) are
+# deliberately NOT imported here at module scope: `checker_types.py` imports
+# `abicheck.impact.model.ImpactAssessment` while it is still being defined,
+# and `impact.correlation` imports `checker_types.Change` at its own module
+# scope -- eagerly importing `.correlation` from this package's `__init__`
+# would close that cycle (`checker_types -> impact -> impact.correlation ->
+# checker_types`, the middle module not yet finished initializing). Callers
+# needing the composer import `abicheck.impact.correlation` directly (e.g.
+# `reporter.py`, `reporter_markdown.py`), which is safe once `checker_types`
+# has finished loading.

--- a/abicheck/impact/correlation.py
+++ b/abicheck/impact/correlation.py
@@ -110,11 +110,16 @@ EVIDENCE_LEVEL_BY_KIND: dict[ChangeKind, str] = {
 }
 
 #: Rank order for every evidence level this module can produce, weakest
-#: first — used only to pick a group's
-#: :attr:`RootCauseGroup.strongest_evidence_level` and to order
-#: :attr:`RootCauseGroup.evidence_levels`; not exposed as a standalone
-#: numeric score since the levels themselves are the stable, documented
-#: vocabulary. ``"call_graph_overapprox"`` is not one of
+#: first — used to pick a group's :attr:`RootCauseGroup.strongest_evidence_level`
+#: and to order :attr:`RootCauseGroup.evidence_levels`. Public (G29 Phase 6
+#: follow-up) so a caller folding several already-computed per-finding
+#: ``root_cause_evidence`` values back into one group-level summary (e.g.
+#: ``reporter._to_json_root_cause``'s ``root_causes[]`` rollup, when a
+#: report-level group and a correlator group disagree on membership — see
+#: that function's own docstring) can rank them the same way this module
+#: does, without duplicating the order. The levels themselves stay the
+#: stable, documented vocabulary; this is only their sort key.
+#: ``"call_graph_overapprox"`` is not one of
 #: :data:`EVIDENCE_LEVEL_BY_KIND`'s values — it's a per-``Change`` downgrade
 #: :func:`_evidence_level_for` applies, so it can't be derived from that
 #: dict's values the way the other four levels could; ranked below
@@ -122,7 +127,7 @@ EVIDENCE_LEVEL_BY_KIND: dict[ChangeKind, str] = {
 #: than an exact one) but above ``"artifact_proven"`` (it still proves *some*
 #: reachability path exists, which a bare export-table removal says nothing
 #: about).
-_EVIDENCE_RANK = {
+EVIDENCE_RANK = {
     "artifact_proven": 0,
     "call_graph_overapprox": 1,
     "call_graph_proven": 2,
@@ -150,7 +155,7 @@ class RootCauseGroup:
     def evidence_levels(self) -> tuple[str, ...]:
         """This group's distinct evidence levels, weakest first."""
         seen = {level for _, level in self.members}
-        return tuple(sorted(seen, key=lambda level: _EVIDENCE_RANK.get(level, -1)))
+        return tuple(sorted(seen, key=lambda level: EVIDENCE_RANK.get(level, -1)))
 
     @property
     def strongest_evidence_level(self) -> str | None:
@@ -160,7 +165,7 @@ class RootCauseGroup:
             return None
         return max(
             (level for _, level in self.members),
-            key=lambda level: _EVIDENCE_RANK.get(level, -1),
+            key=lambda level: EVIDENCE_RANK.get(level, -1),
         )
 
     def to_dict(self) -> dict[str, object]:
@@ -217,7 +222,7 @@ def _evidence_level_for(change: Change) -> str:
         base = "call_graph_overapprox"
     if (
         change.reachability_kind == "consumer_proven"
-        and _EVIDENCE_RANK["consumer_proven"] > _EVIDENCE_RANK[base]
+        and EVIDENCE_RANK["consumer_proven"] > EVIDENCE_RANK[base]
     ):
         return "consumer_proven"
     return base

--- a/abicheck/impact/engine.py
+++ b/abicheck/impact/engine.py
@@ -105,6 +105,7 @@ def assess_change(
     *,
     suppressed: bool = False,
     root_cause: tuple[str, str] | None = None,
+    root_cause_evidence: dict[str, object] | None = None,
 ) -> ImpactAssessment:
     """Derive an ``ImpactAssessment`` from *change*'s existing fields.
 
@@ -128,6 +129,16 @@ def assess_change(
     ``root_cause_id``/``root_cause_display``/``impact_group_id`` unset, same
     as any caller that doesn't have whole-result context to offer (e.g. a
     unit test constructing one bare ``Change``).
+
+    *root_cause_evidence* (G29 Phase 6 follow-up), when given, is *change*'s
+    own entry from
+    :func:`~abicheck.impact.correlation.correlate_root_causes` — computed by
+    the caller the same way *root_cause* is (whole-``DiffResult`` context
+    this function doesn't have), via
+    :func:`~abicheck.reporter_markdown.root_cause_evidence_lookup_for_changes`.
+    ``None`` leaves :attr:`~abicheck.impact.model.ImpactAssessment.
+    root_cause_evidence` unset, same as any caller with no correlator
+    context to offer.
 
     ``Change.impact_assessment`` (ADR-052 D2 follow-up, scoped
     implementation), when a producer set it directly, supplies this
@@ -172,6 +183,7 @@ def assess_change(
             root_cause_id=root_cause_id,
             root_cause_display=root_cause_display,
             impact_group_id=root_cause_id,
+            root_cause_evidence=root_cause_evidence,
         )
     return ImpactAssessment(
         reachability_state=getattr(
@@ -187,4 +199,5 @@ def assess_change(
         root_cause_id=root_cause_id,
         root_cause_display=root_cause_display,
         impact_group_id=root_cause_id,
+        root_cause_evidence=root_cause_evidence,
     )

--- a/abicheck/impact/model.py
+++ b/abicheck/impact/model.py
@@ -206,11 +206,25 @@ class ImpactAssessment:
     ``impact_assessment`` doesn't balloon with a rootCauseId that names
     nothing but itself. ``impact_group_id`` is currently always identical to
     ``root_cause_id`` — a placeholder alias, not yet a distinct concept
-    (Phase 6's ``RootCauseCorrelator`` is what would ever make them diverge,
-    e.g. bucketing several distinct root causes that share one broader
-    consumer-visible event under one group while keeping their own
-    individual root-cause identities); see ADR-052's "Deliberately not
-    implemented" section.
+    (a genuine divergence would need bucketing several distinct root causes
+    that share one broader consumer-visible event under one group while
+    keeping their own individual root-cause identities, which no producer
+    does yet); see ADR-052's "Deliberately not implemented" section.
+
+    ``root_cause_evidence`` (G29 Phase 6 follow-up) is this finding's own
+    entry from :func:`~abicheck.impact.correlation.correlate_root_causes`,
+    when *this* finding is a member of one of that composer's multi-piece
+    groups — the four load-failure kinds named in that module's docstring,
+    correlated by shared symbol identity. Unlike ``root_cause_id`` (a bare
+    grouping key shared by *any* two findings with the same
+    ``caused_by_type``/``symbol``, regardless of kind), this field only ever
+    populates for the narrower, ranked-evidence family the correlator
+    covers, and carries this finding's own ``evidence_level`` alongside the
+    whole group's ``strongest_evidence_level``/``evidence_levels`` — so a
+    consumer can tell "this piece is only artifact-proven, but the group as
+    a whole also has consumer proof" without re-running the correlator
+    itself. ``None`` whenever this finding isn't a correlator-group member,
+    which includes every finding of a kind the correlator doesn't cover.
     """
 
     reachability_state: ReachabilityState = ReachabilityState.UNKNOWN
@@ -224,6 +238,7 @@ class ImpactAssessment:
     root_cause_id: str | None = None
     root_cause_display: str | None = None
     impact_group_id: str | None = None
+    root_cause_evidence: dict[str, object] | None = None
 
     def has_signal(self) -> bool:
         """True when this assessment carries information beyond the
@@ -241,6 +256,7 @@ class ImpactAssessment:
             or self.correlated_change_kind is not None
             or self.evidence_category is not None
             or self.root_cause_id is not None
+            or self.root_cause_evidence is not None
         )
 
     def to_dict(self) -> dict[str, object]:
@@ -262,4 +278,6 @@ class ImpactAssessment:
             d["root_cause_id"] = self.root_cause_id
             d["root_cause_display"] = self.root_cause_display
             d["impact_group_id"] = self.impact_group_id
+        if self.root_cause_evidence is not None:
+            d["root_cause_evidence"] = dict(self.root_cause_evidence)
         return d

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -39,7 +39,6 @@ from .checker_policy import (
 )
 from .checker_types import validate_check_id, validate_evidence_depth
 from .impact import assess_change
-from .impact.correlation import correlate_root_causes
 from .report_model import VERDICT_TO_SEVERITY_LABEL as _VERDICT_TO_SEVERITY_LABEL
 from .report_summary import build_summary, surface_breakdown
 
@@ -594,15 +593,9 @@ def _add_entries_to_root_causes(
 def _scoped_only_changes_filtered(
     result: DiffResult, show_only: str | None
 ) -> list[Change]:
-    """``result.scoped_only_changes``, filtered by the same ``--show-only``
-    as the caller's own ``changes`` list -- the shared computation
-    :func:`_scoped_only_extra_causes` and
-    :func:`~abicheck.impact.correlation.correlate_root_causes` callers below
-    both need, kept as one function so the two can never filter differently
-    (Codex review: an evidence lookup built from an unfiltered scoped-only
-    set could correlate a finding via a sibling ``--show-only`` had already
-    excluded).
-    """
+    """``result.scoped_only_changes``, filtered by ``--show-only`` the same
+    way ``changes`` already is -- shared by every caller below so the two
+    never filter differently (Codex review)."""
     scoped_only = list(getattr(result, "scoped_only_changes", ()) or ())
     if show_only and scoped_only:
         scoped_only = apply_show_only(
@@ -618,23 +611,16 @@ def _scoped_only_changes_filtered(
 def _scoped_only_extra_causes(
     result: DiffResult, show_only: str | None
 ) -> frozenset[str]:
-    """``caused_by_type`` values from ``result.scoped_only_changes``, filtered
-    by the same ``--show-only`` as the caller's own ``changes`` list (G29
+    """``caused_by_type`` values from ``result.scoped_only_changes`` (G29
     Phase 3 follow-up, review finding).
 
-    The scoped-gate (``--used-by``/``--required-symbol``) fold-in in
-    ``cli_compare_fold.py`` appends scoped-only changes to a report *after*
-    a JSON serializer has already built its root-cause lookup — without
-    folding their ``caused_by_type`` into the grouping here too, a change in
-    ``changes`` that only correlates via one of those later-appended
-    findings would be locked into its own singleton group, contradicting
-    ``sarif.to_sarif``/``junit_report._build_testsuite``'s identical
-    computation (both already fold this in). Shared by every JSON mode that
-    calls :func:`~abicheck.reporter_markdown.root_cause_lookup_for_changes`
-    — not just ``--report-mode root-cause`` — so a finding's
-    ``impact_assessment.root_cause_id`` can't diverge from its
-    ``root_causes[].root_cause_id``/SARIF/JUnit sibling depending on which
-    report mode rendered it.
+    ``cli_compare_fold.py``'s scoped-gate fold-in appends scoped-only
+    changes *after* a JSON serializer already built its root-cause lookup --
+    folding their ``caused_by_type`` in here too keeps a `changes` entry
+    that only correlates via one of those later-appended findings from
+    being locked into its own singleton group, matching
+    ``sarif.to_sarif``/``junit_report._build_testsuite``'s identical,
+    single-pass fold.
     """
     scoped_only = _scoped_only_changes_filtered(result, show_only)
     return frozenset(c.caused_by_type for c in scoped_only if c.caused_by_type)
@@ -643,28 +629,65 @@ def _scoped_only_extra_causes(
 def _scoped_only_evidence_lookup(
     result: DiffResult, changes: list[Change], show_only: str | None
 ) -> dict[str, dict[str, object]]:
-    """``finding_id -> root_cause_evidence`` for *changes* combined with
-    *result*'s own filtered ``scoped_only_changes`` (G29 Phase 6 follow-up,
-    Codex review).
+    """``finding_id -> root_cause_evidence`` for *changes* plus *result*'s
+    filtered ``scoped_only_changes`` (G29 Phase 6, Codex review).
 
-    ``RootCauseCorrelator`` groups by the actual ``Change`` objects it's
-    given, so a regular finding that only correlates via a scoped-only
-    (``--used-by``/``--required-symbol``) sibling -- e.g. a
-    ``FUNC_REMOVED``/``INTERNAL_SYMBOL_REQUIRED_BY_PUBLIC_API`` pair split
-    across ``changes`` and ``scoped_only_changes`` -- needs the sibling in
-    the same :func:`~abicheck.impact.correlation.correlate_root_causes` call
-    to be recognized as a group at all; a lookup built from *changes* alone
-    (as :func:`root_cause_evidence_lookup_for_changes` would be if called
-    directly here) silently under-correlates, contradicting
-    ``sarif.to_sarif``'s identical ``changes + scoped_only_changes``
-    computation. The returned lookup covers *both* sides -- a caller
-    rendering only ``changes`` (e.g. :func:`_add_changes_block`, before
-    ``cli_compare_fold.py``'s later scoped-only fold-in) still finds every
-    entry it needs by ``finding_id``, and the fold-in itself reuses this
-    same lookup for the scoped-only entries it appends.
+    A finding correlating only via a scoped-only sibling needs that sibling
+    in the same :func:`~abicheck.impact.correlation.correlate_root_causes`
+    call to be recognized -- a lookup over *changes* alone under-correlates,
+    unlike ``sarif.to_sarif``'s identical combined computation. Shared by a
+    caller rendering only ``changes`` and ``cli_compare_fold.py``'s later
+    scoped-only fold-in.
     """
     scoped_only = _scoped_only_changes_filtered(result, show_only)
     return root_cause_evidence_lookup_for_changes(changes + scoped_only)
+
+
+def _root_cause_group_evidence(
+    group_changes: list[Change], rc_evidence: dict[str, dict[str, object]]
+) -> dict[str, object] | None:
+    """Fold a ``root_causes[]`` group's members' own ``root_cause_evidence``
+    into one group-level summary (G29 Phase 6, Codex review).
+
+    Deliberately doesn't match a correlator group by ``root_cause_id``
+    equality: the two grouping schemes disagree for a bare-symbol pair
+    sharing no ``caused_by_type`` (report grouping keeps each its own
+    singleton; the correlator's ``caused_by_type or symbol`` key merges them
+    -- reproduced by a ``FUNC_REMOVED``/scoped-only
+    ``CONSUMER_RUNTIME_LOAD_FAILED`` pair, ``--used-by --verify-runtime``'s
+    real shape), so the hashes never match even though both findings are one
+    correlator group. Folding each member's own already-correct evidence
+    instead sidesteps the mismatch: every member of one group carries an
+    identical summary by construction, so this is a no-op re-derivation in
+    the common case. ``None`` when no member has any evidence.
+    """
+    from .impact.correlation import EVIDENCE_RANK
+
+    strongest: str | None = None
+    levels: set[str] = set()
+    found = False
+    for c in group_changes:
+        member_evidence = rc_evidence.get(_finding_id(c))
+        if member_evidence is None:
+            continue
+        found = True
+        member_levels = member_evidence.get("evidence_levels") or ()
+        levels.update(str(level) for level in cast(Sequence[object], member_levels))
+        member_strongest = member_evidence.get("strongest_evidence_level")
+        if member_strongest is not None and (
+            strongest is None
+            or EVIDENCE_RANK.get(str(member_strongest), -1)
+            > EVIDENCE_RANK.get(strongest, -1)
+        ):
+            strongest = str(member_strongest)
+    if not found:
+        return None
+    return {
+        "strongest_evidence_level": strongest,
+        "evidence_levels": sorted(
+            levels, key=lambda level: EVIDENCE_RANK.get(level, -1)
+        ),
+    }
 
 
 def _to_json_root_cause(
@@ -681,12 +704,12 @@ def _to_json_root_cause(
     singleton group keyed by its own ``symbol`` -- reusing the existing
     ``caused_by_type`` field ``diff_filtering.py``'s redundancy collapse and
     ``internal_leak.py``'s call-graph-leak overlay already set, rather than
-    requiring new producer wiring. This is a first, JSON-only slice of the
-    plan's root-cause grouping: the full `RootCauseCorrelator` (G29 Phase 6)
-    will additionally correlate across consumer-overlay findings that don't
-    share a `caused_by_type` today; `root_cause_id` here is a stable hash of
-    the grouping key, not the eventual correlator's own identifier scheme
-    (ADR-052, "Deliberately not implemented this slice").
+    requiring new producer wiring. ``root_cause_id`` is a stable hash of this
+    grouping key -- deliberately a different scheme from
+    `RootCauseCorrelator`'s own (G29 Phase 6), whose evidence-ranked groups
+    each `root_causes[]` entry additionally annotates with
+    ``strongest_evidence_level``/``evidence_levels`` (see
+    :func:`_root_cause_group_evidence`) without adopting its id scheme.
     """
     changes = list(result.changes)
     if show_only:
@@ -734,21 +757,6 @@ def _to_json_root_cause(
     }
     entries = [entry_by_id[id(c)] for c in changes]
     grouped = _group_changes_by_root_cause(changes, extra_causes=extra_causes)
-    # G29 Phase 6 follow-up: a group's own evidence summary (this is a
-    # group-level fold, not a per-finding one -- keyed by the same
-    # root_cause_id this loop already computes below). Correlated over
-    # `changes` plus the same filtered scoped-only set _rc_evidence above
-    # uses (Codex review) -- root_causes[] itself only ever groups `changes`
-    # (scoped-only findings are folded into a *separate* payload by
-    # cli_compare_fold.py, never into this array), but a group that only
-    # exists because of a scoped-only sibling must still report the
-    # strongest evidence actually available for it.
-    _group_evidence = {
-        group.root_cause_id: group
-        for group in correlate_root_causes(
-            changes + _scoped_only_changes_filtered(result, show_only)
-        )
-    }
 
     root_causes = []
     for key, root_display, group_changes in grouped:
@@ -759,10 +767,12 @@ def _to_json_root_cause(
             "finding_count": len(group_changes),
             "findings": [entry_by_id[id(c)] for c in group_changes],
         }
-        rc_group = _group_evidence.get(root_cause_id)
-        if rc_group is not None:
-            entry["strongest_evidence_level"] = rc_group.strongest_evidence_level
-            entry["evidence_levels"] = list(rc_group.evidence_levels)
+        group_evidence = _root_cause_group_evidence(group_changes, _rc_evidence)
+        if group_evidence is not None:
+            entry["strongest_evidence_level"] = group_evidence[
+                "strongest_evidence_level"
+            ]
+            entry["evidence_levels"] = group_evidence["evidence_levels"]
         root_causes.append(entry)
 
     d = _build_json_base(result)
@@ -993,14 +1003,11 @@ def _suppressed_change_entry(
     "suppressed"`` was advertised but never actually reachable from
     production reporting).
 
-    ``root_cause`` (G29 Phase 3 follow-up): the caller resolves this from a
-    lookup scoped to ``result.suppressed_changes`` itself -- a suppressed
-    finding's root cause is computed relative to other *suppressed* findings,
-    not folded together with the kept ``changes[]`` list's own grouping.
-
-    ``root_cause_evidence`` (G29 Phase 6 follow-up): same scoping, via
-    :func:`~abicheck.reporter_markdown.root_cause_evidence_lookup_for_changes`
-    over ``result.suppressed_changes``.
+    ``root_cause``/``root_cause_evidence`` (G29 Phase 3/6 follow-ups): the
+    caller resolves both from a lookup scoped to ``result.suppressed_changes``
+    itself -- a suppressed finding's root cause is computed relative to other
+    *suppressed* findings, not folded together with the kept ``changes[]``
+    list's own grouping.
     """
     entry: dict[str, object] = {
         "kind": c.kind.value,
@@ -1100,14 +1107,11 @@ def _add_changes_block(
     *show_only* folds ``result.scoped_only_changes``' ``caused_by_type``
     values into the root-cause grouping the same way ``_to_json_root_cause``
     does (review finding) -- without it, a finding here correlating only via
-    a scoped-only overlay silently lost its
-    ``impact_assessment.root_cause_id``, disagreeing with root-cause mode,
-    SARIF, and JUnit for the identical finding. ``root_cause_evidence``
-    (G29 Phase 6 follow-up, Codex review) gets the same treatment via
-    :func:`_scoped_only_evidence_lookup`, which correlates against the
-    actual scoped-only ``Change`` objects (not just their ``caused_by_type``
-    strings) -- ``RootCauseCorrelator`` needs the real sibling to recognize
-    a multi-piece group at all.
+    a scoped-only overlay silently lost its ``impact_assessment.root_cause_id``,
+    disagreeing with root-cause mode, SARIF, and JUnit. ``root_cause_evidence``
+    (G29 Phase 6, Codex review) gets the same treatment via
+    :func:`_scoped_only_evidence_lookup`, correlating against the real
+    scoped-only ``Change`` objects rather than just their ``caused_by_type``.
     """
     _rc_lookup = root_cause_lookup_for_changes(
         changes, extra_causes=_scoped_only_extra_causes(result, show_only)
@@ -1516,14 +1520,10 @@ def _change_to_dict(
     ``impact_assessment.root_cause_id`` is populated. Callers resolve this
     once per report via
     :func:`~abicheck.reporter_markdown.root_cause_lookup_for_changes` rather
-    than recomputing it per change.
-
-    ``root_cause_evidence`` (G29 Phase 6 follow-up), when given, is *c*'s own
-    entry from :func:`~abicheck.impact.correlation.correlate_root_causes`,
-    resolved once per report via
-    :func:`~abicheck.reporter_markdown.root_cause_evidence_lookup_for_changes`
-    — forwarded to :func:`~abicheck.impact.engine.assess_change` so
-    ``impact_assessment.root_cause_evidence`` is populated.
+    than recomputing it per change. ``root_cause_evidence`` (G29 Phase 6) is
+    the analogous per-change entry from
+    :func:`~abicheck.impact.correlation.correlate_root_causes`, resolved the
+    same way.
 
     ``evidence_tiers`` is the owning comparison's ``DiffResult.evidence_tiers``
     (P0 evidence-provider audit) — when a caller has it (most do; the

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -89,6 +89,13 @@ from .reporter_markdown import (
     to_review_digest as to_review_digest,
     to_stat as to_stat,
 )
+from .root_cause_evidence import (
+    entry_root_cause_evidence,
+    fold_evidence_summaries,
+    root_cause_group_evidence,
+    scoped_only_changes_filtered,
+    scoped_only_evidence_lookup,
+)
 from .schemas import REPORT_SCHEMA_VERSION
 from .semver import recommend_release
 
@@ -373,7 +380,7 @@ def _to_json_leaf(
     _rc_lookup = root_cause_lookup_for_changes(
         changes, extra_causes=_scoped_only_extra_causes(result, show_only)
     )
-    _rc_evidence = _scoped_only_evidence_lookup(result, changes, show_only)
+    _rc_evidence = scoped_only_evidence_lookup(result, changes, show_only)
 
     effective_policy = result.policy or "strict_abi"
     eff_sets = result._effective_kind_sets()
@@ -564,6 +571,15 @@ def _add_entries_to_root_causes(
     scoped-gate entries computed after :func:`_to_json_root_cause` already
     grouped ``result.changes`` (else they'd sit in ``changes[]`` but never in
     ``root_causes``). No-op if *d* has no ``root_causes`` list.
+
+    Each touched group's ``strongest_evidence_level``/``evidence_levels``
+    (G29 Phase 6, Codex review) is recomputed from *all* its findings --
+    pre-existing and newly folded-in alike -- every time a group is touched,
+    via :func:`~abicheck.root_cause_evidence.fold_evidence_summaries` over each finding's own
+    ``impact_assessment.root_cause_evidence``. Without this, a scoped-only
+    entry folded into an existing (or brand-new) group here never
+    contributed its own evidence to the group summary at all, unlike a
+    group :func:`_to_json_root_cause` builds entirely from ``changes``.
     """
     root_causes = d.get("root_causes")
     if not isinstance(root_causes, list):
@@ -573,6 +589,7 @@ def _add_entries_to_root_causes(
         for group in root_causes
         if isinstance(group, dict)
     }
+    touched: set[str] = set()
     for key, root_display, entry in keyed_entries:
         root_cause_id = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
         group = by_id.get(root_cause_id)
@@ -587,25 +604,18 @@ def _add_entries_to_root_causes(
             by_id[root_cause_id] = group
         group["findings"].append(entry)
         group["finding_count"] = len(group["findings"])
-    d["root_cause_count"] = len(root_causes)
-
-
-def _scoped_only_changes_filtered(
-    result: DiffResult, show_only: str | None
-) -> list[Change]:
-    """``result.scoped_only_changes``, filtered by ``--show-only`` the same
-    way ``changes`` already is -- shared by every caller below so the two
-    never filter differently (Codex review)."""
-    scoped_only = list(getattr(result, "scoped_only_changes", ()) or ())
-    if show_only and scoped_only:
-        scoped_only = apply_show_only(
-            scoped_only,
-            show_only,
-            policy=result.policy,
-            kind_sets=result._effective_kind_sets(),
-            policy_file=result.policy_file,
+        touched.add(root_cause_id)
+    for root_cause_id in touched:
+        group = by_id[root_cause_id]
+        evidence = fold_evidence_summaries(
+            entry_root_cause_evidence(f)
+            for f in group["findings"]
+            if isinstance(f, dict)
         )
-    return scoped_only
+        if evidence is not None:
+            group["strongest_evidence_level"] = evidence["strongest_evidence_level"]
+            group["evidence_levels"] = evidence["evidence_levels"]
+    d["root_cause_count"] = len(root_causes)
 
 
 def _scoped_only_extra_causes(
@@ -622,72 +632,8 @@ def _scoped_only_extra_causes(
     ``sarif.to_sarif``/``junit_report._build_testsuite``'s identical,
     single-pass fold.
     """
-    scoped_only = _scoped_only_changes_filtered(result, show_only)
+    scoped_only = scoped_only_changes_filtered(result, show_only)
     return frozenset(c.caused_by_type for c in scoped_only if c.caused_by_type)
-
-
-def _scoped_only_evidence_lookup(
-    result: DiffResult, changes: list[Change], show_only: str | None
-) -> dict[str, dict[str, object]]:
-    """``finding_id -> root_cause_evidence`` for *changes* plus *result*'s
-    filtered ``scoped_only_changes`` (G29 Phase 6, Codex review).
-
-    A finding correlating only via a scoped-only sibling needs that sibling
-    in the same :func:`~abicheck.impact.correlation.correlate_root_causes`
-    call to be recognized -- a lookup over *changes* alone under-correlates,
-    unlike ``sarif.to_sarif``'s identical combined computation. Shared by a
-    caller rendering only ``changes`` and ``cli_compare_fold.py``'s later
-    scoped-only fold-in.
-    """
-    scoped_only = _scoped_only_changes_filtered(result, show_only)
-    return root_cause_evidence_lookup_for_changes(changes + scoped_only)
-
-
-def _root_cause_group_evidence(
-    group_changes: list[Change], rc_evidence: dict[str, dict[str, object]]
-) -> dict[str, object] | None:
-    """Fold a ``root_causes[]`` group's members' own ``root_cause_evidence``
-    into one group-level summary (G29 Phase 6, Codex review).
-
-    Deliberately doesn't match a correlator group by ``root_cause_id``
-    equality: the two grouping schemes disagree for a bare-symbol pair
-    sharing no ``caused_by_type`` (report grouping keeps each its own
-    singleton; the correlator's ``caused_by_type or symbol`` key merges them
-    -- reproduced by a ``FUNC_REMOVED``/scoped-only
-    ``CONSUMER_RUNTIME_LOAD_FAILED`` pair, ``--used-by --verify-runtime``'s
-    real shape), so the hashes never match even though both findings are one
-    correlator group. Folding each member's own already-correct evidence
-    instead sidesteps the mismatch: every member of one group carries an
-    identical summary by construction, so this is a no-op re-derivation in
-    the common case. ``None`` when no member has any evidence.
-    """
-    from .impact.correlation import EVIDENCE_RANK
-
-    strongest: str | None = None
-    levels: set[str] = set()
-    found = False
-    for c in group_changes:
-        member_evidence = rc_evidence.get(_finding_id(c))
-        if member_evidence is None:
-            continue
-        found = True
-        member_levels = member_evidence.get("evidence_levels") or ()
-        levels.update(str(level) for level in cast(Sequence[object], member_levels))
-        member_strongest = member_evidence.get("strongest_evidence_level")
-        if member_strongest is not None and (
-            strongest is None
-            or EVIDENCE_RANK.get(str(member_strongest), -1)
-            > EVIDENCE_RANK.get(strongest, -1)
-        ):
-            strongest = str(member_strongest)
-    if not found:
-        return None
-    return {
-        "strongest_evidence_level": strongest,
-        "evidence_levels": sorted(
-            levels, key=lambda level: EVIDENCE_RANK.get(level, -1)
-        ),
-    }
 
 
 def _to_json_root_cause(
@@ -709,7 +655,7 @@ def _to_json_root_cause(
     `RootCauseCorrelator`'s own (G29 Phase 6), whose evidence-ranked groups
     each `root_causes[]` entry additionally annotates with
     ``strongest_evidence_level``/``evidence_levels`` (see
-    :func:`_root_cause_group_evidence`) without adopting its id scheme.
+    :func:`~abicheck.root_cause_evidence.root_cause_group_evidence`) without adopting its id scheme.
     """
     changes = list(result.changes)
     if show_only:
@@ -741,7 +687,7 @@ def _to_json_root_cause(
     # mode provides it, `_to_json_leaf` included) and `root_causes[].findings`
     # never drift from each other.
     _rc_lookup = root_cause_lookup_for_changes(changes, extra_causes=extra_causes)
-    _rc_evidence = _scoped_only_evidence_lookup(result, changes, show_only)
+    _rc_evidence = scoped_only_evidence_lookup(result, changes, show_only)
     entry_by_id = {
         id(c): _change_to_dict(
             c,
@@ -767,7 +713,7 @@ def _to_json_root_cause(
             "finding_count": len(group_changes),
             "findings": [entry_by_id[id(c)] for c in group_changes],
         }
-        group_evidence = _root_cause_group_evidence(group_changes, _rc_evidence)
+        group_evidence = root_cause_group_evidence(group_changes, _rc_evidence)
         if group_evidence is not None:
             entry["strongest_evidence_level"] = group_evidence[
                 "strongest_evidence_level"
@@ -1110,13 +1056,13 @@ def _add_changes_block(
     a scoped-only overlay silently lost its ``impact_assessment.root_cause_id``,
     disagreeing with root-cause mode, SARIF, and JUnit. ``root_cause_evidence``
     (G29 Phase 6, Codex review) gets the same treatment via
-    :func:`_scoped_only_evidence_lookup`, correlating against the real
+    :func:`~abicheck.root_cause_evidence.scoped_only_evidence_lookup`, correlating against the real
     scoped-only ``Change`` objects rather than just their ``caused_by_type``.
     """
     _rc_lookup = root_cause_lookup_for_changes(
         changes, extra_causes=_scoped_only_extra_causes(result, show_only)
     )
-    _rc_evidence = _scoped_only_evidence_lookup(result, changes, show_only)
+    _rc_evidence = scoped_only_evidence_lookup(result, changes, show_only)
     d["changes"] = [
         _change_to_dict(
             c,

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -39,6 +39,7 @@ from .checker_policy import (
 )
 from .checker_types import validate_check_id, validate_evidence_depth
 from .impact import assess_change
+from .impact.correlation import correlate_root_causes
 from .report_model import VERDICT_TO_SEVERITY_LABEL as _VERDICT_TO_SEVERITY_LABEL
 from .report_summary import build_summary, surface_breakdown
 
@@ -82,6 +83,7 @@ from .reporter_markdown import (
     _to_markdown_root_cause as _to_markdown_root_cause,
     apply_show_only as apply_show_only,
     operation_for_kind as operation_for_kind,
+    root_cause_evidence_lookup_for_changes as root_cause_evidence_lookup_for_changes,
     root_cause_for_change as root_cause_for_change,
     root_cause_lookup_for_changes as root_cause_lookup_for_changes,
     to_markdown as to_markdown,
@@ -372,6 +374,7 @@ def _to_json_leaf(
     _rc_lookup = root_cause_lookup_for_changes(
         changes, extra_causes=_scoped_only_extra_causes(result, show_only)
     )
+    _rc_evidence = root_cause_evidence_lookup_for_changes(changes)
 
     effective_policy = result.policy or "strict_abi"
     eff_sets = result._effective_kind_sets()
@@ -447,7 +450,11 @@ def _to_json_leaf(
         # impact_assessment follow the same precedent so a root TYPE_*
         # change (exactly the category the layout-reachability walk tags
         # most often) doesn't lose them in --report-mode leaf.
-        assessment = assess_change(c, root_cause=_rc_lookup.get(_finding_id(c)))
+        assessment = assess_change(
+            c,
+            root_cause=_rc_lookup.get(_finding_id(c)),
+            root_cause_evidence=_rc_evidence.get(_finding_id(c)),
+        )
         entry["reachability_state"] = assessment.reachability_state.value
         if assessment.has_signal():
             entry["impact_assessment"] = assessment.to_dict()
@@ -490,6 +497,7 @@ def _to_json_leaf(
             policy=effective_policy,
             kind_sets=eff_sets,
             root_cause=_rc_lookup.get(_finding_id(c)),
+            root_cause_evidence=_rc_evidence.get(_finding_id(c)),
             policy_file=result.policy_file,
             evidence_tiers=result.evidence_tiers,
             severity_config=severity_config,
@@ -667,6 +675,7 @@ def _to_json_root_cause(
     # mode provides it, `_to_json_leaf` included) and `root_causes[].findings`
     # never drift from each other.
     _rc_lookup = root_cause_lookup_for_changes(changes, extra_causes=extra_causes)
+    _rc_evidence = root_cause_evidence_lookup_for_changes(changes)
     entry_by_id = {
         id(c): _change_to_dict(
             c,
@@ -674,6 +683,7 @@ def _to_json_root_cause(
             kind_sets=eff_sets,
             policy_file=result.policy_file,
             root_cause=_rc_lookup.get(_finding_id(c)),
+            root_cause_evidence=_rc_evidence.get(_finding_id(c)),
             evidence_tiers=result.evidence_tiers,
             severity_config=severity_config,
         )
@@ -681,16 +691,28 @@ def _to_json_root_cause(
     }
     entries = [entry_by_id[id(c)] for c in changes]
     grouped = _group_changes_by_root_cause(changes, extra_causes=extra_causes)
+    # G29 Phase 6 follow-up: a group's own evidence summary (this is a
+    # group-level fold, not a per-finding one -- keyed by the same
+    # root_cause_id this loop already computes below, from
+    # RootCauseCorrelator's own groups over the identical `changes`).
+    _group_evidence = {
+        group.root_cause_id: group for group in correlate_root_causes(changes)
+    }
 
-    root_causes = [
-        {
-            "root_cause_id": hashlib.sha256(key.encode("utf-8")).hexdigest()[:16],
+    root_causes = []
+    for key, root_display, group_changes in grouped:
+        root_cause_id = hashlib.sha256(key.encode("utf-8")).hexdigest()[:16]
+        entry: dict[str, object] = {
+            "root_cause_id": root_cause_id,
             "root": root_display,
             "finding_count": len(group_changes),
             "findings": [entry_by_id[id(c)] for c in group_changes],
         }
-        for key, root_display, group_changes in grouped
-    ]
+        rc_group = _group_evidence.get(root_cause_id)
+        if rc_group is not None:
+            entry["strongest_evidence_level"] = rc_group.strongest_evidence_level
+            entry["evidence_levels"] = list(rc_group.evidence_levels)
+        root_causes.append(entry)
 
     d = _build_json_base(result)
     _add_abi_surface_breakdown(d, result)
@@ -908,7 +930,10 @@ def _add_show_only_filter(
 
 
 def _suppressed_change_entry(
-    c: Change, *, root_cause: tuple[str, str] | None = None
+    c: Change,
+    *,
+    root_cause: tuple[str, str] | None = None,
+    root_cause_evidence: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Minimal audit-trail entry for one suppressed change, plus the
     impact-assessment decision it was actually suppressed with (G29 Phase 3
@@ -921,13 +946,22 @@ def _suppressed_change_entry(
     lookup scoped to ``result.suppressed_changes`` itself -- a suppressed
     finding's root cause is computed relative to other *suppressed* findings,
     not folded together with the kept ``changes[]`` list's own grouping.
+
+    ``root_cause_evidence`` (G29 Phase 6 follow-up): same scoping, via
+    :func:`~abicheck.reporter_markdown.root_cause_evidence_lookup_for_changes`
+    over ``result.suppressed_changes``.
     """
     entry: dict[str, object] = {
         "kind": c.kind.value,
         "symbol": c.symbol,
         "description": c.description,
     }
-    assessment = assess_change(c, suppressed=True, root_cause=root_cause)
+    assessment = assess_change(
+        c,
+        suppressed=True,
+        root_cause=root_cause,
+        root_cause_evidence=root_cause_evidence,
+    )
     entry["reachability_state"] = assessment.reachability_state.value
     if assessment.has_signal():
         entry["impact_assessment"] = assessment.to_dict()
@@ -943,11 +977,16 @@ def _suppressed_change_entry(
 def _add_suppression(d: dict[str, object], result: DiffResult) -> None:
     """Add suppression block (file flag, count, suppressed change list)."""
     _rc_lookup = root_cause_lookup_for_changes(result.suppressed_changes)
+    _rc_evidence = root_cause_evidence_lookup_for_changes(result.suppressed_changes)
     d["suppression"] = {
         "file_provided": result.suppression_file_provided,
         "suppressed_count": result.suppressed_count,
         "suppressed_changes": [
-            _suppressed_change_entry(c, root_cause=_rc_lookup.get(_finding_id(c)))
+            _suppressed_change_entry(
+                c,
+                root_cause=_rc_lookup.get(_finding_id(c)),
+                root_cause_evidence=_rc_evidence.get(_finding_id(c)),
+            )
             for c in result.suppressed_changes
         ],
     }
@@ -1017,6 +1056,7 @@ def _add_changes_block(
     _rc_lookup = root_cause_lookup_for_changes(
         changes, extra_causes=_scoped_only_extra_causes(result, show_only)
     )
+    _rc_evidence = root_cause_evidence_lookup_for_changes(changes)
     d["changes"] = [
         _change_to_dict(
             c,
@@ -1024,6 +1064,7 @@ def _add_changes_block(
             kind_sets=eff_sets,
             policy_file=result.policy_file,
             root_cause=_rc_lookup.get(_finding_id(c)),
+            root_cause_evidence=_rc_evidence.get(_finding_id(c)),
             evidence_tiers=result.evidence_tiers,
             severity_config=severity_config,
         )
@@ -1401,6 +1442,7 @@ def _change_to_dict(
     policy_file: object | None = None,
     evidence_status_override: EvidenceStatus | None = None,
     root_cause: tuple[str, str] | None = None,
+    root_cause_evidence: dict[str, object] | None = None,
     evidence_tiers: Sequence[str] = (),
     severity_config: SeverityConfig | None = None,
 ) -> dict[str, object]:
@@ -1419,6 +1461,13 @@ def _change_to_dict(
     once per report via
     :func:`~abicheck.reporter_markdown.root_cause_lookup_for_changes` rather
     than recomputing it per change.
+
+    ``root_cause_evidence`` (G29 Phase 6 follow-up), when given, is *c*'s own
+    entry from :func:`~abicheck.impact.correlation.correlate_root_causes`,
+    resolved once per report via
+    :func:`~abicheck.reporter_markdown.root_cause_evidence_lookup_for_changes`
+    — forwarded to :func:`~abicheck.impact.engine.assess_change` so
+    ``impact_assessment.root_cause_evidence`` is populated.
 
     ``evidence_tiers`` is the owning comparison's ``DiffResult.evidence_tiers``
     (P0 evidence-provider audit) — when a caller has it (most do; the
@@ -1492,7 +1541,9 @@ def _change_to_dict(
     # reachability/impact fields above; only emitted when it carries
     # information beyond the all-defaults case, matching this function's own
     # convention of not padding every plain finding with an empty object.
-    assessment = assess_change(c, root_cause=root_cause)
+    assessment = assess_change(
+        c, root_cause=root_cause, root_cause_evidence=root_cause_evidence
+    )
     d["reachability_state"] = assessment.reachability_state.value
     if assessment.has_signal():
         d["impact_assessment"] = assessment.to_dict()
@@ -1656,6 +1707,7 @@ def appcompat_to_json(result: object, indent: int = 2) -> str:
     appcompat_kind_sets = _kind_sets_fn() if callable(_kind_sets_fn) else None
     appcompat_policy_file = getattr(full_diff, "policy_file", None)
     _rc_lookup = root_cause_lookup_for_changes(breaking)
+    _rc_evidence = root_cause_evidence_lookup_for_changes(breaking)
     d["relevant_changes"] = [
         _change_to_dict(
             c,
@@ -1664,6 +1716,7 @@ def appcompat_to_json(result: object, indent: int = 2) -> str:
             policy_file=appcompat_policy_file,
             evidence_status_override=EvidenceStatus.CONSUMER_PROVEN,
             root_cause=_rc_lookup.get(_finding_id(c)),
+            root_cause_evidence=_rc_evidence.get(_finding_id(c)),
         )
         for c in breaking
     ]

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -374,7 +374,7 @@ def _to_json_leaf(
     _rc_lookup = root_cause_lookup_for_changes(
         changes, extra_causes=_scoped_only_extra_causes(result, show_only)
     )
-    _rc_evidence = root_cause_evidence_lookup_for_changes(changes)
+    _rc_evidence = _scoped_only_evidence_lookup(result, changes, show_only)
 
     effective_policy = result.policy or "strict_abi"
     eff_sets = result._effective_kind_sets()
@@ -591,6 +591,30 @@ def _add_entries_to_root_causes(
     d["root_cause_count"] = len(root_causes)
 
 
+def _scoped_only_changes_filtered(
+    result: DiffResult, show_only: str | None
+) -> list[Change]:
+    """``result.scoped_only_changes``, filtered by the same ``--show-only``
+    as the caller's own ``changes`` list -- the shared computation
+    :func:`_scoped_only_extra_causes` and
+    :func:`~abicheck.impact.correlation.correlate_root_causes` callers below
+    both need, kept as one function so the two can never filter differently
+    (Codex review: an evidence lookup built from an unfiltered scoped-only
+    set could correlate a finding via a sibling ``--show-only`` had already
+    excluded).
+    """
+    scoped_only = list(getattr(result, "scoped_only_changes", ()) or ())
+    if show_only and scoped_only:
+        scoped_only = apply_show_only(
+            scoped_only,
+            show_only,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
+    return scoped_only
+
+
 def _scoped_only_extra_causes(
     result: DiffResult, show_only: str | None
 ) -> frozenset[str]:
@@ -612,16 +636,35 @@ def _scoped_only_extra_causes(
     ``root_causes[].root_cause_id``/SARIF/JUnit sibling depending on which
     report mode rendered it.
     """
-    scoped_only = list(getattr(result, "scoped_only_changes", ()) or ())
-    if show_only and scoped_only:
-        scoped_only = apply_show_only(
-            scoped_only,
-            show_only,
-            policy=result.policy,
-            kind_sets=result._effective_kind_sets(),
-            policy_file=result.policy_file,
-        )
+    scoped_only = _scoped_only_changes_filtered(result, show_only)
     return frozenset(c.caused_by_type for c in scoped_only if c.caused_by_type)
+
+
+def _scoped_only_evidence_lookup(
+    result: DiffResult, changes: list[Change], show_only: str | None
+) -> dict[str, dict[str, object]]:
+    """``finding_id -> root_cause_evidence`` for *changes* combined with
+    *result*'s own filtered ``scoped_only_changes`` (G29 Phase 6 follow-up,
+    Codex review).
+
+    ``RootCauseCorrelator`` groups by the actual ``Change`` objects it's
+    given, so a regular finding that only correlates via a scoped-only
+    (``--used-by``/``--required-symbol``) sibling -- e.g. a
+    ``FUNC_REMOVED``/``INTERNAL_SYMBOL_REQUIRED_BY_PUBLIC_API`` pair split
+    across ``changes`` and ``scoped_only_changes`` -- needs the sibling in
+    the same :func:`~abicheck.impact.correlation.correlate_root_causes` call
+    to be recognized as a group at all; a lookup built from *changes* alone
+    (as :func:`root_cause_evidence_lookup_for_changes` would be if called
+    directly here) silently under-correlates, contradicting
+    ``sarif.to_sarif``'s identical ``changes + scoped_only_changes``
+    computation. The returned lookup covers *both* sides -- a caller
+    rendering only ``changes`` (e.g. :func:`_add_changes_block`, before
+    ``cli_compare_fold.py``'s later scoped-only fold-in) still finds every
+    entry it needs by ``finding_id``, and the fold-in itself reuses this
+    same lookup for the scoped-only entries it appends.
+    """
+    scoped_only = _scoped_only_changes_filtered(result, show_only)
+    return root_cause_evidence_lookup_for_changes(changes + scoped_only)
 
 
 def _to_json_root_cause(
@@ -675,7 +718,7 @@ def _to_json_root_cause(
     # mode provides it, `_to_json_leaf` included) and `root_causes[].findings`
     # never drift from each other.
     _rc_lookup = root_cause_lookup_for_changes(changes, extra_causes=extra_causes)
-    _rc_evidence = root_cause_evidence_lookup_for_changes(changes)
+    _rc_evidence = _scoped_only_evidence_lookup(result, changes, show_only)
     entry_by_id = {
         id(c): _change_to_dict(
             c,
@@ -693,10 +736,18 @@ def _to_json_root_cause(
     grouped = _group_changes_by_root_cause(changes, extra_causes=extra_causes)
     # G29 Phase 6 follow-up: a group's own evidence summary (this is a
     # group-level fold, not a per-finding one -- keyed by the same
-    # root_cause_id this loop already computes below, from
-    # RootCauseCorrelator's own groups over the identical `changes`).
+    # root_cause_id this loop already computes below). Correlated over
+    # `changes` plus the same filtered scoped-only set _rc_evidence above
+    # uses (Codex review) -- root_causes[] itself only ever groups `changes`
+    # (scoped-only findings are folded into a *separate* payload by
+    # cli_compare_fold.py, never into this array), but a group that only
+    # exists because of a scoped-only sibling must still report the
+    # strongest evidence actually available for it.
     _group_evidence = {
-        group.root_cause_id: group for group in correlate_root_causes(changes)
+        group.root_cause_id: group
+        for group in correlate_root_causes(
+            changes + _scoped_only_changes_filtered(result, show_only)
+        )
     }
 
     root_causes = []
@@ -1051,12 +1102,17 @@ def _add_changes_block(
     does (review finding) -- without it, a finding here correlating only via
     a scoped-only overlay silently lost its
     ``impact_assessment.root_cause_id``, disagreeing with root-cause mode,
-    SARIF, and JUnit for the identical finding.
+    SARIF, and JUnit for the identical finding. ``root_cause_evidence``
+    (G29 Phase 6 follow-up, Codex review) gets the same treatment via
+    :func:`_scoped_only_evidence_lookup`, which correlates against the
+    actual scoped-only ``Change`` objects (not just their ``caused_by_type``
+    strings) -- ``RootCauseCorrelator`` needs the real sibling to recognize
+    a multi-piece group at all.
     """
     _rc_lookup = root_cause_lookup_for_changes(
         changes, extra_causes=_scoped_only_extra_causes(result, show_only)
     )
-    _rc_evidence = root_cause_evidence_lookup_for_changes(changes)
+    _rc_evidence = _scoped_only_evidence_lookup(result, changes, show_only)
     d["changes"] = [
         _change_to_dict(
             c,

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -803,6 +803,48 @@ def root_cause_lookup_for_changes(
     return lookup
 
 
+def root_cause_evidence_lookup_for_changes(
+    changes: list[Change],
+) -> dict[str, dict[str, object]]:
+    """``finding_id -> root_cause_evidence`` for every change that is a
+    member of a G29 Phase 6 ``RootCauseCorrelator`` group (G29 Phase 6
+    follow-up: wiring the correlator's output into the JSON/SARIF
+    ``impact_assessment`` surface).
+
+    Deliberately independent of :func:`root_cause_lookup_for_changes` above:
+    that function's ``root_cause_id``/``root_cause_display`` grouping covers
+    *any* two findings sharing a ``caused_by_type``/``symbol``, for every
+    ``ChangeKind``; :func:`~abicheck.impact.correlation.correlate_root_causes`
+    covers only the four load-failure kinds its own module docstring names
+    (``FUNC_REMOVED``/``INTERNAL_SYMBOL_REQUIRED_BY_PUBLIC_API``/
+    ``CONSUMER_REQUIRED_SYMBOL_REMOVED``/``CONSUMER_RUNTIME_LOAD_FAILED``),
+    ranked by evidence strength, and drops a symbol with only one correlated
+    piece. Built directly from the actual ``Change`` objects the correlator
+    grouped — not by matching root-cause ids after the fact — so this stays
+    correct independent of whether the two functions' grouping keys happen
+    to agree for a given finding.
+
+    Scoped to *changes* only: unlike ``root_cause_lookup_for_changes``, this
+    has no ``extra_causes`` parameter, so a correlated sibling that exists
+    only as a scoped-only (``--used-by``/``--required-symbol``) finding
+    appended to a report after this runs is not seen — deliberately left for
+    a follow-up, mirroring this module's own "Deliberately not implemented
+    this slice" precedent rather than growing this helper's contract
+    unverified.
+    """
+    from .impact.correlation import correlate_root_causes
+
+    lookup: dict[str, dict[str, object]] = {}
+    for group in correlate_root_causes(changes):
+        for member_change, level in group.members:
+            lookup[_finding_id(member_change)] = {
+                "evidence_level": level,
+                "strongest_evidence_level": group.strongest_evidence_level,
+                "evidence_levels": list(group.evidence_levels),
+            }
+    return lookup
+
+
 def _resolve_scoped_gate_findings(
     result: DiffResult,
     severity_config: SeverityConfig | None,

--- a/abicheck/root_cause_evidence.py
+++ b/abicheck/root_cause_evidence.py
@@ -1,0 +1,148 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``RootCauseCorrelator`` (G29 Phase 6) evidence helpers shared by
+``reporter.py``/``cli_compare_fold.py``'s JSON serialization.
+
+Split out of ``reporter.py`` (AI-readiness file-size cap -- both it and
+``reporter_markdown.py``, the more obvious home, were already at or near
+the 2000-line hard cap when this Phase 6 follow-up landed) rather than
+grown in place. Leaf module: only reaches ``reporter_markdown.py`` (the
+``--used-by``/``--required-symbol`` show-only filter and the per-finding
+root-cause-evidence lookup) and ``impact.correlation`` (the evidence rank
+order), so it introduces no new import-cycle risk.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING, cast
+
+from .reporter_markdown import (
+    _finding_id,
+    apply_show_only,
+    root_cause_evidence_lookup_for_changes,
+)
+
+if TYPE_CHECKING:
+    from .checker_types import Change, DiffResult
+
+
+def scoped_only_changes_filtered(
+    result: DiffResult, show_only: str | None
+) -> list[Change]:
+    """``result.scoped_only_changes``, filtered by ``--show-only`` the same
+    way the caller's own ``changes`` list already is -- shared so callers
+    can never filter the two lists differently (Codex review)."""
+    scoped_only = list(getattr(result, "scoped_only_changes", ()) or ())
+    if show_only and scoped_only:
+        scoped_only = apply_show_only(
+            scoped_only,
+            show_only,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
+    return scoped_only
+
+
+def scoped_only_evidence_lookup(
+    result: DiffResult, changes: list[Change], show_only: str | None
+) -> dict[str, dict[str, object]]:
+    """``finding_id -> root_cause_evidence`` for *changes* plus *result*'s
+    filtered ``scoped_only_changes`` (G29 Phase 6, Codex review).
+
+    A finding correlating only via a scoped-only (``--used-by``/
+    ``--required-symbol``) sibling needs that sibling in the same
+    :func:`~abicheck.impact.correlation.correlate_root_causes` call to be
+    recognized -- a lookup over *changes* alone under-correlates, unlike
+    ``sarif.to_sarif``'s identical combined computation. Shared by a caller
+    rendering only ``changes`` and ``cli_compare_fold.py``'s later
+    scoped-only fold-in.
+    """
+    scoped_only = scoped_only_changes_filtered(result, show_only)
+    return root_cause_evidence_lookup_for_changes(changes + scoped_only)
+
+
+def fold_evidence_summaries(
+    evidences: Iterable[dict[str, object] | None],
+) -> dict[str, object] | None:
+    """Fold several per-finding ``root_cause_evidence`` dicts (each already
+    correct on its own) into one group-level summary (G29 Phase 6, Codex
+    review): the strongest ``strongest_evidence_level`` seen, and the union
+    of every ``evidence_levels`` list, ranked.
+
+    Deliberately not a re-derivation via ``correlate_root_causes`` + a
+    ``root_cause_id``-equality lookup -- a report-level group and a
+    correlator group can genuinely disagree on membership (a bare-symbol
+    pair sharing no ``caused_by_type``: report grouping keeps each its own
+    singleton, the correlator's ``caused_by_type or symbol`` key merges
+    them -- reproduced by ``--used-by --verify-runtime``'s
+    ``FUNC_REMOVED``/``CONSUMER_RUNTIME_LOAD_FAILED`` pair), so matching by
+    id silently misses group-level evidence for exactly that shape even
+    though each finding's own per-finding evidence already shows it.
+    Folding already-correct member evidence instead sidesteps that mismatch
+    entirely: every member of one real correlator group carries an
+    identical summary by construction, so this is a no-op re-derivation in
+    the common case. ``None`` when nothing in *evidences* has any.
+    """
+    from .impact.correlation import EVIDENCE_RANK
+
+    strongest: str | None = None
+    levels: set[str] = set()
+    found = False
+    for member_evidence in evidences:
+        if member_evidence is None:
+            continue
+        found = True
+        member_levels = member_evidence.get("evidence_levels") or ()
+        levels.update(str(level) for level in cast(Sequence[object], member_levels))
+        member_strongest = member_evidence.get("strongest_evidence_level")
+        if member_strongest is not None and (
+            strongest is None
+            or EVIDENCE_RANK.get(str(member_strongest), -1)
+            > EVIDENCE_RANK.get(strongest, -1)
+        ):
+            strongest = str(member_strongest)
+    if not found:
+        return None
+    return {
+        "strongest_evidence_level": strongest,
+        "evidence_levels": sorted(
+            levels, key=lambda level: EVIDENCE_RANK.get(level, -1)
+        ),
+    }
+
+
+def root_cause_group_evidence(
+    group_changes: list[Change], rc_evidence: dict[str, dict[str, object]]
+) -> dict[str, object] | None:
+    """A ``root_causes[]`` group's evidence summary, folded from its own
+    members' already-correct per-finding ``root_cause_evidence`` (see
+    :func:`fold_evidence_summaries` for why this isn't a
+    ``root_cause_id``-matched re-derivation)."""
+    return fold_evidence_summaries(
+        rc_evidence.get(_finding_id(c)) for c in group_changes
+    )
+
+
+def entry_root_cause_evidence(entry: dict[str, object]) -> dict[str, object] | None:
+    """A serialized finding dict's own ``impact_assessment.root_cause_evidence``,
+    or ``None`` when absent."""
+    assessment = entry.get("impact_assessment")
+    if not isinstance(assessment, dict):
+        return None
+    evidence = assessment.get("root_cause_evidence")
+    return evidence if isinstance(evidence, dict) else None

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -58,6 +58,7 @@ from abicheck.reporter import (
 from abicheck.reporter_markdown import (
     ShowOnlyFilter,
     _root_cause_key_and_display,
+    root_cause_evidence_lookup_for_changes,
     root_cause_lookup_for_changes,
 )
 from abicheck.severity import missing_contract_exit_code
@@ -333,6 +334,7 @@ def _result_for(
     evidence_status_override: EvidenceStatus | None = None,
     root_cause: tuple[str, str] | None = None,
     impact_root_cause: tuple[str, str] | None = None,
+    impact_root_cause_evidence: dict[str, object] | None = None,
 ) -> dict[str, Any]:
     """Produce a SARIF result object for a Change.
 
@@ -350,6 +352,13 @@ def _result_for(
     ``rootCause`` fields. Kept as a separate parameter rather than reusing
     *root_cause* so that existing, tested behavior of those top-level
     properties can't shift when this field was added.
+
+    *impact_root_cause_evidence* (G29 Phase 6 follow-up) is *change*'s own
+    entry from :func:`~abicheck.impact.correlation.correlate_root_causes`,
+    resolved once per document via
+    :func:`~abicheck.reporter_markdown.root_cause_evidence_lookup_for_changes`
+    — feeds ``impactAssessment.root_cause_evidence``, unconditionally (any
+    *report_mode*), mirroring *impact_root_cause* above.
 
     *relevant_ids*, when not ``None``, means a ``--used-by``/``--required-symbol``
     gate is active: a change whose :func:`_finding_id` is absent from the set is
@@ -404,7 +413,11 @@ def _result_for(
     # JSON output gained -- reachabilityState always present (the tri-state
     # signal from PR #607, never surfaced in SARIF before this), and the
     # unified impactAssessment object when it carries more than the defaults.
-    assessment = assess_change(change, root_cause=impact_root_cause)
+    assessment = assess_change(
+        change,
+        root_cause=impact_root_cause,
+        root_cause_evidence=impact_root_cause_evidence,
+    )
     properties["reachabilityState"] = assessment.reachability_state.value
     if assessment.has_signal():
         properties["impactAssessment"] = assessment.to_dict()
@@ -767,6 +780,13 @@ def to_sarif(
     # together so a scoped-only change's caused_by_type can still correlate
     # with a regular change, same as referenced_causes above.
     _impact_rc_lookup = root_cause_lookup_for_changes(changes + scoped_only_changes)
+    # G29 Phase 6 follow-up: RootCauseCorrelator's own evidence-ranked
+    # groups, over the same combined change set -- mirrors reporter.py's
+    # JSON wiring so a finding's impactAssessment.root_cause_evidence agrees
+    # across formats.
+    _impact_rc_evidence = root_cause_evidence_lookup_for_changes(
+        changes + scoped_only_changes
+    )
 
     def _root_cause_for(
         caused_by_type: str | None,
@@ -807,6 +827,7 @@ def to_sarif(
                     _finding_id(change),
                 ),
                 impact_root_cause=_impact_rc_lookup.get(_finding_id(change)),
+                impact_root_cause_evidence=_impact_rc_evidence.get(_finding_id(change)),
             )
         )
 
@@ -832,6 +853,7 @@ def to_sarif(
                     _finding_id(change),
                 ),
                 impact_root_cause=_impact_rc_lookup.get(_finding_id(change)),
+                impact_root_cause_evidence=_impact_rc_evidence.get(_finding_id(change)),
             )
         )
 

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -346,7 +346,21 @@ from typing import Any
 #:       produced it) needs no change. Bumped rather than left silent because
 #:       the field's schema description named one specific producer/kind
 #:       pairing, which a strict consumer could have relied on.
-REPORT_SCHEMA_VERSION = "2.28"
+#: 2.29 — G29 Phase 6 follow-up: wires the already-implemented
+#:       ``RootCauseCorrelator`` (``abicheck.impact.correlation.
+#:       correlate_root_causes``) into the JSON/SARIF ``impact_assessment``
+#:       surface. Adds ``change.impact_assessment.root_cause_evidence``
+#:       (this finding's own evidence rank plus the whole correlator
+#:       group's ``strongest_evidence_level``/``evidence_levels``), present
+#:       only for a finding that is a member of one of the correlator's
+#:       multi-piece groups -- the four load-failure kinds named in that
+#:       module's docstring -- and, under ``--report-mode root-cause``,
+#:       ``root_causes[].strongest_evidence_level``/``evidence_levels`` for
+#:       the same groups. Purely additive: absent for every other finding
+#:       and group, unconditional on report_mode (mirroring root_cause_id/
+#:       impact_group_id's own precedent), and never affects ``verdict``,
+#:       ``severity``, or any exit code.
+REPORT_SCHEMA_VERSION = "2.29"
 
 #: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as
 #: ``scan_schema_version`` at the top level of both public scan dict shapes:

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -377,6 +377,31 @@
             "items": {
               "$ref": "#/$defs/change"
             }
+          },
+          "strongest_evidence_level": {
+            "type": "string",
+            "description": "G29 Phase 6 follow-up (schema 2.29): present only when this group is also a RootCauseCorrelator group (see change.impact_assessment.root_cause_evidence) -- the group's most-trustworthy evidence level.",
+            "enum": [
+              "artifact_proven",
+              "call_graph_overapprox",
+              "call_graph_proven",
+              "consumer_proven",
+              "runtime_proven"
+            ]
+          },
+          "evidence_levels": {
+            "type": "array",
+            "description": "G29 Phase 6 follow-up (schema 2.29): present iff strongest_evidence_level is -- this group's distinct evidence levels, weakest first.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "artifact_proven",
+                "call_graph_overapprox",
+                "call_graph_proven",
+                "consumer_proven",
+                "runtime_proven"
+              ]
+            }
           }
         }
       }
@@ -1294,6 +1319,45 @@
             "impact_group_id": {
               "type": "string",
               "description": "G29 Phase 3 follow-up (ADR-052, schema 2.19): currently always identical to root_cause_id -- a placeholder alias until Phase 6's RootCauseCorrelator gives it independent meaning (e.g. bucketing several distinct root causes under one broader consumer-visible event). Present iff root_cause_id is."
+            },
+            "root_cause_evidence": {
+              "type": "object",
+              "description": "G29 Phase 6 follow-up (schema 2.29): this finding's own entry from the RootCauseCorrelator (abicheck.impact.correlation.correlate_root_causes) -- present only when this finding is a member of one of that composer's multi-piece groups (the four load-failure kinds: func_removed, internal_symbol_required_by_public_api, consumer_required_symbol_removed, consumer_runtime_load_failed, correlated by shared symbol identity). evidence_level is this finding's own rank; strongest_evidence_level/evidence_levels describe the whole group. Unconditional on report_mode, same as root_cause_id/impact_group_id above.",
+              "properties": {
+                "evidence_level": {
+                  "type": "string",
+                  "enum": [
+                    "artifact_proven",
+                    "call_graph_overapprox",
+                    "call_graph_proven",
+                    "consumer_proven",
+                    "runtime_proven"
+                  ]
+                },
+                "strongest_evidence_level": {
+                  "type": "string",
+                  "enum": [
+                    "artifact_proven",
+                    "call_graph_overapprox",
+                    "call_graph_proven",
+                    "consumer_proven",
+                    "runtime_proven"
+                  ]
+                },
+                "evidence_levels": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "artifact_proven",
+                      "call_graph_overapprox",
+                      "call_graph_proven",
+                      "consumer_proven",
+                      "runtime_proven"
+                    ]
+                  }
+                }
+              }
             },
             "proof_path": {
               "type": "object",

--- a/changelog.d/20260812_080000_claude_g29_phase6_root_cause_evidence_wiring.md
+++ b/changelog.d/20260812_080000_claude_g29_phase6_root_cause_evidence_wiring.md
@@ -1,0 +1,21 @@
+### Added
+
+- **`RootCauseCorrelator` output wired into JSON/SARIF (G29 Phase 6
+  follow-up)** — the evidence-ranked groups `abicheck.impact.correlation.
+  correlate_root_causes` already computed (see the earlier "`RootCauseCorrelator`
+  (G29 Phase 6 first slice)" entry) now surface on the report itself. Every
+  finding that is a member of one of the correlator's multi-piece groups
+  gains `impact_assessment.root_cause_evidence` — `evidence_level` for that
+  finding's own rank, `strongest_evidence_level`/`evidence_levels` for the
+  whole group — in JSON (`changes[]`, `--report-mode leaf`,
+  `suppression.suppressed_changes[]`) and SARIF (`properties.impactAssessment`),
+  unconditional on `report_mode` like the existing `root_cause_id`/
+  `impact_group_id` fields. JSON `--report-mode root-cause`'s `root_causes[]`
+  groups gain the matching group-level `strongest_evidence_level`/
+  `evidence_levels`. New `reporter_markdown.root_cause_evidence_lookup_for_changes`
+  resolves this once per report, the same way `root_cause_lookup_for_changes`
+  already resolves `root_cause_id`. Purely additive (schema 2.29): absent for
+  every finding/group the four-kind correlator doesn't cover, and every
+  pre-existing `root_cause_id`/`impact_group_id` value is unchanged — this
+  annotates the existing grouping with evidence strength rather than
+  changing how findings are grouped.

--- a/changelog.d/20260812_080000_claude_g29_phase6_root_cause_evidence_wiring.md
+++ b/changelog.d/20260812_080000_claude_g29_phase6_root_cause_evidence_wiring.md
@@ -41,4 +41,15 @@
   contract, unchanged) — so the two id schemes never matched even though
   each finding's own per-finding evidence already showed group membership.
   Fixed by folding each report group's already-correct member-level
-  evidence directly, rather than re-deriving group membership by id.
+  evidence directly, rather than re-deriving group membership by id. A
+  third, related gap: `cli_compare_fold.py`'s own `--report-mode root-cause`
+  fold-in (`_add_entries_to_root_causes`) appends a scoped-only finding's
+  entry to an existing or brand-new `root_causes[]` group *after* the JSON
+  serializer already built its groups, but never recomputed that group's
+  own `strongest_evidence_level`/`evidence_levels` afterward — fixed by
+  recomputing every touched group's evidence summary from *all* its
+  findings (pre-existing and newly-folded-in alike) each time the fold-in
+  runs. The evidence-folding helpers moved to a new leaf module,
+  `abicheck/root_cause_evidence.py` (AI-readiness file-size cap — this
+  follow-up's additions pushed `reporter.py` to 2046 lines, over the
+  2000-line hard cap).

--- a/changelog.d/20260812_080000_claude_g29_phase6_root_cause_evidence_wiring.md
+++ b/changelog.d/20260812_080000_claude_g29_phase6_root_cause_evidence_wiring.md
@@ -19,3 +19,26 @@
   pre-existing `root_cause_id`/`impact_group_id` value is unchanged — this
   annotates the existing grouping with evidence strength rather than
   changing how findings are grouped.
+
+### Fixed
+
+- **`root_cause_evidence` now correlates across `--used-by`/`--required-symbol`
+  scoped-only findings, and `root_causes[]` group-level evidence no longer
+  drops for a bare-symbol pair** (review findings on the entry above). A
+  regular finding whose only correlation signal was a scoped-only sibling
+  (e.g. a `FUNC_REMOVED`/`CONSUMER_REQUIRED_SYMBOL_REMOVED` pair split across
+  `changes` and `scoped_only_changes`) previously got no evidence at all —
+  `RootCauseCorrelator` needs the real sibling `Change` object, not just its
+  `caused_by_type` string, to recognize the pair as a group. Separately, a
+  `root_causes[]` group's own `strongest_evidence_level`/`evidence_levels`
+  were matched against the correlator's groups by `root_cause_id` equality,
+  which silently missed a case the report's own grouping and the
+  correlator's grouping disagree on: two correlator-eligible findings
+  sharing a bare symbol with *neither* carrying `caused_by_type` (e.g.
+  `--used-by --verify-runtime`'s `FUNC_REMOVED`/`CONSUMER_RUNTIME_LOAD_FAILED`
+  pair) are one correlator group but two separate singleton report groups
+  (`root_cause_id`'s own "only `caused_by_type` correlates findings"
+  contract, unchanged) — so the two id schemes never matched even though
+  each finding's own per-finding evidence already showed group membership.
+  Fixed by folding each report group's already-correct member-level
+  evidence directly, rather than re-deriving group membership by id.

--- a/docs/contribute/plans/g29-impact-analysis-layer.md
+++ b/docs/contribute/plans/g29-impact-analysis-layer.md
@@ -1830,11 +1830,28 @@ stronger tier (`appcompat._attach_consumer_impact` enriching a shared
 `FUNC_REMOVED` in place), downgraded when an `INTERNAL_SYMBOL_REQUIRED_BY_
 PUBLIC_API` finding's own proof path is `internal_leak`'s
 `"overapprox: "`-prefixed over-approximation of a virtual/function-pointer
-dispatch target. **Still open**: wiring its output
-into the JSON/SARIF `root_cause_id`/`impact_group_id` surface (today those
-are still `reporter_markdown`'s independent `caused_by_type`-only grouping,
-per `ImpactAssessment`'s own docstring) and the eight new detector/overlay
-`ChangeKind`s below.
+dispatch target. **Wired into JSON/SARIF (this pass)**: every finding that
+is a member of one of the correlator's multi-piece groups now carries
+`impact_assessment.root_cause_evidence` (`evidence_level` for this finding,
+`strongest_evidence_level`/`evidence_levels` for the whole group), and JSON
+`--report-mode root-cause`'s `root_causes[]` groups gain the same
+`strongest_evidence_level`/`evidence_levels` fields — computed via a new
+`reporter_markdown.root_cause_evidence_lookup_for_changes`, threaded through
+`reporter.py`/`sarif.py` alongside the existing `root_cause`/
+`impact_root_cause` plumbing (schema 2.29). Deliberately conservative: this
+*annotates* the existing `root_cause_id`/`impact_group_id` grouping (still
+`reporter_markdown`'s independent `caused_by_type`-else-`symbol` rule,
+unchanged) with the correlator's evidence ranking rather than replacing that
+grouping's identity scheme or making `impact_group_id` diverge from
+`root_cause_id` — the correlator's own `root_cause_id` already hashes the
+identical key, so no re-keying was needed, and every existing
+`root_cause_id`/`impact_group_id` value for every pre-existing report is
+byte-for-byte unchanged. **Still open**: the eight new detector/overlay
+`ChangeKind`s below (a materially larger, differently-shaped follow-up —
+new producers, new example pairs, new FP-rate corpus cases — deliberately
+not attempted in the same pass as the wiring above), and `impact_group_id`
+actually diverging from `root_cause_id` by re-bucketing findings through the
+correlator's own groups rather than only annotating the existing ones.
 
 New examples (each needs a negative twin, per the review):
 
@@ -1877,7 +1894,7 @@ abicheck/internal_leak.py   # TraversalPolicy + effect_transitions (Phase 2 D5, 
 abicheck/impact/
     model.py           # ImpactAssessment, GraphProofPath, FindingDecision (Phase 3 slices 1/7, DONE — ADR-052)
     engine.py           # assess_change(...) (Phase 3 slices 1/7, DONE — ADR-052)
-    correlation.py       # RootCauseCorrelator (Phase 6, DONE — correlate_root_causes/RootCauseGroup; report-surface wiring still open)
+    correlation.py       # RootCauseCorrelator (Phase 6, DONE — correlate_root_causes/RootCauseGroup; wired into JSON/SARIF root_cause_evidence, schema 2.29)
     root_causes.py
     consumer_graph.py    # Phase 4 slice 1, DONE — ADR-057 (consumer graph + the source join)
     use_cases.py         # Phase 4 slice 2, DONE — ADR-057 amendment (manifest + use_case/test_case graph join; trace ingestion still not started)

--- a/docs/contribute/plans/g29-impact-analysis-layer.md
+++ b/docs/contribute/plans/g29-impact-analysis-layer.md
@@ -1853,6 +1853,64 @@ not attempted in the same pass as the wiring above), and `impact_group_id`
 actually diverging from `root_cause_id` by re-bucketing findings through the
 correlator's own groups rather than only annotating the existing ones.
 
+**The wiring above needed three follow-up review rounds to land correctly**
+(all Codex, same PR): (1) the per-finding lookups were built from `changes`
+alone, so a finding correlating only via a scoped-only
+(`--used-by`/`--required-symbol`) sibling got no evidence at all —
+`RootCauseCorrelator` needs the real sibling `Change` object, not just its
+`caused_by_type` string, to recognize a pair as a group; (2) the
+`root_causes[]` group-level rollup matched a report group against a
+correlator group by `root_cause_id` **equality**, which is wrong whenever
+the two grouping schemes disagree on membership — a bare-symbol pair
+sharing no `caused_by_type` (`--used-by --verify-runtime`'s real shape) is
+one correlator group but two singleton report groups, so the hashes never
+matched even though each finding's own per-finding evidence already showed
+membership; fixed by folding each group's own members' already-correct
+evidence directly instead of re-deriving membership by id; (3) the same gap
+existed a layer up, in `cli_compare_fold.py`'s own `--report-mode
+root-cause` fold-in (`_add_entries_to_root_causes`), which appends a
+scoped-only entry to an existing-or-new group *after* the JSON serializer
+already built it, but never recomputed that group's own evidence summary
+afterward. Worth recording as its own lesson before attempting any of the
+eight new detectors below: a naive `root_cause_id`-equality join between
+two independently-computed groupings is not safe by default whenever either
+grouping has its own fallback/singleton rule — the correlator's grouping is
+strictly *coarser* than the report's in exactly the no-`caused_by_type`
+case, and nothing about that asymmetry is visible from either grouping's
+own code without deliberately tracing a bare-symbol, no-`caused_by_type`
+input through both.
+
+**A related, adjacent gap was found (not fixed) while scoping
+`GRAPH_COVERAGE_INSUFFICIENT_FOR_SUPPRESSION`'s "generalizes
+`SUPPRESSION_REACHABILITY_UNKNOWN`" description above, and is worth
+recording before anyone else picks that item up.** `Suppression.
+_passes_reachability_gate` (`suppression.py`) has *two* reachability modes
+whose behavior on a graph-coverage gap differs, and only one of them has a
+diagnostic today. `reachability: "proven-unreachable-only"` treats
+`Change.reachability_state == UNKNOWN` as a **withheld match** unless
+`allow_unknown_reachability: true` — this is exactly what
+`SUPPRESSION_REACHABILITY_UNKNOWN` reports. `reachability:
+"unreachable-only"` (a different, valid value) instead gates on
+`not change.public_reachable` — and `Change.public_reachable` defaults to
+`False` the same way whether it was *proven* `False` or simply never
+examined (`UNKNOWN` reachability with insufficient graph coverage), so a
+`reachability: "unreachable-only"` rule can **silently succeed** at
+suppressing a change graph coverage never actually cleared, with no
+diagnostic at all — a real gap, structurally similar to the one
+`SUPPRESSION_REACHABILITY_UNKNOWN` closed for the other mode, but on the
+*opposite* failure direction (this one risks a false negative — silently
+accepting a suppression that should have been withheld — rather than a
+false positive). A single `GRAPH_COVERAGE_INSUFFICIENT_FOR_SUPPRESSION`
+`ChangeKind` that literally "generalizes" the existing case (by simply
+reusing its detection path under a new name) would not close this gap; closing
+it for real needs either extending `unreachable-only`'s own gate to
+distinguish proven-`False` from `UNKNOWN` (a semantic change to a suppression
+mode real policy files already rely on — needs its own compatibility
+analysis, not a drive-by) or a second, independently-designed diagnostic
+covering this mode specifically. Not attempted here — flagged rather than
+guessed at, per this file's own "known gaps over risky reactive patches"
+convention.
+
 New examples (each needs a negative twin, per the review):
 
 | Case | Scenario |

--- a/docs/contribute/plans/g29-impact-analysis-layer.md
+++ b/docs/contribute/plans/g29-impact-analysis-layer.md
@@ -1911,6 +1911,77 @@ covering this mode specifically. Not attempted here — flagged rather than
 guessed at, per this file's own "known gaps over risky reactive patches"
 convention.
 
+**Two more of the eight, investigated (not implemented) in this same pass —
+both turn out to be a scoping question first, not an extraction gap:**
+
+- **`CONSUMER_IMPACT_PATH_CONFIRMED`.** `appcompat.py`'s consumer-overlay
+  pipeline (`_has_impact_evidence`, `_enrich_covered_changes`,
+  `_merge_consumer_impact_paths`) already computes and surfaces exactly this
+  information — a confirmed consumer→symbol proof path — today, as an
+  in-place mutation of the *existing* `Change`'s `impact_assessment` fields
+  (`reachability_kind`, `reachability_state`, the proof-path plumbing this
+  plan's Phase 3/4 sections already document as DONE), not as a standalone
+  finding. Minting a *new* `ChangeKind` for the same fact would mean either
+  (a) a second, parallel representation of information a report already
+  carries once (the two-representations-of-one-fact drift this repo's own
+  `docs/AGENTS.md` governing rule and `change_registry.py`'s "one
+  `ChangeKindMeta` entry" convention both exist to prevent), or (b)
+  redefining what the overlay does — attaching a *new* raw finding instead
+  of annotating an existing one — which is a real design change to
+  `appcompat.py`'s enrichment contract, not a new-detector addition. The
+  table entry above ("impact overlay on an existing raw break, not a new raw
+  break") already states this outcome as the intent; what's newly confirmed
+  is that the current code already delivers it, so there may be nothing left
+  to build here beyond documentation — worth a maintainer decision on
+  whether to close this row entirely rather than implement it.
+- **`USE_CASE_IMPACT_CONFIRMED`.** `abicheck/impact/use_cases.py`'s own
+  module docstring is explicit that this is deferred pending new CLI
+  surface: `explain_use_case_impact()` exists and is wired only through
+  `project validate-use-cases --against-new` (an opt-in diagnostic command),
+  not through `compare`'s own report pipeline. Surfacing this as a
+  `compare`-time `ChangeKind` needs a real design decision this plan has not
+  made — a new `compare --use-cases <manifest>` flag (or equivalent),
+  `REPORT_SCHEMA_VERSION` bump, and new FP-gate examples proving a use case
+  that doesn't reach the changed branch stays compatible (this is exactly
+  `case203` below) — not a drive-by extension of the existing
+  `project`-group command. Per this file's own root-command admission bar
+  (`AGENTS.md` "Adding a new top-level command"), this also needs to clear
+  that bar or land as a `compare` option instead; not attempted here.
+
+**A fourth item was scoped for implementation attempt in this pass
+(`PUBLIC_VIRTUAL_DISPATCH_SET_CHANGED`) and deliberately not attempted,
+based on evidence rather than a guess.** `abicheck/buildsource/
+virtual_dispatch_graph.py` already emits the two graph facts a comparison
+detector would need (`VIRTUAL_CALL_MAY_DISPATCH_TO`,
+`TYPE_HAS_VTABLE`) — the raw data exists. What stopped the attempt is this
+same plan's own recorded history for *that exact module* and its three
+siblings (`callback_graph.py`, `macro_graph.py`, `template_graph.py`,
+directly above and below this entry): each required double-digit rounds of
+Codex review to reach its current DONE/PARTIAL state, and the findings in
+those rounds were not stylistic — coverage-stamping bugs that made a
+degraded extraction silently read as complete, propagation bugs that lost a
+graph fact between fold and report, and at least one review round finding a
+correctness bug in a *previous* review round's own fix. A new detector
+consuming `VIRTUAL_CALL_MAY_DISPATCH_TO`/`TYPE_HAS_VTABLE` inherits every
+one of those failure modes by construction (comparing two runs' worth of
+already-fact-checked-fragile graph output, across old/new coverage that can
+differ), plus its own new one: this plan's explicit constraint that "a
+possible-target-set change must never read as a confirmed break" (echoed
+in `resolution` always being `"overapprox"` in the two Part A/B functions'
+own docstrings) means the comparison logic itself — not just the extraction
+— has to get old-vs-new overapprox-set diffing right without silently
+producing a false `BREAKING` the first time a target set merely reorders or
+a base's coverage degrades between runs. Building and shipping that
+correctly, with its own FP-rate corpus cases (`case197` below) and without
+a live oneAPI/multi-round-Codex-review cycle available in this session, is
+not achievable to the correctness bar this codebase's own `AGENTS.md`
+"Known gaps over risky reactive patches" convention sets — recorded here as
+a scoped, concrete blocker (not "too hard, unspecified") for whoever picks
+this row up next: start from `virtual_dispatch_graph.py`'s own two
+functions, budget for the same class of review-round findings this plan's
+Phase 5 section already itemizes for the identical module, and do not skip
+straight to a detector without first re-reading that history.
+
 New examples (each needs a negative twin, per the review):
 
 | Case | Scenario |

--- a/docs/learn/impact-analysis.md
+++ b/docs/learn/impact-analysis.md
@@ -115,8 +115,22 @@ independently-nullable keys:
   an uncorrelated singleton finding, so a plain finding's
   `impact_assessment` doesn't balloon with a root cause naming nothing but
   itself. `impact_group_id` is currently always identical to
-  `root_cause_id` — a placeholder alias until Phase 6's
-  `RootCauseCorrelator` gives it independent meaning.
+  `root_cause_id` — a placeholder alias until a future revision gives it
+  independent meaning.
+- `root_cause_evidence` (G29 Phase 6) is this finding's own entry from the
+  `RootCauseCorrelator` (`abicheck.impact.correlation.correlate_root_causes`)
+  — present only when this finding is a member of one of that composer's
+  multi-piece groups: the four load-failure kinds (a symbol vanishing from
+  the export table, an internal dependency of a public entry point, a real
+  consumer's own unresolved import, and that consumer actually failing to
+  load), correlated by shared symbol identity and ranked by evidence
+  strength (`artifact_proven` → `call_graph_overapprox` → `call_graph_proven`
+  → `consumer_proven` → `runtime_proven`). `evidence_level` is this
+  finding's own rank; `strongest_evidence_level`/`evidence_levels` describe
+  the whole correlated group, so a consumer can tell "this piece alone is
+  only artifact-proven, but the group as a whole also has consumer proof"
+  without re-running the correlator itself. Unconditional on `report_mode`,
+  same as `root_cause_id`/`impact_group_id`.
 
 `impact_assessment` intentionally duplicates data already published at the
 top level — it exists so a consumer can query one object instead of several
@@ -156,6 +170,14 @@ assumptions. `root_cause_id` is a stable hash of the grouping key, so it is
 consistent across JSON/markdown/SARIF/JUnit for the same underlying report —
 none of the four formats can disagree about which findings share a root
 cause.
+
+When a `root_causes[]` group is also one of the `RootCauseCorrelator`'s own
+multi-piece groups (see `root_cause_evidence` above), the group entry gains
+`strongest_evidence_level`/`evidence_levels` — the group-level counterpart
+of each member finding's own `impact_assessment.root_cause_evidence`.
+Absent for a group `--report-mode root-cause` groups by the broader
+`caused_by_type`/`symbol` rule but that the narrower, four-kind correlator
+doesn't cover.
 
 JUnit's own `<testcase>` groups by *symbol*, not by finding
 (`_partition_changes`), so a symbol with more than one change gets multiple
@@ -215,8 +237,12 @@ being wired through the impact layer are the remainder of G29 Phase 4. `root_cau
 but `impact_group_id` is currently only ever an alias of `root_cause_id` —
 distinguishing them (e.g. bucketing several distinct root causes that share
 one broader consumer-visible event under one group while keeping their own
-individual root-cause identities) needs the full root-cause correlator (G29
-Phase 6). Computing `root_cause_id` needs whole-`DiffResult` context (which
+individual root-cause identities) is still open; the `RootCauseCorrelator`
+(G29 Phase 6) that would drive that distinction is implemented and now wired
+into the report surface as `root_cause_evidence` (documented above), but it
+doesn't yet feed `impact_group_id` itself — that would need the correlator's
+groups to actually re-bucket findings rather than only annotate them, a
+distinct follow-up. Computing `root_cause_id` needs whole-`DiffResult` context (which
 findings elsewhere reference this one) that a single finding's read view
 can't see on its own — the caller resolves it per report/scope
 (`reporter_markdown.root_cause_lookup_for_changes`) and passes it in; see

--- a/docs/reference/schemas/v1/compare_report.schema.json
+++ b/docs/reference/schemas/v1/compare_report.schema.json
@@ -377,6 +377,31 @@
             "items": {
               "$ref": "#/$defs/change"
             }
+          },
+          "strongest_evidence_level": {
+            "type": "string",
+            "description": "G29 Phase 6 follow-up (schema 2.29): present only when this group is also a RootCauseCorrelator group (see change.impact_assessment.root_cause_evidence) -- the group's most-trustworthy evidence level.",
+            "enum": [
+              "artifact_proven",
+              "call_graph_overapprox",
+              "call_graph_proven",
+              "consumer_proven",
+              "runtime_proven"
+            ]
+          },
+          "evidence_levels": {
+            "type": "array",
+            "description": "G29 Phase 6 follow-up (schema 2.29): present iff strongest_evidence_level is -- this group's distinct evidence levels, weakest first.",
+            "items": {
+              "type": "string",
+              "enum": [
+                "artifact_proven",
+                "call_graph_overapprox",
+                "call_graph_proven",
+                "consumer_proven",
+                "runtime_proven"
+              ]
+            }
           }
         }
       }
@@ -1294,6 +1319,45 @@
             "impact_group_id": {
               "type": "string",
               "description": "G29 Phase 3 follow-up (ADR-052, schema 2.19): currently always identical to root_cause_id -- a placeholder alias until Phase 6's RootCauseCorrelator gives it independent meaning (e.g. bucketing several distinct root causes under one broader consumer-visible event). Present iff root_cause_id is."
+            },
+            "root_cause_evidence": {
+              "type": "object",
+              "description": "G29 Phase 6 follow-up (schema 2.29): this finding's own entry from the RootCauseCorrelator (abicheck.impact.correlation.correlate_root_causes) -- present only when this finding is a member of one of that composer's multi-piece groups (the four load-failure kinds: func_removed, internal_symbol_required_by_public_api, consumer_required_symbol_removed, consumer_runtime_load_failed, correlated by shared symbol identity). evidence_level is this finding's own rank; strongest_evidence_level/evidence_levels describe the whole group. Unconditional on report_mode, same as root_cause_id/impact_group_id above.",
+              "properties": {
+                "evidence_level": {
+                  "type": "string",
+                  "enum": [
+                    "artifact_proven",
+                    "call_graph_overapprox",
+                    "call_graph_proven",
+                    "consumer_proven",
+                    "runtime_proven"
+                  ]
+                },
+                "strongest_evidence_level": {
+                  "type": "string",
+                  "enum": [
+                    "artifact_proven",
+                    "call_graph_overapprox",
+                    "call_graph_proven",
+                    "consumer_proven",
+                    "runtime_proven"
+                  ]
+                },
+                "evidence_levels": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "enum": [
+                      "artifact_proven",
+                      "call_graph_overapprox",
+                      "call_graph_proven",
+                      "consumer_proven",
+                      "runtime_proven"
+                    ]
+                  }
+                }
+              }
             },
             "proof_path": {
               "type": "object",

--- a/docs/use/output-formats.md
+++ b/docs/use/output-formats.md
@@ -648,7 +648,7 @@ Every JSON report carries a top-level `report_schema_version` field
 
 ```json
 {
-  "report_schema_version": "2.28",
+  "report_schema_version": "2.29",
   "library": "libfoo.so.1",
   "verdict": "BREAKING"
 }

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1849,6 +1849,49 @@ class TestUsedByScoping:
             "func_removed", "pe_ordinal_retargeted",
         }
 
+    def test_json_full_mode_scoped_only_correlator_evidence(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # G29 Phase 6 follow-up (Codex review): a scoped-only
+        # CONSUMER_REQUIRED_SYMBOL_REMOVED sibling of a real FUNC_REMOVED
+        # change is a genuine RootCauseCorrelator two-piece group -- both the
+        # pre-existing regular `changes[]` entry (root, via
+        # reporter._add_changes_block) and the newly-appended scoped-only
+        # entry (via cli_compare_fold.py's own fold-in) must carry the same
+        # correlator evidence for the same underlying group.
+        from abicheck import dumper as dumper_mod
+
+        old, new = _breaking_pair()  # real diff: "bar"/_Z3barv removed
+        app_path = tmp_path / "app"
+        app_path.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        old_p = tmp_path / "old.so"
+        old_p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        new_p = tmp_path / "new.so"
+        new_p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        monkeypatch.setattr(dumper_mod, "dump", MagicMock(side_effect=[old, new]))
+        scoped_only = Change(
+            kind=ChangeKind.CONSUMER_REQUIRED_SYMBOL_REMOVED,
+            symbol="pub_entry",
+            description="required by consumer",
+            caused_by_type="_Z3barv",
+        )
+        res = self._result(verdict=Verdict.BREAKING, breaking_for_app=[scoped_only])
+        self._patch_scope(monkeypatch, res)
+        result = _invoke(
+            "compare", str(old_p), str(new_p), "--used-by", str(app_path),
+            "--format", "json",
+        )
+        assert result.exit_code == 4
+        data = json.loads(result.stdout)
+        entries = {c["kind"]: c for c in data["changes"]}
+        assert set(entries) == {"func_removed", "consumer_required_symbol_removed"}
+        for entry in entries.values():
+            evidence = entry["impact_assessment"]["root_cause_evidence"]
+            assert evidence["strongest_evidence_level"] == "consumer_proven"
+            assert evidence["evidence_levels"] == [
+                "artifact_proven", "consumer_proven",
+            ]
+
     def test_markdown_root_cause_mode_merges_scoped_only_into_existing_group(
         self, tmp_path, monkeypatch
     ) -> None:

--- a/tests/test_cov95_cli.py
+++ b/tests/test_cov95_cli.py
@@ -1892,6 +1892,51 @@ class TestUsedByScoping:
                 "artifact_proven", "consumer_proven",
             ]
 
+    def test_json_root_cause_mode_scoped_only_bare_symbol_group_evidence(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # Third Codex review finding: --used-by --verify-runtime's real
+        # shape -- a FUNC_REMOVED and a scoped-only CONSUMER_RUNTIME_LOAD_
+        # FAILED sharing a bare symbol, neither carrying caused_by_type.
+        # RootCauseCorrelator merges them, but _root_cause_key_and_display's
+        # "only caused_by_type correlates findings" contract keeps each its
+        # own singleton --report-mode root-cause group (one built by
+        # _to_json_root_cause before the fold-in, one newly created by
+        # _add_entries_to_root_causes during it). Both singletons must carry
+        # the same group-level evidence their shared correlator group has.
+        from abicheck import dumper as dumper_mod
+
+        old, new = _breaking_pair()  # real diff: "bar"/_Z3barv removed
+        app_path = tmp_path / "app"
+        app_path.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        old_p = tmp_path / "old.so"
+        old_p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        new_p = tmp_path / "new.so"
+        new_p.write_bytes(b"\x7fELF" + b"\x00" * 200)
+        monkeypatch.setattr(dumper_mod, "dump", MagicMock(side_effect=[old, new]))
+        scoped_only = Change(
+            kind=ChangeKind.CONSUMER_RUNTIME_LOAD_FAILED,
+            symbol="_Z3barv",
+            description="runtime load failed",
+        )
+        res = self._result(verdict=Verdict.BREAKING, breaking_for_app=[scoped_only])
+        self._patch_scope(monkeypatch, res)
+        result = _invoke(
+            "compare", str(old_p), str(new_p), "--used-by", str(app_path),
+            "--format", "json", "--report-mode", "root-cause",
+        )
+        assert result.exit_code == 4
+        data = json.loads(result.stdout)
+        assert data["root_cause_count"] == 2
+        groups = {
+            group["findings"][0]["kind"]: group for group in data["root_causes"]
+        }
+        assert set(groups) == {"func_removed", "consumer_runtime_load_failed"}
+        for group in groups.values():
+            assert group["finding_count"] == 1
+            assert group["strongest_evidence_level"] == "runtime_proven"
+            assert group["evidence_levels"] == ["artifact_proven", "runtime_proven"]
+
     def test_markdown_root_cause_mode_merges_scoped_only_into_existing_group(
         self, tmp_path, monkeypatch
     ) -> None:

--- a/tests/test_impact_model.py
+++ b/tests/test_impact_model.py
@@ -387,6 +387,49 @@ class TestAssessChange:
         assert assessment.has_signal() is False
 
 
+class TestAssessChangeRootCauseEvidence:
+    """G29 Phase 6 follow-up: wiring RootCauseCorrelator's output into
+    ImpactAssessment.root_cause_evidence."""
+
+    def test_none_by_default(self) -> None:
+        change = _change()
+        assessment = assess_change(change, root_cause=("id", "display"))
+        assert assessment.root_cause_evidence is None
+        assert "root_cause_evidence" not in assessment.to_dict()
+
+    def test_evidence_dict_surfaces_in_to_dict(self) -> None:
+        change = _change()
+        evidence = {
+            "evidence_level": "artifact_proven",
+            "strongest_evidence_level": "consumer_proven",
+            "evidence_levels": ["artifact_proven", "consumer_proven"],
+        }
+        assessment = assess_change(
+            change, root_cause=("id", "display"), root_cause_evidence=evidence
+        )
+        assert assessment.root_cause_evidence == evidence
+        d = assessment.to_dict()
+        assert d["root_cause_evidence"] == evidence
+        # to_dict copies rather than aliasing the caller's dict.
+        assert d["root_cause_evidence"] is not evidence
+
+    def test_evidence_alone_makes_has_signal_true(self) -> None:
+        change = _change()
+        assessment = assess_change(
+            change,
+            root_cause_evidence={"evidence_level": "artifact_proven"},
+        )
+        assert assessment.has_signal() is True
+
+    def test_root_cause_evidence_not_read_from_cache(self) -> None:
+        cached = ImpactAssessment(root_cause_evidence={"evidence_level": "stale"})
+        change = _change(impact_assessment=cached)
+        assessment = assess_change(
+            change, root_cause_evidence={"evidence_level": "fresh"}
+        )
+        assert assessment.root_cause_evidence == {"evidence_level": "fresh"}
+
+
 class TestAssessChangeWithCachedImpactAssessment:
     """ADR-052 D2 follow-up (G29 Phase 3, scoped implementation):
     Change.impact_assessment, when a producer set it directly, supplies
@@ -533,3 +576,70 @@ class TestReporterIntegration:
         assert entry["impact_assessment"]["decision"]["suppression_rule"] == (
             "workaround-123"
         )
+
+
+class TestRootCauseEvidenceReporterIntegration:
+    """G29 Phase 6 follow-up: RootCauseCorrelator's evidence-ranked groups,
+    end to end through reporter.py's JSON output."""
+
+    def _correlated_pair(self) -> tuple[Change, Change]:
+        removed = _change(
+            kind=ChangeKind.FUNC_REMOVED,
+            symbol="internal_helper",
+            description="internal_helper removed",
+        )
+        leaked = _change(
+            kind=ChangeKind.INTERNAL_SYMBOL_REQUIRED_BY_PUBLIC_API,
+            symbol="internal_helper",
+            description="internal_helper required by public entry",
+            caused_by_type="internal_helper",
+        )
+        return removed, leaked
+
+    def test_default_mode_carries_root_cause_evidence(self) -> None:
+        removed, leaked = self._correlated_pair()
+        result = DiffResult(
+            old_version="1.0",
+            new_version="2.0",
+            library="libfoo.so",
+            changes=[removed, leaked],
+        )
+        payload = json.loads(reporter.to_json(result))
+        evidences = [
+            c["impact_assessment"]["root_cause_evidence"] for c in payload["changes"]
+        ]
+        assert len(evidences) == 2
+        for evidence in evidences:
+            assert evidence["strongest_evidence_level"] == "call_graph_proven"
+            assert evidence["evidence_levels"] == [
+                "artifact_proven",
+                "call_graph_proven",
+            ]
+        assert {e["evidence_level"] for e in evidences} == {
+            "artifact_proven",
+            "call_graph_proven",
+        }
+
+    def test_root_cause_mode_groups_carry_evidence_summary(self) -> None:
+        removed, leaked = self._correlated_pair()
+        result = DiffResult(
+            old_version="1.0",
+            new_version="2.0",
+            library="libfoo.so",
+            changes=[removed, leaked],
+        )
+        payload = json.loads(reporter.to_json(result, report_mode="root-cause"))
+        assert len(payload["root_causes"]) == 1
+        group = payload["root_causes"][0]
+        assert group["strongest_evidence_level"] == "call_graph_proven"
+        assert group["evidence_levels"] == ["artifact_proven", "call_graph_proven"]
+
+    def test_uncorrelated_finding_has_no_root_cause_evidence(self) -> None:
+        change = _change(kind=ChangeKind.FUNC_PARAMS_CHANGED, symbol="foo")
+        result = DiffResult(
+            old_version="1.0", new_version="2.0", library="libfoo.so", changes=[change]
+        )
+        payload = json.loads(reporter.to_json(result))
+        entry = payload["changes"][0]
+        assessment = entry.get("impact_assessment", {})
+        assert "root_cause_evidence" not in assessment

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -802,6 +802,68 @@ class TestImpactAssessmentRootCause:
             "ns::internal::helper"
         )
 
+    def test_correlates_evidence_via_a_scoped_only_sibling(self):
+        """G29 Phase 6 follow-up (Codex review): a regular finding in
+        result.changes that only correlates via a scoped-only
+        (--used-by/--required-symbol) sibling must still get
+        impact_assessment.root_cause_evidence -- RootCauseCorrelator needs
+        the actual scoped-only Change object, not just its caused_by_type
+        string, to recognize the pair as a multi-piece group."""
+        root = Change(
+            ChangeKind.FUNC_REMOVED,
+            "ns::internal::helper",
+            "helper removed",
+        )
+        scoped_only_overlay = Change(
+            ChangeKind.CONSUMER_REQUIRED_SYMBOL_REMOVED,
+            "pub_entry",
+            "required by consumer",
+            caused_by_type="ns::internal::helper",
+        )
+        r = _result(Verdict.BREAKING, changes=[root])
+        r.scoped_only_changes = (scoped_only_overlay,)  # type: ignore[attr-defined]
+        d = json.loads(to_json(r))  # report_mode defaults to "full"
+        evidence = d["changes"][0]["impact_assessment"]["root_cause_evidence"]
+        assert evidence["strongest_evidence_level"] == "consumer_proven"
+        assert evidence["evidence_levels"] == ["artifact_proven", "consumer_proven"]
+
+    def test_leaf_mode_also_correlates_evidence_via_scoped_only_sibling(self):
+        root = Change(
+            ChangeKind.FUNC_REMOVED,
+            "ns::internal::helper",
+            "helper removed",
+        )
+        scoped_only_overlay = Change(
+            ChangeKind.CONSUMER_REQUIRED_SYMBOL_REMOVED,
+            "pub_entry",
+            "required by consumer",
+            caused_by_type="ns::internal::helper",
+        )
+        r = _result(Verdict.BREAKING, changes=[root])
+        r.scoped_only_changes = (scoped_only_overlay,)  # type: ignore[attr-defined]
+        d = json.loads(to_json(r, report_mode="leaf"))
+        evidence = d["changes"][0]["impact_assessment"]["root_cause_evidence"]
+        assert evidence["strongest_evidence_level"] == "consumer_proven"
+
+    def test_root_cause_mode_group_evidence_via_scoped_only_sibling(self):
+        root = Change(
+            ChangeKind.FUNC_REMOVED,
+            "ns::internal::helper",
+            "helper removed",
+        )
+        scoped_only_overlay = Change(
+            ChangeKind.CONSUMER_REQUIRED_SYMBOL_REMOVED,
+            "pub_entry",
+            "required by consumer",
+            caused_by_type="ns::internal::helper",
+        )
+        r = _result(Verdict.BREAKING, changes=[root])
+        r.scoped_only_changes = (scoped_only_overlay,)  # type: ignore[attr-defined]
+        d = json.loads(to_json(r, report_mode="root-cause"))
+        assert len(d["root_causes"]) == 1
+        group = d["root_causes"][0]
+        assert group["strongest_evidence_level"] == "consumer_proven"
+
     def test_matches_root_cause_mode_id(self):
         # Cross-check: the unconditional impact_assessment id must equal
         # --report-mode root-cause's own root_cause_id for the same root.

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -864,6 +864,48 @@ class TestImpactAssessmentRootCause:
         group = d["root_causes"][0]
         assert group["strongest_evidence_level"] == "consumer_proven"
 
+    def test_root_cause_mode_group_evidence_for_bare_symbol_pair(self):
+        """Codex review: --used-by --verify-runtime's real shape -- a
+        FUNC_REMOVED and a CONSUMER_RUNTIME_LOAD_FAILED sharing a bare
+        symbol, neither carrying caused_by_type. RootCauseCorrelator merges
+        them (its own key is `caused_by_type or symbol`), but
+        _root_cause_key_and_display's "only caused_by_type correlates
+        findings" contract keeps each its own singleton report group (two
+        distinct `finding:<id>` keys) -- so matching group-level evidence by
+        root_cause_id equality would miss it entirely, even though each
+        finding's own per-finding root_cause_evidence already (correctly)
+        shows group membership. The group-level rollup must fold from the
+        members' own evidence instead."""
+        removed = Change(
+            ChangeKind.FUNC_REMOVED,
+            "regressed_symbol",
+            "symbol removed",
+        )
+        runtime_failed = Change(
+            ChangeKind.CONSUMER_RUNTIME_LOAD_FAILED,
+            "regressed_symbol",
+            "runtime load failed",
+        )
+        r = _result(Verdict.BREAKING, changes=[removed])
+        r.scoped_only_changes = (runtime_failed,)  # type: ignore[attr-defined]
+        d = json.loads(to_json(r, report_mode="root-cause"))
+        # Two singleton report groups (no caused_by_type link) -- the
+        # deliberate "first-slice" report-grouping contract, unaffected by
+        # this fix.
+        assert d["root_cause_count"] == 1
+        assert len(d["root_causes"][0]["findings"]) == 1
+        group = d["root_causes"][0]
+        assert group["strongest_evidence_level"] == "runtime_proven"
+        assert group["evidence_levels"] == ["artifact_proven", "runtime_proven"]
+        # The finding's own nested evidence already showed this (unaffected
+        # by the bug -- built directly from correlator membership).
+        assert (
+            d["changes"][0]["impact_assessment"]["root_cause_evidence"][
+                "strongest_evidence_level"
+            ]
+            == "runtime_proven"
+        )
+
     def test_matches_root_cause_mode_id(self):
         # Cross-check: the unconditional impact_assessment id must equal
         # --report-mode root-cause's own root_cause_id for the same root.

--- a/tests/test_sarif.py
+++ b/tests/test_sarif.py
@@ -1148,6 +1148,69 @@ class TestImpactAssessmentRootCause:
         assert full_ids == rc_ids
 
 
+class TestImpactAssessmentRootCauseEvidence:
+    """``impactAssessment.root_cause_evidence`` (G29 Phase 6 follow-up):
+    wiring RootCauseCorrelator's evidence-ranked groups into SARIF."""
+
+    def _correlated_result(self) -> object:
+        root = Change(
+            ChangeKind.FUNC_REMOVED,
+            "ns::internal::helper",
+            "helper removed",
+        )
+        overlay = Change(
+            ChangeKind.INTERNAL_SYMBOL_REQUIRED_BY_PUBLIC_API,
+            "pub_entry",
+            "required",
+            caused_by_type="ns::internal::helper",
+        )
+        return _make_result([root, overlay], verdict=Verdict.BREAKING)
+
+    def test_uncorrelated_finding_has_no_root_cause_evidence(self) -> None:
+        r = _make_result([_breaking_change()], verdict=Verdict.BREAKING)
+        doc = to_sarif(r)
+        props = doc["runs"][0]["results"][0]["properties"]
+        assessment = props.get("impactAssessment", {})
+        assert "root_cause_evidence" not in assessment
+
+    def test_correlated_findings_carry_evidence_summary(self) -> None:
+        r = self._correlated_result()
+        doc = to_sarif(r)
+        results = doc["runs"][0]["results"]
+        evidences = [
+            res["properties"]["impactAssessment"]["root_cause_evidence"]
+            for res in results
+        ]
+        for evidence in evidences:
+            assert evidence["strongest_evidence_level"] == "call_graph_proven"
+            assert evidence["evidence_levels"] == [
+                "artifact_proven",
+                "call_graph_proven",
+            ]
+        assert {e["evidence_level"] for e in evidences} == {
+            "artifact_proven",
+            "call_graph_proven",
+        }
+
+    def test_root_cause_evidence_unconditional_on_report_mode(self) -> None:
+        # Same evidence in both full and root-cause report modes -- unlike
+        # properties.rootCauseId (exclusive to root-cause mode),
+        # impactAssessment.root_cause_evidence is unconditional, mirroring
+        # root_cause_id/impact_group_id's own precedent.
+        r = self._correlated_result()
+        full_doc = to_sarif(r)
+        rc_doc = to_sarif(r, report_mode="root-cause")
+        full_evidence = [
+            res["properties"]["impactAssessment"]["root_cause_evidence"]
+            for res in full_doc["runs"][0]["results"]
+        ]
+        rc_evidence = [
+            res["properties"]["impactAssessment"]["root_cause_evidence"]
+            for res in rc_doc["runs"][0]["results"]
+        ]
+        assert full_evidence == rc_evidence
+
+
 class TestNotComparable:
     """ADR-050 D2 -- the comparability-gate hard-fail path has no DiffResult
     at all, so it gets its own dedicated renderer instead of to_sarif."""


### PR DESCRIPTION
## Summary

G29's `RootCauseCorrelator` (`abicheck.impact.correlation.correlate_root_causes`) was implemented in an earlier PR but its evidence-ranked groups were never surfaced on a report — the plan tracked this explicitly as "still open". This PR wires it into the JSON/SARIF `impact_assessment` surface (schema 2.29):

- Every finding that is a member of one of the correlator's multi-piece groups (the four load-failure kinds: `func_removed`, `internal_symbol_required_by_public_api`, `consumer_required_symbol_removed`, `consumer_runtime_load_failed`) now carries `impact_assessment.root_cause_evidence` — this finding's own `evidence_level`, plus the whole group's `strongest_evidence_level`/`evidence_levels`.
- Present in JSON (`changes[]`, `--report-mode leaf`, `suppression.suppressed_changes[]`, `appcompat_to_json`) and SARIF (`properties.impactAssessment`), unconditional on `report_mode` — mirroring the existing `root_cause_id`/`impact_group_id` precedent.
- JSON `--report-mode root-cause`'s `root_causes[]` groups gain the matching group-level `strongest_evidence_level`/`evidence_levels`.
- New `reporter_markdown.root_cause_evidence_lookup_for_changes` resolves this once per report, built directly from the correlator's own `Change` objects rather than by matching `root_cause_id` after the fact — so it stays correct independent of whether the two functions' grouping keys happen to agree for a given finding.

**Deliberately conservative:** this only *annotates* the existing `root_cause_id`/`impact_group_id` grouping (still `reporter_markdown`'s independent `caused_by_type`-else-`symbol` rule, unchanged) with the correlator's evidence ranking — it does not re-key or restructure anything. Every pre-existing report's `root_cause_id`/`impact_group_id` value is byte-for-byte unchanged. `impact_group_id` actually diverging from `root_cause_id` (re-bucketing findings through the correlator's own groups) remains open, documented as a distinct follow-up.

## Changes

- `abicheck/impact/model.py` — `ImpactAssessment.root_cause_evidence` field + `to_dict()`/`has_signal()` wiring.
- `abicheck/impact/engine.py` — `assess_change(..., root_cause_evidence=...)`, always recomputed fresh (never read from a cached `impact_assessment`, matching `root_cause_id`'s existing precedent).
- `abicheck/reporter_markdown.py` — new `root_cause_evidence_lookup_for_changes()`.
- `abicheck/reporter.py` / `abicheck/sarif.py` — wired through every relevant call site.
- `abicheck/schemas/__init__.py` + `abicheck/schemas/compare_report.schema.json` + `docs/reference/schemas/v1/compare_report.schema.json` — schema bumped to 2.29.
- `docs/learn/impact-analysis.md`, `docs/contribute/plans/g29-impact-analysis-layer.md` — updated to reflect the new field and remaining gap.
- `docs/use/output-formats.md` — fixed a doc-drift (`report_schema_version` example was still `2.28`), caught by `scripts/check_ai_readiness.py`.
- `changelog.d/20260812_080000_claude_g29_phase6_root_cause_evidence_wiring.md`.

## Testing

- New/updated tests in `tests/test_impact_model.py` and `tests/test_sarif.py` covering `root_cause_evidence` end to end (JSON + SARIF, full mode, root-cause mode, uncorrelated findings staying absent).
- `pytest tests/test_impact_model.py tests/test_root_cause_correlator.py tests/test_reporter.py tests/test_sarif.py tests/test_junit_report.py tests/test_junit_report_root_cause.py tests/test_report_schema.py tests/test_schemas_registry.py` — all pass.
- `mypy abicheck/` on touched files — clean.
- `ruff check` / `ruff format --check` on touched files — clean.
- `scripts/check_ai_readiness.py` — clean (pre-existing, unrelated ADR-verified-commit errors aside, caused by a stale local `origin/main` in this sandbox, not this change).
- `scripts/check_docs_contract.py` — 0 errors.
- Full fast unit suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`) was still running in the sandbox at PR-creation time due to environment slowness; will report back if it surfaces anything.

## Out of scope (per plan)

The eight new Phase 6 detector `ChangeKind`s (`PUBLIC_CONSUMER_COMPILED_DEPENDENCY_CHANGED`, `PUBLIC_TEMPLATE_INSTANTIATION_TARGET_CHANGED`, `PUBLIC_VIRTUAL_DISPATCH_SET_CHANGED`, `PUBLIC_MACRO_CONTRACT_CHANGED`, `PUBLIC_CALLBACK_TARGET_CHANGED`, `GRAPH_COVERAGE_INSUFFICIENT_FOR_SUPPRESSION`, `CONSUMER_IMPACT_PATH_CONFIRMED`, `USE_CASE_IMPACT_CONFIRMED`) and the `case194`-`case205` example pairs are a materially larger, separate follow-up and are not attempted in this PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHqTe4JKHA4ZuJigqdRNpZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DHqTe4JKHA4ZuJigqdRNpZ)_