### PR TITLE
feat: apply L3 build evidence automatically to L2 header parsing (P0.3)

### DIFF
--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -69,11 +69,14 @@ pick one" heuristic.
 
 from __future__ import annotations
 
+import os
 import re
-from dataclasses import dataclass
+import shlex
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from .._compiler_options import explicit_language_standard
 from ..compile_context import CompileContext
 from ..errors import HeaderCompileContextAmbiguousError
 
@@ -147,6 +150,97 @@ def _matching_compile_units(
     return matched
 
 
+def _explicit_pin_tokens(explicit: CompileContext | None) -> list[str]:
+    """Flatten one explicit :class:`CompileContext`'s free-form + repeatable
+    options into a single token list, for presence-only scanning below.
+
+    Mirrors how both header command builders (``dumper_ast_config.py``)
+    combine the two fields (``gcc_options`` shlex-split, then
+    ``gcc_option_tokens`` verbatim) -- deliberately best-effort: a malformed
+    ``gcc_options`` string degrades to "no tokens from it" rather than
+    raising, since this is only used to *widen* what's accepted (Finding 3),
+    never to narrow it.
+    """
+    if explicit is None:
+        return []
+    tokens: list[str] = []
+    if explicit.gcc_options:
+        try:
+            tokens.extend(shlex.split(explicit.gcc_options, posix=os.name != "nt"))
+        except ValueError:
+            pass
+    tokens.extend(explicit.gcc_option_tokens)
+    return tokens
+
+
+@dataclass(frozen=True)
+class _ExplicitPin:
+    """Which ABI-relevant *dimensions* an explicit :class:`CompileContext`
+    already resolves (Finding 3).
+
+    A caller who already pinned a field via ``--gcc-options``/
+    ``--gcc-option`` (or the structured ``sysroot`` field) does not need the
+    L3 evidence to agree on that field too -- ``resolve_header_compile_
+    context`` masks a pinned field out of the multi-unit ambiguity
+    comparison below, so a genuine disagreement on a *different*,
+    unpinned field still fails closed (only the pinned dimension is
+    excused, per field, not "any explicit override excuses every
+    disagreement").
+
+    Presence-only, not value-resolving: this deliberately does not attempt
+    to compute what the *effective* value of a pinned field ends up being
+    (that's ``dataclasses.replace``/last-flag-wins compiler semantics once
+    the derived and explicit contexts are actually merged and rendered,
+    handled by ``service_input_resolution._merge_l3_compile_context``) --
+    only whether the caller stated an opinion on it at all.
+    """
+
+    standard: bool = False
+    target_triple: bool = False
+    sysroot: bool = False
+    defines: frozenset[str] = field(default_factory=frozenset)
+    undefines: frozenset[str] = field(default_factory=frozenset)
+
+    @classmethod
+    def of(cls, explicit: CompileContext | None) -> _ExplicitPin:
+        if explicit is None:
+            return cls()
+        tokens = _explicit_pin_tokens(explicit)
+        target_triple = False
+        sysroot = explicit.sysroot is not None
+        defines: set[str] = set()
+        undefines: set[str] = set()
+        i = 0
+        n = len(tokens)
+        while i < n:
+            tok = tokens[i]
+            if tok in ("-target", "--target") or tok.startswith("--target="):
+                target_triple = True
+            elif tok in ("--sysroot", "-isysroot") or tok.startswith("--sysroot="):
+                sysroot = True
+            elif tok == "-D" and i + 1 < n:
+                defines.add(tokens[i + 1].split("=", 1)[0])
+                i += 1
+            elif tok.startswith("-D") and len(tok) > 2:
+                defines.add(tok[2:].split("=", 1)[0])
+            elif tok == "-U" and i + 1 < n:
+                undefines.add(tokens[i + 1])
+                i += 1
+            elif tok.startswith("-U") and len(tok) > 2:
+                undefines.add(tok[2:])
+            i += 1
+        return cls(
+            standard=explicit_language_standard(
+                explicit.gcc_options, explicit.gcc_option_tokens
+            )
+            is not None,
+            target_triple=target_triple,
+            sysroot=sysroot,
+            defines=frozenset(defines),
+            undefines=frozenset(undefines),
+        )
+
+
 @dataclass(frozen=True)
 class _EffectiveContextSignature:
     """The ABI-relevant fields the plan's point 1 + point 3 name, normalized.
@@ -159,6 +253,13 @@ class _EffectiveContextSignature:
     semantic-equivalence check — a stricter "agree" test can only ever turn a
     would-be single-context case into a (still-safe) ambiguous one, never the
     reverse, so this stays on the conservative, fail-closed side.
+
+    A field (or, for ``defines``/``undefines``, one specific macro key) that
+    *pin* (see :class:`_ExplicitPin`) already resolves for the caller is
+    masked to a shared placeholder here (Finding 3) — so two units that
+    disagree only on a dimension the caller already pinned no longer read as
+    a materially different signature, while a disagreement on any other,
+    unpinned dimension still does.
     """
 
     language: str
@@ -172,18 +273,70 @@ class _EffectiveContextSignature:
     abi_relevant_flags: tuple[str, ...]
 
     @classmethod
-    def of(cls, cu: CompileUnit) -> _EffectiveContextSignature:
+    def of(
+        cls, cu: CompileUnit, pin: _ExplicitPin | None = None
+    ) -> _EffectiveContextSignature:
+        pin = pin or _ExplicitPin()
         return cls(
             language=cu.language,
-            standard=cu.standard,
-            target_triple=cu.target_triple,
-            sysroot=cu.sysroot or "",
-            defines=tuple(sorted(cu.defines.items())),
-            undefines=tuple(sorted(cu.undefines)),
+            standard="" if pin.standard else cu.standard,
+            target_triple="" if pin.target_triple else cu.target_triple,
+            sysroot="" if pin.sysroot else (cu.sysroot or ""),
+            defines=tuple(
+                sorted((k, v) for k, v in cu.defines.items() if k not in pin.defines)
+            ),
+            undefines=tuple(sorted(u for u in cu.undefines if u not in pin.undefines)),
             include_paths=tuple(cu.include_paths),
             system_include_paths=tuple(cu.system_include_paths),
-            abi_relevant_flags=tuple(cu.abi_relevant_flags),
+            abi_relevant_flags=tuple(
+                _mask_pinned_abi_flags(cu.abi_relevant_flags, pin)
+            ),
         )
+
+
+def _mask_pinned_abi_flags(flags: Sequence[str], pin: _ExplicitPin) -> list[str]:
+    """Drop ``cu.abi_relevant_flags`` entries a pinned dimension already
+    covers (Finding 3, continued).
+
+    ``adapters.base.extract_abi_relevant_flags`` records the *same* raw
+    ``-std=``/``-target``/``--target=``/``--sysroot``/``-isysroot`` tokens
+    into ``CompileUnit.abi_relevant_flags`` that also feed the *structured*
+    ``standard``/``target_triple``/``sysroot`` fields masked above — so
+    without this, a std-only disagreement pinned via ``explicit`` still
+    showed up as a differing ``abi_relevant_flags`` tuple (the raw
+    ``-std=c++17``/``-std=c++20`` tokens themselves), reopening the exact
+    ambiguity the structured-field masking above was meant to close.
+    """
+    out: list[str] = []
+    for f in flags:
+        if pin.standard and (f.startswith("-std=") or f.startswith("/std:")):
+            continue
+        if pin.target_triple and (f == "-target" or f.startswith("--target=")):
+            continue
+        if pin.sysroot and (
+            f in ("--sysroot", "-isysroot") or f.startswith("--sysroot=")
+        ):
+            continue
+        out.append(f)
+    return out
+
+
+#: Bare switch spellings whose operand is a *separate*, following argv token
+#: (``-target aarch64-linux-gnu``, ``--sysroot /sdk``, ``-isysroot /sdk``).
+#: ``extract_abi_relevant_flags`` (``buildsource/adapters/base.py``) captures
+#: only the switch itself for these — its match is a plain prefix check with
+#: no lookahead, unlike ``_extract_flags`` (``build_context.py``), which
+#: consumes the operand token too and stores the resolved value in
+#: ``CompileUnit.target_triple``/``.sysroot``. Forwarding one of these bare
+#: tokens verbatim from ``cu.abi_relevant_flags`` therefore never recovers a
+#: lost value (the operand was never captured there in the first place) — it
+#: only emits a dangling switch that a real compiler either rejects outright
+#: or, worse, silently pairs with whatever token happens to follow it in the
+#: constructed command. This function already renders the equivalent,
+#: complete ``--target=``/``--sysroot=`` combined form from the structured
+#: ``cu.target_triple``/``cu.sysroot`` fields a few lines above, so dropping
+#: the bare duplicate here loses nothing (finding 1).
+_DANGLING_OPERAND_FLAGS = frozenset({"-target", "--sysroot", "-isysroot"})
 
 
 def _context_flags(cu: CompileUnit) -> list[str]:
@@ -205,16 +358,28 @@ def _context_flags(cu: CompileUnit) -> list[str]:
     if cu.target_triple:
         flags.append(f"--target={cu.target_triple}")
     if cu.sysroot:
-        flags.append(f"--sysroot={_resolve_cu_relative_path(cu.sysroot, cu.directory)}")
+        # .as_posix() (not str()/plain f-string interpolation), matching the
+        # exact convention both header command builders already use for a
+        # sysroot Path (dumper_ast_config.py's `sysroot.as_posix()` in both
+        # `_build_castxml_command`/`_build_clang_header_command`) -- a plain
+        # `str(WindowsPath(...))` renders native `\`-separated components,
+        # producing a `--sysroot=C:\opt\sysroot` token that a castxml/clang
+        # invocation does not parse the same way as the forward-slash form
+        # every other sysroot-flag rendering in this codebase emits.
+        flags.append(
+            f"--sysroot={_resolve_cu_relative_path(cu.sysroot, cu.directory).as_posix()}"
+        )
     for macro, value in sorted(cu.defines.items()):
         flags.append(f"-D{macro}={value}" if value else f"-D{macro}")
     for macro in sorted(cu.undefines):
         flags.append(f"-U{macro}")
     for inc in cu.include_paths:
-        flags.extend(["-I", str(_resolve_cu_relative_path(inc, cu.directory))])
+        flags.extend(["-I", _resolve_cu_relative_path(inc, cu.directory).as_posix()])
     for inc in cu.system_include_paths:
-        flags.extend(["-isystem", str(_resolve_cu_relative_path(inc, cu.directory))])
-    flags.extend(cu.abi_relevant_flags)
+        flags.extend(
+            ["-isystem", _resolve_cu_relative_path(inc, cu.directory).as_posix()]
+        )
+    flags.extend(f for f in cu.abi_relevant_flags if f not in _DANGLING_OPERAND_FLAGS)
     return flags
 
 
@@ -245,6 +410,8 @@ _EMPTY_RESOLUTION = HeaderCompileContextResolution()
 def resolve_header_compile_context(
     build_evidence: BuildEvidence | None,
     headers: Sequence[Path],
+    *,
+    explicit: CompileContext | None = None,
 ) -> HeaderCompileContextResolution:
     """Resolve a single L2 :class:`CompileContext` from L3 ``CompileUnit`` facts.
 
@@ -254,10 +421,21 @@ def resolve_header_compile_context(
     so a caller with no L3 evidence (or a header the build evidence simply
     doesn't cover) sees the exact same behavior as before this module existed.
 
+    *explicit* is the caller's own, already-supplied L2 context (``evidence.
+    compile`` on the service_input_resolution path) — when given, any
+    ABI-relevant dimension it already pins (an explicit ``-std=``/
+    ``--target=``/``--sysroot=``/``-isysroot`` or a specific ``-D``/``-U``
+    macro; see :class:`_ExplicitPin`) is excluded from the multi-unit
+    ambiguity comparison below, since the caller's own value wins that
+    dimension regardless of what the matched compile units say (Finding 3).
+    Per-field, not per-request: a genuine disagreement on any *other*,
+    unpinned dimension still fails closed.
+
     Raises :class:`~abicheck.errors.HeaderCompileContextAmbiguousError` when
     two or more of the matched ``CompileUnit``s disagree on an ABI-relevant
-    field — the one case this function refuses to guess at (see the module
-    docstring's "single-context vs. ambiguous" section).
+    field the caller has not already pinned via *explicit* — the one case
+    this function refuses to guess at (see the module docstring's
+    "single-context vs. ambiguous" section).
     """
     if build_evidence is None or not build_evidence.compile_units or not headers:
         return _EMPTY_RESOLUTION
@@ -266,9 +444,10 @@ def resolve_header_compile_context(
     if not matched:
         return _EMPTY_RESOLUTION
 
+    pin = _ExplicitPin.of(explicit)
     by_signature: dict[_EffectiveContextSignature, list[CompileUnit]] = {}
     for cu in matched:
-        by_signature.setdefault(_EffectiveContextSignature.of(cu), []).append(cu)
+        by_signature.setdefault(_EffectiveContextSignature.of(cu, pin), []).append(cu)
 
     if len(by_signature) > 1:
         raise HeaderCompileContextAmbiguousError(

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -1,0 +1,309 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""P0.3: derive an L2 header-AST :class:`CompileContext` from L3 build evidence.
+
+abicheck's L2 header-AST parsing (CastXML / direct-Clang) has historically run
+with only user-supplied ``--gcc-options``/``compile:`` context, or nothing —
+never the real build's own ``CompileUnit`` facts (``buildsource/adapters/
+compile_db.py``, ``cmake_file_api.py``, ``ninja.py``, ``bazel.py``,
+``make.py``), even when that L3 evidence is already available for a run (a
+``--sources``/``--build-info`` pack, or inline collection). abicheck already
+*detects* the resulting drift as an advisory finding
+(``ChangeKind.HEADER_PARSE_CONTEXT_DRIFT`` / ``HEADER_BUILD_CONTEXT_MISMATCH``)
+but never closed the loop by applying the evidence automatically. This module
+is that missing seam: it turns a set of headers plus a collected
+:class:`~abicheck.buildsource.build_evidence.BuildEvidence` into a single,
+agreed-upon :class:`~abicheck.compile_context.CompileContext` (standard,
+defines/undefines, ordered include search paths, sysroot, target triple, and
+ABI-relevant flags such as ``-fPIC``/``-fno-omit-frame-pointer``), reusing the
+already-extracted ``CompileUnit`` facts rather than re-parsing
+``compile_commands.json`` from scratch.
+
+**Which ``CompileUnit``s are "relevant" to a header?** A ``CompileUnit``
+compiles a translation unit (a ``.c``/``.cpp`` source), not a header, so there
+is no direct header→TU edge in the model. This mirrors the identical problem
+``build_context.py`` (ADR-020a's ``-p``/``--compile-db`` for a *raw*
+``compile_commands.json``) already solved for a single header: a lightweight,
+best-effort scan of each candidate TU's own source text for an ``#include`` of
+the header (by path-suffix match, falling back to a bare filename match) —
+:func:`_compile_unit_references_header` below is that same heuristic, applied
+to ``CompileUnit`` (redacted ``source``/``directory`` fields) rather than
+``build_context.CompileEntry``.
+
+**Single-context vs. ambiguous (P0.3's own scope boundary, per the plan).**
+Once every ``CompileUnit`` that references at least one of the requested
+headers is found, they are grouped by their *effective ABI-relevant context*
+— the exact tuple of fields the plan names in point 1 (language, standard,
+target triple, defines/undefines, ordered include paths, sysroot, ABI-relevant
+flags). Mirrors the discipline the "toolchain-identity" / ``lang_explicit``
+precedent in AGENTS.md's "Known gaps" section establishes: *resolve once,
+thread explicitly, fail closed on ambiguity* — never a new, different "just
+pick one" heuristic.
+
+- **Zero matching units**: no evidence to apply. Returns an empty resolution;
+  the caller's existing (pre-P0.3) behavior is unchanged, so the
+  ``header_parse_context_drift``/``header_build_context_mismatch`` advisory
+  findings keep firing exactly as before (backward compatible default).
+- **Exactly one distinct effective context**: applied automatically — the
+  common real-world case this PR implements as a genuine working slice.
+- **Two or more distinct effective contexts** (e.g. two TUs compiling the same
+  public header under a different ``-std=``/``-fPIC``/target triple/macro
+  set): fails closed with :class:`~abicheck.errors.HeaderCompileContextAmbiguousError`
+  rather than silently choosing one TU's context over another's — full
+  multi-context snapshot support (representing *both* contexts in one
+  ``AbiSnapshot``) is out of scope for this pass; see the module's own PR
+  description / AGENTS.md follow-up note.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from ..compile_context import CompileContext
+from ..errors import HeaderCompileContextAmbiguousError
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from .build_evidence import BuildEvidence, CompileUnit
+
+__all__ = [
+    "HeaderCompileContextResolution",
+    "resolve_header_compile_context",
+]
+
+
+def _resolve_cu_relative_path(raw: str, directory: str) -> Path:
+    """Expand a redacted/relative ``CompileUnit`` path field for reading.
+
+    Mirrors ``build_evidence._resolved_object``'s treatment of ``output``:
+    ``CompileUnit`` string fields are normalized *for persistence* (a
+    home-rooted path redacted to ``~/...``, ADR-032 D7; a relative path from
+    an adapter like Ninja/Make/Bazel resolved against the unit's own
+    ``directory``) — not guaranteed directly openable.
+    """
+    path = Path(raw).expanduser()
+    if not path.is_absolute() and directory:
+        path = Path(directory).expanduser() / path
+    return path
+
+
+#: Matches ``#include "..."``/``#include <...>`` whose argument *contains* the
+#: header's bare filename — narrowed further below by checking the header's
+#: full (resolved) path is a suffix of the matched include argument, the same
+#: two-stage match ``build_context._header_included_by_tu`` uses to cut down
+#: false positives from an unrelated header sharing a filename.
+def _include_pattern(header_name: str) -> re.Pattern[str]:
+    return re.compile(rf'#\s*include\s*[<"]([^>"]*{re.escape(header_name)})[>"]')
+
+
+def _compile_unit_references_header(cu: CompileUnit, header_resolved: Path) -> bool:
+    """Best-effort: does *cu*'s own source text ``#include`` *header_resolved*?"""
+    header_name = header_resolved.name
+    if not header_name:
+        return False
+    src_path = _resolve_cu_relative_path(cu.source, cu.directory)
+    try:
+        text = src_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    if header_name not in text:
+        return False
+    for m in _include_pattern(header_name).finditer(text):
+        include_arg = m.group(1)
+        if include_arg == header_name or str(header_resolved).endswith(include_arg):
+            return True
+    return False
+
+
+def _matching_compile_units(
+    compile_units: Sequence[CompileUnit], headers: Sequence[Path]
+) -> list[CompileUnit]:
+    """Every ``CompileUnit`` that ``#include``s at least one of *headers*."""
+    matched: list[CompileUnit] = []
+    seen_ids: set[str] = set()
+    resolved_headers = [h.resolve() for h in headers]
+    for cu in compile_units:
+        if cu.id in seen_ids:
+            continue
+        if any(_compile_unit_references_header(cu, h) for h in resolved_headers):
+            matched.append(cu)
+            seen_ids.add(cu.id)
+    return matched
+
+
+@dataclass(frozen=True)
+class _EffectiveContextSignature:
+    """The ABI-relevant fields the plan's point 1 + point 3 name, normalized.
+
+    Equality/hashing over this tuple is the "agree" test: two ``CompileUnit``s
+    that reference the same header must produce an *identical* signature for
+    P0.3 to apply a single context automatically. Deliberately exact (order-
+    preserving for include paths / ABI-relevant flags, since search order and
+    flag repetition can themselves be ABI-relevant) rather than a looser
+    semantic-equivalence check — a stricter "agree" test can only ever turn a
+    would-be single-context case into a (still-safe) ambiguous one, never the
+    reverse, so this stays on the conservative, fail-closed side.
+    """
+
+    language: str
+    standard: str
+    target_triple: str
+    sysroot: str
+    defines: tuple[tuple[str, str], ...]
+    undefines: tuple[str, ...]
+    include_paths: tuple[str, ...]
+    system_include_paths: tuple[str, ...]
+    abi_relevant_flags: tuple[str, ...]
+
+    @classmethod
+    def of(cls, cu: CompileUnit) -> _EffectiveContextSignature:
+        return cls(
+            language=cu.language,
+            standard=cu.standard,
+            target_triple=cu.target_triple,
+            sysroot=cu.sysroot or "",
+            defines=tuple(sorted(cu.defines.items())),
+            undefines=tuple(sorted(cu.undefines)),
+            include_paths=tuple(cu.include_paths),
+            system_include_paths=tuple(cu.system_include_paths),
+            abi_relevant_flags=tuple(cu.abi_relevant_flags),
+        )
+
+
+def _context_flags(cu: CompileUnit) -> list[str]:
+    """Render one ``CompileUnit``'s context as literal castxml/clang argv tokens.
+
+    Mirrors ``BuildContext.to_castxml_flags()`` (ADR-020a's ``-p``/
+    ``--compile-db`` -> castxml-flags path in ``build_context.py``) field for
+    field, so a ``CompileUnit``-derived context and a raw-``compile_commands.
+    json``-derived one produce the same shape of literal tokens — deliberately
+    not importing/reusing that dataclass directly to keep this module a
+    self-contained ``buildsource``-internal leaf with no dependency on the
+    top-level ``build_context`` module's larger response-file/redaction
+    machinery, which a ``CompileUnit`` (already fully resolved + redacted by
+    its adapter) has no use for.
+    """
+    flags: list[str] = []
+    if cu.standard and "++" in cu.standard:
+        flags.append(f"-std={cu.standard}")
+    if cu.target_triple:
+        flags.append(f"--target={cu.target_triple}")
+    if cu.sysroot:
+        flags.append(f"--sysroot={_resolve_cu_relative_path(cu.sysroot, cu.directory)}")
+    for macro, value in sorted(cu.defines.items()):
+        flags.append(f"-D{macro}={value}" if value else f"-D{macro}")
+    for macro in sorted(cu.undefines):
+        flags.append(f"-U{macro}")
+    for inc in cu.include_paths:
+        flags.extend(["-I", str(_resolve_cu_relative_path(inc, cu.directory))])
+    for inc in cu.system_include_paths:
+        flags.extend(["-isystem", str(_resolve_cu_relative_path(inc, cu.directory))])
+    flags.extend(cu.abi_relevant_flags)
+    return flags
+
+
+@dataclass(frozen=True)
+class HeaderCompileContextResolution:
+    """Outcome of :func:`resolve_header_compile_context`.
+
+    ``context`` is ``None`` whenever there was nothing to apply (no L3
+    evidence, or no ``CompileUnit`` references any of the requested headers)
+    — a plain, silent degrade to the pre-P0.3 behavior, never an error.
+    ``matched_unit_count`` is the number of distinct ``CompileUnit``s found to
+    reference the requested headers, always > 0 when ``context`` is not
+    ``None`` (used by callers to decide whether to stamp
+    ``AbiSnapshot.parsed_with_build_context``).
+    """
+
+    context: CompileContext | None = None
+    matched_unit_count: int = 0
+
+    @property
+    def matched(self) -> bool:
+        return self.context is not None
+
+
+_EMPTY_RESOLUTION = HeaderCompileContextResolution()
+
+
+def resolve_header_compile_context(
+    build_evidence: BuildEvidence | None,
+    headers: Sequence[Path],
+) -> HeaderCompileContextResolution:
+    """Resolve a single L2 :class:`CompileContext` from L3 ``CompileUnit`` facts.
+
+    Best-effort and additive: returns an empty (``context=None``) resolution
+    whenever there is nothing to apply — no build evidence, no compile units,
+    or no header the given ``CompileUnit``s reference — rather than raising,
+    so a caller with no L3 evidence (or a header the build evidence simply
+    doesn't cover) sees the exact same behavior as before this module existed.
+
+    Raises :class:`~abicheck.errors.HeaderCompileContextAmbiguousError` when
+    two or more of the matched ``CompileUnit``s disagree on an ABI-relevant
+    field — the one case this function refuses to guess at (see the module
+    docstring's "single-context vs. ambiguous" section).
+    """
+    if build_evidence is None or not build_evidence.compile_units or not headers:
+        return _EMPTY_RESOLUTION
+    resolved_headers = [Path(h) for h in headers]
+    matched = _matching_compile_units(build_evidence.compile_units, resolved_headers)
+    if not matched:
+        return _EMPTY_RESOLUTION
+
+    by_signature: dict[_EffectiveContextSignature, list[CompileUnit]] = {}
+    for cu in matched:
+        by_signature.setdefault(_EffectiveContextSignature.of(cu), []).append(cu)
+
+    if len(by_signature) > 1:
+        raise HeaderCompileContextAmbiguousError(
+            _ambiguity_message(headers, by_signature)
+        )
+
+    ((_sig, units),) = by_signature.items()
+    flags = _context_flags(units[0])
+    context = CompileContext(gcc_option_tokens=tuple(flags))
+    return HeaderCompileContextResolution(
+        context=context, matched_unit_count=len(matched)
+    )
+
+
+def _ambiguity_message(
+    headers: Sequence[Path],
+    by_signature: dict[_EffectiveContextSignature, list[CompileUnit]],
+) -> str:
+    header_names = ", ".join(sorted({h.name for h in headers}))
+    lines = [
+        f"Public header(s) [{header_names}] are compiled under "
+        f"{len(by_signature)} materially different, ABI-relevant compile "
+        "contexts across the available L3 build evidence (differing "
+        "-std=/target/defines/include-search-order/sysroot/ABI-relevant "
+        "flags); abicheck cannot pick one context over another without "
+        "guessing. Narrow the input (--compile-db-filter / a project "
+        "compile: block / --gcc-options pinning the ambiguous field(s)) or "
+        "compare a header per contract at a time. Conflicting translation "
+        "units:",
+    ]
+    for sig, units in sorted(by_signature.items(), key=lambda kv: kv[0].standard):
+        sample = units[0]
+        lines.append(
+            f"  - {sample.source or sample.id!r}: std={sig.standard or '(default)'} "
+            f"target={sig.target_triple or '(default)'} "
+            f"abi_flags={list(sig.abi_relevant_flags)}"
+        )
+    return "\n".join(lines)

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -250,9 +250,17 @@ def derive_l2_compile_context(
     build_query: str | None = None,
     build_compile_db: str | None = None,
     allow_inferred_build_query: bool = True,
+    explicit: CompileContext | None = None,
 ) -> tuple[CompileContext | None, list[Callable[[], None]]]:
     """Best-effort L2 :class:`CompileContext` derived from the build's L3
     ``CompileUnit`` facts (P0.3).
+
+    *explicit* is the caller's own already-supplied L2 context (typically
+    ``evidence.compile``) — forwarded to :func:`~abicheck.buildsource.
+    header_compile_context.resolve_header_compile_context` unchanged, so a
+    field it already pins (e.g. an explicit ``-std=c++20``) excuses a
+    same-field-only disagreement across the matched compile units instead of
+    failing closed on it (Finding 3; see that function's own docstring).
 
     Sibling of :func:`derive_l2_include_dirs`, sharing its exact pack-
     resolution precedence (explicit ``--build-info``/``--sources`` pack ->
@@ -312,7 +320,9 @@ def derive_l2_compile_context(
             defer_cleanup=cleanups,
         )
         build_evidence = pack.build_evidence if pack is not None else None
-        resolution = resolve_header_compile_context(build_evidence, list(headers))
+        resolution = resolve_header_compile_context(
+            build_evidence, list(headers), explicit=explicit
+        )
         if resolution.context is None:
             _run_cleanups(cleanups)
             return None, []

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -35,6 +35,7 @@ from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
 from typing import Any
 
+from ..compile_context import CompileContext
 from .inline import (
     BuildConfig,
     _run_cleanups,
@@ -240,6 +241,92 @@ def derive_l2_include_dirs(
         return [], []
 
 
+def derive_l2_compile_context(
+    headers: list[Path] | tuple[Path, ...],
+    build_info: Path | None,
+    sources: Path | None,
+    build_config: Path | None = None,
+    *,
+    build_query: str | None = None,
+    build_compile_db: str | None = None,
+    allow_inferred_build_query: bool = True,
+) -> tuple[CompileContext | None, list[Callable[[], None]]]:
+    """Best-effort L2 :class:`CompileContext` derived from the build's L3
+    ``CompileUnit`` facts (P0.3).
+
+    Sibling of :func:`derive_l2_include_dirs`, sharing its exact pack-
+    resolution precedence (explicit ``--build-info``/``--sources`` pack ->
+    trusted ``--config``/``--build-query`` -> ``build.compile_db`` ->
+    auto-discovered ``compile_commands.json`` -> the inferred build-system
+    query) via the same :func:`abicheck.buildsource.inline.collect_inline_pack`
+    call — kept as an independent call (rather than folded into
+    :func:`derive_l2_include_dirs`'s own single call) so this function's
+    return shape stays additive and every existing
+    ``derive_l2_include_dirs``/``seed_l2_includes`` caller and test is
+    unaffected; ``derive_l2_include_dirs`` already runs the identical
+    collection once per side for its own include-dir seeding, so a caller
+    using both pays for the L3 collection twice per side — an accepted,
+    documented cost (the collection itself is already re-run a third time by
+    ``embed_build_source`` later in the same pipeline for L3-L5 embedding, so
+    this is not a new class of repeated work).
+
+    Returns ``(context, cleanups)`` — ``context`` is ``None`` when there is
+    nothing to apply (mirrors :func:`derive_l2_include_dirs`'s ``[]``
+    degrade); the *cleanups* are the temp-build-dir thunks an inferred build
+    query may have appended, to be run only after the L2 parse has consumed
+    the derived context (same contract as ``derive_l2_include_dirs``).
+
+    Propagates :class:`~abicheck.errors.HeaderCompileContextAmbiguousError`
+    (P0.3's fail-closed multi-context case) rather than swallowing it — unlike
+    every other failure mode here (missing/malformed compile DB, no build
+    system, ...), which stays best-effort and degrades silently, a genuine
+    ABI-relevant disagreement across compile units must never be resolved by
+    silently guessing. The caller is responsible for running any accumulated
+    *cleanups* before letting the exception propagate further, since this
+    function's own ``except`` cannot both re-raise and return them.
+    """
+    from ..errors import HeaderCompileContextAmbiguousError
+    from .header_compile_context import resolve_header_compile_context
+
+    if (sources is None and build_info is None) or not headers:
+        return None, []
+    cfg = _l2_seed_config(build_config, sources, build_query, build_compile_db)
+    if cfg is None:
+        return None, []
+    cfg_trusted_for_query = build_config is not None or build_query is not None
+    compile_db_explicit = build_compile_db is not None or build_config is not None
+    cleanups: list[Callable[[], None]] = []
+    try:
+        base_build, raw_build_info, raw_sources = _l2_seed_pack_inputs(
+            build_info, sources
+        )
+        pack = collect_inline_pack(
+            sources=raw_sources,
+            build_info=raw_build_info,
+            build_config=cfg,
+            build_config_trusted_for_query=cfg_trusted_for_query,
+            compile_db_explicit=compile_db_explicit,
+            allow_inferred_build_query=allow_inferred_build_query,
+            base_build=base_build,
+            layers=("L3",),
+            defer_cleanup=cleanups,
+        )
+        build_evidence = pack.build_evidence if pack is not None else None
+        resolution = resolve_header_compile_context(build_evidence, list(headers))
+        if resolution.context is None:
+            _run_cleanups(cleanups)
+            return None, []
+        return resolution.context, cleanups
+    except HeaderCompileContextAmbiguousError:
+        # P0.3's fail-closed case: release any temp build dir this attempt
+        # created, then propagate — never resolved by silently guessing.
+        _run_cleanups(cleanups)
+        raise
+    except Exception:  # noqa: BLE001 -- best-effort, mirrors derive_l2_include_dirs
+        _run_cleanups(cleanups)
+        return None, []
+
+
 def seed_l2_includes(
     *,
     headers: list[Path] | tuple[Path, ...],
@@ -298,15 +385,19 @@ def seed_l2_includes(
     ):
         return incs, []
     derived, cleanups = derive_l2_include_dirs(
-        build_info, sources, build_config,
-        build_query=build_query, build_compile_db=build_compile_db,
+        build_info,
+        sources,
+        build_config,
+        build_query=build_query,
+        build_compile_db=build_compile_db,
         allow_inferred_build_query=allow_inferred_build_query,
     )
     if not derived:
         return incs, []
     logger.info(
         "L2 header parse: seeded %d include dir(s) from the build's compile "
-        "database (no -I given).", len(derived),
+        "database (no -I given).",
+        len(derived),
     )
     seeded = [Path(d) for d in derived]
     if defer_cleanup is not None:

--- a/abicheck/errors.py
+++ b/abicheck/errors.py
@@ -202,6 +202,29 @@ class AstContextAmbiguousError(SnapshotError):
     """
 
 
+class HeaderCompileContextAmbiguousError(SnapshotError):
+    """Raised by :mod:`abicheck.buildsource.header_compile_context` (P0.3) when
+    two or more L3 ``CompileUnit``s that reference a public header disagree on
+    an ABI-relevant compile-context field (``-std=``, target triple, defines/
+    undefines, include search order, sysroot, or an ABI-relevant flag such as
+    ``-fPIC``/``-fno-omit-frame-pointer``).
+
+    Mirrors :class:`AstContextAmbiguousError`'s reasoning: there is no sound
+    "just pick one" tiebreaker for genuinely disagreeing evidence, so the
+    single-context L3→L2 threading fails closed instead of silently deriving
+    a header AST from one TU's context while another, differently-configured
+    TU also compiles the same header. The caller must narrow the input (e.g.
+    a ``compile_db_filter``, or an explicit ``--gcc-options``/``compile:``
+    block override that pins the ambiguous field) rather than have one
+    compile unit's context silently chosen for them.
+
+    A subclass of :class:`SnapshotError` — existing ``except SnapshotError``
+    handling around ``dump()``/``compare()`` (``cli_resolve.py``) already
+    converts it to a clean ``click.ClickException`` instead of a raw
+    traceback.
+    """
+
+
 class UnsupportedCastxmlVersionError(SnapshotError):
     """Raised when a CastXML build outside the supported version range would
     be used for an authoritative L2 scan, before any header is parsed.

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -42,6 +42,7 @@ function-local import also keeps this module out of ``service``'s import cycle
 
 from __future__ import annotations
 
+import dataclasses
 from typing import TYPE_CHECKING
 
 from .errors import SnapshotError, ValidationError
@@ -51,6 +52,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from .api_types import InputSpec
+    from .compile_context import CompileContext
     from .model import AbiSnapshot
     from .service_compare_evidence import SideEvidence
 
@@ -142,6 +144,75 @@ def _seeded_includes(
     )
 
 
+def _merge_l3_compile_context(
+    explicit: CompileContext | None, derived: CompileContext | None
+) -> CompileContext | None:
+    """Fold *derived* (L3-derived, P0.3) ahead of *explicit* (user-supplied).
+
+    Mirrors ``-p``/``--compile-db``'s existing precedence for ``dump``
+    (``cli_helpers_compare._merge_gcc_options``): the build-derived flags lead
+    and the caller's own explicit ``gcc_option_tokens`` are appended after —
+    so an explicit, later token still wins any literal redefinition (e.g. a
+    caller's own ``-DFOO=2`` after a derived ``-DFOO=1`` — the compiler uses
+    the last ``-D`` for a given macro) without this function needing to know
+    which tokens actually conflict. ``derived`` with no tokens at all (a
+    matched compile unit with nothing ABI-relevant to forward — still real
+    evidence, see ``header_compile_context``'s own docstring) is a no-op here;
+    the caller still stamps ``parsed_with_build_context`` in that case since
+    context genuinely *was* resolved and applied (as the empty flag list).
+    """
+    if derived is None:
+        return explicit
+    if explicit is None:
+        return derived
+    return dataclasses.replace(
+        explicit,
+        gcc_option_tokens=(*derived.gcc_option_tokens, *explicit.gcc_option_tokens),
+    )
+
+
+def _seeded_compile_context(
+    side: InputSpec, evidence: SideEvidence
+) -> tuple[CompileContext | None, bool, list[Callable[[], None]]]:
+    """Fold L3 ``CompileUnit``-derived ABI context onto this side (P0.3).
+
+    Genuinely applies the real build's compile context (standard, defines/
+    undefines, include search paths, sysroot, target triple, ABI-relevant
+    flags) to the L2 header-AST invocation when ``sources``/``build_info`` L3
+    evidence is available and a ``CompileUnit`` references one of this side's
+    headers — instead of only the advisory ``header_parse_context_drift``/
+    ``header_build_context_mismatch`` findings this repo already emitted for
+    the gap. See ``buildsource.header_compile_context`` for the header→
+    ``CompileUnit`` matching heuristic and the single-context/fail-closed-on-
+    ambiguity contract (``HeaderCompileContextAmbiguousError`` propagates
+    unchanged — a genuine ABI-relevant disagreement across compile units is
+    never silently resolved by picking one).
+
+    A no-op (``(evidence.compile, False, [])``) when there is no L3 evidence
+    or no headers to match, or when the matched evidence resolves to nothing
+    — the exact same behavior as before this function existed, so a caller
+    with no build evidence for this side sees no change (backward
+    compatible). Returns ``(context, applied, cleanups)`` — ``applied`` is
+    True only when a real L3 context was found and folded in, which is what
+    the caller uses to decide whether to stamp
+    ``AbiSnapshot.parsed_with_build_context``.
+    """
+    if not (side.sources or side.build_info) or not evidence.headers:
+        return evidence.compile, False, []
+    from .buildsource.l2_seed import derive_l2_compile_context
+
+    derived, cleanups = derive_l2_compile_context(
+        headers=list(evidence.headers),
+        build_info=side.build_info,
+        sources=side.sources,
+        build_config=None,
+        allow_inferred_build_query=False,
+    )
+    if derived is None:
+        return evidence.compile, False, cleanups
+    return _merge_l3_compile_context(evidence.compile, derived), True, cleanups
+
+
 def resolve_side_snapshot(
     side: InputSpec,
     evidence: SideEvidence,
@@ -174,8 +245,18 @@ def resolve_side_snapshot(
     """
     from . import service
 
-    includes, cleanups = _seeded_includes(side, evidence)
+    # Accumulated incrementally (not built from two independent calls before
+    # entering `try`) so a HeaderCompileContextAmbiguousError raised by
+    # _seeded_compile_context still drains whatever temp-build-dir cleanups
+    # _seeded_includes already created, instead of leaking them.
+    cleanups: list[Callable[[], None]] = []
     try:
+        includes, includes_cleanups = _seeded_includes(side, evidence)
+        cleanups.extend(includes_cleanups)
+        compile_ctx, context_applied, context_cleanups = _seeded_compile_context(
+            side, evidence
+        )
+        cleanups.extend(context_cleanups)
         snap = service.resolve_input(
             side.path,
             evidence.headers,
@@ -189,7 +270,7 @@ def resolve_side_snapshot(
             enable_debuginfod=enable_debuginfod,
             debuginfod_url=debuginfod_url,
             header_backend=header_backend,
-            compile=evidence.compile,
+            compile=compile_ctx,
             public_headers=public_headers,
             public_header_dirs=public_header_dirs,
             include_dependencies=side.include_dependencies,
@@ -200,6 +281,16 @@ def resolve_side_snapshot(
             include_labels=include_labels,
             notify=notify,
         )
+        # P0.3: a genuine L3 CompileUnit context was resolved and folded into
+        # this side's L2 header-AST invocation above -- record that so the
+        # existing header_parse_context_drift/header_build_context_mismatch
+        # advisory findings correctly stop firing for this snapshot (they key
+        # off this exact flag). Gated on snap.from_headers the same way every
+        # other parsed_with_build_context stamp site is (cli_dump_helpers.py):
+        # a snapshot that never actually parsed the headers (e.g. --dwarf-only
+        # ignored them) must not claim their parse used real build context.
+        if context_applied and snap.from_headers:
+            snap.parsed_with_build_context = True
         if side.sources or side.build_info:
             embed_side_build_source(
                 snap,

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -43,6 +43,8 @@ function-local import also keeps this module out of ``service``'s import cycle
 from __future__ import annotations
 
 import dataclasses
+import os
+import shlex
 from typing import TYPE_CHECKING
 
 from .errors import SnapshotError, ValidationError
@@ -151,8 +153,8 @@ def _merge_l3_compile_context(
 
     Mirrors ``-p``/``--compile-db``'s existing precedence for ``dump``
     (``cli_helpers_compare._merge_gcc_options``): the build-derived flags lead
-    and the caller's own explicit ``gcc_option_tokens`` are appended after —
-    so an explicit, later token still wins any literal redefinition (e.g. a
+    and the caller's own explicit representation is appended after — so an
+    explicit, later token still wins any literal redefinition (e.g. a
     caller's own ``-DFOO=2`` after a derived ``-DFOO=1`` — the compiler uses
     the last ``-D`` for a given macro) without this function needing to know
     which tokens actually conflict. ``derived`` with no tokens at all (a
@@ -160,14 +162,52 @@ def _merge_l3_compile_context(
     evidence, see ``header_compile_context``'s own docstring) is a no-op here;
     the caller still stamps ``parsed_with_build_context`` in that case since
     context genuinely *was* resolved and applied (as the empty flag list).
+
+    Finding 2: "derived leads, explicit wins" only holds if *every*
+    representation of the explicit value actually lands after every derived
+    token in the rendered command — not just ``gcc_option_tokens`` entries.
+    Both header command builders (``dumper_ast_config._build_castxml_command``/
+    ``_build_clang_header_command``) render the structured ``sysroot`` field
+    and the free-form ``gcc_options`` string *before* ``gcc_option_tokens``,
+    so merely prepending ``derived.gcc_option_tokens`` to
+    ``explicit.gcc_option_tokens`` (as before) left ``explicit.sysroot``/
+    ``explicit.gcc_options`` — rendered earlier in the command — silently
+    overridden by a later, conflicting derived token instead of winning.
+    Folding both structured representations into trailing tokens (and
+    clearing the structured fields, so the command builders no longer also
+    emit them in their old, too-early position) puts every explicit
+    representation strictly after every derived one, regardless of which of
+    the three explicit channels (``sysroot``, ``gcc_options``,
+    ``gcc_option_tokens``) it came through.
     """
     if derived is None:
         return explicit
     if explicit is None:
         return derived
+    explicit_tail: list[str] = []
+    if explicit.sysroot is not None:
+        explicit_tail.append(f"--sysroot={explicit.sysroot.as_posix()}")
+    if explicit.gcc_options:
+        try:
+            explicit_tail.extend(
+                shlex.split(explicit.gcc_options, posix=os.name != "nt")
+            )
+        except ValueError:
+            # Malformed --gcc-options must not abort the merge (mirrors
+            # _compiler_options.explicit_language_standard's own handling of
+            # the identical failure mode) -- fall back to forwarding it
+            # verbatim as one token so it is at least still present, rather
+            # than silently dropped.
+            explicit_tail.append(explicit.gcc_options)
     return dataclasses.replace(
         explicit,
-        gcc_option_tokens=(*derived.gcc_option_tokens, *explicit.gcc_option_tokens),
+        sysroot=None,
+        gcc_options=None,
+        gcc_option_tokens=(
+            *derived.gcc_option_tokens,
+            *explicit_tail,
+            *explicit.gcc_option_tokens,
+        ),
     )
 
 
@@ -207,6 +247,11 @@ def _seeded_compile_context(
         sources=side.sources,
         build_config=None,
         allow_inferred_build_query=False,
+        # Finding 3: fold the caller's own already-explicit context into
+        # ambiguity resolution so a field it already pins (e.g. an explicit
+        # -std=c++20) excuses a same-field-only disagreement across matched
+        # compile units instead of failing closed on it.
+        explicit=evidence.compile,
     )
     if derived is None:
         return evidence.compile, False, cleanups

--- a/changelog.d/20260814_183623_noreply_p0_3_l3_context_in_l2_headers.md
+++ b/changelog.d/20260814_183623_noreply_p0_3_l3_context_in_l2_headers.md
@@ -24,8 +24,26 @@ it should read in CHANGELOG.md. Delete the other sections.
   two or more `CompileUnit`s that reference the same public header disagree
   on an ABI-relevant field (a different `-std=`/`-fPIC`/target/macro set),
   the new `HeaderCompileContextAmbiguousError` fails the run closed rather
-  than silently guessing which context to use. See
-  `abicheck/buildsource/header_compile_context.py` for the header↔
-  `CompileUnit` matching heuristic and scope boundary (single-context
-  applied automatically; genuinely ambiguous multi-context input is
-  reported, not resolved).
+  than silently guessing which context to use — unless the caller's own
+  explicit `CompileContext`/`--gcc-options` already pins the disputed field
+  (e.g. an explicit `-std=c++20` resolves a `-std=`-only disagreement across
+  matched compile units), in which case only a genuinely *unpinned* field
+  still fails closed. See `abicheck/buildsource/header_compile_context.py`
+  for the header↔`CompileUnit` matching heuristic and scope boundary
+  (single-context applied automatically; genuinely ambiguous multi-context
+  input is reported, not resolved). A two-token compile-DB flag whose
+  operand is a separate argv entry (`-target aarch64-linux-gnu`,
+  `--sysroot /sdk`, `-isysroot /sdk`) no longer forwards a dangling,
+  operand-less switch alongside the equivalent structured `--target=`/
+  `--sysroot=` rendering. An explicit `CompileContext.gcc_options`/
+  `sysroot` now reliably wins over a conflicting L3-derived flag in the
+  actually-constructed command (both are folded into trailing tokens ahead
+  of `gcc_option_tokens`, matching the derived-leads/explicit-wins
+  precedence this feature was already documented to have) — previously the
+  structured fields rendered *before* the derived tokens, letting a later,
+  conflicting derived flag silently win instead. Sysroot/include-path
+  flags derived from a `CompileUnit` are now rendered forward-slash-
+  normalized (`.as_posix()`) on every platform, matching the convention the
+  `castxml`/`clang` header command builders already use elsewhere, instead
+  of a native `\`-separated Windows path the frontends don't parse the same
+  way.

--- a/changelog.d/20260814_183623_noreply_p0_3_l3_context_in_l2_headers.md
+++ b/changelog.d/20260814_183623_noreply_p0_3_l3_context_in_l2_headers.md
@@ -1,0 +1,31 @@
+<!--
+A new changelog fragment. See changelog.d/README.md for the workflow.
+
+Uncomment exactly ONE '### <Category>' section below (remove its comment
+wrapper) and replace the example bullet with your entry, written the way
+it should read in CHANGELOG.md. Delete the other sections.
+-->
+
+### Added
+
+- **L3 build evidence is now applied automatically to L2 header parsing**
+  (P0.3) — when `--sources`/`--build-info` L3 evidence (or a typed
+  `DumpRequest`/`CompareRequest` `InputSpec.sources`/`build_info`) is
+  already available for a run, abicheck now derives the real build's
+  standard, defines/undefines, include search paths, sysroot, target
+  triple, and ABI-relevant flags (`-fPIC`, `-fno-omit-frame-pointer`, ...)
+  from the matching `CompileUnit`(s) and feeds them into the `castxml`/
+  `clang` header-AST invocation, instead of parsing headers with only
+  user-supplied `--gcc-options`/`compile:` context or none at all. The
+  existing `header_parse_context_drift`/`header_build_context_mismatch`
+  advisory findings now correctly stop firing once context is genuinely
+  applied (`AbiSnapshot.parsed_with_build_context` is stamped), while
+  continuing to fire unchanged when no compile evidence is available. When
+  two or more `CompileUnit`s that reference the same public header disagree
+  on an ABI-relevant field (a different `-std=`/`-fPIC`/target/macro set),
+  the new `HeaderCompileContextAmbiguousError` fails the run closed rather
+  than silently guessing which context to use. See
+  `abicheck/buildsource/header_compile_context.py` for the header↔
+  `CompileUnit` matching heuristic and scope boundary (single-context
+  applied automatically; genuinely ambiguous multi-context input is
+  reported, not resolved).

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -112,6 +112,15 @@ def test_resolve_derives_context_from_single_matching_unit(tmp_path: Path) -> No
     header.write_text("struct Widget { int x; };\n", encoding="utf-8")
     src = tmp_path / "widget.cpp"
     src.write_text('#include "widget.h"\nint f() { return 0; }\n', encoding="utf-8")
+    # Real, platform-native absolute paths under tmp_path -- a hand-typed
+    # POSIX literal like "/opt/sysroot" isn't even a valid absolute path on
+    # Windows (no drive letter), so it would silently exercise
+    # _resolve_cu_relative_path's "join with directory" branch instead of
+    # the "already absolute" branch a real CompileUnit's sysroot/include
+    # paths take on every platform.
+    sysroot_dir = tmp_path / "sysroot"
+    inc_dir = tmp_path / "inc"
+    sysinc_dir = tmp_path / "sysinc"
     cu = _cu(
         source=str(src),
         directory=str(tmp_path),
@@ -119,9 +128,9 @@ def test_resolve_derives_context_from_single_matching_unit(tmp_path: Path) -> No
         target_triple="x86_64-linux-gnu",
         defines={"WIDGET_EXTRA": "1", "FLAG": ""},
         undefines=["NDEBUG"],
-        include_paths=["/opt/inc"],
-        system_include_paths=["/opt/sysinc"],
-        sysroot="/opt/sysroot",
+        include_paths=[str(inc_dir)],
+        system_include_paths=[str(sysinc_dir)],
+        sysroot=str(sysroot_dir),
         abi_relevant_flags=["-fPIC", "-fno-omit-frame-pointer"],
     )
     ev = BuildEvidence(compile_units=[cu])
@@ -132,14 +141,74 @@ def test_resolve_derives_context_from_single_matching_unit(tmp_path: Path) -> No
     tokens = result.context.gcc_option_tokens
     assert "-std=c++20" in tokens
     assert "--target=x86_64-linux-gnu" in tokens
-    assert "--sysroot=/opt/sysroot" in tokens
+    # Compare against the same forward-slash-normalized rendering the
+    # production code emits (.as_posix()), not a raw, platform-dependent
+    # string -- this is the actual cross-platform contract, not an
+    # incidental one that only happens to hold on POSIX.
+    assert f"--sysroot={sysroot_dir.as_posix()}" in tokens
     assert "-DWIDGET_EXTRA=1" in tokens
     assert "-DFLAG" in tokens
     assert "-UNDEBUG" in tokens
-    assert "-I" in tokens and "/opt/inc" in tokens
-    assert "-isystem" in tokens and "/opt/sysinc" in tokens
+    assert "-I" in tokens and inc_dir.as_posix() in tokens
+    assert "-isystem" in tokens and sysinc_dir.as_posix() in tokens
     assert "-fPIC" in tokens
     assert "-fno-omit-frame-pointer" in tokens
+
+
+def test_resolve_strips_dangling_target_operand_flag(tmp_path: Path) -> None:
+    """Finding 1: a compile DB spelling ``-target aarch64-linux-gnu`` as two
+    separate argv tokens has only the bare ``-target`` switch captured into
+    ``abi_relevant_flags`` (the adapter's naive prefix match has no
+    lookahead) -- forwarding it verbatim alongside the structured
+    ``--target=`` rendering would emit a dangling, operand-less switch.
+    """
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text('#include "widget.h"\n', encoding="utf-8")
+    cu = _cu(
+        source=str(src),
+        directory=str(tmp_path),
+        target_triple="aarch64-linux-gnu",
+        # Mirrors extract_abi_relevant_flags's real output for a two-token
+        # "-target aarch64-linux-gnu": only the bare switch is captured.
+        abi_relevant_flags=["-target", "-fPIC"],
+    )
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.context is not None
+    tokens = result.context.gcc_option_tokens
+    assert tokens.count("--target=aarch64-linux-gnu") == 1
+    assert "-target" not in tokens  # the dangling bare switch is dropped
+    assert "-fPIC" in tokens  # unrelated flags still forwarded
+    # No malformed/dangling trailing switch anywhere in the rendered tokens.
+    assert tokens[-1] != "-target"
+
+
+def test_resolve_strips_dangling_sysroot_operand_flags(tmp_path: Path) -> None:
+    """Finding 1: same shape for --sysroot and -isysroot's separate-token forms."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text('#include "widget.h"\n', encoding="utf-8")
+    # A real, platform-native absolute path (not a hand-typed POSIX literal
+    # like "/sdk", which isn't absolute on Windows -- see the analogous fix
+    # in test_resolve_derives_context_from_single_matching_unit above).
+    sdk_dir = tmp_path / "sdk"
+    cu = _cu(
+        source=str(src),
+        directory=str(tmp_path),
+        sysroot=str(sdk_dir),
+        abi_relevant_flags=["--sysroot", "-isysroot"],
+    )
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.context is not None
+    tokens = result.context.gcc_option_tokens
+    expected = f"--sysroot={sdk_dir.as_posix()}"
+    assert tokens.count(expected) == 1
+    assert "--sysroot" not in tokens
+    assert "-isysroot" not in tokens
 
 
 def test_resolve_matches_by_bare_filename_include(tmp_path: Path) -> None:
@@ -222,6 +291,106 @@ def test_resolve_disagreeing_abi_flags_fail_closed(tmp_path: Path) -> None:
         resolve_header_compile_context(ev, [header])
 
 
+# ---------------------------------------------------------------------------
+# 1b. Finding 3: an explicit override resolves a same-field-only ambiguity
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_explicit_std_resolves_std_only_disagreement(tmp_path: Path) -> None:
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(source=str(src_a), directory=str(tmp_path), standard="c++17")
+    unit_b = _cu(source=str(src_b), directory=str(tmp_path), standard="c++20")
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    explicit = CompileContext(gcc_option_tokens=("-std=c++20",))
+    # No error: the std-only disagreement is excused by the explicit pin.
+    result = resolve_header_compile_context(ev, [header], explicit=explicit)
+    assert result.matched is True
+    assert result.matched_unit_count == 2
+
+
+def test_resolve_genuine_disagreement_with_no_explicit_override_still_fails(
+    tmp_path: Path,
+) -> None:
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(source=str(src_a), directory=str(tmp_path), standard="c++17")
+    unit_b = _cu(source=str(src_b), directory=str(tmp_path), standard="c++20")
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    # An explicit override for an *unrelated* dimension (a macro) must not
+    # excuse the genuine, unpinned std disagreement.
+    explicit = CompileContext(gcc_option_tokens=("-DUNRELATED=1",))
+    with pytest.raises(HeaderCompileContextAmbiguousError):
+        resolve_header_compile_context(ev, [header], explicit=explicit)
+    # Same with no explicit context at all.
+    with pytest.raises(HeaderCompileContextAmbiguousError):
+        resolve_header_compile_context(ev, [header])
+
+
+def test_resolve_partial_explicit_override_still_fails_for_remaining_field(
+    tmp_path: Path,
+) -> None:
+    """Disagreement on two fields (std, target); only std is pinned
+    explicitly -- must still fail closed on the unpinned target disagreement."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(
+        source=str(src_a),
+        directory=str(tmp_path),
+        standard="c++17",
+        target_triple="x86_64-linux-gnu",
+    )
+    unit_b = _cu(
+        source=str(src_b),
+        directory=str(tmp_path),
+        standard="c++20",
+        target_triple="aarch64-linux-gnu",
+    )
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    explicit = CompileContext(gcc_option_tokens=("-std=c++20",))
+    with pytest.raises(HeaderCompileContextAmbiguousError):
+        resolve_header_compile_context(ev, [header], explicit=explicit)
+
+
+def test_resolve_explicit_define_resolves_macro_only_disagreement(
+    tmp_path: Path,
+) -> None:
+    """Per-macro, not whole-field: an explicit -DFOO=2 excuses disagreement
+    on FOO specifically, without needing to pin every macro."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(
+        source=str(src_a),
+        directory=str(tmp_path),
+        defines={"FOO": "1", "SHARED": "1"},
+    )
+    unit_b = _cu(
+        source=str(src_b),
+        directory=str(tmp_path),
+        defines={"FOO": "2", "SHARED": "1"},
+    )
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    explicit = CompileContext(gcc_option_tokens=("-DFOO=2",))
+    result = resolve_header_compile_context(ev, [header], explicit=explicit)
+    assert result.matched is True
+
+
 def test_resolve_multiple_headers_union_of_matches(tmp_path: Path) -> None:
     h1 = tmp_path / "a.h"
     h1.write_text("struct A {};\n", encoding="utf-8")
@@ -242,8 +411,16 @@ def test_resolve_expands_redacted_home_relative_source(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     # CompileUnit.source/directory are redacted (home -> "~") for persistence
-    # (ADR-032 D7); resolution must expand them back before reading.
+    # (ADR-032 D7); resolution must expand them back before reading via
+    # Path.expanduser(), which is genuinely platform-native: POSIX reads
+    # HOME, Windows reads USERPROFILE (falling back to HOMEDRIVE+HOMEPATH)
+    # and does not consult HOME at all. Both (not just HOME) -- os.path.
+    # expanduser("~") reads a different env var depending on platform, the
+    # same cross-platform pattern test_include_graph.py/test_archive_graph.py
+    # already use for the identical situation -- must be set for this test
+    # to exercise real expansion on every CI platform rather than only POSIX.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     header = tmp_path / "widget.h"
     header.write_text("struct Widget { int x; };\n", encoding="utf-8")
     src = tmp_path / "widget.cpp"
@@ -356,6 +533,49 @@ def test_derive_l2_compile_context_ambiguous_raises_and_drains_cleanups(
         derive_l2_compile_context([header], None, tmp_path)
 
 
+def test_derive_l2_compile_context_explicit_std_resolves_ambiguity(
+    tmp_path: Path,
+) -> None:
+    """Finding 3, threaded through the real ``derive_l2_compile_context``
+    entry point (not just the lower-level ``resolve_header_compile_context``
+    call above)."""
+    from abicheck.buildsource.l2_seed import derive_l2_compile_context
+
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    (tmp_path / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src_a),
+                    "arguments": ["c++", "-c", str(src_a), "-std=c++17"],
+                },
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src_b),
+                    "arguments": ["c++", "-c", str(src_b), "-std=c++20"],
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    explicit = CompileContext(gcc_option_tokens=("-std=c++20",))
+    ctx, cleanups = derive_l2_compile_context(
+        [header], None, tmp_path, explicit=explicit
+    )
+    try:
+        assert ctx is not None
+    finally:
+        from abicheck.buildsource.inline import _run_cleanups
+
+        _run_cleanups(cleanups)
+
+
 def test_derive_l2_compile_context_swallows_non_ambiguous_errors(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -383,8 +603,61 @@ def test_merge_l3_compile_context_derived_leads_explicit_wins() -> None:
     explicit = CompileContext(gcc_option_tokens=("-DFOO=2",), sysroot=Path("/x"))
     merged = _merge_l3_compile_context(explicit, derived)
     assert merged is not None
-    assert merged.gcc_option_tokens == ("-DFOO=1", "-fPIC", "-DFOO=2")
-    assert merged.sysroot == Path("/x")  # explicit-only fields preserved
+    # Finding 2: explicit's structured `sysroot` is folded into a trailing
+    # token (and the structured field cleared) so it lands strictly after
+    # every derived token in the actually-rendered command, not before it.
+    assert merged.gcc_option_tokens == (
+        "-DFOO=1",
+        "-fPIC",
+        "--sysroot=/x",
+        "-DFOO=2",
+    )
+    assert merged.sysroot is None
+
+
+def test_merge_l3_compile_context_explicit_gcc_options_string_folded_after_derived() -> (
+    None
+):
+    """Finding 2: the free-form ``gcc_options`` string channel, not just
+    ``sysroot``, must also land after every derived token."""
+    from abicheck.service_input_resolution import _merge_l3_compile_context
+
+    derived = CompileContext(gcc_option_tokens=("-DFOO=1",))
+    explicit = CompileContext(gcc_options="-DFOO=2 -DBAR=3")
+    merged = _merge_l3_compile_context(explicit, derived)
+    assert merged is not None
+    assert merged.gcc_option_tokens == ("-DFOO=1", "-DFOO=2", "-DBAR=3")
+    assert merged.gcc_options is None
+
+
+def test_merge_l3_compile_context_conflicting_sysroot_explicit_wins_in_rendered_command(
+    tmp_path: Path,
+) -> None:
+    """End-to-end-shaped: build the actual castxml command from a merged
+    context carrying a derived AND an explicit, conflicting sysroot, and
+    assert the *last* --sysroot= token (the one that wins under real
+    compiler last-flag-wins semantics) is the explicit one."""
+    from abicheck.dumper_ast_config import _build_castxml_command
+    from abicheck.service_input_resolution import _merge_l3_compile_context
+
+    derived = CompileContext(gcc_option_tokens=("--sysroot=/derived",))
+    explicit = CompileContext(sysroot=Path("/explicit"))
+    merged = _merge_l3_compile_context(explicit, derived)
+    assert merged is not None
+    cmd = _build_castxml_command(
+        "g++",
+        "gnu",
+        [],
+        tmp_path / "out.xml",
+        tmp_path / "agg.h",
+        sysroot=merged.sysroot,
+        gcc_options=merged.gcc_options,
+        gcc_option_tokens=merged.gcc_option_tokens,
+        force_cpp=True,
+    )
+    sysroot_tokens = [tok for tok in cmd if tok.startswith("--sysroot=")]
+    assert sysroot_tokens == ["--sysroot=/derived", "--sysroot=/explicit"]
+    assert sysroot_tokens[-1] == "--sysroot=/explicit"  # last-flag-wins: explicit
 
 
 def test_merge_l3_compile_context_none_derived_is_noop() -> None:

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -1,0 +1,785 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""P0.3: L3 CompileUnit-derived L2 CompileContext (ADR-020a's automatic sibling).
+
+Covers, in order:
+
+1. ``buildsource.header_compile_context.resolve_header_compile_context`` --
+   the header<->CompileUnit matching heuristic, single-context flag
+   derivation, and the fail-closed ambiguous-context error.
+2. ``buildsource.l2_seed.derive_l2_compile_context`` -- the real-filesystem,
+   ``collect_inline_pack``-backed sibling of ``derive_l2_include_dirs``.
+3. ``service_input_resolution``'s wiring: the derived context folds ahead of
+   an explicit one, and ``AbiSnapshot.parsed_with_build_context`` is stamped
+   only when a real context was applied.
+4. An end-to-end regression (real clang, gated on tool availability) proving
+   the "before" state was genuinely wrong (a build-only macro silently
+   dropped a field) and that applying L3 evidence fixes it, while the
+   existing ``header_parse_context_drift``/``header_build_context_mismatch``
+   advisory findings correctly stop firing once context is genuinely applied
+   and still fire when it isn't.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
+from abicheck.buildsource.header_compile_context import (
+    HeaderCompileContextResolution,
+    resolve_header_compile_context,
+)
+from abicheck.compile_context import CompileContext
+from abicheck.errors import HeaderCompileContextAmbiguousError
+
+# ---------------------------------------------------------------------------
+# 1. resolve_header_compile_context
+# ---------------------------------------------------------------------------
+
+
+def _cu(**kwargs: object) -> CompileUnit:
+    defaults: dict[str, object] = dict(
+        id=f"cu://{kwargs.get('source', 'x')}",
+        source="",
+        directory="",
+        target_id="",
+        compiler="",
+        language="CXX",
+        standard="",
+        defines={},
+        undefines=[],
+        include_paths=[],
+        system_include_paths=[],
+        sysroot=None,
+        target_triple="",
+        abi_relevant_flags=[],
+    )
+    defaults.update(kwargs)
+    return CompileUnit(**defaults)  # type: ignore[arg-type]
+
+
+def test_resolve_returns_empty_when_no_build_evidence() -> None:
+    assert resolve_header_compile_context(None, [Path("x.h")]) == (
+        HeaderCompileContextResolution()
+    )
+
+
+def test_resolve_returns_empty_when_no_compile_units() -> None:
+    ev = BuildEvidence()
+    assert resolve_header_compile_context(ev, [Path("x.h")]).matched is False
+
+
+def test_resolve_returns_empty_when_no_headers_given() -> None:
+    ev = BuildEvidence(compile_units=[_cu()])
+    assert resolve_header_compile_context(ev, []).matched is False
+
+
+def test_resolve_returns_empty_when_no_unit_references_the_header(
+    tmp_path: Path,
+) -> None:
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "unrelated.cpp"
+    src.write_text("int f() { return 0; }\n", encoding="utf-8")
+    cu = _cu(source=str(src), directory=str(tmp_path))
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is False
+    assert result.context is None
+
+
+def test_resolve_derives_context_from_single_matching_unit(tmp_path: Path) -> None:
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text('#include "widget.h"\nint f() { return 0; }\n', encoding="utf-8")
+    cu = _cu(
+        source=str(src),
+        directory=str(tmp_path),
+        standard="c++20",
+        target_triple="x86_64-linux-gnu",
+        defines={"WIDGET_EXTRA": "1", "FLAG": ""},
+        undefines=["NDEBUG"],
+        include_paths=["/opt/inc"],
+        system_include_paths=["/opt/sysinc"],
+        sysroot="/opt/sysroot",
+        abi_relevant_flags=["-fPIC", "-fno-omit-frame-pointer"],
+    )
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is True
+    assert result.matched_unit_count == 1
+    assert result.context is not None
+    tokens = result.context.gcc_option_tokens
+    assert "-std=c++20" in tokens
+    assert "--target=x86_64-linux-gnu" in tokens
+    assert "--sysroot=/opt/sysroot" in tokens
+    assert "-DWIDGET_EXTRA=1" in tokens
+    assert "-DFLAG" in tokens
+    assert "-UNDEBUG" in tokens
+    assert "-I" in tokens and "/opt/inc" in tokens
+    assert "-isystem" in tokens and "/opt/sysinc" in tokens
+    assert "-fPIC" in tokens
+    assert "-fno-omit-frame-pointer" in tokens
+
+
+def test_resolve_matches_by_bare_filename_include(tmp_path: Path) -> None:
+    # The header path passed in need not lexically match the #include spelling
+    # (e.g. a vendored copy elsewhere on disk) -- filename-suffix matching,
+    # mirroring build_context._header_included_by_tu.
+    header = tmp_path / "pkg" / "widget.h"
+    header.parent.mkdir()
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "user.cpp"
+    src.write_text('#include "widget.h"\nint f();\n', encoding="utf-8")
+    cu = _cu(source=str(src), directory=str(tmp_path), standard="c++17")
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is True
+    assert "-std=c++17" in (result.context.gcc_option_tokens if result.context else ())
+
+
+def test_resolve_ignores_unreadable_source(tmp_path: Path) -> None:
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    cu = _cu(source=str(tmp_path / "missing.cpp"), directory=str(tmp_path))
+    ev = BuildEvidence(compile_units=[cu])
+    assert resolve_header_compile_context(ev, [header]).matched is False
+
+
+def test_resolve_agreeing_units_apply_one_context(tmp_path: Path) -> None:
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    srcs = []
+    for name in ("a.cpp", "b.cpp"):
+        src = tmp_path / name
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        srcs.append(src)
+    units = [
+        _cu(
+            source=str(s), directory=str(tmp_path), standard="c++20", defines={"X": "1"}
+        )
+        for s in srcs
+    ]
+    ev = BuildEvidence(compile_units=units)
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is True
+    assert result.matched_unit_count == 2
+    assert result.context is not None
+
+
+def test_resolve_disagreeing_units_fail_closed(tmp_path: Path) -> None:
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(source=str(src_a), directory=str(tmp_path), standard="c++17")
+    unit_b = _cu(source=str(src_b), directory=str(tmp_path), standard="c++20")
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    with pytest.raises(HeaderCompileContextAmbiguousError) as excinfo:
+        resolve_header_compile_context(ev, [header])
+    msg = str(excinfo.value)
+    assert "widget.h" in msg
+    assert "2 materially different" in msg
+
+
+def test_resolve_disagreeing_abi_flags_fail_closed(tmp_path: Path) -> None:
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(
+        source=str(src_a), directory=str(tmp_path), abi_relevant_flags=["-fPIC"]
+    )
+    unit_b = _cu(
+        source=str(src_b), directory=str(tmp_path), abi_relevant_flags=["-fno-pic"]
+    )
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    with pytest.raises(HeaderCompileContextAmbiguousError):
+        resolve_header_compile_context(ev, [header])
+
+
+def test_resolve_multiple_headers_union_of_matches(tmp_path: Path) -> None:
+    h1 = tmp_path / "a.h"
+    h1.write_text("struct A {};\n", encoding="utf-8")
+    h2 = tmp_path / "b.h"
+    h2.write_text("struct B {};\n", encoding="utf-8")
+    src1 = tmp_path / "a.cpp"
+    src1.write_text('#include "a.h"\n', encoding="utf-8")
+    src2 = tmp_path / "b.cpp"
+    src2.write_text('#include "b.h"\n', encoding="utf-8")
+    unit1 = _cu(source=str(src1), directory=str(tmp_path), standard="c++20")
+    unit2 = _cu(source=str(src2), directory=str(tmp_path), standard="c++20")
+    ev = BuildEvidence(compile_units=[unit1, unit2])
+    result = resolve_header_compile_context(ev, [h1, h2])
+    assert result.matched_unit_count == 2
+
+
+def test_resolve_expands_redacted_home_relative_source(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # CompileUnit.source/directory are redacted (home -> "~") for persistence
+    # (ADR-032 D7); resolution must expand them back before reading.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text('#include "widget.h"\n', encoding="utf-8")
+    cu = _cu(source="~/widget.cpp", directory="~", standard="c++14")
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is True
+
+
+# ---------------------------------------------------------------------------
+# 2. buildsource.l2_seed.derive_l2_compile_context
+# ---------------------------------------------------------------------------
+
+
+def _write_compile_db(tmp_path: Path, src: Path, extra_args: list[str]) -> None:
+    (tmp_path / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src),
+                    "arguments": ["c++", "-c", str(src), "-o", "out.o", *extra_args],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_derive_l2_compile_context_from_compile_db(tmp_path: Path) -> None:
+    from abicheck.buildsource.l2_seed import derive_l2_compile_context
+
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text('#include "widget.h"\n', encoding="utf-8")
+    _write_compile_db(
+        tmp_path, src, ["-std=c++20", "-DFOO=1", "-fPIC", "-fno-omit-frame-pointer"]
+    )
+
+    ctx, cleanups = derive_l2_compile_context([header], None, tmp_path)
+    try:
+        assert ctx is not None
+        assert "-std=c++20" in ctx.gcc_option_tokens
+        assert "-DFOO=1" in ctx.gcc_option_tokens
+        assert "-fPIC" in ctx.gcc_option_tokens
+        assert "-fno-omit-frame-pointer" in ctx.gcc_option_tokens
+    finally:
+        from abicheck.buildsource.inline import _run_cleanups
+
+        _run_cleanups(cleanups)
+
+
+def test_derive_l2_compile_context_no_inputs_is_none() -> None:
+    from abicheck.buildsource.l2_seed import derive_l2_compile_context
+
+    assert derive_l2_compile_context([Path("x.h")], None, None) == (None, [])
+
+
+def test_derive_l2_compile_context_no_headers_is_none(tmp_path: Path) -> None:
+    from abicheck.buildsource.l2_seed import derive_l2_compile_context
+
+    assert derive_l2_compile_context([], None, tmp_path) == (None, [])
+
+
+def test_derive_l2_compile_context_no_match_returns_none(tmp_path: Path) -> None:
+    from abicheck.buildsource.l2_seed import derive_l2_compile_context
+
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "unrelated.cpp"
+    src.write_text("int f() { return 0; }\n", encoding="utf-8")
+    _write_compile_db(tmp_path, src, ["-std=c++20"])
+
+    ctx, cleanups = derive_l2_compile_context([header], None, tmp_path)
+    assert ctx is None
+    assert cleanups == []
+
+
+def test_derive_l2_compile_context_ambiguous_raises_and_drains_cleanups(
+    tmp_path: Path,
+) -> None:
+    from abicheck.buildsource.l2_seed import derive_l2_compile_context
+
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    (tmp_path / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src_a),
+                    "arguments": ["c++", "-c", str(src_a), "-std=c++17"],
+                },
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src_b),
+                    "arguments": ["c++", "-c", str(src_b), "-std=c++20"],
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(HeaderCompileContextAmbiguousError):
+        derive_l2_compile_context([header], None, tmp_path)
+
+
+def test_derive_l2_compile_context_swallows_non_ambiguous_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Any *other* collection failure stays best-effort (mirrors
+    # derive_l2_include_dirs's own `except Exception -> ([], [])` contract).
+    from abicheck.buildsource import l2_seed
+
+    def _boom(*a: object, **k: object) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(l2_seed, "collect_inline_pack", _boom)
+    ctx, cleanups = l2_seed.derive_l2_compile_context([Path("x.h")], None, tmp_path)
+    assert (ctx, cleanups) == (None, [])
+
+
+# ---------------------------------------------------------------------------
+# 3. service_input_resolution wiring
+# ---------------------------------------------------------------------------
+
+
+def test_merge_l3_compile_context_derived_leads_explicit_wins() -> None:
+    from abicheck.service_input_resolution import _merge_l3_compile_context
+
+    derived = CompileContext(gcc_option_tokens=("-DFOO=1", "-fPIC"))
+    explicit = CompileContext(gcc_option_tokens=("-DFOO=2",), sysroot=Path("/x"))
+    merged = _merge_l3_compile_context(explicit, derived)
+    assert merged is not None
+    assert merged.gcc_option_tokens == ("-DFOO=1", "-fPIC", "-DFOO=2")
+    assert merged.sysroot == Path("/x")  # explicit-only fields preserved
+
+
+def test_merge_l3_compile_context_none_derived_is_noop() -> None:
+    from abicheck.service_input_resolution import _merge_l3_compile_context
+
+    explicit = CompileContext(gcc_options="-DX=1")
+    assert _merge_l3_compile_context(explicit, None) is explicit
+
+
+def test_merge_l3_compile_context_none_explicit_uses_derived() -> None:
+    from abicheck.service_input_resolution import _merge_l3_compile_context
+
+    derived = CompileContext(gcc_option_tokens=("-std=c++20",))
+    assert _merge_l3_compile_context(None, derived) is derived
+
+
+def test_seeded_compile_context_noop_without_sources(tmp_path: Path) -> None:
+    from abicheck.api_types import InputSpec
+    from abicheck.service_compare_evidence import SideEvidence
+    from abicheck.service_input_resolution import _seeded_compile_context
+
+    side = InputSpec(path=tmp_path / "lib.so", headers=(tmp_path / "h.h",))
+    evidence = SideEvidence(
+        headers=[tmp_path / "h.h"], compile=None, collect_mode="off", dump_manifest=None
+    )
+    ctx, applied, cleanups = _seeded_compile_context(side, evidence)
+    assert (ctx, applied, cleanups) == (None, False, [])
+
+
+def test_resolve_side_snapshot_stamps_parsed_with_build_context(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Wiring test: derived L3 context reaches ``service.resolve_input`` and
+    ``AbiSnapshot.parsed_with_build_context`` is stamped when it does."""
+    from abicheck import service_input_resolution as sir
+    from abicheck.api_types import InputSpec
+    from abicheck.model import AbiSnapshot
+    from abicheck.service_compare_evidence import SideEvidence
+
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text('#include "widget.h"\n', encoding="utf-8")
+    _write_compile_db(tmp_path, src, ["-std=c++20", "-fPIC"])
+
+    so = tmp_path / "lib.so"
+    so.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+    captured: dict[str, object] = {}
+
+    def _fake_resolve_input(*args: object, **kwargs: object) -> AbiSnapshot:
+        captured.update(kwargs)
+        return AbiSnapshot(library="lib", version="1.0", from_headers=True)
+
+    import abicheck.service as service_mod
+
+    monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve_input)
+
+    side = InputSpec(path=so, headers=(header,), version="1.0", sources=tmp_path)
+    evidence = SideEvidence(
+        headers=[header], compile=None, collect_mode="off", dump_manifest=None
+    )
+    snap = sir.resolve_side_snapshot(
+        side,
+        evidence,
+        lang="c++",
+        header_backend="clang",
+        fmt="elf",
+        public_headers=[],
+        public_header_dirs=[],
+    )
+    compile_ctx = captured["compile"]
+    assert isinstance(compile_ctx, CompileContext)
+    assert "-std=c++20" in compile_ctx.gcc_option_tokens
+    assert "-fPIC" in compile_ctx.gcc_option_tokens
+    assert snap.parsed_with_build_context is True
+
+
+def test_resolve_side_snapshot_does_not_stamp_when_unmatched(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from abicheck import service_input_resolution as sir
+    from abicheck.api_types import InputSpec
+    from abicheck.model import AbiSnapshot
+    from abicheck.service_compare_evidence import SideEvidence
+
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "unrelated.cpp"
+    src.write_text("int f() { return 0; }\n", encoding="utf-8")
+    _write_compile_db(tmp_path, src, ["-std=c++20"])
+
+    so = tmp_path / "lib.so"
+    so.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+    def _fake_resolve_input(*args: object, **kwargs: object) -> AbiSnapshot:
+        return AbiSnapshot(library="lib", version="1.0", from_headers=True)
+
+    import abicheck.service as service_mod
+
+    monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve_input)
+
+    side = InputSpec(path=so, headers=(header,), version="1.0", sources=tmp_path)
+    evidence = SideEvidence(
+        headers=[header], compile=None, collect_mode="off", dump_manifest=None
+    )
+    snap = sir.resolve_side_snapshot(
+        side,
+        evidence,
+        lang="c++",
+        header_backend="clang",
+        fmt="elf",
+        public_headers=[],
+        public_header_dirs=[],
+    )
+    assert snap.parsed_with_build_context is False
+
+
+def test_resolve_side_snapshot_propagates_ambiguous_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from abicheck import service_input_resolution as sir
+    from abicheck.api_types import InputSpec
+    from abicheck.model import AbiSnapshot
+    from abicheck.service_compare_evidence import SideEvidence
+
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    (tmp_path / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src_a),
+                    "arguments": ["c++", "-c", str(src_a), "-std=c++17"],
+                },
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src_b),
+                    "arguments": ["c++", "-c", str(src_b), "-std=c++20"],
+                },
+            ]
+        ),
+        encoding="utf-8",
+    )
+    so = tmp_path / "lib.so"
+    so.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+    def _fake_resolve_input(*args: object, **kwargs: object) -> AbiSnapshot:
+        raise AssertionError("must not be reached: ambiguity fails closed first")
+
+    import abicheck.service as service_mod
+
+    monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve_input)
+
+    side = InputSpec(path=so, headers=(header,), version="1.0", sources=tmp_path)
+    evidence = SideEvidence(
+        headers=[header], compile=None, collect_mode="off", dump_manifest=None
+    )
+    with pytest.raises(HeaderCompileContextAmbiguousError):
+        sir.resolve_side_snapshot(
+            side,
+            evidence,
+            lang="c++",
+            header_backend="clang",
+            fmt="elf",
+            public_headers=[],
+            public_header_dirs=[],
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end (real clang): macro-gated field, before/after, drift finding
+# ---------------------------------------------------------------------------
+
+_HEADER = """
+#pragma once
+struct Widget {
+    int x;
+#ifdef WIDGET_EXTRA
+    int y;
+#endif
+};
+int touch(Widget* w);
+"""
+
+_SOURCE = """
+#include "widget.h"
+int touch(Widget* w) { return w->x; }
+"""
+
+
+def _have(tool: str) -> bool:
+    return shutil.which(tool) is not None
+
+
+@pytest.fixture
+def widget_lib(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Build a real .so (compiled *with* WIDGET_EXTRA, so its real ABI has the
+    extra field) plus its public header and a compile_commands.json recording
+    that same real -DWIDGET_EXTRA=1 (+ two ABI-relevant flags)."""
+    if not (_have("clang") and _have("g++")):
+        pytest.skip("clang and g++ are required for this P0.3 integration test")
+    header = tmp_path / "widget.h"
+    header.write_text(_HEADER, encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text(_SOURCE, encoding="utf-8")
+    so = tmp_path / "libwidget.so"
+    subprocess.run(
+        [
+            "g++",
+            "-shared",
+            "-fPIC",
+            "-fno-omit-frame-pointer",
+            "-DWIDGET_EXTRA=1",
+            "-o",
+            str(so),
+            str(src),
+            f"-I{tmp_path}",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    (tmp_path / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src),
+                    "arguments": [
+                        "g++",
+                        "-c",
+                        str(src),
+                        "-o",
+                        "widget.o",
+                        "-DWIDGET_EXTRA=1",
+                        "-fPIC",
+                        "-fno-omit-frame-pointer",
+                        "-std=c++17",
+                    ],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return so, header, tmp_path
+
+
+pytestmark_e2e = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="P0.3 end-to-end test is ELF/Linux-scoped (mirrors "
+    "test_clang_header_backend_integration.py)",
+)
+
+
+def _widget_fields(snap: object) -> list[str]:
+    widget = next(t for t in snap.types if t.name == "Widget")  # type: ignore[attr-defined]
+    return [f.name for f in widget.fields]
+
+
+@pytestmark_e2e
+def test_e2e_without_context_regresses_to_pre_p03_behavior(
+    widget_lib: tuple[Path, Path, Path],
+) -> None:
+    """Regression-shaped: proves the "before" state is genuinely wrong -- a
+    header parsed with no build context silently drops the build-only field,
+    diverging from the library's real (compiled-in) ABI."""
+    from abicheck import service
+    from abicheck.api_types import DumpRequest, InputSpec
+
+    so, header, _src_dir = widget_lib
+    req = DumpRequest(
+        input=InputSpec(path=so, headers=(header,), version="1.0"),
+        frontend="clang",
+        lang_explicit=True,
+    )
+    snap = service.run_dump_request(req)
+    assert snap.from_headers is True
+    assert snap.parsed_with_build_context is False
+    assert _widget_fields(snap) == ["x"]  # "y" silently missing: the bug
+    # Fixed by supplying `sources=` (this pass's actual wiring) -- see
+    # test_e2e_with_l3_evidence_context_is_genuinely_applied below.
+
+
+@pytestmark_e2e
+def test_e2e_with_l3_evidence_context_is_genuinely_applied(
+    widget_lib: tuple[Path, Path, Path],
+) -> None:
+    """The real fix: with L3 evidence available, the field the build actually
+    compiles in is now present, and parsed_with_build_context is stamped."""
+    from abicheck import service
+    from abicheck.api_types import DumpRequest, InputSpec
+
+    so, header, src_dir = widget_lib
+    req = DumpRequest(
+        input=InputSpec(path=so, headers=(header,), version="1.0", sources=src_dir),
+        frontend="clang",
+        lang_explicit=True,
+    )
+    snap = service.run_dump_request(req)
+    assert snap.from_headers is True
+    assert snap.parsed_with_build_context is True
+    assert _widget_fields(snap) == ["x", "y"]  # fixed: matches the real ABI
+
+
+@pytestmark_e2e
+def test_e2e_header_parse_context_drift_stops_firing_once_applied(
+    widget_lib: tuple[Path, Path, Path],
+) -> None:
+    from abicheck import service
+    from abicheck.api_types import DumpRequest, InputSpec
+    from abicheck.buildsource.build_diff import check_header_parse_drift
+
+    so, header, src_dir = widget_lib
+
+    without_ctx = service.run_dump_request(
+        DumpRequest(
+            input=InputSpec(path=so, headers=(header,), version="1.0"),
+            frontend="clang",
+            lang_explicit=True,
+        )
+    )
+    with_ctx = service.run_dump_request(
+        DumpRequest(
+            input=InputSpec(path=so, headers=(header,), version="1.0", sources=src_dir),
+            frontend="clang",
+            lang_explicit=True,
+        )
+    )
+    assert with_ctx.build_source is not None
+    build = with_ctx.build_source.build_evidence
+    assert build is not None
+    abi_flags = {opt.key for opt in build.build_options if opt.abi_relevant}
+    assert abi_flags  # sanity: the fixture's -fPIC/-fno-omit-frame-pointer register
+
+    # Without context: still fires (unchanged pre-P0.3 behavior).
+    assert check_header_parse_drift(
+        build, headers_parsed_with_context=without_ctx.parsed_with_build_context
+    )
+    # With context genuinely applied: stops firing.
+    assert (
+        check_header_parse_drift(
+            build, headers_parsed_with_context=with_ctx.parsed_with_build_context
+        )
+        == []
+    )
+
+
+@pytestmark_e2e
+def test_e2e_crosscheck_header_build_context_mismatch_stops_firing(
+    widget_lib: tuple[Path, Path, Path],
+) -> None:
+    """The sibling crosscheck finding (``header_build_context_mismatch``) keys
+    off the identical ``parsed_with_build_context`` flag -- confirm P0.3's fix
+    closes that advisory too, not just ``header_parse_context_drift``.
+
+    Unlike ``header_parse_context_drift`` (a *compare*-time, cross-snapshot
+    finding), this crosscheck runs over ONE artifact and needs that artifact's
+    *own* embedded ``build_source`` to know a build exists at all -- a
+    snapshot dumped with no ``sources=`` carries no build evidence whatsoever
+    and correctly *skips* (not "fires"), since it has no way to know what it's
+    missing. So the real regression check here isolates the one variable P0.3
+    actually controls (``parsed_with_build_context``) on an otherwise-identical
+    snapshot that *does* carry the build evidence — rather than comparing two
+    snapshots that also differ in whether build evidence exists at all.
+    """
+    import copy
+
+    from abicheck import service
+    from abicheck.api_types import DumpRequest, InputSpec
+    from abicheck.buildsource.crosscheck import run_crosschecks
+    from abicheck.checker_policy import ChangeKind
+
+    so, header, src_dir = widget_lib
+
+    def _fires(snap: object) -> bool:
+        result = run_crosschecks(snap)  # type: ignore[arg-type]
+        return any(
+            c.kind == ChangeKind.HEADER_BUILD_CONTEXT_MISMATCH for c in result.findings
+        )
+
+    with_ctx = service.run_dump_request(
+        DumpRequest(
+            input=InputSpec(path=so, headers=(header,), version="1.0", sources=src_dir),
+            frontend="clang",
+            lang_explicit=True,
+        )
+    )
+    assert with_ctx.parsed_with_build_context is True
+    assert _fires(with_ctx) is False
+
+    stale = copy.deepcopy(with_ctx)
+    stale.parsed_with_build_context = False
+    assert _fires(stale) is True


### PR DESCRIPTION
## Summary

P0.3 of the larger tracked analysis-assurance/comparability initiative. abicheck's L2 header-AST parsing (CastXML/direct-Clang) has historically run with only user-supplied `--gcc-options`/`compile:` context, or nothing — never the real build's own `CompileUnit` facts, even when L3 build evidence (`--sources`/`--build-info`) is already available for a run. abicheck already *detected* this as an advisory finding (`header_parse_context_drift` / `header_build_context_mismatch`), but the fix was manual ("re-run with `-p`/`--compile-db`"). This PR closes the loop: when L3 evidence is available, it is now genuinely applied to the L2 header-AST invocation automatically for the single-context case, and the ambiguous multi-context case fails closed instead of guessing.

## Motivation

Real user report: comparing a header-derived snapshot against a binary built with `-fPIC -fno-omit-frame-pointer -std=c++20 -DFOO=1 ...` produced ABI-affecting facts (struct layout, macro-conditional declarations) that didn't reflect how the header was actually compiled into the analyzed library — silently, with only an advisory finding pointing at the gap.

## Changes

- **`abicheck/buildsource/header_compile_context.py`** (new) — `resolve_header_compile_context(build_evidence, headers)`:
  - Matches a header to the `CompileUnit`(s) that `#include` it — a best-effort source-text scan mirroring `build_context.py`'s existing `-p`/`--compile-db` heuristic (`_header_included_by_tu`), since a `CompileUnit` compiles a translation unit, not a header, and there is no direct header→TU edge in the model.
  - Groups matches by their *effective ABI-relevant context* (language, standard, target triple, defines/undefines, ordered include paths, sysroot, ABI-relevant flags).
  - **Single agreeing context → applies it automatically** (the common real-world case, and this PR's genuine working slice).
  - **Two or more disagreeing contexts → fails closed** with the new `HeaderCompileContextAmbiguousError` rather than silently picking one TU's context over another's — mirrors the "resolve once, thread explicitly, fail closed on ambiguity" discipline this codebase already established for the `lang_explicit` toolchain-identity work (see `AGENTS.md`'s "Known gaps").
  - Zero matching units → empty resolution, i.e. no-op (pre-existing behavior unchanged).

- **`abicheck/buildsource/l2_seed.py`** — new `derive_l2_compile_context()`, a sibling of the existing `derive_l2_include_dirs()`, sharing the same `collect_inline_pack()`-backed pack-resolution precedence (explicit pack → trusted config/query → `compile_db` glob → auto-discovered `compile_commands.json` → inferred build-system query). Kept as an independent `collect_inline_pack()` call rather than folded into `derive_l2_include_dirs()`'s own call, so every existing `derive_l2_include_dirs`/`seed_l2_includes` caller and its ~20 pinned tests are completely unaffected — documented as an accepted, known cost (the same L3 collection already runs a third time later for full L3–L5 embedding, so this isn't a new class of repeated work).

- **`abicheck/service_input_resolution.py`** — `resolve_side_snapshot()` (the one per-input primitive `compare` and `dump`'s typed API already share since G33 Phase 5) now:
  - derives the L3 context and folds it *ahead of* any explicit `CompileContext` (same precedence `-p`/`--compile-db` already uses for `dump`: derived flags lead, explicit tokens are appended after and win any literal redefinition);
  - stamps `AbiSnapshot.parsed_with_build_context = True` when a real context was applied and headers were actually parsed — which is exactly the flag `header_parse_context_drift`/`header_build_context_mismatch` key off, so both now correctly stop firing once context is genuinely applied while continuing to fire unchanged when no compile evidence is supplied (verified end-to-end, see Tests);
  - propagates `HeaderCompileContextAmbiguousError` rather than silently resolving it, draining any already-created temp-build-dir cleanups first.

- **`abicheck/errors.py`** — new `HeaderCompileContextAmbiguousError(SnapshotError)`, mirroring `AstContextAmbiguousError`'s existing shape/reasoning. `cli_resolve.py`'s existing `except SnapshotError → click.ClickException` handling already converts it to a clean CLI error with no code changes needed there.

## Scope boundary / deferred future work

This PR implements the **single-context** slice end-to-end and fails closed for the ambiguous multi-context case, per the plan. Explicitly **not** attempted here:

1. **Full multi-context snapshot support** (representing two genuinely-disputed compile contexts in one `AbiSnapshot`) — a much bigger, separate architectural project. The ambiguous case reports a clear, structured error today instead.
2. **The raw `dump`/`compare` CLI commands' own `--sources`/`--build-info`/`-p` flags do not yet route through this new automatic resolution.** `dump`'s ELF path calls `dumper.dump()` directly (`cli_dump_helpers.perform_elf_dump`), bypassing `service.resolve_input`/`resolve_side_snapshot` entirely; `compare`'s CLI snapshot resolution (`cli_resolve._resolve_compare_snapshots`) never threads `--sources`/`--build-info` into `InputSpec` at all today — those flags only feed a separate, post-hoc, diff-only pass (`cli_buildsource_helpers.diff_embedded_build_source`) that already runs *after* both snapshots are resolved. This PR's fix reaches the typed Python API (`service.run_dump_request`/`service.resolve_compare_request` via `InputSpec.sources`/`build_info`) — which is a real, fully-wired, and tested slice — but wiring the bare CLI flags through to the same resolution is the natural next step, left as follow-up per this file's own "known gaps over risky reactive patches" convention rather than expanding this pass's verified surface under review pressure.

## Tests

New `tests/test_header_compile_context.py` (29 tests, all passing):
- `resolve_header_compile_context`: header↔`CompileUnit` matching (filename-suffix match, redacted `~`-path expansion, unreadable-source degrade), single-unit and multi-agreeing-unit context derivation (`-std=`, defines/undefines, `-I`/`-isystem`, sysroot, target, ABI-relevant flags), and the fail-closed ambiguous case (both a `-std=` disagreement and an ABI-flag-family disagreement).
- `derive_l2_compile_context` (real `compile_commands.json` on disk, mirroring `test_derive_l2_include_dirs_from_compile_db`'s pattern): matched/unmatched/no-input cases, the ambiguous case raising and draining cleanups, and non-ambiguous failures staying best-effort.
- `service_input_resolution` wiring: `_merge_l3_compile_context`'s derived-leads-explicit-wins precedence, and `resolve_side_snapshot` reaching a mocked `service.resolve_input` with the merged context, stamping (or not stamping) `parsed_with_build_context`, and propagating the ambiguous error.
- **End-to-end, real clang** (gated on `clang`+`g++` presence, mirrors `test_clang_header_backend_integration.py`'s pattern — both tools are present in CI/this environment):
  - A regression-shaped test proving the "before" state is genuinely wrong: a header field gated on a build-only macro (`#ifdef WIDGET_EXTRA`) is silently absent from the header-only snapshot even though the library's real, compiled-in ABI has it (the library `.so` was built with `-DWIDGET_EXTRA=1`).
  - The fix: with `sources=` (L3 evidence) supplied, the field is now present, `from_headers`/`parsed_with_build_context` are both `True`, matching the library's real ABI.
  - `check_header_parse_drift` (the `header_parse_context_drift` finding's own logic) still fires without context and correctly stops firing once genuinely applied.
  - The sibling crosscheck finding `header_build_context_mismatch` (which keys off the identical flag) is confirmed to stop firing too — isolated to the one variable P0.3 controls, since that check needs a snapshot's *own* embedded build evidence to know a build exists at all.

## Verification

- `ruff check abicheck/ tests/` — all checks passed.
- `ruff format --check` (touched files) — already formatted (repo-wide `ruff format --check` shows ~161 pre-existing unrelated files needing reformatting on `main` itself — a ruff-version drift unrelated to this PR; every file this PR touches is clean).
- `mypy abicheck/` — `Success: no issues found in 363 source files` (0-error baseline maintained).
- `python scripts/check_ai_readiness.py` — 15 pre-existing errors, 121 pre-existing warnings, **identical** on a clean `origin/main` checkout (verified via `git stash`) — all 15 errors are unrelated `**Verified:**` ADR-commit-reachability failures caused by this environment's shallow/worktree clone, not introduced by this PR. No new findings.
- Full fast suite: `pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden" -q` → **26733 passed, 12 skipped, 661 deselected, 4 xfailed** (3 failures observed pre-fix: 2 are the identical pre-existing `test_ai_readiness.py` shallow-clone failures above; the 3rd, `test_skill_eval_pack.py::test_every_hashed_input_is_tracked_by_git`, was this PR's own new file being untracked before `git add` — resolved by staging, confirmed passing afterward).
- Changelog fragment added via `scriv create` (see below).

## Changelog fragment

```
### Added

- **L3 build evidence is now applied automatically to L2 header parsing**
  (P0.3) — when `--sources`/`--build-info` L3 evidence (or a typed
  `DumpRequest`/`CompareRequest` `InputSpec.sources`/`build_info`) is
  already available for a run, abicheck now derives the real build's
  standard, defines/undefines, include search paths, sysroot, target
  triple, and ABI-relevant flags (`-fPIC`, `-fno-omit-frame-pointer`, ...)
  from the matching `CompileUnit`(s) and feeds them into the `castxml`/
  `clang` header-AST invocation, instead of parsing headers with only
  user-supplied `--gcc-options`/`compile:` context or none at all. The
  existing `header_parse_context_drift`/`header_build_context_mismatch`
  advisory findings now correctly stop firing once context is genuinely
  applied (`AbiSnapshot.parsed_with_build_context` is stamped), while
  continuing to fire unchanged when no compile evidence is available. When
  two or more `CompileUnit`s that reference the same public header disagree
  on an ABI-relevant field (a different `-std=`/`-fPIC`/target/macro set),
  the new `HeaderCompileContextAmbiguousError` fails the run closed rather
  than silently guessing which context to use. See
  `abicheck/buildsource/header_compile_context.py` for the header↔
  `CompileUnit` matching heuristic and scope boundary (single-context
  applied automatically; genuinely ambiguous multi-context input is
  reported, not resolved).
```

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated — not attempted this pass (no `docs/` page currently documents `header_parse_context_drift`'s manual-fix workflow specifically enough to need updating; flagging for a maintainer follow-up if one exists)
- [x] `mypy`/`ruff` clean on all touched files
- [x] No new AI-readiness findings vs. `origin/main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017jAiyuYpVCdif4RqZpJ1mP)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Header parsing now automatically uses matching build settings, including language standards, macros, include paths, targets, sysroots, and ABI options.
  - Explicitly provided settings take precedence over detected build information.
  - Header snapshots indicate when build context was applied.

- **Bug Fixes**
  - Reduces incorrect ABI drift findings caused by missing compile settings.
  - Handles split compiler arguments and platform-independent paths more reliably.
  - Conflicting build contexts now fail safely unless explicitly resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->