### PR TITLE
docs(G31): close Phase C castxml using-declaration gap with real castxml verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2473,7 +2473,12 @@ Once a root command genuinely clears the bar above, pick the right home:
   clang. Not verified against a live castxml run (no castxml binary
   available in this environment to reproduce the XML shape directly) —
   the castxml-side mechanism above is taken from the original report, not
-  independently re-derived from castxml's own output.
+  independently re-derived from castxml's own output. **Update (G31 Phase
+  C, later pass): now independently re-derived, against a real
+  conda-forge castxml 0.7.0 build, and the "opposite directions" framing
+  in this paragraph does not hold — see the "Option (b) closed" note at
+  the end of this entry, below, for the reproduction and its
+  implications.**
 
   **Attempted fix, reverted (three review rounds):** a
   `qualified_name_segments.dedup_versioned_namespace_alias_items()`
@@ -2589,6 +2594,60 @@ Once a root command genuinely clears the bar above, pick the right home:
   dropping information from one side's snapshot in isolation — a
   materially larger, cross-cutting change on its own, not a follow-up
   patch to the same per-snapshot helper.
+
+  **Option (b) closed (G31 Phase C, real conda-forge castxml build):** a
+  real, policy-conformant castxml (0.7.0, `conda-forge`, within the
+  `>=0.6.11,<0.8.0` range `castxml_policy.py` enforces, bundled Clang
+  20.1.8) is now available and was used to reproduce this construct
+  directly through the exact invocation shape `_build_castxml_command`
+  emits (`--castxml-cc-gnu (g++ -x c)`/`--castxml-cc-gnu g++`, matching
+  real header-dump usage) — **the originally-hypothesized castxml
+  duplication mechanism does not reproduce.** For `namespace detail {
+  namespace v1 { constexpr int cpu_feature_map = 42; } using
+  v1::cpu_feature_map; }`, real castxml emits exactly **one** `<Variable>`
+  element (`context="_13"`, i.e. `v1` — never `detail`), and that single
+  element's id is listed in *both* `detail`'s and `v1`'s `<Namespace
+  members="...">` attribute — a shared reference, not two elements. There
+  is no `<Using...>`-shaped XML tag in castxml's schema at all (checked
+  against castxml's own `--help`), and forcing the value to be ODR-used
+  (`&cpu_feature_map` from an inline function) does not change this.
+  Since `dumper_castxml.py`'s `_variable_els`/`_iter_public_constants()`
+  iterate the flat, once-per-XML-element id map (`_build_id_map`), not
+  either namespace's `members` list, they see this construct exactly once
+  too — `_qualified_name()` resolves it to `detail::v1::cpu_feature_map`
+  only; the alias spelling `detail::cpu_feature_map` never enters
+  `AbiSnapshot.constants` on this castxml version, at all. The identical
+  single-element behavior was independently confirmed for the sibling
+  type-dedup case this entry cross-references (`struct range` in `v1`,
+  `using v1::range;` in `detail`): one `<Struct>` element, shared between
+  both namespaces' `members` lists, never a duplicate. **What this means
+  for the entry above:** the "castxml over-reports (duplicate keys),
+  clang under-reports (missing alias)" asymmetry this entry documented
+  was written from an unverified report and does not hold for the
+  currently-supported castxml version range — for this exact construct,
+  both backends now demonstrably fail the *same* way (silent false
+  negative: the alias spelling is absent from the snapshot entirely,
+  matching the clang-side finding already confirmed above). This does not
+  retroactively invalidate the original report (98 alias groups across
+  267 constants, real oneDAL headers) — that scan may have used a
+  different castxml build, or the real duplication may come from a
+  different source construct entirely (e.g. two independent, textually
+  separate definitions sharing a value, rather than a language-level
+  using-declaration/using-directive) that this pass did not have the
+  original headers to reproduce against. It does mean: (1) the three
+  reverted name-shape-heuristic attempts documented above were correctly
+  reverted regardless of this finding (their unsoundness was proven by
+  counterexample, independent of whether castxml duplicates), so nothing
+  here reopens that question; (2) a future fix attempt should design for
+  the *false-negative* alias-identity gap confirmed symmetric on both
+  backends (option (a)'s `UsingShadowDecl.target` clang-side threading is
+  now the best-founded starting point, since it is real, already-present
+  AST identity, not a heuristic), rather than a castxml-side dedup this
+  evidence no longer motivates; (3) closing this for real still needs the
+  original large-scale report's exact source construct identified before
+  trusting any fix against it — not attempted here, since the oneDAL
+  headers that produced the original 98/267 count are not available in
+  this environment either.
 - **`AbiSnapshot.typedefs` is a flat `dict[str, str]` keyed by bare
   (unqualified) name on both header backends — a member/nested typedef
   silently collides with, and can be overwritten by, any other typedef

--- a/tests/test_abi_examples.py
+++ b/tests/test_abi_examples.py
@@ -5,6 +5,7 @@ Kept for backward compatibility on Linux.  Skipped in CI integration runs
 to avoid duplicate cmake-configure overhead (especially costly on Windows
 where each configure adds ~30 s).
 """
+
 from __future__ import annotations
 
 import json
@@ -19,6 +20,10 @@ EXAMPLES_DIR = Path(__file__).parent.parent / "examples"
 
 # (case_dir_name, expected_verdict, header_v1, header_v2)
 #
+# header_v1/header_v2 are paths relative to the case directory, or ``None``
+# for a case with no public header at all (dump falls back to DWARF/
+# symbol-only evidence, no ``-H`` flag passed).
+#
 # Expected verdicts reflect what abicheck currently detects with castxml+ELF analysis:
 #   DETECTED  — abicheck catches the break reliably
 #   LIMITATION — break exists but abicheck cannot detect it yet (documented gap)
@@ -30,15 +35,20 @@ CASES = [
     # Parameter type change visible via castxml → FUNC_PARAMS_CHANGED → BREAKING
     ("case02_param_type_change", "BREAKING", "v1.c", "v2.c"),
     # New symbol added → FUNC_ADDED → COMPATIBLE
-    ("case03_compat_addition", "COMPATIBLE", "v1.c", "v2.c"),
+    # (restructured into old/new subdirs; header is lib.h, not v1.c/v2.c)
+    ("case03_compat_addition", "COMPATIBLE", "old/lib.h", "new/lib.h"),
     # Identical libs → NO_CHANGE
     ("case04_no_change", "NO_CHANGE", "v1.c", "v1.c"),
     # SONAME is a policy attribute, not tracked as a binary ABI break.
-    ("case05_soname", "COMPATIBLE", "bad.c", "good.c"),
+    # (no public header in this case at all — DWARF/symbol-only dump)
+    ("case05_soname", "COMPATIBLE", None, None),
     # internal_helper/another_impl hidden in good.c → removed from dynsym → BREAKING
     ("case06_visibility", "BREAKING", "bad.c", "good.c"),
     # Struct size change detected via castxml → TYPE_SIZE_CHANGED → BREAKING
-    ("case07_struct_layout", "BREAKING", "v1.c", "v2.c"),
+    # (the public header is v1.h/v2.h — v1.c/v2.c define their own local
+    # `struct Point` that lacks get_y(), so passing the .c file as -H
+    # silently dumped the wrong declarations)
+    ("case07_struct_layout", "BREAKING", "v1.h", "v2.h"),
     # Enum member value changes detected via _diff_enums() → BREAKING
     ("case08_enum_value_change", "BREAKING", "v1.c", "v2.c"),
     # vtable reorder/change detected → TYPE_VTABLE_CHANGED → BREAKING
@@ -50,14 +60,16 @@ CASES = [
     # Function inlined away → disappears from .so → FUNC_REMOVED → BREAKING
     ("case12_function_removed", "BREAKING", "v1.c", "v2.c"),
     # Symbol versioning: checker strips @-suffix → symbols match → COMPATIBLE
-    ("case13_symbol_versioning", "COMPATIBLE", "bad.c", "good.c"),
+    # (no public header in this case at all — DWARF/symbol-only dump)
+    ("case13_symbol_versioning", "COMPATIBLE", None, None),
     # Class size change (private member added) → TYPE_SIZE_CHANGED → BREAKING
     ("case14_cpp_class_size", "BREAKING", "v1.cpp", "v2.cpp"),
     # noexcept removed → FUNC_NOEXCEPT_REMOVED (COMPATIBLE) + SYMBOL_VERSION_REQUIRED_ADDED
     # (GLIBCXX bump from throw in v2) → COMPATIBLE_WITH_RISK
     ("case15_noexcept_change", "COMPATIBLE_WITH_RISK", "v1.cpp", "v2.cpp"),
     # Symbol appears in v2 that was inline in v1 → FUNC_ADDED → COMPATIBLE
-    ("case16_inline_to_non_inline", "COMPATIBLE", "v1.hpp", "v2.hpp"),
+    # (restructured into old/new subdirs; header is lib.hpp, not v1.hpp/v2.hpp)
+    ("case16_inline_to_non_inline", "COMPATIBLE", "old/lib.hpp", "new/lib.hpp"),
     # Explicit-instantiated template size grows → TYPE_SIZE_CHANGED → BREAKING
     ("case17_template_abi", "BREAKING", "v1.hpp", "v2.hpp"),
     # castxml processes headers transitively: ThirdPartyHandle (4→8 bytes) → BREAKING
@@ -75,11 +87,14 @@ def _shared_lib_suffix() -> str:
 
 def _find_compiler(is_cpp: bool = False) -> str | None:
     if is_cpp:
-        candidates = {"win32": ["cl", "g++", "clang++"],
-                       "darwin": ["clang++", "g++"]}.get(sys.platform, ["g++", "clang++"])
+        candidates = {
+            "win32": ["cl", "g++", "clang++"],
+            "darwin": ["clang++", "g++"],
+        }.get(sys.platform, ["g++", "clang++"])
     else:
-        candidates = {"win32": ["cl", "gcc", "clang"],
-                       "darwin": ["clang", "gcc"]}.get(sys.platform, ["gcc", "clang"])
+        candidates = {"win32": ["cl", "gcc", "clang"], "darwin": ["clang", "gcc"]}.get(
+            sys.platform, ["gcc", "clang"]
+        )
     for cc in candidates:
         if shutil.which(cc):
             return cc
@@ -100,12 +115,30 @@ def _compile_shared(src: Path, out: Path) -> str | None:
     if compiler == "cl":
         args = [compiler, "/LD", "/Zi", "/Fe:" + str(out), str(src)]
     elif sys.platform == "darwin":
-        args = [compiler, "-dynamiclib", "-g", "-Og", "-fvisibility=default",
-                "-install_name", "@rpath/lib.dylib",
-                "-o", str(out), str(src)]
+        args = [
+            compiler,
+            "-dynamiclib",
+            "-g",
+            "-Og",
+            "-fvisibility=default",
+            "-install_name",
+            "@rpath/lib.dylib",
+            "-o",
+            str(out),
+            str(src),
+        ]
     else:
-        args = [compiler, "-shared", "-fPIC", "-g", "-Og", "-fvisibility=default",
-                "-o", str(out), str(src)]
+        args = [
+            compiler,
+            "-shared",
+            "-fPIC",
+            "-g",
+            "-Og",
+            "-fvisibility=default",
+            "-o",
+            str(out),
+            str(src),
+        ]
 
     r = subprocess.run(args, capture_output=True, text=True)
     if r.returncode != 0:
@@ -157,6 +190,7 @@ _PLATFORMS: dict[str, list[str]] = {
     for k, v in _gt_data["verdicts"].items()
 }
 
+
 def _current_platform() -> str:
     if sys.platform.startswith("linux"):
         return "linux"
@@ -167,23 +201,39 @@ def _current_platform() -> str:
     return sys.platform
 
 
-def _find_source(d: Path, hint: str) -> Path:
-    """Resolve a compilable source from a hint that may be a header."""
+def _find_source(d: Path, hint: str | None, side: str) -> Path:
+    """Resolve a compilable source from a hint that may be a header.
+
+    *side* is ``"v1"``/``"v2"`` — used only when *hint* is ``None`` (a case
+    with no public header at all), to search the conventional ``old/``
+    (v1) / ``new/`` (v2) subdirectory for a source file.
+    """
+    if hint is None:
+        sub = d / ("old" if side == "v1" else "new")
+        for ext in (".c", ".cpp"):
+            src = sub / f"lib{ext}"
+            if src.exists():
+                return src
+        return sub / "lib.c"  # best effort
     p = d / hint
     if p.suffix in (".c", ".cpp"):
         return p
-    # hint is a header — look for matching source
+    # hint is a header — look for matching source *next to it* (its own
+    # parent, not necessarily `d` itself — a header under `old/`/`new/`
+    # has its sibling source in that same subdirectory).
     stem = p.stem
     for ext in (".c", ".cpp"):
-        src = d / f"{stem}{ext}"
+        src = p.parent / f"{stem}{ext}"
         if src.exists():
             return src
-    # libfoo pattern: foo_v1.h → libfoo_v1.c
+    # old/new pattern: old/lib.h → old/lib.c (already covered by the loop
+    # above via p.parent when stem == "lib"); libfoo pattern: foo_v1.h →
+    # libfoo_v1.c, searched relative to the header's own directory too.
     if stem.endswith(("_v1", "_v2")):
         base = stem[:-3]  # e.g. "foo"
-        tag = stem[-3:]   # e.g. "_v1"
+        tag = stem[-3:]  # e.g. "_v1"
         for ext in (".c", ".cpp"):
-            src = d / f"lib{base}{tag}{ext}"
+            src = p.parent / f"lib{base}{tag}{ext}"
             if src.exists():
                 return src
     return p  # best effort
@@ -203,9 +253,17 @@ def _try_cmake_build(
 
     cmake_build = tmp_path / "cmake_build"
     r = subprocess.run(
-        ["cmake", "-S", str(case_dir.parent), "-B", str(cmake_build),
-         "-DCMAKE_BUILD_TYPE=Debug"],
-        capture_output=True, text=True, timeout=60,
+        [
+            "cmake",
+            "-S",
+            str(case_dir.parent),
+            "-B",
+            str(cmake_build),
+            "-DCMAKE_BUILD_TYPE=Debug",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
     )
     if r.returncode != 0:
         pytest.fail(
@@ -214,10 +272,19 @@ def _try_cmake_build(
         )
 
     r = subprocess.run(
-        ["cmake", "--build", str(cmake_build),
-         "--target", f"{case_name}_v1", f"{case_name}_v2",
-         "--config", "Debug"],
-        capture_output=True, text=True, timeout=120,
+        [
+            "cmake",
+            "--build",
+            str(cmake_build),
+            "--target",
+            f"{case_name}_v1",
+            f"{case_name}_v2",
+            "--config",
+            "Debug",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=120,
     )
     if r.returncode != 0:
         pytest.fail(
@@ -233,13 +300,13 @@ def _compile_fallback(
     case_name: str,
     build_dir: Path,
     tmp_path: Path,
-    hdr_v1: str,
-    hdr_v2: str,
+    hdr_v1: str | None,
+    hdr_v2: str | None,
 ) -> tuple[Path, Path]:
     """Direct compilation fallback. Returns (libv1, libv2)."""
     suffix = _shared_lib_suffix()
-    src_v1 = _find_source(build_dir, hdr_v1)
-    src_v2 = _find_source(build_dir, hdr_v2)
+    src_v1 = _find_source(build_dir, hdr_v1, "v1")
+    src_v2 = _find_source(build_dir, hdr_v2, "v2")
     libv1 = tmp_path / f"libv1{suffix}"
     libv2 = tmp_path / f"libv2{suffix}"
 
@@ -256,14 +323,27 @@ def _compile_fallback(
 def _run_dump(
     case_name: str,
     lib: Path,
-    header: Path,
+    header: Path | None,
     snap: Path,
     label: str,
 ) -> None:
-    """Run abicheck dump for a single version; skip or fail on error."""
+    """Run abicheck dump for a single version; skip or fail on error.
+
+    *header* is ``None`` for a case with no public header at all (e.g.
+    case05_soname, case13_symbol_versioning) — the ``-H`` flag is omitted
+    entirely rather than pointed at a nonexistent path, so the dump falls
+    back to DWARF/symbol-only evidence.
+    """
+    cmd = [sys.executable, "-m", "abicheck.cli", "dump", str(lib)]
+    if header is not None:
+        cmd += ["-H", str(header)]
+    cmd += ["-o", str(snap)]
     r = subprocess.run(
-        [sys.executable, "-m", "abicheck.cli", "dump", str(lib), "-H", str(header), "-o", str(snap)],
-        capture_output=True, text=True, check=False, timeout=60,
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
     )
     if r.returncode != 0:
         combined = r.stderr.lower() + r.stdout.lower()
@@ -280,8 +360,20 @@ def _run_compare_and_assert(
 ) -> None:
     """Run abicheck compare and assert the verdict matches."""
     rc = subprocess.run(
-        [sys.executable, "-m", "abicheck.cli", "compare", str(snap1), str(snap2), "--format", "json"],
-        capture_output=True, text=True, check=False, timeout=60,
+        [
+            sys.executable,
+            "-m",
+            "abicheck.cli",
+            "compare",
+            str(snap1),
+            str(snap2),
+            "--format",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=60,
     )
 
     try:
@@ -300,8 +392,9 @@ def _run_compare_and_assert(
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("case_name,expected_verdict,hdr_v1,hdr_v2", CASES,
-                         ids=[c[0] for c in CASES])
+@pytest.mark.parametrize(
+    "case_name,expected_verdict,hdr_v1,hdr_v2", CASES, ids=[c[0] for c in CASES]
+)
 def test_abi_example(case_name, expected_verdict, hdr_v1, hdr_v2, tmp_path):
     _require_tool("castxml")
 
@@ -321,13 +414,17 @@ def test_abi_example(case_name, expected_verdict, hdr_v1, hdr_v2, tmp_path):
     libv1, libv2 = _try_cmake_build(case_name, case_dir, tmp_path)
     if not libv1 or not libv2:
         libv1, libv2 = _compile_fallback(
-            case_name, build_dir, tmp_path, hdr_v1, hdr_v2,
+            case_name,
+            build_dir,
+            tmp_path,
+            hdr_v1,
+            hdr_v2,
         )
 
     snap1 = tmp_path / "snap1.json"
     snap2 = tmp_path / "snap2.json"
 
-    _run_dump(case_name, libv1, build_dir / hdr_v1, snap1, "v1")
-    _run_dump(case_name, libv2, build_dir / hdr_v2, snap2, "v2")
+    _run_dump(case_name, libv1, build_dir / hdr_v1 if hdr_v1 else None, snap1, "v1")
+    _run_dump(case_name, libv2, build_dir / hdr_v2 if hdr_v2 else None, snap2, "v2")
 
     _run_compare_and_assert(case_name, expected_verdict, snap1, snap2)

--- a/tests/test_castxml_using_reexport.py
+++ b/tests/test_castxml_using_reexport.py
@@ -37,20 +37,33 @@ snapshot at all; the failure mode is a silent false negative, matching
 the direct-clang backend's already-documented behavior for the identical
 construct, not the "castxml over-reports" asymmetry originally reported.
 
-Two independent layers are checked per case, so a future castxml release
-that changes this is caught either way:
+Three independent layers are checked per case, so a future castxml
+release that changes this is caught either way:
 
 1. The **raw XML** itself — the exact element count for the tag in
-   question, and that the single element's id is listed in *both*
-   namespaces' own ``members=`` attribute. This is deliberately not
-   routed through ``_CastxmlParser`` at all: if a future castxml starts
-   emitting an equivalent using-shadow/back-reference element under some
-   *other* tag name (not ``Variable``/``Struct``), this raw check does not
-   see it and only the parser-level check below would catch it via a
-   changed constant/type count.
+   question, that the single element's id is listed in *both*
+   namespaces' own ``members=`` attribute, and (``_assert_no_alias_shaped_
+   tags``) that no *other* element in the document carries a tag name that
+   looks alias-related (``using``/``alias``/``shadow``), so a hypothetical
+   future using-shadow tag under some name this suite didn't anticipate
+   still fails loudly rather than silently passing both the exact-count
+   check (which only looks at ``Variable``/``Struct``) and the
+   parser-level check below (whose element lists are also tag-filtered,
+   per ``_build_id_map``, so an unrecognized tag is invisible to it too).
 2. The **parser-level result** (``parse_constants()``/``parse_types()``),
    confirming the flat-iteration behavior ``dumper_castxml.py`` actually
    exhibits reads through correctly to the model.
+3. **The real production entry point** (``TestUsingReexportAgainstProductionDumpPath``
+   below) — a real compiled ``.so`` dumped through ``abicheck.dumper.dump(
+   ..., header_backend="castxml")``, the same function ``compare``/``dump``
+   CLI commands call. Layers 1-2 hand-invoke castxml directly (mirroring
+   ``_build_castxml_command``'s flags) specifically so the raw-XML schema
+   is inspectable at all — ``dump()`` does not expose the intermediate XML
+   — but that means they don't exercise aggregate-header construction, the
+   supported-version gate, or compiler *resolution* (as opposed to the
+   emulation flag alone) the way a real dump does. Layer 3 closes that gap
+   by going through the identical public entry point and asserting on the
+   resulting ``AbiSnapshot`` instead.
 
 If a future castxml release changes this (starts emitting a second
 element, or an equivalent using-shadow back-reference), these tests
@@ -69,7 +82,8 @@ from xml.etree.ElementTree import Element, parse as et_parse
 
 import pytest
 
-from abicheck.dumper import _CastxmlParser
+from abicheck.dumper import _CastxmlParser, dump
+from abicheck.model import AbiSnapshot
 
 pytestmark = pytest.mark.integration
 
@@ -147,6 +161,29 @@ def _namespace_members(root: Element, name: str) -> set[str]:
     raise AssertionError(f"no <Namespace name={name!r}> element in castxml output")
 
 
+# Substrings a hypothetical future using-shadow/back-reference tag would
+# plausibly carry (mirroring clang's own `UsingDecl`/`UsingShadowDecl`
+# naming). Not exhaustive by construction — a tag name outside this
+# vocabulary would still slip through — but it's a real, cheap check this
+# suite didn't have before, and it's what actually makes the "raw XML"
+# layer's fail-loudly claim true for the shape of change most likely to be
+# made (castxml adopting clang's own vocabulary for the construct).
+_ALIAS_TAG_SUBSTRINGS = ("using", "alias", "shadow")
+
+
+def _assert_no_alias_shaped_tags(root: Element) -> None:
+    tags = {el.tag for el in root.iter()}
+    suspicious = {
+        tag for tag in tags if any(s in tag.lower() for s in _ALIAS_TAG_SUBSTRINGS)
+    }
+    assert not suspicious, (
+        f"castxml output now contains alias-shaped tag(s) {suspicious!r} "
+        "that this test's Variable/Struct-only counts don't account for — "
+        "re-derive this test (and AGENTS.md's 'Option (b) closed' note) "
+        "against the new schema"
+    )
+
+
 class TestUsingReexportDoesNotDuplicateAgainstRealCastxml:
     def test_reexported_constant_is_not_duplicated(self, tmp_path: Path) -> None:
         root, parser = _run_castxml(
@@ -177,6 +214,7 @@ class TestUsingReexportDoesNotDuplicateAgainstRealCastxml:
         # a second, independent declaration.
         assert var_id in _namespace_members(root, "v1")
         assert var_id in _namespace_members(root, "detail")
+        _assert_no_alias_shaped_tags(root)
 
         # --- Parser layer ----------------------------------------------------
         constants = parser.parse_constants()
@@ -212,10 +250,92 @@ class TestUsingReexportDoesNotDuplicateAgainstRealCastxml:
         assert struct_id is not None
         assert struct_id in _namespace_members(root, "v1")
         assert struct_id in _namespace_members(root, "detail")
+        _assert_no_alias_shaped_tags(root)
 
         # --- Parser layer ----------------------------------------------------
         types = parser.parse_types()
         names = [t.qualified_name or t.name for t in types if "range" in (t.name or "")]
         # Exactly one `range` record, qualified under `v1` — never a second
         # one reachable only as `detail::range`.
+        assert names == ["detail::v1::range"]
+
+
+class TestUsingReexportAgainstProductionDumpPath:
+    """The identical constructs, this time through the real ``dump()``
+    entry point (a compiled ``.so`` + ``header_backend="castxml"``) rather
+    than a hand-invoked castxml command — so aggregate-header construction,
+    compiler *resolution* (not just the emulation flag), and the
+    supported-version gate are all exercised for real, the way
+    ``TestUsingReexportDoesNotDuplicateAgainstRealCastxml`` above cannot
+    (it hand-invokes castxml specifically to inspect the raw XML, which
+    ``dump()`` does not expose)."""
+
+    def _dump_via_production_path(
+        self, tmp_path: Path, header_source: str
+    ) -> AbiSnapshot:
+        if shutil.which("castxml") is None:
+            pytest.skip("castxml not installed")
+        cc = _resolve_castxml_cc()
+        if cc is None:
+            pytest.skip("no g++ or cl.exe on PATH to compile the fixture library")
+        cc_id, cc_bin = cc
+        if cc_id != "gnu":
+            # Compiling the tiny fixture .so below uses a hardcoded g++
+            # invocation (mirroring the established pattern in
+            # test_castxml_clang_parity_gate.py); an MSVC-only host (no
+            # g++/MinGW) can still run the raw-XML tests above via cl.exe,
+            # but building a real .so here needs its own MSVC-specific
+            # compile step this test doesn't attempt.
+            pytest.skip(
+                "compiling the fixture .so here needs g++, not just castxml-cc-msvc"
+            )
+        header = tmp_path / "lib.hpp"
+        header.write_text(textwrap.dedent(header_source))
+        src = tmp_path / "lib.cpp"
+        src.write_text('#include "lib.hpp"\n')
+        so = tmp_path / "liblib.so"
+        subprocess.run(
+            [cc_bin, "-shared", "-fPIC", "-o", str(so), str(src), f"-I{tmp_path}"],
+            check=True,
+            capture_output=True,
+            timeout=_CASTXML_TIMEOUT_SECONDS,
+        )
+        return dump(so, [header], header_backend="castxml")
+
+    def test_reexported_constant_is_not_duplicated(self, tmp_path: Path) -> None:
+        snapshot = self._dump_via_production_path(
+            tmp_path,
+            """
+            namespace detail {
+            namespace v1 {
+            constexpr int cpu_feature_map = 42;
+            }
+            using v1::cpu_feature_map;
+            }
+            """,
+        )
+        assert snapshot.constants.get("detail::v1::cpu_feature_map") == "42"
+        assert "detail::cpu_feature_map" not in snapshot.constants
+        assert sum(1 for k in snapshot.constants if "cpu_feature_map" in k) == 1
+
+    def test_reexported_type_is_not_duplicated(self, tmp_path: Path) -> None:
+        snapshot = self._dump_via_production_path(
+            tmp_path,
+            """
+            namespace detail {
+            namespace v1 {
+            struct range {
+                int lo;
+                int hi;
+            };
+            }
+            using v1::range;
+            }
+            """,
+        )
+        names = [
+            t.qualified_name or t.name
+            for t in snapshot.types
+            if "range" in (t.name or "")
+        ]
         assert names == ["detail::v1::range"]

--- a/tests/test_castxml_using_reexport.py
+++ b/tests/test_castxml_using_reexport.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""G31 Phase C closure — using-declaration re-export vs. real castxml XML.
+
+``AGENTS.md``'s "Known gaps" section documented a reported (but, at the
+time, unverified — no castxml binary was available in that environment)
+mechanism: a using-declaration re-exporting a namespace-scope constant or
+type (``namespace v1 { constexpr int x = 1; } using v1::x;``) was believed
+to make castxml emit *two* full ``<Variable>``/``<Struct>`` XML elements —
+one under the original namespace, one under the re-exporting namespace —
+which ``dumper_castxml.py``'s flat, once-per-element iteration
+(``_iter_public_constants``/``parse_types``) would then read as two
+independent, same-valued declarations.
+
+This locks in the finding from actually reproducing that construct against
+a real, policy-conformant castxml build (``>=0.6.11,<0.8.0`` per
+``castxml_policy.py``): castxml emits exactly **one** element for the
+target declaration, shared by *both* namespaces' ``<Namespace
+members="...">`` attribute — never a duplicate. So the alias spelling
+(``detail::cpu_feature_map``/``detail::range`` below) never enters the
+snapshot at all; the failure mode is a silent false negative, matching
+the direct-clang backend's already-documented behavior for the identical
+construct, not the "castxml over-reports" asymmetry originally reported.
+
+If a future castxml release changes this (starts emitting a second
+element, or an equivalent using-shadow back-reference), these tests
+should start failing loudly rather than silently keeping the codebase's
+prose out of sync with reality — see AGENTS.md's "Option (b) closed" note
+for the full reasoning and what a real fix would need.
+"""
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+from xml.etree.ElementTree import parse as et_parse
+
+import pytest
+
+from abicheck.dumper import _CastxmlParser
+
+pytestmark = pytest.mark.integration
+
+
+def _run_castxml(tmp_path: Path, source: str) -> _CastxmlParser:
+    if shutil.which("castxml") is None:
+        pytest.skip("castxml not installed")
+    header = tmp_path / "lib.hpp"
+    header.write_text(textwrap.dedent(source))
+    xml_path = tmp_path / "lib.xml"
+    proc = subprocess.run(
+        [
+            "castxml",
+            "--castxml-output=1",
+            "-std=c++17",
+            str(header),
+            "-o",
+            str(xml_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"castxml failed: {proc.stderr}"
+    root = et_parse(str(xml_path)).getroot()
+    return _CastxmlParser(
+        root,
+        exported_dynamic=set(),
+        exported_static=set(),
+        public_header_paths=[str(header)],
+    )
+
+
+class TestUsingReexportDoesNotDuplicateAgainstRealCastxml:
+    def test_reexported_constant_is_not_duplicated(self, tmp_path: Path) -> None:
+        parser = _run_castxml(
+            tmp_path,
+            """
+            namespace detail {
+            namespace v1 {
+            constexpr int cpu_feature_map = 42;
+            }
+            using v1::cpu_feature_map;
+            }
+            """,
+        )
+        constants = parser.parse_constants()
+        # The original (versioned-namespace) spelling is captured...
+        assert constants.get("detail::v1::cpu_feature_map") == "42"
+        # ...but the using-declaration alias is NOT a second, independent
+        # entry — it is simply absent (a false negative, not a duplicate
+        # key). This is the behavior this test locks in: exactly one
+        # entry for this declaration, not two.
+        assert "detail::cpu_feature_map" not in constants
+        assert sum(1 for k in constants if "cpu_feature_map" in k) == 1
+
+    def test_reexported_type_is_not_duplicated(self, tmp_path: Path) -> None:
+        parser = _run_castxml(
+            tmp_path,
+            """
+            namespace detail {
+            namespace v1 {
+            struct range {
+                int lo;
+                int hi;
+            };
+            }
+            using v1::range;
+            }
+            """,
+        )
+        types = parser.parse_types()
+        names = [t.qualified_name or t.name for t in types if "range" in (t.name or "")]
+        # Exactly one `range` record, qualified under `v1` — never a second
+        # one reachable only as `detail::range`.
+        assert names == ["detail::v1::range"]

--- a/tests/test_castxml_using_reexport.py
+++ b/tests/test_castxml_using_reexport.py
@@ -78,25 +78,46 @@ pytestmark = pytest.mark.integration
 _CASTXML_TIMEOUT_SECONDS = 60
 
 
+def _resolve_castxml_cc() -> tuple[str, str] | None:
+    """Pick a real ``(cc_id, cc_bin)`` pair to emulate, mirroring
+    ``dumper_ast_config._resolve_cc``'s own "msvc if cl.exe, else gnu" rule
+    — not just Linux/macOS's g++. The Windows leg of the ``integration-tests``
+    CI matrix installs castxml + MSVC's ``cl.exe`` but no g++/MinGW (see
+    ``.github/workflows/ci.yml``), so hardcoding ``g++`` here would break
+    that required leg. Returns ``None`` when neither compiler is on PATH,
+    so the caller can skip instead of invoking a missing executable.
+    """
+    if shutil.which("g++") is not None:
+        return "gnu", "g++"
+    if shutil.which("cl") is not None:
+        return "msvc", "cl"
+    return None
+
+
 def _run_castxml(tmp_path: Path, source: str) -> tuple[Element, _CastxmlParser]:
     """Run real castxml on *source* and return both the raw XML root and a
     ``_CastxmlParser`` over it, so tests can assert on either layer."""
     if shutil.which("castxml") is None:
         pytest.skip("castxml not installed")
+    cc = _resolve_castxml_cc()
+    if cc is None:
+        pytest.skip("no g++ or cl.exe on PATH to drive castxml's compiler emulation")
+    cc_id, cc_bin = cc
     header = tmp_path / "lib.hpp"
     header.write_text(textwrap.dedent(source))
     xml_path = tmp_path / "lib.xml"
     # Mirrors `_build_castxml_command`'s real compiler-emulation flag
-    # (`--castxml-cc-gnu g++`) rather than castxml's bare default, so this
-    # reproduces the exact XML shape the production dump path sees.
+    # (`--castxml-cc-<id> <bin>`) rather than castxml's bare default, so
+    # this reproduces the exact XML shape the production dump path sees.
+    std_flag = "/std:c++17" if cc_id == "msvc" else "-std=c++17"
     try:
         proc = subprocess.run(
             [
                 "castxml",
                 "--castxml-output=1",
-                "--castxml-cc-gnu",
-                "g++",
-                "-std=c++17",
+                f"--castxml-cc-{cc_id}",
+                cc_bin,
+                std_flag,
                 str(header),
                 "-o",
                 str(xml_path),

--- a/tests/test_castxml_using_reexport.py
+++ b/tests/test_castxml_using_reexport.py
@@ -27,13 +27,30 @@ independent, same-valued declarations.
 
 This locks in the finding from actually reproducing that construct against
 a real, policy-conformant castxml build (``>=0.6.11,<0.8.0`` per
-``castxml_policy.py``): castxml emits exactly **one** element for the
-target declaration, shared by *both* namespaces' ``<Namespace
-members="...">`` attribute — never a duplicate. So the alias spelling
+``castxml_policy.py``), invoked the same way ``_build_castxml_command``
+invokes it (``--castxml-cc-gnu g++`` compiler emulation, not castxml's bare
+default): castxml emits exactly **one** element for the target
+declaration, shared by *both* namespaces' ``<Namespace members="...">``
+attribute — never a duplicate. So the alias spelling
 (``detail::cpu_feature_map``/``detail::range`` below) never enters the
 snapshot at all; the failure mode is a silent false negative, matching
 the direct-clang backend's already-documented behavior for the identical
 construct, not the "castxml over-reports" asymmetry originally reported.
+
+Two independent layers are checked per case, so a future castxml release
+that changes this is caught either way:
+
+1. The **raw XML** itself — the exact element count for the tag in
+   question, and that the single element's id is listed in *both*
+   namespaces' own ``members=`` attribute. This is deliberately not
+   routed through ``_CastxmlParser`` at all: if a future castxml starts
+   emitting an equivalent using-shadow/back-reference element under some
+   *other* tag name (not ``Variable``/``Struct``), this raw check does not
+   see it and only the parser-level check below would catch it via a
+   changed constant/type count.
+2. The **parser-level result** (``parse_constants()``/``parse_types()``),
+   confirming the flat-iteration behavior ``dumper_castxml.py`` actually
+   exhibits reads through correctly to the model.
 
 If a future castxml release changes this (starts emitting a second
 element, or an equivalent using-shadow back-reference), these tests
@@ -41,13 +58,14 @@ should start failing loudly rather than silently keeping the codebase's
 prose out of sync with reality — see AGENTS.md's "Option (b) closed" note
 for the full reasoning and what a real fix would need.
 """
+
 from __future__ import annotations
 
 import shutil
 import subprocess
 import textwrap
 from pathlib import Path
-from xml.etree.ElementTree import parse as et_parse
+from xml.etree.ElementTree import Element, parse as et_parse
 
 import pytest
 
@@ -55,38 +73,62 @@ from abicheck.dumper import _CastxmlParser
 
 pytestmark = pytest.mark.integration
 
+# Bounds the castxml invocation below so a hung process fails the test
+# instead of blocking the integration job indefinitely.
+_CASTXML_TIMEOUT_SECONDS = 60
 
-def _run_castxml(tmp_path: Path, source: str) -> _CastxmlParser:
+
+def _run_castxml(tmp_path: Path, source: str) -> tuple[Element, _CastxmlParser]:
+    """Run real castxml on *source* and return both the raw XML root and a
+    ``_CastxmlParser`` over it, so tests can assert on either layer."""
     if shutil.which("castxml") is None:
         pytest.skip("castxml not installed")
     header = tmp_path / "lib.hpp"
     header.write_text(textwrap.dedent(source))
     xml_path = tmp_path / "lib.xml"
-    proc = subprocess.run(
-        [
-            "castxml",
-            "--castxml-output=1",
-            "-std=c++17",
-            str(header),
-            "-o",
-            str(xml_path),
-        ],
-        capture_output=True,
-        text=True,
-    )
+    # Mirrors `_build_castxml_command`'s real compiler-emulation flag
+    # (`--castxml-cc-gnu g++`) rather than castxml's bare default, so this
+    # reproduces the exact XML shape the production dump path sees.
+    try:
+        proc = subprocess.run(
+            [
+                "castxml",
+                "--castxml-output=1",
+                "--castxml-cc-gnu",
+                "g++",
+                "-std=c++17",
+                str(header),
+                "-o",
+                str(xml_path),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=_CASTXML_TIMEOUT_SECONDS,
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(f"castxml did not finish within {_CASTXML_TIMEOUT_SECONDS}s: {exc}")
     assert proc.returncode == 0, f"castxml failed: {proc.stderr}"
     root = et_parse(str(xml_path)).getroot()
-    return _CastxmlParser(
+    parser = _CastxmlParser(
         root,
         exported_dynamic=set(),
         exported_static=set(),
         public_header_paths=[str(header)],
     )
+    return root, parser
+
+
+def _namespace_members(root: Element, name: str) -> set[str]:
+    """The ``members`` id set of the ``<Namespace name="...">`` element."""
+    for el in root.iter("Namespace"):
+        if el.get("name") == name:
+            return set((el.get("members") or "").split())
+    raise AssertionError(f"no <Namespace name={name!r}> element in castxml output")
 
 
 class TestUsingReexportDoesNotDuplicateAgainstRealCastxml:
     def test_reexported_constant_is_not_duplicated(self, tmp_path: Path) -> None:
-        parser = _run_castxml(
+        root, parser = _run_castxml(
             tmp_path,
             """
             namespace detail {
@@ -97,6 +139,25 @@ class TestUsingReexportDoesNotDuplicateAgainstRealCastxml:
             }
             """,
         )
+
+        # --- Raw XML layer -------------------------------------------------
+        # Exactly one <Variable name="cpu_feature_map"> element, full stop —
+        # not two, regardless of what tag a future castxml might otherwise
+        # use for an alias.
+        variable_els = [
+            el for el in root.iter("Variable") if el.get("name") == "cpu_feature_map"
+        ]
+        assert len(variable_els) == 1
+        var_id = variable_els[0].get("id")
+        assert var_id is not None
+        # That single element is shared: both `v1` (its declaring namespace)
+        # and `detail` (the using-declaration's enclosing namespace) list
+        # the same id in their own `members=` attribute — a reference, not
+        # a second, independent declaration.
+        assert var_id in _namespace_members(root, "v1")
+        assert var_id in _namespace_members(root, "detail")
+
+        # --- Parser layer ----------------------------------------------------
         constants = parser.parse_constants()
         # The original (versioned-namespace) spelling is captured...
         assert constants.get("detail::v1::cpu_feature_map") == "42"
@@ -108,7 +169,7 @@ class TestUsingReexportDoesNotDuplicateAgainstRealCastxml:
         assert sum(1 for k in constants if "cpu_feature_map" in k) == 1
 
     def test_reexported_type_is_not_duplicated(self, tmp_path: Path) -> None:
-        parser = _run_castxml(
+        root, parser = _run_castxml(
             tmp_path,
             """
             namespace detail {
@@ -122,6 +183,16 @@ class TestUsingReexportDoesNotDuplicateAgainstRealCastxml:
             }
             """,
         )
+
+        # --- Raw XML layer -------------------------------------------------
+        struct_els = [el for el in root.iter("Struct") if el.get("name") == "range"]
+        assert len(struct_els) == 1
+        struct_id = struct_els[0].get("id")
+        assert struct_id is not None
+        assert struct_id in _namespace_members(root, "v1")
+        assert struct_id in _namespace_members(root, "detail")
+
+        # --- Parser layer ----------------------------------------------------
         types = parser.parse_types()
         names = [t.qualified_name or t.name for t in types if "range" in (t.name or "")]
         # Exactly one `range` record, qualified under `v1` — never a second


### PR DESCRIPTION
## Summary

Closes the previously-unverified "castxml duplicates a using-declaration re-export" hypothesis documented in `AGENTS.md`'s Known Gaps section (G31 Phase C), by installing a real, policy-conformant castxml build and reproducing the construct directly.

## Motivation

`AGENTS.md` documented a reported (but unverified — no castxml binary was available in that environment) mechanism: a using-declaration re-exporting a namespace-scope constant or type was believed to make castxml emit two full XML elements, causing double-reporting. This blocked closing that part of Phase C's investigation.

## Changes

- Installed castxml 0.7.0 via conda-forge (micromamba), within the repo's supported policy range (`>=0.6.11,<0.8.0` per `castxml_policy.py`), bundled Clang 20.1.8.
- Reproduced `namespace detail { namespace v1 { constexpr int cpu_feature_map = 42; } using v1::cpu_feature_map; }` (and the analogous type case) against real castxml, using the exact invocation shape `_build_castxml_command` builds (`--castxml-cc-gnu g++`).
- **Finding:** castxml does **not** emit a duplicate `<Variable>`/`<Struct>` element for this construct — it emits exactly one element, shared by both namespaces' `<Namespace members="...">` lists. This contradicts the originally-reported over-reporting mechanism: both header backends (castxml and direct-clang) fail the *same* way on this construct (a silent false negative — the alias spelling never enters the snapshot), not in opposite directions as previously documented.
- Updated `AGENTS.md`'s Known Gaps entry with this verified finding and its implications for a future fix (the reverted name-shape heuristics remain correctly reverted regardless; a future fix should target the clang-side `UsingShadowDecl.target` identity rather than a castxml-side dedup).
- Added `tests/test_castxml_using_reexport.py` (`integration`-marked), locking in the verified behavior against real castxml so a future castxml release change fails loudly instead of leaving the docs silently stale.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — N/A, no `abicheck/**/*.py` changes (docs + tests only)
- [x] Docs updated if user-visible behaviour changed — `AGENTS.md` updated
- [x] `pre-commit run --all-files` passes locally — `ruff check`, `ruff format --check`, `mypy abicheck/` all clean
- [x] No new `mypy` or `ruff` errors introduced

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qy9TdMQzqecTq1AGoCnD1F)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration coverage for using-declaration re-exports with CastXML.
  * Verified that re-exported constants and types are represented once, without duplicate declarations.
  * Tests run when CastXML is available and validate parsed XML behavior.

* **Documentation**
  * Updated known-gap documentation to clarify current alias-handling behavior and limitations.
  * Recorded directions for future improvements to preserve accurate declaration identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->