### PR TITLE
fix: stamp symbol_binding on visibility-hidden exports; disclose scan policy rules

### DIFF
--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -353,9 +353,12 @@ class Change:
     # precedent predates this dataclass's own instance of the same bug).
     vtable_covers_unverifiable_layout_gap: bool = field(default=False, kw_only=True)
     # ELF symbol linkage (Function.elf_binding / Variable.elf_binding's value
-    # string — "global"/"weak"/"local"/"unique"/"other") of the removed
-    # symbol, stamped by diff_symbols._check_removed_function/_var_removed on
-    # FUNC_REMOVED/FUNC_REMOVED_ELF_ONLY/VAR_REMOVED findings, and by
+    # string — "global"/"weak"/"local"/"unique"/"other") of the removed (or
+    # visibility-hidden) symbol, stamped by
+    # diff_symbols._check_removed_function/_var_removed on
+    # FUNC_REMOVED/FUNC_REMOVED_ELF_ONLY/VAR_REMOVED/FUNC_VISIBILITY_CHANGED
+    # findings (the old side's binding — still real ELF-linkage evidence for
+    # a symbol that went hidden, not just one that vanished outright), and by
     # diff_platform._diff_elf_deleted_fallback on FUNC_DELETED_ELF_FALLBACK
     # (the other common export-disappearance path — a function still
     # declared but silently absent from .dynsym). None for every other

--- a/abicheck/cli_scan_baseline.py
+++ b/abicheck/cli_scan_baseline.py
@@ -291,7 +291,11 @@ def _addition_finding_dicts(
         c for c in getattr(diff, "compatible", None) or ()
         if _change_kind_str(c) in _ADDITION_KIND_VALUES
     ]
-    dicts = _baseline_finding_dicts(addition_changes[:cap], "compatible")
+    dicts = _baseline_finding_dicts(
+        addition_changes[:cap],
+        "compatible",
+        policy_file=getattr(diff, "policy_file", None),
+    )
     return dicts, len(addition_changes) > len(dicts), len(addition_changes)
 
 
@@ -319,7 +323,11 @@ def _quality_finding_dicts(
         c for c in getattr(diff, "compatible", None) or ()
         if _change_kind_str(c) not in _ADDITION_KIND_VALUES
     ]
-    dicts = _baseline_finding_dicts(quality_changes[:cap], "compatible")
+    dicts = _baseline_finding_dicts(
+        quality_changes[:cap],
+        "compatible",
+        policy_file=getattr(diff, "policy_file", None),
+    )
     return dicts, len(quality_changes) > len(dicts), len(quality_changes)
 
 
