### PR TITLE
fix(clang-plugin): refuse unsafe same-major apt fallback for Intel icx/icpx

### DIFF
--- a/actions/collect-facts/action.yml
+++ b/actions/collect-facts/action.yml
@@ -81,14 +81,48 @@ inputs:
       Compiler used for the build (informational for replay/wrapper; for
       clang-plugin this selects which clang the plugin is built against and
       must match the clang that later loads it via -fplugin=). Vendor
-      compilers built on top of Clang are supported here too (e.g. Intel's
+      compilers built on top of Clang are recognized here too (e.g. Intel's
       icpx/icx) -- the real LLVM major is read from the compiler's own
       __clang_major__ macro, not parsed out of --version (which for icpx/icx
-      prints a vendor product version, not an LLVM number). See
-      llvm-cmake-prefix below for pointing the plugin build at that vendor's
-      bundled LLVM/Clang dev files.
+      prints a vendor product version, not an LLVM number), and the compiler
+      is separately probed for __INTEL_LLVM_COMPILER to detect the Intel
+      oneAPI DPC++/C++ Compiler fork specifically. See llvm-cmake-prefix and
+      plugin-artifact below -- for that fork, building against a same-major
+      apt/distro Clang development package is refused (real testing found
+      the result an ABI mismatch that crashes rather than merely fails to
+      load; see contrib/abicheck-clang-plugin/README.md's Intel oneAPI
+      section), so one of those two inputs is required instead.
     required: false
     default: 'clang++'
