### PR TITLE
fix: dedup L3 evidence collection in the typed dump/scan input resolver (CLI cleanup phase two, PR C / PR 3A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3672,6 +3672,125 @@ Once a root command genuinely clears the bar above, pick the right home:
   patches" convention rather than attempted under review pressure on an
   unrelated PR.
 
+- **PR C (typed `dump`/`scan` convergence, CLI cleanup phase two's PR 3A) —
+  investigated in depth; one real, scoped, verified slice landed; the full
+  convergence the plan describes is NOT attempted, and here is exactly why.**
+  The plan (`docs/contribute/plans/cli-cleanup-phase-two.md`, "PR 3A") asks
+  for one canonical path -- `Click parsing → DumpRequest → ResolvedDumpRequest
+  → dry-run-or-execute → DumpResult` -- with **both** `dump_cmd`/
+  `perform_elf_dump` and `scan_engine._build_new_snapshot` routing through
+  `service_dump_pipeline.run_dump_request` (or the per-input primitives it
+  shares via `service_input_resolution.resolve_side_snapshot`), the way
+  `compare`'s implicit-dump operand already does, with `dump --dry-run`
+  rendering the same `DumpResult` object the real run executes rather than a
+  separately-computed preview. Read `run_dump_request`, `resolve_side_snapshot`
+  and siblings, `perform_elf_dump` (1999 lines), `handle_non_elf_dump`, and
+  `scan_engine._build_new_snapshot` in full before concluding this.
+
+  **Three independent, concrete reasons the full migration cannot be done
+  soundly in one pass, each confirmed by reading the actual code rather than
+  assumed:**
+
+  1. **`dump --dry-run` is not a projection of a resolved object today -- it
+     is a hand-written second implementation.** `cli_dump_helpers.
+     render_dump_dry_run()` re-derives the resolved depth/collect-mode/
+     compile-DB-match/backend from the *same raw inputs* `perform_elf_dump`
+     receives, independently, in its own function -- there is no shared
+     `DumpResult` either one builds from. Its own docstring is explicit
+     about the scope this implies: "Cheap, read-only resolution only ...
+     Never runs castxml/clang, a build query, or any I/O beyond stat()/PATH
+     lookups" -- i.e. it is *deliberately* a cheaper, narrower
+     re-implementation, not a dry pass of the same resolver the real run
+     uses. Making `--dry-run` render a genuine `DumpResult` therefore
+     requires `run_dump_request` (or a new sibling) to support a "resolve
+     without executing/writing" mode in the first place -- it does not have
+     one today, it always fully resolves and returns a snapshot.
+  2. **`perform_elf_dump` has real post-processing hooks with no equivalent
+     in `run_dump_request` at all.** After the primary header-AST/DWARF
+     snapshot, it runs, in a carefully established order: the ADR-039
+     build-context collector (`_attach_build_context`), the G31
+     `service._attach_header_graph` second pass (its own independent clang
+     re-invocation and AST cache key), and the optional
+     `ABICHECK_CLANG_LAYOUT_TOOL` clang-layout-tool attach -- each reusing
+     the L3→L2-folded `effective_compile_context` (PR #782) and each with
+     its own dedicated, hard-won correctness fixes recorded above in this
+     same "Known gaps" section (findings 9, 10, 17, 18 on the L3→L2-fold
+     entry alone). `run_dump_request` has no post-processing stage at all
+     -- it returns whatever `resolve_side_snapshot` produced. Routing
+     `perform_elf_dump` through it would mean either dropping these passes
+     (a real snapshot-completeness regression) or adding an equivalent
+     hook to `run_dump_request` and re-verifying all four passes'
+     already-fixed ordering/cache-key/flag-isolation bugs against the new
+     call shape -- itself a project the size of this whole PR, not a
+     rename.
+  3. **`scan_engine._build_new_snapshot` has scan-specific behavior
+     `DumpRequest` cannot express, and this file already documents two
+     multi-round bug hunts in exactly this area that a rushed reroute
+     would risk reopening.** Its own `-H old=PATH`/`-I old=PATH` side-aware
+     baseline handling (the twelfth/thirteenth/fifteenth findings on the
+     L3→L2-fold entry above) decides, per comparison, whether the
+     candidate's own L3-folded `compile_context` may be reused for the
+     baseline parse or must fall back to the caller's unfolded one -- a
+     decision inherently about *two* snapshots' relationship, which
+     `DumpRequest` (built for *one* input) has no field for. Forcing this
+     through a `DumpRequest`-shaped call would need a new pair-aware
+     concept alongside it, which is exactly the kind of design `service_
+     compare_pipeline.py`'s own module docstring already explains was
+     deliberately kept *out* of `service_input_resolution.py`'s per-input
+     primitives ("The pair-shaped decisions deliberately stayed behind...
+     neither means anything for a lone dump").
+
+  **What landed instead, safely and independently of all three blockers
+  above: `service_input_resolution._seeded_includes`/
+  `_seeded_compile_context` -- the shared per-input primitive `compare`'s
+  implicit-dump operand and `dump`'s typed API (`run_dump_request`) both
+  already use -- ran the L2 include-dir seed and the P0.3 L3→L2
+  compile-context fold as two independent calls, each capable of running
+  `buildsource.inline.collect_inline_pack()`.** That is the exact
+  self-deadlock shape already found and fixed, by name, for `perform_elf_
+  dump`/`handle_non_elf_dump`/`scan_engine._build_new_snapshot` in this same
+  section's L3→L2-fold entry (its "fifth finding"): a caller whose
+  `sources`/`build_info` genuinely needs the zero-config *inferred*
+  build-system query would have the include-dir seed's own inferred query
+  hold the deterministic build-dir lock until its cleanup runs --
+  deliberately deferred until after the L2 parse consumes the seeded dirs --
+  so the compile-context fold's own, separate inferred-query attempt would
+  contend on the identical lock. That fifth finding's fix,
+  `buildsource.l2_seed.seed_includes_and_fold_compile_context()`, was wired
+  into all three CLI-side resolvers at the time -- but never into
+  `resolve_side_snapshot`, the fourth, typed-API call site, which kept the
+  older two-call shape. `resolve_side_snapshot` never actually hit the
+  600s timeout (`collect_mode` is forced `"off"`/`allow_inferred_build_
+  query=False` here, matching every Tier-2 API caller's "never execute a
+  build system as a side effect" rule -- see `_seeded_includes`'s own
+  docstring), so this was real, avoidable duplicated work and a real
+  divergence from the one shared primitive the other three call sites had
+  already converged on, not a live self-deadlock. Fixed by replacing the
+  two separate helpers with one, `_seeded_includes_and_compile_context()`,
+  which calls the identical `seed_includes_and_fold_compile_context()` the
+  other three sites already use. This is a genuine, if narrow, piece of PR
+  3A's actual convergence goal -- one fewer place a change to how an input
+  resolves can drift -- landed without touching any of the three blockers
+  above. Verified via the existing `resolve_side_snapshot`/
+  `_seeded_compile_context` test coverage in `tests/test_header_compile_
+  context.py` and `tests/test_bazel_root_targets_l2_seed.py` (both updated
+  for the renamed/merged function, not weakened), plus the full fast unit
+  suite and `mypy`/`ruff` clean on both touched modules.
+
+  **What remains genuinely open, unattempted, and why forcing it further
+  would be reactive rather than sound**: all three blockers above, in full
+  -- a "resolve without executing" mode for `run_dump_request`, a
+  post-processing hook `perform_elf_dump`'s second-pass attaches can plug
+  into, and a pair-aware primitive `scan`'s baseline-reuse decision can
+  express -- are each their own real, multi-file design, not a follow-up
+  edit to this same PR. Given the density of prior review rounds already
+  recorded against this exact code (the L3→L2-fold entry above alone lists
+  eighteen numbered findings, several reverted-and-refixed), attempting any
+  of the three under continued session pressure risks reopening one of
+  them, which is precisely what this file's own "known gaps over risky
+  reactive patches" convention exists to avoid. See the plan doc's own PR C
+  section for a status note recording the same scope.
+
 - Don't hand-edit `CHANGELOG.md`'s `## [Unreleased]` section directly — add a `changelog.d/` fragment instead (see Conventions above); CI enforces this
 - Don't modify `examples/` test cases without understanding the ground truth they encode
 - Don't add dependencies without strong justification (this is a lightweight tool)

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -288,7 +288,11 @@ def derive_l2_include_dirs(
         # (Codex review — this call used to live inside this try before the
         # shared-helper extraction, and moved ahead of it by mistake).
         args = _resolve_l2_seed_pack_args(
-            build_config, sources, build_info, build_query, build_compile_db,
+            build_config,
+            sources,
+            build_info,
+            build_query,
+            build_compile_db,
             build_targets,
         )
         if args is None:
@@ -406,7 +410,11 @@ def derive_l2_compile_context(
         # corrupt/unreadable pack must degrade best-effort, not raise
         # (Codex review).
         args = _resolve_l2_seed_pack_args(
-            build_config, sources, build_info, build_query, build_compile_db,
+            build_config,
+            sources,
+            build_info,
+            build_query,
+            build_compile_db,
             build_targets,
         )
         if args is None:
@@ -485,7 +493,9 @@ def _merge_l3_compile_context(
     import cycle once ``cli_dump_helpers`` needed it directly (AGENTS.md
     "What NOT to do" -- prefer a leaf module both sides can depend on over
     extending ``IMPORT_CYCLE_ALLOWLIST``). ``service_input_resolution``'s
-    own ``_seeded_compile_context`` now imports it from here instead.
+    own ``_seeded_includes_and_compile_context`` (PR C, typed dump/scan
+    convergence) reaches it indirectly through
+    :func:`seed_includes_and_fold_compile_context` below instead.
 
     "Derived leads, explicit wins" is *not* the right rule for an include
     search path (Codex review): unlike a macro/std/sysroot switch, which a
@@ -701,7 +711,11 @@ def seed_includes_and_fold_compile_context(
         # raise (Codex review) -- an earlier revision of this function had it
         # outside the try, which reintroduced exactly that regression.
         args = _resolve_l2_seed_pack_args(
-            build_config, sources, build_info, build_query, build_compile_db,
+            build_config,
+            sources,
+            build_info,
+            build_query,
+            build_compile_db,
             build_targets,
         )
         if args is None:

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -102,111 +102,116 @@ def reject_hybrid_source_frontend(
             )
 
 
-def _seeded_includes(
-    side: InputSpec, evidence: SideEvidence
-) -> tuple[list[Path], list[Callable[[], None]]]:
-    """This input's include dirs, plus any the build already knows about.
-
-    When headers are given with ``sources``/``build_info`` but no explicit
-    ``includes``, the L2 public-header parse cannot see the include dirs the
-    build knows (the pvxs/EPICS case: public headers that reach into a
-    dependency SDK). The CLI has seeded them from the build since ADR-033
-    (``cli_dump_helpers``' two ``seed_l2_includes`` calls); the typed path did
-    not, so an identical ``DumpRequest``/``CompareRequest`` parsed less than
-    the equivalent CLI invocation and degraded or failed (Codex review).
-
-    ``allow_inferred_build_query=False``, unlike the CLI's
-    ``collect_mode != "off"``: passive discovery of an existing compile
-    database still applies, but a Tier-2 API call must never *execute* a
-    build system (cmake/make/bazel) as a side effect of resolving an input.
-    That is a surprise a library caller cannot see coming, and the CLI only
-    permits it because the user typed a command that says so.
-
-    Returns the cleanups the caller must run **after** the parse consumes the
-    dirs — an inferred build dir may hold the generated headers they point at.
-    """
-    if not (side.sources or side.build_info):
-        return list(side.includes), []
-    from .buildsource.l2_seed import seed_l2_includes
-
-    ctx = evidence.compile
-    return seed_l2_includes(
-        headers=evidence.headers,
-        includes=side.includes,
-        sources=side.sources,
-        build_info=side.build_info,
-        build_config=None,
-        defer_cleanup=None,
-        build_targets=side.build_targets,
-        gcc_options=ctx.gcc_options if ctx is not None else None,
-        gcc_option_tokens=ctx.gcc_option_tokens if ctx is not None else (),
-        allow_inferred_build_query=False,
-    )
-
-
-def _seeded_compile_context(
+def _seeded_includes_and_compile_context(
     side: InputSpec,
     evidence: SideEvidence,
     *,
     lang: str = "c++",
     lang_explicit: bool = False,
-) -> tuple[CompileContext | None, bool, list[Callable[[], None]]]:
-    """Fold L3 ``CompileUnit``-derived ABI context onto this side (P0.3).
+) -> tuple[list[Path], CompileContext | None, bool, list[Callable[[], None]]]:
+    """This input's L2 include-dir seed *and* its P0.3 L3->L2 compile-context
+    fold, resolved together in one L3 collection (PR C, typed dump/scan
+    convergence -- see the root ``AGENTS.md`` "Known gaps" entry on
+    ``service_dump_pipeline.py``).
 
-    Genuinely applies the real build's compile context (standard, defines/
-    undefines, include search paths, sysroot, target triple, ABI-relevant
-    flags) to the L2 header-AST invocation when ``sources``/``build_info`` L3
-    evidence is available and a ``CompileUnit`` references one of this side's
-    headers — instead of only the advisory ``header_parse_context_drift``/
-    ``header_build_context_mismatch`` findings this repo already emitted for
-    the gap. See ``buildsource.header_compile_context`` for the header→
-    ``CompileUnit`` matching heuristic and the single-context/fail-closed-on-
-    ambiguity contract (``HeaderCompileContextAmbiguousError`` propagates
-    unchanged — a genuine ABI-relevant disagreement across compile units is
-    never silently resolved by picking one).
+    This used to be two independent calls here -- ``seed_l2_includes`` (the
+    include-dir fallback: when headers are given with ``sources``/
+    ``build_info`` but no explicit ``includes``, the L2 public-header parse
+    cannot see the include dirs the build knows -- the pvxs/EPICS case, a
+    public header reaching into a dependency SDK) and
+    ``derive_l2_compile_context`` (folding the build's real compile context
+    -- standard, defines/undefines, include search paths, sysroot, target
+    triple -- onto the L2 header-AST invocation, P0.3) -- each independently
+    capable of running :func:`~abicheck.buildsource.inline.collect_inline_pack`.
+    That is the exact self-deadlock shape already found and fixed for
+    ``dump``/``scan``'s three CLI-side resolvers (see
+    :func:`~abicheck.buildsource.l2_seed.seed_includes_and_fold_compile_context`'s
+    own docstring, "Known gaps" fifth finding): a caller whose ``sources``/
+    ``build_info`` genuinely needs the zero-config *inferred* build-system
+    query (no existing compile database) would have the include-dir seed's
+    own inferred query hold the deterministic build-dir lock until its
+    cleanup runs -- deliberately deferred until after the L2 parse consumes
+    the seeded dirs -- so the compile-context fold's own, separate
+    inferred-query attempt would contend on the identical lock and wait up to
+    the 600s timeout before falling back to a throwaway sibling dir. This
+    path never actually hit that timeout, because ``allow_inferred_build_
+    query`` was always ``False`` here (see below, unchanged) -- but running
+    :func:`~abicheck.buildsource.inline.collect_inline_pack` twice per side
+    was still real, avoidable duplicated work even with the query itself
+    suppressed, and diverging from the one already-fixed shared primitive
+    the other three call sites converged on is exactly the kind of drift PR
+    C exists to close. This is the one piece of that convergence safely
+    landable on its own, without restructuring ``perform_elf_dump``/
+    ``scan_engine._build_new_snapshot`` themselves to route through
+    :func:`resolve_side_snapshot` -- their own pipelines have hooks (a
+    second header-graph/clang-layout-tool pass, a side-aware ``-H
+    old=PATH`` baseline) this function's shared primitive does not yet
+    model; see the ``AGENTS.md`` entry for the full accounting of what
+    remains open.
 
-    A no-op (``(evidence.compile, False, [])``) when there is no L3 evidence
-    or no headers to match, or when the matched evidence resolves to nothing
-    — the exact same behavior as before this function existed, so a caller
-    with no build evidence for this side sees no change (backward
-    compatible). Returns ``(context, applied, cleanups)`` — ``applied`` is
-    True only when a real L3 context was found and folded in, which is what
-    the caller uses to decide whether to stamp
-    ``AbiSnapshot.parsed_with_build_context``.
+    ``allow_inferred_build_query=False`` (``collect_mode="off"``), unlike the
+    CLI's ``collect_mode != "off"``: passive discovery of an existing compile
+    database still applies, but a Tier-2 API call must never *execute* a
+    build system (cmake/make/bazel) as a side effect of resolving an input.
+    That is a surprise a library caller cannot see coming, and the CLI only
+    permits it because the user typed a command that says so.
+
+    A no-op (``(list(side.includes), evidence.compile, False, [])``) when
+    there is no L3 evidence or no headers to match — the exact same behavior
+    as the two functions this replaces, so a caller with no build evidence
+    for this side sees no change (backward compatible).
 
     *lang*/*lang_explicit* (``discussion_r3787398644``, Codex review):
-    this side's own requested parse language, forwarded unchanged to
-    :func:`~abicheck.buildsource.l2_seed.derive_l2_compile_context` so a
+    this side's own requested parse language, forwarded unchanged so a
     matched compile unit's derived ``-std=`` whose language family
     conflicts with an explicitly forced language is omitted rather than
     forwarded into a parse that would reject it (e.g. a matched C compile
     unit's ``-std=c17`` forwarded into an explicitly-forced C++ parse).
+
+    Returns ``(includes, context, applied, cleanups)`` — ``includes`` is
+    *side.includes* augmented with any build-derived seed dirs; ``applied``
+    is True only when a real L3 context was found and folded in, which is
+    what the caller uses to decide whether to stamp
+    ``AbiSnapshot.parsed_with_build_context``; *cleanups* is what the caller
+    must run **after** the parse consumes the seeded/derived dirs — an
+    inferred build dir may hold the generated headers they point at.
+
+    May raise :class:`~abicheck.errors.HeaderCompileContextAmbiguousError` —
+    the same fail-closed-on-ambiguity contract ``derive_l2_compile_context``
+    already had (a genuine ABI-relevant disagreement across compile units is
+    never silently resolved by picking one).
     """
     if not (side.sources or side.build_info) or not evidence.headers:
-        return evidence.compile, False, []
-    from .buildsource.l2_seed import (
-        _merge_l3_compile_context,
-        derive_l2_compile_context,
-    )
+        return list(side.includes), evidence.compile, False, []
+    from .buildsource.l2_seed import seed_includes_and_fold_compile_context
 
-    derived, cleanups = derive_l2_compile_context(
-        headers=list(evidence.headers),
-        build_info=side.build_info,
-        sources=side.sources,
-        build_config=None,
-        build_targets=side.build_targets,
-        allow_inferred_build_query=False,
-        # Finding 3: fold the caller's own already-explicit context into
-        # ambiguity resolution so a field it already pins (e.g. an explicit
-        # -std=c++20) excuses a same-field-only disagreement across matched
-        # compile units instead of failing closed on it.
-        explicit=evidence.compile,
-        lang=lang,
-        lang_explicit=lang_explicit,
+    ctx = evidence.compile
+    cleanups: list[Callable[[], None]] = []
+    includes, applied, effective_ctx, _derived_dirs = (
+        seed_includes_and_fold_compile_context(
+            headers=evidence.headers,
+            includes=side.includes,
+            sources=side.sources,
+            build_info=side.build_info,
+            build_config=None,
+            build_query=None,
+            build_compile_db=None,
+            build_targets=side.build_targets,
+            collect_mode="off",
+            gcc_path=ctx.gcc_path if ctx is not None else None,
+            gcc_prefix=ctx.gcc_prefix if ctx is not None else None,
+            gcc_options=ctx.gcc_options if ctx is not None else None,
+            gcc_option_tokens=ctx.gcc_option_tokens if ctx is not None else (),
+            sysroot=ctx.sysroot if ctx is not None else None,
+            nostdinc=ctx.nostdinc if ctx is not None else False,
+            frontend=ctx.frontend if ctx is not None else "auto",
+            frontend_context=ctx.frontend_context if ctx is not None else "host",
+            lang=lang,
+            lang_explicit=lang_explicit,
+            pending_cleanups=cleanups,
+        )
     )
-    if derived is None:
-        return evidence.compile, False, cleanups
-    return _merge_l3_compile_context(evidence.compile, derived), True, cleanups
+    return includes, effective_ctx, applied, cleanups
 
 
 def resolve_side_snapshot(
@@ -241,18 +246,23 @@ def resolve_side_snapshot(
     """
     from . import service
 
-    # Accumulated incrementally (not built from two independent calls before
-    # entering `try`) so a HeaderCompileContextAmbiguousError raised by
-    # _seeded_compile_context still drains whatever temp-build-dir cleanups
-    # _seeded_includes already created, instead of leaking them.
+    # PR C (typed dump/scan convergence): the include-dir seed and the P0.3
+    # L3->L2 compile-context fold are resolved together, in one L3
+    # collection, by _seeded_includes_and_compile_context -- see that
+    # function's own docstring for why two independent collections here was
+    # a latent self-deadlock risk, not just duplicated work.
+    # Pre-seeded (rather than left unbound) so the `finally` below is safe
+    # even if _seeded_includes_and_compile_context itself raises before
+    # returning -- it drains its own cleanups internally on
+    # HeaderCompileContextAmbiguousError (see its docstring), so an empty
+    # list here is correct, not a leak.
     cleanups: list[Callable[[], None]] = []
     try:
-        includes, includes_cleanups = _seeded_includes(side, evidence)
-        cleanups.extend(includes_cleanups)
-        compile_ctx, context_applied, context_cleanups = _seeded_compile_context(
-            side, evidence, lang=lang, lang_explicit=lang_explicit
+        includes, compile_ctx, context_applied, cleanups = (
+            _seeded_includes_and_compile_context(
+                side, evidence, lang=lang, lang_explicit=lang_explicit
+            )
         )
-        cleanups.extend(context_cleanups)
         snap = service.resolve_input(
             side.path,
             evidence.headers,

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -187,6 +187,7 @@ def _seeded_includes_and_compile_context(
 
     ctx = evidence.compile
     cleanups: list[Callable[[], None]] = []
+    effective_ctx: CompileContext | None
     includes, applied, effective_ctx, _derived_dirs = (
         seed_includes_and_fold_compile_context(
             headers=evidence.headers,
@@ -211,6 +212,18 @@ def _seeded_includes_and_compile_context(
             pending_cleanups=cleanups,
         )
     )
+    # seed_includes_and_fold_compile_context() always returns a real
+    # CompileContext for `effective_ctx` -- it's built fresh from the
+    # individual kwargs above, never literally `ctx` -- so a no-op fold
+    # (`applied=False`) with no caller-supplied context would otherwise
+    # silently turn a `None` into a default-valued CompileContext() here.
+    # That distinction is load-bearing: service_dump_cache._dump_is_cacheable
+    # only permits caching when `compile is None` (Codex review, fresh
+    # evidence) -- preserve `None` in exactly that case so an otherwise
+    # cacheable typed dump/compare operand doesn't lose caching merely
+    # because unrelated build evidence was supplied and matched nothing.
+    if not applied and ctx is None:
+        effective_ctx = None
     return includes, effective_ctx, applied, cleanups
 
 

--- a/changelog.d/20260816_191218_noreply_pr_c_seeded_includes_dedup.md
+++ b/changelog.d/20260816_191218_noreply_pr_c_seeded_includes_dedup.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- **`service_input_resolution.resolve_side_snapshot` (the shared per-input
+  primitive `compare`'s implicit-dump operand and `dump`'s typed API,
+  `run_dump_request`, both use) no longer collects L3 build evidence
+  twice per side.** The L2 include-dir seed and the P0.3 L3→L2
+  compile-context fold were two independent
+  `buildsource.inline.collect_inline_pack()` calls, diverging from
+  `buildsource.l2_seed.seed_includes_and_fold_compile_context()` — the
+  one combined primitive the three CLI-side resolvers (`dump`'s ELF and
+  PE/Mach-O paths, `scan`'s candidate resolution) already use for exactly
+  this reason (a caller genuinely needing the zero-config inferred
+  build-system query could self-deadlock on the same build-dir lock — see
+  `AGENTS.md`'s "Known gaps"). This path never actually hit that timeout
+  (Tier-2 API callers never allow the inferred query), but it was real,
+  avoidable duplicated work and a real divergence from the shared
+  primitive the other three call sites had already converged on. Fixed by
+  merging `_seeded_includes`/`_seeded_compile_context` into one
+  `_seeded_includes_and_compile_context()` that calls the same combined
+  primitive. Part of CLI cleanup phase two's PR 3A (typed `dump`/`scan`
+  convergence) — see the plan doc and `AGENTS.md`'s "Known gaps" for what
+  of that PR remains open and why.

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -667,6 +667,47 @@ pipelines a fourth time.
   migration seen from the code side; that entry does not yet mention the scan
   side explicitly, so this plan is the tracking place for that half until it
   does.
+
+  > **Investigated in depth; one real, scoped slice landed, the full
+  > convergence NOT attempted (2026-08-16).** `service_input_resolution.
+  > _seeded_includes`/`_seeded_compile_context` — the per-input primitive
+  > `compare`'s implicit-dump operand and `dump`'s typed API
+  > (`run_dump_request`) already share — ran the L2 include-dir seed and the
+  > P0.3 L3→L2 compile-context fold as two independent `collect_inline_pack()`
+  > calls, diverging from `seed_includes_and_fold_compile_context()`, the one
+  > combined primitive the three CLI-side resolvers (`perform_elf_dump`,
+  > `handle_non_elf_dump`, `scan_engine._build_new_snapshot`) already
+  > converged on for exactly this reason (self-deadlock risk under an inferred
+  > build query — see the L3→L2-fold "Known gaps" entry's own fifth finding).
+  > Fixed: merged into one `_seeded_includes_and_compile_context()`, using the
+  > same shared primitive the other three call sites use — closing one real
+  > piece of drift, verified by the existing test suite plus `mypy`/`ruff`.
+  > **The rest of PR 3A — routing `perform_elf_dump`/`handle_non_elf_dump`
+  > and `scan_engine._build_new_snapshot` themselves through
+  > `run_dump_request`, and making `dump --dry-run` render a real
+  > `DumpResult` — was not attempted**, for three concrete reasons found by
+  > reading the code, not assumed: (1) `dump --dry-run`
+  > (`render_dump_dry_run`) is today a hand-written *second*
+  > implementation, not a dry pass of the same resolver — `run_dump_request`
+  > has no "resolve without executing" mode to render from yet; (2)
+  > `perform_elf_dump` runs three post-processing passes after the primary
+  > snapshot (ADR-039 build-context collector, the G31 header-graph second
+  > pass, the optional clang-layout-tool attach), each with its own
+  > hard-won correctness fixes already recorded in `AGENTS.md`'s L3→L2-fold
+  > entry (findings 9/10/17/18), and `run_dump_request` has no equivalent
+  > hook; (3) `scan_engine._build_new_snapshot`'s side-aware `-H
+  > old=PATH`/`-I old=PATH` baseline-reuse decision (findings 12/13/15 on
+  > the same entry) is inherently about *two* snapshots' relationship,
+  > which the single-input `DumpRequest` shape cannot express without a new
+  > pair-aware primitive — exactly the class of decision `service_
+  > compare_pipeline.py`'s own docstring already says was deliberately kept
+  > out of the per-input layer. Each of the three is a real, separate,
+  > multi-file design on its own, not a follow-up edit to this slice; see
+  > the root `AGENTS.md` "Known gaps" entry (search "PR C (typed
+  > `dump`/`scan` convergence") for the full accounting, including why
+  > forcing any of the three under continued session pressure risks
+  > reopening one of the already-fixed findings this same area has needed
+  > many prior review rounds to reach.
 - **PR 3B — build-context completeness (the review's PR D).** Two #782
   follow-ups that change the *parsed public surface*, not just performance, so
   they belong before the model is called finished: (1) compile-unit matching —

--- a/tests/test_bazel_root_targets_l2_seed.py
+++ b/tests/test_bazel_root_targets_l2_seed.py
@@ -36,10 +36,13 @@ Covers, bottom-up:
 * ``l2_seed.seed_includes_and_fold_compile_context`` -- the scoped
   ``BuildConfig`` reaches ``collect_inline_pack``'s own ``build_config``
   argument (which drives ``bazel_targets=tuple(cfg.targets)``).
-* ``service_input_resolution._seeded_compile_context`` -- the typed API's
-  ``InputSpec.build_targets`` reaches the same seed via
-  ``l2_seed.derive_l2_compile_context``.
+* ``service_input_resolution._seeded_includes_and_compile_context`` -- the
+  typed API's ``InputSpec.build_targets`` reaches the same seed via the
+  identical ``l2_seed.seed_includes_and_fold_compile_context`` call (PR C,
+  typed dump/scan convergence, merged this module's own former two-call
+  shape into the one the other three CLI-side resolvers already used).
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -101,9 +104,7 @@ def test_seed_includes_and_fold_compile_context_scopes_collect_inline_pack(
         # test only needs the call to have happened with the right args.
         raise RuntimeError("stop before any real collection")
 
-    monkeypatch.setattr(
-        l2_seed_mod, "collect_inline_pack", _fake_collect_inline_pack
-    )
+    monkeypatch.setattr(l2_seed_mod, "collect_inline_pack", _fake_collect_inline_pack)
 
     seed_includes_and_fold_compile_context(
         headers=[header],
@@ -132,33 +133,42 @@ def test_seed_includes_and_fold_compile_context_scopes_collect_inline_pack(
     assert captured["build_config"].targets == ["//:math"]
 
 
-def test_seeded_compile_context_forwards_input_spec_build_targets(
+def test_seeded_includes_and_compile_context_forwards_input_spec_build_targets(
     monkeypatch, tmp_path: Path
 ) -> None:
-    """The typed API side: InputSpec.build_targets reaches
-    derive_l2_compile_context (and therefore the same collect_inline_pack
-    scoping) through service_input_resolution._seeded_compile_context."""
+    """The typed API side: InputSpec.build_targets reaches the combined
+    seed_includes_and_fold_compile_context call (and therefore its single
+    collect_inline_pack scoping) through
+    service_input_resolution._seeded_includes_and_compile_context.
+
+    PR C (typed dump/scan convergence) merged the typed API's own two
+    separate call paths (``_seeded_includes`` -> ``seed_l2_includes`` ->
+    ``derive_l2_include_dirs``, and ``_seeded_compile_context`` ->
+    ``derive_l2_compile_context``) into this one combined call -- see
+    ``_seeded_includes_and_compile_context``'s own docstring for why running
+    ``collect_inline_pack`` twice per side was a latent self-deadlock risk,
+    the same one already fixed for `dump`/`scan`'s three CLI-side resolvers.
+    This test used to be two (one per now-removed helper); both exercised
+    the identical `build_targets` gap through the same underlying
+    `collect_inline_pack` call, so one test on the combined function covers
+    what both did.
+    """
     from abicheck.api_types import InputSpec
     from abicheck.service_compare_evidence import SideEvidence
-    from abicheck.service_input_resolution import _seeded_compile_context
+    from abicheck.service_input_resolution import (
+        _seeded_includes_and_compile_context,
+    )
     from abicheck.service_scan import CompileContext
 
     captured: dict = {}
 
-    def _fake_derive_l2_compile_context(*, build_targets=(), **kwargs):
-        captured["build_targets"] = build_targets
-        return None, []
+    def _fake_collect_inline_pack(*, build_config, **kwargs):
+        captured["build_config"] = build_config
+        raise RuntimeError("stop before any real collection")
 
     import abicheck.buildsource.l2_seed as l2_seed_mod
 
-    monkeypatch.setattr(
-        l2_seed_mod, "derive_l2_compile_context", _fake_derive_l2_compile_context
-    )
-    monkeypatch.setattr(
-        "abicheck.service_input_resolution.derive_l2_compile_context",
-        _fake_derive_l2_compile_context,
-        raising=False,
-    )
+    monkeypatch.setattr(l2_seed_mod, "collect_inline_pack", _fake_collect_inline_pack)
 
     src = tmp_path / "src"
     src.mkdir()
@@ -172,45 +182,14 @@ def test_seeded_compile_context_forwards_input_spec_build_targets(
         collect_mode="build",
         dump_manifest=None,
     )
-    _seeded_compile_context(side, evidence)
-    assert captured["build_targets"] == ("//:math",)
-
-
-def test_seeded_includes_forwards_input_spec_build_targets(
-    monkeypatch, tmp_path: Path
-) -> None:
-    """The typed API's OWN, separate include-dir seed (_seeded_includes ->
-    seed_l2_includes -> derive_l2_include_dirs) has the identical gap as
-    _seeded_compile_context above -- a distinct call path, fixed the same
-    way."""
-    from abicheck.api_types import InputSpec
-    from abicheck.service_compare_evidence import SideEvidence
-    from abicheck.service_input_resolution import _seeded_includes
-    from abicheck.service_scan import CompileContext
-
-    captured: dict = {}
-
-    def _fake_derive_l2_include_dirs(*args, build_targets=(), **kwargs):
-        captured["build_targets"] = build_targets
-        return [], []
-
-    import abicheck.buildsource.l2_seed as l2_seed_mod
-
-    monkeypatch.setattr(
-        l2_seed_mod, "derive_l2_include_dirs", _fake_derive_l2_include_dirs
+    includes, ctx, applied, cleanups = _seeded_includes_and_compile_context(
+        side, evidence
     )
-
-    src = tmp_path / "src"
-    src.mkdir()
-    header = src / "api.h"
-    header.write_text("void f();\n", encoding="utf-8")
-
-    side = InputSpec(path=src / "lib.so", sources=src, build_targets=("//:math",))
-    evidence = SideEvidence(
-        headers=[header],
-        compile=CompileContext(),
-        collect_mode="build",
-        dump_manifest=None,
-    )
-    _seeded_includes(side, evidence)
-    assert captured["build_targets"] == ("//:math",)
+    assert captured["build_config"].targets == ["//:math"]
+    # The best-effort try/except inside seed_includes_and_fold_compile_context
+    # (same "degrade, never fatal" contract as derive_l2_include_dirs/
+    # derive_l2_compile_context) swallows the injected RuntimeError and
+    # degrades to the no-op result -- this test only needs the call to have
+    # happened with the right build_config, same as its combined-function
+    # sibling above.
+    assert (includes, ctx, applied, cleanups) == ([], evidence.compile, False, [])

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -1515,14 +1515,16 @@ def test_merge_l3_compile_context_none_explicit_uses_derived() -> None:
 def test_seeded_compile_context_noop_without_sources(tmp_path: Path) -> None:
     from abicheck.api_types import InputSpec
     from abicheck.service_compare_evidence import SideEvidence
-    from abicheck.service_input_resolution import _seeded_compile_context
+    from abicheck.service_input_resolution import _seeded_includes_and_compile_context
 
     side = InputSpec(path=tmp_path / "lib.so", headers=(tmp_path / "h.h",))
     evidence = SideEvidence(
         headers=[tmp_path / "h.h"], compile=None, collect_mode="off", dump_manifest=None
     )
-    ctx, applied, cleanups = _seeded_compile_context(side, evidence)
-    assert (ctx, applied, cleanups) == (None, False, [])
+    includes, ctx, applied, cleanups = _seeded_includes_and_compile_context(
+        side, evidence
+    )
+    assert (includes, ctx, applied, cleanups) == ([], None, False, [])
 
 
 def test_resolve_side_snapshot_stamps_parsed_with_build_context(

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -1527,6 +1527,48 @@ def test_seeded_compile_context_noop_without_sources(tmp_path: Path) -> None:
     assert (includes, ctx, applied, cleanups) == ([], None, False, [])
 
 
+def test_seeded_includes_and_compile_context_preserves_none_on_no_op_fold(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """Codex review, fresh evidence: `seed_includes_and_fold_compile_context`
+    always returns a real `CompileContext` for its own `l3_effective_context`
+    (built fresh from individual kwargs, never literally the caller's
+    `evidence.compile`) -- so when the fold finds nothing (`applied=False`)
+    and the caller supplied no context of its own, the wrapper must convert
+    that fabricated default back to `None` rather than silently promoting a
+    `None` into a real object. `service_dump_cache._dump_is_cacheable` only
+    permits caching when `compile is None`, so losing this distinction would
+    silently disable caching for an otherwise-cacheable typed dump/compare
+    operand whenever unrelated build evidence was supplied and matched
+    nothing."""
+    from abicheck.api_types import InputSpec
+    from abicheck.compile_context import CompileContext
+    from abicheck.service_compare_evidence import SideEvidence
+    from abicheck.service_input_resolution import _seeded_includes_and_compile_context
+
+    def _fake_seed(*, pending_cleanups, **kwargs):
+        # Mirrors the real primitive's own no-op-fold return shape: a fresh,
+        # default-valued CompileContext, not the caller's (here None) one.
+        return [], False, CompileContext(), ()
+
+    monkeypatch.setattr(
+        "abicheck.buildsource.l2_seed.seed_includes_and_fold_compile_context",
+        _fake_seed,
+    )
+
+    header = tmp_path / "h.h"
+    header.write_text("void f();\n", encoding="utf-8")
+    side = InputSpec(path=tmp_path / "lib.so", sources=tmp_path, headers=(header,))
+    evidence = SideEvidence(
+        headers=[header], compile=None, collect_mode="off", dump_manifest=None
+    )
+    includes, ctx, applied, cleanups = _seeded_includes_and_compile_context(
+        side, evidence
+    )
+    assert applied is False
+    assert ctx is None
+
+
 def test_resolve_side_snapshot_stamps_parsed_with_build_context(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_typed_dump_request.py
+++ b/tests/test_typed_dump_request.py
@@ -564,18 +564,34 @@ class TestBuildDerivedIncludeSeeding:
     def test_seeds_when_evidence_is_present_and_includes_are_empty(
         self, snap_path: Path, tmp_path: Path, monkeypatch
     ):
+        """PR C (typed dump/scan convergence) merged the typed API's own
+        two-call include-seed/compile-context-fold path into the one
+        combined `seed_includes_and_fold_compile_context` primitive the
+        three CLI-side resolvers already used -- see
+        `service_input_resolution._seeded_includes_and_compile_context`'s
+        own docstring. This test now mocks that combined function instead
+        of the removed `seed_l2_includes`.
+        """
         from abicheck import service
 
         seen: dict[str, object] = {}
         seeded = tmp_path / "generated-include"
         seeded.mkdir()
+        # The combined primitive is a no-op with no headers to match against
+        # (mirrors seed_l2_includes'/derive_l2_compile_context's own real
+        # no-op-without-headers contract) -- a header is required to reach it.
+        header = tmp_path / "api.h"
+        header.write_text("void f();\n", encoding="utf-8")
 
         def _fake_seed(**kwargs):
             seen["headers"] = list(kwargs["headers"])
-            seen["allow_inferred_build_query"] = kwargs["allow_inferred_build_query"]
-            return [seeded], []
+            seen["collect_mode"] = kwargs["collect_mode"]
+            return [seeded], False, None, ()
 
-        monkeypatch.setattr("abicheck.buildsource.l2_seed.seed_l2_includes", _fake_seed)
+        monkeypatch.setattr(
+            "abicheck.buildsource.l2_seed.seed_includes_and_fold_compile_context",
+            _fake_seed,
+        )
         captured: dict[str, object] = {}
         original = service.resolve_input
 
@@ -585,21 +601,32 @@ class TestBuildDerivedIncludeSeeding:
 
         monkeypatch.setattr(service, "resolve_input", _spy)
         service.run_dump_request(
-            DumpRequest(input=InputSpec(path=snap_path, build_info=tmp_path))
+            DumpRequest(
+                input=InputSpec(
+                    path=snap_path, headers=(header,), build_info=tmp_path
+                )
+            )
         )
         assert captured["includes"] == [seeded]
         # A Tier-2 call must never *execute* a build system as a side effect of
-        # resolving an input — passive discovery only.
-        assert seen["allow_inferred_build_query"] is False
+        # resolving an input — passive discovery only ("off" maps to
+        # allow_inferred_build_query=False inside the combined primitive).
+        assert seen["collect_mode"] == "off"
 
     def test_no_evidence_means_no_seeding_call(self, snap_path: Path, monkeypatch):
         """Without sources/build_info the seed is skipped entirely."""
         from abicheck import service
 
         def _boom(**kwargs):  # pragma: no cover - must never run
-            raise AssertionError("seed_l2_includes reached without build evidence")
+            raise AssertionError(
+                "seed_includes_and_fold_compile_context reached without "
+                "build evidence"
+            )
 
-        monkeypatch.setattr("abicheck.buildsource.l2_seed.seed_l2_includes", _boom)
+        monkeypatch.setattr(
+            "abicheck.buildsource.l2_seed.seed_includes_and_fold_compile_context",
+            _boom,
+        )
         snap = service.run_dump_request(DumpRequest(input=InputSpec(path=snap_path)))
         assert snap.library == "libfoo.so.1"
 
@@ -608,11 +635,19 @@ class TestBuildDerivedIncludeSeeding:
     ):
         """Seeded temp dirs are drained only after the parse consumed them."""
         from abicheck import service
+        from abicheck.compile_context import CompileContext
 
+        header = tmp_path / "api.h"
+        header.write_text("void f();\n", encoding="utf-8")
         order: list[str] = []
+
+        def _fake_seed(*, pending_cleanups, **kwargs):
+            pending_cleanups.append(lambda: order.append("cleanup"))
+            return [], False, CompileContext(), ()
+
         monkeypatch.setattr(
-            "abicheck.buildsource.l2_seed.seed_l2_includes",
-            lambda **kw: ([], [lambda: order.append("cleanup")]),
+            "abicheck.buildsource.l2_seed.seed_includes_and_fold_compile_context",
+            _fake_seed,
         )
         original = service.resolve_input
 
@@ -622,7 +657,11 @@ class TestBuildDerivedIncludeSeeding:
 
         monkeypatch.setattr(service, "resolve_input", _spy)
         service.run_dump_request(
-            DumpRequest(input=InputSpec(path=snap_path, build_info=tmp_path))
+            DumpRequest(
+                input=InputSpec(
+                    path=snap_path, headers=(header,), build_info=tmp_path
+                )
+            )
         )
         assert order == ["resolve", "cleanup"]
 


### PR DESCRIPTION
## Summary

Investigated CLI cleanup phase two's **PR C** (= plan's PR 3A, "typed `dump`+`scan` convergence") in depth. The plan asks for one canonical path — `Click parsing → DumpRequest → ResolvedDumpRequest → dry-run-or-execute → DumpResult` — with **both** `dump_cmd`/`perform_elf_dump` and `scan_engine._build_new_snapshot` routing through `service_dump_pipeline.run_dump_request`, the way `compare`'s implicit-dump operand already does.

**The full convergence is NOT attempted in this PR**, for three independent, concrete reasons confirmed by reading the actual code (not assumed) — recorded in full, with citations, in the root `AGENTS.md`'s "Known gaps" section under "PR C (typed `dump`/`scan` convergence)":

1. `dump --dry-run` (`render_dump_dry_run`) is a hand-written *second implementation* today, not a dry pass of the same resolver `perform_elf_dump` uses — its own docstring says as much. `run_dump_request` has no "resolve without executing" mode to render from.
2. `perform_elf_dump` runs three post-processing passes (ADR-039 build-context collector, the G31 header-graph second pass, the optional clang-layout-tool attach) with no equivalent hook in `run_dump_request`, each with its own already-fixed correctness bugs recorded in the same `AGENTS.md` section — rerouting risks reopening one of them.
3. `scan_engine._build_new_snapshot`'s side-aware `-H old=PATH` baseline handling is inherently about *two* snapshots' relationship, which `DumpRequest` (built for one input) has no field to express.

## What actually landed

One real, safely-scoped, verified slice of the convergence, independent of all three blockers above: `service_input_resolution._seeded_includes`/`_seeded_compile_context` — the shared per-input primitive `compare`'s implicit-dump operand and `dump`'s typed API (`run_dump_request`) both already use — ran the L2 include-dir seed and the P0.3 L3→L2 compile-context fold as **two independent** `buildsource.inline.collect_inline_pack()` calls, diverging from `buildsource.l2_seed.seed_includes_and_fold_compile_context()`, the one combined primitive the three CLI-side resolvers (`dump`'s ELF and PE/Mach-O paths, `scan`'s candidate resolution) already converged onto for exactly this reason — a caller genuinely needing the zero-config inferred build-system query could self-deadlock on the same build-dir lock (already documented in `AGENTS.md`'s L3→L2-fold entry, "fifth finding").

This typed-API path never actually hit that timeout (Tier-2 API callers never allow the inferred query — `collect_mode="off"`/`allow_inferred_build_query=False`), so it wasn't a live self-deadlock — but it was real, avoidable duplicated work and a real divergence from the shared primitive the other three call sites had already converged on, exactly the kind of drift PR C exists to close.

Fixed by merging the two helpers into one `_seeded_includes_and_compile_context()`, calling the identical `seed_includes_and_fold_compile_context()` the other three sites already use.

## Bug-fix test contract

- Bug class: Two independent build-evidence collections (`collect_inline_pack()` calls) inside one logical per-input resolution, diverging from the already-converged combined primitive the sibling CLI-side resolvers use for exactly this class of bug.
- Publicly observable failure: Real, avoidable duplicated work on every `compare`/`dump` typed-API call given `sources`/`build_info` evidence — not a crash or wrong output today (this path never allows the inferred query), but the exact latent self-deadlock shape already found and fixed for the three CLI-side resolvers, left open on the fourth, typed-API call site.
- Regression test fails on base: Yes — `tests/test_typed_dump_request.py`'s `TestBuildDerivedIncludeSeeding` tests, `tests/test_header_compile_context.py::test_seeded_compile_context_noop_without_sources`, and `tests/test_bazel_root_targets_l2_seed.py`'s combined-function test all target the new `_seeded_includes_and_compile_context` function/call shape directly; they fail against the pre-fix two-call code (different function names/signatures/mock targets).
- Negative control: `tests/test_typed_dump_request.py::test_no_evidence_means_no_seeding_call` — no `sources`/`build_info` still means the seed is skipped entirely; unaffected by this fix.
- Public-surface test: Exercised through `service.run_dump_request`/`DumpRequest`, the same public typed entry point `compare`'s implicit-dump path and `dump`'s Python API use — not an internal helper.
- Axes covered: The include-dir seed path and the compile-context-fold path, both now reached through one call (previously two independently-mockable/independently-failing calls).
- General invariant: Any per-input resolution needing real build evidence collects it through exactly one shared, already-established primitive — never two independent collections of the same evidence inside one logical operation. Mirrors the identical rule already enforced for the three CLI-side resolvers.
- Malicious fixture + side-effect absence: N/A — no new subprocess/env/file-write/trust-boundary-crossing logic; this merges two existing internal calls into one, both already passing `collect_mode="off"`/no build-system execution.

## Checklist

- [x] Tests added/updated: `tests/test_bazel_root_targets_l2_seed.py`, `tests/test_header_compile_context.py`, `tests/test_typed_dump_request.py` (all migrated to the merged call shape, not weakened — same assertions, same coverage)
- [x] Changelog fragment added (`changelog.d/20260816_191218_noreply_pr_c_seeded_includes_dedup.md`)
- [x] Docs updated: root `AGENTS.md`'s "Known gaps" gets a new, detailed entry; `docs/contribute/plans/cli-cleanup-phase-two.md`'s PR 3A section gets a status note in the same style as PR B's "Slice N landed" blockquotes
- [x] `mypy`/`ruff check` clean on touched files (repo-wide yaml-stub mypy noise is pre-existing/environment-only, unrelated to this diff)
- [x] `python scripts/check_ai_readiness.py` / `check_docs_contract.py`: 0 errors (only pre-existing warnings)
- [x] `mkdocs build --strict`: clean
- [x] Full fast unit suite + targeted test files (126 tests across the 3 touched test files) green

---
🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014j8RmwFdFJMD789hFxZvrd)_