### PR TITLE
fix(tests,docs): reduce perf-scaling test flakiness; fix stale capability-matrix prose

### DIFF
--- a/docs/reference/header-backend-capabilities.md
+++ b/docs/reference/header-backend-capabilities.md
@@ -262,24 +262,32 @@ this" apart from "abicheck saw no change".
   either. DWARF reads the compiler's artificial vptr member and does know the
   primary offset for real; the multiple-inheritance case needs both a model
   field that can hold more than one vptr and the `VTableContext` route above.
-- **`EnumType.underlying_type` on CastXML (and therefore hybrid).** Only the
-  clang backend populates it; a CastXML-parsed enum keeps the model default
-  `int` whatever the header declared. No diff detector reads the field
-  (`enum_underlying_size_changed` is computed from DWARF), but `tu_merge.py`'s
-  ODR-conflict check does — so a multi-TU CastXML dump cannot detect an
-  underlying-type conflict between two declarations of the same enum.
+- **`EnumType.underlying_type` on an unfixed enum, clang backend only.**
+  CastXML (and therefore hybrid, which inherits castxml's real answer here)
+  reads the compiler-picked underlying integer type correctly either way —
+  fixed or implementation-chosen. clang reads the real value only for a
+  *fixed* enum (`enum E : short`); for an unfixed enum it hard-codes `"int"`,
+  since clang's AST JSON exposes no compiler-selected-underlying-type fact
+  for that case at all (Codex review, PR #719 follow-up) — the true value can
+  differ (e.g. `unsigned int`, chosen from the member value range). No diff
+  detector reads the field (`enum_underlying_size_changed` is computed from
+  DWARF), but `tu_merge.py`'s ODR-conflict check does, so a multi-TU
+  `"clang"`-producer dump can still miss an underlying-type conflict on an
+  unfixed enum.
 - **Facts a hybrid merge does not inherit from clang.** A hybrid snapshot is
   castxml-based: only the fields `dumper_hybrid.py` explicitly backfills take
   clang's value. `is_template_pattern`, `has_anonymous_aggregate_fields` and
   `underlying_type` are not on that list, so for a declaration both backends
   saw, clang's answer is dropped. (For a declaration only clang saw, the whole
   entry is appended verbatim and the facts survive.)
-- **Opaque types are absent, not opaque, on the clang backend.** clang's
-  `parse_types` skips every non-definition, so a forward-declared handle type
-  (`struct Session;` with no definition in the public headers) simply does not
-  appear in a clang snapshot, where CastXML emits it with `is_opaque=True`.
-  Comparing across the two producers therefore sees a type that "does not
-  exist" rather than one that is incomplete.
+- **Opaque types — closed.** clang's `parse_types` previously skipped every
+  non-definition record entirely, so a forward-declared handle type
+  (`struct Session;` with no definition in the public headers) was simply
+  absent from a clang snapshot, where CastXML emitted it with
+  `is_opaque=True`. Closed in PR #719: clang now emits an opaque stub for a
+  forward-declaration-only identity too (see the `is_opaque` matrix row
+  above for the exact collapsing rule when both a forward decl and a
+  definition share one identity in the same TU).
 - **All three model fields this section used to flag as "nothing populates"
   now have a producer.** `Param.is_va_list` (schema v23) and
   `Variable.value`/`Variable.access` (schema v24), each closed in a G31

--- a/tests/_perf_scaling.py
+++ b/tests/_perf_scaling.py
@@ -49,10 +49,21 @@ def measure_scaling_exponent(
     per-call regression, and not the mean, which lets a single stalled
     scheduler tick dominate a small sample). The exponent is then the slope
     of an ordinary least-squares fit of ``log(elapsed)`` against ``log(n)``
-    over all ``sizes`` -- with 3+ sizes this is materially less sensitive to
-    any one size's noise than a two-point ratio, since a single outlier only
-    pulls the fitted line, it doesn't solely determine it the way it does
-    when there are only two points to begin with.
+    over all ``sizes``.
+
+    **``sizes`` must not be evenly spaced in log-space** (a plain geometric
+    progression like ``(500, 1000, 2000)`` is exactly that). OLS slope is
+    ``sum((x - mean_x) * (y - mean_y)) / sum((x - mean_x) ** 2)``; for an odd
+    count of log-evenly-spaced points, the middle point's ``x`` *equals*
+    ``mean_x`` exactly, so its ``(x - mean_x)`` term is zero and it drops out
+    of both sums regardless of its own timing -- the fit silently collapses
+    to the two endpoints' ratio, the exact single-sample sensitivity this
+    helper exists to avoid (confirmed empirically: three evenly log-spaced
+    points reproduce the endpoint-only slope to the last bit; caught by
+    review before this shipped). Callers must pick sizes with irregular
+    log-spacing (this module raises if they don't) -- an easy way is a
+    non-doubling step size, e.g. ``(500, 900, 1400, 2000)`` rather than
+    ``(500, 1000, 2000, 4000)``.
     """
     if len(sizes) < 2:
         raise ValueError("need at least two sizes to estimate a scaling exponent")
@@ -62,6 +73,16 @@ def measure_scaling_exponent(
         points.append((math.log(n), math.log(statistics.median(samples))))
     mean_x = sum(x for x, _ in points) / len(points)
     mean_y = sum(y for _, y in points) / len(points)
+    if len(points) > 2:
+        for x, _ in points:
+            if math.isclose(x, mean_x, rel_tol=1e-9, abs_tol=1e-9):
+                raise ValueError(
+                    f"sizes={sizes!r} are evenly spaced in log-space: a point "
+                    "sits exactly at the mean, so it contributes nothing to "
+                    "the least-squares slope and the fit silently degrades "
+                    "to a two-point ratio -- pick irregularly log-spaced "
+                    "sizes instead (see this function's docstring)"
+                )
     numerator = sum((x - mean_x) * (y - mean_y) for x, y in points)
     denominator = sum((x - mean_x) ** 2 for x, _ in points)
     if denominator == 0:

--- a/tests/_perf_scaling.py
+++ b/tests/_perf_scaling.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared sub-quadratic-scaling measurement for the perf integration tests.
+
+``test_perf_dump_scaling.py``, ``test_perf_dwarf_session_scaling.py``, and
+``test_performance.py`` each guarded an O(n^2) regression the same way: time
+one small size, time one 4x-larger size, and assert the two-point log-log
+ratio (the "exponent") stays under a fixed bound. That is a single sample of
+a noisy quantity (wall-clock time on a shared CI runner) turned directly into
+a pass/fail boundary -- one slow tick on either measurement swings the ratio
+by more than the bound's margin, which is exactly what a real run measured
+(exponent 1.98 against a 1.9 threshold, on an otherwise unregressed
+``main``). This module doesn't change what's being asserted (still a fixed
+sub-quadratic ceiling, not a base-vs-head relative regression -- that needs
+its own baseline-file design, out of scope here); it changes how the
+exponent is estimated, the same way the report's own recommendation did:
+more sizes, repeated per-size measurement collapsed with the median (not the
+mean, so one outlier tick doesn't drag the estimate), and an ordinary
+least-squares fit across every point instead of one point-to-point ratio.
+"""
+
+from __future__ import annotations
+
+import math
+import statistics
+from collections.abc import Callable
+
+
+def measure_scaling_exponent(
+    fn: Callable[[int], float], sizes: tuple[int, ...], *, repeats: int = 3
+) -> float:
+    """Least-squares log-log scaling exponent of ``fn(n)``'s elapsed seconds.
+
+    ``fn`` is called ``repeats`` times per size; the *median* elapsed time is
+    kept for that size (not the min, which would optimistically hide a real
+    per-call regression, and not the mean, which lets a single stalled
+    scheduler tick dominate a small sample). The exponent is then the slope
+    of an ordinary least-squares fit of ``log(elapsed)`` against ``log(n)``
+    over all ``sizes`` -- with 3+ sizes this is materially less sensitive to
+    any one size's noise than a two-point ratio, since a single outlier only
+    pulls the fitted line, it doesn't solely determine it the way it does
+    when there are only two points to begin with.
+    """
+    if len(sizes) < 2:
+        raise ValueError("need at least two sizes to estimate a scaling exponent")
+    points: list[tuple[float, float]] = []
+    for n in sizes:
+        samples = [max(fn(n), 1e-6) for _ in range(repeats)]
+        points.append((math.log(n), math.log(statistics.median(samples))))
+    mean_x = sum(x for x, _ in points) / len(points)
+    mean_y = sum(y for _, y in points) / len(points)
+    numerator = sum((x - mean_x) * (y - mean_y) for x, y in points)
+    denominator = sum((x - mean_x) ** 2 for x, _ in points)
+    if denominator == 0:
+        # Every size collapsed to the same log(n) -- can't happen with
+        # distinct positive sizes, but stay defined rather than dividing by
+        # zero if a caller ever passes duplicates.
+        return 0.0
+    return numerator / denominator

--- a/tests/test_perf_dump_scaling.py
+++ b/tests/test_perf_dump_scaling.py
@@ -61,12 +61,15 @@ def _compile_so(src: str, path: Path, *, debug: bool = False) -> None:
 def test_elf_parse_scaling_stays_subquadratic(tmp_path: Path) -> None:
     """Parsing a 4x-larger symbol table must not take ~16x longer.
 
-    Three sizes, median-of-3 per size, least-squares exponent (see
+    Four sizes, median-of-3 per size, least-squares exponent (see
     ``_perf_scaling.py``) instead of one size pair and one timing each — a
     single noisy tick on either end of a two-point ratio used to be able to
     fail this outright.
     """
-    sizes = (500, 1000, 2000)
+    # Deliberately *not* evenly log-spaced (see _perf_scaling.py's docstring)
+    # -- a plain doubling progression makes the middle point(s) contribute
+    # nothing to the least-squares slope.
+    sizes = (500, 900, 1400, 2000)
     compiled: dict[int, Path] = {}
 
     def _measure(n: int) -> float:
@@ -98,7 +101,10 @@ def test_dwarf_parse_scaling_stays_subquadratic(tmp_path: Path) -> None:
     library dump time — against an O(n^2) regression in the DIE walk. Same
     median-of-repeats/least-squares measurement as the ELF test above.
     """
-    sizes = (500, 1000, 2000)
+    # Deliberately *not* evenly log-spaced (see _perf_scaling.py's docstring)
+    # -- a plain doubling progression makes the middle point(s) contribute
+    # nothing to the least-squares slope.
+    sizes = (500, 900, 1400, 2000)
     compiled: dict[int, Path] = {}
 
     def _measure(n: int) -> float:

--- a/tests/test_perf_dump_scaling.py
+++ b/tests/test_perf_dump_scaling.py
@@ -17,13 +17,13 @@ Requires ``gcc`` on Linux (gcc produces Mach-O on macOS, PE on Windows).
 
 from __future__ import annotations
 
-import math
 import subprocess
 import sys
 import time
 from pathlib import Path
 
 import pytest
+from _perf_scaling import measure_scaling_exponent
 
 from abicheck.dwarf_metadata import parse_dwarf_metadata
 from abicheck.elf_metadata import parse_elf_metadata
@@ -59,19 +59,30 @@ def _compile_so(src: str, path: Path, *, debug: bool = False) -> None:
 
 @pytest.mark.integration
 def test_elf_parse_scaling_stays_subquadratic(tmp_path: Path) -> None:
-    """Parsing a 4x-larger symbol table must not take ~16x longer."""
-    timings: list[tuple[int, float]] = []
-    for n in (500, 2000):
-        so = tmp_path / f"lib{n}.so"
-        _compile_so(_gen_source(n), so)
+    """Parsing a 4x-larger symbol table must not take ~16x longer.
+
+    Three sizes, median-of-3 per size, least-squares exponent (see
+    ``_perf_scaling.py``) instead of one size pair and one timing each — a
+    single noisy tick on either end of a two-point ratio used to be able to
+    fail this outright.
+    """
+    sizes = (500, 1000, 2000)
+    compiled: dict[int, Path] = {}
+
+    def _measure(n: int) -> float:
+        so = compiled.get(n)
+        if so is None:
+            so = tmp_path / f"lib{n}.so"
+            _compile_so(_gen_source(n), so)
+            compiled[n] = so
         start = time.monotonic()
         meta = parse_elf_metadata(so)
-        timings.append((n, max(time.monotonic() - start, 1e-3)))
+        elapsed = max(time.monotonic() - start, 1e-3)
         exported = sum(1 for s in meta.symbols if s.name.startswith("func_"))
         assert exported >= n // 2, f"expected ~{n} exports, parsed {exported}"
+        return elapsed
 
-    (n1, t1), (n2, t2) = timings
-    exponent = math.log(t2 / t1) / math.log(n2 / n1)
+    exponent = measure_scaling_exponent(_measure, sizes)
     # True quadratic would be ~2.0; generous bound catches a real regression
     # without flaking on shared CI runners.
     assert exponent < 1.9, (
@@ -84,23 +95,29 @@ def test_dwarf_parse_scaling_stays_subquadratic(tmp_path: Path) -> None:
     """Parsing a 4x-larger DWARF DIE tree must not take ~16x longer.
 
     Guards ``parse_dwarf_metadata`` — the debug-info parse that dominates real
-    library dump time — against an O(n^2) regression in the DIE walk.
+    library dump time — against an O(n^2) regression in the DIE walk. Same
+    median-of-repeats/least-squares measurement as the ELF test above.
     """
-    timings: list[tuple[int, float]] = []
-    for n in (500, 2000):
-        so = tmp_path / f"libdw{n}.so"
-        _compile_so(_gen_dwarf_source(n), so, debug=True)
+    sizes = (500, 1000, 2000)
+    compiled: dict[int, Path] = {}
+
+    def _measure(n: int) -> float:
+        so = compiled.get(n)
+        if so is None:
+            so = tmp_path / f"libdw{n}.so"
+            _compile_so(_gen_dwarf_source(n), so, debug=True)
+            compiled[n] = so
         start = time.monotonic()
         meta = parse_dwarf_metadata(so)
-        timings.append((n, max(time.monotonic() - start, 1e-3)))
+        elapsed = max(time.monotonic() - start, 1e-3)
         # The DWARF parse should recover the per-TU structs (best-effort: skip
         # if this toolchain emitted no usable DWARF rather than asserting a count
         # that depends on the gcc/DWARF version).
         if not meta.structs:
             pytest.skip("no DWARF structs parsed (toolchain emitted no usable DWARF)")
+        return elapsed
 
-    (n1, t1), (n2, t2) = timings
-    exponent = math.log(t2 / t1) / math.log(n2 / n1)
+    exponent = measure_scaling_exponent(_measure, sizes)
     assert exponent < 1.9, (
         f"DWARF parse scaling exponent {exponent:.2f} regressed toward O(n^2)"
     )

--- a/tests/test_perf_dwarf_session_scaling.py
+++ b/tests/test_perf_dwarf_session_scaling.py
@@ -36,13 +36,13 @@ Requires ``g++`` on Linux (gcc/g++ produce Mach-O/PE elsewhere).
 
 from __future__ import annotations
 
-import math
 import subprocess
 import sys
 import time
 from pathlib import Path
 
 import pytest
+from _perf_scaling import measure_scaling_exponent
 
 pytestmark = [
     pytest.mark.integration,
@@ -55,6 +55,7 @@ pytestmark = [
 
 def _require_tool(name: str) -> None:
     import shutil
+
     if shutil.which(name) is None:
         pytest.skip(f"{name} not found in PATH")
 
@@ -87,7 +88,7 @@ def _compile_multi_cu_lib(tmp_path: Path, label: str, n_cus: int) -> Path:
         cpp = src_dir / f"cu{i}.cpp"
         cpp.write_text(
             f'#include "shared.h"\n'
-            f"extern \"C\" int use_{i}(void) {{\n"
+            f'extern "C" int use_{i}(void) {{\n'
             f"    scale::Box<int> b;\n"
             f"    b.value = {i};\n"
             f"    b.history.push_back({i});\n"
@@ -102,7 +103,9 @@ def _compile_multi_cu_lib(tmp_path: Path, label: str, n_cus: int) -> Path:
         r = subprocess.run(
             ["g++", "-shared", "-fPIC", "-g", "-Og", "-o", str(so_file)]
             + [str(c) for c in cpp_files],
-            capture_output=True, text=True, timeout=60,
+            capture_output=True,
+            text=True,
+            timeout=60,
         )
     except subprocess.TimeoutExpired:
         pytest.skip("g++ compilation timed out after 60s")
@@ -138,7 +141,9 @@ def test_session_reuse_faster_than_independent_opens(tmp_path: Path) -> None:
     t0 = time.perf_counter()
     dwarf_meta = parse_dwarf_metadata(so)
     dwarf_adv = parse_advanced_dwarf(so)
-    legacy_snap = build_snapshot_from_dwarf(so, elf_meta, dwarf_meta, dwarf_adv, version="legacy")
+    legacy_snap = build_snapshot_from_dwarf(
+        so, elf_meta, dwarf_meta, dwarf_adv, version="legacy"
+    )
     legacy_elapsed = max(time.perf_counter() - t0, 1e-4)
 
     # Current production path: one shared DwarfSession across all three passes.
@@ -168,7 +173,9 @@ def test_session_reuse_faster_than_independent_opens(tmp_path: Path) -> None:
     )
 
 
-def test_dwarf_only_dump_scaling_with_cu_count_stays_subquadratic(tmp_path: Path) -> None:
+def test_dwarf_only_dump_scaling_with_cu_count_stays_subquadratic(
+    tmp_path: Path,
+) -> None:
     """The production dwarf_only dump() path must not go quadratic as the
     number of compilation units grows — guards against a hidden O(n^2) in the
     session/cache path itself (e.g. a per-CU cache lookup that degrades),
@@ -178,17 +185,23 @@ def test_dwarf_only_dump_scaling_with_cu_count_stays_subquadratic(tmp_path: Path
     _require_tool("g++")
     from abicheck.dumper import dump
 
-    timings: list[tuple[int, float]] = []
-    for n_cus in (8, 32):
-        so = _compile_multi_cu_lib(tmp_path, f"scale{n_cus}", n_cus=n_cus)
+    n_cus_values = (8, 16, 32)
+    compiled: dict[int, Path] = {}
+
+    def _measure(n_cus: int) -> float:
+        so = compiled.get(n_cus)
+        if so is None:
+            so = _compile_multi_cu_lib(tmp_path, f"scale{n_cus}", n_cus=n_cus)
+            compiled[n_cus] = so
         start = time.perf_counter()
         snap = dump(so, [], dwarf_only=True)
         elapsed = max(time.perf_counter() - start, 1e-3)
-        timings.append((n_cus, elapsed))
         assert snap.functions, f"expected exported functions at n_cus={n_cus}"
+        return elapsed
 
-    (n1, t1), (n2, t2) = timings
-    exponent = math.log(t2 / t1) / math.log(n2 / n1)
+    # Three CU counts, median-of-3 per count, least-squares exponent (see
+    # ``_perf_scaling.py``) instead of one pair and one timing each.
+    exponent = measure_scaling_exponent(_measure, n_cus_values)
     # True quadratic would be ~2.0; matches the generous bound used by the
     # sibling single-CU scaling test to avoid flaking on shared CI runners.
     assert exponent < 1.9, (

--- a/tests/test_perf_dwarf_session_scaling.py
+++ b/tests/test_perf_dwarf_session_scaling.py
@@ -185,7 +185,10 @@ def test_dwarf_only_dump_scaling_with_cu_count_stays_subquadratic(
     _require_tool("g++")
     from abicheck.dumper import dump
 
-    n_cus_values = (8, 16, 32)
+    # Deliberately *not* evenly log-spaced (see _perf_scaling.py's docstring)
+    # -- a plain doubling progression makes the middle point(s) contribute
+    # nothing to the least-squares slope.
+    n_cus_values = (8, 12, 20, 32)
     compiled: dict[int, Path] = {}
 
     def _measure(n_cus: int) -> float:
@@ -199,7 +202,7 @@ def test_dwarf_only_dump_scaling_with_cu_count_stays_subquadratic(
         assert snap.functions, f"expected exported functions at n_cus={n_cus}"
         return elapsed
 
-    # Three CU counts, median-of-3 per count, least-squares exponent (see
+    # Four CU counts, median-of-3 per count, least-squares exponent (see
     # ``_perf_scaling.py``) instead of one pair and one timing each.
     exponent = measure_scaling_exponent(_measure, n_cus_values)
     # True quadratic would be ~2.0; matches the generous bound used by the

--- a/tests/test_perf_scaling_helper.py
+++ b/tests/test_perf_scaling_helper.py
@@ -99,21 +99,58 @@ def test_requires_at_least_two_sizes():
 
 
 def test_repeats_use_median_not_mean_or_min():
-    """A single high outlier among repeats must not dominate the estimate
-    the way a mean would, and the median must not optimistically pick the
-    minimum either."""
-    calls: dict[int, int] = {500: 0, 900: 0, 1400: 0, 2000: 0}
+    """Median-of-3 must recover the true exponent even with an outlier
+    present, in a fixture that would *actually* fail under mean or min
+    aggregation instead -- not one where all three aggregators happen to
+    agree (a constant-multiplier or negligible outlier changes a mean's
+    fitted *intercept*, not its slope, so a naive fixture can pass under
+    mean/min/median alike without exercising the median requirement at
+    all; caught by review on the first version of this test)."""
+    sizes = (500, 900, 1400, 2000)
+
+    def true_value(n: int) -> float:
+        return 0.001 * n  # exponent 1
+
+    def outlier(n: int) -> float:
+        # Quadratic (exponent 2) and strictly below true_value(n) at every
+        # tested size: never the sorted-middle element against two equal
+        # true_value(n) samples (so it can't become the median regardless
+        # of magnitude), but large enough -- and differently-shaped enough
+        # -- to visibly bend both a mean (true_value*2/3 plus a growing,
+        # not-negligible third term) and a min (which would just report the
+        # outlier outright) away from true_value's own exponent of 1.
+        return 4e-7 * n**2
+
+    assert all(outlier(n) < true_value(n) for n in sizes), (
+        "fixture precondition: outlier must never be the largest sample, "
+        "or median would stop recovering true_value exactly"
+    )
+
+    calls: dict[int, int] = dict.fromkeys(sizes, 0)
 
     def fn(n: int) -> float:
         calls[n] += 1
-        # Every call returns the same "true" value except one outlier per
-        # size that would drag a mean far off (but not a median of 3).
-        base = 0.001 * n
-        if calls[n] == 2:
-            return base * 100
-        return base
+        # Two of three repeats are the true value, so the median always
+        # recovers it exactly regardless of the outlier's magnitude; the
+        # third repeat is the outlier.
+        return outlier(n) if calls[n] == 2 else true_value(n)
 
-    exponent = measure_scaling_exponent(fn, (500, 900, 1400, 2000), repeats=3)
-    # True exponent is 1.0; a mean-based estimate polluted by the 100x
-    # outlier on every size would not land anywhere near this.
+    exponent = measure_scaling_exponent(fn, sizes, repeats=3)
     assert exponent == pytest.approx(1.0, abs=1e-6)
+
+    # Prove this fixture actually distinguishes the aggregators -- computed
+    # independently via the same least-squares formula the helper uses, not
+    # by calling the (median-only) helper again.
+    def _fit(vals: list[float]) -> float:
+        xs = [math.log(n) for n in sizes]
+        ys = [math.log(v) for v in vals]
+        mean_x = sum(xs) / len(xs)
+        mean_y = sum(ys) / len(ys)
+        num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+        den = sum((x - mean_x) ** 2 for x in xs)
+        return num / den
+
+    mean_exponent = _fit([(2 * true_value(n) + outlier(n)) / 3 for n in sizes])
+    min_exponent = _fit([min(true_value(n), outlier(n)) for n in sizes])
+    assert abs(mean_exponent - 1.0) > 0.1, "fixture doesn't actually distinguish mean"
+    assert abs(min_exponent - 1.0) > 0.1, "fixture doesn't actually distinguish min"

--- a/tests/test_perf_scaling_helper.py
+++ b/tests/test_perf_scaling_helper.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``_perf_scaling.measure_scaling_exponent`` itself.
+
+The perf integration tests that consume this helper need real compiled
+binaries and don't run in the default fast suite, so the helper's own
+correctness -- and in particular the degenerate-spacing guard added after a
+review round caught evenly log-spaced sizes silently collapsing the fit to a
+two-point ratio -- needs coverage that runs unconditionally.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from _perf_scaling import measure_scaling_exponent
+
+
+def test_recovers_known_linear_exponent():
+    """A function that scales exactly as ``n^1`` must fit to exponent ~1."""
+    exponent = measure_scaling_exponent(
+        lambda n: 0.001 * n, (500, 900, 1400, 2000), repeats=1
+    )
+    assert exponent == pytest.approx(1.0, abs=1e-6)
+
+
+def test_recovers_known_quadratic_exponent():
+    """A function that scales exactly as ``n^2`` must fit to exponent ~2."""
+    exponent = measure_scaling_exponent(
+        lambda n: 0.001 * n**2, (500, 900, 1400, 2000), repeats=1
+    )
+    assert exponent == pytest.approx(2.0, abs=1e-6)
+
+
+def test_evenly_log_spaced_three_points_rejected():
+    """A plain geometric progression must be rejected, not silently degrade
+    to a two-point ratio (Codex review: the middle point of an odd-length,
+    evenly log-spaced size set sits exactly at ``mean_x`` and contributes
+    zero to the least-squares slope regardless of its own timing)."""
+    with pytest.raises(ValueError, match="evenly spaced"):
+        measure_scaling_exponent(lambda n: 0.001 * n, (500, 1000, 2000), repeats=1)
+
+
+def test_evenly_log_spaced_five_points_rejected():
+    """The degenerate-spacing hazard isn't specific to three points: any odd
+    count of evenly log-spaced sizes has its exact middle point sit at
+    ``mean_x``, whatever the count."""
+    with pytest.raises(ValueError, match="evenly spaced"):
+        measure_scaling_exponent(
+            lambda n: 0.001 * n, (250, 500, 1000, 2000, 4000), repeats=1
+        )
+
+
+def test_middle_point_is_provably_ignored_without_the_guard():
+    """Direct proof of the bug the guard prevents: with evenly log-spaced
+    sizes, the fitted slope from 3 points equals the raw two-endpoint ratio
+    -- i.e. the middle point's own timing has *zero* effect on the result,
+    however it's chosen. Computed by hand (bypassing the guard) rather than
+    asserted against the guarded function, since the guard's whole job is to
+    refuse to compute this value at all."""
+    sizes = (500, 1000, 2000)
+    xs = [math.log(n) for n in sizes]
+    mean_x = sum(xs) / len(xs)
+
+    def slope_for(mid_y: float) -> float:
+        ys = [math.log(0.001 * sizes[0]), mid_y, math.log(0.001 * sizes[2])]
+        mean_y = sum(ys) / len(ys)
+        num = sum((x - mean_x) * (y - mean_y) for x, y in zip(xs, ys))
+        den = sum((x - mean_x) ** 2 for x in xs)
+        return num / den
+
+    endpoint_slope = (math.log(0.001 * sizes[2]) - math.log(0.001 * sizes[0])) / (
+        xs[2] - xs[0]
+    )
+    # Two wildly different guesses for the middle point's own value produce
+    # the identical slope -- proof the middle point is inert, not just
+    # under-weighted.
+    assert slope_for(-100.0) == pytest.approx(endpoint_slope, rel=1e-9)
+    assert slope_for(100.0) == pytest.approx(endpoint_slope, rel=1e-9)
+
+
+def test_requires_at_least_two_sizes():
+    with pytest.raises(ValueError, match="at least two"):
+        measure_scaling_exponent(lambda n: 1.0, (500,))
+
+
+def test_repeats_use_median_not_mean_or_min():
+    """A single high outlier among repeats must not dominate the estimate
+    the way a mean would, and the median must not optimistically pick the
+    minimum either."""
+    calls: dict[int, int] = {500: 0, 900: 0, 1400: 0, 2000: 0}
+
+    def fn(n: int) -> float:
+        calls[n] += 1
+        # Every call returns the same "true" value except one outlier per
+        # size that would drag a mean far off (but not a median of 3).
+        base = 0.001 * n
+        if calls[n] == 2:
+            return base * 100
+        return base
+
+    exponent = measure_scaling_exponent(fn, (500, 900, 1400, 2000), repeats=3)
+    # True exponent is 1.0; a mean-based estimate polluted by the 100x
+    # outlier on every size would not land anywhere near this.
+    assert exponent == pytest.approx(1.0, abs=1e-6)

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -406,8 +406,15 @@ class TestTypeChurnScaling:
         # is inside the timed/repeated measurement. Deliberately *not* evenly
         # log-spaced (see _perf_scaling.py's docstring) -- a plain doubling
         # progression makes the middle point(s) contribute nothing to the
-        # least-squares slope.
-        snapshots = {n: _build_type_churn(n) for n in (500, 900, 1400, 2000)}
+        # least-squares slope. Floor kept at the original test's 1000, not
+        # lowered to 500: fixed per-call `compare()` overhead (C + a*n^2)
+        # flattens the *apparent* exponent at small n, so including a
+        # smaller size measurably dilutes sensitivity to a real quadratic
+        # regression (Codex review: verified numerically that a synthetic
+        # C + a*n^2 regression fits to ~1.88 -- under this test's own 1.9
+        # ceiling -- with a 500-inclusive sweep, against ~1.95 -- correctly
+        # over it -- with the original 1000-floor sweep).
+        snapshots = {n: _build_type_churn(n) for n in (1000, 1300, 1650, 2000)}
 
         def _measure(n: int) -> float:
             old, new = snapshots[n]
@@ -422,6 +429,34 @@ class TestTypeChurnScaling:
         # to genuine O(n^2) (exponent >= 1.9) should fail this guard.
         assert exponent < 1.9, (
             f"compare scaling exponent {exponent:.2f} regressed toward O(n^2)"
+        )
+
+    def test_scaling_sizes_still_catch_a_synthetic_quadratic_regression(self) -> None:
+        """Regression guard for the guard: pin the sensitivity argument in
+        the comment above with an executable check, so a future change back
+        to a smaller-inclusive sweep (e.g. re-adding 500) is caught here
+        directly rather than only by comment (Codex review, fresh evidence).
+
+        Models fixed-overhead-plus-quadratic ``compare()`` cost as
+        ``C + a*n**2`` with ``C`` set to the same proportion of ``a*1000**2``
+        used to verify this sizing choice, and asserts the *current* size
+        sweep still fits that synthetic regression above the 1.9 ceiling --
+        i.e. this test would actually fail if the regression it exists to
+        catch really happened.
+        """
+        sizes = (1000, 1300, 1650, 2000)
+        a = 1.0
+        c = 0.05 * a * 1000**2
+
+        def synthetic_regressed_cost(n: int) -> float:
+            return c + a * n**2
+
+        exponent = measure_scaling_exponent(synthetic_regressed_cost, sizes, repeats=1)
+        assert exponent >= 1.9, (
+            f"the current size sweep {sizes} fits a synthetic C + a*n^2 "
+            f"regression to exponent {exponent:.3f}, under the 1.9 ceiling "
+            "the real test asserts against -- it would silently pass a real "
+            "quadratic regression"
         )
 
 

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -403,8 +403,11 @@ class TestTypeChurnScaling:
 
     def test_type_churn_scaling_stays_subquadratic(self) -> None:
         # Pre-build the snapshot pair per size once; only `compare()` itself
-        # is inside the timed/repeated measurement.
-        snapshots = {n: _build_type_churn(n) for n in (500, 1000, 2000)}
+        # is inside the timed/repeated measurement. Deliberately *not* evenly
+        # log-spaced (see _perf_scaling.py's docstring) -- a plain doubling
+        # progression makes the middle point(s) contribute nothing to the
+        # least-squares slope.
+        snapshots = {n: _build_type_churn(n) for n in (500, 900, 1400, 2000)}
 
         def _measure(n: int) -> float:
             old, new = snapshots[n]
@@ -412,7 +415,7 @@ class TestTypeChurnScaling:
             compare(old, new)
             return max(time.monotonic() - start, 1e-3)
 
-        # Three sizes, median-of-3 per size, least-squares exponent (see
+        # Four sizes, median-of-3 per size, least-squares exponent (see
         # ``_perf_scaling.py``) instead of one size pair and one timing each.
         exponent = measure_scaling_exponent(_measure, tuple(snapshots))
         # True quadratic would be ~2.0; current behaviour is ~1.3. A regression

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -10,6 +10,7 @@ import json
 import time
 
 import pytest
+from _perf_scaling import measure_scaling_exponent
 
 from abicheck.checker import Change, ChangeKind, DiffResult, Verdict, compare
 from abicheck.html_report import generate_html_report
@@ -401,17 +402,19 @@ class TestTypeChurnScaling:
         assert len(result.changes) > 0
 
     def test_type_churn_scaling_stays_subquadratic(self) -> None:
-        import math
+        # Pre-build the snapshot pair per size once; only `compare()` itself
+        # is inside the timed/repeated measurement.
+        snapshots = {n: _build_type_churn(n) for n in (500, 1000, 2000)}
 
-        timings: list[tuple[int, float]] = []
-        for n in (1000, 2000):
-            old, new = _build_type_churn(n)
+        def _measure(n: int) -> float:
+            old, new = snapshots[n]
             start = time.monotonic()
             compare(old, new)
-            timings.append((n, max(time.monotonic() - start, 1e-3)))
+            return max(time.monotonic() - start, 1e-3)
 
-        (n1, t1), (n2, t2) = timings
-        exponent = math.log(t2 / t1) / math.log(n2 / n1)
+        # Three sizes, median-of-3 per size, least-squares exponent (see
+        # ``_perf_scaling.py``) instead of one size pair and one timing each.
+        exponent = measure_scaling_exponent(_measure, tuple(snapshots))
         # True quadratic would be ~2.0; current behaviour is ~1.3. A regression
         # to genuine O(n^2) (exponent >= 1.9) should fail this guard.
         assert exponent < 1.9, (


### PR DESCRIPTION
## Summary

Reduces flakiness in the four DWARF/ELF/type-churn sub-quadratic scaling guards, and fixes two stale bullets in `docs/reference/header-backend-capabilities.md` that contradicted the page's own generated capability table.

## Motivation

A prior audit of `main`'s CI health flagged `test_perf_dump_scaling.py`'s DWARF scaling test as a source of red CI: a real run measured a scaling exponent of 1.98 against the 1.9 pass threshold, without a real regression. The root cause is structural, not a one-off fluke: every one of these four tests estimated its exponent from **exactly two sizes and one timing per size** — a single slow scheduler tick on either measurement can swing a two-point log-log ratio past the threshold on an otherwise healthy `main`.

Separately, verifying an older scan report's backend-capability claims against current `main` found that `header-backend-capabilities.md`'s hand-authored "Known gaps" section had drifted stale relative to its own generated fact-matrix table (`EnumType.underlying_type` and opaque-forward-declaration handling were both already fixed on the CastXML/clang backends, but the prose still described the old, broken behavior).

## Changes

- Adds `tests/_perf_scaling.py` — a shared `measure_scaling_exponent()` helper: times 3 sizes, keeps the *median* of 3 repeats per size (not min/mean), and fits the exponent via ordinary least squares across all points instead of one point-to-point ratio. The pass/fail threshold (`exponent < 1.9`) is unchanged — only the estimate feeding it is more robust to single-sample noise.
- Wires the helper into all four affected tests:
  - `test_perf_dump_scaling.py::test_elf_parse_scaling_stays_subquadratic`
  - `test_perf_dump_scaling.py::test_dwarf_parse_scaling_stays_subquadratic`
  - `test_perf_dwarf_session_scaling.py::test_dwarf_only_dump_scaling_with_cu_count_stays_subquadratic`
  - `test_performance.py::TestTypeChurnScaling::test_type_churn_scaling_stays_subquadratic`
  - Compiled `.so` fixtures are built once per size and reused across the repeated timing passes, so this doesn't multiply compile cost by the repeat count.
- Fixes two stale "Known gaps" bullets in `docs/reference/header-backend-capabilities.md` (hand-authored prose, `generated: false` — the generated fact-matrix table itself was already correct):
  - `EnumType.underlying_type` — CastXML (and hybrid) is now full; only clang's *unfixed*-enum case stays partial.
  - Opaque forward declarations — closed on the clang backend in PR #719; the bullet still described the pre-#719 "absent, not opaque" behavior.

## Verification

- All four affected tests re-run manually against real `gcc`/`g++` output (pass).
- `mypy abicheck/` — clean.
- `python scripts/check_ai_readiness.py` — no new errors/warnings (the 2 pre-existing ADR-receipt errors are unrelated and reproduce identically on unmodified `main`).
- `python scripts/check_docs_contract.py` — no new warnings.
- `ruff check`/`ruff format --check` on the touched files — clean.

Out of scope for this PR (each is its own larger, separately-scoped design per this repo's "known gaps over risky reactive patches" convention, not attempted here):
- A true base-vs-head *relative* regression model (like `test_header_graph_perf_gate.py`'s baseline-file approach) for these four tests — this PR only makes the existing fixed-threshold estimate less noisy.
- The Windows-only `test_collect_source_graph_folds_override_and_macro_graph_passes` CI failure, which needs a Windows runner to diagnose and isn't reproducible from source alone.

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md` (N/A: this PR touches only `tests/` and `docs/`, not `abicheck/**/*.py`)
- [x] Docs updated if user-visible behaviour changed
- [x] `pre-commit run --all-files`-equivalent checks (`ruff check`, `ruff format --check`, `mypy`) pass locally on touched files
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012evgzjnCXJDw3diTyKkEVp)_