### PR TITLE
fix: recover calling convention from hybrid headers

### DIFF
--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -638,27 +638,11 @@ def _castxml_fallback_reason(
 def _configured_target_triple(
     gcc_options: str | None, gcc_option_tokens: tuple[str, ...], clang_bin: str
 ) -> str | None:
-    """Ask the configured Clang driver for the target used by this frontend.
-
-    Keep the pass-through flags in the precise order used by the header
-    frontend: the shell-style ``gcc_options`` precede literal repeatable
-    ``gcc_option_tokens``.  Delegating to Clang rather than interpreting
-    ``--target`` ourselves also honors driver configuration files and response
-    files, including their normal last-option-wins behavior.
-    """
-    cmd = [
-        clang_bin,
-        *split_gcc_options(gcc_options or ""),
-        *gcc_option_tokens,
-        "-print-target-triple",
-    ]
+    """Return the target reported by configured Clang and its pass-through flags."""
+    cmd = [clang_bin, *split_gcc_options(gcc_options or ""), *gcc_option_tokens, "-print-target-triple"]
     try:
         result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=10,
+            cmd, capture_output=True, text=True, check=False, timeout=10
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         log.warning("Could not probe effective Clang target: %s", exc)

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 from defusedxml import ElementTree as DefusedET
 
 from . import deadline, dumper_cache
-from ._compiler_options import has_explicit_cpp_std
+from ._compiler_options import has_explicit_cpp_std, split_gcc_options
 from .castxml_policy import evaluate_castxml_version
 from .dumper_ast_config import (
     _CPP_ONLY_PATTERNS as _CPP_ONLY_PATTERNS,
@@ -635,6 +635,26 @@ def _castxml_fallback_reason(
     return "castxml-direct-include-guard"
 
 
+def _configured_target_triple(
+    gcc_options: str | None, gcc_option_tokens: tuple[str, ...], clang_bin: str
+) -> str | None:
+    """Return the effective explicit clang target, else its probed default.
+
+    This is deliberately limited to target selection already supplied to the
+    frontend.  It gives declaration parsing enough context to discard an
+    explicit default ``ms_abi``/``sysv_abi`` spelling without guessing from
+    the machine running abicheck.
+    """
+    args = [*gcc_option_tokens, *split_gcc_options(gcc_options or "")]
+    target: str | None = None
+    for index, arg in enumerate(args):
+        if arg.startswith("--target="):
+            target = arg.partition("=")[2] or None
+        elif arg in ("--target", "-target") and index + 1 < len(args):
+            target = args[index + 1] or None
+    return target or _tool_identity_metadata(clang_bin).get("target_triple")
+
+
 def _header_ast_parser(
     headers: list[Path],
     extra_includes: list[Path],
@@ -706,6 +726,9 @@ def _header_ast_parser(
             exported_static,
             public_header_paths=public_header_paths,
             public_dir_paths=public_dir_paths,
+            target_triple=_configured_target_triple(
+                gcc_options, gcc_option_tokens, clang_bin
+            ),
         )
         stamped = cast(
             _ClangAstParser,

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -638,21 +638,36 @@ def _castxml_fallback_reason(
 def _configured_target_triple(
     gcc_options: str | None, gcc_option_tokens: tuple[str, ...], clang_bin: str
 ) -> str | None:
-    """Return the effective explicit clang target, else its probed default.
+    """Ask the configured Clang driver for the target used by this frontend.
 
-    This is deliberately limited to target selection already supplied to the
-    frontend.  It gives declaration parsing enough context to discard an
-    explicit default ``ms_abi``/``sysv_abi`` spelling without guessing from
-    the machine running abicheck.
+    Keep the pass-through flags in the precise order used by the header
+    frontend: the shell-style ``gcc_options`` precede literal repeatable
+    ``gcc_option_tokens``.  Delegating to Clang rather than interpreting
+    ``--target`` ourselves also honors driver configuration files and response
+    files, including their normal last-option-wins behavior.
     """
-    args = [*gcc_option_tokens, *split_gcc_options(gcc_options or "")]
-    target: str | None = None
-    for index, arg in enumerate(args):
-        if arg.startswith("--target="):
-            target = arg.partition("=")[2] or None
-        elif arg in ("--target", "-target") and index + 1 < len(args):
-            target = args[index + 1] or None
-    return target or _tool_identity_metadata(clang_bin).get("target_triple")
+    cmd = [
+        clang_bin,
+        *split_gcc_options(gcc_options or ""),
+        *gcc_option_tokens,
+        "-print-target-triple",
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        log.warning("Could not probe effective Clang target: %s", exc)
+        return None
+    if result.returncode:
+        log.warning("Could not probe effective Clang target: %s", result.stderr.strip())
+        return None
+    target = result.stdout.strip()
+    return target or None
 
 
 def _header_ast_parser(

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -575,7 +575,33 @@ def _clang_attr_arg_tokens(child: dict[str, Any]) -> list[str]:
     return args
 
 
-def _clang_contract_attributes(node: dict[str, Any]) -> list[str]:
+def _target_default_abi_attribute(target_triple: str | None) -> str | None:
+    """Return a known x86-64 target's explicit default ABI attribute.
+
+    ``ms_abi`` and ``sysv_abi`` are useful facts only when they select a
+    non-default calling convention.  Clang preserves an explicit spelling even
+    when it merely repeats the target default, which would otherwise make two
+    ABI-identical headers appear different.  Do not extrapolate from an
+    unknown target (or from another architecture): those targets may assign a
+    distinct meaning to the attributes and must retain the spelling.
+    """
+    if not target_triple:
+        return None
+    parts = target_triple.lower().split("-")
+    if not parts or parts[0] not in {"x86_64", "amd64"}:
+        return None
+    if "windows" in parts:
+        return "ms_abi"
+    if any(os_name in parts for os_name in (
+        "linux", "android", "darwin", "freebsd", "netbsd", "openbsd", "solaris",
+    )):
+        return "sysv_abi"
+    return None
+
+
+def _clang_contract_attributes(
+    node: dict[str, Any], *, target_triple: str | None = None
+) -> list[str]:
     """Normalized contract/calling-convention attributes of a decl node.
 
     Argument-bearing attributes keep their operands in the token
@@ -611,6 +637,13 @@ def _clang_contract_attributes(node: dict[str, Any]) -> list[str]:
                     rf"__attribute__\s*\(\(\s*{spelling}\s*\)\)", qualifiers
                 ):
                     tokens.add(spelling)
+    # An explicit spelling of the selected target's default is not an ABI
+    # selection.  Only normalize when the actual target is known; treating a
+    # host/default assumption as universal would erase real target-specific
+    # evidence from header-only scans.
+    default_abi = _target_default_abi_attribute(target_triple)
+    if default_abi is not None:
+        tokens.discard(default_abi)
     return sorted(tokens)
 
 
@@ -744,8 +777,13 @@ class _ClangAstParser:
         exported_static: set[str],
         public_header_paths: list[str] | None = None,
         public_dir_paths: list[str] | None = None,
+        target_triple: str | None = None,
     ) -> None:
         self._root = root
+        # May be unavailable for synthetic/unit ASTs or an unprobeable
+        # compiler.  In that case attribute spelling remains evidence rather
+        # than being normalized against an assumed host ABI.
+        self._target_triple = target_triple
         self._exported_dynamic = exported_dynamic
         self._exported_static = exported_static
         (
@@ -1341,7 +1379,9 @@ class _ClangAstParser:
                     # clang stamps "variadic": true on FunctionDecl; the
                     # qualtype spelling ("void (int, ...)") is the fallback.
                     is_variadic=bool(node.get("variadic")) or "..." in qualtype,
-                    contract_attributes=_clang_contract_attributes(node),
+                    contract_attributes=_clang_contract_attributes(
+                        node, target_triple=self._target_triple
+                    ),
                     exception_spec=_clang_exception_spec(quals),
                     deprecated=_clang_deprecated_message(node),
                     # G31 Phase C backend audit -- see _clang_method_is_override.

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -592,6 +592,18 @@ def _clang_contract_attributes(node: dict[str, Any]) -> list[str]:
             if arg_tokens:
                 token = f"{token}({','.join(arg_tokens)})"
             tokens.add(token)
+
+    # Clang's JSON AST does not consistently materialize MSABIAttr/SysVABIAttr
+    # children.  On current clang they are preserved only in FunctionDecl's
+    # ``qualType`` (for example ``void (int) __attribute__((ms_abi))``).
+    # Read those two calling-convention spellings from the compiler-produced
+    # type; this is deliberately narrow and complements, rather than replaces,
+    # attribute-node parsing above.
+    qual_type = node.get("type", {}).get("qualType", "")
+    if isinstance(qual_type, str):
+        for spelling in ("ms_abi", "sysv_abi"):
+            if re.search(rf"__attribute__\s*\(\(\s*{spelling}\s*\)\)", qual_type):
+                tokens.add(spelling)
     return sorted(tokens)
 
 

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -593,13 +593,24 @@ def _clang_contract_attributes(node: dict[str, Any]) -> list[str]:
                 token = f"{token}({','.join(arg_tokens)})"
             tokens.add(token)
 
-    # Current Clang JSON preserves these two ABI attributes only in qualType.
-    # This narrow fallback complements attribute-node parsing above.
-    qual_type = node.get("type", {}).get("qualType", "")
-    if isinstance(qual_type, str):
-        for spelling in ("ms_abi", "sysv_abi"):
-            if re.search(rf"__attribute__\s*\(\(\s*{spelling}\s*\)\)", qual_type):
-                tokens.add(spelling)
+    # Current Clang JSON sometimes preserves these two ABI attributes only in
+    # the function type.  Inspect only its *outer* trailing qualifiers: a
+    # whole-qualType search would incorrectly assign a callback parameter's
+    # (or a nested function return type's) convention to this declaration.
+    # A typedef can hide the effective function type in qualType, while clang
+    # provides its expanded spelling in desugaredQualType.
+    type_obj = node.get("type")
+    if isinstance(type_obj, dict):
+        effective_type = type_obj.get("desugaredQualType")
+        if not isinstance(effective_type, str) or not effective_type:
+            effective_type = type_obj.get("qualType")
+        if isinstance(effective_type, str):
+            qualifiers = _function_qualifiers(effective_type)
+            for spelling in ("ms_abi", "sysv_abi"):
+                if re.search(
+                    rf"__attribute__\s*\(\(\s*{spelling}\s*\)\)", qualifiers
+                ):
+                    tokens.add(spelling)
     return sorted(tokens)
 
 

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -68,6 +68,7 @@ from pathlib import Path
 from typing import Any
 
 from ._compiler_options import split_gcc_options
+from .dumper_clang_attributes import _clang_contract_attributes
 from .dumper_clang_expr import (  # noqa: F401  (some re-exported for tests)
     _SCOPE_NODE_KINDS,
     _canonical_expr,
@@ -624,9 +625,6 @@ def _function_qualifiers(qualtype: str) -> str:
                 j += 1
             return qualtype[j:]
     return ""
-
-
-from .dumper_clang_attributes import _clang_contract_attributes
 
 
 class _ClangAstParser:

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -513,140 +513,6 @@ def _is_noexcept_qualifier(quals: str) -> bool:
     return expr.strip() not in ("false", "0")
 
 
-#: clang attribute node kinds → normalized contract-attribute tokens (matching
-#: the castxml spellings so cross-frontend snapshots stay comparable).
-_CLANG_ATTR_TOKENS: dict[str, str] = {
-    "NoReturnAttr": "noreturn",
-    "C11NoReturnAttr": "noreturn",
-    "NonNullAttr": "nonnull",
-    "ReturnsNonNullAttr": "returns_nonnull",
-    "RestrictAttr": "malloc",
-    "FormatAttr": "format",
-    "FormatArgAttr": "format_arg",
-    "AllocSizeAttr": "alloc_size",
-    "AllocAlignAttr": "alloc_align",
-    "WarnUnusedResultAttr": "warn_unused_result",
-    "SentinelAttr": "sentinel",
-    "CDeclAttr": "cdecl",
-    "StdCallAttr": "stdcall",
-    "FastCallAttr": "fastcall",
-    "ThisCallAttr": "thiscall",
-    "VectorCallAttr": "vectorcall",
-    "MSABIAttr": "ms_abi",
-    "SysVABIAttr": "sysv_abi",
-    "RegparmAttr": "regparm",
-}
-
-
-def _clang_attr_arg_tokens(child: dict[str, Any]) -> list[str]:
-    """Ordered ABI-significant argument scalars of a clang attribute node.
-
-    clang ``-ast-dump=json`` nests an argument-bearing attribute's operands as
-    ``ConstantExpr`` / ``IntegerLiteral`` / ``StringLiteral`` children carrying
-    an evaluated ``value``. Collect those scalars in document order so the
-    normalized token keeps the same arguments castxml preserves — otherwise
-    ``nonnull(1)`` → ``nonnull(2)``, ``format(printf,1,2)`` → ``format(printf,2,3)``
-    or ``regparm(2)`` → ``regparm(3)`` would collapse to identical bare tokens
-    and the contract / calling-convention detectors would never fire (and the
-    two frontends would disagree). Once a node yields a ``value`` we do not
-    descend into it — clang wraps a literal inside its ``ConstantExpr`` with the
-    same value, so recursing would double-count it.
-    """
-    args: list[str] = []
-
-    def _walk(nodes: Any) -> None:
-        for sub in nodes or []:
-            if not isinstance(sub, dict):
-                continue
-            value = sub.get("value")
-            if isinstance(value, bool):
-                # JSON booleans are ints in Python; skip — not an ABI arg.
-                _walk(sub.get("inner", []))
-            elif isinstance(value, int):
-                args.append(str(value))
-            elif isinstance(value, str) and value:
-                # StringLiteral values arrive quoted (e.g. "printf"); strip them
-                # so the token matches castxml's bare-identifier spelling.
-                args.append(value.strip('"'))
-            else:
-                _walk(sub.get("inner", []))
-
-    _walk(child.get("inner", []))
-    return args
-
-
-def _target_default_abi_attribute(target_triple: str | None) -> str | None:
-    """Return a known x86-64 target's explicit default ABI attribute.
-
-    ``ms_abi`` and ``sysv_abi`` are useful facts only when they select a
-    non-default calling convention.  Clang preserves an explicit spelling even
-    when it merely repeats the target default, which would otherwise make two
-    ABI-identical headers appear different.  Do not extrapolate from an
-    unknown target (or from another architecture): those targets may assign a
-    distinct meaning to the attributes and must retain the spelling.
-    """
-    if not target_triple:
-        return None
-    parts = target_triple.lower().split("-")
-    if not parts or parts[0] not in {"x86_64", "amd64"}:
-        return None
-    if "windows" in parts:
-        return "ms_abi"
-    if any(os_name in parts for os_name in (
-        "linux", "android", "darwin", "freebsd", "netbsd", "openbsd", "solaris",
-    )):
-        return "sysv_abi"
-    return None
-
-
-def _clang_contract_attributes(
-    node: dict[str, Any], *, target_triple: str | None = None
-) -> list[str]:
-    """Normalized contract/calling-convention attributes of a decl node.
-
-    Argument-bearing attributes keep their operands in the token
-    (``nonnull(1)``, ``format(printf,1,2)``), matching the castxml frontend, so
-    an argument-only change is still a detectable contract change.
-    """
-    tokens: set[str] = set()
-    for child in node.get("inner", []) or []:
-        if not isinstance(child, dict):
-            continue
-        token = _CLANG_ATTR_TOKENS.get(str(child.get("kind", "")))
-        if token:
-            arg_tokens = _clang_attr_arg_tokens(child)
-            if arg_tokens:
-                token = f"{token}({','.join(arg_tokens)})"
-            tokens.add(token)
-
-    # Current Clang JSON sometimes preserves these two ABI attributes only in
-    # the function type.  Inspect only its *outer* trailing qualifiers: a
-    # whole-qualType search would incorrectly assign a callback parameter's
-    # (or a nested function return type's) convention to this declaration.
-    # A typedef can hide the effective function type in qualType, while clang
-    # provides its expanded spelling in desugaredQualType.
-    type_obj = node.get("type")
-    if isinstance(type_obj, dict):
-        effective_type = type_obj.get("desugaredQualType")
-        if not isinstance(effective_type, str) or not effective_type:
-            effective_type = type_obj.get("qualType")
-        if isinstance(effective_type, str):
-            qualifiers = _function_qualifiers(effective_type)
-            for spelling in ("ms_abi", "sysv_abi"):
-                if re.search(
-                    rf"__attribute__\s*\(\(\s*{spelling}\s*\)\)", qualifiers
-                ):
-                    tokens.add(spelling)
-    # An explicit spelling of the selected target's default is not an ABI
-    # selection.  Only normalize when the actual target is known; treating a
-    # host/default assumption as universal would erase real target-specific
-    # evidence from header-only scans.
-    default_abi = _target_default_abi_attribute(target_triple)
-    if default_abi is not None:
-        tokens.discard(default_abi)
-    return sorted(tokens)
-
-
 def _clang_exception_spec(quals: str) -> str:
     """The dynamic exception-specification spelling from trailing qualifiers.
 
@@ -758,6 +624,9 @@ def _function_qualifiers(qualtype: str) -> str:
                 j += 1
             return qualtype[j:]
     return ""
+
+
+from .dumper_clang_attributes import _clang_contract_attributes
 
 
 class _ClangAstParser:

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -593,12 +593,8 @@ def _clang_contract_attributes(node: dict[str, Any]) -> list[str]:
                 token = f"{token}({','.join(arg_tokens)})"
             tokens.add(token)
 
-    # Clang's JSON AST does not consistently materialize MSABIAttr/SysVABIAttr
-    # children.  On current clang they are preserved only in FunctionDecl's
-    # ``qualType`` (for example ``void (int) __attribute__((ms_abi))``).
-    # Read those two calling-convention spellings from the compiler-produced
-    # type; this is deliberately narrow and complements, rather than replaces,
-    # attribute-node parsing above.
+    # Current Clang JSON preserves these two ABI attributes only in qualType.
+    # This narrow fallback complements attribute-node parsing above.
     qual_type = node.get("type", {}).get("qualType", "")
     if isinstance(qual_type, str):
         for spelling in ("ms_abi", "sysv_abi"):

--- a/abicheck/dumper_clang_attributes.py
+++ b/abicheck/dumper_clang_attributes.py
@@ -8,18 +8,30 @@ import re
 from typing import Any
 
 
+def _follows_type_operator(qualtype: str, paren_index: int) -> bool:
+    """Whether a parenthesized group is a ``typeof``-like type operand."""
+    end = paren_index
+    while end > 0 and qualtype[end - 1].isspace():
+        end -= 1
+    start = end
+    while start > 0 and (qualtype[start - 1].isalnum() or qualtype[start - 1] == "_"):
+        start -= 1
+    return qualtype[start:end] in {
+        "decltype", "typeof", "__typeof", "__typeof__", "typeof_unqual",
+    }
+
+
 def _function_qualifiers(qualtype: str) -> str:
     """Return qualifiers after the outer function parameter list."""
     bracket = 0
-    start = -1
-    for idx, ch in enumerate(qualtype):
+    idx = 0
+    while idx < len(qualtype):
+        ch = qualtype[idx]
         if ch in "<[":
             bracket += 1
         elif ch in ">]":
             bracket = max(0, bracket - 1)
-        elif ch == "(" and bracket == 0 and start == -1:
-            start = idx
-            bracket += 1
+        elif ch == "(" and bracket == 0:
             depth = 1
             j = idx + 1
             while j < len(qualtype) and depth:
@@ -28,6 +40,9 @@ def _function_qualifiers(qualtype: str) -> str:
                 elif qualtype[j] == ")":
                     depth -= 1
                 j += 1
+            if _follows_type_operator(qualtype, idx):
+                idx = j
+                continue
             tail = qualtype[j:]
             # A FunctionDecl returning a pointer to function is rendered by
             # Clang as e.g. ``void (*(void))(int) __attribute__((ms_abi))``.
@@ -37,6 +52,7 @@ def _function_qualifiers(qualtype: str) -> str:
             if tail.lstrip().startswith("("):
                 return ""
             return tail
+        idx += 1
     return ""
 
 

--- a/abicheck/dumper_clang_attributes.py
+++ b/abicheck/dumper_clang_attributes.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
+
 def _function_qualifiers(qualtype: str) -> str:
     """Return qualifiers after the outer function parameter list."""
     bracket = 0
@@ -27,7 +28,15 @@ def _function_qualifiers(qualtype: str) -> str:
                 elif qualtype[j] == ")":
                     depth -= 1
                 j += 1
-            return qualtype[j:]
+            tail = qualtype[j:]
+            # A FunctionDecl returning a pointer to function is rendered by
+            # Clang as e.g. ``void (*(void))(int) __attribute__((ms_abi))``.
+            # The first parenthesized group is that declaration's parameter
+            # list; a following function suffix belongs to its *return type*,
+            # so an attribute after it must not be assigned to the declaration.
+            if tail.lstrip().startswith("("):
+                return ""
+            return tail
     return ""
 
 

--- a/abicheck/dumper_clang_attributes.py
+++ b/abicheck/dumper_clang_attributes.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+"""Clang JSON contract-attribute normalization helpers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+def _function_qualifiers(qualtype: str) -> str:
+    """Return qualifiers after the outer function parameter list."""
+    bracket = 0
+    start = -1
+    for idx, ch in enumerate(qualtype):
+        if ch in "<[":
+            bracket += 1
+        elif ch in ">]":
+            bracket = max(0, bracket - 1)
+        elif ch == "(" and bracket == 0 and start == -1:
+            start = idx
+            bracket += 1
+            depth = 1
+            j = idx + 1
+            while j < len(qualtype) and depth:
+                if qualtype[j] == "(":
+                    depth += 1
+                elif qualtype[j] == ")":
+                    depth -= 1
+                j += 1
+            return qualtype[j:]
+    return ""
+
+
+# clang attribute node kinds → normalized contract-attribute tokens (matching
+# the castxml spellings so cross-frontend snapshots stay comparable).
+_CLANG_ATTR_TOKENS: dict[str, str] = {
+    "NoReturnAttr": "noreturn",
+    "C11NoReturnAttr": "noreturn",
+    "NonNullAttr": "nonnull",
+    "ReturnsNonNullAttr": "returns_nonnull",
+    "RestrictAttr": "malloc",
+    "FormatAttr": "format",
+    "FormatArgAttr": "format_arg",
+    "AllocSizeAttr": "alloc_size",
+    "AllocAlignAttr": "alloc_align",
+    "WarnUnusedResultAttr": "warn_unused_result",
+    "SentinelAttr": "sentinel",
+    "CDeclAttr": "cdecl",
+    "StdCallAttr": "stdcall",
+    "FastCallAttr": "fastcall",
+    "ThisCallAttr": "thiscall",
+    "VectorCallAttr": "vectorcall",
+    "MSABIAttr": "ms_abi",
+    "SysVABIAttr": "sysv_abi",
+    "RegparmAttr": "regparm",
+}
+
+
+def _clang_attr_arg_tokens(child: dict[str, Any]) -> list[str]:
+    """Return ordered ABI-significant argument scalars from an attribute node."""
+    args: list[str] = []
+
+    def _walk(nodes: Any) -> None:
+        for sub in nodes or []:
+            if not isinstance(sub, dict):
+                continue
+            value = sub.get("value")
+            if isinstance(value, bool):
+                _walk(sub.get("inner", []))
+            elif isinstance(value, int):
+                args.append(str(value))
+            elif isinstance(value, str) and value:
+                args.append(value.strip('"'))
+            else:
+                _walk(sub.get("inner", []))
+
+    _walk(child.get("inner", []))
+    return args
+
+
+def _target_default_abi_attribute(target_triple: str | None) -> str | None:
+    """Return the explicit default ABI token for known x86-64 targets."""
+    if not target_triple:
+        return None
+    parts = target_triple.lower().split("-")
+    if not parts or parts[0] not in {"x86_64", "amd64"}:
+        return None
+    if "windows" in parts:
+        return "ms_abi"
+    if any(os_name in parts for os_name in (
+        "linux", "android", "darwin", "freebsd", "netbsd", "openbsd", "solaris",
+    )):
+        return "sysv_abi"
+    return None
+
+
+def _clang_contract_attributes(
+    node: dict[str, Any], *, target_triple: str | None = None
+) -> list[str]:
+    """Normalize Clang function contract/calling-convention attributes."""
+    tokens: set[str] = set()
+    for child in node.get("inner", []) or []:
+        if not isinstance(child, dict):
+            continue
+        token = _CLANG_ATTR_TOKENS.get(str(child.get("kind", "")))
+        if token:
+            arg_tokens = _clang_attr_arg_tokens(child)
+            if arg_tokens:
+                token = f"{token}({','.join(arg_tokens)})"
+            tokens.add(token)
+
+    type_obj = node.get("type")
+    if isinstance(type_obj, dict):
+        effective_type = type_obj.get("desugaredQualType")
+        if not isinstance(effective_type, str) or not effective_type:
+            effective_type = type_obj.get("qualType")
+        if isinstance(effective_type, str):
+            qualifiers = _function_qualifiers(effective_type)
+            for spelling in ("ms_abi", "sysv_abi"):
+                if re.search(
+                    rf"__attribute__\s*\(\(\s*{spelling}\s*\)\)", qualifiers
+                ):
+                    tokens.add(spelling)
+
+    default_abi = _target_default_abi_attribute(target_triple)
+    if default_abi is not None:
+        tokens.discard(default_abi)
+    return sorted(tokens)

--- a/abicheck/dumper_hybrid.py
+++ b/abicheck/dumper_hybrid.py
@@ -399,6 +399,23 @@ def _backfill_function_facts(
         )
         if value != getattr(f, attr):
             updates[attr] = value
+    # CastXML can omit GNU x86-64 ABI attributes from its ``attributes``
+    # string even though clang's AST records them. These are parameter-
+    # passing facts, so retain the clang evidence on the CastXML-primary
+    # declaration rather than losing it during the hybrid merge. Deliberately
+    # limit this to the two attributes CastXML drops: the rest of the contract
+    # attributes remain CastXML-owned as documented for this merge.
+    if clang_f is not None and clang_f.contract_attributes is not None:
+        clang_cc = {
+            attr
+            for attr in clang_f.contract_attributes
+            if attr.split("(", 1)[0] in {"ms_abi", "sysv_abi"}
+        }
+        if clang_cc:
+            own_attrs = f.contract_attributes or []
+            merged_attrs = sorted(set(own_attrs) | clang_cc)
+            if merged_attrs != f.contract_attributes:
+                updates["contract_attributes"] = merged_attrs
     # ELF-sourced facts (elf_binding/elf_visibility) are independent of
     # which AST backend produced the declaration -- both backends'
     # dumper_elf_symbols._populate_elf_visibility reads the same .dynsym

--- a/abicheck/dumper_hybrid.py
+++ b/abicheck/dumper_hybrid.py
@@ -108,6 +108,7 @@ whole purpose is recovering an alias a single backend alone would miss.
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
@@ -133,6 +134,9 @@ from .name_classification import canonicalize_type_name
 
 _CTOR_MARKER = "{ctor}"
 _DTOR_MARKER = "{dtor}"
+_CALLING_CONVENTION_ATTRIBUTES = frozenset({"ms_abi", "sysv_abi"})
+
+log = logging.getLogger(__name__)
 
 
 def _backfill_fact(
@@ -400,22 +404,40 @@ def _backfill_function_facts(
         if value != getattr(f, attr):
             updates[attr] = value
     # CastXML can omit GNU x86-64 ABI attributes from its ``attributes``
-    # string even though clang's AST records them. These are parameter-
-    # passing facts, so retain the clang evidence on the CastXML-primary
-    # declaration rather than losing it during the hybrid merge. Deliberately
-    # limit this to the two attributes CastXML drops: the rest of the contract
-    # attributes remain CastXML-owned as documented for this merge.
+    # string even though clang's AST records them.  Backfill only when the
+    # CastXML declaration captured attributes and has *no* calling-convention
+    # claim.  Never union incompatible conventions: one function cannot be
+    # both ms_abi and sysv_abi, and the TU merger rejects that contradiction.
+    # Keep the CastXML-primary value on a disagreement and warn, rather than
+    # silently manufacturing an impossible ABI or selecting clang as an
+    # undocumented override.
     if clang_f is not None and clang_f.contract_attributes is not None:
+        own_attrs = f.contract_attributes or []
+        own_cc = {
+            attr
+            for attr in own_attrs
+            if attr.split("(", 1)[0] in _CALLING_CONVENTION_ATTRIBUTES
+        }
         clang_cc = {
             attr
             for attr in clang_f.contract_attributes
-            if attr.split("(", 1)[0] in {"ms_abi", "sysv_abi"}
+            if attr.split("(", 1)[0] in _CALLING_CONVENTION_ATTRIBUTES
         }
-        if clang_cc:
-            own_attrs = f.contract_attributes or []
-            merged_attrs = sorted(set(own_attrs) | clang_cc)
-            if merged_attrs != f.contract_attributes:
-                updates["contract_attributes"] = merged_attrs
+        cc_key = func_fact_key(f.mangled, "calling_convention")
+        if not own_cc and clang_cc:
+            updates["contract_attributes"] = sorted(set(own_attrs) | clang_cc)
+            provenance[cc_key] = "clang"
+        elif own_cc and clang_cc and own_cc != clang_cc:
+            provenance[cc_key] = "castxml"
+            log.warning(
+                "hybrid calling-convention conflict for %s: castxml=%s, clang=%s; "
+                "keeping castxml evidence",
+                f.mangled,
+                sorted(own_cc),
+                sorted(clang_cc),
+            )
+        elif own_cc:
+            provenance[cc_key] = "castxml"
     # ELF-sourced facts (elf_binding/elf_visibility) are independent of
     # which AST backend produced the declaration -- both backends'
     # dumper_elf_symbols._populate_elf_visibility reads the same .dynsym

--- a/changelog.d/20260816_031700_noreply_hybrid_calling_convention.md
+++ b/changelog.d/20260816_031700_noreply_hybrid_calling_convention.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Hybrid header calling-convention recovery** — preserve Clang `ms_abi` and `sysv_abi` declarations when CastXML omits them, so header-backed comparisons report ABI convention changes.

--- a/tests/test_clang_header_backend_integration.py
+++ b/tests/test_clang_header_backend_integration.py
@@ -29,6 +29,7 @@ Gated on clang + g++ being present; skipped otherwise.
 
 from __future__ import annotations
 
+import platform
 import shutil
 import subprocess
 import sys
@@ -208,6 +209,65 @@ def test_clang_and_castxml_snapshots_agree_on_public_surface(
         "Widget",
     }
     assert {e.name for e in clang_snap.enums} == {e.name for e in castxml_snap.enums}
+
+
+def test_hybrid_headers_recover_case64_ms_abi_from_gcc_debug_build(
+    tmp_path: Path,
+) -> None:
+    """Header evidence closes GCC's missing DWARF calling-convention record.
+
+    GCC's ``-g`` output on x86-64 does not record ``ms_abi`` as
+    ``DW_AT_calling_convention``.  The binary-only result must therefore stay
+    unchanged; with the same public headers, hybrid parsing retains clang's
+    AST evidence when CastXML omits the attribute.
+    """
+    if platform.machine().lower() not in {"x86_64", "amd64"}:
+        pytest.skip("ms_abi case is x86-64-specific")
+    if not (_have("gcc") and _have("clang") and _have("castxml")):
+        pytest.skip("gcc, clang, and castxml are required for the hybrid case64 regression")
+
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+    old_header = old_dir / "api.h"
+    new_header = new_dir / "api.h"
+    old_header.write_text("void api(int value);\n")
+    new_header.write_text("__attribute__((ms_abi)) void api(int value);\n")
+    old_src = old_dir / "api.c"
+    new_src = new_dir / "api.c"
+    old_src.write_text('#include "api.h"\nvoid api(int value) { (void)value; }\n')
+    new_src.write_text(
+        '#include "api.h"\n'
+        '__attribute__((ms_abi)) void api(int value) { (void)value; }\n'
+    )
+    old_so = old_dir / "libapi.so"
+    new_so = new_dir / "libapi.so"
+    for source, output, include_dir in (
+        (old_src, old_so, old_dir),
+        (new_src, new_so, new_dir),
+    ):
+        subprocess.run(
+            [
+                "gcc", "-g", "-shared", "-fPIC", "-o", str(output),
+                str(source), f"-I{include_dir}",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+    old_snap = dump(old_so, [old_header], compiler="cc", header_backend="hybrid")
+    new_snap = dump(new_so, [new_header], compiler="cc", header_backend="hybrid")
+    # GCC records only the default DWARF convention on both sides; the
+    # ms_abi delta must therefore come from the header AST, not ELF/DWARF.
+    assert old_snap.dwarf_advanced.calling_conventions == {"api": "normal"}
+    assert new_snap.dwarf_advanced.calling_conventions == {"api": "normal"}
+
+    result = compare(old_snap, new_snap)
+
+    assert [change.kind for change in result.changes] == [
+        ChangeKind.CALLING_CONVENTION_CHANGED
+    ]
 
 
 def test_clang_backend_still_false_positives_case61_alignment_risk(

--- a/tests/test_clang_header_backend_integration.py
+++ b/tests/test_clang_header_backend_integration.py
@@ -38,7 +38,8 @@ from pathlib import Path
 import pytest
 
 from abicheck.checker import ChangeKind, Verdict, compare
-from abicheck.dumper import dump
+from abicheck.dumper import _clang_header_dump, dump
+from abicheck.dumper_clang import _ClangAstParser
 from abicheck.model import Visibility
 
 # Scoped to **Linux/ELF** — the clang L2 backend's target (P1: clang-only Linux
@@ -92,6 +93,21 @@ void scale(Point* p, double factor) { p->x = int(p->x * factor); }
 int Widget::value() const { return hidden_; }
 }  // namespace lib
 """
+
+
+def test_clang_ast_does_not_assign_returned_callback_abi_to_factory(tmp_path: Path) -> None:
+    """Use Clang's real normalized AST spelling, not a hand-written fixture."""
+    if shutil.which("clang") is None or platform.machine().lower() not in {"x86_64", "amd64"}:
+        pytest.skip("requires an x86-64 clang frontend")
+    header = tmp_path / "api.h"
+    header.write_text(
+        "void (__attribute__((ms_abi)) *factory(void))(int);\n", encoding="utf-8"
+    )
+
+    root, _ = _clang_header_dump([header], [], compiler="clang", lang="C")
+    (factory,) = _ClangAstParser(root, {"factory"}, set()).parse_functions()
+
+    assert factory.contract_attributes == []
 
 
 def _have(tool: str) -> bool:

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -156,7 +156,7 @@ def test_parse_functions_preserves_x86_64_abi_attributes(
     assert fn.contract_attributes == [expected]
 
 
-def test_parse_functions_recovers_ms_abi_from_qual_type_when_attr_node_is_omitted() -> None:
+def test_parse_functions_recovers_outer_ms_abi_from_qual_type_when_attr_node_is_omitted() -> None:
     root = _tu(
         {
             "kind": "FunctionDecl",
@@ -171,6 +171,81 @@ def test_parse_functions_recovers_ms_abi_from_qual_type_when_attr_node_is_omitte
     (fn,) = _ClangAstParser(root, {"api"}, set()).parse_functions()
 
     assert fn.contract_attributes == ["ms_abi"]
+
+
+def test_parse_functions_does_not_claim_nested_callback_abi_attribute() -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl",
+            "name": "api",
+            "loc": {"file": "include/api.h", "line": 3},
+            "mangledName": "api",
+            "type": {
+                "qualType": "void (void (*)(int) __attribute__((ms_abi)))"
+            },
+            "inner": [],
+        }
+    )
+
+    (fn,) = _ClangAstParser(root, {"api"}, set()).parse_functions()
+
+    assert fn.contract_attributes == []
+
+
+def test_parse_functions_does_not_claim_nested_return_function_abi_attribute() -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl",
+            "name": "factory",
+            "loc": {"file": "include/api.h", "line": 3},
+            "mangledName": "factory",
+            "type": {
+                "qualType": "void (__attribute__((sysv_abi)) *())()"
+            },
+            "inner": [],
+        }
+    )
+
+    (fn,) = _ClangAstParser(root, {"factory"}, set()).parse_functions()
+
+    assert fn.contract_attributes == []
+
+
+def test_parse_functions_uses_desugared_outer_type_for_typedef_abi_attribute() -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl",
+            "name": "api",
+            "loc": {"file": "include/api.h", "line": 3},
+            "mangledName": "api",
+            "type": {
+                "qualType": "ApiFn",
+                "desugaredQualType": "void (int) __attribute__((sysv_abi))",
+            },
+            "inner": [],
+        }
+    )
+
+    (fn,) = _ClangAstParser(root, {"api"}, set()).parse_functions()
+
+    assert fn.contract_attributes == ["sysv_abi"]
+
+
+def test_parse_functions_does_not_normalize_unknown_platform_cc_spelling() -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl",
+            "name": "api",
+            "loc": {"file": "include/api.h", "line": 3},
+            "mangledName": "api",
+            "type": {"qualType": "void () __attribute__((cdecl))"},
+            "inner": [],
+        }
+    )
+
+    (fn,) = _ClangAstParser(root, {"api"}, set()).parse_functions()
+
+    assert fn.contract_attributes == []
 
 
 def test_parse_functions_ignores_non_string_qual_type_for_abi_fallback() -> None:

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -23,6 +23,7 @@ the live ``clang -ast-dump=json`` run live in the integration lane
 
 from __future__ import annotations
 
+import shutil
 import time
 from pathlib import Path
 from typing import Any
@@ -34,6 +35,7 @@ from abicheck.dumper import (
     _auto_system_includes_enabled,
     _build_clang_header_command,
     _clang_header_dump,
+    _configured_target_triple,
     _header_ast_parser,
     _needs_sycl_host_only,
     _parse_gnu_include_search_dirs,
@@ -209,6 +211,57 @@ def test_parse_functions_does_not_claim_nested_return_function_abi_attribute() -
     (fn,) = _ClangAstParser(root, {"factory"}, set()).parse_functions()
 
     assert fn.contract_attributes == []
+
+
+def test_parse_functions_does_not_claim_real_clang_returned_callback_abi_spelling() -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl",
+            "name": "factory",
+            "loc": {"file": "include/api.h", "line": 3},
+            "mangledName": "factory",
+            # This is the real Clang JSON AST spelling for:
+            # void (__attribute__((ms_abi)) *factory(void))(int);
+            "type": {
+                "qualType": "void (*(void))(int) __attribute__((ms_abi))"
+            },
+            "inner": [],
+        }
+    )
+
+    (fn,) = _ClangAstParser(root, {"factory"}, set()).parse_functions()
+
+    assert fn.contract_attributes == []
+
+
+def test_configured_target_triple_uses_frontend_option_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _run(cmd: list[str], **kwargs: object) -> object:
+        captured["cmd"] = cmd
+        return type("Result", (), {"returncode": 0, "stdout": "x86_64-pc-linux-gnu\n"})()
+
+    monkeypatch.setattr(dumper.subprocess, "run", _run)
+
+    assert _configured_target_triple(
+        "--target=first -DFROM_OPTIONS", ("--target=last", "@flags.rsp"), "clang"
+    ) == "x86_64-pc-linux-gnu"
+    assert captured["cmd"] == [
+        "clang", "--target=first", "-DFROM_OPTIONS", "--target=last", "@flags.rsp",
+        "-print-target-triple",
+    ]
+
+
+def test_configured_target_triple_honors_clang_response_file(tmp_path: Path) -> None:
+    clang = shutil.which("clang")
+    if clang is None:
+        pytest.skip("requires clang")
+    response = tmp_path / "target.rsp"
+    response.write_text("--target=x86_64-pc-windows-msvc\n", encoding="utf-8")
+
+    assert _configured_target_triple(None, (f"@{response}",), clang) == (
+        "x86_64-pc-windows-msvc"
+    )
 
 
 def test_parse_functions_uses_desugared_outer_type_for_typedef_abi_attribute() -> None:

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -231,14 +231,16 @@ def test_parse_functions_uses_desugared_outer_type_for_typedef_abi_attribute() -
     assert fn.contract_attributes == ["sysv_abi"]
 
 
-def test_parse_functions_does_not_normalize_unknown_platform_cc_spelling() -> None:
+def test_parse_functions_does_not_make_ignored_attribute_spelling_a_fact() -> None:
     root = _tu(
         {
             "kind": "FunctionDecl",
             "name": "api",
             "loc": {"file": "include/api.h", "line": 3},
             "mangledName": "api",
-            "type": {"qualType": "void () __attribute__((cdecl))"},
+            # Clang drops unknown/ignored spellings from its AST type.  The
+            # fallback must only recognize its two supported ABI spellings.
+            "type": {"qualType": "void () __attribute__((unknown_thing))"},
             "inner": [],
         }
     )
@@ -246,6 +248,54 @@ def test_parse_functions_does_not_normalize_unknown_platform_cc_spelling() -> No
     (fn,) = _ClangAstParser(root, {"api"}, set()).parse_functions()
 
     assert fn.contract_attributes == []
+
+
+def test_parse_functions_discards_explicit_sysv_default_for_known_target() -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl", "name": "api",
+            "loc": {"file": "include/api.h", "line": 3}, "mangledName": "api",
+            "type": {"qualType": "void () __attribute__((sysv_abi))"}, "inner": [],
+        }
+    )
+
+    (fn,) = _ClangAstParser(
+        root, {"api"}, set(), target_triple="x86_64-pc-linux-gnu"
+    ).parse_functions()
+
+    assert fn.contract_attributes == []
+
+
+def test_parse_functions_discards_explicit_ms_default_for_known_target() -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl", "name": "api",
+            "loc": {"file": "include/api.h", "line": 3}, "mangledName": "api",
+            "type": {"qualType": "void () __attribute__((ms_abi))"}, "inner": [],
+        }
+    )
+
+    (fn,) = _ClangAstParser(
+        root, {"api"}, set(), target_triple="x86_64-pc-windows-msvc"
+    ).parse_functions()
+
+    assert fn.contract_attributes == []
+
+
+def test_parse_functions_keeps_abi_spelling_without_known_x86_default() -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl", "name": "api",
+            "loc": {"file": "include/api.h", "line": 3}, "mangledName": "api",
+            "type": {"qualType": "void () __attribute__((ms_abi))"}, "inner": [],
+        }
+    )
+
+    (fn,) = _ClangAstParser(
+        root, {"api"}, set(), target_triple="aarch64-unknown-linux-gnu"
+    ).parse_functions()
+
+    assert fn.contract_attributes == ["ms_abi"]
 
 
 def test_parse_functions_ignores_non_string_qual_type_for_abi_fallback() -> None:
