### PR TITLE
fix(cc_wrapper): resolve clang backend against the wrapped compiler

### DIFF
--- a/abicheck/buildsource/source_extractors/_argv.py
+++ b/abicheck/buildsource/source_extractors/_argv.py
@@ -64,6 +64,14 @@ _VERSION_SUFFIX_RE = re.compile(r"-\d+(?:\.\d+)*$")
 COMPILER_LAUNCHERS = frozenset(
     {"ccache", "sccache", "distcc", "icecc", "icerun", "buildcache"}
 )
+#: ccache's own documented per-invocation config-override form —
+#: ``ccache KEY=VALUE ... compiler [compiler options]`` (ccache manual,
+#: "Configuration" section, e.g. ``ccache compiler_check="%compiler%
+#: --version" gcc -c foo.c``) — lets a caller override a config setting
+#: without touching ``ccache.conf``/env vars. A bare ``KEY=VALUE`` token here
+#: is never a flag (it never starts with ``-``), so it is unambiguous against
+#: real compiler argv.
+_LAUNCHER_CONFIG_OVERRIDE_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 #: Preprocessor macro define/undef option prefixes. Their *values* reach the
 #: compiler verbatim (argv, no shell expansion), so a literal ``~`` in e.g.
 #: ``-DDEFAULT_DIR=~/app`` must NOT be home-expanded during replay — unlike the
@@ -175,12 +183,20 @@ def basename(path: str) -> str:
 
 
 def strip_launchers(argv: list[str]) -> list[str]:
-    """Drop leading compiler-launcher tokens (``ccache``/``sccache``/…)."""
+    """Drop leading compiler-launcher tokens (``ccache``/``sccache``/…).
+
+    Also skips any ``KEY=VALUE`` per-invocation config-override tokens ccache
+    accepts immediately after its own name (``ccache compiler_check=content
+    gcc -c foo.c``) — otherwise the override token, not the real compiler, is
+    left as the new ``argv[0]``.
+    """
     i = 0
     while i < len(argv) and basename(argv[i]).lower().removesuffix(
         ".exe"
     ) in COMPILER_LAUNCHERS:
         i += 1
+        while i < len(argv) and _LAUNCHER_CONFIG_OVERRIDE_RE.match(argv[i]):
+            i += 1
     return argv[i:]
 
 

