### PR TITLE
fix: close two evidence-crediting holes in the gates from #769

### DIFF
--- a/scripts/check_bugfix_test_contract.py
+++ b/scripts/check_bugfix_test_contract.py
@@ -152,10 +152,7 @@ _TRUST_BOUNDARY_PREFIXES = (".github/workflows/", ".github/actions/")
 
 #: Directory component that marks a test tree.
 _TEST_DIR = "tests"
-#: Basename shapes that mark a test module.
-_TEST_BASENAME_PREFIX = "test_"
-_TEST_BASENAME_SUFFIX = "_test.py"
-_TEST_BASENAMES = frozenset({"conftest.py"})
+
 #: Prose suffixes. A file under `tests/` with one of these is documentation,
 #: not an executable test or a fixture — editing `tests/CLAUDE.md` alongside a
 #: shipped-code fix must not satisfy "you changed a test" (Codex review).
@@ -543,34 +540,34 @@ def touches_shipped_code(paths: list[str]) -> bool:
 def is_test_path(path: str) -> bool:
     """Is *path* a test file?
 
-    Deliberately structural — a `tests/` **directory component**, or a test
-    **basename** — rather than a substring search for `test_` anywhere in the
-    path. The substring form matched shipped sources whose names merely contain
-    it, including `scripts/summarize_test_durations.py` and this checker itself
+    Deliberately structural — a `tests/` **directory component** — rather than
+    a substring search for `test_` anywhere in the path. The substring form
+    matched shipped sources whose names merely contain it, including
+    `scripts/summarize_test_durations.py` and this checker itself
     (`check_bugfix_test_contract.py`), so a fix editing only those satisfied
     the structural requirement with no test at all — passing exactly the case
     it exists to reject (Codex review).
+
+    A test **basename** outside any such directory used to count too, and no
+    longer does. `testpaths = ["tests"]` and the canonical command is `pytest
+    tests/`, so a `test_*.py`/`*_test.py` file elsewhere is never collected by
+    any lane — accepting it credited a file nothing runs (Codex review). The
+    one real file it matched proves the point:
+    `agent-evals/tasks/*/hidden_tests/test_*.py`, an eval fixture that the
+    test suite deliberately does not execute. Every directory named `tests`
+    in this repository *is* run by some lane (the root suite, the clang
+    plugin's, the layout tool's), so the directory rule needs no allowlist.
     """
     parts = PurePosixPath(path).parts
     if not parts:
         return False
-    name = parts[-1]
-    if _TEST_DIR in parts[:-1]:
-        # Inside a test tree, any file type can be test *data* (fixtures,
-        # golden snapshots) — only prose is excluded, and not under golden/.
-        is_prose = name.endswith(_DOC_SUFFIXES)
-        return not is_prose or _TEST_DATA_DIR in parts[:-1]
-    # Outside a test tree, the basename forms must be actual Python test
-    # modules: `docs/test_plan.md` and `examples/test_notes.txt` start with
-    # `test_` and are prose, and counting them satisfied the structural
-    # requirement with no executable test changed (Codex review).
-    if not name.endswith(".py"):
+    if _TEST_DIR not in parts[:-1]:
         return False
-    return (
-        name.startswith(_TEST_BASENAME_PREFIX)
-        or name.endswith(_TEST_BASENAME_SUFFIX)
-        or name in _TEST_BASENAMES
-    )
+    # Inside a test tree, any file type can be test *data* (fixtures, golden
+    # snapshots) — only prose is excluded, and not under golden/.
+    name = parts[-1]
+    is_prose = name.endswith(_DOC_SUFFIXES)
+    return not is_prose or _TEST_DATA_DIR in parts[:-1]
 
 
 def touches_tests(paths: list[str]) -> bool:

--- a/scripts/check_mutation_score.py
+++ b/scripts/check_mutation_score.py
@@ -239,6 +239,17 @@ def parse_removed_lines(diff_text: str) -> dict[str, set[int]]:
     return removed
 
 