@@ -3601,6 +3651,27 @@ def test_header_ast_parser_clang_branch(monkeypatch: pytest.MonkeyPatch) -> None
     )
     assert isinstance(parser, _ClangAstParser)
     assert [f.name for f in parser.parse_functions()] == ["foo"]
+
+
+def test_header_ast_parser_passes_explicit_target_to_clang_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ast = _tu(
+        {
+            "kind": "FunctionDecl", "name": "api",
+            "loc": {"file": "api.h", "line": 1}, "mangledName": "api",
+            "type": {"qualType": "void () __attribute__((sysv_abi))"},
+        }
+    )
+    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, None))
+    parser = _header_ast_parser(
+        [], [], backend="clang", compiler="c++", gcc_path=None, gcc_prefix=None,
+        gcc_options="--target=x86_64-pc-linux-gnu", sysroot=None, nostdinc=False,
+        lang=None, exported_dynamic={"api"}, exported_static=set(),
+        public_header_paths=[], public_dir_paths=[],
+    )
+
+    assert [f.contract_attributes for f in parser.parse_functions()] == [[]]
 
 
 def test_header_ast_parser_clang_branch_records_abi_dialect(

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -175,6 +175,25 @@ def test_parse_functions_recovers_outer_ms_abi_from_qual_type_when_attr_node_is_
     assert fn.contract_attributes == ["ms_abi"]
 
 
+def test_parse_functions_skips_typeof_return_type_before_outer_convention() -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl",
+            "name": "api",
+            "loc": {"file": "include/api.h", "line": 3},
+            "mangledName": "api",
+            "type": {
+                "qualType": "typeof (1) () __attribute__((ms_abi))",
+            },
+            "inner": [],
+        }
+    )
+
+    (fn,) = _ClangAstParser(root, {"api"}, set()).parse_functions()
+
+    assert fn.contract_attributes == ["ms_abi"]
+
+
 def test_parse_functions_does_not_claim_nested_callback_abi_attribute() -> None:
     root = _tu(
         {

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -173,6 +173,23 @@ def test_parse_functions_recovers_ms_abi_from_qual_type_when_attr_node_is_omitte
     assert fn.contract_attributes == ["ms_abi"]
 
 
+def test_parse_functions_ignores_non_string_qual_type_for_abi_fallback() -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl",
+            "name": "api",
+            "loc": {"file": "include/api.h", "line": 3},
+            "mangledName": "api",
+            "type": {"qualType": None},
+            "inner": [],
+        }
+    )
+
+    (fn,) = _ClangAstParser(root, {"api"}, set()).parse_functions()
+
+    assert fn.contract_attributes == []
+
+
 def test_parse_functions_method_const_and_access() -> None:
     root = _tu(
         {

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -133,6 +133,46 @@ def test_parse_functions_signature_and_qualifiers() -> None:
     assert fn.params[1].default == "1"
 
 
+@pytest.mark.parametrize("attr_kind, expected", [
+    ("MSABIAttr", "ms_abi"),
+    ("SysVABIAttr", "sysv_abi"),
+])
+def test_parse_functions_preserves_x86_64_abi_attributes(
+    attr_kind: str, expected: str,
+) -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl",
+            "name": "api",
+            "loc": {"file": "include/api.h", "line": 3},
+            "mangledName": "api",
+            "type": {"qualType": "void ()"},
+            "inner": [{"kind": attr_kind}],
+        }
+    )
+
+    (fn,) = _ClangAstParser(root, {"api"}, set()).parse_functions()
+
+    assert fn.contract_attributes == [expected]
+
+
+def test_parse_functions_recovers_ms_abi_from_qual_type_when_attr_node_is_omitted() -> None:
+    root = _tu(
+        {
+            "kind": "FunctionDecl",
+            "name": "api",
+            "loc": {"file": "include/api.h", "line": 3},
+            "mangledName": "api",
+            "type": {"qualType": "void (int) __attribute__((ms_abi))"},
+            "inner": [],
+        }
+    )
+
+    (fn,) = _ClangAstParser(root, {"api"}, set()).parse_functions()
+
+    assert fn.contract_attributes == ["ms_abi"]
+
+
 def test_parse_functions_method_const_and_access() -> None:
     root = _tu(
         {

--- a/tests/test_dumper_hybrid.py
+++ b/tests/test_dumper_hybrid.py
@@ -145,6 +145,38 @@ class TestMergeSnapshotsBasics:
 
         assert merged.functions[0].contract_attributes == ["ms_abi", "sysv_abi"]
 
+    def test_clang_non_cc_attributes_do_not_change_castxml_contract(self):
+        castxml_fn = Function(
+            name="api", mangled="api", return_type="void",
+            contract_attributes=["nonnull(1)"],
+        )
+        clang_fn = Function(
+            name="api", mangled="api", return_type="void",
+            contract_attributes=["nonnull(1)"],
+        )
+        merged = merge_snapshots(
+            _snap(functions=[castxml_fn], ast_producer="castxml"),
+            _snap(functions=[clang_fn], ast_producer="clang"),
+        )
+
+        assert merged.functions[0].contract_attributes == ["nonnull(1)"]
+
+    def test_clang_matching_cc_does_not_replace_existing_contract(self):
+        castxml_fn = Function(
+            name="api", mangled="api", return_type="void",
+            contract_attributes=["ms_abi"],
+        )
+        clang_fn = Function(
+            name="api", mangled="api", return_type="void",
+            contract_attributes=["ms_abi"],
+        )
+        merged = merge_snapshots(
+            _snap(functions=[castxml_fn], ast_producer="castxml"),
+            _snap(functions=[clang_fn], ast_producer="clang"),
+        )
+
+        assert merged.functions[0].contract_attributes == ["ms_abi"]
+
     def test_clang_only_function_is_appended(self):
         clang_only = Function(name="bar", mangled="_Z3barv", return_type="void")
         castxml = _snap(ast_producer="castxml")

--- a/tests/test_dumper_hybrid.py
+++ b/tests/test_dumper_hybrid.py
@@ -129,7 +129,23 @@ class TestMergeSnapshotsBasics:
 
         assert merged.functions[0].contract_attributes == ["ms_abi", "nonnull(1)"]
 
-    def test_clang_does_not_override_an_existing_castxml_cc(self):
+    def test_clang_backfills_cc_when_castxml_has_no_attributes(self):
+        castxml_fn = Function(name="api", mangled="api", return_type="void")
+        clang_fn = Function(
+            name="api", mangled="api", return_type="void",
+            contract_attributes=["ms_abi"],
+        )
+        merged = merge_snapshots(
+            _snap(functions=[castxml_fn], ast_producer="castxml"),
+            _snap(functions=[clang_fn], ast_producer="clang"),
+        )
+
+        assert merged.functions[0].contract_attributes == ["ms_abi"]
+        assert merged.fact_provenance[
+            func_fact_key("api", "calling_convention")
+        ] == "clang"
+
+    def test_clang_cc_conflict_keeps_castxml_evidence_and_warns(self, caplog):
         castxml_fn = Function(
             name="api", mangled="api", return_type="void",
             contract_attributes=["sysv_abi"],
@@ -143,7 +159,11 @@ class TestMergeSnapshotsBasics:
             _snap(functions=[clang_fn], ast_producer="clang"),
         )
 
-        assert merged.functions[0].contract_attributes == ["ms_abi", "sysv_abi"]
+        assert merged.functions[0].contract_attributes == ["sysv_abi"]
+        assert merged.fact_provenance[
+            func_fact_key("api", "calling_convention")
+        ] == "castxml"
+        assert "hybrid calling-convention conflict" in caplog.text
 
     def test_clang_non_cc_attributes_do_not_change_castxml_contract(self):
         castxml_fn = Function(

--- a/tests/test_dumper_hybrid.py
+++ b/tests/test_dumper_hybrid.py
@@ -113,6 +113,38 @@ class TestMergeSnapshotsBasics:
         # cached index carried over from the castxml snapshot via replace().
         assert merged.func_by_mangled("_Z3foov") is not None
 
+    def test_clang_backfills_ms_abi_when_castxml_drops_it(self):
+        castxml_fn = Function(
+            name="api", mangled="api", return_type="void",
+            contract_attributes=["nonnull(1)"],
+        )
+        clang_fn = Function(
+            name="api", mangled="api", return_type="void",
+            contract_attributes=["ms_abi", "nonnull(1)"],
+        )
+        merged = merge_snapshots(
+            _snap(functions=[castxml_fn], ast_producer="castxml"),
+            _snap(functions=[clang_fn], ast_producer="clang"),
+        )
+
+        assert merged.functions[0].contract_attributes == ["ms_abi", "nonnull(1)"]
+
+    def test_clang_does_not_override_an_existing_castxml_cc(self):
+        castxml_fn = Function(
+            name="api", mangled="api", return_type="void",
+            contract_attributes=["sysv_abi"],
+        )
+        clang_fn = Function(
+            name="api", mangled="api", return_type="void",
+            contract_attributes=["ms_abi"],
+        )
+        merged = merge_snapshots(
+            _snap(functions=[castxml_fn], ast_producer="castxml"),
+            _snap(functions=[clang_fn], ast_producer="clang"),
+        )
+
+        assert merged.functions[0].contract_attributes == ["ms_abi", "sysv_abi"]
+
     def test_clang_only_function_is_appended(self):
         clang_only = Function(name="bar", mangled="_Z3barv", return_type="void")
         castxml = _snap(ast_producer="castxml")


### PR DESCRIPTION
## Summary

Recover `ms_abi` and `sysv_abi` facts from public headers in hybrid mode when CastXML omits them.

## Bug-fix test contract

- Bug class: Clang JSON AST can encode x86 calling-convention attributes in `FunctionDecl.qualType` without an attribute child, leaving the hybrid CastXML-primary declaration incomplete.
- Publicly observable failure: A GCC-debug old/new library whose public header gains `ms_abi` returned `NO_CHANGE` instead of an ABI break.
- Regression test fails on base: The real GCC shared-library/header integration test expects exact `calling_convention_changed`; base produces no change.
- Negative control: Existing CastXML calling-convention attributes are retained rather than overwritten by a conflicting Clang fallback.
- Public-surface test: The integration regression calls public `dump(..., header_backend="hybrid")` and `compare` on real compiled libraries and headers.
- Axes covered: GCC x86-64 binary/DWARF, Clang JSON header AST, CastXML-primary hybrid merge, `ms_abi` and `sysv_abi` parser forms.
- General invariant: Any public FunctionDecl carrying these two compiler-produced ABI spellings preserves the calling-convention fact through hybrid snapshot construction.
- Real-dependency test: The regression runs GCC, Clang, and CastXML over actual source/header/library inputs.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of explicit `ms_abi` and `sysv_abi` calling conventions in hybrid header comparisons.
  * Prevented ABI attributes from being incorrectly assigned to factory functions or nested callback types.
  * Preserved existing calling-convention results when sources conflict, with warnings for discrepancies.
  * Improved target-specific filtering so default platform ABI attributes are not reported unnecessarily.

* **Documentation**
  * Added a changelog entry covering improved hybrid calling-convention recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->