### PR TITLE
docs(plans): re-sequence CLI cleanup phase two after #780/#782

### DIFF
--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -185,9 +185,13 @@ standing red lane, not #770's regression.
 3. Reconcile branch protection with reality. The repository reports
    `protected: true` with `required_status_checks.enforcement_level: off` and
    empty `contexts`/`checks`; unless an equivalent GitHub Ruleset supplies them,
-   a red CI does not block merge. Add required checks (branch protection or
-   Ruleset) covering the Linux/macOS/Windows unit lanes, `lint-and-types`, and
-   `ai-readiness`.
+   a red CI does not block merge. Add required checks per the classification
+   rule stated below (Codex review caught an earlier draft of this item
+   restating a second, stale required-check list — `.github/AGENTS.md`'s
+   `ci.yml` row names only the canonical Linux/3.13 `unit-tests` lane,
+   `ai-readiness`, `fair-metadata`, `lint-and-types`, and `packaging` as the
+   core required jobs; macOS and Windows are separate matrix legs the table
+   does not require, and this item must not diverge from that classification).
 4. Add exact-merge-SHA verification on `push: main`, so a merge that did not
    run the checks it claimed is detectable after the fact.
 
@@ -597,16 +601,28 @@ print a context the real run does not use, the L3→L2 fold could diverge again,
 and every future context field would need hand-threading through three
 pipelines a fourth time.
 
