### PR TITLE
fix: confine check-single baseline artifact staging

### DIFF
--- a/.github/workflows/check-single.yml
+++ b/.github/workflows/check-single.yml
@@ -76,8 +76,9 @@ on:
         default: ''
       baseline-artifact-name:
         description: >-
-          Optional: an artifact name to download into the directory named
-          by baseline-path before running check-target.
+          Optional: an artifact name to download into the workflow-owned
+          .check-single-baseline directory before running check-target.
+          When set, baseline-path is ignored.
         type: string
         default: ''
       build-output-artifact-name:
@@ -402,16 +403,14 @@ jobs:
       - name: Clear baseline staging before download
         if: inputs.baseline-artifact-name != ''
         shell: bash
-        env:
-          BASELINE_STAGING_PATH: ${{ inputs.baseline-path }}
-        run: rm -rf "$BASELINE_STAGING_PATH"
+        run: rm -rf .check-single-baseline
 
       - name: Download baseline artifact
         if: inputs.baseline-artifact-name != ''
         uses: actions/download-artifact@v8
         with:
           name: ${{ inputs.baseline-artifact-name }}
-          path: ${{ inputs.baseline-path }}
+          path: .check-single-baseline
 
       - name: Clear build-output staging before download
         if: inputs.build-output-artifact-name != ''
@@ -436,7 +435,7 @@ jobs:
           bundle-members: ${{ inputs.bundle-members }}
           profile: ${{ inputs.profile }}
           baseline-channel: ${{ inputs.baseline-channel }}
-          baseline-path: ${{ inputs.baseline-path }}
+          baseline-path: ${{ inputs.baseline-artifact-name != '' && '.check-single-baseline' || inputs.baseline-path }}
           baseline-required: ${{ inputs.baseline-required }}
           candidate-build-output: ${{ inputs.candidate-build-output }}
           requested-depth: ${{ inputs.requested-depth }}

--- a/docs/reference/reusable-workflows.md
+++ b/docs/reference/reusable-workflows.md
@@ -62,7 +62,6 @@ jobs:
       name: libfoo
       profile: linux-x86_64-gcc13
       baseline-channel: accepted-main
-      baseline-path: ./restored-baseline
       baseline-artifact-name: abicheck-baseline-accepted-main
       requested-depth: headers
       candidate-artifact-name: my-build-output
@@ -73,6 +72,11 @@ jobs:
 are all optional (default empty, meaning "no download, use the path as
 given") — a caller whose `new-library`/`baseline-path`/`candidate-build-output`
 already point at a checked-in fixture doesn't need any of them.
+When `baseline-artifact-name` is set, the workflow downloads it only into its
+private `.check-single-baseline` staging directory and passes that fixed path
+to `check-target`; `baseline-path` is ignored in that mode. This confinement
+prevents a caller-controlled path from deleting or overwriting the workflow's
+self-checkout (including the local Action executed afterward).
 
 ## `check-project.yml`
 

--- a/tests/test_reusable_workflows.py
+++ b/tests/test_reusable_workflows.py
@@ -241,11 +241,11 @@ class TestCheckSingleOptionalArtifactStaging:
         ):
             assert names.index(step_name) < run_idx
 
-    def test_baseline_artifact_downloads_into_baseline_path(self) -> None:
+    def test_baseline_artifact_downloads_into_workflow_owned_staging(self) -> None:
         data = _load(CHECK_SINGLE)
         steps = _steps(data["jobs"]["check"])
         step = next(s for s in steps if s.get("name") == "Download baseline artifact")
