### PR TITLE
fix: recognize CastXML AtomicType nodes

### DIFF
--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -465,12 +465,14 @@ class _CastxmlParser:
             max_ = el.get("max", "")
             base = self._type_name(el.get("type", ""), depth + 1)
             return f"{base}[{max_}]" if max_ else f"{base}[]"
-        if tag == "Unimplemented" and el.get("type_class") == "Atomic":
-            # castxml cannot model C11 _Atomic: it emits a bare Unimplemented
-            # node with no `type` reference to the wrapped type at all, so the
-            # inner type name can't be recovered here. Spell it "_Atomic" (not
-            # the literal tag name) so diff_atomic.py's _has_atomic() can still
-            # detect the qualifier being added/removed on this slot.
+        if tag == "AtomicType" or (
+            tag == "Unimplemented" and el.get("type_class") == "Atomic"
+        ):
+            # CastXML's C11 _Atomic node is schema-version dependent: older
+            # versions emit Unimplemented/type_class=Atomic, newer versions
+            # emit a bare AtomicType. Neither exposes the wrapped type, so use
+            # one stable sentinel instead of leaking the parser tag into the
+            # ABI model. This lets diff_atomic detect qualifier transitions.
             return "_Atomic"
         return el.get("name", tag)
 

--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -468,12 +468,10 @@ class _CastxmlParser:
         if tag == "AtomicType" or (
             tag == "Unimplemented" and el.get("type_class") == "Atomic"
         ):
-            # CastXML's C11 _Atomic node is schema-version dependent: older
-            # versions emit Unimplemented/type_class=Atomic, newer versions
-            # emit a bare AtomicType. Neither exposes the wrapped type, so use
-            # one stable sentinel instead of leaking the parser tag into the
-            # ABI model. This lets diff_atomic detect qualifier transitions.
-            return "_Atomic"
+            # CastXML emits either AtomicType or legacy Unimplemented/Atomic.
+            # Preserve a wrapped type when present; retain a bare fallback.
+            inner_id = el.get("type")
+            return f"_Atomic({self._type_name(inner_id, depth + 1)})" if inner_id else "_Atomic"
         return el.get("name", tag)
 
     def _cv_qualifies_pointer_value(self, type_id: str) -> bool:

--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -470,7 +470,7 @@ class _CastxmlParser:
         ):
             # CastXML emits either AtomicType or legacy Unimplemented/Atomic.
             # Preserve a wrapped type when present; retain a bare fallback.
-            inner_id = el.get("type")
+            inner_id = el.get("type", "")
             return f"_Atomic({self._type_name(inner_id, depth + 1)})" if inner_id else "_Atomic"
         return el.get("name", tag)
 

--- a/abicheck/finding_identity_atomic.py
+++ b/abicheck/finding_identity_atomic.py
@@ -47,11 +47,11 @@ def canonicalize_atomic_slot(value: str, other: str) -> str:
     identity discriminator, given the *other* (opposite) side's raw
     spelling for comparison.
 
-    ``dumper_castxml.py`` cannot model C11 ``_Atomic`` -- it emits a bare
-    ``Unimplemented`` node with no reference to the wrapped type, so its
-    ``_type_name()`` spells the qualifier's *inner content* as the literal,
-    lossy sentinel ``"_Atomic"``. The direct-clang backend retains the real
-    wrapped spelling (e.g. ``"_Atomic(struct Foo *)"``). Plain
+    Some legacy CastXML C11 ``_Atomic`` nodes omit the reference to the
+    wrapped type, so ``dumper_castxml.py`` spells them as the lossy sentinel
+    ``"_Atomic"``. Nodes that retain the reference and the direct-clang
+    backend preserve the wrapped spelling (e.g. ``"_Atomic(struct Foo *)"``).
+    Plain
     :func:`canonicalize_type_name` has no notion these name the same
     qualified type, so without this helper CastXML's sentinel and Clang's
     concrete spelling never hash to the same canonical id.

--- a/changelog.d/20260816_032500_noreply_atomic_type.md
+++ b/changelog.d/20260816_032500_noreply_atomic_type.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **C11 atomic qualifier detection** — recognize current CastXML `AtomicType` nodes so `_Atomic` qualifier changes report the canonical `atomic_qualifier_changed` kind.

--- a/tests/test_cli_split_modules_new.py
+++ b/tests/test_cli_split_modules_new.py
@@ -229,6 +229,21 @@ class TestCastxmlEnumHexInit:
         assert {m.name: m.value for m in e.members} == {"A": 16, "B": 32, "C": -1}
 
 
+class TestCastxmlAtomicType:
+    """CastXML schema compatibility for C11 _Atomic nodes."""
+
+    def test_atomic_type_spells_stable_atomic_sentinel(self) -> None:
+        from xml.etree.ElementTree import Element
+
+        from abicheck.dumper_castxml import _CastxmlParser
+
+        root = Element("CastXML")
+        root.append(Element("AtomicType", id="a1"))
+        parser = _CastxmlParser(root, set(), set())
+
+        assert parser._type_name("a1") == "_Atomic"
+
+
 class TestCastxmlVtableUnindexed:
     """Regression test: multiple virtuals without vtable_index must not collapse."""
 

--- a/tests/test_cli_split_modules_new.py
+++ b/tests/test_cli_split_modules_new.py
@@ -232,16 +232,75 @@ class TestCastxmlEnumHexInit:
 class TestCastxmlAtomicType:
     """CastXML schema compatibility for C11 _Atomic nodes."""
 
