### PR TITLE
fix: preserve typedef alignment in CastXML fallback

### DIFF
--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -503,8 +503,8 @@ class _CastxmlParser:
         Distinct from a Variable's own ``align`` attribute (an *explicit*
         alignas/``__attribute__((aligned))`` override on the declaration —
         see ``parse_variables``): this walks through cv-qualifiers, typedefs,
-        elaborated-type wrappers, and array types to the underlying type node
-        and reads its own ``align``, which castxml always populates with the
+        elaborated-type wrappers, and array types to the nearest type node
+        with its own ``align`` and reads that value, which castxml populates with the
         compiler's actual computed alignment (the same attribute
         ``_build_record_type`` already trusts unconditionally for
         structs/unions/classes). ``ArrayType`` carries no ``align``/``size``
@@ -524,9 +524,12 @@ class _CastxmlParser:
         el = self._resolve(id_)
         if el is None:
             return None
+        align = self._optional_int_attr(el, "align")
+        if align is not None:
+            return align
         if el.tag in ("CvQualifiedType", "Typedef", "ElaboratedType", "ArrayType"):
             return self._type_alignment_bits(el.get("type", ""), depth + 1)
-        return self._optional_int_attr(el, "align")
+        return None
 
     def _resolve_cv_restrict(self, id_: str, depth: int = 0) -> tuple[bool, bool, bool]:
         """Whether *id_*'s own (top-level) qualification is const/volatile/restrict.

--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -500,14 +500,11 @@ class _CastxmlParser:
     def _type_alignment_bits(self, id_: str, depth: int = 0) -> int | None:
         """Natural (computed) alignment in bits for a type id, if castxml exposes it.
 
-        Distinct from a Variable's own ``align`` attribute (an *explicit*
-        alignas/``__attribute__((aligned))`` override on the declaration —
-        see ``parse_variables``): this walks through cv-qualifiers, typedefs,
-        elaborated-type wrappers, and array types to the nearest type node
-        with its own ``align`` and reads that value, which castxml populates with the
-        compiler's actual computed alignment (the same attribute
-        ``_build_record_type`` already trusts unconditionally for
-        structs/unions/classes). ``ArrayType`` carries no ``align``/``size``
+        Unlike a Variable's own explicit ``align`` attribute (see
+        ``parse_variables``), this walks through cv-qualifiers, typedefs,
+        elaborated types, and arrays to the nearest type node with ``align``.
+        CastXML populates it with the compiler's computed alignment, as trusted
+        by ``_build_record_type`` for records. ``ArrayType`` carries no ``align``/``size``
         of its own (confirmed empirically: an array's alignment is always its
         element type's) — recursing into its ``type`` is required, not just
         an optimization, or every exported array global would silently fall

--- a/changelog.d/20260813_013000_openclaw_castxml_typedef_alignment.md
+++ b/changelog.d/20260813_013000_openclaw_castxml_typedef_alignment.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Preserved typedef alignment in the CastXML fallback.** Exported variables now retain alignment declared on typedef nodes instead of incorrectly falling through to the underlying type.

--- a/tests/test_dumper_unit_phase0.py
+++ b/tests/test_dumper_unit_phase0.py
@@ -152,3 +152,25 @@ def test_cache_key_changes_with_inputs(tmp_path: Path) -> None:
 
     # Determinism: same inputs → same key
     assert k1 == _cache_key([h1], [inc], compiler="c++")
+
+
+def test_castxml_type_alignment_preserves_typedef_align() -> None:
+    root = Element("GCC_XML")
+    SubElement(root, "FundamentalType", id="t_int", name="int", align="32")
+    SubElement(root, "Typedef", id="td_over", name="over", type="t_int", align="128")
+    SubElement(root, "Variable", id="v1", name="g", mangled="g", type="td_over")
+
+    parser = _CastxmlParser(root, exported_dynamic=set(), exported_static={"g"})
+
+    assert parser._type_alignment_bits("td_over") == 128
+    assert parser.parse_variables()[0].alignment_bits == 128
+
+
+def test_castxml_type_alignment_falls_through_unaligned_typedef() -> None:
+    root = Element("GCC_XML")
+    SubElement(root, "FundamentalType", id="t_int", name="int", align="32")
+    SubElement(root, "Typedef", id="td_plain", name="plain", type="t_int")
+
+    parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+
+    assert parser._type_alignment_bits("td_plain") == 32


### PR DESCRIPTION
### Motivation
- A CastXML alignment fallback unwrapped `Typedef`/wrapper nodes before reading a node's own `align`, which caused typedef-level `align` attributes to be ignored and produced incorrect declared-alignment evidence that could suppress real exported-variable alignment reductions.

### Description
- Read the current node's `align` via `self._optional_int_attr(el, "align")` before recursing through `CvQualifiedType`, `Typedef`, `ElaboratedType`, and `ArrayType` in `_type_alignment_bits` so typedef-level alignment overrides are preserved.
- Update the `_type_alignment_bits` docstring to clarify that the search returns the nearest type node with its own `align` value.
- Add two regression tests in `tests/test_dumper_unit_phase0.py` to assert that an aligned typedef preserves its alignment for parsed variables and that an unaligned typedef falls through to the underlying type's alignment.
- Modified files: `abicheck/dumper_castxml.py` and `tests/test_dumper_unit_phase0.py`.

### Testing
- Ran `pytest -q tests/test_dumper_unit_phase0.py`, which completed successfully with `5 passed`.
- Ran `git diff --check` to ensure no whitespace/format issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5af658de0c832b9cb1e1450ae9b054)