-        assert step["with"]["path"] == "${{ inputs.baseline-path }}"
+        assert step["with"]["path"] == ".check-single-baseline"
 
     @pytest.mark.parametrize(
         ("clear_name", "download_name"),
@@ -263,10 +263,10 @@ class TestCheckSingleOptionalArtifactStaging:
     ) -> None:
         """The earlier `actions/checkout` step already populates the whole
         workspace from the caller's own repository -- a stale checked-in
-        file at `candidate`/the resolved `baseline-path`/`build-output`
+        file at `candidate`/the fixed baseline staging path/`build-output`
         would otherwise survive an artifact download that doesn't happen to
         overwrite it (a missing file, or a differently-laid-out artifact),
-        and `new-library`/`baseline-path` are fixed caller-supplied paths
+        and `new-library` is a fixed caller-supplied path
         here (unlike check-project.yml's glob-based candidate resolver), so
         a stale file is scanned/compared as if it were the real upload
         (Codex review). The clear must share its download's own `if:` --
@@ -280,7 +280,7 @@ class TestCheckSingleOptionalArtifactStaging:
         assert clear_step.get("if") == download_step.get("if")
         assert names.index(clear_name) < names.index(download_name)
 
-    def test_baseline_clear_step_targets_the_resolved_baseline_path(self) -> None:
+    def test_baseline_staging_cannot_target_a_caller_controlled_path(self) -> None:
         data = _load(CHECK_SINGLE)
         steps = _steps(data["jobs"]["check"])
         clear_step = next(
@@ -288,10 +288,14 @@ class TestCheckSingleOptionalArtifactStaging:
             for s in steps
             if s.get("name") == "Clear baseline staging before download"
         )
-        assert (
-            clear_step["env"]["BASELINE_STAGING_PATH"] == "${{ inputs.baseline-path }}"
+        assert clear_step["run"] == "rm -rf .check-single-baseline"
+        assert "env" not in clear_step
+
+        run_step = next(s for s in steps if s.get("name") == "Run check-target")
+        assert run_step["with"]["baseline-path"] == (
+            "${{ inputs.baseline-artifact-name != '' && '.check-single-baseline' "
+            "|| inputs.baseline-path }}"
         )
-        assert "$BASELINE_STAGING_PATH" in clear_step["run"]
 
 
 class TestCheckProjectAlwaysOnRequirements:
@@ -1024,7 +1028,9 @@ class TestCandidateResolverConfinesMatchesToTheArtifactRoot:
             "isn't a bug in the workflow script itself."
         ),
     )
-    def test_absolute_pattern_is_rejected_without_globbing(self, tmp_path: Path) -> None:
+    def test_absolute_pattern_is_rejected_without_globbing(
+        self, tmp_path: Path
+    ) -> None:
         # An absolute recursive pattern like '/**/*' would otherwise expand
         # glob.glob against the whole runner filesystem BEFORE the
         # commonpath confinement check ever ran -- a needlessly slow/heavy


### PR DESCRIPTION
### Motivation

- The reusable workflow accepted a caller-controlled `baseline-path` and, when `baseline-artifact-name` was provided, performed `rm -rf` and artifact extraction into that path before executing a locally-checked-out action, enabling an attacker to overwrite workflow-owned files (including local action code) or delete arbitrary workspace locations.
- Constrain where downloaded baseline artifacts land to prevent path-traversal, absolute-path, or workspace-overwrite attacks while preserving the workflow's artifact-staging functionality.

### Description

- Changed `.github/workflows/check-single.yml` so that when `baseline-artifact-name` is set the workflow stages the downloaded baseline into a fixed, workflow-owned directory: `.check-single-baseline`, and the `rm -rf`/download steps operate only on that directory instead of the caller-provided `baseline-path`.
- Updated the `Run check-target` step to pass the confined path (`.check-single-baseline`) to `check-target` when a baseline artifact was downloaded, otherwise preserve the original `inputs.baseline-path` behavior.
- Clarified the `baseline-artifact-name` input description to document that `baseline-path` is ignored when `baseline-artifact-name` is used, and added corresponding docs to `docs/reference/reusable-workflows.md` explaining the confinement behavior.
- Added/updated structural tests in `tests/test_reusable_workflows.py` to assert the download uses the workflow-owned staging directory, the clear step targets the fixed directory, and the `baseline-path` passed to `check-target` is the confined path when applicable.

### Testing

- Ran `pytest tests/test_reusable_workflows.py -q`, which passed (`80 passed`).
- Ran linter/format checks with `ruff check` and `ruff format --check`, and applied formatting fixes; checks succeeded after formatting.
- Ran the repository AI-readiness script with `python scripts/check_ai_readiness.py`; it completed with no errors (warnings remained unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6408626918832baf3e18ec602daec8)