### PR TITLE
fix: populate BuildEvidence.targets on zero-config Bazel --sources scans

### DIFF
--- a/abicheck/buildsource/build_query.py
+++ b/abicheck/buildsource/build_query.py
@@ -814,6 +814,7 @@ def run_inferred_build_query(
             return None
         if not _resolve_query_launcher(cmd, system, which, extractors):
             return None
+        query_start = time.monotonic()
         proc = _run_query_process(cmd, system, sources, timeout, merged, extractors)
         if proc is None:
             return None
@@ -823,12 +824,27 @@ def run_inferred_build_query(
         # zero-config `--sources` path previously always reported 0 targets
         # regardless of workspace contents. Run after the primary query so a
         # cquery failure never affects whether the primary aquery evidence
-        # (compile/link units) is merged.
-        cquery_stdout = (
-            _run_bazel_cquery_supplement(sources, timeout, which, merged)
-            if system == "bazel"
-            else None
-        )
+        # (compile/link units) is merged. Shares *timeout*'s budget with the
+        # aquery call just completed rather than getting its own fresh
+        # allotment: without an active scan --budget (deadline.remaining() is
+        # None), each of `_run_query_process`/`_run_bazel_cquery_supplement`
+        # would otherwise independently cap at the full local `timeout`
+        # default, so a slow aquery followed by a hung cquery could still
+        # block for nearly 2x INFERRED_QUERY_TIMEOUT_S (Codex review). A
+        # remaining budget that's already exhausted skips the supplement
+        # outright rather than handing `run_bounded` a non-positive timeout.
+        cquery_remaining = max(0.0, timeout - (time.monotonic() - query_start))
+        cquery_stdout: str | None = None
+        if system == "bazel":
+            if cquery_remaining > 0:
+                cquery_stdout = _run_bazel_cquery_supplement(
+                    sources, cquery_remaining, which, merged
+                )
+            else:
+                merged.diagnostics.append(
+                    "build_query_auto: bazel cquery supplement skipped — "
+                    "aquery already used the full inferred-query timeout budget"
+                )
         return _merge_query_result(
             proc,
             system,

--- a/abicheck/buildsource/build_query.py
+++ b/abicheck/buildsource/build_query.py
@@ -650,6 +650,10 @@ def _run_bazel_cquery_supplement(
     if cmd[0] == "bazel" and which("bazel") is None and which("bazelisk") is not None:
         cmd[0] = "bazelisk"
     if not _query_tool_available(cmd[0], which):
+        merged.diagnostics.append(
+            f"build_query_auto: bazel cquery supplement unavailable: "
+            f"`{cmd[0]}` is not installed"
+        )
         return None
     scan_remaining = deadline.remaining()
     effective_timeout = (
@@ -835,7 +839,12 @@ def run_inferred_build_query(
         # outright rather than handing `run_bounded` a non-positive timeout.
         cquery_remaining = max(0.0, timeout - (time.monotonic() - query_start))
         cquery_stdout: str | None = None
-        if system == "bazel":
+        # A nonzero aquery exit is handled by `_merge_query_result` below as a
+        # `failed` extractor record without ever looking at `cquery_stdout` --
+        # running the supplement in that case would spend up to the whole
+        # remaining budget on a result that's guaranteed to be discarded
+        # (Codex review).
+        if system == "bazel" and proc.returncode == 0:
             if cquery_remaining > 0:
                 cquery_stdout = _run_bazel_cquery_supplement(
                     sources, cquery_remaining, which, merged

--- a/abicheck/buildsource/build_query.py
+++ b/abicheck/buildsource/build_query.py
@@ -347,6 +347,28 @@ def inferred_query_command(
     return None
 
 
+def inferred_bazel_cquery_command() -> list[str]:
+    """The fixed, abicheck-authored ``bazel cquery`` companion to the aquery
+    command above.
+
+    Zero-config ``--sources`` on a Bazel workspace previously only ever ran
+    ``bazel aquery`` — never ``cquery`` — so ``BuildEvidence.targets`` stayed
+    empty no matter what the workspace contained: verified directly against
+    :class:`~.adapters.bazel.BazelAdapter`, whose ``_collect_cquery`` method
+    is the *only* one that ever appends to ``ev.targets`` (``_collect_aquery``
+    only ever populates ``compile_units``/``link_units``). This mirrors that
+    gap the same way an explicit ``--build-info`` bazel-cquery/-aquery pair
+    already can (see ``BazelAdapter.__init__``'s ``cquery=``/``aquery=``
+    parameters), scoped to the identical ``deps(//...)`` universe the aquery
+    command above resolves so the two stay consistent with each other. No
+    ``--include_param_files``: unlike aquery's action argv (which spills
+    long command lines to ``@params`` files that must be expanded to see
+    real source/flag content), cquery's jsonproto already carries each
+    target's fields inline.
+    """
+    return ["bazel", "cquery", "--output=jsonproto", "deps(//...)"]
+
+
 @dataclass(frozen=True)
 class _MakeLauncher:
     """Resolved GNU Make executable plus the user-facing spelling we probed."""
@@ -607,6 +629,61 @@ def _ingest_make_dry_run_transcript(
         merged.diagnostics.append(f"build_query_auto: make ingest failed ({exc})")
 
 
+def _run_bazel_cquery_supplement(
+    sources: Path,
+    timeout: float,
+    which: Callable[[str], str | None],
+    merged: BuildEvidence,
+) -> str | None:
+    """Best-effort ``bazel cquery`` companion to the aquery query above.
+
+    Returns the cquery stdout on success, or ``None`` on any failure (missing
+    tool, timeout, non-zero exit, subprocess error). Deliberately silent on
+    failure rather than appending a ``failed`` :class:`ExtractorRecord`: this
+    is a *supplement* to the aquery-derived compile/link evidence (it only
+    ever adds ``BuildEvidence.targets``), never the primary signal, so its
+    own failure must not demote an otherwise-successful aquery ingest from
+    ``ok``/``partial`` to ``failed``. Still recorded as a diagnostic so the
+    miss is visible without changing the extractor's own status.
+    """
+    cmd = inferred_bazel_cquery_command()
+    if cmd[0] == "bazel" and which("bazel") is None and which("bazelisk") is not None:
+        cmd[0] = "bazelisk"
+    if not _query_tool_available(cmd[0], which):
+        return None
+    scan_remaining = deadline.remaining()
+    effective_timeout = (
+        timeout if scan_remaining is None else min(timeout, scan_remaining)
+    )
+    try:
+        with deadline.deadline_scope(effective_timeout):
+            proc = deadline.run_bounded(  # noqa: S603 - fixed abicheck-authored argv, shell=False
+                cmd,
+                cwd=str(sources),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                timeout=timeout,
+            )
+    except deadline.DeadlineExceeded as exc:
+        merged.diagnostics.append(
+            f"build_query_auto: bazel cquery supplement aborted: scan deadline exceeded ({exc})"
+        )
+        return None
+    except (OSError, subprocess.SubprocessError) as exc:
+        merged.diagnostics.append(
+            f"build_query_auto: bazel cquery supplement failed to run: {exc}"
+        )
+        return None
+    if proc.returncode != 0:
+        merged.diagnostics.append(
+            f"build_query_auto: bazel cquery supplement exited {proc.returncode}: "
+            f"{(proc.stderr or '').strip()[:200]}"
+        )
+        return None
+    return str(proc.stdout)
+
+
 def _merge_query_result(
     proc: subprocess.CompletedProcess[str],
     system: str,
@@ -614,6 +691,8 @@ def _merge_query_result(
     merged: BuildEvidence,
     extractors: list[ExtractorRecord],
     build_dir: Path | None,
+    *,
+    cquery_stdout: str | None = None,
 ) -> Path | None:
     """Merge a completed inferred query into *merged*, recording failures as diagnostics."""
     if proc.returncode != 0 and system == "make":
@@ -646,6 +725,7 @@ def _merge_query_result(
             merged,
             extractors,
             build_dir=build_dir,
+            cquery_stdout=cquery_stdout,
         )
     except (OSError, ValueError, KeyError, TypeError) as exc:
         extractors.append(
@@ -737,7 +817,27 @@ def run_inferred_build_query(
         proc = _run_query_process(cmd, system, sources, timeout, merged, extractors)
         if proc is None:
             return None
-        return _merge_query_result(proc, system, sources, merged, extractors, build_dir)
+        # Bazel gets a second, best-effort `cquery` run alongside the primary
+        # `aquery` above: aquery alone never populates `BuildEvidence.targets`
+        # (only BazelAdapter's cquery-processing method does), so the
+        # zero-config `--sources` path previously always reported 0 targets
+        # regardless of workspace contents. Run after the primary query so a
+        # cquery failure never affects whether the primary aquery evidence
+        # (compile/link units) is merged.
+        cquery_stdout = (
+            _run_bazel_cquery_supplement(sources, timeout, which, merged)
+            if system == "bazel"
+            else None
+        )
+        return _merge_query_result(
+            proc,
+            system,
+            sources,
+            merged,
+            extractors,
+            build_dir,
+            cquery_stdout=cquery_stdout,
+        )
     finally:
         _schedule_build_dir_release(build_dir, release, cleanup)
 
@@ -750,6 +850,8 @@ def _ingest_query_output(
     extractors: list[ExtractorRecord],
     build_dir: Path | None = None,
     query_returncode: int = 0,
+    *,
+    cquery_stdout: str | None = None,
 ) -> Path | None:
     """Parse a successful query's output and merge it into *merged* (returns None).
 
@@ -795,18 +897,39 @@ def _ingest_query_output(
         ) as tf:
             tf.write(stdout)
             aq = Path(tf.name)
+        cq: Path | None = None
+        if cquery_stdout:
+            with tempfile.NamedTemporaryFile(
+                "w", suffix=".cquery.json", delete=False
+            ) as tf2:
+                tf2.write(cquery_stdout)
+                cq = Path(tf2.name)
         try:
             # workspace=sources anchors the aquery's relative source/include
-            # paths to the tree so source matching + L4 replay resolve.
-            ev = BazelAdapter(aquery=aq, workspace=sources, allow_query=False).collect()
+            # paths to the tree so source matching + L4 replay resolve. cq is
+            # None when the best-effort cquery supplement didn't produce
+            # output (BazelAdapter treats a None cquery as simply "no
+            # cquery evidence", same as an explicit --build-info aquery-only
+            # pack) — ev.targets then stays empty, same as before this fix.
+            ev = BazelAdapter(
+                aquery=aq, cquery=cq, workspace=sources, allow_query=False
+            ).collect()
         finally:
             aq.unlink(missing_ok=True)
+            if cq is not None:
+                cq.unlink(missing_ok=True)
         merged.merge(ev)
+        detail = f"auto-ran `bazel aquery`; {len(ev.compile_units)} compile unit(s)"
+        detail += (
+            f", `bazel cquery`; {len(ev.targets)} target(s)"
+            if cq is not None
+            else "; bazel cquery supplement unavailable, 0 target(s)"
+        )
         extractors.append(
             ExtractorRecord(
                 name="build_query_auto",
                 status="ok" if ev.compile_units else "partial",
-                detail=f"auto-ran `bazel aquery`; {len(ev.compile_units)} compile unit(s)",
+                detail=detail,
             )
         )
         return None

--- a/changelog.d/20260813_221329_noreply_abicheck_bazel_lab_architecture_drehqu.md
+++ b/changelog.d/20260813_221329_noreply_abicheck_bazel_lab_architecture_drehqu.md
@@ -1,0 +1,23 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Fixed
+
+- **Zero-config Bazel `--sources` scans now populate `BuildEvidence.targets`** —
+  the auto-inference path (`buildsource/build_query.py`) previously only ever
+  ran `bazel aquery` for a detected Bazel workspace, which never populates
+  `BuildEvidence.targets` (only `BazelAdapter`'s `cquery`-processing method
+  does), so a plain `dump --sources`/`compare --sources` against a Bazel
+  checkout always reported zero resolved targets no matter what the
+  workspace contained. A second, best-effort `bazel cquery --output=jsonproto
+  deps(//...)` now runs alongside the existing aquery, and both are merged
+  through the same `BazelAdapter` call an explicit `--build-info`
+  bazel-cquery/-aquery pair already uses. The cquery run is a pure
+  supplement — a launcher/timeout/parse failure only appends a diagnostic
+  and leaves `targets` empty, never demoting the aquery-derived
+  compile/link-unit ingest from `ok`/`partial` to `failed`.

--- a/tests/test_build_query_inference.py
+++ b/tests/test_build_query_inference.py
@@ -1338,6 +1338,38 @@ def test_cquery_supplement_skipped_when_aquery_exits_nonzero(
     assert ext[-1].status == "failed"
 
 
+def test_cquery_supplement_deadline_exceeded_degrades_to_diagnostic(
+    tmp_path: Path, monkeypatch
+):
+    from abicheck import deadline
+
+    def _raise(*_a, **_k):
+        raise deadline.DeadlineExceeded(-1.0)
+
+    monkeypatch.setattr(_bq.deadline, "run_bounded", _raise)
+    merged = BuildEvidence()
+    out = _bq._run_bazel_cquery_supplement(
+        tmp_path, 600.0, lambda tool: f"/usr/bin/{tool}", merged
+    )
+    assert out is None
+    assert any("cquery supplement aborted" in d for d in merged.diagnostics)
+
+
+def test_cquery_supplement_subprocess_error_degrades_to_diagnostic(
+    tmp_path: Path, monkeypatch
+):
+    def boom(*_a, **_k):
+        raise OSError("no bazel")
+
+    monkeypatch.setattr(_bq.deadline, "run_bounded", boom)
+    merged = BuildEvidence()
+    out = _bq._run_bazel_cquery_supplement(
+        tmp_path, 600.0, lambda tool: f"/usr/bin/{tool}", merged
+    )
+    assert out is None
+    assert any("cquery supplement failed to run" in d for d in merged.diagnostics)
+
+
 def test_collect_inline_pack_defers_build_dir_cleanup(tmp_path: Path, monkeypatch):
     # Fast-lane guard for the cleanup-lifetime contract (the real end-to-end check
     # lives in tests/test_scan_levels_integration.py): when a caller passes

--- a/tests/test_build_query_inference.py
+++ b/tests/test_build_query_inference.py
@@ -191,6 +191,24 @@ class _FakeProc:
         self.stderr = stderr
 
 
+def _fake_monotonic_sequence(*values):
+    """A ``time.monotonic`` stand-in yielding *values* in order, then repeating
+    the last one for any further call. Avoids over-fitting a test to the exact
+    number of ``time.monotonic()`` calls an implementation detail (like a
+    nested ``deadline.deadline_scope()``) happens to make."""
+    it = iter(values)
+    last = [values[-1]]
+
+    def _fake() -> float:
+        try:
+            last[0] = next(it)
+        except StopIteration:
+            pass
+        return last[0]
+
+    return _fake
+
+
 def test_run_cmake_ingests_out_of_tree_and_merges(tmp_path: Path, monkeypatch):
     # cmake configures into an OUT-OF-TREE temp dir (never under --sources); the
     # compile DB is ingested + merged and the temp dir removed. Returns None
@@ -1181,6 +1199,87 @@ def test_run_bazel_cquery_supplement_failure_does_not_demote_aquery_status(
     assert len(merged.compile_units) == 1
     assert ext[-1].status == "ok"  # aquery ingest still succeeds
     assert any("cquery supplement" in d for d in merged.diagnostics)
+
+
+def test_run_bazel_cquery_supplement_shares_timeout_budget_with_aquery(
+    tmp_path: Path, monkeypatch
+):
+    # Codex review, PR #751: without an active scan deadline, aquery and the
+    # cquery supplement must not each independently get their own full local
+    # `timeout` -- that could block for nearly 2x the default 600s ceiling.
+    # The supplement's own effective timeout is `timeout - elapsed(aquery)`,
+    # so a slow aquery leaves the supplement a correspondingly smaller share.
+    (tmp_path / "MODULE.bazel").write_text("module(name='x')\n")
+    seen_cquery_timeouts: list[float] = []
+
+    def fake_run(cmd, **kw):
+        if cmd[1] == "cquery":
+            seen_cquery_timeouts.append(kw["timeout"])
+            return _FakeProc(0, stdout='{"results": []}')
+        return _FakeProc(0, stdout='{"actions": []}')
+
+    # 1st call = query_start (0.0); 2nd call = the aquery-side
+    # `deadline.deadline_scope()` entry (irrelevant to the assertion, `run_bounded`
+    # itself is replaced above so it makes no further monotonic() calls of its
+    # own); 3rd call = the elapsed-time read back in run_inferred_build_query,
+    # simulating a 450s-slow aquery against a 600s local `timeout`. Any further
+    # call (e.g. the cquery-side deadline_scope entry) repeats the last value --
+    # by then the cquery timeout has already been computed and passed along.
+    monkeypatch.setattr(_bq.deadline, "run_bounded", fake_run)
+    monkeypatch.setattr(
+        _bq.time, "monotonic", _fake_monotonic_sequence(0.0, 0.0, 450.0)
+    )
+    merged, ext = BuildEvidence(), []
+    out = run_inferred_build_query(
+        tmp_path, merged, ext, which=lambda tool: f"/usr/bin/{tool}"
+    )
+    assert out is None
+    assert len(seen_cquery_timeouts) == 1
+    # Remaining budget is timeout(600) - elapsed(450) = 150, not a fresh 600.
+    assert seen_cquery_timeouts[0] == pytest.approx(150.0)
+
+
+def test_run_bazel_cquery_supplement_skipped_when_aquery_exhausts_budget(
+    tmp_path: Path, monkeypatch
+):
+    # When aquery alone already consumed the whole local timeout budget, the
+    # cquery supplement must be skipped outright (never handed a
+    # non-positive timeout) rather than attempted with 0s left.
+    (tmp_path / "MODULE.bazel").write_text("module(name='x')\n")
+    aquery_json = json.dumps(
+        {
+            "actions": [
+                {
+                    "mnemonic": "CppCompile",
+                    "arguments": ["/usr/bin/g++", "-c", "impl.cc", "-o", "impl.o"],
+                    "primaryOutputId": "1",
+                }
+            ],
+            "artifacts": [{"id": "1", "execPath": "impl.o"}],
+        }
+    )
+    called = {"cquery": False}
+
+    def fake_run(cmd, **kw):
+        if cmd[1] == "cquery":
+            called["cquery"] = True
+        return _FakeProc(0, stdout=aquery_json)
+
+    # Same call-position reasoning as the test above: 1st call = query_start,
+    # 2nd = the aquery-side deadline_scope entry (irrelevant), 3rd = the
+    # elapsed-time read -- here simulating an aquery that alone already used
+    # up (and exceeded) the whole 600s local `timeout`.
+    monkeypatch.setattr(_bq.deadline, "run_bounded", fake_run)
+    monkeypatch.setattr(
+        _bq.time, "monotonic", _fake_monotonic_sequence(0.0, 0.0, 10_000.0)
+    )
+    merged, ext = BuildEvidence(), []
+    out = run_inferred_build_query(
+        tmp_path, merged, ext, which=lambda tool: f"/usr/bin/{tool}"
+    )
+    assert out is None
+    assert called["cquery"] is False
+    assert any("budget" in d for d in merged.diagnostics)
 
 
 def test_collect_inline_pack_defers_build_dir_cleanup(tmp_path: Path, monkeypatch):

--- a/tests/test_build_query_inference.py
+++ b/tests/test_build_query_inference.py
@@ -1282,6 +1282,62 @@ def test_run_bazel_cquery_supplement_skipped_when_aquery_exhausts_budget(
     assert any("budget" in d for d in merged.diagnostics)
 
 
+def test_cquery_supplement_records_diagnostic_when_launcher_unavailable(
+    tmp_path: Path, monkeypatch
+):
+    # CodeRabbit review, PR #751: the missing-launcher branch previously
+    # returned silently -- record a diagnostic like every other cquery
+    # supplement failure path does. `which` reports `bazel` available for
+    # the two primary-aquery-side lookups (the launcher-swap check and
+    # _query_tool_available), then unavailable from the third call onward,
+    # simulating the launcher vanishing before the cquery supplement's own
+    # (separate) availability check runs.
+    (tmp_path / "MODULE.bazel").write_text("module(name='x')\n")
+    call_count = {"n": 0}
+
+    def fake_which(_tool):
+        call_count["n"] += 1
+        return "/usr/bin/bazel" if call_count["n"] <= 2 else None
+
+    monkeypatch.setattr(
+        _bq.deadline,
+        "run_bounded",
+        lambda cmd, **kw: _FakeProc(0, stdout='{"actions": []}'),
+    )
+    merged, ext = BuildEvidence(), []
+    out = run_inferred_build_query(tmp_path, merged, ext, which=fake_which)
+    assert out is None
+    assert merged.targets == []
+    assert any("cquery supplement unavailable" in d for d in merged.diagnostics)
+
+
+def test_cquery_supplement_skipped_when_aquery_exits_nonzero(
+    tmp_path: Path, monkeypatch
+):
+    # Codex review, PR #751: a nonzero aquery exit is handled by
+    # _merge_query_result as a `failed` extractor record without ever
+    # looking at cquery_stdout -- running the supplement in that case would
+    # spend up to the whole remaining budget on a result guaranteed to be
+    # discarded.
+    (tmp_path / "MODULE.bazel").write_text("module(name='x')\n")
+    called = {"cquery": False}
+
+    def fake_run(cmd, **kw):
+        if cmd[1] == "cquery":
+            called["cquery"] = True
+            return _FakeProc(0, stdout='{"results": []}')
+        return _FakeProc(1, stderr="analysis error")
+
+    monkeypatch.setattr(_bq.deadline, "run_bounded", fake_run)
+    merged, ext = BuildEvidence(), []
+    out = run_inferred_build_query(
+        tmp_path, merged, ext, which=lambda tool: f"/usr/bin/{tool}"
+    )
+    assert out is None
+    assert called["cquery"] is False
+    assert ext[-1].status == "failed"
+
+
 def test_collect_inline_pack_defers_build_dir_cleanup(tmp_path: Path, monkeypatch):
     # Fast-lane guard for the cleanup-lifetime contract (the real end-to-end check
     # lives in tests/test_scan_levels_integration.py): when a caller passes

--- a/tests/test_build_query_inference.py
+++ b/tests/test_build_query_inference.py
@@ -30,6 +30,7 @@ from abicheck.buildsource.build_evidence import BuildEvidence
 from abicheck.buildsource.build_query import (
     ABICHECK_BUILD_DIR,
     detect_build_system,
+    inferred_bazel_cquery_command,
     inferred_query_command,
     run_inferred_build_query,
 )
@@ -1078,6 +1079,108 @@ def test_run_bazel_empty_action_graph_is_partial(tmp_path: Path, monkeypatch):
     )
     assert ext[-1].name == "build_query_auto"
     assert ext[-1].status == "partial"  # no CppCompile actions
+
+
+def test_bazel_cquery_command_is_fixed_and_scoped(tmp_path: Path):
+    cmd = inferred_bazel_cquery_command()
+    assert cmd[:2] == ["bazel", "cquery"]
+    assert "--output=jsonproto" in cmd
+    assert cmd[-1] == "deps(//...)"
+    # No --include_param_files here: cquery's jsonproto carries target fields
+    # inline, unlike aquery's action argv which spills to @params files.
+    assert "--include_param_files" not in cmd
+
+
+def test_run_bazel_populates_targets_from_cquery_supplement(
+    tmp_path: Path, monkeypatch
+):
+    # Regression: zero-config `--sources` on a Bazel workspace previously only
+    # ever ran `bazel aquery`, which never populates BuildEvidence.targets —
+    # only BazelAdapter's cquery-processing method appends to `ev.targets`.
+    (tmp_path / "MODULE.bazel").write_text("module(name='x')\n")
+    aquery_json = json.dumps(
+        {
+            "actions": [
+                {
+                    "mnemonic": "CppCompile",
+                    "arguments": ["/usr/bin/g++", "-c", "impl.cc", "-o", "impl.o"],
+                    "primaryOutputId": "1",
+                }
+            ],
+            "artifacts": [{"id": "1", "execPath": "impl.o"}],
+        }
+    )
+    cquery_json = json.dumps(
+        {
+            "results": [
+                {
+                    "target": {
+                        "rule": {
+                            "name": "//:math",
+                            "ruleClass": "cc_library",
+                            "attribute": [
+                                {"name": "srcs", "stringListValue": ["impl.cc"]},
+                            ],
+                        }
+                    },
+                    "configurationId": "cfg1",
+                }
+            ]
+        }
+    )
+
+    def fake_run(cmd, **kw):
+        if cmd[1] == "cquery":
+            return _FakeProc(0, stdout=cquery_json)
+        return _FakeProc(0, stdout=aquery_json)
+
+    monkeypatch.setattr(_bq.deadline, "run_bounded", fake_run)
+    merged, ext = BuildEvidence(), []
+    out = run_inferred_build_query(
+        tmp_path, merged, ext, which=lambda tool: f"/usr/bin/{tool}"
+    )
+    assert out is None
+    assert len(merged.targets) == 1
+    assert merged.targets[0].id == "target:////:math"
+    assert ext[-1].status in ("ok", "partial")
+    assert "target(s)" in ext[-1].detail
+
+
+def test_run_bazel_cquery_supplement_failure_does_not_demote_aquery_status(
+    tmp_path: Path, monkeypatch
+):
+    # The cquery supplement is best-effort: its own failure must not turn an
+    # otherwise-successful aquery ingest into a "failed" extractor record —
+    # only a diagnostic, and BuildEvidence.targets simply stays empty.
+    (tmp_path / "MODULE.bazel").write_text("module(name='x')\n")
+    aquery_json = json.dumps(
+        {
+            "actions": [
+                {
+                    "mnemonic": "CppCompile",
+                    "arguments": ["/usr/bin/g++", "-c", "impl.cc", "-o", "impl.o"],
+                    "primaryOutputId": "1",
+                }
+            ],
+            "artifacts": [{"id": "1", "execPath": "impl.o"}],
+        }
+    )
+
+    def fake_run(cmd, **kw):
+        if cmd[1] == "cquery":
+            return _FakeProc(1, stderr="cquery boom")
+        return _FakeProc(0, stdout=aquery_json)
+
+    monkeypatch.setattr(_bq.deadline, "run_bounded", fake_run)
+    merged, ext = BuildEvidence(), []
+    out = run_inferred_build_query(
+        tmp_path, merged, ext, which=lambda tool: f"/usr/bin/{tool}"
+    )
+    assert out is None
+    assert merged.targets == []
+    assert len(merged.compile_units) == 1
+    assert ext[-1].status == "ok"  # aquery ingest still succeeds
+    assert any("cquery supplement" in d for d in merged.diagnostics)
 
 
 def test_collect_inline_pack_defers_build_dir_cleanup(tmp_path: Path, monkeypatch):


### PR DESCRIPTION
## Problem

`buildsource/build_query.py`'s zero-config `--sources` auto-inference path only ever ran `bazel aquery` for a detected Bazel workspace. `BuildEvidence.targets` is populated *only* by `BazelAdapter`'s cquery-processing method (`_collect_cquery`) — never by its aquery one (`_collect_aquery`, which only ever fills `compile_units`/`link_units`) — so a plain `dump --sources` / `compare --sources` against a Bazel checkout always reported zero resolved targets, no matter what the workspace actually contained.

This is exactly the gap [`abicheck-bazel-lab`](https://github.com/napetrov/abicheck-bazel-lab)'s `build_bazel_evidence_pack.py` script was built to work around for the explicit `--build-info` path (by constructing a `BazelAdapter` directly with both pre-captured cquery and aquery files) — that workaround is no longer necessary for the zero-config path once this lands.

## Fix

- `inferred_bazel_cquery_command()` — a fixed, abicheck-authored `bazel cquery --output=jsonproto deps(//...)`, scoped identically to the existing aquery command (same `deps(//...)` universe), so the two stay consistent.
- `_run_bazel_cquery_supplement()` — runs it as a second, independent subprocess alongside the existing aquery call in `run_inferred_build_query()`.
- Both results are merged through **one** `BazelAdapter(aquery=..., cquery=..., ...).collect()` call, mirroring how an explicit `--build-info` bazel-cquery/-aquery pair already combines both.

The cquery run is a pure supplement, never the primary signal:
- A missing launcher, timeout, non-zero exit, or parse failure only appends a diagnostic to `BuildEvidence.diagnostics` and leaves `targets` empty (the pre-existing behavior) — it never demotes the aquery-derived compile/link-unit ingest's own extractor status from `ok`/`partial` to `failed`.
- No `--include_param_files` on the cquery command (unlike aquery): cquery's jsonproto already carries each target's fields inline, unlike aquery's action argv which can spill to `@params` files.

## Testing

- Two new regression tests in `tests/test_build_query_inference.py`:
  - `test_run_bazel_populates_targets_from_cquery_supplement` — end-to-end, both aquery and cquery succeed, `BuildEvidence.targets` is populated.
  - `test_run_bazel_cquery_supplement_failure_does_not_demote_aquery_status` — cquery fails, aquery still succeeds, extractor status stays `ok`, `targets` stays empty, failure recorded only as a diagnostic.
  - Plus a command-shape test for `inferred_bazel_cquery_command()`.
- All 60 tests in `tests/test_build_query_inference.py` pass, including every pre-existing test (none needed changes — the existing single-response `fake_run` mocks return the same fixture for both the aquery and cquery calls, which the cquery-side parser degrades gracefully on).
- `tests/test_buildsource_inline_nodb.py` and `tests/test_bazel_adapter.py` pass (142 total across the three files).
- `mypy abicheck/` — clean (360 files).
- `ruff check` / `ruff format --check` — clean.
- `scripts/check_ai_readiness.py` — 0 errors.
- Changelog fragment added via `scriv create`.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019S6MjuZW7ineG3bboJTGBq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved zero-configuration Bazel source scans with supplemental target discovery.
  - Scan results now combine target information with existing compile and link evidence.
  - Added support for Bazelisk when running supplementary discovery.

- **Bug Fixes**
  - Supplementary discovery failures no longer reduce the status of successful primary scan results.
  - Improved timeout handling ensures scans respect the available execution time.

- **Documentation**
  - Added release documentation covering the enhanced Bazel scanning behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->