### PR TITLE
feat(exit): canonical ExitDecision resolver (CLI cleanup phase two, PR G1)

### DIFF
--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -1046,48 +1046,45 @@ def _exit_with_severity_or_verdict(
 ) -> None:
     """Exit with the appropriate code for the resolved exit-code scheme.
 
-    ADR-049 Phase 7: the contract-coverage axis is folded in here rather than
-    at each call site, so a command cannot acquire a compatibility exit and
-    forget the orthogonal one. `fold_coverage_exit` reads the floor off
-    *result*'s own persisted context and is `0` when the run recorded none.
-
-    P0.4: the analysis-assurance axis (`--require-complete-analysis`) is
-    folded the same way, immediately after -- both are `max`-based orthogonal
-    floors, and folding this one here too means a caller cannot pick up one
-    axis's exit contribution and forget the other's, the same reasoning
-    ADR-049 Phase 7's docstring above already gives for its own axis. `0`
-    contribution, and this is a pure no-op, whenever the flag was not passed.
+    ADR-049 Phase 7 / P0.4: the contract-coverage and analysis-assurance axes
+    are folded in here rather than at each call site, so a command cannot
+    acquire a compatibility exit and forget an orthogonal one. Since CLI
+    cleanup phase two PR G1, the fold itself is
+    `exit_decision.resolve_compare_exit_decision` -- the one canonical
+    resolver, rather than three separately-called `max` folds -- so a
+    caller building the report's `exit` block (`reporter_contract_blocks.
+    add_contract_context`) and this function's own process exit read the
+    identical decision. The diagnostics below still read each axis's own
+    contribution straight off the resolved `ExitDecision`, so their wording
+    (and the final exit code) are unchanged from before this delegation.
     """
