### PR TITLE
fix: P0.3 follow-up — close review gaps left by merge timing on #762

### DIFF
--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -81,6 +81,7 @@ from .._compiler_options import explicit_language_standard
 from ..compile_context import CompileContext
 from ..errors import HeaderCompileContextAmbiguousError
 from ..header_utils import iter_directory_headers
+from .adapters.base import _is_msvc_command
 from .build_query import PRUNED_HEADER_DIR_SEGMENTS
 
 if TYPE_CHECKING:
@@ -365,7 +366,16 @@ class _ExplicitPin:
 #: :func:`_is_structured_field_flag`'s ``cu_standard`` parameter and
 #: :func:`_msvc_std_flag_matches_captured_standard`, which compares each
 #: ``/std:`` token's own value against ``cu_standard`` rather than trusting
-#: mere presence.
+#: mere presence. A third case (P2 review, ``discussion_r3787672845``) found
+#: that even *agreeing* values do not make ``-std=``/``/std:`` interchangeable
+#: on clang-cl: ``clang-cl`` ignores a bare ``-std=`` (warns "unknown argument
+#: ignored") and relies on ``/std:`` alone to set the dialect, so a unit like
+#: ``clang-cl -std=c++20 /std:c++20`` must still retain ``/std:`` in the
+#: rendered command even though both spellings agree. See
+#: :func:`_is_structured_field_flag`'s ``msvc`` parameter, which -- for a
+#: compile unit detected as MSVC/clang-cl-dialect
+#: (``adapters.base._is_msvc_command`` on ``cu.argv``) -- never masks
+#: ``/std:`` at all, regardless of value agreement.
 #: The bare, separate-operand switch spellings (whose own following argv
 #: token is the operand, captured structurally instead — this same set is
 #: reused verbatim by ``_context_flags``, via :func:`_is_structured_field_flag`,
@@ -430,25 +440,38 @@ def _msvc_std_flag_matches_captured_standard(
 
     P2 review finding (``discussion_r3787584574``): ``clang-cl`` accepts
     BOTH GCC/Clang's ``-std=`` and MSVC's ``/std:`` on one command line, and
-    per real ``clang-cl`` semantics the LATER, MSVC-style ``/std:`` wins —
+    per real ``clang-cl`` semantics the LATER, MSVC-style ``/std:`` wins --
     confirmed empirically (``clang-cl -std=c++17 /std:c++20`` compiles under
     C++20, ``-std=`` ignored). ``build_context.py``'s ``_consume_std_extra``/
     ``_STD_RE`` unconditionally captures any ``-std=...`` token into
     ``cu.standard`` with no notion of a later, overriding ``/std:`` on the
-    same argv — so ``bool(cu.standard)`` being true proves only that *some*
+    same argv -- so ``bool(cu.standard)`` being true proves only that *some*
     token populated the field, not that ``/std:`` itself is what did it, or
-    that the two agree. Comparing the ``/std:`` token's own value (case-
-    normalized) against ``cu_standard`` directly answers the right question:
-    when they genuinely match, ``cu.standard`` already carries exactly what
-    this ``/std:`` token says and the raw survivor really is redundant
-    (mirrors the already-established ``--target=``/``-target`` spelling-
-    divergence tolerance: a differently-spelled *equal* value is masked, but
-    a *disagreeing* value never is); when they don't match — whether because
-    ``cu.standard`` came from a different token entirely (this finding's
-    ``-std=c++17`` vs. ``/std:c++20`` repro) or because it's simply a real
-    disagreement — ``/std:`` must be retained, in both the ambiguity
-    signature and the rendered context, since it is what a real ``clang-cl``
-    (or MSVC ``cl.exe``) actually honors.
+    that the two agree.
+
+    **Superseded for an MSVC/clang-cl compile unit (P2 review,
+    ``discussion_r3787672845``, fresh evidence): this function's own
+    "values agree, so the raw ``/std:`` survivor is redundant" reasoning
+    does not hold there either.** ``clang-cl -std=c++20 /std:c++20`` has
+    *agreeing* values, but that does not make the two spellings
+    interchangeable -- confirmed empirically: ``clang-cl /?`` documents
+    ``/std:<value>`` as "Set language version," while compiling with a bare
+    ``-std=c++20`` and no ``/std:`` at all produces ``warning: unknown
+    argument ignored`` and remains at clang-cl's *default* dialect, not
+    C++20. So dropping ``/std:`` and keeping only the structurally-rendered
+    ``-std=`` (this function's caller, :func:`_is_structured_field_flag`,
+    always renders ``-std={cu.standard}`` from the structured field
+    regardless of what happens to the raw ``/std:`` survivor) silently
+    changes the dialect L2 actually replays under, even when the two
+    tokens' values happen to match. This function is therefore only
+    reached, via :func:`_is_structured_field_flag`, for a compile unit
+    *not* detected as MSVC/clang-cl-style (see that function's own ``msvc``
+    parameter) -- kept as a conservative fallback for the unusual case of a
+    ``/std:``-shaped token surviving ``extract_abi_relevant_flags`` on an
+    argv :func:`~abicheck.buildsource.adapters.base._is_msvc_command`
+    didn't recognize as MSVC-dialect, rather than deleted outright, since a
+    real MSVC/clang-cl unit never reaches this value-comparison path
+    anymore.
     """
     if not cu_standard:
         return False
@@ -456,24 +479,37 @@ def _msvc_std_flag_matches_captured_standard(
     return token_value.strip().casefold() == cu_standard.strip().casefold()
 
 
-def _is_structured_field_flag(flag: str, *, cu_standard: str) -> bool:
+def _is_structured_field_flag(flag: str, *, cu_standard: str, msvc: bool) -> bool:
     """Whether *flag* is fully represented by a structured
     ``target_triple``/``sysroot``/``standard`` field already, per the sets
     above.
 
     ``cu_standard`` must be ``cu.standard`` (the actual string, not merely
-    its truthiness) for the compile unit *flag* came from — it gates only
+    its truthiness) for the compile unit *flag* came from -- it gates only
     the conditional ``/std:`` prefix