@@ -356,7 +364,9 @@ def _add_severity_blocking_compatible_findings(
         return
     cap = _resolve_max_baseline_findings(max_findings)
     findings: list[dict[str, Any]] = list(summary.get("findings") or [])
-    added = _baseline_finding_dicts(blocking, "compatible")
+    added = _baseline_finding_dicts(
+        blocking, "compatible", policy_file=getattr(diff, "policy_file", None)
+    )
     # Both groups get a share; neither may evict the other outright. Two
     # opposite failures were found here in successive reviews, and each fix
     # caused the next:
@@ -501,6 +511,7 @@ def _baseline_finding_dicts(
     bucket: str,
     *,
     pre_suppression_bucket_of: Any = None,
+    policy_file: Any = None,
 ) -> list[dict[str, Any]]:
     """Project *changes* (one verdict bucket) into small, renderable dicts.
 
@@ -538,8 +549,17 @@ def _baseline_finding_dicts(
     means a suppressed finding's *entry* must say more than "suppressed";
     without this a reader could not tell a suppressed ABI break apart from a
     suppressed cosmetic quality note.
+
+    *policy_file*, when given, is the run's resolved ``PolicyFile`` (same
+    object ``DiffResult.policy_file`` carries) -- passed through to stamp
+    ``reclassified_by`` the identical way ``reporter._change_to_dict`` does
+    for ``compare``'s own JSON report (Codex review, upstream ask #2):
+    without it, a ``scan --format json`` reader saw a downgraded verdict
+    with no way to tell *which* ``reclassify:`` rule produced it, unlike the
+    compare/report path.
     """
     from .finding_identity import report_finding_id
+    from .reporter import _reclassified_by_for_change
 
     findings = []
     for c in changes:
@@ -560,6 +580,9 @@ def _baseline_finding_dicts(
         binding = getattr(c, "symbol_binding", None)
         if binding:
             entry["symbol_binding"] = binding
+        reclassified_by = _reclassified_by_for_change(c, policy_file)
+        if reclassified_by:
+            entry["reclassified_by"] = reclassified_by
         _add_contract_fields(entry, c)
         if bucket == "suppressed":
             entry["suppression_rule"] = getattr(c, "suppression_rule", None)
@@ -736,6 +759,33 @@ def _baseline_summary(diff: Any, max_findings: int | None = None) -> dict[str, A
     resolved_policy = getattr(diff, "policy", None)
     if resolved_policy is not None:
         summary["policy"] = resolved_policy
+    # Codex review, upstream ask #2: `scan --format json` carried the
+    # resolved policy *name* (above) but never the active `policy_overrides`/
+    # `policy_reclassify` rule set `compare`'s own JSON report discloses
+    # (`reporter._add_policy_overrides`) -- a reviewer saw a downgraded
+    # verdict with no way to tell which rule produced it, unlike the
+    # compare/report path. Mirrors that function's shape exactly (same key
+    # names, same `ReclassifyRule.to_report_dict()` encoding) but reads
+    # `policy_file` via `getattr` rather than a direct attribute access,
+    # matching every other duck-typed read in this function -- `diff` here
+    # is a real `DiffResult` in production but a lightweight stand-in
+    # (`SimpleNamespace`) in several existing tests that don't model every
+    # field.
+    policy_file = getattr(diff, "policy_file", None)
+    if policy_file is not None and getattr(policy_file, "overrides", None):
+        summary["policy_overrides"] = {
+            kind.value: verdict.value for kind, verdict in policy_file.overrides.items()
+        }
+        if getattr(policy_file, "source_path", None):
+            summary["policy_file"] = str(policy_file.source_path)
+    if policy_file is not None and getattr(policy_file, "reclassify", None):
+        from .reclassify import active_reclassify_rules
+
+        active = active_reclassify_rules(policy_file.reclassify)
+        if active:
+            summary["policy_reclassify"] = [rule.to_report_dict() for rule in active]
+            if getattr(policy_file, "source_path", None):
+                summary["policy_file"] = str(policy_file.source_path)
     # ADR-049 D9 conserves every detector fact in exactly one visible
     # outcome. The four buckets above are the *compatibility* axis, so since
     # Phase 7 they exclude findings contract evaluation did not score -- and
@@ -800,7 +850,9 @@ def _baseline_summary(diff: Any, max_findings: int | None = None) -> dict[str, A
     ):
         remaining = max(0, cap - len(findings))
         included, excluded = bucket_changes[:remaining], bucket_changes[remaining:]
-        findings.extend(_baseline_finding_dicts(included, bucket_name))
+        findings.extend(
+            _baseline_finding_dicts(included, bucket_name, policy_file=policy_file)
+        )
         # Keep tallying excluded kinds across every remaining bucket (not just
         # the one that first hit the cap) -- a bucket entirely past the cap
         # would otherwise contribute nothing to `findings_truncated_kinds`,
@@ -849,6 +901,7 @@ def _baseline_summary(diff: Any, max_findings: int | None = None) -> dict[str, A
             suppressed_changes[:cap],
             "suppressed",
             pre_suppression_bucket_of=lambda c: _pre_suppression_bucket(diff, c),
+            policy_file=policy_file,
         )
         if len(suppressed_changes) > cap:
             summary["suppressed_truncated"] = True

--- a/abicheck/diff_symbols.py
+++ b/abicheck/diff_symbols.py
@@ -288,6 +288,8 @@ def _check_removed_function(
             name=f_old.name,
             old_value=f_old.visibility.value,
             new_value=f_hidden.visibility.value,
+            # See Change.symbol_binding's docstring -- stamped here too, not just on removal below.
+            symbol_binding=f_old.elf_binding.value if f_old.elf_binding else None,
         )
     removed_kind = (
         ChangeKind.FUNC_REMOVED_ELF_ONLY

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -627,7 +627,28 @@ REPORT_SCHEMA_VERSION = "2.34"
 #:        exact "N safe" header count (once the count itself was corrected
 #:        to read the full ``diff.compatible`` scalar) with nothing
 #:        itemized underneath it to explain what those N findings were.
-SCAN_SCHEMA_VERSION = "1.13"
+#: 1.14 -- upstream ask #2 (Codex review): ``scan --format json`` had no
+#:        policy-audit disclosure at all -- a reviewer saw a downgraded
+#:        verdict with no way to tell which rule produced it, unlike the
+#:        ``compare``/report path (``reporter._add_policy_overrides``,
+#:        report_schema_version 2.30/2.31). The ``diff`` block gains the
+#:        identical two top-level keys, byte-for-byte the same shape
+#:        (``ReclassifyRule.to_report_dict()`` encoding, shared with
+#:        ``reporter.py``/``sarif.py`` so the three can't drift): optional
+#:        ``policy_overrides`` (kind -> verdict, from ``PolicyFile.overrides``)
+#:        and ``policy_reclassify`` (the active, non-expired
+#:        ``PolicyFile.reclassify`` rule set), plus ``policy_file`` (the
+#:        source path) when either is present. Each finding dict
+#:        (``_baseline_finding_dicts``, ``findings``/``additions``/
+#:        ``quality``/``suppressed``) also gains the optional
+#:        ``reclassified_by`` key -- the same per-finding audit value
+#:        ``compare``'s ``change.reclassified_by`` (report_schema_version
+#:        2.31) already stamps, computed by the identical
+#:        ``reporter._reclassified_by_for_change`` helper so the two commands
+#:        can't disagree about which rule decided a shared finding. All keys
+#:        are additive and omitted when no policy file (or no active rule)
+#:        applies, so an ordinary scan is unchanged from 1.13.
+SCAN_SCHEMA_VERSION = "1.14"
 
 _SCHEMA_DIR = Path(__file__).resolve().parent
 COMPARE_REPORT_SCHEMA_PATH = _SCHEMA_DIR / "compare_report.schema.json"

--- a/abicheck/suppression.py
+++ b/abicheck/suppression.py
@@ -862,8 +862,8 @@ def _matches_binding(binding: str, change: Change) -> bool:
 
     ``change.symbol_binding`` is ``None`` for every change kind other than
     ``FUNC_REMOVED``/``FUNC_REMOVED_ELF_ONLY``/``VAR_REMOVED``/
-    ``FUNC_DELETED_ELF_FALLBACK`` (the only kinds any detector stamps it
-    on), and also ``None`` on one of those whose binding
+    ``FUNC_DELETED_ELF_FALLBACK``/``FUNC_VISIBILITY_CHANGED`` (the only
+    kinds any detector stamps it on), and also ``None`` on one of those whose binding
     was never captured (non-ELF platform, older snapshot, no matching
     ``.dynsym`` entry). A rule with an explicit ``binding:`` selector never
     matches either case — an unknown binding is not the same fact as a
@@ -1016,11 +1016,11 @@ class Suppression:
     # AbiSnapshot's own PR #582 fix — see those fields' docstrings.
     binding: str | None = field(default=None, kw_only=True)
     """``"global" | "weak" | "local" | "unique" | "other"`` — the removed
-    symbol's ELF linkage (``Change.symbol_binding``, from
-    ``Function.elf_binding``/``Variable.elf_binding``). Only ever set on a
-    ``FUNC_REMOVED``/``FUNC_REMOVED_ELF_ONLY``/``VAR_REMOVED``/
-    ``FUNC_DELETED_ELF_FALLBACK`` finding; a rule combining this with any
-    other ``change_kind`` never matches.
+    (or visibility-hidden) symbol's ELF linkage (``Change.symbol_binding``,
+    from ``Function.elf_binding``/``Variable.elf_binding``). Only ever set
+    on a ``FUNC_REMOVED``/``FUNC_REMOVED_ELF_ONLY``/``VAR_REMOVED``/
+    ``FUNC_DELETED_ELF_FALLBACK``/``FUNC_VISIBILITY_CHANGED`` finding; a
+    rule combining this with any other ``change_kind`` never matches.
     Conjunctive with every other selector (AND semantics), like
     :attr:`member_name` — combine with :attr:`symbol_pattern` or
     :attr:`namespace` to scope it. Never matches a change whose binding was

--- a/changelog.d/20260813_223201_noreply_symbol_binding_policy_disclosure_0pit2l.md
+++ b/changelog.d/20260813_223201_noreply_symbol_binding_policy_disclosure_0pit2l.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **`func_visibility_changed` now stamps `Change.symbol_binding`.** A public
+  export demoted to `HIDDEN` previously left `symbol_binding` unset, unlike
+  the four removal kinds — so a `binding: weak` selector (`suppression.py`'s
+  or `reclassify.py`'s ``ReclassifyRule``) matched none of these findings,
+  forcing a project onto a kind-global `overrides:` entry instead of a
+  symbol-scoped rule. The old side's real ELF linkage is now stamped the
+  same way it already is for `func_removed`/`var_removed`/
+  `func_deleted_elf_fallback`.
+
+### Added
+
+- **`scan --format json` now discloses active policy rules.** The always-on
+  `scan --against` summary gains the optional `policy_overrides`/
+  `policy_reclassify`/`policy_file` keys (mirroring `compare`'s own JSON
+  report, `reporter._add_policy_overrides`), and each finding dict
+  (`findings`/`additions`/`quality`/`suppressed`) gains an optional
+  `reclassified_by` key naming which `reclassify:` rule actually decided its
+  verdict. Previously a `scan --format json` reviewer saw a downgraded
+  verdict with no way to tell which rule produced it (`SCAN_SCHEMA_VERSION`
+  1.13 → 1.14).

--- a/docs/use/output-formats.md
+++ b/docs/use/output-formats.md
@@ -720,15 +720,30 @@ The block also carries `policy` — the resolved compatibility policy name
 real comparison (absent only for the `NOT_COMPARABLE`/audit-only `diff`
 shapes, which never reach policy classification).
 
+Since schema 1.14, the block also discloses the active `--policy-file`
+audit trail — previously a `scan --format json` reader could see a
+downgraded verdict with no way to tell which rule produced it, unlike the
+`compare`/report path. `policy_overrides` (a `ChangeKind -> verdict` map)
+and `policy_reclassify` (the active, non-expired selector-scoped
+`reclassify:` rule set — see [Suppressions](suppressions.md)) mirror
+`compare`'s own JSON report byte-for-byte, and `policy_file` names the
+source path when either is present. Each `findings`/`additions`/`quality`/
+`suppressed` entry also gains an optional `reclassified_by` key naming
+which rule actually decided that finding's verdict. All four keys are
+omitted when no policy file (or no active rule) applies.
+
 ```json
 {
-  "scan_schema_version": "1.13",
+  "scan_schema_version": "1.14",
   "diff": {
     "breaking": 25,
     "findings": ["... 20 entries ..."],
     "findings_truncated": true,
     "findings_truncated_kinds": {"func_removed": 5},
-    "additions": ["... up to 20 entries ..."]
+    "additions": ["... up to 20 entries ..."],
+    "policy_overrides": {"func_removed": "COMPATIBLE_WITH_RISK"},
+    "policy_reclassify": [{"to": "COMPATIBLE_WITH_RISK", "binding": "weak"}],
+    "policy_file": "policy.yml"
   }
 }
 ```

--- a/tests/test_cli_scan_baseline.py
+++ b/tests/test_cli_scan_baseline.py
@@ -308,6 +308,9 @@ class TestBaselineSummaryKeysArePinned:
             "quality_truncated",
             "quality_total",
             "policy",
+            "policy_overrides",
+            "policy_reclassify",
+            "policy_file",
         }
     )
 
@@ -343,6 +346,26 @@ class TestBaselineSummaryKeysArePinned:
             )
             for i in range(30)
         ]
+        from pathlib import Path
+
+        from abicheck.checker_policy import Verdict
+        from abicheck.policy_file import PolicyFile
+        from abicheck.reclassify import ReclassifyRule
+
+        policy_file = PolicyFile(
+            base_policy="strict_abi",
+            overrides={ChangeKind.FUNC_VISIBILITY_CHANGED: Verdict.COMPATIBLE_WITH_RISK},
+            reclassify=[
+                ReclassifyRule(
+                    to_verdict=Verdict.COMPATIBLE_WITH_RISK,
+                    change_kind="func_removed",
+                    symbol_pattern="_Z.*",
+                    binding="weak",
+                    reason="COMDAT-inline demotions",
+                )
+            ],
+            source_path=Path("policy.yml"),
+        )
         return types.SimpleNamespace(
             breaking=breaking,
             source_breaks=[],
@@ -356,6 +379,7 @@ class TestBaselineSummaryKeysArePinned:
             ],
             suppressed_changes=suppressed,
             policy="strict_abi",
+            policy_file=policy_file,
         )
 
     def test_every_emitted_key_is_pinned(self) -> None:
@@ -377,6 +401,116 @@ class TestBaselineSummaryKeysArePinned:
         diff = self._diff_exercising_every_optional_key()
         summary = csb._baseline_summary(diff, max_findings=5)
         assert self._KNOWN_KEYS <= set(summary)
+
+
+class TestBaselinePolicyDisclosure:
+    """``scan --format json`` policy-audit disclosure (Codex review, upstream
+    ask #2): the resolved ``policy_overrides``/``policy_reclassify`` rule set
+    and each finding's own ``reclassified_by`` attribution, mirroring what
+    ``compare``'s JSON report already discloses via
+    ``reporter._add_policy_overrides``/``_reclassified_by_for_change``.
+    """
+
+    @staticmethod
+    def _diff_with_policy_file(policy_file):
+        from abicheck.checker_policy import ChangeKind
+        from abicheck.checker_types import Change
+
+        change = Change(
+            kind=ChangeKind.FUNC_REMOVED, symbol="_Z1fv", description="d", symbol_binding="weak"
+        )
+        return types.SimpleNamespace(
+            breaking=[change],
+            source_breaks=[],
+            risk=[],
+            compatible=[],
+            not_evaluated=[],
+            detector_results=[],
+            suppressed_changes=[],
+            policy="strict_abi",
+            policy_file=policy_file,
+        )
+
+    def test_no_policy_file_omits_disclosure_keys(self) -> None:
+        diff = self._diff_with_policy_file(None)
+        summary = csb._baseline_summary(diff)
+        assert "policy_overrides" not in summary
+        assert "policy_reclassify" not in summary
+        assert "policy_file" not in summary
+        assert "reclassified_by" not in summary["findings"][0]
+
+    def test_kind_global_override_is_disclosed(self) -> None:
+        from pathlib import Path
+
+        from abicheck.checker_policy import ChangeKind, Verdict
+        from abicheck.policy_file import PolicyFile
+
+        policy_file = PolicyFile(
+            base_policy="strict_abi",
+            overrides={ChangeKind.FUNC_REMOVED: Verdict.COMPATIBLE_WITH_RISK},
+            source_path=Path("policy.yml"),
+        )
+        diff = self._diff_with_policy_file(policy_file)
+        summary = csb._baseline_summary(diff)
+        assert summary["policy_overrides"] == {"func_removed": "COMPATIBLE_WITH_RISK"}
+        assert summary["policy_file"] == "policy.yml"
+
+    def test_selector_scoped_reclassify_rule_is_disclosed_active_only(self) -> None:
+        from pathlib import Path
+
+        from abicheck.checker_policy import Verdict
+        from abicheck.policy_file import PolicyFile
+        from abicheck.reclassify import ReclassifyRule
+
+        active = ReclassifyRule(
+            to_verdict=Verdict.COMPATIBLE_WITH_RISK,
+            symbol_pattern="_Z1.*",
+            binding="weak",
+            reason="COMDAT-inline demotions",
+        )
+        import datetime
+
+        expired = ReclassifyRule(
+            to_verdict=Verdict.COMPATIBLE,
+            symbol_pattern="_Z2.*",
+            expires=datetime.date(2000, 1, 1),
+        )
+        policy_file = PolicyFile(
+            base_policy="strict_abi",
+            reclassify=[active, expired],
+            source_path=Path("policy.yml"),
+        )
+        diff = self._diff_with_policy_file(policy_file)
+        summary = csb._baseline_summary(diff)
+        assert len(summary["policy_reclassify"]) == 1
+        assert summary["policy_reclassify"][0]["to"] == "COMPATIBLE_WITH_RISK"
+        assert summary["policy_reclassify"][0]["binding"] == "weak"
+        assert summary["policy_file"] == "policy.yml"
+        # The rule actually decided this finding's verdict -- disclosed
+        # per-finding too, not just as part of the active rule set.
+        assert summary["findings"][0]["reclassified_by"] == "COMDAT-inline demotions"
+
+    def test_non_matching_rule_leaves_finding_undisclosed(self) -> None:
+        from pathlib import Path
+
+        from abicheck.checker_policy import Verdict
+        from abicheck.policy_file import PolicyFile
+        from abicheck.reclassify import ReclassifyRule
+
+        rule = ReclassifyRule(
+            to_verdict=Verdict.COMPATIBLE_WITH_RISK,
+            symbol_pattern="_Znomatch.*",
+            reason="unrelated",
+        )
+        policy_file = PolicyFile(
+            base_policy="strict_abi", reclassify=[rule], source_path=Path("policy.yml")
+        )
+        diff = self._diff_with_policy_file(policy_file)
+        summary = csb._baseline_summary(diff)
+        # The rule is still disclosed as part of the active rule set...
+        assert len(summary["policy_reclassify"]) == 1
+        # ...but never attributed to a finding it didn't actually decide.
+        assert "reclassified_by" not in summary["findings"][0]
 
 
 class TestPublicProvenanceSet:

--- a/tests/test_symbol_binding_field.py
+++ b/tests/test_symbol_binding_field.py
@@ -155,6 +155,48 @@ class TestChangeSymbolBindingStamp:
         change = _check_removed_function("_Z1fv", f_old, {}, elf_only_mode=False)
         assert change.symbol_binding is None
 
+    def test_func_visibility_changed_stamps_symbol_binding(self) -> None:
+        # Codex review, upstream ask #1: FUNC_VISIBILITY_CHANGED (a public
+        # export demoted to HIDDEN, not a removal) is the other common
+        # export-loss shape a `binding:` selector needs to scope, alongside
+        # the four removal kinds -- an unstamped visibility-hidden finding
+        # forced oneDAL's own reclassify rules to fall back to a kind-global
+        # override instead of a binding-scoped one.
+        from abicheck.model import Visibility
+
+        f_old = Function(
+            name="f",
+            mangled="_Z1fv",
+            return_type="void",
+            visibility=Visibility.PUBLIC,
+            elf_binding=SymbolBinding.WEAK,
+        )
+        f_hidden = Function(
+            name="f",
+            mangled="_Z1fv",
+            return_type="void",
+            visibility=Visibility.HIDDEN,
+        )
+        change = _check_removed_function(
+            "_Z1fv", f_old, {"_Z1fv": f_hidden}, elf_only_mode=False
+        )
+        assert change.kind == ChangeKind.FUNC_VISIBILITY_CHANGED
+        assert change.symbol_binding == "weak"
+
+    def test_func_visibility_changed_no_binding_captured_is_none(self) -> None:
+        from abicheck.model import Visibility
+
+        f_old = Function(
+            name="f", mangled="_Z1fv", return_type="void", visibility=Visibility.PUBLIC
+        )
+        f_hidden = Function(
+            name="f", mangled="_Z1fv", return_type="void", visibility=Visibility.HIDDEN
+        )
+        change = _check_removed_function(
+            "_Z1fv", f_old, {"_Z1fv": f_hidden}, elf_only_mode=False
+        )
+        assert change.symbol_binding is None
+
     def test_var_removed_stamps_symbol_binding(self) -> None:
         v_old = Variable(
             name="g", mangled="g", type="int", elf_binding=SymbolBinding.GLOBAL


### PR DESCRIPTION
## Summary

Two upstream asks addressed:

**#1 — `binding:` scoping for `func_visibility_changed`.** `diff_symbols._check_removed_function`'s `FUNC_VISIBILITY_CHANGED` branch (a public export demoted to `HIDDEN`) never stamped `Change.symbol_binding`, unlike the four removal kinds (`FUNC_REMOVED`/`FUNC_REMOVED_ELF_ONLY`/`VAR_REMOVED`/`FUNC_DELETED_ELF_FALLBACK`). Since `_matches_binding` fails closed on `None`, a `binding: weak` selector (`suppression.py`'s `Suppression` or `reclassify.py`'s `ReclassifyRule`) matched none of these findings — forcing a project onto a kind-global `overrides:` entry instead of a symbol-scoped `reclassify:`/suppression rule. Now stamped from the old side's real ELF linkage (`f_old.elf_binding`), the same evidence already available for a symbol that vanished outright.

**#2 — policy disclosure on `scan --format json`.** `scan --against`'s always-on JSON summary carried the resolved policy *name* (`"policy": "strict_abi"`) but never the active `--policy-file` audit trail `compare`'s own JSON report has long carried (`reporter._add_policy_overrides`) — a reviewer saw a downgraded verdict with no way to tell which rule produced it. The summary now discloses the same two keys byte-for-byte (`policy_overrides`, `policy_reclassify`, plus `policy_file` for the source path), and every finding dict (`findings`/`additions`/`quality`/`suppressed`) gains an optional `reclassified_by` key naming which rule actually decided that finding's verdict — computed by the same `reporter._reclassified_by_for_change` helper `compare` uses, so the two commands can't disagree about a shared finding. `SCAN_SCHEMA_VERSION` 1.13 → 1.14 (additive; an ordinary scan with no active policy file is byte-identical to before).

## Changes

- `abicheck/diff_symbols.py` — stamp `symbol_binding` on `FUNC_VISIBILITY_CHANGED`.
- `abicheck/checker_types.py`, `abicheck/suppression.py` — updated docstrings listing which `ChangeKind`s carry `symbol_binding`.
- `abicheck/cli_scan_baseline.py` — `_baseline_finding_dicts` gains an optional `policy_file` param (stamps `reclassified_by`); `_baseline_summary` discloses `policy_overrides`/`policy_reclassify`/`policy_file`; wired through every finding-dict call site.
- `abicheck/schemas/__init__.py` — `SCAN_SCHEMA_VERSION` 1.13 → 1.14 with a history entry.
- `docs/use/output-formats.md` — documents the new scan JSON keys.
- Tests: `tests/test_symbol_binding_field.py` (new `FUNC_VISIBILITY_CHANGED` stamping cases), `tests/test_cli_scan_baseline.py` (new `TestBaselinePolicyDisclosure` class, `_KNOWN_KEYS` pin updated).
- Changelog fragment.

## Testing

- `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"` — 26572 passed
- `ruff check abicheck/ tests/`, `mypy abicheck/` — clean
- `python scripts/check_ai_readiness.py` — 0 errors (unrelated pre-existing warnings only)
- `python scripts/check_docs_contract.py` — 0 errors (unrelated pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017LxretesyeUobGdVWbfSku)_