+def pure_deletion_paths(diff_text: str) -> set[str]:
+    """Paths with at least one hunk that removes lines and adds none.
+
+    The narrower question behind "can an unresolvable base hide a failure".
+    A *modification* removes and adds in the same hunk, so its new side is
+    already attributed and the removed side adds nothing the gate needs. Only
+    a hunk with no new side at all has its evidence exclusively in the base.
+    """
+    return {path for path, old, new in _hunks(diff_text) if old[1] and not new[1]}
+
+
 def _hunks(diff_text: str) -> Iterator[tuple[str, tuple[int, int], tuple[int, int]]]:
     """`(path, (old_start, old_count), (new_start, new_count))` per hunk."""
     current: str | None = None
@@ -731,12 +742,34 @@ def main(argv: list[str] | None = None) -> int:
             # deleted guard has *all* of its evidence in the removed half, so
             # saying nothing here would let a gate that resolved none of it
             # print the same "OK" line as one that resolved all of it.
+            #
+            # Whether that is fatal depends on what the unresolved removals
+            # could have hidden. A removal in a module with no surviving
+            # mutant cannot hide a diff-scoped failure — there is no survivor
+            # to attribute — so warning is the honest answer. A removal in a
+            # module that *does* carry a survivor is a failed measurement:
+            # exiting 0 there is a pass the run never earned, whatever the
+            # warning says (Codex review).
+            at_risk = sorted(
+                {r.module_path for r in records if r.is_survivor}
+                & pure_deletion_paths(diff_text)
+            )
             print(
                 "mutation-score: WARNING — could not read the base revision "
                 f"({args.base_ref}), so lines this branch *removed* were not "
                 "attributed to any function. The diff-scoped result below "
                 "covers added and modified lines only."
             )
+            if at_risk:
+                print(
+                    "ERROR: those unattributed removals are in module(s) that "
+                    "carry surviving mutants, so a survivor in a function this "
+                    "branch gutted would go unreported: "
+                    + ", ".join(at_risk)
+                    + ". Fetch the base revision (the PR lane checks out with "
+                    "fetch-depth: 0) and re-run."
+                )
+                return 1
         n_funcs = sum(len(v) for v in touched.values())
         print(f"mutation-score: diff-scoped over {n_funcs} changed function(s)")
         if n_funcs:

--- a/scripts/check_mutation_score.py
+++ b/scripts/check_mutation_score.py
@@ -65,6 +65,7 @@ witness; see ``scripts/mutation_results.py``.
 from __future__ import annotations
 
 import argparse
+import functools
 import json
 import re
 import shutil
@@ -206,15 +207,15 @@ def parse_changed_lines(diff_text: str) -> dict[str, set[int]]:
     are answered separately by `parse_removed_lines`, against the base.
     """
     changed: dict[str, set[int]] = {}
-    for path, _old, new in _hunks(diff_text):
+    for _old_path, new_path, _old, new in _hunks(diff_text):
         start, count = new
-        if count:
-            changed.setdefault(path, set()).update(range(start, start + count))
+        if count and new_path is not None:
+            changed.setdefault(new_path, set()).update(range(start, start + count))
     return changed
 
 
-def parse_removed_lines(diff_text: str) -> dict[str, set[int]]:
-    """Map ``path -> *base-side* line numbers this diff removes.
+def parse_removed_lines(diff_text: str) -> dict[str, tuple[str, set[int]]]:
+    """Map ``key path -> (base-side path, base-side line numbers removed)``.
 
     Deleting a guard is one of the most direct ways to weaken a detector, so
     the removed lines have to reach the gate somehow — but they exist only in
@@ -226,51 +227,102 @@ def parse_removed_lines(diff_text: str) -> dict[str, set[int]]:
 
     Base-side numbers are not a guess — they are what the hunk header says —
     and resolving them against the base file's own AST answers exactly "which
-    function did this line live in". A deleted function resolves to its own
-    name, which no longer exists in the new tree and therefore matches no
-    mutant; a deleted line inside a surviving function resolves to that
-    function, which is the case worth catching.
+    function did this line live in".
+
+    Two paths, because a hunk can name two. The *base* path is the one to
+    read the removed lines out of (`--- a/...`, which git still emits for a
+    rename or a whole-file deletion, where the new side is a different name
+    or `/dev/null`). The *key* path is the one to attribute the result to —
+    the new name, because that is what a mutant key carries. Conflating them
+    meant a renamed module's removals were looked up under a name the base
+    does not have, answered `None`, and silently dropped (Codex, CodeRabbit).
     """