-    (``_STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES``), via
-    :func:`_msvc_std_flag_matches_captured_standard`: a ``/std:`` token is
-    redundant with the structured ``standard`` field only when that field's
-    *value* genuinely came from (or agrees with) this exact ``/std:`` token
-    — not merely whenever the field happens to be non-empty, since a
-    co-present ``-std=`` on the same compile unit (``clang-cl``'s dual
-    ``-std=``/``/std:`` support) can populate ``cu.standard`` from a
-    *different* token entirely, one that a real ``clang-cl`` does not even
-    honor once ``/std:`` is also present. The other prefixes/exact flags are
-    unconditionally redundant and ignore this argument.
+    (``_STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES``) when *msvc* is
+    ``False``, via :func:`_msvc_std_flag_matches_captured_standard`: a
+    ``/std:`` token is redundant with the structured ``standard`` field
+    only when that field's *value* genuinely came from (or agrees with)
+    this exact ``/std:`` token -- not merely whenever the field happens to
+    be non-empty, since a co-present ``-std=`` on the same compile unit
+    (``clang-cl``'s dual ``-std=``/``/std:`` support) can populate
+    ``cu.standard`` from a *different* token entirely, one that a real
+    ``clang-cl`` doesn't even honor once ``/std:`` is also present.
+
+    ``msvc`` (P2 review, ``discussion_r3787672845``, fresh evidence): ``True``
+    when the compile unit *flag* came from was detected as an MSVC/clang-cl
+    dialect command (:func:`~abicheck.buildsource.adapters.base.
+    _is_msvc_command` on ``cu.argv``). For such a unit, ``/std:`` is
+    **never** masked, regardless of whether its own value agrees with
+    ``cu_standard`` -- see :func:`_msvc_std_flag_matches_captured_standard`'s
+    own updated docstring for why value-agreement does not make ``-std=``
+    and ``/std:`` interchangeable on clang-cl: clang-cl ignores a bare
+    ``-std=`` entirely and relies on ``/std:`` alone to set the dialect, so
+    dropping ``/std:`` breaks the real compile even when the two spellings
+    happen to agree. Only a compile unit *not* detected as MSVC-dialect
+    still uses the value-comparison fallback above. The other prefixes/
+    exact flags are unconditionally redundant and ignore both arguments.
     """
     if flag in _STRUCTURED_FIELD_EXACT_FLAGS or flag.startswith(
         _STRUCTURED_FIELD_FLAG_PREFIXES
@@ -481,6 +517,8 @@ def _is_structured_field_flag(flag: str, *, cu_standard: str) -> bool:
         return True
     for prefix in _STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES:
         if flag.startswith(prefix):
+            if msvc:
+                return False
             return _msvc_std_flag_matches_captured_standard(flag, prefix, cu_standard)
     return False
 
@@ -543,14 +581,17 @@ class _EffectiveContextSignature:
             system_include_paths=tuple(cu.system_include_paths),
             abi_relevant_flags=tuple(
                 _mask_pinned_abi_flags(
-                    cu.abi_relevant_flags, pin, cu_standard=cu.standard
+                    cu.abi_relevant_flags,
+                    pin,
+                    cu_standard=cu.standard,
+                    msvc=_is_msvc_command(cu.argv),
                 )
             ),
         )
 
 
 def _mask_pinned_abi_flags(
-    flags: Sequence[str], pin: _ExplicitPin, *, cu_standard: str
+    flags: Sequence[str], pin: _ExplicitPin, *, cu_standard: str, msvc: bool
 ) -> list[str]:
     """Drop ``cu.abi_relevant_flags`` entries a structured field already
     covers.
@@ -591,9 +632,17 @@ def _mask_pinned_abi_flags(
     populate ``cu.standard`` from a *different*, non-``/std:`` token that a
     real ``clang-cl`` doesn't even honor once ``/std:`` is also present, so
     a merely-non-empty ``cu.standard`` is not enough to mask ``/std:``).
+
+    ``msvc`` (P2 review, ``discussion_r3787672845``) is passed straight
+    through to ``_is_structured_field_flag`` too: for a compile unit
+    detected as MSVC/clang-cl-dialect, ``/std:`` is never masked here
+    either, regardless of whether its value agrees with ``cu_standard`` —
+    see that function's own updated docstring.
     """
     return [
-        f for f in flags if not _is_structured_field_flag(f, cu_standard=cu_standard)
+        f
+        for f in flags
+        if not _is_structured_field_flag(f, cu_standard=cu_standard, msvc=msvc)
     ]
 
 
@@ -620,6 +669,28 @@ def _derived_standard_language_family(standard: str) -> str | None:
     if not standard:
         return None
     return _LANG_FAMILY_CXX if "++" in standard else _LANG_FAMILY_C
+
+
+def _cu_language_family(language: str) -> str | None:
+    """Which language family (C vs. C++) a ``CompileUnit.language`` value
+    names, or ``None`` for an unrecognized/empty value.
+
+    ``CompileUnit.language`` is populated by ``adapters.base.detect_language``/
+    ``effective_language`` as one of ``"C"``/``"CXX"``/``"OBJC"``/
+    ``"OBJCXX"``/``"CUDA"``/``""`` -- a normalized token independent of
+    whether ``cu.standard`` happens to be populated at all (unlike
+    :func:`_derived_standard_language_family`, which reads the *standard*
+    string and returns ``None`` whenever it's empty, e.g. a compile unit
+    with no explicit ``-std=``). Only ``"C"``/``"CXX"`` map to a recognized
+    family here; every other value returns ``None``, the same
+    "no family, no opinion" contract the standard-derived sibling uses for
+    its own empty/unrecognized case.
+    """
+    if language == "C":
+        return _LANG_FAMILY_C
+    if language == "CXX":
+        return _LANG_FAMILY_CXX
+    return None
 
 
 def _forced_language_family(lang: str | None, *, lang_explicit: bool) -> str | None:
@@ -754,7 +825,9 @@ def _context_flags(cu: CompileUnit, *, forced_language: str | None = None) -> li
     flags.extend(
         f
         for f in cu.abi_relevant_flags
-        if not _is_structured_field_flag(f, cu_standard=cu.standard)
+        if not _is_structured_field_flag(
+            f, cu_standard=cu.standard, msvc=_is_msvc_command(cu.argv)
+        )
     )
     return flags
 
@@ -814,6 +887,37 @@ def resolve_header_compile_context(
     rejects outright (see :func:`_context_flags`'s own docstring for the
     confirmed repro). Every other derived field is unaffected.
 
+    **Forced language is applied *before* ambiguity grouping, not only to
+    the single already-resolved unit's rendered flags (P2 review,
+    ``discussion_r3787672845``, fresh evidence).** When the same header is
+    referenced by otherwise-identical C and C++ compile units (e.g. neither
+    carries an explicit ``-std=``, so ``cu.standard`` is empty on both and
+    :func:`_standard_conflicts_with_forced_language`'s own std-conflict
+    check above has nothing to compare), an explicit ``--lang c++`` still
+    used to raise :class:`~abicheck.errors.HeaderCompileContextAmbiguousError`
+    even though the caller already resolved the ambiguity by naming the
+    language explicitly -- ``_EffectiveContextSignature`` groups on
+    ``cu.language`` (``"C"`` vs. ``"CXX"``, populated independently of
+    ``cu.standard``) before *forced_language* was ever computed, so the two
+    units' genuinely different ``language`` fields alone triggered the
+    ambiguity error before the caller's own explicit disambiguation could
+    apply. Fixed by resolving *forced_language* first and narrowing the
+    matched-unit set to units whose own language family
+    (:func:`_cu_language_family`) agrees with it *before* signature
+    grouping runs, whenever at least one matched unit actually has that
+    family -- a unit of the "wrong" family for an explicitly forced parse
+    is exactly the ambiguity-in-language case the caller's own explicit
+    request already resolved, so excluding it here can only ever turn a
+    would-be ambiguous case into a single-context one, never hide a
+    genuine disagreement *within* the forced language (two C++ units that
+    still disagree on, say, ``target_triple`` still group into two
+    signatures and still raise). If *no* matched unit has the forced
+    family (the explicit language names something the build evidence
+    simply doesn't cover for this header), the full matched set is used
+    unfiltered instead, exactly the pre-existing behavior -- narrowing to
+    an empty set would silently discard real L3 evidence for a language
+    mismatch this function has no way to resolve.
+
     *explicit* is the caller's own, already-supplied L2 context (``evidence.
     compile`` on the service_input_resolution path) — when given, any
     ABI-relevant dimension it already pins (an explicit ``-std=``/
@@ -837,6 +941,21 @@ def resolve_header_compile_context(
     if not matched:
         return _EMPTY_RESOLUTION
 
+    # Resolve the forced language *before* signature grouping (P2 review,
+    # discussion_r3787672845): narrow to units whose own language family
+    # agrees with an explicitly forced one, whenever at least one such unit
+    # exists, so the caller's own explicit disambiguation is applied before
+    # -- not after -- the ambiguity check runs. See this function's own
+    # docstring for the full reasoning and the fail-open-to-unfiltered
+    # fallback when no matched unit has the forced family.
+    forced_language = _forced_language_family(lang, lang_explicit=lang_explicit)
+    if forced_language is not None:
+        language_matched = [
+            cu for cu in matched if _cu_language_family(cu.language) == forced_language
+        ]
+        if language_matched:
+            matched = language_matched
+
     pin = _ExplicitPin.of(explicit)
     by_signature: dict[_EffectiveContextSignature, list[CompileUnit]] = {}
     for cu in matched:
@@ -848,7 +967,6 @@ def resolve_header_compile_context(
         )
 
     ((_sig, units),) = by_signature.items()
-    forced_language = _forced_language_family(lang, lang_explicit=lang_explicit)
     flags = _context_flags(units[0], forced_language=forced_language)
     context = CompileContext(gcc_option_tokens=tuple(flags))
     return HeaderCompileContextResolution(

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -325,15 +325,36 @@ class _ExplicitPin:
 #: relies on: a raw flag excluded here is still compared, just via its
 #: structured field instead, so no real disagreement can be hidden by this
 #: exclusion — only a spelling-only non-disagreement stops being flagged as
-#: one. ``-std=``/``/std:`` (standard) is included too: a compile unit could
-#: in principle carry both a structured ``standard`` and a raw ``-std=...``
+#: one. ``-std=`` (standard) is included too: a compile unit could in
+#: principle carry both a structured ``standard`` and a raw ``-std=...``
 #: survivor in ``abi_relevant_flags`` (the adapter's own extraction and its
 #: structured-field derivation are independent passes over the same argv),
 #: and the identical spelling-divergence risk applies. Unlike
 #: :class:`_ExplicitPin`'s masking below (which only excludes a dimension the
 #: *caller* explicitly pinned), this exclusion is unconditional -- it never
 #: depends on whether an ``explicit`` context was even given, since the raw
-#: flag is redundant with its structured field regardless.
+#: flag is redundant with its structured field regardless. This holds for
+#: ``-std=`` specifically because it is *always* captured into
+#: ``CompileUnit.standard`` whenever present: ``build_context.py``'s
+#: ``_consume_std_extra`` matches every ``-std=...`` token unconditionally
+#: (``_STD_RE``) and assigns ``ctx.language_standard`` from it, with no path
+#: that leaves a real ``-std=`` token unconsumed -- so masking it can never
+#: hide a disagreement the structured field doesn't already carry.
+#:
+#: **MSVC's ``/std:`` does NOT get the same unconditional treatment (review
+#: finding) -- it is masked only when ``CompileUnit.standard`` is actually
+#: populated for that unit.** Nothing in this codebase parses ``/std:`` into
+#: ``CompileUnit.standard`` at all: ``abicheck/buildsource/adapters/base.py``'s
+#: ``_add_generic_flag_option`` says so explicitly ("MSVC ``/std:`` is not
+#: parsed into cu.standard") and only normalizes it into a *separate*
+#: ``BuildOption``, itself gated on ``if not cu.standard``. So for a typical
+#: MSVC compile unit ``cu.standard`` is empty and the raw
+#: ``/std:c++17``/``/std:c++20`` token in ``abi_relevant_flags`` is the
+#: *only* place the standard is recorded at all -- masking it unconditionally
+#: would collapse two MSVC units that genuinely disagree on their language
+#: standard into one signature and silently apply the first unit's standard,
+#: instead of raising ``HeaderCompileContextAmbiguousError``. See
+#: :func:`_is_structured_field_flag`'s ``standard_captured`` parameter.
 #: The bare, separate-operand switch spellings (whose own following argv
 #: token is the operand, captured structurally instead — see
 #: ``_DANGLING_OPERAND_FLAGS`` below for the identical set used the same way
@@ -359,28 +380,53 @@ _STRUCTURED_FIELD_EXACT_FLAGS = frozenset(
 )
 
 #: The complete, single-token combined-form spellings (operand attached via
-#: ``=``/``:``) — safe to match by prefix since each is already a fixed,
-#: literal lead-in with no sibling flag sharing it: no real clang/gcc/MSVC
-#: flag begins with ``--target=``, ``--sysroot=``, ``-std=``, or ``/std:``
-#: other than the flag itself (checked against a real ``clang --help``/
-#: ``clang -cc1 --help`` for the exact same reason as the exact-match set
-#: above — unlike the bare ``-target``/``--sysroot`` switches, none of these
-#: combined forms collide with an unrelated flag).
+#: ``=``) — safe to match by prefix since each is already a fixed, literal
+#: lead-in with no sibling flag sharing it: no real clang/gcc flag begins
+#: with ``--target=``, ``--sysroot=``, or ``-std=`` other than the flag
+#: itself (checked against a real ``clang --help``/``clang -cc1 --help`` for
+#: the exact same reason as the exact-match set above — unlike the bare
+#: ``-target``/``--sysroot`` switches, none of these combined forms collide
+#: with an unrelated flag). Each of these is *always* fully redundant with
+#: its structured field once present (see the module-level comment above for
+#: ``-std=``'s own justification), so unconditional prefix-masking is safe
+#: for all three. ``/std:`` is deliberately **not** in this tuple — see
+#: ``_STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES`` below.
 _STRUCTURED_FIELD_FLAG_PREFIXES = (
     "--target=",
     "--sysroot=",
     "-std=",
-    "/std:",
 )
 
+#: Combined-form spellings that are redundant with a structured field only
+#: *conditionally*, per compile unit — currently just MSVC's ``/std:``,
+#: which is never parsed into ``CompileUnit.standard`` (see the module-level
+#: comment above ``_STRUCTURED_FIELD_EXACT_FLAGS`` for the full reasoning).
+#: Masking a flag in this tuple requires the caller to separately confirm
+#: the corresponding structured field is genuinely populated for *that*
+#: compile unit (``_is_structured_field_flag``'s ``standard_captured``).
+_STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES = ("/std:",)
 
-def _is_structured_field_flag(flag: str) -> bool:
+
+def _is_structured_field_flag(flag: str, *, standard_captured: bool) -> bool:
     """Whether *flag* is fully represented by a structured
-    ``target_triple``/``sysroot``/``standard`` field already, per the two
-    sets above.
+    ``target_triple``/``sysroot``/``standard`` field already, per the sets
+    above.
+
+    ``standard_captured`` must be ``bool(cu.standard)`` for the compile unit
+    *flag* came from — it gates only the conditional ``/std:`` prefix
+    (``_STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES``): a ``/std:`` token is
+    redundant with the structured ``standard`` field only when that field
+    was genuinely populated for this unit, since nothing in this codebase
+    ever parses ``/std:`` itself into ``CompileUnit.standard``. The other
+    prefixes/exact flags are unconditionally redundant and ignore this
+    argument.
     """
-    return flag in _STRUCTURED_FIELD_EXACT_FLAGS or flag.startswith(
+    if flag in _STRUCTURED_FIELD_EXACT_FLAGS or flag.startswith(
         _STRUCTURED_FIELD_FLAG_PREFIXES
+    ):
+        return True
+    return standard_captured and flag.startswith(
+        _STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES
     )
 
 
@@ -441,12 +487,16 @@ class _EffectiveContextSignature:
             include_paths=tuple(cu.include_paths),
             system_include_paths=tuple(cu.system_include_paths),
             abi_relevant_flags=tuple(
-                _mask_pinned_abi_flags(cu.abi_relevant_flags, pin)
+                _mask_pinned_abi_flags(
+                    cu.abi_relevant_flags, pin, standard_captured=bool(cu.standard)
+                )
             ),
         )
 
 
-def _mask_pinned_abi_flags(flags: Sequence[str], pin: _ExplicitPin) -> list[str]:
+def _mask_pinned_abi_flags(
+    flags: Sequence[str], pin: _ExplicitPin, *, standard_captured: bool
+) -> list[str]:
     """Drop ``cu.abi_relevant_flags`` entries a structured field already
     covers.
 
@@ -472,8 +522,20 @@ def _mask_pinned_abi_flags(flags: Sequence[str], pin: _ExplicitPin) -> list[str]
     (e.g. a pinned macro spelled only as a raw flag) that genuinely needs
     per-pin conditioning rather than the unconditional rule; it plays no
     role in today's target/sysroot/standard exclusion.
+
+    ``standard_captured`` (``bool(cu.standard)`` for the compile unit *flags*
+    came from) is passed straight through to ``_is_structured_field_flag``
+    and is genuinely conditional, unlike *pin*: it gates only the MSVC
+    ``/std:`` prefix, which — unlike ``-std=`` — is never parsed into
+    ``CompileUnit.standard``, so it is redundant with the structured field
+    only when that field happens to be populated for this specific unit (see
+    ``_STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES``'s own docstring).
     """
-    return [f for f in flags if not _is_structured_field_flag(f)]
+    return [
+        f
+        for f in flags
+        if not _is_structured_field_flag(f, standard_captured=standard_captured)
+    ]
 
 
 #: Bare switch spellings whose operand is a *separate*, following argv token

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -540,7 +540,69 @@ def _mask_pinned_abi_flags(
     ]
 
 
-def _context_flags(cu: CompileUnit) -> list[str]:
+#: ``CompileUnit.standard``'s two language families, as returned by
+#: :func:`_derived_standard_language_family`/:func:`_forced_language_family`.
+_LANG_FAMILY_C = "c"
+_LANG_FAMILY_CXX = "c++"
+
+
+def _derived_standard_language_family(standard: str) -> str | None:
+    """Which language family (C vs. C++) *standard* (a ``CompileUnit.
+    standard`` value, e.g. ``"c17"``/``"c++20"``/``"gnu++17"``/``"gnu11"``)
+    belongs to, or ``None`` for an empty/unrecognized value.
+
+    A GNU-dialect C++ standard is spelled ``"gnu++NN"`` -- not
+    ``"gnuc++NN"`` -- so a plain ``"c++"``-prefix check after stripping a
+    ``"gnu"`` prefix would wrongly read it as C (Codex review, caught by
+    this function's own unit test). Checking for the ``"++"`` marker
+    anywhere in the value instead correctly covers both ``"c++20"`` and
+    ``"gnu++17"`` while still reading ``"c17"``/``"gnu11"`` as C, mirroring
+    how a real compiler treats ``-std=gnu++17`` as a C++ standard and
+    ``-std=gnu11`` as a C standard.
+    """
+    if not standard:
+        return None
+    return _LANG_FAMILY_CXX if "++" in standard else _LANG_FAMILY_C
+
+
+def _forced_language_family(lang: str | None, *, lang_explicit: bool) -> str | None:
+    """Which language family the caller *explicitly* forced for this parse,
+    if any (Codex review, ``discussion_r3787398644``).
+
+    Mirrors ``dumper._resolve_force_cpp``'s own "an explicit ``--lang
+    c++``/``cpp`` always wins" contract and the ``lang_explicit`` convention
+    AGENTS.md's "Known gaps" section establishes (the ``--lang c++``/
+    ``lang_explicit`` toolchain-identity precedent this module's own
+    docstring already points to): only a genuinely explicit request pins a
+    family here. ``lang_explicit=False`` (the default -- includes Click's
+    own non-explicit ``"c++"`` default value) returns ``None``, a no-op,
+    so an auto-detected/default-language parse is completely unaffected by
+    this function and keeps forwarding every derived ``-std=`` exactly as
+    before.
+    """
+    if not lang_explicit or not lang:
+        return None
+    return _LANG_FAMILY_CXX if lang.upper() in ("C++", "CPP") else _LANG_FAMILY_C
+
+
+def _standard_conflicts_with_forced_language(
+    standard: str, forced_language: str | None
+) -> bool:
+    """Whether *standard*'s own language family disagrees with *forced_language*.
+
+    ``False`` whenever nothing was explicitly forced (``forced_language is
+    None``) or *standard* has no recognizable family of its own (empty) --
+    the pre-existing, unconditional behavior in both cases. Only a genuine,
+    resolved disagreement (a C-family derived standard while C++ was
+    explicitly forced, or vice versa) returns ``True``.
+    """
+    if forced_language is None:
+        return False
+    derived_family = _derived_standard_language_family(standard)
+    return derived_family is not None and derived_family != forced_language
+
+
+def _context_flags(cu: CompileUnit, *, forced_language: str | None = None) -> list[str]:
     """Render one ``CompileUnit``'s context as literal castxml/clang argv tokens.
 
     Mirrors ``BuildContext.to_castxml_flags()`` (ADR-020a's ``-p``/
@@ -579,9 +641,34 @@ def _context_flags(cu: CompileUnit) -> list[str]:
     genuinely independent of every structured field this function already
     renders (``-fPIC``, ``-fno-omit-frame-pointer``, ``-target-abi``, ...)
     survives into the final command.
+
+    *forced_language* (``discussion_r3787398644``, Codex review): the
+    language family (``"c"``/``"c++"``) the caller *explicitly* requested
+    for this parse, or ``None`` (the default, a complete no-op) when
+    nothing was explicitly forced. A matched compile unit's own
+    ``cu.standard`` can genuinely disagree in family with an explicitly
+    forced language -- e.g. the matched unit is plain C (``standard=
+    "c17"``) while the caller passed ``DumpRequest(lang="c++",
+    lang_explicit=True)`` to force a C++ parse of the same header(s). Since
+    a real compiler rejects a C-family ``-std=`` in C++ mode outright
+    (confirmed: Clang aborts with "invalid argument '-std=c17' not allowed
+    with 'C++'"), forwarding the matched unit's derived standard verbatim
+    in that case breaks a supported, explicit language override rather than
+    merely being redundant with it. Per the finding's own suggested
+    resolution -- "omit a derived standard whose language family conflicts
+    with the explicitly selected mode" -- this only ever *drops* the
+    conflicting derived ``-std=`` token; it never synthesizes a translated
+    equivalent (no ``c17`` -> ``c++17`` guessing), matching this module's
+    existing fail-closed-over-guessing discipline. Every other field this
+    function renders (target triple, sysroot, defines/undefines, include
+    paths, other ABI-relevant flags) is untouched by *forced_language* --
+    only the one field whose family can actually conflict with a forced
+    language is ever omitted.
     """
     flags: list[str] = []
-    if cu.standard:
+    if cu.standard and not _standard_conflicts_with_forced_language(
+        cu.standard, forced_language
+    ):
         flags.append(f"-std={cu.standard}")
     if cu.target_triple:
         flags.append(f"--target={cu.target_triple}")
@@ -644,6 +731,8 @@ def resolve_header_compile_context(
     headers: Sequence[Path],
     *,
     explicit: CompileContext | None = None,
+    lang: str | None = None,
+    lang_explicit: bool = False,
 ) -> HeaderCompileContextResolution:
     """Resolve a single L2 :class:`CompileContext` from L3 ``CompileUnit`` facts.
 
@@ -652,6 +741,21 @@ def resolve_header_compile_context(
     or no header the given ``CompileUnit``s reference — rather than raising,
     so a caller with no L3 evidence (or a header the build evidence simply
     doesn't cover) sees the exact same behavior as before this module existed.
+
+    *lang*/*lang_explicit* (``discussion_r3787398644``, Codex review): the
+    caller's own requested parse language, threaded the same additive,
+    default-``None``/``False`` way ``DumpRequest.lang``/``lang_explicit`` are
+    threaded through ``resolve_input``/``run_dump`` elsewhere in this codebase
+    (see AGENTS.md's "Known gaps" ``--lang c++``/``lang_explicit`` entry) —
+    a no-op for every existing caller that doesn't pass them. When
+    *lang_explicit* is ``True`` and it disagrees in language *family* with the
+    resolved compile unit's own ``standard`` (e.g. the matched unit is C
+    (``standard="c17"``) while the caller explicitly forced ``lang="c++"``),
+    the conflicting derived ``-std=`` token is omitted from the rendered
+    context rather than forwarded verbatim — forwarding it would hand a
+    C-family standard flag to a forced-C++ parse, which a real compiler
+    rejects outright (see :func:`_context_flags`'s own docstring for the
+    confirmed repro). Every other derived field is unaffected.
 
     *explicit* is the caller's own, already-supplied L2 context (``evidence.
     compile`` on the service_input_resolution path) — when given, any
@@ -687,7 +791,8 @@ def resolve_header_compile_context(
         )
 
     ((_sig, units),) = by_signature.items()
-    flags = _context_flags(units[0])
+    forced_language = _forced_language_family(lang, lang_explicit=lang_explicit)
+    flags = _context_flags(units[0], forced_language=forced_language)
     context = CompileContext(gcc_option_tokens=tuple(flags))
     return HeaderCompileContextResolution(
         context=context, matched_unit_count=len(matched)

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -334,14 +334,54 @@ class _ExplicitPin:
 #: *caller* explicitly pinned), this exclusion is unconditional -- it never
 #: depends on whether an ``explicit`` context was even given, since the raw
 #: flag is redundant with its structured field regardless.
+#: The bare, separate-operand switch spellings (whose own following argv
+#: token is the operand, captured structurally instead — see
+#: ``_DANGLING_OPERAND_FLAGS`` below for the identical set used the same way
+#: in ``_context_flags``). Matched by *exact* token equality, not by prefix:
+#: a real ``clang -cc1``/driver invocation has several distinct flags that
+#: merely start with the same characters and are NOT represented by any
+#: structured field here — ``-target-abi``, ``-target-cpu``,
+#: ``-target-feature``, ``-target-linker-version``,
+#: ``-target-sdk-version=<value>`` (confirmed via a real ``clang -cc1
+#: --help``) all begin with ``-target`` but carry independent ABI-relevant
+#: information ``CompileUnit.target_triple`` does not capture at all. A
+#: bare-prefix ``startswith("-target")`` match (the historical form of this
+#: check) silently masked those too, collapsing two compile units that
+#: genuinely disagree on e.g. ``-target-sdk-version=`` into one signature
+#: instead of raising ``HeaderCompileContextAmbiguousError`` (Codex review).
+_STRUCTURED_FIELD_EXACT_FLAGS = frozenset(
+    {
+        "-target",
+        "--target",
+        "--sysroot",
+        "-isysroot",
+    }
+)
+
+#: The complete, single-token combined-form spellings (operand attached via
+#: ``=``/``:``) — safe to match by prefix since each is already a fixed,
+#: literal lead-in with no sibling flag sharing it: no real clang/gcc/MSVC
+#: flag begins with ``--target=``, ``--sysroot=``, ``-std=``, or ``/std:``
+#: other than the flag itself (checked against a real ``clang --help``/
+#: ``clang -cc1 --help`` for the exact same reason as the exact-match set
+#: above — unlike the bare ``-target``/``--sysroot`` switches, none of these
+#: combined forms collide with an unrelated flag).
 _STRUCTURED_FIELD_FLAG_PREFIXES = (
-    "--sysroot",
-    "-isysroot",
-    "--target",
-    "-target",
+    "--target=",
+    "--sysroot=",
     "-std=",
     "/std:",
 )
+
+
+def _is_structured_field_flag(flag: str) -> bool:
+    """Whether *flag* is fully represented by a structured
+    ``target_triple``/``sysroot``/``standard`` field already, per the two
+    sets above.
+    """
+    return flag in _STRUCTURED_FIELD_EXACT_FLAGS or flag.startswith(
+        _STRUCTURED_FIELD_FLAG_PREFIXES
+    )
 
 
 @dataclass(frozen=True)
@@ -433,7 +473,7 @@ def _mask_pinned_abi_flags(flags: Sequence[str], pin: _ExplicitPin) -> list[str]
     per-pin conditioning rather than the unconditional rule; it plays no
     role in today's target/sysroot/standard exclusion.
     """
-    return [f for f in flags if not f.startswith(_STRUCTURED_FIELD_FLAG_PREFIXES)]
+    return [f for f in flags if not _is_structured_field_flag(f)]
 
 
 #: Bare switch spellings whose operand is a *separate*, following argv token

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -79,6 +79,8 @@ from typing import TYPE_CHECKING
 from .._compiler_options import explicit_language_standard
 from ..compile_context import CompileContext
 from ..errors import HeaderCompileContextAmbiguousError
+from ..header_utils import iter_directory_headers
+from .build_query import PRUNED_HEADER_DIR_SEGMENTS
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -132,6 +134,51 @@ def _compile_unit_references_header(cu: CompileUnit, header_resolved: Path) -> b
         if include_arg == header_name or str(header_resolved).endswith(include_arg):
             return True
     return False
+
+
+def _expand_header_directories(headers: Sequence[Path]) -> list[Path]:
+    """Expand any directory-shaped entry in *headers* into its real header files.
+
+    ``InputSpec.headers``/``-H`` may name a whole directory rather than an
+    individual header file, and the normal L2 path already expands such an
+    entry (``service_scan.expand_header_inputs``) into its actual header
+    files before parsing -- without this, matching against the raw directory
+    path itself finds no ``#include "<dirname>"``-shaped text in any TU
+    source, so no compile unit is ever matched and this whole seam silently
+    no-ops for a directory input.
+
+    Deliberately *not* a call to ``service_scan.expand_header_inputs``
+    itself: that function lives in the CLI/service import-cycle-allowlisted
+    cluster, and (transitively, via ``scan_engine`` -> ``buildsource.
+    l2_seed``) importing it from here -- a `buildsource/` leaf module
+    `l2_seed.py` itself calls into -- closes a real import cycle
+    (``header_compile_context`` -> ``service_scan`` -> ``scan_engine`` ->
+    ``buildsource.l2_seed`` -> ``header_compile_context``), exactly what
+    AGENTS.md's "What NOT to do" asks a change to avoid rather than
+    resolve by extending ``IMPORT_CYCLE_ALLOWLIST``. Reusing
+    ``header_utils.iter_directory_headers`` directly instead (the same
+    walk ``expand_header_inputs`` itself delegates to, filtered by the
+    identical ``HEADER_SUFFIXES``/pruned-segment set) keeps the expanded
+    header set identical to what L2 actually parses, without the cycle.
+
+    Best-effort, matching this module's own contract: a header path that
+    doesn't exist, isn't a file/directory, or is an empty header directory
+    is silently dropped rather than raised -- ``expand_header_inputs``
+    itself raises ``ValidationError`` for those cases (real user-facing
+    validation for an explicit ``-H``), but this function only ever
+    degrades to "no evidence to apply" for the P0.3 seam, never surfaces a
+    new failure mode for a header the seam merely couldn't expand.
+    """
+    out: list[Path] = []
+    for h in headers:
+        if h.is_dir():
+            out.extend(iter_directory_headers(h, PRUNED_HEADER_DIR_SEGMENTS))
+        elif h.is_file():
+            out.append(h)
+        # Neither a file nor a directory (missing, broken symlink, ...): best
+        # effort, drop it -- matches `_compile_unit_references_header`'s own
+        # silent-skip-on-unreadable-input contract for the source side.
+    return out
 
 
 def _matching_compile_units(
@@ -241,6 +288,46 @@ class _ExplicitPin:
         )
 
 
+#: Raw ``abi_relevant_flags`` prefixes that are just alternate spellings of a
+#: field this signature already compares *structurally* (``target_triple``/
+#: ``sysroot``/``standard``). ``CompileUnit.abi_relevant_flags`` is captured
+#: from raw argv by ``buildsource.adapters.base.extract_abi_relevant_flags``
+#: (a prefix match over ``ABI_RELEVANT_FLAG_PREFIXES``) independently of the
+#: adapter's own structured-field derivation, so two compile units resolving
+#: to the *identical* structured value (e.g. ``target_triple ==
+#: "aarch64-linux-gnu"`` on both) can still carry differently-spelled raw
+#: survivors of the same flag (a complete single-token ``--target=X`` on one
+#: unit, a split two-token ``-target X`` on another — the same ambiguity
+#: already named in ``source_extractors._argv.STRUCTURED_TOOLCHAIN_FLAG_
+#: PREFIXES``, which this list mirrors for the identical reason: those raw
+#: flags "must NOT be carried through" as their own signal once a structured
+#: field already represents them). Comparing the raw duplicates here as well
+#: would raise a false ``HeaderCompileContextAmbiguousError`` even though the
+#: two units' *effective* contexts genuinely agree. Excluding them from the
+#: signature is safe in the same "only ever turns ambiguous into single-
+#: context" direction ``_EffectiveContextSignature``'s own docstring already
+#: relies on: a raw flag excluded here is still compared, just via its
+#: structured field instead, so no real disagreement can be hidden by this
+#: exclusion — only a spelling-only non-disagreement stops being flagged as
+#: one. ``-std=``/``/std:`` (standard) is included too: a compile unit could
+#: in principle carry both a structured ``standard`` and a raw ``-std=...``
+#: survivor in ``abi_relevant_flags`` (the adapter's own extraction and its
+#: structured-field derivation are independent passes over the same argv),
+#: and the identical spelling-divergence risk applies. Unlike
+#: :class:`_ExplicitPin`'s masking below (which only excludes a dimension the
+#: *caller* explicitly pinned), this exclusion is unconditional -- it never
+#: depends on whether an ``explicit`` context was even given, since the raw
+#: flag is redundant with its structured field regardless.
+_STRUCTURED_FIELD_FLAG_PREFIXES = (
+    "--sysroot",
+    "-isysroot",
+    "--target",
+    "-target",
+    "-std=",
+    "/std:",
+)
+
+
 @dataclass(frozen=True)
 class _EffectiveContextSignature:
     """The ABI-relevant fields the plan's point 1 + point 3 name, normalized.
@@ -260,6 +347,15 @@ class _EffectiveContextSignature:
     disagree only on a dimension the caller already pinned no longer read as
     a materially different signature, while a disagreement on any other,
     unpinned dimension still does.
+
+    ``abi_relevant_flags`` here is *also* not ``cu.abi_relevant_flags``
+    verbatim, independent of ``pin``: see ``_STRUCTURED_FIELD_FLAG_PREFIXES``
+    and :func:`_mask_pinned_abi_flags` — a raw flag already fully represented
+    by ``target_triple``/``sysroot``/``standard`` is excluded unconditionally,
+    so two compile units that agree on the structured value but spell the
+    flag that produced it differently (``--target=X`` vs. ``-target X``)
+    compare equal here instead of falsely disagreeing, whether or not the
+    caller pinned anything.
     """
 
     language: str
@@ -295,30 +391,33 @@ class _EffectiveContextSignature:
 
 
 def _mask_pinned_abi_flags(flags: Sequence[str], pin: _ExplicitPin) -> list[str]:
-    """Drop ``cu.abi_relevant_flags`` entries a pinned dimension already
-    covers (Finding 3, continued).
+    """Drop ``cu.abi_relevant_flags`` entries a structured field already
+    covers.
 
     ``adapters.base.extract_abi_relevant_flags`` records the *same* raw
     ``-std=``/``-target``/``--target=``/``--sysroot``/``-isysroot`` tokens
     into ``CompileUnit.abi_relevant_flags`` that also feed the *structured*
-    ``standard``/``target_triple``/``sysroot`` fields masked above — so
-    without this, a std-only disagreement pinned via ``explicit`` still
-    showed up as a differing ``abi_relevant_flags`` tuple (the raw
-    ``-std=c++17``/``-std=c++20`` tokens themselves), reopening the exact
-    ambiguity the structured-field masking above was meant to close.
+    ``standard``/``target_triple``/``sysroot`` fields
+    :meth:`_EffectiveContextSignature.of` already compares directly (see
+    ``_STRUCTURED_FIELD_FLAG_PREFIXES``'s own docstring) -- so two units
+    agreeing on the structured value but spelling the flag that produced it
+    differently (a complete ``--target=X`` vs. a split ``-target X``
+    survivor) must not read as disagreeing raw-flag tuples.
+
+    Unconditional, not gated on *pin*: this is a strict superset of what a
+    pin-conditioned exclusion would give (Finding 3's own motivating case —
+    a std-only disagreement the caller has explicitly pinned via
+    ``explicit`` still needing its raw ``-std=c++17``/``-std=c++20``
+    survivors excluded, or it would reopen the exact ambiguity the
+    structured-field pin-masking in ``.of()`` was meant to close, is one
+    instance of the general rule this function already applies regardless
+    of ``pin``). *pin* is accepted for a symmetrical call signature with the
+    structured-field masking above and is reserved for a future dimension
+    (e.g. a pinned macro spelled only as a raw flag) that genuinely needs
+    per-pin conditioning rather than the unconditional rule; it plays no
+    role in today's target/sysroot/standard exclusion.
     """
-    out: list[str] = []
-    for f in flags:
-        if pin.standard and (f.startswith("-std=") or f.startswith("/std:")):
-            continue
-        if pin.target_triple and (f == "-target" or f.startswith("--target=")):
-            continue
-        if pin.sysroot and (
-            f in ("--sysroot", "-isysroot") or f.startswith("--sysroot=")
-        ):
-            continue
-        out.append(f)
-    return out
+    return [f for f in flags if not f.startswith(_STRUCTURED_FIELD_FLAG_PREFIXES)]
 
 
 #: Bare switch spellings whose operand is a *separate*, following argv token
@@ -439,7 +538,7 @@ def resolve_header_compile_context(
     """
     if build_evidence is None or not build_evidence.compile_units or not headers:
         return _EMPTY_RESOLUTION
-    resolved_headers = [Path(h) for h in headers]
+    resolved_headers = _expand_header_directories([Path(h) for h in headers])
     matched = _matching_compile_units(build_evidence.compile_units, resolved_headers)
     if not matched:
         return _EMPTY_RESOLUTION

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -356,9 +356,11 @@ class _ExplicitPin:
 #: instead of raising ``HeaderCompileContextAmbiguousError``. See
 #: :func:`_is_structured_field_flag`'s ``standard_captured`` parameter.
 #: The bare, separate-operand switch spellings (whose own following argv
-#: token is the operand, captured structurally instead — see
-#: ``_DANGLING_OPERAND_FLAGS`` below for the identical set used the same way
-#: in ``_context_flags``). Matched by *exact* token equality, not by prefix:
+#: token is the operand, captured structurally instead — this same set is
+#: reused verbatim by ``_context_flags``, via :func:`_is_structured_field_flag`,
+#: to exclude the identical raw survivors from the final *rendered* command,
+#: not only from this ambiguity-signature comparison). Matched by *exact*
+#: token equality, not by prefix:
 #: a real ``clang -cc1``/driver invocation has several distinct flags that
 #: merely start with the same characters and are NOT represented by any
 #: structured field here — ``-target-abi``, ``-target-cpu``,
@@ -538,24 +540,6 @@ def _mask_pinned_abi_flags(
     ]
 
 
-#: Bare switch spellings whose operand is a *separate*, following argv token
-#: (``-target aarch64-linux-gnu``, ``--sysroot /sdk``, ``-isysroot /sdk``).
-#: ``extract_abi_relevant_flags`` (``buildsource/adapters/base.py``) captures
-#: only the switch itself for these — its match is a plain prefix check with
-#: no lookahead, unlike ``_extract_flags`` (``build_context.py``), which
-#: consumes the operand token too and stores the resolved value in
-#: ``CompileUnit.target_triple``/``.sysroot``. Forwarding one of these bare
-#: tokens verbatim from ``cu.abi_relevant_flags`` therefore never recovers a
-#: lost value (the operand was never captured there in the first place) — it
-#: only emits a dangling switch that a real compiler either rejects outright
-#: or, worse, silently pairs with whatever token happens to follow it in the
-#: constructed command. This function already renders the equivalent,
-#: complete ``--target=``/``--sysroot=`` combined form from the structured
-#: ``cu.target_triple``/``cu.sysroot`` fields a few lines above, so dropping
-#: the bare duplicate here loses nothing (finding 1).
-_DANGLING_OPERAND_FLAGS = frozenset({"-target", "--sysroot", "-isysroot"})
-
-
 def _context_flags(cu: CompileUnit) -> list[str]:
     """Render one ``CompileUnit``'s context as literal castxml/clang argv tokens.
 
@@ -568,6 +552,33 @@ def _context_flags(cu: CompileUnit) -> list[str]:
     top-level ``build_context`` module's larger response-file/redaction
     machinery, which a ``CompileUnit`` (already fully resolved + redacted by
     its adapter) has no use for.
+
+    The trailing ``cu.abi_relevant_flags`` pass-through excludes any flag
+    :func:`_is_structured_field_flag` already recognizes as fully represented
+    by the ``-std=``/``--target=``/``--sysroot=`` tokens this function just
+    rendered a few lines above from the structured ``cu.standard``/
+    ``cu.target_triple``/``cu.sysroot`` fields — the *same* predicate
+    :func:`_mask_pinned_abi_flags` already uses to keep the ambiguity-
+    signature *comparison* from seeing these as independent dimensions
+    (``_EffectiveContextSignature.of``). Sharing one predicate between "does
+    this raw flag disagree with another unit's" and "should this raw flag be
+    rendered at all" matters beyond staying DRY: a real compiler applies
+    last-flag-wins semantics to a repeated ``-target``/``--sysroot``/``-std``
+    family switch, so appending the *raw*, unmodified survivor after the
+    already-correct structured rendering doesn't just duplicate it, it
+    silently overrides it. Concretely, a ``CompileDbAdapter``-sourced unit
+    resolving its structured ``sysroot`` to an absolute path while a
+    differently-spelled raw survivor (``-isysroot sdk``, still relative to
+    the compile unit's own ``directory``, never abicheck's) remained in
+    ``cu.abi_relevant_flags`` used to render
+    ``--sysroot=<abs>`` ... ``-isysroot sdk`` in that order — the trailing,
+    uncorrected relative flag then won on last-flag-wins semantics, so the
+    header was parsed against a sysroot relative to abicheck's own current
+    directory rather than the compile unit's. Excluding every structured-
+    field-covered raw flag from the rendered tail closes that: only a flag
+    genuinely independent of every structured field this function already
+    renders (``-fPIC``, ``-fno-omit-frame-pointer``, ``-target-abi``, ...)
+    survives into the final command.
     """
     flags: list[str] = []
     if cu.standard:
@@ -596,7 +607,11 @@ def _context_flags(cu: CompileUnit) -> list[str]:
         flags.extend(
             ["-isystem", _resolve_cu_relative_path(inc, cu.directory).as_posix()]
         )
-    flags.extend(f for f in cu.abi_relevant_flags if f not in _DANGLING_OPERAND_FLAGS)
+    flags.extend(
+        f
+        for f in cu.abi_relevant_flags
+        if not _is_structured_field_flag(f, standard_captured=bool(cu.standard))
+    )
     return flags
 
 

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -38,7 +38,7 @@ is no direct header→TU edge in the model. This mirrors the identical problem
 ``compile_commands.json``) already solved for a single header: a lightweight,
 best-effort scan of each candidate TU's own source text for an ``#include`` of
 the header (by path-suffix match, falling back to a bare filename match) —
-:func:`_compile_unit_references_header` below is that same heuristic, applied
+:func:`_cu_references_any_header` below is that same heuristic, applied
 to ``CompileUnit`` (redacted ``source``/``directory`` fields) rather than
 ``build_context.CompileEntry``.
 
@@ -73,6 +73,7 @@ import os
 import re
 import shlex
 from dataclasses import dataclass, field
+from functools import cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -113,26 +114,41 @@ def _resolve_cu_relative_path(raw: str, directory: str) -> Path:
 #: full (resolved) path is a suffix of the matched include argument, the same
 #: two-stage match ``build_context._header_included_by_tu`` uses to cut down
 #: false positives from an unrelated header sharing a filename.
+#:
+#: Cached: the same header name (`Path.name`) recurs across every compile
+#: unit a multi-TU build's headers get matched against, and compiling the
+#: same pattern once per (unit, header) pair — the shape this was called in
+#: before the read/scan refactor below — was pure repeated overhead for an
+#: identical regex.
+@cache
 def _include_pattern(header_name: str) -> re.Pattern[str]:
     return re.compile(rf'#\s*include\s*[<"]([^>"]*{re.escape(header_name)})[>"]')
 
 
-def _compile_unit_references_header(cu: CompileUnit, header_resolved: Path) -> bool:
-    """Best-effort: does *cu*'s own source text ``#include`` *header_resolved*?"""
-    header_name = header_resolved.name
-    if not header_name:
-        return False
+def _cu_references_any_header(
+    cu: CompileUnit, headers_resolved: Sequence[Path]
+) -> bool:
+    """Best-effort: does *cu*'s own source text ``#include`` any of *headers_resolved*?
+
+    Reads *cu*'s source text exactly once and tests it against every
+    candidate header, rather than re-reading and re-scanning the same file
+    once per header (the shape :func:`_matching_compile_units` used to drive
+    this in, an O(units * headers) file-read cost for what is inherently one
+    read per unit).
+    """
     src_path = _resolve_cu_relative_path(cu.source, cu.directory)
     try:
         text = src_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return False
-    if header_name not in text:
-        return False
-    for m in _include_pattern(header_name).finditer(text):
-        include_arg = m.group(1)
-        if include_arg == header_name or str(header_resolved).endswith(include_arg):
-            return True
+    for header_resolved in headers_resolved:
+        header_name = header_resolved.name
+        if not header_name or header_name not in text:
+            continue
+        for m in _include_pattern(header_name).finditer(text):
+            include_arg = m.group(1)
+            if include_arg == header_name or str(header_resolved).endswith(include_arg):
+                return True
     return False
 
 
@@ -176,7 +192,7 @@ def _expand_header_directories(headers: Sequence[Path]) -> list[Path]:
         elif h.is_file():
             out.append(h)
         # Neither a file nor a directory (missing, broken symlink, ...): best
-        # effort, drop it -- matches `_compile_unit_references_header`'s own
+        # effort, drop it -- matches `_cu_references_any_header`'s own
         # silent-skip-on-unreadable-input contract for the source side.
     return out
 
@@ -191,7 +207,7 @@ def _matching_compile_units(
     for cu in compile_units:
         if cu.id in seen_ids:
             continue
-        if any(_compile_unit_references_header(cu, h) for h in resolved_headers):
+        if _cu_references_any_header(cu, resolved_headers):
             matched.append(cu)
             seen_ids.add(cu.id)
     return matched
@@ -452,7 +468,7 @@ def _context_flags(cu: CompileUnit) -> list[str]:
     its adapter) has no use for.
     """
     flags: list[str] = []
-    if cu.standard and "++" in cu.standard:
+    if cu.standard:
         flags.append(f"-std={cu.standard}")
     if cu.target_triple:
         flags.append(f"--target={cu.target_triple}")

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -342,19 +342,30 @@ class _ExplicitPin:
 #: hide a disagreement the structured field doesn't already carry.
 #:
 #: **MSVC's ``/std:`` does NOT get the same unconditional treatment (review
-#: finding) -- it is masked only when ``CompileUnit.standard`` is actually
-#: populated for that unit.** Nothing in this codebase parses ``/std:`` into
-#: ``CompileUnit.standard`` at all: ``abicheck/buildsource/adapters/base.py``'s
-#: ``_add_generic_flag_option`` says so explicitly ("MSVC ``/std:`` is not
-#: parsed into cu.standard") and only normalizes it into a *separate*
-#: ``BuildOption``, itself gated on ``if not cu.standard``. So for a typical
-#: MSVC compile unit ``cu.standard`` is empty and the raw
-#: ``/std:c++17``/``/std:c++20`` token in ``abi_relevant_flags`` is the
-#: *only* place the standard is recorded at all -- masking it unconditionally
-#: would collapse two MSVC units that genuinely disagree on their language
-#: standard into one signature and silently apply the first unit's standard,
-#: instead of raising ``HeaderCompileContextAmbiguousError``. See
-#: :func:`_is_structured_field_flag`'s ``standard_captured`` parameter.
+#: finding) -- it is masked only when ``CompileUnit.standard`` genuinely
+#: agrees with that specific ``/std:`` token's own value.** Nothing in this
+#: codebase parses ``/std:`` into ``CompileUnit.standard`` at all:
+#: ``abicheck/buildsource/adapters/base.py``'s ``_add_generic_flag_option``
+#: says so explicitly ("MSVC ``/std:`` is not parsed into cu.standard") and
+#: only normalizes it into a *separate* ``BuildOption``, itself gated on
+#: ``if not cu.standard``. So for a typical MSVC compile unit ``cu.standard``
+#: is empty and the raw ``/std:c++17``/``/std:c++20`` token in
+#: ``abi_relevant_flags`` is the *only* place the standard is recorded at
+#: all -- masking it unconditionally would collapse two MSVC units that
+#: genuinely disagree on their language standard into one signature and
+#: silently apply the first unit's standard, instead of raising
+#: ``HeaderCompileContextAmbiguousError``. A second, later-found case (P2
+#: review, ``discussion_r3787584574``) means a merely-non-empty
+#: ``cu.standard`` is *still* not sufficient: ``clang-cl`` accepts BOTH
+#: ``-std=`` and ``/std:`` on one command line and honors the LATER,
+#: MSVC-style ``/std:`` — but ``build_context.py``'s unconditional ``-std=``
+#: capture has no notion of that precedence, so a unit like ``clang-cl
+#: -std=c++17 /std:c++20`` gets ``cu.standard == "c++17"`` (from ``-std=``,
+#: not from ``/std:``) while the real, honored standard is ``c++20``. See
+#: :func:`_is_structured_field_flag`'s ``cu_standard`` parameter and
+#: :func:`_msvc_std_flag_matches_captured_standard`, which compares each
+#: ``/std:`` token's own value against ``cu_standard`` rather than trusting
+#: mere presence.
 #: The bare, separate-operand switch spellings (whose own following argv
 #: token is the operand, captured structurally instead — this same set is
 #: reused verbatim by ``_context_flags``, via :func:`_is_structured_field_flag`,
@@ -404,32 +415,74 @@ _STRUCTURED_FIELD_FLAG_PREFIXES = (
 #: which is never parsed into ``CompileUnit.standard`` (see the module-level
 #: comment above ``_STRUCTURED_FIELD_EXACT_FLAGS`` for the full reasoning).
 #: Masking a flag in this tuple requires the caller to separately confirm
-#: the corresponding structured field is genuinely populated for *that*
-#: compile unit (``_is_structured_field_flag``'s ``standard_captured``).
+#: the corresponding structured field is genuinely populated *from that
+#: exact token* for that compile unit (``_is_structured_field_flag``'s
+#: ``cu_standard`` — see its docstring for why a merely-non-empty
+#: ``cu.standard`` is not sufficient).
 _STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES = ("/std:",)
 
 
-def _is_structured_field_flag(flag: str, *, standard_captured: bool) -> bool:
+def _msvc_std_flag_matches_captured_standard(
+    flag: str, prefix: str, cu_standard: str
+) -> bool:
+    """Does *flag* (an ``/std:<value>`` token starting with *prefix*) spell
+    the *same* standard already captured in *cu_standard*?
+
+    P2 review finding (``discussion_r3787584574``): ``clang-cl`` accepts
+    BOTH GCC/Clang's ``-std=`` and MSVC's ``/std:`` on one command line, and
+    per real ``clang-cl`` semantics the LATER, MSVC-style ``/std:`` wins —
+    confirmed empirically (``clang-cl -std=c++17 /std:c++20`` compiles under
+    C++20, ``-std=`` ignored). ``build_context.py``'s ``_consume_std_extra``/
+    ``_STD_RE`` unconditionally captures any ``-std=...`` token into
+    ``cu.standard`` with no notion of a later, overriding ``/std:`` on the
+    same argv — so ``bool(cu.standard)`` being true proves only that *some*
+    token populated the field, not that ``/std:`` itself is what did it, or
+    that the two agree. Comparing the ``/std:`` token's own value (case-
+    normalized) against ``cu_standard`` directly answers the right question:
+    when they genuinely match, ``cu.standard`` already carries exactly what
+    this ``/std:`` token says and the raw survivor really is redundant
+    (mirrors the already-established ``--target=``/``-target`` spelling-
+    divergence tolerance: a differently-spelled *equal* value is masked, but
+    a *disagreeing* value never is); when they don't match — whether because
+    ``cu.standard`` came from a different token entirely (this finding's
+    ``-std=c++17`` vs. ``/std:c++20`` repro) or because it's simply a real
+    disagreement — ``/std:`` must be retained, in both the ambiguity
+    signature and the rendered context, since it is what a real ``clang-cl``
+    (or MSVC ``cl.exe``) actually honors.
+    """
+    if not cu_standard:
+        return False
+    token_value = flag[len(prefix) :]
+    return token_value.strip().casefold() == cu_standard.strip().casefold()
+
+
+def _is_structured_field_flag(flag: str, *, cu_standard: str) -> bool:
     """Whether *flag* is fully represented by a structured
     ``target_triple``/``sysroot``/``standard`` field already, per the sets
     above.
 
-    ``standard_captured`` must be ``bool(cu.standard)`` for the compile unit
-    *flag* came from — it gates only the conditional ``/std:`` prefix
-    (``_STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES``): a ``/std:`` token is
-    redundant with the structured ``standard`` field only when that field
-    was genuinely populated for this unit, since nothing in this codebase
-    ever parses ``/std:`` itself into ``CompileUnit.standard``. The other
-    prefixes/exact flags are unconditionally redundant and ignore this
-    argument.
+    ``cu_standard`` must be ``cu.standard`` (the actual string, not merely
+    its truthiness) for the compile unit *flag* came from — it gates only
+    the conditional ``/std:`` prefix
+    (``_STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES``), via
+    :func:`_msvc_std_flag_matches_captured_standard`: a ``/std:`` token is
+    redundant with the structured ``standard`` field only when that field's
+    *value* genuinely came from (or agrees with) this exact ``/std:`` token
+    — not merely whenever the field happens to be non-empty, since a
+    co-present ``-std=`` on the same compile unit (``clang-cl``'s dual
+    ``-std=``/``/std:`` support) can populate ``cu.standard`` from a
+    *different* token entirely, one that a real ``clang-cl`` does not even
+    honor once ``/std:`` is also present. The other prefixes/exact flags are
+    unconditionally redundant and ignore this argument.
     """
     if flag in _STRUCTURED_FIELD_EXACT_FLAGS or flag.startswith(
         _STRUCTURED_FIELD_FLAG_PREFIXES
     ):
         return True
-    return standard_captured and flag.startswith(
-        _STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES
-    )
+    for prefix in _STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES:
+        if flag.startswith(prefix):
+            return _msvc_std_flag_matches_captured_standard(flag, prefix, cu_standard)
+    return False
 
 
 @dataclass(frozen=True)
@@ -490,14 +543,14 @@ class _EffectiveContextSignature:
             system_include_paths=tuple(cu.system_include_paths),
             abi_relevant_flags=tuple(
                 _mask_pinned_abi_flags(
-                    cu.abi_relevant_flags, pin, standard_captured=bool(cu.standard)
+                    cu.abi_relevant_flags, pin, cu_standard=cu.standard
                 )
             ),
         )
 
 
 def _mask_pinned_abi_flags(
-    flags: Sequence[str], pin: _ExplicitPin, *, standard_captured: bool
+    flags: Sequence[str], pin: _ExplicitPin, *, cu_standard: str
 ) -> list[str]:
     """Drop ``cu.abi_relevant_flags`` entries a structured field already
     covers.
@@ -525,18 +578,22 @@ def _mask_pinned_abi_flags(
     per-pin conditioning rather than the unconditional rule; it plays no
     role in today's target/sysroot/standard exclusion.
 
-    ``standard_captured`` (``bool(cu.standard)`` for the compile unit *flags*
-    came from) is passed straight through to ``_is_structured_field_flag``
-    and is genuinely conditional, unlike *pin*: it gates only the MSVC
-    ``/std:`` prefix, which — unlike ``-std=`` — is never parsed into
-    ``CompileUnit.standard``, so it is redundant with the structured field
-    only when that field happens to be populated for this specific unit (see
-    ``_STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES``'s own docstring).
+    ``cu_standard`` (``cu.standard`` itself, not merely its truthiness, for
+    the compile unit *flags* came from) is passed straight through to
+    ``_is_structured_field_flag`` and is genuinely conditional, unlike
+    *pin*: it gates only the MSVC ``/std:`` prefix, which — unlike
+    ``-std=`` — is never parsed into ``CompileUnit.standard``, so it is
+    redundant with the structured field only when that field's *value*
+    genuinely agrees with this specific ``/std:`` token (see
+    ``_STRUCTURED_FIELD_CONDITIONAL_FLAG_PREFIXES``'s own docstring and
+    :func:`_msvc_std_flag_matches_captured_standard` — a co-present
+    ``-std=`` on the same unit, e.g. ``clang-cl``'s dual support, can
+    populate ``cu.standard`` from a *different*, non-``/std:`` token that a
+    real ``clang-cl`` doesn't even honor once ``/std:`` is also present, so
+    a merely-non-empty ``cu.standard`` is not enough to mask ``/std:``).
     """
     return [
-        f
-        for f in flags
-        if not _is_structured_field_flag(f, standard_captured=standard_captured)
+        f for f in flags if not _is_structured_field_flag(f, cu_standard=cu_standard)
     ]
 
 
@@ -697,7 +754,7 @@ def _context_flags(cu: CompileUnit, *, forced_language: str | None = None) -> li
     flags.extend(
         f
         for f in cu.abi_relevant_flags
-        if not _is_structured_field_flag(f, standard_captured=bool(cu.standard))
+        if not _is_structured_field_flag(f, cu_standard=cu.standard)
     )
     return flags
 

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -250,13 +250,19 @@ def derive_l2_include_dirs(
     """
     if sources is None and build_info is None:
         return [], []
-    args = _resolve_l2_seed_pack_args(
-        build_config, sources, build_info, build_query, build_compile_db
-    )
-    if args is None:
-        return [], []
     cleanups: list[Callable[[], None]] = []
     try:
+        # Pack resolution (config load + any --sources/--build-info pack load)
+        # happens inside this same protected section: a corrupt/unreadable
+        # pack (bad manifest.json/build_evidence.json) must degrade to "no
+        # seeded dirs" like every other failure mode here, not raise through
+        # (Codex review — this call used to live inside this try before the
+        # shared-helper extraction, and moved ahead of it by mistake).
+        args = _resolve_l2_seed_pack_args(
+            build_config, sources, build_info, build_query, build_compile_db
+        )
+        if args is None:
+            return [], []
         # Reuse the same L3-collection path embed_build_source drives, restricted
         # to build context only (no L4/L5), so every supported build-info form —
         # a collected pack, a Bazel aquery/cquery, an explicit/auto-discovered/
@@ -350,13 +356,17 @@ def derive_l2_compile_context(
 
     if (sources is None and build_info is None) or not headers:
         return None, []
-    args = _resolve_l2_seed_pack_args(
-        build_config, sources, build_info, build_query, build_compile_db
-    )
-    if args is None:
-        return None, []
     cleanups: list[Callable[[], None]] = []
     try:
+        # Pack resolution stays inside this protected section for the same
+        # reason as derive_l2_include_dirs's own copy of this comment: a
+        # corrupt/unreadable pack must degrade best-effort, not raise
+        # (Codex review).
+        args = _resolve_l2_seed_pack_args(
+            build_config, sources, build_info, build_query, build_compile_db
+        )
+        if args is None:
+            return None, []
         pack = collect_inline_pack(
             sources=args.sources,
             build_info=args.build_info,

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -110,6 +110,59 @@ def _l2_seed_pack_inputs(
     return base_build, raw_build_info, raw_sources
 
 
+@dataclasses.dataclass(frozen=True)
+class _L2SeedPackArgs:
+    """Everything :func:`derive_l2_include_dirs` and :func:`derive_l2_compile_context`
+    need to make their own, independent ``collect_inline_pack(..., layers=("L3",))``
+    call, resolved identically for both.
+
+    Config resolution (:func:`_l2_seed_config`), the trust flags derived from
+    it, and the pack/build-info precedence (:func:`_l2_seed_pack_inputs`) were
+    previously duplicated verbatim between the two ``derive_l2_*`` functions;
+    this bundles that shared argument-*building* step into one helper both
+    consume. Deliberately does **not** call ``collect_inline_pack`` itself —
+    each ``derive_l2_*`` function keeps its own independent call (see
+    :func:`derive_l2_compile_context`'s own docstring for why: an accepted,
+    documented double-collection cost, not a duplication to also fold away
+    here), so this only removes the genuinely-identical setup work ahead of
+    that call.
+    """
+
+    sources: Path | None
+    build_info: Path | None
+    build_config: BuildConfig
+    build_config_trusted_for_query: bool
+    compile_db_explicit: bool
+    base_build: Any
+
+
+def _resolve_l2_seed_pack_args(
+    build_config: Path | None,
+    sources: Path | None,
+    build_info: Path | None,
+    build_query: str | None,
+    build_compile_db: str | None,
+) -> _L2SeedPackArgs | None:
+    """Resolve *build_config*/*sources*/*build_info* into ``collect_inline_pack``
+    call arguments, or ``None`` when there is no config to seed from (the
+    caller's existing "nothing to apply" degrade).
+    """
+    cfg = _l2_seed_config(build_config, sources, build_query, build_compile_db)
+    if cfg is None:
+        return None
+    base_build, raw_build_info, raw_sources = _l2_seed_pack_inputs(build_info, sources)
+    return _L2SeedPackArgs(
+        sources=raw_sources,
+        build_info=raw_build_info,
+        build_config=cfg,
+        build_config_trusted_for_query=(
+            build_config is not None or build_query is not None
+        ),
+        compile_db_explicit=build_compile_db is not None or build_config is not None,
+        base_build=base_build,
+    )
+
+
 def _unit_include_dirs(cu: Any) -> list[str]:
     """One compile unit's normal-priority include dirs, structured + argv.
 
@@ -197,16 +250,13 @@ def derive_l2_include_dirs(
     """
     if sources is None and build_info is None:
         return [], []
-    cfg = _l2_seed_config(build_config, sources, build_query, build_compile_db)
-    if cfg is None:
+    args = _resolve_l2_seed_pack_args(
+        build_config, sources, build_info, build_query, build_compile_db
+    )
+    if args is None:
         return [], []
-    cfg_trusted_for_query = build_config is not None or build_query is not None
-    compile_db_explicit = build_compile_db is not None or build_config is not None
     cleanups: list[Callable[[], None]] = []
     try:
-        base_build, raw_build_info, raw_sources = _l2_seed_pack_inputs(
-            build_info, sources
-        )
         # Reuse the same L3-collection path embed_build_source drives, restricted
         # to build context only (no L4/L5), so every supported build-info form —
         # a collected pack, a Bazel aquery/cquery, an explicit/auto-discovered/
@@ -215,13 +265,13 @@ def derive_l2_include_dirs(
         # this by hand kept missing input forms (packs, bazel); collect_inline_pack
         # owns them, plus the temp-build-dir cleanup lifecycle via defer_cleanup.
         pack = collect_inline_pack(
-            sources=raw_sources,
-            build_info=raw_build_info,
-            build_config=cfg,
-            build_config_trusted_for_query=cfg_trusted_for_query,
-            compile_db_explicit=compile_db_explicit,
+            sources=args.sources,
+            build_info=args.build_info,
+            build_config=args.build_config,
+            build_config_trusted_for_query=args.build_config_trusted_for_query,
+            compile_db_explicit=args.compile_db_explicit,
             allow_inferred_build_query=allow_inferred_build_query,
-            base_build=base_build,
+            base_build=args.base_build,
             layers=("L3",),
             defer_cleanup=cleanups,
         )
@@ -289,33 +339,32 @@ def derive_l2_compile_context(
     every other failure mode here (missing/malformed compile DB, no build
     system, ...), which stays best-effort and degrades silently, a genuine
     ABI-relevant disagreement across compile units must never be resolved by
-    silently guessing. The caller is responsible for running any accumulated
-    *cleanups* before letting the exception propagate further, since this
-    function's own ``except`` cannot both re-raise and return them.
+    silently guessing. This function drains any accumulated *cleanups* itself
+    before re-raising on that path (mirroring every other failure branch
+    here) — a function that both re-raises and returns a value has no channel
+    to hand the exception a value along with it, so the caller receives none
+    and has nothing left to run.
     """
     from ..errors import HeaderCompileContextAmbiguousError
     from .header_compile_context import resolve_header_compile_context
 
     if (sources is None and build_info is None) or not headers:
         return None, []
-    cfg = _l2_seed_config(build_config, sources, build_query, build_compile_db)
-    if cfg is None:
+    args = _resolve_l2_seed_pack_args(
+        build_config, sources, build_info, build_query, build_compile_db
+    )
+    if args is None:
         return None, []
-    cfg_trusted_for_query = build_config is not None or build_query is not None
-    compile_db_explicit = build_compile_db is not None or build_config is not None
     cleanups: list[Callable[[], None]] = []
     try:
-        base_build, raw_build_info, raw_sources = _l2_seed_pack_inputs(
-            build_info, sources
-        )
         pack = collect_inline_pack(
-            sources=raw_sources,
-            build_info=raw_build_info,
-            build_config=cfg,
-            build_config_trusted_for_query=cfg_trusted_for_query,
-            compile_db_explicit=compile_db_explicit,
+            sources=args.sources,
+            build_info=args.build_info,
+            build_config=args.build_config,
+            build_config_trusted_for_query=args.build_config_trusted_for_query,
+            compile_db_explicit=args.compile_db_explicit,
             allow_inferred_build_query=allow_inferred_build_query,
-            base_build=base_build,
+            base_build=args.base_build,
             layers=("L3",),
             defer_cleanup=cleanups,
         )

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -307,6 +307,8 @@ def derive_l2_compile_context(
     build_compile_db: str | None = None,
     allow_inferred_build_query: bool = True,
     explicit: CompileContext | None = None,
+    lang: str | None = None,
+    lang_explicit: bool = False,
 ) -> tuple[CompileContext | None, list[Callable[[], None]]]:
     """Best-effort L2 :class:`CompileContext` derived from the build's L3
     ``CompileUnit`` facts (P0.3).
@@ -317,6 +319,16 @@ def derive_l2_compile_context(
     field it already pins (e.g. an explicit ``-std=c++20``) excuses a
     same-field-only disagreement across the matched compile units instead of
     failing closed on it (Finding 3; see that function's own docstring).
+
+    *lang*/*lang_explicit* (``discussion_r3787398644``, Codex review):
+    forwarded unchanged to :func:`~abicheck.buildsource.
+    header_compile_context.resolve_header_compile_context` — the same
+    additive, default-``None``/``False`` threading pattern as *explicit*
+    above, so a caller's explicitly-forced parse language (e.g.
+    ``DumpRequest(lang="c++", lang_explicit=True)``) suppresses a matched
+    compile unit's own derived ``-std=`` when its language family conflicts,
+    rather than forwarding a C-family standard into a forced-C++ parse (see
+    that function's own docstring for the confirmed repro).
 
     Sibling of :func:`derive_l2_include_dirs`, sharing its exact pack-
     resolution precedence (explicit ``--build-info``/``--sources`` pack ->
@@ -380,7 +392,11 @@ def derive_l2_compile_context(
         )
         build_evidence = pack.build_evidence if pack is not None else None
         resolution = resolve_header_compile_context(
-            build_evidence, list(headers), explicit=explicit
+            build_evidence,
+            list(headers),
+            explicit=explicit,
+            lang=lang,
+            lang_explicit=lang_explicit,
         )
         if resolution.context is None:
             _run_cleanups(cleanups)

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -212,7 +212,11 @@ def _merge_l3_compile_context(
 
 
 def _seeded_compile_context(
-    side: InputSpec, evidence: SideEvidence
+    side: InputSpec,
+    evidence: SideEvidence,
+    *,
+    lang: str = "c++",
+    lang_explicit: bool = False,
 ) -> tuple[CompileContext | None, bool, list[Callable[[], None]]]:
     """Fold L3 ``CompileUnit``-derived ABI context onto this side (P0.3).
 
@@ -236,6 +240,14 @@ def _seeded_compile_context(
     True only when a real L3 context was found and folded in, which is what
     the caller uses to decide whether to stamp
     ``AbiSnapshot.parsed_with_build_context``.
+
+    *lang*/*lang_explicit* (``discussion_r3787398644``, Codex review):
+    this side's own requested parse language, forwarded unchanged to
+    :func:`~abicheck.buildsource.l2_seed.derive_l2_compile_context` so a
+    matched compile unit's derived ``-std=`` whose language family
+    conflicts with an explicitly forced language is omitted rather than
+    forwarded into a parse that would reject it (e.g. a matched C compile
+    unit's ``-std=c17`` forwarded into an explicitly-forced C++ parse).
     """
     if not (side.sources or side.build_info) or not evidence.headers:
         return evidence.compile, False, []
@@ -252,6 +264,8 @@ def _seeded_compile_context(
         # -std=c++20) excuses a same-field-only disagreement across matched
         # compile units instead of failing closed on it.
         explicit=evidence.compile,
+        lang=lang,
+        lang_explicit=lang_explicit,
     )
     if derived is None:
         return evidence.compile, False, cleanups
@@ -299,7 +313,7 @@ def resolve_side_snapshot(
         includes, includes_cleanups = _seeded_includes(side, evidence)
         cleanups.extend(includes_cleanups)
         compile_ctx, context_applied, context_cleanups = _seeded_compile_context(
-            side, evidence
+            side, evidence, lang=lang, lang_explicit=lang_explicit
         )
         cleanups.extend(context_cleanups)
         snap = service.resolve_input(

--- a/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
+++ b/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
@@ -98,3 +98,23 @@
   request (`lang_explicit=False`, including Click's own non-explicit
   `"c++"` default) remains a complete no-op, so every existing caller's
   behavior is unchanged.
+- **An eighth review round found the `/std:` masking above still relied on
+  `bool(cu.standard)`, which proves only that *some* token populated the
+  structured field — not that `/std:` itself did, or that the two agree.**
+  `clang-cl` accepts BOTH GCC/Clang's `-std=` and MSVC's `/std:` on one
+  command line, and per real `clang-cl` semantics the LATER, MSVC-style
+  `/std:` wins (confirmed empirically: `clang-cl -std=c++17 /std:c++20`
+  compiles under C++20, `-std=` ignored) — but `build_context.py`'s
+  `-std=` capture has no notion of that precedence, so a compile unit like
+  `clang-cl -std=c++17 /std:c++20` gets `cu.standard == "c++17"` (from
+  `-std=`, not from `/std:`) while the real, honored standard is `c++20`.
+  `standard_captured=bool(cu.standard)` therefore masked away the
+  disagreeing `/std:c++20` survivor as "redundant," silently parsing under
+  the wrong standard. `_is_structured_field_flag()` now takes the actual
+  `cu_standard` string and, via a new
+  `_msvc_std_flag_matches_captured_standard()` helper, compares each
+  `/std:` token's own value (case-normalized) against `cu_standard`
+  directly — masking only when they genuinely agree, and retaining `/std:`
+  in both the ambiguity signature and the rendered context whenever they
+  disagree, matching what a real `clang-cl`/`cl.exe` invocation actually
+  honors.

--- a/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
+++ b/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
@@ -18,3 +18,24 @@
   `_compile_unit_references_header()`, reading each compile unit's source
   once and reusing a `functools.cache`d compiled pattern per header name
   instead of re-reading and re-compiling once per (unit, header) pair.
+- **Two more review gaps closed on this same PR, both against the
+  `_resolve_l2_seed_pack_args()` extraction and the ambiguity-signature
+  masking above.** (1) The shared pack-resolution call (including
+  `BuildSourcePack.load()`) had moved ahead of `derive_l2_include_dirs()`'s/
+  `derive_l2_compile_context()`'s own `try` block during the extraction, so
+  a corrupt/unreadable `--sources`/`--build-info` pack (bad `manifest.json`
+  or `build/build_evidence.json`) crashed the whole best-effort L2 seeding
+  path with a raw decoding exception instead of degrading to an empty seed.
+  Both callers now resolve the pack args inside their own protected
+  section again, restoring the pre-refactor best-effort contract. (2) The
+  `-target`/`--sysroot`/`-isysroot` ambiguity-signature masking in
+  `header_compile_context.py` matched by bare prefix, which also matched
+  unrelated, genuinely-independent flags that merely start with the same
+  characters — confirmed via a real `clang -cc1 --help`:
+  `-target-sdk-version=<value>`, `-target-abi`, `-target-cpu`,
+  `-target-feature`, `-target-linker-version`. Two compile units disagreeing
+  only on one of those were silently treated as agreeing instead of raising
+  `HeaderCompileContextAmbiguousError`. Masking is now restricted to the
+  actual structured spellings: exact `-target`/`--target`/`--sysroot`/
+  `-isysroot` (separate-operand switches) plus the single-token combined
+  forms `--target=...`/`--sysroot=...`/`-std=...`/`/std:...`.

--- a/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
+++ b/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
@@ -74,3 +74,27 @@
   structured-field-covered raw flags from the rendered tail, so the two
   code paths (comparison vs. rendering) share one source of truth instead
   of two independently-evolving copies.
+- **A sixth review round found the matched compile unit's own derived
+  `-std=` could be forwarded straight into a header parse whose language
+  was explicitly forced to the *other* family, and a real Clang invocation
+  rejects that combination outright.** Confirmed end to end: a matched C
+  compile unit (`standard="c17"`) with the caller explicitly requesting
+  `DumpRequest(lang="c++", lang_explicit=True)` forwarded `-std=c17` into
+  the forced-C++ header invocation, and Clang aborted with `invalid
+  argument '-std=c17' not allowed with 'C++'` — a supported, explicit
+  language override could no longer parse the header.
+  `resolve_header_compile_context()`/`derive_l2_compile_context()`/
+  `_seeded_compile_context()`/`resolve_side_snapshot()` now thread the
+  caller's own requested language (`lang`/`lang_explicit`) down to
+  `_context_flags()`, the same additive, default-`None`/`False` pattern
+  this codebase already uses for `DumpRequest.lang`/`lang_explicit`
+  elsewhere. Two new pure helpers, `_derived_standard_language_family()`
+  and `_forced_language_family()`, resolve each side's language family
+  (`"c"`/`"c++"`), and `_context_flags()` omits the derived `-std=` token
+  only when the two families genuinely disagree — never synthesizing a
+  translated equivalent (no `c17` → `c++17` guessing), and never touching
+  any other derived field (target triple, sysroot, defines/undefines,
+  include paths, other ABI-relevant flags). A non-explicit language
+  request (`lang_explicit=False`, including Click's own non-explicit
+  `"c++"` default) remains a complete no-op, so every existing caller's
+  behavior is unchanged.

--- a/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
+++ b/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
@@ -118,3 +118,46 @@
   in both the ambiguity signature and the rendered context whenever they
   disagree, matching what a real `clang-cl`/`cl.exe` invocation actually
   honors.
+- **A ninth review round found the eighth round's own value-agreement fix
+  still went too far for `clang-cl` specifically: agreeing values do not
+  make `-std=` and `/std:` interchangeable there.** `clang-cl -std=c++20
+  /std:c++20` has matching values on both spellings, but `clang-cl`
+  ignores a bare `-std=` entirely (warns "unknown argument ignored") and
+  relies on `/std:` alone to set the language dialect — confirmed via
+  `clang-cl /?`, which documents `/std:<value>` as "Set language version."
+  Dropping `/std:` because it happened to agree with the structurally
+  rendered `-std=` therefore still silently changed the dialect L2 replays
+  under. `_is_structured_field_flag()` now takes a `msvc: bool` computed
+  once per compile unit from its own `argv` via
+  `adapters.base._is_msvc_command()` (reusing the existing MSVC/clang-cl
+  driver-detection heuristic rather than inventing a new one): for a
+  compile unit detected as MSVC/clang-cl-dialect, `/std:` is never masked
+  — in either the ambiguity signature or the rendered command — regardless
+  of whether its value agrees with `cu.standard`. The eighth round's
+  value-comparison fallback (`_msvc_std_flag_matches_captured_standard()`)
+  is retained only for the conservative, unlikely case of a `/std:`-shaped
+  token surviving on a compile unit `_is_msvc_command()` doesn't recognize
+  as MSVC-dialect.
+- **A tenth review round found the ambiguity-detection/signature-grouping
+  step ran *before* an explicitly forced language was resolved, so an
+  explicit `--lang c++` could still raise `HeaderCompileContextAmbiguousError`
+  for a language disagreement the caller had already resolved.** Two
+  otherwise-identical compile units differing only in `cu.language` (one C,
+  one C++, neither carrying an explicit `-std=` for the standard-conflict
+  check introduced in the sixth round to compare against) grouped into two
+  distinct `_EffectiveContextSignature`s purely on their differing
+  `cu.language` field — before `forced_language` was ever computed — and
+  raised the ambiguity error even with `lang="c++"`/`lang_explicit=True`
+  passed in. `resolve_header_compile_context()` now resolves
+  `forced_language` first and narrows the matched-unit set (via a new
+  `_cu_language_family()` helper reading `cu.language`, independent of
+  whether `cu.standard` happens to be populated) to units whose own
+  language family agrees with it, before signature grouping runs — falling
+  back to the full, unfiltered matched set whenever no matched unit
+  actually has the forced family, so a genuine "the build evidence doesn't
+  cover this language" case degrades to the pre-existing behavior rather
+  than silently discarding real L3 evidence. A genuine disagreement
+  *within* the forced language (e.g. two C++ units still disagreeing on
+  `target_triple`) still raises exactly as before, and the companion
+  no-forced-language case (the same two-unit C/C++ setup with no explicit
+  `lang`) still correctly raises `HeaderCompileContextAmbiguousError`.

--- a/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
+++ b/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
@@ -39,3 +39,19 @@
   actual structured spellings: exact `-target`/`--target`/`--sysroot`/
   `-isysroot` (separate-operand switches) plus the single-token combined
   forms `--target=...`/`--sysroot=...`/`-std=...`/`/std:...`.
+- **A further review finding on the same masking: MSVC `/std:` was
+  unconditionally treated as redundant with `CompileUnit.standard`, which
+  it never populates.** `-std=` (GCC/Clang) is always parsed into the
+  structured `standard` field whenever present, so masking it out of the
+  ambiguity signature can never hide a real disagreement — but nothing in
+  this codebase parses MSVC's `/std:` into `CompileUnit.standard` at all
+  (`adapters/base.py`'s own `_add_generic_flag_option` normalizes it into a
+  separate `BuildOption` only when `cu.standard` is empty). Two MSVC
+  compile units disagreeing only on `/std:c++17` vs. `/std:c++20`, with
+  `standard` empty on both, were therefore silently collapsed to one
+  signature — applying the first unit's standard — instead of raising
+  `HeaderCompileContextAmbiguousError`. `/std:` is now masked only when
+  `CompileUnit.standard` is genuinely populated for that specific compile
+  unit (i.e. the structured field actually captured the value, making the
+  raw flag truly redundant); when `standard` is empty, `/std:` stays in the
+  ambiguity signature so two disagreeing units still raise.

--- a/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
+++ b/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **P0.3 header→compile-unit context resolution now emits `-std=` for plain
+  C standards, not only C++** — `_context_flags()` previously gated
+  `-std=` on `"++" in cu.standard`, silently dropping `-std=c11`/
+  `-std=gnu11`/etc. for a C compile unit even though the derived context is
+  documented to apply generally. Also closes review gaps left open by PR
+  #762 merging before this follow-up landed: a stale docstring on
+  `derive_l2_compile_context` claiming the *caller* must drain cleanups on
+  the `HeaderCompileContextAmbiguousError` path (the function drains them
+  itself before re-raising), a duplicated pack-resolution block between
+  `derive_l2_include_dirs`/`derive_l2_compile_context` now extracted into a
+  shared `_resolve_l2_seed_pack_args()` helper, missing
+  `@pytest.mark.integration` markers on the real-compiler P0.3 end-to-end
+  tests (the default fast test lane now correctly excludes them), and
+  redundant per-header file reads/regex compiles in header→compile-unit
+  `#include` matching — `_cu_references_any_header()` replaces the previous
+  `_compile_unit_references_header()`, reading each compile unit's source
+  once and reusing a `functools.cache`d compiled pattern per header name
+  instead of re-reading and re-compiling once per (unit, header) pair.

--- a/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
+++ b/changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md
@@ -55,3 +55,22 @@
   unit (i.e. the structured field actually captured the value, making the
   raw flag truly redundant); when `standard` is empty, `/std:` stays in the
   ambiguity signature so two disagreeing units still raise.
+- **A review finding on the *rendering* path, not the ambiguity-signature
+  comparison: `_context_flags()` still appended a raw, structured-field-
+  covered flag after the correct rendering it duplicates.** The masking
+  above (`_is_structured_field_flag()`) was wired only into the
+  ambiguity-*comparison* path (`_mask_pinned_abi_flags()`), so two compile
+  units spelling an equivalent sysroot as `--sysroot=/…/sdk` and
+  `--sysroot=sdk`/`-isysroot sdk` correctly compared as agreeing — but
+  `_context_flags()` itself, which renders the literal argv passed to
+  castxml/clang, still appended the selected unit's raw, unmodified
+  survivor after the already-rendered, absolute structured `--sysroot=`
+  token. A real compiler's last-flag-wins semantics then let the trailing,
+  uncorrected *relative* raw flag silently override the correct one, so
+  the header was parsed against a sysroot relative to abicheck's own
+  current directory rather than the compile unit's — potentially failing
+  or producing incorrect L2 evidence. `_context_flags()` now reuses the
+  identical `_is_structured_field_flag()` predicate to exclude the same
+  structured-field-covered raw flags from the rendered tail, so the two
+  code paths (comparison vs. rendering) share one source of truth instead
+  of two independently-evolving copies.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -171,6 +171,77 @@ def widget_lib(tmp_path: Path) -> tuple[Path, Path, Path]:
     return so, header, tmp_path
 
 
+_C_WIDGET_HEADER = """
+#pragma once
+struct Widget {
+    int x;
+    int y;
+};
+int touch(struct Widget* w);
+"""
+
+_C_WIDGET_SOURCE = """
+#include "widget.h"
+int touch(struct Widget* w) { return w->x; }
+"""
+
+
+@pytest.fixture
+def c_widget_lib(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Build a real, plain-C .so plus its public header and a
+    compile_commands.json recording a real ``gcc -std=c17`` compile of it.
+
+    Shared by ``tests/test_header_compile_context.py``'s P0.3
+    ``@pytest.mark.integration`` end-to-end suite (real clang/gcc required)
+    for ``discussion_r3787398644``'s own repro shape: a matched C compile
+    unit (``standard="c17"``) with the caller explicitly forcing a C++
+    parse of the same header via ``DumpRequest(lang="c++",
+    lang_explicit=True)``.
+    """
+    if not (_have_tool("clang") and _have_tool("gcc")):
+        pytest.skip("clang and gcc are required for this P0.3 integration test")
+    header = tmp_path / "widget.h"
+    header.write_text(_C_WIDGET_HEADER, encoding="utf-8")
+    src = tmp_path / "widget.c"
+    src.write_text(_C_WIDGET_SOURCE, encoding="utf-8")
+    so = tmp_path / "libwidget.so"
+    subprocess.run(
+        [
+            "gcc",
+            "-shared",
+            "-fPIC",
+            "-std=c17",
+            "-o",
+            str(so),
+            str(src),
+            f"-I{tmp_path}",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    (tmp_path / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src),
+                    "arguments": [
+                        "gcc",
+                        "-c",
+                        str(src),
+                        "-o",
+                        "widget.o",
+                        "-fPIC",
+                        "-std=c17",
+                    ],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return so, header, tmp_path
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register --update-goldens CLI option for golden-output tests."""
     parser.addoption(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,85 @@ def source_tree_with_compile_db(tmp_path: Path) -> Path:
     return src
 
 
+_WIDGET_HEADER = """
+#pragma once
+struct Widget {
+    int x;
+#ifdef WIDGET_EXTRA
+    int y;
+#endif
+};
+int touch(Widget* w);
+"""
+
+_WIDGET_SOURCE = """
+#include "widget.h"
+int touch(Widget* w) { return w->x; }
+"""
+
+
+def _have_tool(tool: str) -> bool:
+    return shutil.which(tool) is not None
+
+
+@pytest.fixture
+def widget_lib(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Build a real .so (compiled *with* WIDGET_EXTRA, so its real ABI has the
+    extra field) plus its public header and a compile_commands.json recording
+    that same real -DWIDGET_EXTRA=1 (+ two ABI-relevant flags).
+
+    Shared by ``tests/test_header_compile_context.py``'s P0.3
+    ``@pytest.mark.integration`` end-to-end suite (real clang/g++ required),
+    per AGENTS.md's guidance that a real-compiler fixture like this belongs
+    in ``conftest.py``/``tests/fixtures/`` rather than inline in a test file.
+    """
+    if not (_have_tool("clang") and _have_tool("g++")):
+        pytest.skip("clang and g++ are required for this P0.3 integration test")
+    header = tmp_path / "widget.h"
+    header.write_text(_WIDGET_HEADER, encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text(_WIDGET_SOURCE, encoding="utf-8")
+    so = tmp_path / "libwidget.so"
+    subprocess.run(
+        [
+            "g++",
+            "-shared",
+            "-fPIC",
+            "-fno-omit-frame-pointer",
+            "-DWIDGET_EXTRA=1",
+            "-o",
+            str(so),
+            str(src),
+            f"-I{tmp_path}",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    (tmp_path / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src),
+                    "arguments": [
+                        "g++",
+                        "-c",
+                        str(src),
+                        "-o",
+                        "widget.o",
+                        "-DWIDGET_EXTRA=1",
+                        "-fPIC",
+                        "-fno-omit-frame-pointer",
+                        "-std=c++17",
+                    ],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return so, header, tmp_path
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     """Register --update-goldens CLI option for golden-output tests."""
     parser.addoption(

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -536,6 +536,76 @@ def test_resolve_exact_target_and_sysroot_spellings_still_masked(
     assert result.matched_unit_count == 2
 
 
+def test_resolve_msvc_std_colon_disagreement_with_unpopulated_standard_field_still_raises(
+    tmp_path: Path,
+) -> None:
+    """Review finding: MSVC ``/std:`` is never parsed into
+    ``CompileUnit.standard`` (unlike GCC/Clang's ``-std=``), so when
+    ``standard`` is empty on both units, the raw ``/std:c++17``/
+    ``/std:c++20`` survivor in ``abi_relevant_flags`` is the ONLY signal
+    recording the language standard at all. Unconditionally masking it (the
+    way ``-std=``/``--target=``/``--sysroot=`` are unconditionally masked)
+    would silently collapse these two genuinely-disagreeing MSVC units into
+    one signature and apply the first unit's standard -- this must instead
+    raise ``HeaderCompileContextAmbiguousError``."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(
+        source=str(src_a),
+        directory=str(tmp_path),
+        standard="",
+        abi_relevant_flags=["/std:c++17"],
+    )
+    unit_b = _cu(
+        source=str(src_b),
+        directory=str(tmp_path),
+        standard="",
+        abi_relevant_flags=["/std:c++20"],
+    )
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    with pytest.raises(HeaderCompileContextAmbiguousError):
+        resolve_header_compile_context(ev, [header])
+
+
+def test_resolve_msvc_std_colon_stays_masked_when_standard_field_populated_and_agrees(
+    tmp_path: Path,
+) -> None:
+    """Companion to the test above: once ``CompileUnit.standard`` genuinely
+    captured the language standard for BOTH units (and they agree), a
+    ``/std:`` survivor in ``abi_relevant_flags`` really is redundant and
+    must stay masked -- including when it carries a differing raw spelling
+    from what produced the now-agreeing structured value, mirroring the
+    already-established ``--target=``/``-target`` spelling-divergence
+    tolerance."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(
+        source=str(src_a),
+        directory=str(tmp_path),
+        standard="c++20",
+        abi_relevant_flags=["/std:c++20"],
+    )
+    unit_b = _cu(
+        source=str(src_b),
+        directory=str(tmp_path),
+        standard="c++20",
+        abi_relevant_flags=["/std:c++20"],
+    )
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is True
+    assert result.matched_unit_count == 2
+    assert result.context is not None
+
+
 def test_resolve_multiple_headers_union_of_matches(tmp_path: Path) -> None:
     h1 = tmp_path / "a.h"
     h1.write_text("struct A {};\n", encoding="utf-8")

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -337,6 +337,111 @@ def test_standard_conflicts_with_forced_language() -> None:
     assert _standard_conflicts_with_forced_language("", "c++") is False
 
 
+def test_cu_language_family() -> None:
+    from abicheck.buildsource.header_compile_context import _cu_language_family
+
+    assert _cu_language_family("C") == "c"
+    assert _cu_language_family("CXX") == "c++"
+    assert _cu_language_family("OBJC") is None
+    assert _cu_language_family("") is None
+
+
+def test_resolve_forced_language_resolves_language_ambiguity_before_grouping(
+    tmp_path: Path,
+) -> None:
+    """P2 review finding (``discussion_r3787672845``): two otherwise-
+    identical compile units differing ONLY in ``cu.language`` (one C, one
+    C++, neither carrying an explicit ``-std=``, so
+    ``_standard_conflicts_with_forced_language`` has nothing to compare)
+    used to raise ``HeaderCompileContextAmbiguousError`` even when the
+    caller passed an explicit ``lang="c++"``/``lang_explicit=True`` --
+    because ``_EffectiveContextSignature`` grouped on ``cu.language`` before
+    ``forced_language`` was ever computed. With the fix, the forced
+    language is resolved *first* and narrows the matched-unit set to the
+    C++ unit before signature grouping runs, so no ambiguity error is
+    raised and the resolved context reflects the forced C++ unit."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_c = tmp_path / "a.c"
+    src_c.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_cxx = tmp_path / "b.cpp"
+    src_cxx.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_c = _cu(
+        source=str(src_c),
+        directory=str(tmp_path),
+        language="C",
+        standard="",
+        defines={"SHARED": "1"},
+    )
+    unit_cxx = _cu(
+        source=str(src_cxx),
+        directory=str(tmp_path),
+        language="CXX",
+        standard="",
+        defines={"SHARED": "1"},
+    )
+    ev = BuildEvidence(compile_units=[unit_c, unit_cxx])
+    result = resolve_header_compile_context(
+        ev, [header], lang="c++", lang_explicit=True
+    )
+    assert result.matched is True
+    assert result.matched_unit_count == 1
+    assert result.context is not None
+    assert "-DSHARED=1" in result.context.gcc_option_tokens
+
+
+def test_resolve_mixed_language_units_without_forced_language_still_ambiguous(
+    tmp_path: Path,
+) -> None:
+    """Companion to the test above: WITHOUT an explicit forced language, the
+    identical two-unit (one C, one C++) setup must still correctly raise
+    ``HeaderCompileContextAmbiguousError`` -- the forced-language narrowing
+    must never kick in, and never mask, a genuine language disagreement the
+    caller hasn't resolved."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_c = tmp_path / "a.c"
+    src_c.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_cxx = tmp_path / "b.cpp"
+    src_cxx.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_c = _cu(source=str(src_c), directory=str(tmp_path), language="C", standard="")
+    unit_cxx = _cu(
+        source=str(src_cxx), directory=str(tmp_path), language="CXX", standard=""
+    )
+    ev = BuildEvidence(compile_units=[unit_c, unit_cxx])
+    with pytest.raises(HeaderCompileContextAmbiguousError):
+        resolve_header_compile_context(ev, [header])
+
+
+def test_resolve_forced_language_falls_back_to_unfiltered_set_when_no_unit_matches(
+    tmp_path: Path,
+) -> None:
+    """When an explicit forced language names something no matched compile
+    unit actually is (here: forcing C++ while every matched unit is C), the
+    full, unfiltered matched set is used instead of narrowing to an empty
+    one -- narrowing to nothing would silently discard real L3 evidence
+    this function has no way to resolve a language mismatch for. A single
+    agreeing C unit still resolves to one context (not an ambiguity, and
+    not "no evidence")."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "a.c"
+    src.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit = _cu(source=str(src), directory=str(tmp_path), language="C", standard="c17")
+    ev = BuildEvidence(compile_units=[unit])
+    result = resolve_header_compile_context(
+        ev, [header], lang="c++", lang_explicit=True
+    )
+    assert result.matched is True
+    assert result.matched_unit_count == 1
+    assert result.context is not None
+    # The lone C unit's own -std=c17 conflicts with the forced C++ language
+    # (via _standard_conflicts_with_forced_language), so it's still omitted
+    # -- this is the pre-existing round-7 behavior, unaffected by the
+    # fallback-to-unfiltered path itself.
+    assert not any(t.startswith("-std=") for t in result.context.gcc_option_tokens)
+
+
 def test_explicit_pin_of_covers_bare_operand_and_malformed_options_branches() -> None:
     """Direct unit coverage for ``_ExplicitPin.of``'s less-common branches
     (bare-operand ``-target``/``-isysroot``/``-D``/``-U`` spellings, and a
@@ -904,6 +1009,77 @@ def test_resolve_msvc_std_colon_disagreement_raises_even_with_standard_field_pop
     ev = BuildEvidence(compile_units=[unit_a, unit_b])
     with pytest.raises(HeaderCompileContextAmbiguousError):
         resolve_header_compile_context(ev, [header])
+
+
+def test_resolve_msvc_std_colon_retained_when_values_agree_on_clang_cl(
+    tmp_path: Path,
+) -> None:
+    """P2 review finding (``discussion_r3787672845``): even when the
+    ``/std:<value>`` token AGREES with the structured ``cu.standard`` field,
+    the two spellings are still NOT interchangeable on a clang-cl-dialect
+    compile unit. ``clang-cl /?`` documents ``/std:<value>`` as "Set
+    language version," while a bare ``-std=c++20`` with no ``/std:`` at all
+    produces "warning: unknown argument ignored" and compiles at clang-cl's
+    *default* dialect, not C++20 -- so dropping ``/std:c++20`` here (the
+    pre-fix behavior, since the two values genuinely agree) would silently
+    change the dialect L2 actually replays under. A unit detected as
+    MSVC/clang-cl-dialect (via its own ``argv``) must retain ``/std:c++20``
+    regardless of value agreement."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "a.cpp"
+    src.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit = _cu(
+        source=str(src),
+        directory=str(tmp_path),
+        standard="c++20",
+        abi_relevant_flags=["-std=c++20", "/std:c++20"],
+        argv=["clang-cl", "-std=c++20", "/std:c++20", "-c", str(src)],
+    )
+    ev = BuildEvidence(compile_units=[unit])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is True
+    assert result.context is not None
+    tokens = list(result.context.gcc_option_tokens)
+    assert "/std:c++20" in tokens
+    # The structurally-rendered -std=c++20 comes first; /std:c++20 -- what
+    # clang-cl actually honors -- must come after it (last-flag-wins).
+    assert tokens.index("-std=c++20") < tokens.index("/std:c++20")
+
+
+def test_resolve_msvc_std_colon_agreement_across_units_stays_unambiguous_and_retained(
+    tmp_path: Path,
+) -> None:
+    """Companion to the test above at multi-unit scope: two clang-cl units
+    that fully agree (including on ``/std:``) must still resolve to a
+    single, non-ambiguous context, and the retained ``/std:c++20`` survives
+    into the rendered command for that single context."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(
+        source=str(src_a),
+        directory=str(tmp_path),
+        standard="c++20",
+        abi_relevant_flags=["-std=c++20", "/std:c++20"],
+        argv=["clang-cl", "-std=c++20", "/std:c++20", "-c", str(src_a)],
+    )
+    unit_b = _cu(
+        source=str(src_b),
+        directory=str(tmp_path),
+        standard="c++20",
+        abi_relevant_flags=["-std=c++20", "/std:c++20"],
+        argv=["clang-cl", "-std=c++20", "/std:c++20", "-c", str(src_b)],
+    )
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is True
+    assert result.matched_unit_count == 2
+    assert result.context is not None
+    assert "/std:c++20" in list(result.context.gcc_option_tokens)
 
 
 def test_resolve_multiple_headers_union_of_matches(tmp_path: Path) -> None:

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -254,6 +254,59 @@ def test_resolve_strips_dangling_sysroot_operand_flags(tmp_path: Path) -> None:
     assert "-isysroot" not in tokens
 
 
+def test_context_flags_excludes_relative_sysroot_duplicate_after_structured_field(
+    tmp_path: Path,
+) -> None:
+    """Reviewer finding: a raw combined-form sysroot survivor in
+    ``abi_relevant_flags`` (e.g. ``--sysroot=sdk``, still relative to the
+    compile unit's own ``directory``) must not be appended after the
+    already-rendered, absolute structured ``--sysroot=<abs>`` token --
+    last-flag-wins compiler semantics would otherwise let the later,
+    uncorrected relative flag silently override the correct one, so the
+    header gets parsed against a sysroot relative to abicheck's own current
+    directory instead of the compile unit's.
+
+    Reproduces the exact ``CompileDbAdapter`` shape from the finding: the
+    structured field resolves to an absolute path while a *differently
+    spelled*, still-relative raw duplicate
+    (``('--sysroot=/.../sdk', '--sysroot=sdk')``) survives independently in
+    ``abi_relevant_flags``, since the adapter's raw-flag extraction and its
+    structured-field derivation are two independent passes over the same
+    argv.
+    """
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text('#include "widget.h"\n', encoding="utf-8")
+    sdk_dir = tmp_path / "sdk"
+    cu = _cu(
+        source=str(src),
+        directory=str(tmp_path),
+        sysroot=str(sdk_dir),
+        # The raw, uncorrected combined-form survivor a real adapter can
+        # independently capture alongside the resolved, absolute structured
+        # `sysroot` field -- relative to `cu.directory`, not abicheck's cwd.
+        abi_relevant_flags=["--sysroot=sdk", "-fPIC"],
+    )
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.context is not None
+    tokens = result.context.gcc_option_tokens
+    expected = f"--sysroot={sdk_dir.as_posix()}"
+    # Only the correct, absolute structured rendering appears -- the raw
+    # relative duplicate is excluded entirely, not merely deduplicated
+    # against a differently-spelled copy of itself.
+    assert tokens.count(expected) == 1
+    assert "--sysroot=sdk" not in tokens
+    assert "-fPIC" in tokens
+    # And, precisely: the absolute sysroot flag is not immediately
+    # shadowed by anything else naming --sysroot/-isysroot afterward.
+    sysroot_idx = tokens.index(expected)
+    assert not any(
+        t.startswith(("--sysroot", "-isysroot")) for t in tokens[sysroot_idx + 1 :]
+    )
+
+
 def test_resolve_matches_by_bare_filename_include(tmp_path: Path) -> None:
     # The header path passed in need not lexically match the #include spelling
     # (e.g. a vendored copy elsewhere on disk) -- filename-suffix matching,

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -477,6 +477,65 @@ def test_resolve_agreeing_structured_fields_with_different_raw_flag_spellings_no
     assert result.context is not None
 
 
+def test_resolve_target_sdk_version_disagreement_still_raises(tmp_path: Path) -> None:
+    """A bare prefix match on ``-target`` would have masked
+    ``-target-sdk-version=<value>`` too -- a real ``clang -cc1`` flag that is
+    NOT represented by ``target_triple`` at all. Two units disagreeing only
+    on it must still raise, not silently collapse to one signature."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(
+        source=str(src_a),
+        directory=str(tmp_path),
+        abi_relevant_flags=["-target-sdk-version=13.0"],
+    )
+    unit_b = _cu(
+        source=str(src_b),
+        directory=str(tmp_path),
+        abi_relevant_flags=["-target-sdk-version=14.0"],
+    )
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    with pytest.raises(HeaderCompileContextAmbiguousError):
+        resolve_header_compile_context(ev, [header])
+
+
+def test_resolve_exact_target_and_sysroot_spellings_still_masked(
+    tmp_path: Path,
+) -> None:
+    """The precision fix must not regress the exact structured spellings
+    (``-target``/``--target``/``--target=...``/``--sysroot``/
+    ``--sysroot=...``/``-isysroot``) themselves -- those still mask cleanly
+    when the structured field already agrees."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(
+        source=str(src_a),
+        directory=str(tmp_path),
+        target_triple="aarch64-linux-gnu",
+        sysroot="/opt/sysroot",
+        abi_relevant_flags=["--target=aarch64-linux-gnu", "--sysroot=/opt/sysroot"],
+    )
+    unit_b = _cu(
+        source=str(src_b),
+        directory=str(tmp_path),
+        target_triple="aarch64-linux-gnu",
+        sysroot="/opt/sysroot",
+        abi_relevant_flags=["-target", "--sysroot", "-isysroot"],
+    )
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is True
+    assert result.matched_unit_count == 2
+
+
 def test_resolve_multiple_headers_union_of_matches(tmp_path: Path) -> None:
     h1 = tmp_path / "a.h"
     h1.write_text("struct A {};\n", encoding="utf-8")
@@ -675,6 +734,67 @@ def test_derive_l2_compile_context_swallows_non_ambiguous_errors(
     monkeypatch.setattr(l2_seed, "collect_inline_pack", _boom)
     ctx, cleanups = l2_seed.derive_l2_compile_context([Path("x.h")], None, tmp_path)
     assert (ctx, cleanups) == (None, [])
+
+
+def _write_corrupt_pack(pack_dir: Path) -> None:
+    """A directory ``is_pack_dir()`` recognizes as a (corrupt) pack: a
+    ``manifest.json`` present but unparseable, matching ``is_pack_dir``'s own
+    documented "present but unparseable: keep treating it as a (corrupt) pack"
+    contract -- ``BuildSourcePack.load()`` then raises decoding it."""
+    pack_dir.mkdir(parents=True, exist_ok=True)
+    (pack_dir / "manifest.json").write_text("{not valid json", encoding="utf-8")
+
+
+def test_derive_l2_include_dirs_corrupt_sources_pack_degrades_to_empty(
+    tmp_path: Path,
+) -> None:
+    """P2 regression: a ``--sources`` pack recognized by ``is_pack_dir`` but
+    failing to load (corrupt ``manifest.json``) must degrade this best-effort
+    seeding to ``([], [])``, not raise -- ``BuildSourcePack.load()`` used to
+    run inside this function's own protected section pre-refactor; the shared
+    ``_resolve_l2_seed_pack_args`` extraction moved it ahead of the ``try``
+    by mistake (Codex review)."""
+    from abicheck.buildsource.l2_seed import derive_l2_include_dirs
+
+    pack_dir = tmp_path / "pack"
+    _write_corrupt_pack(pack_dir)
+    assert derive_l2_include_dirs(None, pack_dir) == ([], [])
+
+
+def test_derive_l2_include_dirs_corrupt_build_info_pack_degrades_to_empty(
+    tmp_path: Path,
+) -> None:
+    """Same as above via ``--build-info`` naming the corrupt pack directly."""
+    from abicheck.buildsource.l2_seed import derive_l2_include_dirs
+
+    pack_dir = tmp_path / "pack"
+    _write_corrupt_pack(pack_dir)
+    assert derive_l2_include_dirs(pack_dir, None) == ([], [])
+
+
+def test_derive_l2_compile_context_corrupt_sources_pack_degrades_to_empty(
+    tmp_path: Path,
+) -> None:
+    """Same P2 regression as above, for ``derive_l2_compile_context``."""
+    from abicheck.buildsource.l2_seed import derive_l2_compile_context
+
+    pack_dir = tmp_path / "pack"
+    _write_corrupt_pack(pack_dir)
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    assert derive_l2_compile_context([header], None, pack_dir) == (None, [])
+
+
+def test_derive_l2_compile_context_corrupt_build_info_pack_degrades_to_empty(
+    tmp_path: Path,
+) -> None:
+    from abicheck.buildsource.l2_seed import derive_l2_compile_context
+
+    pack_dir = tmp_path / "pack"
+    _write_corrupt_pack(pack_dir)
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    assert derive_l2_compile_context([header], pack_dir, None) == (None, [])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -107,6 +107,34 @@ def test_resolve_returns_empty_when_no_unit_references_the_header(
     assert result.context is None
 
 
+def test_resolve_expands_directory_header_input_before_matching(
+    tmp_path: Path,
+) -> None:
+    # A `-H`/InputSpec.headers entry may name a whole directory rather than a
+    # single file (the normal L2 path expands it via
+    # `service_scan.expand_header_inputs` before parsing). Passing the raw,
+    # unexpanded directory here must not silently no-op: it should be
+    # expanded to its real header files first, so a compile unit that
+    # `#include`s one of those files is still matched and the derived context
+    # still applies -- reproducing the reported gap (before the fix, matching
+    # against the directory path itself finds no `#include "headers"`-shaped
+    # text in any TU, so nothing matches and `parsed_with_build_context`
+    # never gets stamped).
+    header_dir = tmp_path / "headers"
+    header_dir.mkdir()
+    header = header_dir / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text('#include "widget.h"\nint f() { return 0; }\n', encoding="utf-8")
+    cu = _cu(source=str(src), directory=str(tmp_path), standard="c++20")
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(ev, [header_dir])
+    assert result.matched is True
+    assert result.matched_unit_count == 1
+    assert result.context is not None
+    assert "-std=c++20" in result.context.gcc_option_tokens
+
+
 def test_resolve_derives_context_from_single_matching_unit(tmp_path: Path) -> None:
     header = tmp_path / "widget.h"
     header.write_text("struct Widget { int x; };\n", encoding="utf-8")
@@ -389,6 +417,49 @@ def test_resolve_explicit_define_resolves_macro_only_disagreement(
     explicit = CompileContext(gcc_option_tokens=("-DFOO=2",))
     result = resolve_header_compile_context(ev, [header], explicit=explicit)
     assert result.matched is True
+
+
+def test_resolve_agreeing_structured_fields_with_different_raw_flag_spellings_not_ambiguous(
+    tmp_path: Path,
+) -> None:
+    # Two compile units that resolve to the IDENTICAL structured
+    # target_triple/sysroot, but whose adapter-captured raw
+    # `abi_relevant_flags` spell the flag that produced it differently
+    # (a complete single-token `--target=X` vs. a split two-token `-target`
+    # survivor, likewise for sysroot) must NOT be reported as ambiguous --
+    # the raw spelling carries no information the structured field doesn't
+    # already carry, and this holds with no explicit CompileContext at all
+    # (unlike the Finding-3 tests above, which need an explicit pin to
+    # excuse a genuine structured-field disagreement, this is a spelling-
+    # only non-disagreement the signature must never have raised on in the
+    # first place).
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(
+        source=str(src_a),
+        directory=str(tmp_path),
+        standard="c++20",
+        target_triple="aarch64-linux-gnu",
+        sysroot="/opt/sysroot",
+        abi_relevant_flags=["--target=aarch64-linux-gnu", "--sysroot=/opt/sysroot"],
+    )
+    unit_b = _cu(
+        source=str(src_b),
+        directory=str(tmp_path),
+        standard="c++20",
+        target_triple="aarch64-linux-gnu",
+        sysroot="/opt/sysroot",
+        abi_relevant_flags=["-target", "-isysroot"],
+    )
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is True
+    assert result.matched_unit_count == 2
+    assert result.context is not None
 
 
 def test_resolve_multiple_headers_union_of_matches(tmp_path: Path) -> None:

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -198,6 +198,181 @@ def test_resolve_derives_c_standard_not_only_cxx(tmp_path: Path) -> None:
     assert "-std=c17" in result.context.gcc_option_tokens
 
 
+def test_resolve_omits_conflicting_c_standard_when_cxx_explicitly_forced(
+    tmp_path: Path,
+) -> None:
+    """Codex review, discussion_r3787398644: the matched compile unit is C
+    with standard="c17", but the caller explicitly requested C++
+    (lang="c++", lang_explicit=True). Forwarding the matched unit's derived
+    -std=c17 into a forced-C++ header invocation makes Clang abort with
+    "invalid argument '-std=c17' not allowed with 'C++'" -- so the
+    conflicting derived standard must be omitted, not forwarded.
+
+    Without the fix, this asserts False (the pre-fix code renders
+    "-std=c17" here unconditionally) -- i.e. this test fails against the
+    pre-fix code and passes after it.
+    """
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.c"
+    src.write_text('#include "widget.h"\nint f(void) { return 0; }\n', encoding="utf-8")
+    cu = _cu(source=str(src), directory=str(tmp_path), language="C", standard="c17")
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(
+        ev, [header], lang="c++", lang_explicit=True
+    )
+    assert result.matched is True
+    assert result.context is not None
+    tokens = result.context.gcc_option_tokens
+    assert not any(t.startswith("-std=") for t in tokens), tokens
+
+
+def test_resolve_keeps_matching_cxx_standard_when_cxx_explicitly_forced(
+    tmp_path: Path,
+) -> None:
+    """The non-conflicting counterpart: a matched C++ unit's own -std= is
+    still forwarded when the explicitly forced language agrees with it --
+    forced_language must only ever suppress a genuine conflict, never a
+    standard that already agrees."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text('#include "widget.h"\nint f() { return 0; }\n', encoding="utf-8")
+    cu = _cu(source=str(src), directory=str(tmp_path), language="CXX", standard="c++20")
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(
+        ev, [header], lang="c++", lang_explicit=True
+    )
+    assert result.matched is True
+    assert result.context is not None
+    assert "-std=c++20" in result.context.gcc_option_tokens
+
+
+def test_resolve_keeps_c_standard_when_language_not_explicitly_forced(
+    tmp_path: Path,
+) -> None:
+    """lang_explicit=False (the default -- includes an unspecified/auto-detect
+    request) must be a complete no-op: the matched unit's own -std=c17 is
+    still forwarded exactly as before, even if a non-explicit ``lang="c++"``
+    (e.g. Click's own default) happens to be passed alongside it."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.c"
+    src.write_text('#include "widget.h"\nint f(void) { return 0; }\n', encoding="utf-8")
+    cu = _cu(source=str(src), directory=str(tmp_path), language="C", standard="c17")
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(
+        ev, [header], lang="c++", lang_explicit=False
+    )
+    assert result.matched is True
+    assert result.context is not None
+    assert "-std=c17" in result.context.gcc_option_tokens
+
+
+def test_resolve_omits_conflicting_cxx_standard_when_c_explicitly_forced(
+    tmp_path: Path,
+) -> None:
+    """The reverse conflict direction: a matched C++ unit's -std=c++20 must
+    be omitted when the caller explicitly forces lang="c" -- symmetric with
+    the C-forced-into-C++ case the review finding names."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.cpp"
+    src.write_text('#include "widget.h"\nint f() { return 0; }\n', encoding="utf-8")
+    cu = _cu(source=str(src), directory=str(tmp_path), language="CXX", standard="c++20")
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(ev, [header], lang="c", lang_explicit=True)
+    assert result.matched is True
+    assert result.context is not None
+    tokens = result.context.gcc_option_tokens
+    assert not any(t.startswith("-std=") for t in tokens), tokens
+
+
+# ---------------------------------------------------------------------------
+# 1b. Pure-function unit tests for the language-family helpers
+#     (discussion_r3787398644), mirroring _is_structured_field_flag's own
+#     small-helper-with-direct-tests treatment above.
+# ---------------------------------------------------------------------------
+
+
+def test_derived_standard_language_family() -> None:
+    from abicheck.buildsource.header_compile_context import (
+        _derived_standard_language_family,
+    )
+
+    assert _derived_standard_language_family("c17") == "c"
+    assert _derived_standard_language_family("c11") == "c"
+    assert _derived_standard_language_family("gnu11") == "c"
+    assert _derived_standard_language_family("c++20") == "c++"
+    assert _derived_standard_language_family("gnu++17") == "c++"
+    assert _derived_standard_language_family("") is None
+
+
+def test_forced_language_family() -> None:
+    from abicheck.buildsource.header_compile_context import _forced_language_family
+
+    assert _forced_language_family("c++", lang_explicit=True) == "c++"
+    assert _forced_language_family("cpp", lang_explicit=True) == "c++"
+    assert _forced_language_family("c", lang_explicit=True) == "c"
+    # Not explicit: always a no-op regardless of the lang value.
+    assert _forced_language_family("c++", lang_explicit=False) is None
+    assert _forced_language_family("c", lang_explicit=False) is None
+    # No lang at all: a no-op even if lang_explicit were somehow True.
+    assert _forced_language_family(None, lang_explicit=True) is None
+    assert _forced_language_family("", lang_explicit=True) is None
+
+
+def test_standard_conflicts_with_forced_language() -> None:
+    from abicheck.buildsource.header_compile_context import (
+        _standard_conflicts_with_forced_language,
+    )
+
+    assert _standard_conflicts_with_forced_language("c17", "c++") is True
+    assert _standard_conflicts_with_forced_language("c++20", "c") is True
+    assert _standard_conflicts_with_forced_language("c17", "c") is False
+    assert _standard_conflicts_with_forced_language("c++20", "c++") is False
+    # No forced language: never a conflict, regardless of standard.
+    assert _standard_conflicts_with_forced_language("c17", None) is False
+    # Empty/unrecognized standard: nothing to conflict with.
+    assert _standard_conflicts_with_forced_language("", "c++") is False
+
+
+def test_explicit_pin_of_covers_bare_operand_and_malformed_options_branches() -> None:
+    """Direct unit coverage for ``_ExplicitPin.of``'s less-common branches
+    (bare-operand ``-target``/``-isysroot``/``-D``/``-U`` spellings, and a
+    malformed ``gcc_options`` string) that no existing end-to-end
+    ``resolve_header_compile_context(..., explicit=...)`` case happens to
+    exercise -- these are pre-existing branches from earlier P0.3 review
+    rounds, added here per Codex's coverage note on this PR rather than a
+    fresh finding of this pass."""
+    from abicheck.buildsource.header_compile_context import _ExplicitPin
+
+    # Malformed gcc_options (unbalanced quote) must degrade to "no tokens
+    # from it" rather than raising.
+    pin = _ExplicitPin.of(CompileContext(gcc_options="'unterminated"))
+    assert pin == _ExplicitPin()
+
+    # Bare (space-separated-operand) spellings of -target/-isysroot/-D/-U.
+    pin = _ExplicitPin.of(
+        CompileContext(
+            gcc_option_tokens=(
+                "-target",
+                "aarch64-linux-gnu",
+                "-isysroot",
+                "/sdk",
+                "-D",
+                "FOO=1",
+                "-U",
+                "BAR",
+            )
+        )
+    )
+    assert pin.target_triple is True
+    assert pin.sysroot is True
+    assert "FOO" in pin.defines
+    assert "BAR" in pin.undefines
+
+
 def test_resolve_strips_dangling_target_operand_flag(tmp_path: Path) -> None:
     """Finding 1: a compile DB spelling ``-target aarch64-linux-gnu`` as two
     separate argv tokens has only the bare ``-target`` switch captured into
@@ -743,6 +918,35 @@ def test_derive_l2_compile_context_from_compile_db(tmp_path: Path) -> None:
         _run_cleanups(cleanups)
 
 
+def test_derive_l2_compile_context_omits_conflicting_c_standard_when_cxx_forced(
+    tmp_path: Path,
+) -> None:
+    """discussion_r3787398644, threaded down to derive_l2_compile_context:
+    a real compile_commands.json matching to a C compile unit
+    (standard=c17, via the .c source extension), with the caller explicitly
+    forcing lang="c++" -- the derived -std=c17 must not be forwarded."""
+    from abicheck.buildsource.l2_seed import derive_l2_compile_context
+
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.c"
+    src.write_text('#include "widget.h"\n', encoding="utf-8")
+    _write_compile_db(tmp_path, src, ["-std=c17"])
+
+    ctx, cleanups = derive_l2_compile_context(
+        [header], None, tmp_path, lang="c++", lang_explicit=True
+    )
+    try:
+        assert ctx is not None
+        assert not any(t.startswith("-std=") for t in ctx.gcc_option_tokens), (
+            ctx.gcc_option_tokens
+        )
+    finally:
+        from abicheck.buildsource.inline import _run_cleanups
+
+        _run_cleanups(cleanups)
+
+
 def test_derive_l2_compile_context_no_inputs_is_none() -> None:
     from abicheck.buildsource.l2_seed import derive_l2_compile_context
 
@@ -1065,6 +1269,66 @@ def test_resolve_side_snapshot_stamps_parsed_with_build_context(
     assert snap.parsed_with_build_context is True
 
 
+def test_resolve_side_snapshot_omits_conflicting_c_standard_when_cxx_forced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """discussion_r3787398644, threaded all the way through resolve_side_
+    snapshot (the exact caller ``service_dump_pipeline.run_dump_request``
+    uses): a matched C compile unit (standard=c17) with the side's own
+    ``lang="c++", lang_explicit=True`` must not carry -std=c17 into the
+    compile context handed to ``service.resolve_input``.
+
+    Without the fix, ``compile_ctx.gcc_option_tokens`` contains
+    "-std=c17" here -- exactly the token a real forced-C++ Clang/CastXML
+    invocation rejects (see the module-level docstring in
+    ``header_compile_context._context_flags`` for the confirmed repro).
+    """
+    from abicheck import service_input_resolution as sir
+    from abicheck.api_types import InputSpec
+    from abicheck.model import AbiSnapshot
+    from abicheck.service_compare_evidence import SideEvidence
+
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.c"
+    src.write_text('#include "widget.h"\n', encoding="utf-8")
+    _write_compile_db(tmp_path, src, ["-std=c17"])
+
+    so = tmp_path / "lib.so"
+    so.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+    captured: dict[str, object] = {}
+
+    def _fake_resolve_input(*args: object, **kwargs: object) -> AbiSnapshot:
+        captured.update(kwargs)
+        return AbiSnapshot(library="lib", version="1.0", from_headers=True)
+
+    import abicheck.service as service_mod
+
+    monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve_input)
+
+    side = InputSpec(path=so, headers=(header,), version="1.0", sources=tmp_path)
+    evidence = SideEvidence(
+        headers=[header], compile=None, collect_mode="off", dump_manifest=None
+    )
+    snap = sir.resolve_side_snapshot(
+        side,
+        evidence,
+        lang="c++",
+        lang_explicit=True,
+        header_backend="clang",
+        fmt="elf",
+        public_headers=[],
+        public_header_dirs=[],
+    )
+    compile_ctx = captured["compile"]
+    assert isinstance(compile_ctx, CompileContext)
+    assert not any(t.startswith("-std=") for t in compile_ctx.gcc_option_tokens), (
+        compile_ctx.gcc_option_tokens
+    )
+    assert snap.parsed_with_build_context is True
+
+
 def test_resolve_side_snapshot_does_not_stamp_when_unmatched(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1235,6 +1499,40 @@ def test_e2e_with_l3_evidence_context_is_genuinely_applied(
     assert snap.from_headers is True
     assert snap.parsed_with_build_context is True
     assert _widget_fields(snap) == ["x", "y"]  # fixed: matches the real ABI
+
+
+@pytestmark_e2e
+def test_e2e_forced_cxx_dump_succeeds_against_c_compile_unit_std(
+    c_widget_lib: tuple[Path, Path, Path],
+) -> None:
+    """End-to-end reproduction of ``discussion_r3787398644``'s own repro:
+    ``run_dump_request`` with a real ``gcc -std=c17`` compile database
+    matched against the requested header(s), and the caller explicitly
+    forcing a C++ parse (``DumpRequest``'s own default ``lang="c++"``, plus
+    ``lang_explicit=True``).
+
+    Before the fix, this raises: the matched C compile unit's own
+    ``-std=c17`` is forwarded verbatim into the forced-C++ Clang header
+    invocation, and Clang aborts with "invalid argument '-std=c17' not
+    allowed with 'C++'" -- reproduced directly against this fixture without
+    the fix applied. After the fix, the conflicting derived standard is
+    omitted and the dump succeeds, with the real L3 context (target
+    triple/defines/etc.) still genuinely applied.
+    """
+    from abicheck import service
+    from abicheck.api_types import DumpRequest, InputSpec
+
+    so, header, src_dir = c_widget_lib
+    req = DumpRequest(
+        input=InputSpec(path=so, headers=(header,), version="1.0", sources=src_dir),
+        frontend="clang",
+        lang_explicit=True,  # lang defaults to "c++" -- the finding's own repro
+    )
+    snap = service.run_dump_request(req)
+    assert snap.from_headers is True
+    assert snap.parsed_with_build_context is True
+    widget = next(t for t in snap.types if t.name == "Widget")
+    assert [f.name for f in widget.fields] == ["x", "y"]
 
 
 @pytestmark_e2e

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -834,6 +834,78 @@ def test_resolve_msvc_std_colon_stays_masked_when_standard_field_populated_and_a
     assert result.context is not None
 
 
+def test_resolve_msvc_std_colon_retained_when_disagreeing_with_populated_standard_field(
+    tmp_path: Path,
+) -> None:
+    """P2 review finding (``discussion_r3787584574``): ``clang-cl`` accepts
+    BOTH GCC/Clang's ``-std=`` and MSVC's ``/std:`` on one command line, and
+    per real ``clang-cl`` semantics the LATER, MSVC-style ``/std:`` wins --
+    confirmed empirically (``clang-cl -std=c++17 /std:c++20`` compiles under
+    C++20, ``-std=`` ignored). ``cu.standard`` here is populated to
+    ``"c++17"`` by the co-present ``-std=c++17`` token (mirroring
+    ``build_context.py``'s unconditional ``-std=`` capture), NOT by the
+    disagreeing ``/std:c++20`` survivor also present in
+    ``abi_relevant_flags`` -- so ``bool(cu.standard)`` alone (the previous,
+    now-wrong gate) would have wrongly treated ``/std:c++20`` as redundant
+    with the structured field and masked it away. The fix instead compares
+    the ``/std:`` token's own value against ``cu.standard`` and, finding
+    them disagree, retains ``/std:c++20`` in the rendered context -- which
+    is what a real ``clang-cl`` invocation actually honors."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "a.cpp"
+    src.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit = _cu(
+        source=str(src),
+        directory=str(tmp_path),
+        standard="c++17",
+        abi_relevant_flags=["-std=c++17", "/std:c++20"],
+    )
+    ev = BuildEvidence(compile_units=[unit])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is True
+    assert result.context is not None
+    tokens = list(result.context.gcc_option_tokens)
+    assert "/std:c++20" in tokens
+    # -std=c++17 (rendered from the structured field) must come *before*
+    # /std:c++20 in the final token list, so real compiler last-flag-wins
+    # semantics let /std:c++20 -- what clang-cl actually honors -- win.
+    assert tokens.index("-std=c++17") < tokens.index("/std:c++20")
+
+
+def test_resolve_msvc_std_colon_disagreement_raises_even_with_standard_field_populated(
+    tmp_path: Path,
+) -> None:
+    """Companion to the above: since ``/std:`` now stays in the per-unit
+    ambiguity signature whenever it disagrees with ``cu.standard`` (rather
+    than being unconditionally masked once ``cu.standard`` is merely
+    non-empty), two compile units both carrying a populated ``cu.standard``
+    from a co-present ``-std=`` -- but disagreeing ``/std:`` survivors --
+    must still raise ``HeaderCompileContextAmbiguousError``, not silently
+    collapse into one signature."""
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src_a = tmp_path / "a.cpp"
+    src_a.write_text('#include "widget.h"\n', encoding="utf-8")
+    src_b = tmp_path / "b.cpp"
+    src_b.write_text('#include "widget.h"\n', encoding="utf-8")
+    unit_a = _cu(
+        source=str(src_a),
+        directory=str(tmp_path),
+        standard="c++17",
+        abi_relevant_flags=["-std=c++17", "/std:c++20"],
+    )
+    unit_b = _cu(
+        source=str(src_b),
+        directory=str(tmp_path),
+        standard="c++17",
+        abi_relevant_flags=["-std=c++17", "/std:c++23"],
+    )
+    ev = BuildEvidence(compile_units=[unit_a, unit_b])
+    with pytest.raises(HeaderCompileContextAmbiguousError):
+        resolve_header_compile_context(ev, [header])
+
+
 def test_resolve_multiple_headers_union_of_matches(tmp_path: Path) -> None:
     h1 = tmp_path / "a.h"
     h1.write_text("struct A {};\n", encoding="utf-8")

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -36,8 +36,6 @@ Covers, in order:
 from __future__ import annotations
 
 import json
-import shutil
-import subprocess
 import sys
 from pathlib import Path
 
@@ -181,6 +179,23 @@ def test_resolve_derives_context_from_single_matching_unit(tmp_path: Path) -> No
     assert "-isystem" in tokens and sysinc_dir.as_posix() in tokens
     assert "-fPIC" in tokens
     assert "-fno-omit-frame-pointer" in tokens
+
+
+def test_resolve_derives_c_standard_not_only_cxx(tmp_path: Path) -> None:
+    # Regression: _context_flags previously only emitted -std= when
+    # "++" in cu.standard, silently omitting a plain C standard
+    # (-std=c17/-std=gnu11/...) even though the module claims to apply the
+    # standard generally, C and C++ alike.
+    header = tmp_path / "widget.h"
+    header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+    src = tmp_path / "widget.c"
+    src.write_text('#include "widget.h"\nint f(void) { return 0; }\n', encoding="utf-8")
+    cu = _cu(source=str(src), directory=str(tmp_path), language="C", standard="c17")
+    ev = BuildEvidence(compile_units=[cu])
+    result = resolve_header_compile_context(ev, [header])
+    assert result.matched is True
+    assert result.context is not None
+    assert "-std=c17" in result.context.gcc_option_tokens
 
 
 def test_resolve_strips_dangling_target_operand_flag(tmp_path: Path) -> None:
@@ -908,84 +923,25 @@ def test_resolve_side_snapshot_propagates_ambiguous_error(
 # 4. End-to-end (real clang): macro-gated field, before/after, drift finding
 # ---------------------------------------------------------------------------
 
-_HEADER = """
-#pragma once
-struct Widget {
-    int x;
-#ifdef WIDGET_EXTRA
-    int y;
-#endif
-};
-int touch(Widget* w);
-"""
-
-_SOURCE = """
-#include "widget.h"
-int touch(Widget* w) { return w->x; }
-"""
+# ``widget_lib`` (the real g++-compiled shared library + compile_commands.json
+# fixture the suite below depends on) lives in ``tests/conftest.py`` -- shared,
+# real-compiler fixtures belong there rather than inline in a test file (see
+# AGENTS.md's test-quality conventions), and pytest auto-discovers it as a
+# regular fixture with no import needed here.
 
 
-def _have(tool: str) -> bool:
-    return shutil.which(tool) is not None
-
-
-@pytest.fixture
-def widget_lib(tmp_path: Path) -> tuple[Path, Path, Path]:
-    """Build a real .so (compiled *with* WIDGET_EXTRA, so its real ABI has the
-    extra field) plus its public header and a compile_commands.json recording
-    that same real -DWIDGET_EXTRA=1 (+ two ABI-relevant flags)."""
-    if not (_have("clang") and _have("g++")):
-        pytest.skip("clang and g++ are required for this P0.3 integration test")
-    header = tmp_path / "widget.h"
-    header.write_text(_HEADER, encoding="utf-8")
-    src = tmp_path / "widget.cpp"
-    src.write_text(_SOURCE, encoding="utf-8")
-    so = tmp_path / "libwidget.so"
-    subprocess.run(
-        [
-            "g++",
-            "-shared",
-            "-fPIC",
-            "-fno-omit-frame-pointer",
-            "-DWIDGET_EXTRA=1",
-            "-o",
-            str(so),
-            str(src),
-            f"-I{tmp_path}",
-        ],
-        check=True,
-        capture_output=True,
+def pytestmark_e2e(func: object) -> object:
+    """Composed marker for the real-clang/g++ end-to-end suite below: needs a
+    real toolchain (``@pytest.mark.integration`` -- excluded from the
+    default fast lane, which runs ``-m "not integration and ..."``, per
+    AGENTS.md) and is ELF/Linux-scoped.
+    """
+    skip = pytest.mark.skipif(
+        not sys.platform.startswith("linux"),
+        reason="P0.3 end-to-end test is ELF/Linux-scoped (mirrors "
+        "test_clang_header_backend_integration.py)",
     )
-    (tmp_path / "compile_commands.json").write_text(
-        json.dumps(
-            [
-                {
-                    "directory": str(tmp_path),
-                    "file": str(src),
-                    "arguments": [
-                        "g++",
-                        "-c",
-                        str(src),
-                        "-o",
-                        "widget.o",
-                        "-DWIDGET_EXTRA=1",
-                        "-fPIC",
-                        "-fno-omit-frame-pointer",
-                        "-std=c++17",
-                    ],
-                }
-            ]
-        ),
-        encoding="utf-8",
-    )
-    return so, header, tmp_path
-
-
-pytestmark_e2e = pytest.mark.skipif(
-    not sys.platform.startswith("linux"),
-    reason="P0.3 end-to-end test is ELF/Linux-scoped (mirrors "
-    "test_clang_header_backend_integration.py)",
-)
+    return pytest.mark.integration(skip(func))
 
 
 def _widget_fields(snap: object) -> list[str]:


### PR DESCRIPTION
## Summary

Closes the remaining review gaps from `abicheck/abicheck#762` (P0.3: L3 build
context in L2 header seeding) — PR #762 merged before this follow-up work
landed, which was a timing/coordination issue, not a review miss. This PR
picks the work back up from where it was left off, cherry-picking the one
already-committed fix and adding the rest.

## Motivation

`#762`'s review left five items open:

1. `_context_flags()` only emitted `-std=` for C++ standards
   (`"++" in cu.standard`), silently dropping `-std=c11`/`-std=gnu11`/etc.
   for a plain C compile unit even though the derived context is documented
   to apply generally.
2. The real-clang/g++ P0.3 end-to-end test group in
   `tests/test_header_compile_context.py` was missing
   `@pytest.mark.integration`, so the default fast CI lane
   (`-m "not integration and ..."`) wasn't actually excluding it, and its
   `widget_lib` real-compiler fixture was inline in the test file instead of
   `tests/conftest.py`, per this repo's shared-fixture convention.
3. `derive_l2_compile_context()`'s docstring incorrectly said the *caller*
   is responsible for draining accumulated cleanups before letting
   `HeaderCompileContextAmbiguousError` propagate — the function already
   drains them itself before re-raising.
4. `derive_l2_include_dirs()`/`derive_l2_compile_context()` duplicated an
   identical pack-resolution setup block.
5. Header→compile-unit `#include` matching re-read and re-scanned the same
   compile unit's source file once per candidate header
   (`O(units * headers)` file reads), and recompiled the same `#include`
   regex on every call.

Two P2 findings from the same review round (directory-shaped header inputs
not expanded before header→compile-unit matching; raw split-form compiler
flags not normalized against structured fields) were already fixed and
cherry-picked as this branch's first commit
(`fix: expand directory header inputs and normalize structured flags in
P0.3 context resolution`).

## Changes

- `abicheck/buildsource/header_compile_context.py`: `_context_flags()` now
  emits `-std={cu.standard}` for any non-empty standard, not only a C++ one.
  Replaced `_compile_unit_references_header()` with
  `_cu_references_any_header()`, which reads each compile unit's source
  text exactly once and tests it against every candidate header, and
  `functools.cache`s the compiled `#include` pattern per header name.
- `abicheck/buildsource/l2_seed.py`: extracted the duplicated
  config/pack-input resolution shared by `derive_l2_include_dirs()` and
  `derive_l2_compile_context()` into `_resolve_l2_seed_pack_args()`.
  Corrected `derive_l2_compile_context()`'s docstring — it drains
  `cleanups` itself before re-raising `HeaderCompileContextAmbiguousError`.
- `tests/conftest.py`: moved the `widget_lib` real-g++-compiled fixture
  here from `tests/test_header_compile_context.py`.
- `tests/test_header_compile_context.py`: added a `pytestmark_e2e`
  composed marker (`@pytest.mark.integration` + the existing Linux-only
  skip) to the real-compiler end-to-end test group; added a regression
  test for the C-standard fix
  (`test_resolve_derives_c_standard_not_only_cxx`).
- `changelog.d/20260814_201916_noreply_p0_3_followup_fixes.md`: new
  fragment.

## Verification

- `ruff check abicheck/ tests/` — all checks passed.
- `ruff format --check` on all files touched by this PR — clean (the
  repo-wide `ruff format --check` run shows pre-existing drift on ~330-490
  unrelated files, byte-identical on `origin/main`; not touched here).
- `mypy abicheck/` — `Success: no issues found in 364 source files` (0-error
  baseline maintained).
- `pytest tests/test_header_compile_context.py -m "not integration and not
  libabigail and not abicc and not slow and not golden"` — 37 passed, 4
  deselected.
- `pytest tests/test_header_compile_context.py -m integration` — 4 passed
  (real g++/clang/castxml toolchain), confirming the newly-marked tests
  still pass when run explicitly.
- Full fast suite, `pytest tests/ -m "not integration and not libabigail
  and not abicc and not slow and not golden" -q` — 26787 passed, 11
  skipped, 665 deselected, 4 xfailed, 21 failed. All 21 failures were
  verified to be pre-existing, environment-only failures unrelated to this
  PR (reproduced identically against a clean `origin/main` checkout in a
  throwaway worktree): 19 are `abicheck.errors.UnsupportedCastxmlVersionError`
  from this sandbox's apt-installed CastXML 0.6.3, below the
  `>=0.6.11,<0.8.0` supported floor; 2 are `tests/test_ai_readiness.py`
  failures from the pre-existing `adr-status-sync` "Verified: commit not
  reachable from origin/main" errors that also exist unchanged on `main`.
- `python scripts/check_ai_readiness.py` — 15 errors / 122 warnings,
  byte-for-byte identical to a clean `origin/main` checkout (verified via a
  throwaway worktree at the same commit) — no new findings from this PR.
- Rebased cleanly onto latest `origin/main` (`85c1bb15`, includes P0.2/P0.4
  work that landed after this branch's base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017jAiyuYpVCdif4RqZpJ1mP)_