### PR TITLE
feat(policy): selector-scoped reclassification (reclassify:)

### DIFF
--- a/abicheck/checker.py
+++ b/abicheck/checker.py
@@ -762,7 +762,8 @@ def compare(
             Available: "strict_abi" (default), "sdk_vendor", "plugin_abi".
             Ignored when *policy_file* is provided.
         policy_file: Optional :class:`~abicheck.policy_file.PolicyFile` instance
-            for user-defined per-kind verdict overrides.  When provided,
+            for user-defined per-kind (``overrides:``) or selector-scoped
+            (``reclassify:``) verdict re-classification.  When provided,
             *policy* is used only as the ``base_policy`` fallback inside the
             file (i.e. the file's own ``base_policy`` field takes precedence).
         env_matrix: Optional declared deployment constraints (ADR-020b). When

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1008,6 +1008,11 @@ def _attach_suppression_audit(result: Any, suppression: Any) -> None:
         + list(result.suppressed_changes)
         + list(getattr(result, "scoped_only_changes", ()) or ()),
         breaking_kinds=effective_breaking_kinds,
+        # Codex review: a selector-scoped `reclassify:` rule isn't
+        # expressible in effective_breaking_kinds at all (that's a
+        # kind-wide set); pass the policy file through so `audit()` can
+        # classify a reclassified finding by its own rule's resolution.
+        policy_file=getattr(result, "policy_file", None),
     )
 
 

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -393,7 +393,8 @@ def policy_options(func: F) -> F:
         "policy_file_path",
         type=POLICY_FILE_PARAM,
         default=None,
-        help="YAML policy file with per-kind verdict overrides, or a built-in name "
+        help="YAML policy file with per-kind ('overrides:') or selector-scoped "
+        "('reclassify:') verdict re-classification, or a built-in name "
         "(e.g. 'security'). Overrides --policy.",
     )(func)
     func = click.option(

--- a/abicheck/cli_scan_baseline.py
+++ b/abicheck/cli_scan_baseline.py
@@ -342,6 +342,17 @@ def _blocking_compatible_changes(diff: Any, blamed: set[str]) -> list[Any]:
     gate itself routed through -- so the two cannot disagree about which
     category a finding belongs to, and an ADR-027 per-finding demotion is
     honoured identically in both.
+
+    Passes ``diff.policy_file`` through, not just ``diff._effective_kind_sets()``
+    (Codex review): a kind-global `overrides:` entry is already baked into
+    the kind sets, but a selector-scoped `reclassify:` rule (A: selector-
+    scoped reclassification) isn't expressible as a kind set at all -- only
+    the real ``PolicyFile`` object can answer "did a rule reclassify *this
+    symbol*". Without it, a `reclassify:`-demoted finding that still blocks
+    the gate (e.g. reclassified to a category the severity preset also
+    errors on) was silently missing from the scan's own blocking-findings
+    report, even though the gate itself (`_build_severity_json`, which does
+    already pass `policy_file`) correctly named it as blocking.
     """
     from .severity import classify_change_object
 
@@ -352,6 +363,7 @@ def _blocking_compatible_changes(diff: Any, blamed: set[str]) -> list[Any]:
                 change,
                 policy=getattr(diff, "policy", None),
                 kind_sets=diff._effective_kind_sets(),
+                policy_file=getattr(diff, "policy_file", None),
             )
         except Exception:  # pragma: no cover - duck-typed stand-ins in tests
             continue

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -639,6 +639,12 @@ def _confidence_html(result: object) -> str:
             for k, v in policy_file.overrides.items()
         )
         rows.append(f"<tr><th>Policy overrides</th><td>{overrides}</td></tr>")
+    if policy_file and getattr(policy_file, "reclassify", None):
+        # Codex review: mirrors the JSON `policy_reclassify` disclosure
+        # (reporter.py's `_add_policy_overrides`) -- the active rule set,
+        # not a per-finding "which rule fired" attribution.
+        rules = ", ".join(h(rule.describe()) for rule in policy_file.reclassify)
+        rows.append(f"<tr><th>Policy reclassify</th><td>{rules}</td></tr>")
     for w in cov_warns:
         rows.append(f"<tr><th>Coverage gap</th><td>{h(w)}</td></tr>")
 

--- a/abicheck/html_report.py
+++ b/abicheck/html_report.py
@@ -642,9 +642,15 @@ def _confidence_html(result: object) -> str:
     if policy_file and getattr(policy_file, "reclassify", None):
         # Codex review: mirrors the JSON `policy_reclassify` disclosure
         # (reporter.py's `_add_policy_overrides`) -- the active rule set,
-        # not a per-finding "which rule fired" attribution.
-        rules = ", ".join(h(rule.describe()) for rule in policy_file.reclassify)
-        rows.append(f"<tr><th>Policy reclassify</th><td>{rules}</td></tr>")
+        # not a per-finding "which rule fired" attribution. Filtered through
+        # active_reclassify_rules so an expired rule isn't disclosed as
+        # though it were still in effect.
+        from .reclassify import active_reclassify_rules
+
+        active_rules = active_reclassify_rules(policy_file.reclassify)
+        if active_rules:
+            rules = ", ".join(h(rule.describe()) for rule in active_rules)
+            rows.append(f"<tr><th>Policy reclassify</th><td>{rules}</td></tr>")
     for w in cov_warns:
         rows.append(f"<tr><th>Coverage gap</th><td>{h(w)}</td></tr>")
 

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -819,14 +819,52 @@ class PolicyFile:
         # a kind-global `overrides:` entry or a selector-scoped one; a rule
         # bypassing the CLI's HIGH RISK diagnostic purely by being
         # selector-scoped instead of global would make the new primitive a
-        # blind spot for the same safety check. Only a rule that names a
-        # `change_kind` can be checked here -- a rule scoped purely by
-        # symbol/pattern with no kind filter applies to whichever kind a
-        # matching finding happens to carry, and there is no single
-        # `base_verdict` to compare against without one.
+        # blind spot for the same safety check. A rule that names a
+        # `change_kind` is checked against that kind's own base verdict
+        # below, same as `overrides:`. A rule scoped purely by symbol/pattern
+        # with no kind filter applies to whichever kind a matching finding
+        # happens to carry, so there's no single `base_verdict` to compare
+        # against -- that shape gets its own, more conservative check inside
+        # the loop instead of being silently skipped (a second Codex review
+        # round: skipping it entirely left a kind-unscoped 'ignore'/'risk'
+        # rule with no safety diagnostic at all, even though it's the
+        # widest-blast-radius shape a reclassify rule can take).
         slug_to_kind = {k.value: k for k in ChangeKind}
         for rule in self.reclassify:
             if rule.change_kind is None:
+                # A kind-unscoped rule (selector fields only, e.g. `symbol:`/
+                # `symbol_pattern:` with no `kind:`) applies to *whichever*
+                # kind a matching finding happens to carry, including a
+                # critical one like `func_removed` (Codex review) -- there is
+                # no single `base_verdict` to compare against the way the
+                # kind-scoped branch below does, so this can't reproduce the
+                # exact "downgraded from this base policy's own verdict for
+                # that kind" check. But a rule downgrading to 'ignore'/'risk'
+                # with no kind filter at all is inherently the widest,
+                # riskiest shape a reclassify rule can take -- it silences
+                # every kind a matching symbol/pattern could ever produce,
+                # critical kinds included -- so it's warned unconditionally
+                # rather than silently skipped, same spirit as the kind-scoped
+                # HIGH RISK/RISK diagnostics just phrased for the unknown-kind
+                # case.
+                if rule.to_verdict == Verdict.COMPATIBLE:
+                    warnings.append(
+                        f"HIGH RISK: reclassify rule downgrades to 'ignore' "
+                        f"with no 'kind:' filter ({rule.describe()}) — this "
+                        f"silences every finding kind a matching symbol "
+                        f"produces, including critical breaking kinds like "
+                        f"'func_removed'. Add a 'kind:' filter to scope this "
+                        f"rule, or verify this is intentional."
+                    )
+                elif rule.to_verdict == Verdict.COMPATIBLE_WITH_RISK:
+                    warnings.append(
+                        f"RISK: reclassify rule downgrades to 'risk' with no "
+                        f"'kind:' filter ({rule.describe()}) — this affects "
+                        f"every finding kind a matching symbol produces, "
+                        f"including critical breaking kinds. Add a 'kind:' "
+                        f"filter to scope this rule, or verify this is "
+                        f"intentional."
+                    )
                 continue
             kind = slug_to_kind[rule.change_kind]  # already validated at load time
             verdict = rule.to_verdict

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -37,6 +37,17 @@ Format example (``my_policy.yaml``)::
       param_renamed:         ignore
       calling_convention_changed: warn
 
+    # Optional: selector-scoped reclassification (see reclassify.py). Unlike
+    # `overrides:` above, each rule is scoped to a symbol/pattern/namespace
+    # selector -- same grammar as suppress:'s Suppression rules -- instead of
+    # applying to every symbol of that kind project-wide. Unlike suppress:,
+    # the finding is kept (reclassified), never deleted.
+    reclassify:
+      - kind: func_visibility_changed
+        symbol_pattern: "_ZN6oneapi3dal.*"
+        to: risk
+        reason: "COMDAT-inline demotions; consumers already embed their own copy"
+
 Usage::
 
     abicheck compare old.json new.json --policy-file my_policy.yaml
@@ -56,6 +67,7 @@ import contextvars
 import hashlib
 import threading
 from dataclasses import dataclass, field
+from datetime import date
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -68,8 +80,16 @@ from .checker_policy import (
 )
 from .errors import PolicyError
 
+# NOTE: `.reclassify` is deliberately imported lazily (function-local) below,
+# never at module top level. `reclassify.py` imports `.suppression`, which
+# imports `.checker_types`, which imports `PolicyFile` from *this* module --
+# a top-level import here would complete that cycle. This mirrors the
+# existing convention every `SuppressionList` consumer in this codebase
+# already follows for the same reason (see e.g. `checker.py`, `service.py`).
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from .reclassify import ReclassifyRule
 
 # Severity name -> Verdict mapping
 _SEVERITY_MAP: dict[str, Verdict] = {
@@ -246,6 +266,92 @@ def _parse_overrides(overrides_raw: Any, path: Path) -> dict[ChangeKind, Verdict
     return overrides
 
 
+def _parse_reclassify_expires(raw: Any, path: Path, index: int) -> date | None:
+    """Parse one ``reclassify[i].expires`` value (ISO 8601 string, or a
+    YAML-native date PyYAML already decoded)."""
+    if raw is None:
+        return None
+    if isinstance(raw, date):
+        return raw
+    if isinstance(raw, str):
+        try:
+            return date.fromisoformat(raw)
+        except ValueError as e:
+            raise PolicyError(
+                f"reclassify[{index}].expires in {path}: invalid date {raw!r} "
+                "(expected ISO 8601, e.g. 2026-06-01)"
+            ) from e
+    raise PolicyError(
+        f"reclassify[{index}].expires in {path}: must be a date, got "
+        + type(raw).__name__
+    )
+
+
+def _parse_reclassify(raw: Any, path: Path) -> list[ReclassifyRule]:
+    """Validate and parse the ``reclassify:`` block (A: selector-scoped
+    reclassification) into a list of :class:`ReclassifyRule`.
+
+    Unlike ``overrides:`` (keyed by ``ChangeKind`` alone), each entry here
+    carries the same selector grammar :mod:`abicheck.suppression` already
+    implements, plus a required ``to:`` severity -- see
+    ``abicheck/reclassify.py``'s module docstring.
+    """
+    from .reclassify import RECLASSIFY_KNOWN_KEYS, ReclassifyRule
+
+    if not isinstance(raw, list):
+        raise PolicyError(
+            "'reclassify' must be a YAML list of rules, got " + type(raw).__name__
+        )
+
+    rules: list[ReclassifyRule] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise PolicyError(
+                f"reclassify[{i}] in {path}: must be a YAML mapping, got "
+                + type(entry).__name__
+            )
+        unknown = set(entry) - RECLASSIFY_KNOWN_KEYS
+        if unknown:
+            raise PolicyError(
+                f"reclassify[{i}] in {path}: unknown key(s) {sorted(unknown)}. "
+                f"Valid keys: {sorted(RECLASSIFY_KNOWN_KEYS)}"
+            )
+        if "to" not in entry:
+            raise PolicyError(f"reclassify[{i}] in {path}: missing required 'to' field")
+        to_raw = entry["to"]
+        to_verdict = parse_severity_value(to_raw)
+        if to_verdict is None:
+            raise PolicyError(
+                f"reclassify[{i}] in {path}: invalid 'to' value {to_raw!r}. "
+                "Valid values: break, warn, risk, ignore"
+            )
+        kind = entry.get("kind")
+        if kind is not None and not isinstance(kind, str):
+            raise PolicyError(f"reclassify[{i}].kind in {path}: must be a string")
+
+        try:
+            rule = ReclassifyRule(
+                to_verdict=to_verdict,
+                to=str(to_raw),
+                symbol=entry.get("symbol"),
+                symbol_pattern=entry.get("symbol_pattern"),
+                type_pattern=entry.get("type_pattern"),
+                member_name=entry.get("member_name"),
+                namespace=entry.get("namespace"),
+                entity_namespace=entry.get("entity_namespace"),
+                cause_namespace=entry.get("cause_namespace"),
+                source_location=entry.get("source_location"),
+                change_kind=kind,
+                reason=entry.get("reason"),
+                label=entry.get("label"),
+                expires=_parse_reclassify_expires(entry.get("expires"), path, i),
+            )
+        except ValueError as e:
+            raise PolicyError(f"reclassify[{i}] in {path}: {e}") from e
+        rules.append(rule)
+    return rules
+
+
 def _parse_frozen_namespaces(frozen_raw: Any) -> list[str]:
     """Validate and parse the ``frozen_namespaces`` list of glob patterns."""
     if not isinstance(frozen_raw, list):
@@ -321,16 +427,24 @@ def _resolve_change_verdict(
     api_break: frozenset[Any],
     compatible: frozenset[Any],
     risk: frozenset[Any],
+    reclassify: list[ReclassifyRule] | None = None,
 ) -> Verdict:
     """Resolve the effective verdict for a single *change* object.
 
     Priority order (highest first):
     1. ``change.effective_verdict`` — ADR-025 / ADR-033 D7 modulation (frozen-
        namespace floor still applied).
-    2. ``overrides[kind]`` — per-kind policy override (frozen-namespace floor
+    2. ``reclassify:`` — the first selector-scoped rule (in file order) whose
+       selectors match this change (frozen-namespace floor still applied).
+       Consulted ahead of the kind-global ``overrides:`` entry for the same
+       kind since a rule scoped to a selector is strictly more specific than
+       one scoped to a bare kind (see ``abicheck/reclassify.py``).
+    3. ``overrides[kind]`` — per-kind policy override (frozen-namespace floor
        still applied; downgrades on frozen symbols are silently rejected).
-    3. Base policy verdict.
+    4. Base policy verdict.
     """
+    from .reclassify import first_matching_reclassify_verdict
+
     kind = change.kind
     fnv = getattr(change, "frozen_namespace_violation", None)
     frozen = isinstance(fnv, str) and bool(fnv)
@@ -343,6 +457,13 @@ def _resolve_change_verdict(
         return eff
 
     base_v = compute_verdict([change], policy=base_policy)
+
+    reclass_v = first_matching_reclassify_verdict(reclassify or [], change)
+    if reclass_v is not None:
+        if frozen and _VERDICT_ORDER.index(reclass_v) < _VERDICT_ORDER.index(base_v):
+            return base_v
+        return reclass_v
+
     if kind in overrides:
         override_v = overrides[kind]
         if frozen and _VERDICT_ORDER.index(override_v) < _VERDICT_ORDER.index(base_v):
@@ -389,6 +510,13 @@ class PolicyFile:
 
     base_policy: str = "strict_abi"
     overrides: dict[ChangeKind, Verdict] = field(default_factory=dict)
+    # A: selector-scoped reclassification (abicheck/reclassify.py) — the
+    # third policy-file primitive, between overrides: (kind-global, no
+    # selector) and suppress: (selector-scoped, but deletes the finding).
+    # Consulted ahead of `overrides[kind]` for the same kind in
+    # `compute_verdict`/`_resolve_change_verdict`, since a selector-scoped
+    # rule is strictly more specific than a bare-kind one.
+    reclassify: list[ReclassifyRule] = field(default_factory=list)
     source_path: Path | None = None
     #: sha256 of the exact raw bytes :meth:`load` read, when it loaded this
     #: document from a file. Captured at parse time on purpose: a consumer
@@ -482,6 +610,7 @@ class PolicyFile:
 
         base_policy = _parse_base_policy(raw)
         overrides = _parse_overrides(raw.get("overrides", {}), path)
+        reclassify = _parse_reclassify(raw.get("reclassify", []), path)
         frozen_namespaces = _parse_frozen_namespaces(raw.get("frozen_namespaces", []))
         internal_namespaces = _parse_internal_namespaces(raw.get("internal_namespaces", []))
         source_only, build_drift, graph_risk, require_evidence = _parse_evidence_policy(
@@ -491,6 +620,7 @@ class PolicyFile:
         return cls(
             base_policy=base_policy,
             overrides=overrides,
+            reclassify=reclassify,
             source_path=path,
             source_sha256=digest,
             frozen_namespaces=frozen_namespaces,
@@ -542,7 +672,8 @@ class PolicyFile:
 
         verdicts = [
             _resolve_change_verdict(
-                change, self.base_policy, self.overrides, _b, _a, _c, _r
+                change, self.base_policy, self.overrides, _b, _a, _c, _r,
+                self.reclassify,
             )
             for change in changes
         ]
@@ -562,6 +693,10 @@ class PolicyFile:
                 lines.append(f"  {kind.value}: {sev}")
         else:
             lines.append("overrides: (none)")
+        if self.reclassify:
+            lines.append("reclassify:")
+            for rule in self.reclassify:
+                lines.append(f"  {rule.describe()}")
         return "\n".join(lines)
 
     def validate_overrides(self) -> list[str]:

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -287,6 +287,39 @@ def _parse_reclassify_expires(raw: Any, path: Path, index: int) -> date | None:
     )
 
 
+#: reclassify[i] keys whose value must be a string when present -- every
+#: selector plus the free-text `reason`/`label` fields. `kind`/`to`/`expires`
+#: have their own dedicated, differently-shaped validation below and are
+#: deliberately not in this set.
+_RECLASSIFY_STRING_FIELDS: tuple[str, ...] = (
+    "symbol", "symbol_pattern", "type_pattern", "member_name", "namespace",
+    "entity_namespace", "cause_namespace", "source_location", "reason",
+    "label",
+)
+
+
+def _require_reclassify_string_field(
+    entry: dict[str, Any], key: str, index: int, path: Path
+) -> str | None:
+    """Validate one optional string-valued ``reclassify[i]`` field.
+
+    Codex review: a non-string value here (e.g. a bare YAML ``42``) either
+    crashes with an uncaught ``TypeError`` deep inside ``re.compile``/
+    ``fnmatch.translate`` (``symbol_pattern``/``type_pattern``/every
+    ``namespace`` variant) or loads silently and simply never matches
+    (``symbol``, compared via ``==`` against the always-string
+    ``change.symbol``) -- neither is the hard, up-front ``PolicyError`` this
+    module's other selector validation already gives every other bad value.
+    """
+    val = entry.get(key)
+    if val is None or isinstance(val, str):
+        return val
+    raise PolicyError(
+        f"reclassify[{index}].{key} in {path}: must be a string, got "
+        + type(val).__name__
+    )
+
+
 def _parse_reclassify(raw: Any, path: Path) -> list[ReclassifyRule]:
     """Validate and parse the ``reclassify:`` block (A: selector-scoped
     reclassification) into a list of :class:`ReclassifyRule`.
@@ -328,22 +361,26 @@ def _parse_reclassify(raw: Any, path: Path) -> list[ReclassifyRule]:
         kind = entry.get("kind")
         if kind is not None and not isinstance(kind, str):
             raise PolicyError(f"reclassify[{i}].kind in {path}: must be a string")
+        string_fields = {
+            key: _require_reclassify_string_field(entry, key, i, path)
+            for key in _RECLASSIFY_STRING_FIELDS
+        }
 
         try:
             rule = ReclassifyRule(
                 to_verdict=to_verdict,
                 to=str(to_raw),
-                symbol=entry.get("symbol"),
-                symbol_pattern=entry.get("symbol_pattern"),
-                type_pattern=entry.get("type_pattern"),
-                member_name=entry.get("member_name"),
-                namespace=entry.get("namespace"),
-                entity_namespace=entry.get("entity_namespace"),
-                cause_namespace=entry.get("cause_namespace"),
-                source_location=entry.get("source_location"),
+                symbol=string_fields["symbol"],
+                symbol_pattern=string_fields["symbol_pattern"],
+                type_pattern=string_fields["type_pattern"],
+                member_name=string_fields["member_name"],
+                namespace=string_fields["namespace"],
+                entity_namespace=string_fields["entity_namespace"],
+                cause_namespace=string_fields["cause_namespace"],
+                source_location=string_fields["source_location"],
                 change_kind=kind,
-                reason=entry.get("reason"),
-                label=entry.get("label"),
+                reason=string_fields["reason"],
+                label=string_fields["label"],
                 expires=_parse_reclassify_expires(entry.get("expires"), path, i),
             )
         except ValueError as e:

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -812,6 +812,48 @@ class PolicyFile:
                     f"'{kind.value}' (BREAKING) downgraded to 'ignore' — "
                     f"verify this is intentional."
                 )
+
+        # A: selector-scoped reclassification (Codex review) -- a
+        # `reclassify:` rule downgrading a critical/breaking kind is exactly
+        # the mistake this check exists to catch, whether it's expressed as
+        # a kind-global `overrides:` entry or a selector-scoped one; a rule
+        # bypassing the CLI's HIGH RISK diagnostic purely by being
+        # selector-scoped instead of global would make the new primitive a
+        # blind spot for the same safety check. Only a rule that names a
+        # `change_kind` can be checked here -- a rule scoped purely by
+        # symbol/pattern with no kind filter applies to whichever kind a
+        # matching finding happens to carry, and there is no single
+        # `base_verdict` to compare against without one.
+        slug_to_kind = {k.value: k for k in ChangeKind}
+        for rule in self.reclassify:
+            if rule.change_kind is None:
+                continue
+            kind = slug_to_kind[rule.change_kind]  # already validated at load time
+            verdict = rule.to_verdict
+            base_verdict = _raw_verdict_for_kind(
+                kind, base_breaking, base_api_break, base_compatible, base_risk
+            )
+            if _VERDICT_ORDER.index(verdict) >= _VERDICT_ORDER.index(base_verdict):
+                continue
+            selector = rule.describe()
+            if kind in _CRITICAL_BREAKING_KINDS:
+                if verdict == Verdict.COMPATIBLE:
+                    warnings.append(
+                        f"HIGH RISK: '{kind.value}' reclassified to 'ignore' "
+                        f"({selector}) — this is almost certainly a mistake. "
+                        f"This kind causes hard crashes when the ABI changes."
+                    )
+                elif verdict == Verdict.COMPATIBLE_WITH_RISK:
+                    warnings.append(
+                        f"RISK: '{kind.value}' reclassified to 'risk' "
+                        f"({selector}) — this kind usually causes binary "
+                        f"incompatibility. Consider keeping it as 'break'."
+                    )
+            elif kind in base_breaking and verdict == Verdict.COMPATIBLE:
+                warnings.append(
+                    f"'{kind.value}' (BREAKING) reclassified to 'ignore' "
+                    f"({selector}) — verify this is intentional."
+                )
         return warnings
 
 

--- a/abicheck/policy_file.py
+++ b/abicheck/policy_file.py
@@ -67,7 +67,7 @@ import contextvars
 import hashlib
 import threading
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -268,9 +268,21 @@ def _parse_overrides(overrides_raw: Any, path: Path) -> dict[ChangeKind, Verdict
 
 def _parse_reclassify_expires(raw: Any, path: Path, index: int) -> date | None:
     """Parse one ``reclassify[i].expires`` value (ISO 8601 string, or a
-    YAML-native date PyYAML already decoded)."""
+    YAML-native date/datetime PyYAML already decoded).
+
+    Checks ``datetime`` before ``date`` (Codex review): a ``datetime`` is
+    itself a ``date`` subclass, so an unquoted YAML timestamp like
+    ``2026-08-12T00:00:00`` -- which PyYAML decodes as a ``datetime``, not a
+    ``date`` -- would otherwise pass the ``isinstance(raw, date)`` branch
+    unnormalized and later crash ``Suppression.is_expired()``'s ``date.today()
+    > self.expires`` comparison (``TypeError``: can't compare ``date`` and
+    ``datetime``). Normalized to ``.date()`` here, mirroring
+    ``suppression.py``'s ``_parse_expires`` handling of the identical case.
+    """
     if raw is None:
         return None
+    if isinstance(raw, datetime):
+        return raw.date()
     if isinstance(raw, date):
         return raw
     if isinstance(raw, str):
@@ -553,7 +565,20 @@ class PolicyFile:
     # Consulted ahead of `overrides[kind]` for the same kind in
     # `compute_verdict`/`_resolve_change_verdict`, since a selector-scoped
     # rule is strictly more specific than a bare-kind one.
-    reclassify: list[ReclassifyRule] = field(default_factory=list)
+    #
+    # `kw_only=True` (Codex review): PolicyFile is public API (constructed
+    # positionally by external callers, e.g. `PolicyFile(base, overrides,
+    # source_path)`), and every field from here on was already assigned a
+    # position before this one existed. Inserting an ordinary positional
+    # field here would silently reinterpret every existing positional
+    # caller's `source_path` argument (and everything after it) as this
+    # field instead -- the exact `Change`-dataclass field-ordering mistake
+    # this repo's own AGENTS.md already documents and reverted once. A
+    # `kw_only` field is excluded from the positional section of the
+    # generated `__init__` regardless of where it's declared, so every
+    # existing positional call keeps binding to the exact fields it always
+    # did.
+    reclassify: list[ReclassifyRule] = field(default_factory=list, kw_only=True)
     source_path: Path | None = None
     #: sha256 of the exact raw bytes :meth:`load` read, when it loaded this
     #: document from a file. Captured at parse time on purpose: a consumer

--- a/abicheck/pr_comment.py
+++ b/abicheck/pr_comment.py
@@ -311,22 +311,42 @@ def _suppressed_count(report: dict[str, object]) -> int:
 
 
 def _reclassified_count(report: dict[str, object]) -> int:
-    """The number of ``changes`` whose kind was moved to a different verdict
-    bucket by a ``--policy-file`` override (``reporter._add_policy_overrides``'s
-    ``policy_overrides`` map: ``ChangeKind`` value -> overridden ``Verdict``).
+    """The number of ``changes`` whose verdict was moved to a different
+    bucket by a ``--policy-file`` reclassification -- either a kind-global
+    ``overrides:`` entry (``reporter._add_policy_overrides``'s
+    ``policy_overrides`` map: ``ChangeKind`` value -> overridden ``Verdict``)
+    or a selector-scoped ``reclassify:`` rule (``reporter._change_to_dict``'s
+    per-change ``reclassified_by`` marker).
 
-    ``0`` for a report without any overrides, which is every run that didn't
-    pass ``--policy-file``.
+    Counts each matching change once even if both mechanisms could apply --
+    a change carrying ``reclassified_by`` was, by construction, decided by
+    the ``reclassify:`` rule (:func:`abicheck.severity.
+    reclassify_rule_for_change` is consulted ahead of ``overrides:``, same
+    precedence as the run's own verdict), so it isn't double-counted against
+    ``policy_overrides`` too even when its kind also appears there (Codex
+    review: a selector-scoped rule silently bypassed this count and the "🔀
+    N findings reclassified" PR-comment notice entirely, since only the
+    kind-keyed ``overrides:`` map was recognized here -- a `func_removed`
+    downgraded to `ignore` by a `reclassify:` rule read as an unremarked
+    "safe" change).
+
+    ``0`` for a report with neither, which is every run that didn't pass
+    ``--policy-file``.
     """
     overrides = report.get("policy_overrides")
     changes = report.get("changes")
-    if not isinstance(overrides, dict) or not overrides or not isinstance(changes, list):
+    if not isinstance(changes, list):
         return 0
-    return sum(
-        1
-        for c in changes
-        if isinstance(c, dict) and str(c.get("kind", "")) in overrides
-    )
+    overrides_dict = overrides if isinstance(overrides, dict) else {}
+    count = 0
+    for c in changes:
+        if not isinstance(c, dict):
+            continue
+        if c.get("reclassified_by"):
+            count += 1
+        elif overrides_dict and str(c.get("kind", "")) in overrides_dict:
+            count += 1
+    return count
 
 
 def _breaking_categories(findings: list[Finding]) -> frozenset[str]:

--- a/abicheck/reclassify.py
+++ b/abicheck/reclassify.py
@@ -228,6 +228,16 @@ class ReclassifyRule:
                 bits.append(f"{field_name}={val!r}")
         if self.reason:
             bits.append(f"reason={self.reason!r}")
+        # Codex review: the Markdown/HTML report renderers call describe()
+        # to disclose an active rule, but a rule with no other reason to
+        # mention it (or with a label alongside a reason) was silently
+        # missing its own expiry -- a reader of those two formats had no
+        # way to tell when a temporary waiver stops applying. to_report_dict()
+        # already included both; describe() should too.
+        if self.label:
+            bits.append(f"label={self.label!r}")
+        if self.expires is not None:
+            bits.append(f"expires={self.expires.isoformat()!r}")
         return "reclassify(" + ", ".join(bits) + ")"
 
     def to_report_dict(self) -> dict[str, str]:

--- a/abicheck/reclassify.py
+++ b/abicheck/reclassify.py
@@ -97,7 +97,7 @@ from __future__ import annotations
 
 import importlib
 from dataclasses import dataclass, field
-from datetime import date
+from datetime import date, datetime
 from typing import Any
 
 from .checker_policy import Verdict
@@ -197,6 +197,18 @@ class ReclassifyRule:
                 f"Invalid to_verdict {self.to_verdict!r}. Valid values: "
                 f"{sorted(v.value for v in _VALID_RECLASSIFY_VERDICTS)}"
             )
