### PR TITLE
fix: P0.4 follow-up — close review gaps left by merge timing on #763

### DIFF
--- a/abicheck/analysis_assurance.py
+++ b/abicheck/analysis_assurance.py
@@ -56,15 +56,37 @@ Nothing here shells out, re-parses a binary, or re-runs an extractor.
   ``compare --depth source`` that never actually reached source evidence
   (both sides lacking a compile database, say) silently read
   ``requested_depth=None``/``depth_satisfied=None`` and could still report
-  ``status="complete"``. Fixed at the one front end that knows the user's
-  real, explicit ``--depth`` request: ``cli_compare_helpers.
-  _report_compare_result`` now copies its own Click-validated ``--depth``
+  ``status="complete"``. Fixed first at the one front end that knows the
+  user's real, explicit ``--depth`` request: ``cli_compare_helpers.
+  _report_compare_result`` copies its own Click-validated ``--depth``
   string onto ``DiffResult.requested_depth`` before recomputing this block
   (never an *inferred* depth from bare ``--sources``/``--build-info`` or
   ``.abicheck.yml``'s ``source.method`` -- only an explicit flag is this
-  comparison's stated request in the same on-the-record way). Any other
-  caller that never sets ``DiffResult.requested_depth`` keeps the prior,
-  unaffected behavior (``None``, depth-completeness untested).
+  comparison's stated request in the same on-the-record way). That fix was
+  CLI-only, though the underlying gap was not (P2 review,
+  ``discussion_r3787839902``): ``service.run_compare_request()`` -- the
+  shared, typed Python-API/MCP entry point ``service_compare_pipeline.
+  classify_compare_pair`` implements -- never gets this treatment, since
+  the CLI's own ``compare`` command resolves its evidence through
+  ``resolve_compare_request`` but classifies through a hand-rolled
+  ``compare_snapshots`` call of its own (its ``--depth`` flag never even
+  reaches ``CompareRequest.depth``; that field only carries a real value
+  for a *direct* typed-API caller). Fixed there too:
+  ``classify_compare_pair`` now applies the identical ``if request.depth
+  is not None`` stamp-and-recompute, so a direct
+  ``service.run_compare_request(CompareRequest(..., depth="headers"))``
+  call gets the same `requested_depth`/`depth_satisfied` receipt the CLI
+  already did, without disturbing a caller that never sets
+  ``CompareRequest.depth`` (unaffected, same as before). The two call
+  sites are not one shared helper because each recomputes from genuinely
+  different inputs the pipeline made available at a different point: the
+  CLI recomputes with a possibly out-of-band ``--old/new-build-info``/
+  ``--old/new-sources`` pack (`_resolve_side_pack`) that never touches
+  ``old``/``new`` directly, while ``classify_compare_pair`` recomputes from
+  each snapshot's own already-embedded ``build_source`` (mirroring
+  ``checker.compare()``'s own call) since a typed request's
+  ``InputSpec.sources``/``build_info`` are embedded before resolution ever
+  returns -- there is no separate out-of-band pack to fold in on that path.
   ``effective_depth`` is always computed here, independent of that field,
   from what each side's snapshot actually carries (mirrors
   ``cli_dump_helpers.evidence_depth_label``'s logic, reimplemented locally

--- a/abicheck/analysis_assurance.py
+++ b/abicheck/analysis_assurance.py
@@ -49,15 +49,28 @@ Nothing here shells out, re-parses a binary, or re-runs an extractor.
 - Requested-vs-effective *depth* reuses ``checker_types.EVIDENCE_DEPTH_VALUES``
   (``binary``/``headers``/``build``/``source``) rather than inventing a
   parallel vocabulary. ``requested_depth`` mirrors
-  ``DiffResult.requested_depth`` -- the G30 report-identity field nothing
-  populates yet (see that field's own docstring) -- so until a front end
-  starts setting it, this stays ``None`` and depth-completeness reduces to
-  reporting ``effective_depth`` alone. ``effective_depth`` is always
-  computed here, independent of that field, from what each side's snapshot
-  actually carries (mirrors ``cli_dump_helpers.evidence_depth_label``'s
-  logic, reimplemented locally rather than imported -- importing a CLI-layer
-  module from here would reach back through ``cli.py`` into ``checker.py``
-  and grow the CLI-registration import cycle the AI-readiness gate rejects).
+  ``DiffResult.requested_depth`` -- the G30 report-identity field. Finding
+  (review, P1, round 9): this field was documented as unpopulated by any
+  front end and this module's own ``depth_satisfied`` gate reduced to
+  reporting ``effective_depth`` alone as a result -- so an explicit
+  ``compare --depth source`` that never actually reached source evidence
+  (both sides lacking a compile database, say) silently read
+  ``requested_depth=None``/``depth_satisfied=None`` and could still report
+  ``status="complete"``. Fixed at the one front end that knows the user's
+  real, explicit ``--depth`` request: ``cli_compare_helpers.
+  _report_compare_result`` now copies its own Click-validated ``--depth``
+  string onto ``DiffResult.requested_depth`` before recomputing this block
+  (never an *inferred* depth from bare ``--sources``/``--build-info`` or
+  ``.abicheck.yml``'s ``source.method`` -- only an explicit flag is this
+  comparison's stated request in the same on-the-record way). Any other
+  caller that never sets ``DiffResult.requested_depth`` keeps the prior,
+  unaffected behavior (``None``, depth-completeness untested).
+  ``effective_depth`` is always computed here, independent of that field,
+  from what each side's snapshot actually carries (mirrors
+  ``cli_dump_helpers.evidence_depth_label``'s logic, reimplemented locally
+  rather than imported -- importing a CLI-layer module from here would
+  reach back through ``cli.py`` into ``checker.py`` and grow the
+  CLI-registration import cycle the AI-readiness gate rejects).
 - ``target_accounting`` (expected vs. resolved Bazel targets) rolls up P0.2's
   root-target resolution (``BuildEvidence.target_scope``) now that it has
   landed -- ``requested``/``resolved`` stay ``None`` only when neither side
@@ -1117,6 +1130,28 @@ def _graph_completeness(
     # ``--require-complete-analysis`` the same way the other coverage gaps in
     # this function already do, since neither side's individually-confirmed
     # coverage translates into anything the graph diff could actually use.
+    #
+    # Finding (review, P1, round 9): the fix above only fired on a
+    # *disjoint* pair -- ``isdisjoint()`` is true only when the two sets
+    # share NO member at all. It missed the partially-overlapping case: old
+    # confirmed ``{"call_graph", "type_graph"}``, new confirmed only
+    # ``{"call_graph"}``. The two sets are not disjoint (they share
+    # ``call_graph``), so the old check left ``graph_completeness`` at
+    # whatever the per-side loop above computed (``"complete"`` when nothing
+    # else tripped) -- but ``buildsource/source_graph_findings.py`` only
+    # ever trusts a family when it is confirmed on BOTH sides (see e.g.
+    # ``_family_confirmed``/``_common_dependency_edge_kinds`` in that
+    # module), so ``type_graph`` -- confirmed on old, never even attempted
+    # on new -- is silently skipped for this comparison exactly the same way
+    # a fully-disjoint pair is, just for one family instead of all of them.
+    # A subset relationship is still a real coverage gap: whatever family is
+    # in one side's confirmed set but not the other's was never examined on
+    # both sides, and the cross-snapshot diff cannot compare it. Fixed by
+    # comparing the two sets for *any* inequality (``!=``) rather than only
+    # a total disjunction -- a subset, superset, or partial-overlap pair are
+    # all "the two sides disagree on what they confirmed" just as much as a
+    # fully disjoint pair is, and each reports which family/families are
+    # confirmed on only one side.
     old_confirmed_families = {
         name for name, ok in (old_graph.extractor_passes or {}).items() if ok
     } | {name for name, ok in (old_graph.narrowed_passes or {}).items() if ok}
@@ -1125,18 +1160,20 @@ def _graph_completeness(
     } | {name for name, ok in (new_graph.narrowed_passes or {}).items() if ok}
     asymmetric_family_coverage = False
     if (
-        old_confirmed_families
-        and new_confirmed_families
-        and old_confirmed_families.isdisjoint(new_confirmed_families)
-    ):
+        old_confirmed_families or new_confirmed_families
+    ) and old_confirmed_families != new_confirmed_families:
         asymmetric_family_coverage = True
+        only_old = sorted(old_confirmed_families - new_confirmed_families)
+        only_new = sorted(new_confirmed_families - old_confirmed_families)
+        one_sided = sorted(set(only_old) | set(only_new))
         notes.append(
             "graph completeness unknown: the old side confirmed coverage "
-            f"only for {sorted(old_confirmed_families)!r} while the new "
-            f"side confirmed coverage only for {sorted(new_confirmed_families)!r} "
-            "-- the two sides share no common source-graph pass family, so "
-            "the cross-snapshot graph diff has no family it can actually "
-            "compare on both sides"
+            f"for {sorted(old_confirmed_families)!r} while the new side "
+            f"confirmed coverage for {sorted(new_confirmed_families)!r} -- "
+            f"{one_sided!r} family/families are confirmed on only one side, "
+            "and buildsource/source_graph_findings.py only trusts a family "
+            "when BOTH sides cover it, so the cross-snapshot graph diff "
+            "cannot compare on it"
         )
 
     if degraded:

--- a/abicheck/checker_types.py
+++ b/abicheck/checker_types.py
@@ -65,11 +65,15 @@ EVIDENCE_DEPTH_VALUES = frozenset({"binary", "headers", "build", "source"})
 def validate_evidence_depth(field_name: str, value: str) -> None:
     """Reject a depth spelling outside EVIDENCE_DEPTH_VALUES (G30 P0.3).
 
-    Nothing populates ``requested_depth``/``effective_depth`` yet, but a
-    future caller (G30 P1.3) setting a typo'd value would otherwise only be
-    caught by the JSON Schema — which production code never runs against
-    (only opt-in tests do). Fail fast here instead, at the point the caller
-    actually sets the field, matching
+    ``cli_compare_helpers._report_compare_result`` is the first real caller
+    to populate ``requested_depth`` (P0.4 round 9, from the CLI's own
+    Click-validated ``--depth`` string, which is already restricted to this
+    exact set — see ``cli_params.DepthParam``), so a typo'd value reaching
+    this field is not expected in practice today; kept as a fail-fast check
+    for any future caller (G30 P1.3) that sets it from a less-validated
+    source, since a bad value would otherwise only be caught by the JSON
+    Schema — which production code never runs against (only opt-in tests
+    do). Matches
     ``mcp_server._validate_public_depth``'s same check on the same set.
     Shared by ``reporter._add_check_identity`` (compare) and
     ``ScanOutcome.to_dict`` (scan) so both validate identically.

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1065,6 +1065,7 @@ def _report_compare_result(
     old_build_info: Path | None, new_build_info: Path | None,
     old_sources: Path | None, new_sources: Path | None,
     require_complete_analysis: bool = False,
+    depth: str | None = None,
 ) -> None:
     """Everything after the comparison: annotate, scope, render, exit.
 
@@ -1076,6 +1077,29 @@ def _report_compare_result(
     from .cli_compare_receipt import record_resolved_config
 
     record_resolved_config(result, resolved_cfg, evaluation_config)
+
+    # P0.4 (P1 review, round 9): `DiffResult.requested_depth` -- the G30
+    # report-identity field `analysis_assurance.compute_analysis_assurance`
+    # reads to gate `depth_satisfied` -- was never actually populated by any
+    # front end (see that field's own comment in checker_types.py), so an
+    # explicit `compare --depth source` that never reached source evidence
+    # (e.g. both sides lack a compile database, so the effective depth stays
+    # `headers`) silently read `requested_depth=None`, `depth_satisfied=None`,
+    # and could still report `status="complete"` under
+    # `--require-complete-analysis`. `depth` here is `run_compare`'s own
+    # raw, Click-validated `--depth` string (one of
+    # `checker_types.EVIDENCE_DEPTH_VALUES`, `None` when the flag was
+    # omitted) -- copy it onto the result before recomputing
+    # `analysis_assurance` below so the requested-vs-effective gate actually
+    # has something to check. Only ever set when the flag was explicitly
+    # given, mirroring the same "explicit override, never inferred"
+    # discipline `_resolve_compare_collect_mode` already applies to `depth`
+    # itself for collect-mode resolution -- an inferred depth (from
+    # `--sources`/`--build-info` alone, or `.abicheck.yml`'s `source.method`)
+    # is not this comparison's stated request in the same on-the-record way
+    # an explicit `--depth` flag is.
+    if depth is not None:
+        result.requested_depth = depth
     if layer_coverage_rows:
         result.layer_coverage = layer_coverage_rows
     # Pass all injected findings (probe-matrix + evidence) so artifact-backed
@@ -1804,6 +1828,7 @@ def run_compare(
         old_build_info=old_build_info, new_build_info=new_build_info,
         old_sources=old_sources, new_sources=new_sources,
         require_complete_analysis=require_complete_analysis,
+        depth=depth,
     )
 
 

--- a/abicheck/service_compare_pipeline.py
+++ b/abicheck/service_compare_pipeline.py
@@ -130,7 +130,9 @@ def resolve_sides_sequentially(request: CompareRequest) -> bool:
         "no",
     ):
         return True
-    return request.old.dump_manifest is not None or request.new.dump_manifest is not None
+    return (
+        request.old.dump_manifest is not None or request.new.dump_manifest is not None
+    )
 
 
 def _manifest_forced_includes(dump_manifest: object) -> list[Path]:
@@ -147,17 +149,17 @@ def _manifest_forced_includes(dump_manifest: object) -> list[Path]:
     ]
 
 
-def _pair_compile_context(
-    request: CompareRequest, lang: str
-) -> CompileContext | None:
+def _pair_compile_context(request: CompareRequest, lang: str) -> CompileContext | None:
     """The pair-wide C++20 dialect override, if the header sets imply one."""
     from .compile_context import CompileContext
     from .service_scan import pair_wide_cxx20_std_override
 
     override = pair_wide_cxx20_std_override(
         lang,
-        list(request.old.headers) + _manifest_forced_includes(request.old.dump_manifest),
-        list(request.new.headers) + _manifest_forced_includes(request.new.dump_manifest),
+        list(request.old.headers)
+        + _manifest_forced_includes(request.old.dump_manifest),
+        list(request.new.headers)
+        + _manifest_forced_includes(request.new.dump_manifest),
         None,
         (),
     )
@@ -361,9 +363,7 @@ def resolve_compare_request(
     # ADR-055 D1: `--follow-deps`'s transitive DependencyInfo. After both sides
     # resolve, not inside `_resolve_side`: it reads the on-disk ELF, so it
     # gains nothing from the extraction threads.
-    populate_pair_dependency_info(
-        request, old, new, old_fmt=old_fmt, new_fmt=new_fmt
-    )
+    populate_pair_dependency_info(request, old, new, old_fmt=old_fmt, new_fmt=new_fmt)
     enforce_requested_depth(request.depth, (("old", old), ("new", new)))
     return ResolvedComparePair(
         old=old,
@@ -448,6 +448,41 @@ def classify_compare_pair(
     attach_evidence_metrics(result, evidence_metrics, extra_changes or [], quiet=True)
     result.old_metadata = service.collect_metadata(request.old.path)
     result.new_metadata = service.collect_metadata(request.new.path)
+
+    # P0.4 follow-up (P2 review, discussion_r3787839902): `DiffResult.
+    # requested_depth`/`analysis_assurance.requested_depth`/`depth_satisfied`
+    # were only ever stamped by the CLI's own `cli_compare_helpers.
+    # _report_compare_result` -- this shared classification half of
+    # `run_compare_request` (the typed Python API / MCP `abi_compare` entry
+    # point) never populated either, so a direct caller passing an explicit,
+    # successfully-resolved `CompareRequest.depth` still read
+    # `requested_depth=None`/`depth_satisfied=None` and could report
+    # `status="complete"` even though a depth was genuinely requested.
+    # `request.depth` is the same "explicit override, never inferred"
+    # sentinel `CompareRequest.depth`'s own field comment documents (`None`
+    # when the caller never set it -- there is no separate Click
+    # parameter-source concept for a plain dataclass, so `None`-vs-set is
+    # already the request's own "was this explicit" signal); only stamp it
+    # when it is not `None`, mirroring the CLI's identical `if depth is not
+    # None` guard. Recomputes `analysis_assurance` the same way
+    # `checker.compare()` itself does (`old_pack`/`new_pack` from each
+    # snapshot's own *embedded* `build_source` -- this path has no
+    # out-of-band `--old/new-build-info`/`--old/new-sources` pack directory
+    # of the CLI's own to fold in, since `InputSpec.sources`/`build_info`
+    # are embedded into `old`/`new` before `resolve_compare_request` ever
+    # returns), so `layer_coverage`/`requested_depth` -- both only known
+    # after `compare_snapshots` returns -- are reflected too.
+    if request.depth is not None:
+        result.requested_depth = request.depth
+    from .analysis_assurance import compute_analysis_assurance
+
+    result.analysis_assurance = compute_analysis_assurance(
+        result,
+        old,
+        new,
+        old_pack=getattr(old, "build_source", None),
+        new_pack=getattr(new, "build_source", None),
+    )
     # ADR-055 D2/D4: `suppression` is carried out so a front end applying a
     # post-classification concern (appcompat's `scope_diff_to_app`) reuses the
     # list this call already resolved instead of loading it a second time.

--- a/changelog.d/20260814_183041_noreply_p0_4_analysis_assurance.md
+++ b/changelog.d/20260814_183041_noreply_p0_4_analysis_assurance.md
@@ -247,6 +247,28 @@
   `DiffResult.requested_depth` before recomputing `analysis_assurance` —
   only ever from an *explicit* flag, never an inferred depth from bare
   `--sources`/`--build-info` or `.abicheck.yml`'s `source.method`.
+- **`service.run_compare_request()` — the typed Python API / MCP
+  `abi_compare` entry point — now also propagates an explicit
+  `CompareRequest.depth` onto `requested_depth`/`depth_satisfied`** (P2
+  review, PR #767 follow-up, `discussion_r3787839902`). The round-9 fix
+  above was CLI-only: `cli_compare_helpers._report_compare_result` stamps
+  `DiffResult.requested_depth` from `compare`'s own Click-validated
+  `--depth`, but a direct typed-API caller passing
+  `CompareRequest(..., depth="headers")` never routes through that CLI
+  helper, so the identical successfully-reached, explicit depth request
+  still silently read `requested_depth=None`/`depth_satisfied=None` and
+  could report `status="complete"`. Fixed in the shared
+  `service_compare_pipeline.classify_compare_pair` (the classification half
+  both `run_compare_request` and the native `compare` CLI's
+  `resolve_and_apply` path build on) with the identical `if depth is not
+  None` guard, then recomputing `analysis_assurance` from each snapshot's
+  own embedded `build_source` (this path has no out-of-band
+  `--old/new-build-info`/`--old/new-sources` pack directory to fold in, so
+  it mirrors `checker.compare()`'s own recomputation rather than the CLI
+  helper's `_resolve_side_pack`). The CLI's own stamp in
+  `_report_compare_result` is deliberately kept, not removed — it still
+  needs to recompute after resolving its own out-of-band pack, which
+  `classify_compare_pair` has no visibility into.
 - **`graph_completeness`'s asymmetric-confirmed-family check now rejects a
   PARTIALLY overlapping family-set pair, not only a fully disjoint one**
   (P1 review, round 9 — fresh evidence after round 8's disjoint-family

--- a/changelog.d/20260814_183041_noreply_p0_4_analysis_assurance.md
+++ b/changelog.d/20260814_183041_noreply_p0_4_analysis_assurance.md
@@ -234,4 +234,33 @@
   sets (from the same `extractor_passes`/`narrowed_passes` dicts already
   read); a total mismatch now reads `graph_completeness="unknown"`, folding
   into `status="partial"` the same way the other coverage gaps already do.
+- **`compare`'s own `--depth` flag now actually reaches
+  `analysis_assurance.requested_depth`** (P1 review, round 9). Nothing
+  populated `DiffResult.requested_depth` before this fix, so an explicit
+  `compare --depth source` that never actually reached source evidence
+  (both sides lacking a compile database, say — the effective depth stays
+  `headers`) silently read `requested_depth=None`/`depth_satisfied=None`
+  and could still report `status="complete"`, letting
+  `--require-complete-analysis` exit `0` despite the explicitly requested
+  depth never being reached. `cli_compare_helpers._report_compare_result`
+  now copies its own Click-validated `--depth` string onto
+  `DiffResult.requested_depth` before recomputing `analysis_assurance` —
+  only ever from an *explicit* flag, never an inferred depth from bare
+  `--sources`/`--build-info` or `.abicheck.yml`'s `source.method`.
+- **`graph_completeness`'s asymmetric-confirmed-family check now rejects a
+  PARTIALLY overlapping family-set pair, not only a fully disjoint one**
+  (P1 review, round 9 — fresh evidence after round 8's disjoint-family
+  fix). Old confirming `{call_graph, type_graph}` against new confirming
+  only `{call_graph}` is not disjoint (they share `call_graph`), so the
+  round-8 `isdisjoint()` check left `graph_completeness="complete"` even
+  though `buildsource/source_graph_findings.py` only trusts a family when
+  BOTH sides cover it — `type_graph`, confirmed on old and never even
+  attempted on new, was silently skipped for this comparison the same way
+  a fully disjoint pair already was, just for one family instead of all of
+  them. Fixed by comparing the two sides' confirmed-family sets for *any*
+  inequality (`!=`) rather than only total disjunction — a subset,
+  superset, or partial-overlap pair are all "the two sides disagree on
+  what they confirmed" just as much as a fully disjoint pair, and the
+  resulting note now names which family/families are confirmed on only
+  one side.
 

--- a/tests/test_analysis_assurance.py
+++ b/tests/test_analysis_assurance.py
@@ -988,7 +988,7 @@ class TestGraphCompleteness:
         assert aa.graph_completeness != "complete"
         assert aa.graph_completeness == "unknown"
         assert aa.status == "partial"
-        assert any("share no common" in n for n in aa.notes)
+        assert any("confirmed on only one side" in n for n in aa.notes)
 
     def test_overlapping_confirmed_family_on_same_name_is_still_complete(
         self, tmp_path: Path

--- a/tests/test_analysis_assurance_depth_and_graph_overlap.py
+++ b/tests/test_analysis_assurance_depth_and_graph_overlap.py
@@ -1,0 +1,338 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""P0.4 round-9 review findings, split out of ``test_analysis_assurance.py``
+(``_extra``-style sibling, matching e.g. ``test_call_graph_extra.py``) purely
+to stay under the AI-readiness file-size hard cap -- the parent file was
+already at the 1500-line soft-limit WARN before these two findings' tests
+were added, and the tests below (~260 lines) pushed it past the 2000-line
+hard cap.
+
+Finding 1: ``DiffResult.requested_depth`` was never populated by any front
+end, so an explicit ``compare --depth source`` that never reached source
+evidence could still report ``status="complete"``.
+
+Finding 2: the round-8 asymmetric-confirmed-graph-family fix only detected a
+fully DISJOINT family-set pair (``isdisjoint()``); a partially overlapping
+pair (old confirms a superset of what new confirms) fell through to
+``"complete"`` even though the uncovered family is only trusted on one side.
+
+Duplicates the two small fixtures it needs (``_header_pair``/``_write``)
+rather than importing them from the parent module -- every other
+``_extra``-style sibling test file in this suite is self-contained the same
+way, and there is no existing cross-test-module import to follow instead.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from abicheck import checker
+from abicheck.analysis_assurance import compute_analysis_assurance
+from abicheck.cli import main
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.serialization import snapshot_to_json
+
+
+def _fn(name: str, mangled: str) -> Function:
+    return Function(
+        name=name, mangled=mangled, return_type="int", visibility=Visibility.PUBLIC
+    )
+
+
+def _write(tmp_path: Path, old: AbiSnapshot, new: AbiSnapshot) -> tuple[Path, Path]:
+    old_p = tmp_path / "old.json"
+    new_p = tmp_path / "new.json"
+    old_p.write_text(snapshot_to_json(old), encoding="utf-8")
+    new_p.write_text(snapshot_to_json(new), encoding="utf-8")
+    return old_p, new_p
+
+
+def _header_pair() -> tuple[AbiSnapshot, AbiSnapshot]:
+    """A real, header-scoped, unchanged pair -- resolves a clean public
+    surface, so ``scope_resolved`` is True and ``status`` should read
+    ``"complete"`` with no gating flag involved. Mirrors
+    ``test_analysis_assurance._header_pair`` exactly.
+    """
+    common = {"library": "libfoo.so.1", "from_headers": True}
+    fns = [_fn("pub_a", "_Z5pub_av")]
+    return (
+        AbiSnapshot(version="1.0", functions=fns, **common),
+        AbiSnapshot(version="2.0", functions=fns, **common),
+    )
+
+
+class TestRequestedDepthPropagation:
+    """Round-9 review, Finding 1: the CLI's own resolved ``--depth`` flag
+    was never copied onto ``DiffResult.requested_depth`` before
+    ``analysis_assurance`` read it, so an explicit ``compare --depth
+    source`` that never actually reached source evidence (both sides lack
+    a compile database, say -- the effective depth stays ``headers``)
+    silently read ``requested_depth=None``/``depth_satisfied=None`` and
+    could still report ``status="complete"``, letting
+    ``--require-complete-analysis`` exit 0 despite the explicitly requested
+    depth never being reached.
+    """
+
+    def test_unit_level_unsatisfied_requested_depth_is_failed(self) -> None:
+        """Direct unit-level check: compute_analysis_assurance reads
+        DiffResult.requested_depth (now populated by the CLI) and gates on
+        it -- headers-only evidence never satisfies an explicit 'source'
+        request."""
+        old, new = _header_pair()
+        result = checker.compare(old, new)
+        assert result.analysis_assurance.status == "complete"  # sanity: no gap yet
+        result.requested_depth = "source"
+        aa = compute_analysis_assurance(result, old, new)
+        assert aa.requested_depth == "source"
+        assert aa.effective_depth == "headers"
+        assert aa.depth_satisfied is False
+        assert aa.status == "failed"
+        assert any("requested depth 'source' not reached" in n for n in aa.notes), (
+            aa.notes
+        )
+
+    def test_unit_level_satisfied_requested_depth_stays_complete(self) -> None:
+        """Companion positive case: an explicit requested depth that IS
+        reached must not regress to a non-complete status."""
+        old, new = _header_pair()
+        result = checker.compare(old, new)
+        result.requested_depth = "headers"
+        aa = compute_analysis_assurance(result, old, new)
+        assert aa.requested_depth == "headers"
+        assert aa.effective_depth == "headers"
+        assert aa.depth_satisfied is True
+        assert aa.status == "complete"
+
+    def test_cli_depth_source_with_no_compile_database_is_not_complete(
+        self, tmp_path: Path
+    ) -> None:
+        """End-to-end: `compare --depth source` on two plain header-scoped
+        JSON snapshots, with no --sources/--build-info given at all (so no
+        L4/L5 evidence is ever collected and the effective depth stays
+        'headers') must not read status='complete'."""
+        old, new = _header_pair()
+        old_p, new_p = _write(tmp_path, old, new)
+
+        res = CliRunner().invoke(
+            main,
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--depth",
+                "source",
+                "--format",
+                "json",
+            ],
+        )
+        assert res.exit_code in (0, 1, 2, 4), res.output
+        payload = json.loads(res.output[res.output.index("{") :])
+        aa = payload["analysis_assurance"]
+        assert aa["requested_depth"] == "source", aa
+        assert aa["effective_depth"] == "headers", aa
+        assert aa["depth_satisfied"] is False, aa
+        assert aa["status"] == "failed", aa
+
+    def test_require_complete_analysis_exits_nonzero_for_unsatisfied_depth(
+        self, tmp_path: Path
+    ) -> None:
+        old, new = _header_pair()
+        old_p, new_p = _write(tmp_path, old, new)
+
+        res = CliRunner().invoke(
+            main,
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--depth",
+                "source",
+                "--require-complete-analysis",
+            ],
+        )
+        assert res.exit_code != 0, res.output
+
+    def test_depth_omitted_does_not_populate_requested_depth(
+        self, tmp_path: Path
+    ) -> None:
+        """No --depth flag at all must leave requested_depth None (never an
+        inferred value), matching the pre-existing default behavior for
+        every caller that doesn't opt into an explicit depth request."""
+        old, new = _header_pair()
+        old_p, new_p = _write(tmp_path, old, new)
+
+        res = CliRunner().invoke(
+            main,
+            ["compare", str(old_p), str(new_p), "--format", "json"],
+        )
+        assert res.exit_code in (0, 1, 2, 4), res.output
+        payload = json.loads(res.output[res.output.index("{") :])
+        aa = payload["analysis_assurance"]
+        assert aa["requested_depth"] is None, aa
+        assert aa["status"] == "complete", aa
+
+
+class TestGraphCompletenessPartialFamilyOverlap:
+    """Round-9 review, Finding 2: the round-8 fix only flagged a fully
+    DISJOINT confirmed-family pair (``isdisjoint()``); a partially
+    overlapping pair -- old confirmed {call_graph, type_graph}, new
+    confirmed only {call_graph} -- is not disjoint (they share
+    call_graph), so it fell through to "complete" even though
+    buildsource/source_graph_findings.py only trusts a family when BOTH
+    sides cover it, meaning type_graph was silently skipped for this
+    comparison.
+    """
+
+    def _pack_with_graph(self, tmp_path: Path, name: str, graph) -> object:
+        from abicheck.buildsource.pack import BuildSourcePack
+
+        return BuildSourcePack(root=tmp_path / name, source_graph=graph)
+
+    def test_partial_overlap_confirmed_families_is_not_complete(
+        self, tmp_path: Path
+    ) -> None:
+        from abicheck.buildsource.source_graph import SourceGraphSummary
+
+        old, new = _header_pair()
+        old.build_source = self._pack_with_graph(
+            tmp_path,
+            "old_pack",
+            SourceGraphSummary(
+                extractor_passes={"call_graph": True, "type_graph": True}
+            ),
+        )
+        new.build_source = self._pack_with_graph(
+            tmp_path,
+            "new_pack",
+            SourceGraphSummary(extractor_passes={"call_graph": True}),
+        )
+        result = checker.compare(old, new)
+        aa = result.analysis_assurance
+        assert aa.graph_completeness != "complete", aa
+        assert aa.graph_completeness == "unknown", aa
+        assert aa.status == "partial", aa
+        assert any("confirmed on only one side" in n for n in aa.notes), aa.notes
+        assert any("type_graph" in n for n in aa.notes), aa.notes
+
+    def test_require_complete_analysis_exits_nonzero_for_partial_overlap(
+        self, tmp_path: Path
+    ) -> None:
+        from abicheck.buildsource.source_graph import SourceGraphSummary
+
+        old, new = _header_pair()
+        old.build_source = self._pack_with_graph(
+            tmp_path,
+            "old_pack",
+            SourceGraphSummary(
+                extractor_passes={"call_graph": True, "type_graph": True}
+            ),
+        )
+        new.build_source = self._pack_with_graph(
+            tmp_path,
+            "new_pack",
+            SourceGraphSummary(extractor_passes={"call_graph": True}),
+        )
+        old_p, new_p = _write(tmp_path, old, new)
+
+        res = CliRunner().invoke(
+            main,
+            [
+                "compare",
+                str(old_p),
+                str(new_p),
+                "--require-complete-analysis",
+            ],
+        )
+        assert res.exit_code != 0, res.output
+
+    def test_disjoint_confirmed_families_still_asymmetric(self, tmp_path: Path) -> None:
+        """Companion: round 8's original disjoint case must not regress
+        under the new inequality-based check."""
+        from abicheck.buildsource.source_graph import SourceGraphSummary
+
+        old, new = _header_pair()
+        old.build_source = self._pack_with_graph(
+            tmp_path,
+            "old_pack",
+            SourceGraphSummary(
+                extractor_passes={
+                    "header_call_graph": True,
+                    "header_type_graph": True,
+                }
+            ),
+        )
+        new.build_source = self._pack_with_graph(
+            tmp_path,
+            "new_pack",
+            SourceGraphSummary(
+                extractor_passes={"call_graph": True, "type_graph": True}
+            ),
+        )
+        result = checker.compare(old, new)
+        aa = result.analysis_assurance
+        assert aa.graph_completeness == "unknown", aa
+        assert aa.status == "partial", aa
+        assert any("confirmed on only one side" in n for n in aa.notes), aa.notes
+
+    def test_identical_confirmed_families_still_complete(self, tmp_path: Path) -> None:
+        """Companion: both sides confirming the EXACT same family set must
+        still read complete -- the new inequality check must not regress
+        the ordinary, matching-family case."""
+        from abicheck.buildsource.source_graph import SourceGraphSummary
+
+        old, new = _header_pair()
+        old.build_source = self._pack_with_graph(
+            tmp_path,
+            "old_pack",
+            SourceGraphSummary(
+                extractor_passes={"call_graph": True, "type_graph": True}
+            ),
+        )
+        new.build_source = self._pack_with_graph(
+            tmp_path,
+            "new_pack",
+            SourceGraphSummary(
+                extractor_passes={"call_graph": True, "type_graph": True}
+            ),
+        )
+        result = checker.compare(old, new)
+        aa = result.analysis_assurance
+        assert aa.graph_completeness == "complete", aa
+        assert aa.status == "complete", aa
+
+    def test_unit_level_isdisjoint_vs_inequality_direct(self, tmp_path: Path) -> None:
+        """Direct unit-level check of _graph_completeness itself, isolating
+        the predicate from the rest of the rollup."""
+        from abicheck.analysis_assurance import _graph_completeness
+        from abicheck.buildsource.pack import BuildSourcePack
+        from abicheck.buildsource.source_graph import SourceGraphSummary
+
+        old_pack = BuildSourcePack(
+            root=tmp_path / "old",
+            source_graph=SourceGraphSummary(
+                extractor_passes={"call_graph": True, "type_graph": True}
+            ),
+        )
+        new_pack = BuildSourcePack(
+            root=tmp_path / "new",
+            source_graph=SourceGraphSummary(extractor_passes={"call_graph": True}),
+        )
+        status, notes = _graph_completeness(old_pack, new_pack)
+        assert status == "unknown"
+        assert any("confirmed on only one side" in n for n in notes), notes

--- a/tests/test_analysis_assurance_depth_and_graph_overlap.py
+++ b/tests/test_analysis_assurance_depth_and_graph_overlap.py
@@ -33,6 +33,16 @@ Duplicates the two small fixtures it needs (``_header_pair``/``_write``)
 rather than importing them from the parent module -- every other
 ``_extra``-style sibling test file in this suite is self-contained the same
 way, and there is no existing cross-test-module import to follow instead.
+
+Finding 3 (PR #767 follow-up, P2 review ``discussion_r3787839902``): Finding
+1's fix above was CLI-only (``cli_compare_helpers._report_compare_result``);
+a direct ``service.run_compare_request()``/``CompareRequest`` caller -- the
+typed Python API / MCP ``abi_compare`` entry point, which never routes
+through that CLI helper -- still read ``requested_depth=None``/
+``depth_satisfied=None`` for an explicit, successfully-reached
+``CompareRequest.depth``. ``TestRequestedDepthPropagationSharedPipeline``
+below is the direct-API-level regression the CLI-only test suite never
+covered.
 """
 
 from __future__ import annotations
@@ -46,7 +56,7 @@ from abicheck import checker
 from abicheck.analysis_assurance import compute_analysis_assurance
 from abicheck.cli import main
 from abicheck.model import AbiSnapshot, Function, Visibility
-from abicheck.serialization import snapshot_to_json
+from abicheck.serialization import save_snapshot, snapshot_to_json
 
 
 def _fn(name: str, mangled: str) -> Function:
@@ -186,6 +196,117 @@ class TestRequestedDepthPropagation:
         aa = payload["analysis_assurance"]
         assert aa["requested_depth"] is None, aa
         assert aa["status"] == "complete", aa
+
+
+class TestRequestedDepthPropagationSharedPipeline:
+    """PR #767 follow-up (P2 review, ``discussion_r3787839902``): the CLI-only
+    fix above (``cli_compare_helpers._report_compare_result``) left the
+    shared ``service_compare_pipeline.classify_compare_pair`` -- what
+    ``service.run_compare_request()`` (the typed Python API / MCP
+    ``abi_compare`` entry point) actually runs -- never populating either
+    ``DiffResult.requested_depth`` or ``analysis_assurance.depth_satisfied``
+    for a direct caller's explicit ``CompareRequest.depth``.
+    """
+
+    def _snapshot_files(self, tmp_path: Path) -> tuple[Path, Path]:
+        old, new = _header_pair()
+        old_p = tmp_path / "old.json"
+        new_p = tmp_path / "new.json"
+        save_snapshot(old, old_p)
+        save_snapshot(new, new_p)
+        return old_p, new_p
+
+    def test_direct_api_satisfied_depth_populates_requested_depth(
+        self, tmp_path: Path
+    ) -> None:
+        """The exact repro from the review finding: a direct
+        ``run_compare_request(CompareRequest(..., depth="headers"))`` call on
+        two plain header-scoped snapshots reaches 'headers' evidence (so the
+        request IS satisfied) -- before this fix, the returned result still
+        silently read ``requested_depth=None``/``depth_satisfied=None``
+        despite the caller's explicit, successfully-reached request."""
+        from abicheck.api_types import CompareRequest, InputSpec
+        from abicheck.service import run_compare_request
+
+        old_p, new_p = self._snapshot_files(tmp_path)
+        request = CompareRequest(
+            old=InputSpec.of(old_p), new=InputSpec.of(new_p), depth="headers"
+        )
+        result = run_compare_request(request).diff
+
+        assert result.requested_depth == "headers", result
+        aa = result.analysis_assurance
+        assert aa.requested_depth == "headers", aa
+        assert aa.effective_depth == "headers", aa
+        assert aa.depth_satisfied is True, aa
+        assert aa.status == "complete", aa
+
+    def test_direct_api_no_depth_leaves_requested_depth_none(
+        self, tmp_path: Path
+    ) -> None:
+        """Companion negative case: a caller that never sets
+        ``CompareRequest.depth`` must see the identical, unaffected
+        ``requested_depth=None`` behavior as before this fix."""
+        from abicheck.api_types import CompareRequest, InputSpec
+        from abicheck.service import run_compare_request
+
+        old_p, new_p = self._snapshot_files(tmp_path)
+        request = CompareRequest(old=InputSpec.of(old_p), new=InputSpec.of(new_p))
+        result = run_compare_request(request).diff
+
+        assert result.requested_depth is None, result
+        assert result.analysis_assurance.requested_depth is None
+        assert result.analysis_assurance.depth_satisfied is None
+        assert result.analysis_assurance.status == "complete"
+
+    def test_classify_compare_pair_unsatisfied_depth_is_not_complete(
+        self, tmp_path: Path
+    ) -> None:
+        """Direct unit-level check of the fixed function itself
+        (``classify_compare_pair``), bypassing ``resolve_compare_request``'s
+        own separate ``enforce_requested_depth`` hard-fail (a request whose
+        depth is unreachable from a plain JSON-snapshot resolve raises
+        ``ValidationError`` before classification is ever reached -- see
+        ``service_input_resolution.enforce_requested_depth``) so the
+        'requested but not satisfied' half of this fix's own gate
+        (``analysis_assurance.status != 'complete'``) is exercised the same
+        way the CLI-fix's own
+        ``test_unit_level_unsatisfied_requested_depth_is_failed`` above
+        exercises it -- by constructing an already-resolved pair directly
+        rather than going through the full resolve step."""
+        from abicheck.api_types import CompareRequest, InputSpec
+        from abicheck.service_compare_evidence import SideEvidence
+        from abicheck.service_compare_pipeline import (
+            ResolvedComparePair,
+            classify_compare_pair,
+        )
+
+        old, new = _header_pair()
+        old_p, new_p = self._snapshot_files(tmp_path)
+        request = CompareRequest(
+            old=InputSpec.of(old_p),
+            new=InputSpec.of(new_p),
+            depth="source",
+        )
+        evidence = SideEvidence(
+            headers=[], compile=None, collect_mode="off", dump_manifest=None
+        )
+        pair = ResolvedComparePair(
+            old=old,
+            new=new,
+            old_fmt=None,
+            new_fmt=None,
+            old_evidence=evidence,
+            new_evidence=evidence,
+        )
+        result = classify_compare_pair(request, pair).diff
+
+        assert result.requested_depth == "source", result
+        aa = result.analysis_assurance
+        assert aa.requested_depth == "source", aa
+        assert aa.effective_depth == "headers", aa
+        assert aa.depth_satisfied is False, aa
+        assert aa.status != "complete", aa
 
 
 class TestGraphCompletenessPartialFamilyOverlap:


### PR DESCRIPTION
PR #763 (the P0.4 "first-class `analysis_assurance` model" effort) merged into `main` at `891bd9d7` while its 9th review round was still in flight — a merge-timing race, the same situation PR #766 documents for #762. Two review findings from that round arrived after the merge and are addressed here instead, against `main`.

## Finding 1 (P1) — Propagate the requested depth into assurance

`compute_analysis_assurance()` gates `depth_satisfied` off `DiffResult.requested_depth`, but nothing ever populated that field. An explicit `compare --depth source` that never actually reached source evidence (e.g. both sides lack a compile database, so the effective depth stays `headers`) silently read `requested_depth=None`/`depth_satisfied=None` and could still report `status="complete"`, letting `--require-complete-analysis` exit `0` despite the explicitly requested depth never being reached.

Fixed in `abicheck/cli_compare_helpers.py`'s `_report_compare_result`: it now copies its own Click-validated `--depth` string onto `DiffResult.requested_depth` before recomputing `analysis_assurance` — only from an *explicit* flag, never an inferred depth from bare `--sources`/`--build-info` or `.abicheck.yml`'s `source.method`.

## Finding 2 (P1) — Reject partially overlapping graph coverage

Round 8's fix in `abicheck/analysis_assurance.py`'s `_graph_completeness()` flagged asymmetric confirmed-family coverage only when the two sides' confirmed-family sets were fully **disjoint** (`isdisjoint()`). Fresh evidence: a **partial-overlap** case — old confirms `{call_graph, type_graph}`, new confirms only `{call_graph}` — is not disjoint (they share `call_graph`), so it fell through to `"complete"` even though `buildsource/source_graph_findings.py` only trusts a family when **both** sides cover it, meaning `type_graph` was silently skipped for that comparison.

Fixed by comparing the two sides' confirmed-family sets for any inequality (`!=`) rather than only total disjunction — subset, superset, and partial-overlap pairs are all "the two sides disagree on what they confirmed," same as a fully disjoint pair.

## Testing

- New regression tests for both findings, at the unit level (calling `compute_analysis_assurance`/`_graph_completeness` directly) and end-to-end through the real `compare` CLI.
- Companion tests confirm round 8's original disjoint case, and the "both sides confirm the identical set" case, are unaffected.
- New tests split into a sibling file (`tests/test_analysis_assurance_depth_and_graph_overlap.py`) to keep `tests/test_analysis_assurance.py` under the AI-readiness file-size hard cap.
- `ruff check`, `ruff format --check` (new/changed lines), `mypy abicheck/` (0 errors), `pytest tests/test_analysis_assurance*.py`, and the full fast suite all pass; the fast suite's 21 failures are the same pre-existing, environment-only (castxml/toolchain-availability, ADR-verified-commit staleness) failures present on `origin/main` before this change.
- `python scripts/check_ai_readiness.py`: 15 errors, identical to the `origin/main` baseline (no new findings).
- Changelog fragment `changelog.d/20260814_183041_noreply_p0_4_analysis_assurance.md` amended with both fixes.

---
_Generated by [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_017jAiyuYpVCdif4RqZpJ1mP)_