### PR TITLE
fix: P0.4 follow-up round 2 — close review gaps left by merge timing on #767

### DIFF
--- a/abicheck/analysis_assurance.py
+++ b/abicheck/analysis_assurance.py
@@ -115,6 +115,7 @@ Nothing here shells out, re-parses a binary, or re-runs an extractor.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -126,6 +127,7 @@ from .model import AbiSnapshot
 
 if TYPE_CHECKING:
     from .buildsource.pack import BuildSourcePack
+    from .buildsource.source_graph import SourceGraphSummary
 
 __all__ = [
     "ANALYSIS_ASSURANCE_SCHEMA_VERSION",
@@ -191,6 +193,12 @@ def _is_l5_graph_extractor_record(name: str) -> bool:
     ``":"``."""
     family = name.split(":", 1)[0]
     return family in _L5_GRAPH_EXTRACTOR_FAMILIES
+
+
+#: P0.4 (P2 review): ``fold_archive_graph`` correctly records nothing on a side with no ``static_library`` node.
+_CONDITIONALLY_APPLICABLE_FAMILIES: dict[str, Callable[[SourceGraphSummary], bool]] = {
+    "archive_graph": lambda sg: any(n.kind == "static_library" for n in sg.nodes),
+}
 
 
 @dataclass
@@ -1229,19 +1237,23 @@ def _graph_completeness(
     if (
         old_confirmed_families or new_confirmed_families
     ) and old_confirmed_families != new_confirmed_families:
-        asymmetric_family_coverage = True
-        only_old = sorted(old_confirmed_families - new_confirmed_families)
-        only_new = sorted(new_confirmed_families - old_confirmed_families)
-        one_sided = sorted(set(only_old) | set(only_new))
-        notes.append(
-            "graph completeness unknown: the old side confirmed coverage "
-            f"for {sorted(old_confirmed_families)!r} while the new side "
-            f"confirmed coverage for {sorted(new_confirmed_families)!r} -- "
-            f"{one_sided!r} family/families are confirmed on only one side, "
-            "and buildsource/source_graph_findings.py only trusts a family "
-            "when BOTH sides cover it, so the cross-snapshot graph diff "
-            "cannot compare on it"
-        )
+        # Finding (P2 review): exclude a family genuinely inapplicable on the side lacking confirmation.
+        _cap = _CONDITIONALLY_APPLICABLE_FAMILIES
+
+        def _gap(a: set[str], b: set[str], other: SourceGraphSummary) -> set[str]:
+            return {f for f in a - b if _cap.get(f) is None or _cap[f](other)}
+
+        only_old = _gap(old_confirmed_families, new_confirmed_families, new_graph)
+        only_new = _gap(new_confirmed_families, old_confirmed_families, old_graph)
+        one_sided = sorted(only_old | only_new)
+        asymmetric_family_coverage = bool(one_sided)
+        if one_sided:
+            notes.append(
+                f"graph completeness unknown: {one_sided!r} family/families are "
+                f"confirmed on only one side (old={sorted(old_confirmed_families)!r}, "
+                f"new={sorted(new_confirmed_families)!r}) -- only a family both sides "
+                "cover is trusted (buildsource/source_graph_findings.py)"
+            )
 
     if degraded:
         return "degraded", notes

--- a/abicheck/service_compare_pipeline.py
+++ b/abicheck/service_compare_pipeline.py
@@ -494,8 +494,23 @@ def classify_compare_pair(
     # are embedded into `old`/`new` before `resolve_compare_request` ever
     # returns), so `layer_coverage`/`requested_depth` -- both only known
     # after `compare_snapshots` returns -- are reflected too.
+    #
+    # P0.4 follow-up (P2 review): `CompareRequest.validation_errors()`
+    # (`_depth_errors` in `api_types.py`) accepts `depth` case-insensitively
+    # (`depth.lower() in USER_DEPTHS`), and every consumer of the *value*
+    # (`enforce_requested_depth`'s own `depth.lower()` lookup into
+    # `_DEPTH_RANK` above, line 194's `request.depth.lower() == "binary"`
+    # check) normalizes case before using it -- so a valid, successfully
+    # validated request like `depth="HEADERS"` reached this assignment with
+    # its original casing preserved. That un-normalized string then broke
+    # every downstream reader that expects the lowercase
+    # `EVIDENCE_DEPTH_VALUES` spelling: `compute_analysis_assurance()`'s
+    # depth-rank lookup silently missed (falling back to a wrong default),
+    # and `validate_evidence_depth()` (every JSON reporter) raised
+    # `ValueError` outright. Stamp the same lowercased form the rest of this
+    # module already normalizes to, not the raw request string.
     if request.depth is not None:
-        result.requested_depth = request.depth
+        result.requested_depth = request.depth.lower()
     from .analysis_assurance import compute_analysis_assurance
 
     result.analysis_assurance = compute_analysis_assurance(

--- a/changelog.d/20260814_183041_noreply_p0_4_analysis_assurance.md
+++ b/changelog.d/20260814_183041_noreply_p0_4_analysis_assurance.md
@@ -285,4 +285,40 @@
   what they confirmed" just as much as a fully disjoint pair, and the
   resulting note now names which family/families are confirmed on only
   one side.
+- **`service_compare_pipeline.classify_compare_pair` now stamps
+  `DiffResult.requested_depth` case-normalized, not the raw request
+  string** (P2 review, PR #767 follow-up round 2). `CompareRequest.
+  validation_errors()` accepts `depth` case-insensitively
+  (`depth.lower() in USER_DEPTHS`) and every consumer of the resolved value
+  already normalizes case before using it (`enforce_requested_depth`'s
+  `_DEPTH_RANK` lookup, this same function's own `depth.lower() ==
+  "binary"` check) — so a valid, successfully validated direct-API request
+  like `CompareRequest(..., depth="HEADERS")` reached the just-added
+  `requested_depth` stamp with its original uppercase casing intact. That
+  broke every downstream reader expecting the lowercase
+  `EVIDENCE_DEPTH_VALUES` spelling: `compute_analysis_assurance()`'s
+  depth-rank lookup missed silently, and `validate_evidence_depth()`
+  (every JSON reporter) raised `ValueError` outright. Fixed by stamping
+  `request.depth.lower()`.
+- **`_graph_completeness`'s cross-side family-asymmetry check no longer
+  flags a conditionally-applicable pass family that is genuinely
+  inapplicable on the side lacking confirmation** (P2 review, PR #767
+  follow-up round 2 — a regression in round 9's own `!=` fix, above).
+  `fold_archive_graph()` (`buildsource/inline_graph_fold.py`) deliberately
+  records `archive_graph` only when a side's graph carries at least one
+  `static_library` node, returning with no `ExtractorRecord` at all
+  otherwise — a correct no-op, not a shortfall. A fully collected release
+  that drops its last static-library link input entirely (old side
+  confirmed `archive_graph`, new side genuinely has nothing to introspect)
+  is a legitimate build difference, but the round-9 set-inequality check
+  read it as `graph_completeness="unknown"` regardless, failing
+  `--require-complete-analysis` for a comparison with no real evidence
+  gap. Fixed with a new `_CONDITIONALLY_APPLICABLE_FAMILIES` mapping
+  (family name -> "does this side's own graph carry something for it to
+  examine") consulted by the asymmetry check: a family confirmed on one
+  side but correctly inapplicable on the other is excluded from the
+  asymmetric set, while a family applicable on both sides but confirmed on
+  only one (the pass should have run there but didn't, or ran degraded)
+  still folds into `graph_completeness="unknown"`/`status="partial"`
+  unchanged.
 

--- a/tests/test_analysis_assurance_depth_and_graph_overlap.py
+++ b/tests/test_analysis_assurance_depth_and_graph_overlap.py
@@ -241,6 +241,41 @@ class TestRequestedDepthPropagationSharedPipeline:
         assert aa.depth_satisfied is True, aa
         assert aa.status == "complete", aa
 
+    def test_direct_api_uppercase_depth_is_normalized(self, tmp_path: Path) -> None:
+        """PR #767 follow-up (P2 review, ``service_compare_pipeline.py:476``):
+        ``CompareRequest.validation_errors()`` (``_depth_errors`` in
+        ``api_types.py``) accepts ``depth`` case-insensitively
+        (``depth.lower() in USER_DEPTHS``), so a direct caller passing
+        ``depth="HEADERS"`` reaches classification successfully. Before this
+        fix, ``classify_compare_pair`` stamped the raw, un-normalized
+        ``request.depth`` onto ``DiffResult.requested_depth``, which broke
+        every downstream reader expecting the lowercase
+        ``EVIDENCE_DEPTH_VALUES`` spelling -- most visibly,
+        ``validate_evidence_depth()`` (every JSON reporter) raised
+        ``ValueError`` outright. This must fail against the pre-fix code."""
+        from abicheck.api_types import CompareRequest, InputSpec
+        from abicheck.checker_types import validate_evidence_depth
+        from abicheck.reporter import to_json
+        from abicheck.service import run_compare_request
+
+        old_p, new_p = self._snapshot_files(tmp_path)
+        request = CompareRequest(
+            old=InputSpec.of(old_p), new=InputSpec.of(new_p), depth="HEADERS"
+        )
+        result = run_compare_request(request).diff
+
+        assert result.requested_depth == "headers", result
+        aa = result.analysis_assurance
+        assert aa.requested_depth == "headers", aa
+        assert aa.effective_depth == "headers", aa
+        assert aa.depth_satisfied is True, aa
+        assert aa.status == "complete", aa
+
+        # Does not raise -- pre-fix, the uppercase requested_depth crashed
+        # validate_evidence_depth() / every JSON reporter.
+        validate_evidence_depth("requested_depth", result.requested_depth)
+        to_json(result)
+
     def test_direct_api_no_depth_leaves_requested_depth_none(
         self, tmp_path: Path
     ) -> None:
@@ -572,3 +607,171 @@ class TestExportAccountingDedupsLegacyPersistedOverlap:
         assert aa.export_accounting.internal == 2
         assert aa.export_accounting.unaccounted == 0
         assert aa.export_accounting.source_linked == 2
+class TestGraphCompletenessConditionallyApplicableFamily:
+    """PR #767 follow-up (P2 review): the round-9 ``!=`` fix above (Finding 2
+    in that round) is too aggressive for a *conditionally applicable* pass
+    family. ``fold_archive_graph`` (``inline_graph_fold.py``) only ever
+    records ``archive_graph`` when the graph carries at least one
+    ``static_library`` node -- it returns silently, with no
+    ``ExtractorRecord`` at all, when there is nothing to introspect. A
+    release that drops its last static-library link input entirely (old side
+    confirmed ``archive_graph``, new side genuinely has no
+    ``static_library`` node to examine) is a legitimate difference between
+    the two builds, not evidence asymmetry, and must not read as
+    ``graph_completeness == "unknown"``.
+    """
+
+    def _pack_with_graph(self, tmp_path: Path, name: str, graph) -> object:
+        from abicheck.buildsource.pack import BuildSourcePack
+
+        return BuildSourcePack(root=tmp_path / name, source_graph=graph)
+
+    def test_archive_graph_correctly_inapplicable_on_one_side_is_complete(
+        self, tmp_path: Path
+    ) -> None:
+        """The exact repro from the review finding: old confirms
+        ``archive_graph`` because it linked a static library; new links no
+        static library at all, so the pass correctly never ran there. This
+        must read as complete, not unknown."""
+        from abicheck.analysis_assurance import _graph_completeness
+        from abicheck.buildsource.graph_facts import GraphNode
+        from abicheck.buildsource.pack import BuildSourcePack
+        from abicheck.buildsource.source_graph import SourceGraphSummary
+
+        old_pack = BuildSourcePack(
+            root=tmp_path / "old",
+            source_graph=SourceGraphSummary(
+                nodes=[
+                    GraphNode(id="static_library://libfoo.a", kind="static_library")
+                ],
+                extractor_passes={"archive_graph": True, "call_graph": True},
+            ),
+        )
+        new_pack = BuildSourcePack(
+            root=tmp_path / "new",
+            source_graph=SourceGraphSummary(
+                nodes=[], extractor_passes={"call_graph": True}
+            ),
+        )
+        status, notes = _graph_completeness(old_pack, new_pack)
+        assert status == "complete", notes
+
+    def test_archive_graph_correctly_inapplicable_end_to_end(
+        self, tmp_path: Path
+    ) -> None:
+        """Same repro through the full ``checker.compare()`` rollup, not just
+        the unit-level ``_graph_completeness`` call."""
+        from abicheck.buildsource.graph_facts import GraphNode
+        from abicheck.buildsource.source_graph import SourceGraphSummary
+
+        old, new = _header_pair()
+        old.build_source = self._pack_with_graph(
+            tmp_path,
+            "old_pack",
+            SourceGraphSummary(
+                nodes=[
+                    GraphNode(id="static_library://libfoo.a", kind="static_library")
+                ],
+                extractor_passes={"archive_graph": True, "call_graph": True},
+            ),
+        )
+        new.build_source = self._pack_with_graph(
+            tmp_path,
+            "new_pack",
+            SourceGraphSummary(nodes=[], extractor_passes={"call_graph": True}),
+        )
+        result = checker.compare(old, new)
+        aa = result.analysis_assurance
+        assert aa.graph_completeness == "complete", aa
+        assert aa.status == "complete", aa
+
+    def test_archive_graph_genuine_asymmetry_still_detected(
+        self, tmp_path: Path
+    ) -> None:
+        """Companion: BOTH sides have a static_library link input (so the
+        pass is applicable on both), but only one side actually confirmed
+        the pass ran. This is a real evidence gap and must still read as
+        unknown/asymmetric -- the conditional-applicability exemption must
+        not over-correct into silencing a genuine shortfall for this
+        family."""
+        from abicheck.analysis_assurance import _graph_completeness
+        from abicheck.buildsource.graph_facts import GraphNode
+        from abicheck.buildsource.pack import BuildSourcePack
+        from abicheck.buildsource.source_graph import SourceGraphSummary
+
+        old_pack = BuildSourcePack(
+            root=tmp_path / "old",
+            source_graph=SourceGraphSummary(
+                nodes=[
+                    GraphNode(id="static_library://libfoo.a", kind="static_library")
+                ],
+                extractor_passes={"archive_graph": True},
+            ),
+        )
+        new_pack = BuildSourcePack(
+            root=tmp_path / "new",
+            source_graph=SourceGraphSummary(
+                nodes=[
+                    GraphNode(id="static_library://libfoo.a", kind="static_library")
+                ],
+                extractor_passes={},
+            ),
+        )
+        status, notes = _graph_completeness(old_pack, new_pack)
+        assert status == "unknown", notes
+        assert any("archive_graph" in n for n in notes), notes
+
+    def test_archive_graph_genuine_asymmetry_end_to_end(self, tmp_path: Path) -> None:
+        """End-to-end companion to the genuine-asymmetry unit test above."""
+        from abicheck.buildsource.graph_facts import GraphNode
+        from abicheck.buildsource.source_graph import SourceGraphSummary
+
+        old, new = _header_pair()
+        old.build_source = self._pack_with_graph(
+            tmp_path,
+            "old_pack",
+            SourceGraphSummary(
+                nodes=[
+                    GraphNode(id="static_library://libfoo.a", kind="static_library")
+                ],
+                extractor_passes={"archive_graph": True},
+            ),
+        )
+        new.build_source = self._pack_with_graph(
+            tmp_path,
+            "new_pack",
+            SourceGraphSummary(
+                nodes=[
+                    GraphNode(id="static_library://libfoo.a", kind="static_library")
+                ],
+                extractor_passes={},
+            ),
+        )
+        result = checker.compare(old, new)
+        aa = result.analysis_assurance
+        assert aa.graph_completeness == "unknown", aa
+        assert aa.status == "partial", aa
+
+    def test_unconditional_family_absent_on_both_sides_still_asymmetric(
+        self, tmp_path: Path
+    ) -> None:
+        """Sanity check that the exemption is scoped to
+        conditionally-applicable families only: an ordinary,
+        unconditionally-attempted family (``call_graph``) confirmed on one
+        side and not the other must still read as asymmetric -- there is no
+        node-presence signal that could ever exempt it."""
+        from abicheck.analysis_assurance import _graph_completeness
+        from abicheck.buildsource.pack import BuildSourcePack
+        from abicheck.buildsource.source_graph import SourceGraphSummary
+
+        old_pack = BuildSourcePack(
+            root=tmp_path / "old",
+            source_graph=SourceGraphSummary(extractor_passes={"call_graph": True}),
+        )
+        new_pack = BuildSourcePack(
+            root=tmp_path / "new",
+            source_graph=SourceGraphSummary(extractor_passes={}),
+        )
+        status, notes = _graph_completeness(old_pack, new_pack)
+        assert status == "unknown", notes
+        assert any("call_graph" in n for n in notes), notes


### PR DESCRIPTION
PR #767 (the P0.4 "first-class `analysis_assurance` model" follow-up) merged into `main` at `9f0df1dcd` while two fresh review findings were still in flight — the same merge-timing race PR #767 itself documents for #763, and #766 documents for #762. Both findings are addressed here instead, against `main`.

## Finding 1 (P2, `abicheck/service_compare_pipeline.py:476`) — Normalize the API depth before stamping the result

`CompareRequest.validation_errors()` (`_depth_errors` in `api_types.py`) accepts `depth` case-insensitively (`depth.lower() in USER_DEPTHS`), and every consumer of the resolved value already normalizes case before using it (`enforce_requested_depth`'s `_DEPTH_RANK` lookup; this same function's own `request.depth.lower() == "binary"` check a few lines up). So a valid, successfully validated direct-API request like `CompareRequest(..., depth="HEADERS")` reached the just-landed `requested_depth` stamp with its original uppercase casing preserved.

That broke every downstream reader expecting the lowercase `EVIDENCE_DEPTH_VALUES` spelling: `compute_analysis_assurance()`'s depth-rank lookup silently missed (falling back to a wrong default), and, more visibly, `validate_evidence_depth()` — called from every JSON reporter — raised `ValueError` outright.

Fixed in `service_compare_pipeline.classify_compare_pair` by stamping `request.depth.lower()` instead of the raw request string.

## Finding 2 (P2, `abicheck/analysis_assurance.py:1186`) — Exclude inapplicable pass families from asymmetry

Round 9's fix (landed in #767) changed `_graph_completeness()`'s confirmed-family-set comparison from `isdisjoint()` to `!=`, correctly catching a partial-overlap case. That change is now too aggressive: it also flags a **conditionally applicable** pass family as asymmetric even when the side lacking confirmation is genuinely inapplicable for it, not merely short on evidence.

`fold_archive_graph()` (`buildsource/inline_graph_fold.py`) deliberately records `archive_graph` only when a side's graph carries at least one `static_library` node — it returns immediately, with no `ExtractorRecord` at all, when there's nothing to introspect. A fully collected release that drops its last static-library link input entirely (old side confirmed `archive_graph`, new side genuinely has nothing to examine) is a legitimate build difference, not evidence asymmetry — but the round-9 `!=` check read it as `graph_completeness="unknown"` regardless, failing `--require-complete-analysis` for a comparison with no real evidence gap.

Investigated every other `fold_*` function in the same module (`fold_call_graph`/`fold_type_graph`/`fold_override_graph`/`fold_template_graph`/`fold_macro_graph`/`fold_callback_graph`/`fold_include_graph`) — `fold_archive_graph` is the only one with this "only run when the relevant input exists" shape; the rest are unconditionally attempted every `fold_semantic_graphs` run. Fixed with a new `_CONDITIONALLY_APPLICABLE_FAMILIES` mapping (family name → the predicate `_graph_completeness` uses to ask "does this side's own graph carry something for this family to examine at all") consulted by the asymmetry check: a family confirmed on one side but correctly inapplicable on the other is excluded from the asymmetric set, while a family applicable on both sides but confirmed on only one (the pass should have run there but didn't, or ran degraded) still folds into `"unknown"`/`"partial"` unchanged.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: Two distinct, unrelated defect shapes in the same follow-up pass. (1) A value validated case-insensitively at the API boundary (`CompareRequest.validation_errors()`'s `depth.lower() in USER_DEPTHS`) was stamped onto `DiffResult.requested_depth` in its raw, un-normalized form at the one call site that had not yet been updated to match every *other* consumer of the same field, which already normalizes case before reading it (`enforce_requested_depth`'s `_DEPTH_RANK` lookup, and `classify_compare_pair`'s own neighboring `request.depth.lower() == "binary"` check three lines above the bug). A validated-but-not-yet-normalized value reaching a persisted/reported field is the recurring shape. (2) A boolean asymmetry check (`isdisjoint()` → `!=`) tightened in the immediately preceding round to correctly catch a partial-overlap evidence gap, without being checked against a case where non-overlap is not a gap at all: a pass family (`archive_graph`) that is only conditionally applicable per side (it legitimately produces no record when a side's graph has no `static_library` node to examine), where the stricter comparison now conflates "genuinely inapplicable here" with "applicable but not confirmed."
- Publicly observable failure: (1) A direct Python-API call, `run_compare_request(CompareRequest(old=..., new=..., depth="HEADERS"))` (also reachable via the MCP `abi_compare` entry point, which shares the same `classify_compare_pair` pipeline) — despite being a valid, successfully-validated request — produced a `DiffResult.requested_depth` value (`"HEADERS"`) that every JSON reporter's `validate_evidence_depth()` rejects, raising `ValueError` and aborting the comparison outright instead of returning a report. (2) `abicheck compare --require-complete-analysis` (or any caller reading `analysis_assurance.status`) reported `graph_completeness="unknown"`/`status="partial"` and a non-zero exit for a comparison where the new side legitimately has no static-library link input at all — a genuine, uninteresting build difference, not an evidence gap — blocking a release gate for nothing.
- Regression test fails on base: Verified empirically, not asserted from reading the diff: checked out `e723460c` (this PR's head), reverted only `abicheck/service_compare_pipeline.py` and `abicheck/analysis_assurance.py` to their `origin/main` content (keeping the new test file), and re-ran the new tests. `TestRequestedDepthPropagationSharedPipeline::test_direct_api_uppercase_depth_is_normalized` and `TestGraphCompletenessConditionallyApplicableFamily::test_archive_graph_correctly_inapplicable_on_one_side_is_complete` / `test_archive_graph_correctly_inapplicable_end_to_end` fail on base (3 failures) with exactly the errors this PR fixes: an `assert 'headers' == ...` chain contradicted by the un-normalized casing bug's `ValueError` path, and `assert status == "complete"` / `assert aa.graph_completeness == "complete"` both instead observing `"unknown"`. The other three new tests in the same classes (the negative controls) pass unchanged on base, as expected, since they exercise pre-existing correct behavior the fix does not touch.
- Negative control: `test_direct_api_no_depth_leaves_requested_depth_none` (already-existing sibling, unaffected by the casing fix — no `depth` means no normalization is exercised at all) plus, new in this PR: `test_archive_graph_genuine_asymmetry_still_detected` / `test_archive_graph_genuine_asymmetry_end_to_end` (both sides genuinely have a `static_library` node, only one side's `archive_graph` pass confirmed — must still read `"unknown"`/`"partial"`, proving the exemption doesn't over-correct into silencing a real gap) and `test_unconditional_family_absent_on_both_sides_still_asymmetric` (an ordinary unconditionally-attempted family, `call_graph`, confirmed on one side and not the other — has no node-presence predicate in `_CONDITIONALLY_APPLICABLE_FAMILIES` at all, so it must still read as asymmetric, proving the exemption is scoped to the one family it names and not a general loosening of the `!=` check).
- Public-surface test: Yes for both findings, at the real caller-facing entry point rather than only the internal helper. Finding 1's `test_direct_api_uppercase_depth_is_normalized` goes through `abicheck.service.run_compare_request()` with a real `CompareRequest`/`InputSpec` pair (the typed Python API / MCP `abi_compare` entry point), not a direct `classify_compare_pair()` call, and additionally calls the real `validate_evidence_depth()` and `reporter.to_json()` chokepoints to prove the previously-raised `ValueError` no longer fires. Finding 2's `test_archive_graph_correctly_inapplicable_end_to_end` goes through `checker.compare()` (the full rollup, not just `_graph_completeness()` in isolation) and asserts on `result.analysis_assurance.status`, the field `--require-complete-analysis` gates on.
- Axes covered: Direct typed-API path only for Finding 1 (`run_compare_request`/`CompareRequest`) — the CLI `--depth` path for the *same* underlying bug was already fixed and tested in the prior round (#767), so this PR's tests specifically close the direct-API gap that round left open, not the CLI axis again. Finding 2 was checked at both the unit level (`_graph_completeness()` called directly with hand-built `BuildSourcePack`/`SourceGraphSummary` fixtures) and end-to-end (`checker.compare()`), and across three input shapes for the one conditionally-applicable family (`archive_graph`): correctly-inapplicable-on-one-side, genuinely-asymmetric-on-both-applicable-sides, and an unconditional family for contrast. Not covered: the MCP `abi_compare` tool itself is not separately exercised (it shares `run_compare_request` with the direct-API test, so it is covered by construction, not by a dedicated MCP-level test), and no other `fold_*` family besides `archive_graph` was added to `_CONDITIONALLY_APPLICABLE_FAMILIES` or given its own test, since the PR's own investigation found `archive_graph` is the only family with this conditional shape today.
- General invariant: (1) Every value stamped onto `DiffResult.requested_depth` — from every entry point that can set it — is now the same lowercase, `EVIDENCE_DEPTH_VALUES`-spelled form every downstream reader (`compute_analysis_assurance`, `validate_evidence_depth`, every JSON reporter) already assumes, regardless of the case a caller supplied at the validated API boundary. (2) `_graph_completeness()`'s asymmetry check now holds a strictly narrower invariant than the plain `!=` it replaced: two sides' confirmed-family sets differ *and*, for every family only one side confirms, that family is genuinely applicable (has something to examine) on the side lacking confirmation. A family inapplicable on one side by construction (per `_CONDITIONALLY_APPLICABLE_FAMILIES`'s predicate) is not evidence asymmetry there, while every other family, and this one family when it is applicable on both sides, keeps the prior round's `!=` behavior exactly.

<!-- Conditional — a menu, not a place to answer. GitHub hides comment
regions from the rendered description, and the checker ignores them for
exactly that reason: an answer nobody can see is not evidence. Copy the
rows the checker asks for OUT of this comment, above it:
- Real-dependency test:
- Malicious fixture + side-effect absence:
- Must-merge / must-not-merge pair:
- False-positive removed / real break preserved:
- Verdict, gate and exit code checked independently:
- Known unsupported cases:
-->

## Testing

- New regression tests for both findings: direct-API case-insensitive-depth propagation (fails against pre-fix code with a `ValueError`), unit-level and end-to-end `archive_graph` correct-inapplicability cases, and companion tests confirming a genuine same-family asymmetry (both sides have static-library inputs, only one side's pass confirmed) still correctly reads as asymmetric, plus a sanity check that an ordinary unconditional family (`call_graph`) is unaffected by the exemption.
- `ruff check`, `ruff format --check` (changed files), `mypy abicheck/` (0 new errors — matches the pre-existing 13 PyYAML-stub errors on `origin/main`), `pytest tests/test_analysis_assurance*.py`, and the full fast suite all pass; the fast suite's 20 failures are the same pre-existing, environment-only (unsupported castxml version, ADR-verified-commit staleness) failures present on `origin/main` before this change.
- `python scripts/check_ai_readiness.py`: identical to the `origin/main` baseline (no new findings) — kept `analysis_assurance.py` at exactly the 1500-line soft limit to avoid a new file-size WARN.
- Changelog fragment `changelog.d/20260814_183041_noreply_p0_4_analysis_assurance.md` amended with both fixes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017jAiyuYpVCdif4RqZpJ1mP)_