### PR TITLE
fix: close canonical_finding_id backend-dependence for three type-slot kinds

### DIFF
--- a/abicheck/finding_identity.py
+++ b/abicheck/finding_identity.py
@@ -1189,6 +1189,54 @@ def _canonicalize_params_list(value: str) -> str:
     )
 
 
+# Matches an `_Atomic`-qualified spelling in either form castxml/clang emit:
+# a bare `_Atomic` sentinel (castxml, see below) or a real wrapped spelling
+# like `_Atomic(struct Foo *)` (clang). Anchored to the whole string (after
+# stripping) rather than reusing diff_atomic.py's own word-boundary search,
+# since this helper's job is "is this ENTIRE type-slot spelling the atomic
+# side of the transition", not "does _Atomic appear anywhere".
+_ATOMIC_SLOT_RE = re.compile(r"^_Atomic\b")
+
+
+def _canonicalize_atomic_slot(value: str) -> str:
+    """Canonicalize one ``diff_atomic.py`` type-slot spelling for the
+    identity discriminator (Codex review, fresh evidence).
+
+    ``dumper_castxml.py`` cannot model C11 ``_Atomic`` at all -- it emits a
+    bare ``Unimplemented`` node with no reference to the wrapped type, so
+    its own ``_type_name()`` spells the qualified side of the transition as
+    the literal, lossy sentinel ``"_Atomic"`` (see that function's own
+    comment). The direct-clang backend, by contrast, retains the real
+    wrapped spelling clang's own AST printer produces (e.g.
+    ``"_Atomic(struct Foo *)"``). Plain :func:`canonicalize_type_name`
+    normalizes whitespace/const-ordering/pointer-sigil spacing, but has no
+    notion of "these two spellings name the same qualified type" -- so
+    without this helper, CastXML's bare sentinel and Clang's concrete
+    spelling would never hash to the same canonical id for the identical
+    qualifier-added/-removed transition, defeating the whole point of
+    adding ``atomic_qualifier_changed`` to
+    :data:`_TYPE_BEARING_DISCRIMINATOR_KINDS`.
+
+    Safe to collapse the qualified side down to the bare ``"_Atomic"``
+    sentinel for identity purposes: ``diff_atomic.py``'s own detection
+    (``_has_atomic``) only ever tests *presence* of the qualifier via a
+    regex search, never compares the wrapped type across old/new -- two
+    genuinely different ``_Atomic``-wrapped inner types on the same slot
+    can never both reach this detector as two distinct findings (the
+    detector only fires on a presence transition, and continues past an
+    unchanged, still-``_Atomic`` slot entirely) -- so no real discriminating
+    information is lost. The *unqualified* side of the transition (the
+    plain, non-``_Atomic`` type both backends spell reliably) is left to
+    ordinary :func:`canonicalize_type_name` normalization, since that side's
+    exact spelling IS backend-comparable and still needs to distinguish,
+    e.g., an unrelated base-type change from a pure qualifier change.
+    """
+    stripped = value.strip()
+    if _ATOMIC_SLOT_RE.match(stripped):
+        return "_Atomic"
+    return canonicalize_type_name(stripped)
+
+
 def _stringify_change_value(value: object) -> str:
     """Deterministic string form of a ``Change.old_value``/``new_value``.
 
@@ -1406,6 +1454,13 @@ def _change_discriminator(
             # canonicalization, not one whole-string call.
             old_str = _canonicalize_params_list(old_str)
             new_str = _canonicalize_params_list(new_str)
+        elif kind_value == "atomic_qualifier_changed":
+            # See _canonicalize_atomic_slot's own docstring: CastXML's bare
+            # "_Atomic" sentinel and Clang's real wrapped spelling must
+            # collapse to the same value, which plain canonicalize_type_name
+            # cannot do on its own.
+            old_str = _canonicalize_atomic_slot(old_str)
+            new_str = _canonicalize_atomic_slot(new_str)
         else:
             old_str = canonicalize_type_name(old_str)
             new_str = canonicalize_type_name(new_str)
@@ -1420,10 +1475,25 @@ def _change_discriminator(
                 # raw old/new substrings with their already-canonicalized
                 # forms directly, rather than canonicalizing the sentence
                 # as one opaque blob.
-                if raw_old_str:
-                    desc = desc.replace(raw_old_str, old_str)
-                if raw_new_str:
-                    desc = desc.replace(raw_new_str, new_str)
+                #
+                # Substitute the LONGER raw string first (Codex review,
+                # fresh evidence): atomic_qualifier_changed's own
+                # "qualifier added" direction embeds the unqualified raw
+                # spelling verbatim *inside* the qualified one (e.g. raw_old
+                # "struct Foo *" is a literal substring of raw_new
+                # "_Atomic(struct Foo *)") -- replacing the shorter raw_old
+                # first would also rewrite the copy embedded inside
+                # raw_new's own span before raw_new's own replace ever runs,
+                # so raw_new's exact text no longer appears in desc and its
+                # replace becomes a silent no-op, leaving the qualified
+                # side's stale, backend-specific spelling in the discriminator.
+                for raw, canon in sorted(
+                    ((raw_old_str, old_str), (raw_new_str, new_str)),
+                    key=lambda pair: len(pair[0]),
+                    reverse=True,
+                ):
+                    if raw:
+                        desc = desc.replace(raw, canon)
             else:
                 desc = canonicalize_type_name(desc)
         parts.append(desc)

--- a/abicheck/finding_identity.py
+++ b/abicheck/finding_identity.py
@@ -1200,58 +1200,40 @@ _ATOMIC_SLOT_RE = re.compile(r"^_Atomic\b")
 
 def _canonicalize_atomic_slot(value: str) -> str:
     """Canonicalize one ``diff_atomic.py`` type-slot spelling for the
-    identity discriminator (Codex review, fresh evidence, two rounds).
+    identity discriminator (Codex review, two rounds).
 
-    ``dumper_castxml.py`` cannot model C11 ``_Atomic`` at all -- it emits a
-    bare ``Unimplemented`` node with no reference to the wrapped type, so
-    its own ``_type_name()`` spells the *inner content* of the qualifier as
-    the literal, lossy sentinel ``"_Atomic"`` (see that function's own
-    comment). The direct-clang backend, by contrast, retains the real
-    wrapped spelling clang's own AST printer produces (e.g.
-    ``"_Atomic(struct Foo *)"``). Plain :func:`canonicalize_type_name`
-    normalizes whitespace/const-ordering/pointer-sigil spacing, but has no
-    notion of "these two spellings name the same qualified type" -- so
-    without this helper, CastXML's bare sentinel and Clang's concrete
-    spelling would never hash to the same canonical id for the identical
-    qualifier-added/-removed transition, defeating the whole point of
-    adding ``atomic_qualifier_changed`` to
-    :data:`_TYPE_BEARING_DISCRIMINATOR_KINDS`.
+    ``dumper_castxml.py`` cannot model C11 ``_Atomic`` -- it emits a bare
+    ``Unimplemented`` node with no reference to the wrapped type, so its
+    ``_type_name()`` spells the qualifier's *inner content* as the literal,
+    lossy sentinel ``"_Atomic"``. The direct-clang backend retains the real
+    wrapped spelling (e.g. ``"_Atomic(struct Foo *)"``). Plain
+    :func:`canonicalize_type_name` has no notion these name the same
+    qualified type, so without this helper CastXML's sentinel and Clang's
+    concrete spelling never hash to the same canonical id.
 
     Safe to collapse everything *inside* an ``_Atomic(...)`` wrapper (or a
-    bare ``"_Atomic"`` with nothing following) down to a fixed marker for
-    identity purposes: ``diff_atomic.py``'s own detection (``_has_atomic``)
-    only ever tests *presence* of the qualifier via a regex search, never
-    compares the wrapped type across old/new -- two genuinely different
-    ``_Atomic``-wrapped inner types on the same slot can never both reach
-    this detector as two distinct findings (it only fires on a presence
-    transition, and continues past an unchanged, still-``_Atomic`` slot
-    entirely) -- so no discriminating information about the wrapped
-    content is lost.
+    bare ``"_Atomic"``) to a fixed marker: ``diff_atomic.py``'s own
+    detection (``_has_atomic``) only tests qualifier *presence*, never
+    compares the wrapped type across old/new, so no discriminating
+    information about the wrapped content is lost.
 
     **Not** safe to collapse a declarator applied *outside* the wrapper
