### PR TITLE
ci: make path-filtered docs-pr/test-action checks requirable (PR A)

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -30,6 +30,92 @@ Not every workflow here blocks a merge. Before assuming a red check means
 | `test-action.yml` | Yes, when `action/**`/`action.yml` changes | See `action/AGENTS.md` |
 | `bugfix-test-contract.yml` | Yes, on `fix:`/`perf:`/`security:` PRs | Structural half: a fix changing shipped code must change a test. Declared half: the PR body must answer the bug-fix test contract, plus any conditional the diff triggers. Bypass with the `skip-test-contract` label. See `scripts/check_bugfix_test_contract.py` for what each answer is for. |
 | `publish.yml` / `pages.yml` | N/A (release/deploy only) | Not PR gates |
+| `verify-merge-checks.yml` | N/A (post-merge only, `push: main`) | Not a PR gate — see "Required-status-check configuration" below. |
+
+## Required-status-check configuration (CLI cleanup phase two, PR A / PR 0B)
+
+The table above states which workflows are *supposed to* gate a merge; this
+section is the mechanical rule for turning that into a real GitHub
+required-status-checks list (Ruleset or classic branch protection), and the
+two things this repo added so a path-filtered "Yes, when X changes" row can
+actually be required without stranding every PR that doesn't touch X.
+
+**The rule**, applied fresh against the table above at configuration time —
+not a hand-copied snapshot, which drifted wrong three times in a row before
+this was written down as a rule instead of a list (see the CLI cleanup
+phase-two plan's own PR 0B section for that history):
+
+1. For every workflow the table marks required (unconditionally or "when X
+   changes"), read its own `on: pull_request:` block.
+2. **No `paths:` filter** (the workflow always runs on a PR against `main`;
+   an internal diff check or label decides applicability instead) → require
+   its own check name directly. `changelog-check.yml`/`cli-interface-check.yml`/
+   `bugfix-test-contract.yml`/`dependency-review.yml`/`security.yml`/`ci.yml`
+   are all in this bucket.
+3. **Has a `paths:` filter** (the workflow may not run at all on an
+   unrelated PR) → never require its own check name directly — no native
+   GitHub mechanism (classic branch protection or a Ruleset's required-
+   status-checks rule) conditions "required" on which paths a given PR
+   touched, so doing so strands every PR that doesn't touch that path.
+   `docs-pr.yml` and `test-action.yml` are in this bucket, and each has a
+   **neutral-aggregate gate job living in `ci.yml`** instead
+   (`docs-pr-required`/`test-action-required`, both unconditioned like every
+   other `ci.yml` job): each re-evaluates the exact same `paths:` filter its
+   target workflow's own trigger uses; when the paths don't match, there is
+   nothing to gate and the job succeeds immediately; when they do match, the
+   target workflow is guaranteed to have been triggered by the same
+   `pull_request` event, so the gate job polls that workflow's own aggregate
+   check (`build-docs` for `docs-pr.yml`; the added `test-action-summary`
+   job's `test-action summary` check for `test-action.yml`, since that
+   workflow fans out to 17+ independent jobs with no single existing
+   pass/fail check to point at) for the same head SHA and mirrors its
+   conclusion. **Require `docs-pr-required`/`test-action-required` in the
+   Ruleset, never `build-docs`/`test-action summary` directly** — the whole
+   point is that the wrapper is unconditionally present while the wrapped
+   check may not be.
+4. Anything the table marks **not required** stays out of the required set
+   entirely — this rule does not change that classification.
+
+**The required-check list, applying this rule to the table above (2026-08,
+`main` at the CLI cleanup phase-two governance PR):** `ai-readiness`,
+`fair-metadata` (check name `FAIR metadata and packaging`), `lint-and-types`,
+`unit-tests (ubuntu-latest, 3.13, false)` (the canonical Linux/3.13 lane —
+not every matrix leg, see "one stable aggregate check" below),
+`packaging (ubuntu-latest)`, `packaging (windows-latest)`,
+`changelog-fragment`, `cli-interface-diff`, `test-contract`,
+`Dependency Review`, `Security Scan`, `CodeQL Analysis (python)`,
+`docs-pr-required`, `test-action-required`.
+
+**This document states the rule and the resulting list; it does not itself
+turn the list into an enforced Ruleset.** That configuration step is a
+repository-admin action (GitHub Settings → Rules, or the REST/GraphQL
+Rulesets API with an admin-scoped token) outside what an automated PR can
+carry out — apply the list above there by hand, or with `gh api` /
+equivalent tooling that holds that access, and re-derive it from this
+section's rule (not by re-copying this list verbatim) if the table above has
+since changed.
+
+**Prefer one stable aggregate required check per always-required workflow**
+over requiring every matrix leg individually — a matrix-leg-level required
+list goes stale on every matrix edit and is the usual reason required checks
+get turned back off. `test-action.yml`'s own `test-action-summary` job
+(`needs:` every job in that workflow, `if: always()`) is exactly this for a
+fan-out workflow with no single existing pass/fail check; `docs-pr.yml`
+already has only one job (`build-docs`) and needed no separate aggregate.
+
+**Exact-merge-SHA verification (item 4).** `verify-merge-checks.yml` runs on
+every push to `main` and looks up the PR GitHub associates with that commit
+(covers squash/merge/rebase merges alike), then re-checks that PR's own
+already-recorded *tested head SHA* — not the new merge commit, which most of
+the required workflows above never re-run against (`pull_request`-only
+triggers) and which wouldn't prove anything about what was reviewed even if
+they did — against the unconditional half of the required-check list above
+(the two neutral-aggregate checks are deliberately excluded; see the
+workflow's own header comment for why). It cannot block an already-completed
+merge; it fails loudly on `main`'s own Actions tab instead, which is what
+makes a merge that slipped through a misconfigured or momentarily-disabled
+Ruleset *detectable* rather than invisible — the exact gap that let the
+#782 merge SHA go out with no full `ci.yml` sweep having run against it.
 
 ## Local equivalence (CLAUDE.md "M0-3")
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -69,10 +69,13 @@ phase-two plan's own PR 0B section for that history):
    job's `test-action summary` check for `test-action.yml`, since that
    workflow fans out to 17+ independent jobs with no single existing
    pass/fail check to point at) for the same head SHA and mirrors its
-   conclusion. **Require `docs-pr-required`/`test-action-required` in the
-   Ruleset, never `build-docs`/`test-action summary` directly** — the whole
-   point is that the wrapper is unconditionally present while the wrapped
-   check may not be.
+   conclusion. **Require the gate jobs' own emitted check names in the
+   Ruleset — `docs-pr (required)`/`test-action (required)` (each job's own
+   `name:` override, not its job id `docs-pr-required`/`test-action-required`;
+   GitHub Rulesets match a required status check by its reported check-run
+   name, not by workflow job id) — never `build-docs`/`test-action summary`
+   directly.** The whole point is that the wrapper is unconditionally present
+   while the wrapped check may not be.
 4. Anything the table marks **not required** stays out of the required set
    entirely — this rule does not change that classification.
 
@@ -84,7 +87,10 @@ not every matrix leg, see "one stable aggregate check" below),
 `packaging (ubuntu-latest)`, `packaging (windows-latest)`,
 `changelog-fragment`, `cli-interface-diff`, `test-contract`,
 `Dependency Review`, `Security Scan`, `CodeQL Analysis (python)`,
-`docs-pr-required`, `test-action-required`.
+`docs-pr (required)`, `test-action (required)` (the `name:` values of
+`ci.yml`'s `docs-pr-required`/`test-action-required` jobs — see the note in
+rule step 3 above on why the check name, not the job id, is what a Ruleset
+actually requires).
 
 **This document states the rule and the resulting list; it does not itself
 turn the list into an enforced Ruleset.** That configuration step is a
@@ -109,13 +115,19 @@ every push to `main` and looks up the PR GitHub associates with that commit
 already-recorded *tested head SHA* — not the new merge commit, which most of
 the required workflows above never re-run against (`pull_request`-only
 triggers) and which wouldn't prove anything about what was reviewed even if
-they did — against the unconditional half of the required-check list above
-(the two neutral-aggregate checks are deliberately excluded; see the
-workflow's own header comment for why). It cannot block an already-completed
-merge; it fails loudly on `main`'s own Actions tab instead, which is what
-makes a merge that slipped through a misconfigured or momentarily-disabled
-Ruleset *detectable* rather than invisible — the exact gap that let the
-#782 merge SHA go out with no full `ci.yml` sweep having run against it.
+they did — against the required-check list above, including the two
+neutral-aggregate gate checks themselves (`docs-pr (required)`/
+`test-action (required)`, which are unconditioned and so exist on every PR
+head SHA); only the *path-filtered* checks those gates wrap (`build-docs`,
+`test-action summary`) are deliberately excluded from this second pass, since
+whether those exist at all depends on the same path filter the gate job
+already re-evaluated as a required check on the PR itself — see the
+workflow's own header comment for the full reasoning. It cannot block an
+already-completed merge; it fails loudly on `main`'s own Actions tab instead,
+which is what makes a merge that slipped through a misconfigured or
+momentarily-disabled Ruleset *detectable* rather than invisible — the exact
+gap that let the PR #782 merge SHA go out with no full `ci.yml` sweep having
+run against it.
 
 ## Local equivalence (CLAUDE.md "M0-3")
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,3 +528,146 @@ jobs:
           pip install build twine
           python -m build
           twine check dist/*
+
+  # ── PR A / PR 0B (CLI cleanup phase two): neutral-aggregate required
+  # checks for path-filtered workflows ────────────────────────────────────
+  #
+  # docs-pr.yml and test-action.yml are both `paths:`-filtered at the
+  # workflow level -- they simply don't run on a PR that doesn't touch their
+  # paths, and GitHub's branch-protection/Ruleset required-status-checks
+  # mechanism has no native way to say "required only when these paths
+  # changed" (checked directly against the GitHub REST/GraphQL API surface;
+  # confirmed absent). Requiring `build-docs`/`test-action-summary` directly
+  # would therefore strand every PR that never touches `docs/**`/
+  # `action/**`, since GitHub blocks merge on a required check that never
+  # reports at all, the same as on a failing one.
+  #
+  # These two jobs are the fix: `ci.yml` itself carries no `paths:` filter
+  # (it always runs), so each job independently re-evaluates the SAME path
+  # filter the target workflow's own trigger uses. When the paths don't
+  # match, there is nothing to gate and the job succeeds immediately. When
+  # they do match, the target workflow is guaranteed to have been triggered
+  # by the same `pull_request` event (running in parallel with this one), so
+  # this job polls that workflow's own aggregate check for the same head SHA
+  # and mirrors its conclusion -- succeeding, failing, or timing out loudly
+  # if the target check never completes. Only meaningful for `pull_request`
+  # events: neither `docs-pr.yml` nor `test-action.yml`'s `build-docs`/
+  # `test-action-summary` check re-runs on a `push`-triggered merge commit
+  # (a different, untested SHA), so waiting on `push` would only time out.
+  docs-pr-required:
+    name: docs-pr (required)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      checks: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - name: Detect whether docs-pr.yml's own paths changed
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'abicheck/schemas/**'
+              - 'examples/**'
+              - 'mkdocs.yml'
+              - 'scripts/gen_examples_docs.py'
+              - 'scripts/publish_schemas.py'
+              - '.github/workflows/pages.yml'
+              - '.github/workflows/docs-pr.yml'
+      - name: Wait for docs-pr.yml's build-docs check and mirror its outcome
+        if: steps.filter.outputs.docs == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+            const checkName = 'build-docs';
+            const timeoutMs = 25 * 60 * 1000;
+            const pollMs = 15 * 1000;
+            const start = Date.now();
+            while (Date.now() - start < timeoutMs) {
+              const { data } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sha,
+              });
+              const run = data.check_runs.find(r => r.name === checkName);
+              if (run && run.status === 'completed') {
+                core.info(`${checkName} completed with conclusion: ${run.conclusion}`);
+                if (!['success', 'neutral', 'skipped'].includes(run.conclusion)) {
+                  core.setFailed(`${checkName} did not succeed (conclusion: ${run.conclusion})`);
+                }
+                return;
+              }
+              core.info(run
+                ? `${checkName} status: ${run.status} -- waiting`
+                : `${checkName} not reported yet -- waiting`);
+              await new Promise(r => setTimeout(r, pollMs));
+            }
+            core.setFailed(`Timed out waiting for ${checkName} to complete`);
+      - name: Nothing to gate
+        if: steps.filter.outputs.docs != 'true'
+        run: echo "docs-pr.yml's own paths didn't change -- nothing to gate."
+
+  test-action-required:
+    name: test-action (required)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: read
+      checks: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
+      - name: Detect whether test-action.yml's own paths changed
+        id: filter
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706  # v4
+        with:
+          filters: |
+            action:
+              - 'action.yml'
+              - 'action/**'
+              - 'actions/check-target/**'
+              - 'actions/resolve-baseline/**'
+              - 'abicheck/**'
+              - 'pyproject.toml'
+              - 'pixi.lock'
+              - '.github/workflows/test-action.yml'
+              - '.github/workflows/check-single.yml'
+              - 'tests/fixtures/action/**'
+      - name: Wait for test-action.yml's summary check and mirror its outcome
+        if: steps.filter.outputs.action == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const sha = context.payload.pull_request.head.sha;
+            const checkName = 'test-action summary';
+            const timeoutMs = 35 * 60 * 1000;
+            const pollMs = 15 * 1000;
+            const start = Date.now();
+            while (Date.now() - start < timeoutMs) {
+              const { data } = await github.rest.checks.listForRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: sha,
+              });
+              const run = data.check_runs.find(r => r.name === checkName);
+              if (run && run.status === 'completed') {
+                core.info(`${checkName} completed with conclusion: ${run.conclusion}`);
+                if (!['success', 'neutral', 'skipped'].includes(run.conclusion)) {
+                  core.setFailed(`${checkName} did not succeed (conclusion: ${run.conclusion})`);
+                }
+                return;
+              }
+              core.info(run
+                ? `${checkName} status: ${run.status} -- waiting`
+                : `${checkName} not reported yet -- waiting`);
+              await new Promise(r => setTimeout(r, pollMs));
+            }
+            core.setFailed(`Timed out waiting for ${checkName} to complete`);
+      - name: Nothing to gate
+        if: steps.filter.outputs.action != 'true'
+        run: echo "test-action.yml's own paths didn't change -- nothing to gate."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -562,6 +562,7 @@ jobs:
     permissions:
       contents: read
       checks: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Detect whether docs-pr.yml's own paths changed
@@ -580,7 +581,7 @@ jobs:
               - '.github/workflows/docs-pr.yml'
       - name: Wait for docs-pr.yml's build-docs check and mirror its outcome
         if: steps.filter.outputs.docs == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             const sha = context.payload.pull_request.head.sha;
@@ -593,11 +594,13 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: sha,
+                check_name: checkName,
+                per_page: 100,
               });
               const run = data.check_runs.find(r => r.name === checkName);
               if (run && run.status === 'completed') {
                 core.info(`${checkName} completed with conclusion: ${run.conclusion}`);
-                if (!['success', 'neutral', 'skipped'].includes(run.conclusion)) {
+                if (!['success', 'neutral'].includes(run.conclusion)) {
                   core.setFailed(`${checkName} did not succeed (conclusion: ${run.conclusion})`);
                 }
                 return;
@@ -620,6 +623,7 @@ jobs:
     permissions:
       contents: read
       checks: read
+      pull-requests: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6
       - name: Detect whether test-action.yml's own paths changed
@@ -640,7 +644,7 @@ jobs:
               - 'tests/fixtures/action/**'
       - name: Wait for test-action.yml's summary check and mirror its outcome
         if: steps.filter.outputs.action == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             const sha = context.payload.pull_request.head.sha;
@@ -653,11 +657,13 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: sha,
+                check_name: checkName,
+                per_page: 100,
               });
               const run = data.check_runs.find(r => r.name === checkName);
               if (run && run.status === 'completed') {
                 core.info(`${checkName} completed with conclusion: ${run.conclusion}`);
-                if (!['success', 'neutral', 'skipped'].includes(run.conclusion)) {
+                if (!['success', 'neutral'].includes(run.conclusion)) {
                   core.setFailed(`${checkName} did not succeed (conclusion: ${run.conclusion})`);
                 }
                 return;

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -712,7 +712,7 @@ jobs:
     steps:
       - name: Fail if any test-action.yml job did not succeed
         run: |
-          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}" == "true" ]]; then
             echo "::error::One or more test-action.yml jobs did not succeed:"
             echo '${{ toJSON(needs) }}'
             exit 1

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -677,3 +677,44 @@ jobs:
             echo "::error::Expected verdict BREAKING, got ${{ steps.abi-legacy-false.outputs.verdict }}"
             exit 1
           fi
+
+  # One stable, always-added-when-triggered required check representing this
+  # whole workflow's pass/fail state (CLI cleanup phase two, PR A/PR 0B) --
+  # requiring every job above individually goes stale on every matrix/job
+  # edit, which is the usual reason a repo's required-check list rots. `if:
+  # always()` so a cancelled/skipped dependency is visible here too, not
+  # silently treated as "didn't run, so nothing to report."
+  test-action-summary:
+    name: test-action summary
+    if: always()
+    needs:
+      - test-compare-breaking
+      - test-compare-compatible
+      - test-compare-sarif
+      - test-compare-json
+      - test-fail-on-breaking
+      - test-action-infrastructure
+      - test-check-target
+      - test-multiplatform
+      - test-severity-addition-error
+      - test-appcompat-full
+      - test-appcompat-weak
+      - test-additions-pass-by-default
+      - test-scan-baseline-breaking
+      - test-scan-audit
+      - test-scan-estimate
+      - test-dependency-source-conda-forge
+      - test-dependency-source-none-and-legacy-alias
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    steps:
+      - name: Fail if any test-action.yml job did not succeed
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "::error::One or more test-action.yml jobs did not succeed:"
+            echo '${{ toJSON(needs) }}'
+            exit 1
+          fi
+          echo "All test-action.yml jobs succeeded."

--- a/.github/workflows/verify-merge-checks.yml
+++ b/.github/workflows/verify-merge-checks.yml
@@ -1,0 +1,140 @@
+name: Verify Merge Checks
+
+# CLI cleanup phase two, PR A / PR 0B (item 4): a red required check doesn't
+# retroactively un-merge a bad PR, so this workflow exists to make a merge
+# that did NOT actually run the required checks *detectable after the fact*
+# rather than silently invisible -- the exact gap the plan's PR 0B section
+# names (the #782 merge SHA that never ran a full ci.yml sweep on push:main).
+#
+# It cannot block the merge itself (nothing can, after the fact) -- it fails
+# loudly on `main`'s own Actions tab instead, which is what makes a merge
+# that slipped through detectable rather than invisible.
+#
+# Why this doesn't just re-run the checks on the push SHA: most of the
+# required workflows below trigger on `pull_request` only, not `push`, and a
+# squash/merge commit's SHA is a NEW commit distinct from the PR's actually-
+# tested head SHA anyway -- re-running on the push SHA would prove nothing
+# about what was reviewed. Instead this looks up the merged PR (GitHub's own
+# commit<->PR association, which covers squash/merge/rebase alike) and
+# verifies its real, already-recorded head-SHA check results.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  verify-merge-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      checks: read
+      pull-requests: read
+    steps:
+      - name: Verify the merged PR's tested head SHA passed every required check
+        uses: actions/github-script@v8
+        with:
+          script: |
+            // Kept in sync by hand with .github/AGENTS.md's "Required vs.
+            // informational workflows" table and the neutral-aggregate gate
+            // jobs in ci.yml (`docs-pr-required`/`test-action-required`) --
+            // this is the set of checks that exist unconditionally on every
+            // PR head SHA regardless of which paths it touched. The two
+            // path-filtered aggregate checks (`build-docs`, `test-action
+            // summary`) are deliberately NOT verified here: whether they
+            // exist at all depends on the same path filter their own
+            // neutral-aggregate gate job already re-evaluates, and
+            // duplicating that logic here would only risk the two drifting
+            // apart -- the gate job is already what makes their absence-when-
+            // inapplicable safe, and it already ran as a *required* check on
+            // the PR itself.
+            const REQUIRED_CHECKS = [
+              'ai-readiness',
+              'FAIR metadata and packaging',
+              'lint-and-types',
+              'unit-tests (ubuntu-latest, 3.13, false)',
+              'packaging (ubuntu-latest)',
+              'packaging (windows-latest)',
+              'changelog-fragment',
+              'cli-interface-diff',
+              'test-contract',
+              'Dependency Review',
+              'Security Scan',
+              'CodeQL Analysis (python)',
+            ];
+
+            const sha = context.sha;
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: sha,
+            });
+
+            if (prs.length === 0) {
+              core.warning(
+                `No pull request is associated with merge commit ${sha} -- either a ` +
+                `direct push to main, or GitHub has not indexed the association yet. ` +
+                `Cannot verify required checks for this merge; not failing on that alone.`
+              );
+              return;
+            }
+
+            // A commit can legitimately be associated with more than one PR
+            // (e.g. a stacked branch merged separately); prefer the one whose
+            // merge_commit_sha is exactly this push, falling back to the
+            // first association for a fast-forward/rebase merge where
+            // merge_commit_sha may not equal the pushed SHA.
+            const target = prs.find(pr => pr.merge_commit_sha === sha) || prs[0];
+            const headSha = target.head.sha;
+
+            core.info(`Merge commit ${sha} <- PR #${target.number}, tested head ${headSha}`);
+
+            // Not paginated: today's full required-check set plus every
+            // matrix leg is well under the 100-per-page ceiling (~78
+            // check runs observed). Revisit if that changes.
+            const { data: checkRunsResp } = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: headSha,
+              per_page: 100,
+            });
+
+            const byName = new Map();
+            for (const run of checkRunsResp.check_runs) {
+              // A check can be re-run; keep only the most recently started.
+              const existing = byName.get(run.name);
+              if (!existing || new Date(run.started_at) > new Date(existing.started_at)) {
+                byName.set(run.name, run);
+              }
+            }
+
+            const problems = [];
+            for (const name of REQUIRED_CHECKS) {
+              const run = byName.get(name);
+              if (!run) {
+                problems.push(`${name}: no check run found for head ${headSha}`);
+              } else if (run.status !== 'completed') {
+                problems.push(`${name}: status=${run.status} (never completed)`);
+              } else if (!['success', 'neutral'].includes(run.conclusion)) {
+                problems.push(`${name}: conclusion=${run.conclusion}`);
+              }
+            }
+
+            if (problems.length > 0) {
+              core.setFailed(
+                `Merge commit ${sha} (PR #${target.number}, head ${headSha}) did not have ` +
+                `every required check passing:\n` + problems.map(p => ` - ${p}`).join('\n')
+              );
+            } else {
+              core.info(
+                `All ${REQUIRED_CHECKS.length} required checks passed for ` +
+                `PR #${target.number}'s tested head ${headSha}.`
+              );
+            }

--- a/.github/workflows/verify-merge-checks.yml
+++ b/.github/workflows/verify-merge-checks.yml
@@ -104,10 +104,23 @@ jobs:
             const candidates = prs.filter(
               pr => pr.merged_at && pr.base && pr.base.ref === 'main'
             );
+
+            if (candidates.length === 0) {
+              // No association is actually eligible (e.g. this push's commit
+              // is also present in some open, unmerged, or differently-based
+              // PR) -- there's nothing real to verify. Falling back to an
+              // unfiltered `prs[0]` here would silently validate an unrelated
+              // PR's head SHA instead, which could read as green or red for
+              // reasons that have nothing to do with this actual merge.
+              core.warning(
+                `Merge commit ${sha} has ${prs.length} associated PR(s), none merged to ` +
+                `\`main\` -- nothing eligible to verify; not failing on that alone.`
+              );
+              return;
+            }
+
             const target =
-              candidates.find(pr => pr.merge_commit_sha === sha) ||
-              candidates[0] ||
-              prs[0];
+              candidates.find(pr => pr.merge_commit_sha === sha) || candidates[0];
             const headSha = target.head.sha;
 
             core.info(`Merge commit ${sha} <- PR #${target.number}, tested head ${headSha}`);

--- a/.github/workflows/verify-merge-checks.yml
+++ b/.github/workflows/verify-merge-checks.yml
@@ -39,22 +39,27 @@ jobs:
       pull-requests: read
     steps:
       - name: Verify the merged PR's tested head SHA passed every required check
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             // Kept in sync by hand with .github/AGENTS.md's "Required vs.
             // informational workflows" table and the neutral-aggregate gate
-            // jobs in ci.yml (`docs-pr-required`/`test-action-required`) --
+            // jobs in ci.yml (job ids `docs-pr-required`/`test-action-
+            // required`, whose emitted check-run names are `docs-pr
+            // (required)`/`test-action (required)` via their own `name:`
+            // override -- what a Ruleset actually matches against is the
+            // emitted name, not the job id, so this list uses the names) --
             // this is the set of checks that exist unconditionally on every
-            // PR head SHA regardless of which paths it touched. The two
-            // path-filtered aggregate checks (`build-docs`, `test-action
-            // summary`) are deliberately NOT verified here: whether they
-            // exist at all depends on the same path filter their own
-            // neutral-aggregate gate job already re-evaluates, and
-            // duplicating that logic here would only risk the two drifting
-            // apart -- the gate job is already what makes their absence-when-
-            // inapplicable safe, and it already ran as a *required* check on
-            // the PR itself.
+            // PR head SHA regardless of which paths it touched. Both gate
+            // jobs themselves are unconditioned (only their *internal* wait
+            // step is path-gated), so they belong in this list; the two
+            // path-filtered aggregate checks they wrap (`build-docs`,
+            // `test-action summary`) are deliberately NOT verified here:
+            // whether those exist at all depends on the same path filter
+            // their own gate job already re-evaluates, and duplicating that
+            // logic here would only risk the two drifting apart -- the gate
+            // job already ran as a *required*, unconditional check on the PR
+            // itself and is what this list actually verifies.
             const REQUIRED_CHECKS = [
               'ai-readiness',
               'FAIR metadata and packaging',
@@ -68,6 +73,8 @@ jobs:
               'Dependency Review',
               'Security Scan',
               'CodeQL Analysis (python)',
+              'docs-pr (required)',
+              'test-action (required)',
             ];
 
             const sha = context.sha;
@@ -87,19 +94,25 @@ jobs:
             }
 
             // A commit can legitimately be associated with more than one PR
-            // (e.g. a stacked branch merged separately); prefer the one whose
-            // merge_commit_sha is exactly this push, falling back to the
-            // first association for a fast-forward/rebase merge where
-            // merge_commit_sha may not equal the pushed SHA.
-            const target = prs.find(pr => pr.merge_commit_sha === sha) || prs[0];
+            // (e.g. a stacked branch merged separately, or an unrelated open
+            // PR that happens to contain this same commit) -- restrict to
+            // merged PRs that actually targeted `main` before picking one,
+            // so an unrelated candidate can never be selected. Prefer the
+            // one whose merge_commit_sha is exactly this push, falling back
+            // to the first eligible candidate for a fast-forward/rebase
+            // merge where merge_commit_sha may not equal the pushed SHA.
+            const candidates = prs.filter(
+              pr => pr.merged_at && pr.base && pr.base.ref === 'main'
+            );
+            const target =
+              candidates.find(pr => pr.merge_commit_sha === sha) ||
+              candidates[0] ||
+              prs[0];
             const headSha = target.head.sha;
 
             core.info(`Merge commit ${sha} <- PR #${target.number}, tested head ${headSha}`);
 
-            // Not paginated: today's full required-check set plus every
-            // matrix leg is well under the 100-per-page ceiling (~78
-            // check runs observed). Revisit if that changes.
-            const { data: checkRunsResp } = await github.rest.checks.listForRef({
+            const checkRuns = await github.paginate(github.rest.checks.listForRef, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               ref: headSha,
@@ -107,10 +120,15 @@ jobs:
             });
 
             const byName = new Map();
-            for (const run of checkRunsResp.check_runs) {
+            for (const run of checkRuns) {
               // A check can be re-run; keep only the most recently started.
+              // `Date.parse` of a missing/malformed `started_at` is `NaN`,
+              // and every comparison with `NaN` is false -- fall back to 0
+              // so a queued run with no `started_at` yet still loses to any
+              // real timestamp instead of winning by default.
+              const startedAt = r => (r.started_at ? Date.parse(r.started_at) : 0);
               const existing = byName.get(run.name);
-              if (!existing || new Date(run.started_at) > new Date(existing.started_at)) {
+              if (!existing || startedAt(run) >= startedAt(existing)) {
                 byName.set(run.name, run);
               }
             }

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -87,7 +87,7 @@ code half and the governance half now have genuinely different statuses:
 | | Scope | Status |
 |---|---|---|
 | **PR 0A** | The Windows test failures themselves (items 1–2 below) | **Closed at the test level** — the Windows unit *and* integration lanes passed on PR #782; the specific MSYS/Git-Bash failures described under "Verified state" are no longer the current blocker |
-| **PR 0B** | Required checks / Ruleset + exact-merge-SHA verification (items 3–4) | **Still open, still P0** — this is what actually makes a red CI block a merge |
+| **PR 0B** | Required checks / Ruleset + exact-merge-SHA verification (items 3–4) | **Code side implemented; the Ruleset toggle itself is still an outstanding manual step** — see status note below |
 
 **PR 0B is the one to do first, and it is the review's PR A.** The branch API
 still reports `protected: true` with
@@ -98,6 +98,24 @@ Separately, the exact merge SHA of #782 did not run a full CI sweep on
 `push: main` in the returned workflow set (AgentReady completed; Examples
 Validation was still running; no separate full `ci.yml` run over that exact
 SHA), which is precisely what item 4 exists to make detectable.
+
+> **Status note.** Every code-side prerequisite for item 3 is implemented:
+> `.github/AGENTS.md`'s new "Required-status-check configuration" section
+> states the classification rule (superseding the hand-copied-list attempts
+> below, kept here as the historical record of why a rule beat a list) and
+> the concrete required-check name list it produces; `ci.yml` gained the two
+> neutral-aggregate gate jobs (`docs-pr-required`/`test-action-required`)
+> `test-action.yml`'s own `test-action-summary` aggregate they wrap, all
+> structurally guarded by `tests/test_required_checks_governance.py`. Item
+> 4's `verify-merge-checks.yml` (push-to-`main` exact-merge-SHA
+> verification) is implemented and tested the same way. **What remains is
+> exactly one manual action**: an account with repository-admin access must
+> actually configure the GitHub Ruleset (or classic branch protection) to
+> require the check names `.github/AGENTS.md`'s section lists — no tool
+> available to an automated PR reaches that surface (confirmed: neither the
+> GitHub MCP server's tool set nor any CLI available in this environment
+> exposes branch-protection/Ruleset administration). Once that toggle is
+> flipped, PR 0B is fully closed.
 
 **The required-check list must match `.github/AGENTS.md`'s own required-vs-
 informational classification, not the set of workflow names visible in a run

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -104,9 +104,10 @@ SHA), which is precisely what item 4 exists to make detectable.
 > states the classification rule (superseding the hand-copied-list attempts
 > below, kept here as the historical record of why a rule beat a list) and
 > the concrete required-check name list it produces; `ci.yml` gained the two
-> neutral-aggregate gate jobs (`docs-pr-required`/`test-action-required`)
-> `test-action.yml`'s own `test-action-summary` aggregate they wrap, all
-> structurally guarded by `tests/test_required_checks_governance.py`. Item
+> neutral-aggregate gate jobs (`docs-pr-required`/`test-action-required`),
+> and `test-action.yml` gained the `test-action-summary` aggregate they
+> wrap, all structurally guarded by
+> `tests/test_required_checks_governance.py`. Item
 > 4's `verify-merge-checks.yml` (push-to-`main` exact-merge-SHA
 > verification) is implemented and tested the same way. **What remains is
 > exactly one manual action**: an account with repository-admin access must

--- a/tests/test_required_checks_governance.py
+++ b/tests/test_required_checks_governance.py
@@ -1,0 +1,199 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Structural guards for the required-status-check governance mechanism
+(CLI cleanup phase two, PR A / PR 0B; see `.github/AGENTS.md`'s
+"Required-status-check configuration" section for the rule these jobs
+implement).
+
+Two path-filtered workflows (`docs-pr.yml`, `test-action.yml`) cannot be
+required directly -- no native GitHub mechanism conditions "required" on
+which paths a PR touched -- so `ci.yml` carries an always-triggered
+neutral-aggregate gate job per workflow (`docs-pr-required`/
+`test-action-required`) that re-evaluates the *same* path filter and, when
+it matches, polls the target workflow's own aggregate check for the same
+head SHA. These tests don't execute the polling logic (that needs a live
+GitHub API and a real PR, per `.github/AGENTS.md`'s own note) -- they guard
+the two things that would otherwise silently rot: the copied path-filter
+list drifting out of sync with the workflow it mirrors, and a new job added
+to `test-action.yml` escaping its own aggregate's `needs:` list.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = ROOT / ".github" / "workflows"
+
+
+def _load_workflow(name: str) -> dict[str, Any]:
+    raw = yaml.safe_load((WORKFLOWS / name).read_text(encoding="utf-8"))
+    assert isinstance(raw, dict), f"{name}: expected a mapping at the top level"
+    return raw
+
+
+def _jobs(workflow: dict[str, Any]) -> dict[str, Any]:
+    jobs = workflow.get("jobs")
+    assert isinstance(jobs, dict), "workflow has no 'jobs' mapping"
+    return jobs
+
+
+def _paths_filter(workflow: dict[str, Any]) -> list[str]:
+    """The `on: pull_request: paths:` list, or ``[]`` if the workflow carries
+    none (matching PyYAML's own key normalization: a bare ``on:`` key parses
+    as the boolean ``True`` under YAML 1.1, so this looks up both spellings)."""
+    on_block = workflow.get("on", workflow.get(True, {}))
+    pr_block = on_block.get("pull_request", {}) if isinstance(on_block, dict) else {}
+    paths = pr_block.get("paths", []) if isinstance(pr_block, dict) else []
+    assert isinstance(paths, list)
+    return paths
+
+
+class TestNeutralAggregateGateJobsExist:
+    def test_ci_yml_has_docs_pr_required_gate(self) -> None:
+        ci = _load_workflow("ci.yml")
+        jobs = _jobs(ci)
+        assert "docs-pr-required" in jobs
+
+    def test_ci_yml_has_test_action_required_gate(self) -> None:
+        ci = _load_workflow("ci.yml")
+        jobs = _jobs(ci)
+        assert "test-action-required" in jobs
+
+    @pytest.mark.parametrize("job_id", ["docs-pr-required", "test-action-required"])
+    def test_gate_jobs_only_run_on_pull_request(self, job_id: str) -> None:
+        """Neither `docs-pr.yml` nor `test-action.yml`'s own aggregate check
+        re-runs on a `push`-triggered merge commit (a different, untested
+        SHA) -- waiting on `push` would only time out, not gate anything."""
+        ci = _load_workflow("ci.yml")
+        job = _jobs(ci)[job_id]
+        assert job.get("if") == "github.event_name == 'pull_request'"
+
+    @pytest.mark.parametrize("job_id", ["docs-pr-required", "test-action-required"])
+    def test_gate_jobs_carry_no_paths_filter(self, job_id: str) -> None:
+        """The gate jobs live in `ci.yml`, which must stay unconditioned
+        (`ci.yml` as a whole has no `paths:` filter) -- a path filter on
+        `ci.yml` itself would reintroduce the exact "may not run at all"
+        problem these jobs exist to close."""
+        ci = _load_workflow("ci.yml")
+        assert not _paths_filter(ci)
+        # Confirm the job itself exists (sanity: parametrize didn't typo).
+        assert job_id in _jobs(ci)
+
+
+class TestPathFilterStaysInSyncWithTargetWorkflow:
+    """The gate jobs' own `dorny/paths-filter` filter lists are hand-copied
+    from `docs-pr.yml`'s/`test-action.yml`'s own `on: pull_request: paths:`
+    blocks. If one changes without the other, the gate silently stops
+    matching what it's supposed to guard -- exactly the kind of drift this
+    file exists to catch mechanically instead of relying on someone
+    remembering to update both places."""
+
+    def _gate_job_filter_paths(self, ci: dict[str, Any], job_id: str) -> list[str]:
+        job = _jobs(ci)[job_id]
+        for step in job.get("steps", []):
+            if step.get("uses", "").startswith("dorny/paths-filter@"):
+                filters_yaml = step["with"]["filters"]
+                parsed = yaml.safe_load(filters_yaml)
+                # One named filter key per gate job (e.g. `docs:`/`action:`);
+                # take its value regardless of the key's own spelling.
+                (paths,) = parsed.values()
+                assert isinstance(paths, list)
+                return paths
+        pytest.fail(f"{job_id}: no dorny/paths-filter step found")
+
+    def test_docs_pr_required_matches_docs_pr_yml(self) -> None:
+        ci = _load_workflow("ci.yml")
+        docs_pr = _load_workflow("docs-pr.yml")
+        assert self._gate_job_filter_paths(ci, "docs-pr-required") == _paths_filter(
+            docs_pr
+        )
+
+    def test_test_action_required_matches_test_action_yml(self) -> None:
+        ci = _load_workflow("ci.yml")
+        test_action = _load_workflow("test-action.yml")
+        assert self._gate_job_filter_paths(ci, "test-action-required") == _paths_filter(
+            test_action
+        )
+
+
+class TestTestActionSummaryCoversEveryJob:
+    """`test-action-summary` is the one stable required check standing in for
+    all of `test-action.yml`'s fan-out jobs -- a job added to that workflow
+    without also being added to the summary's `needs:` list would silently
+    never gate anything, exactly the kind of escape a matrix-leg-by-leg
+    required-check list already has a documented history of causing."""
+
+    def test_needs_lists_every_other_job(self) -> None:
+        test_action = _load_workflow("test-action.yml")
+        jobs = _jobs(test_action)
+        assert "test-action-summary" in jobs
+        summary = jobs["test-action-summary"]
+        needs = summary.get("needs")
+        assert isinstance(needs, list) and needs, "test-action-summary must list needs"
+        other_jobs = set(jobs) - {"test-action-summary"}
+        assert set(needs) == other_jobs
+
+    def test_runs_even_if_a_dependency_failed_or_was_cancelled(self) -> None:
+        test_action = _load_workflow("test-action.yml")
+        summary = _jobs(test_action)["test-action-summary"]
+        assert summary.get("if") == "always()"
+
+
+class TestVerifyMergeChecksWorkflow:
+    def test_triggers_only_on_push_to_main(self) -> None:
+        wf = _load_workflow("verify-merge-checks.yml")
+        on_block = wf.get("on", wf.get(True))
+        assert set(on_block) == {"push"}
+        assert on_block["push"]["branches"] == ["main"]
+
+    def test_required_checks_list_present_in_script(self) -> None:
+        raw = (WORKFLOWS / "verify-merge-checks.yml").read_text(encoding="utf-8")
+        assert "REQUIRED_CHECKS" in raw
+        # Every unconditional required check named in .github/AGENTS.md's
+        # own derived list should appear in the script's own list literal --
+        # a loose substring check (not a full JS parse), but enough to catch
+        # a check silently dropped from one place and not the other.
+        for name in (
+            "ai-readiness",
+            "FAIR metadata and packaging",
+            "lint-and-types",
+            "unit-tests (ubuntu-latest, 3.13, false)",
+            "packaging (ubuntu-latest)",
+            "packaging (windows-latest)",
+            "changelog-fragment",
+            "cli-interface-diff",
+            "test-contract",
+            "Dependency Review",
+            "Security Scan",
+            "CodeQL Analysis (python)",
+        ):
+            assert name in raw, f"{name!r} missing from verify-merge-checks.yml"
+
+    def test_does_not_require_the_path_filtered_aggregate_checks(self) -> None:
+        """`build-docs`/`test-action summary` are deliberately excluded --
+        whether they exist at all for a given PR head SHA depends on the
+        same path filter the `ci.yml` gate jobs already re-evaluate, so
+        requiring them here too would either duplicate that logic or, if it
+        drifted, produce a false failure on a PR that never touched those
+        paths."""
+        raw = (WORKFLOWS / "verify-merge-checks.yml").read_text(encoding="utf-8")
+        assert "'build-docs'" not in raw
+        assert "'test-action summary'" not in raw

--- a/tests/test_required_checks_governance.py
+++ b/tests/test_required_checks_governance.py
@@ -97,6 +97,59 @@ class TestNeutralAggregateGateJobsExist:
         # Confirm the job itself exists (sanity: parametrize didn't typo).
         assert job_id in _jobs(ci)
 
+    @pytest.mark.parametrize(
+        ("job_id", "expected_check_name"),
+        [
+            ("docs-pr-required", "docs-pr (required)"),
+            ("test-action-required", "test-action (required)"),
+        ],
+    )
+    def test_gate_job_check_name_is_documented_as_required(
+        self, job_id: str, expected_check_name: str
+    ) -> None:
+        """GitHub Rulesets match a required status check by its emitted
+        check-run *name*, not by the workflow job id -- `.github/AGENTS.md`'s
+        required-check list must name what the job actually reports
+        (`name:`), not the job id, or an admin applying that list configures
+        a context that never reports and strands every PR."""
+        job = _jobs(_load_workflow("ci.yml"))[job_id]
+        assert job.get("name") == expected_check_name
+        agents_md = (ROOT / ".github" / "AGENTS.md").read_text(encoding="utf-8")
+        assert f"`{expected_check_name}`" in agents_md
+
+
+class TestGateJobPollingLogic:
+    """Guards on the two gate jobs' own `actions/github-script` polling step
+    -- a `skipped` conclusion must not be silently accepted as a pass (the
+    path filter is what handles "the target workflow never ran"; a check run
+    that exists and reports `skipped` is a different, real signal), and the
+    step should be SHA-pinned like its neighbors rather than a floating tag."""
+
+    @pytest.mark.parametrize("job_id", ["docs-pr-required", "test-action-required"])
+    def test_does_not_accept_a_skipped_conclusion_as_success(self, job_id: str) -> None:
+        ci = _load_workflow("ci.yml")
+        job = _jobs(ci)[job_id]
+        script_step = next(
+            s
+            for s in job["steps"]
+            if s.get("uses", "").startswith("actions/github-script@")
+        )
+        script = script_step["with"]["script"]
+        assert "'success', 'neutral'" in script
+        assert "'skipped'" not in script
+
+    @pytest.mark.parametrize("workflow_name", ["ci.yml", "verify-merge-checks.yml"])
+    def test_github_script_is_pinned_by_sha(self, workflow_name: str) -> None:
+        wf = _load_workflow(workflow_name)
+        for job in _jobs(wf).values():
+            for step in job.get("steps", []):
+                uses = step.get("uses", "")
+                if uses.startswith("actions/github-script@"):
+                    ref = uses.split("@", 1)[1]
+                    assert len(ref) == 40, (
+                        f"{workflow_name}: {uses!r} is not SHA-pinned"
+                    )
+
 
 class TestPathFilterStaysInSyncWithTargetWorkflow:
     """The gate jobs' own `dorny/paths-filter` filter lists are hand-copied
@@ -122,16 +175,18 @@ class TestPathFilterStaysInSyncWithTargetWorkflow:
     def test_docs_pr_required_matches_docs_pr_yml(self) -> None:
         ci = _load_workflow("ci.yml")
         docs_pr = _load_workflow("docs-pr.yml")
-        assert self._gate_job_filter_paths(ci, "docs-pr-required") == _paths_filter(
-            docs_pr
-        )
+        target = _paths_filter(docs_pr)
+        assert target, "docs-pr.yml no longer has an `on: pull_request: paths:` filter"
+        assert self._gate_job_filter_paths(ci, "docs-pr-required") == target
 
     def test_test_action_required_matches_test_action_yml(self) -> None:
         ci = _load_workflow("ci.yml")
         test_action = _load_workflow("test-action.yml")
-        assert self._gate_job_filter_paths(ci, "test-action-required") == _paths_filter(
-            test_action
+        target = _paths_filter(test_action)
+        assert target, (
+            "test-action.yml no longer has an `on: pull_request: paths:` filter"
         )
+        assert self._gate_job_filter_paths(ci, "test-action-required") == target
 
 
 class TestTestActionSummaryCoversEveryJob:
@@ -155,6 +210,21 @@ class TestTestActionSummaryCoversEveryJob:
         test_action = _load_workflow("test-action.yml")
         summary = _jobs(test_action)["test-action-summary"]
         assert summary.get("if") == "always()"
+
+    def test_fails_on_a_skipped_dependency_too(self) -> None:
+        """`if: always()` (above) makes a skipped dependency visible to this
+        job's `needs.*.result`, but visibility alone doesn't fail the run --
+        the shell check must also treat 'skipped' as unsuccessful, or a
+        partially-skipped fan-out reports green through the required gate
+        `test-action-required` (`ci.yml`) polls."""
+        test_action = _load_workflow("test-action.yml")
+        summary = _jobs(test_action)["test-action-summary"]
+        run_step = next(
+            s
+            for s in summary["steps"]
+            if s.get("name") == "Fail if any test-action.yml job did not succeed"
+        )
+        assert "contains(needs.*.result, 'skipped')" in run_step["run"]
 
 
 class TestVerifyMergeChecksWorkflow:
@@ -184,6 +254,11 @@ class TestVerifyMergeChecksWorkflow:
             "Dependency Review",
             "Security Scan",
             "CodeQL Analysis (python)",
+            # The two neutral-aggregate gate jobs' own emitted check names
+            # (not their job ids) -- both are unconditioned like every other
+            # ci.yml job, so they exist on every PR head SHA and belong here.
+            "docs-pr (required)",
+            "test-action (required)",
         ):
             assert name in raw, f"{name!r} missing from verify-merge-checks.yml"
 
@@ -197,3 +272,21 @@ class TestVerifyMergeChecksWorkflow:
         raw = (WORKFLOWS / "verify-merge-checks.yml").read_text(encoding="utf-8")
         assert "'build-docs'" not in raw
         assert "'test-action summary'" not in raw
+
+    def test_check_run_listing_is_paginated(self) -> None:
+        """A hand-added `per_page: 100` ceiling silently drops any check run
+        past the 100th once the repo's check-run count grows past it -- use
+        `github.paginate` instead so there's no ceiling to outgrow."""
+        raw = (WORKFLOWS / "verify-merge-checks.yml").read_text(encoding="utf-8")
+        assert "github.paginate(github.rest.checks.listForRef" in raw
+
+    def test_target_pr_selection_is_restricted_to_merged_prs_targeting_main(
+        self,
+    ) -> None:
+        """`listPullRequestsAssociatedWithCommit` can return an unrelated
+        open PR that happens to contain the same commit -- selection must be
+        restricted to merged PRs based against `main` before falling back to
+        anything, or an unrelated PR's head SHA could be verified instead."""
+        raw = (WORKFLOWS / "verify-merge-checks.yml").read_text(encoding="utf-8")
+        assert "pr.merged_at" in raw
+        assert "pr.base.ref === 'main'" in raw

--- a/tests/test_required_checks_governance.py
+++ b/tests/test_required_checks_governance.py
@@ -290,3 +290,14 @@ class TestVerifyMergeChecksWorkflow:
         raw = (WORKFLOWS / "verify-merge-checks.yml").read_text(encoding="utf-8")
         assert "pr.merged_at" in raw
         assert "pr.base.ref === 'main'" in raw
+
+    def test_empty_candidates_does_not_fall_back_to_an_unfiltered_pr(self) -> None:
+        """If every commit<->PR association GitHub returns is ineligible (not
+        merged, or not based against `main`), the workflow must treat that
+        the same as "no PR associated" rather than silently falling back to
+        `prs[0]` -- an unfiltered fallback can validate a completely
+        unrelated PR's head SHA and read as green or red for reasons that
+        have nothing to do with the actual merge being verified."""
+        raw = (WORKFLOWS / "verify-merge-checks.yml").read_text(encoding="utf-8")
+        assert "candidates.length === 0" in raw
+        assert "|| prs[0]" not in raw


### PR DESCRIPTION
## Summary

Implements CLI cleanup phase two **PR A / PR 0B**: derive a concrete required-status-check list from `.github/AGENTS.md`'s "Required vs. informational workflows" table and close the two mechanical gaps that made it impossible to apply that list directly to a GitHub Ruleset.

## Motivation

The plan's PR 0B section names a concrete incident this closes: a merge SHA (#782) went out with no full `ci.yml` sweep having run against it, because the "required checks" list was never actually enforced and had already drifted from the table three times. Two structural problems made a straightforward required-check list impossible:

1. Two workflows (`docs-pr.yml`, `test-action.yml`) are `paths:`-filtered — no native GitHub mechanism conditions "required" on which paths a PR touched, so requiring their check names directly would strand every PR that doesn't touch those paths.
2. Even after checks are marked required, a red check doesn't retroactively un-merge a bad PR that slipped through a misconfigured or momentarily-disabled Ruleset — there was no way to detect that after the fact.

## Changes

- Add a neutral-aggregate gate job per path-filtered workflow (`docs-pr-required`/`test-action-required` in `ci.yml`, always triggered on `pull_request`, unconditioned): each re-evaluates the exact same `paths:` filter its target workflow uses. When the paths don't match, there's nothing to gate and it succeeds immediately. When they do match, it polls that workflow's own aggregate check for the same head SHA and mirrors its conclusion.
- Add `test-action-summary` to `test-action.yml` (`needs:` every other job, `if: always()`) — that workflow fans out to 17 independent jobs with no single existing pass/fail check for the new gate job to poll against. `docs-pr.yml` already had one (`build-docs`).
- Add `verify-merge-checks.yml` (`push: main` only): looks up the PR GitHub associates with each merge commit and re-verifies that PR's already-recorded head-SHA check results against the unconditional half of the required-check list. It can't block an already-completed merge, but it makes a merge that slipped through detectable on `main`'s Actions tab instead of invisible.
- Document the derivation rule (not a hand-copied list — the exact kind of snapshot that drifted three times before) and the resulting 14-entry required-check list in `.github/AGENTS.md`'s new "Required-status-check configuration" section.
- Update the plan doc's PR 0B status: the code side is implemented; the actual Ruleset toggle remains a manual repository-admin action — no tool available to an automated PR reaches GitHub's branch-protection/Ruleset admin API, so this PR documents the exact list to apply rather than claiming to have applied it.
- Add `tests/test_required_checks_governance.py`: structural guards against the two things that would otherwise silently rot — a gate job's copied path-filter list drifting out of sync with the workflow it mirrors, and a new `test-action.yml` job escaping `test-action-summary`'s `needs:` list. (The live polling behavior itself needs a real PR/GitHub API to exercise, which this PR's own CI run will do.)

## Bug-fix test contract

N/A — this is a `ci:` infrastructure change, not a `fix:`/`perf:`/`security:` PR.

## Checklist

- [x] Tests added / updated for new behaviour (`tests/test_required_checks_governance.py`, 13 tests)
- [x] Changelog fragment — not needed, no `abicheck/**/*.py` files touched
- [x] Docs updated (`.github/AGENTS.md`, `docs/contribute/plans/cli-cleanup-phase-two.md`)
- [x] `python scripts/verify.py`-equivalent checks pass locally: `check_ai_readiness.py` (0 errors), `check_docs_contract.py` (0 errors), `mkdocs build --strict` (clean), fast unit suite, new test file
- [x] No new `ruff` errors introduced (mypy shows only pre-existing, environment-caused `types-PyYAML` stub warnings unrelated to this diff — no Python package files touched)

## Remaining manual step

This PR implements everything code-side can reach. **One step remains outside any automated PR's ability to perform**: an account with repository-admin access must actually configure the GitHub Ruleset (or classic branch protection) to require the 14 checks listed in `.github/AGENTS.md`'s new section, including `docs-pr-required`/`test-action-required` (never `build-docs`/`test-action summary` directly — see that section for why). This is called out explicitly in both `.github/AGENTS.md` and the plan doc rather than silently left undone.

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014j8RmwFdFJMD789hFxZvrd)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated validation of required checks for pull requests and merges to the main branch.
  * Added aggregate status checks for documentation and action-testing workflows, including clear success or failure results.
  * Added verification that merged changes were tested using the exact pull request commit.

* **Documentation**
  * Documented required-check configuration, enforcement, and post-merge verification procedures.
  * Updated CLI cleanup planning to reflect completed governance work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->