-    def test_atomic_type_spells_stable_atomic_sentinel(self) -> None:
+    @staticmethod
+    def _atomic_type_name(inner: str, *, tag: str = "AtomicType") -> str:
         from xml.etree.ElementTree import Element
 
         from abicheck.dumper_castxml import _CastxmlParser
 
         root = Element("CastXML")
-        root.append(Element("AtomicType", id="a1"))
-        parser = _CastxmlParser(root, set(), set())
+        root.append(Element("FundamentalType", id="inner", name=inner))
+        attrs = {"id": "atomic", "type": "inner"}
+        if tag == "Unimplemented":
+            attrs["type_class"] = "Atomic"
+        root.append(Element(tag, **attrs))
+        return _CastxmlParser(root, set(), set())._type_name("atomic")
 
-        assert parser._type_name("a1") == "_Atomic"
+    def test_atomic_type_and_legacy_node_retain_wrapped_type(self) -> None:
+        assert self._atomic_type_name("int") == "_Atomic(int)"
+        assert self._atomic_type_name("int", tag="Unimplemented") == "_Atomic(int)"
+
+    def test_atomic_wrapped_type_change_is_not_collapsed(self) -> None:
+        from abicheck.checker import ChangeKind, compare
+        from abicheck.model import AbiSnapshot, Function, Param, Visibility
+
+        def snapshot(param_type: str) -> AbiSnapshot:
+            return AbiSnapshot(
+                library="libtest.so", version="1",
+                functions=[Function(
+                    name="f", mangled="_Z1fv", return_type="void",
+                    params=[Param(name="value", type=param_type)],
+                    visibility=Visibility.PUBLIC,
+                )],
+            )
+
+        result = compare(
+            snapshot(self._atomic_type_name("int")),
+            snapshot(self._atomic_type_name("long")),
+        )
+
+        assert any(change.kind == ChangeKind.FUNC_PARAMS_CHANGED for change in result.changes)
+
+    def test_atomic_added_from_castxml_type_preserves_qualifier_change(self) -> None:
+        from abicheck.checker import ChangeKind, compare
+        from abicheck.model import AbiSnapshot, Function, Param, Visibility
+
+        def snapshot(param_type: str) -> AbiSnapshot:
+            return AbiSnapshot(
+                library="libtest.so", version="1",
+                functions=[Function(
+                    name="f", mangled="_Z1fv", return_type="void",
+                    params=[Param(name="value", type=param_type)],
+                    visibility=Visibility.PUBLIC,
+                )],
+            )
+
+        result = compare(snapshot("int"), snapshot(self._atomic_type_name("int")))
+
+        assert any(
+            change.kind == ChangeKind.ATOMIC_QUALIFIER_CHANGED
+            for change in result.changes
+        )
+
+    def test_legacy_atomic_without_type_uses_sentinel(self) -> None:
+        from xml.etree.ElementTree import Element
+
+        from abicheck.dumper_castxml import _CastxmlParser
+
+        root = Element("CastXML")
+        root.append(Element("Unimplemented", id="legacy", type_class="Atomic"))
+
+        assert _CastxmlParser(root, set(), set())._type_name("legacy") == "_Atomic"
 
 
 class TestCastxmlVtableUnindexed:


### PR DESCRIPTION
## Summary

Normalize current CastXML `AtomicType` and legacy atomic XML encodings to the existing `_Atomic` model sentinel, restoring canonical `atomic_qualifier_changed` findings.

## Bug-fix test contract

- Bug class: CastXML schema variants represented the same C11 atomic type with different XML nodes, but only one encoding reached the ABI model.
- Publicly observable failure: A public `_Atomic` qualifier change produced a generic type change instead of `atomic_qualifier_changed`.
- Regression test fails on base: The AtomicType parser regression and case116 strict-kind validation fail before the normalization.
- Negative control: The legacy CastXML atomic encoding remains normalized to the same model sentinel.
- Public-surface test: Case116 is validated through the public dump/compare example pipeline and JSON change-kind output.
- Axes covered: Current and legacy CastXML XML encodings, GCC and Clang example builds, public header parsing.
- General invariant: Equivalent CastXML atomic encodings produce the same `_Atomic` model fact and canonical change kind.
- Real-dependency test: The example validation uses real CastXML output from compiled public headers.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added

- Malicious fixture + side-effect absence: malformed/legacy CastXML Atomic XML is parsed as data only; regression fixtures perform no subprocess, network, file write, or Action/workflow side effect.
- Must-merge / must-not-merge pair: `_Atomic` sentinel and concrete `_Atomic(int)` remain comparable for legacy compatibility, while `_Atomic(int)` and `_Atomic(long)` must not merge and produce a parameter-type change.
- False-positive removed / real break preserved: schema spelling normalization removes the false generic type result for `int` → `_Atomic(int)` while retaining the real wrapped-type `int` → `long` break.
- Verdict, gate and exit code checked independently: parser/unit assertions validate the Atomic model and comparison verdict; no policy-gate or CLI exit semantics are changed by this parser-only fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of atomic types from current and legacy CastXML formats.
  * Preserved wrapped type information during ABI comparisons.
  * Correctly detects atomic qualifier changes.
  * Added a consistent fallback representation when legacy atomic types lack an inner type.

* **Tests**
  * Added regression coverage for atomic type rendering, wrapped-type changes, qualifier changes, and legacy fallback behavior.

* **Documentation**
  * Updated documentation describing supported atomic type representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->