+        # A datetime is itself a date subclass, so a Python caller
+        # constructing this rule directly with expires=datetime(...) would
+        # otherwise pass isinstance(expires, date) unnormalized and later
+        # crash Suppression.is_expired()'s `date.today() > self.expires`
+        # comparison (TypeError: can't compare date and datetime) -- the
+        # same YAML-unquoted-timestamp case policy_file.py's
+        # _parse_reclassify_expires already normalizes for the loader path,
+        # applied here too so direct construction (a public API surface,
+        # not just the policy-file loader) doesn't crash on the identical
+        # input shape (Codex review).
+        if isinstance(self.expires, datetime):
+            self.expires = self.expires.date()
         # Delegates all selector validation (mutual exclusivity, unknown
         # change_kind, malformed glob/regex, "at least one selector") to
         # Suppression's own __post_init__ -- a ValueError raised there

--- a/abicheck/reclassify.py
+++ b/abicheck/reclassify.py
@@ -117,6 +117,21 @@ _VALID_RECLASSIFY_VERDICTS: frozenset[Verdict] = frozenset({
     Verdict.COMPATIBLE,
 })
 
+#: The canonical ``to:`` spelling for each valid reclassify verdict --
+#: policy_file.py's `_SEVERITY_MAP` (``break``/``warn``/``risk``/``ignore``)
+#: read in reverse. Duplicated here rather than imported (a static import of
+#: policy_file.py would close the exact import cycle the module docstring
+#: describes) -- this is the whole vocabulary, four entries, and stable by
+#: construction (`_VALID_RECLASSIFY_VERDICTS` names the same four verdicts).
+#: Used by `ReclassifyRule.__post_init__` to canonicalize `self.to` so it can
+#: never disagree with `self.to_verdict` (Codex review).
+_CANONICAL_TO_SPELLING: dict[Verdict, str] = {
+    Verdict.BREAKING: "break",
+    Verdict.API_BREAK: "warn",
+    Verdict.COMPATIBLE_WITH_RISK: "risk",
+    Verdict.COMPATIBLE: "ignore",
+}
+
 
 def _suppression_cls() -> Any:
     """Resolve :class:`abicheck.suppression.Suppression` at call time --
@@ -156,8 +171,14 @@ class ReclassifyRule:
             already resolved from the raw ``to:`` spelling by the loader
             (:func:`abicheck.policy_file.parse_severity_value`), so this
             class carries no severity vocabulary of its own.
-        to: The raw ``to:`` spelling as written in the policy file, kept
-            only for :meth:`describe`/audit output.
+        to: The ``to:`` spelling, for :meth:`describe`/:meth:`to_report_dict`
+            audit output. Canonicalized in ``__post_init__`` to always match
+            ``to_verdict`` (see there) -- for a policy-file-loaded rule this
+            is simply the value the loader already passed in (the loader
+            derives ``to_verdict`` from this same spelling, so they already
+            agree); a directly-constructed rule (a public API surface) that
+            passes an inconsistent or omitted ``to`` gets it overwritten with
+            the canonical spelling for its ``to_verdict`` instead.
         symbol, symbol_pattern, type_pattern, member_name, namespace,
         entity_namespace, cause_namespace, source_location, change_kind,
         expires: Same selector grammar and semantics as the identically
@@ -197,6 +218,18 @@ class ReclassifyRule:
                 f"Invalid to_verdict {self.to_verdict!r}. Valid values: "
                 f"{sorted(v.value for v in _VALID_RECLASSIFY_VERDICTS)}"
             )
+        # Canonicalize `to` from `to_verdict` rather than trusting a caller-
+        # supplied spelling (Codex review, second round on the same audit-
+        # trail concern -- the earlier fix only patched reporter.py's own
+        # reclassified_by fallback; describe() still reads self.to directly,
+        # so Markdown/HTML disclosure could still misdescribe a directly-
+        # constructed rule whose `to` disagreed with, or omitted,
+        # `to_verdict`). This is a no-op for every policy-file-loaded rule:
+        # the loader always derives to_verdict FROM this same spelling, so
+        # they already agree and this simply reassigns the same string.
+        # `to_verdict` is the single source of truth; `to` is always its
+        # derived display spelling.
+        self.to = _CANONICAL_TO_SPELLING[self.to_verdict]
         # A datetime is itself a date subclass, so a Python caller
         # constructing this rule directly with expires=datetime(...) would
         # otherwise pass isinstance(expires, date) unnormalized and later

--- a/abicheck/reclassify.py
+++ b/abicheck/reclassify.py
@@ -75,6 +75,22 @@ at call time (mirroring the lazy ``__getattr__`` shim in
 the sanctioned way around that per CLAUDE.md "What NOT to do" -- extending
 ``IMPORT_CYCLE_ALLOWLIST`` instead would paper over a real, growing SCC.
 ``change``/``Change`` parameters are typed ``Any`` for the same reason.
+
+**Known gap, deliberately not closed here (Codex review, P2):**
+``contract_pipeline.ContractEvaluationStage.build_context()`` -- the ADR-049
+Phase 4 persisted-context assembly under ``compare --contract-evaluation`` --
+folds ``policy_file.overrides`` into the receipt's
+``CompatibilityPolicyConfig`` but does not yet do the same for
+``policy_file.reclassify``. A finding's ``compatibility_decision`` is
+computed correctly either way (``ContractEvaluationStage.classify()`` calls
+the same ``severity.effective_verdict_for_change`` this module is wired
+into), but the *audit receipt* -- the JSON/replay record of what actually
+scored the run -- doesn't yet record which reclassify rule, reason, or
+expiry decided it. Closing this needs the resolved reclassify list threaded
+through ``CompatibilityPolicyConfig``, its JSON serialization (a real
+schema-version concern -- see ``contract_context_io.py``), and
+``contract_replay.py``'s policy-independent replay evaluator -- a scoped,
+independently-verified follow-up, not a same-PR extension of this change.
 """
 
 from __future__ import annotations

--- a/abicheck/reclassify.py
+++ b/abicheck/reclassify.py
@@ -1,0 +1,233 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Selector-scoped reclassification — the third policy-file primitive.
+
+Two rule forms already exist for steering a verdict, each half-right for a
+project that needs the other half:
+
+- ``suppression.py``'s ``Suppression`` — a rich per-symbol/pattern/namespace
+  selector grammar, but its only action is *deleting* the finding.
+- ``policy_file.py``'s ``overrides:`` block — keeps the finding and changes
+  its verdict, but is keyed by ``ChangeKind`` alone, with no selector: the
+  override applies to every symbol of that kind, project-wide.
+
+Neither combination lets a project say "every ``func_visibility_changed`` on
+*this* symbol family is a known, accepted risk — not a suppression, still
+worth seeing, just not BREAKING." A COMDAT-inline-heavy library (oneDAL is
+the motivating case) can have dozens of such symbols; downgrading the whole
+kind globally via ``overrides:`` would also downgrade a genuine visibility
+regression on an unrelated symbol, and suppressing the finding outright
+throws away evidence a reviewer may still want to see.
+
+``ReclassifyRule`` is that third form: the same selector grammar
+:class:`~abicheck.suppression.Suppression` already implements (``symbol``/
+``symbol_pattern``/``type_pattern``/``member_name``/``namespace``/
+``entity_namespace``/``cause_namespace``/``source_location``/
+``change_kind``/``expires``), with ``to:`` instead of deletion. Reuses
+:class:`~abicheck.suppression.Suppression` itself for selector matching
+(via the public :meth:`~abicheck.suppression.Suppression.selector_matches`)
+rather than re-implementing the glob/regex machinery a second time --
+deliberately bypassing that class's reachability / ``allow_public_break``
+gates, since those exist to guard against a rule *hiding* evidence, which
+does not apply here: a reclassified finding stays in the report, just at a
+different verdict.
+
+Loaded as an optional ``reclassify:`` block in a ``--policy-file`` document,
+parsed by :mod:`abicheck.policy_file` (which owns the ``to:`` severity
+vocabulary via ``parse_severity_value``, the same ``break``/``warn``/
+``risk``/``ignore`` spellings ``overrides:`` already uses) and consulted by
+:meth:`abicheck.policy_file.PolicyFile.compute_verdict` ahead of the
+kind-global ``overrides:`` entry for the same kind, since a rule scoped to a
+selector is strictly more specific than one scoped to a bare kind. Format
+example::
+
+    reclassify:
+      - kind: func_visibility_changed
+        symbol_pattern: "_ZN6oneapi3dal.*"
+        to: risk
+        reason: "COMDAT-inline demotions; consumers already embed their own copy"
+
+Deliberately never imports :mod:`abicheck.suppression`/
+:mod:`abicheck.checker_types` at module (or ``TYPE_CHECKING``) scope, even
+though it uses :class:`~abicheck.suppression.Suppression` at runtime and
+type-annotates against ``Change``. ``checker_types.py`` imports ``PolicyFile``
+from ``policy_file.py``, and ``policy_file.py`` is this module's own caller
+-- a static edge to either module here would close that loop into a real
+import cycle (``policy_file -> reclassify -> suppression -> checker_types ->
+policy_file``), which ``scripts/check_ai_readiness.py``'s ``import-cycle-
+growth`` gate treats as SCC growth regardless of whether the importing
+statement is function-local (its cycle detector walks the whole AST, not
+just module scope). Resolving ``Suppression`` via ``importlib.import_module``
+at call time (mirroring the lazy ``__getattr__`` shim in
+``cli_buildsource.py``, a runtime call rather than a static import edge) is
+the sanctioned way around that per CLAUDE.md "What NOT to do" -- extending
+``IMPORT_CYCLE_ALLOWLIST`` instead would paper over a real, growing SCC.
+``change``/``Change`` parameters are typed ``Any`` for the same reason.
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any
+
+from .checker_policy import Verdict
+
+
+def _suppression_cls() -> Any:
+    """Resolve :class:`abicheck.suppression.Suppression` at call time --
+    see the module docstring for why this can't be a static import."""
+    return importlib.import_module("abicheck.suppression").Suppression
+
+
+#: YAML keys accepted in one ``reclassify:`` entry. ``kind`` is this rule
+#: form's own spelling of ``Suppression.change_kind`` (matching the shape of
+#: the user-facing example this module's docstring documents), not a second,
+#: independent selector.
+RECLASSIFY_KNOWN_KEYS: frozenset[str] = frozenset(
+    {
+        "kind",
+        "symbol",
+        "symbol_pattern",
+        "type_pattern",
+        "member_name",
+        "namespace",
+        "entity_namespace",
+        "cause_namespace",
+        "source_location",
+        "to",
+        "reason",
+        "label",
+        "expires",
+    }
+)
+
+
+@dataclass
+class ReclassifyRule:
+    """One selector-scoped reclassification rule.
+
+    Attributes:
+        to_verdict: The verdict this rule forces when its selectors match —
+            already resolved from the raw ``to:`` spelling by the loader
+            (:func:`abicheck.policy_file.parse_severity_value`), so this
+            class carries no severity vocabulary of its own.
+        to: The raw ``to:`` spelling as written in the policy file, kept
+            only for :meth:`describe`/audit output.
+        symbol, symbol_pattern, type_pattern, member_name, namespace,
+        entity_namespace, cause_namespace, source_location, change_kind,
+        expires: Same selector grammar and semantics as the identically
+            named :class:`~abicheck.suppression.Suppression` fields —
+            see that class's docstrings for each. At least one selector
+            is required, enforced by the same validation
+            :class:`Suppression` already performs.
+        reason: Optional human-readable justification, for audit output.
+        label: Optional grouping tag, mirroring
+            :attr:`Suppression.label`.
+    """
+
+    to_verdict: Verdict
+    to: str = ""
+    symbol: str | None = None
+    symbol_pattern: str | None = None
+    type_pattern: str | None = None
+    member_name: str | None = None
+    namespace: str | None = None
+    entity_namespace: str | None = None
+    cause_namespace: str | None = None
+    source_location: str | None = None
+    change_kind: str | None = None
+    reason: str | None = None
+    label: str | None = None
+    expires: date | None = None
+    #: Built at construction time and reused for every :meth:`matches` call
+    #: rather than re-validated/re-compiled per call — mirrors how
+    #: :class:`~abicheck.suppression.Suppression` itself eagerly compiles its
+    #: own patterns. Typed ``Any`` (really a ``Suppression`` instance) --
+    #: see the module docstring.
+    _selector: Any = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        # Delegates all selector validation (mutual exclusivity, unknown
+        # change_kind, malformed glob/regex, "at least one selector") to
+        # Suppression's own __post_init__ -- a ValueError raised there
+        # propagates unchanged to this rule's own construction, so a
+        # ReclassifyRule can never exist with an invalid selector any more
+        # than a Suppression can.
+        self._selector = _suppression_cls()(
+            symbol=self.symbol,
+            symbol_pattern=self.symbol_pattern,
+            type_pattern=self.type_pattern,
+            member_name=self.member_name,
+            namespace=self.namespace,
+            entity_namespace=self.entity_namespace,
+            cause_namespace=self.cause_namespace,
+            source_location=self.source_location,
+            change_kind=self.change_kind,
+            expires=self.expires,
+        )
+
+    def matches(self, change: Any, today: date | None = None) -> bool:
+        """Return True if this rule's selectors match *change* (an
+        :class:`abicheck.checker_types.Change`; typed ``Any`` -- see the
+        module docstring).
+
+        Expired rules (past ``expires``) never match, same as
+        :class:`Suppression`. Deliberately consults only the selector
+        grammar -- see the module docstring for why the reachability /
+        ``allow_public_break`` gates :class:`Suppression` layers on top
+        don't apply to reclassification.
+        """
+        return bool(self._selector.selector_matches(change, today))
+
+    def describe(self) -> str:
+        """One-line human-readable summary, for policy audit output."""
+        bits = [f"to={self.to or self.to_verdict.value}"]
+        for field_name in (
+            "change_kind",
+            "symbol",
+            "symbol_pattern",
+            "type_pattern",
+            "member_name",
+            "namespace",
+            "entity_namespace",
+            "cause_namespace",
+            "source_location",
+        ):
+            val = getattr(self, field_name)
+            if val is not None:
+                bits.append(f"{field_name}={val!r}")
+        if self.reason:
+            bits.append(f"reason={self.reason!r}")
+        return "reclassify(" + ", ".join(bits) + ")"
+
+
+def first_matching_reclassify_verdict(
+    rules: list[ReclassifyRule], change: Any, today: date | None = None
+) -> Verdict | None:
+    """Return the ``to_verdict`` of the first rule in *rules* matching
+    *change*, or ``None`` if none match.
+
+    First-match-wins, in file order — unlike suppression (where every
+    matching rule has the identical effect, "delete"), two reclassify rules
+    can disagree about *what* verdict to apply to the same change, so rule
+    order is meaningful. Documented in ``policy_file.py``'s ``reclassify:``
+    format and enforced here as the one place this resolution happens.
+    """
+    for rule in rules:
+        if rule.matches(change, today):
+            return rule.to_verdict
+    return None

--- a/abicheck/reclassify.py
+++ b/abicheck/reclassify.py
@@ -102,6 +102,21 @@ from typing import Any
 
 from .checker_policy import Verdict
 
+#: The four verdicts a `to:` value is allowed to resolve to -- the exact set
+#: `policy_file.parse_severity_value`'s `break`/`warn`/`risk`/`ignore`
+#: vocabulary maps onto. `NO_CHANGE` is excluded: a `ReclassifyRule`
+#: constructed directly in Python (bypassing that parser -- this class is
+#: public API) with `to_verdict=Verdict.NO_CHANGE` would make a matching
+#: real change disappear from every one of `DiffResult.breaking`/
+#: `source_breaks`/`risk`/`compatible` (Codex review) -- a silently
+#: passing result that conceals a real change, not a lenient reclassification.
+_VALID_RECLASSIFY_VERDICTS: frozenset[Verdict] = frozenset({
+    Verdict.BREAKING,
+    Verdict.API_BREAK,
+    Verdict.COMPATIBLE_WITH_RISK,
+    Verdict.COMPATIBLE,
+})
+
 
 def _suppression_cls() -> Any:
     """Resolve :class:`abicheck.suppression.Suppression` at call time --
@@ -177,6 +192,11 @@ class ReclassifyRule:
     _selector: Any = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
+        if self.to_verdict not in _VALID_RECLASSIFY_VERDICTS:
+            raise ValueError(
+                f"Invalid to_verdict {self.to_verdict!r}. Valid values: "
+                f"{sorted(v.value for v in _VALID_RECLASSIFY_VERDICTS)}"
+            )
         # Delegates all selector validation (mutual exclusivity, unknown
         # change_kind, malformed glob/regex, "at least one selector") to
         # Suppression's own __post_init__ -- a ValueError raised there
@@ -208,6 +228,18 @@ class ReclassifyRule:
         don't apply to reclassification.
         """
         return bool(self._selector.selector_matches(change, today))
+
+    def is_expired(self, today: date | None = None) -> bool:
+        """Return True if this rule has passed its ``expires`` date.
+
+        ``None`` when unset, same as :meth:`Suppression.is_expired`. Used by
+        the report renderers (``reporter.py``'s ``policy_reclassify``,
+        ``reporter_markdown.py``, ``html_report.py``, ``sarif.py``) to
+        exclude an expired rule from the *active* rule set they disclose --
+        listing an expired rule there would claim a downgrade is in effect
+        when :meth:`matches` would actually already refuse to apply it.
+        """
+        return bool(self._selector.is_expired(today))
 
     def describe(self) -> str:
         """One-line human-readable summary, for policy audit output."""
