### PR TITLE
docs: record scan/dump include_sequence residual gap (lab PR #14 evidence)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1571,9 +1571,21 @@ Once a root command genuinely clears the bar above, pick the right home:
   these already carry L3-derived content, so an inferred `-H` root whose
   directory the L3 evidence already covers is **skipped entirely**
   (`inferred` ends up empty, the function returns `([], [])` for that
-  root) rather than reclassified into a different bucket; dump's pre-fold
-  call has a much smaller `skip` set (no L3 content yet), so the same root
-  is far more likely to survive as a plain `-I` extra-include instead.
+  root); dump's pre-fold call has a much smaller `skip` set (no L3 content
+  yet), so the same root is far more likely to survive as a plain `-I`
+  extra-include instead. This omission is real only for the two branches of
+  `skip` that do **not** independently reach `extra_includes`: a
+  `_build_context_include_dirs(ctx)` match (a dir implied only by
+  `gcc_options`/`gcc_option_tokens`, never itself added to `includes`), and
+  the sibling deferred-token branch below. It is *not* an omission when
+  `skip` matches purely because the root is already literally present in
+  `user_includes` — `_dump_elf`'s own `eff_includes = list(includes)`
+  starts from that same list before `resolve_inferred_header_roots` ever
+  runs and is only ever added to, never filtered, so that root's slot
+  survives via the pre-existing `includes` entry regardless of whether the
+  inferred-root call re-adds it (Codex review: an earlier draft of this
+  entry collapsed all three skip/defer shapes into one "no slot" outcome,
+  which is only true for two of them).
   (b) Separately, `perform_elf_dump` computes `inc_extra` from this
   *pre-fold* call and only later builds `extra_includes=eff_includes +
   inc_extra` for the actual `dump(...)` call, where `eff_includes` is the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1613,9 +1613,13 @@ Once a root command genuinely clears the bar above, pick the right home:
   "known gaps over risky reactive patches" convention applies doubly here,
   given how many single-paragraph "found it" claims this same footnote has
   already had to walk back. Consequence for
-  `napetrov/abicheck-bazel-lab`: PR #14's `fresh-to-fresh` control job
-  should be treated as still red on this one residual field, and the lab's
-  own checked-in `abi/math.abicheck.json` should **not** be regenerated
+  `napetrov/abicheck-bazel-lab`: PR #14's `fresh-to-fresh` job (its real
+  workflow-job name) genuinely fails overall — its own
+  `compare fresh-base fresh-head` step passes, but its separate
+  `scan HEAD --against fresh-base.abi.json` step is the one that returns
+  `NOT_COMPARABLE` and fails the job — so it should be treated as still red
+  on this one residual field, and the lab's own checked-in
+  `abi/math.abicheck.json` should **not** be regenerated
   against the new core pin yet — doing so now would just encode a baseline
   that a fresh `scan --against` still can't cleanly compare to, the same
   problem this diagnostic exists to catch, not fix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1496,6 +1496,60 @@ Once a root command genuinely clears the bar above, pick the right home:
   assertion catching `deferred` leaking into the fold's own explicit
   tokens and via the final ordering check).
 