-    (Codex review, second round, fresh evidence): ``dumper_castxml.py``'s
-    ``PointerType``/``ReferenceType`` handling appends its own sigil as a
-    suffix onto whatever it wraps (``self._type_name(pointee) + "*"``), so
+    (round 2): ``dumper_castxml.py``'s ``PointerType``/``ReferenceType``
+    handling appends its own sigil suffix onto whatever it wraps, so
     "pointer to atomic T" (``_Atomic(T) *`` on Clang) spells as
     ``"_Atomic*"`` on CastXML -- distinguishably different from "atomic
-    pointer to T" (``_Atomic(T *)`` on Clang), which spells as the bare
-    ``"_Atomic"`` sentinel (the Atomic node itself is what's wrapped, so no
-    outer sigil is ever appended). These are two different qualified types
-    -- collapsing both down to one identical sentinel (an earlier revision
-    of this function did exactly that) would let an exact ``finding_id``
-    suppression accepted for one transition silently suppress the other,
-    unrelated one. Splitting on the ``_Atomic(...)`` wrapper's own matching
-    close paren (or the bare-sentinel case, with no parens at all) and
-    canonicalizing only what follows preserves this one signal CastXML
-    genuinely retains, while still discarding the wrapped inner type
-    CastXML cannot recover.
+    pointer to T" (``_Atomic(T *)`` on Clang), spelled as the bare
+    ``"_Atomic"`` sentinel (the Atomic node wraps the pointer, so no outer
+    sigil is ever appended). These are two different qualified types --
+    collapsing both to one sentinel would let a ``finding_id`` suppression
+    accepted for one silently suppress the other. Splitting on the
+    wrapper's own matching close paren and canonicalizing only what
+    follows preserves this one signal CastXML retains, while discarding
+    the wrapped inner content it cannot recover.
 
-    The *unqualified* side of the transition (the plain, non-``_Atomic``
-    type both backends spell reliably) is left to ordinary
-    :func:`canonicalize_type_name` normalization by this function's only
-    caller, since that side's exact spelling IS backend-comparable and
-    still needs to distinguish, e.g., an unrelated base-type change from a
-    pure qualifier change.
+    The *unqualified* side of the transition (spelled reliably by both
+    backends) is left to ordinary :func:`canonicalize_type_name`
+    normalization by this function's only caller.
     """
     stripped = value.strip()
     match = _ATOMIC_SLOT_RE.match(stripped)

--- a/abicheck/finding_identity.py
+++ b/abicheck/finding_identity.py
@@ -1057,21 +1057,33 @@ _EQUIVALENT_CHANGE_CATEGORIES = {
 # the pre-fix backend-spelling-mismatch gap on canonical_finding_id, and
 # adding it needs the same per-kind verification, not a blanket sweep.
 #
-# Known gap, accepted rather than chased further (Codex review, PR #753,
-# fifth round: ATOMIC_QUALIFIER_CHANGED is one more concrete instance,
-# `diff_atomic.py`'s old_value/new_value are the raw `iter_type_slot_changes`
-# type-slot spellings). A *derived* classification (e.g. every kind whose
-# emitter calls `iter_type_slot_changes`/passes a `RecordType`/`Param.type`-
-# sourced value as `old=`/`new=`) was considered instead of one more
-# reactive addition -- rejected for this pass: it needs the same per-kind
-# call-site verification this file's own docstring above already commits
-# to (a value's *source* doesn't by itself prove no `{detail}`-carried
-# per-item identity is also at stake, the exact trap the earlier
-# description-dropping attempt fell into), just automated instead of
-# explicit, which trades a visible, auditable list for an implicit one
-# that's harder to review. Matches this codebase's own "known gaps over
-# risky reactive patches" convention (AGENTS.md) rather than a sixth
-# same-session revision of this exact function.
+# Previously a known gap for ATOMIC_QUALIFIER_CHANGED, CHAR8T_MIGRATION, and
+# BIT_INT_WIDTH_CHANGED (Codex review, PR #753, fifth round): all three
+# detectors (`diff_atomic.py`, `diff_char8t.py`, `diff_bit_int.py`) pass
+# `iter_type_slot_changes`'s raw type-slot spellings straight through as
+# `old=`/`new=`, with no `{detail}`-carried per-item identity at stake --
+# `detail` there is a fixed direction string ("qualifier added"/"char-family
+# → char8_t"/"_BitInt width changed N1 → N2"), never a per-item identity like
+# a field/parameter name, so canonicalizing old/new can't collide two
+# distinct findings the way it would for e.g. TYPE_FIELD_TYPE_CHANGED.
+# Verified individually against each kind's emission call site, same bar
+# this set's own docstring above already commits to -- not the rejected
+# *derived* classification (every kind whose emitter calls
+# `iter_type_slot_changes`), added here as three more explicit, individually
+# checked entries instead.
+#
+# A *derived* classification (e.g. every kind whose emitter calls
+# `iter_type_slot_changes`/passes a `RecordType`/`Param.type`-sourced value
+# as `old=`/`new=`) was considered instead of one more reactive addition --
+# rejected: it needs the same per-kind call-site verification this file's
+# own docstring above already commits to (a value's *source* doesn't by
+# itself prove no `{detail}`-carried per-item identity is also at stake, the
+# exact trap the earlier description-dropping attempt fell into), just
+# automated instead of explicit, which trades a visible, auditable list for
+# an implicit one that's harder to review. Matches this codebase's own
+# "known gaps over risky reactive patches" convention (AGENTS.md) rather
+# than a same-session revision of this exact function with no per-kind
+# verification.
 _TYPE_BEARING_DISCRIMINATOR_KINDS = frozenset(
     {
         "func_return_changed",
@@ -1082,6 +1094,14 @@ _TYPE_BEARING_DISCRIMINATOR_KINDS = frozenset(
         "typedef_base_changed",
         "template_param_type_changed",
         "template_return_type_changed",
+        # diff_atomic.py/diff_char8t.py/diff_bit_int.py: old_value/new_value
+        # are iter_type_slot_changes()'s raw type-slot spellings, and
+        # `detail` (folded into `description` via change_registry's
+        # `{detail}` placeholder) is always a fixed direction string, never
+        # a per-item identity -- see this set's own comment above.
+        "atomic_qualifier_changed",
+        "char8t_migration",
+        "bit_int_width_changed",
         # diff_symbols._check_params_change: old/new are
         # _format_params()'s comma-joined `Param.type` spellings, one
         # function-wide finding (no per-parameter `detail`, so nothing is
@@ -1109,14 +1129,22 @@ _TYPE_BEARING_DISCRIMINATOR_KINDS = frozenset(
 #: struct-prefix-strip/const-reorder passes are anchored to string start,
 #: so they never reach text embedded mid-sentence, and the embedded
 #: spelling stays raw even after old_str/new_str themselves are correctly
-#: canonicalized. The other six allowlisted kinds' templates never embed
-#: {old}/{new} at all (`"Return type changed: {name}"` and siblings), so
-#: this set is deliberately narrower than _TYPE_BEARING_DISCRIMINATOR_KINDS.
+#: canonicalized. ``atomic_qualifier_changed``/``char8t_migration``/
+#: ``bit_int_width_changed`` have the identical shape --
+#: ``"_Atomic {detail} on {name}: {old} → {new}. ..."`` and siblings
+#: (``change_registry.py``) all embed ``{old} → {new}`` after a leading
+#: ``{detail}`` clause, never at sentence start. The remaining allowlisted
+#: kinds' templates never embed {old}/{new} at all (`"Return type changed:
+#: {name}"` and siblings), so this set is still narrower than
+#: _TYPE_BEARING_DISCRIMINATOR_KINDS.
 _DESCRIPTION_EMBEDS_VALUES_KINDS = frozenset(
     {
         "struct_field_type_changed",
         "template_param_type_changed",
         "template_return_type_changed",
+        "atomic_qualifier_changed",
+        "char8t_migration",
+        "bit_int_width_changed",
     }
 )
 

--- a/abicheck/finding_identity.py
+++ b/abicheck/finding_identity.py
@@ -1200,11 +1200,11 @@ _ATOMIC_SLOT_RE = re.compile(r"^_Atomic\b")
 
 def _canonicalize_atomic_slot(value: str) -> str:
     """Canonicalize one ``diff_atomic.py`` type-slot spelling for the
