### PR TITLE
fix(buildsource): collapse L4 SYCL replay to a single -cc1 pass

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2172,34 +2172,52 @@ Once a root command genuinely clears the bar above, pick the right home:
   individually-verified follow-up (FP-rate/mutation-score gates), not a
   drive-by extension of this pass's RecordType-scoped fix.
 - **L4 SYCL replay via a resolved `--gcc-path icpx`/`dpcpp` override — flag
-  vocabulary fixed, real host/device multi-pass replay not implemented.**
-  Fixing L4 clang_bin resolution to honor `--gcc-path` (this same PR) meant
-  L4 could for the first time actually invoke a SYCL-capable compiler
-  (`icpx`/`dpcpp`) instead of always a bare `clang`, which surfaced a
-  narrower, real gap: `-fsycl`/`-fsycl-*` wasn't in
-  `adapters.base.ABI_RELEVANT_FLAG_PREFIXES`, so it never reached the
-  reconstructed L4 replay command even when the real build recorded it
-  (Codex review) — fixed, since the existing `abi_relevant_flags`
-  carry-through (`replay_extra_flags`) already handles this class of flag
-  correctly for every other case (`-std=`, `-fvisibility`, …), so this was
-  a one-line vocabulary gap, not a design gap. **Not implemented**, and
-  explicitly out of scope for that narrow fix: reconstructing the real
-  build's own host/device multi-pass invocation. `sycl_context.py` already
-  has real knowledge that a DPC++ driver invocation is internally two
-  `-cc1` passes (`-fsycl-is-host`/`-fsycl-is-device`) for a different
-  purpose (binary-level SYCL detection); L4 replay's single
-  `clang -ast-dump=json` + `json.load()` pipeline has no equivalent
-  awareness. Two specific consequences flagged but not verified against a
-  real `icpx`/`dpcpp` install (no such toolchain available to test
-  against): (1) whether replaying without an explicit `-fsycl-host-only`
-  pin causes `icpx` to attempt a device pass this pipeline can't consume
-  (unconfirmed — the real build's own recorded argv may already pin one
-  case-by-case); (2) whether legacy `dpcpp` specifically emits multi-
-  document (host+device) AST output that would need a structural change to
-  `ClangSourceExtractor`'s single-document `json.load()`. Both need
-  verification against a real oneAPI toolchain before a confident fix, not
-  a guess — a wrong guess here is worse than the pre-existing gap (same
-  principle as the toolchain-profile compiler-family entry above).
+  vocabulary fixed, the two-pass JSON-document crash fixed, real host+device
+  dual-context replay still not implemented.** Fixing L4 clang_bin
+  resolution to honor `--gcc-path` (an earlier PR) meant L4 could for the
+  first time actually invoke a SYCL-capable compiler (`icpx`/`dpcpp`)
+  instead of always a bare `clang`, which surfaced a narrower, real gap:
+  `-fsycl`/`-fsycl-*` wasn't in `adapters.base.ABI_RELEVANT_FLAG_PREFIXES`,
+  so it never reached the reconstructed L4 replay command even when the
+  real build recorded it (Codex review) — fixed, since the existing
+  `abi_relevant_flags` carry-through (`replay_extra_flags`) already handles
+  this class of flag correctly for every other case (`-std=`,
+  `-fvisibility`, …), so this was a one-line vocabulary gap, not a design
+  gap. That fix's own consequence #1 — "whether replaying without an
+  explicit `-fsycl-host-only` pin causes `icpx` to attempt a device pass
+  this pipeline can't consume" — was later **confirmed against a real
+  toolchain**: a real `-fsycl` bazel compile unit (oneDAL, 2.8GB AST) hit
+  exactly this, `json.load()` failing with `Extra data: line 26076735
+  column 2` at the byte offset where the device pass's document begins,
+  i.e. consequence #2 also confirmed (legacy `dpcpp`/`icpx` both emit
+  multi-document host+device AST output for a plain `-fsycl`, the identical
+  shape `sycl_context.py` already handles for the *L2* header-AST backend).
+  **Now fixed** by mirroring the L2 backend's own fix
+  (`dumper_ast_config._build_clang_header_command`/
+  `dumper_clang._needs_sycl_host_only`) rather than adopting
+  `sycl_context.py`'s full host/device dual-context decoder: L4 replay
+  parses ONE compile unit at a time and has no `--frontend-context device`
+  concept to select against (unlike L2's header-AST dump, which can be
+  asked for either context), so there is nothing for a second document to
+  serve here — `_clang_context_args` (shared by both the AST pass and the
+  macro pass) now appends `-fsycl-host-only` whenever
+  `dumper_clang._needs_sycl_host_only` says the resolved compiler is an
+  Intel oneAPI driver with SYCL effectively enabled and no single pass
+  already pinned, collapsing the compile back to the one host-side pass
+  that actually links into the scanned `.so` — the device pass's SPIR-V
+  kernel code never does. Reuses `_needs_sycl_host_only` directly (not a
+  reimplementation) so the last-flag-wins `-fsycl`/`-fno-sycl` scan and the
+  legacy `dpcpp`/`dpcpp-cl` SYCL-implied-by-default handling stay a single
+  source of truth with the L2 fix. The remaining "Extra data" `json.load()`
+  path now also emits an actionable hint (mirroring
+  `dumper_clang_errors._parse_clang_ast_result`'s) for any *other*,
+  not-yet-special-cased offload flag that still produces a multi-document
+  stream, rather than a bare byte offset. **Still not implemented, and
+  deliberately out of scope**: a genuine host+device dual-context L4
+  replay (an L4 counterpart to `--frontend-context device`) — nothing in
+  L4's `SourceAbiTu`/`CompileUnit` model has a notion of "this TU's device
+  pass," so adding one is a real, separate design (schema + linker +
+  cross-check changes), not a follow-up to this crash fix.
 - **`depfile_args_from_argv()`'s `trusted_root` parameter — the self-jail
   vulnerability is closed, real production wiring not implemented.** Closing
   the vulnerability (a compile unit's own `directory` field, attacker-

--- a/abicheck/buildsource/source_extractors/_argv.py
+++ b/abicheck/buildsource/source_extractors/_argv.py
@@ -177,21 +177,47 @@ def basename(path: str) -> str:
 def strip_launchers(argv: list[str]) -> list[str]:
     """Drop leading compiler-launcher tokens (``ccache``/``sccache``/…)."""
     i = 0
-    while i < len(argv) and basename(argv[i]).lower().removesuffix(
-        ".exe"
-    ) in COMPILER_LAUNCHERS:
+    while (
+        i < len(argv)
+        and basename(argv[i]).lower().removesuffix(".exe") in COMPILER_LAUNCHERS
+    ):
         i += 1
     return argv[i:]
 
 
 def pick_compiler_binary(compile_unit: CompileUnit, override: str | None) -> str:
-    """Pick the compiler binary an extractor should emulate for this TU.
+    """Pick the compiler binary an extractor should EMULATE for this TU.
 
     Prefers the compiler actually recorded in the build action (``argv[0]``,
     after unwrapping any launcher) so a clang/clang-cl/cross TU is replayed
     against its real builtin include paths, target defaults, and accepted flags.
     Falls back to g++/gcc by language when no command is available; an explicit
     ``override`` always wins.
+
+    **This is emulation identity, not invocation identity — do not use it to
+    gate whether a flag is safe to append to the command an extractor is
+    about to run.** Without an explicit ``override``, this falls back to the
+    real build's own recorded ``argv[0]`` (e.g. ``icpx``) purely so flag
+    *shape* (MSVC ``/D``/``/I`` vs. GNU ``-D``/``-I``, language-standard
+    spelling, …) matches what the real build used — it says nothing about
+    which binary a given extractor is genuinely going to shell out to. A
+    caller in `castxml.py` passes this value as castxml's own
+    ``--castxml-cc-<id> <path>`` *argument* (castxml itself is invoked, and
+    is explicitly designed to accept an arbitrary compiler identity to
+    emulate), so appending a flag there based on this result is safe by
+    construction. A caller in `clang.py`/`clang_public_roots.py` that
+    instead builds an argv for **this same binary to execute directly**
+    must gate any binary-capability-specific flag (e.g. an Intel-only
+    ``-fsycl-host-only``) on the extractor's own actually-invoked binary
+    (its own ``clang_bin``, distinct from this function's return value)
+    instead — conflating the two let `-fsycl-host-only` get appended to a
+    genuinely stock ``clang`` invocation whenever a SYCL TU's real build
+    happened to use an Intel driver, which stock clang hard-rejects as
+    "unknown argument" (Codex review, `source_extractors/clang.py`'s
+    `_clang_context_args`). See that function's own docstring for the fix
+    and `tests/test_source_extractors_clang.py`'s
+    ``TestSyclHostOnlyGatedOnInvokedBinary`` for the regression matrix any
+    future binary-capability-gated flag addition here should extend.
     """
     if override:
         return override
@@ -267,7 +293,9 @@ def _match_gnu_forced_include(tok: str, argv: list[str], i: int, out: list[str])
     return i
 
 
-def _match_msvc_include_search(tok: str, argv: list[str], i: int, out: list[str]) -> int:
+def _match_msvc_include_search(
+    tok: str, argv: list[str], i: int, out: list[str]
+) -> int:
     """Try to match an MSVC ``/I`` include-search token (MSVC mode only).
 
     Returns the new ``i`` after consumption, or the original ``i`` if no match.
@@ -282,7 +310,9 @@ def _match_msvc_include_search(tok: str, argv: list[str], i: int, out: list[str]
     return i
 
 
-def _match_msvc_forced_include(tok: str, argv: list[str], i: int, out: list[str]) -> int:
+def _match_msvc_forced_include(
+    tok: str, argv: list[str], i: int, out: list[str]
+) -> int:
     """Try to match an MSVC ``/FI`` forced-include token (MSVC mode only).
 
     Returns the new ``i`` after consumption, or the original ``i`` if no match.
@@ -298,9 +328,7 @@ def _match_msvc_forced_include(tok: str, argv: list[str], i: int, out: list[str]
     return i
 
 
-def _scan_argv_for_extra_flags(
-    argv: list[str], cc_id: str, out: list[str]
-) -> None:
+def _scan_argv_for_extra_flags(argv: list[str], cc_id: str, out: list[str]) -> None:
     """Walk ``argv`` and append forced-include / include-search tokens to ``out``.
 
     Handles GNU and (when ``cc_id == "msvc"``) MSVC option families.  Each

--- a/abicheck/buildsource/source_extractors/_argv.py
+++ b/abicheck/buildsource/source_extractors/_argv.py
@@ -248,13 +248,34 @@ def _carry_abi_relevant_flags(
     Skips flags whose prefix matches a structured toolchain option (sysroot,
     target, isysroot) because those are already emitted from the structured
     fields and the split spelling would dangle if re-appended.
+
+    *seen* is checked but never updated by this loop (Codex review, fresh
+    evidence): an earlier revision added each carried flag to *seen* as it
+    went, which silently dropped every REPEAT of an already-carried literal
+    token. That is wrong for a toggle-style flag pair sharing one spelling
+    across BOTH states (``-fsycl``/``-fno-sycl``, ``-fexceptions``/
+    ``-fno-exceptions``, …): a real, layered build config can legitimately
+    record the identical flag more than once
+    (``extract_abi_relevant_flags`` preserves every occurrence, in order,
+    with no dedup of its own), and only the LAST occurrence decides the
+    real compiler's effective state. Deduping WITHIN this carry-through
+    collapsed a sequence like ``-fno-sycl -fsycl -fno-sycl`` down to
+    ``-fno-sycl -fsycl`` (dropping the second, decisive ``-fno-sycl`` as a
+    "duplicate" of the first) — silently reversing the real effective
+    state from disabled to enabled. Checking only the CALLER's initial
+    *seen* (flags already emitted from the structured fields) still avoids
+    re-emitting those, which is this function's only documented purpose;
+    every occurrence of a flag genuinely repeated within
+    ``abi_relevant_flags`` itself is now carried through faithfully, in
+    the real build's own order and multiplicity, so last-flag-wins
+    scanning downstream (e.g. ``dumper_clang._needs_sycl_host_only``) sees
+    the same sequence the real compiler did.
     """
     for flag in abi_relevant_flags:
         if flag.startswith(STRUCTURED_TOOLCHAIN_FLAG_PREFIXES):
             continue
         if flag not in seen:
             out.append(flag)
-            seen.add(flag)
 
 
 def _match_gnu_include_search(tok: str, argv: list[str], i: int, out: list[str]) -> int:

--- a/abicheck/buildsource/source_extractors/castxml.py
+++ b/abicheck/buildsource/source_extractors/castxml.py
@@ -62,8 +62,16 @@ from .base import SourceExtractionError, assemble_source_tu
 #: snapshot -- the same parser started extracting ``EnumType.underlying_type``
 #: for real (previously always the dataclass default ``"int"``), so an
 #: upgrading user's warm per-TU cache would keep replaying the old default
-#: without this bump.
-CASTXML_EXTRACTOR_VERSION = "0.2"
+#: without this bump. 0.3 (Codex review): ``_argv._carry_abi_relevant_flags``
+#: (shared with the clang extractor via ``build_castxml_command``'s own
+#: ``_replay_extra_flags`` call) no longer dedups a repeated flag WITHIN
+#: ``abi_relevant_flags`` itself -- a real, layered build config recording a
+#: toggle-style flag pair more than once (e.g. ``-fexceptions
+#: -fno-exceptions -fexceptions``) previously had every repeat past the
+#: first collapsed away, corrupting the real last-flag-wins state this
+#: extractor replays; bumped so a pre-0.3 cached/persisted entry for the
+#: same TU is never treated as comparable to a fresh, correctly-replayed one.
+CASTXML_EXTRACTOR_VERSION = "0.3"
 
 #: Backwards-compatible aliases — the compile-context → argv helpers now live in
 #: the shared ``_argv`` module (reused by the clang backend, phase 5) but are

--- a/abicheck/buildsource/source_extractors/clang.py
+++ b/abicheck/buildsource/source_extractors/clang.py
@@ -61,6 +61,7 @@ from pathlib import Path
 from typing import Any
 
 from ... import deadline
+from ...dumper_clang import _needs_sycl_host_only
 from ...header_conditionals import _include_guard_macro, _strip_comments
 from ..build_evidence import CompileUnit
 from ..model import LayerConfidence
@@ -224,6 +225,25 @@ def _clang_context_args(
     Mirrors the compile unit's language standard, defines/undefines, include and
     system-include paths, sysroot, target triple, and ABI-relevant flags, so both
     the AST pass and the macro pass parse the same TU the real build compiled.
+
+    A real build's own recorded ``-fsycl`` (carried through via
+    ``replay_extra_flags``'s ``ABI_RELEVANT_FLAG_PREFIXES``) makes Intel's
+    oneAPI DPC++/C++ driver (icx/icpx/dpcpp[-cl]) run *two* separate ``-cc1``
+    passes for one compile — a SYCL device-side pass and a host-side pass,
+    each writing a complete document to the same stdout stream back-to-back
+    with no separator, which breaks both the AST pass's single-document JSON
+    reader and the macro pass's single-stream text reader. Mirrors the fix
+    already shipped for the L2 header-AST backend
+    (``dumper_ast_config._build_clang_header_command`` /
+    ``dumper_clang._needs_sycl_host_only``): append ``-fsycl-host-only`` here
+    too, collapsing the compile back to the single host-side pass that
+    actually links into the scanned binary — the device pass describes
+    SPIR-V kernel code that never becomes part of the host ``.so``'s
+    exported symbols, so L4 replay has no use for it either way. A no-op for
+    any non-Intel driver, or when the caller's own flags already pin a
+    single pass (``-fsycl-host-only``/``-fsycl-device-only``) or explicitly
+    disable SYCL (``-fno-sycl`` last-flag-wins) — see
+    ``_needs_sycl_host_only``'s own docstring for the full precedence.
     """
     cc_bin = pick_compiler_binary(compile_unit, compiler_binary)
     msvc = is_msvc_mode(cc_bin)
@@ -264,6 +284,8 @@ def _clang_context_args(
             if not flag.startswith("-std=")
             and not flag.lower().startswith(("/std:", "-std:"))
         ]
+    if _needs_sycl_host_only(cc_bin, [*cmd, *extra]):
+        extra = [*extra, "-fsycl-host-only"]
     cmd += extra
     return cmd, msvc
 
@@ -317,54 +339,6 @@ def build_clang_macro_command(
     else:
         preprocess = ["-E", "-dD"]
     return [clang_bin, *cmd, *preprocess, "-ferror-limit=0", str(source)]
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 class _ClassifyContext:
@@ -1441,8 +1415,29 @@ class ClangSourceExtractor:
                 with open(ast_path, "rb") as fh:  # bytes: json detects encoding
                     ast_root = json.load(fh)
             except ValueError as exc:
+                # "Extra data" means a second top-level JSON value follows the
+                # first — some other flag not already collapsed to a single
+                # pass above (`_clang_context_args`'s `-fsycl-host-only`
+                # insertion) made this compile emit more than one document to
+                # the same stdout stream (e.g. an OpenMP/CUDA offload target
+                # flag, or a non-Intel SYCL-capable driver this codebase
+                # doesn't yet special-case) — name the likely cause here
+                # rather than a bare byte-offset, mirroring the identical hint
+                # `dumper_clang_errors._parse_clang_ast_result` gives the L2
+                # header-AST backend for the same failure shape.
+                hint = ""
+                if isinstance(exc, json.JSONDecodeError) and exc.msg == "Extra data":
+                    hint = (
+                        " -- this looks like more than one JSON document on "
+                        "stdout, which happens when a compiler flag makes "
+                        "clang run multiple -cc1 passes for one compile (e.g. "
+                        "an unpinned SYCL/OpenMP/CUDA offload flag); pin a "
+                        "single compilation pass (e.g. -fsycl-host-only) in "
+                        "the build's own recorded flags"
+                    )
                 raise SourceExtractionError(
-                    f"clang AST for {compile_unit.source} was not valid JSON: {exc}"
+                    f"clang AST for {compile_unit.source} was not valid JSON: "
+                    f"{exc}{hint}"
                 ) from exc
         finally:
             ast_path.unlink(missing_ok=True)

--- a/abicheck/buildsource/source_extractors/clang.py
+++ b/abicheck/buildsource/source_extractors/clang.py
@@ -131,16 +131,22 @@ from .clang_source_edges import build_source_edges
 #: resolved compiler override (Codex review). 0.9: the reconstructed command now
 #: appends ``-fsycl-host-only`` for a SYCL-enabled Intel oneAPI invocation
 #: (Codex review) -- a pre-0.9 cache entry for the same TU was built without
-#: that flag and must not be reused as-is. 0.10: a real build's own recorded
-#: ``-fsycl-host-only`` (an Intel-only SYCL pass-selector flag carried through
-#: via ``abi_relevant_flags``) is now stripped when the invoked binary isn't
-#: Intel-family, closing the same class of "unknown argument" failure via a
-#: different code path than 0.9's own fix; a recorded ``-fsycl-device-only``
-#: on a non-Intel invoked binary now degrades that one TU (a clear
-#: SourceExtractionError) instead of either failing on the raw "unknown
-#: argument" or silently dropping the selector and replaying it as host code
-#: (Codex review).
-CLANG_EXTRACTOR_VERSION = "0.10"
+#: that flag and must not be reused as-is. 0.10/0.11: a real build's own
+#: recorded ``-fsycl-host-only``/``-fsycl-device-only`` (Intel-only SYCL
+#: pass-selector flags carried through via ``abi_relevant_flags``) on a
+#: non-Intel invoked binary now degrades that one TU (a clear
+#: SourceExtractionError) instead of failing on the raw "unknown argument".
+#: 0.10 first shipped this only for ``-fsycl-device-only``, silently
+#: STRIPPING a recorded ``-fsycl-host-only`` instead -- confirmed against a
+#: real clang install (Codex review) that this was itself wrong: stock
+#: clang's bare ``-fsycl`` defines ``__SYCL_DEVICE_ONLY__`` (device context
+#: by default), so dropping just the host-only selector silently replayed
+#: an explicitly host-pinned TU as device code. 0.11 raises for both
+#: selectors symmetrically; a bare, unselected ``-fsycl`` (ambiguous, no
+#: explicit pin either way) is left carried through as-is, matching the L2
+#: header-AST backend's own established "accepted approximation" for that
+#: shape (see ``_needs_sycl_host_only``'s own docstring).
+CLANG_EXTRACTOR_VERSION = "0.11"
 
 
 @functools.lru_cache(maxsize=8)
@@ -309,39 +315,41 @@ def _clang_context_args(
             if not flag.startswith("-std=")
             and not flag.lower().startswith(("/std:", "-std:"))
         ]
-    if not _is_intel_sycl_driver(clang_bin) and "-fsycl-device-only" in extra:
-        # A real build's own recorded -fsycl-device-only (carried through
-        # above via replay_extra_flags's abi_relevant_flags/argv scan) names
-        # a SYCL *device*-side compilation pass -- a genuinely different
-        # preprocessor context (__SYCL_DEVICE_ONLY__, device-only code
-        # paths), not merely a flag the invoked binary happens to reject.
-        # Silently dropping it and falling through to an ordinary parse
-        # would "succeed" by stamping source facts for the WRONG
-        # compilation context (host, not device-only) -- worse than the
-        # honest hard failure this flag already produced before this
-        # module ever touched it, since L4 has no device-context
-        # representation to replay it correctly under (Codex review). Fail
-        # this one TU explicitly instead, with a clearer message than the
-        # raw "unknown argument" this would otherwise still hit.
-        raise SourceExtractionError(
-            f"compile unit {compile_unit.source!r} was recorded with "
-            "-fsycl-device-only (a SYCL device-side compilation pass), but "
-            f"the binary this command will actually run with ({clang_bin!r}) "
-            "is not an Intel oneAPI DPC++/C++ driver and cannot honor it. "
-            "L4 source-ABI replay has no device-context representation, so "
-            "this translation unit degrades to partial coverage rather "
-            "than being silently replayed as ordinary host code -- pass "
-            "--gcc-path pointing at the real icx/icpx/dpcpp driver to "
-            "extract it."
-        )
     if not _is_intel_sycl_driver(clang_bin):
-        # -fsycl-host-only, unlike -fsycl-device-only above, is safe to
-        # drop rather than fail on: without it, stock clang's bare -fsycl
-        # already parses fine as one ordinary (host-shaped) pass (see this
-        # function's own docstring), so removing just the pass-selector
-        # flag a non-Intel binary would otherwise hard-reject changes
-        # nothing about which compilation context gets replayed.
-        extra = [flag for flag in extra if flag != "-fsycl-host-only"]
+        # A real build's own recorded -fsycl-host-only/-fsycl-device-only
+        # (carried through above via replay_extra_flags's abi_relevant_flags/
+        # argv scan) each pin a SPECIFIC SYCL compilation pass -- and stock
+        # clang cannot honor either: it hard-rejects both as "unknown
+        # argument", AND (confirmed empirically against a real clang 18
+        # install) its own bare -fsycl with NEITHER selector compiles as
+        # DEVICE context by default (defines __SYCL_DEVICE_ONLY__), not
+        # host. So dropping -fsycl-device-only and falling through to a
+        # bare -fsycl "coincidentally" matches its recorded pass -- but
+        # dropping -fsycl-host-only does NOT: it silently flips an
+        # explicitly HOST-pinned TU into a device-context compile (Codex
+        # review; an earlier revision of this fix got exactly this
+        # asymmetry wrong, treating the two selectors as interchangeable).
+        # Both therefore degrade this one TU explicitly (a clear message,
+        # not the raw "unknown argument") rather than ever stamping source
+        # facts for a DIFFERENT compilation context than the one actually
+        # recorded. A bare, unselected -fsycl (no explicit pin either way)
+        # is deliberately left alone -- carried through as-is, matching the
+        # L2 header-AST backend's own established accepted approximation
+        # for that ambiguous shape (see this function's own docstring).
+        pinned = {"-fsycl-host-only", "-fsycl-device-only"} & set(extra)
+        if pinned:
+            raise SourceExtractionError(
+                f"compile unit {compile_unit.source!r} was recorded with "
+                f"{sorted(pinned)!r} (an Intel-only SYCL pass-selector "
+                "flag), but the binary this command will actually run "
+                f"with ({clang_bin!r}) is not an Intel oneAPI DPC++/C++ "
+                "driver and cannot honor it. L4 source-ABI replay has no "
+                "way to correctly represent that pass under a different "
+                "compiler, so this translation unit degrades to partial "
+                "coverage rather than being silently replayed under the "
+                "wrong compilation context -- pass --gcc-path pointing at "
+                "the real icx/icpx/dpcpp driver to extract it."
+            )
     if _needs_sycl_host_only(clang_bin, [*cmd, *extra]):
         extra = [*extra, "-fsycl-host-only"]
     cmd += extra

--- a/abicheck/buildsource/source_extractors/clang.py
+++ b/abicheck/buildsource/source_extractors/clang.py
@@ -132,21 +132,15 @@ from .clang_source_edges import build_source_edges
 #: appends ``-fsycl-host-only`` for a SYCL-enabled Intel oneAPI invocation
 #: (Codex review) -- a pre-0.9 cache entry for the same TU was built without
 #: that flag and must not be reused as-is. 0.10: a real build's own recorded
-#: ``-fsycl-host-only``/``-fsycl-device-only`` (Intel-only SYCL pass-selector
-#: flags carried through via ``abi_relevant_flags``) is now stripped when the
-#: invoked binary isn't Intel-family, closing the same class of "unknown
-#: argument" failure via a different code path than 0.9's own fix.
+#: ``-fsycl-host-only`` (an Intel-only SYCL pass-selector flag carried through
+#: via ``abi_relevant_flags``) is now stripped when the invoked binary isn't
+#: Intel-family, closing the same class of "unknown argument" failure via a
+#: different code path than 0.9's own fix; a recorded ``-fsycl-device-only``
+#: on a non-Intel invoked binary now degrades that one TU (a clear
+#: SourceExtractionError) instead of either failing on the raw "unknown
+#: argument" or silently dropping the selector and replaying it as host code
+#: (Codex review).
 CLANG_EXTRACTOR_VERSION = "0.10"
-
-#: Intel oneAPI SYCL pass-selector flags (``-fsycl-host-only``/
-#: ``-fsycl-device-only``): meaningful ONLY on an Intel oneAPI driver
-#: (:func:`abicheck.dumper_clang._is_intel_sycl_driver`) -- every other
-#: clang-family binary hard-rejects both as "unknown argument". Shared
-#: between the insertion gate (``_needs_sycl_host_only``, which checks
-#: membership to detect an already-pinned pass) and the strip below (which
-#: removes a real build's own recorded use of either flag when the binary
-#: this command will actually run with doesn't understand them).
-_INTEL_ONLY_SYCL_PASS_FLAGS = frozenset({"-fsycl-host-only", "-fsycl-device-only"})
 
 
 @functools.lru_cache(maxsize=8)
@@ -315,19 +309,39 @@ def _clang_context_args(
             if not flag.startswith("-std=")
             and not flag.lower().startswith(("/std:", "-std:"))
         ]
+    if not _is_intel_sycl_driver(clang_bin) and "-fsycl-device-only" in extra:
+        # A real build's own recorded -fsycl-device-only (carried through
+        # above via replay_extra_flags's abi_relevant_flags/argv scan) names
+        # a SYCL *device*-side compilation pass -- a genuinely different
+        # preprocessor context (__SYCL_DEVICE_ONLY__, device-only code
+        # paths), not merely a flag the invoked binary happens to reject.
+        # Silently dropping it and falling through to an ordinary parse
+        # would "succeed" by stamping source facts for the WRONG
+        # compilation context (host, not device-only) -- worse than the
+        # honest hard failure this flag already produced before this
+        # module ever touched it, since L4 has no device-context
+        # representation to replay it correctly under (Codex review). Fail
+        # this one TU explicitly instead, with a clearer message than the
+        # raw "unknown argument" this would otherwise still hit.
+        raise SourceExtractionError(
+            f"compile unit {compile_unit.source!r} was recorded with "
+            "-fsycl-device-only (a SYCL device-side compilation pass), but "
+            f"the binary this command will actually run with ({clang_bin!r}) "
+            "is not an Intel oneAPI DPC++/C++ driver and cannot honor it. "
+            "L4 source-ABI replay has no device-context representation, so "
+            "this translation unit degrades to partial coverage rather "
+            "than being silently replayed as ordinary host code -- pass "
+            "--gcc-path pointing at the real icx/icpx/dpcpp driver to "
+            "extract it."
+        )
     if not _is_intel_sycl_driver(clang_bin):
-        # A real build's own recorded -fsycl-host-only/-fsycl-device-only
-        # (carried through above via replay_extra_flags's abi_relevant_flags/
-        # argv scan) is just as Intel-only as the flag WE would otherwise
-        # append below -- every non-Intel clang-family binary hard-rejects
-        # both the same way. Strip them so a TU whose real build already
-        # pinned a single SYCL pass explicitly still replays under a
-        # non-Intel invoked binary instead of failing on "unknown argument"
-        # via this different code path (Codex review: caught by the
-        # generalized Hypothesis property test below, not the original
-        # report -- a bare -fsycl is deliberately left alone, since stock
-        # clang parses that one fine as an ordinary single pass).
-        extra = [flag for flag in extra if flag not in _INTEL_ONLY_SYCL_PASS_FLAGS]
+        # -fsycl-host-only, unlike -fsycl-device-only above, is safe to
+        # drop rather than fail on: without it, stock clang's bare -fsycl
+        # already parses fine as one ordinary (host-shaped) pass (see this
+        # function's own docstring), so removing just the pass-selector
+        # flag a non-Intel binary would otherwise hard-reject changes
+        # nothing about which compilation context gets replayed.
+        extra = [flag for flag in extra if flag != "-fsycl-host-only"]
     if _needs_sycl_host_only(clang_bin, [*cmd, *extra]):
         extra = [*extra, "-fsycl-host-only"]
     cmd += extra

--- a/abicheck/buildsource/source_extractors/clang.py
+++ b/abicheck/buildsource/source_extractors/clang.py
@@ -61,7 +61,7 @@ from pathlib import Path
 from typing import Any
 
 from ... import deadline
-from ...dumper_clang import _needs_sycl_host_only
+from ...dumper_clang import _is_intel_sycl_driver, _needs_sycl_host_only
 from ...header_conditionals import _include_guard_macro, _strip_comments
 from ..build_evidence import CompileUnit
 from ..model import LayerConfidence
@@ -131,8 +131,22 @@ from .clang_source_edges import build_source_edges
 #: resolved compiler override (Codex review). 0.9: the reconstructed command now
 #: appends ``-fsycl-host-only`` for a SYCL-enabled Intel oneAPI invocation
 #: (Codex review) -- a pre-0.9 cache entry for the same TU was built without
-#: that flag and must not be reused as-is.
-CLANG_EXTRACTOR_VERSION = "0.9"
+#: that flag and must not be reused as-is. 0.10: a real build's own recorded
+#: ``-fsycl-host-only``/``-fsycl-device-only`` (Intel-only SYCL pass-selector
+#: flags carried through via ``abi_relevant_flags``) is now stripped when the
+#: invoked binary isn't Intel-family, closing the same class of "unknown
+#: argument" failure via a different code path than 0.9's own fix.
+CLANG_EXTRACTOR_VERSION = "0.10"
+
+#: Intel oneAPI SYCL pass-selector flags (``-fsycl-host-only``/
+#: ``-fsycl-device-only``): meaningful ONLY on an Intel oneAPI driver
+#: (:func:`abicheck.dumper_clang._is_intel_sycl_driver`) -- every other
+#: clang-family binary hard-rejects both as "unknown argument". Shared
+#: between the insertion gate (``_needs_sycl_host_only``, which checks
+#: membership to detect an already-pinned pass) and the strip below (which
+#: removes a real build's own recorded use of either flag when the binary
+#: this command will actually run with doesn't understand them).
+_INTEL_ONLY_SYCL_PASS_FLAGS = frozenset({"-fsycl-host-only", "-fsycl-device-only"})
 
 
 @functools.lru_cache(maxsize=8)
@@ -301,6 +315,19 @@ def _clang_context_args(
             if not flag.startswith("-std=")
             and not flag.lower().startswith(("/std:", "-std:"))
         ]
+    if not _is_intel_sycl_driver(clang_bin):
+        # A real build's own recorded -fsycl-host-only/-fsycl-device-only
+        # (carried through above via replay_extra_flags's abi_relevant_flags/
+        # argv scan) is just as Intel-only as the flag WE would otherwise
+        # append below -- every non-Intel clang-family binary hard-rejects
+        # both the same way. Strip them so a TU whose real build already
+        # pinned a single SYCL pass explicitly still replays under a
+        # non-Intel invoked binary instead of failing on "unknown argument"
+        # via this different code path (Codex review: caught by the
+        # generalized Hypothesis property test below, not the original
+        # report -- a bare -fsycl is deliberately left alone, since stock
+        # clang parses that one fine as an ordinary single pass).
+        extra = [flag for flag in extra if flag not in _INTEL_ONLY_SYCL_PASS_FLAGS]
     if _needs_sycl_host_only(clang_bin, [*cmd, *extra]):
         extra = [*extra, "-fsycl-host-only"]
     cmd += extra

--- a/abicheck/buildsource/source_extractors/clang.py
+++ b/abicheck/buildsource/source_extractors/clang.py
@@ -128,8 +128,11 @@ from .clang_source_edges import build_source_edges
 #: clang extractor schema/behaviour version, recorded in the dump provenance and
 #: folded into the per-TU cache key (ADR-030 D8). Bump on ANY recipe change so a
 #: stale ``--cache-dir`` never reuses an old dump. 0.8: also folds in the
-#: resolved compiler override (Codex review).
-CLANG_EXTRACTOR_VERSION = "0.8"
+#: resolved compiler override (Codex review). 0.9: the reconstructed command now
+#: appends ``-fsycl-host-only`` for a SYCL-enabled Intel oneAPI invocation
+#: (Codex review) -- a pre-0.9 cache entry for the same TU was built without
+#: that flag and must not be reused as-is.
+CLANG_EXTRACTOR_VERSION = "0.9"
 
 
 @functools.lru_cache(maxsize=8)

--- a/abicheck/buildsource/source_extractors/clang.py
+++ b/abicheck/buildsource/source_extractors/clang.py
@@ -218,7 +218,7 @@ def _std_flag(standard: str, msvc: bool) -> list[str]:
 
 
 def _clang_context_args(
-    compile_unit: CompileUnit, compiler_binary: str | None
+    compile_unit: CompileUnit, compiler_binary: str | None, *, clang_bin: str = "clang"
 ) -> tuple[list[str], bool]:
     """The shared compile-context argv prefix (no mode tail / source) and msvc flag.
 
@@ -244,6 +244,20 @@ def _clang_context_args(
     single pass (``-fsycl-host-only``/``-fsycl-device-only``) or explicitly
     disable SYCL (``-fno-sycl`` last-flag-wins) — see
     ``_needs_sycl_host_only``'s own docstring for the full precedence.
+
+    The host-only decision is gated on *clang_bin* — the binary this command
+    will actually be run with — not on ``pick_compiler_binary``'s *emulated*
+    compiler below (``cc_bin``, used only for flag-shape decisions like
+    ``msvc``/language-standard translation). Without ``--gcc-path``/an
+    explicit ``compiler_binary`` override, ``cc_bin`` falls back to the real
+    build's own recorded ``argv[0]`` (e.g. ``icpx``) purely to emulate its
+    accepted flag shape, while *clang_bin* stays the generic default
+    (``"clang"``) that is genuinely invoked. Gating on ``cc_bin`` instead
+    would append ``-fsycl-host-only`` to a stock clang invocation whenever a
+    SYCL TU's real build happened to use an Intel driver — stock clang
+    hard-rejects the flag ("unknown argument"), turning every such TU into a
+    failed/partial L4 extraction instead of the single ordinary pass stock
+    clang already parses a bare ``-fsycl`` as (Codex review).
     """
     cc_bin = pick_compiler_binary(compile_unit, compiler_binary)
     msvc = is_msvc_mode(cc_bin)
@@ -284,7 +298,7 @@ def _clang_context_args(
             if not flag.startswith("-std=")
             and not flag.lower().startswith(("/std:", "-std:"))
         ]
-    if _needs_sycl_host_only(cc_bin, [*cmd, *extra]):
+    if _needs_sycl_host_only(clang_bin, [*cmd, *extra]):
         extra = [*extra, "-fsycl-host-only"]
     cmd += extra
     return cmd, msvc
@@ -301,7 +315,7 @@ def build_clang_command(
 
     A clang-cl/MSVC compile unit is driven through clang's ``cl`` driver mode.
     """
-    cmd, _msvc = _clang_context_args(compile_unit, compiler_binary)
+    cmd, _msvc = _clang_context_args(compile_unit, compiler_binary, clang_bin=clang_bin)
     # Syntax-only AST dump to stdout as JSON. -ferror-limit=0 keeps parsing past
     # recoverable errors so a single bad decl does not blank the whole dump.
     return [
@@ -329,7 +343,7 @@ def build_clang_macro_command(
     ``public_macro_value_changed`` to ever fire (Codex review #339, P2). Same
     compile context as the AST pass so the macro set matches the real build.
     """
-    cmd, msvc = _clang_context_args(compile_unit, compiler_binary)
+    cmd, msvc = _clang_context_args(compile_unit, compiler_binary, clang_bin=clang_bin)
     # cl-driver mode ignores -dD; clang-cl's `/d1PP` is the documented "retain
     # macro definitions in /E mode" flag, so a Windows/clang-cl build still emits
     # #define directives for macros_from_preprocessor (Codex review #339, P2). We

--- a/abicheck/buildsource/source_extractors/clang.py
+++ b/abicheck/buildsource/source_extractors/clang.py
@@ -145,8 +145,14 @@ from .clang_source_edges import build_source_edges
 #: selectors symmetrically; a bare, unselected ``-fsycl`` (ambiguous, no
 #: explicit pin either way) is left carried through as-is, matching the L2
 #: header-AST backend's own established "accepted approximation" for that
-#: shape (see ``_needs_sycl_host_only``'s own docstring).
-CLANG_EXTRACTOR_VERSION = "0.11"
+#: shape (see ``_needs_sycl_host_only``'s own docstring). 0.12:
+#: ``_argv._carry_abi_relevant_flags`` (shared by castxml/clang) no longer
+#: dedups a repeated flag WITHIN ``abi_relevant_flags`` itself -- a real,
+#: layered build config can legitimately record the same toggle-style flag
+#: more than once (e.g. ``-fno-sycl -fsycl -fno-sycl``), and the old dedup
+#: silently dropped every repeat, corrupting last-flag-wins state for any
+#: such pair, not just SYCL (Codex review).
+CLANG_EXTRACTOR_VERSION = "0.12"
 
 
 @functools.lru_cache(maxsize=8)

--- a/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
+++ b/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
@@ -34,6 +34,12 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   through verbatim via `abi_relevant_flags`) reached a non-Intel invoked
   binary unchanged, hitting the identical "unknown argument" failure
   independent of the insertion-side fix above. `_clang_context_args` now
-  also strips both Intel-only SYCL pass-selector flags from the carried-
-  through flags whenever the invoked binary isn't Intel-family (bumping
-  `CLANG_EXTRACTOR_VERSION` to `0.10`).
+  strips a carried-through `-fsycl-host-only` whenever the invoked binary
+  isn't Intel-family — harmless to drop, since stock clang's bare `-fsycl`
+  already parses fine as one ordinary host-shaped pass. A carried-through
+  `-fsycl-device-only` is handled differently, not stripped: it names a
+  genuinely different (device-side) compilation context, so silently
+  dropping it would replay the TU as ordinary host code and could fabricate
+  false L4 findings rather than honestly degrade coverage — it now raises a
+  clear `SourceExtractionError` for that one translation unit instead
+  (Codex review; bumping `CLANG_EXTRACTOR_VERSION` to `0.10`).

--- a/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
+++ b/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
@@ -1,0 +1,21 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **L4 source-ABI replay (`abicheck/buildsource/source_extractors/clang.py`)
+  broke on a real build's own recorded `-fsycl`**: Intel's oneAPI DPC++/C++
+  driver (`icx`/`icpx`/`dpcpp`/`dpcpp-cl`) runs two separate `-cc1` passes
+  for one `-fsycl` compile — a SYCL device-side pass and a host-side pass —
+  each writing a complete JSON document to the same stdout stream back to
+  back with no separator, so a single-document `json.load()` failed with
+  `Extra data` at the host/device split (reproduced against a real 2.8GB
+  `-fsycl` oneDAL translation unit). `_clang_context_args` now appends
+  `-fsycl-host-only` for such a compile unit — collapsing it back to the
+  single host-side pass that actually links into the scanned binary —
+  mirroring the identical fix already shipped for the L2 header-AST backend
+  (`dumper_ast_config._build_clang_header_command`). A leftover multi-document
+  stream from any other, not-yet-special-cased offload flag now also raises
+  an actionable `SourceExtractionError` naming the likely cause instead of a
+  bare byte-offset, matching the L2 backend's own hint.

--- a/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
+++ b/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
@@ -18,4 +18,13 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   (`dumper_ast_config._build_clang_header_command`). A leftover multi-document
   stream from any other, not-yet-special-cased offload flag now also raises
   an actionable `SourceExtractionError` naming the likely cause instead of a
-  bare byte-offset, matching the L2 backend's own hint.
+  bare byte-offset, matching the L2 backend's own hint. `_clang_context_args`
+  was found to gate that flag on `pick_compiler_binary`'s *emulated* compiler
+  (which falls back to the compile unit's own recorded `argv[0]`) rather than
+  the binary L4 actually invokes (`clang_bin`) — fixed to take `clang_bin`
+  explicitly, and `_argv.pick_compiler_binary`'s docstring now documents the
+  emulated-vs-invoked distinction generally so a future binary-capability-
+  gated flag here doesn't repeat the same mistake; `tests/
+  test_source_extractors_clang.py::TestSyclHostOnlyGatedOnInvokedBinary`
+  sweeps a matrix of invoked/recorded-`argv[0]` combinations as a regression
+  guard for the whole bug class, not just the one reported pair.

--- a/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
+++ b/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
@@ -27,4 +27,13 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   gated flag here doesn't repeat the same mistake; `tests/
   test_source_extractors_clang.py::TestSyclHostOnlyGatedOnInvokedBinary`
   sweeps a matrix of invoked/recorded-`argv[0]` combinations as a regression
-  guard for the whole bug class, not just the one reported pair.
+  guard for the whole bug class, not just the one reported pair. A
+  generalized Hypothesis property test in the same class then found the
+  same bug class reachable via a second, different code path: a real
+  build's own recorded `-fsycl-host-only`/`-fsycl-device-only` (carried
+  through verbatim via `abi_relevant_flags`) reached a non-Intel invoked
+  binary unchanged, hitting the identical "unknown argument" failure
+  independent of the insertion-side fix above. `_clang_context_args` now
+  also strips both Intel-only SYCL pass-selector flags from the carried-
+  through flags whenever the invoked binary isn't Intel-family (bumping
+  `CLANG_EXTRACTOR_VERSION` to `0.10`).

--- a/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
+++ b/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
@@ -50,5 +50,24 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   replaying it under a different compilation context than the one actually
   recorded. A bare, unselected `-fsycl` (no explicit pin either way) is
   deliberately left untouched, matching the L2 backend's own established
-  accepted approximation for that ambiguous shape. Bumps
-  `CLANG_EXTRACTOR_VERSION` to `0.11`.
+  accepted approximation for that ambiguous shape.
+- **`_argv._carry_abi_relevant_flags` (shared by the castxml and clang
+  extractors) silently corrupted last-flag-wins toggle state for a repeated
+  flag**: `extract_abi_relevant_flags` preserves every occurrence of a
+  matching flag from the real build's argv, in order, with no dedup of its
+  own — but the carry-through step deduped a flag against every earlier
+  occurrence of the *identical literal token* it had already carried, not
+  just against flags already emitted from the structured fields. A layered
+  build config recording e.g. `-fno-sycl -fsycl -fno-sycl` (SYCL enabled
+  then explicitly disabled again) collapsed to `-fno-sycl -fsycl` — the
+  decisive final `-fno-sycl` silently dropped as a "duplicate" of the
+  first — reversing the real effective state and, combined with the
+  `-fsycl-host-only` insertion fix above, could append `-fsycl-host-only`
+  and stamp SYCL-host facts for a translation unit the real build compiled
+  *without* SYCL at all (Codex review). Fixed by only checking (never
+  updating) the caller's initial "already emitted from structured fields"
+  set, so every genuine repeat within `abi_relevant_flags` itself now
+  survives in the real build's own order and multiplicity — the same class
+  of fix applies to any other toggle-style flag pair sharing one spelling
+  (`-fexceptions`/`-fno-exceptions`, …), not just `-fsycl`/`-fno-sycl`.
+  Bumps `CLANG_EXTRACTOR_VERSION` to `0.12`.

--- a/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
+++ b/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
@@ -70,4 +70,10 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   survives in the real build's own order and multiplicity — the same class
   of fix applies to any other toggle-style flag pair sharing one spelling
   (`-fexceptions`/`-fno-exceptions`, …), not just `-fsycl`/`-fno-sycl`.
-  Bumps `CLANG_EXTRACTOR_VERSION` to `0.12`.
+  This shared carry-through helper is also used by the castxml extractor's
+  `build_castxml_command` (via its own `_replay_extra_flags` alias), so a
+  persisted baseline produced under the old, deduplicating recipe and a
+  fresh castxml extraction now advertise DIFFERENT producer versions rather
+  than being silently treated as comparable (Codex review). Bumps
+  `CLANG_EXTRACTOR_VERSION` to `0.12` and `CASTXML_EXTRACTOR_VERSION` to
+  `0.3`.

--- a/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
+++ b/changelog.d/20260812_211823_noreply_l4_sycl_two_pass_fix_vwgkww.md
@@ -33,13 +33,22 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   build's own recorded `-fsycl-host-only`/`-fsycl-device-only` (carried
   through verbatim via `abi_relevant_flags`) reached a non-Intel invoked
   binary unchanged, hitting the identical "unknown argument" failure
-  independent of the insertion-side fix above. `_clang_context_args` now
-  strips a carried-through `-fsycl-host-only` whenever the invoked binary
-  isn't Intel-family — harmless to drop, since stock clang's bare `-fsycl`
-  already parses fine as one ordinary host-shaped pass. A carried-through
-  `-fsycl-device-only` is handled differently, not stripped: it names a
-  genuinely different (device-side) compilation context, so silently
-  dropping it would replay the TU as ordinary host code and could fabricate
-  false L4 findings rather than honestly degrade coverage — it now raises a
-  clear `SourceExtractionError` for that one translation unit instead
-  (Codex review; bumping `CLANG_EXTRACTOR_VERSION` to `0.10`).
+  independent of the insertion-side fix above. A first pass at closing this
+  stripped a carried-through `-fsycl-host-only` (on the assumption it was
+  harmless to drop, since stock clang's bare `-fsycl` "parses fine as one
+  ordinary pass") while raising `SourceExtractionError` only for
+  `-fsycl-device-only`. A second Codex review round caught that assumption
+  itself was wrong: verified empirically against a real clang install, bare
+  `-fsycl` with no selector defines `__SYCL_DEVICE_ONLY__` — i.e. it
+  compiles as **device** context by default, not host — so dropping just
+  `-fsycl-host-only` silently replayed an explicitly host-pinned TU as
+  device code, the identical misrepresentation risk already recognized for
+  `-fsycl-device-only`. Both Intel-only pass-selector flags are now handled
+  identically: a recorded `-fsycl-host-only` OR `-fsycl-device-only` on a
+  non-Intel invoked binary raises a clear `SourceExtractionError` for that
+  one translation unit (degrading it to partial coverage) instead of ever
+  replaying it under a different compilation context than the one actually
+  recorded. A bare, unselected `-fsycl` (no explicit pin either way) is
+  deliberately left untouched, matching the L2 backend's own established
+  accepted approximation for that ambiguous shape. Bumps
+  `CLANG_EXTRACTOR_VERSION` to `0.11`.

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -720,6 +720,33 @@ def test_build_command_sycl_host_only_skipped_when_already_pinned() -> None:
     assert cmd.count("-fsycl-device-only") == 1
 
 
+def test_build_command_sycl_host_only_gated_on_invoked_binary_not_recorded_argv() -> (
+    None
+):
+    """The host-only decision must be gated on the binary this command will
+    actually be RUN with (``clang_bin``), not on ``pick_compiler_binary``'s
+    *emulated* compiler, which falls back to the compile unit's own recorded
+    ``argv[0]`` when no ``--gcc-path``/``compiler_binary`` override is given.
+    Without an override, L4 replay invokes the generic default ``"clang"``
+    even for a TU whose real build used ``icpx`` -- appending
+    ``-fsycl-host-only`` there would hit stock clang's "unknown argument"
+    hard-rejection on every such SYCL TU (Codex review)."""
+    cu = _cu(
+        argv=["icpx", "-fsycl", "-c", "foo.cpp"],
+        abi_relevant_flags=["-fsycl"],
+    )
+    # No explicit clang_bin/compiler_binary override -- mirrors
+    # `_make_source_extractor`'s own default (`compiler_binary=None` whenever
+    # `clang_bin == "clang"`), so `pick_compiler_binary` falls back to `cu`'s
+    # own recorded `argv[0]` ("icpx") purely for flag-shape emulation, while
+    # the binary actually invoked stays the generic default.
+    cmd = build_clang_command(cu, Path("foo.cpp"))
+    assert cmd[0] == "clang"
+    assert "-fsycl-host-only" not in cmd
+    macro_cmd = build_clang_macro_command(cu, Path("foo.cpp"))
+    assert "-fsycl-host-only" not in macro_cmd
+
+
 # -- source_abi_from_clang_ast (pure, D4) ------------------------------------
 
 

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -831,6 +831,82 @@ class TestSyclHostOnlyGatedOnInvokedBinary:
 
         assert clang_mod._needs_sycl_host_only is dumper_clang._needs_sycl_host_only
 
+    @pytest.mark.slow
+    def test_property_intel_only_sycl_pass_flags_never_reach_a_non_intel_invoked_binary(
+        self,
+    ) -> None:
+        """The STRUCTURAL invariant behind the whole matrix above, checked
+        generatively rather than against a fixed list of examples: for ANY
+        invoked binary name and ANY compile unit (recorded argv[0], SYCL
+        flags, pinning), neither ``-fsycl-host-only`` nor
+        ``-fsycl-device-only`` may appear in the built command unless the
+        binary genuinely invoked understands them -- whether abicheck would
+        have appended one itself, or the real build's own recorded argv/
+        abi_relevant_flags already carried one through. That second path is
+        not hypothetical: this exact property test, run against an earlier
+        revision of this fix that only closed the insertion side, found it
+        (a real build recorded as ``icpx -fsycl-host-only``, replayed
+        against a plain ``clang`` invocation, reproduced "unknown
+        argument"). Also fuzzes casing/``.exe`` suffixes and random
+        recorded-argv0/flag noise, so a future regression shaped differently
+        from any single hand-picked example still falls out of this
+        property rather than needing its own new example test."""
+        from hypothesis import given, settings, strategies as st
+
+        driver_stem = st.sampled_from(
+            [
+                "icx",
+                "icpx",
+                "dpcpp",
+                "dpcpp-cl",
+                "clang",
+                "clang++",
+                "clang-cl",
+                "gcc",
+                "g++",
+                "cl",
+            ]
+        )
+        binary_name = st.builds(
+            lambda stem, exe: f"{stem}{'.exe' if exe else ''}",
+            driver_stem,
+            st.booleans(),
+        )
+        sycl_flag = st.sampled_from(
+            ["-fsycl", "-fno-sycl", "-fsycl-host-only", "-fsycl-device-only"]
+        )
+
+        @given(
+            invoked=binary_name,
+            recorded_argv0=binary_name,
+            flags=st.lists(sycl_flag, max_size=3),
+        )
+        @settings(max_examples=200, deadline=None)
+        def _check(invoked: str, recorded_argv0: str, flags: list[str]) -> None:
+            cu = _cu(
+                argv=[recorded_argv0, *flags, "-c", "foo.cpp"],
+                abi_relevant_flags=list(flags),
+            )
+            invoked_is_intel = Path(invoked).stem.lower().removesuffix(".exe") in {
+                "icx",
+                "icpx",
+                "dpcpp",
+                "dpcpp-cl",
+            }
+            for cmd in (
+                build_clang_command(cu, Path("foo.cpp"), clang_bin=invoked),
+                build_clang_macro_command(cu, Path("foo.cpp"), clang_bin=invoked),
+            ):
+                assert cmd[0] == invoked
+                pinned = {"-fsycl-host-only", "-fsycl-device-only"} & set(cmd)
+                if pinned:
+                    assert invoked_is_intel, (
+                        f"{pinned} reached a non-Intel invoked binary {invoked!r} "
+                        f"(recorded argv[0]={recorded_argv0!r}, flags={flags!r})"
+                    )
+
+        _check()
+
 
 # -- source_abi_from_clang_ast (pure, D4) ------------------------------------
 

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -747,6 +747,91 @@ def test_build_command_sycl_host_only_gated_on_invoked_binary_not_recorded_argv(
     assert "-fsycl-host-only" not in macro_cmd
 
 
+class TestSyclHostOnlyGatedOnInvokedBinary:
+    """Generalized regression matrix for the Codex-flagged P1 above: a
+    binary-capability-gated flag (``-fsycl-host-only``) must depend ONLY on
+    the binary a command will actually be RUN with (``clang_bin``), never on
+    ``pick_compiler_binary``'s *emulated* compiler (``cc_bin``, which falls
+    back to the compile unit's own recorded ``argv[0]`` absent an explicit
+    override -- see ``_argv.pick_compiler_binary``'s own docstring for why
+    the two must never be conflated). The individual example tests above
+    pin the specific reported scenario; this class sweeps a matrix so the
+    SAME class of bug (a future binary-specific flag gated on the wrong one
+    of the two binaries) is caught for any invoked/recorded combination, not
+    just the one pair a hand-picked example happened to cover.
+    """
+
+    #: Clang-family binaries `_is_intel_sycl_driver` recognizes as
+    #: DPC++-capable -- the flag must be appended for every one of these when
+    #: actually invoked, regardless of what the compile unit's own argv[0]
+    #: recorded.
+    _INTEL_DRIVERS = ("icpx", "dpcpp", "dpcpp-cl")
+    #: Non-Intel clang-family (and non-clang) binaries -- none of these
+    #: understand ``-fsycl-host-only``; it must never be appended for any of
+    #: them, regardless of what the compile unit's own argv[0] recorded.
+    _NON_INTEL_DRIVERS = ("clang", "clang++", "clang-cl", "gcc", "g++")
+    #: Swept independently of the invoked binary above -- this is exactly the
+    #: input ``pick_compiler_binary`` falls back to reading when no explicit
+    #: ``compiler_binary`` override is given, and it must have NO bearing on
+    #: the outcome once ``clang_bin`` is passed explicitly.
+    _RECORDED_ARGV0 = ("clang", "icpx", "dpcpp", "gcc", "cl.exe")
+
+    @pytest.mark.parametrize("invoked", _INTEL_DRIVERS)
+    @pytest.mark.parametrize("recorded_argv0", _RECORDED_ARGV0)
+    def test_appended_for_intel_invoked_binary_regardless_of_recorded_argv0(
+        self, invoked: str, recorded_argv0: str
+    ) -> None:
+        cu = _cu(
+            argv=[recorded_argv0, "-fsycl", "-c", "foo.cpp"],
+            abi_relevant_flags=["-fsycl"],
+        )
+        ast_cmd = build_clang_command(cu, Path("foo.cpp"), clang_bin=invoked)
+        assert "-fsycl-host-only" in ast_cmd
+        macro_cmd = build_clang_macro_command(cu, Path("foo.cpp"), clang_bin=invoked)
+        assert "-fsycl-host-only" in macro_cmd
+
+    @pytest.mark.parametrize("invoked", _NON_INTEL_DRIVERS)
+    @pytest.mark.parametrize("recorded_argv0", _RECORDED_ARGV0)
+    def test_skipped_for_non_intel_invoked_binary_regardless_of_recorded_argv0(
+        self, invoked: str, recorded_argv0: str
+    ) -> None:
+        cu = _cu(
+            argv=[recorded_argv0, "-fsycl", "-c", "foo.cpp"],
+            abi_relevant_flags=["-fsycl"],
+        )
+        ast_cmd = build_clang_command(cu, Path("foo.cpp"), clang_bin=invoked)
+        assert "-fsycl-host-only" not in ast_cmd
+        macro_cmd = build_clang_macro_command(cu, Path("foo.cpp"), clang_bin=invoked)
+        assert "-fsycl-host-only" not in macro_cmd
+
+    @pytest.mark.parametrize("recorded_argv0", _RECORDED_ARGV0)
+    def test_skipped_with_no_override_regardless_of_recorded_argv0(
+        self, recorded_argv0: str
+    ) -> None:
+        """The extractor's own real default (no ``--gcc-path``, so
+        ``clang_bin``/``compiler_binary`` are never passed at all) always
+        invokes plain ``"clang"`` -- never Intel-family -- no matter what the
+        compile unit's own build recorded itself as."""
+        cu = _cu(
+            argv=[recorded_argv0, "-fsycl", "-c", "foo.cpp"],
+            abi_relevant_flags=["-fsycl"],
+        )
+        cmd = build_clang_command(cu, Path("foo.cpp"))
+        assert cmd[0] == "clang"
+        assert "-fsycl-host-only" not in cmd
+
+    def test_needs_sycl_host_only_is_the_single_l2_l4_source_of_truth(self) -> None:
+        """L4's predicate must be the SAME function object the L2 header-AST
+        backend uses (``dumper_clang._needs_sycl_host_only``), not an
+        independently reimplemented copy that could silently drift out of
+        sync with the last-flag-wins ``-fsycl``/``-fno-sycl`` scan or the
+        legacy ``dpcpp``/``dpcpp-cl`` SYCL-implied-by-default handling."""
+        from abicheck import dumper_clang
+        from abicheck.buildsource.source_extractors import clang as clang_mod
+
+        assert clang_mod._needs_sycl_host_only is dumper_clang._needs_sycl_host_only
+
+
 # -- source_abi_from_clang_ast (pure, D4) ------------------------------------
 
 

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -677,6 +677,49 @@ def test_build_command_carries_sycl_language_mode() -> None:
     assert "-fsycl" in cmd
 
 
+def test_build_command_collapses_sycl_to_host_only_pass() -> None:
+    """A real build's own recorded ``-fsycl`` on an Intel oneAPI driver makes
+    the driver run a device pass AND a host pass, each emitting a full JSON
+    document to the same stdout stream -- breaking the single-document JSON
+    reader (``Extra data`` at the host/device split, reported against a real
+    2.8GB -fsycl oneDAL TU). ``-fsycl-host-only`` must be appended so the
+    reconstructed command emits exactly one document, mirroring the identical
+    fix already shipped for the L2 header-AST backend."""
+    cu = _cu(
+        argv=["icpx", "-fsycl", "-c", "foo.cpp"],
+        abi_relevant_flags=["-fsycl"],
+    )
+    ast_cmd = build_clang_command(cu, Path("foo.cpp"), clang_bin="icpx")
+    assert "-fsycl-host-only" in ast_cmd
+    macro_cmd = build_clang_macro_command(cu, Path("foo.cpp"), clang_bin="icpx")
+    assert "-fsycl-host-only" in macro_cmd
+
+
+def test_build_command_sycl_host_only_skipped_for_non_intel_driver() -> None:
+    """Stock upstream clang hard-rejects ``-fsycl-host-only`` ("unknown
+    argument") -- appending it unconditionally for any clang-family binary
+    would turn a working ``--gcc-path clang`` + ``-fsycl`` replay into a
+    guaranteed failure."""
+    cu = _cu(
+        argv=["clang++", "-fsycl", "-c", "foo.cpp"],
+        abi_relevant_flags=["-fsycl"],
+    )
+    cmd = build_clang_command(cu, Path("foo.cpp"), clang_bin="clang++")
+    assert "-fsycl-host-only" not in cmd
+
+
+def test_build_command_sycl_host_only_skipped_when_already_pinned() -> None:
+    """A caller that already pinned a single pass explicitly must not get a
+    redundant/conflicting second one appended."""
+    cu = _cu(
+        argv=["icpx", "-fsycl", "-fsycl-device-only", "-c", "foo.cpp"],
+        abi_relevant_flags=["-fsycl", "-fsycl-device-only"],
+    )
+    cmd = build_clang_command(cu, Path("foo.cpp"), clang_bin="icpx")
+    assert "-fsycl-host-only" not in cmd
+    assert cmd.count("-fsycl-device-only") == 1
+
+
 # -- source_abi_from_clang_ast (pure, D4) ------------------------------------
 
 
@@ -2447,6 +2490,20 @@ def test_extract_rechecks_deadline_after_loading_ast(monkeypatch) -> None:  # ty
 def test_extract_invalid_json_raises(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     extractor = _patch_run(monkeypatch, lambda cmd, **kw: _emit_ast(kw, "{not json"))
     with pytest.raises(SourceExtractionError, match="not valid JSON"):
+        extractor.extract(_cu(), public_header_roots=["include/foo.h"])
+
+
+def test_extract_two_document_json_raises_actionable_hint(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """A flag combination this codebase doesn't already collapse to a single
+    pass (unlikely once ``-fsycl-host-only`` is appended for the Intel-driver
+    case, but not provably exhaustive over every offload flag) still hits
+    ``json.load``'s "Extra data" error on a two-document stream. The message
+    must name the actual cause instead of a bare byte-offset."""
+    import json
+
+    payload = json.dumps(_ast()) + json.dumps(_ast())
+    extractor = _patch_run(monkeypatch, lambda cmd, **kw: _emit_ast(kw, payload))
+    with pytest.raises(SourceExtractionError, match="more than one JSON document"):
         extractor.extract(_cu(), public_header_roots=["include/foo.h"])
 
 

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -820,6 +820,43 @@ class TestSyclHostOnlyGatedOnInvokedBinary:
         assert cmd[0] == "clang"
         assert "-fsycl-host-only" not in cmd
 
+    def test_host_only_stripped_but_device_only_degrades_instead_of_replaying_as_host(
+        self,
+    ) -> None:
+        """``-fsycl-host-only`` and ``-fsycl-device-only`` look symmetric but
+        are NOT: dropping the former changes nothing (stock clang's bare
+        ``-fsycl`` already parses as one ordinary host-shaped pass), while
+        dropping the latter would silently replay a device-only TU as
+        ordinary host code -- a different compilation context, not just a
+        missing selector flag. A recorded ``-fsycl-device-only`` on a
+        non-Intel invoked binary must raise instead of fabricating host
+        facts for it (Codex review)."""
+        host_only_cu = _cu(
+            argv=["icpx", "-fsycl", "-fsycl-host-only", "-c", "foo.cpp"],
+            abi_relevant_flags=["-fsycl", "-fsycl-host-only"],
+        )
+        cmd = build_clang_command(host_only_cu, Path("foo.cpp"), clang_bin="clang")
+        assert "-fsycl-host-only" not in cmd
+        assert "-fsycl-device-only" not in cmd
+
+        device_only_cu = _cu(
+            argv=["icpx", "-fsycl", "-fsycl-device-only", "-c", "foo.cpp"],
+            abi_relevant_flags=["-fsycl", "-fsycl-device-only"],
+        )
+        with pytest.raises(SourceExtractionError, match="fsycl-device-only"):
+            build_clang_command(device_only_cu, Path("foo.cpp"), clang_bin="clang")
+        with pytest.raises(SourceExtractionError, match="fsycl-device-only"):
+            build_clang_macro_command(
+                device_only_cu, Path("foo.cpp"), clang_bin="clang"
+            )
+        # An Intel-family invoked binary genuinely understands the flag --
+        # must NOT raise, and must keep it (both are real single-pass pins).
+        intel_cmd = build_clang_command(
+            device_only_cu, Path("foo.cpp"), clang_bin="icpx"
+        )
+        assert "-fsycl-device-only" in intel_cmd
+        assert "-fsycl-host-only" not in intel_cmd
+
     def test_needs_sycl_host_only_is_the_single_l2_l4_source_of_truth(self) -> None:
         """L4's predicate must be the SAME function object the L2 header-AST
         backend uses (``dumper_clang._needs_sycl_host_only``), not an
@@ -839,15 +876,21 @@ class TestSyclHostOnlyGatedOnInvokedBinary:
         generatively rather than against a fixed list of examples: for ANY
         invoked binary name and ANY compile unit (recorded argv[0], SYCL
         flags, pinning), neither ``-fsycl-host-only`` nor
-        ``-fsycl-device-only`` may appear in the built command unless the
-        binary genuinely invoked understands them -- whether abicheck would
-        have appended one itself, or the real build's own recorded argv/
-        abi_relevant_flags already carried one through. That second path is
-        not hypothetical: this exact property test, run against an earlier
-        revision of this fix that only closed the insertion side, found it
-        (a real build recorded as ``icpx -fsycl-host-only``, replayed
-        against a plain ``clang`` invocation, reproduced "unknown
-        argument"). Also fuzzes casing/``.exe`` suffixes and random
+        ``-fsycl-device-only`` may ever appear in a successfully BUILT
+        command unless the binary genuinely invoked understands them --
+        whether abicheck would have appended one itself, or the real
+        build's own recorded argv/abi_relevant_flags already carried one
+        through. That second path is not hypothetical: this exact property
+        test, run against an earlier revision of this fix that only closed
+        the insertion side, found it (a real build recorded as ``icpx
+        -fsycl-host-only``, replayed against a plain ``clang`` invocation,
+        reproduced "unknown argument"). A recorded ``-fsycl-device-only`` on
+        a non-Intel invoked binary is a NAMES-A-DIFFERENT-COMPILATION-
+        CONTEXT case, not a plain unsupported-flag case (Codex review): it
+        must degrade that TU (``SourceExtractionError``) rather than
+        silently drop the selector and replay it as ordinary host code, so
+        this property checks for the raise in that one case instead of a
+        clean command. Also fuzzes casing/``.exe`` suffixes and random
         recorded-argv0/flag noise, so a future regression shaped differently
         from any single hand-picked example still falls out of this
         property rather than needing its own new example test."""
@@ -893,10 +936,15 @@ class TestSyclHostOnlyGatedOnInvokedBinary:
                 "dpcpp",
                 "dpcpp-cl",
             }
-            for cmd in (
-                build_clang_command(cu, Path("foo.cpp"), clang_bin=invoked),
-                build_clang_macro_command(cu, Path("foo.cpp"), clang_bin=invoked),
-            ):
+            device_only_on_non_intel = (
+                not invoked_is_intel and "-fsycl-device-only" in flags
+            )
+            for builder in (build_clang_command, build_clang_macro_command):
+                if device_only_on_non_intel:
+                    with pytest.raises(SourceExtractionError):
+                        builder(cu, Path("foo.cpp"), clang_bin=invoked)
+                    continue
+                cmd = builder(cu, Path("foo.cpp"), clang_bin=invoked)
                 assert cmd[0] == invoked
                 pinned = {"-fsycl-host-only", "-fsycl-device-only"} & set(cmd)
                 if pinned:

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -21,6 +21,7 @@ the fast lane; the end-to-end clang run is marked ``integration``.
 from __future__ import annotations
 
 import os
+import re
 import textwrap
 from pathlib import Path
 
@@ -820,42 +821,50 @@ class TestSyclHostOnlyGatedOnInvokedBinary:
         assert cmd[0] == "clang"
         assert "-fsycl-host-only" not in cmd
 
-    def test_host_only_stripped_but_device_only_degrades_instead_of_replaying_as_host(
-        self,
+    @pytest.mark.parametrize("pin", ("-fsycl-host-only", "-fsycl-device-only"))
+    def test_explicitly_pinned_pass_degrades_on_non_intel_instead_of_reinterpreting(
+        self, pin: str
     ) -> None:
-        """``-fsycl-host-only`` and ``-fsycl-device-only`` look symmetric but
-        are NOT: dropping the former changes nothing (stock clang's bare
-        ``-fsycl`` already parses as one ordinary host-shaped pass), while
-        dropping the latter would silently replay a device-only TU as
-        ordinary host code -- a different compilation context, not just a
-        missing selector flag. A recorded ``-fsycl-device-only`` on a
-        non-Intel invoked binary must raise instead of fabricating host
-        facts for it (Codex review)."""
-        host_only_cu = _cu(
-            argv=["icpx", "-fsycl", "-fsycl-host-only", "-c", "foo.cpp"],
-            abi_relevant_flags=["-fsycl", "-fsycl-host-only"],
+        """``-fsycl-host-only`` and ``-fsycl-device-only`` look symmetric and
+        MUST be treated symmetrically: an earlier revision of this fix
+        silently dropped ``-fsycl-host-only`` on the (wrong) assumption that
+        stock clang's bare ``-fsycl`` already parses as an ordinary,
+        roughly-host-shaped pass. Confirmed empirically against a real
+        clang install that this is false: bare ``-fsycl`` with NO selector
+        defines ``__SYCL_DEVICE_ONLY__`` (device context by default), so
+        dropping just ``-fsycl-host-only`` silently replayed an explicitly
+        HOST-pinned TU as device code -- the identical misrepresentation
+        risk already recognized for ``-fsycl-device-only`` (Codex review,
+        second round). Both selectors now raise identically for a non-Intel
+        invoked binary rather than ever guessing which context to
+        (mis)represent."""
+        cu = _cu(
+            argv=["icpx", "-fsycl", pin, "-c", "foo.cpp"],
+            abi_relevant_flags=["-fsycl", pin],
         )
-        cmd = build_clang_command(host_only_cu, Path("foo.cpp"), clang_bin="clang")
+        with pytest.raises(SourceExtractionError, match=re.escape(pin)):
+            build_clang_command(cu, Path("foo.cpp"), clang_bin="clang")
+        with pytest.raises(SourceExtractionError, match=re.escape(pin)):
+            build_clang_macro_command(cu, Path("foo.cpp"), clang_bin="clang")
+        # An Intel-family invoked binary genuinely understands the flag --
+        # must NOT raise, and must keep it (a real, honorable single-pass pin).
+        intel_cmd = build_clang_command(cu, Path("foo.cpp"), clang_bin="icpx")
+        assert pin in intel_cmd
+
+    def test_bare_unselected_sycl_flag_is_left_alone_on_non_intel_binary(self) -> None:
+        """A bare, unselected ``-fsycl`` (no explicit host/device pin either
+        way) is deliberately NOT treated as a degrade-worthy mismatch --
+        matching the L2 header-AST backend's own established "accepted
+        approximation" for this ambiguous shape (there is no explicit,
+        recorded intent this replay would be contradicting)."""
+        cu = _cu(
+            argv=["icpx", "-fsycl", "-c", "foo.cpp"],
+            abi_relevant_flags=["-fsycl"],
+        )
+        cmd = build_clang_command(cu, Path("foo.cpp"), clang_bin="clang")
+        assert "-fsycl" in cmd
         assert "-fsycl-host-only" not in cmd
         assert "-fsycl-device-only" not in cmd
-
-        device_only_cu = _cu(
-            argv=["icpx", "-fsycl", "-fsycl-device-only", "-c", "foo.cpp"],
-            abi_relevant_flags=["-fsycl", "-fsycl-device-only"],
-        )
-        with pytest.raises(SourceExtractionError, match="fsycl-device-only"):
-            build_clang_command(device_only_cu, Path("foo.cpp"), clang_bin="clang")
-        with pytest.raises(SourceExtractionError, match="fsycl-device-only"):
-            build_clang_macro_command(
-                device_only_cu, Path("foo.cpp"), clang_bin="clang"
-            )
-        # An Intel-family invoked binary genuinely understands the flag --
-        # must NOT raise, and must keep it (both are real single-pass pins).
-        intel_cmd = build_clang_command(
-            device_only_cu, Path("foo.cpp"), clang_bin="icpx"
-        )
-        assert "-fsycl-device-only" in intel_cmd
-        assert "-fsycl-host-only" not in intel_cmd
 
     def test_needs_sycl_host_only_is_the_single_l2_l4_source_of_truth(self) -> None:
         """L4's predicate must be the SAME function object the L2 header-AST
@@ -884,13 +893,21 @@ class TestSyclHostOnlyGatedOnInvokedBinary:
         test, run against an earlier revision of this fix that only closed
         the insertion side, found it (a real build recorded as ``icpx
         -fsycl-host-only``, replayed against a plain ``clang`` invocation,
-        reproduced "unknown argument"). A recorded ``-fsycl-device-only`` on
-        a non-Intel invoked binary is a NAMES-A-DIFFERENT-COMPILATION-
-        CONTEXT case, not a plain unsupported-flag case (Codex review): it
-        must degrade that TU (``SourceExtractionError``) rather than
-        silently drop the selector and replay it as ordinary host code, so
-        this property checks for the raise in that one case instead of a
-        clean command. Also fuzzes casing/``.exe`` suffixes and random
+        reproduced "unknown argument"). A recorded explicit pass selector
+        (either one) on a non-Intel invoked binary is a NAMES-A-DIFFERENT-
+        COMPILATION-CONTEXT case, not a plain unsupported-flag case (Codex
+        review, two rounds -- the first fix treated the two selectors
+        asymmetrically, silently dropping ``-fsycl-host-only`` on the
+        mistaken assumption that stock clang's bare ``-fsycl`` is
+        host-shaped; confirmed empirically against a real clang install
+        that it is device-shaped by default instead): it must degrade that
+        TU (``SourceExtractionError``) rather than silently drop the
+        selector and replay it under a DIFFERENT context than the one
+        actually recorded, so this property checks for the raise in
+        EITHER pinned case, symmetrically, instead of a clean command. A
+        bare, unselected ``-fsycl`` stays a clean (non-raising) command,
+        matching the L2 backend's own accepted approximation for that
+        ambiguous shape. Also fuzzes casing/``.exe`` suffixes and random
         recorded-argv0/flag noise, so a future regression shaped differently
         from any single hand-picked example still falls out of this
         property rather than needing its own new example test."""
@@ -918,6 +935,7 @@ class TestSyclHostOnlyGatedOnInvokedBinary:
         sycl_flag = st.sampled_from(
             ["-fsycl", "-fno-sycl", "-fsycl-host-only", "-fsycl-device-only"]
         )
+        _PASS_SELECTORS = {"-fsycl-host-only", "-fsycl-device-only"}
 
         @given(
             invoked=binary_name,
@@ -936,17 +954,17 @@ class TestSyclHostOnlyGatedOnInvokedBinary:
                 "dpcpp",
                 "dpcpp-cl",
             }
-            device_only_on_non_intel = (
-                not invoked_is_intel and "-fsycl-device-only" in flags
+            pinned_on_non_intel = not invoked_is_intel and (
+                _PASS_SELECTORS & set(flags)
             )
             for builder in (build_clang_command, build_clang_macro_command):
-                if device_only_on_non_intel:
+                if pinned_on_non_intel:
                     with pytest.raises(SourceExtractionError):
                         builder(cu, Path("foo.cpp"), clang_bin=invoked)
                     continue
                 cmd = builder(cu, Path("foo.cpp"), clang_bin=invoked)
                 assert cmd[0] == invoked
-                pinned = {"-fsycl-host-only", "-fsycl-device-only"} & set(cmd)
+                pinned = _PASS_SELECTORS & set(cmd)
                 if pinned:
                     assert invoked_is_intel, (
                         f"{pinned} reached a non-Intel invoked binary {invoked!r} "

--- a/tests/test_source_extractors_clang.py
+++ b/tests/test_source_extractors_clang.py
@@ -664,6 +664,55 @@ def test_build_command_carries_abi_flags_and_unwraps_launcher() -> None:
     assert "ccache" not in cmd
 
 
+def test_replay_extra_flags_preserves_repeated_toggle_flags_in_order() -> None:
+    """A layered build config can legitimately record the SAME literal flag
+    more than once (e.g. a base default followed by a target-specific
+    override, followed by a later reset) -- ``extract_abi_relevant_flags``
+    preserves every occurrence, in order, with no dedup of its own. An
+    earlier revision of ``_carry_abi_relevant_flags`` deduped WITHIN the
+    carry-through itself, silently dropping every repeat of an
+    already-carried token -- collapsing ``-fno-sycl -fsycl -fno-sycl`` down
+    to ``-fno-sycl -fsycl`` and reversing the real last-flag-wins state from
+    disabled to enabled (Codex review). Every occurrence must now survive,
+    in the original order, so downstream last-flag-wins scanning sees
+    exactly what the real compiler saw."""
+    from abicheck.buildsource.source_extractors._argv import replay_extra_flags
+
+    cu = _cu(
+        argv=["icpx", "-fno-sycl", "-fsycl", "-fno-sycl", "-c", "foo.cpp"],
+        abi_relevant_flags=["-fno-sycl", "-fsycl", "-fno-sycl"],
+    )
+    extra = replay_extra_flags(cu, [], "gnu")
+    assert extra == ["-fno-sycl", "-fsycl", "-fno-sycl"]
+
+
+def test_build_command_respects_final_disabled_sycl_toggle_despite_earlier_enable() -> (
+    None
+):
+    """The end-to-end consequence of the dedup-ordering bug above: a
+    compile unit recorded as ``-fno-sycl -fsycl -fno-sycl`` (SYCL enabled
+    then explicitly disabled again -- last-flag-wins means SYCL is OFF for
+    this real TU) must NOT get ``-fsycl-host-only`` appended, even on a
+    genuinely Intel-family invoked binary. Appending it would fabricate a
+    SYCL-host AST for a TU the real build compiled WITHOUT SYCL (Codex
+    review)."""
+    cu = _cu(
+        argv=["icpx", "-fno-sycl", "-fsycl", "-fno-sycl", "-c", "foo.cpp"],
+        abi_relevant_flags=["-fno-sycl", "-fsycl", "-fno-sycl"],
+    )
+    cmd = build_clang_command(cu, Path("foo.cpp"), clang_bin="icpx")
+    assert "-fsycl-host-only" not in cmd
+    # The sanity check: the SAME sequence ending in -fsycl (SYCL enabled)
+    # DOES still get the flag appended, proving this isn't just "never
+    # appends" but genuinely reads the final toggle state.
+    enabled_cu = _cu(
+        argv=["icpx", "-fno-sycl", "-fsycl", "-c", "foo.cpp"],
+        abi_relevant_flags=["-fno-sycl", "-fsycl"],
+    )
+    enabled_cmd = build_clang_command(enabled_cu, Path("foo.cpp"), clang_bin="icpx")
+    assert "-fsycl-host-only" in enabled_cmd
+
+
 def test_build_command_carries_sycl_language_mode() -> None:
     """-fsycl must reach the reconstructed L4 replay command via
     abi_relevant_flags -- a resolved --gcc-path override can now actually
@@ -970,6 +1019,51 @@ class TestSyclHostOnlyGatedOnInvokedBinary:
                         f"{pinned} reached a non-Intel invoked binary {invoked!r} "
                         f"(recorded argv[0]={recorded_argv0!r}, flags={flags!r})"
                     )
+
+        _check()
+
+    @pytest.mark.slow
+    def test_property_host_only_insertion_reflects_true_last_flag_wins_state(
+        self,
+    ) -> None:
+        """Generalizes ``test_replay_extra_flags_preserves_repeated_toggle_
+        flags_in_order``/``test_build_command_respects_final_disabled_sycl_
+        toggle_despite_earlier_enable`` above: for ANY sequence of
+        ``-fsycl``/``-fno-sycl`` toggles -- including repeats, exactly what
+        a layered build config can legitimately record -- on a compile unit
+        replayed via a genuinely Intel-family invoked binary,
+        ``-fsycl-host-only`` must be appended iff the LAST toggle in the
+        ORIGINAL, un-deduped sequence actually enables SYCL (honoring a
+        legacy ``dpcpp`` driver's own SYCL-on-by-default), computed here
+        independently of ``_needs_sycl_host_only``'s own implementation so
+        this test cannot pass merely by re-deriving the same bug. Directly
+        exercises the code path an earlier revision of the carry-through
+        dedup corrupted (Codex review)."""
+        from hypothesis import given, settings, strategies as st
+
+        from abicheck.dumper_clang import _dpcpp_defaults_sycl_on
+
+        intel_driver = st.sampled_from(["icpx", "icx", "dpcpp"])
+        toggle = st.sampled_from(["-fsycl", "-fno-sycl"])
+
+        @given(invoked=intel_driver, toggles=st.lists(toggle, max_size=5))
+        @settings(max_examples=200, deadline=None)
+        def _check(invoked: str, toggles: list[str]) -> None:
+            cu = _cu(
+                argv=[invoked, *toggles, "-c", "foo.cpp"],
+                abi_relevant_flags=list(toggles),
+            )
+            enabled = _dpcpp_defaults_sycl_on(invoked)
+            for tok in toggles:
+                if tok == "-fsycl":
+                    enabled = True
+                elif tok == "-fno-sycl":
+                    enabled = False
+            cmd = build_clang_command(cu, Path("foo.cpp"), clang_bin=invoked)
+            assert ("-fsycl-host-only" in cmd) == enabled, (
+                f"invoked={invoked!r} toggles={toggles!r} expected "
+                f"enabled={enabled} but got cmd={cmd!r}"
+            )
 
         _check()
 


### PR DESCRIPTION
## Summary

Fixes L4 source-ABI replay crashing on a real build's own recorded `-fsycl` flag by collapsing Intel oneAPI's two-pass SYCL compile to a single pass, mirroring the fix already shipped for the L2 header-AST backend.

## Motivation

L4 replay (`abicheck/buildsource/source_extractors/clang.py`) shells out `clang -Xclang -ast-dump=json` per translation unit and parses the result with a plain single-document `json.load()`. Intel's oneAPI DPC++/C++ driver (`icx`/`icpx`/`dpcpp`/`dpcpp-cl`) runs *two* separate `-cc1` passes for one `-fsycl` compile — a device-side pass and a host-side pass — each writing a complete JSON document to the same stdout stream back-to-back with no separator. `json.load()` then fails with `Extra data: line N column 2 (char M)` at the byte offset where the second document begins.

This was reproduced against a real 2.8GB `-fsycl` oneDAL translation unit (1 of 3 sampled `-fsycl` TUs failed this way), and is one of the two blockers keeping L4 unusable for a SYCL-heavy codebase — 425 of 2202 compile units in the referenced corpus are `-fsycl`.

The same problem was already solved for the *L2* header-AST backend (`dumper_ast_config._build_clang_header_command` / `dumper_clang._needs_sycl_host_only`, PR #643): append `-fsycl-host-only` to collapse the driver back to a single pass, since the device pass describes SPIR-V kernel code that is never part of the host `.so`'s exported symbols anyway.

## Changes

- `_clang_context_args` (shared by both the L4 AST pass and the macro `-E -dD` pass) now appends `-fsycl-host-only` whenever `dumper_clang._needs_sycl_host_only` determines the resolved compiler is an Intel oneAPI driver with SYCL effectively enabled and no single pass already pinned — reusing the exact same predicate the L2 fix uses, rather than a reimplementation, so the last-flag-wins `-fsycl`/`-fno-sycl` scan and the legacy `dpcpp`/`dpcpp-cl` SYCL-implied-by-default handling stay a single source of truth.
- The remaining `json.load()` "Extra data" failure path (for any other, not-yet-special-cased offload flag) now raises an actionable `SourceExtractionError` naming the likely cause instead of a bare byte offset, mirroring `dumper_clang_errors._parse_clang_ast_result`'s existing hint.
- Updated the corresponding "Known gaps" entry in `AGENTS.md` to record what's now fixed vs. what's still deliberately out of scope (a genuine host+device dual-context L4 replay).
- Added regression tests: the host-only collapse fires for an Intel driver, is a no-op for stock clang (which hard-rejects the flag), is a no-op when a single pass is already pinned, and the actionable-hint fallback for an unhandled two-document stream.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`AGENTS.md` known-gaps entry)
- [x] `ruff check`/`ruff format --check`/`mypy abicheck/` pass locally with no new issues
- [x] Targeted test suite (`clang`/`sycl`/`buildsource`/`source_replay`/`dumper`, 2610 tests) passes

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KDfvNMVX1jpCyEQbmvbMZa)_