-    removed: dict[str, set[int]] = {}
-    for path, old, _new in _hunks(diff_text):
+    removed: dict[str, tuple[str, set[int]]] = {}
+    for old_path, new_path, old, _new in _hunks(diff_text):
         start, count = old
-        if count:
-            removed.setdefault(path, set()).update(range(start, start + count))
+        if not count or old_path is None:
+            continue
+        # A deleted file has no new name; key it by its old one. Nothing in
+        # the new tree carries mutants for it, so this normally matches
+        # nothing — but a `--results-file` saved from an earlier revision can
+        # still name it, and a whole deleted module having no entry at all is
+        # the one shape nothing downstream can notice (CodeRabbit).
+        key = new_path or old_path
+        removed.setdefault(key, (old_path, set()))[1].update(
+            range(start, start + count)
+        )
     return removed
 
 
 def pure_deletion_paths(diff_text: str) -> set[str]:
-    """Paths with at least one hunk that removes lines and adds none.
+    """Key paths with at least one hunk that removes lines and adds none.
 
     The narrower question behind "can an unresolvable base hide a failure".
     A *modification* removes and adds in the same hunk, so its new side is
     already attributed and the removed side adds nothing the gate needs. Only
     a hunk with no new side at all has its evidence exclusively in the base.
     """
-    return {path for path, old, new in _hunks(diff_text) if old[1] and not new[1]}
+    return {
+        (new_path or old_path)
+        for old_path, new_path, old, new in _hunks(diff_text)
+        if old[1] and not new[1] and (new_path or old_path)
+    }
 
 
-def _hunks(diff_text: str) -> Iterator[tuple[str, tuple[int, int], tuple[int, int]]]:
-    """`(path, (old_start, old_count), (new_start, new_count))` per hunk."""
-    current: str | None = None
+def unresolved_removals(
+    removed: dict[str, tuple[str, set[int]]],
+    read_base: Callable[[str], str | None] | None,
+) -> set[str]:
+    """Key paths whose removed lines could not be read out of the base.
+
+    Per path, not "is there a reader at all". A reader can exist and still
+    answer `None` for one path — a file absent from the merge base, an
+    unreadable blob — and keying the risk check on the reader alone let
+    exactly that case through as a silent skip (Codex, CodeRabbit).
+    """
+    return {
+        key
+        for key, (base_path, _lines) in removed.items()
+        if key.endswith(".py") and (read_base is None or read_base(base_path) is None)
+    }
+
+
+def _hunks(
+    diff_text: str,
+) -> Iterator[tuple[str | None, str | None, tuple[int, int], tuple[int, int]]]:
+    """`(old_path, new_path, (old_start, old_count), (new_start, new_count))`.
+
+    Either path is `None` when its side is `/dev/null` — an added file has no
+    old side, a deleted file no new side. Both are tracked because the two
+    sides answer different questions: the new path is what a mutant key
+    carries, the old path is where the removed lines can actually be read.
+
+    A deleted file's `+++ /dev/null` used to leave the *previous* file's name
+    in scope, so its `@@ -1,5 +0,0 @@` hunk was recorded against a file the
+    branch never touched (CodeRabbit review); resetting on `diff --git` and
+    tracking both sides explicitly removes that whole class.
+    """
+    old_path: str | None = None
+    new_path: str | None = None
     for line in diff_text.splitlines():
+        if line.startswith("diff --git "):
+            old_path = new_path = None
+            continue
+        if line.startswith("--- "):
+            target = line[4:].strip()
+            old_path = target[2:] if target.startswith("a/") else None
+            continue
         if line.startswith("+++ "):
             target = line[4:].strip()
-            # A deleted file's header is `+++ /dev/null`, which does not match
-            # `+++ b/` — so `current` kept pointing at the *previous* file and
-            # the deletion's `@@ -1,5 +0,0 @@` hunk was recorded against it.
-            # The diff-scoped gate then failed on a function the branch never
-            # touched (CodeRabbit review). The old `/dev/null` guard could
-            # never fire: it ran after the `b/` prefix had already been
-            # stripped.
-            current = target[2:] if target.startswith("b/") else None
+            new_path = target[2:] if target.startswith("b/") else None
             continue
-        if current is None:
+        if old_path is None and new_path is None:
             continue
         m = _HUNK.match(line)
         if m:
             yield (
-                current,
+                old_path,
+                new_path,
                 (int(m.group(1)), int(m.group(2)) if m.group(2) is not None else 1),
                 (int(m.group(3)), int(m.group(4)) if m.group(4) is not None else 1),
             )
@@ -279,16 +331,19 @@ def _hunks(diff_text: str) -> Iterator[tuple[str, tuple[int, int], tuple[int, in
 def changed_functions(
     changed: dict[str, set[int]],
     repo_root: Path,
-    removed: dict[str, set[int]] | None = None,
+    removed: dict[str, tuple[str, set[int]]] | None = None,
     read_base: Callable[[str], str | None] | None = None,
 ) -> dict[str, set[str]]:
     """Map ``path -> qualnames of functions this diff touched``.
 
     Two resolutions, against two different revisions: added and modified lines
     against the working tree, removed lines against *the base*, since that is