-    identity discriminator (Codex review, fresh evidence).
+    identity discriminator (Codex review, fresh evidence, two rounds).
 
     ``dumper_castxml.py`` cannot model C11 ``_Atomic`` at all -- it emits a
     bare ``Unimplemented`` node with no reference to the wrapped type, so
-    its own ``_type_name()`` spells the qualified side of the transition as
+    its own ``_type_name()`` spells the *inner content* of the qualifier as
     the literal, lossy sentinel ``"_Atomic"`` (see that function's own
     comment). The direct-clang backend, by contrast, retains the real
     wrapped spelling clang's own AST printer produces (e.g.
@@ -1217,24 +1217,72 @@ def _canonicalize_atomic_slot(value: str) -> str:
     adding ``atomic_qualifier_changed`` to
     :data:`_TYPE_BEARING_DISCRIMINATOR_KINDS`.
 
-    Safe to collapse the qualified side down to the bare ``"_Atomic"``
-    sentinel for identity purposes: ``diff_atomic.py``'s own detection
-    (``_has_atomic``) only ever tests *presence* of the qualifier via a
-    regex search, never compares the wrapped type across old/new -- two
-    genuinely different ``_Atomic``-wrapped inner types on the same slot
-    can never both reach this detector as two distinct findings (the
-    detector only fires on a presence transition, and continues past an
-    unchanged, still-``_Atomic`` slot entirely) -- so no real discriminating
-    information is lost. The *unqualified* side of the transition (the
-    plain, non-``_Atomic`` type both backends spell reliably) is left to
-    ordinary :func:`canonicalize_type_name` normalization, since that side's
-    exact spelling IS backend-comparable and still needs to distinguish,
-    e.g., an unrelated base-type change from a pure qualifier change.
+    Safe to collapse everything *inside* an ``_Atomic(...)`` wrapper (or a
+    bare ``"_Atomic"`` with nothing following) down to a fixed marker for
+    identity purposes: ``diff_atomic.py``'s own detection (``_has_atomic``)
+    only ever tests *presence* of the qualifier via a regex search, never
+    compares the wrapped type across old/new -- two genuinely different
+    ``_Atomic``-wrapped inner types on the same slot can never both reach
+    this detector as two distinct findings (it only fires on a presence
+    transition, and continues past an unchanged, still-``_Atomic`` slot
+    entirely) -- so no discriminating information about the wrapped
+    content is lost.
+
+    **Not** safe to collapse a declarator applied *outside* the wrapper
+    (Codex review, second round, fresh evidence): ``dumper_castxml.py``'s
+    ``PointerType``/``ReferenceType`` handling appends its own sigil as a
+    suffix onto whatever it wraps (``self._type_name(pointee) + "*"``), so
+    "pointer to atomic T" (``_Atomic(T) *`` on Clang) spells as
+    ``"_Atomic*"`` on CastXML -- distinguishably different from "atomic
+    pointer to T" (``_Atomic(T *)`` on Clang), which spells as the bare
+    ``"_Atomic"`` sentinel (the Atomic node itself is what's wrapped, so no
+    outer sigil is ever appended). These are two different qualified types
+    -- collapsing both down to one identical sentinel (an earlier revision
+    of this function did exactly that) would let an exact ``finding_id``
+    suppression accepted for one transition silently suppress the other,
+    unrelated one. Splitting on the ``_Atomic(...)`` wrapper's own matching
+    close paren (or the bare-sentinel case, with no parens at all) and
+    canonicalizing only what follows preserves this one signal CastXML
+    genuinely retains, while still discarding the wrapped inner type
+    CastXML cannot recover.
+
+    The *unqualified* side of the transition (the plain, non-``_Atomic``
+    type both backends spell reliably) is left to ordinary
+    :func:`canonicalize_type_name` normalization by this function's only
+    caller, since that side's exact spelling IS backend-comparable and
+    still needs to distinguish, e.g., an unrelated base-type change from a
+    pure qualifier change.
     """
     stripped = value.strip()
-    if _ATOMIC_SLOT_RE.match(stripped):
+    match = _ATOMIC_SLOT_RE.match(stripped)
+    if not match:
+        return canonicalize_type_name(stripped)
+    trailing = stripped[match.end() :]
+    if trailing.startswith("("):
+        # Find the close paren matching the one right after "_Atomic",
+        # tracking nesting depth so an inner type that itself contains
+        # parens (a function-pointer pointee, say) doesn't end the search
+        # early. Everything up to and including that close paren is the
+        # wrapped inner content being discarded; anything after it is an
+        # outer declarator that must survive.
+        depth = 0
+        close_idx = None
+        for i, ch in enumerate(trailing):
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    close_idx = i
+                    break
+        # Unbalanced parens shouldn't occur for a real type-slot spelling,
+        # but degrade to "no trailing declarator" rather than raising or
+        # keeping unparsed text in the identity.
+        trailing = trailing[close_idx + 1 :] if close_idx is not None else ""
+    trailing = trailing.strip()
+    if not trailing:
         return "_Atomic"
-    return canonicalize_type_name(stripped)
+    return f"_Atomic {canonicalize_type_name(trailing)}"
 
 
 def _stringify_change_value(value: object) -> str:

--- a/abicheck/finding_identity.py
+++ b/abicheck/finding_identity.py
@@ -78,6 +78,7 @@ from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Generic, TypeVar
 
+from .finding_identity_atomic import canonicalize_atomic_slot
 from .name_classification import canonicalize_type_name
 
 if TYPE_CHECKING:
@@ -1189,84 +1190,6 @@ def _canonicalize_params_list(value: str) -> str:
     )
 
 
-# Matches an `_Atomic`-qualified spelling in either form castxml/clang emit:
-# a bare `_Atomic` sentinel (castxml, see below) or a real wrapped spelling
-# like `_Atomic(struct Foo *)` (clang). Anchored to the whole string (after
-# stripping) rather than reusing diff_atomic.py's own word-boundary search,
-# since this helper's job is "is this ENTIRE type-slot spelling the atomic
-# side of the transition", not "does _Atomic appear anywhere".
-_ATOMIC_SLOT_RE = re.compile(r"^_Atomic\b")
-
-
-def _canonicalize_atomic_slot(value: str) -> str:
-    """Canonicalize one ``diff_atomic.py`` type-slot spelling for the
-    identity discriminator (Codex review, two rounds).
-
-    ``dumper_castxml.py`` cannot model C11 ``_Atomic`` -- it emits a bare
-    ``Unimplemented`` node with no reference to the wrapped type, so its
-    ``_type_name()`` spells the qualifier's *inner content* as the literal,
-    lossy sentinel ``"_Atomic"``. The direct-clang backend retains the real
-    wrapped spelling (e.g. ``"_Atomic(struct Foo *)"``). Plain
-    :func:`canonicalize_type_name` has no notion these name the same
-    qualified type, so without this helper CastXML's sentinel and Clang's
-    concrete spelling never hash to the same canonical id.
-
-    Safe to collapse everything *inside* an ``_Atomic(...)`` wrapper (or a
-    bare ``"_Atomic"``) to a fixed marker: ``diff_atomic.py``'s own
-    detection (``_has_atomic``) only tests qualifier *presence*, never
-    compares the wrapped type across old/new, so no discriminating
-    information about the wrapped content is lost.
-
-    **Not** safe to collapse a declarator applied *outside* the wrapper
-    (round 2): ``dumper_castxml.py``'s ``PointerType``/``ReferenceType``
-    handling appends its own sigil suffix onto whatever it wraps, so
-    "pointer to atomic T" (``_Atomic(T) *`` on Clang) spells as
-    ``"_Atomic*"`` on CastXML -- distinguishably different from "atomic
-    pointer to T" (``_Atomic(T *)`` on Clang), spelled as the bare
-    ``"_Atomic"`` sentinel (the Atomic node wraps the pointer, so no outer
-    sigil is ever appended). These are two different qualified types --
-    collapsing both to one sentinel would let a ``finding_id`` suppression
-    accepted for one silently suppress the other. Splitting on the
-    wrapper's own matching close paren and canonicalizing only what
-    follows preserves this one signal CastXML retains, while discarding
-    the wrapped inner content it cannot recover.
-
-    The *unqualified* side of the transition (spelled reliably by both
-    backends) is left to ordinary :func:`canonicalize_type_name`
-    normalization by this function's only caller.
-    """
-    stripped = value.strip()
-    match = _ATOMIC_SLOT_RE.match(stripped)
-    if not match:
-        return canonicalize_type_name(stripped)
-    trailing = stripped[match.end() :]
-    if trailing.startswith("("):
-        # Find the close paren matching the one right after "_Atomic",
-        # tracking nesting depth so an inner type that itself contains
-        # parens (a function-pointer pointee, say) doesn't end the search
-        # early. Everything up to and including that close paren is the
-        # wrapped inner content being discarded; anything after it is an
-        # outer declarator that must survive.
-        depth = 0
-        close_idx = None
-        for i, ch in enumerate(trailing):
-            if ch == "(":
-                depth += 1
-            elif ch == ")":
-                depth -= 1
-                if depth == 0:
-                    close_idx = i
-                    break
-        # Unbalanced parens shouldn't occur for a real type-slot spelling,
-        # but degrade to "no trailing declarator" rather than raising or
-        # keeping unparsed text in the identity.
-        trailing = trailing[close_idx + 1 :] if close_idx is not None else ""
-    trailing = trailing.strip()
-    if not trailing:
-        return "_Atomic"
-    return f"_Atomic {canonicalize_type_name(trailing)}"
-
-
 def _stringify_change_value(value: object) -> str:
     """Deterministic string form of a ``Change.old_value``/``new_value``.
 