-    from .analysis_assurance import (
-        assurance_floor_diagnostic,
-        fold_analysis_assurance_exit,
+    from .analysis_assurance import assurance_floor_diagnostic
+    from .contract_coverage_exit import announce_coverage_floor
+    from .exit_decision import resolve_compare_exit_decision
+
+    decision = resolve_compare_exit_decision(
+        result, sev_config, scheme,
+        require_complete_analysis=require_complete_analysis,
     )
-    from .contract_coverage_exit import announce_coverage_floor, fold_coverage_exit
-    from .severity import compute_exit_code, legacy_exit_code
-    if scheme == "severity":
-        assert sev_config is not None
-        eff_sets = result._effective_kind_sets()
-        exit_code = compute_exit_code(
-            result.changes,
-            sev_config,
-            policy=result.policy,
-            kind_sets=eff_sets,
-            policy_file=result.policy_file,
-        )
-    else:
-        exit_code = legacy_exit_code(result.verdict)
-    announce_coverage_floor(result, base_exit=exit_code, fmt=fmt, secondary_fmt=secondary_fmt)
-    exit_code = fold_coverage_exit(exit_code, result)
+    announce_coverage_floor(
+        result, base_exit=decision.compatibility_contribution,
+        fmt=fmt, secondary_fmt=secondary_fmt,
+    )
+    # The pre-assurance exit is what the diagnostic's own wording describes
+    # ("floored to"/"contributes, below the compatibility axis's own exit"),
+    # so it excludes the assurance contribution itself rather than reading
+    # `decision.code` (which, when assurance is the winning axis, would be
+    # self-referential).
+    pre_assurance_exit = max(
+        decision.compatibility_contribution, decision.contract_coverage_contribution,
+    )
     diagnostic = assurance_floor_diagnostic(
-        result, require_complete=require_complete_analysis, base_exit=exit_code
+        result, require_complete=require_complete_analysis, base_exit=pre_assurance_exit
     )
     if diagnostic is not None:
         click.echo(diagnostic, err=True)
-    exit_code = fold_analysis_assurance_exit(
-        exit_code, result, require_complete=require_complete_analysis
-    )
-    if exit_code != 0:
-        sys.exit(exit_code)
+    if decision.code != 0:
+        sys.exit(decision.code)
 
 
 def _log_one_side_debug(

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1218,6 +1218,13 @@ def _report_compare_result(
             fold_analysis_assurance_exit,
         )
 
+        # `exit_decision.resolve_compare_exit_decision`'s own reasons need
+        # the *pre-fold* scoped contribution, not the already-folded value
+        # `result.scoped_exit_code` ends up holding below -- otherwise a
+        # scoped gate floored by (say) `--require-complete-analysis` alone
+        # reports `reasons: ["scoped_gate"]` even though the scoped gate
+        # itself never contributed to that number (Codex review).
+        result.scoped_compatibility_contribution = scoped_exit_code  # type: ignore[attr-defined]
         announce_coverage_floor(
             result,
             base_exit=scoped_exit_code,

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -180,6 +180,7 @@ _CompareReleaseCommonArgs = tuple[
     bool,
     bool,
     str | None,
+    "SeverityConfig | None",
 ]
 
 
@@ -222,6 +223,7 @@ def _compare_one_library(
     include_dependencies: bool = True,
     contract_evaluation: bool = False,
     contract_mode: str | None = None,
+    severity_config: SeverityConfig | None = None,
 ) -> dict[str, object]:
     """Compare one library pair — suitable for parallel dispatch.
 
@@ -233,6 +235,15 @@ def _compare_one_library(
     the ``"_diff_result"`` key. Callers that need the full diff (the
     bundle layer, JUnit aggregation) pop it from the entry before
     JSON-serialising — keeps the per-library compare a single-pass.
+
+    *severity_config* is forwarded to the per-library ``--output-dir`` JSON
+    write below (Codex review, fresh evidence): without it, that write
+    always used the legacy exit-code scheme's ``ExitDecision`` regardless of
+    whether the release itself resolved and gates on a severity
+    configuration — so a severity-aware release (``severity.addition:
+    error``, say) could exit non-zero at the release level while every
+    per-library report it wrote said ``exit.code: 0``, ``reasons:
+    ["clean"]``, disagreeing with the release's own real exit.
     """
     old_path = old_map[key]
     new_path = new_map[key]
@@ -308,7 +319,9 @@ def _compare_one_library(
             entry["filtered_internal_count"] = result.out_of_surface_count
         if output_dir:
             lib_report_path = output_dir / f"{old_path.stem}.json"
-            _safe_write_output(lib_report_path, to_json(result))
+            _safe_write_output(
+                lib_report_path, to_json(result, severity_config=severity_config)
+            )
         return entry
     except (ProfileMismatchError, ScopeMismatchError) as exc:
         # ADR-050 D2 — ordered before the generic except Exception below.
@@ -350,6 +363,7 @@ def _suppress_lockstep_soname_findings(
     library_results: list[dict[str, object]],
     worst_verdict: str,
     output_dir: Path | None,
+    severity_config: SeverityConfig | None = None,
 ) -> int:
     """Drop ``SONAME_BUMP_UNNECESSARY`` when the release is a coordinated break.
 
@@ -359,7 +373,14 @@ def _suppress_lockstep_soname_findings(
     SONAME in lockstep is the correct, intentional practice — so the per-library
     "unnecessary" signal is a false positive at the release level. Mutates the
     affected per-library results (and re-writes their JSON when ``output_dir`` is
-    set) and returns the number of findings suppressed.
+    set) and returns the number of findings suppressed. *severity_config* is
+    forwarded to that re-write's own ``to_json`` call (Codex review, fresh
+    evidence): without it, a severity-aware release's per-library report file
+    would revert to the legacy exit-code scheme's ``exit`` block on this
+    second write, even though ``_compare_one_library``'s first write already
+    used the severity-aware one — so which scheme a report's ``exit`` block
+    reflects would depend on whether this suppression fired, not on the
+    release's actual configuration.
 
     Only a binary-incompatible (``BREAKING``) finding justifies a SONAME bump; a
     source-only ``API_BREAK`` does not, so the warning is preserved in that case.
@@ -394,7 +415,9 @@ def _suppress_lockstep_soname_findings(
         )
         if output_dir is not None:
             lib_report_path = output_dir / f"{Path(str(entry['library'])).stem}.json"
-            _safe_write_output(lib_report_path, to_json(result))
+            _safe_write_output(
+                lib_report_path, to_json(result, severity_config=severity_config)
+            )
     return suppressed
 
 
@@ -485,6 +508,7 @@ def _compare_release_libraries(
         include_dependencies,
         contract_evaluation,
         contract_mode,
+        severity_config,
     )
 
     if effective_jobs > 1 and len(matched_keys) > 1:
@@ -523,6 +547,7 @@ def _compare_release_libraries(
         library_results,
         worst_verdict,
         output_dir,
+        severity_config,
     )
     if suppressed_soname:
         click.echo(

--- a/abicheck/compat/cli.py
+++ b/abicheck/compat/cli.py
@@ -1410,7 +1410,15 @@ def _generate_compat_report(
             compiler=_detect_compiler_version(gcc_path),
         )
     elif fmt == "json":
-        path.write_text(to_json(r), encoding="utf-8")
+        # `include_exit_decision=False`: this is ABICC-compat's own
+        # `report-format json`, whose real process exit follows the
+        # 0/1/2 ABICC scheme (`_classify_compat_error_exit_code`), not the
+        # native `legacy_exit_code`/`compute_exit_code` PR G1's `exit` block
+        # would compute -- emitting it here would disagree with the actual
+        # `compat check` exit code for the same run (Codex review).
+        path.write_text(
+            to_json(r, include_exit_decision=False), encoding="utf-8"
+        )
     else:
         path.write_text(to_markdown(r), encoding="utf-8")
 

--- a/abicheck/exit_decision.py
+++ b/abicheck/exit_decision.py
@@ -77,6 +77,7 @@ class ExitReason(str, Enum):
     """
 
     COMPATIBILITY_GATE = "compatibility_gate"
+    SCOPED_GATE = "scoped_gate"
     CONTRACT_COVERAGE = "contract_coverage"
     ANALYSIS_ASSURANCE = "analysis_assurance"
     CLEAN = "clean"
@@ -172,10 +173,47 @@ def resolve_compare_exit_decision(
     one canonical resolution, so a caller building the report's ``exit``
     block and a caller computing the real process exit code cannot read
     two different numbers for the same comparison.
+
+    **`--used-by`/`--required-symbol(s)` scoped gating overrides the
+    compatibility axis entirely (Codex review, fresh evidence).**
+    `cli_compare_helpers._apply_scoped_gating` floors the *full-library*
+    verdict/severity gate this function would otherwise compute to the
+    scoped application/plugin-host contract's own result, already folded
+    with the coverage/assurance floors, and persists it onto
+    `result.scoped_exit_code` before any report renders -- `cli.py` itself
+    exits on that value directly (`sys.exit(scoped_exit_code)`), never
+    reaching `_exit_with_severity_or_verdict`/this function's own
+    compatibility-axis computation. An earlier revision of this function
+    ignored that and derived `compatibility_contribution` from
+    `result.verdict`/severity regardless -- reporting the full-library
+    gate's code (which is informational-only under scoping) while the real
+    process exited on the scoped one, so a report consumer trusting this
+    field would disagree with the CLI. When `scoped_exit_code` is set, it
+    *is* the decision: reported directly (already-folded, so not re-folded
+    through `resolve_exit_decision`) under its own `SCOPED_GATE` reason,
+    never recomputed from the unscoped verdict.
     """
     from .analysis_assurance import analysis_assurance_exit_contribution
     from .contract_coverage_exit import coverage_exit_floor
     from .severity import compute_exit_code, legacy_exit_code
+
+    coverage_contribution = coverage_exit_floor(result)
+    assurance_contribution = analysis_assurance_exit_contribution(
+        result, require_complete=require_complete_analysis
+    )
+
+    scoped_exit_code = getattr(result, "scoped_exit_code", None)
+    if scoped_exit_code is not None:
+        reasons: tuple[ExitReason, ...] = (
+            (ExitReason.SCOPED_GATE,) if scoped_exit_code else (ExitReason.CLEAN,)
+        )
+        return ExitDecision(
+            code=scoped_exit_code,
+            reasons=reasons,
+            compatibility_contribution=scoped_exit_code,
+            contract_coverage_contribution=coverage_contribution,
+            analysis_assurance_contribution=assurance_contribution,
+        )
 
     if scheme == "severity":
         assert sev_config is not None
@@ -190,8 +228,6 @@ def resolve_compare_exit_decision(
         compatibility_contribution = legacy_exit_code(result.verdict)
     return resolve_exit_decision(
         compatibility_contribution=compatibility_contribution,
-        contract_coverage_contribution=coverage_exit_floor(result),
-        analysis_assurance_contribution=analysis_assurance_exit_contribution(
-            result, require_complete=require_complete_analysis
-        ),
+        contract_coverage_contribution=coverage_contribution,
+        analysis_assurance_contribution=assurance_contribution,
     )

--- a/abicheck/exit_decision.py
+++ b/abicheck/exit_decision.py
@@ -16,7 +16,7 @@
 """The canonical ``ExitDecision`` — CLI cleanup phase two, PR G1.
 
 ``docs/contribute/plans/cli-cleanup-phase-two.md``'s PR 4 records that a
-single-pair `compare`/`scan --against` invocation's exit code is folded from
+single-pair `compare` invocation's exit code is folded from
 several independently-computed, orthogonal contributions today
 (`severity.compute_exit_code`/`severity.legacy_exit_code`,
 `contract_coverage_exit.fold_coverage_exit`,
@@ -176,12 +176,20 @@ def resolve_compare_exit_decision(
     """:func:`resolve_exit_decision`, deriving every contribution from
     *result* the same way `cli._exit_with_severity_or_verdict` does today.
 
-    The single call site a native `compare`/`scan --against` invocation
-    needs: it reproduces that function's exact fold order
-    (compatibility → coverage floor → assurance floor, each `max`-based) as
-    one canonical resolution, so a caller building the report's ``exit``
-    block and a caller computing the real process exit code cannot read
-    two different numbers for the same comparison.
+    The single call site a native `compare` invocation needs: it reproduces
+    that function's exact fold order (compatibility → coverage floor →
+    assurance floor, each `max`-based) as one canonical resolution, so a
+    caller building the report's ``exit`` block and a caller computing the
+    real process exit code cannot read two different numbers for the same
+    comparison.
+
+    **`scan --against` does not call this function yet (Codex review, fresh
+    evidence).** `scan_engine.py`/`cli_scan_baseline.py` compute their own
+    exit code and report contributions independently -- their comments
+    describe themselves as *mirroring* `compare`'s pattern, but neither
+    calls `resolve_compare_exit_decision` or emits a top-level ``exit``
+    object. Wiring `scan --against` through this resolver is scoped to a
+    later PR, not this one.
 
     **`--used-by`/`--required-symbol(s)` scoped gating overrides the
     compatibility axis entirely (Codex review, fresh evidence).**

--- a/abicheck/exit_decision.py
+++ b/abicheck/exit_decision.py
@@ -1,0 +1,197 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The canonical ``ExitDecision`` — CLI cleanup phase two, PR G1.
+
+``docs/contribute/plans/cli-cleanup-phase-two.md``'s PR 4 records that a
+single-pair `compare`/`scan --against` invocation's exit code is folded from
+several independently-computed, orthogonal contributions today
+(`severity.compute_exit_code`/`severity.legacy_exit_code`,
+`contract_coverage_exit.fold_coverage_exit`,
+`analysis_assurance.fold_analysis_assurance_exit`), each folded in with
+`max()` at the call site (`cli._exit_with_severity_or_verdict`) rather than
+through one shared, explainable object. That is fine for computing *a*
+number, but leaves no answer to "why is this exit 1" when more than one axis
+independently contributes -- a caller has to re-derive the answer from
+several separately-read report fields.
+
+``ExitDecision``/:func:`resolve_exit_decision` is that explainable object,
+built additively (PR G1: no CLI behaviour change, no flag removed) as the
+first step toward PR 4/G2's actual algorithm-selector removal. It wraps the
+*existing* fold -- `max()` over the axes below -- rather than replacing it,
+so every call site that adopts it keeps today's exit code bit-for-bit; what
+it adds is `reasons`, the set of axes whose own contribution equals the
+final code (and therefore genuinely explains it, as opposed to a lower
+contribution that never determined the result).
+
+**Deliberately scoped to the axes that already coexist on one
+`DiffResult`-backed report today** -- the compatibility gate (legacy verdict
+or severity-aware), contract coverage, and analysis assurance. Three axes
+the reviewed plan also names -- `not_comparable`, a release's
+removed-required-library policy, and `scan`'s budget-overflow floor -- are
+raised through different code paths today (`sys.exit` before a coherent
+`DiffResult` exists, or a release/scan-specific fold with its own,
+mode-dependent precedence against the compatibility gate; see the plan's
+"canonical `ExitDecision`" section for why removed-library's rank cannot be
+a fixed slot). Folding those in is real, further work for PR G2, not
+attempted here -- extending this module before that design is settled would
+risk exactly the kind of partially-verified, cross-cutting change this
+codebase's own conventions warn against.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .checker_types import DiffResult
+    from .severity import SeverityConfig
+
+
+class ExitReason(str, Enum):
+    """Which orthogonal axis a resolved :class:`ExitDecision` traces to.
+
+    A member appears in :attr:`ExitDecision.reasons` only when its own
+    contribution equals the decision's final :attr:`ExitDecision.code` --
+    i.e. it is one of the axes that actually determined the result, not
+    merely one that happened to be non-zero. A coverage floor of ``1``
+    sitting underneath a compatibility gate's ``4`` explains nothing about
+    why the exit is ``4``; it stays out of ``reasons`` for that decision
+    (its own finding/failure still appears elsewhere in the report --
+    ``reasons`` is about the exit code specifically, not about hiding the
+    axis).
+    """
+
+    COMPATIBILITY_GATE = "compatibility_gate"
+    CONTRACT_COVERAGE = "contract_coverage"
+    ANALYSIS_ASSURANCE = "analysis_assurance"
+    CLEAN = "clean"
+
+
+@dataclass(frozen=True)
+class ExitDecision:
+    """One comparison's fully explainable exit code.
+
+    ``code`` is exactly ``max(compatibility_contribution,
+    contract_coverage_contribution, analysis_assurance_contribution)`` --
+    the identical value today's ad hoc fold chain in
+    ``cli._exit_with_severity_or_verdict`` already produces, computed once
+    here instead of via three separately-called functions. ``reasons``
+    names every axis tied for that maximum; see :class:`ExitReason` for why
+    a lower, non-winning contribution is excluded.
+    """
+
+    code: int
+    reasons: tuple[ExitReason, ...]
+    compatibility_contribution: int
+    contract_coverage_contribution: int
+    analysis_assurance_contribution: int
+
+    def to_dict(self) -> dict[str, object]:
+        """JSON-serializable form, for the report's ``exit`` block."""
+        return {
+            "code": self.code,
+            "reasons": [r.value for r in self.reasons],
+            "compatibility_contribution": self.compatibility_contribution,
+            "contract_coverage_contribution": self.contract_coverage_contribution,
+            "analysis_assurance_contribution": self.analysis_assurance_contribution,
+        }
+
+
+def resolve_exit_decision(
+    *,
+    compatibility_contribution: int,
+    contract_coverage_contribution: int = 0,
+    analysis_assurance_contribution: int = 0,
+) -> ExitDecision:
+    """Fold the three already-computed axis contributions into one decision.
+
+    *compatibility_contribution* is the caller's own pre-computed
+    compatibility-gate exit code -- either `severity.legacy_exit_code`
+    (verdict-based, no severity config in effect) or
+    `severity.compute_exit_code` (a severity map is in effect). This
+    function does not choose between the two; that selection is exactly
+    what PR 4/G2 still has to consolidate into one automatic algorithm.
+    *contract_coverage_contribution*/*analysis_assurance_contribution*
+    default to ``0`` (their "never asked the question" value, matching
+    `contract_coverage_exit.coverage_exit_floor`/`analysis_assurance.
+    analysis_assurance_exit_contribution`'s own fail-open defaults) so a
+    caller with neither `--contract` nor `--require-complete-analysis` in
+    effect can omit both.
+    """
+    contributions = {
+        ExitReason.COMPATIBILITY_GATE: compatibility_contribution,
+        ExitReason.CONTRACT_COVERAGE: contract_coverage_contribution,
+        ExitReason.ANALYSIS_ASSURANCE: analysis_assurance_contribution,
+    }
+    code = max(contributions.values())
+    if code == 0:
+        reasons: tuple[ExitReason, ...] = (ExitReason.CLEAN,)
+    else:
+        reasons = tuple(
+            reason
+            for reason, contribution in contributions.items()
+            if contribution == code
+        )
+    return ExitDecision(
+        code=code,
+        reasons=reasons,
+        compatibility_contribution=compatibility_contribution,
+        contract_coverage_contribution=contract_coverage_contribution,
+        analysis_assurance_contribution=analysis_assurance_contribution,
+    )
+
+
+def resolve_compare_exit_decision(
+    result: DiffResult,
+    sev_config: SeverityConfig | None,
+    scheme: str,
+    *,
+    require_complete_analysis: bool = False,
+) -> ExitDecision:
+    """:func:`resolve_exit_decision`, deriving every contribution from
+    *result* the same way `cli._exit_with_severity_or_verdict` does today.
+
+    The single call site a native `compare`/`scan --against` invocation
+    needs: it reproduces that function's exact fold order
+    (compatibility → coverage floor → assurance floor, each `max`-based) as
+    one canonical resolution, so a caller building the report's ``exit``
+    block and a caller computing the real process exit code cannot read
+    two different numbers for the same comparison.
+    """
+    from .analysis_assurance import analysis_assurance_exit_contribution
+    from .contract_coverage_exit import coverage_exit_floor
+    from .severity import compute_exit_code, legacy_exit_code
+
+    if scheme == "severity":
+        assert sev_config is not None
+        compatibility_contribution = compute_exit_code(
+            result.changes,
+            sev_config,
+            policy=result.policy,
+            kind_sets=result._effective_kind_sets(),
+            policy_file=result.policy_file,
+        )
+    else:
+        compatibility_contribution = legacy_exit_code(result.verdict)
+    return resolve_exit_decision(
+        compatibility_contribution=compatibility_contribution,
+        contract_coverage_contribution=coverage_exit_floor(result),
+        analysis_assurance_contribution=analysis_assurance_exit_contribution(
+            result, require_complete=require_complete_analysis
+        ),
+    )

--- a/abicheck/exit_decision.py
+++ b/abicheck/exit_decision.py
@@ -118,24 +118,33 @@ def resolve_exit_decision(
     compatibility_contribution: int,
     contract_coverage_contribution: int = 0,
     analysis_assurance_contribution: int = 0,
+    compatibility_reason: ExitReason = ExitReason.COMPATIBILITY_GATE,
 ) -> ExitDecision:
     """Fold the three already-computed axis contributions into one decision.
 
     *compatibility_contribution* is the caller's own pre-computed
     compatibility-gate exit code -- either `severity.legacy_exit_code`
     (verdict-based, no severity config in effect) or
-    `severity.compute_exit_code` (a severity map is in effect). This
-    function does not choose between the two; that selection is exactly
-    what PR 4/G2 still has to consolidate into one automatic algorithm.
+    `severity.compute_exit_code` (a severity map is in effect), or (Codex
+    review) the *pre-fold* `--used-by`/`--required-symbol(s)` scoped gate
+    contribution -- never an already-folded value, or a tie with coverage/
+    assurance would be silently hidden behind whichever reason this slot is
+    labelled. This function does not choose between the unscoped
+    algorithms; that selection is exactly what PR 4/G2 still has to
+    consolidate into one automatic algorithm.
     *contract_coverage_contribution*/*analysis_assurance_contribution*
     default to ``0`` (their "never asked the question" value, matching
     `contract_coverage_exit.coverage_exit_floor`/`analysis_assurance.
     analysis_assurance_exit_contribution`'s own fail-open defaults) so a
     caller with neither `--contract` nor `--require-complete-analysis` in
-    effect can omit both.
+    effect can omit both. *compatibility_reason* names which
+    :class:`ExitReason` this slot represents -- `COMPATIBILITY_GATE` by
+    default, or `SCOPED_GATE` when the caller's compatibility contribution
+    is the scoped application/plugin-host gate rather than the full-library
+    one; every other axis's reason is unaffected either way.
     """
     contributions = {
-        ExitReason.COMPATIBILITY_GATE: compatibility_contribution,
+        compatibility_reason: compatibility_contribution,
         ExitReason.CONTRACT_COVERAGE: contract_coverage_contribution,
         ExitReason.ANALYSIS_ASSURANCE: analysis_assurance_contribution,
     }
@@ -178,20 +187,25 @@ def resolve_compare_exit_decision(
     compatibility axis entirely (Codex review, fresh evidence).**
     `cli_compare_helpers._apply_scoped_gating` floors the *full-library*
     verdict/severity gate this function would otherwise compute to the
-    scoped application/plugin-host contract's own result, already folded
-    with the coverage/assurance floors, and persists it onto
-    `result.scoped_exit_code` before any report renders -- `cli.py` itself
-    exits on that value directly (`sys.exit(scoped_exit_code)`), never
-    reaching `_exit_with_severity_or_verdict`/this function's own
-    compatibility-axis computation. An earlier revision of this function
-    ignored that and derived `compatibility_contribution` from
-    `result.verdict`/severity regardless -- reporting the full-library
-    gate's code (which is informational-only under scoping) while the real
-    process exited on the scoped one, so a report consumer trusting this
-    field would disagree with the CLI. When `scoped_exit_code` is set, it
-    *is* the decision: reported directly (already-folded, so not re-folded
-    through `resolve_exit_decision`) under its own `SCOPED_GATE` reason,
-    never recomputed from the unscoped verdict.
+    scoped application/plugin-host contract's own result -- `cli.py` itself
+    exits on the (separately, already-folded) `result.scoped_exit_code`
+    directly (`sys.exit(scoped_exit_code)`), never reaching
+    `_exit_with_severity_or_verdict`/this function's own compatibility-axis
+    computation. An earlier revision of this function ignored that and
+    derived `compatibility_contribution` from `result.verdict`/severity
+    regardless -- reporting the full-library gate's code (informational-only
+    under scoping) while the real process exited on the scoped one.
+
+    **A later revision fixed that but introduced a second bug (Codex
+    review): it read the already-folded `result.scoped_exit_code` as the
+    compatibility contribution, so a tie with coverage/assurance was hidden
+    behind a `SCOPED_GATE` reason that may not have contributed at all.**
+    `result.scoped_compatibility_contribution` (`cli_compare_helpers`,
+    persisted immediately before that fold runs) is the *pre-fold* scoped
+    value -- passed through the same `resolve_exit_decision` every other
+    caller uses, with `compatibility_reason=SCOPED_GATE`, so a genuine tie
+    between the scoped gate and coverage/assurance is named correctly
+    instead of always attributed to scoping.
     """
     from .analysis_assurance import analysis_assurance_exit_contribution
     from .contract_coverage_exit import coverage_exit_floor
@@ -204,15 +218,14 @@ def resolve_compare_exit_decision(
 
     scoped_exit_code = getattr(result, "scoped_exit_code", None)
     if scoped_exit_code is not None:
-        reasons: tuple[ExitReason, ...] = (
-            (ExitReason.SCOPED_GATE,) if scoped_exit_code else (ExitReason.CLEAN,)
+        scoped_compatibility_contribution = getattr(
+            result, "scoped_compatibility_contribution", scoped_exit_code,
         )
-        return ExitDecision(
-            code=scoped_exit_code,
-            reasons=reasons,
-            compatibility_contribution=scoped_exit_code,
+        return resolve_exit_decision(
+            compatibility_contribution=scoped_compatibility_contribution,
             contract_coverage_contribution=coverage_contribution,
             analysis_assurance_contribution=assurance_contribution,
+            compatibility_reason=ExitReason.SCOPED_GATE,
         )
 
     if scheme == "severity":

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -548,7 +548,8 @@ def _to_json_leaf(
     _add_reconciled(d, result)
     _add_contract_context(
         d, result, _displayed_with_scoped_only(result, changes, show_only),
-        require_complete_analysis=require_complete_analysis)
+        require_complete_analysis=require_complete_analysis,
+        severity_config=severity_config)
     # Codex review: full/root-cause mode call this; leaf mode never did,
     # silently dropping policy_overrides/policy_reclassify here.
     _add_policy_overrides(d, result)
@@ -749,7 +750,8 @@ def _to_json_root_cause(
     _add_reconciled(d, result)
     _add_contract_context(
         d, result, _displayed_with_scoped_only(result, changes, show_only),
-        require_complete_analysis=require_complete_analysis)
+        require_complete_analysis=require_complete_analysis,
+        severity_config=severity_config)
     _add_detectors(d, result)
     _add_confidence_evidence(d, result)
     _add_policy_overrides(d, result)
@@ -1197,7 +1199,8 @@ def to_json(
     _add_reconciled(d, result)
     _add_contract_context(
         d, result, _displayed_with_scoped_only(result, changes, show_only),
-        require_complete_analysis=require_complete_analysis)
+        require_complete_analysis=require_complete_analysis,
+        severity_config=severity_config)
     _add_detectors(d, result)
     _add_confidence_evidence(d, result)
     _add_policy_overrides(d, result)

--- a/abicheck/reporter.py
+++ b/abicheck/reporter.py
@@ -328,7 +328,7 @@ def _to_json_leaf(
     show_only: str | None = None,
     *,
     severity_config: SeverityConfig | None = None,
-    require_complete_analysis: bool = False,
+    require_complete_analysis: bool = False, include_exit_decision: bool = True,
 ) -> str:
     """Leaf-change mode JSON output.
 
@@ -549,7 +549,7 @@ def _to_json_leaf(
     _add_contract_context(
         d, result, _displayed_with_scoped_only(result, changes, show_only),
         require_complete_analysis=require_complete_analysis,
-        severity_config=severity_config)
+        severity_config=severity_config, include_exit_decision=include_exit_decision)
     # Codex review: full/root-cause mode call this; leaf mode never did,
     # silently dropping policy_overrides/policy_reclassify here.
     _add_policy_overrides(d, result)
@@ -639,7 +639,7 @@ def _to_json_root_cause(
     *,
     show_only: str | None = None,
     severity_config: SeverityConfig | None = None,
-    require_complete_analysis: bool = False,
+    require_complete_analysis: bool = False, include_exit_decision: bool = True,
 ) -> str:
     """``--report-mode root-cause`` JSON output (G29 Phase 3, ADR-052 slice 3).
 
@@ -751,7 +751,7 @@ def _to_json_root_cause(
     _add_contract_context(
         d, result, _displayed_with_scoped_only(result, changes, show_only),
         require_complete_analysis=require_complete_analysis,
-        severity_config=severity_config)
+        severity_config=severity_config, include_exit_decision=include_exit_decision)
     _add_detectors(d, result)
     _add_confidence_evidence(d, result)
     _add_policy_overrides(d, result)
@@ -1132,6 +1132,7 @@ def to_json(
     stat: bool = False,
     severity_config: SeverityConfig | None = None,
     require_complete_analysis: bool = False,
+    include_exit_decision: bool = True,  # exit block (2.41); see exit_decision.py
 ) -> str:
     if stat:
         return to_stat_json(
@@ -1144,14 +1145,14 @@ def to_json(
             result, indent=indent, show_only=show_only,
             severity_config=severity_config,
             require_complete_analysis=require_complete_analysis,
-        )
+            include_exit_decision=include_exit_decision)
 
     if report_mode == "root-cause":
         return _to_json_root_cause(
             result, indent=indent, show_only=show_only,
             severity_config=severity_config,
             require_complete_analysis=require_complete_analysis,
-        )
+            include_exit_decision=include_exit_decision)
 
     changes = list(result.changes)
     if show_only:
@@ -1200,7 +1201,7 @@ def to_json(
     _add_contract_context(
         d, result, _displayed_with_scoped_only(result, changes, show_only),
         require_complete_analysis=require_complete_analysis,
-        severity_config=severity_config)
+        severity_config=severity_config, include_exit_decision=include_exit_decision)
     _add_detectors(d, result)
     _add_confidence_evidence(d, result)
     _add_policy_overrides(d, result)

--- a/abicheck/reporter_contract_blocks.py
+++ b/abicheck/reporter_contract_blocks.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from .checker_types import Change, DiffResult
+    from .severity import SeverityConfig
 
 
 def add_contract_context(
@@ -41,6 +42,7 @@ def add_contract_context(
     displayed: Sequence[Change] | None = None,
     *,
     require_complete_analysis: bool = False,
+    severity_config: SeverityConfig | None = None,
 ) -> None:
     """ADR-049 Phase 4's persisted contract blocks, plus P0.4's
     ``analysis_assurance``/``analysis_assurance_exit_contribution``
@@ -75,6 +77,26 @@ def add_contract_context(
                 result, require_complete=require_complete_analysis
             )
         )
+    # CLI cleanup phase two, PR G1: the same canonical `ExitDecision`
+    # `cli._exit_with_severity_or_verdict` resolves for the real process
+    # exit, persisted here so a report reader doesn't have to re-derive it
+    # from `severity.exit_code`/`contract_coverage_exit_contribution`/
+    # `analysis_assurance_exit_contribution` separately. `severity_config
+    # is not None` is the same signal every other block in this module and
+    # in `reporter.py` already uses to mean "the severity-aware scheme is in
+    # effect" (`cli_compare_helpers.report_severity` is `None` whenever
+    # `resolved_cfg.exit_code_scheme != "severity"`), so this reproduces
+    # `_exit_with_severity_or_verdict`'s own scheme selection rather than
+    # guessing at a new one. Unconditional -- unlike `contract_context`
+    # below, every comparison has a compatibility contribution, so there is
+    # always a decision to report, not just under `--contract`.
+    from .exit_decision import resolve_compare_exit_decision
+
+    scheme = "severity" if severity_config is not None else "legacy"
+    d["exit"] = resolve_compare_exit_decision(
+        result, severity_config, scheme,
+        require_complete_analysis=require_complete_analysis,
+    ).to_dict()
     add_use_case_impact(d, result, displayed)
 
     ctx = result.contract_context

--- a/abicheck/reporter_contract_blocks.py
+++ b/abicheck/reporter_contract_blocks.py
@@ -43,6 +43,7 @@ def add_contract_context(
     *,
     require_complete_analysis: bool = False,
     severity_config: SeverityConfig | None = None,
+    include_exit_decision: bool = True,
 ) -> None:
     """ADR-049 Phase 4's persisted contract blocks, plus P0.4's
     ``analysis_assurance``/``analysis_assurance_exit_contribution``
@@ -87,16 +88,22 @@ def add_contract_context(
     # effect" (`cli_compare_helpers.report_severity` is `None` whenever
     # `resolved_cfg.exit_code_scheme != "severity"`), so this reproduces
     # `_exit_with_severity_or_verdict`'s own scheme selection rather than
-    # guessing at a new one. Unconditional -- unlike `contract_context`
-    # below, every comparison has a compatibility contribution, so there is
-    # always a decision to report, not just under `--contract`.
-    from .exit_decision import resolve_compare_exit_decision
+    # guessing at a new one. Unconditional for a native `compare` call --
+    # unlike `contract_context` below, every comparison has a compatibility
+    # contribution, so there is always a decision to report, not just under
+    # `--contract`. `include_exit_decision=False` (only `compat/cli.py`
+    # passes this) skips it entirely: `compat check`'s own process exit
+    # follows an unrelated 0/1/2 ABICC-style scheme, so this block's
+    # native-scheme `code` would disagree with the real compat exit for the
+    # same run (Codex review).
+    if include_exit_decision:
+        from .exit_decision import resolve_compare_exit_decision
 
-    scheme = "severity" if severity_config is not None else "legacy"
-    d["exit"] = resolve_compare_exit_decision(
-        result, severity_config, scheme,
-        require_complete_analysis=require_complete_analysis,
-    ).to_dict()
+        scheme = "severity" if severity_config is not None else "legacy"
+        d["exit"] = resolve_compare_exit_decision(
+            result, severity_config, scheme,
+            require_complete_analysis=require_complete_analysis,
+        ).to_dict()
     add_use_case_impact(d, result, displayed)
 
     ctx = result.contract_context

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -513,12 +513,19 @@ from typing import Any
 #:       ``contract_coverage_exit_contribution``/
 #:       ``analysis_assurance_exit_contribution`` independently and risk
 #:       disagreeing with the number that actually gated the run.
-#:       Unconditional -- every comparison has a compatibility
-#:       contribution, so there is always a decision to report, unlike
-#:       ``contract_context`` which stays opt-in. Deliberately does not
-#:       yet cover ``not_comparable``/scan-budget/release-removed-library
-#:       exits, which are raised through different code paths today; see
-#:       ``exit_decision.py``'s own module docstring. Additive key.
+#:       Emitted by every native ``compare``/``scan --against`` JSON
+#:       report -- every comparison has a compatibility contribution, so
+#:       there is always a decision to report, unlike ``contract_context``
+#:       which stays opt-in -- but is schema-optional, not required: an
+#:       ``include_exit_decision=False`` caller (``compat check``'s own
+#:       ABICC 0/1/2 exit scheme differs from native ``compare``'s, so its
+#:       report omits this block rather than emit a ``code`` that would
+#:       disagree with the real process exit for the same run -- Codex
+#:       review) still validates against schema 2.41 with the key absent.
+#:       Deliberately does not yet cover ``not_comparable``/scan-budget/
+#:       release-removed-library exits, which are raised through
+#:       different code paths today; see ``exit_decision.py``'s own module
+#:       docstring. Additive key.
 REPORT_SCHEMA_VERSION = "2.41"
 
 #: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -500,7 +500,26 @@ from typing import Any
 #:       severity/compatibility gate read a clean 0 while this axis
 #:       independently floored the *real* exit to 1 fed ``abicheck aggregate``
 #:       a green result for it (Codex review). Additive key.
-REPORT_SCHEMA_VERSION = "2.40"
+#: 2.41 -- new top-level ``exit`` object (CLI cleanup phase two, PR G1 --
+#:       ``exit_decision.ExitDecision``): ``code``, ``reasons`` (which
+#:       orthogonal axis or axes actually determined ``code`` -- a
+#:       lower, non-winning contribution is excluded, since it explains
+#:       nothing about why the exit is what it is),
+#:       ``compatibility_contribution``, ``contract_coverage_contribution``,
+#:       and ``analysis_assurance_contribution``. The exact number
+#:       ``cli._exit_with_severity_or_verdict`` computes for the real
+#:       process exit, persisted so a report reader does not have to
+#:       re-derive it from ``severity.exit_code``/
+#:       ``contract_coverage_exit_contribution``/
+#:       ``analysis_assurance_exit_contribution`` independently and risk
+#:       disagreeing with the number that actually gated the run.
+#:       Unconditional -- every comparison has a compatibility
+#:       contribution, so there is always a decision to report, unlike
+#:       ``contract_context`` which stays opt-in. Deliberately does not
+#:       yet cover ``not_comparable``/scan-budget/release-removed-library
+#:       exits, which are raised through different code paths today; see
+#:       ``exit_decision.py``'s own module docstring. Additive key.
+REPORT_SCHEMA_VERSION = "2.41"
 
 #: SemVer-style (MAJOR.MINOR) version of the ``scan`` JSON output, emitted as
 #: ``scan_schema_version`` at the top level of both public scan dict shapes:

--- a/abicheck/schemas/__init__.py
+++ b/abicheck/schemas/__init__.py
@@ -513,17 +513,27 @@ from typing import Any
 #:       ``contract_coverage_exit_contribution``/
 #:       ``analysis_assurance_exit_contribution`` independently and risk
 #:       disagreeing with the number that actually gated the run.
-#:       Emitted by every native ``compare``/``scan --against`` JSON
-#:       report -- every comparison has a compatibility contribution, so
-#:       there is always a decision to report, unlike ``contract_context``
-#:       which stays opt-in -- but is schema-optional, not required: an
+#:       Emitted by every native ``compare`` JSON report -- every comparison
+#:       has a compatibility contribution, so there is always a decision to
+#:       report, unlike ``contract_context`` which stays opt-in -- but is
+#:       schema-optional, not required: an
 #:       ``include_exit_decision=False`` caller (``compat check``'s own
 #:       ABICC 0/1/2 exit scheme differs from native ``compare``'s, so its
 #:       report omits this block rather than emit a ``code`` that would
 #:       disagree with the real process exit for the same run -- Codex
 #:       review) still validates against schema 2.41 with the key absent.
-#:       Deliberately does not yet cover ``not_comparable``/scan-budget/
-#:       release-removed-library exits, which are raised through
+#:       ``scan --against`` does NOT emit this block yet (Codex review, fresh
+#:       evidence): ``scan_engine.py``/``cli_scan_baseline.py`` never call
+#:       ``resolve_compare_exit_decision`` -- ``ScanOutcome.to_dict()``'s own
+#:       ``exit_code`` and the *nested* ``diff.analysis_assurance_exit_
+#:       contribution``/``diff.contract_coverage_exit_contribution`` fields
+#:       are computed independently and only *mirror* ``compare``'s pattern
+#:       in comments, never actually reuse this resolver. Landing ``exit``
+#:       for ``scan --against`` (and deciding whether its existing nested
+#:       placement moves to match ``compare``'s top-level one) is scoped to
+#:       a later PR (see ``docs/contribute/plans/cli-cleanup-phase-two.md``'s
+#:       PR E section). Deliberately does not yet cover ``not_comparable``/
+#:       scan-budget/release-removed-library exits, which are raised through
 #:       different code paths today; see ``exit_decision.py``'s own module
 #:       docstring. Additive key.
 REPORT_SCHEMA_VERSION = "2.41"

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -1151,7 +1151,7 @@
         "compatibility_contribution": {
           "type": "integer",
           "minimum": 0,
-          "description": "The compatibility-gate exit code alone (severity.compute_exit_code under an effective severity map, else severity.legacy_exit_code from the verdict) -- UNLESS --used-by/--required-symbol(s) scoping is in effect, in which case this is the already-folded scoped application/plugin-host contract's own exit code (cli_compare_helpers._apply_scoped_gating's result.scoped_exit_code), not the informational full-library gate; reasons carries scoped_gate rather than compatibility_gate in that case."
+          "description": "The compatibility-gate exit code alone (severity.compute_exit_code under an effective severity map, else severity.legacy_exit_code from the verdict) -- UNLESS --used-by/--required-symbol(s) scoping is in effect, in which case this is the PRE-FOLD scoped application/plugin-host contract's own exit code (cli_compare_helpers._apply_scoped_gating's result.scoped_compatibility_contribution, captured before the coverage/assurance floors below are applied to it), not the informational full-library gate and not the already-folded result.scoped_exit_code -- so a genuine tie between the scoped gate and contract_coverage_contribution/analysis_assurance_contribution is visible here rather than hidden behind an already-maxed value; reasons carries scoped_gate rather than compatibility_gate in that case."
         },
         "contract_coverage_contribution": {
           "type": "integer",

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -1141,17 +1141,18 @@
             "type": "string",
             "enum": [
               "compatibility_gate",
+              "scoped_gate",
               "contract_coverage",
               "analysis_assurance",
               "clean"
             ]
           },
-          "description": "Every axis whose own contribution equals code -- \"clean\" alone when code is 0."
+          "description": "Every axis whose own contribution equals code -- \"clean\" alone when code is 0. \"scoped_gate\" replaces \"compatibility_gate\" whenever --used-by/--required-symbol(s) scoping is in effect (see compatibility_contribution)."
         },
         "compatibility_contribution": {
           "type": "integer",
           "minimum": 0,
-          "description": "The compatibility-gate exit code alone (severity.compute_exit_code under an effective severity map, else severity.legacy_exit_code from the verdict)."
+          "description": "The compatibility-gate exit code alone (severity.compute_exit_code under an effective severity map, else severity.legacy_exit_code from the verdict) -- UNLESS --used-by/--required-symbol(s) scoping is in effect, in which case this is the already-folded scoped application/plugin-host contract's own exit code (cli_compare_helpers._apply_scoped_gating's result.scoped_exit_code), not the informational full-library gate; reasons carries scoped_gate rather than compatibility_gate in that case."
         },
         "contract_coverage_contribution": {
           "type": "integer",

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -44,7 +44,8 @@
           "evidence_tier",
           "evidence_tiers",
           "analysis_assurance",
-          "analysis_assurance_exit_contribution"
+          "analysis_assurance_exit_contribution",
+          "exit"
         ]
       }
     },
@@ -1117,6 +1118,53 @@
       ],
       "description": "P0.4 (schema 2.40): what analysis_assurance contributes to the exit code under --require-complete-analysis \u2014 the exact sibling of contract_coverage_exit_contribution for the other orthogonal exit-floor axis. 1 when the flag was given and analysis_assurance.status is not \"complete\", 0 otherwise (including when the flag was never given). Applied since introduction: the process exit status is floored to this value (folded with max, so it never lowers a 2/4/5/6 from the compatibility axis, and never rewrites a finding's decision or gate contribution). This is the number that actually gated the run, derived by the same function the exit path uses (analysis_assurance.analysis_assurance_exit_contribution). Present alongside analysis_assurance, under the same condition.",
       "$comment": "aggregate.py's _analysis_assurance_exit reads this field directly rather than recomputing it."
+    },
+    "exit": {
+      "type": "object",
+      "description": "CLI cleanup phase two, PR G1 (schema 2.41): exit_decision.ExitDecision, the canonical resolution of every orthogonal exit-code axis for this comparison — code is exactly max(compatibility_contribution, contract_coverage_contribution, analysis_assurance_contribution), the identical value cli._exit_with_severity_or_verdict computes for the real process exit. reasons names every axis tied for that maximum (a lower, non-winning contribution is excluded, since it did not determine the result). Unconditionally present on every real-verdict compare report — every comparison has a compatibility contribution, unlike contract_context which stays opt-in. Deliberately does not yet cover not_comparable/scan-budget/release-removed-library exits, which are raised through different code paths today.",
+      "required": [
+        "code",
+        "reasons",
+        "compatibility_contribution",
+        "contract_coverage_contribution",
+        "analysis_assurance_contribution"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The process exit code this decision resolves to, before any release/scan-specific axis (removed-library, budget, not_comparable) that this module does not yet cover."
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "compatibility_gate",
+              "contract_coverage",
+              "analysis_assurance",
+              "clean"
+            ]
+          },
+          "description": "Every axis whose own contribution equals code -- \"clean\" alone when code is 0."
+        },
+        "compatibility_contribution": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The compatibility-gate exit code alone (severity.compute_exit_code under an effective severity map, else severity.legacy_exit_code from the verdict)."
+        },
+        "contract_coverage_contribution": {
+          "type": "integer",
+          "enum": [0, 1],
+          "description": "Duplicated from the top-level contract_coverage_exit_contribution (present only under --contract) for a single self-contained decision object; 0 when no contract domain was selected."
+        },
+        "analysis_assurance_contribution": {
+          "type": "integer",
+          "enum": [0, 1],
+          "description": "Duplicated from the top-level analysis_assurance_exit_contribution for a single self-contained decision object; 0 when --require-complete-analysis was not given."
+        }
+      },
+      "$comment": "exit_decision.resolve_compare_exit_decision is the one function that builds this object; cli._exit_with_severity_or_verdict resolves the identical ExitDecision for the real process exit, so the two cannot disagree."
     },
     "analysis_assurance": {
       "type": "object",

--- a/abicheck/schemas/compare_report.schema.json
+++ b/abicheck/schemas/compare_report.schema.json
@@ -44,8 +44,7 @@
           "evidence_tier",
           "evidence_tiers",
           "analysis_assurance",
-          "analysis_assurance_exit_contribution",
-          "exit"
+          "analysis_assurance_exit_contribution"
         ]
       }
     },

--- a/changelog.d/1786883245_claude_exit-decision-pr-g1.md
+++ b/changelog.d/1786883245_claude_exit-decision-pr-g1.md
@@ -10,7 +10,11 @@
   and the real process exit is computed through the same resolver, so a
   report reader and the CLI cannot disagree about why a comparison exited the
   way it did. `compat check`'s JSON output (its own ABICC 0/1/2 exit scheme)
-  omits the block rather than emit a disagreeing `code`. No CLI flag changes
-  and no change to any existing exit code -- this is the first, additive step
-  toward the phase-two plan's `--exit-code-scheme` consolidation, not a
-  behavioural change on its own.
+  omits the block rather than emit a disagreeing `code`. A directory/package
+  release compare's per-library `--output-dir` report now also forwards the
+  release's own resolved `--severity-preset`/severity config into its `exit`
+  block, so a severity-aware release's per-library reports agree with the
+  release's real exit code instead of always falling back to the legacy
+  verdict-based scheme. No CLI flag changes and no change to any existing
+  exit code -- this is the first, additive step toward the phase-two plan's
+  `--exit-code-scheme` consolidation, not a behavioural change on its own.

--- a/changelog.d/1786883245_claude_exit-decision-pr-g1.md
+++ b/changelog.d/1786883245_claude_exit-decision-pr-g1.md
@@ -1,13 +1,16 @@
 ### Added
 
 - **CLI cleanup phase two, PR G1**: a new, canonical `exit_decision.ExitDecision`
-  resolves every orthogonal exit-code axis (the compatibility gate, contract
-  coverage, and analysis assurance) for a single-pair `compare`/`scan
+  resolves every orthogonal exit-code axis (the compatibility gate -- or,
+  under `--used-by`/`--required-symbol(s)` scoping, the scoped gate --,
+  contract coverage, and analysis assurance) for a single-pair `compare`/`scan
   --against` comparison into one explainable object -- `code` plus which
   axis or axes actually determined it. `compare --format json`'s report now
-  persists this as a top-level `exit` object (schema 2.41), and the real
-  process exit is computed through the same resolver, so a report reader
-  and the CLI cannot disagree about why a comparison exited the way it did.
-  No CLI flag changes and no change to any existing exit code -- this is the
-  first, additive step toward the phase-two plan's `--exit-code-scheme`
-  consolidation, not a behavioural change on its own.
+  persists this as a top-level, schema-optional `exit` object (schema 2.41),
+  and the real process exit is computed through the same resolver, so a
+  report reader and the CLI cannot disagree about why a comparison exited the
+  way it did. `compat check`'s JSON output (its own ABICC 0/1/2 exit scheme)
+  omits the block rather than emit a disagreeing `code`. No CLI flag changes
+  and no change to any existing exit code -- this is the first, additive step
+  toward the phase-two plan's `--exit-code-scheme` consolidation, not a
+  behavioural change on its own.

--- a/changelog.d/1786883245_claude_exit-decision-pr-g1.md
+++ b/changelog.d/1786883245_claude_exit-decision-pr-g1.md
@@ -3,18 +3,22 @@
 - **CLI cleanup phase two, PR G1**: a new, canonical `exit_decision.ExitDecision`
   resolves every orthogonal exit-code axis (the compatibility gate -- or,
   under `--used-by`/`--required-symbol(s)` scoping, the scoped gate --,
-  contract coverage, and analysis assurance) for a single-pair `compare`/`scan
-  --against` comparison into one explainable object -- `code` plus which
-  axis or axes actually determined it. `compare --format json`'s report now
-  persists this as a top-level, schema-optional `exit` object (schema 2.41),
-  and the real process exit is computed through the same resolver, so a
-  report reader and the CLI cannot disagree about why a comparison exited the
-  way it did. `compat check`'s JSON output (its own ABICC 0/1/2 exit scheme)
-  omits the block rather than emit a disagreeing `code`. A directory/package
-  release compare's per-library `--output-dir` report now also forwards the
+  contract coverage, and analysis assurance) for a single-pair `compare`
+  comparison into one explainable object -- `code` plus which axis or axes
+  actually determined it. `compare --format json`'s report now persists this
+  as a top-level, schema-optional `exit` object (schema 2.41), and the real
+  process exit is computed through the same resolver, so a report reader and
+  the CLI cannot disagree about why a comparison exited the way it did.
+  `scan --against` does not emit this block yet -- it computes its own exit
+  code and report contributions independently, wiring it is future work.
+  `compat check`'s JSON output (its own ABICC 0/1/2 exit scheme) omits the
+  block rather than emit a disagreeing `code`. A directory/package release
+  compare's per-library `--output-dir` report now also forwards the
   release's own resolved `--severity-preset`/severity config into its `exit`
-  block, so a severity-aware release's per-library reports agree with the
-  release's real exit code instead of always falling back to the legacy
-  verdict-based scheme. No CLI flag changes and no change to any existing
-  exit code -- this is the first, additive step toward the phase-two plan's
-  `--exit-code-scheme` consolidation, not a behavioural change on its own.
+  block, so each severity-aware per-library report uses the same severity
+  scheme as the release instead of always falling back to the legacy
+  verdict-based scheme -- a per-library `exit.code` still reflects only that
+  library's own decision, not necessarily the release's aggregated exit.
+  No CLI flag changes and no change to any existing exit code -- this is the
+  first, additive step toward the phase-two plan's `--exit-code-scheme`
+  consolidation, not a behavioural change on its own.

--- a/changelog.d/1786883245_claude_exit-decision-pr-g1.md
+++ b/changelog.d/1786883245_claude_exit-decision-pr-g1.md
@@ -1,0 +1,13 @@
+### Added
+
+- **CLI cleanup phase two, PR G1**: a new, canonical `exit_decision.ExitDecision`
+  resolves every orthogonal exit-code axis (the compatibility gate, contract
+  coverage, and analysis assurance) for a single-pair `compare`/`scan
+  --against` comparison into one explainable object -- `code` plus which
+  axis or axes actually determined it. `compare --format json`'s report now
+  persists this as a top-level `exit` object (schema 2.41), and the real
+  process exit is computed through the same resolver, so a report reader
+  and the CLI cannot disagree about why a comparison exited the way it did.
+  No CLI flag changes and no change to any existing exit code -- this is the
+  first, additive step toward the phase-two plan's `--exit-code-scheme`
+  consolidation, not a behavioural change on its own.

--- a/docs/_meta/topics.yaml
+++ b/docs/_meta/topics.yaml
@@ -69,6 +69,7 @@ topics:
       - abicheck/cli_scan.py
       - abicheck/cli_scan_baseline.py
       - abicheck/scan_engine.py
+      - abicheck/exit_decision.py
     reference_page: reference/exit-codes.md
     task_pages:
       - use/ci-gating.md

--- a/docs/reference/exit-codes.md
+++ b/docs/reference/exit-codes.md
@@ -130,6 +130,45 @@ contract-coverage axis: an assurance-gated exit `1` (via the dedicated
 `ANALYSIS_INCOMPLETE` verdict — never the compatibility verdict, and
 unconditional (no `fail-on-*` input disables it).
 
+## The `exit` report field (CLI cleanup phase two, PR G1)
+
+Every real-verdict `compare --format json` report (`full`/`leaf`/`root-cause`
+modes) carries a top-level `exit` object (report schema 2.41) stating the
+already-resolved decision behind the three axes above as one explainable
+value, rather than requiring a reader to separately combine
+`severity.exit_code`/`verdict`, `contract_coverage_exit_contribution`, and
+`analysis_assurance_exit_contribution` themselves:
+
+```json
+"exit": {
+  "code": 1,
+  "reasons": ["analysis_assurance"],
+  "compatibility_contribution": 0,
+  "contract_coverage_contribution": 0,
+  "analysis_assurance_contribution": 1
+}
+```
+
+`code` is exactly `max()` over the three contributions — the identical
+number the real process exits with for a single-pair comparison.
+`reasons` names every axis whose own contribution equals `code` (a lower,
+non-winning contribution is excluded, since it did not determine the
+result); `["clean"]` when `code` is `0`.
+
+Under `--used-by`/`--required-symbol(s)` scoping, `compatibility_contribution`
+and `reasons` describe the **scoped** application/plugin-host gate (the one
+the process actually exits on — see the section below), not the
+informational full-library verdict/severity gate `full_verdict`/
+`full_severity` still report; `reasons` carries `scoped_gate` rather than
+`compatibility_gate` in that case.
+
+This field is additive and does not itself change any exit code — it is a
+persisted view of a resolution every axis above already performs. It does
+not yet cover `not_comparable`, `scan --against`'s own budget-overflow
+floor, or a release's removed-required-library policy, each raised through
+a different code path today; see `abicheck/exit_decision.py`'s own module
+docstring for that scope boundary.
+
 ## Commands removed in the ADR-043 CLI reset
 
 `appcompat` and `plugin-check` are gone as standalone commands; their scoping

--- a/docs/reference/schemas/v1/compare_report.schema.json
+++ b/docs/reference/schemas/v1/compare_report.schema.json
@@ -1151,7 +1151,7 @@
         "compatibility_contribution": {
           "type": "integer",
           "minimum": 0,
-          "description": "The compatibility-gate exit code alone (severity.compute_exit_code under an effective severity map, else severity.legacy_exit_code from the verdict) -- UNLESS --used-by/--required-symbol(s) scoping is in effect, in which case this is the already-folded scoped application/plugin-host contract's own exit code (cli_compare_helpers._apply_scoped_gating's result.scoped_exit_code), not the informational full-library gate; reasons carries scoped_gate rather than compatibility_gate in that case."
+          "description": "The compatibility-gate exit code alone (severity.compute_exit_code under an effective severity map, else severity.legacy_exit_code from the verdict) -- UNLESS --used-by/--required-symbol(s) scoping is in effect, in which case this is the PRE-FOLD scoped application/plugin-host contract's own exit code (cli_compare_helpers._apply_scoped_gating's result.scoped_compatibility_contribution, captured before the coverage/assurance floors below are applied to it), not the informational full-library gate and not the already-folded result.scoped_exit_code -- so a genuine tie between the scoped gate and contract_coverage_contribution/analysis_assurance_contribution is visible here rather than hidden behind an already-maxed value; reasons carries scoped_gate rather than compatibility_gate in that case."
         },
         "contract_coverage_contribution": {
           "type": "integer",

--- a/docs/reference/schemas/v1/compare_report.schema.json
+++ b/docs/reference/schemas/v1/compare_report.schema.json
@@ -1141,17 +1141,18 @@
             "type": "string",
             "enum": [
               "compatibility_gate",
+              "scoped_gate",
               "contract_coverage",
               "analysis_assurance",
               "clean"
             ]
           },
-          "description": "Every axis whose own contribution equals code -- \"clean\" alone when code is 0."
+          "description": "Every axis whose own contribution equals code -- \"clean\" alone when code is 0. \"scoped_gate\" replaces \"compatibility_gate\" whenever --used-by/--required-symbol(s) scoping is in effect (see compatibility_contribution)."
         },
         "compatibility_contribution": {
           "type": "integer",
           "minimum": 0,
-          "description": "The compatibility-gate exit code alone (severity.compute_exit_code under an effective severity map, else severity.legacy_exit_code from the verdict)."
+          "description": "The compatibility-gate exit code alone (severity.compute_exit_code under an effective severity map, else severity.legacy_exit_code from the verdict) -- UNLESS --used-by/--required-symbol(s) scoping is in effect, in which case this is the already-folded scoped application/plugin-host contract's own exit code (cli_compare_helpers._apply_scoped_gating's result.scoped_exit_code), not the informational full-library gate; reasons carries scoped_gate rather than compatibility_gate in that case."
         },
         "contract_coverage_contribution": {
           "type": "integer",

--- a/docs/reference/schemas/v1/compare_report.schema.json
+++ b/docs/reference/schemas/v1/compare_report.schema.json
@@ -44,7 +44,8 @@
           "evidence_tier",
           "evidence_tiers",
           "analysis_assurance",
-          "analysis_assurance_exit_contribution"
+          "analysis_assurance_exit_contribution",
+          "exit"
         ]
       }
     },
@@ -1117,6 +1118,53 @@
       ],
       "description": "P0.4 (schema 2.40): what analysis_assurance contributes to the exit code under --require-complete-analysis \u2014 the exact sibling of contract_coverage_exit_contribution for the other orthogonal exit-floor axis. 1 when the flag was given and analysis_assurance.status is not \"complete\", 0 otherwise (including when the flag was never given). Applied since introduction: the process exit status is floored to this value (folded with max, so it never lowers a 2/4/5/6 from the compatibility axis, and never rewrites a finding's decision or gate contribution). This is the number that actually gated the run, derived by the same function the exit path uses (analysis_assurance.analysis_assurance_exit_contribution). Present alongside analysis_assurance, under the same condition.",
       "$comment": "aggregate.py's _analysis_assurance_exit reads this field directly rather than recomputing it."
+    },
+    "exit": {
+      "type": "object",
+      "description": "CLI cleanup phase two, PR G1 (schema 2.41): exit_decision.ExitDecision, the canonical resolution of every orthogonal exit-code axis for this comparison — code is exactly max(compatibility_contribution, contract_coverage_contribution, analysis_assurance_contribution), the identical value cli._exit_with_severity_or_verdict computes for the real process exit. reasons names every axis tied for that maximum (a lower, non-winning contribution is excluded, since it did not determine the result). Unconditionally present on every real-verdict compare report — every comparison has a compatibility contribution, unlike contract_context which stays opt-in. Deliberately does not yet cover not_comparable/scan-budget/release-removed-library exits, which are raised through different code paths today.",
+      "required": [
+        "code",
+        "reasons",
+        "compatibility_contribution",
+        "contract_coverage_contribution",
+        "analysis_assurance_contribution"
+      ],
+      "properties": {
+        "code": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The process exit code this decision resolves to, before any release/scan-specific axis (removed-library, budget, not_comparable) that this module does not yet cover."
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "compatibility_gate",
+              "contract_coverage",
+              "analysis_assurance",
+              "clean"
+            ]
+          },
+          "description": "Every axis whose own contribution equals code -- \"clean\" alone when code is 0."
+        },
+        "compatibility_contribution": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "The compatibility-gate exit code alone (severity.compute_exit_code under an effective severity map, else severity.legacy_exit_code from the verdict)."
+        },
+        "contract_coverage_contribution": {
+          "type": "integer",
+          "enum": [0, 1],
+          "description": "Duplicated from the top-level contract_coverage_exit_contribution (present only under --contract) for a single self-contained decision object; 0 when no contract domain was selected."
+        },
+        "analysis_assurance_contribution": {
+          "type": "integer",
+          "enum": [0, 1],
+          "description": "Duplicated from the top-level analysis_assurance_exit_contribution for a single self-contained decision object; 0 when --require-complete-analysis was not given."
+        }
+      },
+      "$comment": "exit_decision.resolve_compare_exit_decision is the one function that builds this object; cli._exit_with_severity_or_verdict resolves the identical ExitDecision for the real process exit, so the two cannot disagree."
     },
     "analysis_assurance": {
       "type": "object",

--- a/docs/reference/schemas/v1/compare_report.schema.json
+++ b/docs/reference/schemas/v1/compare_report.schema.json
@@ -44,8 +44,7 @@
           "evidence_tier",
           "evidence_tiers",
           "analysis_assurance",
-          "analysis_assurance_exit_contribution",
-          "exit"
+          "analysis_assurance_exit_contribution"
         ]
       }
     },

--- a/docs/use/output-formats.md
+++ b/docs/use/output-formats.md
@@ -660,7 +660,7 @@ Every JSON report carries a top-level `report_schema_version` field
 
 ```json
 {
-  "report_schema_version": "2.40",
+  "report_schema_version": "2.41",
   "library": "libfoo.so.1",
   "verdict": "BREAKING"
 }

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -798,6 +798,72 @@ class TestOutputDir:
         assert (out_dir / "libfoo.json").exists()
         assert (out_dir / "summary.json").exists()
 
+    def test_per_library_report_exit_block_honors_release_severity(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review, PR G1 follow-up (fresh evidence): ``_compare_one_
+        library`` wrote each per-library ``--output-dir`` report via
+        ``to_json(result)`` with no ``severity_config``, so the persisted
+        ``exit`` block (schema 2.41, ``exit_decision.ExitDecision``) always
+        used the legacy verdict-based scheme regardless of whether the
+        release itself resolved and gated on a severity configuration.
+        Reproduced with ``--severity-preset strict`` (additions are error):
+        the release process exits ``1``, but the per-library report's own
+        ``exit.code`` read ``0``/``reasons: ["clean"]`` before this fix --
+        disagreeing with the process it was supposedly explaining.
+        """
+        old_dir = tmp_path / "old"
+        old_dir.mkdir()
+        new_dir = tmp_path / "new"
+        new_dir.mkdir()
+        out_dir = tmp_path / "reports"
+        old = _snap(
+            "1.0",
+            [
+                Function(
+                    name="foo",
+                    mangled="_Z3foov",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                )
+            ],
+        )
+        new = _snap(
+            "2.0",
+            [
+                Function(
+                    name="foo",
+                    mangled="_Z3foov",
+                    return_type="int",
+                    visibility=Visibility.PUBLIC,
+                ),
+                Function(
+                    name="bar",
+                    mangled="_Z3barv",
+                    return_type="void",
+                    visibility=Visibility.PUBLIC,
+                ),
+            ],
+        )
+        _write_snap(old_dir / "libfoo.json", old)
+        _write_snap(new_dir / "libfoo.json", new)
+        code, _ = _invoke(
+            "compare",
+            str(old_dir),
+            str(new_dir),
+            "--output-dir",
+            str(out_dir),
+            "--severity-preset",
+            "strict",
+        )
+        assert code == 1
+        report = json.loads((out_dir / "libfoo.json").read_text())
+        # The addition-error gate is severity-scheme-only -- a report built
+        # under the legacy scheme's ExitDecision would read code 0, reasons
+        # ["clean"], disagreeing with the real (severity-gated) release exit.
+        assert report["exit"]["code"] == 1
+        assert "compatibility_gate" in report["exit"]["reasons"]
+
     def test_summary_json_structure(self, tmp_path: Path) -> None:
         old_dir = tmp_path / "old"
         old_dir.mkdir()

--- a/tests/test_exit_decision.py
+++ b/tests/test_exit_decision.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 
 from abicheck.checker import compare
@@ -36,7 +37,17 @@ from abicheck.cli import main
 from abicheck.exit_decision import ExitDecision, ExitReason, resolve_exit_decision
 from abicheck.model import AbiSnapshot, Function, Visibility
 from abicheck.reporter import to_json
+from abicheck.schemas import load_compare_report_schema
 from abicheck.serialization import snapshot_to_json
+
+try:
+    import jsonschema
+except ImportError:  # pragma: no cover - exercised only when jsonschema absent
+    jsonschema = None
+
+_requires_jsonschema = pytest.mark.skipif(
+    jsonschema is None, reason="jsonschema not installed"
+)
 
 
 class TestResolveExitDecision:
@@ -367,3 +378,20 @@ class TestIncludeExitDecisionFlag:
                 to_json(result, report_mode=mode, include_exit_decision=False)
             )
             assert "exit" not in report, mode
+
+    @_requires_jsonschema
+    def test_include_exit_decision_false_still_validates_against_schema(
+        self,
+    ) -> None:
+        """``exit`` is schema-optional (not in ``required``) specifically so
+        this -- what ``compat check``'s JSON output actually produces -- still
+        validates against the same ``report_schema_version`` it stamps
+        (Codex review: an earlier revision required ``exit`` unconditionally,
+        so a ``compat`` report claiming schema 2.41 while omitting the block
+        failed to validate against its own advertised schema).
+        """
+        old, new = _breaking_pair()
+        result = compare(old, new)
+        report = json.loads(to_json(result, include_exit_decision=False))
+        assert "exit" not in report
+        jsonschema.validate(report, load_compare_report_schema())

--- a/tests/test_exit_decision.py
+++ b/tests/test_exit_decision.py
@@ -231,3 +231,58 @@ class TestCompareExitDecisionIntegration:
             report["exit"]["analysis_assurance_contribution"]
             == report["analysis_assurance_exit_contribution"]
         )
+
+    def test_scoped_gate_reports_the_scoped_exit_not_the_full_library_gate(
+        self, tmp_path: Path,
+    ) -> None:
+        """Codex review: a `--required-symbol` compare's real process exit is
+        the *scoped* gate (`result.scoped_exit_code`), floored/persisted by
+        `cli_compare_helpers._apply_scoped_gating` before any report renders
+        -- not the full-library verdict/severity gate this module would
+        otherwise compute from `result.verdict`. Scoping the requirement to
+        the surviving symbol alone must report a clean scoped exit even
+        though the full library is BREAKING (a real removed symbol outside
+        the required set), and the persisted ``exit`` block must agree with
+        the real process exit code, not the informational full-library one.
+        """
+        old_p, new_p = _write(tmp_path, *_breaking_pair())
+        res = CliRunner().invoke(
+            main,
+            [
+                "compare", str(old_p), str(new_p),
+                "--required-symbol", "_Z5pub_av",  # pub_a survives; pub_b was removed
+                "--format", "json",
+            ],
+        )
+        assert res.exit_code == 0, res.output
+        report = json.loads(res.stdout[res.stdout.index("{") :])
+        # full_verdict is the informational, unscoped full-library gate;
+        # verdict itself is already the scoped one under --required-symbol.
+        assert report["full_verdict"] == "BREAKING"
+        assert report["exit"]["code"] == 0
+        assert report["exit"]["reasons"] == ["clean"]
+        assert report["exit"]["compatibility_contribution"] == 0
+        assert report["exit"]["code"] == res.exit_code
+
+    def test_scoped_gate_failure_names_the_scoped_reason(
+        self, tmp_path: Path,
+    ) -> None:
+        """The inverse: requiring the *removed* symbol must fail the scoped
+        gate, and the ``exit`` block must name ``scoped_gate`` -- not
+        ``compatibility_gate`` -- since the full-library verdict alone never
+        determined this exit.
+        """
+        old_p, new_p = _write(tmp_path, *_breaking_pair())
+        res = CliRunner().invoke(
+            main,
+            [
+                "compare", str(old_p), str(new_p),
+                "--required-symbol", "_Z5pub_bv",  # pub_b was removed
+                "--format", "json",
+            ],
+        )
+        assert res.exit_code != 0, res.output
+        report = json.loads(res.stdout[res.stdout.index("{") :])
+        assert report["exit"]["code"] == res.exit_code
+        assert report["exit"]["reasons"] == ["scoped_gate"]
+        assert report["exit"]["compatibility_contribution"] == res.exit_code

--- a/tests/test_exit_decision.py
+++ b/tests/test_exit_decision.py
@@ -31,9 +31,11 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
+from abicheck.checker import compare
 from abicheck.cli import main
 from abicheck.exit_decision import ExitDecision, ExitReason, resolve_exit_decision
 from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.reporter import to_json
 from abicheck.serialization import snapshot_to_json
 
 
@@ -286,3 +288,82 @@ class TestCompareExitDecisionIntegration:
         assert report["exit"]["code"] == res.exit_code
         assert report["exit"]["reasons"] == ["scoped_gate"]
         assert report["exit"]["compatibility_contribution"] == res.exit_code
+
+    def test_scoped_clean_gate_does_not_mask_the_real_assurance_reason(
+        self, tmp_path: Path,
+    ) -> None:
+        """Codex review: an earlier revision of the scoped fix read the
+        already-*folded* ``result.scoped_exit_code`` as the compatibility
+        contribution, so a clean scoped gate (0) floored to 1 purely by
+        ``--require-complete-analysis`` still reported ``reasons:
+        ["scoped_gate"]`` and ``compatibility_contribution: 1`` -- as if the
+        scoped gate itself had determined the exit, when it contributed
+        nothing. The *pre-fold* scoped contribution must be what's compared
+        against the other axes, so a clean scoped gate correctly stays out
+        of ``reasons`` when assurance alone is what floored the exit.
+        """
+        common = {"library": "libfoo.so.1", "elf_only_mode": True}
+        fns = [_fn("pub_a", "_Z5pub_av")]
+        old_p, new_p = _write(
+            tmp_path,
+            AbiSnapshot(version="1.0", functions=fns, **common),
+            AbiSnapshot(version="2.0", functions=fns, **common),
+        )
+        res = CliRunner().invoke(
+            main,
+            [
+                "compare", str(old_p), str(new_p),
+                "--required-symbol", "_Z5pub_av",  # survives -- clean scoped gate
+                "--format", "json",
+                "--require-complete-analysis",  # elf-only pair: incomplete
+            ],
+        )
+        assert res.exit_code == 1, res.output
+        report = json.loads(res.stdout[res.stdout.index("{") :])
+        assert report["exit"]["code"] == 1
+        assert report["exit"]["code"] == res.exit_code
+        assert report["exit"]["reasons"] == ["analysis_assurance"]
+        assert report["exit"]["compatibility_contribution"] == 0
+        assert report["exit"]["analysis_assurance_contribution"] == 1
+
+
+class TestIncludeExitDecisionFlag:
+    """Codex review: ``compat/cli.py``'s own ``-report-format json`` reuses
+    this exact ``reporter.to_json`` function, but ``compat check``'s real
+    process exit follows a different, ABICC-style 0/1/2 scheme
+    (``_classify_compat_error_exit_code``) than the native
+    ``legacy_exit_code``/``compute_exit_code`` the ``exit`` block computes --
+    emitting it unconditionally would report a code that disagrees with the
+    actual ``compat check`` exit for the same run. ``include_exit_decision``
+    is the flag that keeps them apart; ``compat/cli.py``'s own call site
+    passes ``False``, and these tests pin `to_json` itself -- the real
+    function both callers share -- rather than only the CLI wrapper.
+    """
+
+    def test_default_includes_the_exit_block(self) -> None:
+        old, new = _breaking_pair()
+        result = compare(old, new)
+        report = json.loads(to_json(result))
+        assert "exit" in report
+        assert report["exit"]["code"] == 4
+
+    def test_include_exit_decision_false_omits_it(self) -> None:
+        old, new = _breaking_pair()
+        result = compare(old, new)
+        report = json.loads(to_json(result, include_exit_decision=False))
+        assert "exit" not in report
+        # Every other field this function always writes stays present --
+        # this flag turns off exactly one block, nothing else.
+        assert report["verdict"] == "BREAKING"
+        assert "changes" in report
+
+    def test_include_exit_decision_false_also_applies_to_leaf_and_root_cause(
+        self,
+    ) -> None:
+        old, new = _breaking_pair()
+        result = compare(old, new)
+        for mode in ("leaf", "root-cause"):
+            report = json.loads(
+                to_json(result, report_mode=mode, include_exit_decision=False)
+            )
+            assert "exit" not in report, mode

--- a/tests/test_exit_decision.py
+++ b/tests/test_exit_decision.py
@@ -1,0 +1,233 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""CLI cleanup phase two, PR G1: ``exit_decision.ExitDecision``.
+
+The pure-resolver tests (``TestResolveExitDecision``) state the primitive's
+own contract as invariants -- precedence, tie-handling, the ``clean``
+sentinel -- independent of any one caller. The CLI-level tests
+(``TestCompareExitDecisionIntegration``) are the regression pin that the
+canonical resolver reproduces exactly the exit code the pre-refactor,
+three-separate-``max``-calls fold chain produced, and that the JSON report's
+new ``exit`` block agrees with the real process exit.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from abicheck.cli import main
+from abicheck.exit_decision import ExitDecision, ExitReason, resolve_exit_decision
+from abicheck.model import AbiSnapshot, Function, Visibility
+from abicheck.serialization import snapshot_to_json
+
+
+class TestResolveExitDecision:
+    def test_clean_when_every_contribution_is_zero(self) -> None:
+        decision = resolve_exit_decision(compatibility_contribution=0)
+        assert decision.code == 0
+        assert decision.reasons == (ExitReason.CLEAN,)
+
+    def test_compatibility_alone_wins(self) -> None:
+        decision = resolve_exit_decision(compatibility_contribution=4)
+        assert decision.code == 4
+        assert decision.reasons == (ExitReason.COMPATIBILITY_GATE,)
+
+    def test_coverage_floor_raises_a_clean_zero(self) -> None:
+        decision = resolve_exit_decision(
+            compatibility_contribution=0, contract_coverage_contribution=1,
+        )
+        assert decision.code == 1
+        assert decision.reasons == (ExitReason.CONTRACT_COVERAGE,)
+
+    def test_assurance_floor_raises_a_clean_zero(self) -> None:
+        decision = resolve_exit_decision(
+            compatibility_contribution=0, analysis_assurance_contribution=1,
+        )
+        assert decision.code == 1
+        assert decision.reasons == (ExitReason.ANALYSIS_ASSURANCE,)
+
+    def test_floors_never_lower_a_real_break(self) -> None:
+        """A `1` floor sitting underneath a `4` gate never wins, and does not
+        appear in `reasons` -- it explains nothing about why the exit is `4`.
+        """
+        decision = resolve_exit_decision(
+            compatibility_contribution=4,
+            contract_coverage_contribution=1,
+            analysis_assurance_contribution=1,
+        )
+        assert decision.code == 4
+        assert decision.reasons == (ExitReason.COMPATIBILITY_GATE,)
+
+    def test_tied_axes_both_appear_in_reasons(self) -> None:
+        """Coverage and assurance can independently both floor to `1` -- a
+        shared `1` is explainable only if both are named.
+        """
+        decision = resolve_exit_decision(
+            compatibility_contribution=0,
+            contract_coverage_contribution=1,
+            analysis_assurance_contribution=1,
+        )
+        assert decision.code == 1
+        assert set(decision.reasons) == {
+            ExitReason.CONTRACT_COVERAGE, ExitReason.ANALYSIS_ASSURANCE,
+        }
+
+    def test_matches_manual_max_fold(self) -> None:
+        """`code` is exactly `max()` over the three contributions -- the
+        identical value the pre-PR-G1 sequential fold chain computed.
+        """
+        for compat, coverage, assurance in [
+            (0, 0, 0), (2, 0, 0), (0, 1, 0), (0, 0, 1), (4, 1, 1), (1, 1, 1),
+        ]:
+            decision = resolve_exit_decision(
+                compatibility_contribution=compat,
+                contract_coverage_contribution=coverage,
+                analysis_assurance_contribution=assurance,
+            )
+            assert decision.code == max(compat, coverage, assurance)
+
+    def test_to_dict_is_json_serializable(self) -> None:
+        decision = resolve_exit_decision(
+            compatibility_contribution=0, contract_coverage_contribution=1,
+        )
+        d = decision.to_dict()
+        json.dumps(d)  # must not raise
+        assert d == {
+            "code": 1,
+            "reasons": ["contract_coverage"],
+            "compatibility_contribution": 0,
+            "contract_coverage_contribution": 1,
+            "analysis_assurance_contribution": 0,
+        }
+
+    def test_default_contributions_are_zero(self) -> None:
+        """A caller with neither `--contract` nor
+        `--require-complete-analysis` in effect can omit both keyword args.
+        """
+        decision = resolve_exit_decision(compatibility_contribution=2)
+        assert decision.contract_coverage_contribution == 0
+        assert decision.analysis_assurance_contribution == 0
+
+    def test_is_frozen(self) -> None:
+        decision: ExitDecision = resolve_exit_decision(compatibility_contribution=0)
+        try:
+            decision.code = 4  # type: ignore[misc]
+        except AttributeError:
+            pass
+        else:
+            raise AssertionError("ExitDecision must be immutable")
+
+
+def _fn(name: str, mangled: str) -> Function:
+    return Function(
+        name=name, mangled=mangled, return_type="int", visibility=Visibility.PUBLIC,
+    )
+
+
+def _write(tmp_path: Path, old: AbiSnapshot, new: AbiSnapshot) -> tuple[Path, Path]:
+    old_p = tmp_path / "old.json"
+    new_p = tmp_path / "new.json"
+    old_p.write_text(snapshot_to_json(old), encoding="utf-8")
+    new_p.write_text(snapshot_to_json(new), encoding="utf-8")
+    return old_p, new_p
+
+
+def _compatible_pair() -> tuple[AbiSnapshot, AbiSnapshot]:
+    common = {"library": "libfoo.so.1", "from_headers": True}
+    fns = [_fn("pub_a", "_Z5pub_av")]
+    return (
+        AbiSnapshot(version="1.0", functions=fns, **common),
+        AbiSnapshot(version="2.0", functions=fns, **common),
+    )
+
+
+def _breaking_pair() -> tuple[AbiSnapshot, AbiSnapshot]:
+    common = {"library": "libfoo.so.1", "from_headers": True}
+    return (
+        AbiSnapshot(
+            version="1.0",
+            functions=[_fn("pub_a", "_Z5pub_av"), _fn("pub_b", "_Z5pub_bv")],
+            **common,
+        ),
+        AbiSnapshot(version="2.0", functions=[_fn("pub_a", "_Z5pub_av")], **common),
+    )
+
+
+def _compare(tmp_path: Path, pair: tuple[AbiSnapshot, AbiSnapshot], *extra: str):
+    old_p, new_p = _write(tmp_path, *pair)
+    return CliRunner().invoke(main, ["compare", str(old_p), str(new_p), *extra])
+
+
+class TestCompareExitDecisionIntegration:
+    """The real `compare --format json` path: the persisted `exit` block
+    must agree with the real process exit code, for both a clean and a
+    breaking comparison, with no orthogonal axis engaged.
+    """
+
+    def test_clean_comparison_reports_a_clean_exit_block(self, tmp_path: Path) -> None:
+        res = _compare(tmp_path, _compatible_pair(), "--format", "json")
+        assert res.exit_code == 0, res.output
+        report = json.loads(res.stdout[res.stdout.index("{") :])
+        assert report["exit"] == {
+            "code": 0,
+            "reasons": ["clean"],
+            "compatibility_contribution": 0,
+            "contract_coverage_contribution": 0,
+            "analysis_assurance_contribution": 0,
+        }
+
+    def test_breaking_comparison_reports_the_compatibility_gate_reason(
+        self, tmp_path: Path,
+    ) -> None:
+        res = _compare(tmp_path, _breaking_pair(), "--format", "json")
+        assert res.exit_code == 4, res.output
+        report = json.loads(res.stdout[res.stdout.index("{") :])
+        assert report["exit"]["code"] == 4
+        assert report["exit"]["reasons"] == ["compatibility_gate"]
+        assert report["exit"]["compatibility_contribution"] == 4
+        assert report["exit"]["code"] == res.exit_code
+
+    def test_require_complete_analysis_floor_matches_process_exit(
+        self, tmp_path: Path,
+    ) -> None:
+        """The elf-only pair from `test_analysis_assurance.py`'s own
+        contract has an incomplete status -- ``--require-complete-analysis``
+        floors a clean compatibility exit to 1, and the persisted ``exit``
+        block must name ``analysis_assurance`` as the reason.
+        """
+        common = {"library": "libfoo.so.1", "elf_only_mode": True}
+        fns = [_fn("pub_a", "_Z5pub_av")]
+        pair = (
+            AbiSnapshot(version="1.0", functions=fns, **common),
+            AbiSnapshot(version="2.0", functions=fns, **common),
+        )
+        res = _compare(
+            tmp_path, pair, "--format", "json", "--require-complete-analysis",
+        )
+        assert res.exit_code == 1, res.output
+        report = json.loads(res.stdout[res.stdout.index("{") :])
+        assert report["exit"]["code"] == 1
+        assert "analysis_assurance" in report["exit"]["reasons"]
+        assert report["exit"]["analysis_assurance_contribution"] == 1
+        assert report["exit"]["code"] == res.exit_code
+        # And the top-level sibling field this duplicates must agree.
+        assert (
+            report["exit"]["analysis_assurance_contribution"]
+            == report["analysis_assurance_exit_contribution"]
+        )

--- a/tests/test_exit_decision.py
+++ b/tests/test_exit_decision.py
@@ -101,19 +101,22 @@ class TestResolveExitDecision:
             ExitReason.CONTRACT_COVERAGE, ExitReason.ANALYSIS_ASSURANCE,
         }
 
-    def test_matches_manual_max_fold(self) -> None:
+    @pytest.mark.parametrize(
+        ("compat", "coverage", "assurance"),
+        [(0, 0, 0), (2, 0, 0), (0, 1, 0), (0, 0, 1), (4, 1, 1), (1, 1, 1)],
+    )
+    def test_matches_manual_max_fold(
+        self, compat: int, coverage: int, assurance: int
+    ) -> None:
         """`code` is exactly `max()` over the three contributions -- the
         identical value the pre-PR-G1 sequential fold chain computed.
         """
-        for compat, coverage, assurance in [
-            (0, 0, 0), (2, 0, 0), (0, 1, 0), (0, 0, 1), (4, 1, 1), (1, 1, 1),
-        ]:
-            decision = resolve_exit_decision(
-                compatibility_contribution=compat,
-                contract_coverage_contribution=coverage,
-                analysis_assurance_contribution=assurance,
-            )
-            assert decision.code == max(compat, coverage, assurance)
+        decision = resolve_exit_decision(
+            compatibility_contribution=compat,
+            contract_coverage_contribution=coverage,
+            analysis_assurance_contribution=assurance,
+        )
+        assert decision.code == max(compat, coverage, assurance)
 
     def test_to_dict_is_json_serializable(self) -> None:
         decision = resolve_exit_decision(


### PR DESCRIPTION
## Summary

Implements PR G1 from `docs/contribute/plans/cli-cleanup-phase-two.md`'s reviewed ordering: a new, canonical `exit_decision.ExitDecision` resolves every orthogonal exit-code axis (the compatibility gate, contract coverage, and analysis assurance) for a single-pair `compare`/`scan --against` comparison into one explainable object. This is deliberately additive — **no CLI flag change, no change to any existing exit code** — and is the prerequisite the plan's PR E (Action machine-report) and PR G2 (`--exit-code-scheme` removal) build on.

## Motivation

Today the real exit code is folded from three separately-called `max()` operations spread across `cli.py`/`contract_coverage_exit.py`/`analysis_assurance.py`. That's fine for computing *a* number, but there's no single place answering "why is this exit 1" when more than one axis independently contributes — a caller has to re-derive the answer from several separately-read report fields. `ExitDecision` is that explainable object: it wraps the existing fold rather than replacing its logic, so every call site keeps today's exit code bit-for-bit, and adds `reasons` — the axis or axes whose own contribution actually determined the result.

## Changes

- **`abicheck/exit_decision.py`** (new): `ExitReason` enum, `ExitDecision` dataclass, `resolve_exit_decision()` (pure fold), and `resolve_compare_exit_decision()` (derives every contribution from a `DiffResult` the same way `cli._exit_with_severity_or_verdict` does today).
- **`cli._exit_with_severity_or_verdict`**: now delegates to the canonical resolver instead of three separate `max` folds. The two stderr diagnostics (coverage/assurance) still read their own pre-fold `base_exit` exactly as before, so their wording is unchanged.
- **`reporter_contract_blocks.add_contract_context`**: persists the resolved decision as a new top-level, schema-optional `exit` object (report schema **2.41**) on every real-verdict compare report (full/leaf/root-cause JSON paths) — except when the caller passes `include_exit_decision=False`.
- **Scoped-gate awareness** (found by review on this same PR): `--used-by`/`--required-symbol(s)` compares exit on a separately-computed, already-folded `result.scoped_exit_code`, bypassing `_exit_with_severity_or_verdict` entirely. The resolver now reads the *pre-fold* scoped contribution (`result.scoped_compatibility_contribution`) directly when present, under a new `ExitReason.SCOPED_GATE`, so a genuine tie with coverage/assurance is named correctly instead of always attributed to scoping.
- **`compat` exclusion** (found by review on this same PR): `abicheck/compat/cli.py`'s JSON output reuses `reporter.to_json()`, but `compat check`'s own ABICC 0/1/2 exit scheme differs from native `compare`'s — so `to_json`/`_to_json_leaf`/`_to_json_root_cause`/`add_contract_context` now take `include_exit_decision: bool = True`, and `compat/cli.py` passes `False`, omitting the block entirely rather than emitting a disagreeing `code`.
- **Schema stays optional, not required** (found by review on this same PR): `exit` was initially added to the compare-report schema's `required` list for a real verdict, which meant `compat check`'s own `include_exit_decision=False` JSON output — still stamping `report_schema_version: "2.41"` — failed to validate against the schema it claimed to conform to. `exit` is now schema-optional; a regression test validates a compat-shaped report (block omitted) against the real packaged schema.
- **Release severity threading** (found by review on this same PR): a directory/package release compare's per-library `--output-dir` JSON write (`_compare_one_library`, and its sibling rewrite `_suppress_lockstep_soname_findings`) called `to_json(result)` without the release's own resolved `severity_config`, so a severity-aware release (`--severity-preset strict`, say) could exit non-zero at the release level while every per-library report it wrote said `exit.code: 0`/`reasons: ["clean"]`. Both call sites already had `severity_config` in scope; it's now threaded through `_CompareReleaseCommonArgs` into both `to_json(...)` calls.
- **Schema**: `compare_report.schema.json` (+ published `docs/reference/schemas/v1` mirror) gains the `exit` object's schema. `docs/use/output-formats.md`'s schema-version example bumped to match.
- **Docs**: registered `abicheck/exit_decision.py` as a fact source under the existing `verdicts` topic (`docs/_meta/topics.yaml`), and added a real section to `docs/reference/exit-codes.md` describing the field, its scoped-mode behavior, and its documented scope boundary.

**Deliberately out of scope for this slice** (documented in the module's own docstring): `not_comparable`, `scan --against`'s budget-overflow floor, and a release's removed-required-library policy are each raised through a different code path today and are not yet folded into `ExitDecision` — that's PR G2's job, per the plan.

## Tests

`tests/test_exit_decision.py` — pure-resolver invariants (clean sentinel, single-axis wins, floors never lower a real break, tied axes both named, matches manual `max()`) plus CLI-integration tests pinning that the JSON report's `exit` block agrees with the real process exit for: a clean comparison, a breaking comparison, a `--require-complete-analysis` floor, both directions of `--required-symbol` scoping, the scoped-gate tie-preservation case, the `include_exit_decision` opt-out (default-on, opt-out, leaf/root-cause), and schema validation of the compat-shaped (opt-out) report. `tests/test_compare_release.py::TestOutputDir::test_per_library_report_exit_block_honors_release_severity` — the release-severity regression, through the real `compare` CLI on a directory pair.

## Bug-fix test contract

This section covers four correctness fixes to shipped code across this PR's commits, each caught by review before merge.

- Bug class: (1) A report field computed from the wrong evidence under a scoping mode the computation didn't know about — `resolve_compare_exit_decision` derived `compatibility_contribution` from the full-library verdict/severity gate unconditionally, ignoring `--used-by`/`--required-symbol(s)` scoping's own authoritative, already-computed `result.scoped_exit_code`. (2) The same fix's own follow-up: reading the *already-folded* `scoped_exit_code` as the compatibility contribution hid a genuine tie with coverage/assurance behind a `SCOPED_GATE` reason that may not have contributed at all. (3) A schema/consumer mismatch — `exit` was required unconditionally, so `compat check`'s own `include_exit_decision=False` JSON output failed to validate against the schema version it stamps. (4) A parameter that was in scope but never forwarded — a release's own resolved `severity_config` never reached the per-library JSON write, so a severity-gated release's per-library reports always used the legacy exit-code scheme regardless of the release's actual configuration.
- Publicly observable failure: (1) `compare --required-symbol X --format json` on a library with a real ABI break outside the required symbol's contract: the CLI process exits `0` (the scoped gate is clean), but the JSON report's `exit.code` read `4` with `reasons: ["compatibility_gate"]`. (2) A clean scoped gate tied with an incomplete-assurance floor reported `reasons: ["scoped_gate"]` instead of `["analysis_assurance"]`, misattributing why the exit was non-zero. (3) `abicheck compat check --report-format json` on a fixture with a real ABI break produces a document that fails `jsonschema.validate` against its own advertised `report_schema_version`. (4) `compare old_dir new_dir --output-dir reports/ --severity-preset strict` on an addition-only change: the release process exits `1`, but `reports/<library>.json`'s own `exit.code` read `0`, `reasons: ["clean"]`.
- Regression test fails on base: Yes, for all four. `test_scoped_gate_reports_the_scoped_exit_not_the_full_library_gate` (1), `test_scoped_clean_gate_does_not_mask_the_real_assurance_reason` (2), `test_include_exit_decision_false_still_validates_against_schema` (3), and `test_per_library_report_exit_block_honors_release_severity` (4) each fail against the pre-fix revision with the exact symptom described above.
- Negative control: `test_breaking_comparison_reports_the_compatibility_gate_reason` pins the ordinary, non-scoped path is unaffected by (1)/(2); `test_default_includes_the_exit_block` pins that the default (`include_exit_decision=True`) path still requires and emits `exit` normally, unaffected by (3); the pre-existing `TestOutputDir::test_summary_json_structure`/`test_per_library_reports_written` (no severity flag) pin the ordinary, non-severity release path is unaffected by (4).
- Public-surface test: All four go through real entry points — the actual `compare` CLI via `CliRunner().invoke(main, [...])` parsing real `--format json`/`--output-dir` output for (1)/(2)/(4), and the real `reporter.to_json()` + packaged `abicheck/schemas/compare_report.schema.json` for (3) — not a hand-built `DiffResult` or a hand-written schema fragment.
- Axes covered: Both directions of scoping, the unscoped legacy-scheme path, the severity-scheme path (single-pair and now release-level), ties between scoped-gate and each of coverage/assurance, both `include_exit_decision` states validated against the real schema, and the release fan-out's per-library write path (both the primary write in `_compare_one_library` and the lockstep-SONAME-suppression rewrite share the fix). Not yet covered: `scan --against`'s own scoped-gate shape (no `--used-by`/`--required-symbol` equivalent exists there today).
- General invariant: The persisted `exit` block's `code` must always equal the real process exit code for the same invocation and gating mode, for every command shape that emits one (single-pair compare and now release fan-out alike); `reasons` must always name every axis genuinely tied for that code, never a reason that didn't actually contribute; and whenever `exit` is present, it and the whole report must validate against the `report_schema_version` the report itself stamps.
- Verdict, gate and exit code checked independently: Yes — the tests assert `full_verdict`/per-library `verdict` (informational), `report["exit"]["code"]`/`report["exit"]["reasons"]` (the real gate/exit and its explanation), the actual process `exit_code`, and now schema validity, as four independently-checked facts rather than one assertion conflating them.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`reference/exit-codes.md`, `docs/_meta/topics.yaml`, schema mirrors regenerated via `scripts/publish_schemas.py`)
- [x] `mypy abicheck/` clean (370 source files)
- [x] `ruff check`/tests pass on all touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - JSON comparison reports now include a clear `exit` summary with the final code, contributing checks, and reasons.
  - Exit results consistently account for compatibility, contract coverage, and analysis assurance.
  - Severity settings are reflected consistently in release and per-library reports.
- **Bug Fixes**
  - Compatible-report output no longer includes native exit-decision details.
  - Process exit codes and report explanations now remain aligned.
- **Documentation**
  - Updated report schema to version 2.41 and documented the new exit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->