+  plugin-artifact:
+    description: >
+      clang-plugin only: path to an already-built, already-certified
+      libabicheck-facts.* shared object to use directly, skipping the CMake
+      build entirely. This is the recommended path for a vendor fork whose
+      plugin-development SDK isn't available in this job (Intel's icpx/icx
+      chief among them) -- build once against the exact toolchain image,
+      publish the artifact (a GitHub Release asset, an OCI artifact, or a
+      layer in the same pinned image as the compiler), and have the calling
+      workflow resolve/download it before this Action runs. The artifact is
+      still smoke-tested against the resolved `compiler` before use (same
+      check a from-source build gets), so a stale or mismatched artifact
+      fails loudly here rather than crashing or misbehaving inside your real
+      build. Pair with plugin-artifact-sha256 to pin the exact binary a
+      client repository's lock manifest names, rather than trusting whatever
+      the download step happened to fetch.
+    required: false
+    default: ''
+  plugin-artifact-sha256:
+    description: >
+      Expected sha256 digest of plugin-artifact. When set, the artifact's
+      digest is checked before it is smoke-tested or used, and a mismatch
+      fails the step -- this is the "lock manifest" half of the certified-
+      artifact distribution model (see contrib/abicheck-clang-plugin/
+      README.md): a client repository commits this digest (plus the
+      resolved compiler fingerprint), not the binary itself. Ignored when
+      plugin-artifact is not set.
+    required: false
+    default: ''
   install-deps:
     description: >
       Install system dependencies needed by the selected producer (clang/
@@ -201,6 +235,8 @@ runs:
         INPUT_LIBRARY: ${{ inputs.library }}
         INPUT_EXTRACTOR: ${{ inputs.extractor }}
         INPUT_COMPILER: ${{ inputs.compiler }}
+        INPUT_PLUGIN_ARTIFACT: ${{ inputs.plugin-artifact }}
+        INPUT_PLUGIN_ARTIFACT_SHA256: ${{ inputs.plugin-artifact-sha256 }}
         INPUT_INSTALL_DEPS: ${{ inputs.install-deps }}
         INPUT_LLVM_CMAKE_PREFIX: ${{ inputs.llvm-cmake-prefix }}
         ACTION_PATH: ${{ github.action_path }}

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -91,6 +91,8 @@ PUBLIC_ROOTS="${INPUT_PUBLIC_ROOTS:-}"
 LIBRARY="${INPUT_LIBRARY:-}"
 EXTRACTOR="${INPUT_EXTRACTOR:-auto}"
 COMPILER="${INPUT_COMPILER:-clang++}"
+PLUGIN_ARTIFACT="${INPUT_PLUGIN_ARTIFACT:-}"
+PLUGIN_ARTIFACT_SHA256="${INPUT_PLUGIN_ARTIFACT_SHA256:-}"
 INSTALL_DEPS="${INPUT_INSTALL_DEPS:-true}"
 LLVM_CMAKE_PREFIX="${INPUT_LLVM_CMAKE_PREFIX:-}"
 ACTION_PATH="${ACTION_PATH:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
@@ -203,6 +205,31 @@ _llvm_major_from_predefined_macros() {
   # incidentally, via a trailing `head -1` that always exits 0).
   printf '%s' "$defines" | grep -oE '#define __clang_major__ [0-9]+' | grep -oE '[0-9]+$'
   return 0
+}
+
+# Detect whether $COMPILER is Intel's oneAPI DPC++/C++ Compiler (icpx/icx) --
+# a downstream LLVM fork with its own patches and, per real testing (see
+# contrib/abicheck-clang-plugin/README.md's Intel oneAPI section), its own
+# C++-standard-library ABI choice on at least some builds -- not merely
+# "some Clang reporting the same __clang_major__". This is a strictly
+# narrower and separate question from LLVM major: two compilers can report
+# the identical major while being different, ABI-incompatible builds, which
+# is exactly why a same-major apt/distro Clang dev package is not a safe
+# substitute for this fork specifically (see _prepare_clang_plugin below).
+# __INTEL_LLVM_COMPILER is a predefined macro only Intel's fork defines,
+# so its mere presence is a reliable, vendor-scoped signal (unlike
+# __clang_major__, which every Clang-family compiler defines identically).
+# Always prints "true" or "false" (never empty) -- this has exactly two
+# answers, unlike the "empty means not found" contract the other detection
+# helpers above use for a value that can genuinely be unknown.
+_is_intel_llvm_compiler() {
+  local compiler="$1" defines
+  defines=$("$compiler" -dM -E -x c++ - < /dev/null 2>/dev/null) || true
+  if printf '%s' "$defines" | grep -q '#define __INTEL_LLVM_COMPILER'; then
+    echo "true"
+  else
+    echo "false"
+  fi
 }
 
 # Resolve a CMake prefix path for a vendor-bundled LLVM/Clang install, so
@@ -494,6 +521,82 @@ _prepare_wrapper() {
   _write_output "producer-version" ""
 }
 
+
+# Shared tail of the clang-plugin producer, once a plugin_so path is settled
+# (either freshly built, or handed in via plugin-artifact) -- smoke-test it
+# against the resolved $COMPILER, assemble the caller's compile flags, and
+# emit outputs/env. version_suffix is appended to producer-version verbatim
+# (e.g. "+experimental" for a still-uncertified vendor-fork build) so a
+# downstream consumer/CI receipt can tell an ordinary vanilla-Clang plugin
+# apart from one this Action itself does not consider certified.
+_finish_clang_plugin() {
+  local plugin_so="$1" major="$2" version_suffix="$3"
+  [[ -f "$plugin_so" ]] || _fail "plugin_so '$plugin_so' does not exist."
+
+  # Smoke-test: the plugin must at least load into the compiler without
+  # crashing, on a trivial translation unit, before we hand its path to the
+  # caller's real build. Writes its facts to an isolated scratch directory,
+  # NOT $OUTPUT -- that is the real pack the caller's build populates next,
+  # and phase: verify only checks "the pack has at least one file", so a
+  # smoke-test record left sitting in $OUTPUT would make a pack that never
+  # received real facts (build step skipped, wrong flags, wrong TU) look
+  # ready anyway.
+  local smoke_dir smoke_src smoke_out
+  smoke_dir=$(mktemp -d)
+  smoke_src="$smoke_dir/smoke.cpp"
+  smoke_out="$smoke_dir/out"
+  printf 'int abicheck_smoke_test() { return 0; }\n' > "$smoke_src"
+  mkdir -p "$smoke_out"
+  if ! "$COMPILER" -std=c++17 \
+      -fplugin="$plugin_so" \
+      -Xclang -plugin-arg-abicheck-facts -Xclang "out=$smoke_out" \
+      -fsyntax-only "$smoke_src" 2>"$smoke_dir/stderr.log"; then
+    cat "$smoke_dir/stderr.log" >&2
+    _fail "the Clang plugin at '$plugin_so' failed to load on a smoke-test translation unit -- see the compiler output above. This usually means '$COMPILER' is not the same LLVM major ($major) the plugin was built against (for plugin-artifact: the artifact does not match this job's resolved compiler, or was built for a different C++ standard-library ABI -- see contrib/abicheck-clang-plugin/README.md's Intel oneAPI section)."
+  fi
+  echo "Clang plugin smoke test passed ($plugin_so loads into $COMPILER)."
+  _reset_output_dir
+
+  # Assemble the exact flags the caller's build needs to add, one -Xclang
+  # pair per public root (public-roots= is repeatable per the plugin docs).
+  local plugin_flags="-fplugin=$plugin_so -Xclang -plugin-arg-abicheck-facts -Xclang out=$OUTPUT"
+  if [[ -n "$PUBLIC_ROOTS" ]]; then
+    local root resolved
+    while IFS= read -r root; do
+      if [[ -n "$root" ]]; then
+        resolved=$(_resolve_public_root "$root")
+        plugin_flags="$plugin_flags -Xclang -plugin-arg-abicheck-facts -Xclang public-roots=$resolved"
+      fi
+    done <<< "$PUBLIC_ROOTS"
+  fi
+  [[ -n "$LIBRARY" ]] && plugin_flags="$plugin_flags -Xclang -plugin-arg-abicheck-facts -Xclang library=$LIBRARY"
+
+  # The plugin's identity is fully fixed the moment it's resolved here (built
+  # or handed in) -- the caller's later build populates the *pack*, it never
+  # changes the plugin binary itself -- so compute the complete documented
+  # identity (LLVM major + a content digest of the plugin) now rather than
+  # emitting a partial value at prepare and clearing it at verify (CodeRabbit
+  # review). Persisted via GITHUB_ENV so the separate phase: verify
+  # invocation of this script (a fresh process) can re-emit the same value
+  # instead of re-deriving or losing it.
+  local plugin_digest
+  plugin_digest=$(python3 -c '
+import hashlib, sys
+print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest()[:12])
+' "$plugin_so")
+  local producer_version="llvm-$major+plugin-sha256-$plugin_digest$version_suffix"
+
+  _write_env "ABICHECK_PLUGIN_SO" "$plugin_so"
+  _write_env "ABICHECK_PLUGIN_FLAGS" "$plugin_flags"
+  _write_env "ABICHECK_PRODUCER_VERSION" "$producer_version"
+  echo "::notice::producer: clang-plugin ready at $plugin_so. Add these flags to your compile command (also exported as \$ABICHECK_PLUGIN_FLAGS): $plugin_flags -- run your build next, then call this Action again with phase: verify to check the collected pack at '$OUTPUT'."
+  _write_output "producer" "clang-plugin"
+  _write_output "mode" "pack"
+  _write_output "pack-path" "$OUTPUT"
+  _write_output "ready" "false"
+  _write_output "producer-version" "$producer_version"
+}
+
 _prepare_clang_plugin() {
   command -v "$COMPILER" >/dev/null 2>&1 || _fail "compiler '$COMPILER' not found on PATH -- producer: clang-plugin needs the loading Clang available to detect and match its LLVM major."
   local version_output="" major
@@ -505,6 +608,31 @@ _prepare_clang_plugin() {
   [[ -n "$major" ]] || _fail "could not determine the Clang/LLVM major version '$COMPILER' is based on -- tried '__clang_major__' via '$COMPILER -dM -E -x c++ -' and parsing '$COMPILER --version':
 $version_output"
   echo "detected LLVM major $major from $COMPILER"
+
+  local is_intel_llvm
+  is_intel_llvm=$(_is_intel_llvm_compiler "$COMPILER")
+  [[ "$is_intel_llvm" == "true" ]] && echo "detected the Intel oneAPI DPC++/C++ Compiler fork (__INTEL_LLVM_COMPILER) -- see contrib/abicheck-clang-plugin/README.md's Intel oneAPI section for what this changes below."
+
+  # plugin-artifact: use an already-built, already-certified binary directly
+  # -- this is the recommended path for a vendor fork whose plugin-
+  # development SDK isn't available in this job (see action.yml's
+  # description). Skips the whole build step below; still goes through the
+  # identical smoke test every from-source build gets.
+  if [[ -n "$PLUGIN_ARTIFACT" ]]; then
+    [[ -f "$PLUGIN_ARTIFACT" ]] || _fail "plugin-artifact '$PLUGIN_ARTIFACT' does not exist -- expected a pre-built libabicheck-facts.* shared object."
+    if [[ -n "$PLUGIN_ARTIFACT_SHA256" ]]; then
+      local actual_sha256
+      actual_sha256=$(python3 -c '
+import hashlib, sys
+print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())
+' "$PLUGIN_ARTIFACT")
+      [[ "$actual_sha256" == "$PLUGIN_ARTIFACT_SHA256" ]] \
+        || _fail "plugin-artifact-sha256 mismatch for '$PLUGIN_ARTIFACT': expected $PLUGIN_ARTIFACT_SHA256, got $actual_sha256 -- refusing to load an artifact whose digest does not match the pinned lock (see contrib/abicheck-clang-plugin/README.md's certified-artifact distribution model). A client repository should commit this digest, not the binary, and refresh it deliberately when the certified artifact changes."
+    fi
+    echo "using plugin-artifact '$PLUGIN_ARTIFACT' (skipping the CMake build)."
+    _finish_clang_plugin "$PLUGIN_ARTIFACT" "$major" ""
+    return
+  fi
 
   local bundled_cmake_prefix compiler_path
   compiler_path=$(command -v "$COMPILER" 2>/dev/null || true)
@@ -530,8 +658,27 @@ $version_output"
     # llvm-cmake-prefix doc previously asserted this auto-detects "true for
     # a sourced Intel oneAPI environment", which does not hold for the
     # actual package layout).
-    echo "::notice::\$CMPLR_ROOT is set ('$CMPLR_ROOT') but no LLVM/Clang CMake package was found at '$CMPLR_ROOT/lib/cmake/llvm' -- this is expected for a stock Intel oneAPI DPC++/C++ Compiler install, which ships IntelSYCL/IntelDPCPP CMake modules there instead, not an LLVM/Clang plugin-development SDK. Falling back to apt-get, which will likely fail for a vendor LLVM major. If you have a matching LLVM+Clang CMake package available (e.g. built separately to match '$COMPILER'), set the llvm-cmake-prefix input to it."
+    echo "::notice::\$CMPLR_ROOT is set ('$CMPLR_ROOT') but no LLVM/Clang CMake package was found at '$CMPLR_ROOT/lib/cmake/llvm' -- this is expected for a stock Intel oneAPI DPC++/C++ Compiler install, which ships IntelSYCL/IntelDPCPP CMake modules there instead, not an LLVM/Clang plugin-development SDK."
   fi
+
+  # Refuse the same-major apt/distro fallback for the Intel oneAPI fork
+  # specifically -- real testing (contrib/abicheck-clang-plugin/README.md's
+  # Intel oneAPI section) found the resulting plugin an ABI mismatch against
+  # the loading icpx/icx (RTTI typeinfo layout, and libstdc++-vs-libc++
+  # standard-library containers crossing the Clang plugin ABI boundary in
+  # ParseArgs) that crashes rather than merely fails to load -- a same-major
+  # __clang_major__ match does not mean a compatible build for this fork
+  # (contrib/abicheck-clang-plugin/AGENTS.md's "LLVM-major sensitivity"
+  # section already documents this for the matrix in general; this is the
+  # concrete, previously-silent case where the apt-get fallback below would
+  # otherwise have attempted it anyway). No such fallback exists to attempt
+  # for this fork here: only a genuine vendor-bundled SDK (bundled_cmake_
+  # prefix, e.g. llvm-cmake-prefix pointed at Intel's own LLVM/Clang CMake
+  # package) or a pre-certified plugin-artifact are accepted.
+  if [[ "$is_intel_llvm" == "true" && -z "$bundled_cmake_prefix" ]]; then
+    _fail "compiler '$COMPILER' is Intel's oneAPI DPC++/C++ Compiler (icpx/icx) -- a downstream LLVM fork, not vanilla Clang. Building the Clang facts plugin against a same-major distro/apt Clang development package (clang-$major/llvm-$major-dev/libclang-$major-dev) is refused here: real testing found the resulting plugin an ABI mismatch against Intel's driver (RTTI typeinfo, and libstdc++-vs-libc++ standard-library containers crossing the plugin ABI boundary) that crashes rather than merely fails to load -- see contrib/abicheck-clang-plugin/README.md's Intel oneAPI section. Supported paths: (1) set llvm-cmake-prefix to Intel's own matching LLVM/Clang CMake package if you have one, so the plugin builds against the exact fork; or (2) set plugin-artifact to a pre-built, pre-certified plugin .so for this exact icpx/icx build (recommended -- see the README section above for the certified-artifact distribution model). producer: replay or producer: wrapper (the portable, always-supported paths) remain the correct default for this compiler otherwise."
+  fi
+
   if [[ -z "$bundled_cmake_prefix" && "$INSTALL_DEPS" == "true" ]]; then
     if [[ "$(uname -s)" == "Linux" ]] && command -v apt-get >/dev/null 2>&1 && command -v sudo >/dev/null 2>&1; then
       echo "::group::Install clang-$major dev packages for the plugin build"
@@ -565,8 +712,27 @@ $version_output"
   fi
   local cmake_hint
   cmake_hint=$(_cmake_configure_failure_hint "$bundled_cmake_prefix" "$llvm_cmake_dir" "$major")
+
+  # A vendor-bundled build against the Intel oneAPI fork specifically is
+  # still not a certified path (see README.md's Intel oneAPI section: only
+  # a minimal AST plugin has been verified end-to-end; the full plugin's
+  # own conformance/ingestion suite has not) -- pass the ABI knobs real
+  # testing found necessary (-fno-rtti, -stdlib=libc++) and mark the
+  # resulting producer-version as experimental so a downstream consumer/CI
+  # receipt can tell it apart from an ordinary certified vanilla-Clang
+  # build. Every other build path (vanilla apt.llvm.org/Apple/Debian Clang,
+  # or a non-Intel vendor toolchain) is completely unaffected -- both extra
+  # cmake defines and the version suffix are empty otherwise.
+  local extra_cmake_defines=() version_suffix=""
+  if [[ "$is_intel_llvm" == "true" ]]; then
+    extra_cmake_defines=(-DABICHECK_PLUGIN_RTTI=off -DABICHECK_PLUGIN_STDLIB=libc++)
+    version_suffix="+experimental-intel-llvm"
+    echo "::notice::Building against the vendor-bundled Intel oneAPI LLVM/Clang SDK -- passing -DABICHECK_PLUGIN_RTTI=off -DABICHECK_PLUGIN_STDLIB=libc++ (the recipe real testing found necessary; see README.md). This build is NOT certified: only a minimal AST plugin has been verified end-to-end against icpx/icx, not this full plugin's own conformance suite. Prefer plugin-artifact with a build you have separately certified for production use."
+  fi
+
   cmake -S "$plugin_src" -B "$build_dir" \
     ${llvm_cmake_dir:+-DCMAKE_PREFIX_PATH="$llvm_cmake_dir/.."} \
+    "${extra_cmake_defines[@]}" \
     || _fail "cmake configure failed for the Clang plugin -- $cmake_hint"
   cmake --build "$build_dir" || _fail "cmake build failed for the Clang plugin."
   echo "::endgroup::"
@@ -575,68 +741,7 @@ $version_output"
   plugin_so=$(find "$build_dir" -maxdepth 2 -name 'libabicheck-facts.*' | head -1)
   [[ -n "$plugin_so" ]] || _fail "Clang plugin build did not produce libabicheck-facts.* under '$build_dir'."
 
-  # Smoke-test: the plugin must at least load into the compiler without
-  # crashing, on a trivial translation unit, before we hand its path to the
-  # caller's real build. Writes its facts to an isolated scratch directory,
-  # NOT $OUTPUT -- that is the real pack the caller's build populates next,
-  # and phase: verify only checks "the pack has at least one file", so a
-  # smoke-test record left sitting in $OUTPUT would make a pack that never
-  # received real facts (build step skipped, wrong flags, wrong TU) look
-  # ready anyway.
-  local smoke_dir smoke_src smoke_out
-  smoke_dir=$(mktemp -d)
-  smoke_src="$smoke_dir/smoke.cpp"
-  smoke_out="$smoke_dir/out"
-  printf 'int abicheck_smoke_test() { return 0; }\n' > "$smoke_src"
-  mkdir -p "$smoke_out"
-  if ! "$COMPILER" -std=c++17 \
-      -fplugin="$plugin_so" \
-      -Xclang -plugin-arg-abicheck-facts -Xclang "out=$smoke_out" \
-      -fsyntax-only "$smoke_src" 2>"$smoke_dir/stderr.log"; then
-    cat "$smoke_dir/stderr.log" >&2
-    _fail "the built Clang plugin failed to load on a smoke-test translation unit -- see the compiler output above. This usually means '$COMPILER' is not the same LLVM major ($major) the plugin was built against."
-  fi
-  echo "Clang plugin smoke test passed ($plugin_so loads into $COMPILER)."
-  _reset_output_dir
-
-  # Assemble the exact flags the caller's build needs to add, one -Xclang
-  # pair per public root (public-roots= is repeatable per the plugin docs).
-  local plugin_flags="-fplugin=$plugin_so -Xclang -plugin-arg-abicheck-facts -Xclang out=$OUTPUT"
-  if [[ -n "$PUBLIC_ROOTS" ]]; then
-    local root resolved
-    while IFS= read -r root; do
-      if [[ -n "$root" ]]; then
-        resolved=$(_resolve_public_root "$root")
-        plugin_flags="$plugin_flags -Xclang -plugin-arg-abicheck-facts -Xclang public-roots=$resolved"
-      fi
-    done <<< "$PUBLIC_ROOTS"
-  fi
-  [[ -n "$LIBRARY" ]] && plugin_flags="$plugin_flags -Xclang -plugin-arg-abicheck-facts -Xclang library=$LIBRARY"
-
-  # The plugin's identity is fully fixed the moment it's built here -- the
-  # caller's later build populates the *pack*, it never changes the plugin
-  # binary itself -- so compute the complete documented identity (LLVM major
-  # + a content digest of the built plugin) now rather than emitting a
-  # partial value at prepare and clearing it at verify (CodeRabbit review).
-  # Persisted via GITHUB_ENV so the separate phase: verify invocation of
-  # this script (a fresh process) can re-emit the same value instead of
-  # re-deriving or losing it.
-  local plugin_digest
-  plugin_digest=$(python3 -c '
-import hashlib, sys
-print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest()[:12])
-' "$plugin_so")
-  local producer_version="llvm-$major+plugin-sha256-$plugin_digest"
-
-  _write_env "ABICHECK_PLUGIN_SO" "$plugin_so"
-  _write_env "ABICHECK_PLUGIN_FLAGS" "$plugin_flags"
-  _write_env "ABICHECK_PRODUCER_VERSION" "$producer_version"
-  echo "::notice::producer: clang-plugin ready at $plugin_so. Add these flags to your compile command (also exported as \$ABICHECK_PLUGIN_FLAGS): $plugin_flags -- run your build next, then call this Action again with phase: verify to check the collected pack at '$OUTPUT'."
-  _write_output "producer" "clang-plugin"
-  _write_output "mode" "pack"
-  _write_output "pack-path" "$OUTPUT"
-  _write_output "ready" "false"
-  _write_output "producer-version" "$producer_version"
+  _finish_clang_plugin "$plugin_so" "$major" "$version_suffix"
 }
 
 _verify_pack() {

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -554,7 +554,38 @@ _finish_clang_plugin() {
     cat "$smoke_dir/stderr.log" >&2
     _fail "the Clang plugin at '$plugin_so' failed to load on a smoke-test translation unit -- see the compiler output above. This usually means '$COMPILER' is not the same LLVM major ($major) the plugin was built against (for plugin-artifact: the artifact does not match this job's resolved compiler, or was built for a different C++ standard-library ABI -- see contrib/abicheck-clang-plugin/README.md's Intel oneAPI section)."
   fi
-  echo "Clang plugin smoke test passed ($plugin_so loads into $COMPILER)."
+  # A successful exit code alone doesn't prove $plugin_so is genuinely the
+  # abicheck-facts plugin -- clang's own -fplugin= just dlopen()s the named
+  # shared object; a wrong or stale artifact (a mismatched download, a build
+  # that produced a different plugin under the same filename) can load
+  # cleanly and still register no "abicheck-facts" action, silently no-op on
+  # -Xclang -plugin-arg-abicheck-facts, and exit 0 (Codex review). The real
+  # plugin's FactsConsumer::HandleTranslationUnit runs unconditionally per
+  # TU and writes a manifest.json + TU record even for a public-declaration-
+  # free smoke TU like this one (writeTu()/ensureManifest() have no
+  # publicCount gate -- confirmed by reading AbicheckFactsPlugin.cpp), so
+  # requiring a real TU record here is a genuine positive signal, not
+  # something the trivial smoke source could fail on legitimately. Catching
+  # this now, before the caller's real (potentially expensive) build runs,
+  # is strictly earlier than the identical tu_count==0 check phase: verify
+  # already performs on the real pack.
+  local smoke_validate
+  if ! smoke_validate=$(python3 -c '
+import sys
+from abicheck.buildsource.inputs_validate import validate_inputs_pack
+
+try:
+    report = validate_inputs_pack(sys.argv[1])
+except (FileNotFoundError, ValueError) as exc:
+    print(f"not a readable abicheck_inputs pack: {exc}")
+    sys.exit(1)
+if report.tu_count == 0:
+    print("zero TU records written")
+    sys.exit(1)
+' "$smoke_out"); then
+    _fail "the Clang plugin at '$plugin_so' loaded into '$COMPILER' and exited successfully, but the smoke-test compile emitted no facts ($smoke_validate) -- this usually means the loaded shared object is not actually the abicheck-facts plugin (a wrong or stale plugin-artifact, or a build that produced a different plugin under the same filename)."
+  fi
+  echo "Clang plugin smoke test passed ($plugin_so loads into $COMPILER, and emitted real TU facts)."
   _reset_output_dir
 
   # Assemble the exact flags the caller's build needs to add, one -Xclang

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -225,7 +225,18 @@ _llvm_major_from_predefined_macros() {
 _is_intel_llvm_compiler() {
   local compiler="$1" defines
   defines=$("$compiler" -dM -E -x c++ - < /dev/null 2>/dev/null) || true
-  if printf '%s' "$defines" | grep -q '#define __INTEL_LLVM_COMPILER'; then
+  # Match directly against the already-fully-captured $defines string with a
+  # bash pattern, not `printf ... | grep -q` -- `-q` exits as soon as it
+  # finds a match, and under this script's global `set -o pipefail` that can
+  # SIGPIPE the upstream `printf` on a large macro dump (icpx's own -dM -E
+  # output runs to hundreds/thousands of lines) before it finishes writing,
+  # making the pipeline's exit status reflect the killed writer rather than
+  # the real match and silently taking the "false" branch below -- exactly
+  # defeating the Intel-fork detection this function exists to provide.
+  # $defines is already in memory from the command substitution above, so no
+  # pipe (and no such race) is needed at all (Codex review, reproduced with
+  # a large fake macro dump).
+  if [[ "$defines" == *"#define __INTEL_LLVM_COMPILER"* ]]; then
     echo "true"
   else
     echo "false"

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -569,6 +569,13 @@ _finish_clang_plugin() {
   # this now, before the caller's real (potentially expensive) build runs,
   # is strictly earlier than the identical tu_count==0 check phase: verify
   # already performs on the real pack.
+  # Check report.errors too, not just tu_count -- a stale/incompatible
+  # artifact can genuinely load, register the "abicheck-facts" action, and
+  # write a TU record that validate_inputs_pack() still flags as invalid
+  # (e.g. an incompatible fact-set version/name), same as _verify_pack
+  # checks on the real pack below. Leaving this unchecked would accept the
+  # artifact and export its flags before the caller's real build runs,
+  # defeating the point of catching a stale artifact early (Codex review).
   local smoke_validate
   if ! smoke_validate=$(python3 -c '
 import sys
@@ -579,11 +586,14 @@ try:
 except (FileNotFoundError, ValueError) as exc:
     print(f"not a readable abicheck_inputs pack: {exc}")
     sys.exit(1)
+if report.errors:
+    print("pack validation error(s): " + "; ".join(report.errors))
+    sys.exit(1)
 if report.tu_count == 0:
     print("zero TU records written")
     sys.exit(1)
 ' "$smoke_out"); then
-    _fail "the Clang plugin at '$plugin_so' loaded into '$COMPILER' and exited successfully, but the smoke-test compile emitted no facts ($smoke_validate) -- this usually means the loaded shared object is not actually the abicheck-facts plugin (a wrong or stale plugin-artifact, or a build that produced a different plugin under the same filename)."
+    _fail "the Clang plugin at '$plugin_so' loaded into '$COMPILER' and exited successfully, but the smoke-test compile emitted no valid facts ($smoke_validate) -- this usually means the loaded shared object is not actually the abicheck-facts plugin, or is a stale/incompatible build of it (a wrong or stale plugin-artifact, or a build that produced a different plugin under the same filename)."
   fi
   echo "Clang plugin smoke test passed ($plugin_so loads into $COMPILER, and emitted real TU facts)."
   _reset_output_dir

--- a/actions/collect-facts/run.sh
+++ b/actions/collect-facts/run.sh
@@ -620,6 +620,17 @@ $version_output"
   # identical smoke test every from-source build gets.
   if [[ -n "$PLUGIN_ARTIFACT" ]]; then
     [[ -f "$PLUGIN_ARTIFACT" ]] || _fail "plugin-artifact '$PLUGIN_ARTIFACT' does not exist -- expected a pre-built libabicheck-facts.* shared object."
+    # Resolve to an absolute path up front, same rationale as $OUTPUT further
+    # up: the caller's real build (invoked from its own build directory, per
+    # the documented CMake compiler-launcher recipe) and this Action's own
+    # separate phase: verify invocation both run as different processes with
+    # a potentially different cwd than this prepare step -- a relative
+    # plugin-artifact would silently stop pointing at the validated file
+    # once exported into ABICHECK_PLUGIN_SO/ABICHECK_PLUGIN_FLAGS's
+    # -fplugin= (Codex review).
+    if ! _is_absolute_path "$PLUGIN_ARTIFACT"; then
+      PLUGIN_ARTIFACT="$(_native_pwd)/$PLUGIN_ARTIFACT"
+    fi
     if [[ -n "$PLUGIN_ARTIFACT_SHA256" ]]; then
       local actual_sha256
       actual_sha256=$(python3 -c '
@@ -730,7 +741,15 @@ print(hashlib.sha256(open(sys.argv[1], "rb").read()).hexdigest())
     echo "::notice::Building against the vendor-bundled Intel oneAPI LLVM/Clang SDK -- passing -DABICHECK_PLUGIN_RTTI=off -DABICHECK_PLUGIN_STDLIB=libc++ (the recipe real testing found necessary; see README.md). This build is NOT certified: only a minimal AST plugin has been verified end-to-end against icpx/icx, not this full plugin's own conformance suite. Prefer plugin-artifact with a build you have separately certified for production use."
   fi
 
+  # Pin CMake to the exact resolved compiler binary rather than letting it
+  # fall back to its own default (or an ambient $CXX) discovery -- without
+  # this, a caller resolving a vendor toolchain via llvm-cmake-prefix could
+  # still have CMake silently configure against a *different*, PATH-default
+  # C++ compiler (e.g. the runner's g++), which the Intel ABI knobs above
+  # then fail loudly against (g++ rejects -stdlib=) rather than silently
+  # producing a plugin that doesn't actually match $COMPILER (Codex review).
   cmake -S "$plugin_src" -B "$build_dir" \
+    -DCMAKE_CXX_COMPILER="$compiler_path" \
     ${llvm_cmake_dir:+-DCMAKE_PREFIX_PATH="$llvm_cmake_dir/.."} \
     "${extra_cmake_defines[@]}" \
     || _fail "cmake configure failed for the Clang plugin -- $cmake_hint"

--- a/contrib/abicheck-clang-plugin/AGENTS.md
+++ b/contrib/abicheck-clang-plugin/AGENTS.md
@@ -49,6 +49,20 @@ A build of this plugin only loads into the exact clang it was built against
   `ClangConfig.cmake`). Building against that fork's *own* source at the
   matching release commit is the only reliable path if support is ever
   wanted; a green matrix leg here is not evidence toward that.
+  **Confirmed, not just theorized, for Intel's fork**: real testing against
+  a real `icpx` install found a same-major distro Clang build both (a)
+  fails to load outright with RTTI enabled and (b) crashes once it *does*
+  load, from a libstdc++-vs-libc++ standard-library ABI mismatch crossing
+  the Clang plugin interface — see README.md's "Intel oneAPI (icx/icpx) —
+  experimental, not certified" section for the full findings and the
+  `ABICHECK_PLUGIN_RTTI`/`ABICHECK_PLUGIN_STDLIB` CMake overrides this
+  produced. `actions/collect-facts/run.sh`'s `_prepare_clang_plugin`
+  refuses the same-major apt fallback for this specific fork (detected via
+  the `__INTEL_LLVM_COMPILER` predefined macro) rather than silently
+  attempting a build known to produce a broken artifact — don't revert that
+  refusal to "fix" a user's build failure; point them at `llvm-cmake-prefix`
+  (a genuine vendor SDK) or `plugin-artifact` (a pre-certified binary)
+  instead, per the README's recommended distribution model.
 - This asymmetry is *why* the plugin is optional infrastructure: Full source
   scan and the `abicheck-cc` wrapper remain the portable, always-supported
   producers. Don't propose making the plugin required without addressing

--- a/contrib/abicheck-clang-plugin/CMakeLists.txt
+++ b/contrib/abicheck-clang-plugin/CMakeLists.txt
@@ -16,11 +16,46 @@ target_include_directories(abicheck-facts SYSTEM PRIVATE ${LLVM_INCLUDE_DIRS} ${
 target_compile_definitions(abicheck-facts PRIVATE ${LLVM_DEFINITIONS})
 target_compile_features(abicheck-facts PRIVATE cxx_std_17)
 
+# Explicit overrides for the two ABI knobs a downstream LLVM fork can get
+# wrong relative to what find_package(LLVM) reports -- see the Intel
+# oneAPI/icx experimental section in README.md. Both default to "auto"
+# (today's pre-existing, unmodified behavior for every vanilla apt.llvm.org/
+# Apple/Debian Clang toolchain): RTTI follows the discovered
+# LLVM_ENABLE_RTTI value below, and the standard library follows whatever
+# -stdlib the toolchain defaults to.
+set(ABICHECK_PLUGIN_RTTI "auto" CACHE STRING
+  "RTTI mode for the plugin: auto (honor the discovered LLVM_ENABLE_RTTI), on, or off.")
+set_property(CACHE ABICHECK_PLUGIN_RTTI PROPERTY STRINGS auto on off)
+
+set(ABICHECK_PLUGIN_STDLIB "auto" CACHE STRING
+  "C++ standard library ABI to build the plugin against: auto (toolchain default), libc++, or libstdc++.")
+set_property(CACHE ABICHECK_PLUGIN_STDLIB PROPERTY STRINGS auto libc++ libstdc++)
+
 # LLVM/Clang are conventionally built without RTTI; a plugin that links their
 # symbols must match, or it fails to load (undefined typeinfo). Honor the
-# loading toolchain's setting when CMake exposes it.
-if(NOT LLVM_ENABLE_RTTI)
+# loading toolchain's setting when CMake exposes it, unless the caller
+# overrides it explicitly (a vendor-bundled LLVM/Clang CMake package does not
+# always populate LLVM_ENABLE_RTTI, so "auto" can mean "unknown, assume RTTI
+# is on" rather than "confirmed on").
+if(ABICHECK_PLUGIN_RTTI STREQUAL "off")
   target_compile_options(abicheck-facts PRIVATE -fno-rtti)
+elseif(ABICHECK_PLUGIN_RTTI STREQUAL "auto" AND NOT LLVM_ENABLE_RTTI)
+  target_compile_options(abicheck-facts PRIVATE -fno-rtti)
+endif()
+
+# Some toolchains (observed for Intel's icpx/icx oneAPI compiler) run their
+# Clang frontend against libc++ rather than the host's libstdc++, even on
+# Linux -- a plugin built against the wrong one crosses the Clang plugin
+# ABI boundary (ParseArgs's std::vector<std::string> argument, among others)
+# with mismatched container layouts and crashes rather than merely failing
+# to load. "auto" (the default) changes nothing, matching every existing
+# vanilla-Clang build.
+if(ABICHECK_PLUGIN_STDLIB STREQUAL "libc++")
+  target_compile_options(abicheck-facts PRIVATE -stdlib=libc++)
+  target_link_options(abicheck-facts PRIVATE -stdlib=libc++)
+elseif(ABICHECK_PLUGIN_STDLIB STREQUAL "libstdc++")
+  target_compile_options(abicheck-facts PRIVATE -stdlib=libstdc++)
+  target_link_options(abicheck-facts PRIVATE -stdlib=libstdc++)
 endif()
 
 # Clang plugins link against the loading clang's symbols; do not bundle LLVM.

--- a/contrib/abicheck-clang-plugin/CMakeLists.txt
+++ b/contrib/abicheck-clang-plugin/CMakeLists.txt
@@ -31,15 +31,33 @@ set(ABICHECK_PLUGIN_STDLIB "auto" CACHE STRING
   "C++ standard library ABI to build the plugin against: auto (toolchain default), libc++, or libstdc++.")
 set_property(CACHE ABICHECK_PLUGIN_STDLIB PROPERTY STRINGS auto libc++ libstdc++)
 
+# The cache STRINGS property above is GUI-only (a CMake ComboBox hint) --
+# CMake does not enforce it on a value supplied via -D, so a case mismatch
+# or typo (e.g. -DABICHECK_PLUGIN_RTTI=OFF, the CMake ON/OFF convention)
+# would otherwise silently fall through both case-sensitive STREQUAL
+# branches below, matching neither "off" nor "auto" and producing a plugin
+# missing the ABI fix the caller explicitly asked for -- exactly the
+# Intel-oneAPI load/crash failure this option exists to prevent (Codex
+# review). Normalize case, then fail loudly on anything else.
+string(TOLOWER "${ABICHECK_PLUGIN_RTTI}" _abicheck_plugin_rtti)
+if(NOT _abicheck_plugin_rtti MATCHES "^(auto|on|off)$")
+  message(FATAL_ERROR "ABICHECK_PLUGIN_RTTI must be one of auto, on, off (got: '${ABICHECK_PLUGIN_RTTI}')")
+endif()
+
+string(TOLOWER "${ABICHECK_PLUGIN_STDLIB}" _abicheck_plugin_stdlib)
+if(NOT _abicheck_plugin_stdlib MATCHES "^(auto|libc\\+\\+|libstdc\\+\\+)$")
+  message(FATAL_ERROR "ABICHECK_PLUGIN_STDLIB must be one of auto, libc++, libstdc++ (got: '${ABICHECK_PLUGIN_STDLIB}')")
+endif()
+
 # LLVM/Clang are conventionally built without RTTI; a plugin that links their
 # symbols must match, or it fails to load (undefined typeinfo). Honor the
 # loading toolchain's setting when CMake exposes it, unless the caller
 # overrides it explicitly (a vendor-bundled LLVM/Clang CMake package does not
 # always populate LLVM_ENABLE_RTTI, so "auto" can mean "unknown, assume RTTI
 # is on" rather than "confirmed on").
-if(ABICHECK_PLUGIN_RTTI STREQUAL "off")
+if(_abicheck_plugin_rtti STREQUAL "off")
   target_compile_options(abicheck-facts PRIVATE -fno-rtti)
-elseif(ABICHECK_PLUGIN_RTTI STREQUAL "auto" AND NOT LLVM_ENABLE_RTTI)
+elseif(_abicheck_plugin_rtti STREQUAL "auto" AND NOT LLVM_ENABLE_RTTI)
   target_compile_options(abicheck-facts PRIVATE -fno-rtti)
 endif()
 
@@ -50,10 +68,10 @@ endif()
 # with mismatched container layouts and crashes rather than merely failing
 # to load. "auto" (the default) changes nothing, matching every existing
 # vanilla-Clang build.
-if(ABICHECK_PLUGIN_STDLIB STREQUAL "libc++")
+if(_abicheck_plugin_stdlib STREQUAL "libc++")
   target_compile_options(abicheck-facts PRIVATE -stdlib=libc++)
   target_link_options(abicheck-facts PRIVATE -stdlib=libc++)
-elseif(ABICHECK_PLUGIN_STDLIB STREQUAL "libstdc++")
+elseif(_abicheck_plugin_stdlib STREQUAL "libstdc++")
   target_compile_options(abicheck-facts PRIVATE -stdlib=libstdc++)
   target_link_options(abicheck-facts PRIVATE -stdlib=libstdc++)
 endif()

--- a/contrib/abicheck-clang-plugin/README.md
+++ b/contrib/abicheck-clang-plugin/README.md
@@ -318,6 +318,91 @@ matrix version, so the plugin and the wrapper's extractor use the identical
 clang — the precondition for byte-for-byte parity). It is a standalone,
 non-blocking workflow, never a required abicheck-CI gate.
 
+## Intel oneAPI (icx/icpx) — experimental, not certified
+
+The plugin can load into Intel's oneAPI DPC++/C++ Compiler (`icpx`/`icx`), a
+downstream LLVM fork — but a same-major distro/apt Clang development package
+is **not** a safe substitute for building against it, and the
+`collect-facts` Action (`producer: clang-plugin`) refuses that fallback for
+this compiler specifically. This is a policy, not a hypothetical: a real,
+end-to-end evaluation against Intel(R) oneAPI DPC++/C++ Compiler 2026.1.1
+(Clang 22 frontend, `__INTEL_LLVM_COMPILER`) found real ABI mismatches, not
+mere API differences:
+
+- **RTTI.** A plugin built with RTTI enabled fails to load into `icpx`
+  (`undefined symbol: _ZTIN5clang15PluginASTActionE`) — `icpx` itself is
+  built without RTTI, and this CMakeLists.txt's existing `LLVM_ENABLE_RTTI`
+  auto-detection has no way to see that unless a genuine Intel-provided LLVM
+  CMake package is on hand to report it. `-fno-rtti` is required
+  (`ABICHECK_PLUGIN_RTTI=off`, see below).
+- **C++ standard library.** `icpx`'s frontend stack uses libc++
+  (`std::__1::…`) even on Linux, while a plugin built against a stock
+  distro/apt Clang links libstdc++ (`std::__cxx11::…`). The Clang plugin
+  ABI crosses this boundary directly — `ParseArgs`'s own
+  `const std::vector<std::string> &args` parameter is exactly where this
+  was reproduced as a real crash (exit 139) the moment the plugin actually
+  reads the argument vector, which this plugin's `FactsAction::ParseArgs`
+  does immediately. `-stdlib=libc++` is required
+  (`ABICHECK_PLUGIN_STDLIB=libc++`, see below).
+- **Do not link `libclang-cpp`/`libLLVM` into the plugin as a workaround.**
+  That reproduces a *different* crash — duplicate LLVM command-line-option
+  registration between the plugin's bundled copy and the loading compiler's
+  own (`fatal error: inconsistency in registered CommandLine options`). The
+  plugin must stay an unlinked module whose Clang/LLVM symbols resolve from
+  the loading process, exactly as the existing "do not bundle LLVM" comment
+  in `CMakeLists.txt` already states for every other toolchain too.
+
+`CMakeLists.txt` exposes both knobs as explicit overrides
+(`-DABICHECK_PLUGIN_RTTI=off -DABICHECK_PLUGIN_STDLIB=libc++`) rather than
+guessing; every other toolchain's build is unaffected (`auto`, the default,
+changes nothing). `collect-facts` passes both automatically whenever it
+builds against a vendor-bundled Intel LLVM/Clang SDK (`llvm-cmake-prefix`
+resolves one) — see `run.sh`'s `_prepare_clang_plugin`.
+
+**What is verified, and what is not.** A minimal, argument-blind AST plugin
+built with this recipe loads and runs correctly under `icpx` — confirmed
+end to end. This plugin's own conformance suite
+(`tests/conformance.py`, differential parity against the wrapper) and
+`scan_flow.py` (pack → `abicheck dump --build-info` → binary matching) have
+**not** been run against `icpx` in this environment. Until they have, treat
+any from-source `icpx` build of this plugin as **experimental**, not a
+certified producer for a real release gate — `collect-facts` marks it as
+such in `producer-version` (an `+experimental-intel-llvm` suffix) precisely
+so a downstream consumer can tell it apart from an ordinary certified
+vanilla-Clang build. The default, always-supported paths for `icpx`/`icx`
+remain Full source scan (`dump --sources`) and the `abicheck-cc` wrapper
+(both exercise the real per-TU compiler context, including
+`icpx`'s SYCL host/device handling); the plugin is an optional, opt-in
+optimization on top of that, same as for every other toolchain.
+
+### Recommended distribution model: certified artifact, not same-major rebuild
+
+A vendor toolchain's own plugin-development SDK is rarely available as an
+apt/distro package (a *stock* `icpx`/`icx` install ships `IntelSYCL`/
+`IntelDPCPP` CMake modules, never `LLVMConfig.cmake`/`ClangConfig.cmake` —
+see `contrib/abicheck-clang-plugin/AGENTS.md`), and — per the ABI findings
+above — even when a matching upstream Clang *is* available, building
+against it instead of the vendor's own fork is not a safe substitute for
+this fork specifically. The one binary that is genuinely safe to load is one
+built against the *exact* toolchain image that will later load it, and
+that build is expensive and slow enough that it does not belong in every
+client repository's own CI run.
+
+The supported model is therefore: build the plugin **once** per exact
+toolchain fingerprint (compiler family + version + build date, the resolved
+frontend binary's own digest, target triple, RTTI/stdlib mode, this plugin's
+source commit), publish that binary as a versioned artifact (a GitHub
+Release asset, an OCI artifact, or a layer baked into the same pinned
+toolchain image that contains the compiler), and have each consuming
+workflow point `collect-facts`'s `plugin-artifact` input at it — optionally
+pinned with `plugin-artifact-sha256`. A client repository commits the lock
+(the fingerprint fields plus the artifact digest), not the binary itself;
+an air-gapped deployment that must vendor the `.so` alongside the lock is an
+explicit, opt-in exception to that, not the default. `collect-facts` still
+runs the same smoke test against a supplied `plugin-artifact` that a
+from-source build gets, so a stale or mismatched artifact fails loudly
+before it ever reaches your real build.
+
 ## Compiler fallbacks (documented, not required)
 
 A build that cannot load a Clang plugin can still feed the same

--- a/docs/_meta/topics.yaml
+++ b/docs/_meta/topics.yaml
@@ -140,6 +140,7 @@ topics:
     fact_sources:
       - abicheck/buildsource
       - contrib/abicheck-clang-plugin
+      - actions/collect-facts/action.yml
     reference_page: use/build-evidence-setup.md
 
   baseline-storage-backends:

--- a/docs/use/producing-source-facts.md
+++ b/docs/use/producing-source-facts.md
@@ -174,26 +174,17 @@ LLVM+Clang CMake package matching the compiler's exact LLVM major.
     Unlike vanilla Clang, `collect-facts` **refuses** to fall back to
     installing a same-major `clang-N`/`llvm-N-dev`/`libclang-N-dev` package
     when it detects Intel's oneAPI fork specifically (via the
-    `__INTEL_LLVM_COMPILER` predefined macro). Real end-to-end testing found
-    that build an ABI mismatch against the loading `icpx`/`icx` — an RTTI
-    typeinfo load failure, and a libstdc++-vs-libc++ standard-library crash
-    once the plugin actually reads its own arguments — not a merely-degraded
-    result. Two paths are supported instead: `llvm-cmake-prefix` pointed at
-    Intel's own matching LLVM/Clang CMake package (when you have one), or
-    the new `plugin-artifact` input pointed at an already-built,
-    already-certified plugin binary — the recommended path, since a real
-    ICX build is slow enough, and depends on a specific enough toolchain
-    image, that it belongs in a one-time build step rather than every
-    client repository's own CI run. See
-    `contrib/abicheck-clang-plugin/README.md`'s "Intel oneAPI (icx/icpx) —
-    experimental, not certified" section for the full findings and the
-    recommended certified-artifact distribution model. Even a successful
-    from-source build against a genuine vendor SDK is marked
-    `+experimental-intel-llvm` in the `producer-version` output — this
-    plugin's own conformance/ingestion test suite has not been run against
-    `icpx`/`icx` in the environment that produced this policy. `dump
+    `__INTEL_LLVM_COMPILER` predefined macro) — that build is a real ABI
+    mismatch against the loading `icpx`/`icx`, not a merely-degraded result.
+    Use `llvm-cmake-prefix` pointed at Intel's own matching LLVM/Clang CMake
+    package if you have one, or (recommended) the `plugin-artifact` input
+    pointed at an already-built, already-certified plugin binary. `dump
     --sources` (Full source scan) and the `abicheck-cc` wrapper remain the
-    portable, always-supported paths for this compiler.
+    portable, always-supported paths for this compiler otherwise. See
+    `contrib/abicheck-clang-plugin/README.md`'s "Intel oneAPI (icx/icpx) —
+    experimental, not certified" section (the canonical source) for the
+    full findings, the ABI knobs a from-source build needs, and the
+    certified-artifact distribution model.
 
 ## The one trap: public-roots must match how headers *resolve*
 

--- a/docs/use/producing-source-facts.md
+++ b/docs/use/producing-source-facts.md
@@ -170,6 +170,31 @@ plugin-development SDK. For a stock Intel install, expect to set
 `llvm-cmake-prefix` explicitly, pointing at a separately obtained or built
 LLVM+Clang CMake package matching the compiler's exact LLVM major.
 
+!!! warning "Intel's `icpx`/`icx` fork: no same-major apt fallback, experimental status"
+    Unlike vanilla Clang, `collect-facts` **refuses** to fall back to
+    installing a same-major `clang-N`/`llvm-N-dev`/`libclang-N-dev` package
+    when it detects Intel's oneAPI fork specifically (via the
+    `__INTEL_LLVM_COMPILER` predefined macro). Real end-to-end testing found
+    that build an ABI mismatch against the loading `icpx`/`icx` — an RTTI
+    typeinfo load failure, and a libstdc++-vs-libc++ standard-library crash
+    once the plugin actually reads its own arguments — not a merely-degraded
+    result. Two paths are supported instead: `llvm-cmake-prefix` pointed at
+    Intel's own matching LLVM/Clang CMake package (when you have one), or
+    the new `plugin-artifact` input pointed at an already-built,
+    already-certified plugin binary — the recommended path, since a real
+    ICX build is slow enough, and depends on a specific enough toolchain
+    image, that it belongs in a one-time build step rather than every
+    client repository's own CI run. See
+    `contrib/abicheck-clang-plugin/README.md`'s "Intel oneAPI (icx/icpx) —
+    experimental, not certified" section for the full findings and the
+    recommended certified-artifact distribution model. Even a successful
+    from-source build against a genuine vendor SDK is marked
+    `+experimental-intel-llvm` in the `producer-version` output — this
+    plugin's own conformance/ingestion test suite has not been run against
+    `icpx`/`icx` in the environment that produced this policy. `dump
+    --sources` (Full source scan) and the `abicheck-cc` wrapper remain the
+    portable, always-supported paths for this compiler.
+
 ## The one trap: public-roots must match how headers *resolve*
 
 !!! warning "Point the public-header root at the resolved path, not the install dir"

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -423,6 +423,59 @@ class TestLlvmMajorFromPredefinedMacros:
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
 )
+class TestIsIntelLlvmCompiler:
+    """__INTEL_LLVM_COMPILER is a separate, narrower question than the LLVM
+    major above: two compilers can report the identical __clang_major__
+    while being different, ABI-incompatible builds (contrib/abicheck-clang-
+    plugin/README.md's Intel oneAPI section) -- this is the signal
+    _prepare_clang_plugin uses to refuse the same-major apt/distro fallback
+    for that specific fork."""
+
+    def _fake_compiler(self, tmp_path: Path, *defines: str) -> Path:
+        script = tmp_path / "fake-compiler"
+        printf_lines = "\n".join(f"  printf '{line}\\n'" for line in defines)
+        script.write_text(
+            "#!/bin/sh\n"
+            'if [ "$1" = "-dM" ]; then\n'
+            f"{printf_lines}\n"
+            "  exit 0\n"
+            "fi\n"
+            "exit 1\n"
+        )
+        script.chmod(0o755)
+        return script
+
+    def test_true_for_intel_llvm_compiler(self, tmp_path: Path) -> None:
+        compiler = self._fake_compiler(
+            tmp_path,
+            "#define __clang_major__ 22",
+            "#define __INTEL_LLVM_COMPILER 20260101",
+        )
+        result = _run_predicate(f'_is_intel_llvm_compiler "{compiler}"')
+        assert result.stdout.strip() == "true"
+
+    def test_false_for_vanilla_clang(self, tmp_path: Path) -> None:
+        compiler = self._fake_compiler(tmp_path, "#define __clang_major__ 18")
+        result = _run_predicate(f'_is_intel_llvm_compiler "{compiler}"')
+        assert result.stdout.strip() == "false"
+
+    def test_false_when_compiler_does_not_support_dM(self, tmp_path: Path) -> None:
+        script = tmp_path / "fake-gcc"
+        script.write_text("#!/bin/sh\nexit 1\n")
+        script.chmod(0o755)
+        result = _run_predicate(f'_is_intel_llvm_compiler "{script}"')
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "false"
+
+    def test_false_when_compiler_not_found(self) -> None:
+        result = _run_predicate('_is_intel_llvm_compiler "/no/such/compiler-xyz"')
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "false"
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
 class TestNormalizeWinPath:
     """Regression (Codex review): a native Windows env var like $CMPLR_ROOT
     (set by a vendor batch/setup step, e.g. "C:\\Program Files (x86)\\
@@ -895,6 +948,161 @@ class TestInvalidInputsRejected:
         )
         assert result.returncode == 1
         assert "producer: auto" in result.stdout
+
+
+def _fake_dm_compiler(
+    tmp_path: Path, *defines: str, name: str = "fake-compiler"
+) -> Path:
+    """A fake compiler that answers -dM -E with the given #define lines and
+    otherwise fails -- for tests that only exercise LLVM-major/vendor
+    detection, not an actual compile."""
+    script = tmp_path / name
+    printf_lines = "\n".join(f"  printf '{line}\\n'" for line in defines)
+    script.write_text(
+        f'#!/bin/sh\nif [ "$1" = "-dM" ]; then\n{printf_lines}\n  exit 0\nfi\nexit 1\n'
+    )
+    script.chmod(0o755)
+    return script
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
+class TestClangPluginIntelLlvmRefusal:
+    """P0 fix: producer: clang-plugin used to fall back to installing a
+    same-major apt/distro Clang dev package for ANY compiler, Intel's
+    icpx/icx oneAPI fork included -- real testing found the resulting
+    plugin an ABI mismatch (RTTI, libstdc++-vs-libc++) that crashes rather
+    than merely fails to load (contrib/abicheck-clang-plugin/README.md's
+    Intel oneAPI section). This fork must instead be refused outright
+    unless a genuine vendor-bundled SDK or a plugin-artifact was supplied."""
+
+    def test_refuses_apt_fallback_for_intel_llvm_without_vendor_sdk(
+        self, tmp_path: Path
+    ) -> None:
+        compiler = _fake_dm_compiler(
+            tmp_path,
+            "#define __clang_major__ 22",
+            "#define __INTEL_LLVM_COMPILER 20260101",
+        )
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "clang-plugin",
+                "INPUT_COMPILER": str(compiler),
+                "INPUT_INSTALL_DEPS": "false",
+                "CMPLR_ROOT": "",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "Intel oneAPI DPC++/C++ Compiler" in result.stdout
+        assert "plugin-artifact" in result.stdout
+        assert "llvm-cmake-prefix" in result.stdout
+
+    def test_does_not_misfire_for_a_vanilla_same_major_clang(
+        self, tmp_path: Path
+    ) -> None:
+        # A vanilla Clang that merely shares an LLVM major with some real
+        # apt.llvm.org package must still be allowed to fall through to the
+        # ordinary apt-get path -- the refusal is scoped to the Intel
+        # oneAPI fork specifically, detected via __INTEL_LLVM_COMPILER, not
+        # to any particular major number.
+        compiler = _fake_dm_compiler(tmp_path, "#define __clang_major__ 18")
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "clang-plugin",
+                "INPUT_COMPILER": str(compiler),
+                "INPUT_INSTALL_DEPS": "false",
+                "CMPLR_ROOT": "",
+            },
+            tmp_path,
+        )
+        assert "Intel oneAPI DPC++/C++ Compiler" not in result.stdout
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
+class TestClangPluginArtifactProducer:
+    """plugin-artifact: use an already-built, already-certified plugin
+    binary directly, skipping the CMake build entirely -- the recommended
+    path for a vendor fork whose plugin-development SDK isn't available in
+    this job (see action.yml's description and README.md's Intel oneAPI
+    section)."""
+
+    def _fake_compiler(self, tmp_path: Path, *defines: str) -> Path:
+        # Unlike _fake_dm_compiler above, this one also succeeds a
+        # non--dM invocation (the smoke-test compile), since the artifact
+        # path must reach and pass that smoke test.
+        script = tmp_path / "fake-compiler"
+        printf_lines = "\n".join(f"  printf '{line}\\n'" for line in defines)
+        script.write_text(
+            "#!/bin/sh\n"
+            'if [ "$1" = "-dM" ]; then\n'
+            f"{printf_lines}\n"
+            "  exit 0\n"
+            "fi\n"
+            "exit 0\n"
+        )
+        script.chmod(0o755)
+        return script
+
+    def test_plugin_artifact_skips_build_and_succeeds(self, tmp_path: Path) -> None:
+        compiler = self._fake_compiler(tmp_path, "#define __clang_major__ 18")
+        artifact = tmp_path / "libabicheck-facts.so"
+        artifact.write_bytes(b"fake-plugin-binary")
+        output = tmp_path / "abicheck_inputs"
+        result, github_env, github_output = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "clang-plugin",
+                "INPUT_COMPILER": str(compiler),
+                "INPUT_PLUGIN_ARTIFACT": str(artifact),
+                "INPUT_OUTPUT": str(output),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        outputs = _parse_kv_file(github_output)
+        assert outputs["producer"] == "clang-plugin"
+        assert outputs["mode"] == "pack"
+        assert outputs["ready"] == "false"
+        assert outputs["producer-version"].startswith("llvm-18+plugin-sha256-")
+        env = _parse_kv_file(github_env)
+        assert env["ABICHECK_PLUGIN_SO"] == str(artifact)
+
+    def test_plugin_artifact_sha256_mismatch_fails(self, tmp_path: Path) -> None:
+        compiler = self._fake_compiler(tmp_path, "#define __clang_major__ 18")
+        artifact = tmp_path / "libabicheck-facts.so"
+        artifact.write_bytes(b"fake-plugin-binary")
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "clang-plugin",
+                "INPUT_COMPILER": str(compiler),
+                "INPUT_PLUGIN_ARTIFACT": str(artifact),
+                "INPUT_PLUGIN_ARTIFACT_SHA256": "0" * 64,
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "sha256 mismatch" in result.stdout
+
+    def test_plugin_artifact_missing_file_fails(self, tmp_path: Path) -> None:
+        compiler = self._fake_compiler(tmp_path, "#define __clang_major__ 18")
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "clang-plugin",
+                "INPUT_COMPILER": str(compiler),
+                "INPUT_PLUGIN_ARTIFACT": str(tmp_path / "does-not-exist.so"),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "does not exist" in result.stdout
 
 
 @pytest.mark.skipif(
@@ -1456,12 +1664,18 @@ class TestClangPluginSmokeTestIsolation:
         # toolchain to run at all, so assert the invariant statically
         # against the source instead (same technique as
         # test_smoke_compile_never_targets_output_dir above).
+        #
+        # _reset_output_dir now lives in the shared _finish_clang_plugin tail
+        # (both the from-source build and the plugin-artifact path route
+        # through it, so it's checked once rather than duplicated) -- widen
+        # the scanned region to start at _finish_clang_plugin, immediately
+        # before _prepare_clang_plugin, through _verify_pack.
         text = RUN_SH.read_text(encoding="utf-8")
-        start = text.index("_prepare_clang_plugin() {")
+        start = text.index("_finish_clang_plugin() {")
         end = text.index("\n_verify_pack() {", start)
         plugin_block = text[start:end]
         assert "_reset_output_dir\n" in plugin_block, (
-            "_prepare_clang_plugin must clear any stale pack at $OUTPUT "
+            "_finish_clang_plugin must clear any stale pack at $OUTPUT "
             "(via _reset_output_dir) before use, not a bare mkdir -p that "
             "leaves old source_facts/*.jsonl in place"
         )

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -467,6 +467,40 @@ class TestIsIntelLlvmCompiler:
         assert result.returncode == 0, result.stderr
         assert result.stdout.strip() == "false"
 
+    def test_true_for_large_macro_dump_with_match_near_the_start(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): the previous implementation piped the
+        # captured macro dump through `printf ... | grep -q ...` under this
+        # script's global `set -o pipefail` -- `grep -q` exits as soon as it
+        # finds a match. If the match comes early, relative to a large
+        # remaining dump (icpx's own -dM -E output runs to hundreds/
+        # thousands of lines), grep can close the pipe's read end while
+        # `printf` (writing from a real subprocess, since it's piped) is
+        # still blocked writing the rest into a full pipe buffer -- SIGPIPE
+        # kills that printf, and under pipefail the pipeline's exit status
+        # reflects the killed writer, not the real match, silently taking
+        # the "false" branch below. Put the real match FIRST, then pad well
+        # past a typical 64KB pipe buffer, so grep can exit long before
+        # printf finishes writing.
+        script = tmp_path / "fake-compiler-large-dump"
+        script.write_text(
+            "#!/bin/sh\n"
+            'if [ "$1" = "-dM" ]; then\n'
+            "  printf '#define __INTEL_LLVM_COMPILER 20260101\\n'\n"
+            "  i=0\n"
+            "  while [ $i -lt 20000 ]; do\n"
+            "    printf '#define ABICHECK_PADDING_DEFINE_%d 1\\n' \"$i\"\n"
+            "    i=$((i + 1))\n"
+            "  done\n"
+            "  exit 0\n"
+            "fi\n"
+            "exit 1\n"
+        )
+        script.chmod(0o755)
+        result = _run_predicate(f'_is_intel_llvm_compiler "{script}"')
+        assert result.stdout.strip() == "true"
+
     def test_false_when_compiler_not_found(self) -> None:
         result = _run_predicate('_is_intel_llvm_compiler "/no/such/compiler-xyz"')
         assert result.returncode == 0, result.stderr

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -1104,6 +1104,60 @@ class TestClangPluginArtifactProducer:
         assert result.returncode == 1
         assert "does not exist" in result.stdout
 
+    def test_relative_plugin_artifact_is_resolved_to_absolute(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): a relative plugin-artifact must be
+        # resolved against this prepare step's own cwd before being
+        # exported into ABICHECK_PLUGIN_SO/ABICHECK_PLUGIN_FLAGS -- the
+        # caller's real build (a different process, run from its own build
+        # directory per the documented CMake compiler-launcher recipe)
+        # would otherwise resolve the same relative path against the wrong
+        # directory and fail to find the validated artifact.
+        compiler = self._fake_compiler(tmp_path, "#define __clang_major__ 18")
+        (tmp_path / "libabicheck-facts.so").write_bytes(b"fake-plugin-binary")
+        result, github_env, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "clang-plugin",
+                "INPUT_COMPILER": str(compiler),
+                "INPUT_PLUGIN_ARTIFACT": "libabicheck-facts.so",
+            },
+            tmp_path,
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        env = _parse_kv_file(github_env)
+        expected = str(tmp_path / "libabicheck-facts.so")
+        assert env["ABICHECK_PLUGIN_SO"] == expected
+        assert f"-fplugin={expected}" in env["ABICHECK_PLUGIN_FLAGS"]
+
+
+@pytest.mark.skipif(
+    not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"
+)
+class TestClangPluginCmakeCompilerSelection:
+    """Regression (CodeRabbit review): the CMake configure invocation used
+    to omit -DCMAKE_CXX_COMPILER, so CMake could silently select a
+    different C++ compiler than the one this script resolved (e.g. the
+    runner's default g++) -- for a vendor-SDK build that also passes
+    -stdlib=libc++ (see TestClangPluginIntelLlvmRefusal), that produces a
+    hard configure failure against a non-Clang compiler instead of a
+    plugin that actually matches $COMPILER. Can't exercise the real cmake
+    configure without a matching libclang-<N>-dev toolchain, so assert the
+    invariant statically against the source, the same technique
+    TestClangPluginSmokeTestIsolation uses."""
+
+    def test_cmake_configure_pins_the_resolved_compiler(self) -> None:
+        text = RUN_SH.read_text(encoding="utf-8")
+        start = text.index('cmake -S "$plugin_src" -B "$build_dir"')
+        end = text.index("cmake configure failed", start)
+        configure_block = text[start:end]
+        assert '-DCMAKE_CXX_COMPILER="$compiler_path"' in configure_block, (
+            "the plugin's cmake configure must pin CMAKE_CXX_COMPILER to "
+            "the resolved compiler_path, not rely on CMake's own default "
+            "or an ambient $CXX"
+        )
+
 
 @pytest.mark.skipif(
     not RUN_SH.is_file(), reason="actions/collect-facts/run.sh not found"

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -1035,7 +1035,13 @@ class TestClangPluginArtifactProducer:
     def _fake_compiler(self, tmp_path: Path, *defines: str) -> Path:
         # Unlike _fake_dm_compiler above, this one also succeeds a
         # non--dM invocation (the smoke-test compile), since the artifact
-        # path must reach and pass that smoke test.
+        # path must reach and pass that smoke test. It also has to write a
+        # real, minimal abicheck_inputs pack into the out= directory the
+        # smoke test passes, since _finish_clang_plugin now requires a real
+        # TU record there (Codex review: a wrong/stale artifact could
+        # otherwise dlopen cleanly, register no "abicheck-facts" action,
+        # and exit 0 without ever emitting facts) -- a fake compiler that
+        # only exits 0 no longer models a genuine plugin load.
         script = tmp_path / "fake-compiler"
         printf_lines = "\n".join(f"  printf '{line}\\n'" for line in defines)
         script.write_text(
@@ -1043,6 +1049,21 @@ class TestClangPluginArtifactProducer:
             'if [ "$1" = "-dM" ]; then\n'
             f"{printf_lines}\n"
             "  exit 0\n"
+            "fi\n"
+            'outdir=""\n'
+            'for arg in "$@"; do\n'
+            '  case "$arg" in\n'
+            '    out=*) outdir="${arg#out=}" ;;\n'
+            "  esac\n"
+            "done\n"
+            'if [ -n "$outdir" ]; then\n'
+            '  python3 -c "\n'
+            "import sys\n"
+            "from abicheck.buildsource.inputs_emit import init_inputs_pack, append_source_facts\n"
+            "from abicheck.buildsource.source_abi import SourceAbiTu\n"
+            "init_inputs_pack(sys.argv[1], library='fake')\n"
+            "append_source_facts(sys.argv[1], [SourceAbiTu(tu_id='cu://smoke', target_id='target://fake', source='smoke.cpp')])\n"
+            '" "$outdir" || exit 1\n'
             "fi\n"
             "exit 0\n"
         )
@@ -1103,6 +1124,36 @@ class TestClangPluginArtifactProducer:
         )
         assert result.returncode == 1
         assert "does not exist" in result.stdout
+
+    def test_plugin_artifact_that_emits_no_facts_fails(self, tmp_path: Path) -> None:
+        # Regression (Codex review): a loadable-but-wrong .so (dlopen
+        # succeeds, but it never registers the "abicheck-facts" action)
+        # would previously pass the smoke test on exit code alone. A
+        # compiler that exits 0 without ever writing a real pack into out=
+        # must now fail the smoke test instead of being accepted.
+        script = tmp_path / "fake-compiler-no-facts"
+        script.write_text(
+            "#!/bin/sh\n"
+            'if [ "$1" = "-dM" ]; then\n'
+            "  printf '#define __clang_major__ 18\\n'\n"
+            "  exit 0\n"
+            "fi\n"
+            "exit 0\n"
+        )
+        script.chmod(0o755)
+        artifact = tmp_path / "libabicheck-facts.so"
+        artifact.write_bytes(b"loadable-but-not-really-the-plugin")
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "clang-plugin",
+                "INPUT_COMPILER": str(script),
+                "INPUT_PLUGIN_ARTIFACT": str(artifact),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "emitted no facts" in result.stdout
 
     def test_relative_plugin_artifact_is_resolved_to_absolute(
         self, tmp_path: Path

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -1263,7 +1263,13 @@ class TestClangPluginArtifactProducer:
         )
         assert result.returncode == 0, result.stdout + result.stderr
         env = _parse_kv_file(github_env)
-        expected = str(tmp_path / "libabicheck-facts.so")
+        # run.sh resolves the relative path via _native_pwd (forward-slash/
+        # cygpath -m form on Windows Git Bash), not Python's str(Path) --
+        # same reasoning as _native_abspath's own docstring above (Codex
+        # review: this assertion originally compared against str(Path),
+        # which is backslash-separated on native Windows Python and never
+        # matches what run.sh actually exports there).
+        expected = _native_abspath(tmp_path / "libabicheck-facts.so")
         assert env["ABICHECK_PLUGIN_SO"] == expected
         assert f"-fplugin={expected}" in env["ABICHECK_PLUGIN_FLAGS"]
 

--- a/tests/test_action_collect_facts.py
+++ b/tests/test_action_collect_facts.py
@@ -1153,7 +1153,58 @@ class TestClangPluginArtifactProducer:
             tmp_path,
         )
         assert result.returncode == 1
-        assert "emitted no facts" in result.stdout
+        assert "emitted no valid facts" in result.stdout
+
+    def test_plugin_artifact_with_invalid_pack_contents_fails(
+        self, tmp_path: Path
+    ) -> None:
+        # Regression (Codex review): validate_inputs_pack() can return a
+        # positive tu_count *and* report.errors at once (e.g. duplicate
+        # tu_ids) -- a stale/incompatible artifact that emits at least one
+        # readable-but-invalid TU record must still fail the smoke test,
+        # not just a zero-TU pack.
+        script = tmp_path / "fake-compiler-duplicate-tu"
+        script.write_text(
+            "#!/bin/sh\n"
+            'if [ "$1" = "-dM" ]; then\n'
+            "  printf '#define __clang_major__ 18\\n'\n"
+            "  exit 0\n"
+            "fi\n"
+            'outdir=""\n'
+            'for arg in "$@"; do\n'
+            '  case "$arg" in\n'
+            '    out=*) outdir="${arg#out=}" ;;\n'
+            "  esac\n"
+            "done\n"
+            'if [ -n "$outdir" ]; then\n'
+            '  python3 -c "\n'
+            "import sys\n"
+            "from abicheck.buildsource.inputs_emit import init_inputs_pack, append_source_facts\n"
+            "from abicheck.buildsource.source_abi import SourceAbiTu\n"
+            "init_inputs_pack(sys.argv[1], library='fake')\n"
+            "append_source_facts(sys.argv[1], [\n"
+            "    SourceAbiTu(tu_id='cu://smoke', target_id='target://fake', source='smoke.cpp'),\n"
+            "    SourceAbiTu(tu_id='cu://smoke', target_id='target://fake', source='smoke.cpp'),\n"
+            "])\n"
+            '" "$outdir" || exit 1\n'
+            "fi\n"
+            "exit 0\n"
+        )
+        script.chmod(0o755)
+        artifact = tmp_path / "libabicheck-facts.so"
+        artifact.write_bytes(b"loadable-but-emits-an-invalid-pack")
+        result, _, _ = _run_action(
+            {
+                "INPUT_PHASE": "prepare",
+                "INPUT_PRODUCER": "clang-plugin",
+                "INPUT_COMPILER": str(script),
+                "INPUT_PLUGIN_ARTIFACT": str(artifact),
+            },
+            tmp_path,
+        )
+        assert result.returncode == 1
+        assert "emitted no valid facts" in result.stdout
+        assert "duplicate tu_id" in result.stdout
 
     def test_relative_plugin_artifact_is_resolved_to_absolute(
         self, tmp_path: Path


### PR DESCRIPTION
## Summary

Correct `producer: clang-plugin`'s behavior for Intel's oneAPI DPC++/C++ Compiler (`icpx`/`icx`) based on a real, end-to-end evaluation (Intel oneAPI 2026.1.1, Clang 22 frontend) that found the plugin's existing same-major apt-fallback build path produces an ABI-mismatched, crashing artifact for this compiler specifically — not a merely-degraded one.

## Motivation

Real testing showed:
- A plugin built with RTTI enabled fails to load into `icpx` (`undefined symbol: _ZTIN5clang15PluginASTActionE`).
- A plugin built against libstdc++ crashes (exit 139) once it reads its own arguments, because `icpx`'s frontend stack uses libc++ containers across the same Clang plugin ABI boundary (`ParseArgs`'s `std::vector<std::string>`).
- Linking `libclang-cpp`/`libLLVM` into the plugin as a workaround instead produces a different crash (duplicate LLVM command-line-option registration).

`actions/collect-facts/run.sh` previously fell back to installing a same-major `clang-$major`/`llvm-$major-dev`/`libclang-$major-dev` apt package for *any* compiler reporting a matching `__clang_major__`, Intel's fork included — silently attempting a build now known to produce a broken artifact.

## Changes

- `actions/collect-facts/run.sh`: detect the Intel oneAPI fork via the `__INTEL_LLVM_COMPILER` predefined macro (`_is_intel_llvm_compiler`) and refuse the same-major apt fallback for it specifically. Add a `plugin-artifact`/`plugin-artifact-sha256` input pair to use an already-built, already-certified plugin binary directly — the recommended distribution model (build once per exact toolchain fingerprint, publish the artifact, commit only a digest/lock in client repos). When building against a genuine vendor-bundled Intel LLVM/Clang SDK (`llvm-cmake-prefix`), pass the `-fno-rtti -stdlib=libc++` recipe real testing found necessary, and mark `producer-version` as `+experimental-intel-llvm`.
- `contrib/abicheck-clang-plugin/CMakeLists.txt`: add explicit `ABICHECK_PLUGIN_RTTI` (`auto|on|off`) and `ABICHECK_PLUGIN_STDLIB` (`auto|libc++|libstdc++`) overrides. `auto` is a no-op, so every existing vanilla-Clang build is unaffected.
- Document the findings, the certified-artifact distribution model, and the experimental/not-certified status in `contrib/abicheck-clang-plugin/README.md` and `AGENTS.md`, and in `docs/use/producing-source-facts.md`.
- `tests/test_action_collect_facts.py`: cover `_is_intel_llvm_compiler`, the apt-fallback refusal (and that it doesn't misfire for vanilla Clang), and the `plugin-artifact` path (success, sha256 mismatch, missing file).

Default behavior for `dump --sources` (Full source scan) and the `abicheck-cc` wrapper — the portable, always-supported ICX paths — is unchanged.

## Checklist

- [x] Tests added / updated for new behaviour (`tests/test_action_collect_facts.py`, 92 tests pass locally)
- [x] Changelog fragment — not added: this PR touches no `abicheck/**/*.py` files (shell/CMake/Action config/docs/tests only), so `changelog.d/README.md`'s trigger doesn't apply
- [x] Docs updated (`contrib/abicheck-clang-plugin/README.md`, `AGENTS.md`, `docs/use/producing-source-facts.md`)
- [x] `ruff check`/`ruff format --check` pass on the touched Python test file; `bash -n` and a YAML parse pass on the shell/Action changes
- [x] No new `mypy`/`ruff` errors introduced

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SiMc6SKcRKwHQZuYb6VG68)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental support for Intel oneAPI `icx` and `icpx` toolchains.
  * Added support for using prebuilt Clang plugins with optional SHA-256 verification.
  * Added configurable RTTI and standard-library compatibility settings for plugin builds.

* **Bug Fixes**
  * Prevented unsafe fallback to potentially incompatible system packages for Intel compilers.

* **Documentation**
  * Added guidance for Intel toolchain setup, compatibility requirements, certified plugin artifacts, and fallback options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->