-- **PR 3A — typed `dump` convergence (the review's PR C).** One canonical path:
+- **PR 3A — typed `dump` *and `scan`* convergence (the review's PR C) — both
+  remaining resolvers, not just one.** An earlier draft of this section scoped
+  3A to `dump_cmd`/`perform_elf_dump` alone, which would still leave
+  `scan_engine._build_new_snapshot` as a second, independent interpreter of
+  the same `.abicheck.yml` build input once 3C removes the CLI flags — the
+  identical structural divergence this whole section exists to close, just
+  moved from a `dump`-vs-`compare` mismatch to a `dump`-vs-`scan` one
+  (Codex review). Both must converge in this slice: one canonical path,
   `Click parsing → DumpRequest → ResolvedDumpRequest → dry-run or execution →
-  DumpResult`, with `dump_cmd`/`perform_elf_dump` routing through
-  `service_dump_pipeline.run_dump_request` the way `compare`'s implicit-dump
-  operand already does. `DumpResult` states the snapshot, requested vs.
-  effective depth, the resolved compile context, the build-query decision, the
-  source scope, the dependency scope, diagnostics, and the storage result — and
-  `--dry-run` renders *that object*, so the printed plan and the executed run
-  cannot disagree. The root `AGENTS.md` "Known gaps" entry on
-  `service_dump_pipeline.py` is the same migration seen from the code side.
+  DumpResult`, with `dump_cmd`/`perform_elf_dump` **and**
+  `scan_engine._build_new_snapshot` both routing through
+  `service_dump_pipeline.run_dump_request` (or the per-input primitives it
+  shares with `resolve_side_snapshot` — see `service_input_resolution.py`),
+  the way `compare`'s implicit-dump operand already does. `DumpResult` states
+  the snapshot, requested vs. effective depth, the resolved compile context,
+  the build-query decision, the source scope, the dependency scope,
+  diagnostics, and the storage result — and `--dry-run` renders *that
+  object*, so the printed plan and the executed run cannot disagree. The root
+  `AGENTS.md` "Known gaps" entry on `service_dump_pipeline.py` is the same
+  migration seen from the code side; that entry does not yet mention the scan
+  side explicitly, so this plan is the tracking place for that half until it
+  does.
 - **PR 3B — build-context completeness (the review's PR D).** Two #782
   follow-ups that change the *parsed public surface*, not just performance, so
   they belong before the model is called finished: (1) compile-unit matching —
@@ -618,7 +634,11 @@ pipelines a fourth time.
   even though the run reports a match and stamps `parsed_with_build_context`.
   Both are already recorded as known gaps in the root `AGENTS.md`.
 - **PR 3C — the removal itself** (everything the rest of this section
-  describes), landing only after 3A and 3B.
+  describes), landing only after **all three** resolvers converge — 3A (both
+  `dump` and `scan`) and 3B. 3C must not land on 3A-covers-`dump`-only; a
+  `.abicheck.yml` build input used for a `dump` baseline and a
+  `scan --against` candidate needs one interpreter, not two, before the flags
+  that configure it are removed.
 
 `dump --build-query` and `dump --build-compile-db` describe how the *project*
 is built, not what this snapshot is. They are already documented as CLI
@@ -1013,10 +1033,12 @@ PR B  effective configuration parity — packs resolved once into one
                                        GateOptions, shared by compare /
                                        release / scan / Action, digest in
                                        every report
-PR C  typed dump convergence          = PR 3A — DumpRequest →
+PR C  typed dump+scan convergence     = PR 3A — DumpRequest →
                                        ResolvedDumpRequest → DumpResult, one
-                                       resolver for CLI/Python/Action, JSON
-                                       dry-run rendered from that object
+                                       resolver for dump CLI/Python/Action
+                                       *and* scan_engine's candidate
+                                       resolution, JSON dry-run rendered
+                                       from that object
 PR D  build-context completeness      = PR 3B — matched compile-unit
                                        selection, forced includes, provenance
                                        tests

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -431,24 +431,41 @@ So the prerequisite below is not just "uncap the findings": the persisted
 report must be the single source for *both* the annotations and the gate
 explanation, for both operand shapes.
 
-The shape the Action should be able to read, uniformly, for a single-library
-compare, a release/package compare, and `scan --against`:
+**Not a proposed common envelope — (Codex review) `compatibility.verdict`/
+`findings` below were an illustrative shorthand, and neither exists in
+`compare_report.schema.json` (which is top-level `verdict`/`changes`) nor in
+scan's or release's own, differently-shaped report structures.** Introducing
+those spellings for real would be a major-version schema migration this PR
+does not undertake, and would leave two sources for the same verdict/finding
+set free to drift. What actually generalizes across all three operand shapes
+today, without inventing a new envelope, is only the three fields PR G1/#780
+already ship at the top level of whichever shape a given command emits:
+`exit`, `contract_coverage_exit_contribution`,
+`analysis_assurance_exit_contribution`. The Action's renderer keeps reading
+each operand's own existing `verdict`/`changes` (single-library),
+per-library summaries (release), or scan's own result shape through the
+adapter it already has for that shape — PR E's job is only to route the gate
+*explanation* through the shared `exit` block instead of re-deriving it from
+stderr, not to unify how verdicts/findings are structured. A single-library
+compare report, unmodified by this section, already reads:
 
 ```json
 {
-  "compatibility": {"verdict": "COMPATIBLE"},
-  "gate": {"exit_code": 0, "blocking": false},
+  "verdict": "COMPATIBLE",
   "contract_coverage_exit_contribution": 0,
   "analysis_assurance_exit_contribution": 1,
   "exit": {"code": 1, "reasons": ["analysis_assurance"]},
-  "findings": []
+  "changes": []
 }
 ```
 
 With that in place the Action does not parse stderr, does not re-run any
 comparison, does not guess why the exit was `1`, renders annotations from the
 persisted findings and the Job Summary from the same object, and behaves
-identically for a single pair and a release fan-out. The `exit` block is the
+identically for a single pair and a release fan-out — reading `exit` the same
+way regardless of which command's report it is, while still reading
+`verdict`/`changes` (or that operand's own equivalent) unchanged. The `exit`
+block is the
 same object PR 4/G formalizes as `ExitDecision`. Build it once and consume it
 once — which is why PR G is split, and the split is load-bearing for this
 section rather than cosmetic: **G1** builds the decision object and emits its

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -438,16 +438,31 @@ scan's or release's own, differently-shaped report structures.** Introducing
 those spellings for real would be a major-version schema migration this PR
 does not undertake, and would leave two sources for the same verdict/finding
 set free to drift. What actually generalizes across all three operand shapes
-today, without inventing a new envelope, is only the three fields PR G1/#780
-already ship at the top level of whichever shape a given command emits:
-`exit`, `contract_coverage_exit_contribution`,
-`analysis_assurance_exit_contribution`. The Action's renderer keeps reading
-each operand's own existing `verdict`/`changes` (single-library),
-per-library summaries (release), or scan's own result shape through the
-adapter it already has for that shape — PR E's job is only to route the gate
-*explanation* through the shared `exit` block instead of re-deriving it from
-stderr, not to unify how verdicts/findings are structured. A single-library
-compare report, unmodified by this section, already reads:
+is the *concept* of three fields — `exit`, `contract_coverage_exit_
+contribution`, `analysis_assurance_exit_contribution` — not yet a uniform
+*location* for them today. `compare` (PR G1, landed) puts all three at the
+report's top level. **`scan --against` does not (fresh evidence, Codex
+review):** `ScanOutcome.to_dict()` (`scan_engine.py`) nests its whole
+`diff_summary` under a `"diff"` key, and `_baseline_summary()`
+(`cli_scan_baseline.py`) writes `analysis_assurance_exit_contribution` and
+the contract-coverage block *into that nested summary*, not the outer
+`ScanOutcome` dict — so today they live at `report["diff"].
+analysis_assurance_exit_contribution`, not `report.
+analysis_assurance_exit_contribution`. G1 never touched
+`cli_scan_baseline.py` at all, so `exit` does not exist for `scan --against`
+yet, in either location. PR E's job is therefore two things, not one: land
+`exit` for `scan --against` (mirroring G1's `compare` wiring, called from
+`_baseline_summary`/`_run_baseline_compare` the way `add_contract_context`
+is called from `compare`'s own JSON path), and decide — as part of that
+wiring, not as a drive-by rename — whether `scan`'s existing nested
+placement moves to the top level to match `compare`, or `compare`'s renderer
+adapter learns to read scan's nested location instead. Whichever is chosen,
+the Action's renderer keeps reading each operand's own existing
+`verdict`/`changes` (single-library), per-library summaries (release), or
+scan's own result shape through the adapter it already has for that shape —
+this section is only about where the *gate-explanation* fields live, not
+about unifying verdict/finding structures. A single-library compare report,
+unmodified by this section, already reads:
 
 ```json
 {
@@ -462,10 +477,10 @@ compare report, unmodified by this section, already reads:
 With that in place the Action does not parse stderr, does not re-run any
 comparison, does not guess why the exit was `1`, renders annotations from the
 persisted findings and the Job Summary from the same object, and behaves
-identically for a single pair and a release fan-out — reading `exit` the same
-way regardless of which command's report it is, while still reading
-`verdict`/`changes` (or that operand's own equivalent) unchanged. The `exit`
-block is the
+identically for a single pair and a release fan-out — once PR E lands
+`exit` for `scan --against` at whichever location this section's `scan`
+resolution above settles on, while still reading `verdict`/`changes` (or
+that operand's own equivalent) unchanged. The `exit` block is the
 same object PR 4/G formalizes as `ExitDecision`. Build it once and consume it
 once — which is why PR G is split, and the split is load-bearing for this
 section rather than cosmetic: **G1** builds the decision object and emits its

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -16,9 +16,22 @@ interface contract), [ADR-043](../adr/043-cli-pre-1.0-surface-reset.md) /
 (root-surface admission),
 [ADR-047](../adr/047-github-actions-integration-model.md) (Action model),
 [ADR-056](../adr/056-multi-artifact-library-set-scan.md) (`scan --artifact-set`).
-**Effort:** L (seven independent PRs) · **Risk:** mixed — PR 1 is
+**Effort:** L (seven independent PRs, plus three convergence prerequisites
+added by the post-#780/#782 review) · **Risk:** mixed — PR 1 is
 presentation-only, PR 1b is gated on new persisted-report schema work, PR 4
 changes what a CI job's exit code means.
+
+> **Review checkpoint (2026-08-16, `main` at `410caf5`, after
+> [#779](https://github.com/abicheck/abicheck/pull/779),
+> [#780](https://github.com/abicheck/abicheck/pull/780) and
+> [#782](https://github.com/abicheck/abicheck/pull/782)).** PR 1 and PR 2 are
+> implemented and reviewed as correct. The rest of this plan's ordering is
+> **superseded** by the reviewed sequence in "Ordering" at the bottom: the next
+> step is **not** another hard-delete PR. Three shared contracts — one typed
+> `dump` resolution path, one effective pack/gate configuration, one canonical
+> exit decision — have to converge first, or deleting the flags merely freezes
+> today's divergence between parallel paths into the removed-flag baseline. The
+> per-PR sections below carry the prerequisites each one gained.
 
 ## Problem
 
@@ -41,7 +54,8 @@ simplification).
 
 | Candidate | Verdict | Action |
 |---|---|---|
-| `--exit-code-scheme` (compare, scan) | Remove, but reworked | Own ADR + semantics PR: keep two orthogonal axes, drop the *manual algorithm selector* |
+| `--exit-code-scheme` (compare, scan) | Remove, but reworked | Own ADR + semantics PR: keep the orthogonal axes, drop the *manual algorithm selector* — after pack parity and one canonical `ExitDecision` |
+| `--require-complete-analysis` (compare, scan; new in #780) | **Keep** | Real, distinct axis — but move its semantics into the resolved gate/assurance policy instead of leaving it a CLI-only boolean |
 | `compare --stat`, `compare --recommend` | Remove | `--format review` replaces `--stat`; recommendation becomes an unconditional renderer output |
 | `scan --artifact-set` | **Keep** | Refine the value syntax only (repeatable option / manifest); do not overload positional `DIRECTORY` |
 | `--annotate`, `--annotate-additions` | Remove from CLI (PR 1b, not PR 1) | Options on `compare` alone, shared by both operand shapes (no CLI-level split is possible) — blocked on a release-report persistence prerequisite; see PR 1b |
@@ -54,14 +68,34 @@ an old spelling must fail as `No such option` with exit `64`.
 
 ## PR 0 — restore a green CI baseline first
 
-**Status: verified, not separately actioned** — the "Verified state" below
-was confirmed current as of PR #779; the standing Windows lane failure is
-tracked as pre-existing and unrelated to this initiative's own changes, per
-that PR's own thread. The branch-protection/required-checks work (items 3–4
-below) has not been done as part of this initiative.
-
 This is a prerequisite, not a nicety: a breaking interface change cannot be
-evaluated against a red baseline.
+evaluated against a red baseline. **The review splits it in two**, because the
+code half and the governance half now have genuinely different statuses:
+
+| | Scope | Status |
+|---|---|---|
+| **PR 0A** | The Windows test failures themselves (items 1–2 below) | **Closed at the test level** — the Windows unit *and* integration lanes passed on PR #782; the specific MSYS/Git-Bash failures described under "Verified state" are no longer the current blocker |
+| **PR 0B** | Required checks / Ruleset + exact-merge-SHA verification (items 3–4) | **Still open, still P0** — this is what actually makes a red CI block a merge |
+
+**PR 0B is the one to do first, and it is the review's PR A.** The branch API
+still reports `protected: true` with
+`required_status_checks.enforcement_level: off` and empty `contexts`/`checks`.
+Unless an equivalent GitHub Ruleset supplies them, a red CI does not block a
+merge — so PR 0A's green lanes are green by convention, not by enforcement.
+Separately, the exact merge SHA of #782 did not run a full CI sweep on
+`push: main` in the returned workflow set (AgentReady completed; Examples
+Validation was still running; no separate full `ci.yml` run over that exact
+SHA), which is precisely what item 4 exists to make detectable.
+
+Required checks should cover at least: `CI`, `Examples Validation`, `Test
+GitHub Action`, `CLI Interface Check`, `Security & Quality`, `AgentReady`, and
+the docs/schema checks. Prefer **one stable aggregate required check per
+workflow** (or a Ruleset-compatible job) over requiring every matrix leg
+individually — a matrix-leg-level required list goes stale on every matrix
+edit and is the usual reason required checks get turned back off.
+
+The "Verified state" below is kept as the historical record of what PR 0A
+fixed; it describes `main` as of PR #779, not today.
 
 **Verified state** (`ci.yml`, run `31882605683`, head `13be967` on `main`):
 19 of 20 jobs pass; the single failure is
@@ -99,7 +133,8 @@ standing red lane, not #770's regression.
    run the checks it claimed is detectable after the fact.
 
 **Done when** a full `ci.yml` run on `main` is green on Linux, macOS and
-Windows, and a red required check demonstrably blocks a merge.
+Windows (**0A — done**), and a red required check demonstrably blocks a merge
+(**0B — outstanding**).
 
 ## PR 1 — presentation
 
@@ -108,6 +143,14 @@ Windows, and a red required check demonstrably blocks a merge.
 `--used-by`/`--required-symbol` scoped-gate case, found by review after the
 first push), and the release recommendation is unconditional in
 `json`/`markdown`/`review` output.
+
+**Closed — do not reopen.** The review's only remaining housekeeping is
+negative, not new work: the Tier-2 Python compatibility shims
+(`render_output(stat=..., show_recommendation=...)`) must not leak back into
+the CLI as flags, and whether those kwargs are themselves stable Python API or
+removable is a separate pre-1.0 decision, not part of this initiative. Do not
+add `summary`/`release` values to `--report-mode` merely to give the removed
+flags a home (see "`--report-mode` stays as-is" below).
 
 Removes `compare --stat` and `compare --recommend` only. `--annotate` /
 `--annotate-additions` are **not** in this PR — see PR 1b below for why they
@@ -298,9 +341,61 @@ persistence prerequisite completing first:
    workflow/recipe/doc snippet using `extra-args` for this, and state the
    `extra-args` → `annotate` input migration for external callers.
 
+**New invariant (post-#780), and it is the reason PR 1b became PR E in the
+reviewed ordering:**
+
+> The Action never infers a gate's identity or its reason from stderr when the
+> versioned report already carries it.
+
+#780 made this checkable rather than aspirational: reports now persist
+`analysis_assurance`, `analysis_assurance_exit_contribution` and
+`contract_coverage_exit_contribution`, so the *exact* number each orthogonal
+axis folded into the exit code is machine-readable. `action/run.sh`'s
+`_assurance_gated` is already JSON-first (a dedicated
+`require-complete-analysis` boolean input, then
+`analysis_assurance.status` from the report) with the stderr grep kept only as
+the no-readable-JSON fallback — so this is technical debt, not a live bug. But
+the debt is real in two directions and both are PR 1b/E's job:
+
+- the Action still re-derives "did this axis gate" from *input + status*
+  instead of reading the persisted contribution, which is the field that
+  actually decided the exit code;
+- for a release/package operand there is still no persisted report to read at
+  all (see the second wrong idea above), so the stderr fallback is not a
+  fallback there — it is the only path.
+
+So the prerequisite below is not just "uncap the findings": the persisted
+report must be the single source for *both* the annotations and the gate
+explanation, for both operand shapes.
+
+The shape the Action should be able to read, uniformly, for a single-library
+compare, a release/package compare, and `scan --against`:
+
+```json
+{
+  "compatibility": {"verdict": "COMPATIBLE"},
+  "gate": {"exit_code": 0, "blocking": false},
+  "contract_coverage_exit_contribution": 0,
+  "analysis_assurance_exit_contribution": 1,
+  "exit": {"code": 1, "reasons": ["analysis_assurance"]},
+  "findings": []
+}
+```
+
+With that in place the Action does not parse stderr, does not re-run any
+comparison, does not guess why the exit was `1`, renders annotations from the
+persisted findings and the Job Summary from the same object, and behaves
+identically for a single pair and a release fan-out. The `exit` block is the
+same object PR 4/G formalizes as `ExitDecision` — build it once, in PR G, and
+have PR E consume it rather than inventing a second, Action-shaped spelling.
+
 **Tests.** A saved report fixture (both a single-library and a release-style
 report) must produce, through the Action's renderer, byte-identical
-annotations to what the CLI emitted for the same report before the move.
+annotations to what the CLI emitted for the same report before the move. A
+report carrying a non-zero `analysis_assurance_exit_contribution` /
+`contract_coverage_exit_contribution` must produce the correct labelled
+verdict with `STDERR_CONTENT` empty — i.e. the stderr path is provably not
+load-bearing when a report exists.
 `compare --annotate` exits `64` with `No such option` only once step 3 lands —
 not before.
 
@@ -386,12 +481,78 @@ no external-tooling consumers analogous to the aggregate *report*'s
 schema remains future work if an external producer needs one, not part of
 this slice.
 
+**Follow-up, explicitly still open (review):** the policy moved to the right
+*lifecycle stage* (plan time, versioned, alongside the expected target set) but
+not yet to durable *project configuration*. Today it is still restated per
+invocation, via `project plan --gate-missing-required` /
+`--gate-unexpected-target`. A stable gate policy should not have to be re-typed
+on every `project plan` run:
+
+```yaml
+# .abicheck.yml
+aggregate:
+  gate:
+    missing_required: fail
+    unexpected_target: include
+```
+
+Once that key exists and `project plan` sources it, the two `project plan`
+gate flags should be removed too, leaving that command's CLI to project config,
+build outputs, head/project identity, and output. This is a small, independent
+slice — it does **not** block any other PR here, and it is deliberately not
+folded into PR B/PR G's configuration convergence, whose subject is the
+compare/scan gate, not the aggregate target-expectation gate.
+
 **Tests:** manifest-supplied policy; run-plan-supplied policy; default policy;
 missing required target; unexpected analyzed report; unreadable unexpected
 report; `effective_policy` preserved in aggregate JSON; incompatible manifest
 schema rejected; the removed flags exit `64`.
 
 ## PR 3 — build execution moves into trusted config
+
+**Split into three slices by the post-#782 review.** PR #782 fixed a real
+defect — a `dump` baseline and a `scan --against` candidate given the *same*
+`compile_commands.json` could resolve to non-comparable `CompileContext`s,
+because `dump` stored L3 evidence without applying it to its own L2 header
+parse — and it fixed it *additively*, by calling one shared folding primitive
+from three existing paths. That closed the symptom and simultaneously proved
+the structural problem: there are still three resolution paths.
+
+```text
+compare's implicit dump  → resolve_side_snapshot (typed, shared)
+native `dump` CLI        → cli_dump_helpers.perform_elf_dump (its own pipeline)
+scan candidate           → scan_engine._build_new_snapshot (a third)
+```
+
+Deleting `--build-query`/`--build-compile-db` before those converge would move
+the inputs into config while leaving three places that interpret them, so:
+config could apply differently in the CLI and the typed API, `--dry-run` could
+print a context the real run does not use, the L3→L2 fold could diverge again,
+and every future context field would need hand-threading through three
+pipelines a fourth time.
+
+- **PR 3A — typed `dump` convergence (the review's PR C).** One canonical path:
+  `Click parsing → DumpRequest → ResolvedDumpRequest → dry-run or execution →
+  DumpResult`, with `dump_cmd`/`perform_elf_dump` routing through
+  `service_dump_pipeline.run_dump_request` the way `compare`'s implicit-dump
+  operand already does. `DumpResult` states the snapshot, requested vs.
+  effective depth, the resolved compile context, the build-query decision, the
+  source scope, the dependency scope, diagnostics, and the storage result — and
+  `--dry-run` renders *that object*, so the printed plan and the executed run
+  cannot disagree. The root `AGENTS.md` "Known gaps" entry on
+  `service_dump_pipeline.py` is the same migration seen from the code side.
+- **PR 3B — build-context completeness (the review's PR D).** Two #782
+  follow-ups that change the *parsed public surface*, not just performance, so
+  they belong before the model is called finished: (1) compile-unit matching —
+  the L2 include-dir seed is still gathered from *every* `CompileUnit` rather
+  than the matched one(s), so an unrelated TU's colliding generated header can
+  shadow the matched TU's; (2) forced includes — `-include`, `-imacros`, `/FI`,
+  `/FU` are absent from `ABI_RELEVANT_FLAG_PREFIXES`, so a matched unit's
+  macro-controlling forced-include header never reaches the derived L2 context
+  even though the run reports a match and stamps `parsed_with_build_context`.
+  Both are already recorded as known gaps in the root `AGENTS.md`.
+- **PR 3C — the removal itself** (everything the rest of this section
+  describes), landing only after 3A and 3B.
 
 `dump --build-query` and `dump --build-compile-db` describe how the *project*
 is built, not what this snapshot is. They are already documented as CLI
@@ -448,6 +609,40 @@ the parser to lists only — every existing trusted string config would break.
 **Risk:** medium — this is a trust boundary, and it is the one item here where
 a mistake is a security regression rather than a UX one.
 
+## New since the plan was written — `--require-complete-analysis`
+
+#780 added `--require-complete-analysis` to `compare` and `scan --against`. It
+does not touch the compatibility verdict; it contributes exit `1` when
+`analysis_assurance.status != complete`, folded with `max` exactly like
+`--contract`'s coverage axis. **Keep it** — it answers a real and distinct CI
+question ("was this comparison complete enough to trust at all?"), and it is
+not a duplicate spelling of anything.
+
+What it must **not** become is a permanent CLI-only axis. Today it is not part
+of `CompareRequest`/`ScanRequest`, the release/package fan-out rejects it
+outright, `project`'s run plan cannot express it as durable policy, and gate
+packs cannot set it. That is one boolean per assurance dimension, decided at
+the CLI, and it does not scale: the next assurance dimension would arrive as a
+second such boolean.
+
+So fold its *semantics* into the typed gate/assurance policy PR B/PR G build:
+
+```yaml
+assurance:
+  required_status: complete
+# or, equivalently addressed from the gate namespace:
+gate:
+  require_complete_analysis: true
+```
+
+with the ordinary precedence `explicit CLI > run plan > project config >
+built-in default`, resolving to a single field
+(`resolved_gate.require_complete_analysis`) that `compare`, `scan --against`,
+the release compare, `check-target` and `aggregate` all read. The flag itself
+stays as the advanced one-run override. **Do not add a further standalone
+boolean for any new assurance dimension** — add it to the resolved policy
+object instead.
+
 ## PR 4 — one gate algorithm (`--exit-code-scheme` removal)
 
 **This is the item the original draft got wrong, and it gets its own ADR.**
@@ -486,6 +681,61 @@ The report keeps stating both halves explicitly, so the number is explainable:
  "gate": {"exit_code": 1, "blocking": true,
           "reason": "addition configured as error"}}
 ```
+
+**Two prerequisites the post-#780 review adds, both before the flag is
+removed.**
+
+**(1) Pack parity — the review's PR B, and the harder blocker.** `--pack` is
+accepted by a single-pair `compare`, rejected by the release fan-out, and only
+partially honoured by `scan` (`cli_scan.py` rejects a gate pack outright,
+having no gate of its own — see the root `AGENTS.md` on `pack_application.py`).
+A pack can assign `gate.exit_code_scheme` and `gate.severity.*`. Removing
+`--exit-code-scheme` while pack resolution still differs per front end leaves
+no answerable question about how a legacy pack migrates: the answer would be
+"depends which command reads it." Land first: packs resolved **once** into one
+immutable effective configuration (one `CompatibilityEvaluationConfig`, one
+`GateOptions`), the same object used by `compare`, the release fan-out, `scan`
+and the Action, with the same effective-config digest recorded in every
+report. This is also PR 1b/E's prerequisite, which is why it sits early in the
+reviewed ordering rather than inside PR 4.
+
+**(2) One canonical `ExitDecision` — the review's PR G proper.** Since #780
+this is no longer two axes but a set of them, and a flat `max()` is not the
+whole rule: `NOT_COMPARABLE` (`16`) must dominate; a removed required library
+(`8`) has its own release policy and is already checked ahead of the
+coverage-only fallback; scan budget overflow (`5`) is scan-only; usage error
+(`64`) is not a result at all and never appears in a report; and exit `1` has
+several distinct causes that a bare number cannot tell apart. Encode it once:
+
+```python
+@dataclass(frozen=True)
+class ExitDecision:
+    code: int
+    reasons: tuple[ExitReason, ...]
+    compatibility_contribution: int
+    policy_gate_contribution: int
+    contract_coverage_contribution: int
+    analysis_assurance_contribution: int
+    target_coverage_contribution: int
+```
+
+with an explicit precedence resolver, pinned by the ADR and by tests rather
+than distributed across CLI callbacks:
+
+```text
+usage/config error        → 64, outside the report
+not comparable            → 16
+removed required library  →  8  (release policy)
+budget exceeded           →  5  (scan)
+ABI / API / policy gate   →  4 / 2 / 1
+coverage & assurance floors → 1  (max-folded, never lowering the above)
+clean                     →  0
+```
+
+`reasons` is what makes a shared `1` explainable, and it is the same block PR
+1b/E has the Action read instead of inferring from stderr. `docs/reference/
+exit-codes.md` becomes a rendering of this resolver, not a parallel hand-kept
+table.
 
 **Atomic change set:** remove the flag from `compare` and `scan`; migrate the
 Action side — there is **no** `exit-code-scheme` input in `action.yml` to
@@ -551,7 +801,13 @@ the surrounding text already shows as a usage example.
 **Sequencing note:** the syntax cleanup is lower value than finishing set-mode
 *semantics* — expected provider DSO, a symbol moved between sibling libraries,
 duplicated providers, L4 symbol reconciliation, cost estimation, and a
-machine-readable dry-run. Do the semantics first if the two compete.
+machine-readable dry-run. Do the semantics first if the two compete. The
+review reaffirms this and sharpens it: the *only* part of this section that is
+worth doing on its own is replacing the comma-separated value with a repeatable
+option. `--artifact-set-manifest` is worth adding only when it carries a real
+domain contract — member identity, expected-provider ownership, external
+providers, cohort — never merely as nicer syntax. `--artifact-set` itself is an
+explicit safety boundary, not surplus surface; it stays.
 
 ## Merge criteria for every removal PR here
 
@@ -589,6 +845,51 @@ docs/schema gates all green.
 
 ## Ordering
 
+The original ordering (kept below for reference) sequenced by risk. The
+post-#780/#782 review re-sequences by *contract convergence*: every remaining
+removal depends on a shared contract that does not exist yet, so the
+convergence work comes first and each deletion becomes the last step of the
+slice that made it safe.
+
+**Current, authoritative sequence:**
+
+```text
+PR A  repository governance          = PR 0B — required checks / Ruleset,
+                                       exact-merge-SHA verification
+PR B  effective configuration parity — packs resolved once into one
+                                       CompatibilityEvaluationConfig +
+                                       GateOptions, shared by compare /
+                                       release / scan / Action, digest in
+                                       every report
+PR C  typed dump convergence          = PR 3A — DumpRequest →
+                                       ResolvedDumpRequest → DumpResult, one
+                                       resolver for CLI/Python/Action, JSON
+                                       dry-run rendered from that object
+PR D  build-context completeness      = PR 3B — matched compile-unit
+                                       selection, forced includes, provenance
+                                       tests
+PR E  Action machine-report           = PR 1b — uncapped persisted release
+                                       findings, no comparison re-run, no
+                                       stderr inference
+      └─ then DELETE --annotate, --annotate-additions
+PR F  trusted build config            = PR 3C — build.query / build.compile_db
+                                       only from an explicit --config, trust
+                                       receipt in --dry-run, fail closed
+      └─ then DELETE dump --build-query, dump --build-compile-db
+PR G  canonical exit decision         = PR 4 — ExitDecision + reasons + one
+                                       automatic gate algorithm, schema /
+                                       report / Action parity
+      └─ then DELETE --exit-code-scheme
+PR H  artifact-set semantics          = PR 5 — provider ownership, moved and
+                                       duplicated symbols, cost and dry-run;
+                                       syntax refinement last
+```
+
+Independent of the chain, unblocked at any time: PR 1 (**done**), PR 2
+(**done**, minus its `.abicheck.yml` gate-policy sourcing follow-up).
+
+**Superseded original ordering:**
+
 ```text
 PR 0   green CI + required checks     (prerequisite)
 PR 1   presentation                   (low risk)
@@ -598,3 +899,9 @@ PR 3   build execution → trusted config (trust)
 PR 4   gate semantics + ADR           (behavioural, highest risk)
 PR 5   artifact-set syntax refinement (optional, after set-mode semantics)
 ```
+
+The governing principle behind the change: **stop the mechanical CLI cleanup
+until the typed resolution, configuration, gate and report paths are unified.**
+The remaining flags are not the risk; several parallel implementations of the
+same contract are. Deleting a flag that three code paths interpret differently
+does not remove the divergence — it removes the only place a user could see it.

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -91,8 +91,13 @@ SHA), which is precisely what item 4 exists to make detectable.
 informational classification, not the set of workflow names visible in a run
 (Codex review caught an earlier draft that didn't).** `Examples Validation`
 and `agentready.yml` are both explicitly `No (informational)` there, and
-`test-action.yml` is conditional — it runs only when `action/**`/`action.yml`
-changes, path-filtered like several other workflows in that same table. A
+`test-action.yml` is conditional — it runs only when its own trigger's full
+path set changes (`action.yml`, `action/**`, `actions/check-target/**`,
+`actions/resolve-baseline/**`, `abicheck/**`, `pyproject.toml`, `pixi.lock`,
+its own workflow file, `check-single.yml`, `tests/fixtures/action/**` — the
+complete list in `.github/workflows/test-action.yml`'s own `on:` block, not
+the abbreviated "when the CLI surface changes" gloss `.github/AGENTS.md`'s
+table uses), path-filtered like several other workflows in that same table. A
 required check that a path-filtered workflow never starts is not "green by
 default" on an unrelated PR — GitHub blocks merge on a required check that
 never reports at all, the same as on a failing one, so requiring any of these
@@ -103,10 +108,13 @@ catching a different mistake in a hand-copied snapshot, hand-copying a
 fourth one is the wrong fix.** Round 1 conflated "sounds conditional" with
 "is trigger-filtered" (put `CLI Interface Check` in the wrong bucket, missed
 `Changelog Fragment Check`/`Bug-fix test contract` entirely). Round 2 found
-the fixed list still missed `docs-pr.yml` — required whenever
-`docs/**`/`abicheck/schemas/**`/`examples/**`/`mkdocs.yml` changes per
-`.github/AGENTS.md`, *and* genuinely trigger-path-filtered on those same
-paths, the identical shape as `test-action.yml`. Round 3 found the fallback
+the fixed list still missed `docs-pr.yml` — required per `.github/AGENTS.md`
+whenever `docs/**`/`mkdocs.yml` changes (that table's own gloss; the
+workflow's actual `on:` block is wider still: `abicheck/schemas/**`,
+`examples/**`, `scripts/gen_examples_docs.py`, `scripts/publish_schemas.py`,
+and its own plus `pages.yml`'s workflow files), *and* genuinely
+trigger-path-filtered on that same set, the identical shape as
+`test-action.yml`. Round 3 found the fallback
 plan itself wrong: **no native GitHub mechanism — not classic branch
 protection, not a Ruleset's required-status-checks rule — conditions
 "required" on which files a given PR touched.** A Ruleset can require a

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -91,13 +91,11 @@ SHA), which is precisely what item 4 exists to make detectable.
 informational classification, not the set of workflow names visible in a run
 (Codex review caught an earlier draft that didn't).** `Examples Validation`
 and `agentready.yml` are both explicitly `No (informational)` there, and
-`test-action.yml` is conditional — it runs only when its own trigger's full
-path set changes (`action.yml`, `action/**`, `actions/check-target/**`,
-`actions/resolve-baseline/**`, `abicheck/**`, `pyproject.toml`, `pixi.lock`,
-its own workflow file, `check-single.yml`, `tests/fixtures/action/**` — the
-complete list in `.github/workflows/test-action.yml`'s own `on:` block, not
-the abbreviated "when the CLI surface changes" gloss `.github/AGENTS.md`'s
-table uses), path-filtered like several other workflows in that same table. A
+`test-action.yml` is conditional — it runs only when the path set in
+`.github/workflows/test-action.yml`'s own `on:` block changes (wider than
+`.github/AGENTS.md`'s own "when `action/**`/`action.yml` changes" gloss for
+it — that table's cell is a summary, not the filter itself), path-filtered
+like several other workflows in that same table. A
 required check that a path-filtered workflow never starts is not "green by
 default" on an unrelated PR — GitHub blocks merge on a required check that
 never reports at all, the same as on a failing one, so requiring any of these
@@ -109,11 +107,9 @@ fourth one is the wrong fix.** Round 1 conflated "sounds conditional" with
 "is trigger-filtered" (put `CLI Interface Check` in the wrong bucket, missed
 `Changelog Fragment Check`/`Bug-fix test contract` entirely). Round 2 found
 the fixed list still missed `docs-pr.yml` — required per `.github/AGENTS.md`
-whenever `docs/**`/`mkdocs.yml` changes (that table's own gloss; the
-workflow's actual `on:` block is wider still: `abicheck/schemas/**`,
-`examples/**`, `scripts/gen_examples_docs.py`, `scripts/publish_schemas.py`,
-and its own plus `pages.yml`'s workflow files), *and* genuinely
-trigger-path-filtered on that same set, the identical shape as
+whenever `docs/**`/`mkdocs.yml` changes (again that table's summary gloss,
+not `.github/workflows/docs-pr.yml`'s own, wider `on:` block), *and*
+genuinely trigger-path-filtered on its own path set, the identical shape as
 `test-action.yml`. Round 3 found the fallback
 plan itself wrong: **no native GitHub mechanism — not classic branch
 protection, not a Ruleset's required-status-checks rule — conditions

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -59,7 +59,7 @@ simplification).
 | `compare --stat`, `compare --recommend` | Remove | `--format review` replaces `--stat`; recommendation becomes an unconditional renderer output |
 | `scan --artifact-set` | **Keep** | Refine the value syntax only (repeatable option / manifest); do not overload positional `DIRECTORY` |
 | `--annotate`, `--annotate-additions` | Remove from CLI (PR 1b, not PR 1) | Options on `compare` alone, shared by both operand shapes (no CLI-level split is possible) — blocked on a release-report persistence prerequisite; see PR 1b |
-| `dump --build-query`, `dump --build-compile-db` | Remove from CLI | Move to explicitly-trusted `.abicheck.yml`, with a real trust + dry-run contract |
+| `dump --build-query`, `dump --build-compile-db` | Remove from CLI | Move to `.abicheck.yml`; only `build.query` (an executable command) needs the explicit-`--config` trust gate — `build.compile_db` is a data path and carries the ordinary dry-run contract only |
 | `aggregate --on-missing-required`, `--on-unexpected-target` | Remove from CLI | Move the policy into the manifest / run-plan schema alongside the expected target set |
 
 Everything above is a **breaking** change to the native CLI. Consistent with
@@ -708,12 +708,10 @@ reviewed ordering rather than inside PR 4.
 
 **(2) One canonical `ExitDecision` — the review's PR G proper.** Since #780
 this is no longer two axes but a set of them, and a flat `max()` is not the
-whole rule: a non-comparable pair must dominate every other axis; a removed
-required library (`8`) has its own release policy and is already checked ahead
-of the coverage-only fallback; scan budget overflow (`5`) is scan-only; usage
-error (`64`) is not a result at all and never appears in a report; and exit `1`
-has several distinct causes that a bare number cannot tell apart. Encode it
-once:
+whole rule: a non-comparable pair must dominate every other axis; scan budget
+overflow (`5`) is scan-only; usage error (`64`) is not a result at all and
+never appears in a report; and exit `1` has several distinct causes that a
+bare number cannot tell apart. Encode it once:
 
 ```python
 @dataclass(frozen=True)
@@ -732,13 +730,31 @@ than distributed across CLI callbacks — **precedence order, not a renumbering*
 
 ```text
 usage/config error          (outside the report entirely — 64 everywhere)
-not comparable              (dominates every result axis below)
-removed required library    (release policy)
-budget exceeded             (scan only)
-ABI / API / policy gate
+not comparable               (dominates every result axis below)
+budget exceeded              (scan only)
+removed required library  ─┐ mode-dependent (see below) — NOT a fixed rank
+ABI / API / policy gate    ─┘
 coverage & assurance floors (max-folded, never lowering the above)
 clean
 ```
+
+**Removed-required-library's rank is not fixed, and an earlier draft of this
+table got that wrong** (Codex review): today's contract
+(`docs/reference/exit-codes.md`'s release table,
+`tests/test_compare_release.py::test_removed_and_breaking_exits_4_not_8`) is
+mode-dependent, not a constant precedence slot —
+
+- **legacy scheme** (no severity map in effect): an ABI/API break or an
+  operational `ERROR` wins; removed-library is checked only when neither
+  applies.
+- **severity-aware scheme** (a severity map is in effect): removed-library
+  takes precedence over the aggregated `0/1/2/4`.
+
+`ExitDecision`'s resolver must reproduce this switch, not collapse it into one
+row — the existing legacy-mode test (`4`, not `8`, for a release with both a
+breaking pair and a removed library) is exactly the behavior PR G is
+forbidden from changing, since it is a consolidation of the *algorithm
+selector*, not a migration of release exit semantics.
 
 **`ExitDecision` unifies the precedence, not the numbers, and this is a hard
 constraint on PR G, not a detail** (Codex review of this plan caught an earlier
@@ -899,9 +915,11 @@ PR E  Action machine-report           = PR 1b — uncapped persisted release
                                        findings, no comparison re-run, no
                                        stderr inference; reads G1's block
       └─ then DELETE --annotate, --annotate-additions
-PR F  trusted build config            = PR 3C — build.query / build.compile_db
-                                       only from an explicit --config, trust
-                                       receipt in --dry-run, fail closed
+PR F  trusted build config            = PR 3C — build.query executes only
+                                       from an explicit --config (a data
+                                       path like build.compile_db carries no
+                                       such restriction), trust receipt in
+                                       --dry-run, fail closed
       └─ then DELETE dump --build-query, dump --build-compile-db
 PR G2 canonical exit decision, part 2 = PR 4 — one automatic gate algorithm,
                                        schema / report / Action parity

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -647,6 +647,26 @@ assurance:
   required_status: complete
 ```
 
+**The unset/disabled case must be pinned explicitly, not left implicit
+(Codex review).** `AssuranceStatus` (`analysis_assurance.py`) is already a
+five-value *observed*-status enum — `complete`, `partial`, `failed`,
+`not_comparable`, `not_requested` — and `not_requested` there names something
+`analysis_assurance.status` genuinely comes back as. `assurance.required_status`
+is a different axis: a configured *threshold*, not an observation, so it must
+not reuse `not_requested` (or any other observed-status spelling) to mean "no
+gate configured" — that would make one string do double duty as both a real
+status value and an off switch, and risks gating every default invocation the
+moment the field is merely present with an unexpected value. The field is
+**optional and absent by default**: unset (`null`/key omitted) means exactly
+what today's ungated behavior means — `analysis_assurance_exit_contribution`
+returns `0` regardless of the observed status, matching
+`--require-complete-analysis` never having been passed. Only an explicit
+`required_status: complete` (today's one real tier; a future looser or
+stricter tier is a new value here, not a new key) activates the gate. Pin
+this — the optional field, its `null` default, and its serialization — in the
+config schema and in tests before PR B ships it, not as an implementation
+detail discovered while wiring the resolver.
+
 `--require-complete-analysis` stays as the CLI spelling (the advanced one-run
 override), but resolves into `assurance.required_status: complete`, not into a
 parallel `gate.require_complete_analysis` field — the boolean is a resolver
@@ -671,10 +691,13 @@ target report that legitimately exited `1` could aggregate green (its
 contribution silently overridden by a looser aggregate-time policy), or a
 report that explicitly accepted partial assurance could be newly failed
 downstream by a stricter one. If a future need for `aggregate` to *verify*
-consistent assurance policy across targets emerges, that is a configuration-
-digest check against `effective_policy` (PR 2's field), not a second
-resolution — never a value the aggregate derives from its own gate policy and
-substitutes for what each report already recorded.
+consistent assurance policy across targets emerges, that is a check against
+PR B's per-report effective-configuration digest — not PR 2's
+`effective_policy` (that field is `aggregate`'s own `missing_required`/
+`unexpected_target` target-expectation policy, per
+`aggregate_report.schema.json`, and carries no assurance information to
+compare) — and never a value the aggregate derives from its own gate policy
+and substitutes for what each report already recorded.
 
 **Do not add a further standalone boolean for any new assurance dimension**
 on the comparison-producing side — extend the `assurance.required_status`

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -652,12 +652,34 @@ override), but resolves into `assurance.required_status: complete`, not into a
 parallel `gate.require_complete_analysis` field — the boolean is a resolver
 *input alias*, not a second place the value can live. Ordinary precedence
 `explicit CLI > run plan > project config > built-in default` resolves to one
-field (`resolved_gate.assurance_required_status`) that `compare`,
-`scan --against`, the release compare, `check-target` and `aggregate` all
-read. **Do not add a further standalone boolean for any new assurance
-dimension** — extend the `assurance.required_status` value set, or add a
-sibling key under the same `assurance` namespace, never a second top-level
-spelling of the same fact.
+field (`resolved_gate.assurance_required_status`) that the **comparison-
+producing** front ends read directly: `compare`, `scan --against`,
+the release compare, and `check-target`.
+
+**`aggregate` does not join that list, and must not (Codex review).**
+`aggregate.py` already has this invariant for the sibling contract-coverage
+axis, stated in `_contract_coverage_exit`'s own docstring: "read, not
+recomputed... a per-target run that accepted incomplete coverage must not
+have the aggregate re-impose it." `_analysis_assurance_exit` follows the same
+rule for this axis, folding each report's own persisted
+`analysis_assurance_exit_contribution`. That has to stay true here too — a
+matrix leg and the trailing `aggregate` invocation can resolve differing
+project/run-plan settings, so if `aggregate` recomputed
+`resolved_gate.assurance_required_status` from its own config instead of
+folding what each report already decided, two failure modes open at once: a
+target report that legitimately exited `1` could aggregate green (its
+contribution silently overridden by a looser aggregate-time policy), or a
+report that explicitly accepted partial assurance could be newly failed
+downstream by a stricter one. If a future need for `aggregate` to *verify*
+consistent assurance policy across targets emerges, that is a configuration-
+digest check against `effective_policy` (PR 2's field), not a second
+resolution — never a value the aggregate derives from its own gate policy and
+substitutes for what each report already recorded.
+
+**Do not add a further standalone boolean for any new assurance dimension**
+on the comparison-producing side — extend the `assurance.required_status`
+value set, or add a sibling key under the same `assurance` namespace, never a
+second top-level spelling of the same fact.
 
 ## PR 4 — one gate algorithm (`--exit-code-scheme` removal)
 

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -440,10 +440,12 @@ does not undertake, and would leave two sources for the same verdict/finding
 set free to drift. What actually generalizes across all three operand shapes
 is the *concept* of three fields — `exit`, `contract_coverage_exit_
 contribution`, `analysis_assurance_exit_contribution` — not yet a uniform
-*location* for them today. `compare` (PR G1, landed) puts all three at the
-report's top level. **`scan --against` does not (fresh evidence, Codex
-review):** `ScanOutcome.to_dict()` (`scan_engine.py`) nests its whole
-`diff_summary` under a `"diff"` key, and `_baseline_summary()`
+*location* for them today. `compare` puts all three at the report's top
+level, **implemented in a separate, not-yet-merged PR (#789) — "PR G1" here
+names the plan slice, not a landed state of this codebase; treat it as still
+in flight until that PR merges to `main`.** **`scan --against` does not
+(fresh evidence, Codex review):** `ScanOutcome.to_dict()` (`scan_engine.py`)
+nests its whole `diff_summary` under a `"diff"` key, and `_baseline_summary()`
 (`cli_scan_baseline.py`) writes `analysis_assurance_exit_contribution` and
 the contract-coverage block *into that nested summary*, not the outer
 `ScanOutcome` dict — so today they live at `report["diff"].
@@ -873,10 +875,11 @@ reviewed ordering rather than inside PR 4.
 
 **(2) One canonical `ExitDecision` — the review's PR G proper.** Since #780
 this is no longer two axes but a set of them, and a flat `max()` is not the
-whole rule: a non-comparable pair must dominate every other axis; scan budget
-overflow (`5`) is scan-only; usage error (`64`) is not a result at all and
-never appears in a report; and exit `1` has several distinct causes that a
-bare number cannot tell apart. Encode it once:
+whole rule: scan budget overflow (`5`) is scan-only, and so is a pinned depth
+whose evidence can't be collected (`_EvidenceContractError`, exit `1`); usage
+error (`64`) is not a result at all and never appears in a report; and exit
+`1` has several distinct causes that a bare number cannot tell apart. Encode
+it once:
 
 ```python
 @dataclass(frozen=True)
@@ -891,17 +894,48 @@ class ExitDecision:
 ```
 
 with an explicit precedence resolver, pinned by the ADR and by tests rather
-than distributed across CLI callbacks — **precedence order, not a renumbering**:
+than distributed across CLI callbacks — **precedence order, not a renumbering,
+and derived from what the current code actually does, not from what "should"
+dominate (two rows below were wrong in an earlier draft for exactly that
+reason — Codex review, fresh evidence against `scan_engine.py`)**:
 
 ```text
-usage/config error          (outside the report entirely — 64 everywhere)
-not comparable               (dominates every result axis below)
-budget exceeded              (scan only)
-removed required library  ─┐ mode-dependent (see below) — NOT a fixed rank
-ABI / API / policy gate    ─┘
-coverage & assurance floors (max-folded, never lowering the above)
+usage/config error            (outside the report entirely — 64 everywhere)
+scan evidence-contract error  (scan only, exit 1 — see below)
+scan budget exceeded          (scan only, exit 5 — see below; dominates
+                                not-comparable when both would apply)
+not comparable                (dominates the gate/coverage/assurance axes
+                                below, but not budget — see below)
+removed required library    ─┐ mode-dependent (see below) — NOT a fixed rank
+ABI / API / policy gate      ─┘
+coverage & assurance floors   (max-folded, never lowering the above)
 clean
 ```
+
+**Scan evidence-contract error and the budget-vs-comparability ordering, both
+found by review, fresh evidence against `scan_engine.py`:**
+
+- `run_scan_core` raises `_EvidenceContractError` during evidence collection
+  — before a candidate/baseline comparison is even attempted — whenever a
+  pinned (non-`auto`) `--depth`/`--source-method` has no source evidence to
+  satisfy it (ADR-037 D5). `cli_scan.py` maps it to a `click.ClickException`
+  (exit `1`); `service_scan.py` maps it to `ScanResult(verdict=
+  "EVIDENCE_CONTRACT_ERROR", exit_code=1)`. Distinct from usage error `64`
+  (a bad flag combination) and from the gate's own `1` (a severity-scheme
+  error-level finding) — it's "the evidence contract this run pinned itself
+  to could not be met," always scan-only, and an earlier draft of this table
+  omitted it entirely.
+- An earlier draft also had not-comparable dominating budget overflow — the
+  real code does the opposite. `run_scan_core`'s baseline-compare block can
+  set `exit_code = 6` (`NOT_COMPARABLE`) on a `ProfileMismatchError`/
+  `ScopeMismatchError`, but `_check_scan_budget(budget, budget_s, elapsed)`
+  still runs unconditionally afterward and, if the elapsed time is over
+  budget, *raises* `_BudgetOverflow` regardless of what was already decided
+  — discarding the not-comparable result before `ScanOutcome` is even
+  constructed, so the caller maps the exception to exit `5`. So today, when
+  both conditions hold in the same run, budget wins. `ExitDecision`'s
+  resolver must reproduce that order, not the "more fundamental axis should
+  dominate" ordering that reads more natural on paper.
 
 **Removed-required-library's rank is not fixed, and an earlier draft of this
 table got that wrong** (Codex review): today's contract

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -98,49 +98,51 @@ default" on an unrelated PR — GitHub blocks merge on a required check that
 never reports at all, the same as on a failing one, so requiring any of these
 three as written would strand every PR that doesn't touch their paths. Cover:
 
-**The distinction that actually matters is trigger-level path filtering, not
-a workflow's *name* sounding conditional (a second Codex review round caught
-an earlier draft of this list conflating the two).** Checked directly against
-each workflow's own `on: pull_request:` block: `changelog-check.yml`,
-`bugfix-test-contract.yml`, and `cli-interface-check.yml` all carry **no**
-`paths:` filter — they run on every PR and decide applicability *inside* the
-job (a `skip-changelog`/`skip-test-contract` label, or the diffed-CLI-surface
-check's own no-op-when-unchanged logic), so a check run always exists to be
-required. `test-action.yml` alone among this group genuinely is
-trigger-level path-filtered (`paths: [action.yml, action/**, ...]`) — it is
-the one entry that needs the conditional/neutral-aggregate treatment below.
+**This section states a rule, not a list — after three review rounds each
+catching a different mistake in a hand-copied snapshot, hand-copying a
+fourth one is the wrong fix.** Round 1 conflated "sounds conditional" with
+"is trigger-filtered" (put `CLI Interface Check` in the wrong bucket, missed
+`Changelog Fragment Check`/`Bug-fix test contract` entirely). Round 2 found
+the fixed list still missed `docs-pr.yml` — required whenever
+`docs/**`/`abicheck/schemas/**`/`examples/**`/`mkdocs.yml` changes per
+`.github/AGENTS.md`, *and* genuinely trigger-path-filtered on those same
+paths, the identical shape as `test-action.yml`. Round 3 found the fallback
+plan itself wrong: **no native GitHub mechanism — not classic branch
+protection, not a Ruleset's required-status-checks rule — conditions
+"required" on which files a given PR touched.** A Ruleset can require a
+check unconditionally for matching refs; it cannot express "required only
+when `action/**` changed." So there is no first-class way to make a
+trigger-path-filtered workflow's own check required without also stranding
+every PR that doesn't touch its paths — the neutral-aggregate wrapper below
+is not a fallback for when the ideal mechanism is unavailable, it is the
+*only* correct approach for this class of workflow.
 
-- **always-required** (workflow always runs and reports, applicability
-  decided internally — safe to require unconditionally): `CI` (or its
-  constituent jobs), `Security & Quality` (`security.yml`),
-  `dependency-review.yml`, `Changelog Fragment Check`
-  (`changelog-check.yml`), `Bug-fix test contract` (`bugfix-test-contract.yml`),
-  `CLI Interface Check` (`cli-interface-check.yml`), and the docs/schema
-  checks that run unconditionally.
-- **conditionally-required, only for a genuinely trigger-path-filtered
-  workflow**, and only if the branch protection / Ruleset mechanism used
-  actually supports a path-scoped required check (GitHub Rulesets do;
-  classic branch protection's required-status-checks list does not
-  distinguish "didn't run" from "should have run and didn't"): `Test GitHub
-  Action` when `action/**`/`action.yml` changed.
-- **not required**: `Examples Validation`, `AgentReady` — both stay
-  informational, matching `.github/AGENTS.md`; PR 0B does not change that
-  classification, only enforces the subset the table already calls required.
+**The rule PR 0B's implementer applies, once, against `.github/AGENTS.md`'s
+table at implementation time (not against a hand-copied snapshot here,
+which is what has now drifted wrong three times in a row):**
 
-**Don't hand-copy this list again without re-checking each workflow's own
-`on:` block** — this is exactly the second time a plausible-sounding
-classification here turned out wrong on inspection. If PR 0B's implementer
-finds this list has drifted from `.github/AGENTS.md`'s table by then, treat
-that table (and each workflow file's own trigger) as authoritative and fix
-this list to match, not the other way around.
+1. For every workflow that table marks required (unconditionally or "when
+   X changes"), read its own `on: pull_request:` block.
+2. **No `paths:` filter** (the workflow always runs; a `skip-*` label or
+   internal diff check decides applicability) → require its check directly.
+   Example: `changelog-check.yml` has no `paths:` filter — required
+   directly, its own `skip-changelog` label is the escape hatch, not a
+   missing check run.
+3. **Has a `paths:` filter** (the workflow may not run at all on an
+   unrelated PR) → never require its check directly. Add — or extend — one
+   always-triggered neutral-aggregate job that itself reads the same path
+   set that workflow's own condition uses, reports success when the paths
+   don't apply and otherwise mirrors that workflow's real outcome, and
+   require *that* aggregate job instead. Example: both `test-action.yml`
+   and `docs-pr.yml` are in this bucket.
+4. Anything the table marks **not required** (`Examples Validation`,
+   `AgentReady`, `docs-review-triggers.yml`, ...) stays out of the required
+   set entirely; PR 0B does not change that classification.
 
-If the chosen mechanism cannot express "required only when triggered,"
-the safer fallback is an always-running **neutral aggregate status** (a thin
-job that reports success on every PR regardless of whether the conditional
-workflows ran) rather than requiring the conditional workflows' own checks
-directly — the "one stable aggregate check per workflow" rule below still
-holds *within* the always-required set, but must not be used to paper over a
-genuinely conditional workflow.
+This rule is self-checking in a way a copied list is not: step 1 always
+starts from the table's current contents, and steps 2/3 are a mechanical
+read of each workflow's own trigger, not a memory of what a prior draft of
+this document said.
 
 Prefer **one stable aggregate required check per always-required workflow**
 (or a Ruleset-compatible job) over requiring every matrix leg individually —

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -632,23 +632,32 @@ packs cannot set it. That is one boolean per assurance dimension, decided at
 the CLI, and it does not scale: the next assurance dimension would arrive as a
 second such boolean.
 
-So fold its *semantics* into the typed gate/assurance policy PR B/PR G build:
+So fold its *semantics* into the typed gate/assurance policy PR B/PR G build —
+**one persisted key, not two**: an earlier draft of this section showed
+`assurance.required_status` and `gate.require_complete_analysis` as
+interchangeable spellings, which recreates exactly the duplicate-configuration
+surface this cleanup exists to remove and leaves schema authors to guess which
+one is canonical (Codex review). Pick `assurance.required_status` — it is the
+extensible form (a status enum, not a boolean, so a future partial-assurance
+tier is a new value, not a new key) — and treat everything else as an alias
+into it, never a second key:
 
 ```yaml
 assurance:
   required_status: complete
-# or, equivalently addressed from the gate namespace:
-gate:
-  require_complete_analysis: true
 ```
 
-with the ordinary precedence `explicit CLI > run plan > project config >
-built-in default`, resolving to a single field
-(`resolved_gate.require_complete_analysis`) that `compare`, `scan --against`,
-the release compare, `check-target` and `aggregate` all read. The flag itself
-stays as the advanced one-run override. **Do not add a further standalone
-boolean for any new assurance dimension** — add it to the resolved policy
-object instead.
+`--require-complete-analysis` stays as the CLI spelling (the advanced one-run
+override), but resolves into `assurance.required_status: complete`, not into a
+parallel `gate.require_complete_analysis` field — the boolean is a resolver
+*input alias*, not a second place the value can live. Ordinary precedence
+`explicit CLI > run plan > project config > built-in default` resolves to one
+field (`resolved_gate.assurance_required_status`) that `compare`,
+`scan --against`, the release compare, `check-target` and `aggregate` all
+read. **Do not add a further standalone boolean for any new assurance
+dimension** — extend the `assurance.required_status` value set, or add a
+sibling key under the same `assurance` namespace, never a second top-level
+spelling of the same fact.
 
 ## PR 4 — one gate algorithm (`--exit-code-scheme` removal)
 

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -98,18 +98,41 @@ default" on an unrelated PR — GitHub blocks merge on a required check that
 never reports at all, the same as on a failing one, so requiring any of these
 three as written would strand every PR that doesn't touch their paths. Cover:
 
-- always-required: `CI` (or its constituent jobs), `Security & Quality`
-  (`security.yml`), `dependency-review.yml`, and the docs/schema checks that
-  run unconditionally.
-- conditionally-required, **only if the branch protection / Ruleset
-  mechanism used actually supports a path-scoped required check** (GitHub
-  Rulesets do; classic branch protection's required-status-checks list does
-  not distinguish "didn't run" from "should have run and didn't"): `CLI
-  Interface Check` when the CLI surface changed, `Test GitHub Action` when
-  `action/**`/`action.yml` changed.
+**The distinction that actually matters is trigger-level path filtering, not
+a workflow's *name* sounding conditional (a second Codex review round caught
+an earlier draft of this list conflating the two).** Checked directly against
+each workflow's own `on: pull_request:` block: `changelog-check.yml`,
+`bugfix-test-contract.yml`, and `cli-interface-check.yml` all carry **no**
+`paths:` filter — they run on every PR and decide applicability *inside* the
+job (a `skip-changelog`/`skip-test-contract` label, or the diffed-CLI-surface
+check's own no-op-when-unchanged logic), so a check run always exists to be
+required. `test-action.yml` alone among this group genuinely is
+trigger-level path-filtered (`paths: [action.yml, action/**, ...]`) — it is
+the one entry that needs the conditional/neutral-aggregate treatment below.
+
+- **always-required** (workflow always runs and reports, applicability
+  decided internally — safe to require unconditionally): `CI` (or its
+  constituent jobs), `Security & Quality` (`security.yml`),
+  `dependency-review.yml`, `Changelog Fragment Check`
+  (`changelog-check.yml`), `Bug-fix test contract` (`bugfix-test-contract.yml`),
+  `CLI Interface Check` (`cli-interface-check.yml`), and the docs/schema
+  checks that run unconditionally.
+- **conditionally-required, only for a genuinely trigger-path-filtered
+  workflow**, and only if the branch protection / Ruleset mechanism used
+  actually supports a path-scoped required check (GitHub Rulesets do;
+  classic branch protection's required-status-checks list does not
+  distinguish "didn't run" from "should have run and didn't"): `Test GitHub
+  Action` when `action/**`/`action.yml` changed.
 - **not required**: `Examples Validation`, `AgentReady` — both stay
   informational, matching `.github/AGENTS.md`; PR 0B does not change that
   classification, only enforces the subset the table already calls required.
+
+**Don't hand-copy this list again without re-checking each workflow's own
+`on:` block** — this is exactly the second time a plausible-sounding
+classification here turned out wrong on inspection. If PR 0B's implementer
+finds this list has drifted from `.github/AGENTS.md`'s table by then, treat
+that table (and each workflow file's own trigger) as authoritative and fix
+this list to match, not the other way around.
 
 If the chosen mechanism cannot express "required only when triggered,"
 the safer fallback is an always-running **neutral aggregate status** (a thin

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -386,8 +386,15 @@ With that in place the Action does not parse stderr, does not re-run any
 comparison, does not guess why the exit was `1`, renders annotations from the
 persisted findings and the Job Summary from the same object, and behaves
 identically for a single pair and a release fan-out. The `exit` block is the
-same object PR 4/G formalizes as `ExitDecision` — build it once, in PR G, and
-have PR E consume it rather than inventing a second, Action-shaped spelling.
+same object PR 4/G formalizes as `ExitDecision`. Build it once and consume it
+once — which is why PR G is split, and the split is load-bearing for this
+section rather than cosmetic: **G1** builds the decision object and emits its
+report block (no CLI behaviour change, no flag removed) and lands *before* PR
+E; **G2** makes today's `auto` the only gate algorithm and deletes
+`--exit-code-scheme`. Without that split PR E would have to either depend on
+unlanded work or invent the second, Action-shaped spelling this section
+prohibits. If G1 slips, PR E ships its annotations half and leaves the
+gate-explanation half — not a private `exit` block of its own.
 
 **Tests.** A saved report fixture (both a single-library and a release-style
 report) must produce, through the Action's renderer, byte-identical
@@ -701,11 +708,12 @@ reviewed ordering rather than inside PR 4.
 
 **(2) One canonical `ExitDecision` — the review's PR G proper.** Since #780
 this is no longer two axes but a set of them, and a flat `max()` is not the
-whole rule: `NOT_COMPARABLE` (`16`) must dominate; a removed required library
-(`8`) has its own release policy and is already checked ahead of the
-coverage-only fallback; scan budget overflow (`5`) is scan-only; usage error
-(`64`) is not a result at all and never appears in a report; and exit `1` has
-several distinct causes that a bare number cannot tell apart. Encode it once:
+whole rule: a non-comparable pair must dominate every other axis; a removed
+required library (`8`) has its own release policy and is already checked ahead
+of the coverage-only fallback; scan budget overflow (`5`) is scan-only; usage
+error (`64`) is not a result at all and never appears in a report; and exit `1`
+has several distinct causes that a bare number cannot tell apart. Encode it
+once:
 
 ```python
 @dataclass(frozen=True)
@@ -720,22 +728,37 @@ class ExitDecision:
 ```
 
 with an explicit precedence resolver, pinned by the ADR and by tests rather
-than distributed across CLI callbacks:
+than distributed across CLI callbacks — **precedence order, not a renumbering**:
 
 ```text
-usage/config error        → 64, outside the report
-not comparable            → 16
-removed required library  →  8  (release policy)
-budget exceeded           →  5  (scan)
-ABI / API / policy gate   →  4 / 2 / 1
-coverage & assurance floors → 1  (max-folded, never lowering the above)
-clean                     →  0
+usage/config error          (outside the report entirely — 64 everywhere)
+not comparable              (dominates every result axis below)
+removed required library    (release policy)
+budget exceeded             (scan only)
+ABI / API / policy gate
+coverage & assurance floors (max-folded, never lowering the above)
+clean
 ```
 
-`reasons` is what makes a shared `1` explainable, and it is the same block PR
-1b/E has the Action read instead of inferring from stderr. `docs/reference/
-exit-codes.md` becomes a rendering of this resolver, not a parallel hand-kept
-table.
+**`ExitDecision` unifies the precedence, not the numbers, and this is a hard
+constraint on PR G, not a detail** (Codex review of this plan caught an earlier
+draft that wrote a single global number per row). Every command keeps its own
+exit-code scheme, and `docs/reference/exit-codes.md` already says so
+explicitly: a non-comparable pair is `16` for native `compare`, **`6`** for
+`scan --against`, and `9` for `compat check`. A resolver that emitted one
+number for that row would silently renumber `scan`, breaking every script and
+Action consumer that recognises `6` — while PR G is framed as removing the
+*algorithm selector*, not as a command-numbering migration. So the resolver
+answers "which reason wins", and each command's own code table maps the winning
+reason to its own number; renumbering, if ever wanted, is a separate, explicitly
+designed and documented breaking change with its own migration note.
+
+`reasons` is what makes a shared `1` explainable, and it is the same block PR E
+has the Action read instead of inferring from stderr — see the split of PR G
+into **G1** (the decision object and its report block, no CLI change, landing
+*before* PR E) and **G2** (one gate algorithm, `--exit-code-scheme` deleted) in
+"Ordering". `docs/reference/exit-codes.md` becomes a rendering of this resolver
+plus each command's own mapping, not a parallel hand-kept table.
 
 **Atomic change set:** remove the flag from `compare` and `scan`; migrate the
 Action side — there is **no** `exit-code-scheme` input in `action.yml` to
@@ -868,17 +891,20 @@ PR C  typed dump convergence          = PR 3A — DumpRequest →
 PR D  build-context completeness      = PR 3B — matched compile-unit
                                        selection, forced includes, provenance
                                        tests
+PR G1 canonical exit decision, part 1 — ExitDecision + reasons + the report
+                                       block, precedence pinned by ADR and
+                                       tests; NO CLI change, no flag removed.
+                                       Lands before PR E, which consumes it
 PR E  Action machine-report           = PR 1b — uncapped persisted release
                                        findings, no comparison re-run, no
-                                       stderr inference
+                                       stderr inference; reads G1's block
       └─ then DELETE --annotate, --annotate-additions
 PR F  trusted build config            = PR 3C — build.query / build.compile_db
                                        only from an explicit --config, trust
                                        receipt in --dry-run, fail closed
       └─ then DELETE dump --build-query, dump --build-compile-db
-PR G  canonical exit decision         = PR 4 — ExitDecision + reasons + one
-                                       automatic gate algorithm, schema /
-                                       report / Action parity
+PR G2 canonical exit decision, part 2 = PR 4 — one automatic gate algorithm,
+                                       schema / report / Action parity
       └─ then DELETE --exit-code-scheme
 PR H  artifact-set semantics          = PR 5 — provider ownership, moved and
                                        duplicated symbols, cost and dry-run;

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -87,12 +87,42 @@ Separately, the exact merge SHA of #782 did not run a full CI sweep on
 Validation was still running; no separate full `ci.yml` run over that exact
 SHA), which is precisely what item 4 exists to make detectable.
 
-Required checks should cover at least: `CI`, `Examples Validation`, `Test
-GitHub Action`, `CLI Interface Check`, `Security & Quality`, `AgentReady`, and
-the docs/schema checks. Prefer **one stable aggregate required check per
-workflow** (or a Ruleset-compatible job) over requiring every matrix leg
-individually — a matrix-leg-level required list goes stale on every matrix
-edit and is the usual reason required checks get turned back off.
+**The required-check list must match `.github/AGENTS.md`'s own required-vs-
+informational classification, not the set of workflow names visible in a run
+(Codex review caught an earlier draft that didn't).** `Examples Validation`
+and `agentready.yml` are both explicitly `No (informational)` there, and
+`test-action.yml` is conditional — it runs only when `action/**`/`action.yml`
+changes, path-filtered like several other workflows in that same table. A
+required check that a path-filtered workflow never starts is not "green by
+default" on an unrelated PR — GitHub blocks merge on a required check that
+never reports at all, the same as on a failing one, so requiring any of these
+three as written would strand every PR that doesn't touch their paths. Cover:
+
+- always-required: `CI` (or its constituent jobs), `Security & Quality`
+  (`security.yml`), `dependency-review.yml`, and the docs/schema checks that
+  run unconditionally.
+- conditionally-required, **only if the branch protection / Ruleset
+  mechanism used actually supports a path-scoped required check** (GitHub
+  Rulesets do; classic branch protection's required-status-checks list does
+  not distinguish "didn't run" from "should have run and didn't"): `CLI
+  Interface Check` when the CLI surface changed, `Test GitHub Action` when
+  `action/**`/`action.yml` changed.
+- **not required**: `Examples Validation`, `AgentReady` — both stay
+  informational, matching `.github/AGENTS.md`; PR 0B does not change that
+  classification, only enforces the subset the table already calls required.
+
+If the chosen mechanism cannot express "required only when triggered,"
+the safer fallback is an always-running **neutral aggregate status** (a thin
+job that reports success on every PR regardless of whether the conditional
+workflows ran) rather than requiring the conditional workflows' own checks
+directly — the "one stable aggregate check per workflow" rule below still
+holds *within* the always-required set, but must not be used to paper over a
+genuinely conditional workflow.
+
+Prefer **one stable aggregate required check per always-required workflow**
+(or a Ruleset-compatible job) over requiring every matrix leg individually —
+a matrix-leg-level required list goes stale on every matrix edit and is the
+usual reason required checks get turned back off.
 
 The "Verified state" below is kept as the historical record of what PR 0A
 fixed; it describes `main` as of PR #779, not today.


### PR DESCRIPTION
## Summary

Fold the fresh review of `docs/contribute/plans/cli-cleanup-phase-two.md` (against `main` at `410caf5`) into the plan: two stages are done, and the remaining ones are re-sequenced by contract convergence rather than by risk.

## Motivation

The plan was written before #779, #780 and #782 landed. PR 1 (presentation) and PR 2 (aggregate policy) are implemented and reviewed as correct, so the plan's ordering no longer describes the next step. More importantly, #782 showed that the remaining work is not mechanical flag removal: it fixed a real defect (a `dump` baseline and a `scan --against` candidate given the same `compile_commands.json` resolving to non-comparable `CompileContext`s) **additively, across three separate resolution paths**. Deleting a flag that three paths interpret differently removes the only place a user can see the divergence, not the divergence itself — so the shared typed resolution, configuration, gate and report contracts have to converge before each deletion.

Docs-only; no code, schema or behaviour changes.

## Changes

- **PR 0 split.** 0A (the six Windows MSYS/Git-Bash test failures) is closed at the test level — both Windows lanes passed on #782. 0B (required checks / Ruleset, exact-merge-SHA verification) is still open and still P0: the branch API reports `protected: true` with `required_status_checks.enforcement_level: off` and empty `contexts`/`checks`, so a red CI does not block a merge. Adds the suggested required-check set and the "one aggregate check per workflow, not per matrix leg" guidance.
- **PR 1.** Marked closed, with the negative housekeeping recorded: the Tier-2 `render_output(stat=..., show_recommendation=...)` shims must not leak back as CLI flags, and `--report-mode` must not grow `summary`/`release` values to rehome the removed flags.
- **PR 2.** Records the still-open follow-up: the gate policy reached the right lifecycle stage (versioned, alongside the expected target set) but is still restated per `project plan` invocation; an `aggregate.gate` key in `.abicheck.yml` should source it, after which the two `project plan` gate flags go too. Independent of the rest of the chain.
- **PR 1b.** Adds the invariant *"the Action never infers a gate's identity or reason from stderr when the versioned report already carries it"*, the uniform persisted report shape it needs for both operand shapes, and an accurate note on today's state (`_assurance_gated` is already JSON-first via a dedicated Action input plus `analysis_assurance.status`; the debt is that it re-derives the gate rather than reading the persisted `analysis_assurance_exit_contribution`, and that a release operand has no persisted report at all).
- **PR 3 split** into 3A (typed dump convergence — `DumpRequest → ResolvedDumpRequest → DumpResult`, one resolver for CLI/Python/Action, `--dry-run` rendered from that object), 3B (build-context completeness — matched compile-unit selection for the L2 include seed, and `-include`/`-imacros`/`/FI`/`/FU` in `ABI_RELEVANT_FLAG_PREFIXES`; both already recorded as known gaps in the root `AGENTS.md`, both change the parsed public surface), and 3C (the removal itself).
- **PR 4** gains two prerequisites: pack parity (packs resolved once into one `CompatibilityEvaluationConfig` + `GateOptions` shared by compare/release/scan/Action, with an effective-config digest in every report — today `--pack` is accepted by single-pair compare, rejected by the release fan-out, and gate-pack-rejected by scan), and a canonical `ExitDecision` with an explicit precedence resolver, since a flat `max()` cannot express `NOT_COMPARABLE` 16, removed-library 8, scan budget 5, usage 64, or the several distinct causes of a shared exit 1.
- **New section on `--require-complete-analysis`** (#780): keep the flag — it answers a real, distinct question — but move its semantics into the resolved gate/assurance policy with normal precedence, rather than accumulating one CLI-only boolean per assurance dimension.
- **PR 5.** Reaffirmed as refinement, not removal; `--artifact-set-manifest` only when it carries a real domain contract.
- **Ordering** replaced with the reviewed PR A–H sequence, with the original kept inline as superseded and each old PR number mapped to its new slot.

## Checklist

- [x] Tests added / updated for new behaviour — n/a, docs-only
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — n/a, no Python changes
- [x] Docs updated if user-visible behaviour changed — n/a, no behaviour change; this PR is the doc update
- [x] `verify.py --profile pr --only docs-build,docs-contract` passes locally (`mkdocs build --strict` green; docs-contract 0 errors, 0 warnings)
- [x] No new `mypy` or `ruff` errors introduced — no code touched

---
_Generated by [Claude Code](https://claude.ai/code/session_019Mwis9VTYR6gHsxmqBtPFk)_