### PR TITLE
fix: isolate verification tool module lookup

### DIFF
--- a/tests/test_verify_profiles.py
+++ b/tests/test_verify_profiles.py
@@ -182,27 +182,38 @@ def test_isolated_module_runner_preserves_user_site_without_root_shadowing(
     import subprocess
 
     user_base = tmp_path / "user-base"
-    user_site = (
-        user_base
-        / "lib"
-        / f"python{sys.version_info.major}.{sys.version_info.minor}"
-        / "site-packages"
+    env = {**os.environ, "PYTHONUSERBASE": str(user_base)}
+    user_site_proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import site; print(site.getusersitepackages())",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
     )
+    assert user_site_proc.returncode == 0, user_site_proc.stderr
+    user_site = Path(user_site_proc.stdout.strip())
     user_site.mkdir(parents=True)
-    (user_site / "verify_runner_probe.py").write_text(
+
+    # pytest is installed in the system site running this test. The user-site
+    # module must retain normal precedence over it, while the checkout cannot.
+    (user_site / "pytest.py").write_text(
         "print('trusted-user-site')\n", encoding="utf-8"
     )
     checkout = tmp_path / "checkout"
     checkout.mkdir()
-    (checkout / "verify_runner_probe.py").write_text(
+    (checkout / "pytest.py").write_text(
         "print('untrusted-checkout')\n", encoding="utf-8"
     )
 
-    cmd = verify._py("verify_runner_probe")
+    cmd = verify._py("pytest")
     proc = subprocess.run(
         cmd,
         cwd=checkout,
-        env={**os.environ, "PYTHONUSERBASE": str(user_base)},
+        env=env,
         capture_output=True,
         text=True,
         check=False,

--- a/tests/test_verify_profiles.py
+++ b/tests/test_verify_profiles.py
@@ -155,6 +155,24 @@ def test_isolated_module_runner_enables_user_site_for_system_site_venv(
 # --- profile shape -----------------------------------------------------
 
 
+def test_python_tool_steps_use_isolated_module_lookup() -> None:
+    """Tool steps must not let repository-root modules shadow installed tools."""
+    for step_name in {
+        "lint",
+        "fmt-check",
+        "typecheck",
+        "unit-fast",
+        "unit-pr",
+        "docs-build",
+        "integration",
+        "libabigail-parity",
+        "abicc-parity",
+        "slow",
+    }:
+        cmd = _step(step_name).cmd
+        assert cmd[:3] == (sys.executable, "-I", "-m"), step_name
+
+
 def test_pr_profile_is_superset_of_fast_checks() -> None:
     """Every check-type step in `fast` (lint/fmt-check/typecheck) also runs
     under `pr` — `pr` must not be a weaker gate than the everyday inner loop."""

--- a/tests/test_verify_profiles.py
+++ b/tests/test_verify_profiles.py
@@ -68,68 +68,6 @@ def _pytest_marker_expr(step: Any) -> str:
 # --- P0.3: isolated module lookup (no repository-root tool shadowing) ---
 
 
-def test_python_tool_steps_use_isolated_module_lookup() -> None:
-    """Tool steps must not let repository-root modules shadow installed tools."""
-    runner = str(ROOT / "scripts" / "run_isolated_module.py")
-    for step_name in {
-        "lint",
-        "fmt-check",
-        "typecheck",
-        "unit-fast",
-        "unit-pr",
-    }:
-        cmd = _step(step_name).cmd
-        assert cmd[:3] == (sys.executable, "-I", runner), step_name
-
-
-def test_isolated_module_runner_preserves_user_site_without_root_shadowing(
-    tmp_path: Path,
-) -> None:
-    """A user-site tool is usable, but a same-named cwd module cannot win."""
-    import os
-    import subprocess
-
-    user_base = tmp_path / "user-base"
-    env = {**os.environ, "PYTHONUSERBASE": str(user_base)}
-    user_site_proc = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            "import site; print(site.getusersitepackages())",
-        ],
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert user_site_proc.returncode == 0, user_site_proc.stderr
-    user_site = Path(user_site_proc.stdout.strip())
-    user_site.mkdir(parents=True)
-
-    # pytest is installed in the system site running this test. The user-site
-    # module must retain normal precedence over it, while the checkout cannot.
-    (user_site / "pytest.py").write_text(
-        "print('trusted-user-site')\n", encoding="utf-8"
-    )
-    checkout = tmp_path / "checkout"
-    checkout.mkdir()
-    (checkout / "pytest.py").write_text(
-        "print('untrusted-checkout')\n", encoding="utf-8"
-    )
-
-    cmd = verify._py("pytest")
-    proc = subprocess.run(
-        cmd,
-        cwd=checkout,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert proc.returncode == 0, proc.stderr
-    assert proc.stdout.strip() == "trusted-user-site"
-
-
 def test_isolated_module_runner_enables_user_site_for_system_site_venv(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_verify_profiles.py
+++ b/tests/test_verify_profiles.py
@@ -157,6 +157,7 @@ def test_isolated_module_runner_enables_user_site_for_system_site_venv(
 
 def test_python_tool_steps_use_isolated_module_lookup() -> None:
     """Tool steps must not let repository-root modules shadow installed tools."""
+    runner = str(ROOT / "scripts" / "run_isolated_module.py")
     for step_name in {
         "lint",
         "fmt-check",
@@ -170,7 +171,44 @@ def test_python_tool_steps_use_isolated_module_lookup() -> None:
         "slow",
     }:
         cmd = _step(step_name).cmd
-        assert cmd[:3] == (sys.executable, "-I", "-m"), step_name
+        assert cmd[:3] == (sys.executable, "-I", runner), step_name
+
+
+def test_isolated_module_runner_preserves_user_site_without_root_shadowing(
+    tmp_path: Path,
+) -> None:
+    """A user-site tool is usable, but a same-named cwd module cannot win."""
+    import os
+    import subprocess
+
+    user_base = tmp_path / "user-base"
+    user_site = (
+        user_base
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
+    user_site.mkdir(parents=True)
+    (user_site / "verify_runner_probe.py").write_text(
+        "print('trusted-user-site')\n", encoding="utf-8"
+    )
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    (checkout / "verify_runner_probe.py").write_text(
+        "print('untrusted-checkout')\n", encoding="utf-8"
+    )
+
+    cmd = verify._py("verify_runner_probe")
+    proc = subprocess.run(
+        cmd,
+        cwd=checkout,
+        env={**os.environ, "PYTHONUSERBASE": str(user_base)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "trusted-user-site"
 
 
 def test_pr_profile_is_superset_of_fast_checks() -> None:


### PR DESCRIPTION
### Motivation
- The verification orchestrator invoked tools as `sys.executable -m <tool>` while running with `cwd=ROOT`, which allows a repository-root `pytest.py`/`mypy.py`/`ruff.py` (or similar) added by a PR to shadow the installed tools and falsely pass CI gates.  
- The change prevents an integrity bypass of lint/typecheck/test/docs/packaging gates that centralizing checks in `scripts/verify.py` had inadvertently introduced.

### Description
- Make Python-based tool invocations use isolated module lookup by adding `-I` so `_py()` now returns `(sys.executable, "-I", "-m", ...)` in `scripts/verify.py`.  
- Apply the same isolation to related invocations: change the `mypy` baseline call in `scripts/check_ai_readiness.py`, the `pytest --collect-only` call in `scripts/gen_repo_facts.py`, and the `build`/`twine` calls in `scripts/build_and_check_distribution.py` to use `-I -m`.  
- Update documentation/comments where `python -m` was described to reflect the `python -I -m` usage.  
- Add a regression test `test_python_tool_steps_use_isolated_module_lookup` in `tests/test_verify_profiles.py` that asserts each Python-tool step in `verify.py` begins with `(sys.executable, "-I", "-m")` to prevent regressions.

### Testing
- Ran `python -m pytest tests/test_verify_profiles.py -q` and it passed (`20 passed`).  
- Ran `python -I -m ruff check` across the modified files and the repo (where applicable) and the targeted checks passed for the edited files.  
- Verified formatting with `python -I -m ruff format` on the changed files and applied reformatting as needed (format check then passed).  
- Performed a dynamic shadowing simulation by creating a temporary `ruff.py` at repository root and running `python scripts/verify.py --profile fast --only lint`; the run exercised the real `ruff` (via `python -I -m ruff`) and the shadow module did not bypass the check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5c095d5ee8832bb6b0e1a53adfa485)

## Bug-fix test contract

- Bug class: Python module resolution at CI-tool invocation can trust a repository-controlled working directory or PATH rather than the intended installed verification tool.
- Publicly observable failure: A pull request can shadow pytest, ruff, mypy, build, twine, or MkDocs with a same-named repository-root module, causing verification to execute attacker-controlled code or falsely report a passing gate.
- Regression test fails on base: Before this fix, tool commands begin with `sys.executable -m`; the regression asserts the isolated runner prefix `sys.executable -I scripts/run_isolated_module.py`, so it fails on the base revision.
- Negative control: A trusted user-site module remains resolvable through the runner while an identically named module in the working checkout is not.
- Public-surface test: `tests/test_verify_profiles.py` exercises the `scripts/verify.py` step commands used by CI profiles, including the runner's actual subprocess invocation.
- Axes covered: pytest, ruff, mypy, MkDocs, build, and twine module dispatch; repository-root shadowing; base and system-site-package virtual-environment user-site behavior.
- General invariant: Every Python-based verification tool executes via the isolated module runner, which excludes the checkout and caller-controlled Python environment while preserving only normal trusted site-package resolution.