+  **A nineteenth finding, from real Bazel/castxml CI evidence (not a
+  hand-built fixture) on `napetrov/abicheck-bazel-lab`'s diagnostic PR #14,
+  after repinning it to `abicheck/abicheck@84cf3d4` (PR #788) — a narrower
+  residual of this same topic survives the eighth/`_build_new_snapshot`
+  fold fix above, investigated but not fixed.** The lab's
+  `validate-two-fresh-mains.yml` workflow builds BASE and HEAD with real
+  Bazel, captures target-scoped cquery/aquery evidence for both, `dump`s
+  each fresh (`fresh-base.abi.json`/`fresh-head.abi.json`, same code,
+  identical `--sources`/`--build-info`), then separately `scan`s HEAD
+  `--against` the fresh BASE dump. `compare fresh-base fresh-head` (pure
+  `dump` vs `dump`) reads `COMPATIBLE`/`NO_CHANGE` with a complete
+  `analysis_assurance` — confirming `language_standard` parity holds, i.e.
+  the eighth-finding fix above genuinely works. But `scan HEAD --against
+  fresh-base.abi.json` (the same HEAD code, same `-H`/`--sources`/
+  `--build-info` inputs, `dump`'s baseline) still reads `NOT_COMPARABLE`:
+  `diff.reason` names exactly one differing field, `include_sequence` (not
+  `language_standard`, which no longer reproduces) — a narrower,
+  previously-undetected sibling of the field this whole topic exists to
+  close, confirmed via the run's own uploaded `two-fresh-mains-validation`
+  artifact (run
+  https://github.com/napetrov/abicheck-bazel-lab/actions/runs/31950549361,
+  job 95173233150, commit `a7f5a7f`). The most concrete, verified-by-
+  reading (not yet verified against a live repro — no `bazel`/`castxml` in
+  this pass's environment) structural asymmetry: `scan_engine.
+  _build_new_snapshot` passes its raw, **unexpanded** `headers` list
+  (`-H new=math.h -H new=include` — the directory entry still present as a
+  single item) into both `seed_includes_and_fold_compile_context` and
+  `service.resolve_input`, while `cli_dump_helpers.perform_elf_dump` first
+  calls `expand_header_inputs()` — which recursively expands a directory
+  via `header_utils.iter_directory_headers` into individual files, in a
+  deterministic order, with order-preserving dedup — and passes that
+  already-**expanded** `resolved_headers` list to the identical two calls
+  instead. `seed_includes_and_fold_compile_context`'s own use of `headers`
+  is confirmed harmless (`seed_l2_includes` only ever tests it for
+  truthiness, never iterates it), so the divergence — if this asymmetry is
+  indeed the cause, which is not yet confirmed — would have to originate
+  deeper, in whatever directory-expansion `service.resolve_input`/
+  `dumper.dump()`'s own ELF path performs internally on an unexpanded
+  directory entry, which may not traverse/order/dedup identically to
+  `expand_header_inputs`'s explicit, upfront pass. **Not fixed here**: the
+  hypothesis above is code-reading-only, this pass's environment has no
+  `bazel`/`castxml` to build a live repro and verify it, and even if
+  confirmed, the fix (either making `scan_engine._build_new_snapshot` call
+  `expand_header_inputs()` upfront the way `perform_elf_dump` already does,
+  or tracing the deeper internal expansion path to bring it in line) needs
+  the same real-repro verification discipline every other finding in this
+  topic already required, not a guess shipped without it. Consequence for
+  `napetrov/abicheck-bazel-lab`: PR #14's `fresh-to-fresh` control job
+  should be treated as still red on this one residual field, and the lab's
+  own checked-in `abi/math.abicheck.json` should **not** be regenerated
+  against the new core pin yet — doing so now would just encode a baseline
+  that a fresh `scan --against` still can't cleanly compare to, the same
+  problem this diagnostic exists to catch, not fix.
+
 - **`dump --lang c++` is silently discarded on the primary clang header-AST
   pass for a language-ambiguous header, diverging from `_attach_header_graph`'s
   own pass on the identical headers — investigated, not fixed (G31 Phase C

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1517,32 +1517,52 @@ Once a root command genuinely clears the bar above, pick the right home:
   close, confirmed via the run's own uploaded `two-fresh-mains-validation`
   artifact (run
   https://github.com/napetrov/abicheck-bazel-lab/actions/runs/31950549361,
-  job 95173233150, commit `a7f5a7f`). The most concrete, verified-by-
-  reading (not yet verified against a live repro — no `bazel`/`castxml` in
-  this pass's environment) structural asymmetry: `scan_engine.
-  _build_new_snapshot` passes its raw, **unexpanded** `headers` list
-  (`-H new=math.h -H new=include` — the directory entry still present as a
-  single item) into both `seed_includes_and_fold_compile_context` and
-  `service.resolve_input`, while `cli_dump_helpers.perform_elf_dump` first
-  calls `expand_header_inputs()` — which recursively expands a directory
-  via `header_utils.iter_directory_headers` into individual files, in a
-  deterministic order, with order-preserving dedup — and passes that
-  already-**expanded** `resolved_headers` list to the identical two calls
-  instead. `seed_includes_and_fold_compile_context`'s own use of `headers`
-  is confirmed harmless (`seed_l2_includes` only ever tests it for
-  truthiness, never iterates it), so the divergence — if this asymmetry is
-  indeed the cause, which is not yet confirmed — would have to originate
-  deeper, in whatever directory-expansion `service.resolve_input`/
-  `dumper.dump()`'s own ELF path performs internally on an unexpanded
-  directory entry, which may not traverse/order/dedup identically to
-  `expand_header_inputs`'s explicit, upfront pass. **Not fixed here**: the
-  hypothesis above is code-reading-only, this pass's environment has no
-  `bazel`/`castxml` to build a live repro and verify it, and even if
-  confirmed, the fix (either making `scan_engine._build_new_snapshot` call
-  `expand_header_inputs()` upfront the way `perform_elf_dump` already does,
-  or tracing the deeper internal expansion path to bring it in line) needs
-  the same real-repro verification discipline every other finding in this
-  topic already required, not a guess shipped without it. Consequence for
+  job 95173233150, commit `a7f5a7f`).
+
+  **A disconfirmed hypothesis, corrected by Codex review — recorded so a
+  future pass doesn't re-propose it.** This entry's first draft claimed the
+  cause was `scan_engine._build_new_snapshot` passing a raw, unexpanded
+  `headers` list (still containing the directory entry) into
+  `seed_includes_and_fold_compile_context`/`service.resolve_input`, while
+  `perform_elf_dump` pre-expands via `expand_header_inputs()` first. False,
+  verified by reading both paths fully rather than trusting the first,
+  partial read: (1) `header_compile_context.resolve_header_compile_context`
+  — reached from *inside* `seed_includes_and_fold_compile_context`'s own
+  compile-context fold, not just its truthiness-only `seed_l2_includes`
+  half this entry's first draft checked — calls its own
+  `_expand_header_directories()` on the raw `headers` list, whose docstring
+  states it deliberately reuses `header_utils.iter_directory_headers` (the
+  same walk `expand_header_inputs` itself delegates to, same suffix/pruned-
+  segment filters) specifically so the expanded set matches what L2 actually
+  parses. (2) `service.resolve_input`'s own ELF dispatch, `_dump_elf`, calls
+  `expand_header_inputs(headers)` internally (`service.py:1281`) before
+  ever reaching `dumper.dump()` — the identical function `perform_elf_dump`
+  calls explicitly upfront, just one call-stack frame deeper. Both `scan`'s
+  and `dump`'s header lists therefore converge on the identical expanded,
+  deduped, deterministically-ordered file set before any header-AST parse
+  runs; a raw-vs-expanded asymmetry cannot be the cause of the `include_
+  sequence` mismatch. **The real cause remains unidentified.** Two
+  unverified candidates worth checking first in a follow-up pass (neither
+  confirmed, both requiring the same live-repro discipline before trusting
+  either): `perform_elf_dump`'s and `scan_engine._build_new_snapshot`'s
+  calls to `seed_includes_and_fold_compile_context` seed `gcc_path`/
+  `gcc_prefix`/`gcc_options`/`gcc_option_tokens`/`sysroot`/`nostdinc`/
+  `frontend`/`frontend_context` from genuinely different starting points —
+  `dump`'s call reads its own already-resolved local variables (`gcc_path`,
+  `header_backend`, ...), while `scan`'s call reads them off a
+  `compile_context` object (`compile_context.gcc_path if compile_context
+  else None`, `compile_context.frontend if compile_context else "auto"`,
+  ...) that may not be populated identically for every field even when the
+  same CLI flags were given on both commands; and `build_query`/
+  `build_compile_db` are hard-coded `None` on `scan`'s call but forwarded
+  from the caller on `dump`'s, though neither is set by this specific
+  lab repro's own Action inputs, making it an unlikely match for *this*
+  reproduction specifically. **Not fixed here**: no confirmed hypothesis
+  exists yet to fix, this pass's environment has no `bazel`/`castxml` to
+  build and verify one, and per this file's own "known gaps over risky
+  reactive patches" convention, the next candidate needs the same
+  live-repro verification every other finding in this topic already
+  required before being trusted, let alone fixed. Consequence for
   `napetrov/abicheck-bazel-lab`: PR #14's `fresh-to-fresh` control job
   should be treated as still red on this one residual field, and the lab's
   own checked-in `abi/math.abicheck.json` should **not** be regenerated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1541,28 +1541,46 @@ Once a root command genuinely clears the bar above, pick the right home:
   and `dump`'s header lists therefore converge on the identical expanded,
   deduped, deterministically-ordered file set before any header-AST parse
   runs; a raw-vs-expanded asymmetry cannot be the cause of the `include_
-  sequence` mismatch. **The real cause remains unidentified.** Two
-  unverified candidates worth checking first in a follow-up pass (neither
-  confirmed, both requiring the same live-repro discipline before trusting
-  either): `perform_elf_dump`'s and `scan_engine._build_new_snapshot`'s
-  calls to `seed_includes_and_fold_compile_context` seed `gcc_path`/
-  `gcc_prefix`/`gcc_options`/`gcc_option_tokens`/`sysroot`/`nostdinc`/
-  `frontend`/`frontend_context` from genuinely different starting points —
-  `dump`'s call reads its own already-resolved local variables (`gcc_path`,
-  `header_backend`, ...), while `scan`'s call reads them off a
-  `compile_context` object (`compile_context.gcc_path if compile_context
-  else None`, `compile_context.frontend if compile_context else "auto"`,
-  ...) that may not be populated identically for every field even when the
-  same CLI flags were given on both commands; and `build_query`/
-  `build_compile_db` are hard-coded `None` on `scan`'s call but forwarded
-  from the caller on `dump`'s, though neither is set by this specific
-  lab repro's own Action inputs, making it an unlikely match for *this*
-  reproduction specifically. **Not fixed here**: no confirmed hypothesis
-  exists yet to fix, this pass's environment has no `bazel`/`castxml` to
-  build and verify one, and per this file's own "known gaps over risky
-  reactive patches" convention, the next candidate needs the same
-  live-repro verification every other finding in this topic already
-  required before being trusted, let alone fixed. Consequence for
+  sequence` mismatch.
+
+  **A second Codex review round found the real mechanism: a genuine
+  ordering asymmetry in when each path classifies an inferred `-H` header
+  root relative to the L3→L2 fold, confirmed by reading both call
+  sequences in full.** `cli_dump_helpers.perform_elf_dump` calls
+  `header_utils.resolve_inferred_header_roots(headers, includes,
+  gcc_options=effective_gcc_options, gcc_option_tokens=tuple
+  (gcc_option_tokens))` — using its own pre-fold local variables — *before*
+  its later `seed_includes_and_fold_compile_context` call folds real L3
+  evidence into those variables. `scan_engine._build_new_snapshot` calls
+  `seed_includes_and_fold_compile_context` *first*, then passes the
+  returned, already-folded `compile_context` straight into
+  `service.resolve_input(..., compile=compile_context)`; `resolve_input`'s
+  own ELF dispatch, `_dump_elf`, makes its *own* internal
+  `resolve_inferred_header_roots(headers, includes, gcc_options=cc.
+  gcc_options, gcc_option_tokens=cc.gcc_option_tokens)` call reading `cc =
+  compile` — i.e. the already-folded context, not a pre-fold one.
+  `resolve_inferred_header_roots`'s own docstring states its bucket choice
+  depends on exactly this: plain `-I` (high priority) when there is no
+  build context, `-isystem` (lower priority, below build-context dirs) when
+  the compile context already supplies its own includes. So the identical
+  `-H` header root can be classified into a *different* search bucket
+  between the two paths purely because of *when*, relative to the fold,
+  each one asks — dump always asks with an empty/explicit-only context,
+  scan always asks with the real L3-derived one already folded in — which
+  is a directly plausible mechanism for the observed `include_sequence`
+  mismatch (a bucket reassignment changes a root's rendered position in the
+  sequence). **Not fixed here**: this mechanism is verified by reading, not
+  yet by a live repro (this pass's environment still has no `bazel`/
+  `castxml`), and a real fix means reordering one of two large, carefully-
+  sequenced pipelines (`perform_elf_dump` is at its 2000-line hard cap;
+  `scan_engine._build_new_snapshot`'s own ordering exists for the flock-
+  contention reason the "fifth finding" above already documents) — which
+  side should move, and what changes for a header root when no L3 evidence
+  exists at all, needs its own careful design and regression coverage, not
+  a same-round reactive patch — per this file's own "known gaps over risky
+  reactive patches" convention, the same live-repro verification every
+  other finding in this topic already required before being trusted, let
+  alone fixed. Consequence for
   `napetrov/abicheck-bazel-lab`: PR #14's `fresh-to-fresh` control job
   should be treated as still red on this one residual field, and the lab's
   own checked-in `abi/math.abicheck.json` should **not** be regenerated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1543,44 +1543,64 @@ Once a root command genuinely clears the bar above, pick the right home:
   runs; a raw-vs-expanded asymmetry cannot be the cause of the `include_
   sequence` mismatch.
 
-  **A second Codex review round found the real mechanism: a genuine
-  ordering asymmetry in when each path classifies an inferred `-H` header
-  root relative to the L3→L2 fold, confirmed by reading both call
-  sequences in full.** `cli_dump_helpers.perform_elf_dump` calls
-  `header_utils.resolve_inferred_header_roots(headers, includes,
-  gcc_options=effective_gcc_options, gcc_option_tokens=tuple
-  (gcc_option_tokens))` — using its own pre-fold local variables — *before*
-  its later `seed_includes_and_fold_compile_context` call folds real L3
-  evidence into those variables. `scan_engine._build_new_snapshot` calls
-  `seed_includes_and_fold_compile_context` *first*, then passes the
-  returned, already-folded `compile_context` straight into
-  `service.resolve_input(..., compile=compile_context)`; `resolve_input`'s
-  own ELF dispatch, `_dump_elf`, makes its *own* internal
-  `resolve_inferred_header_roots(headers, includes, gcc_options=cc.
-  gcc_options, gcc_option_tokens=cc.gcc_option_tokens)` call reading `cc =
-  compile` — i.e. the already-folded context, not a pre-fold one.
-  `resolve_inferred_header_roots`'s own docstring states its bucket choice
-  depends on exactly this: plain `-I` (high priority) when there is no
-  build context, `-isystem` (lower priority, below build-context dirs) when
-  the compile context already supplies its own includes. So the identical
-  `-H` header root can be classified into a *different* search bucket
-  between the two paths purely because of *when*, relative to the fold,
-  each one asks — dump always asks with an empty/explicit-only context,
-  scan always asks with the real L3-derived one already folded in — which
-  is a directly plausible mechanism for the observed `include_sequence`
-  mismatch (a bucket reassignment changes a root's rendered position in the
-  sequence). **Not fixed here**: this mechanism is verified by reading, not
-  yet by a live repro (this pass's environment still has no `bazel`/
-  `castxml`), and a real fix means reordering one of two large, carefully-
-  sequenced pipelines (`perform_elf_dump` is at its 2000-line hard cap;
-  `scan_engine._build_new_snapshot`'s own ordering exists for the flock-
-  contention reason the "fifth finding" above already documents) — which
-  side should move, and what changes for a header root when no L3 evidence
-  exists at all, needs its own careful design and regression coverage, not
-  a same-round reactive patch — per this file's own "known gaps over risky
-  reactive patches" convention, the same live-repro verification every
-  other finding in this topic already required before being trusted, let
-  alone fixed. Consequence for
+  **Two further Codex review rounds, each finding the previous round's
+  proposed single "the mechanism is X" narrative was itself incomplete —
+  pattern worth naming before the specifics: this area (`perform_elf_dump`
+  vs. `scan_engine._build_new_snapshot`'s relative ordering of the L3→L2
+  fold and `header_utils.resolve_inferred_header_roots`) has enough real
+  asymmetry that every single-paragraph explanation attempted so far turned
+  out to be a true but partial slice of it, not the whole story — so this
+  entry stops trying to assert one and instead lists the verified-by-
+  reading candidate mechanisms found, unranked, without claiming which one
+  (if any single one) explains the specific `include_sequence` mismatch in
+  the CI evidence above.** `perform_elf_dump` calls
+  `resolve_inferred_header_roots(headers, includes, gcc_options=
+  effective_gcc_options, gcc_option_tokens=tuple(gcc_option_tokens))` using
+  its own *pre-fold* local variables, before its later
+  `seed_includes_and_fold_compile_context` call folds real L3 evidence into
+  them; `scan_engine._build_new_snapshot` folds *first*, then passes the
+  already-folded `compile_context` into `resolve_input(..., compile=
+  compile_context)`, whose ELF dispatch `_dump_elf` makes its own internal
+  `resolve_inferred_header_roots(...)` call reading that already-folded
+  context. Two concrete, verified effects of this ordering difference, not
+  one:
+  (a) `resolve_inferred_header_roots`'s own `skip` set is built from
+  `user_includes` (the caller's `includes` parameter) *and*
+  `_build_context_include_dirs(ctx)` (dirs implied by the passed-in
+  `gcc_options`/`gcc_option_tokens`) — for scan's post-fold call, both of
+  these already carry L3-derived content, so an inferred `-H` root whose
+  directory the L3 evidence already covers is **skipped entirely**
+  (`inferred` ends up empty, the function returns `([], [])` for that
+  root) rather than reclassified into a different bucket; dump's pre-fold
+  call has a much smaller `skip` set (no L3 content yet), so the same root
+  is far more likely to survive as a plain `-I` extra-include instead.
+  (b) Separately, `perform_elf_dump` computes `inc_extra` from this
+  *pre-fold* call and only later builds `extra_includes=eff_includes +
+  inc_extra` for the actual `dump(...)` call, where `eff_includes` is the
+  (by then real) L2-seeded include list — if `inc_extra`'s root and
+  `eff_includes` overlap (plausible, since both can independently resolve
+  to the same L3-derived directory), the *same* directory can appear twice
+  in dump's own `extra_includes`, which is what `comparability_fields.
+  _include_slot_tokens` actually tokenizes into `include_sequence` (one
+  token per `declared_includes` slot — itself derived from
+  `extra_includes`/`gcc_option_tokens` together, not straightforwardly one
+  or the other alone, per `_include_slot_tokens`'s own signature). scan's
+  candidate side has no equivalent double-add, since its single fold call
+  already produced the final `includes`/`compile_context` `resolve_input`
+  uses directly. Either effect alone — an omitted slot on scan's side, or a
+  duplicated slot on dump's — changes the resulting slot *count*, which is
+  sufficient to make `include_sequence` differ regardless of which specific
+  slot moved. **Not fixed here, and deliberately not narrowed to one of (a)/
+  (b) without more evidence**: neither this pass nor either Codex round
+  inspected the actual differing `include_sequence` token values from the
+  CI artifact (only `diff.reason`'s field name was read, not its content),
+  so which effect (or another one still unfound) actually fired in this
+  specific repro is genuinely unknown; a real fix needs that inspection (or
+  a live `bazel`/`castxml` repro, absent from this pass's environment)
+  before it can even be scoped, let alone attempted — this file's own
+  "known gaps over risky reactive patches" convention applies doubly here,
+  given how many single-paragraph "found it" claims this same footnote has
+  already had to walk back. Consequence for
   `napetrov/abicheck-bazel-lab`: PR #14's `fresh-to-fresh` control job
   should be treated as still red on this one residual field, and the lab's
   own checked-in `abi/math.abicheck.json` should **not** be regenerated

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1581,13 +1581,25 @@ Once a root command genuinely clears the bar above, pick the right home:
   `eff_includes` overlap (plausible, since both can independently resolve
   to the same L3-derived directory), the *same* directory can appear twice
   in dump's own `extra_includes`, which is what `comparability_fields.
-  _include_slot_tokens` actually tokenizes into `include_sequence` (one
-  token per `declared_includes` slot — itself derived from
-  `extra_includes`/`gcc_option_tokens` together, not straightforwardly one
-  or the other alone, per `_include_slot_tokens`'s own signature). scan's
+  _include_slot_tokens` actually tokenizes into `include_sequence` — one
+  token per `declared_includes` slot, and `dumper_contract.
+  _attach_extraction_contract` builds `declared_includes` **exclusively**
+  from `extra_includes` (`IncludeDir(path=p, ...) for p in extra_includes`,
+  absent a `dump_manifest`); `gcc_option_tokens` (where a *deferred* root
+  rides, as `-isystem`/etc.) never contributes a slot at all (Codex review
+  — corrected from this entry's own prior, wrong claim that both jointly
+  derive slots). This sharpens rather than weakens candidates (a)/(b)
+  below: a root that lands in `extra_includes` always produces a slot: once
+  for dump's `inc_extra`, and *again* if `eff_includes` also independently
+  picked up the same directory (candidate (b), a real duplicate slot); a
+  root that `resolve_inferred_header_roots` either skips outright or
+  reclassifies to a deferred `gcc_option_tokens` flag produces **no** slot
+  at all either way, since neither reaches `extra_includes` (candidate (a),
+  collapsing what looked like two distinct scan-side outcomes — "skipped"
+  vs. "deferred" — into the same net effect on `include_sequence`). scan's
   candidate side has no equivalent double-add, since its single fold call
   already produced the final `includes`/`compile_context` `resolve_input`
-  uses directly. Either effect alone — an omitted slot on scan's side, or a
+  uses directly. Either effect alone — a missing slot on scan's side, or a
   duplicated slot on dump's — changes the resulting slot *count*, which is
   sufficient to make `include_sequence` differ regardless of which specific
   slot moved. **Not fixed here, and deliberately not narrowed to one of (a)/


### PR DESCRIPTION
## Summary

Documents a new, precisely-reproduced residual gap in the existing "dump vs scan L3→L2 fold" AGENTS.md topic, found via real Bazel/castxml CI evidence — not a hypothesis, not a hand-built fixture.

## What happened

`napetrov/abicheck-bazel-lab`#14 (a disposable diagnostic PR) was repinned to this repo's own `main` after PR #788 merged (`84cf3d4`). Its `fresh-to-fresh` control job:

1. Builds BASE and HEAD (identical code, both from the same PR) with real Bazel.
2. Captures target-scoped `cquery`/`aquery` evidence for both.
3. `dump`s each side fresh, using the identical `--sources`/`--build-info`/`-H` inputs.
4. `compare`s the two fresh dumps: **`COMPATIBLE`/`NO_CHANGE`**, `analysis_assurance.status: complete` — confirming the already-documented `language_standard` fix (this topic's "eighth finding") genuinely holds end to end.
5. Separately `scan`s HEAD `--against` the fresh BASE dump (same code, same inputs, just `scan` instead of `dump` building the candidate side): **`NOT_COMPARABLE`**, `diff.reason` naming exactly one differing field — `include_sequence` — not `language_standard`, which no longer reproduces.

Run: https://github.com/napetrov/abicheck-bazel-lab/actions/runs/31950549361 (job `95173233150`, commit `a7f5a7f`).

## What this PR does

Records the finding as a new addendum inside the existing "The native ELF `abicheck dump` path never applies L3 build context..." Known-gaps entry in `AGENTS.md`, including:

- The precise reproduction (real CI run, not a synthetic case).
- A concrete, code-reading-derived hypothesis: `scan_engine._build_new_snapshot` passes its raw, **unexpanded** `headers` list (still containing a directory entry) into `resolve_input`, while `cli_dump_helpers.perform_elf_dump` first expands a directory into individual files via `expand_header_inputs()` before its equivalent call — a structural asymmetry that may (not yet confirmed) explain the `include_sequence` divergence.
- Why it isn't fixed in this PR: this environment has no `bazel`/`castxml` to build and verify a live repro, and per this repo's own "known gaps over risky reactive patches" convention, a fix needs the same real-repro verification discipline every other finding in this topic already required.
- The practical consequence for the lab repo: its checked-in `abi/math.abicheck.json` baseline should not be regenerated against the new core pin yet, since doing so would just encode a baseline a fresh `scan --against` still can't cleanly compare to.

No code changes — `AGENTS.md` only.

## Checklist

- [x] `python scripts/check_ai_readiness.py` — 0 errors
- [x] `python scripts/check_docs_contract.py` — 0 errors (pre-existing WARN unrelated to this change)
- [x] No `.py` files touched, so no changelog fragment needed per `AGENTS.md`'s own rule

---

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0148YM1JdtrGzWfUxXCBekzb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented a known validation limitation when comparing scans against freshly generated baselines.
  * Comparisons may report `NOT_COMPARABLE` because include ordering and duplication differ, even when the language standard matches.
  * Clarified that header expansion is not the observed cause.
  * Recorded potential contributing factors and noted that the issue remains unresolved pending further artifact inspection or live reproduction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->