### PR TITLE
fix: P0.2 follow-up — close review gaps left by merge timing on #764

### DIFF
--- a/abicheck/buildsource/adapters/bazel.py
+++ b/abicheck/buildsource/adapters/bazel.py
@@ -170,7 +170,7 @@ class BazelAdapter:
                 f"bazel: {kind} input not found or unreadable: {self.redaction.path(str(value))}"
             )
             return None
-        if self.workspace is not None and self.target is not None and self.allow_query:
+        if self.workspace is not None and self.targets and self.allow_query:
             return self._run_bazel(kind, ev)
         return None
 

--- a/abicheck/buildsource/build_query.py
+++ b/abicheck/buildsource/build_query.py
@@ -62,7 +62,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from .. import deadline
-from .build_evidence import BuildEvidence
+from .build_evidence import BuildEvidence, TargetScope
 from .model import ExtractorRecord
 
 #: Out-of-source build dir name. abicheck no longer writes a configure tree into
@@ -737,6 +737,18 @@ def _merge_query_result(
         merged.diagnostics.append(
             f"build_query_auto: {system} exited {proc.returncode}"
         )
+        if system == "bazel" and bazel_targets:
+            # A typo'd/nonexistent root target (e.g. `--build-target //:typo`)
+            # makes the aquery itself exit nonzero, well before
+            # `_ingest_query_output` -- the only path that otherwise stamps
+            # `target_scope` -- ever runs. Record the requested labels with an
+            # empty `resolved` set here too, so the L3_build coverage report
+            # still shows "requested: [//:typo], resolved: []" instead of
+            # omitting `requested_roots` entirely, which is exactly the
+            # typo-detection/audit signal this accounting exists to surface.
+            merged.target_scope = TargetScope(
+                requested=list(bazel_targets), resolved=[], transitive_count=None
+            )
         return None
     # Ingestion parses tool output (the cmake compile DB, bazel aquery JSON) —
     # keep it inside the never-raises contract so a malformed payload or a

--- a/changelog.d/20260814_193415_noreply_p0_2_bazel_root_targets.md
+++ b/changelog.d/20260814_193415_noreply_p0_2_bazel_root_targets.md
@@ -19,4 +19,9 @@ it should read in CHANGELOG.md. Delete the other sections.
   `compare`'s implicit raw-`--old/new-sources` dump path. The `L3_build`
   evidence-coverage report row gains `requested_roots`/`resolved_roots`/
   `transitive_targets`/`compile_units`/`link_units` (report schema 2.37),
-  populated only for a scoped run.
+  populated only for a scoped run. A misspelled/nonexistent root target now
+  records the requested label with an empty `resolved` set instead of
+  omitting `requested_roots` entirely, and `BazelAdapter`'s plural
+  `targets=[...]` constructor argument reliably triggers the live
+  cquery/aquery path on its own, without also requiring the legacy
+  singular `target=`.

--- a/tests/test_bazel_root_targets.py
+++ b/tests/test_bazel_root_targets.py
@@ -154,6 +154,34 @@ def test_adapter_targets_without_cquery_evidence_leaves_transitive_count_none():
     assert ev.target_scope.transitive_count is None
 
 
+def test_plural_targets_only_still_runs_live_bazel_query(tmp_path: Path, monkeypatch):
+    # Review finding: a caller using ONLY the new plural `targets=[...]`
+    # interface (no legacy singular `target=`) must still trigger the live
+    # cquery/aquery path -- `_resolve()`'s gate must key off `self.targets`,
+    # not `self.target`, or the documented multi-root interface silently
+    # collects nothing.
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kw):
+        calls.append(cmd)
+        if cmd[1] == "cquery":
+            return _FakeProc(0, stdout=_CQUERY)
+        return _FakeProc(0, stdout=json.dumps({"actions": []}))
+
+    monkeypatch.setattr(
+        "abicheck.buildsource.adapters.bazel.shutil.which",
+        lambda name: f"/usr/bin/{name}" if name == "bazel" else None,
+    )
+    monkeypatch.setattr("abicheck.buildsource.adapters.bazel.subprocess.run", fake_run)
+    ev = BazelAdapter(workspace=tmp_path, targets=["//foo:foo", "//bar:bar"]).collect()
+    assert len(calls) == 2
+    assert any(c[1] == "cquery" for c in calls)
+    assert any(c[1] == "aquery" for c in calls)
+    assert ev.target_scope is not None
+    assert ev.target_scope.requested == ["//foo:foo", "//bar:bar"]
+    assert ev.target_scope.resolved == ["//foo:foo"]
+
+
 def test_target_scope_round_trips_through_build_evidence_json():
     ev = BuildEvidence(
         target_scope=TargetScope(
@@ -268,6 +296,38 @@ def test_run_inferred_build_query_unscoped_leaves_target_scope_none(
         tmp_path, merged, ext, which=lambda tool: f"/usr/bin/{tool}"
     )
     assert merged.target_scope is None
+
+
+def test_run_inferred_build_query_typo_target_still_records_requested_roots(
+    tmp_path: Path, monkeypatch
+):
+    # Review finding: a misspelled/nonexistent root target makes the aquery
+    # itself exit nonzero, so `_merge_query_result` returns before
+    # `_ingest_query_output` (the only path that otherwise stamps
+    # `target_scope`) ever runs. The requested label must still be recorded,
+    # with an empty `resolved` set, rather than omitting `requested_roots`
+    # entirely -- that's the whole point of the typo-detection accounting.
+    (tmp_path / "MODULE.bazel").write_text("module(name='x')\n", encoding="utf-8")
+
+    def fake_run(cmd, **kw):
+        return _FakeProc(1, stdout="", stderr="ERROR: no such target '//:typo'")
+
+    from abicheck.buildsource import build_query as _bq
+
+    monkeypatch.setattr(_bq.deadline, "run_bounded", fake_run)
+    merged, ext = BuildEvidence(), []
+    out = run_inferred_build_query(
+        tmp_path,
+        merged,
+        ext,
+        which=lambda tool: f"/usr/bin/{tool}",
+        bazel_targets=("//:typo",),
+    )
+    assert out is None
+    assert merged.target_scope is not None
+    assert merged.target_scope.requested == ["//:typo"]
+    assert merged.target_scope.resolved == []
+    assert merged.target_scope.transitive_count is None
 
 
 # ── .abicheck.yml `build.targets` ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes two real correctness gaps in Bazel root-target scoping (P0.2, `abicheck/buildsource/adapters/bazel.py` / `abicheck/buildsource/build_query.py`) that were found by code review after #764 had already merged.

## Motivation

#764 ("feat: Bazel root-target scoping for L3 evidence collection (P0.2)") merged into `main` at `c44be3f8` before a follow-up code review of the same change surfaced two bugs. This is a timing/coordination issue, not a review miss on #764 itself — the review simply landed after the merge window closed. This PR is a direct fix on top of the same branch (`p0-2-bazel-root-targets`), rebased onto current `main`, following the same pattern as the P0.3 follow-up work in this repo.

## Changes

- **`BazelAdapter`'s plural `targets=[...]` interface was a silent no-op.** `_resolve()` gated the live cquery/aquery path on `self.target is not None` — the legacy *singular* field — so a caller using only the documented plural `targets=[...]` constructor argument (no legacy `target=`) never actually triggered a live Bazel query. Fixed by gating on `self.targets` (the field the plural interface actually populates) instead.
- **A typo'd/nonexistent Bazel root target vanished from `TargetScope` accounting entirely.** A misspelled `--build-target` label (e.g. `//:typo`) makes the `aquery` invocation itself exit nonzero, well before `_ingest_query_output` — the only path that otherwise stamps `target_scope` — ever runs. `_merge_query_result` returned early on that failed-query path without recording anything, so the `L3_build` evidence-coverage report silently omitted `requested_roots` instead of showing `requested: [//:typo], resolved: []` — defeating this PR's whole point, which is to make a typo'd target visible as "requested but not resolved." Fixed by recording the requested labels with an empty `resolved` set on the failed-query path too.

Both fixes are covered by new regression tests in `tests/test_bazel_root_targets.py`:
- `test_plural_targets_only_still_runs_live_bazel_query` — asserts a plural-only `BazelAdapter(targets=[...])` triggers both the `cquery` and `aquery` calls.
- `test_run_inferred_build_query_typo_target_still_records_requested_roots` — asserts a failed aquery (simulating a typo'd target) still records `requested=["//:typo"], resolved=[]` on `merged.target_scope`.

## Verification

All run against the rebased branch (current `main` tip at the time of this PR):

- `ruff check abicheck/ tests/` — all checks passed
- `ruff format --check` on touched files — already formatted (note: a pre-existing, unrelated repo-wide ruff-version formatting drift affects ~486 other files on `main` itself, confirmed unrelated to this change)
- `mypy abicheck/` — 0 errors (clean, matching the documented 0-error baseline)
- `pytest tests/test_bazel_root_targets.py` — 35 passed
- `pytest tests/test_bazel_adapter.py tests/test_build_query_inference.py tests/test_buildsource_inline_nodb.py` — 148 passed
- Full fast suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`) — 26790 passed, 21 failed, 11 skipped, 4 xfailed. **All 21 failures independently confirmed pre-existing on `main` itself** in this sandboxed environment (no `castxml` binary available for `test_castxml_errors.py`/`test_castxml_toolchain_robustness.py`/one `test_clang_header_backend_integration.py` case; a shallow-clone artifact affecting `test_ai_readiness.py`'s two ADR-verified-commit-reachability tests) — reproduced by checking out bare `origin/main` in the same environment and re-running the identical failing test files, which fail identically with zero relation to this PR's diff.
- `python scripts/check_ai_readiness.py` — identical error/warning set to `origin/main` checked out in this same environment (15 pre-existing errors, all the same shallow-clone ADR-verified-commit artifact noted above — confirmed by running the identical check against a bare `origin/main` checkout, same result). No new findings introduced by this diff.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`changelog.d/20260814_193415_noreply_p0_2_bazel_root_targets.md` updated in place)
- [x] Docs updated if user-visible behaviour changed — n/a (fixes to already-merged, already-documented behavior)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017jAiyuYpVCdif4RqZpJ1mP)_