@@ -287,3 +319,18 @@ def first_matching_reclassify_verdict(
         if rule.matches(change, today):
             return rule.to_verdict
     return None
+
+
+def active_reclassify_rules(
+    rules: list[ReclassifyRule], today: date | None = None
+) -> list[ReclassifyRule]:
+    """Return the subset of *rules* not yet past their ``expires`` date.
+
+    Every report renderer disclosing the *active* rule set (``reporter.py``'s
+    ``policy_reclassify``, ``reporter_markdown.py``, ``html_report.py``,
+    ``sarif.py``) filters through this rather than listing every configured
+    rule verbatim (Codex review) -- an expired rule can never actually match
+    (:meth:`ReclassifyRule.matches`), so disclosing it as active claims a
+    downgrade is in effect when it no longer is.
+    """
+    return [r for r in rules if not r.is_expired(today)]

--- a/abicheck/reclassify.py
+++ b/abicheck/reclassify.py
@@ -230,6 +230,36 @@ class ReclassifyRule:
             bits.append(f"reason={self.reason!r}")
         return "reclassify(" + ", ".join(bits) + ")"
 
+    def to_report_dict(self) -> dict[str, str]:
+        """JSON-serializable audit dict for this rule, shared by every report
+        renderer (``reporter.py``'s ``policy_reclassify``, ``sarif.py``'s
+        ``policyReclassify``) so the field set/spelling can't silently drift
+        between them the way two hand-rolled dict-builders eventually would.
+
+        Lists this rule's own configuration -- the *active rule set*, not a
+        per-finding "did this rule fire" attribution (see the module
+        docstring's known-gap note). Keys present depend on which fields the
+        rule actually set; ``to`` is always present.
+        """
+        out: dict[str, str] = {"to": self.to_verdict.value}
+        if self.change_kind is not None:
+            out["kind"] = self.change_kind
+        for field_name in (
+            "symbol", "symbol_pattern", "type_pattern", "member_name",
+            "namespace", "entity_namespace", "cause_namespace",
+            "source_location",
+        ):
+            val = getattr(self, field_name)
+            if val is not None:
+                out[field_name] = val
+        if self.reason:
+            out["reason"] = self.reason
+        if self.label:
+            out["label"] = self.label
+        if self.expires is not None:
+            out["expires"] = self.expires.isoformat()
+        return out
+
 
 def first_matching_reclassify_verdict(
     rules: list[ReclassifyRule], change: Any, today: date | None = None

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -1032,10 +1032,10 @@ def _add_policy_overrides(d: dict[str, object], result: DiffResult) -> None:
     """Add policy file overrides/reclassify rules (custom re-classifications)
     when present.
 
-    ``policy_reclassify`` (report_schema_version 2.29) lists the *active
+    ``policy_reclassify`` (report_schema_version 2.30) lists the *active
     rule set* -- the same level of audit detail ``policy_overrides`` already
     gives for kind-global overrides -- not a per-finding "which rule fired"
-    attribution (see ``abicheck/schemas/__init__.py``'s 2.29 history entry
+    attribution (see ``abicheck/schemas/__init__.py``'s 2.30 history entry
     for why that's a separately tracked follow-up, Codex review: an ordinary
     comparison reclassifying a finding previously had no trace of the active
     rule anywhere in the standard report). Each rule's dict comes from
@@ -1050,11 +1050,13 @@ def _add_policy_overrides(d: dict[str, object], result: DiffResult) -> None:
         if result.policy_file.source_path:
             d["policy_file"] = str(result.policy_file.source_path)
     if result.policy_file and result.policy_file.reclassify:
-        d["policy_reclassify"] = [
-            rule.to_report_dict() for rule in result.policy_file.reclassify
-        ]
-        if result.policy_file.source_path:
-            d["policy_file"] = str(result.policy_file.source_path)
+        from .reclassify import active_reclassify_rules
+
+        active = active_reclassify_rules(result.policy_file.reclassify)
+        if active:
+            d["policy_reclassify"] = [rule.to_report_dict() for rule in active]
+            if result.policy_file.source_path:
+                d["policy_file"] = str(result.policy_file.source_path)
 
 
 def _add_changes_block(

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -439,6 +439,12 @@ def _to_json_leaf(
             eff = getattr(c, "effective_verdict", None)
             if isinstance(eff, Verdict):
                 entry["effective_verdict"] = eff.value
+        # Same "leaf mode duplicates the full-mode builder" gap as the rest
+        # of this function (Codex review) -- shares _change_to_dict's own
+        # helper so the two entry builders can't drift on this field.
+        _reclassified_by = _reclassified_by_for_change(c, result.policy_file)
+        if _reclassified_by:
+            entry["reclassified_by"] = _reclassified_by
         # ADR-044 P1 item 4: same structured reachability fields
         # _change_to_dict adds for non-type changes — a root TYPE_* change is
         # exactly the category the layout-reachability walk tags most often.
@@ -556,6 +562,9 @@ def _to_json_leaf(
     _add_surface_scope(d, result)
     _add_reconciled(d, result)
     _add_contract_context(d, result)
+    # Codex review: full/root-cause mode call this; leaf mode never did,
+    # silently dropping policy_overrides/policy_reclassify here.
+    _add_policy_overrides(d, result)
     scope = _scope_dict(result)
     if scope is not None:
         d["scope"] = scope
@@ -1455,6 +1464,22 @@ def _change_reachability_fields(c: Any) -> dict[str, Any]:
     return out
 
 
+def _reclassified_by_for_change(c: object, policy_file: object | None) -> str | None:
+    """``reclassified_by`` audit value for *c*, or ``None`` -- shared by
+    :func:`_change_to_dict` and leaf mode's ``_leaf_entry`` (Codex review)
+    so the two entry builders can't drift on this field. Falls back to
+    ``rule.to_verdict.value`` rather than ``rule.to``, since a directly-
+    constructed ``ReclassifyRule`` could leave the latter empty/mismatched
+    -- see ``severity.reclassify_rule_for_change`` for the full precedence.
+    """
+    from .severity import reclassify_rule_for_change
+
+    rule = reclassify_rule_for_change(cast(HasKind, c), policy_file)
+    if rule is None:
+        return None
+    return cast(str, rule.label or rule.reason or rule.to_verdict.value)
+
+
 def _change_to_dict(
     c: object,
     *,
@@ -1507,7 +1532,7 @@ def _change_to_dict(
     kind = getattr(c, "kind", None)
     reclassified_by: str | None = None
     if isinstance(kind, ChangeKind) and kind_sets:
-        from .severity import effective_verdict_for_change, reclassify_rule_for_change
+        from .severity import effective_verdict_for_change
 
         verdict = effective_verdict_for_change(
             cast(HasKind, c),
@@ -1516,31 +1541,9 @@ def _change_to_dict(
             policy_file=policy_file,
         )
         severity = _VERDICT_TO_SEVERITY_LABEL.get(verdict, "unknown")
-        # Selector-scoped `reclassify:` disclosure (Codex review): a
-        # kind-global `overrides:` entry is already visible on the report as
-        # `policy_overrides` and countable by kind alone
-        # (`pr_comment._reclassified_count`), but a `reclassify:` rule is
-        # selector-scoped -- there is no single kind to look up, so without a
-        # per-change marker a JSON consumer (or a report renderer) has no way
-        # to tell *this* finding was reclassified at all. Stamped only when
-        # the matching rule actually decided the verdict (not shadowed by a
-        # higher-priority effective_verdict or blocked by the
-        # frozen-namespace floor) -- see reclassify_rule_for_change's own
-        # docstring.
-        rule = reclassify_rule_for_change(cast(HasKind, c), policy_file)
-        if rule is not None:
-            # `rule.to` is the raw `to:` spelling as loaded from YAML --
-            # always consistent with `rule.to_verdict` for a policy-file-
-            # loaded rule (the loader resolves one from the other), but a
-            # Python caller constructing ReclassifyRule directly can supply
-            # a `to_verdict` with no `to` at all (silently dropping this
-            # disclosure -- `to` defaults to `""`), or, worse, a `to` that
-            # doesn't actually match `to_verdict` (mislabeling the audit
-            # trail, e.g. a `to_verdict=BREAKING` promotion reported as
-            # "ignore"). Falling back to `rule.to_verdict.value` instead of
-            # `rule.to` guarantees this is always non-empty and always
-            # reflects the verdict that was actually applied (Codex review).
-            reclassified_by = rule.label or rule.reason or rule.to_verdict.value
+        # Per-change reclassify: disclosure (Codex review) -- see
+        # _reclassified_by_for_change's own docstring.
+        reclassified_by = _reclassified_by_for_change(c, policy_file)
     elif kind:
         severity = _kind_to_severity(kind, policy)
     else:

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -1529,7 +1529,18 @@ def _change_to_dict(
         # docstring.
         rule = reclassify_rule_for_change(cast(HasKind, c), policy_file)
         if rule is not None:
-            reclassified_by = rule.label or rule.reason or rule.to
+            # `rule.to` is the raw `to:` spelling as loaded from YAML --
+            # always consistent with `rule.to_verdict` for a policy-file-
+            # loaded rule (the loader resolves one from the other), but a
+            # Python caller constructing ReclassifyRule directly can supply
+            # a `to_verdict` with no `to` at all (silently dropping this
+            # disclosure -- `to` defaults to `""`), or, worse, a `to` that
+            # doesn't actually match `to_verdict` (mislabeling the audit
+            # trail, e.g. a `to_verdict=BREAKING` promotion reported as
+            # "ignore"). Falling back to `rule.to_verdict.value` instead of
+            # `rule.to` guarantees this is always non-empty and always
+            # reflects the verdict that was actually applied (Codex review).
+            reclassified_by = rule.label or rule.reason or rule.to_verdict.value
     elif kind:
         severity = _kind_to_severity(kind, policy)
     else:

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -1028,16 +1028,6 @@ def _add_confidence_evidence(d: dict[str, object], result: DiffResult) -> None:
         d["assurance"] = result.assurance
 
 
-#: reclassify[i] selector attributes worth disclosing in the report, in a
-#: stable, deterministic key order. Mirrors abicheck.reclassify's own
-#: RECLASSIFY_KNOWN_KEYS selector subset (kind/to/reason/expires handled
-#: separately below).
-_RECLASSIFY_REPORT_SELECTOR_FIELDS: tuple[str, ...] = (
-    "symbol", "symbol_pattern", "type_pattern", "member_name", "namespace",
-    "entity_namespace", "cause_namespace", "source_location",
-)
-
-
 def _add_policy_overrides(d: dict[str, object], result: DiffResult) -> None:
     """Add policy file overrides/reclassify rules (custom re-classifications)
     when present.
@@ -1048,7 +1038,9 @@ def _add_policy_overrides(d: dict[str, object], result: DiffResult) -> None:
     attribution (see ``abicheck/schemas/__init__.py``'s 2.29 history entry
     for why that's a separately tracked follow-up, Codex review: an ordinary
     comparison reclassifying a finding previously had no trace of the active
-    rule anywhere in the standard report).
+    rule anywhere in the standard report). Each rule's dict comes from
+    ``ReclassifyRule.to_report_dict()`` -- shared with ``sarif.py``'s
+    ``policyReclassify`` so the two can't drift on field set/spelling.
     """
     if result.policy_file and result.policy_file.overrides:
         d["policy_overrides"] = {
@@ -1058,23 +1050,9 @@ def _add_policy_overrides(d: dict[str, object], result: DiffResult) -> None:
         if result.policy_file.source_path:
             d["policy_file"] = str(result.policy_file.source_path)
     if result.policy_file and result.policy_file.reclassify:
-        rules_json: list[dict[str, object]] = []
-        for rule in result.policy_file.reclassify:
-            rule_json: dict[str, object] = {"to": rule.to_verdict.value}
-            if rule.change_kind is not None:
-                rule_json["kind"] = rule.change_kind
-            for field_name in _RECLASSIFY_REPORT_SELECTOR_FIELDS:
-                val = getattr(rule, field_name, None)
-                if val is not None:
-                    rule_json[field_name] = val
-            if rule.reason:
-                rule_json["reason"] = rule.reason
-            if rule.label:
-                rule_json["label"] = rule.label
-            if rule.expires is not None:
-                rule_json["expires"] = rule.expires.isoformat()
-            rules_json.append(rule_json)
-        d["policy_reclassify"] = rules_json
+        d["policy_reclassify"] = [
+            rule.to_report_dict() for rule in result.policy_file.reclassify
+        ]
         if result.policy_file.source_path:
             d["policy_file"] = str(result.policy_file.source_path)
 

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -1028,13 +1028,53 @@ def _add_confidence_evidence(d: dict[str, object], result: DiffResult) -> None:
         d["assurance"] = result.assurance
 
 
+#: reclassify[i] selector attributes worth disclosing in the report, in a
+#: stable, deterministic key order. Mirrors abicheck.reclassify's own
+#: RECLASSIFY_KNOWN_KEYS selector subset (kind/to/reason/expires handled
+#: separately below).
+_RECLASSIFY_REPORT_SELECTOR_FIELDS: tuple[str, ...] = (
+    "symbol", "symbol_pattern", "type_pattern", "member_name", "namespace",
+    "entity_namespace", "cause_namespace", "source_location",
+)
+
+
 def _add_policy_overrides(d: dict[str, object], result: DiffResult) -> None:
-    """Add policy file overrides (custom re-classifications) when present."""
+    """Add policy file overrides/reclassify rules (custom re-classifications)
+    when present.
+
+    ``policy_reclassify`` (report_schema_version 2.29) lists the *active
+    rule set* -- the same level of audit detail ``policy_overrides`` already
+    gives for kind-global overrides -- not a per-finding "which rule fired"
+    attribution (see ``abicheck/schemas/__init__.py``'s 2.29 history entry
+    for why that's a separately tracked follow-up, Codex review: an ordinary
+    comparison reclassifying a finding previously had no trace of the active
+    rule anywhere in the standard report).
+    """
     if result.policy_file and result.policy_file.overrides:
         d["policy_overrides"] = {
             kind.value: verdict.value
             for kind, verdict in result.policy_file.overrides.items()
         }
+        if result.policy_file.source_path:
+            d["policy_file"] = str(result.policy_file.source_path)
+    if result.policy_file and result.policy_file.reclassify:
+        rules_json: list[dict[str, object]] = []
+        for rule in result.policy_file.reclassify:
+            rule_json: dict[str, object] = {"to": rule.to_verdict.value}
+            if rule.change_kind is not None:
+                rule_json["kind"] = rule.change_kind
+            for field_name in _RECLASSIFY_REPORT_SELECTOR_FIELDS:
+                val = getattr(rule, field_name, None)
+                if val is not None:
+                    rule_json[field_name] = val
+            if rule.reason:
+                rule_json["reason"] = rule.reason
+            if rule.label:
+                rule_json["label"] = rule.label
+            if rule.expires is not None:
+                rule_json["expires"] = rule.expires.isoformat()
+            rules_json.append(rule_json)
+        d["policy_reclassify"] = rules_json
         if result.policy_file.source_path:
             d["policy_file"] = str(result.policy_file.source_path)
 

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -1034,13 +1034,14 @@ def _add_policy_overrides(d: dict[str, object], result: DiffResult) -> None:
 
     ``policy_reclassify`` (report_schema_version 2.30) lists the *active
     rule set* -- the same level of audit detail ``policy_overrides`` already
-    gives for kind-global overrides -- not a per-finding "which rule fired"
-    attribution (see ``abicheck/schemas/__init__.py``'s 2.30 history entry
-    for why that's a separately tracked follow-up, Codex review: an ordinary
-    comparison reclassifying a finding previously had no trace of the active
-    rule anywhere in the standard report). Each rule's dict comes from
-    ``ReclassifyRule.to_report_dict()`` -- shared with ``sarif.py``'s
-    ``policyReclassify`` so the two can't drift on field set/spelling.
+    gives for kind-global overrides. The per-finding "which rule fired"
+    attribution 2.30's own history entry originally deferred is a separate
+    field, ``change.reclassified_by`` (report_schema_version 2.31, stamped in
+    ``_change_to_dict`` via ``severity.reclassify_rule_for_change`` -- see
+    ``abicheck/schemas/__init__.py``'s 2.31 history entry). Each rule's dict
+    here comes from ``ReclassifyRule.to_report_dict()`` -- shared with
+    ``sarif.py``'s ``policyReclassify`` so the two can't drift on field
+    set/spelling.
     """
     if result.policy_file and result.policy_file.overrides:
         d["policy_overrides"] = {
@@ -1504,8 +1505,9 @@ def _change_to_dict(
     means the legacy verdict-based scheme, not "no gate".
     """
     kind = getattr(c, "kind", None)
+    reclassified_by: str | None = None
     if isinstance(kind, ChangeKind) and kind_sets:
-        from .severity import effective_verdict_for_change
+        from .severity import effective_verdict_for_change, reclassify_rule_for_change
 
         verdict = effective_verdict_for_change(
             cast(HasKind, c),
@@ -1514,6 +1516,20 @@ def _change_to_dict(
             policy_file=policy_file,
         )
         severity = _VERDICT_TO_SEVERITY_LABEL.get(verdict, "unknown")
+        # Selector-scoped `reclassify:` disclosure (Codex review): a
+        # kind-global `overrides:` entry is already visible on the report as
+        # `policy_overrides` and countable by kind alone
+        # (`pr_comment._reclassified_count`), but a `reclassify:` rule is
+        # selector-scoped -- there is no single kind to look up, so without a
+        # per-change marker a JSON consumer (or a report renderer) has no way
+        # to tell *this* finding was reclassified at all. Stamped only when
+        # the matching rule actually decided the verdict (not shadowed by a
+        # higher-priority effective_verdict or blocked by the
+        # frozen-namespace floor) -- see reclassify_rule_for_change's own
+        # docstring.
+        rule = reclassify_rule_for_change(cast(HasKind, c), policy_file)
+        if rule is not None:
+            reclassified_by = rule.label or rule.reason or rule.to
     elif kind:
         severity = _kind_to_severity(kind, policy)
     else:
@@ -1529,6 +1545,8 @@ def _change_to_dict(
         "new_value": getattr(c, "new_value", None),
         "severity": severity,
     }
+    if reclassified_by:
+        d["reclassified_by"] = reclassified_by
     if isinstance(kind, ChangeKind):
         d["operation"] = operation_for_kind(kind.value)
         d["finding_id"] = _finding_id(c)

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -1821,7 +1821,10 @@ def _append_policy_section(lines: list[str], result: DiffResult) -> None:
 
         active = active_reclassify_rules(result.policy_file.reclassify)
         if active:
-            rules = "; ".join(rule.describe() for rule in active)
+            # CodeRabbit review: code-span-wrap describe()'s raw selector
+            # text (e.g. `_ZN6oneapi3dal.*`) -- unescaped, `_`/`*` read as
+            # Markdown emphasis, same as `Policy overrides` above already does.
+            rules = "; ".join(f"`{rule.describe()}`" for rule in active)
             lines.append(f"> **Policy reclassify**: {rules}")
     lines.append("")
 

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -1813,9 +1813,16 @@ def _append_policy_section(lines: list[str], result: DiffResult) -> None:
         # Codex review: mirrors the JSON `policy_reclassify` disclosure
         # (reporter.py's `_add_policy_overrides`) -- the active rule set,
         # not a per-finding "which rule fired" attribution (see that
-        # function's docstring / schema 2.29 history entry).
-        rules = "; ".join(rule.describe() for rule in result.policy_file.reclassify)
-        lines.append(f"> **Policy reclassify**: {rules}")
+        # function's docstring / schema 2.30 history entry). Filtered
+        # through active_reclassify_rules so an expired rule -- which
+        # ReclassifyRule.matches() would already refuse to apply -- isn't
+        # disclosed as though it were still in effect.
+        from .reclassify import active_reclassify_rules
+
+        active = active_reclassify_rules(result.policy_file.reclassify)
+        if active:
+            rules = "; ".join(rule.describe() for rule in active)
+            lines.append(f"> **Policy reclassify**: {rules}")
     lines.append("")
 
 

--- a/abicheck/reporter_markdown.py
+++ b/abicheck/reporter_markdown.py
@@ -1809,6 +1809,13 @@ def _append_policy_section(lines: list[str], result: DiffResult) -> None:
             for kind, severity in result.policy_file.overrides.items()
         )
         lines.append(f"> **Policy overrides**: {overrides}")
+    if result.policy_file and result.policy_file.reclassify:
+        # Codex review: mirrors the JSON `policy_reclassify` disclosure
+        # (reporter.py's `_add_policy_overrides`) -- the active rule set,
+        # not a per-finding "which rule fired" attribution (see that
+        # function's docstring / schema 2.29 history entry).
+        rules = "; ".join(rule.describe() for rule in result.policy_file.reclassify)
+        lines.append(f"> **Policy reclassify**: {rules}")
     lines.append("")
 
 

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -1099,6 +1099,20 @@ def to_sarif(
                         if result.policy_file and result.policy_file.overrides
                         else {}
                     ),
+                    # Codex review: mirrors reporter.py's JSON
+                    # `policy_reclassify` (report_schema_version 2.29) --
+                    # the active reclassify: rule set, via the same
+                    # ReclassifyRule.to_report_dict() so the two can't drift.
+                    **(
+                        {
+                            "policyReclassify": [
+                                rule.to_report_dict()
+                                for rule in result.policy_file.reclassify
+                            ]
+                        }
+                        if result.policy_file and result.policy_file.reclassify
+                        else {}
+                    ),
                     # ADR-024 §D4/D5: header-scope ledger. Out-of-surface
                     # findings are disclosed here for auditability (never
                     # silently dropped) when --scope-public-headers is active.

--- a/abicheck/sarif.py
+++ b/abicheck/sarif.py
@@ -719,6 +719,15 @@ def to_sarif(
     """
     tool_version = _tool_version()
 
+    # Codex review: filtered so an expired rule -- which ReclassifyRule.
+    # matches() would already refuse to apply -- isn't disclosed in
+    # policyReclassify below as though it were still in effect.
+    _active_reclassify_rules: list[Any] = []
+    if result.policy_file and result.policy_file.reclassify:
+        from .reclassify import active_reclassify_rules
+
+        _active_reclassify_rules = active_reclassify_rules(result.policy_file.reclassify)
+
     changes = list(result.changes)
     if show_only:
         changes = apply_show_only(
@@ -1100,17 +1109,17 @@ def to_sarif(
                         else {}
                     ),
                     # Codex review: mirrors reporter.py's JSON
-                    # `policy_reclassify` (report_schema_version 2.29) --
+                    # `policy_reclassify` (report_schema_version 2.30) --
                     # the active reclassify: rule set, via the same
                     # ReclassifyRule.to_report_dict() so the two can't drift.
                     **(
                         {
                             "policyReclassify": [
                                 rule.to_report_dict()
-                                for rule in result.policy_file.reclassify
+                                for rule in _active_reclassify_rules
                             ]
                         }
-                        if result.policy_file and result.policy_file.reclassify
+                        if _active_reclassify_rules
                         else {}
                     ),
                     # ADR-024 §D4/D5: header-scope ledger. Out-of-surface

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -364,7 +364,8 @@ from typing import Any
 #:       reclassification, ``abicheck/reclassify.py``): when the active
 #:       policy file carries one or more ``reclassify:`` rules, each is
 #:       listed (``kind``, whichever selector fields it set, ``to``,
-#:       ``reason``, ``expires``) alongside the existing ``policy_overrides``/
+#:       ``reason``, ``label``, ``expires``) alongside the existing
+#:       ``policy_overrides``/
 #:       ``policy_file`` keys (Codex review: an ordinary comparison
 #:       reclassifying a finding had no trace of the active rule anywhere in
 #:       the standard report). Lists the *active rule set*, matching the

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -374,7 +374,22 @@ from typing import Any
 #:       a deliberately deferred follow-up, same as the ``--contract-
 #:       evaluation`` receipt gap). Absent, and the report byte-identical,
 #:       when no ``reclassify:`` rule is configured.
-REPORT_SCHEMA_VERSION = "2.30"
+#: 2.31 — the per-``Change`` ``reclassified_by`` field 2.30's own note
+#:       tracked as a deferred follow-up (Codex review, PR #733): a
+#:       ``change`` entry now carries ``reclassified_by`` (the deciding
+#:       ``reclassify:`` rule's ``label``/``reason``/``to`` spelling, first
+#:       one set) when a selector-scoped rule -- not a kind-global
+#:       ``overrides:`` entry -- actually decided its effective verdict
+#:       (:func:`abicheck.severity.reclassify_rule_for_change`). Motivated by
+#:       ``cli_pr_comment``: its ``_reclassified_count()`` only recognized
+#:       ``policy_overrides``' kind-keyed map, so a finding downgraded by a
+#:       selector-scoped rule silently bypassed the PR comment's "🔀 N
+#:       findings reclassified by --policy-file" disclosure and read as an
+#:       unremarked safe change. Purely additive and per-finding-opt-in:
+#:       absent for every change not actually decided by a ``reclassify:``
+#:       rule, which is every report without one, and never affects
+#:       ``verdict``, ``severity``, or any exit code.
+REPORT_SCHEMA_VERSION = "2.31"
 
 #: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as
 #: ``scan_schema_version`` at the top level of both public scan dict shapes:

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -360,7 +360,21 @@ from typing import Any
 #:       and group, unconditional on report_mode (mirroring root_cause_id/
 #:       impact_group_id's own precedent), and never affects ``verdict``,
 #:       ``severity``, or any exit code.
-REPORT_SCHEMA_VERSION = "2.29"
+#: 2.30 — new optional ``policy_reclassify`` array (A: selector-scoped
+#:       reclassification, ``abicheck/reclassify.py``): when the active
+#:       policy file carries one or more ``reclassify:`` rules, each is
+#:       listed (``kind``, whichever selector fields it set, ``to``,
+#:       ``reason``, ``expires``) alongside the existing ``policy_overrides``/
+#:       ``policy_file`` keys (Codex review: an ordinary comparison
+#:       reclassifying a finding had no trace of the active rule anywhere in
+#:       the standard report). Lists the *active rule set*, matching the
+#:       level of detail ``policy_overrides`` already provides for kind-
+#:       global overrides -- not a per-finding "which rule fired" attribution
+#:       (that needs a new per-``Change`` field and is tracked separately as
+#:       a deliberately deferred follow-up, same as the ``--contract-
+#:       evaluation`` receipt gap). Absent, and the report byte-identical,
+#:       when no ``reclassify:`` rule is configured.
+REPORT_SCHEMA_VERSION = "2.30"
 
 #: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as
 #: ``scan_schema_version`` at the top level of both public scan dict shapes:

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -896,7 +896,11 @@
         "type": "object",
         "required": ["to"],
         "properties": {
-          "to": { "type": "string" },
+          "to": {
+            "type": "string",
+            "description": "ReclassifyRule.to_report_dict()'s `to` key is `to_verdict.value` (the resolved Verdict, not the raw `break`/`warn`/`risk`/`ignore` YAML spelling) -- one of these four.",
+            "enum": ["BREAKING", "API_BREAK", "COMPATIBLE_WITH_RISK", "COMPATIBLE"]
+          },
           "kind": { "type": "string" },
           "symbol": { "type": "string" },
           "symbol_pattern": { "type": "string" },
@@ -1246,7 +1250,7 @@
         },
         "reclassified_by": {
           "type": "string",
-          "description": "Schema 2.31: present only when a selector-scoped `--policy-file` `reclassify:` rule (not a kind-global `overrides:` entry) actually decided this finding's effective verdict \u2014 the deciding rule's own `label`, or `reason`, or `to` spelling (first one set). See `policy_reclassify` for the full active rule set this attributes back to."
+          "description": "Schema 2.31: present only when a selector-scoped `--policy-file` `reclassify:` rule (not a kind-global `overrides:` entry) actually decided this finding's effective verdict \u2014 the deciding rule's own `label`, or `reason`, or the applied verdict value (first one set). See `policy_reclassify` for the full active rule set this attributes back to."
         },
         "reviewer_action": {
           "type": "string",

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -1244,6 +1244,10 @@
           "type": "string",
           "description": "The ChangeKind value of a related finding this one shares a cross-reference with \u2014 the structured sibling to a correlation already described in the description prose. Two independent producers set it: (1) ADR-041 P0 roadmap item 2, for a public_api_internal_dependency_added finding correlated with the same public entry's own body/type-hash change this version (e.g. 'inline_body_changed'); (2) schema 2.28, for a layout_unverifiable finding sharing the identical asymmetric-layout-evidence gap as a co-reported type_vtable_changed finding on the same type (always 'type_vtable_changed' in that case). Consumers should treat the value as an opaque ChangeKind slug naming the correlated finding, not assume a specific kind pairing."
         },
+        "reclassified_by": {
+          "type": "string",
+          "description": "Schema 2.31: present only when a selector-scoped `--policy-file` `reclassify:` rule (not a kind-global `overrides:` entry) actually decided this finding's effective verdict \u2014 the deciding rule's own `label`, or `reason`, or `to` spelling (first one set). See `policy_reclassify` for the full active rule set this attributes back to."
+        },
         "reviewer_action": {
           "type": "string",
           "description": "Finer-grained reviewer guidance, present only when recommended_action is 'no_action_required' (a COMPATIBLE addition). recommended_action alone only answers whether the old binary consumer needs to do anything (no); this answers whether a human reviewing the change has anything to check.",

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -891,7 +891,7 @@
     },
     "policy_reclassify": {
       "type": "array",
-      "description": "Active reclassify: rules from the policy file (report_schema_version 2.29), when any are configured -- the same audit-detail level policy_overrides already gives for kind-global overrides, listing the rule set rather than a per-finding \"which rule fired\" attribution. Selector fields present depend on which selector the rule used (see abicheck/reclassify.py).",
+      "description": "Active reclassify: rules from the policy file (report_schema_version 2.30), when any are configured -- the same audit-detail level policy_overrides already gives for kind-global overrides, listing the rule set rather than a per-finding \"which rule fired\" attribution. Selector fields present depend on which selector the rule used (see abicheck/reclassify.py).",
       "items": {
         "type": "object",
         "required": ["to"],

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -889,6 +889,30 @@
         "type": "string"
       }
     },
+    "policy_reclassify": {
+      "type": "array",
+      "description": "Active reclassify: rules from the policy file (report_schema_version 2.29), when any are configured -- the same audit-detail level policy_overrides already gives for kind-global overrides, listing the rule set rather than a per-finding \"which rule fired\" attribution. Selector fields present depend on which selector the rule used (see abicheck/reclassify.py).",
+      "items": {
+        "type": "object",
+        "required": ["to"],
+        "properties": {
+          "to": { "type": "string" },
+          "kind": { "type": "string" },
+          "symbol": { "type": "string" },
+          "symbol_pattern": { "type": "string" },
+          "type_pattern": { "type": "string" },
+          "member_name": { "type": "string" },
+          "namespace": { "type": "string" },
+          "entity_namespace": { "type": "string" },
+          "cause_namespace": { "type": "string" },
+          "source_location": { "type": "string" },
+          "reason": { "type": "string" },
+          "label": { "type": "string" },
+          "expires": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
     "policy_file": {
       "type": "string"
     },

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -338,7 +338,19 @@ def _reclassify_resolved_to_compatible(
     `overrides:`, see `effective_verdict_for_change`), but the addition/
     quality split would still read the *overridden* kind set and miscount
     it as `quality_issues`.
+
+    Must agree with `effective_verdict_for_change`'s own precedence, not
+    just "does some rule happen to match and resolve to COMPATIBLE" (Codex
+    review, fresh evidence): when `change.effective_verdict` is already set,
+    that value wins outright and `reclassify:` is never even consulted to
+    produce the verdict -- a *matching* rule sitting shadowed behind it must
+    not still be treated as "the reclassification that won" here, or an
+    addition kind globally overridden to `break` could get waved into
+    ADDITION merely because an irrelevant reclassify: rule happens to name
+    the same symbol.
     """
+    if isinstance(getattr(change, "effective_verdict", None), Verdict):
+        return False
     if policy_file is None:
         return False
     rules = getattr(policy_file, "reclassify", None)

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -315,8 +315,19 @@ def effective_verdict_for_change(
         ):
             return base_v
         return override_v
-    sets = _resolve_kind_sets(policy, kind_sets)
-    return effective_category(change, *sets)
+    # Reuses `base_sets` (already computed above from `policy_file.
+    # base_policy` when a policy_file is given) rather than recomputing from
+    # the outer `policy`/`kind_sets` parameters directly (Codex review,
+    # pre-existing bug surfaced by suppression.py's audit() calling this
+    # with only `policy_file=` set, no `policy=`/`kind_sets=`): for a
+    # policy_file whose base_policy isn't strict_abi (e.g. plugin_abi), a
+    # finding with no effective_verdict/reclassify/override match fell all
+    # the way back to strict_abi's own kind sets, silently ignoring the
+    # policy file's own base policy. For the no-policy_file case this is a
+    # pure simplification, not a behavior change: base_sets there is already
+    # computed as `_resolve_kind_sets(policy, kind_sets)` -- identical to
+    # what this line used to recompute.
+    return effective_category(change, *base_sets)
 
 
 def _reclassify_resolved_to_compatible(

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -61,7 +61,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import date
 from enum import Enum
-from typing import cast
+from typing import Any, cast
 
 from .checker_policy import (
     ADDITION_KINDS,
@@ -328,6 +328,55 @@ def effective_verdict_for_change(
     # computed as `_resolve_kind_sets(policy, kind_sets)` -- identical to
     # what this line used to recompute.
     return effective_category(change, *base_sets)
+
+
+def reclassify_rule_for_change(
+    change: HasKind, policy_file: object | None, today: date | None = None
+) -> Any | None:
+    """Return the ``ReclassifyRule`` that actually decided *change*'s
+    effective verdict, or ``None`` if no rule did.
+
+    Mirrors :func:`effective_verdict_for_change`'s own precedence exactly: a
+    rule that *matches* but is shadowed by a higher-priority
+    ``effective_verdict`` (an ADR-027 pipeline modulation) or blocked by the
+    frozen-namespace verdict floor did not actually decide the change's
+    verdict, so it is not "the reclassifying rule" for disclosure purposes
+    even though :meth:`~abicheck.reclassify.ReclassifyRule.matches` would say
+    yes.
+
+    Used by ``reporter.py`` to stamp a per-change ``reclassified_by`` field
+    on the JSON report (Codex review: ``cli_pr_comment``'s
+    ``pr_comment._reclassified_count()`` only recognized the kind-global
+    ``policy_overrides`` map, so a PR comment silently omitted the
+    "reclassified by --policy-file" notice for a finding downgraded by a
+    selector-scoped ``reclassify:`` rule instead). Computing this from the
+    real ``Change`` object here -- rather than having ``pr_comment.py``
+    reimplement selector matching against the JSON report alone -- is
+    deliberate: a JSON-serialized change doesn't carry every selector field a
+    rule can match on (``type_pattern``/``member_name``/``namespace``/
+    ``entity_namespace``/``cause_namespace`` have no JSON counterpart), so a
+    JSON-only reimplementation could not be sound.
+    """
+    if isinstance(getattr(change, "effective_verdict", None), Verdict):
+        return None
+    rules = (
+        getattr(policy_file, "reclassify", None) if policy_file is not None else None
+    )
+    if not rules:
+        return None
+    for rule in rules:
+        if rule.matches(change, today):
+            base_policy = getattr(policy_file, "base_policy", None)
+            base_sets = _resolve_kind_sets(base_policy, None)
+            base_v = effective_category(change, *base_sets)
+            reclass_v = rule.to_verdict
+            if (
+                _has_frozen_namespace_violation(change)
+                and _VERDICT_ORDER.index(reclass_v) < _VERDICT_ORDER.index(base_v)
+            ):
+                return None
+            return rule
+    return None
 
 
 def _reclassify_resolved_to_compatible(

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -364,7 +364,14 @@ def reclassify_rule_for_change(
     is already BREAKING (Codex review: a matching-but-no-op rule was still
     stamping ``reclassified_by``, making the PR comment falsely report a
     downgrade that never happened). Only a rule that actually *changes* the
-    verdict from what would apply in its absence counts as deciding it.
+    verdict from what would apply in its absence counts as deciding it. That
+    comparison verdict is computed through the identical frozen-namespace
+    floor the ``overrides:`` branch below applies -- not the override's raw
+    value (Codex review, second round: a frozen-namespace finding with e.g.
+    ``overrides: func_removed: ignore`` plus ``reclassify: ... to: break``
+    would, absent the rule, already clamp back to BREAKING via the floor;
+    comparing against the raw COMPATIBLE override instead made the rule read
+    as deciding a verdict that was already going to be BREAKING anyway).
     """
     if isinstance(getattr(change, "effective_verdict", None), Verdict):
         return None
@@ -383,11 +390,21 @@ def reclassify_rule_for_change(
     # The verdict that would apply if *this* reclassify rule didn't exist --
     # the next step down the same precedence chain effective_verdict_for_change
     # walks (a same-kind overrides: entry, else the base policy's own
-    # verdict) -- so a rule that merely restates it is recognized as a no-op
-    # regardless of which of the two it happens to restate.
-    next_priority_v = (
-        cast(Verdict, overrides[kind]) if overrides and kind in overrides else base_v
-    )
+    # verdict), with the identical frozen-namespace floor clamp the overrides:
+    # branch below applies -- so a rule that merely restates it is recognized
+    # as a no-op regardless of which of the two it happens to restate, and
+    # regardless of whether the floor would already have clamped it.
+    if overrides and kind in overrides:
+        override_v = cast(Verdict, overrides[kind])
+        if (
+            _has_frozen_namespace_violation(change)
+            and _VERDICT_ORDER.index(override_v) < _VERDICT_ORDER.index(base_v)
+        ):
+            next_priority_v = base_v
+        else:
+            next_priority_v = override_v
+    else:
+        next_priority_v = base_v
     for rule in rules:
         if rule.matches(change, today):
             reclass_v = rule.to_verdict

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -356,6 +356,15 @@ def reclassify_rule_for_change(
     rule can match on (``type_pattern``/``member_name``/``namespace``/
     ``entity_namespace``/``cause_namespace`` have no JSON counterpart), so a
     JSON-only reimplementation could not be sound.
+
+    A matching rule whose ``to_verdict`` merely *restates* the verdict the
+    next-priority path (a same-kind ``overrides:`` entry, or the base policy)
+    would already have produced is a no-op, not a reclassification -- e.g.
+    ``func_removed: to: break`` under ``strict_abi``, where ``func_removed``
+    is already BREAKING (Codex review: a matching-but-no-op rule was still
+    stamping ``reclassified_by``, making the PR comment falsely report a
+    downgrade that never happened). Only a rule that actually *changes* the
+    verdict from what would apply in its absence counts as deciding it.
     """
     if isinstance(getattr(change, "effective_verdict", None), Verdict):
         return None
@@ -364,12 +373,26 @@ def reclassify_rule_for_change(
     )
     if not rules:
         return None
+    base_policy = getattr(policy_file, "base_policy", None)
+    base_sets = _resolve_kind_sets(base_policy, None)
+    base_v = effective_category(change, *base_sets)
+    overrides = (
+        getattr(policy_file, "overrides", None) if policy_file is not None else None
+    )
+    kind = change.kind
+    # The verdict that would apply if *this* reclassify rule didn't exist --
+    # the next step down the same precedence chain effective_verdict_for_change
+    # walks (a same-kind overrides: entry, else the base policy's own
+    # verdict) -- so a rule that merely restates it is recognized as a no-op
+    # regardless of which of the two it happens to restate.
+    next_priority_v = (
+        cast(Verdict, overrides[kind]) if overrides and kind in overrides else base_v
+    )
     for rule in rules:
         if rule.matches(change, today):
-            base_policy = getattr(policy_file, "base_policy", None)
-            base_sets = _resolve_kind_sets(base_policy, None)
-            base_v = effective_category(change, *base_sets)
             reclass_v = rule.to_verdict
+            if reclass_v == next_priority_v:
+                return None
             if (
                 _has_frozen_namespace_violation(change)
                 and _VERDICT_ORDER.index(reclass_v) < _VERDICT_ORDER.index(base_v)

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -311,6 +311,32 @@ def effective_verdict_for_change(
     return effective_category(change, *sets)
 
 
+def _reclassify_resolved_to_compatible(change: HasKind, policy_file: object | None) -> bool:
+    """True if a selector-scoped `reclassify:` rule -- not a kind-global
+    `overrides:` entry or the base policy -- is what produced this change's
+    COMPATIBLE verdict.
+
+    Used only to widen the ADDITION-vs-QUALITY_ISSUES gate below (Codex
+    review): ``sets[2]`` there is whatever *kind-global* ``kind_sets`` the
+    caller supplied (typically ``DiffResult._effective_kind_sets()``, which
+    bakes in ``overrides:`` but has no notion of a selector-scoped rule at
+    all). A `reclassify:` rule reclassifying one specific addition-kind
+    finding to `ignore` -- even under a kind-global `overrides:
+    {func_added: break}` that would otherwise move `func_added` out of
+    ``sets[2]`` entirely -- is exactly the case that check cannot see: the
+    verdict already correctly resolved to COMPATIBLE (`reclassify:` outranks
+    `overrides:`, see `effective_verdict_for_change`), but the addition/
+    quality split would still read the *overridden* kind set and miscount
+    it as `quality_issues`.
+    """
+    if policy_file is None:
+        return False
+    rules = getattr(policy_file, "reclassify", None)
+    if not rules:
+        return False
+    return first_matching_reclassify_verdict(rules, change) == Verdict.COMPATIBLE
+
+
 def classify_effective_change(
     change: HasKind,
     *,
@@ -330,8 +356,14 @@ def classify_effective_change(
     # COMPATIBLE (and the unreachable NO_CHANGE — effective_category only ever
     # returns BREAKING/API_BREAK/RISK/COMPATIBLE): an addition keeps its
     # ADDITION bucket; everything else (including a demoted break, or a
-    # hypothetical NO_CHANGE) is a quality issue, never an addition.
-    if change.kind in ADDITION_KINDS and change.kind in sets[2]:
+    # hypothetical NO_CHANGE) is a quality issue, never an addition. A
+    # reclassify: rule's own COMPATIBLE resolution counts as "in sets[2]"
+    # even when a kind-global override moved this kind out of it (see
+    # _reclassify_resolved_to_compatible).
+    if change.kind in ADDITION_KINDS and (
+        change.kind in sets[2]
+        or _reclassify_resolved_to_compatible(change, policy_file)
+    ):
         return IssueCategory.ADDITION
     return IssueCategory.QUALITY_ISSUES
 

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from datetime import date
 from enum import Enum
 from typing import cast
 
@@ -246,6 +247,7 @@ def effective_verdict_for_change(
     policy: str | None = None,
     kind_sets: KindSets | None = None,
     policy_file: object | None = None,
+    today: date | None = None,
 ) -> Verdict:
     """Return the effective verdict for one change.
 
@@ -253,6 +255,12 @@ def effective_verdict_for_change(
     verdict bucket. Frozen-namespace violations are deliberately per-change: if
     an override would downgrade a tagged finding below the base-policy verdict,
     the override is ignored for that one finding.
+
+    *today* is forwarded to a matching `reclassify:` rule's own expiry check
+    (:func:`abicheck.reclassify.first_matching_reclassify_verdict`) -- pass a
+    fixed date for a deterministic/testable caller (e.g.
+    ``SuppressionList.audit()``'s own *today* parameter); ``None`` uses the
+    real current date, same as every other caller already relies on.
     """
     kind = change.kind
     base_policy = getattr(policy_file, "base_policy", policy)
@@ -283,7 +291,7 @@ def effective_verdict_for_change(
         getattr(policy_file, "reclassify", None) if policy_file is not None else None
     )
     if reclassify_rules:
-        reclass_v = first_matching_reclassify_verdict(reclassify_rules, change)
+        reclass_v = first_matching_reclassify_verdict(reclassify_rules, change, today)
         if reclass_v is not None:
             base_v = effective_category(change, *base_sets)
             if (
@@ -311,7 +319,9 @@ def effective_verdict_for_change(
     return effective_category(change, *sets)
 
 
-def _reclassify_resolved_to_compatible(change: HasKind, policy_file: object | None) -> bool:
+def _reclassify_resolved_to_compatible(
+    change: HasKind, policy_file: object | None, today: date | None = None
+) -> bool:
     """True if a selector-scoped `reclassify:` rule -- not a kind-global
     `overrides:` entry or the base policy -- is what produced this change's
     COMPATIBLE verdict.
@@ -334,7 +344,7 @@ def _reclassify_resolved_to_compatible(change: HasKind, policy_file: object | No
     rules = getattr(policy_file, "reclassify", None)
     if not rules:
         return False
-    return first_matching_reclassify_verdict(rules, change) == Verdict.COMPATIBLE
+    return first_matching_reclassify_verdict(rules, change, today) == Verdict.COMPATIBLE
 
 
 def classify_effective_change(
@@ -343,11 +353,12 @@ def classify_effective_change(
     policy: str | None = None,
     kind_sets: KindSets | None = None,
     policy_file: object | None = None,
+    today: date | None = None,
 ) -> IssueCategory:
     """Classify one change, preserving per-finding verdict guards."""
     sets = _resolve_kind_sets(policy, kind_sets)
     verdict = effective_verdict_for_change(
-        change, policy=policy, kind_sets=kind_sets, policy_file=policy_file,
+        change, policy=policy, kind_sets=kind_sets, policy_file=policy_file, today=today,
     )
     if verdict == Verdict.BREAKING:
         return IssueCategory.ABI_BREAKING
@@ -362,7 +373,7 @@ def classify_effective_change(
     # _reclassify_resolved_to_compatible).
     if change.kind in ADDITION_KINDS and (
         change.kind in sets[2]
-        or _reclassify_resolved_to_compatible(change, policy_file)
+        or _reclassify_resolved_to_compatible(change, policy_file, today)
     ):
         return IssueCategory.ADDITION
     return IssueCategory.QUALITY_ISSUES

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -408,12 +408,29 @@ def reclassify_rule_for_change(
     for rule in rules:
         if rule.matches(change, today):
             reclass_v = rule.to_verdict
-            if reclass_v == next_priority_v:
-                return None
-            if (
-                _has_frozen_namespace_violation(change)
-                and _VERDICT_ORDER.index(reclass_v) < _VERDICT_ORDER.index(base_v)
-            ):
+            # The verdict this matching rule *actually* produces, applying
+            # the identical frozen-namespace floor
+            # effective_verdict_for_change's own reclassify branch applies:
+            # when reclass_v is blocked, that branch returns base_v directly
+            # -- it never falls through to consult overrides:, even though
+            # overrides: would have applied had no reclassify rule matched
+            # at all (Codex review, third round: a blocked rule was
+            # previously always read as a no-op, but the real effective
+            # verdict it produces -- base_v -- can still differ from
+            # next_priority_v, e.g. a global `overrides: ... to: break` with
+            # a frozen-namespace `reclassify: ... to: ignore` blocked back
+            # to a weaker base_v than the override would have given: the
+            # rule genuinely changed the outcome from what overrides: alone
+            # would have produced, just not to the verdict it asked for).
+            effective_v = (
+                base_v
+                if (
+                    _has_frozen_namespace_violation(change)
+                    and _VERDICT_ORDER.index(reclass_v) < _VERDICT_ORDER.index(base_v)
+                )
+                else reclass_v
+            )
+            if effective_v == next_priority_v:
                 return None
             return rule
     return None

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -187,6 +187,7 @@ def classify_change_object(
     *,
     policy: str | None = None,
     kind_sets: KindSets | None = None,
+    policy_file: object | None = None,
 ) -> IssueCategory:
     """Classify a *change* honouring its per-finding ``effective_verdict`` (A4).
 
@@ -195,8 +196,19 @@ def classify_change_object(
     ``Change`` carrying ``effective_verdict``) reads compatible in the
     severity-aware exit code and category counts, not just the verdict. Falls
     back to kind-based ``classify_change`` for plain stubs with no override.
+
+    *policy_file* is optional and defaults to ``None`` (unchanged prior
+    behavior for every existing caller that doesn't pass it): without it,
+    only a *kind-global* `overrides:` entry baked into *kind_sets* (e.g. via
+    ``DiffResult._effective_kind_sets()``) is visible here -- a
+    selector-scoped `reclassify:` rule needs the real ``PolicyFile`` object,
+    which *kind_sets* alone cannot express (Codex review: a scan's
+    blocking-finding report was silently omitting a `reclassify:`-demoted
+    finding for exactly this reason).
     """
-    return classify_effective_change(change, policy=policy, kind_sets=kind_sets)
+    return classify_effective_change(
+        change, policy=policy, kind_sets=kind_sets, policy_file=policy_file
+    )
 
 
 _VERDICT_ORDER = [

--- a/abicheck/severity.py
+++ b/abicheck/severity.py
@@ -76,6 +76,7 @@ from .checker_policy import (
 )
 from .contract_gating import is_evaluated
 from .errors import PolicyError
+from .reclassify import first_matching_reclassify_verdict
 
 
 def gate_eligible_changes(changes: Sequence[HasKind]) -> list[HasKind]:
@@ -258,6 +259,27 @@ def effective_verdict_for_change(
         ):
             return raw_v
         return eff
+
+    # A: selector-scoped reclassification (abicheck/reclassify.py) --
+    # consulted ahead of the kind-global `overrides` below, mirroring
+    # PolicyFile._resolve_change_verdict's own priority order exactly, so
+    # this per-finding resolver (severity/category buckets, JSON/HTML/SARIF
+    # labels, severity-based gating) agrees with the legacy verdict
+    # PolicyFile.compute_verdict already computes instead of silently
+    # re-deriving a different answer for the same change.
+    reclassify_rules = (
+        getattr(policy_file, "reclassify", None) if policy_file is not None else None
+    )
+    if reclassify_rules:
+        reclass_v = first_matching_reclassify_verdict(reclassify_rules, change)
+        if reclass_v is not None:
+            base_v = effective_category(change, *base_sets)
+            if (
+                _has_frozen_namespace_violation(change)
+                and _VERDICT_ORDER.index(reclass_v) < _VERDICT_ORDER.index(base_v)
+            ):
+                return base_v
+            return reclass_v
 
     overrides = (
         getattr(policy_file, "overrides", None)

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -1212,6 +1212,20 @@ class Suppression:
             return False
         return self._passes_reachability_gate(change) and self._passes_public_break_gate(change)
 
+    def selector_matches(self, change: Change, today: date | None = None) -> bool:
+        """Return True if this rule's selectors alone match *change*.
+
+        Public alias for :meth:`_selector_match`, deliberately skipping the
+        reachability / ``allow_public_break`` gates :meth:`matches` applies
+        on top. Those gates exist to guard against a suppression rule
+        *hiding* a finding it never should have — a concern that doesn't
+        apply to a consumer that keeps the finding visible and only changes
+        its verdict (``abicheck/reclassify.py``'s ``ReclassifyRule``, which
+        reuses this class purely for its selector grammar rather than
+        re-implementing the glob/regex machinery a second time).
+        """
+        return self._selector_match(change, today)
+
     def would_withhold(self, change: Change, today: date | None = None) -> bool:
         """True if this rule's selectors match *change*, *change* is a
         public-reachable ``BREAKING``/``API_BREAK`` finding, and the

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -30,6 +30,7 @@ from .checker_policy import (
     BREAKING_KINDS,
     ChangeKind,
     ReachabilityState,
+    Verdict,
 )
 from .checker_types import Change
 
@@ -1600,13 +1601,16 @@ class SuppressionList:
         *,
         near_expiry_days: int = 30,
         breaking_kinds: frozenset[ChangeKind] | None = None,
+        policy_file: object | None = None,
     ) -> SuppressionAudit:
         """Audit suppression rules against a set of changes.
 
         Returns a :class:`SuppressionAudit` with:
         - ``stale_rules``: suppressions that matched zero changes (misconfigured?)
         - ``high_risk_matches``: suppressions that matched a change breaking
-          under *breaking_kinds*
+          under *breaking_kinds* (or, when *policy_file* carries a matching
+          ``reclassify:`` rule for that change, under that rule's own
+          resolution instead -- see below)
         - ``expired_rules``: rules past their expiry date
         - ``near_expiry_rules``: rules expiring within *near_expiry_days*
         - ``match_counts``: per-rule match count
@@ -1619,6 +1623,18 @@ class SuppressionList:
         kind away from it, and this audit's "high risk" classification should
         match the verdict the user's own comparison actually produced, not
         the static default.
+
+        *policy_file* is optional and defaults to ``None`` (unchanged prior
+        behavior for every existing caller that doesn't pass it). When given
+        and it carries one or more ``reclassify:`` rules (A: selector-scoped
+        reclassification), a change matching one is classified by that
+        rule's own resolution instead of *breaking_kinds* membership --
+        *breaking_kinds* is a kind-wide set and cannot express a
+        selector-scoped promotion/demotion at all (Codex review: a
+        `reclassify:` rule promoting one specific normally-compatible
+        finding to ``break`` was invisible to this audit, since the change's
+        *kind* was never in any breaking set; a suppression matching that
+        specific finding was silently under-reported as safe).
         """
         if near_expiry_days < 0:
             raise ValueError("near_expiry_days must be non-negative")
@@ -1627,15 +1643,27 @@ class SuppressionList:
         effective_breaking_kinds = (
             BREAKING_KINDS if breaking_kinds is None else breaking_kinds
         )
+        reclassify_rules = getattr(policy_file, "reclassify", None) or []
 
         match_counts: dict[int, int] = {i: 0 for i in range(len(self._suppressions))}
         high_risk: list[tuple[Suppression, Change]] = []
 
         for c in changes:
+            if reclassify_rules:
+                from .reclassify import first_matching_reclassify_verdict
+
+                reclass_v = first_matching_reclassify_verdict(reclassify_rules, c, today)
+            else:
+                reclass_v = None
+            is_breaking = (
+                reclass_v == Verdict.BREAKING
+                if reclass_v is not None
+                else c.kind in effective_breaking_kinds
+            )
             for i, s in enumerate(self._suppressions):
                 if s.matches(c, today=today):
                     match_counts[i] += 1
-                    if c.kind in effective_breaking_kinds:
+                    if is_breaking:
                         high_risk.append((s, c))
 
         stale = [

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -1607,34 +1607,39 @@ class SuppressionList:
 
         Returns a :class:`SuppressionAudit` with:
         - ``stale_rules``: suppressions that matched zero changes (misconfigured?)
-        - ``high_risk_matches``: suppressions that matched a change breaking
-          under *breaking_kinds* (or, when *policy_file* carries a matching
-          ``reclassify:`` rule for that change, under that rule's own
-          resolution instead -- see below)
+        - ``high_risk_matches``: suppressions that matched a change classified
+          as ``BREAKING`` -- via *breaking_kinds* membership, or, when
+          *policy_file* is given, via the same per-finding resolver
+          (:func:`abicheck.severity.effective_verdict_for_change`) the
+          comparison's own verdict/severity/exit-code already went through
+          (see below)
         - ``expired_rules``: rules past their expiry date
         - ``near_expiry_rules``: rules expiring within *near_expiry_days*
         - ``match_counts``: per-rule match count
 
-        *breaking_kinds* defaults to the built-in :data:`BREAKING_KINDS`, but
-        a caller running under an active ``--policy-file`` should pass its
-        effective, override-applied breaking set (e.g.
-        ``result._effective_kind_sets()[0]``) instead -- a policy can promote
-        a normally-API_BREAK kind to BREAKING or demote a normally-BREAKING
-        kind away from it, and this audit's "high risk" classification should
-        match the verdict the user's own comparison actually produced, not
-        the static default.
+        *breaking_kinds* defaults to the built-in :data:`BREAKING_KINDS`; it's
+        only consulted when *policy_file* is ``None`` (see below) -- a caller
+        that has a real ``PolicyFile`` should pass it instead of just its
+        derived breaking set.
 
         *policy_file* is optional and defaults to ``None`` (unchanged prior
-        behavior for every existing caller that doesn't pass it). When given
-        and it carries one or more ``reclassify:`` rules (A: selector-scoped
-        reclassification), a change matching one is classified by that
-        rule's own resolution instead of *breaking_kinds* membership --
-        *breaking_kinds* is a kind-wide set and cannot express a
-        selector-scoped promotion/demotion at all (Codex review: a
-        `reclassify:` rule promoting one specific normally-compatible
-        finding to ``break`` was invisible to this audit, since the change's
-        *kind* was never in any breaking set; a suppression matching that
-        specific finding was silently under-reported as safe).
+        behavior for every existing caller that doesn't pass it, using
+        *breaking_kinds* alone). When given, each change's "high risk"
+        classification is instead decided by
+        :func:`abicheck.severity.effective_verdict_for_change` -- the same
+        resolver ``PolicyFile.compute_verdict``/``classify_effective_change``
+        already use -- rather than *breaking_kinds* membership. A bare
+        kind-wide set cannot express what that resolver's own precedence
+        chain (a pipeline ``effective_verdict`` modulation, then a
+        selector-scoped ``reclassify:`` rule, then a kind-global
+        ``overrides:`` entry, then the base policy, each still subject to
+        the frozen-namespace verdict floor) actually decided for one
+        specific change (Codex review, two rounds: a `reclassify:` rule
+        promoting one specific normally-compatible finding to ``break`` was
+        invisible to a *breaking_kinds*-only check at all; a naive
+        reclassify-only check that bypassed ``effective_verdict``
+        precedence and the frozen-namespace floor was itself still wrong in
+        the opposite direction).
         """
         if near_expiry_days < 0:
             raise ValueError("near_expiry_days must be non-negative")
@@ -1643,23 +1648,33 @@ class SuppressionList:
         effective_breaking_kinds = (
             BREAKING_KINDS if breaking_kinds is None else breaking_kinds
         )
-        reclassify_rules = getattr(policy_file, "reclassify", None) or []
 
         match_counts: dict[int, int] = {i: 0 for i in range(len(self._suppressions))}
         high_risk: list[tuple[Suppression, Change]] = []
 
         for c in changes:
-            if reclassify_rules:
-                from .reclassify import first_matching_reclassify_verdict
+            if policy_file is not None:
+                # Delegate to the shared per-finding resolver rather than
+                # re-checking `reclassify:` alone (Codex review, fresh
+                # evidence): a bare reclassify-only check bypasses both
+                # `change.effective_verdict`'s own precedence (a pipeline
+                # modulation must win outright, matching/overriding
+                # `reclassify:` the same way effective_verdict_for_change's
+                # own topmost branch does) and the frozen-namespace floor (a
+                # `reclassify:`/override resolution below a frozen symbol's
+                # base-policy verdict is rejected there, not honored). Using
+                # the same resolver as PolicyFile.compute_verdict/
+                # classify_effective_change means this audit's "high risk"
+                # classification can never disagree with the verdict the
+                # comparison itself actually produced.
+                from .severity import effective_verdict_for_change
 
-                reclass_v = first_matching_reclassify_verdict(reclassify_rules, c, today)
+                is_breaking = (
+                    effective_verdict_for_change(c, policy_file=policy_file, today=today)
+                    == Verdict.BREAKING
+                )
             else:
-                reclass_v = None
-            is_breaking = (
-                reclass_v == Verdict.BREAKING
-                if reclass_v is not None
-                else c.kind in effective_breaking_kinds
-            )
+                is_breaking = c.kind in effective_breaking_kinds
             for i, s in enumerate(self._suppressions):
                 if s.matches(c, today=today):
                     match_counts[i] += 1

--- a/action.yml
+++ b/action.yml
@@ -479,7 +479,7 @@ inputs:
     required: false
     default: 'strict_abi'
   policy-file:
-    description: 'Path to a YAML policy file with per-kind verdict overrides.'
+    description: 'Path to a YAML policy file with per-kind (overrides:) or selector-scoped (reclassify:) verdict re-classification.'
     required: false
   suppress:
     description: 'Path to a YAML suppression file to filter known/intentional changes.'

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -159,4 +159,25 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   blocked, bypassing `overrides:` entirely; when that raw base verdict
   differs from what `overrides:` would have given absent the rule, the rule
   genuinely changed the outcome (just not to the verdict it asked for) and
-  must still be disclosed.
+  must still be disclosed. `--report-mode leaf`'s JSON output now carries
+  both the run-level `policy_reclassify` key and each root TYPE_* finding's
+  `reclassified_by` attribution — leaf mode built its own entry dict
+  (`_leaf_entry`) instead of routing through `_change_to_dict`, and never
+  called `_add_policy_overrides` at all, so both were silently absent even
+  though the identical comparison's full/root-cause-mode report carried
+  them. The two entry builders now share one helper
+  (`_reclassified_by_for_change`) so they can't drift on this field again.
+  The Markdown `Policy reclassify` line now code-span-wraps each rule's
+  `describe()` text, matching the existing `Policy overrides` line — an
+  unwrapped mangled-name selector (e.g. `symbol_pattern:
+  "_ZN6oneapi3dal.*"`) could otherwise have its `_`/`*` characters read as
+  Markdown emphasis markers. The JSON schema's `policy_reclassify[].to`
+  field now correctly documents and enforces the four values
+  `ReclassifyRule.to_report_dict()` actually emits (`BREAKING`/
+  `API_BREAK`/`COMPATIBLE_WITH_RISK`/`COMPATIBLE`, i.e. the resolved
+  `Verdict`) rather than being unconstrained — it never accepted the raw
+  YAML `break`/`warn`/`risk`/`ignore` spelling in the first place, since
+  that field always serializes the resolved verdict. `report_schema_version`
+  2.30's own changelog/docstring history entry now lists `label` alongside
+  `kind`/`to`/`reason`/`expires` in `policy_reclassify`'s field set,
+  matching what `to_report_dict()` and both schema files already emit.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -43,4 +43,10 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   `policy_file` parameter, threaded through
   `cli_scan_baseline._blocking_compatible_changes`) instead of silently
   omitting it — the gate/exit-code computation was already correct, only
-  the itemized report was missing the symbol.
+  the itemized report was missing the symbol. A `reclassify:` rule
+  downgrading one addition-kind finding to `ignore` now correctly lands in
+  the `addition` severity bucket rather than `quality_issues`, even when a
+  kind-global `overrides:` entry for the same kind would otherwise move it
+  out of the compatible kind set entirely — the scoped rule's own
+  resolution now wins the addition/quality split too, not just the
+  verdict.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -49,4 +49,8 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   kind-global `overrides:` entry for the same kind would otherwise move it
   out of the compatible kind set entirely — the scoped rule's own
   resolution now wins the addition/quality split too, not just the
-  verdict.
+  verdict. Active `reclassify:` rules are now disclosed in the standard
+  JSON report's new `policy_reclassify` key (`report_schema_version` 2.29,
+  additive), alongside the existing `policy_overrides`/`policy_file` keys —
+  previously an ordinary comparison reclassifying a finding left no trace
+  of the active rule anywhere in the standard report.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -150,3 +150,13 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   and `docs/reference/cli-reference.md`), the Python API's
   `checker.compare(policy_file=...)` docstring, and
   `docs/reference/config-file.md`'s policy-file schema summary table.
+  `reclassify_rule_for_change` now correctly attributes a rule that's
+  blocked by the frozen-namespace floor but still changed the effective
+  outcome from what `overrides:` alone would have produced — previously a
+  blocked rule was unconditionally treated as a no-op, but
+  `effective_verdict_for_change`'s own reclassify branch returns the base
+  policy's raw verdict (not the override's) when a matching rule is
+  blocked, bypassing `overrides:` entirely; when that raw base verdict
+  differs from what `overrides:` would have given absent the rule, the rule
+  genuinely changed the outcome (just not to the verdict it asked for) and
+  must still be disclosed.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -133,4 +133,13 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   actually match `to_verdict` could mislabel the audit trail (e.g. a real
   `to_verdict=BREAKING` promotion reported as `"ignore"`); deriving from the
   resolved verdict itself guarantees the disclosure is always present and
-  always accurate.
+  always accurate. `ReclassifyRule.__post_init__` now canonicalizes `to`
+  from `to_verdict` directly, closing the same class of bug at its root:
+  the earlier fix only patched `reporter.py`'s own `reclassified_by`
+  fallback, but `describe()` (used by the Markdown/HTML report renderers)
+  still read `self.to` verbatim, so a directly-constructed rule with an
+  inconsistent or omitted `to` still misdescribed itself there. `to_verdict`
+  is now the single source of truth; `to` is always its derived canonical
+  spelling (`break`/`warn`/`risk`/`ignore`) — a no-op for every
+  policy-file-loaded rule, since the loader already derives one from the
+  other.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -74,4 +74,11 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   longer disclosed as "active" in the JSON/Markdown/HTML/SARIF reports
   (`policy_reclassify`/`policyReclassify`/etc.) — it can never actually
   match, so listing it there previously claimed a downgrade was in effect
-  when it no longer was.
+  when it no longer was. `classify_effective_change`'s addition/quality
+  split no longer widens the `addition` bucket for a `reclassify:` rule
+  that merely *matches* a finding but was shadowed by a higher-priority
+  `effective_verdict` (a pipeline modulation) that actually decided the
+  verdict. `PolicyFile.validate_overrides()` now also flags a `reclassify:`
+  rule downgrading a critical/breaking kind (the same `HIGH RISK`/`RISK`/
+  plain downgrade diagnostics `overrides:` already gets) — previously a
+  selector-scoped downgrade could bypass that safety check entirely.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -53,4 +53,8 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   JSON report's new `policy_reclassify` key (`report_schema_version` 2.29,
   additive), alongside the existing `policy_overrides`/`policy_file` keys —
   previously an ordinary comparison reclassifying a finding left no trace
-  of the active rule anywhere in the standard report.
+  of the active rule anywhere in the standard report. The same disclosure
+  now also appears in the Markdown (`**Policy reclassify**`), HTML
+  (`<tr><th>Policy reclassify</th>...`), and SARIF (`policyReclassify` run
+  property) report formats, mirroring their existing `overrides:`
+  disclosure.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -142,4 +142,11 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   is now the single source of truth; `to` is always its derived canonical
   spelling (`break`/`warn`/`risk`/`ignore`) — a no-op for every
   policy-file-loaded rule, since the loader already derives one from the
-  other.
+  other. Every other `--policy-file` schema summary in the repo now
+  mentions `reclassify:` alongside `overrides:` instead of describing only
+  the older primitive: `--policy-file`'s own `--help` text
+  (`cli_options.py`), the GitHub Action's `policy-file` input description
+  (`action.yml`, regenerated into `docs/reference/github-action-inputs.md`
+  and `docs/reference/cli-reference.md`), the Python API's
+  `checker.compare(policy_file=...)` docstring, and
+  `docs/reference/config-file.md`'s policy-file schema summary table.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -81,4 +81,15 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   verdict. `PolicyFile.validate_overrides()` now also flags a `reclassify:`
   rule downgrading a critical/breaking kind (the same `HIGH RISK`/`RISK`/
   plain downgrade diagnostics `overrides:` already gets) — previously a
-  selector-scoped downgrade could bypass that safety check entirely.
+  selector-scoped downgrade could bypass that safety check entirely. A
+  `reclassify:` rule with no `kind:` filter (selector fields only, so it
+  applies to whichever kind a matching finding happens to carry) is now
+  conservatively flagged too when it downgrades to `risk`/`ignore` — it's
+  the widest-blast-radius shape a rule can take, since it can silence a
+  critical kind like `func_removed` on a matching symbol with no per-kind
+  diagnostic possible; previously it was silently skipped entirely.
+  `effective_verdict_for_change`'s no-match fallback now honors a given
+  `policy_file`'s own `base_policy` (e.g. `plugin_abi`) instead of silently
+  falling back to `strict_abi`'s kind sets — surfaced by
+  `--audit-suppressions`' new `policy_file`-aware high-risk classification
+  calling this resolver with only `policy_file=` set.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -32,4 +32,9 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   ignore` reclassification can't still fail a severity-gated run through
   the other path. A non-string selector value (e.g. `symbol_pattern: 42`)
   is now a hard `PolicyError` at load time instead of an uncaught
-  `TypeError` or a rule that silently never matches.
+  `TypeError` or a rule that silently never matches. `reclassify:`'s
+  `expires` now normalizes an unquoted YAML timestamp (decoded by PyYAML as
+  a `datetime`) to a `date`, matching `suppress:`'s existing handling.
+  `PolicyFile`'s new `reclassify` field is keyword-only, so an external
+  caller constructing `PolicyFile(base, overrides, source_path)`
+  positionally is unaffected.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -118,4 +118,19 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   clamps back to BREAKING via the floor with no reclassify rule involved at
   all, so comparing against the raw (unclamped) override value instead would
   have made the rule read as deciding a verdict that was already going to be
-  BREAKING regardless.
+  BREAKING regardless. `ReclassifyRule`'s `__post_init__` now normalizes a
+  `datetime` `expires` (a `datetime` is itself a `date` subclass, so the
+  type annotation accepted one) to `.date()`, same as `policy_file.py`'s
+  loader already does for an unquoted YAML timestamp — previously only the
+  loader path was normalized, and a Python caller constructing
+  `ReclassifyRule` directly with `expires=datetime(...)` (a public API
+  surface, not just the policy-file loader) crashed with `TypeError: can't
+  compare date and datetime` the first time the rule was matched or its
+  expiry checked. The `reclassified_by` fallback now derives from
+  `rule.to_verdict.value` instead of the raw, caller-supplied `rule.to` —
+  previously a directly-constructed rule with only `to_verdict` set (`to`
+  defaulting to `""`) silently stamped nothing, and a `to` that didn't
+  actually match `to_verdict` could mislabel the audit trail (e.g. a real
+  `to_verdict=BREAKING` promotion reported as `"ignore"`); deriving from the
+  resolved verdict itself guarantees the disclosure is always present and
+  always accurate.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -67,4 +67,11 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   already uses, rather than a standalone `reclassify:` check -- so a
   pipeline-set `effective_verdict` modulation and the frozen-namespace
   verdict floor are honored with the correct precedence too, not just
-  `reclassify:` in isolation.
+  `reclassify:` in isolation. `ReclassifyRule(to_verdict=...)` now rejects
+  `NO_CHANGE` (only `break`/`warn`/`risk`/`ignore`'s four real verdicts are
+  valid reclassification targets — `NO_CHANGE` would make a matching change
+  disappear from every verdict bucket). An expired `reclassify:` rule is no
+  longer disclosed as "active" in the JSON/Markdown/HTML/SARIF reports
+  (`policy_reclassify`/`policyReclassify`/etc.) — it can never actually
+  match, so listing it there previously claimed a downgrade was in effect
+  when it no longer was.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -111,4 +111,11 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   `strict_abi`, where `func_removed` is already BREAKING) — only a rule that
   actually changes the verdict from what the next-priority path (a same-kind
   `overrides:` entry, or the base policy) would produce counts as a real
-  reclassification.
+  reclassification. That next-priority comparison verdict is itself computed
+  through the same frozen-namespace floor the `overrides:` branch applies,
+  not the override's raw value — a frozen-namespace finding with e.g.
+  `overrides: func_removed: ignore` plus `reclassify: ... to: break` already
+  clamps back to BREAKING via the floor with no reclassify rule involved at
+  all, so comparing against the raw (unclamped) override value instead would
+  have made the rule read as deciding a verdict that was already going to be
+  BREAKING regardless.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -105,3 +105,10 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   `pr_comment._reclassified_count()` only recognized the kind-keyed
   `policy_overrides` map — a `func_removed` reclassified to `ignore` for one
   symbol read as an unremarked "safe" change in the PR comment.
+  `reclassify_rule_for_change`/`reclassified_by` no longer stamp a matching
+  rule whose `to:` merely restates the verdict that would already apply
+  without it (e.g. `func_removed` reclassified `to: break` under
+  `strict_abi`, where `func_removed` is already BREAKING) — only a rule that
+  actually changes the verdict from what the next-priority path (a same-kind
+  `overrides:` entry, or the base policy) would produce counts as a real
+  reclassification.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -50,11 +50,15 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   out of the compatible kind set entirely — the scoped rule's own
   resolution now wins the addition/quality split too, not just the
   verdict. Active `reclassify:` rules are now disclosed in the standard
-  JSON report's new `policy_reclassify` key (`report_schema_version` 2.29,
+  JSON report's new `policy_reclassify` key (`report_schema_version` 2.30,
   additive), alongside the existing `policy_overrides`/`policy_file` keys —
   previously an ordinary comparison reclassifying a finding left no trace
   of the active rule anywhere in the standard report. The same disclosure
   now also appears in the Markdown (`**Policy reclassify**`), HTML
   (`<tr><th>Policy reclassify</th>...`), and SARIF (`policyReclassify` run
   property) report formats, mirroring their existing `overrides:`
-  disclosure.
+  disclosure. `--audit-suppressions`' `SuppressionList.audit()` gained an
+  optional `policy_file` parameter: a `reclassify:` rule promoting a
+  normally-compatible finding to `break` for one specific symbol is now
+  correctly flagged as a high-risk suppression match, which a kind-wide
+  `breaking_kinds` set alone could never express.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -37,4 +37,10 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   a `datetime`) to a `date`, matching `suppress:`'s existing handling.
   `PolicyFile`'s new `reclassify` field is keyword-only, so an external
   caller constructing `PolicyFile(base, overrides, source_path)`
-  positionally is unaffected.
+  positionally is unaffected. `scan --against`'s severity-scheme report now
+  correctly names a `reclassify:`-demoted finding as the scan's own
+  blocking cause (`severity.classify_change_object` gained an optional
+  `policy_file` parameter, threaded through
+  `cli_scan_baseline._blocking_compatible_changes`) instead of silently
+  omitting it — the gate/exit-code computation was already correct, only
+  the itemized report was missing the symbol.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -61,4 +61,10 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   optional `policy_file` parameter: a `reclassify:` rule promoting a
   normally-compatible finding to `break` for one specific symbol is now
   correctly flagged as a high-risk suppression match, which a kind-wide
-  `breaking_kinds` set alone could never express.
+  `breaking_kinds` set alone could never express. That classification now
+  routes through the same shared per-finding resolver
+  (`severity.effective_verdict_for_change`) the comparison's own verdict
+  already uses, rather than a standalone `reclassify:` check -- so a
+  pipeline-set `effective_verdict` modulation and the frozen-namespace
+  verdict floor are honored with the correct precedence too, not just
+  `reclassify:` in isolation.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -1,0 +1,27 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Added
+
+- **Selector-scoped reclassification (`reclassify:`), a third `--policy-file`
+  primitive.** `suppress:`'s `Suppression` rules already had a rich
+  per-symbol/pattern/namespace selector grammar but only one action —
+  deleting the finding — while `overrides:` could change a finding's
+  verdict but only per `ChangeKind`, globally, with no selector. Neither let
+  a project say "every `func_visibility_changed` on *this* symbol family is
+  a known, accepted risk" without either downgrading the whole kind
+  project-wide or throwing the finding away entirely — the motivating case
+  is a COMDAT-inline-heavy library like oneDAL, where dozens of symbols need
+  the same downgrade while an unrelated visibility regression elsewhere
+  must still break. `reclassify:` closes that gap: each rule reuses
+  `Suppression`'s exact selector grammar (`symbol`/`symbol_pattern`/
+  `type_pattern`/`member_name`/`namespace`/`entity_namespace`/
+  `cause_namespace`/`source_location`/`change_kind`/`expires`) plus a
+  required `to:` (`break`/`warn`/`risk`/`ignore`, the same vocabulary
+  `overrides:` already uses), and keeps the finding visible at the new
+  verdict instead of deleting it. Consulted ahead of the kind-global
+  `overrides:` entry for the same kind (a selector-scoped rule is strictly
+  more specific), and still respects the existing frozen-namespace verdict
+  floor. See `abicheck/reclassify.py`'s module docstring and
+  `policy_file.py`'s format example.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -92,4 +92,16 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   `policy_file`'s own `base_policy` (e.g. `plugin_abi`) instead of silently
   falling back to `strict_abi`'s kind sets — surfaced by
   `--audit-suppressions`' new `policy_file`-aware high-risk classification
-  calling this resolver with only `policy_file=` set.
+  calling this resolver with only `policy_file=` set. Each `change` entry in
+  the standard JSON report now carries an optional `reclassified_by` field
+  (`report_schema_version` 2.31) naming the specific `reclassify:` rule
+  (`label`/`reason`/`to`, first one set) that actually decided that
+  finding's verdict, via the new `severity.reclassify_rule_for_change` —
+  previously only the run-level `policy_reclassify` active-rule-set listing
+  existed, with no per-finding attribution. `cli_pr_comment`'s sticky
+  PR-comment renderer now recognizes it too: a finding downgraded by a
+  selector-scoped `reclassify:` rule previously bypassed the "🔀 N findings
+  reclassified by `--policy-file`" notice entirely, since
+  `pr_comment._reclassified_count()` only recognized the kind-keyed
+  `policy_overrides` map — a `func_removed` reclassified to `ignore` for one
+  symbol read as an unremarked "safe" change in the PR comment.

--- a/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
+++ b/changelog.d/20260812_120000_claude_selector_scoped_reclassify.md
@@ -24,4 +24,12 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   `overrides:` entry for the same kind (a selector-scoped rule is strictly
   more specific), and still respects the existing frozen-namespace verdict
   floor. See `abicheck/reclassify.py`'s module docstring and
-  `policy_file.py`'s format example.
+  `policy_file.py`'s format example. Consulted by the shared per-finding
+  severity resolver (`severity.effective_verdict_for_change`, and
+  everything built on it — `IssueCategory` buckets, JSON/HTML/SARIF
+  severity labels, severity-based exit codes), not just
+  `PolicyFile.compute_verdict`'s legacy verdict, so a `to: risk`/`to:
+  ignore` reclassification can't still fail a severity-gated run through
+  the other path. A non-string selector value (e.g. `symbol_pattern: 42`)
+  is now a hard `PolicyError` at load time instead of an uncaught
+  `TypeError` or a rule that silently never matches.

--- a/docs/_meta/topics.yaml
+++ b/docs/_meta/topics.yaml
@@ -195,6 +195,7 @@ topics:
     fact_sources:
       - abicheck/policy_file.py
       - abicheck/checker_policy.py
+      - abicheck/reclassify.py
 
   # ADR-049's effective compatibility configuration: the resolved object, its
   # field-level precedence, and the pack-manifest format. Distinct from

--- a/docs/reference/cli-reference.md
+++ b/docs/reference/cli-reference.md
@@ -90,7 +90,7 @@ Compare two ABI surfaces and report changes.
 | `--secondary-output` | no | — | File path to write --secondary-format's output to. Must differ from --output/-o, or the secondary render would silently overwrite the primary report. |
 | `--demangle`, `--no-demangle` | no | — | Demangle C++ symbol names in markdown/review output (default ON; use --no-demangle to turn off). json/sarif always keep raw mangled names, and HTML is rendered structurally and is never demangled regardless of this flag. |
 | `--policy` | no | `strict_abi` | Built-in policy profile for verdict classification. Ignored when --policy-file is given. Choices: `strict_abi`, `sdk_vendor`, `plugin_abi`. |
-| `--policy-file` | no | — | YAML policy file with per-kind verdict overrides, or a built-in name (e.g. 'security'). Overrides --policy. |
+| `--policy-file` | no | — | YAML policy file with per-kind ('overrides:') or selector-scoped ('reclassify:') verdict re-classification, or a built-in name (e.g. 'security'). Overrides --policy. |
 | `--suppress` | no | — | Suppression file (YAML) to filter known/intentional changes. |
 | `--pdb-path` | no | — | Explicit PDB file path for Windows PE debug info. Applies to both sides; scope to one with an 'old='/'new=' prefix, repeating the flag per side (e.g. --pdb-path old=a.pdb --pdb-path new=b.pdb). Overrides automatic PDB discovery (ADR-040). |
 | `--used-by` | no | — | Application binary whose actual imports/required symbol versions scope the comparison (repeatable; folds `appcompat`). The full library comparison still runs once; the worst app-scoped result becomes the primary verdict/exit code, with the full verdict and unrelated changes kept as informational context. OLD/NEW may be real library binaries or JSON snapshots carrying binary evidence (a `dump` of a real library, not headers-only). Mutually exclusive with --required-symbol/--required-symbols. |
@@ -446,7 +446,7 @@ Deterministic source-intelligence scan (classify → always-on tier → level).
 | `--crosscheck` | no | — | Per-check level KEY=LEVEL (off\|info\|warning\|error); repeatable. |
 | `--risk-rules` | no | — | Override the risk\_rules profile (YAML). |
 | `--policy` | no | `strict_abi` | Built-in policy profile for verdict classification. Ignored when --policy-file is given. Choices: `strict_abi`, `sdk_vendor`, `plugin_abi`. |
-| `--policy-file` | no | — | YAML policy file with per-kind verdict overrides, or a built-in name (e.g. 'security'). Overrides --policy. |
+| `--policy-file` | no | — | YAML policy file with per-kind ('overrides:') or selector-scoped ('reclassify:') verdict re-classification, or a built-in name (e.g. 'security'). Overrides --policy. |
 | `--suppress` | no | — | Suppression file (YAML) to filter known/intentional changes. |
 | `--scope-public-headers`, `--no-scope-public-headers` | no | `True` | Restrict findings to the public-header ABI surface (ADR-024): changes to symbols/types not reachable from public-header-declared exported API are recorded as filtered, not reported. Internal-type leaks are never hidden. On by default; use --no-scope-public-headers to report every finding regardless of surface. |
 | `--severity-preset` | no | — | Severity preset: 'default', 'strict', or 'info-only'. Controls exit codes and report labels. Per-category --severity-* options override the chosen preset. Choices: `default`, `strict`, `info-only`. |

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -244,7 +244,7 @@ files**, not in `.abicheck.yml`:
 
 | Concept | File / flag | Top-level schema | Docs |
 |---------|-------------|------------------|------|
-| Policy profile | `--policy-file <file>` (`PolicyFile.load`, `policy_file.py`) — note `--policy` only takes the built-in names `strict_abi`/`sdk_vendor`/`plugin_abi` | `base_policy`, `overrides`, `frozen_namespaces`, `evidence_policy` | [Policies](../use/policies.md) |
+| Policy profile | `--policy-file <file>` (`PolicyFile.load`, `policy_file.py`) — note `--policy` only takes the built-in names `strict_abi`/`sdk_vendor`/`plugin_abi` | `base_policy`, `overrides`, `reclassify`, `frozen_namespaces`, `evidence_policy` | [Policies](../use/policies.md) |
 | Suppression rules | `--suppress <file>` (`suppression.py`) | Suppression rule entries (YAML or ABICC format) | [Suppressions](../use/suppressions.md) |
 
 The `evidence_policy` block is part of the **policy file**, not `.abicheck.yml`.

--- a/docs/reference/github-action-inputs.md
+++ b/docs/reference/github-action-inputs.md
@@ -69,7 +69,7 @@ Every `with:` input and `outputs.*` value for the [abicheck GitHub Action](../us
 | `output-file` | no | — | Path to write the report file. If not set, output goes to stdout and job summary. |
 | `snapshot-compression` | no | — | dump mode only (ADR-059). Storage envelope for the written snapshot: 'auto' (default) infers gzip/zstd/plain from output-file's canonical suffix (.abicheck.json.gz/.abicheck.json.zst/plain .abicheck.json); an explicit 'none', 'gzip', or 'zstd' is used as-is and is a hard error if it contradicts output-file's suffix, mirroring the CLI's own --compression flag it maps to directly. Ignored by every other mode -- compare/scan/deps-tree/deps-compare produce a report, not a stored snapshot, and transparently read a compressed snapshot operand either way via magic-byte detection regardless of this input. |
 | `policy` | no | strict_abi | Built-in policy profile: strict_abi (default), sdk_vendor, plugin_abi. |
-| `policy-file` | no | — | Path to a YAML policy file with per-kind verdict overrides. |
+| `policy-file` | no | — | Path to a YAML policy file with per-kind (overrides:) or selector-scoped (reclassify:) verdict re-classification. |
 | `suppress` | no | — | Path to a YAML suppression file to filter known/intentional changes. |
 | `verbose` | no | false | Enable verbose/debug output from abicheck. |
 | `python-version` | no | 3.13 | Python version for setup-python. |

--- a/docs/reference/schemas/v1/compare_report.schema.json
+++ b/docs/reference/schemas/v1/compare_report.schema.json
@@ -896,7 +896,11 @@
         "type": "object",
         "required": ["to"],
         "properties": {
-          "to": { "type": "string" },
+          "to": {
+            "type": "string",
+            "description": "ReclassifyRule.to_report_dict()'s `to` key is `to_verdict.value` (the resolved Verdict, not the raw `break`/`warn`/`risk`/`ignore` YAML spelling) -- one of these four.",
+            "enum": ["BREAKING", "API_BREAK", "COMPATIBLE_WITH_RISK", "COMPATIBLE"]
+          },
           "kind": { "type": "string" },
           "symbol": { "type": "string" },
           "symbol_pattern": { "type": "string" },
@@ -1246,7 +1250,7 @@
         },
         "reclassified_by": {
           "type": "string",
-          "description": "Schema 2.31: present only when a selector-scoped `--policy-file` `reclassify:` rule (not a kind-global `overrides:` entry) actually decided this finding's effective verdict \u2014 the deciding rule's own `label`, or `reason`, or `to` spelling (first one set). See `policy_reclassify` for the full active rule set this attributes back to."
+          "description": "Schema 2.31: present only when a selector-scoped `--policy-file` `reclassify:` rule (not a kind-global `overrides:` entry) actually decided this finding's effective verdict \u2014 the deciding rule's own `label`, or `reason`, or the applied verdict value (first one set). See `policy_reclassify` for the full active rule set this attributes back to."
         },
         "reviewer_action": {
           "type": "string",

--- a/docs/reference/schemas/v1/compare_report.schema.json
+++ b/docs/reference/schemas/v1/compare_report.schema.json
@@ -1244,6 +1244,10 @@
           "type": "string",
           "description": "The ChangeKind value of a related finding this one shares a cross-reference with \u2014 the structured sibling to a correlation already described in the description prose. Two independent producers set it: (1) ADR-041 P0 roadmap item 2, for a public_api_internal_dependency_added finding correlated with the same public entry's own body/type-hash change this version (e.g. 'inline_body_changed'); (2) schema 2.28, for a layout_unverifiable finding sharing the identical asymmetric-layout-evidence gap as a co-reported type_vtable_changed finding on the same type (always 'type_vtable_changed' in that case). Consumers should treat the value as an opaque ChangeKind slug naming the correlated finding, not assume a specific kind pairing."
         },
+        "reclassified_by": {
+          "type": "string",
+          "description": "Schema 2.31: present only when a selector-scoped `--policy-file` `reclassify:` rule (not a kind-global `overrides:` entry) actually decided this finding's effective verdict \u2014 the deciding rule's own `label`, or `reason`, or `to` spelling (first one set). See `policy_reclassify` for the full active rule set this attributes back to."
+        },
         "reviewer_action": {
           "type": "string",
           "description": "Finer-grained reviewer guidance, present only when recommended_action is 'no_action_required' (a COMPATIBLE addition). recommended_action alone only answers whether the old binary consumer needs to do anything (no); this answers whether a human reviewing the change has anything to check.",

--- a/docs/reference/schemas/v1/compare_report.schema.json
+++ b/docs/reference/schemas/v1/compare_report.schema.json
@@ -891,7 +891,7 @@
     },
     "policy_reclassify": {
       "type": "array",
-      "description": "Active reclassify: rules from the policy file (report_schema_version 2.29), when any are configured -- the same audit-detail level policy_overrides already gives for kind-global overrides, listing the rule set rather than a per-finding \"which rule fired\" attribution. Selector fields present depend on which selector the rule used (see abicheck/reclassify.py).",
+      "description": "Active reclassify: rules from the policy file (report_schema_version 2.30), when any are configured -- the same audit-detail level policy_overrides already gives for kind-global overrides, listing the rule set rather than a per-finding \"which rule fired\" attribution. Selector fields present depend on which selector the rule used (see abicheck/reclassify.py).",
       "items": {
         "type": "object",
         "required": ["to"],

--- a/docs/reference/schemas/v1/compare_report.schema.json
+++ b/docs/reference/schemas/v1/compare_report.schema.json
@@ -889,6 +889,30 @@
         "type": "string"
       }
     },
+    "policy_reclassify": {
+      "type": "array",
+      "description": "Active reclassify: rules from the policy file (report_schema_version 2.29), when any are configured -- the same audit-detail level policy_overrides already gives for kind-global overrides, listing the rule set rather than a per-finding \"which rule fired\" attribution. Selector fields present depend on which selector the rule used (see abicheck/reclassify.py).",
+      "items": {
+        "type": "object",
+        "required": ["to"],
+        "properties": {
+          "to": { "type": "string" },
+          "kind": { "type": "string" },
+          "symbol": { "type": "string" },
+          "symbol_pattern": { "type": "string" },
+          "type_pattern": { "type": "string" },
+          "member_name": { "type": "string" },
+          "namespace": { "type": "string" },
+          "entity_namespace": { "type": "string" },
+          "cause_namespace": { "type": "string" },
+          "source_location": { "type": "string" },
+          "reason": { "type": "string" },
+          "label": { "type": "string" },
+          "expires": { "type": "string" }
+        },
+        "additionalProperties": false
+      }
+    },
     "policy_file": {
       "type": "string"
     },

--- a/docs/use/output-formats.md
+++ b/docs/use/output-formats.md
@@ -648,7 +648,7 @@ Every JSON report carries a top-level `report_schema_version` field
 
 ```json
 {
-  "report_schema_version": "2.30",
+  "report_schema_version": "2.31",
   "library": "libfoo.so.1",
   "verdict": "BREAKING"
 }

--- a/docs/use/output-formats.md
+++ b/docs/use/output-formats.md
@@ -648,7 +648,7 @@ Every JSON report carries a top-level `report_schema_version` field
 
 ```json
 {
-  "report_schema_version": "2.29",
+  "report_schema_version": "2.30",
   "library": "libfoo.so.1",
   "verdict": "BREAKING"
 }

--- a/docs/use/policies.md
+++ b/docs/use/policies.md
@@ -207,7 +207,12 @@ want to see).
 - Active `reclassify:` rules are listed in the standard JSON report's
   `policy_reclassify` key, alongside `policy_overrides`, so a reclassified
   finding's report always carries a trace of the policy that steered it
-  (`report_schema_version` 2.30+).
+  (`report_schema_version` 2.30+). A finding whose effective verdict was
+  actually decided by a selector-scoped rule (not a same-kind `overrides:`
+  entry) additionally carries its own `change.reclassified_by` field, naming
+  the deciding rule's `label`/`reason`/`to` (`report_schema_version` 2.31+) —
+  consumers like the PR-comment renderer use this to disclose the
+  reclassification per-finding, not just as part of the active rule list.
 
 ### Evidence-aware controls (`evidence_policy`)
 

--- a/docs/use/policies.md
+++ b/docs/use/policies.md
@@ -170,6 +170,41 @@ Semantics:
 
 If both `--policy` and `--policy-file` are provided, `--policy-file` wins.
 
+### Selector-scoped reclassification (`reclassify`)
+
+`overrides` above changes a verdict for every symbol of a given `ChangeKind`,
+project-wide. [Suppressions](suppressions.md) can target one symbol/pattern/
+namespace, but only by deleting the finding. `reclassify` is the third
+option: the same selector grammar suppression rules use — `symbol`,
+`symbol_pattern`, `type_pattern`, `member_name`, `namespace`,
+`entity_namespace`, `cause_namespace`, `source_location`, `expires` — plus a
+required `to`, applied instead of deleting the finding:
+
+```yaml
+reclassify:
+  - kind: func_visibility_changed
+    symbol_pattern: "_ZN6oneapi3dal.*"
+    to: risk   # break|warn|risk|ignore, same vocabulary as overrides
+    reason: "COMDAT-inline demotions; consumers already embed their own copy"
+```
+
+Use this when a whole symbol family shares a known, accepted cause (e.g.
+dozens of COMDAT-inline visibility demotions in a template-heavy library)
+that you don't want to downgrade project-wide (too broad — `overrides`)
+or hide entirely (`suppress` — loses the evidence a reviewer may still
+want to see).
+
+- `kind` is this block's spelling of the selector's `change_kind`.
+- Rules are evaluated in file order; the **first** matching rule wins, since
+  (unlike suppression, where every match has the same effect) two rules can
+  disagree about which verdict to apply to the same finding.
+- A `reclassify` match takes priority over a same-kind `overrides` entry
+  (more specific wins), but a pipeline-computed `effective_verdict` (pattern
+  modulation) and the frozen-namespace verdict floor still take precedence
+  over both — see [ci-gating.md](ci-gating.md) for the full classification
+  order.
+- At least one selector is required, same as a suppression rule.
+
 ### Evidence-aware controls (`evidence_policy`)
 
 When a compare also carries build/source evidence (build-info / source packs,

--- a/docs/use/policies.md
+++ b/docs/use/policies.md
@@ -204,6 +204,10 @@ want to see).
   over both — see [ci-gating.md](ci-gating.md) for the full classification
   order.
 - At least one selector is required, same as a suppression rule.
+- Active `reclassify:` rules are listed in the standard JSON report's
+  `policy_reclassify` key, alongside `policy_overrides`, so a reclassified
+  finding's report always carries a trace of the policy that steered it
+  (`report_schema_version` 2.29+).
 
 ### Evidence-aware controls (`evidence_policy`)
 

--- a/docs/use/policies.md
+++ b/docs/use/policies.md
@@ -207,7 +207,7 @@ want to see).
 - Active `reclassify:` rules are listed in the standard JSON report's
   `policy_reclassify` key, alongside `policy_overrides`, so a reclassified
   finding's report always carries a trace of the policy that steered it
-  (`report_schema_version` 2.29+).
+  (`report_schema_version` 2.30+).
 
 ### Evidence-aware controls (`evidence_policy`)
 

--- a/tests/test_pr_comment.py
+++ b/tests/test_pr_comment.py
@@ -1152,6 +1152,50 @@ def test_suppressed_and_reclassified_notes_combine():
     assert "1 finding reclassified by `--policy-file`" in body
 
 
+def test_reclassified_count_recognizes_a_selector_scoped_reclassify_rule():
+    """Codex review: a finding downgraded by a selector-scoped `reclassify:`
+    rule (reporter.py's per-change `reclassified_by` marker,
+    report_schema_version 2.31) previously bypassed this count and the PR
+    comment's disclosure entirely, since only the kind-keyed
+    `policy_overrides` map was recognized -- a `func_removed` reclassified to
+    `ignore` for one symbol read as an unremarked safe change."""
+    report = _compare_report(
+        [
+            {
+                "kind": "func_removed",
+                "symbol": "foo_init",
+                "description": "removed",
+                "severity": "compatible",
+                "reclassified_by": "COMDAT-inline demotions",
+            },
+        ]
+    )
+    model = build_model(report)
+    assert model.reclassified_count == 1
+    body = render_comment(model, sha="cafe1234")
+    assert "1 finding reclassified by `--policy-file`" in body
+
+
+def test_reclassified_count_does_not_double_count_a_change_in_both_mechanisms():
+    """A change carrying `reclassified_by` was, by construction, decided by
+    the `reclassify:` rule (consulted ahead of `overrides:`), so it must not
+    also be counted against a same-kind `policy_overrides` entry."""
+    report = _compare_report(
+        [
+            {
+                "kind": "func_removed",
+                "symbol": "foo_init",
+                "description": "removed",
+                "severity": "compatible",
+                "reclassified_by": "COMDAT-inline demotions",
+            },
+        ]
+    )
+    report["policy_overrides"] = {"func_removed": "COMPATIBLE_WITH_RISK"}
+    model = build_model(report)
+    assert model.reclassified_count == 1
+
+
 def test_pipe_characters_escaped_in_cells():
     report = _compare_report(
         [

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -488,6 +488,28 @@ reclassify:
     assert blocked == [reclassified]
 
 
+def _override_adjusted_kind_sets(pf: PolicyFile, *changes):
+    """The real, override-adjusted kind sets a production caller
+    (sarif.py's ``_severity()``, cli_scan_baseline.py's
+    ``_blocking_compatible_changes``) actually passes as *kind_sets* --
+    ``DiffResult._effective_kind_sets()``. A bare
+    ``classify_effective_change(change, policy_file=pf)`` call with no
+    explicit *kind_sets* falls back to the canonical, override-*unaware*
+    default set instead, which never actually exercises "a kind-global
+    override moved this kind out of ``sets[2]``" at all -- exactly the
+    scenario these tests need to be realistic about (Codex review: an
+    earlier version of this test passed regardless of whether the
+    addition/quality-split fix below was even present, for exactly this
+    reason)."""
+    from abicheck.checker_types import DiffResult
+
+    diff = DiffResult(
+        changes=list(changes), old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+    return diff._effective_kind_sets()
+
+
 def test_reclassify_wins_addition_bucket_over_a_kind_global_override(
     tmp_path: Path,
 ) -> None:
@@ -522,20 +544,63 @@ reclassify:
     pf = PolicyFile.load(p)
     scoped = _change(ChangeKind.FUNC_ADDED, "foo")
     unscoped = _change(ChangeKind.FUNC_ADDED, "bar")
+    kind_sets = _override_adjusted_kind_sets(pf, scoped, unscoped)
 
-    assert classify_effective_change(scoped, policy_file=pf) == IssueCategory.ADDITION
+    assert (
+        classify_effective_change(scoped, kind_sets=kind_sets, policy_file=pf)
+        == IssueCategory.ADDITION
+    )
     # An unrelated func_added symbol still falls through to the (broader)
     # override -- BREAKING, not silently granted the same leniency.
     assert (
-        classify_effective_change(unscoped, policy_file=pf)
+        classify_effective_change(unscoped, kind_sets=kind_sets, policy_file=pf)
         == IssueCategory.ABI_BREAKING
     )
 
     cfg = SeverityConfig(
         quality_issues=SeverityLevel.ERROR, addition=SeverityLevel.INFO
     )
-    assert compute_exit_code([scoped], cfg, policy_file=pf) == 0
-    assert compute_exit_code([scoped], PRESET_DEFAULT, policy_file=pf) == 0
+    assert compute_exit_code([scoped], cfg, kind_sets=kind_sets, policy_file=pf) == 0
+    assert (
+        compute_exit_code([scoped], PRESET_DEFAULT, kind_sets=kind_sets, policy_file=pf)
+        == 0
+    )
+
+
+def test_reclassify_addition_bucket_ignores_a_shadowed_rule(tmp_path: Path) -> None:
+    """Codex review, second round: `_reclassify_resolved_to_compatible` must
+    not widen the ADDITION bucket for a rule that merely *matches* -- only
+    for one that actually *decided* the verdict. When
+    `change.effective_verdict` is already set (a pipeline modulation, which
+    outranks `reclassify:` entirely -- see `effective_verdict_for_change`'s
+    own topmost branch), a same-symbol `reclassify:` rule sits shadowed and
+    must not still grant ADDITION leniency: an addition kind globally
+    overridden to `break`, with effective_verdict=COMPATIBLE set by an
+    unrelated mechanism, stays QUALITY_ISSUES."""
+    from abicheck.severity import IssueCategory, classify_effective_change
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+overrides:
+  func_added: break
+reclassify:
+  - kind: func_added
+    symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(
+        ChangeKind.FUNC_ADDED, "foo", effective_verdict=Verdict.COMPATIBLE
+    )
+    kind_sets = _override_adjusted_kind_sets(pf, change)
+
+    assert (
+        classify_effective_change(change, kind_sets=kind_sets, policy_file=pf)
+        == IssueCategory.QUALITY_ISSUES
+    )
 
 
 # --- standard-report disclosure (reporter.py's policy_reclassify key) ------
@@ -916,3 +981,100 @@ reclassify:
 
     audit = supl.audit([change], policy_file=pf)
     assert audit.high_risk_matches == []
+
+
+# --- PolicyFile.validate_overrides() covers reclassify: too ---------------
+
+
+def test_validate_overrides_flags_a_critical_kind_reclassified_to_ignore(
+    tmp_path: Path,
+) -> None:
+    """Codex review: a `reclassify:` rule downgrading a critical/dangerous
+    kind is exactly the mistake this check exists to catch -- it must not
+    bypass the diagnostic purely by being selector-scoped instead of a
+    kind-global `overrides:` entry."""
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    warnings = pf.validate_overrides()
+    assert len(warnings) == 1
+    assert "HIGH RISK" in warnings[0]
+    assert "func_removed" in warnings[0]
+
+
+def test_validate_overrides_flags_a_critical_kind_reclassified_to_risk(
+    tmp_path: Path,
+) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: type_size_changed
+    symbol: foo
+    to: risk
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    warnings = pf.validate_overrides()
+    assert len(warnings) == 1
+    assert "RISK" in warnings[0]
+
+
+def test_validate_overrides_flags_a_breaking_kind_reclassified_to_ignore(
+    tmp_path: Path,
+) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_virtual_added
+    symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    warnings = pf.validate_overrides()
+    assert len(warnings) == 1
+    assert "BREAKING" in warnings[0]
+
+
+def test_validate_overrides_safe_reclassify_no_warning(tmp_path: Path) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: enum_member_renamed
+    symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    assert pf.validate_overrides() == []
+
+
+def test_validate_overrides_skips_a_kindless_reclassify_rule(tmp_path: Path) -> None:
+    """A rule scoped purely by symbol/namespace, with no `kind:` filter, has
+    no single base_verdict to compare against -- skipped, not a crash, and
+    no false "safe" or "risky" claim either way."""
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    assert pf.validate_overrides() == []

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -63,6 +63,17 @@ def test_reclassify_rule_rejects_unknown_change_kind() -> None:
         )
 
 
+def test_reclassify_rule_rejects_no_change_as_a_target_verdict() -> None:
+    """Codex review: a directly-constructed ReclassifyRule(to_verdict=
+    Verdict.NO_CHANGE, ...) would make a matching real change disappear from
+    every one of DiffResult.breaking/source_breaks/risk/compatible -- a
+    silently passing result that conceals a real change, not a lenient
+    reclassification. The public `to:` YAML vocabulary (break/warn/risk/
+    ignore) can never produce this, but the class itself is public API."""
+    with pytest.raises(ValueError, match="Invalid to_verdict"):
+        ReclassifyRule(to_verdict=Verdict.NO_CHANGE, to="none", symbol="foo")
+
+
 def test_reclassify_rule_expires() -> None:
     from datetime import date
 
@@ -535,7 +546,7 @@ def test_active_reclassify_rules_are_disclosed_in_the_standard_report(
 ) -> None:
     """Codex review: an ordinary comparison reclassifying a finding had no
     trace of the active `reclassify:` rule anywhere in the standard JSON
-    report. `policy_reclassify` (report_schema_version 2.29) now lists the
+    report. `policy_reclassify` (report_schema_version 2.30) now lists the
     active rule set, mirroring the existing `policy_overrides` disclosure."""
     import json
 
@@ -578,7 +589,7 @@ reclassify:
 
 def test_policy_reclassify_absent_without_any_configured_rule(tmp_path: Path) -> None:
     """No `reclassify:` rule => no `policy_reclassify` key at all, keeping
-    every pre-existing report byte-identical (schema 2.29's own
+    every pre-existing report byte-identical (schema 2.30's own
     additive-change guarantee)."""
     import json
 
@@ -689,6 +700,79 @@ def test_reclassify_absent_from_sarif_without_any_configured_rule() -> None:
     diff = DiffResult(changes=[change], old_version="1", new_version="2", library="l")
     props = to_sarif(diff)["runs"][0]["properties"]
     assert "policyReclassify" not in props
+
+
+def _expired_reclassify_diff(tmp_path: Path):
+    from abicheck.checker_types import DiffResult
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: ignore
+    expires: 2020-01-01
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    return DiffResult(
+        changes=[change], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+
+
+def test_expired_reclassify_rule_absent_from_json_report(tmp_path: Path) -> None:
+    """Codex review: an expired rule -- which ReclassifyRule.matches() would
+    already refuse to apply -- must not be disclosed as though it were
+    still active."""
+    import json
+
+    from abicheck.reporter import to_json
+
+    diff = _expired_reclassify_diff(tmp_path)
+    d = json.loads(to_json(diff))
+    assert "policy_reclassify" not in d
+
+
+def test_expired_reclassify_rule_absent_from_markdown_report(tmp_path: Path) -> None:
+    from abicheck.reporter_markdown import to_markdown
+
+    diff = _expired_reclassify_diff(tmp_path)
+    assert "Policy reclassify" not in to_markdown(diff)
+
+
+def test_expired_reclassify_rule_absent_from_html_report(tmp_path: Path) -> None:
+    from abicheck.html_report import generate_html_report
+
+    diff = _expired_reclassify_diff(tmp_path)
+    assert "Policy reclassify" not in generate_html_report(diff)
+
+
+def test_expired_reclassify_rule_absent_from_sarif_report(tmp_path: Path) -> None:
+    from abicheck.sarif import to_sarif
+
+    diff = _expired_reclassify_diff(tmp_path)
+    props = to_sarif(diff)["runs"][0]["properties"]
+    assert "policyReclassify" not in props
+
+
+def test_active_reclassify_rules_filters_expired() -> None:
+    from datetime import date
+
+    from abicheck.reclassify import active_reclassify_rules
+
+    active = ReclassifyRule(to_verdict=Verdict.COMPATIBLE, to="ignore", symbol="a")
+    expired = ReclassifyRule(
+        to_verdict=Verdict.COMPATIBLE,
+        to="ignore",
+        symbol="b",
+        expires=date(2020, 1, 1),
+    )
+    result = active_reclassify_rules([active, expired], today=date(2026, 1, 1))
+    assert result == [active]
 
 
 # --- --audit-suppressions (SuppressionList.audit's policy_file param) ------

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -754,6 +754,23 @@ def test_reclassify_disclosed_in_markdown_report(tmp_path: Path) -> None:
     assert "COMDAT-inline demotions" in md
 
 
+def test_reclassify_markdown_disclosure_is_code_span_wrapped(
+    tmp_path: Path,
+) -> None:
+    """CodeRabbit review: describe() returns raw selector text (e.g.
+    `symbol_pattern='_ZN6oneapi3dal.*'`) -- unescaped, Markdown reads `_`/`*`
+    as emphasis markers, which can mangle a mangled-name selector's
+    rendering. Must be code-span-wrapped, same as the `Policy overrides`
+    line already wraps its own values."""
+    from abicheck.reporter_markdown import to_markdown
+
+    diff = _reclassify_diff_and_policy_path(tmp_path)
+    md = to_markdown(diff)
+    line = next(ln for ln in md.splitlines() if "Policy reclassify" in ln)
+    assert "`reclassify(to=risk" in line
+    assert line.rstrip().endswith("`")
+
+
 def test_reclassify_disclosed_in_html_report(tmp_path: Path) -> None:
     from abicheck.html_report import generate_html_report
 
@@ -1624,3 +1641,100 @@ def test_reclassified_by_falls_back_to_to_verdict_for_a_directly_constructed_rul
 
     d = json.loads(to_json(diff))
     assert d["changes"][0]["reclassified_by"] == "COMPATIBLE"
+
+
+def test_reclassified_by_and_policy_reclassify_present_in_leaf_mode(
+    tmp_path: Path,
+) -> None:
+    """Codex review: `--report-mode leaf` builds its own leaf-entry dict
+    (`_leaf_entry`, for root TYPE_* kinds) rather than routing through
+    `_change_to_dict`, and never called `_add_policy_overrides` at all --
+    both `changes[].reclassified_by` and the run-level `policy_reclassify`
+    key were silently absent from leaf-mode output even though the
+    identical comparison's full-mode report carried both. `type_size_changed`
+    is a root TYPE_* kind (`_ROOT_TYPE_CHANGE_KINDS`), so it's built by
+    `_leaf_entry`, not `_change_to_dict`, exercising the leaf-only path."""
+    import json
+
+    from abicheck.checker_types import DiffResult
+    from abicheck.reporter import to_json
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: type_size_changed
+    symbol: foo
+    to: risk
+    reason: "COMDAT-inline demotions"
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.TYPE_SIZE_CHANGED, "foo")
+    diff = DiffResult(
+        changes=[change], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+
+    d = json.loads(to_json(diff, report_mode="leaf"))
+    assert d["leaf_changes"][0]["reclassified_by"] == "COMDAT-inline demotions"
+    assert d["changes"][0]["reclassified_by"] == "COMDAT-inline demotions"
+    assert d["policy_reclassify"] == [
+        {
+            "to": "COMPATIBLE_WITH_RISK",
+            "kind": "type_size_changed",
+            "symbol": "foo",
+            "reason": "COMDAT-inline demotions",
+        }
+    ]
+
+
+# --- policy_reclassify[].to schema enum (CodeRabbit review) ----------------
+
+
+def test_policy_reclassify_to_field_validates_against_the_published_schema(
+    tmp_path: Path,
+) -> None:
+    """CodeRabbit review: `ReclassifyRule.to_report_dict()`'s `to` key is
+    `to_verdict.value` (a resolved Verdict spelling like
+    `COMPATIBLE_WITH_RISK`), not the raw `break`/`warn`/`risk`/`ignore` YAML
+    spelling -- the schema's `to` enum must match what's actually emitted,
+    not the YAML vocabulary. Skips cleanly if `jsonschema` isn't installed,
+    matching this repo's existing schema-validation test convention."""
+    import json
+
+    pytest.importorskip("jsonschema")
+    import jsonschema
+
+    from abicheck.checker_types import DiffResult
+    from abicheck.reporter import to_json
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_visibility_changed
+    symbol: foo
+    to: risk
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_VISIBILITY_CHANGED, "foo")
+    diff = DiffResult(
+        changes=[change], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+    report = json.loads(to_json(diff))
+    assert report["policy_reclassify"][0]["to"] == "COMPATIBLE_WITH_RISK"
+
+    schema = json.loads(
+        Path("abicheck/schemas/compare_report.schema.json").read_text()
+    )
+    jsonschema.Draft202012Validator.check_schema(schema)
+    to_schema = schema["properties"]["policy_reclassify"]["items"]["properties"]["to"]
+    validator = jsonschema.Draft202012Validator(to_schema)
+    validator.validate(report["policy_reclassify"][0]["to"])
+    with pytest.raises(jsonschema.exceptions.ValidationError):
+        validator.validate("risk")  # the raw YAML spelling, not the schema's

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -1078,3 +1078,48 @@ reclassify:
     )
     pf = PolicyFile.load(p)
     assert pf.validate_overrides() == []
+
+
+# --- effective_verdict_for_change's final fallback honors base_policy -----
+
+
+def test_effective_verdict_for_change_honors_custom_base_policy_with_no_match(
+    tmp_path: Path,
+) -> None:
+    """Codex review: for a policy_file whose base_policy isn't strict_abi
+    (e.g. plugin_abi), a finding with no effective_verdict/reclassify:/
+    overrides: match must fall back to *that* base policy's own kind sets,
+    not silently re-derive strict_abi's. Concrete repro: plugin_abi
+    downgrades calling_convention_changed from BREAKING (strict_abi) to
+    COMPATIBLE -- a bug here reads as BREAKING regardless of the policy
+    file's own base_policy. Pre-existing in effective_verdict_for_change's
+    final fallback line, surfaced by SuppressionList.audit()'s new
+    policy_file=-only call path (this PR) since no earlier caller passed
+    policy_file without also passing a matching kind_sets/policy."""
+    from abicheck.severity import effective_verdict_for_change
+
+    p = tmp_path / "policy.yaml"
+    p.write_text("base_policy: plugin_abi\n", encoding="utf-8")
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.CALLING_CONVENTION_CHANGED, "foo")
+
+    assert effective_verdict_for_change(change, policy_file=pf) == Verdict.COMPATIBLE
+
+
+def test_audit_honors_custom_base_policy_for_a_non_matching_finding(
+    tmp_path: Path,
+) -> None:
+    """Same bug, exercised through the actual --audit-suppressions call
+    path this PR added (SuppressionList.audit(..., policy_file=pf))."""
+    from abicheck.suppression import Suppression, SuppressionList
+
+    p = tmp_path / "policy.yaml"
+    p.write_text("base_policy: plugin_abi\n", encoding="utf-8")
+    pf = PolicyFile.load(p)
+    sup = Suppression(symbol="foo")
+    supl = SuppressionList([sup])
+    change = _change(ChangeKind.CALLING_CONVENTION_CHANGED, "foo")
+
+    # plugin_abi downgrades this kind to COMPATIBLE -- never high-risk.
+    audit = supl.audit([change], policy_file=pf)
+    assert audit.high_risk_matches == []

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -16,6 +16,13 @@ from abicheck.checker_types import Change
 from abicheck.errors import PolicyError
 from abicheck.policy_file import PolicyFile
 from abicheck.reclassify import ReclassifyRule, first_matching_reclassify_verdict
+from abicheck.severity import (
+    PRESET_DEFAULT,
+    IssueCategory,
+    classify_effective_change,
+    compute_exit_code,
+    effective_verdict_for_change,
+)
 
 
 def _change(kind: ChangeKind, symbol: str, **kwargs) -> Change:
@@ -138,6 +145,57 @@ reclassify:
     assert pf.compute_verdict([other]) == Verdict.API_BREAK
 
 
+def test_reclassify_is_honored_by_the_shared_severity_resolver(tmp_path: Path) -> None:
+    """`severity.effective_verdict_for_change` (and everything built on it --
+    IssueCategory buckets, JSON/HTML/SARIF severity labels, severity-based
+    exit codes) must agree with `PolicyFile.compute_verdict` for a
+    reclassified finding, not silently re-derive the pre-reclassify kind
+    category on its own independent code path."""
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_visibility_changed
+    symbol_pattern: "_ZN6oneapi3dal.*"
+    to: risk
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    matched = _change(ChangeKind.FUNC_VISIBILITY_CHANGED, "_ZN6oneapi3dal3fooEv")
+    unmatched = _change(ChangeKind.FUNC_VISIBILITY_CHANGED, "_ZN3foo3barEv")
+
+    assert pf.compute_verdict([matched]) == Verdict.COMPATIBLE_WITH_RISK
+    assert effective_verdict_for_change(matched, policy_file=pf) == Verdict.COMPATIBLE_WITH_RISK
+    assert classify_effective_change(matched, policy_file=pf) == IssueCategory.POTENTIAL_BREAKING
+    assert compute_exit_code([matched], PRESET_DEFAULT, policy_file=pf) == 0
+
+    assert pf.compute_verdict([unmatched]) == Verdict.BREAKING
+    assert effective_verdict_for_change(unmatched, policy_file=pf) == Verdict.BREAKING
+    assert classify_effective_change(unmatched, policy_file=pf) == IssueCategory.ABI_BREAKING
+    assert compute_exit_code([unmatched], PRESET_DEFAULT, policy_file=pf) == 4
+
+
+def test_reclassify_via_severity_resolver_respects_frozen_namespace_floor(
+    tmp_path: Path,
+) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: "frozen_symbol"
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(
+        ChangeKind.FUNC_REMOVED, "frozen_symbol", frozen_namespace_violation="ns::**"
+    )
+    assert effective_verdict_for_change(change, policy_file=pf) == Verdict.BREAKING
+
+
 def test_reclassify_respects_frozen_namespace_floor(tmp_path: Path) -> None:
     """A reclassify rule downgrading a change on a frozen namespace is
     silently rejected, exactly like a kind-global override already is."""
@@ -249,6 +307,42 @@ reclassify:
         encoding="utf-8",
     )
     with pytest.raises(PolicyError, match="must be a YAML mapping"):
+        PolicyFile.load(p)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "symbol",
+        "symbol_pattern",
+        "type_pattern",
+        "member_name",
+        "namespace",
+        "entity_namespace",
+        "cause_namespace",
+        "source_location",
+        "reason",
+        "label",
+    ],
+)
+def test_reclassify_non_string_selector_field_is_a_hard_error(
+    field: str, tmp_path: Path
+) -> None:
+    """A non-string selector value must fail loading up front -- not crash
+    with an uncaught TypeError deep in re.compile/fnmatch (symbol_pattern,
+    type_pattern, every namespace variant) and not load silently as a rule
+    that can never match (symbol, compared via `==`)."""
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        f"""
+reclassify:
+  - kind: func_removed
+    {field}: 42
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(PolicyError, match=f"{field}.*must be a string"):
         PolicyFile.load(p)
 
 

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -525,3 +525,75 @@ reclassify:
     )
     assert compute_exit_code([scoped], cfg, policy_file=pf) == 0
     assert compute_exit_code([scoped], PRESET_DEFAULT, policy_file=pf) == 0
+
+
+# --- standard-report disclosure (reporter.py's policy_reclassify key) ------
+
+
+def test_active_reclassify_rules_are_disclosed_in_the_standard_report(
+    tmp_path: Path,
+) -> None:
+    """Codex review: an ordinary comparison reclassifying a finding had no
+    trace of the active `reclassify:` rule anywhere in the standard JSON
+    report. `policy_reclassify` (report_schema_version 2.29) now lists the
+    active rule set, mirroring the existing `policy_overrides` disclosure."""
+    import json
+
+    from abicheck.checker_types import DiffResult
+    from abicheck.reporter import to_json
+    from abicheck.schemas import REPORT_SCHEMA_VERSION
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_visibility_changed
+    symbol_pattern: "_ZN6oneapi3dal.*"
+    to: risk
+    reason: "COMDAT-inline demotions"
+    expires: 2027-01-01
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_VISIBILITY_CHANGED, "_ZN6oneapi3dal3fooEv")
+    diff = DiffResult(
+        changes=[change], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+
+    d = json.loads(to_json(diff))
+    assert d["report_schema_version"] == REPORT_SCHEMA_VERSION
+    assert d["policy_file"] == str(p)
+    assert d["policy_reclassify"] == [
+        {
+            "to": "COMPATIBLE_WITH_RISK",
+            "kind": "func_visibility_changed",
+            "symbol_pattern": "_ZN6oneapi3dal.*",
+            "reason": "COMDAT-inline demotions",
+            "expires": "2027-01-01",
+        }
+    ]
+
+
+def test_policy_reclassify_absent_without_any_configured_rule(tmp_path: Path) -> None:
+    """No `reclassify:` rule => no `policy_reclassify` key at all, keeping
+    every pre-existing report byte-identical (schema 2.29's own
+    additive-change guarantee)."""
+    import json
+
+    from abicheck.checker_types import DiffResult
+    from abicheck.reporter import to_json
+
+    p = tmp_path / "policy.yaml"
+    p.write_text("overrides:\n  enum_member_renamed: ignore\n", encoding="utf-8")
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.ENUM_MEMBER_RENAMED, "foo")
+    diff = DiffResult(
+        changes=[change], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+
+    d = json.loads(to_json(diff))
+    assert "policy_reclassify" not in d
+    assert d["policy_overrides"] == {"enum_member_renamed": "COMPATIBLE"}

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -1063,16 +1063,62 @@ reclassify:
     assert pf.validate_overrides() == []
 
 
-def test_validate_overrides_skips_a_kindless_reclassify_rule(tmp_path: Path) -> None:
-    """A rule scoped purely by symbol/namespace, with no `kind:` filter, has
-    no single base_verdict to compare against -- skipped, not a crash, and
-    no false "safe" or "risky" claim either way."""
+def test_validate_overrides_flags_a_kindless_reclassify_rule_downgraded_to_ignore(
+    tmp_path: Path,
+) -> None:
+    """Codex review (second round): a rule scoped purely by symbol/namespace,
+    with no `kind:` filter, has no single base_verdict to compare against the
+    way a kind-scoped rule does -- but silently skipping it entirely left the
+    widest-blast-radius shape of reclassify rule (matches every kind a
+    symbol/pattern could ever produce, including func_removed) with no
+    safety diagnostic at all. It's now warned unconditionally rather than
+    silently skipped."""
     p = tmp_path / "policy.yaml"
     p.write_text(
         """
 reclassify:
   - symbol: foo
     to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    warnings = pf.validate_overrides()
+    assert len(warnings) == 1
+    assert "HIGH RISK" in warnings[0]
+    assert "no 'kind:' filter" in warnings[0]
+
+
+def test_validate_overrides_flags_a_kindless_reclassify_rule_downgraded_to_risk(
+    tmp_path: Path,
+) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - symbol: foo
+    to: risk
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    warnings = pf.validate_overrides()
+    assert len(warnings) == 1
+    assert "RISK" in warnings[0]
+    assert "no 'kind:' filter" in warnings[0]
+
+
+def test_validate_overrides_kindless_reclassify_rule_to_warn_is_not_flagged(
+    tmp_path: Path,
+) -> None:
+    """A kindless rule reclassifying to 'break'/'warn' isn't a downgrade at
+    all -- only 'ignore'/'risk' targets warrant the conservative warning."""
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - symbol: foo
+    to: warn
 """.strip(),
         encoding="utf-8",
     )

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -475,3 +475,53 @@ reclassify:
 
     blocked = _blocking_compatible_changes(diff, {"quality_issues"})
     assert blocked == [reclassified]
+
+
+def test_reclassify_wins_addition_bucket_over_a_kind_global_override(
+    tmp_path: Path,
+) -> None:
+    """A `reclassify:` rule downgrading one ADDITION_KINDS finding to
+    `ignore` must land in the `addition` category, not `quality_issues` --
+    even when a kind-global `overrides:` entry for the same kind would
+    otherwise move it out of the compatible kind set entirely (Codex
+    review: `func_added` overridden to `break` globally, with a scoped
+    `reclassify:` rule bringing one specific symbol back to `ignore` --
+    `quality_issues=error`/`addition=info` must exit 0, not 1)."""
+    from abicheck.severity import (
+        PRESET_DEFAULT,
+        IssueCategory,
+        SeverityConfig,
+        SeverityLevel,
+        classify_effective_change,
+        compute_exit_code,
+    )
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+overrides:
+  func_added: break
+reclassify:
+  - kind: func_added
+    symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    scoped = _change(ChangeKind.FUNC_ADDED, "foo")
+    unscoped = _change(ChangeKind.FUNC_ADDED, "bar")
+
+    assert classify_effective_change(scoped, policy_file=pf) == IssueCategory.ADDITION
+    # An unrelated func_added symbol still falls through to the (broader)
+    # override -- BREAKING, not silently granted the same leniency.
+    assert (
+        classify_effective_change(unscoped, policy_file=pf)
+        == IssueCategory.ABI_BREAKING
+    )
+
+    cfg = SeverityConfig(
+        quality_issues=SeverityLevel.ERROR, addition=SeverityLevel.INFO
+    )
+    assert compute_exit_code([scoped], cfg, policy_file=pf) == 0
+    assert compute_exit_code([scoped], PRESET_DEFAULT, policy_file=pf) == 0

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -1,0 +1,287 @@
+"""Tests for A: selector-scoped reclassification (abicheck/reclassify.py)
+and its policy_file.py `reclassify:` wiring.
+
+Covers the third policy-file primitive: same selector grammar as
+`suppress:`'s Suppression rules, but `to:` a verdict instead of deletion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from abicheck.checker_policy import ChangeKind, Verdict
+from abicheck.checker_types import Change
+from abicheck.errors import PolicyError
+from abicheck.policy_file import PolicyFile
+from abicheck.reclassify import ReclassifyRule, first_matching_reclassify_verdict
+
+
+def _change(kind: ChangeKind, symbol: str, **kwargs) -> Change:
+    return Change(kind=kind, symbol=symbol, description="x", **kwargs)
+
+
+# --- ReclassifyRule / first_matching_reclassify_verdict -------------------
+
+
+def test_reclassify_rule_matches_by_symbol_pattern() -> None:
+    rule = ReclassifyRule(
+        to_verdict=Verdict.COMPATIBLE_WITH_RISK,
+        to="risk",
+        change_kind="func_visibility_changed",
+        symbol_pattern=r"_ZN6oneapi3dal.*",
+    )
+    matched = _change(ChangeKind.FUNC_VISIBILITY_CHANGED, "_ZN6oneapi3dal3fooEv")
+    unmatched_symbol = _change(ChangeKind.FUNC_VISIBILITY_CHANGED, "_ZN3foo3barEv")
+    unmatched_kind = _change(ChangeKind.FUNC_REMOVED, "_ZN6oneapi3dal3fooEv")
+
+    assert rule.matches(matched)
+    assert not rule.matches(unmatched_symbol)
+    assert not rule.matches(unmatched_kind)
+
+
+def test_reclassify_rule_requires_a_selector() -> None:
+    with pytest.raises(ValueError):
+        ReclassifyRule(to_verdict=Verdict.COMPATIBLE_WITH_RISK, to="risk")
+
+
+def test_reclassify_rule_rejects_unknown_change_kind() -> None:
+    with pytest.raises(ValueError):
+        ReclassifyRule(
+            to_verdict=Verdict.COMPATIBLE_WITH_RISK,
+            to="risk",
+            symbol="foo",
+            change_kind="not_a_real_kind",
+        )
+
+
+def test_reclassify_rule_expires() -> None:
+    from datetime import date
+
+    rule = ReclassifyRule(
+        to_verdict=Verdict.COMPATIBLE,
+        to="ignore",
+        symbol="foo",
+        expires=date(2020, 1, 1),
+    )
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    assert not rule.matches(change, today=date(2020, 6, 1))
+    assert rule.matches(change, today=date(2019, 1, 1))
+
+
+def test_first_matching_reclassify_verdict_is_first_match_wins() -> None:
+    rules = [
+        ReclassifyRule(to_verdict=Verdict.COMPATIBLE, to="ignore", symbol="foo"),
+        ReclassifyRule(to_verdict=Verdict.BREAKING, to="break", symbol="foo"),
+    ]
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    assert first_matching_reclassify_verdict(rules, change) == Verdict.COMPATIBLE
+
+
+def test_first_matching_reclassify_verdict_none_when_no_rule_matches() -> None:
+    rules = [ReclassifyRule(to_verdict=Verdict.COMPATIBLE, to="ignore", symbol="foo")]
+    change = _change(ChangeKind.FUNC_REMOVED, "bar")
+    assert first_matching_reclassify_verdict(rules, change) is None
+
+
+# --- PolicyFile `reclassify:` loading and priority -------------------------
+
+
+def test_policy_file_loads_reclassify_block(tmp_path: Path) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+base_policy: strict_abi
+reclassify:
+  - kind: func_visibility_changed
+    symbol_pattern: "_ZN6oneapi3dal.*"
+    to: risk
+    reason: "COMDAT-inline demotions"
+""".strip(),
+        encoding="utf-8",
+    )
+
+    pf = PolicyFile.load(p)
+    assert len(pf.reclassify) == 1
+    assert pf.reclassify[0].to_verdict == Verdict.COMPATIBLE_WITH_RISK
+
+    matched = _change(ChangeKind.FUNC_VISIBILITY_CHANGED, "_ZN6oneapi3dal3fooEv")
+    unmatched = _change(ChangeKind.FUNC_VISIBILITY_CHANGED, "_ZN3foo3barEv")
+    assert pf.compute_verdict([matched]) == Verdict.COMPATIBLE_WITH_RISK
+    assert pf.compute_verdict([unmatched]) == Verdict.BREAKING
+
+
+def test_reclassify_takes_priority_over_kind_global_override(tmp_path: Path) -> None:
+    """A selector-scoped reclassify rule is more specific than a bare-kind
+    `overrides:` entry for the same kind, so it wins for a matching symbol —
+    but an unrelated symbol of the same kind still falls through to the
+    (broader) override."""
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+base_policy: strict_abi
+overrides:
+  func_visibility_changed: warn
+reclassify:
+  - kind: func_visibility_changed
+    symbol_pattern: "_ZN6oneapi3dal.*"
+    to: risk
+""".strip(),
+        encoding="utf-8",
+    )
+
+    pf = PolicyFile.load(p)
+    scoped = _change(ChangeKind.FUNC_VISIBILITY_CHANGED, "_ZN6oneapi3dal3fooEv")
+    other = _change(ChangeKind.FUNC_VISIBILITY_CHANGED, "_ZN3foo3barEv")
+    assert pf.compute_verdict([scoped]) == Verdict.COMPATIBLE_WITH_RISK
+    assert pf.compute_verdict([other]) == Verdict.API_BREAK
+
+
+def test_reclassify_respects_frozen_namespace_floor(tmp_path: Path) -> None:
+    """A reclassify rule downgrading a change on a frozen namespace is
+    silently rejected, exactly like a kind-global override already is."""
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+base_policy: strict_abi
+reclassify:
+  - kind: func_removed
+    symbol: "frozen_symbol"
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+
+    pf = PolicyFile.load(p)
+    change = _change(
+        ChangeKind.FUNC_REMOVED, "frozen_symbol", frozen_namespace_violation="ns::**"
+    )
+    assert pf.compute_verdict([change]) == Verdict.BREAKING
+
+
+def test_reclassify_does_not_apply_when_effective_verdict_already_set(
+    tmp_path: Path,
+) -> None:
+    """A pipeline-set `effective_verdict` (ADR-025 modulation) wins over a
+    reclassify rule, matching how it already wins over `overrides:`."""
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+base_policy: strict_abi
+reclassify:
+  - kind: func_removed
+    symbol: "foo"
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+
+    pf = PolicyFile.load(p)
+    change = _change(
+        ChangeKind.FUNC_REMOVED, "foo", effective_verdict=Verdict.API_BREAK
+    )
+    assert pf.compute_verdict([change]) == Verdict.API_BREAK
+
+
+# --- Validation errors ------------------------------------------------------
+
+
+def test_reclassify_missing_to_field_is_a_hard_error(tmp_path: Path) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: "foo"
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(PolicyError, match="missing required 'to'"):
+        PolicyFile.load(p)
+
+
+def test_reclassify_invalid_to_value_is_a_hard_error(tmp_path: Path) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: "foo"
+    to: not_a_real_severity
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(PolicyError, match="invalid 'to' value"):
+        PolicyFile.load(p)
+
+
+def test_reclassify_unknown_key_is_a_hard_error(tmp_path: Path) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: "foo"
+    to: ignore
+    bogus_key: 1
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(PolicyError, match="unknown key"):
+        PolicyFile.load(p)
+
+
+def test_reclassify_not_a_list_is_a_hard_error(tmp_path: Path) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text("reclassify: not-a-list", encoding="utf-8")
+    with pytest.raises(PolicyError, match="must be a YAML list"):
+        PolicyFile.load(p)
+
+
+def test_reclassify_entry_not_a_mapping_is_a_hard_error(tmp_path: Path) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - "not a mapping"
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(PolicyError, match="must be a YAML mapping"):
+        PolicyFile.load(p)
+
+
+def test_reclassify_invalid_selector_is_a_hard_error(tmp_path: Path) -> None:
+    """No symbol/pattern/namespace selector at all -- Suppression's own
+    "at least one selector" validation propagates through PolicyFile.load."""
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    with pytest.raises(PolicyError):
+        PolicyFile.load(p)
+
+
+def test_policy_file_describe_includes_reclassify_rules(tmp_path: Path) -> None:
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_visibility_changed
+    symbol_pattern: "_ZN6oneapi3dal.*"
+    to: risk
+    reason: "COMDAT-inline demotions"
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    text = pf.describe()
+    assert "reclassify:" in text
+    assert "to=risk" in text
+    assert "COMDAT-inline demotions" in text

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -597,3 +597,75 @@ def test_policy_reclassify_absent_without_any_configured_rule(tmp_path: Path) ->
     d = json.loads(to_json(diff))
     assert "policy_reclassify" not in d
     assert d["policy_overrides"] == {"enum_member_renamed": "COMPATIBLE"}
+
+
+def _reclassify_diff_and_policy_path(tmp_path: Path):
+    """Shared fixture for the markdown/HTML/SARIF disclosure tests below."""
+    from abicheck.checker_types import DiffResult
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_visibility_changed
+    symbol_pattern: "_ZN6oneapi3dal.*"
+    to: risk
+    reason: "COMDAT-inline demotions"
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_VISIBILITY_CHANGED, "_ZN6oneapi3dal3fooEv")
+    return DiffResult(
+        changes=[change], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+
+
+def test_reclassify_disclosed_in_markdown_report(tmp_path: Path) -> None:
+    """Codex review: Markdown must disclose active reclassify: rules the
+    same way it already discloses overrides:."""
+    from abicheck.reporter_markdown import to_markdown
+
+    diff = _reclassify_diff_and_policy_path(tmp_path)
+    md = to_markdown(diff)
+    assert "Policy reclassify" in md
+    assert "func_visibility_changed" in md
+    assert "COMDAT-inline demotions" in md
+
+
+def test_reclassify_disclosed_in_html_report(tmp_path: Path) -> None:
+    from abicheck.html_report import generate_html_report
+
+    diff = _reclassify_diff_and_policy_path(tmp_path)
+    html_out = generate_html_report(diff)
+    assert "Policy reclassify" in html_out
+    assert "func_visibility_changed" in html_out
+
+
+def test_reclassify_disclosed_in_sarif_report(tmp_path: Path) -> None:
+    from abicheck.sarif import to_sarif
+
+    diff = _reclassify_diff_and_policy_path(tmp_path)
+    sarif_out = to_sarif(diff)
+    props = sarif_out["runs"][0]["properties"]
+    assert props["policyReclassify"] == [
+        {
+            "to": "COMPATIBLE_WITH_RISK",
+            "kind": "func_visibility_changed",
+            "symbol_pattern": "_ZN6oneapi3dal.*",
+            "reason": "COMDAT-inline demotions",
+        }
+    ]
+
+
+def test_reclassify_absent_from_sarif_without_any_configured_rule() -> None:
+    """Mirrors the existing policyOverrides absence test -- no reclassify:
+    rule => no policyReclassify key, report byte-identical."""
+    from abicheck.checker_types import DiffResult
+    from abicheck.sarif import to_sarif
+
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    diff = DiffResult(changes=[change], old_version="1", new_version="2", library="l")
+    props = to_sarif(diff)["runs"][0]["properties"]
+    assert "policyReclassify" not in props

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -1169,3 +1169,198 @@ def test_audit_honors_custom_base_policy_for_a_non_matching_finding(
     # plugin_abi downgrades this kind to COMPATIBLE -- never high-risk.
     audit = supl.audit([change], policy_file=pf)
     assert audit.high_risk_matches == []
+
+
+# --- severity.reclassify_rule_for_change / reporter's reclassified_by -----
+#
+# Codex review: cli_pr_comment's `pr_comment._reclassified_count()` only
+# recognized the kind-global `policy_overrides` map, so a finding downgraded
+# by a selector-scoped `reclassify:` rule bypassed the PR comment's "🔀 N
+# findings reclassified" disclosure entirely -- it read as an unremarked
+# safe change. Fixed with a per-change `reclassified_by` field
+# (report_schema_version 2.31), stamped by `severity.
+# reclassify_rule_for_change` -- the deciding rule, honoring the same
+# precedence `effective_verdict_for_change` already uses (not shadowed by a
+# pipeline `effective_verdict`, not blocked by the frozen-namespace floor).
+
+
+def test_reclassify_rule_for_change_returns_the_deciding_rule(tmp_path: Path) -> None:
+    from abicheck.severity import reclassify_rule_for_change
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: ignore
+    label: comdat-inline
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    rule = reclassify_rule_for_change(change, pf)
+    assert rule is not None
+    assert rule.label == "comdat-inline"
+
+
+def test_reclassify_rule_for_change_none_when_no_rule_matches(tmp_path: Path) -> None:
+    from abicheck.severity import reclassify_rule_for_change
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: bar
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    assert reclassify_rule_for_change(change, pf) is None
+
+
+def test_reclassify_rule_for_change_none_without_a_policy_file() -> None:
+    from abicheck.severity import reclassify_rule_for_change
+
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    assert reclassify_rule_for_change(change, None) is None
+
+
+def test_reclassify_rule_for_change_shadowed_by_effective_verdict(
+    tmp_path: Path,
+) -> None:
+    """A matching rule that's shadowed by a higher-priority pipeline
+    effective_verdict didn't actually decide the change's verdict, so it
+    isn't "the reclassifying rule" for disclosure purposes."""
+    from abicheck.severity import reclassify_rule_for_change
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(
+        ChangeKind.FUNC_REMOVED, "foo", effective_verdict=Verdict.BREAKING
+    )
+    assert reclassify_rule_for_change(change, pf) is None
+
+
+def test_reclassify_rule_for_change_blocked_by_frozen_namespace_floor(
+    tmp_path: Path,
+) -> None:
+    """A matching rule blocked by the frozen-namespace verdict floor didn't
+    actually decide the change's verdict either -- verified by deliberately
+    reverting the frozen-namespace guard and confirming this test fails."""
+    from abicheck.severity import reclassify_rule_for_change
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(
+        ChangeKind.FUNC_REMOVED,
+        "foo",
+        frozen_namespace_violation="detail.*",
+    )
+    assert reclassify_rule_for_change(change, pf) is None
+
+
+def test_reclassified_by_stamped_in_the_standard_report(tmp_path: Path) -> None:
+    """The JSON report's `changes[].reclassified_by` field names the
+    deciding rule, mirroring reporter.py's `policy_reclassify` (the active
+    rule set) with per-finding attribution."""
+    import json
+
+    from abicheck.checker_types import DiffResult
+    from abicheck.reporter import to_json
+    from abicheck.schemas import REPORT_SCHEMA_VERSION
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: ignore
+    reason: "COMDAT-inline demotions"
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    diff = DiffResult(
+        changes=[change], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+
+    d = json.loads(to_json(diff))
+    assert d["report_schema_version"] == REPORT_SCHEMA_VERSION
+    assert d["changes"][0]["reclassified_by"] == "COMDAT-inline demotions"
+
+
+def test_reclassified_by_absent_when_no_rule_matches(tmp_path: Path) -> None:
+    import json
+
+    from abicheck.checker_types import DiffResult
+    from abicheck.reporter import to_json
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: bar
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    diff = DiffResult(
+        changes=[change], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+
+    d = json.loads(to_json(diff))
+    assert "reclassified_by" not in d["changes"][0]
+
+
+def test_reclassified_by_absent_for_a_kind_global_override(tmp_path: Path) -> None:
+    """A change decided by a kind-global `overrides:` entry (not a
+    `reclassify:` rule) doesn't carry `reclassified_by` -- that field
+    attributes only to a selector-scoped rule; `overrides:`'s own audit
+    trail is `policy_overrides`, already keyed by kind."""
+    import json
+
+    from abicheck.checker_types import DiffResult
+    from abicheck.reporter import to_json
+
+    p = tmp_path / "policy.yaml"
+    p.write_text("overrides:\n  func_removed: ignore\n", encoding="utf-8")
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    diff = DiffResult(
+        changes=[change], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+
+    d = json.loads(to_json(diff))
+    assert "reclassified_by" not in d["changes"][0]
+    assert d["policy_overrides"] == {"func_removed": "COMPATIBLE"}

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -196,6 +196,48 @@ reclassify:
     assert effective_verdict_for_change(change, policy_file=pf) == Verdict.BREAKING
 
 
+def test_policy_file_keeps_existing_positional_field_order() -> None:
+    """PolicyFile is public API constructed positionally by external callers
+    -- `reclassify` must not shift `source_path` (or anything after it) out
+    of its pre-existing positional slot."""
+    from abicheck.policy_file import PolicyFile as PF
+
+    pf = PF("strict_abi", {}, Path("/tmp/x.yaml"))
+    assert pf.base_policy == "strict_abi"
+    assert pf.overrides == {}
+    assert pf.source_path == Path("/tmp/x.yaml")
+    assert pf.reclassify == []
+
+
+def test_reclassify_expires_normalizes_a_yaml_datetime(tmp_path: Path) -> None:
+    """An unquoted YAML timestamp (`2020-08-12T00:00:00`) decodes as a
+    `datetime`, not a `date` -- must be normalized to `.date()` so
+    `Suppression.is_expired()`'s `date.today() > self.expires` comparison
+    doesn't crash with `TypeError: can't compare datetime.date to
+    datetime.datetime`."""
+    from datetime import date
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: ignore
+    expires: 2020-08-12T00:00:00
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    assert pf.reclassify[0].expires == date(2020, 8, 12)
+    assert pf.reclassify[0].matches(
+        _change(ChangeKind.FUNC_REMOVED, "foo"), today=date(2020, 1, 1)
+    ), "before expiry, the rule should still match"
+    assert not pf.reclassify[0].matches(
+        _change(ChangeKind.FUNC_REMOVED, "foo"), today=date(2026, 1, 1)
+    ), "past-expiry rule should stop matching (not crash)"
+
+
 def test_reclassify_respects_frozen_namespace_floor(tmp_path: Path) -> None:
     """A reclassify rule downgrading a change on a frozen namespace is
     silently rejected, exactly like a kind-global override already is."""

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -271,6 +271,28 @@ def test_reclassify_rule_direct_construction_normalizes_a_datetime_expires() -> 
     ), "past-expiry rule should stop matching (not crash)"
 
 
+def test_reclassify_rule_canonicalizes_to_from_to_verdict() -> None:
+    """Codex review (second round on the same audit-trail concern): a
+    directly-constructed rule's `to` is canonicalized from `to_verdict` in
+    `__post_init__`, not trusted verbatim -- so `describe()` (used by the
+    Markdown/HTML renderers) can never disagree with the verdict the rule
+    actually applies, even when a caller supplies an inconsistent or omitted
+    `to`. Verified by deliberately reverting the canonicalization and
+    confirming this test fails."""
+    # Inconsistent `to` -- the rule still promotes to BREAKING (to_verdict is
+    # authoritative for matching/severity), but a naive `self.to` echo would
+    # have described it as "ignore".
+    rule = ReclassifyRule(to_verdict=Verdict.BREAKING, to="ignore", symbol="foo")
+    assert rule.to == "break"
+    assert "to=break" in rule.describe()
+    assert "to=ignore" not in rule.describe()
+
+    # Omitted `to` (the dataclass default "") is likewise canonicalized.
+    rule2 = ReclassifyRule(to_verdict=Verdict.COMPATIBLE_WITH_RISK, symbol="foo")
+    assert rule2.to == "risk"
+    assert "to=risk" in rule2.describe()
+
+
 def test_reclassify_respects_frozen_namespace_floor(tmp_path: Path) -> None:
     """A reclassify rule downgrading a change on a frozen namespace is
     silently rejected, exactly like a kind-global override already is."""

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -1205,6 +1205,82 @@ reclassify:
     assert rule.label == "comdat-inline"
 
 
+def test_reclassify_rule_for_change_none_for_a_no_op_rule(tmp_path: Path) -> None:
+    """Codex review: a matching rule whose `to:` merely restates the verdict
+    the finding already has (func_removed, already BREAKING under
+    strict_abi, reclassified `to: break`) isn't a real reclassification --
+    stamping `reclassified_by` for it would make the PR comment falsely
+    report a downgrade that never happened. Verified by deliberately
+    reverting the no-op check and confirming this test fails."""
+    from abicheck.severity import reclassify_rule_for_change
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: break
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    assert reclassify_rule_for_change(change, pf) is None
+
+
+def test_reclassify_rule_for_change_none_for_a_no_op_rule_restating_an_override(
+    tmp_path: Path,
+) -> None:
+    """The no-op comparison is against whichever verdict would apply next in
+    precedence -- a same-kind `overrides:` entry when one exists, not always
+    the base policy's own verdict."""
+    from abicheck.severity import reclassify_rule_for_change
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+overrides:
+  func_removed: risk
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: risk
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    assert reclassify_rule_for_change(change, pf) is None
+
+
+def test_reclassify_rule_for_change_not_none_when_it_actually_changes_the_verdict(
+    tmp_path: Path,
+) -> None:
+    """Sanity check alongside the two no-op tests above: a rule that *does*
+    change the verdict from what the override/base-policy path would
+    produce is still correctly recognized as deciding."""
+    from abicheck.severity import reclassify_rule_for_change
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+overrides:
+  func_removed: risk
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: warn
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    rule = reclassify_rule_for_change(change, pf)
+    assert rule is not None
+    assert rule.to_verdict == Verdict.API_BREAK
+
+
 def test_reclassify_rule_for_change_none_when_no_rule_matches(tmp_path: Path) -> None:
     from abicheck.severity import reclassify_rule_for_change
 
@@ -1364,3 +1440,35 @@ def test_reclassified_by_absent_for_a_kind_global_override(tmp_path: Path) -> No
     d = json.loads(to_json(diff))
     assert "reclassified_by" not in d["changes"][0]
     assert d["policy_overrides"] == {"func_removed": "COMPATIBLE"}
+
+
+def test_reclassified_by_absent_for_a_no_op_reclassify_rule(tmp_path: Path) -> None:
+    """Codex review: a matching `reclassify:` rule whose `to:` merely
+    restates the finding's already-BREAKING verdict (`func_removed`, `to:
+    break`) is not a real reclassification -- stamping `reclassified_by` for
+    it would make the JSON report (and the PR comment reading it) falsely
+    claim a downgrade that never happened."""
+    import json
+
+    from abicheck.checker_types import DiffResult
+    from abicheck.reporter import to_json
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: break
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    diff = DiffResult(
+        changes=[change], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+
+    d = json.loads(to_json(diff))
+    assert "reclassified_by" not in d["changes"][0]

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -643,6 +643,26 @@ def test_reclassify_disclosed_in_html_report(tmp_path: Path) -> None:
     assert "func_visibility_changed" in html_out
 
 
+def test_reclassify_rule_describe_includes_expiry_and_label() -> None:
+    """Codex review: describe() (what the Markdown/HTML renderers actually
+    call) previously stopped after `reason`, silently omitting `expires`
+    and `label` -- a reader of those two formats had no way to tell when a
+    temporary waiver stops applying. to_report_dict() already included both;
+    describe() must match."""
+    from datetime import date
+
+    rule = ReclassifyRule(
+        to_verdict=Verdict.COMPATIBLE_WITH_RISK,
+        to="risk",
+        symbol="foo",
+        label="workaround",
+        expires=date(2027, 1, 1),
+    )
+    text = rule.describe()
+    assert "label='workaround'" in text
+    assert "expires='2027-01-01'" in text
+
+
 def test_reclassify_disclosed_in_sarif_report(tmp_path: Path) -> None:
     from abicheck.sarif import to_sarif
 
@@ -669,3 +689,85 @@ def test_reclassify_absent_from_sarif_without_any_configured_rule() -> None:
     diff = DiffResult(changes=[change], old_version="1", new_version="2", library="l")
     props = to_sarif(diff)["runs"][0]["properties"]
     assert "policyReclassify" not in props
+
+
+# --- --audit-suppressions (SuppressionList.audit's policy_file param) ------
+
+
+def test_audit_flags_a_reclassify_promoted_finding_as_high_risk(
+    tmp_path: Path,
+) -> None:
+    """Codex review: a `reclassify:` rule promoting one normally-compatible
+    finding to `break` isn't expressible in `effective_breaking_kinds` (a
+    kind-wide set) -- SuppressionList.audit() must classify a matching
+    change by the rule's own resolution instead of falling back to (silently
+    absent) kind-set membership."""
+    from abicheck.suppression import Suppression, SuppressionList
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_added
+    symbol: foo
+    to: break
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    sup = Suppression(symbol="foo")
+    supl = SuppressionList([sup])
+    change = _change(ChangeKind.FUNC_ADDED, "foo")
+
+    # Without policy_file: func_added isn't in the (empty, for this test)
+    # breaking set, so the match isn't flagged high-risk.
+    audit_without = supl.audit([change], breaking_kinds=frozenset())
+    assert audit_without.high_risk_matches == []
+
+    # With policy_file: the reclassify rule's own `to: break` resolution
+    # wins, even though func_added is still absent from breaking_kinds.
+    audit_with = supl.audit([change], breaking_kinds=frozenset(), policy_file=pf)
+    assert len(audit_with.high_risk_matches) == 1
+    assert audit_with.high_risk_matches[0] == (sup, change)
+
+
+def test_audit_reclassify_demotion_is_not_high_risk(tmp_path: Path) -> None:
+    """The inverse: a `reclassify:` rule demoting a normally-breaking kind
+    to `ignore` for one symbol must NOT be reported as high-risk for that
+    symbol, even though the kind is still in breaking_kinds."""
+    from abicheck.suppression import Suppression, SuppressionList
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    sup = Suppression(symbol="foo")
+    supl = SuppressionList([sup])
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+
+    audit = supl.audit(
+        [change], breaking_kinds=frozenset({ChangeKind.FUNC_REMOVED}), policy_file=pf
+    )
+    assert audit.high_risk_matches == []
+
+
+def test_audit_without_policy_file_is_unchanged() -> None:
+    """No policy_file passed at all => identical to the pre-existing
+    behavior (kind-set membership only)."""
+    from abicheck.suppression import Suppression, SuppressionList
+
+    sup = Suppression(symbol="foo")
+    supl = SuppressionList([sup])
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+
+    audit = supl.audit(
+        [change], breaking_kinds=frozenset({ChangeKind.FUNC_REMOVED})
+    )
+    assert len(audit.high_risk_matches) == 1

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -1359,6 +1359,48 @@ reclassify:
     assert reclassify_rule_for_change(change, pf) is None
 
 
+def test_reclassify_rule_for_change_attributes_a_blocked_rule_that_still_changed_the_outcome(
+    tmp_path: Path,
+) -> None:
+    """Codex review (third round on the same frozen-floor interaction): a
+    matching reclassify rule blocked by the frozen-namespace floor still
+    changed the effective outcome if the floor-clamped result (base_v)
+    differs from what overrides: alone would have produced (next_priority_v).
+    `func_noexcept_removed` is a RISK kind (base verdict
+    COMPATIBLE_WITH_RISK under strict_abi); `overrides: ... to: break`
+    (BREAKING) makes next_priority_v BREAKING, and `reclassify: ... to:
+    ignore` (COMPATIBLE) on a frozen-namespace finding is blocked back to
+    base_v (COMPATIBLE_WITH_RISK) -- BREAKING != COMPATIBLE_WITH_RISK, so
+    the rule genuinely changed the outcome (from BREAKING to
+    COMPATIBLE_WITH_RISK) even though it didn't get the verdict it asked
+    for, and must still be attributed. Verified by deliberately reverting
+    to the previous "blocked == always no-op" logic and confirming this
+    test fails."""
+    from abicheck.severity import reclassify_rule_for_change
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+overrides:
+  func_noexcept_removed: break
+reclassify:
+  - kind: func_noexcept_removed
+    symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(
+        ChangeKind.FUNC_NOEXCEPT_REMOVED,
+        "foo",
+        frozen_namespace_violation="detail.*",
+    )
+    rule = reclassify_rule_for_change(change, pf)
+    assert rule is not None
+    assert rule.to_verdict == Verdict.COMPATIBLE
+
+
 def test_reclassify_rule_for_change_none_when_no_rule_matches(tmp_path: Path) -> None:
     from abicheck.severity import reclassify_rule_for_change
 

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -771,3 +771,64 @@ def test_audit_without_policy_file_is_unchanged() -> None:
         [change], breaking_kinds=frozenset({ChangeKind.FUNC_REMOVED})
     )
     assert len(audit.high_risk_matches) == 1
+
+
+def test_audit_reclassify_respects_frozen_namespace_floor(tmp_path: Path) -> None:
+    """Codex review, second round: a naive reclassify-only check in the
+    audit bypassed the frozen-namespace verdict floor. A `to: ignore` rule
+    matching a frozen-namespace change must NOT demote it -- the audit must
+    still flag the suppression as high-risk, via the same shared resolver
+    (severity.effective_verdict_for_change) the comparison's own verdict
+    already went through."""
+    from abicheck.suppression import Suppression, SuppressionList
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    sup = Suppression(symbol="foo")
+    supl = SuppressionList([sup])
+    change = _change(
+        ChangeKind.FUNC_REMOVED, "foo", frozen_namespace_violation="ns::**"
+    )
+
+    audit = supl.audit([change], policy_file=pf)
+    assert len(audit.high_risk_matches) == 1
+
+
+def test_audit_reclassify_yields_to_effective_verdict_precedence(
+    tmp_path: Path,
+) -> None:
+    """Codex review, second round: a pipeline-set `effective_verdict`
+    (ADR-025 modulation) must win over a matching `reclassify:` rule in the
+    audit too, exactly like it already does in
+    `severity.effective_verdict_for_change` itself -- not get silently
+    bypassed by a reclassify-only shortcut."""
+    from abicheck.suppression import Suppression, SuppressionList
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    sup = Suppression(symbol="foo")
+    supl = SuppressionList([sup])
+    change = _change(
+        ChangeKind.FUNC_REMOVED, "foo", effective_verdict=Verdict.COMPATIBLE
+    )
+
+    audit = supl.audit([change], policy_file=pf)
+    assert audit.high_risk_matches == []

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -249,6 +249,28 @@ reclassify:
     ), "past-expiry rule should stop matching (not crash)"
 
 
+def test_reclassify_rule_direct_construction_normalizes_a_datetime_expires() -> None:
+    """Codex review: only the policy-file loader (`_parse_reclassify_expires`)
+    normalized a `datetime` expires to `.date()` -- a Python caller
+    constructing `ReclassifyRule` directly with `expires=datetime(...)` (a
+    `datetime` is itself a `date` subclass, so the type annotation accepts
+    it) hit the identical `TypeError` crash on `is_expired()`/`matches()`.
+    Verified by deliberately reverting the __post_init__ normalization and
+    confirming this test fails with a raised TypeError."""
+    from datetime import date, datetime
+
+    rule = ReclassifyRule(
+        to_verdict=Verdict.COMPATIBLE,
+        to="ignore",
+        symbol="foo",
+        expires=datetime(2020, 8, 12, 0, 0, 0),
+    )
+    assert rule.expires == date(2020, 8, 12)
+    assert not rule.matches(
+        _change(ChangeKind.FUNC_REMOVED, "foo"), today=date(2026, 1, 1)
+    ), "past-expiry rule should stop matching (not crash)"
+
+
 def test_reclassify_respects_frozen_namespace_floor(tmp_path: Path) -> None:
     """A reclassify rule downgrading a change on a frozen namespace is
     silently rejected, exactly like a kind-global override already is."""
@@ -1506,3 +1528,35 @@ reclassify:
 
     d = json.loads(to_json(diff))
     assert "reclassified_by" not in d["changes"][0]
+
+
+def test_reclassified_by_falls_back_to_to_verdict_for_a_directly_constructed_rule() -> (
+    None
+):
+    """Codex review: a Python caller constructing `ReclassifyRule` directly
+    with only `to_verdict` set (`to` defaults to `""`) previously stamped no
+    `reclassified_by` at all -- `rule.label or rule.reason or rule.to`
+    fell through to the empty string. Worse, a `to` that doesn't actually
+    match `to_verdict` would mislabel the audit trail. Falling back to
+    `rule.to_verdict.value` instead of the raw, caller-supplied `to`
+    guarantees the disclosure is always present and always reflects the
+    verdict that was actually applied."""
+    import json
+
+    from abicheck.checker_types import DiffResult
+    from abicheck.reporter import to_json
+
+    # `to=""` (the dataclass default) -- as a direct Python construction
+    # would leave it if the caller only set to_verdict.
+    rule = ReclassifyRule(
+        to_verdict=Verdict.COMPATIBLE, symbol="foo", change_kind="func_removed"
+    )
+    pf = PolicyFile(base_policy="strict_abi", overrides={}, reclassify=[rule])
+    change = _change(ChangeKind.FUNC_REMOVED, "foo")
+    diff = DiffResult(
+        changes=[change], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+
+    d = json.loads(to_json(diff))
+    assert d["changes"][0]["reclassified_by"] == "COMPATIBLE"

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -421,3 +421,57 @@ reclassify:
     assert "reclassify:" in text
     assert "to=risk" in text
     assert "COMDAT-inline demotions" in text
+
+
+# --- cli_scan_baseline._blocking_compatible_changes / classify_change_object ----
+
+
+def test_reclassified_finding_is_identified_as_the_scan_blocker(tmp_path: Path) -> None:
+    """A `reclassify:`-demoted BREAKING finding that lands in `diff.compatible`
+    (as QUALITY_ISSUES, since func_removed isn't an ADDITION_KINDS member)
+    must still be nameable as the scan's own blocking finding -- not just
+    correctly gated (that already worked; `_build_severity_json` passes
+    `policy_file`) but correctly *reported*, via
+    `cli_scan_baseline._blocking_compatible_changes` /
+    `severity.classify_change_object` (Codex review)."""
+    from abicheck.checker_types import DiffResult
+    from abicheck.cli_scan_baseline import _blocking_compatible_changes
+    from abicheck.severity import IssueCategory, classify_change_object
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+reclassify:
+  - kind: func_removed
+    symbol: "_ZN6oneapi3dal3fooEv"
+    to: ignore
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    reclassified = _change(ChangeKind.FUNC_REMOVED, "_ZN6oneapi3dal3fooEv")
+    diff = DiffResult(
+        changes=[reclassified], old_version="1", new_version="2", library="l",
+        policy_file=pf,
+    )
+
+    # The reclassify rule already correctly moves it into `.compatible`
+    # (DiffResult._effective_verdict_for_change already passes policy_file).
+    assert diff.compatible == [reclassified]
+
+    # Without policy_file, classify_change_object can't see the
+    # selector-scoped rule and falls back to the raw kind category.
+    assert (
+        classify_change_object(reclassified, kind_sets=diff._effective_kind_sets())
+        == IssueCategory.ABI_BREAKING
+    )
+    # With it, the reclassification is honored.
+    assert (
+        classify_change_object(
+            reclassified, kind_sets=diff._effective_kind_sets(), policy_file=pf
+        )
+        == IssueCategory.QUALITY_ISSUES
+    )
+
+    blocked = _blocking_compatible_changes(diff, {"quality_issues"})
+    assert blocked == [reclassified]

--- a/tests/test_reclassify.py
+++ b/tests/test_reclassify.py
@@ -1281,6 +1281,40 @@ reclassify:
     assert rule.to_verdict == Verdict.API_BREAK
 
 
+def test_reclassify_rule_for_change_no_op_against_a_floor_clamped_override(
+    tmp_path: Path,
+) -> None:
+    """Codex review (second round): the no-op comparison verdict must apply
+    the identical frozen-namespace floor the `overrides:` branch itself
+    applies -- not the override's raw value. `overrides: func_removed:
+    ignore` (COMPATIBLE) on a frozen-namespace finding already clamps back
+    to BREAKING (the base verdict) via the floor with no reclassify: rule
+    involved at all -- so a `reclassify: ... to: break` rule here restates
+    an already-BREAKING outcome and is a no-op, even though the *raw*
+    override value (COMPATIBLE) differs from `to: break`. Verified by
+    deliberately comparing against the raw override instead of the
+    floor-clamped one and confirming this test fails."""
+    from abicheck.severity import reclassify_rule_for_change
+
+    p = tmp_path / "policy.yaml"
+    p.write_text(
+        """
+overrides:
+  func_removed: ignore
+reclassify:
+  - kind: func_removed
+    symbol: foo
+    to: break
+""".strip(),
+        encoding="utf-8",
+    )
+    pf = PolicyFile.load(p)
+    change = _change(
+        ChangeKind.FUNC_REMOVED, "foo", frozen_namespace_violation="detail.*"
+    )
+    assert reclassify_rule_for_change(change, pf) is None
+
+
 def test_reclassify_rule_for_change_none_when_no_rule_matches(tmp_path: Path) -> None:
     from abicheck.severity import reclassify_rule_for_change
 


### PR DESCRIPTION
## Description

Adds the third policy-file primitive requested: **selector-scoped reclassification**.

Today two primitives each cover half the problem:
- `suppress:` — rich per-symbol/pattern/namespace selector grammar, but its only action is *deleting* the finding.
- `policy_file.py`'s `overrides:` — keeps the finding and changes its verdict, but is keyed by `ChangeKind` alone, globally, with no selector.

Neither lets a project say "every `func_visibility_changed` on *this* symbol family is a known, accepted risk" without either downgrading the whole kind project-wide or throwing the finding away. `reclassify:` closes that gap:

```yaml
reclassify:
  - kind: func_visibility_changed
    symbol_pattern: "_ZN6oneapi3dal.*"
    to: risk
    reason: "COMDAT-inline demotions; consumers already embed their own copy"
```

## Changes

- **`abicheck/reclassify.py`** (new) — `ReclassifyRule` + `first_matching_reclassify_verdict`. Reuses `Suppression`'s exact selector grammar rather than re-implementing the glob/regex machinery. Deliberately resolves `Suppression` via `importlib.import_module` at call time instead of a static import: `checker_types.py` imports `PolicyFile` from `policy_file.py`, so a static `policy_file → reclassify → suppression → checker_types → policy_file` edge would close a new import cycle that `scripts/check_ai_readiness.py`'s `import-cycle-growth` gate rejects. This mirrors the existing lazy `__getattr__` shim pattern in `cli_buildsource.py`.
- **`abicheck/suppression.py`** — new public `Suppression.selector_matches()`: selector matching alone, without the reachability/`allow_public_break` gates (which exist to guard against *hiding* evidence — not applicable here, since a reclassified finding stays visible).
- **`abicheck/policy_file.py`** — parses an optional `reclassify:` block; `_resolve_change_verdict` consults the first matching rule (file order) ahead of the kind-global `overrides:` entry for the same kind (more specific wins), still behind `effective_verdict` and the frozen-namespace verdict floor.
- **`docs/use/policies.md`** — new "Selector-scoped reclassification" section.
- **`changelog.d/`** — fragment via the scriv workflow.
- **`tests/test_reclassify.py`** — 17 new tests (rule matching, priority ordering vs. `overrides:`, frozen-namespace floor, `effective_verdict` precedence, validation errors).

## Verification

- `mypy abicheck/` — clean (354 files).
- `ruff check` / `ruff format --check` — clean on all touched/new files.
- `python scripts/check_ai_readiness.py` — no new errors or import-cycle warnings; the 2 pre-existing `adr-status-sync` errors are unrelated and present on `main` too.
- `pytest tests/test_reclassify.py tests/test_policy_file.py tests/test_suppression*.py tests/test_reachability_aware_suppression.py -q` — 1926 passed.
- Confirmed `tests/test_ai_readiness.py::test_main_returns_zero_on_clean_tree` fails identically on `main` (pre-existing, unrelated to this change — same 2 ADR-verification errors).

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FM9pfR1T5oLfdwXSCDgr7i)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selector-scoped `reclassify` policy rules for targeted finding classification.
  * Added rule expiry, validation, precedence handling, and safety protections.
  * Reports now show active reclassification rules and identify the rule behind each applicable finding.
* **Bug Fixes**
  * Applied selector-based classifications consistently across comparisons, scans, suppression audits, and severity decisions.
* **Documentation**
  * Updated policy configuration, CLI, GitHub Action, output-format, and schema documentation.
* **Tests**
  * Added comprehensive coverage for matching, precedence, expiry, reporting, and safety behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->