-    the only revision in which they exist. Without *read_base* the removed
-    half is simply not resolved — an honest gap the caller reports, rather
-    than a new-side guess that names the wrong function.
+    the only revision in which they exist. Which path each is read from and
+    which it is filed under can differ — see `parse_removed_lines`. Without
+    *read_base*, or for a path the base cannot answer for, the removed half
+    is simply not resolved — an honest gap the caller reports through
+    `unresolved_removals`, rather than a new-side guess naming the wrong
+    function.
     """
     out: dict[str, set[str]] = {}
     for path, lines in changed.items():
@@ -302,15 +357,17 @@ def changed_functions(
         if funcs:
             out[path] = funcs
     if removed and read_base is not None:
-        for path, lines in removed.items():
-            if not path.endswith(".py"):
+        for key_path, (base_path, lines) in removed.items():
+            if not key_path.endswith(".py"):
                 continue
-            base_source = read_base(path)
+            base_source = read_base(base_path)
             if base_source is None:
                 continue
             funcs = functions_covering_lines(base_source, lines)
             if funcs:
-                out.setdefault(path, set()).update(funcs)
+                # Filed under the *new* name: that is what a mutant key
+                # carries, even though the lines were read from the old one.
+                out.setdefault(key_path, set()).update(funcs)
     return out
 
 
@@ -333,6 +390,7 @@ def _base_reader(base_ref: str) -> Callable[[str], str | None] | None:
         return None
     base_sha = proc.stdout.strip()
 
+    @functools.cache
     def _read(path: str) -> str | None:
         shown = subprocess.run(  # noqa: S603 — fixed argv, no shell
             ["git", "show", f"{base_sha}:{path}"],
@@ -737,7 +795,12 @@ def main(argv: list[str] | None = None) -> int:
         touched = changed_functions(
             parse_changed_lines(diff_text), REPO_ROOT, removed, read_base
         )
-        if removed and read_base is None:
+        # Not `unresolved`: that name already holds the count of mutants
+        # that did not resolve, and it is written to the receipt further
+        # down. Shadowing it put a set of paths in that field (caught by the
+        # receipt's own test).
+        unresolved_paths = unresolved_removals(removed, read_base)
+        if unresolved_paths:
             # Not a warning about a corner case: a branch whose only edit is a
             # deleted guard has *all* of its evidence in the removed half, so
             # saying nothing here would let a gate that resolved none of it
@@ -752,13 +815,16 @@ def main(argv: list[str] | None = None) -> int:
             # warning says (Codex review).
             at_risk = sorted(
                 {r.module_path for r in records if r.is_survivor}
+                & unresolved_paths
                 & pure_deletion_paths(diff_text)
             )
             print(
-                "mutation-score: WARNING — could not read the base revision "
-                f"({args.base_ref}), so lines this branch *removed* were not "
-                "attributed to any function. The diff-scoped result below "
-                "covers added and modified lines only."
+                "mutation-score: WARNING — could not read "
+                + ", ".join(sorted(unresolved_paths))
+                + f" out of the base revision ({args.base_ref}), so lines "
+                "this branch *removed* from them were not attributed to any "
+                "function. The diff-scoped result below covers added and "
+                "modified lines only for those paths."
             )
             if at_risk:
                 print(

--- a/tests/test_bugfix_test_contract.py
+++ b/tests/test_bugfix_test_contract.py
@@ -29,6 +29,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import tomllib
 
 _PATH = (
     Path(__file__).resolve().parent.parent / "scripts" / "check_bugfix_test_contract.py"
@@ -528,11 +529,40 @@ class TestContentEvidence:
             "tests/conftest.py",
             "tests/canonical_identity_contract.py",
             "contrib/abicheck-clang-plugin/tests/test_x.py",
-            "foo/bar_test.py",
         ],
     )
     def test_real_test_paths_are_recognised(self, path: str) -> None:
         assert gate.is_test_path(path)
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            # `testpaths = ["tests"]` and the canonical command is `pytest
+            # tests/`, so a test-shaped basename outside a `tests` tree is
+            # never collected by any lane — crediting it accepted a file
+            # nothing runs (Codex review).
+            "foo/bar_test.py",
+            "scripts/test_helper.py",
+            # The one real file the fallback matched, and the clearest case:
+            # an agent-eval fixture the suite deliberately does not execute.
+            "agent-evals/tasks/add-change-kind-small/hidden_tests/test_x.py",
+        ],
+    )
+    def test_a_test_basename_outside_a_test_tree_is_not_collected(
+        self, path: str
+    ) -> None:
+        assert not gate.is_test_path(path)
+
+    def test_the_uncollected_fixture_is_really_uncollected(self) -> None:
+        """The rule above rests on a claim about this repository's own
+        configuration, so read it rather than restate it: anything outside
+        `testpaths` is not collected by the canonical command."""
+        config = tomllib.loads(
+            (Path(gate.__file__).resolve().parent.parent / "pyproject.toml").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert config["tool"]["pytest"]["ini_options"]["testpaths"] == ["tests"]
 
     @pytest.mark.parametrize(
         "path",

--- a/tests/test_mutation_score_gate.py
+++ b/tests/test_mutation_score_gate.py
@@ -1092,7 +1092,7 @@ def test_removed_lines_are_read_from_the_merge_base_not_the_new_file(
     touched = gate.changed_functions(
         {},
         tmp_path,
-        {"abicheck/diff_types.py": {5, 6}},
+        {"abicheck/diff_types.py": ("abicheck/diff_types.py", {5, 6})},
         gate._base_reader("origin/main"),
     )
     assert touched == {"abicheck/diff_types.py": {"removed"}}
@@ -1210,6 +1210,88 @@ def test_a_modification_is_not_treated_as_an_unattributable_removal(
     assert "unattributed removals" not in out
 
 
+def test_a_reader_that_answers_none_for_one_path_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A reader can exist and still not answer for one path.
+
+    Keying the risk check on `read_base is None` asked "is there a reader",
+    not "was this path resolved" — so a base that simply does not carry the
+    file (a rename, an unreadable blob) came back `None`, the removal was
+    skipped, and the survivor in the gutted function passed `--diff-scoped`
+    (Codex and CodeRabbit, independently).
+    """
+    (tmp_path / "abicheck").mkdir()
+    (tmp_path / "abicheck" / "diff_types.py").write_text(_SOURCE, encoding="utf-8")
+    monkeypatch.setattr(gate, "REPO_ROOT", tmp_path)
+    # Callable, and unhelpful — the shape the `is None` guard could not see.
+    _with_base(monkeypatch, {})
+    deletion_diff = _write(
+        tmp_path,
+        "d.diff",
+        "--- a/abicheck/diff_types.py\n+++ b/abicheck/diff_types.py\n@@ -2,1 +1,0 @@\n-    return 1\n",
+    )
+    results = _write(
+        tmp_path, "r.txt", "    abicheck.diff_types.x_alpha__mutmut_1: survived\n"
+    )
+    rc = gate.main(
+        [
+            "--results-file",
+            results,
+            "--baseline-file",
+            _baseline(tmp_path, {"abicheck/diff_types.py": 10}),
+            "--diff-scoped",
+            "--diff-file",
+            deletion_diff,
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 1, out
+    assert "abicheck/diff_types.py" in out
+
+
+def test_a_renamed_module_reads_its_removals_from_the_old_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The other half of the same conflation, and why it is not just a
+    fail-closed: a rename's removed lines *are* readable — under the old
+    name — and belong to the new one, which is what a mutant key carries."""
+    asked = _with_base(monkeypatch, {"abicheck/old_name.py": _SOURCE})
+    (tmp_path / "abicheck").mkdir()
+    (tmp_path / "abicheck" / "diff_types.py").write_text(_SOURCE, encoding="utf-8")
+    removed = gate.parse_removed_lines(
+        "diff --git a/abicheck/old_name.py b/abicheck/diff_types.py\n"
+        "--- a/abicheck/old_name.py\n+++ b/abicheck/diff_types.py\n"
+        "@@ -2,1 +1,0 @@\n-    return 1\n"
+    )
+    assert removed == {"abicheck/diff_types.py": ("abicheck/old_name.py", {2})}
+    touched = gate.changed_functions(
+        {}, tmp_path, removed, gate._base_reader("origin/main")
+    )
+    # Read from the old name, filed under the new one.
+    assert touched == {"abicheck/diff_types.py": {"alpha"}}
+    assert asked == ["abicheck/old_name.py"]
+    assert gate.unresolved_removals(removed, gate._base_reader("origin/main")) == set()
+
+
+def test_a_whole_file_deletion_is_still_a_pure_deletion(tmp_path: Path) -> None:
+    """`+++ /dev/null` has no new path at all, so keying on the new side alone
+    dropped a deleted module from the risk set entirely — the one shape with
+    nothing downstream to notice it (CodeRabbit)."""
+    diff = (
+        "diff --git a/abicheck/gone.py b/abicheck/gone.py\n"
+        "deleted file mode 100644\n"
+        "--- a/abicheck/gone.py\n+++ /dev/null\n"
+        "@@ -1,3 +0,0 @@\n-def f():\n-    return 1\n-\n"
+    )
+    assert gate.pure_deletion_paths(diff) == {"abicheck/gone.py"}
+    assert gate.parse_removed_lines(diff) == {
+        "abicheck/gone.py": ("abicheck/gone.py", {1, 2, 3})
+    }
+    # And it must not leak onto a neighbouring file in the same diff.
+    assert gate.parse_changed_lines(diff) == {}
+
+
 def test_pure_deletion_paths_separates_deletions_from_edits() -> None:
     """The predicate itself: only a hunk with no new side has its evidence
     exclusively in the base."""
@@ -1240,7 +1322,7 @@ def test_a_deleted_module_level_constant_keeps_module_scope(
     touched = gate.changed_functions(
         {},
         tmp_path,
-        {"abicheck/diff_types.py": {1}},
+        {"abicheck/diff_types.py": ("abicheck/diff_types.py", {1})},
         gate._base_reader("origin/main"),
     )
     assert touched == {"abicheck/diff_types.py": {gate.MODULE_SCOPE}}
@@ -1254,7 +1336,7 @@ def test_parse_removed_lines_reads_the_base_side_of_every_hunk() -> None:
         "@@ -5,4 +4,0 @@\n-a\n-b\n-c\n-d\n"
         "@@ -20,1 +17,1 @@\n-old\n+new\n"
     )
-    assert gate.parse_removed_lines(diff) == {"x.py": {5, 6, 7, 8, 20}}
+    assert gate.parse_removed_lines(diff) == {"x.py": ("x.py", {5, 6, 7, 8, 20})}
 
 
 def test_parse_removed_lines_ignores_pure_additions() -> None:

--- a/tests/test_mutation_score_gate.py
+++ b/tests/test_mutation_score_gate.py
@@ -1099,12 +1099,18 @@ def test_removed_lines_are_read_from_the_merge_base_not_the_new_file(
     assert asked == ["abicheck/diff_types.py"]
 
 
-def test_an_unreadable_base_says_so_instead_of_guessing(
+def test_an_unreadable_base_fails_closed_when_a_survivor_could_be_hidden(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """A branch whose only edit is a deletion has all of its evidence on the
     removed side, so an unresolvable base must not print the same OK line as a
-    fully resolved run."""
+    fully resolved run — and must not exit 0 either.
+
+    Warning and exiting 0 was the first version of this, and it was the same
+    can't-fail shape the whole gate exists to remove: the survivor in the
+    function the branch gutted goes unreported, and the run is green (Codex
+    review).
+    """
     (tmp_path / "abicheck").mkdir()
     (tmp_path / "abicheck" / "diff_types.py").write_text(_SOURCE, encoding="utf-8")
     monkeypatch.setattr(gate, "REPO_ROOT", tmp_path)
@@ -1117,7 +1123,7 @@ def test_an_unreadable_base_says_so_instead_of_guessing(
     results = _write(
         tmp_path, "r.txt", "    abicheck.diff_types.x_alpha__mutmut_1: survived\n"
     )
-    gate.main(
+    rc = gate.main(
         [
             "--results-file",
             results,
@@ -1128,7 +1134,91 @@ def test_an_unreadable_base_says_so_instead_of_guessing(
             deletion_diff,
         ]
     )
-    assert "WARNING" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert rc == 1, out
+    assert "WARNING" in out
+    assert "abicheck/diff_types.py" in out
+
+
+def test_an_unreadable_base_only_warns_when_nothing_could_be_hidden(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Negative control, and the reason the failure is conditional: an
+    unattributed removal in a module with no surviving mutant has nothing to
+    hide — there is no survivor to attribute — so failing there would block
+    branches on an absence of evidence that cannot matter."""
+    (tmp_path / "abicheck").mkdir()
+    (tmp_path / "abicheck" / "diff_types.py").write_text(_SOURCE, encoding="utf-8")
+    monkeypatch.setattr(gate, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(gate, "_base_reader", lambda base_ref: None)
+    deletion_diff = _write(
+        tmp_path,
+        "d.diff",
+        "--- a/abicheck/diff_types.py\n+++ b/abicheck/diff_types.py\n@@ -2,1 +1,0 @@\n-    return 1\n",
+    )
+    results = _write(
+        tmp_path, "r.txt", "    abicheck.diff_platform.x_other__mutmut_1: survived\n"
+    )
+    rc = gate.main(
+        [
+            "--results-file",
+            results,
+            "--baseline-file",
+            _baseline(tmp_path, {"abicheck/diff_platform.py": 10}),
+            "--diff-scoped",
+            "--diff-file",
+            deletion_diff,
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0, out
+    assert "WARNING" in out
+
+
+def test_a_modification_is_not_treated_as_an_unattributable_removal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Second negative control: every modified line is removed *and* added, so
+    keying the failure on removals alone would fail closed on an ordinary edit
+    whose new side is already attributed."""
+    (tmp_path / "abicheck").mkdir()
+    (tmp_path / "abicheck" / "diff_types.py").write_text(_SOURCE, encoding="utf-8")
+    monkeypatch.setattr(gate, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(gate, "_base_reader", lambda base_ref: None)
+    edit_diff = _write(
+        tmp_path,
+        "d.diff",
+        "--- a/abicheck/diff_types.py\n+++ b/abicheck/diff_types.py\n"
+        "@@ -2,1 +2,1 @@\n-    return 1\n+    return 2\n",
+    )
+    results = _write(
+        tmp_path, "r.txt", "    abicheck.diff_types.x_untouched__mutmut_1: survived\n"
+    )
+    rc = gate.main(
+        [
+            "--results-file",
+            results,
+            "--baseline-file",
+            _baseline(tmp_path, {"abicheck/diff_types.py": 10}),
+            "--diff-scoped",
+            "--diff-file",
+            edit_diff,
+        ]
+    )
+    out = capsys.readouterr().out
+    assert rc == 0, out
+    assert "unattributed removals" not in out
+
+
+def test_pure_deletion_paths_separates_deletions_from_edits() -> None:
+    """The predicate itself: only a hunk with no new side has its evidence
+    exclusively in the base."""
+    diff = (
+        "--- a/gone.py\n+++ b/gone.py\n@@ -5,4 +4,0 @@\n-a\n-b\n-c\n-d\n"
+        "--- a/edited.py\n+++ b/edited.py\n@@ -20,1 +20,1 @@\n-old\n+new\n"
+        "--- a/added.py\n+++ b/added.py\n@@ -3,0 +4,1 @@\n+x\n"
+    )
+    assert gate.pure_deletion_paths(diff) == {"gone.py"}
 
 
 def test_a_deleted_module_level_constant_keeps_module_scope(


### PR DESCRIPTION
## Summary

Two review findings that arrived on #769 after it was cut, and merged before they could land there. Both are the same shape: a gate crediting evidence that cannot exist.

## Motivation

**A test-shaped basename outside a `tests` tree counted as a regression test.** `testpaths = ["tests"]` and the canonical command is `pytest tests/`, so `foo/bar_test.py` is never collected by any lane — crediting it let a `fix:` PR satisfy the structural half of the bug-fix contract with a file nothing runs. The single real file the fallback matched makes the point better than a hypothetical: `agent-evals/tasks/*/hidden_tests/test_*.py`, an eval fixture the suite deliberately does not execute.

**An unresolvable base was a warning, and the run still exited 0.** With `--diff-scoped` on a deletion-only change, the removed function is absent from `touched`, so a survivor inside the function the branch gutted goes unreported — green for a measurement that never happened, which is exactly the shape the mutation gate exists to remove.

## Changes

- `is_test_path()` — dropped the outside-`tests/` basename fallback. Every directory named `tests` in this repository is executed by some lane (the root suite, the clang plugin's, the layout tool's), so the directory rule needs no allowlist. One test reads `testpaths` out of `pyproject.toml` rather than restating the configuration claim the rule rests on.
- `check_mutation_score.py` — an unattributable removal now fails the run **when it could hide something**: the removals are in a module that carries a surviving mutant. It still only warns when they are not, because a removal in a module with no survivor has nothing to hide, and failing there would block branches on an absence of evidence that cannot matter.
- Keyed on *pure* deletion hunks (`pure_deletion_paths()`), not removals in general: a modification removes and adds in the same hunk and its new side is already attributed, so keying on removals alone failed closed on ordinary edits.

## Verification

Each fix falsified by reverting it:

| Fix | Reverted to | Result |
|---|---|---|
| basename fallback removed | previous fallback | 3 path tests fail |
| fail-closed on at-risk removals | warn-and-exit-0 | survivor-at-risk test fails |
| pure-deletion keying | all removals | ordinary-modification control fails |

Two negative controls each: a module with no survivor (warns, exits 0) and an ordinary modification (no failure). 260 tests pass across the two gate suites; `ruff check`, `ruff format --check` and `check_ai_readiness.py` clean.

## Bug-fix test contract

- Bug class: a gate accepting evidence that cannot exist — an uncollected test file, and an unmeasurable diff reported as measured
- Publicly observable failure: `check_bugfix_test_contract.py` exits 0 for a `fix:` that changed only `foo/bar_test.py`; `check_mutation_score.py --diff-scoped` exits 0 on a deletion-only diff whose base is unreadable while a survivor sits in the deleted function
- Regression test fails on base: yes — `test_a_test_basename_outside_a_test_tree_is_not_collected` and `test_an_unreadable_base_fails_closed_when_a_survivor_could_be_hidden` both fail against the previous predicates
- Negative control: a module with no surviving mutant still only warns, and an ordinary modification is not treated as an unattributable removal — so neither fix can pass by failing on everything
- Public-surface test: yes — both go through `gate.main()` with real argv, not the internal predicates alone
- Axes covered: pure deletion, modification, pure addition; survivor in the same module vs. a different one; test basename inside a `tests` tree, outside one, and in the agent-eval fixture tree
- General invariant: a path is regression evidence only if some lane collects it, and a diff-scoped run exits 0 only when every removal that could carry a survivor was attributed to a function
- Known unsupported cases: a removal spanning several functions inside one mixed hunk is attributed through its new side only; the base-side half is consulted only for hunks with no new side at all

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — n/a, no `abicheck/` source changed
- [x] Docs updated if user-visible behaviour changed — the rules' own docstrings carry the reasoning
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rhf5cz7rTCDBtyFrT6MxG4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rhf5cz7rTCDBtyFrT6MxG4)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test detection to recognize only files collected from valid test directories.
  * Strengthened mutation checks to fail when pure deletions could hide surviving issues and the comparison baseline is unavailable.
  * Preserved non-fatal warnings when no relevant hidden issue is found.

* **Tests**
  * Expanded coverage for test-path validation, deletion detection, and mutation-score enforcement.
  * Added checks for repository test collection settings and common edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->