--- a/abicheck/cc_wrapper.py
+++ b/abicheck/cc_wrapper.py
@@ -155,19 +155,33 @@ def emit_facts_for_command(
         return None
     from .buildsource.source_extractors._argv import strip_launchers
     from .buildsource.source_extractors.resolver import select_source_backend
-    from .dumper_clang import _is_clang_family_binary
+    from .dumper_clang import resolve_source_frontend_clang_bin
 
     # The wrapper's whole job is to replay the TU under the *exact* compiler
     # the real build invoked (argv[0], after unwrapping a ccache/distcc-style
-    # launcher) — defaulting to plain "clang" here would silently ignore that
-    # compiler on a clang-family-only image (e.g. icpx/dpcpp with no bare
-    # "clang" on PATH) and make the clang backend read as unavailable with no
+    # launcher, incl. ccache's own leading KEY=VALUE config overrides) —
+    # defaulting to plain "clang" here would silently ignore that compiler on
+    # a clang-family-only image (e.g. icpx/dpcpp with no bare "clang" on
+    # PATH) and make the clang backend read as unavailable with no
     # diagnostic, even though it could have run against the wrapped compiler.
-    # A non-clang-family wrapped compiler (gcc/MSVC/...) is not itself a
-    # clang-compatible driver, so the plain "clang" default is kept for it.
+    # Reuses the same resolver `dump --sources`/`--build-info` already use
+    # for their own `--gcc-path`-driven L4 replay (dumper_clang.py's own
+    # docstring: "a dump/scan driven by a non-default toolchain... always
+    # shelled out to a plain clang/clang++ ... instead, failing every
+    # invocation") — one tested implementation for "derive the real
+    # clang-compatible driver from context instead of hardcoding a default",
+    # not a second, drive-by copy of the same logic. `exclude_cl_style=False`
+    # matches every other L4-replay caller: unlike the S2 preprocessor
+    # pre-scan (fixed GNU-mode flags), `ClangSourceExtractor` itself already
+    # detects a CL compile unit and re-drives the same binary with
+    # ``--driver-mode=cl``, so excluding a `clang-cl`/`dpcpp-cl` wrapped
+    # compiler here would silently fall back to a plain, non-CL clang that
+    # cannot parse the real build context.
     argv = strip_launchers(list(command))
-    wrapped_bin = argv[0] if argv and argv[0] and not argv[0].startswith("-") else ""
-    clang_bin = wrapped_bin if wrapped_bin and _is_clang_family_binary(wrapped_bin) else "clang"
+    wrapped_bin = argv[0] if argv and argv[0] and not argv[0].startswith("-") else None
+    clang_bin = resolve_source_frontend_clang_bin(
+        wrapped_bin, None, exclude_cl_style=False
+    )
 
     choice, impl = select_source_backend(extractor, clang_bin=clang_bin)
     if impl is None:

--- a/abicheck/cc_wrapper.py
+++ b/abicheck/cc_wrapper.py
@@ -153,10 +153,30 @@ def emit_facts_for_command(
     units = compile_units_from_command(command, directory)
     if not units:
         return None
+    from .buildsource.source_extractors._argv import strip_launchers
     from .buildsource.source_extractors.resolver import select_source_backend
+    from .dumper_clang import _is_clang_family_binary
 
-    _choice, impl = select_source_backend(extractor)
+    # The wrapper's whole job is to replay the TU under the *exact* compiler
+    # the real build invoked (argv[0], after unwrapping a ccache/distcc-style
+    # launcher) — defaulting to plain "clang" here would silently ignore that
+    # compiler on a clang-family-only image (e.g. icpx/dpcpp with no bare
+    # "clang" on PATH) and make the clang backend read as unavailable with no
+    # diagnostic, even though it could have run against the wrapped compiler.
+    # A non-clang-family wrapped compiler (gcc/MSVC/...) is not itself a
+    # clang-compatible driver, so the plain "clang" default is kept for it.
+    argv = strip_launchers(list(command))
+    wrapped_bin = argv[0] if argv and argv[0] and not argv[0].startswith("-") else ""
+    clang_bin = wrapped_bin if wrapped_bin and _is_clang_family_binary(wrapped_bin) else "clang"
+
+    choice, impl = select_source_backend(extractor, clang_bin=clang_bin)
     if impl is None:
+        reason = getattr(choice, "reason", "") or "no backend selected"
+        click.echo(
+            f"abicheck-cc: no usable source-ABI extractor available "
+            f"({reason}); skipping fact extraction for {command[0]!r}",
+            err=True,
+        )
         return None
     target_id = f"target://{library}" if library else ""
     init_inputs_pack(inputs_dir, library=library, version=version, created_by="abicheck-cc")

--- a/changelog.d/20260812_214525_noreply_clang_backend_selection_bug_09u9ul.md
+++ b/changelog.d/20260812_214525_noreply_clang_backend_selection_bug_09u9ul.md
@@ -7,8 +7,21 @@
   foo.o`). On an image with a clang-family compiler on `PATH` but no plain
   `clang` binary (e.g. Intel oneAPI's `icpx`/`dpcpp`), the clang backend
   read as unavailable and `abicheck-cc` silently emitted no facts, with no
-  diagnostic. It now defaults the backend's `clang_bin` to the wrapped
-  compiler (after unwrapping a `ccache`/`distcc`-style launcher) whenever
-  that compiler is clang-family, and prints a warning to stderr when no
-  usable backend resolves at all instead of failing silently.
+  diagnostic. It now reuses the same `resolve_source_frontend_clang_bin()`
+  resolver `dump --sources`/`--build-info`'s own `--gcc-path` handling
+  already uses — one tested implementation for "derive the real
+  clang-compatible driver from context instead of hardcoding a default" —
+  and prints a warning to stderr when no usable backend resolves at all
+  instead of failing silently.
+- **`strip_launchers()` (the shared compiler-launcher-unwrap helper used by
+  `abicheck-cc`, `pick_compiler_binary`, and the `compile_commands.json`
+  CL-style/response-file detection in `build_context.py`) now also skips
+  ccache's own documented per-invocation config-override form,
+  `ccache KEY=VALUE ... compiler [compiler options]`
+  (`ccache compiler_check=content gcc -c foo.c`). Previously only the
+  launcher name itself was dropped, leaving the first override token
+  mistaken for the compiler — this also fixes a latent CL-style
+  misdetection for a `compile_commands.json` action shaped
+  `sccache KEY=VALUE clang-cl @args.rsp`, not just `abicheck-cc`'s own
+  compiler resolution.
 

--- a/changelog.d/20260812_214525_noreply_clang_backend_selection_bug_09u9ul.md
+++ b/changelog.d/20260812_214525_noreply_clang_backend_selection_bug_09u9ul.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **`abicheck-cc` now resolves the clang source-ABI backend against the
+  compiler it is actually wrapping.** `emit_facts_for_command()` previously
+  always asked for a backend named literally `clang`, regardless of the
+  compiler passed on the command line (`abicheck-cc icpx -c foo.cpp -o
+  foo.o`). On an image with a clang-family compiler on `PATH` but no plain
+  `clang` binary (e.g. Intel oneAPI's `icpx`/`dpcpp`), the clang backend
+  read as unavailable and `abicheck-cc` silently emitted no facts, with no
+  diagnostic. It now defaults the backend's `clang_bin` to the wrapped
+  compiler (after unwrapping a `ccache`/`distcc`-style launcher) whenever
+  that compiler is clang-family, and prints a warning to stderr when no
+  usable backend resolves at all instead of failing silently.
+

--- a/tests/test_inputs_emit.py
+++ b/tests/test_inputs_emit.py
@@ -1771,3 +1771,79 @@ def test_emit_keeps_default_clang_bin_for_non_clang_family_compiler(
         ["g++", "-c", "src/foo.cpp"], tmp_path, inputs_dir=tmp_path / "pk"
     )
     assert captured["clang_bin"] == "clang"
+
+
+# -- Generalized clang_bin resolution matrix ----------------------------------
+#
+# The bug this whole section guards against has one shape, seen twice already
+# (a hardcoded "clang" default silently ignoring the real wrapped compiler;
+# then a launcher-config-override token silently ignoring it a second way):
+# *some* wrapped-compiler spelling reaches the fallback path instead of its
+# own real driver, with no diagnostic. A handful of hand-picked examples only
+# proves the cases someone thought to write down. This matrix is the
+# generalization — every clang-family alias, crossed with every launcher
+# wrapping shape (bare / ccache / ccache+overrides / chained launchers),
+# checked against the exact same resolver `dump --sources`'s own `--gcc-path`
+# handling uses (`dumper_clang.resolve_source_frontend_clang_bin`), so this
+# stays a same-answer check rather than a second, independently-guessable one.
+
+
+def _resolved_clang_bin(command: list[str], tmp_path: Path, monkeypatch) -> str | None:
+    captured: dict = {}
+
+    def _fake_select(extractor, **kw):
+        captured.update(kw)
+        return None, None
+
+    monkeypatch.setattr(
+        "abicheck.buildsource.source_extractors.resolver.select_source_backend",
+        _fake_select,
+    )
+    emit_facts_for_command(command, tmp_path, inputs_dir=tmp_path / "pk")
+    return captured.get("clang_bin")
+
+
+#: Every alias `_is_clang_family_binary` recognizes (dumper_clang.py), plus a
+#: versioned/CL-style spelling of each shape it must also cover.
+_CLANG_FAMILY_COMPILERS = [
+    "clang",
+    "clang++",
+    "clang-18",
+    "clang-cl",
+    "clang-cl-20",
+    "icx",
+    "icpx",
+    "dpcpp",
+    "dpcpp-cl",
+]
+#: Real, non-clang-family compilers — must always resolve to the "clang"
+#: fallback (a bare "clang" on PATH is a separate, independently-resolved
+#: concern; this wrapper must never guess a GCC/MSVC binary is clang-safe).
+_NON_CLANG_FAMILY_COMPILERS = ["gcc", "g++", "cc", "c++", "cl", "cl.exe", "icc"]
+#: Launcher-wrapping shapes to cross every compiler spelling against.
+_LAUNCHER_PREFIXES: list[list[str]] = [
+    [],
+    ["ccache"],
+    ["ccache", "compiler_check=content"],
+    ["ccache", "debug=true", "run_second_cpp=false"],
+    ["sccache"],
+    ["ccache", "distcc"],
+]
+
+
+@pytest.mark.parametrize("compiler", _CLANG_FAMILY_COMPILERS)
+@pytest.mark.parametrize("launcher_prefix", _LAUNCHER_PREFIXES, ids=lambda p: "+".join(p) or "bare")
+def test_clang_family_compiler_always_resolves_regardless_of_launcher(
+    compiler: str, launcher_prefix: list[str], tmp_path: Path, monkeypatch
+) -> None:
+    command = [*launcher_prefix, compiler, "-c", "src/foo.cpp"]
+    assert _resolved_clang_bin(command, tmp_path, monkeypatch) == compiler
+
+
+@pytest.mark.parametrize("compiler", _NON_CLANG_FAMILY_COMPILERS)
+@pytest.mark.parametrize("launcher_prefix", _LAUNCHER_PREFIXES, ids=lambda p: "+".join(p) or "bare")
+def test_non_clang_family_compiler_falls_back_to_plain_clang(
+    compiler: str, launcher_prefix: list[str], tmp_path: Path, monkeypatch
+) -> None:
+    command = [*launcher_prefix, compiler, "-c", "src/foo.cpp"]
+    assert _resolved_clang_bin(command, tmp_path, monkeypatch) == "clang"

--- a/tests/test_inputs_emit.py
+++ b/tests/test_inputs_emit.py
@@ -1670,3 +1670,79 @@ def test_emit_none_when_no_backend(tmp_path: Path, monkeypatch) -> None:
         ["c++", "-c", "src/foo.cpp"], tmp_path, inputs_dir=tmp_path / "pk"
     )
     assert out is None
+
+
+def test_emit_warns_when_no_backend_resolves(tmp_path: Path, monkeypatch, capsys) -> None:
+    # The old silent-empty behavior (no diagnostic at all) is the bug being
+    # regression-tested here, not just the return value.
+    monkeypatch.setattr(
+        "abicheck.buildsource.source_extractors.resolver.select_source_backend",
+        lambda extractor, **kw: (None, None),
+    )
+    out = emit_facts_for_command(
+        ["icpx", "-c", "src/foo.cpp"], tmp_path, inputs_dir=tmp_path / "pk"
+    )
+    assert out is None
+    assert "no usable source-ABI extractor" in capsys.readouterr().err
+
+
+def test_emit_defaults_clang_bin_to_clang_family_wrapped_compiler(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # An icpx/dpcpp-only image never has a bare "clang" on PATH — the wrapper
+    # must resolve the clang backend against the compiler it is actually
+    # wrapping, not a hardcoded "clang" that silently reads as unavailable.
+    captured: dict = {}
+
+    def _fake_select(extractor, **kw):
+        captured.update(kw)
+        return None, None
+
+    monkeypatch.setattr(
+        "abicheck.buildsource.source_extractors.resolver.select_source_backend",
+        _fake_select,
+    )
+    emit_facts_for_command(
+        ["icpx", "-c", "src/foo.cpp"], tmp_path, inputs_dir=tmp_path / "pk"
+    )
+    assert captured["clang_bin"] == "icpx"
+
+
+def test_emit_strips_launcher_before_resolving_clang_bin(
+    tmp_path: Path, monkeypatch
+) -> None:
+    captured: dict = {}
+
+    def _fake_select(extractor, **kw):
+        captured.update(kw)
+        return None, None
+
+    monkeypatch.setattr(
+        "abicheck.buildsource.source_extractors.resolver.select_source_backend",
+        _fake_select,
+    )
+    emit_facts_for_command(
+        ["ccache", "clang++", "-c", "src/foo.cpp"], tmp_path, inputs_dir=tmp_path / "pk"
+    )
+    assert captured["clang_bin"] == "clang++"
+
+
+def test_emit_keeps_default_clang_bin_for_non_clang_family_compiler(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # A GCC/MSVC wrapped compiler is not itself a clang-compatible driver —
+    # the plain "clang" default (resolved separately on PATH) is unchanged.
+    captured: dict = {}
+
+    def _fake_select(extractor, **kw):
+        captured.update(kw)
+        return None, None
+
+    monkeypatch.setattr(
+        "abicheck.buildsource.source_extractors.resolver.select_source_backend",
+        _fake_select,
+    )
+    emit_facts_for_command(
+        ["g++", "-c", "src/foo.cpp"], tmp_path, inputs_dir=tmp_path / "pk"
+    )
+    assert captured["clang_bin"] == "clang"

--- a/tests/test_inputs_emit.py
+++ b/tests/test_inputs_emit.py
@@ -1727,6 +1727,31 @@ def test_emit_strips_launcher_before_resolving_clang_bin(
     assert captured["clang_bin"] == "clang++"
 
 
+def test_emit_skips_ccache_config_overrides_before_resolving_clang_bin(
+    tmp_path: Path, monkeypatch
+) -> None:
+    # ccache's own documented invocation form, `ccache KEY=VALUE ... compiler
+    # [compiler options]` (ccache manual, "Configuration" section), prefixes
+    # the real compiler with bare KEY=VALUE config-override tokens — those
+    # must be skipped too, not just the launcher name itself.
+    captured: dict = {}
+
+    def _fake_select(extractor, **kw):
+        captured.update(kw)
+        return None, None
+
+    monkeypatch.setattr(
+        "abicheck.buildsource.source_extractors.resolver.select_source_backend",
+        _fake_select,
+    )
+    emit_facts_for_command(
+        ["ccache", "compiler_check=content", "icpx", "-c", "src/foo.cpp"],
+        tmp_path,
+        inputs_dir=tmp_path / "pk",
+    )
+    assert captured["clang_bin"] == "icpx"
+
+
 def test_emit_keeps_default_clang_bin_for_non_clang_family_compiler(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_source_extractors.py
+++ b/tests/test_source_extractors.py
@@ -1572,3 +1572,53 @@ def test_castxml_parse_public_typedefs_scopes_to_public_headers() -> None:
     tds = parser.parse_public_typedefs()
     assert tds == {"handle_t": "int"}
     assert parser.parse_public_typedef_headers()["handle_t"] == "/inc/api.h"
+
+
+# -- strip_launchers (ADR-030 D2 shared argv helper) --------------------------
+
+
+def test_strip_launchers_drops_bare_launcher() -> None:
+    from abicheck.buildsource.source_extractors._argv import strip_launchers
+
+    assert strip_launchers(["ccache", "clang++", "-c", "foo.cpp"]) == [
+        "clang++", "-c", "foo.cpp",
+    ]
+
+
+def test_strip_launchers_skips_ccache_config_overrides() -> None:
+    # ccache's own documented invocation form: `ccache KEY=VALUE ... compiler
+    # [compiler options]` (ccache manual, "Configuration" section) — a bare
+    # KEY=VALUE token here is a per-invocation config override, not the
+    # compiler, and must be skipped too.
+    from abicheck.buildsource.source_extractors._argv import strip_launchers
+
+    assert strip_launchers(
+        ["ccache", "compiler_check=content", "icpx", "-c", "foo.cpp"]
+    ) == ["icpx", "-c", "foo.cpp"]
+    assert strip_launchers(
+        [
+            "ccache",
+            "debug=true",
+            'compiler_check="%compiler% --version"',
+            "gcc",
+            "-c",
+            "foo.c",
+        ]
+    ) == ["gcc", "-c", "foo.c"]
+
+
+def test_strip_launchers_chained_launchers_with_config_overrides() -> None:
+    from abicheck.buildsource.source_extractors._argv import strip_launchers
+
+    assert strip_launchers(
+        ["ccache", "compiler_check=content", "distcc", "gcc", "-c", "foo.c"]
+    ) == ["gcc", "-c", "foo.c"]
+
+
+def test_strip_launchers_no_config_overrides_for_non_launcher_command() -> None:
+    # A KEY=VALUE-looking token that never follows a recognized launcher name
+    # must not be treated as a config override.
+    from abicheck.buildsource.source_extractors._argv import strip_launchers
+
+    argv = ["FOO=bar", "gcc", "-c", "foo.c"]
+    assert strip_launchers(argv) == argv

--- a/tests/test_source_extractors.py
+++ b/tests/test_source_extractors.py
@@ -24,12 +24,16 @@ import textwrap
 from pathlib import Path
 
 import pytest
+from hypothesis import given, strategies as st
 
 from abicheck.buildsource.build_evidence import CompileUnit
 from abicheck.buildsource.source_extractors import (
     CASTXML_EXTRACTOR_VERSION,
     CastxmlSourceExtractor,
     build_castxml_command,
+)
+from abicheck.buildsource.source_extractors._argv import (
+    COMPILER_LAUNCHERS as _LAUNCHERS,
 )
 from abicheck.buildsource.source_extractors.base import (
     assemble_source_tu,
@@ -1622,3 +1626,54 @@ def test_strip_launchers_no_config_overrides_for_non_launcher_command() -> None:
 
     argv = ["FOO=bar", "gcc", "-c", "foo.c"]
     assert strip_launchers(argv) == argv
+
+
+# -- strip_launchers property test (generalizes past the hand-picked cases) --
+#
+# Per AGENTS.md's own guidance on reusable primitives: a fixed example list
+# only proves the shapes someone thought to write down. This states the
+# actual contract as an invariant — ANY launcher chain, ANY number of
+# ccache-style config overrides after each launcher, ANY real compiler name
+# that isn't itself launcher-shaped — and searches the input space the way
+# an adversarial reviewer (or a real, unusual build system) would, instead of
+# re-confirming only the specific inputs the fix's own author already
+# thought of.
+
+_IDENTIFIER = st.from_regex(r"[A-Za-z_][A-Za-z0-9_]{0,10}", fullmatch=True)
+#: A ccache-style ``KEY=VALUE`` config-override token.
+_OVERRIDE_TOKEN = st.builds(
+    lambda k, v: f"{k}={v}",
+    _IDENTIFIER,
+    st.text(alphabet=st.characters(blacklist_characters="\x00"), max_size=8),
+)
+_LAUNCHER_NAME = st.sampled_from(sorted(_LAUNCHERS))
+#: A plain token that can never be confused for a launcher name or a
+#: KEY=VALUE override (no ``=`` at all, so the override regex can't match).
+_PLAIN_TOKEN = st.text(
+    alphabet=st.characters(min_codepoint=33, max_codepoint=126, blacklist_characters="="),
+    min_size=1,
+    max_size=10,
+).filter(lambda t: t.lower().removesuffix(".exe") not in _LAUNCHERS)
+
+
+@given(
+    segments=st.lists(
+        st.tuples(_LAUNCHER_NAME, st.lists(_OVERRIDE_TOKEN, max_size=3)), max_size=3
+    ),
+    compiler=_PLAIN_TOKEN,
+    rest=st.lists(st.text(min_size=1, max_size=8), max_size=3),
+)
+@pytest.mark.slow
+def test_strip_launchers_strips_exactly_the_launcher_chain_and_its_overrides(
+    segments: list[tuple[str, list[str]]], compiler: str, rest: list[str]
+) -> None:
+    from abicheck.buildsource.source_extractors._argv import strip_launchers
+
+    argv: list[str] = []
+    for launcher, overrides in segments:
+        argv.append(launcher)
+        argv.extend(overrides)
+    argv.append(compiler)
+    argv.extend(rest)
+
+    assert strip_launchers(argv) == [compiler, *rest]


### PR DESCRIPTION
## Summary

`abicheck-cc` now resolves the clang source-ABI backend against the compiler it is actually wrapping, instead of always asking for a backend literally named `clang`.

## Motivation

`emit_facts_for_command()` called `select_source_backend(extractor)` with the default `clang_bin="clang"`, so the wrapper never used the compiler it wraps. On a clang-family-only image (e.g. Intel oneAPI's `icpx`/`dpcpp`, with no bare `clang` on `PATH`), the clang backend read as unavailable and `abicheck-cc` silently ran the real build, exited 0, and emitted no facts — with no diagnostic at all.

Reproduced: on such an image, `abicheck-cc icpx -c tu_daal.cpp -o tu_daal.o` produced an empty `abicheck_inputs/` pack. With a `clang` → `icpx` shim added to `PATH` it worked immediately (functions: 8705, types: 1933, templates: 838, inline_bodies: 2727, macros: 62, variables: 8), confirming the backend itself works fine once it can actually resolve the intended compiler.

## Changes

- `emit_facts_for_command()` (`abicheck/cc_wrapper.py`) now defaults `clang_bin` to the wrapped compiler (`command[0]`, after unwrapping a `ccache`/`sccache`/`distcc`-style launcher via the existing `strip_launchers()` helper) whenever that compiler is clang-family (`dumper_clang._is_clang_family_binary` — covers plain `clang`/`clang++` as well as the `icx`/`icpx`/`dpcpp`/`dpcpp-cl` aliases). A non-clang-family wrapped compiler (gcc, MSVC, ...) keeps the previous `"clang"` default, which is resolved separately against `PATH`.
- When no usable backend resolves at all, the wrapper now prints a warning to stderr (previously fully silent) so a missing/unusable extractor is visible instead of just producing an empty pack.
- Added regression tests in `tests/test_inputs_emit.py` covering: `clang_bin` resolving to a clang-family wrapped compiler, a launcher (`ccache`) being stripped first, a non-clang-family compiler keeping the `"clang"` default, and the new stderr warning when no backend resolves.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed (no user-facing docs describe this default; behavior itself now matches what was already documented)
- [x] `ruff check` / `mypy abicheck/cc_wrapper.py` pass locally
- [x] No new `mypy` or `ruff` errors introduced

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01N1GCf5LXUag9bZUZz7VJq9)_