### PR TITLE
fix: name live flags in runtime hints, and guard compare's internal --write

### DIFF
--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1373,9 +1373,9 @@ def _embed_inline_source_side(
     if fmt is None:
         ignored = []
         if sources_raw:
-            ignored.append(f"--{label}-sources source tree")
+            ignored.append(f"--sources {label}= source tree")
         if build_info_raw:
-            ignored.append(f"raw --{label}-build-info")
+            ignored.append(f"raw --build-info {label}=")
         click.echo(
             f"Warning: {label} input {input_path} is a snapshot, not a native "
             f"binary; the {' and '.join(ignored)} is ignored (dump the binary "
@@ -1390,7 +1390,7 @@ def _embed_inline_source_side(
     # auto-bumped the depth).
     if collect_mode == "off":
         click.echo(
-            f"Warning: --{label}-sources/--{label}-build-info was given but the "
+            f"Warning: --sources {label}=/--build-info {label}= was given but the "
             "selected --depth collects no evidence; ignoring it. Use --depth "
             "build or --depth source to collect from it.",
             err=True,
@@ -1431,10 +1431,10 @@ def _embed_inline_source_side(
     ):
         raise click.UsageError(
             f"--depth source is incompatible with --ast-frontend hybrid for "
-            f"the --{label}-sources tree: L4 source-ABI replay has no "
+            f"the --sources {label}= tree: L4 source-ABI replay has no "
             "dual-backend hybrid extractor (unlike the L2 header-AST "
-            f"snapshot). Pass --{label}-ast-frontend castxml or "
-            f"--{label}-ast-frontend clang (or the unscoped --ast-frontend) "
+            f"snapshot). Pass --ast-frontend {label}=castxml or "
+            f"--ast-frontend {label}=clang (or an unsided --ast-frontend) "
             "for a --depth source compare."
         )
     # CLI-audit P2 ("business logic depends on Click-to-Click orchestration"):

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -224,12 +224,12 @@ def _resolve_compare_collect_mode(
     if old_sources is not None or new_sources is not None:
         return (
             resolve_dump_depth("source", "off"),
-            "source (inferred: --old-sources/--new-sources given, no --depth)",
+            "source (inferred: --sources old=/new= given, no --depth)",
         )
     if old_build_info is not None or new_build_info is not None:
         return (
             resolve_dump_depth("build", "off"),
-            "build (inferred: --old-build-info/--new-build-info given, no --depth)",
+            "build (inferred: --build-info old=/new= given, no --depth)",
         )
     return "off", "off (no --depth, no --sources/--build-info, no source.method)"
 

--- a/action/run.sh
+++ b/action/run.sh
@@ -273,16 +273,31 @@ _is_release_style_operand() {
 # present restores the older, always-correct "no PR_JSON at all" fallback
 # path instead.
 #
-# A simple substring/word-boundary check on the raw string, matching this
-# script's existing extra-args handling (`CMD+=($INPUT_EXTRA_ARGS)`, plain
-# word-splitting, not full shell quoting) -- good enough to catch the
-# documented flag spellings without parsing arbitrary quoting.
+# Answered by splitting the value the same way the command line itself does
+# rather than by matching the raw string. `CMD+=($INPUT_EXTRA_ARGS)` is an
+# unquoted expansion, so bash word-splits on IFS -- space, tab AND newline --
+# and a `extra-args: |` YAML literal block (or anything with a tab, or with
+# another argument before it) produces a real `--write` token that a
+# literal-space substring check does not see (Codex review). It then injected
+# ours anyway and lost to the user's, which is precisely the case this guard
+# exists to prevent. `set --` reuses that identical splitting, so the guard
+# and the argv can never disagree about what a token is; it also inherits the
+# same pathname expansion, deliberately, for the same reason.
+#
+# Still not full shell-quoting parsing: an exotically quoted `--write` evades
+# this, matching this script's existing plain word-splitting handling of
+# extra-args everywhere else.
 _extra_args_has_write_flag() {
-  case " ${INPUT_EXTRA_ARGS:-} " in
-    *' --write '* | *' --write='*)
-      return 0
-      ;;
-  esac
+  local _arg
+  # shellcheck disable=SC2086  # word-splitting is the point; see above.
+  set -- ${INPUT_EXTRA_ARGS:-}
+  for _arg in "$@"; do
+    case "$_arg" in
+      --write | --write=*)
+        return 0
+        ;;
+    esac
+  done
   return 1
 }
 

--- a/action/run.sh
+++ b/action/run.sh
@@ -1108,9 +1108,18 @@ elif [[ "$MODE" == "compare" ]]; then
     # (directory/package operands) rejects --write, so it's
     # skipped there too, falling back to the rerun path in
     # _maybe_post_pr_comment (Codex review).
+    #
+    # Also skipped when the user's own `extra-args` already carries
+    # `--write`, the same guard the scan branch below applies (Codex review):
+    # extra-args is appended *after* this, and Click honors the last
+    # occurrence, so ours would lose and leave $PR_JSON empty -- at which
+    # point _maybe_post_pr_comment reruns the whole comparison just to obtain
+    # JSON, doubling a potentially expensive analysis to produce a file this
+    # very injection existed to avoid rerunning for.
     if [[ "$FORMAT" != "json" ]] \
        && ! _is_release_style_operand "${INPUT_OLD_LIBRARY:-}" \
-       && ! _is_release_style_operand "${INPUT_NEW_LIBRARY:-}"; then
+       && ! _is_release_style_operand "${INPUT_NEW_LIBRARY:-}" \
+       && ! _extra_args_has_write_flag; then
       PR_JSON=$(mktemp "${RUNNER_TEMP:-/tmp}/abicheck-pr-json.XXXXXX")
       CMD+=(--write "json=$PR_JSON")
     fi

--- a/changelog.d/20260815_105000_claude_cli_cleanup_followups.md
+++ b/changelog.d/20260815_105000_claude_cli_cleanup_followups.md
@@ -1,0 +1,19 @@
+<!-- Follow-ups to #770, found by review after that PR merged. -->
+
+### Fixed
+
+- **Runtime messages no longer name removed side-prefixed flags.** The
+  `--depth source` + `--ast-frontend hybrid` rejection told the user to pass
+  `--old-ast-frontend castxml`, and three warnings described the operand as an
+  `--old-sources`/`--old-build-info` tree. `--ast-frontend`, `--sources` and
+  `--build-info` are all side-aware now, so following any of those hints
+  produced a second, unrelated unknown-option error; they name the live
+  `old=`/`new=` spellings.
+
+- **The Action's compare branch no longer injects a `--write` that loses.**
+  Its internal `--write json=$PR_JSON` is added before `extra-args`, and Click
+  honors the last occurrence, so a user's own `--write` left `$PR_JSON` empty
+  and the PR-comment step reran the whole comparison purely to obtain JSON --
+  doubling a potentially expensive analysis to produce the file that injection
+  exists to avoid rerunning for. Compare now applies the same
+  `_extra_args_has_write_flag` guard the scan branch already had.

--- a/changelog.d/20260815_105000_claude_cli_cleanup_followups.md
+++ b/changelog.d/20260815_105000_claude_cli_cleanup_followups.md
@@ -16,4 +16,8 @@
   and the PR-comment step reran the whole comparison purely to obtain JSON --
   doubling a potentially expensive analysis to produce the file that injection
   exists to avoid rerunning for. Compare now applies the same
-  `_extra_args_has_write_flag` guard the scan branch already had.
+  `_extra_args_has_write_flag` guard the scan branch already had, and that
+  guard now splits `extra-args` the same way `CMD+=($INPUT_EXTRA_ARGS)` does
+  instead of matching literal spaces -- an `extra-args: |` YAML literal block
+  puts a newline between arguments, which produces a real `--write` token the
+  old check could not see.

--- a/tests/test_action_run_sh_compare_pr_json_write.py
+++ b/tests/test_action_run_sh_compare_pr_json_write.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``action/run.sh``'s compare branch must not inject a losing ``--write``.
+
+Compare mode adds an internal ``--write json=$PR_JSON`` so the sticky PR
+comment can reuse this run's own analysis instead of re-invoking abicheck.
+``extra-args`` is appended *after* it and Click honors the last occurrence,
+so when the user's own ``extra-args`` already carries ``--write`` the
+injected one loses and ``$PR_JSON`` stays empty -- at which point
+``_maybe_post_pr_comment`` reruns the whole comparison purely to obtain
+JSON, doubling a potentially expensive analysis to produce the very file the
+injection existed to avoid rerunning for (Codex review).
+
+The scan branch already guarded this with ``_extra_args_has_write_flag``;
+compare did not. Driven through the real ``run.sh`` against a fake
+``abicheck`` on ``$PATH`` that records its own argv, so this proves what
+reaches the command line rather than what the script appears to intend.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+from _workflow_exec import bash_executable
+
+RUN_SH = Path(__file__).resolve().parents[1] / "action" / "run.sh"
+
+
+def _compare_argv(tmp_path: Path, env_extra: dict[str, str]) -> str:
+    """Run compare mode and return the argv the CLI stub actually received."""
+    fake_bin = tmp_path / "fakebin"
+    fake_bin.mkdir()
+    captured = tmp_path / "captured_argv.txt"
+    stub = fake_bin / "abicheck"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf \'%s\\n\' "$*" >> "{captured}"\n'
+        'echo \'{"verdict":"COMPATIBLE"}\'\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+    old_json = tmp_path / "old.json"
+    new_json = tmp_path / "new.json"
+    old_json.write_text("{}", encoding="utf-8")
+    new_json.write_text("{}", encoding="utf-8")
+
+    base_env = {k: v for k, v in os.environ.items() if not k.startswith("INPUT_")}
+    env = {
+        **base_env,
+        "PATH": f"{fake_bin}{os.pathsep}{base_env.get('PATH', '')}",
+        "INPUT_MODE": "compare",
+        "INPUT_OLD_LIBRARY": str(old_json),
+        "INPUT_NEW_LIBRARY": str(new_json),
+        "INPUT_FORMAT": "markdown",
+        "INPUT_ADD_JOB_SUMMARY": "false",
+        "INPUT_PR_COMMENT": "false",
+        "GITHUB_OUTPUT": str(tmp_path / "gh_output"),
+        "GITHUB_STEP_SUMMARY": str(tmp_path / "gh_summary"),
+        **env_extra,
+    }
+    result = subprocess.run(
+        [bash_executable(), str(RUN_SH)],
+        capture_output=True, text=True, env=env, cwd=tmp_path, check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert captured.is_file(), "abicheck stub was never invoked"
+    return captured.read_text(encoding="utf-8").strip()
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="action/run.sh not found")
+class TestCompareDoesNotInjectALosingWrite:
+    @pytest.mark.parametrize("spelling", ["--write json=mine.json", "--write=json=mine.json"])
+    def test_a_user_write_suppresses_the_internal_one(
+        self, tmp_path: Path, spelling: str
+    ) -> None:
+        # Both documented spellings, since the guard matches on the raw
+        # string and a separator-only difference would slip past a check
+        # written for just one of them.
+        argv = _compare_argv(tmp_path, {"INPUT_EXTRA_ARGS": spelling})
+        assert argv.count("--write") == 1, argv
+        assert "mine.json" in argv
+        # The injected one names a mktemp path under RUNNER_TEMP/tmp; its
+        # absence is the whole point.
+        assert "abicheck-pr-json" not in argv, argv
+
+    def test_without_a_user_write_the_internal_one_is_still_injected(
+        self, tmp_path: Path
+    ) -> None:
+        # The negative control: the guard must not disable the injection
+        # outright, or every non-JSON PR run pays for the rerun this exists
+        # to avoid.
+        argv = _compare_argv(tmp_path, {})
+        assert argv.count("--write") == 1, argv
+        assert "abicheck-pr-json" in argv, argv
+
+    def test_a_json_primary_still_injects_nothing(self, tmp_path: Path) -> None:
+        # Pre-existing behaviour, pinned here so the new guard cannot be
+        # mistaken for what suppresses this case.
+        argv = _compare_argv(tmp_path, {"INPUT_FORMAT": "json"})
+        assert "--write" not in argv, argv
+
+
+def test_both_branches_share_the_same_write_guard() -> None:
+    """compare and scan must not drift apart on this.
+
+    Only scan carried the guard, which is exactly how compare shipped
+    without it; asserting both call sites reference the shared helper keeps
+    a future edit to one from silently leaving the other behind.
+    """
+    text = RUN_SH.read_text(encoding="utf-8")
+    guarded = [
+        line for line in text.splitlines() if "_extra_args_has_write_flag" in line
+    ]
+    # One definition, one docstring cross-reference per branch, and two
+    # actual call sites -- assert on the calls specifically.
+    calls = [line for line in guarded if "! _extra_args_has_write_flag" in line]
+    assert len(calls) == 2, guarded

--- a/tests/test_action_run_sh_helpers.py
+++ b/tests/test_action_run_sh_helpers.py
@@ -281,6 +281,38 @@ class TestExtraArgsHasWriteFlag:
     def test_write_flag_at_the_end_of_extra_args(self) -> None:
         assert self._predicate("--verbose --write text=out.txt")
 
+    def _predicate_ansi_c(self, escaped: str) -> bool:
+        """Like :meth:`_predicate`, but *escaped* is passed through bash's
+        ``$'...'`` quoting so ``\\n``/``\\t`` become real whitespace.
+
+        Python's ``!r`` renders a newline as the two characters backslash-n,
+        and inside bash single quotes that stays two characters -- so the
+        plain helper cannot express the very input these cases are about.
+        """
+        return _run_predicate(
+            f"INPUT_EXTRA_ARGS=$'{escaped}' _extra_args_has_write_flag"
+        )
+
+    def test_write_after_a_newline(self) -> None:
+        # `extra-args: |` (a YAML literal block) is ordinary Action usage and
+        # puts a newline between arguments. `CMD+=($INPUT_EXTRA_ARGS)` splits
+        # on IFS -- space, tab AND newline -- so this really is a `--write`
+        # token on the command line; a literal-space substring check did not
+        # see it, injected ours anyway, and lost to the user's (Codex review).
+        assert self._predicate_ansi_c(r"--verbose\n--write text=out.txt")
+
+    def test_write_after_a_tab(self) -> None:
+        assert self._predicate_ansi_c(r"--verbose\t--write text=out.txt")
+
+    def test_write_as_the_only_arg_with_surrounding_newlines(self) -> None:
+        # A literal block usually ends with a trailing newline too.
+        assert self._predicate_ansi_c(r"\n--write text=out.txt\n")
+
+    def test_newline_separated_without_a_write_is_still_false(self) -> None:
+        # The negative control for the same splitting: newlines must not make
+        # the guard fire on their own.
+        assert not self._predicate_ansi_c(r"--verbose\n--gate-api-break")
+
     def test_does_not_false_positive_on_a_substring(self) -> None:
         # A flag merely containing "write" as a substring (not a real
         # standalone token) must not trip the detector.

--- a/tests/test_compare_dispatch.py
+++ b/tests/test_compare_dispatch.py
@@ -675,7 +675,7 @@ def test_embed_inline_source_rejects_hybrid_frontend_at_depth_source(
 
 
 def test_the_hybrid_rejection_names_only_live_flags(
-    tmp_path: Path, monkeypatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A recovery hint that names a removed flag is worse than none.
 

--- a/tests/test_compare_dispatch.py
+++ b/tests/test_compare_dispatch.py
@@ -674,6 +674,47 @@ def test_embed_inline_source_rejects_hybrid_frontend_at_depth_source(
     assert called["n"] == 0  # rejected before the inline dump ever runs
 
 
+def test_the_hybrid_rejection_names_only_live_flags(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A recovery hint that names a removed flag is worse than none.
+
+    The message told the user to pass ``--old-ast-frontend castxml`` /
+    ``--new-ast-frontend clang`` and described the operand as an
+    ``--old-sources`` tree. All three spellings are gone -- ``--ast-frontend``
+    and ``--sources`` are side-aware now -- so following the instruction
+    produced a second, unrelated unknown-option error (Codex review).
+    """
+    import abicheck.cli as climod
+    from abicheck.service_scan import CompileContext
+
+    tree = tmp_path / "src"
+    tree.mkdir()
+
+    class _Ctx:
+        def invoke(self, _cmd, **kwargs):  # type: ignore[no-untyped-def]
+            raise AssertionError("must not run the inline dump")
+
+    monkeypatch.setattr(climod, "_normalize_binary_input", lambda p: (Path(p), "elf"))
+    with pytest.raises(climod.click.UsageError) as excinfo:
+        climod._embed_inline_source_side(
+            _Ctx(), input_path=tmp_path / "lib.so", sources=tree,
+            headers=(), includes=(), version="1.0", lang="c++",
+            header_backend="hybrid", compile_context=CompileContext(),
+            frontend_explicit=True, nostdinc_explicit=False, build_info=None,
+            follow_deps=False, search_paths=(),
+            ld_library_path="", dwarf_only=False, debug_format=None,
+            pdb_path=None, collect_mode="source-target", out_dir=tmp_path,
+            label="old", depth="source",
+        )
+    msg = str(excinfo.value)
+    for dead in ("--old-ast-frontend", "--new-ast-frontend", "--old-sources"):
+        assert dead not in msg, msg
+    # ...and it still names a real way out, so the fix is not just deletion.
+    assert "--ast-frontend old=castxml" in msg, msg
+    assert "--sources old=" in msg, msg
+
+
 def test_embed_inline_source_hybrid_not_rejected_below_depth_source(
     tmp_path: Path, monkeypatch
 ) -> None:

--- a/tests/test_compare_dispatch.py
+++ b/tests/test_compare_dispatch.py
@@ -715,6 +715,92 @@ def test_the_hybrid_rejection_names_only_live_flags(
     assert "--sources old=" in msg, msg
 
 
+def _embed_side_capturing_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    *,
+    fmt: str | None,
+    collect_mode: str,
+    sources_raw: bool = True,
+    build_info_raw: bool = False,
+) -> str:
+    """Drive one ignored-evidence warning path and return what it printed."""
+    import abicheck.cli as climod
+    from abicheck.service_scan import CompileContext
+
+    tree = tmp_path / "src"
+    tree.mkdir()
+    db = tmp_path / "compile_commands.json"
+    db.write_text("[]", encoding="utf-8")
+
+    class _Ctx:
+        def invoke(self, _cmd, **kwargs):  # type: ignore[no-untyped-def]
+            raise AssertionError("must not reach the inline dump")
+
+    monkeypatch.setattr(climod, "_normalize_binary_input", lambda p: (Path(p), fmt))
+    climod._embed_inline_source_side(
+        _Ctx(), input_path=tmp_path / "old.json",
+        sources=tree if sources_raw else None,
+        headers=(), includes=(), version="1.0", lang="c++",
+        header_backend="castxml", compile_context=CompileContext(),
+        frontend_explicit=False, nostdinc_explicit=False,
+        build_info=db if build_info_raw else None,
+        follow_deps=False, search_paths=(),
+        ld_library_path="", dwarf_only=False, debug_format=None,
+        pdb_path=None, collect_mode=collect_mode, out_dir=tmp_path,
+        label="old", depth=None,
+    )
+    return capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("sources_raw", "build_info_raw", "expected"),
+    [
+        (True, False, "--sources old= source tree"),
+        (False, True, "raw --build-info old="),
+        (True, True, "--sources old= source tree and raw --build-info old="),
+    ],
+)
+def test_a_snapshot_input_names_the_live_spelling_of_what_it_ignored(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    sources_raw: bool,
+    build_info_raw: bool,
+    expected: str,
+) -> None:
+    """A snapshot operand ignores raw evidence and says so -- in live flags.
+
+    The warning named an `--old-sources` tree and a `raw --old-build-info`;
+    both spellings are gone (`--sources`/`--build-info` are side-aware now),
+    so a reader following the message to re-run with the evidence attached
+    hit an unknown option (Codex review, alongside the frontend hint).
+    """
+    err = _embed_side_capturing_warning(
+        tmp_path, monkeypatch, capsys,
+        fmt=None, collect_mode="source-target",
+        sources_raw=sources_raw, build_info_raw=build_info_raw,
+    )
+    assert expected in err, err
+    for dead in ("--old-sources", "--old-build-info"):
+        assert dead not in err, err
+
+
+def test_a_depth_that_collects_nothing_names_the_live_spelling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # The sibling path, same rewrite: --depth binary/headers resolves
+    # collect_mode to "off", so raw evidence is ignored with a note.
+    err = _embed_side_capturing_warning(
+        tmp_path, monkeypatch, capsys, fmt="elf", collect_mode="off",
+    )
+    assert "--sources old=/--build-info old= was given" in err, err
+    assert "--old-sources" not in err, err
+
+
 def test_embed_inline_source_hybrid_not_rejected_below_depth_source(
     tmp_path: Path, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Summary

Two review findings raised against #770's final commit that arrived after it merged, so they land here as a follow-up rather than an amendment — plus a third found by review of this PR.

## Motivation

Both original findings are cases where the hard cleanup removed a spelling but something that *names* that spelling was left behind — one in user-facing recovery hints, one in the Action's argv assembly.

A recovery instruction that cannot be followed is worse than no instruction: it costs the reader a second failed run before they learn nothing they were told was current. And an injected flag that silently loses to a user's own doesn't just get ignored — it makes the PR-comment step rerun the entire comparison.

## Changes

- **Runtime hints name only live flags.** The `--depth source` + `--ast-frontend hybrid` rejection told the user to pass `--old-ast-frontend castxml` / `--new-ast-frontend clang`; three warnings described the operand as an `--old-sources` / `--old-build-info` tree; and `compare`'s depth-inference reason string said `--old-sources/--new-sources given`. `--ast-frontend`, `--sources` and `--build-info` are all side-aware now, so every one of those produced a second, unrelated unknown-option error. They name the live `old=`/`new=` spellings. Review flagged the frontend pair; the `--sources`/`--build-info` spellings in the same message and in the reason string were found alongside them.

- **`action/run.sh`'s compare branch guards its internal `--write`.** It injects `--write json=$PR_JSON` so the sticky PR comment can reuse this run's analysis instead of re-invoking abicheck. `extra-args` is appended *after* it and Click honors the last occurrence, so a user's own `--write` left `$PR_JSON` empty and `_maybe_post_pr_comment` reran the whole comparison purely to obtain JSON — doubling a potentially expensive analysis to produce the very file the injection exists to avoid rerunning for. The scan branch already had `_extra_args_has_write_flag`; compare now applies it too.

- **That guard now splits `extra-args` on real IFS.** It matched literal-space boundaries on the raw string, but `CMD+=($INPUT_EXTRA_ARGS)` is an unquoted expansion and bash word-splits on space, tab **and newline** — so an `extra-args: |` YAML literal block produced a real `--write` token the guard could not see, injected ours anyway, and lost. It now reuses that identical splitting via `set --`, so the guard and the argv can never disagree about what a token is. Pre-existing on the scan branch; the compare branch inherited it on adopting the helper.

## Bug-fix test contract

- Bug class: a removed CLI spelling left behind in something that *names* it — a user-facing recovery hint, and an Action-assembled argv fragment whose position makes it lose to user input. Not unrelated typos: both are "the flag went away, the reference to it did not". The third is the same guard answering on a different tokenization than the command line it guards.
- Publicly observable failure: following the `--depth source` + hybrid rejection's own instruction exits 64 with `No such option: --old-ast-frontend`; and an Action compare step whose `extra-args` carries `--write` (on one line or as a YAML literal block) leaves `$PR_JSON` empty, so the PR-comment path re-runs the full comparison.
- Regression test fails on base: yes — `test_the_hybrid_rejection_names_only_live_flags`, 3 of the 5 cases in `tests/test_action_run_sh_compare_pr_json_write.py`, and the 3 new whitespace cases in `TestExtraArgsHasWriteFlag` each fail against the revision preceding their fix (verified by reverting each fix in place).
- Negative control: the hint test asserts the message still names a *real* way out (`--ast-frontend old=castxml`, `--sources old=`), so it cannot be satisfied by deleting the advice; `test_without_a_user_write_the_internal_one_is_still_injected` and `test_a_json_primary_still_injects_nothing` pass on base and after, so the guard cannot be satisfied by disabling the injection; `test_newline_separated_without_a_write_is_still_false` pins that newline splitting does not make the guard fire on its own.
- Public-surface test: the `--write` behaviour is driven through the real `action/run.sh` against a fake `abicheck` on `$PATH` that records its own argv — what reaches the command line, not what the script appears to intend.
- Axes covered: both documented `--write` spellings (`--write json=…` and `--write=json=…`); all three IFS whitespace characters (space, tab, newline) plus leading/trailing newlines; JSON vs non-JSON primary format; and both `_embed_inline_source_side` labels via the shared `{label}` interpolation.
- General invariant: `test_both_branches_share_the_same_write_guard` asserts compare and scan both reference `_extra_args_has_write_flag`, so a future edit to one cannot silently leave the other behind — which is exactly how compare shipped without it.
- Malicious fixture + side-effect absence: the `--write` tests **execute** `action/run.sh` for real rather than asserting its text — a fake `abicheck` on `$PATH` records the argv it was actually invoked with, and the assertions are on that argv (`argv.count("--write") == 1`, and the absence of the internal `abicheck-pr-json` mktemp path). The hostile-shaped input is the user-supplied `extra-args` string, exercised in the forms that defeat a naive text check: `--write=` rather than `--write `, and whitespace-separated variants including a YAML-literal-block newline. The side-effect asserted absent is the injected sidecar: when the user supplies their own `--write`, no `abicheck-pr-json` path appears on the command line at all, so no stray empty temp file is created and the guard is proven to have suppressed the injection rather than merely producing a tidier duplicate. The guard predicate itself is additionally executed directly (`TestExtraArgsHasWriteFlag`) against each whitespace form.
- Known unsupported cases: the guard performs the same plain word-splitting `run.sh` applies to `extra-args` everywhere else, not full shell-quoting parsing; an exotically quoted `--write` still evades it, as it evaded the pre-existing scan-side guard. It also inherits that expansion's pathname globbing, deliberately, so the guard and the argv stay in agreement.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added — `changelog.d/20260815_105000_claude_cli_cleanup_followups.md`
- [x] Docs updated if user-visible behaviour changed — n/a, no documented flag changed; only messages naming already-removed ones
- [ ] `pre-commit run --all-files` passes locally — `verify.py`'s `fmt-check` step fails identically on unmodified `main` here (the tree has never been `ruff format`-clean), so it is not a signal from this branch
- [x] No new `mypy` or `ruff` errors introduced

Verification: `ruff check abicheck/ tests/` clean, `python -m mypy abicheck/` clean (367 files), `bash -n action/run.sh` clean, and the CI-equivalent unit lane at **28177 passed, 2 failed** — both the pre-existing ADR `**Verified:**` receipt failures that fail identically on unmodified `main` in this environment, because the clone is shallow and those commits are not reachable from `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkoWr6uGQA7HBkfrGfDLbp