@@ -1485,12 +1408,15 @@ def _change_discriminator(
             old_str = _canonicalize_params_list(old_str)
             new_str = _canonicalize_params_list(new_str)
         elif kind_value == "atomic_qualifier_changed":
-            # See _canonicalize_atomic_slot's own docstring: CastXML's bare
-            # "_Atomic" sentinel and Clang's real wrapped spelling must
-            # collapse to the same value, which plain canonicalize_type_name
-            # cannot do on its own.
-            old_str = _canonicalize_atomic_slot(old_str)
-            new_str = _canonicalize_atomic_slot(new_str)
+            # See canonicalize_atomic_slot's own docstring
+            # (finding_identity_atomic.py): CastXML's bare "_Atomic"
+            # sentinel and Clang's real wrapped spelling must collapse to
+            # the same value, which plain canonicalize_type_name cannot do
+            # on its own. Each side needs the OTHER side's raw spelling to
+            # tell a redundant qualifier-only wrap apart from a compound
+            # change that also altered the payload.
+            old_str = canonicalize_atomic_slot(raw_old_str, raw_new_str)
+            new_str = canonicalize_atomic_slot(raw_new_str, raw_old_str)
         else:
             old_str = canonicalize_type_name(old_str)
             new_str = canonicalize_type_name(new_str)

--- a/abicheck/finding_identity_atomic.py
+++ b/abicheck/finding_identity_atomic.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``atomic_qualifier_changed`` type-slot canonicalization for
+:mod:`abicheck.finding_identity` (``canonical_finding_id``, Codex review,
+three rounds).
+
+Split out of ``finding_identity.py`` purely to keep that file under the
+2000-line hard cap (CLAUDE.md file-size gate) -- this is a leaf helper with
+no dependency back on the rest of that module beyond
+:func:`~abicheck.name_classification.canonicalize_type_name`.
+"""
+
+from __future__ import annotations
+
+import re
+
+from .name_classification import canonicalize_type_name
+
+# Matches an `_Atomic`-qualified spelling (after stripping a leading
+# const/volatile prefix -- see _CV_PREFIX_RE) in either form castxml/clang
+# emit: a bare `_Atomic` sentinel (castxml, see below) or a real wrapped
+# spelling like `_Atomic(struct Foo *)` (clang). Anchored rather than
+# reusing diff_atomic.py's own word-boundary search, since this helper's job
+# is "is this ENTIRE type-slot spelling the atomic side", not "does
+# _Atomic appear anywhere".
+_ATOMIC_SLOT_RE = re.compile(r"^_Atomic\b")
+# A leading cv-qualifier castxml's CvQualifiedType prefixes onto a
+# non-pointer-value base (e.g. "const _Atomic" wrapping the Atomic node) --
+# stripped before atomic detection, then reattached to the result.
+_CV_PREFIX_RE = re.compile(r"^(const|volatile)\s+")
+
+
+def canonicalize_atomic_slot(value: str, other: str) -> str:
+    """Canonicalize one ``diff_atomic.py`` type-slot spelling for the
+    identity discriminator, given the *other* (opposite) side's raw
+    spelling for comparison.
+
+    ``dumper_castxml.py`` cannot model C11 ``_Atomic`` -- it emits a bare
+    ``Unimplemented`` node with no reference to the wrapped type, so its
+    ``_type_name()`` spells the qualifier's *inner content* as the literal,
+    lossy sentinel ``"_Atomic"``. The direct-clang backend retains the real
+    wrapped spelling (e.g. ``"_Atomic(struct Foo *)"``). Plain
+    :func:`canonicalize_type_name` has no notion these name the same
+    qualified type, so without this helper CastXML's sentinel and Clang's
+    concrete spelling never hash to the same canonical id.
+
+    Collapsing the wrapped content to a fixed marker is only safe when it
+    is *redundant* with the transition's other side -- reconstructing
+    ``qualifiers + inner + outer-declarator`` and comparing it (through
+    :func:`canonicalize_type_name`, so spelling/ordering differences don't
+    matter) against ``other``. If they match, the qualifier is the only
+    real change (``diff_atomic.py``'s own detection, ``_has_atomic``, only
+    tests presence) and CastXML's inner content is genuinely unrecoverable
+    noise -- collapse. If they DON'T match, a compound change (e.g. ``int``
+    -> ``_Atomic(long)``) also altered the payload; collapsing that would
+    conflate it with a pure ``int`` -> ``_Atomic(int)`` qualifier change
+    under one ``finding_id`` -- keep the payload instead.
+
+    A declarator applied *outside* the wrapper is never discarded:
+    ``dumper_castxml.py``'s ``PointerType``/``ReferenceType`` handling
+    appends its own sigil suffix onto whatever it wraps, so "pointer to
+    atomic T" (``_Atomic(T) *`` on Clang) spells as ``"_Atomic*"`` on
+    CastXML -- distinguishably different from "atomic pointer to T"
+    (``_Atomic(T *)`` on Clang), spelled as the bare ``"_Atomic"`` sentinel
+    (the Atomic node wraps the pointer, so no outer sigil is appended).
+    Collapsing both to one sentinel would conflate two different qualified
+    types.
+    """
+    stripped = value.strip()
+    rest = stripped
+    quals: list[str] = []
+    while True:
+        m = _CV_PREFIX_RE.match(rest)
+        if not m:
+            break
+        quals.append(m.group(1))
+        rest = rest[m.end() :]
+    match = _ATOMIC_SLOT_RE.match(rest)
+    if not match:
+        return canonicalize_type_name(stripped)
+    trailing = rest[match.end() :]
+    inner = None
+    if trailing.startswith("("):
+        # Find the close paren matching the one right after "_Atomic",
+        # tracking nesting depth so an inner type that itself contains
+        # parens (a function-pointer pointee, say) doesn't end the search
+        # early. Unbalanced parens shouldn't occur for a real type-slot
+        # spelling, but degrade to "no trailing declarator" rather than
+        # raising or keeping unparsed text in the identity.
+        depth = 0
+        close_idx = None
+        for i, ch in enumerate(trailing):
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+                if depth == 0:
+                    close_idx = i
+                    break
+        inner = trailing[1:close_idx] if close_idx is not None else None
+        trailing = trailing[close_idx + 1 :] if close_idx is not None else ""
+    trailing = trailing.strip()
+    redundant = inner is None or canonicalize_type_name(
+        " ".join(p for p in (*quals, inner, trailing) if p)
+    ) == canonicalize_type_name(other.strip())
+    core = (
+        "_Atomic"
+        if inner is None or redundant
+        else f"_Atomic({canonicalize_type_name(inner)})"
+    )
+    if trailing:
+        core = f"{core} {canonicalize_type_name(trailing)}"
+    if quals:
+        core = f"{' '.join(sorted(set(quals)))} {core}"
+    return core

--- a/changelog.d/20260814_120000_claude_canonical_id_backend_gap_h6hfh5.md
+++ b/changelog.d/20260814_120000_claude_canonical_id_backend_gap_h6hfh5.md
@@ -1,0 +1,13 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+-->
+
+### Fixed
+
+- **`canonical_finding_id` is now backend-stable for `ATOMIC_QUALIFIER_CHANGED`,
+  `CHAR8T_MIGRATION`, and `BIT_INT_WIDTH_CHANGED`.** These three type-slot
+  detectors were missing from the canonical-id type-canonicalization
+  allowlist, so CastXML's and Clang's differing type spellings (e.g.
+  `char const*` vs. `char const *`) for the identical finding hashed to two
+  different `canonical_finding_id` values — silently breaking the
+  cross-backend `finding_id:` suppression contract for these three kinds.

--- a/tests/test_canonical_finding_id.py
+++ b/tests/test_canonical_finding_id.py
@@ -377,7 +377,7 @@ class TestCanonicalFindingIdScopedCanonicalization:
             # type-slot spellings. CastXML cannot model _Atomic at all and
             # spells the qualified side as the bare, lossy sentinel
             # "_Atomic" (dumper_castxml.py's own _type_name()); Clang keeps
-            # the real wrapped spelling -- _canonicalize_atomic_slot is what
+            # the real wrapped spelling -- canonicalize_atomic_slot is what
             # collapses these to the same canonical id.
             (
                 ChangeKind.ATOMIC_QUALIFIER_CHANGED,
@@ -527,7 +527,7 @@ class TestCanonicalFindingIdScopedCanonicalization:
         # canonicalize_type_name has no notion that these name the same
         # qualified type, so the fix's first revision (canonicalize_type_name
         # alone) still failed to match here even after atomic_qualifier_changed
-        # was added to the allowlist -- _canonicalize_atomic_slot is what
+        # was added to the allowlist -- canonicalize_atomic_slot is what
         # closes it.
         castxml = make_change(
             ChangeKind.ATOMIC_QUALIFIER_CHANGED,
@@ -551,7 +551,7 @@ class TestCanonicalFindingIdScopedCanonicalization:
 
     def test_atomic_qualifier_changed_preserves_outer_declarator(self):
         # Regression (Codex review, canonical-id-backend-gap, second P1
-        # finding): an earlier revision of _canonicalize_atomic_slot
+        # finding): an earlier revision of canonicalize_atomic_slot
         # collapsed the ENTIRE qualified spelling to the bare "_Atomic"
         # sentinel regardless of what followed it -- but "atomic pointer to
         # T" (_Atomic(T *) on Clang, "_Atomic" on CastXML -- the Atomic node
@@ -607,6 +607,91 @@ class TestCanonicalFindingIdScopedCanonicalization:
         assert report_canonical_finding_id(
             atomic_pointer_castxml
         ) != report_canonical_finding_id(pointer_to_atomic_castxml)
+
+    def test_atomic_qualifier_changed_preserves_compound_payload_change(self):
+        # Regression (Codex review, canonical-id-backend-gap, third P1
+        # finding): a slot that both gains the qualifier AND changes its
+        # base type in the same transition (e.g. int -> _Atomic(long)) must
+        # not collapse to the same canonical id as a pure qualifier-only
+        # change on the identical unqualified type (int -> _Atomic(int)) --
+        # these are two structurally different ABI transitions, and a
+        # finding_id suppression accepted for one must not silently
+        # suppress the other.
+        qualifier_only = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooi",
+            name="parameter 0 of '_Z3fooi'",
+            detail="qualifier added",
+            old="int",
+            new="_Atomic(int)",
+        )
+        compound_change = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooi",
+            name="parameter 0 of '_Z3fooi'",
+            detail="qualifier added",
+            old="int",
+            new="_Atomic(long)",
+        )
+        assert report_canonical_finding_id(
+            qualifier_only
+        ) != report_canonical_finding_id(compound_change)
+
+        # The compound change still matches an equivalent spelling of
+        # itself (same payload, different pointer spacing).
+        compound_change_respaced = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooi",
+            name="parameter 0 of '_Z3fooi'",
+            detail="qualifier added",
+            old="int",
+            new="_Atomic( long )",
+        )
+        assert report_canonical_finding_id(
+            compound_change
+        ) == report_canonical_finding_id(compound_change_respaced)
+
+    def test_atomic_qualifier_changed_normalizes_cv_qualified_spellings(self):
+        # Regression (Codex review, canonical-id-backend-gap, fourth P1
+        # finding): a const/volatile-qualified atomic slot spells
+        # differently across backends too -- CastXML's CvQualifiedType
+        # wraps the lossy Atomic node as "const _Atomic" (prefix form, since
+        # the wrapped node isn't a pointer value), while Clang keeps
+        # "const _Atomic(int)". The leading "const "/"volatile " prefix
+        # broke the anchored _Atomic-detection regex, so both fell back to
+        # plain canonicalize_type_name and stayed distinct.
+        castxml = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooi",
+            name="parameter 0 of '_Z3fooi'",
+            detail="qualifier added",
+            old="const int",
+            new="const _Atomic",
+        )
+        clang = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooi",
+            name="parameter 0 of '_Z3fooi'",
+            detail="qualifier added",
+            old="const int",
+            new="const _Atomic(int)",
+        )
+        assert report_canonical_finding_id(castxml) == report_canonical_finding_id(
+            clang
+        )
+        # A cv-qualified compound change (payload also differs) must still
+        # stay distinct from the plain cv-qualified qualifier-only change.
+        clang_compound = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooi",
+            name="parameter 0 of '_Z3fooi'",
+            detail="qualifier added",
+            old="const int",
+            new="const _Atomic(long)",
+        )
+        assert report_canonical_finding_id(clang) != report_canonical_finding_id(
+            clang_compound
+        )
 
     def test_atomic_qualifier_changed_description_substitution_handles_containment(
         self,

--- a/tests/test_canonical_finding_id.py
+++ b/tests/test_canonical_finding_id.py
@@ -32,7 +32,11 @@ import yaml
 from abicheck.checker_policy import ChangeKind
 from abicheck.checker_types import Change, DiffResult
 from abicheck.diff_helpers import make_change
-from abicheck.finding_identity import report_canonical_finding_id, report_finding_id
+from abicheck.finding_identity import (
+    report_canonical_finding_id,
+    report_finding_id,
+    resolve_change_identity,
+)
 from abicheck.reporter import to_json
 from abicheck.suppression import Suppression, SuppressionList
 
@@ -370,12 +374,16 @@ class TestCanonicalFindingIdScopedCanonicalization:
             # diff_atomic.py: `detail` is a fixed direction string
             # ("qualifier added"/"qualifier removed"), never a per-item
             # identity -- old/new are the raw iter_type_slot_changes()
-            # type-slot spellings.
+            # type-slot spellings. CastXML cannot model _Atomic at all and
+            # spells the qualified side as the bare, lossy sentinel
+            # "_Atomic" (dumper_castxml.py's own _type_name()); Clang keeps
+            # the real wrapped spelling -- _canonicalize_atomic_slot is what
+            # collapses these to the same canonical id.
             (
                 ChangeKind.ATOMIC_QUALIFIER_CHANGED,
                 "qualifier added",
                 "struct Foo*",
-                "_Atomic(struct Foo*)",
+                "_Atomic",
                 "struct Foo *",
                 "_Atomic(struct Foo *)",
             ),
@@ -395,16 +403,22 @@ class TestCanonicalFindingIdScopedCanonicalization:
             # transition.
             (
                 ChangeKind.BIT_INT_WIDTH_CHANGED,
-                "_BitInt width changed 17 → 17",
+                "_BitInt width changed 17 → 33",
                 "_BitInt(17)*",
+                "_BitInt(33) *",
                 "_BitInt(17) *",
-                "_BitInt(17) *",
-                "_BitInt(17)*",
+                "_BitInt(33)*",
             ),
         ],
     )
     def test_type_slot_kinds_are_backend_stable(
-        self, kind, detail, old_castxml, new_castxml, old_clang, new_clang
+        self,
+        kind: ChangeKind,
+        detail: str,
+        old_castxml: str,
+        new_castxml: str,
+        old_clang: str,
+        new_clang: str,
     ):
         # Regression (canonical-id-backend-gap): ATOMIC_QUALIFIER_CHANGED,
         # CHAR8T_MIGRATION, and BIT_INT_WIDTH_CHANGED were all missing from
@@ -504,6 +518,70 @@ class TestCanonicalFindingIdScopedCanonicalization:
         assert report_canonical_finding_id(
             width_17_to_33
         ) != report_canonical_finding_id(width_17_to_65)
+
+    def test_atomic_qualifier_changed_castxml_lossy_sentinel_matches_clang(self):
+        # Regression (Codex review, canonical-id-backend-gap, P1 finding):
+        # dumper_castxml.py cannot model C11 _Atomic at all and spells the
+        # qualified side as the bare, lossy sentinel "_Atomic" -- Clang keeps
+        # the real wrapped spelling ("_Atomic(struct Foo *)"). Plain
+        # canonicalize_type_name has no notion that these name the same
+        # qualified type, so the fix's first revision (canonicalize_type_name
+        # alone) still failed to match here even after atomic_qualifier_changed
+        # was added to the allowlist -- _canonicalize_atomic_slot is what
+        # closes it.
+        castxml = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooPKc",
+            name="parameter 0 of '_Z3fooPKc'",
+            detail="qualifier added",
+            old="struct Foo*",
+            new="_Atomic",
+        )
+        clang = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooPKc",
+            name="parameter 0 of '_Z3fooPKc'",
+            detail="qualifier added",
+            old="struct Foo *",
+            new="_Atomic(struct Foo *)",
+        )
+        assert report_canonical_finding_id(castxml) == report_canonical_finding_id(
+            clang
+        )
+
+    def test_atomic_qualifier_changed_description_substitution_handles_containment(
+        self,
+    ):
+        # Regression (Codex review, fresh evidence): _change_discriminator's
+        # description substitution replaced raw_old_str, then raw_new_str,
+        # unconditionally in that order. For a "qualifier added" transition
+        # the unqualified raw_old spelling ("struct Foo *") is a literal
+        # substring of the qualified raw_new spelling
+        # ("_Atomic(struct Foo *)") -- replacing raw_old first also rewrote
+        # the copy embedded inside raw_new's own span, so raw_new's exact
+        # text no longer appeared in the description and its own replace
+        # silently no-opped, leaving the qualified side's stale,
+        # backend-specific spelling in the discriminator. Verified directly
+        # against the rendered description, not just the opaque hash.
+        clang = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooPKc",
+            name="parameter 0 of '_Z3fooPKc'",
+            detail="qualifier added",
+            old="struct Foo *",
+            new="_Atomic(struct Foo *)",
+        )
+        canonical_desc_fragment = "Foo * → _Atomic"
+        # The rendered description must fully collapse the qualified side to
+        # the bare sentinel -- not leave a stale "_Atomic(Foo *)" behind.
+        assert (
+            canonical_desc_fragment
+            in resolve_change_identity(clang, canonicalize_values=True).primary_id
+        )
+        assert (
+            "_Atomic(Foo *)"
+            not in resolve_change_identity(clang, canonicalize_values=True).primary_id
+        )
 
     def test_equivalent_category_kinds_still_distinguish_old_new(self):
         # Regression (Codex review, PR #753, fourth round): a bare

--- a/tests/test_canonical_finding_id.py
+++ b/tests/test_canonical_finding_id.py
@@ -364,6 +364,147 @@ class TestCanonicalFindingIdScopedCanonicalization:
         )
         assert report_canonical_finding_id(a) != report_canonical_finding_id(c)
 
+    @pytest.mark.parametrize(
+        ("kind", "detail", "old_castxml", "new_castxml", "old_clang", "new_clang"),
+        [
+            # diff_atomic.py: `detail` is a fixed direction string
+            # ("qualifier added"/"qualifier removed"), never a per-item
+            # identity -- old/new are the raw iter_type_slot_changes()
+            # type-slot spellings.
+            (
+                ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+                "qualifier added",
+                "struct Foo*",
+                "_Atomic(struct Foo*)",
+                "struct Foo *",
+                "_Atomic(struct Foo *)",
+            ),
+            # diff_char8t.py: `detail` is "char-family → char8_t" or the
+            # reverse, again fixed rather than per-item.
+            (
+                ChangeKind.CHAR8T_MIGRATION,
+                "char-family → char8_t",
+                "char const*",
+                "char8_t const*",
+                "char const *",
+                "char8_t const *",
+            ),
+            # diff_bit_int.py: `detail` embeds the width transition itself
+            # (e.g. "_BitInt width changed 17 → 33"), not a field/parameter
+            # name, so it stays identical across backends for the identical
+            # transition.
+            (
+                ChangeKind.BIT_INT_WIDTH_CHANGED,
+                "_BitInt width changed 17 → 17",
+                "_BitInt(17)*",
+                "_BitInt(17) *",
+                "_BitInt(17) *",
+                "_BitInt(17)*",
+            ),
+        ],
+    )
+    def test_type_slot_kinds_are_backend_stable(
+        self, kind, detail, old_castxml, new_castxml, old_clang, new_clang
+    ):
+        # Regression (canonical-id-backend-gap): ATOMIC_QUALIFIER_CHANGED,
+        # CHAR8T_MIGRATION, and BIT_INT_WIDTH_CHANGED were all missing from
+        # _TYPE_BEARING_DISCRIMINATOR_KINDS/_DESCRIPTION_EMBEDS_VALUES_KINDS
+        # despite passing iter_type_slot_changes()'s raw type-slot spellings
+        # straight through as old_value/new_value, and description_template
+        # embedding "{old} → {new}" mid-sentence after a leading {detail}
+        # clause (same shape as struct_field_type_changed) -- so a CastXML
+        # report's canonical_finding_id never matched Clang's equivalent
+        # finding for these three kinds.
+        def slot_change(field: str, old: str, new: str) -> Change:
+            return make_change(
+                kind,
+                symbol="_Z3fooPKc",
+                name="parameter 0 of '_Z3fooPKc'",
+                detail=field,
+                old=old,
+                new=new,
+            )
+
+        castxml = slot_change(detail, old_castxml, new_castxml)
+        clang = slot_change(detail, old_clang, new_clang)
+        assert report_canonical_finding_id(castxml) == report_canonical_finding_id(
+            clang
+        )
+
+        # A suppression rule minted from one backend's report matches the
+        # equivalent finding reported by the other.
+        rule = Suppression(
+            finding_id=report_canonical_finding_id(castxml), reason="accepted"
+        )
+        assert rule.matches(clang)
+
+    def test_type_slot_kinds_still_distinguish_semantically_different_transitions(
+        self,
+    ):
+        # A genuinely different transition on the same symbol/kind must not
+        # collapse to the same canonical id -- verified across all three
+        # kinds' own distinguishing axis (direction for atomic/char8_t,
+        # width for _BitInt).
+        atomic_added = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooPKc",
+            name="parameter 0 of '_Z3fooPKc'",
+            detail="qualifier added",
+            old="struct Foo*",
+            new="_Atomic(struct Foo*)",
+        )
+        atomic_removed = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooPKc",
+            name="parameter 0 of '_Z3fooPKc'",
+            detail="qualifier removed",
+            old="_Atomic(struct Foo*)",
+            new="struct Foo*",
+        )
+        assert report_canonical_finding_id(atomic_added) != report_canonical_finding_id(
+            atomic_removed
+        )
+
+        char8_to_char = make_change(
+            ChangeKind.CHAR8T_MIGRATION,
+            symbol="_Z3fooPKc",
+            name="parameter 0 of '_Z3fooPKc'",
+            detail="char8_t → char-family",
+            old="char8_t const*",
+            new="char const*",
+        )
+        char_to_char8 = make_change(
+            ChangeKind.CHAR8T_MIGRATION,
+            symbol="_Z3fooPKc",
+            name="parameter 0 of '_Z3fooPKc'",
+            detail="char-family → char8_t",
+            old="char const*",
+            new="char8_t const*",
+        )
+        assert report_canonical_finding_id(
+            char8_to_char
+        ) != report_canonical_finding_id(char_to_char8)
+
+        width_17_to_33 = make_change(
+            ChangeKind.BIT_INT_WIDTH_CHANGED,
+            symbol="_Z3fooPKc",
+            name="parameter 0 of '_Z3fooPKc'",
+            detail="_BitInt width changed 17 → 33",
+            old="_BitInt(17)*",
+            new="_BitInt(33)*",
+        )
+        width_17_to_65 = make_change(
+            ChangeKind.BIT_INT_WIDTH_CHANGED,
+            symbol="_Z3fooPKc",
+            name="parameter 0 of '_Z3fooPKc'",
+            detail="_BitInt width changed 17 → 65",
+            old="_BitInt(17)*",
+            new="_BitInt(65)*",
+        )
+        assert report_canonical_finding_id(
+            width_17_to_33
+        ) != report_canonical_finding_id(width_17_to_65)
+
     def test_equivalent_category_kinds_still_distinguish_old_new(self):
         # Regression (Codex review, PR #753, fourth round): a bare
         # "category:type_size_change" discriminator (used to collapse
@@ -589,7 +730,7 @@ class TestFindingIdSuppressionSelector:
         # selector -- it can never match any actual finding.
         yaml_path = tmp_path / "suppress.yaml"
         yaml_path.write_text(
-            "version: 1\nsuppressions:\n  - finding_id: \"\"\n    reason: r\n"
+            'version: 1\nsuppressions:\n  - finding_id: ""\n    reason: r\n'
         )
         with pytest.raises(ValueError, match="finding_id"):
             SuppressionList.load(yaml_path)

--- a/tests/test_canonical_finding_id.py
+++ b/tests/test_canonical_finding_id.py
@@ -549,6 +549,65 @@ class TestCanonicalFindingIdScopedCanonicalization:
             clang
         )
 
+    def test_atomic_qualifier_changed_preserves_outer_declarator(self):
+        # Regression (Codex review, canonical-id-backend-gap, second P1
+        # finding): an earlier revision of _canonicalize_atomic_slot
+        # collapsed the ENTIRE qualified spelling to the bare "_Atomic"
+        # sentinel regardless of what followed it -- but "atomic pointer to
+        # T" (_Atomic(T *) on Clang, "_Atomic" on CastXML -- the Atomic node
+        # wraps the whole pointer, so CastXML's PointerType-appends-"*"
+        # logic never runs) and "pointer to atomic T" (_Atomic(T) * on
+        # Clang, "_Atomic*" on CastXML -- PointerType wraps the Atomic node
+        # and appends its own suffix) are two different qualified types.
+        # Collapsing both to the same sentinel would let a finding_id
+        # suppression accepted for one silently suppress the other.
+        atomic_pointer = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooPi",
+            name="parameter 0 of '_Z3fooPi'",
+            detail="qualifier added",
+            old="int *",
+            new="_Atomic(int *)",
+        )
+        pointer_to_atomic = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooPi",
+            name="parameter 0 of '_Z3fooPi'",
+            detail="qualifier added",
+            old="int *",
+            new="_Atomic(int) *",
+        )
+        assert report_canonical_finding_id(
+            atomic_pointer
+        ) != report_canonical_finding_id(pointer_to_atomic)
+
+        # And each still matches its own CastXML-spelled equivalent.
+        atomic_pointer_castxml = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooPi",
+            name="parameter 0 of '_Z3fooPi'",
+            detail="qualifier added",
+            old="int*",
+            new="_Atomic",
+        )
+        pointer_to_atomic_castxml = make_change(
+            ChangeKind.ATOMIC_QUALIFIER_CHANGED,
+            symbol="_Z3fooPi",
+            name="parameter 0 of '_Z3fooPi'",
+            detail="qualifier added",
+            old="int*",
+            new="_Atomic*",
+        )
+        assert report_canonical_finding_id(
+            atomic_pointer
+        ) == report_canonical_finding_id(atomic_pointer_castxml)
+        assert report_canonical_finding_id(
+            pointer_to_atomic
+        ) == report_canonical_finding_id(pointer_to_atomic_castxml)
+        assert report_canonical_finding_id(
+            atomic_pointer_castxml
+        ) != report_canonical_finding_id(pointer_to_atomic_castxml)
+
     def test_atomic_qualifier_changed_description_substitution_handles_containment(
         self,
     ):


### PR DESCRIPTION
## Summary

`canonical_finding_id` (introduced by #753) is still backend-dependent for `ATOMIC_QUALIFIER_CHANGED`, `CHAR8T_MIGRATION`, and `BIT_INT_WIDTH_CHANGED`, breaking the cross-backend `finding_id:` suppression contract for these three kinds.

## Motivation

`canonical_finding_id` is meant to let a suppression rule minted from one header backend's report (e.g. CastXML) reliably match the equivalent finding from another (e.g. Clang), even when the two backends spell a type differently (`"char const*"` vs `"char const *"`).

`diff_atomic.py`, `diff_char8t.py`, and `diff_bit_int.py` all pass `iter_type_slot_changes()`'s raw backend type spellings straight through as `old_value`/`new_value`, and each kind's `description_template` embeds `"{old} → {new}"` mid-sentence after a leading `{detail}` clause — the same shape `struct_field_type_changed` already handles. None of the three kinds was in `_TYPE_BEARING_DISCRIMINATOR_KINDS`/`_DESCRIPTION_EMBEDS_VALUES_KINDS` (`finding_identity.py`), so their raw, backend-specific spelling remained part of the CANONICAL-tier primary ID and changed the resulting hash — this was already called out as a known, accepted gap for `ATOMIC_QUALIFIER_CHANGED` specifically in a code comment, but `CHAR8T_MIGRATION` and `BIT_INT_WIDTH_CHANGED` have the identical data flow and weren't mentioned there.

Concretely: `suppression.py`'s `Suppression._matches_finding_id()` does strict equality against a freshly computed `report_canonical_finding_id()`, with no fallback — so a `finding_id:` rule copied from one backend's report silently fails to match the equivalent finding from the other, producing recurring unsuppressed findings after switching frontend or CI profile.

## Changes

- Added `atomic_qualifier_changed`, `char8t_migration`, and `bit_int_width_changed` to `_TYPE_BEARING_DISCRIMINATOR_KINDS` and `_DESCRIPTION_EMBEDS_VALUES_KINDS` in `abicheck/finding_identity.py`, after verifying each kind's `{detail}` is always a fixed direction/transition string (never a per-item identity like a field or parameter name) — the same safety bar the existing allowlist entries already meet, so this doesn't risk collapsing two distinct findings the way an unconditional sweep would.
- Added parameterized regression tests in `tests/test_canonical_finding_id.py` covering all three kinds:
  1. equivalent CastXML/Clang type spellings collapse to one canonical id;
  2. a `finding_id:` suppression rule minted from one backend's report matches the equivalent finding from the other;
  3. semantically different transitions (opposite atomic direction, different char8_t migration direction, different `_BitInt` width) still produce distinct canonical ids.
- Added a `changelog.d/` fragment.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated if user-visible behaviour changed — not applicable (internal identity-hashing fix, no user-facing docs to update)
- [x] `ruff check`, `ruff format --check`, `mypy abicheck/` all pass locally
- [x] No new `mypy` or `ruff` errors introduced

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01KnTc7WeobEKRgXGS91ZxLt)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency of finding identifiers across supported analysis backends for atomic qualifier, `char8_t`, and `_BitInt` width changes.
  * Cross-backend suppression now works reliably when equivalent type differences are reported with varying spellings.

* **Tests**
  * Added regression coverage to verify stable identifiers while preserving distinctions between different type transitions.

* **Documentation**
  * Added a changelog entry describing the backend-stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->