### PR TITLE
fix: apply forced includes and matched-unit include dirs to the L2 header parse (CLI cleanup phase two, PR D / PR 3B)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1512,6 +1512,22 @@ Once a root command genuinely clears the bar above, pick the right home:
   is shared — each caller keeps its own basename derivation, since the
   adapter's is backslash-aware and `_argv`'s is not, and changing L4's would
   have been a behavior change outside this PR's scope.
+  (4) A fourth round found the file-hashing fix in (1) still missed the case
+  where a forced include is resolved only through the `-I` chain
+  (`-I /build/gen -include config`): the bare operand stats against
+  abicheck's own working directory rather than the build's, and the search
+  directory is walked only through the suffix-filtered
+  `iter_cache_header_files`, which skips an extensionless or `.def` name — so
+  nothing hashed the real file. `forced_include_operand_paths` now also emits
+  one candidate per include-search directory in the same token list, whether
+  or not it exists. Deliberate: `_cache_key` contributes a non-existent path's
+  string and moves on, a candidate that *starts* existing is a real change to
+  what the compiler resolves, and since the search is first-match-wins a
+  candidate under a directory the compiler would never reach can only
+  over-invalidate — a spurious miss, never a stale hit, which is the correct
+  direction for a cache key to err in. Worth noting how this one was found:
+  the previous round's own new test *pinned* the unresolved bare operand as
+  expected output, which made a real gap read as a settled decision.
   **Residual, deliberately unclosed:** because a
   forced include still never enters `abi_relevant_flags`, it is still not
   projected into a `BuildOption` by `derive_build_options`, so swapping one

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1471,8 +1471,8 @@ Once a root command genuinely clears the bar above, pick the right home:
   `service._attach_header_graph`, the L2 seed's own `derived_include_dirs`
   return) — covers the forced header's directory, closing for this input
   the same staleness class the tenth and seventeenth findings above each
-  had to close individually. **Two follow-on findings from the Codex review
-  of this same change, both real and both fixed.** (1) The cache-key channel
+  had to close individually. **Eight follow-on findings from review of this
+  same change, every one real and every one fixed.** (1) The cache-key channel
   takes directories and walks them with `iter_cache_header_files`, which is
   suffix-filtered by `CACHE_HEADER_SUFFIXES` — correct for "catch transitive
   includes under a search root", wrong for a file named explicitly because it
@@ -1585,6 +1585,21 @@ Once a root command genuinely clears the bar above, pick the right home:
   position, which the structured fields do not record. It can only matter for a
   command mixing spellings in one bucket (a structurally-captured GNU `-I`
   alongside an MSVC `/I`), which no single real driver accepts.
+  (8) An eighth round (CodeRabbit) found the dedup in (6) flattened the
+  caller's two option spellings through its own second copy of that
+  flattening, unguarded — so an unbalanced quote in the free-form
+  `gcc_options` string made `shlex` raise `ValueError: No closing quotation`
+  straight out of `resolve_header_compile_context`, aborting an L2
+  compile-context resolution that every caller treats as best-effort, over a
+  malformed *caller* string. `_explicit_pin_tokens` — the same module's own
+  flattening for the `_ExplicitPin` scan, ten lines away — already had the
+  guard and already documented why ("degrades to 'no tokens from it' rather
+  than raising, since this is only used to *widen* what's accepted"). The
+  duplicate is now routed through it, so there is one flattening definition
+  and one degrade rule rather than two that could disagree again. Worth
+  naming the shape, since it is the same one as (3): a second copy of an
+  existing primitive drifts from it silently, and the drift shows up as the
+  copy lacking a property the original was deliberately given.
   **Residual, deliberately unclosed:** because a
   forced include still never enters `abi_relevant_flags`, it is still not
   projected into a `BuildOption` by `derive_build_options`, so swapping one

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1567,6 +1567,24 @@ Once a root command genuinely clears the bar above, pick the right home:
   the *derived* copy dropped on a match, keeping the established "explicit
   wins" precedence and losing nothing, since both name the same file. A
   *different* explicit forced header does not suppress the derived one.
+  (7) A seventh round found the search chain (5) added resolved through the
+  *wrong order within a bucket*: it sorted the argv-derived dirs, because
+  `_build_context_include_dirs` returns a set and determinism was the stated
+  goal. But a compiler takes the **first** match in a bucket in argv order, so
+  `-iquote z -iquote a -include config.h` resolves `z/config.h` while the
+  sorted chain pinned `a/config.h` — a different file, potentially different
+  macros, i.e. deterministic and wrong. The lesson is the trade that was made
+  without noticing it was a trade: determinism was available *by preserving
+  argv order*, so sorting bought nothing and cost correctness. Fixed by
+  factoring `header_utils.build_context_include_dirs_ordered` out as the real
+  implementation (argv order, first-occurrence-wins dedup) with the
+  set-returning `_build_context_include_dirs` now a thin collapse of it — every
+  pre-existing caller only asks "is this directory covered", so none change.
+  One residual, recorded at the call site: within a bucket, structured entries
+  are emitted before argv-derived ones rather than interleaved by true argv
+  position, which the structured fields do not record. It can only matter for a
+  command mixing spellings in one bucket (a structurally-captured GNU `-I`
+  alongside an MSVC `/I`), which no single real driver accepts.
   **Residual, deliberately unclosed:** because a
   forced include still never enters `abi_relevant_flags`, it is still not
   projected into a `BuildOption` by `derive_build_options`, so swapping one

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1498,6 +1498,20 @@ Once a root command genuinely clears the bar above, pick the right home:
   as `compile=`. That is the same "close it where the tokens land, rather than
   threading a new channel" move the tenth and seventeenth findings made, now
   applied to the fourth and last header-parse cache key.
+  (3) A third round found the *dialect* vocabulary had drifted between the two
+  layers this work now shares a recognizer across:
+  `adapters.base._is_msvc_command` listed only `cl`/`clang-cl` while
+  `_argv.is_msvc_mode` (L4) also knew `dpcpp-cl` and version-suffixed drivers
+  (`clang-cl-20`). A CL-mode command spelled with GNU `-c` rather than `/c`
+  therefore read as GNU dialect on the build-evidence side, silently dropping
+  its `/FI` from the derived L2 context while L4 replayed it correctly. Fixed
+  at the cause rather than at the new call site: `header_utils.
+  is_msvc_driver_stem` is now the one vocabulary both use, so the fix also
+  reaches `_is_msvc_command`'s pre-existing consumers (source detection,
+  forced-language detection, structured-field masking). Only the *name* test
+  is shared — each caller keeps its own basename derivation, since the
+  adapter's is backslash-aware and `_argv`'s is not, and changing L4's would
+  have been a behavior change outside this PR's scope.
   **Residual, deliberately unclosed:** because a
   forced include still never enters `abi_relevant_flags`, it is still not
   projected into a `BuildOption` by `derive_build_options`, so swapping one

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1528,6 +1528,28 @@ Once a root command genuinely clears the bar above, pick the right home:
   direction for a cache key to err in. Worth noting how this one was found:
   the previous round's own new test *pinned* the unresolved bare operand as
   expected output, which made a real gap read as a settled decision.
+  (5) A fifth round found the rendered forced include could point at nothing:
+  `_context_flags` emits only the structured `include_paths`/
+  `system_include_paths`, and the compile-DB adapter parses only
+  `-I`/`-isystem` into those — so a unit resolving its forced include through
+  an argv-only `-iquote gen` or MSVC `/Igen` had that directory in neither
+  field, and a bare `-include config` was emitted into a command that could
+  not find it. That is *worse* than the pre-existing behaviour of not
+  forwarding the forced include at all: a hard "file not found", or silently
+  the wrong same-named file. Fixed by resolving the operand against the
+  unit's own full search chain (`_forced_include_search_dirs`: `directory`
+  first, then quote/normal/system/after-system buckets, each combining the
+  structured field with the argv-only spellings) and emitting the absolute
+  path of the first match — removing the dependency on the rendered search
+  order rather than betting on it. **Deliberately *not* done: rendering
+  argv-only search dirs into the derived context.** That is the wider,
+  pre-existing fidelity gap the same review names — a *transitively* included
+  header the build reaches through `-iquote` is still unreachable to the L2
+  parse — but closing it changes include search order for every matched unit,
+  a materially broader behaviour change than this function's own correctness
+  requires, and it interacts with the bucket-ordering gap `_split_include_
+  tokens` already documents (the sixth finding above). Recorded in
+  `_forced_include_flags`'s own docstring as a residual.
   **Residual, deliberately unclosed:** because a
   forced include still never enters `abi_relevant_flags`, it is still not
   projected into a `BuildOption` by `derive_build_options`, so swapping one

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1550,6 +1550,23 @@ Once a root command genuinely clears the bar above, pick the right home:
   requires, and it interacts with the bucket-ordering gap `_split_include_
   tokens` already documents (the sixth finding above). Recorded in
   `_forced_include_flags`'s own docstring as a residual.
+  (6) A sixth round found the same double-inclusion hazard that rules out
+  routing through `abi_relevant_flags`, reached from the other side:
+  `_merge_l3_compile_context` concatenates derived and explicit tokens
+  without deduplication, so a caller passing `--compiler-option -include
+  config.h` for a build whose compile database records the same forced header
+  got `-include config.h` **twice** — and an unguarded header is then
+  processed twice and fails to compile. Reproduced literally. This one is
+  worse than its arithmetic suggests, and the reason is worth keeping: the
+  caller passing the option by hand is precisely the one who was *working
+  around* the absence of this feature, so the duplicate would have broken
+  exactly the users the change exists to help. Fixed by
+  `explicit_forced_include_keys` (both caller spellings —
+  `gcc_option_tokens` and the free-form `gcc_options` string — each
+  contributing the operand as written and its resolved absolute path) with
+  the *derived* copy dropped on a match, keeping the established "explicit
+  wins" precedence and losing nothing, since both name the same file. A
+  *different* explicit forced header does not suppress the derived one.
   **Residual, deliberately unclosed:** because a
   forced include still never enters `abi_relevant_flags`, it is still not
   projected into a `BuildOption` by `derive_build_options`, so swapping one

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1299,6 +1299,31 @@ Once a root command genuinely clears the bar above, pick the right home:
   scoped fix reactive to one review comment on one PR. Documented in
   `_existing_include_dirs`'s own docstring alongside this entry.
 
+  **Closed by PR D (plan "PR 3B", build-context completeness), and the
+  cross-cutting worry above turned out to be obsolete rather than
+  addressed.** The entry says the fix needs restricting "both
+  `_existing_include_dirs`'s caller here *and* `_seeded_includes` in
+  `service_input_resolution.py`" — two independent call sites. That was
+  true when written; PR C (#795) since merged those two into one, so
+  `service_input_resolution._seeded_includes_and_compile_context` and all
+  three CLI-side resolvers now reach the seed through the single
+  `l2_seed.seed_includes_and_fold_compile_context`. There was one call site
+  left to restrict, not two. `HeaderCompileContextResolution` gained
+  `matched_units` (the tuple; `matched_unit_count` stays as a derived
+  property, so the two cannot drift), and the combined primitive now
+  resolves the compile context *before* seeding and passes
+  `resolution.matched_units` to `_existing_include_dirs` — falling back to
+  every unit only when nothing matched, which is the case the seed was
+  built for in the first place (a public header the compile DB does not
+  cover, reaching into a dependency SDK) and where there is no narrower set
+  to prefer. Reordering is otherwise unobservable: the one path that skips
+  the seed is the fail-closed ambiguity raise, which aborts the call either
+  way. Regression coverage:
+  `tests/test_build_context_completeness.py::TestIncludeSeedIsRestrictedToMatchedUnits`
+  (the positive case, the no-match fallback, and the `matched_units`/
+  `matched_unit_count` consistency), verified to fail against the pre-fix
+  `seed_units = units`.
+
   **A twelfth finding, from a further Codex review round (P1), on
   `run_scan_core`'s own forwarding of the folded context to the baseline
   parse — real and fixed.** The eighth finding above fixed `run_scan_core`
@@ -1387,6 +1412,78 @@ Once a root command genuinely clears the bar above, pick the right home:
   other pre-existing paths already depend on, not a scoped fix reactive
   to one review comment on this PR. Documented in `ABI_RELEVANT_FLAG_
   PREFIXES`'s own docstring alongside this entry.
+
+  **Closed by PR D (plan "PR 3B"), but *not* by the fix this entry
+  proposed — that fix was investigated and found to be actively wrong,
+  which is the part worth not rediscovering.** The gap is real and the
+  consequence stated above is accurate: the derived L2 `CompileContext`
+  never carried a matched compile unit's own macro-controlling
+  forced-include header, so the header parse saw a materially different
+  translation unit while still reporting a real match and stamping
+  `parsed_with_build_context`. But routing the fix through
+  `ABI_RELEVANT_FLAG_PREFIXES`/`extract_abi_relevant_flags`, as this entry
+  proposed, would have **broken L4 replay**, which already handles forced
+  includes correctly and by a different route:
+  `source_extractors._argv.replay_extra_flags` carries
+  `abi_relevant_flags` through (`_carry_abi_relevant_flags`) *and*,
+  separately and unconditionally, re-scans the unit's raw `argv` for
+  forced-include/include-search tokens (`_scan_argv_for_extra_flags`,
+  which is deliberately **not** passed the `seen` set the first pass
+  builds — see that function's own docstring for why deduping there was
+  itself a reverted bug). Capturing a forced include into
+  `abi_relevant_flags` would therefore have made every L4 replay command
+  carry `-include config.h` twice: a silent double inclusion that a header
+  without include guards turns into a hard redefinition error. The general
+  shape is worth naming, since this list has now attracted two fixes aimed
+  at it: `ABI_RELEVANT_FLAG_PREFIXES` is not the only channel a compile
+  unit's flags reach a consumer through, so "the flag is missing from the
+  list" is not by itself evidence that adding it to the list is the fix —
+  check which consumers already reach the same fact by another route first.
+  Closed at the layer that actually had the gap instead:
+  `header_utils.forced_include_operands` is now the one shared recognizer
+  (the same option vocabulary and the same separate/joined spellings
+  `_argv`'s replay matchers use, since `match_gnu_forced_include`/
+  `match_msvc_forced_include` moved into that leaf — the one that already
+  owns this codebase's include-flag vocabulary and that both consumers
+  already sit above, so sharing costs no new import edge — and `_argv`
+  imports them), and `header_compile_context._forced_include_flags` renders its
+  result into the L2 command straight from `cu.argv`, never through
+  `abi_relevant_flags` — so L4 replay is bit-for-bit untouched. Three
+  rendering decisions carry their own reasoning in the code: a relative
+  operand is pinned to the compile unit's own `directory` **only when that
+  resolves to a real file** (GCC documents a two-stage lookup, and pinning
+  a generated header the build finds through its `-I` chain to a
+  non-existent path would turn a header that would have been found into a
+  hard "file not found"); MSVC `/FI` renders as GNU `-include`, matching
+  what this module already does for `-D`/`-I`/`--sysroot=`, since the
+  consumer is always a GNU-driver castxml/clang invocation; and
+  `-include-pch` (version-locked to the compiler build that produced it,
+  which L2's castxml-bundled/host clang is not) plus `/FU` (managed C++/CLI
+  `#using`, naming no C/C++ header at all) are deliberately dropped rather
+  than rendered. Two consequences beyond the rendering itself: a forced
+  include now participates in `_EffectiveContextSignature`, so two units
+  forcing *different* macro-controlling headers fail closed instead of
+  silently applying whichever grouped first (equivalent spellings of the
+  *same* header still agree, since the signature compares the rendered
+  tokens); and `header_utils.cache_relevant_operand_dirs` — the union of
+  `include_operand_dirs` with the new `forced_include_operand_dirs`, now
+  used by all three header-parse cache keys (`service._dump_elf`,
+  `service._attach_header_graph`, the L2 seed's own `derived_include_dirs`
+  return) — covers the forced header's directory, closing for this input
+  the same staleness class the tenth and seventeenth findings above each
+  had to close individually. **Residual, deliberately unclosed:** because a
+  forced include still never enters `abi_relevant_flags`, it is still not
+  projected into a `BuildOption` by `derive_build_options`, so swapping one
+  build's forced-include header for another does not raise
+  `ABI_RELEVANT_BUILD_FLAG_CHANGED` (ADR-029 D9's build-evidence drift
+  signal). Closing *that* half needs a structured `CompileUnit` field every
+  adapter populates, a `BUILD_EVIDENCE_VERSION` bump and `build_diff`
+  wiring — a schema slice of its own, not a follow-on to the L2 rendering
+  fix, and specifically not another attempt to route it through this list.
+  Regression coverage: `tests/test_build_context_completeness.py` (the
+  recognizer, the rendered context, the ambiguity signature, the cache-key
+  union, and — as the executable record of the wrong fix —
+  `TestReplayStillEmitsForcedIncludesExactlyOnce`).
 
   **A fifteenth finding, from a further Codex review round (P1), on the
   thirteenth finding's own header-equality fix — a real gap in the fix

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1471,7 +1471,34 @@ Once a root command genuinely clears the bar above, pick the right home:
   `service._attach_header_graph`, the L2 seed's own `derived_include_dirs`
   return) — covers the forced header's directory, closing for this input
   the same staleness class the tenth and seventeenth findings above each
-  had to close individually. **Residual, deliberately unclosed:** because a
+  had to close individually. **Two follow-on findings from the Codex review
+  of this same change, both real and both fixed.** (1) The cache-key channel
+  takes directories and walks them with `iter_cache_header_files`, which is
+  suffix-filtered by `CACHE_HEADER_SUFFIXES` — correct for "catch transitive
+  includes under a search root", wrong for a file named explicitly because it
+  is *itself* part of the parse. A forced include routinely carries a suffix
+  that list does not name (`-imacros settings.def`) or none at all
+  (`-include generated/config`), so hashing only its parent left an edit to it
+  invisible while the unchanged option token kept the key identical. Fixed by
+  having `dumper_ast_config._cache_key` hash a non-directory entry's own mtime
+  directly (a strict widening — such an entry previously contributed only its
+  path string) and having `forced_include_operand_paths` return the file
+  alongside its parent; `cache_relevant_operand_dirs` was renamed
+  `cache_relevant_operand_paths` to stay honest about carrying both.
+  (2) The PE/Mach-O path never received the widened set at all:
+  `cli_dump_helpers.handle_non_elf_dump` binds the derived-dirs return as
+  `_l3_include_dirs` and discards it, since `dump_native_binary`/
+  `service.run_dump` exposes no `extra_hash_dirs` hook. Rather than thread one
+  through `run_dump`/`resolve_input` — the change this same entry's earlier
+  text assumed was required, carried by every caller of those — the fix is
+  local: `service_header_scoped._try_header_scoped_dump` folds
+  `cache_relevant_operand_paths(cc.gcc_option_tokens)` into its own
+  `deferred_dirs`, deriving the identical set from the very tokens those dirs
+  came from, since `handle_non_elf_dump` already passes the merged L3 context
+  as `compile=`. That is the same "close it where the tokens land, rather than
+  threading a new channel" move the tenth and seventeenth findings made, now
+  applied to the fourth and last header-parse cache key.
+  **Residual, deliberately unclosed:** because a
   forced include still never enters `abi_relevant_flags`, it is still not
   projected into a `BuildOption` by `derive_build_options`, so swapping one
   build's forced-include header for another does not raise

--- a/abicheck/buildsource/adapters/base.py
+++ b/abicheck/buildsource/adapters/base.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import hashlib
 from typing import Protocol, runtime_checkable
 
+from ...header_utils import is_msvc_driver_stem
 from ..build_evidence import BuildEvidence, BuildOption, CompileUnit
 
 # Source-file extension → normalized language token.
@@ -371,7 +372,6 @@ def source_from_argv(argv: list[str]) -> str:
 
 #: Driver basenames that mark a command as MSVC-dialect (``/`` introduces an
 #: option, not a path). ``clang-cl`` mimics ``cl`` exactly.
-_MSVC_DRIVERS: frozenset[str] = frozenset({"cl", "cl.exe", "clang-cl", "clang-cl.exe"})
 
 _MSVC_COMBINED_OPTION_PREFIXES: tuple[str, ...] = (
     "/fi",
@@ -391,9 +391,15 @@ def _is_msvc_command(argv: list[str]) -> bool:
     """True if *argv* uses MSVC/clang-cl option syntax (``/opt`` not paths).
 
     Detected either by the ``/c`` compile marker (GNU uses ``-c``) or by a
-    ``cl``/``clang-cl`` driver basename anywhere in the leading tokens (the
-    driver may be a full path, e.g. ``C:\\VS\\bin\\cl.exe``), or by clang's
-    explicit ``--driver-mode=cl`` spelling.
+    CL-mode driver basename anywhere in the leading tokens (the driver may be
+    a full path, e.g. ``C:\\VS\\bin\\cl.exe``), or by clang's explicit
+    ``--driver-mode=cl`` spelling.
+
+    Driver-name recognition is ``header_utils.is_msvc_driver_stem`` — the one
+    vocabulary the L4 replay path uses too, so ``dpcpp-cl`` and a
+    version-suffixed ``clang-cl-20`` are recognized here as well. They were
+    not, and a such a command spelled with GNU ``-c`` rather than ``/c`` then
+    read as GNU dialect on this side while L4 replayed it as CL (Codex review).
     """
     if "/c" in argv:
         return True
@@ -413,7 +419,7 @@ def _is_msvc_command(argv: list[str]) -> bool:
         if arg.lower() == "--driver-mode=cl":
             return True
         base = arg.replace("\\", "/").rsplit("/", 1)[-1].lower()
-        if base in _MSVC_DRIVERS:
+        if is_msvc_driver_stem(base):
             return True
         i += 1
     return False

--- a/abicheck/buildsource/adapters/base.py
+++ b/abicheck/buildsource/adapters/base.py
@@ -46,27 +46,42 @@ _LANG_BY_EXT: dict[str, str] = {
 #: toolchain flag with a dedicated finding). Per ADR-028 D3 these are risk/
 #: source-level signals — the artifact diff proves any concrete break.
 #:
-#: Known gap (Codex review, AGENTS.md's L3->L2 fold entry, not fixed here):
-#: does not include GNU/clang ``-include``/``-imacros`` or MSVC ``/FI``/``/FU``
-#: (forced pre-include) -- SOURCE_OPERAND_FLAGS below already recognizes these
-#: as value-taking for a *different* purpose (not mistaking the operand for
-#: the TU source file), but that recognition never feeds this list, so a
-#: matched compile unit's own forced-include header is silently absent from
-#: ``CompileUnit.abi_relevant_flags`` and therefore from
-#: ``header_compile_context``'s derived L2 ``CompileContext`` -- the P0.3
-#: L3->L2 fold (``buildsource.l2_seed.resolve_header_compile_context``,
-#: reached from ``dump``/``scan``/``compare``'s implicit-dump path alike)
-#: can report a real match (``matched_unit_count > 0``, ``parsed_with_
-#: build_context`` stamped) while still parsing without a macro-controlling
-#: forced-include header the real build always applies. Unlike this
-#: tuple's other prefix-only entries, ``-include``/``-imacros``/``/FI``
-#: always carry a required following value that must travel with them, so
-#: adding the bare prefix alone (the pattern every other entry here uses)
-#: would append only the flag, silently dropping the header filename that
-#: is the entire point -- a correct fix needs a new spaced-value-flag
-#: branch in :func:`extract_abi_relevant_flags` (mirroring, but distinct
-#: from, its existing ``-D``/``/D`` split-form handling), not a bare
-#: addition to this tuple.
+#: **Forced pre-includes (``-include``/``-imacros``/``/FI``) are deliberately
+#: NOT in this tuple, and the fix an earlier draft of this comment proposed --
+#: "a new spaced-value-flag branch in :func:`extract_abi_relevant_flags`" --
+#: was investigated and found to be actively wrong (PR D / plan PR 3B).** The
+#: L2 gap it described is real: ``header_compile_context``'s derived L2
+#: ``CompileContext`` never saw a matched compile unit's own macro-controlling
+#: forced-include header, so the P0.3 L3->L2 fold could report a real match
+#: (``matched_unit_count > 0``, ``parsed_with_build_context`` stamped) while
+#: still parsing without it. But routing the fix through *this* list would
+#: have broken L4 replay, which already handles forced includes correctly and
+#: by a different route: ``source_extractors._argv.replay_extra_flags``
+#: carries ``abi_relevant_flags`` through
+#: (``_carry_abi_relevant_flags``) **and**, separately and unconditionally,
+#: re-scans the unit's raw ``argv`` for forced-include/include-search tokens
+#: (``_scan_argv_for_extra_flags``, which is not passed the ``seen`` set the
+#: first pass builds). Capturing a forced include here would therefore have
+#: made every L4 replay command carry ``-include config.h`` **twice** -- a
+#: silent double-inclusion that a header without include guards turns into a
+#: hard redefinition error.
+#:
+#: The gap is closed at the layer that actually had it instead:
+#: ``header_utils.forced_include_operands`` is the one shared recognizer (the
+#: same option vocabulary and the same separate/joined spellings ``_argv``'s
+#: own replay matchers use, since those matchers live there now too), and
+#: ``header_compile_context._context_flags`` renders its result into the L2
+#: command directly from ``cu.argv`` -- never through
+#: ``abi_relevant_flags``, so L4 replay is untouched.
+#:
+#: Residual, deliberately-unclosed half: because a forced include is not in
+#: this tuple, it is still not projected into a ``BuildOption`` by
+#: :func:`derive_build_options`, so swapping one build's forced-include header
+#: for another does not raise ``ABI_RELEVANT_BUILD_FLAG_CHANGED`` (ADR-029
+#: D9's build-evidence drift signal). Closing *that* needs a structured
+#: ``CompileUnit`` field every adapter populates plus a
+#: ``BUILD_EVIDENCE_VERSION`` bump and ``build_diff`` wiring -- a schema slice
+#: of its own, not a follow-on to the L2 rendering fix. See ``AGENTS.md``.
 ABI_RELEVANT_FLAG_PREFIXES: tuple[str, ...] = (
     "-std=", "/std:", "-stdlib=",
     "--target=", "-target", "-mabi=", "/arch:", "-m32", "-m64",
@@ -265,7 +280,6 @@ SOURCE_OPERAND_FLAGS: frozenset[str] = frozenset({
     "-I", "-isystem", "-iquote", "-idirafter", "-D", "-U",
     "/FI", "/FU",
 })
-
 
 def _is_bare_input(arg: str, msvc: bool) -> bool:
     """Like :func:`_is_source_token` but without the known-extension requirement.

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -824,7 +824,39 @@ def _forced_include_search_dirs(cu: CompileUnit) -> list[Path]:
     return dirs
 
 
-def _forced_include_flags(cu: CompileUnit) -> list[str]:
+def explicit_forced_include_keys(explicit: CompileContext | None) -> frozenset[str]:
+    """Every forced pre-include the *caller* already supplies, as match keys.
+
+    Both spellings a caller can use reach here: ``gcc_option_tokens`` and the
+    free-form ``gcc_options`` string (split the same way the header command
+    builders split it). Each operand contributes two keys — the operand
+    exactly as written, and its resolved absolute path — so a derived
+    occurrence matches whether the two sides spell it identically or the
+    derived one has been pinned to an absolute path by
+    :func:`_forced_include_flags`'s own search-chain resolution.
+    """
+    if explicit is None:
+        return frozenset()
+    tokens = [
+        *explicit.gcc_option_tokens,
+        *split_gcc_options(explicit.gcc_options or ""),
+    ]
+    keys: set[str] = set()
+    for _option, operand in {
+        *forced_include_operands(tokens, msvc=False),
+        *forced_include_operands(tokens, msvc=True),
+    }:
+        keys.add(operand)
+        try:
+            keys.add(str(Path(operand).expanduser().resolve()))
+        except OSError:  # pragma: no cover - defensive, resolve() is strict=False
+            pass
+    return frozenset(keys)
+
+
+def _forced_include_flags(
+    cu: CompileUnit, *, explicit_forced_includes: frozenset[str] = frozenset()
+) -> list[str]:
     """Render *cu*'s own forced pre-includes as literal clang argv tokens.
 
     A build that forces a macro-controlling header in (``-include config.h``,
@@ -875,6 +907,24 @@ def _forced_include_flags(cu: CompileUnit) -> list[str]:
     relative token is the only honest thing to say about a file this side
     cannot locate.
 
+    *explicit_forced_includes* are the keys of every forced pre-include the
+    caller already supplies (:func:`explicit_forced_include_keys`), and a
+    derived occurrence matching one is **dropped** (Codex review, PR D, fifth
+    round). ``_merge_l3_compile_context`` concatenates derived and explicit
+    tokens without deduplication, so without this a caller passing
+    ``--compiler-option -include config.h`` for a build whose compile database
+    records the same forced header gets ``-include config.h`` **twice** — and
+    a header without include guards is then processed twice and fails to
+    compile. This is the identical double-inclusion hazard that rules out
+    routing forced includes through ``CompileUnit.abi_relevant_flags`` (see
+    ``ABI_RELEVANT_FLAG_PREFIXES``'s comment), reached from the other side.
+    It matters more than the arithmetic suggests: the caller passing the
+    option by hand is precisely the one who was *working around* the absence
+    of this feature, so the duplicate would break exactly the users this
+    change is meant to help. Dropping the derived copy rather than the
+    explicit one keeps the established "explicit wins" precedence, and loses
+    nothing — both name the same file.
+
     **Residual, pre-existing and deliberately not fixed here:**
     ``_context_flags`` still does not render argv-only include-search
     directories at all, so a *transitively* included header that the real
@@ -901,13 +951,26 @@ def _forced_include_flags(cu: CompileUnit) -> list[str]:
                 (d / operand_path for d in search_dirs if (d / operand_path).is_file()),
                 None,
             )
-        flags.extend(
-            [rendered_option, resolved.as_posix() if resolved is not None else operand]
-        )
+        rendered_operand = resolved.as_posix() if resolved is not None else operand
+        if explicit_forced_includes and (
+            operand in explicit_forced_includes
+            or rendered_operand in explicit_forced_includes
+            or (
+                resolved is not None
+                and str(resolved.resolve()) in explicit_forced_includes
+            )
+        ):
+            continue
+        flags.extend([rendered_option, rendered_operand])
     return flags
 
 
-def _context_flags(cu: CompileUnit, *, forced_language: str | None = None) -> list[str]:
+def _context_flags(
+    cu: CompileUnit,
+    *,
+    forced_language: str | None = None,
+    explicit_forced_includes: frozenset[str] = frozenset(),
+) -> list[str]:
     """Render one ``CompileUnit``'s context as literal castxml/clang argv tokens.
 
     Mirrors ``BuildContext.to_castxml_flags()`` (ADR-020a's ``-p``/
@@ -1010,7 +1073,9 @@ def _context_flags(cu: CompileUnit, *, forced_language: str | None = None) -> li
     # function just rendered above it. Order within the group is the build's
     # own: forced includes are cumulative, never last-one-wins, so none of
     # the override reasoning that governs the tokens above applies here.
-    flags.extend(_forced_include_flags(cu))
+    flags.extend(
+        _forced_include_flags(cu, explicit_forced_includes=explicit_forced_includes)
+    )
     return flags
 
 
@@ -1163,7 +1228,11 @@ def resolve_header_compile_context(
         )
 
     ((_sig, units),) = by_signature.items()
-    flags = _context_flags(units[0], forced_language=forced_language)
+    flags = _context_flags(
+        units[0],
+        forced_language=forced_language,
+        explicit_forced_includes=explicit_forced_include_keys(explicit),
+    )
     context = CompileContext(gcc_option_tokens=tuple(flags))
     return HeaderCompileContextResolution(context=context, matched_units=tuple(matched))
 

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -844,13 +844,19 @@ def explicit_forced_include_keys(explicit: CompileContext | None) -> frozenset[s
     occurrence matches whether the two sides spell it identically or the
     derived one has been pinned to an absolute path by
     :func:`_forced_include_flags`'s own search-chain resolution.
+
+    Flattening goes through :func:`_explicit_pin_tokens`, the one place this
+    module combines a caller's two option spellings, rather than a second copy
+    of it: an unbalanced quote in the free-form ``gcc_options`` string makes
+    ``shlex`` raise, and a duplicated flattening here raised it straight out of
+    a resolution path documented as best-effort — aborting the whole L2
+    compile-context resolution over a malformed *caller* string instead of
+    degrading to "the caller supplies no forced include", which only ever
+    widens what the derived side may contribute.
     """
     if explicit is None:
         return frozenset()
-    tokens = [
-        *explicit.gcc_option_tokens,
-        *split_gcc_options(explicit.gcc_options or ""),
-    ]
+    tokens = _explicit_pin_tokens(explicit)
     keys: set[str] = set()
     for _option, operand in {
         *forced_include_operands(tokens, msvc=False),

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -78,7 +78,7 @@ from typing import TYPE_CHECKING
 from .._compiler_options import explicit_language_standard, split_gcc_options
 from ..compile_context import CompileContext
 from ..errors import HeaderCompileContextAmbiguousError
-from ..header_utils import iter_directory_headers
+from ..header_utils import forced_include_operands, iter_directory_headers
 from .adapters.base import _is_msvc_command
 from .build_query import PRUNED_HEADER_DIR_SEGMENTS
 
@@ -549,6 +549,16 @@ class _EffectiveContextSignature:
     flag that produced it differently (``--target=X`` vs. ``-target X``)
     compare equal here instead of falsely disagreeing, whether or not the
     caller pinned anything.
+
+    ``forced_includes`` (plan PR 3B / PR D) compares exactly the tokens
+    :func:`_forced_include_flags` would *render*, not the raw argv spellings —
+    so two units forcing the same header in through a different-but-equivalent
+    spelling (``-include cfg.h`` vs. ``/FIcfg.h``, or a relative vs. absolute
+    operand resolving to the same real file) agree, while two units forcing in
+    genuinely *different* macro-controlling headers now disagree and fail
+    closed. Before this field existed a forced include was invisible to the
+    whole comparison, so that second case silently applied whichever unit
+    happened to group first.
     """
 
     language: str
@@ -560,6 +570,7 @@ class _EffectiveContextSignature:
     include_paths: tuple[str, ...]
     system_include_paths: tuple[str, ...]
     abi_relevant_flags: tuple[str, ...]
+    forced_includes: tuple[str, ...] = ()
 
     @classmethod
     def of(
@@ -585,6 +596,7 @@ class _EffectiveContextSignature:
                     msvc=_is_msvc_command(cu.argv),
                 )
             ),
+            forced_includes=tuple(_forced_include_flags(cu)),
         )
 
 
@@ -728,6 +740,73 @@ def _standard_conflicts_with_forced_language(
     return derived_family is not None and derived_family != forced_language
 
 
+#: Forced-include options :func:`_forced_include_flags` deliberately does NOT
+#: render into the L2 header-parse command, mapped to the reason:
+#:
+#: ``-include-pch`` — a precompiled header is locked to the exact compiler
+#: build that produced it. L2 parses with castxml's own bundled Clang or the
+#: host ``clang``, never necessarily the build's compiler, so replaying a
+#: ``.pch`` is a hard parse failure far more often than it is a fidelity win.
+#: L4 replay, which *does* use the real compiler, still carries it
+#: (``_argv.replay_extra_flags``).
+#:
+#: ``/FU`` — MSVC's forced ``#using`` of a managed (C++/CLI) assembly. It
+#: names no C/C++ header and has no GNU-driver equivalent to render as, so
+#: there is nothing to forward. It is not in ``adapters.base``'s recognizer
+#: vocabulary at all for the same reason.
+_UNRENDERABLE_FORCED_INCLUDE_OPTS = frozenset({"-include-pch"})
+
+
+def _forced_include_flags(cu: CompileUnit) -> list[str]:
+    """Render *cu*'s own forced pre-includes as literal clang argv tokens.
+
+    A build that forces a macro-controlling header in (``-include config.h``,
+    ``/FIconfig.h``) parses its own headers with that header's macros already
+    defined; an L2 header parse that omits it sees a materially different
+    translation unit — different ``#if`` branches taken, different struct
+    layouts — while still reporting a real compile-unit match and stamping
+    ``AbiSnapshot.parsed_with_build_context``. That is the gap this closes
+    (plan PR 3B / PR D, "build-context completeness").
+
+    Read straight from ``cu.argv`` via the shared recognizer in
+    :func:`~abicheck.header_utils.forced_include_operands`, **not**
+    from ``cu.abi_relevant_flags``: routing forced includes through that list
+    instead would double-emit them on every L4 replay command, since
+    ``_argv.replay_extra_flags`` both carries ``abi_relevant_flags`` and
+    independently re-scans raw argv for the same tokens. See
+    ``ABI_RELEVANT_FLAG_PREFIXES``'s own comment for the full accounting.
+
+    MSVC's ``/FI`` renders as GNU ``-include``, matching what this module
+    already does for every other field — ``-D``/``-I``/``--sysroot=`` are all
+    rendered GNU-style regardless of the recorded command's dialect, because
+    the consumer is always a GNU-driver castxml/clang invocation
+    (``dumper_ast_config``). See :data:`_UNRENDERABLE_FORCED_INCLUDE_OPTS` for
+    the two spellings that are deliberately dropped instead.
+
+    The operand is resolved against ``cu.directory`` (the compile command's
+    own cwd, which abicheck's is not) **only when that resolves to a real
+    file**. A bare ``-include config.h`` naming a generated header the build
+    finds through its ``-I`` chain must stay relative, or pinning it to a
+    non-existent ``<directory>/config.h`` would turn a header the include
+    search would have found into a hard "file not found" — GCC documents
+    exactly this two-stage lookup ("first searched in the preprocessor's
+    working directory", then the ``-iquote``/``-I`` chain), and the second
+    stage is the one this fallback preserves.
+    """
+    flags: list[str] = []
+    for option, operand in forced_include_operands(
+        cu.argv, msvc=_is_msvc_command(cu.argv)
+    ):
+        if option in _UNRENDERABLE_FORCED_INCLUDE_OPTS:
+            continue
+        rendered_option = "-include" if option == "/FI" else option
+        resolved = _resolve_cu_relative_path(operand, cu.directory)
+        flags.extend(
+            [rendered_option, resolved.as_posix() if resolved.is_file() else operand]
+        )
+    return flags
+
+
 def _context_flags(cu: CompileUnit, *, forced_language: str | None = None) -> list[str]:
     """Render one ``CompileUnit``'s context as literal castxml/clang argv tokens.
 
@@ -827,6 +906,11 @@ def _context_flags(cu: CompileUnit, *, forced_language: str | None = None) -> li
             f, cu_standard=cu.standard, msvc=_is_msvc_command(cu.argv)
         )
     )
+    # Last, so a forced header resolves through the include search this
+    # function just rendered above it. Order within the group is the build's
+    # own: forced includes are cumulative, never last-one-wins, so none of
+    # the override reasoning that governs the tokens above applies here.
+    flags.extend(_forced_include_flags(cu))
     return flags
 
 
@@ -837,14 +921,28 @@ class HeaderCompileContextResolution:
     ``context`` is ``None`` whenever there was nothing to apply (no L3
     evidence, or no ``CompileUnit`` references any of the requested headers)
     — a plain, silent degrade to the pre-P0.3 behavior, never an error.
-    ``matched_unit_count`` is the number of distinct ``CompileUnit``s found to
-    reference the requested headers, always > 0 when ``context`` is not
-    ``None`` (used by callers to decide whether to stamp
-    ``AbiSnapshot.parsed_with_build_context``).
+
+    ``matched_units`` are the distinct ``CompileUnit``s found to reference the
+    requested headers (after any explicit-language narrowing), always
+    non-empty when ``context`` is not ``None``. Exposing the units themselves
+    — not just how many there were — is what lets a caller restrict *other*
+    build-derived L2 inputs to the same set: ``l2_seed``'s include-dir seed
+    used to gather dirs from every compile unit in the build, so in a
+    multi-TU project an unrelated TU's own generated-header directory could
+    ride along and shadow the matched TU's own colliding header, on a run
+    that then stamped ``parsed_with_build_context`` from this (separate)
+    successful resolution (plan PR 3B / PR D).
+
+    ``matched_unit_count`` stays as the derived read view callers already use
+    to decide whether to stamp ``AbiSnapshot.parsed_with_build_context``.
     """
 
     context: CompileContext | None = None
-    matched_unit_count: int = 0
+    matched_units: tuple[CompileUnit, ...] = ()
+
+    @property
+    def matched_unit_count(self) -> int:
+        return len(self.matched_units)
 
     @property
     def matched(self) -> bool:
@@ -967,9 +1065,7 @@ def resolve_header_compile_context(
     ((_sig, units),) = by_signature.items()
     flags = _context_flags(units[0], forced_language=forced_language)
     context = CompileContext(gcc_option_tokens=tuple(flags))
-    return HeaderCompileContextResolution(
-        context=context, matched_unit_count=len(matched)
-    )
+    return HeaderCompileContextResolution(context=context, matched_units=tuple(matched))
 
 
 def _ambiguity_message(
@@ -981,18 +1077,24 @@ def _ambiguity_message(
         f"Public header(s) [{header_names}] are compiled under "
         f"{len(by_signature)} materially different, ABI-relevant compile "
         "contexts across the available L3 build evidence (differing "
-        "-std=/target/defines/include-search-order/sysroot/ABI-relevant "
-        "flags); abicheck cannot pick one context over another without "
-        "guessing. Narrow the input (--compile-db-filter / a project "
+        "-std=/target/defines/include-search-order/sysroot/forced-includes/"
+        "ABI-relevant flags); abicheck cannot pick one context over another "
+        "without guessing. Narrow the input (--compile-db-filter / a project "
         "compile: block / --compiler-option pinning the ambiguous field(s)) or "
         "compare a header per contract at a time. Conflicting translation "
         "units:",
     ]
+    # Only shown when some signature actually has one, so the common
+    # (forced-include-free) message is unchanged -- but shown for *every*
+    # signature once any does, since "this one forces nothing" is exactly
+    # half of that disagreement and an omitted field reads as agreement.
+    show_forced = any(sig.forced_includes for sig in by_signature)
     for sig, units in sorted(by_signature.items(), key=lambda kv: kv[0].standard):
         sample = units[0]
+        forced = f" forced_includes={list(sig.forced_includes)}" if show_forced else ""
         lines.append(
             f"  - {sample.source or sample.id!r}: std={sig.standard or '(default)'} "
             f"target={sig.target_triple or '(default)'} "
-            f"abi_flags={list(sig.abi_relevant_flags)}"
+            f"abi_flags={list(sig.abi_relevant_flags)}{forced}"
         )
     return "\n".join(lines)

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -756,6 +756,73 @@ def _standard_conflicts_with_forced_language(
 #: vocabulary at all for the same reason.
 _UNRENDERABLE_FORCED_INCLUDE_OPTS = frozenset({"-include-pch"})
 
+#: The compile unit's own include-search chain, in the order a real
+#: preprocessor consults it, expressed as the argv prefixes each bucket is
+#: spelled with. Only used to *locate* a forced pre-include (see
+#: :func:`_forced_include_search_dirs`); the structured ``include_paths``/
+#: ``system_include_paths`` fields are folded into the matching buckets by
+#: that function, since the compile-DB adapter parses ``-I``/``-isystem`` into
+#: them while leaving every other spelling in argv only.
+_FORCED_INCLUDE_SEARCH_BUCKETS: tuple[tuple[str, ...], ...] = (
+    ("-iquote",),
+    ("-I", "/I"),
+    ("-isystem", "-cxx-isystem", "/imsvc", "/external:I"),
+    ("-idirafter",),
+)
+
+
+def _forced_include_search_dirs(cu: CompileUnit) -> list[Path]:
+    """Where *cu*'s own compile command would look for a forced pre-include.
+
+    GCC and Clang both resolve ``-include foo`` against the preprocessor's
+    working directory first and the include-search chain after, so this is
+    that chain: the unit's ``directory``, then quote-bucket dirs, then the
+    normal ``-I`` bucket, then system dirs, then after-system dirs.
+
+    Both halves of each bucket are needed, and that is the point (Codex
+    review, PR D, fourth round): the compile-DB adapter parses only
+    ``-I``/``-isystem`` into the structured ``include_paths``/
+    ``system_include_paths`` fields, leaving ``-iquote``/``/I``/``-idirafter``
+    in argv alone — so a unit that resolves its forced include through
+    ``-iquote gen`` has that directory in *neither* structured field.
+    Consulting argv here is what lets :func:`_forced_include_flags` emit an
+    absolute, always-resolvable path instead of a bare operand the rendered
+    command could not find.
+
+    Deterministic: structured entries keep their recorded order, argv-derived
+    dirs within a bucket are sorted (``_build_context_include_dirs`` returns a
+    set), so the same compile unit always yields the same chain.
+    """
+    from ..header_utils import _build_context_include_dirs
+
+    argv = list(cu.argv)
+    structured: dict[str, list[str]] = {
+        "-I": list(cu.include_paths),
+        "-isystem": list(cu.system_include_paths),
+    }
+    dirs: list[Path] = []
+    if cu.directory:
+        dirs.append(Path(cu.directory).expanduser())
+    for bucket in _FORCED_INCLUDE_SEARCH_BUCKETS:
+        for prefix in bucket:
+            dirs.extend(
+                _resolve_cu_relative_path(d, cu.directory)
+                for d in structured.get(prefix, ())
+            )
+        if argv:
+            dirs.extend(
+                Path(d)
+                for d in sorted(
+                    _build_context_include_dirs(
+                        argv,
+                        base_dir=cu.directory or None,
+                        expand_user=True,
+                        prefixes=bucket,
+                    )
+                )
+            )
+    return dirs
+
 
 def _forced_include_flags(cu: CompileUnit) -> list[str]:
     """Render *cu*'s own forced pre-includes as literal clang argv tokens.
@@ -783,16 +850,41 @@ def _forced_include_flags(cu: CompileUnit) -> list[str]:
     (``dumper_ast_config``). See :data:`_UNRENDERABLE_FORCED_INCLUDE_OPTS` for
     the two spellings that are deliberately dropped instead.
 
-    The operand is resolved against ``cu.directory`` (the compile command's
-    own cwd, which abicheck's is not) **only when that resolves to a real
-    file**. A bare ``-include config.h`` naming a generated header the build
-    finds through its ``-I`` chain must stay relative, or pinning it to a
-    non-existent ``<directory>/config.h`` would turn a header the include
-    search would have found into a hard "file not found" — GCC documents
-    exactly this two-stage lookup ("first searched in the preprocessor's
-    working directory", then the ``-iquote``/``-I`` chain), and the second
-    stage is the one this fallback preserves.
+    The operand is resolved against the compile unit's **own search chain**
+    (:func:`_forced_include_search_dirs`) — its ``directory`` first, then the
+    include buckets in the order a real preprocessor consults them, exactly
+    the two-stage lookup GCC documents for ``-include`` ("first searched in
+    the preprocessor's working directory", then the ``-iquote``/``-I``
+    chain) — and emitted as the absolute path of the first existing match.
+
+    Resolving through the *whole* chain rather than ``directory`` alone is
+    load-bearing, not a refinement (Codex review, PR D, fourth round). This
+    function renders a forced include into a command whose include-search
+    flags are **not** the unit's own: ``_context_flags`` emits only the
+    structured ``include_paths``/``system_include_paths``, so an argv-only
+    ``-iquote gen`` or MSVC ``/Igen`` is absent from the rendered command
+    entirely. Emitting a bare ``-include config`` that only that missing
+    directory could resolve would turn a working parse into a hard "file not
+    found", or silently select a different same-named file — strictly worse
+    than the pre-existing behaviour of not forwarding the forced include at
+    all. Pinning the absolute path removes the dependency on the rendered
+    search order instead of betting on it.
+
+    An operand that matches nowhere in the chain is emitted as written: it may
+    still be found through a search path the caller supplies, and a bare
+    relative token is the only honest thing to say about a file this side
+    cannot locate.
+
+    **Residual, pre-existing and deliberately not fixed here:**
+    ``_context_flags`` still does not render argv-only include-search
+    directories at all, so a *transitively* included header that the real
+    build reaches through ``-iquote``/``/I`` remains unreachable to the L2
+    parse. That is a fidelity gap in the derived context predating forced
+    includes — closing it changes include search order for every matched
+    unit, which is a materially wider behaviour change than this function's
+    own correctness needs. See ``AGENTS.md``.
     """
+    search_dirs = _forced_include_search_dirs(cu)
     flags: list[str] = []
     for option, operand in forced_include_operands(
         cu.argv, msvc=_is_msvc_command(cu.argv)
@@ -800,9 +892,17 @@ def _forced_include_flags(cu: CompileUnit) -> list[str]:
         if option in _UNRENDERABLE_FORCED_INCLUDE_OPTS:
             continue
         rendered_option = "-include" if option == "/FI" else option
-        resolved = _resolve_cu_relative_path(operand, cu.directory)
+        operand_path = Path(operand).expanduser()
+        resolved: Path | None = None
+        if operand_path.is_absolute():
+            resolved = operand_path if operand_path.is_file() else None
+        else:
+            resolved = next(
+                (d / operand_path for d in search_dirs if (d / operand_path).is_file()),
+                None,
+            )
         flags.extend(
-            [rendered_option, resolved.as_posix() if resolved.is_file() else operand]
+            [rendered_option, resolved.as_posix() if resolved is not None else operand]
         )
     return flags
 

--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -789,11 +789,23 @@ def _forced_include_search_dirs(cu: CompileUnit) -> list[Path]:
     absolute, always-resolvable path instead of a bare operand the rendered
     command could not find.
 
-    Deterministic: structured entries keep their recorded order, argv-derived
-    dirs within a bucket are sorted (``_build_context_include_dirs`` returns a
-    set), so the same compile unit always yields the same chain.
+    Order within a bucket is the command line's own, not sorted (Codex review,
+    PR D, sixth round). A compiler takes the *first* match in a bucket, so
+    ``-iquote z -iquote a -include config.h`` resolves ``z/config.h``; sorting
+    would pin the derived parse to ``a/config.h`` — deterministic, and a
+    different file with potentially different macros.
+    :func:`~abicheck.header_utils.build_context_include_dirs_ordered` exists
+    for exactly this, and is deterministic by preserving argv order rather
+    than by discarding it.
+
+    **Residual:** within one bucket, structured entries are emitted before
+    argv-derived ones rather than interleaved by their true argv positions —
+    the structured fields record no position. This can only matter for a
+    command mixing spellings in the same bucket (a GNU ``-I``, captured
+    structurally, alongside an MSVC ``/I``, which is not), which no single
+    real driver accepts.
     """
-    from ..header_utils import _build_context_include_dirs
+    from ..header_utils import build_context_include_dirs_ordered
 
     argv = list(cu.argv)
     structured: dict[str, list[str]] = {
@@ -812,13 +824,11 @@ def _forced_include_search_dirs(cu: CompileUnit) -> list[Path]:
         if argv:
             dirs.extend(
                 Path(d)
-                for d in sorted(
-                    _build_context_include_dirs(
-                        argv,
-                        base_dir=cu.directory or None,
-                        expand_user=True,
-                        prefixes=bucket,
-                    )
+                for d in build_context_include_dirs_ordered(
+                    argv,
+                    base_dir=cu.directory or None,
+                    expand_user=True,
+                    prefixes=bucket,
                 )
             )
     return dirs

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -591,7 +591,7 @@ def _split_include_tokens(
 def _include_operand_dirs(tokens: tuple[str, ...]) -> tuple[Path, ...]:
     """Every directory in *tokens* an AST cache key must cover for staleness.
 
-    Thin alias for :func:`~abicheck.header_utils.cache_relevant_operand_dirs`
+    Thin alias for :func:`~abicheck.header_utils.cache_relevant_operand_paths`
     -- the extraction moved to ``header_utils`` (a leaf module ``service.py``
     already imports from too) once ``service._attach_header_graph``'s own
     independent second header parse needed the identical extraction for its
@@ -601,9 +601,9 @@ def _include_operand_dirs(tokens: tuple[str, ...]) -> tuple[Path, ...]:
     PR D). Kept here under its original private name so this module's own
     callers/tests don't need updating.
     """
-    from ..header_utils import cache_relevant_operand_dirs
+    from ..header_utils import cache_relevant_operand_paths
 
-    return cache_relevant_operand_dirs(tokens)
+    return cache_relevant_operand_paths(tokens)
 
 
 def seed_includes_and_fold_compile_context(

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -218,19 +218,22 @@ def _existing_include_dirs(units: Iterable[Any]) -> list[str]:
     existence check — otherwise every home-rooted include dir (the common CI
     case this fallback targets) would be silently dropped.
 
-    Known gap (Codex review, not fixed here): deliberately scans *every*
-    compile unit, not only the one(s) ``resolve_header_compile_context``
-    matches to the headers actually being parsed -- ``HeaderCompileContext
-    Resolution`` exposes only a ``matched_unit_count``, not which units
-    matched, so there is no narrower set to restrict to without widening
-    that return shape. In a multi-TU build an unrelated TU's own generated
-    header directory (e.g. a colliding ``config.h``) can therefore ride
-    along in this seed and shadow the matched TU's own header for a caller
-    that also stamps ``parsed_with_build_context`` from the (separate)
-    successful fold — same pre-existing shape as ``service_input_
-    resolution._seeded_includes``/``_seeded_compile_context``, which
-    `compare`'s implicit-dump path already combines identically. See
-    AGENTS.md's "Known gaps" entry for the same note.
+    Scans exactly the *units* it is handed, and it is the caller's job to hand
+    it the narrowest honest set. :func:`seed_includes_and_fold_compile_context`
+    passes ``HeaderCompileContextResolution.matched_units`` whenever the fold
+    matched any (plan PR 3B / PR D), closing the gap where an unrelated TU's
+    own generated-header directory could ride along in this seed and shadow
+    the matched TU's own colliding header — on a run that then stamped
+    ``parsed_with_build_context`` from the (separate) successful fold, so it
+    read as *more* authoritative than the seed actually was. It falls back to
+    every compile unit only when nothing matched, which is the case this seed
+    was built for in the first place (a public header the compile DB does not
+    cover, reaching into a dependency SDK) and where there is no narrower set
+    to prefer.
+
+    :func:`derive_l2_include_dirs` still passes every unit, and correctly so:
+    it takes no ``headers`` argument at all, so it has nothing to match
+    against.
     """
     seen: set[str] = set()
     out: list[str] = []
@@ -586,18 +589,21 @@ def _split_include_tokens(
 
 
 def _include_operand_dirs(tokens: tuple[str, ...]) -> tuple[Path, ...]:
-    """The directory operand of every include-search token in *tokens*.
+    """Every directory in *tokens* an AST cache key must cover for staleness.
 
-    Thin alias for :func:`~abicheck.header_utils.include_operand_dirs` --
-    moved there (a leaf module ``service.py`` already imports from too) once
-    ``service._attach_header_graph``'s own independent second header parse
-    needed the identical extraction for its own ``gcc_option_tokens``
-    (Codex review); kept here under its original private name so this
-    module's own callers/tests don't need updating.
+    Thin alias for :func:`~abicheck.header_utils.cache_relevant_operand_dirs`
+    -- the extraction moved to ``header_utils`` (a leaf module ``service.py``
+    already imports from too) once ``service._attach_header_graph``'s own
+    independent second header parse needed the identical extraction for its
+    own ``gcc_option_tokens`` (Codex review), and widened from include-search
+    dirs alone to their union with the dirs holding forced pre-included
+    headers once the L3->L2 fold started deriving those too (plan PR 3B /
+    PR D). Kept here under its original private name so this module's own
+    callers/tests don't need updating.
     """
-    from ..header_utils import include_operand_dirs
+    from ..header_utils import cache_relevant_operand_dirs
 
-    return include_operand_dirs(tokens)
+    return cache_relevant_operand_dirs(tokens)
 
 
 def seed_includes_and_fold_compile_context(
@@ -734,16 +740,11 @@ def seed_includes_and_fold_compile_context(
         build_evidence = pack.build_evidence if pack is not None else None
         units = build_evidence.compile_units if build_evidence is not None else []
 
-        if want_seed:
-            seeded_dirs = _existing_include_dirs(units)
-            if seeded_dirs:
-                logger.info(
-                    "L2 header parse: seeded %d include dir(s) from the "
-                    "build's compile database (no -I given).",
-                    len(seeded_dirs),
-                )
-                incs = incs + [Path(d) for d in seeded_dirs]
-
+        # Resolve *before* seeding, so the seed can be restricted to the
+        # compile unit(s) that actually compile these headers (plan PR 3B /
+        # PR D). Ordering is otherwise unobservable: the one path that does
+        # not fall through to the seed below is the fail-closed ambiguity
+        # raise, which aborts the whole call either way.
         resolution = resolve_header_compile_context(
             build_evidence,
             list(headers),
@@ -751,6 +752,23 @@ def seed_includes_and_fold_compile_context(
             lang=lang,
             lang_explicit=lang_explicit,
         )
+
+        if want_seed:
+            seed_units = list(resolution.matched_units) or units
+            seeded_dirs = _existing_include_dirs(seed_units)
+            if seeded_dirs:
+                logger.info(
+                    "L2 header parse: seeded %d include dir(s) from %s (no -I given).",
+                    len(seeded_dirs),
+                    (
+                        f"the {len(resolution.matched_units)} compile unit(s) "
+                        "matching these headers"
+                        if resolution.matched_units
+                        else "the build's compile database"
+                    ),
+                )
+                incs = incs + [Path(d) for d in seeded_dirs]
+
         if resolution.context is None:
             if cleanups:
                 pending_cleanups.extend(cleanups)

--- a/abicheck/buildsource/source_extractors/_argv.py
+++ b/abicheck/buildsource/source_extractors/_argv.py
@@ -33,6 +33,7 @@ import os
 import re
 from collections.abc import Sequence
 
+from ...header_utils import match_gnu_forced_include, match_msvc_forced_include
 from ..build_evidence import CompileUnit
 
 #: Languages that make the GNU fallback compiler ``g++`` rather than ``gcc``.
@@ -83,15 +84,15 @@ MACRO_DEFINITION_PREFIXES = ("-D", "-U", "/D", "/U")
 #: split spelling (``-isysroot /sdk`` → just ``-isysroot``, operand dropped), so
 #: re-appending it dangles and swallows the following argv token.
 STRUCTURED_TOOLCHAIN_FLAG_PREFIXES = ("--sysroot", "-isysroot", "--target", "-target")
-#: GNU forced-include options. Only ``-include``/``-imacros`` also have a joined
-#: ``-include<file>`` spelling; ``-include-pch`` is separate-operand only (clang
-#: ``-include-pch <file>``) and must not be read as a joined ``-include``.
-_GNU_FORCED_INCLUDE_OPTS = frozenset({"-include", "-imacros"})
-_GNU_SEPARATE_INCLUDE_OPTS = frozenset({"-include", "-imacros", "-include-pch"})
-#: MSVC/clang-cl forced-include options in their separate-operand spelling
-#: (``/FI file`` or ``-FI file``); the joined ``/FIfile`` form is handled by
-#: prefix.
-_MSVC_FORCED_INCLUDE_OPTS = frozenset({"/FI", "-FI"})
+#: The forced-include option vocabulary and its two matchers now live in
+#: ``abicheck.header_utils`` (the leaf that already owns this codebase's
+#: include-flag vocabulary, and which both this module and
+#: ``buildsource.header_compile_context`` already sit above), so the L4 replay
+#: path here and the L2 header-parse path there recognize exactly the same
+#: spellings from one implementation. Re-bound to the historical private names
+#: so the call sites below read unchanged.
+_match_gnu_forced_include = match_gnu_forced_include
+_match_msvc_forced_include = match_msvc_forced_include
 #: GNU include-search options that take a directory operand and are NOT
 #: normalized into the structured ``include_paths``/``system_include_paths``
 #: buckets (those cover ``-I``/``-isystem`` only). Dropping them makes the
@@ -312,24 +313,6 @@ def _match_gnu_include_search(tok: str, argv: list[str], i: int, out: list[str])
     return i
 
 
-def _match_gnu_forced_include(tok: str, argv: list[str], i: int, out: list[str]) -> int:
-    """Try to match a GNU forced-include token (``-include``/``-imacros``/``-include-pch``).
-
-    Returns the new ``i`` after consumption, or the original ``i`` if no match.
-    The separate-operand spelling (all three options) and the joined spelling
-    (``-include``/``-imacros`` only, never ``-include-pch``) are both handled.
-    """
-    if tok in _GNU_SEPARATE_INCLUDE_OPTS and i + 1 < len(argv):
-        out += [tok, argv[i + 1]]  # -include / -imacros / -include-pch <file>
-        return i + 2
-    if tok not in _GNU_SEPARATE_INCLUDE_OPTS and any(
-        tok.startswith(opt) and len(tok) > len(opt) for opt in _GNU_FORCED_INCLUDE_OPTS
-    ):
-        out.append(tok)  # -includefile / -imacrosfile (joined)
-        return i + 1
-    return i
-
-
 def _match_msvc_include_search(
     tok: str, argv: list[str], i: int, out: list[str]
 ) -> int:
@@ -347,24 +330,6 @@ def _match_msvc_include_search(
     return i
 
 
-def _match_msvc_forced_include(
-    tok: str, argv: list[str], i: int, out: list[str]
-) -> int:
-    """Try to match an MSVC ``/FI`` forced-include token (MSVC mode only).
-
-    Returns the new ``i`` after consumption, or the original ``i`` if no match.
-    Both the separate (``/FI file``) and joined (``/FIfile``, ``-FIfile``)
-    spellings are handled.
-    """
-    if tok in _MSVC_FORCED_INCLUDE_OPTS and i + 1 < len(argv):
-        out += [tok, argv[i + 1]]  # /FI file (separate operand)
-        return i + 2
-    if len(tok) > 3 and (tok.startswith("/FI") or tok.startswith("-FI")):
-        out.append(tok)  # /FIfile (joined)
-        return i + 1
-    return i
-
-
 def _scan_argv_for_extra_flags(argv: list[str], cc_id: str, out: list[str]) -> None:
     """Walk ``argv`` and append forced-include / include-search tokens to ``out``.
 
@@ -375,13 +340,17 @@ def _scan_argv_for_extra_flags(argv: list[str], cc_id: str, out: list[str]) -> N
     i = 0
     while i < len(argv):
         tok = argv[i]
-        new_i = _match_gnu_forced_include(tok, argv, i, out)
+        # The two forced-include matchers are shared with the L2 header-parse
+        # path (header_utils) and return (new_i, option, operand); only the
+        # index matters here, since replay hands `out`'s verbatim tokens
+        # straight back to the real compiler.
+        new_i, _opt, _operand = _match_gnu_forced_include(tok, argv, i, out)
         if new_i == i:
             new_i = _match_gnu_include_search(tok, argv, i, out)
         if new_i == i and cc_id == "msvc":
             new_i = _match_msvc_include_search(tok, argv, i, out)
         if new_i == i and cc_id == "msvc":
-            new_i = _match_msvc_forced_include(tok, argv, i, out)
+            new_i, _opt, _operand = _match_msvc_forced_include(tok, argv, i, out)
         i = new_i if new_i != i else i + 1
 
 

--- a/abicheck/buildsource/source_extractors/_argv.py
+++ b/abicheck/buildsource/source_extractors/_argv.py
@@ -42,27 +42,12 @@ from ..build_evidence import CompileUnit
 
 #: Languages that make the GNU fallback compiler ``g++`` rather than ``gcc``.
 CXX_LANGS = frozenset({"cxx", "c++", "cpp"})
-#: Compiler basenames that mean the extractor should run in MSVC mode.
-#: ``dpcpp-cl``/``dpcpp-cl.exe`` is Intel's oneAPI DPC++/C++ CL-compatible
-#: driver (the same CL-mode convention as ``clang-cl``, just Intel-branded);
-#: without it here, ``dumper_clang.resolve_source_frontend_clang_bin``'s
-#: ``exclude_cl_style=False`` (L4 source-ABI replay) resolves ``--compiler
-#: dpcpp-cl`` correctly, but this module still built a GNU-shaped command for
-#: it instead of adding ``--driver-mode=cl``, so the CL-mode override never
-#: actually reached the driver (Codex review).
-MSVC_BINARIES = frozenset(
-    {"cl", "cl.exe", "clang-cl", "clang-cl.exe", "dpcpp-cl", "dpcpp-cl.exe"}
-)
-#: The same names with any ``.exe`` suffix stripped, for matching after a
-#: version suffix has also been removed (``is_msvc_mode`` normalizes both).
-_MSVC_STEMS = frozenset(name.removesuffix(".exe") for name in MSVC_BINARIES)
-#: Matches a trailing numeric version suffix LLVM/Debian packaging commonly
-#: appends to an unversioned driver name (``clang-cl-20``, ``clang-20.1``) --
-#: without stripping it, ``is_msvc_mode("clang-cl-20")`` would miss a real
-#: CL-mode driver just because it carries its LLVM major-version suffix
-#: (Codex review): the S2 pre-scan (and, via ``pick_compiler_binary``, L4
-#: replay) would then drive it with GNU-only flags it silently ignores.
-_VERSION_SUFFIX_RE = re.compile(r"-\d+(?:\.\d+)*$")
+# The CL-mode driver vocabulary this module once owned now lives in
+# ``header_utils.is_msvc_driver_stem`` — ``is_msvc_mode`` below delegates to it,
+# so the build-evidence adapter and this replay path cannot drift on which
+# drivers are CL-mode (they had: ``dpcpp-cl`` and version-suffixed spellings
+# such as ``clang-cl-20`` were known here and not there).
+
 #: Compiler-launcher wrappers that prefix the real compiler in a build action
 #: (``ccache clang++ -c foo.cpp``). The extractor must emulate the real compiler,
 #: not the launcher, which would otherwise run without its compiler operand.

--- a/abicheck/buildsource/source_extractors/_argv.py
+++ b/abicheck/buildsource/source_extractors/_argv.py
@@ -33,7 +33,11 @@ import os
 import re
 from collections.abc import Sequence
 
-from ...header_utils import match_gnu_forced_include, match_msvc_forced_include
+from ...header_utils import (
+    is_msvc_driver_stem,
+    match_gnu_forced_include,
+    match_msvc_forced_include,
+)
 from ..build_evidence import CompileUnit
 
 #: Languages that make the GNU fallback compiler ``g++`` rather than ``gcc``.
@@ -251,10 +255,12 @@ def is_msvc_mode(cc_bin: str) -> bool:
     back to the same check with a trailing version suffix stripped, so a
     packaged ``clang-cl-20``/``clang-cl-20.exe`` is still recognized.
     """
-    stem = basename(cc_bin).lower()
-    if stem in MSVC_BINARIES:
-        return True
-    return _VERSION_SUFFIX_RE.sub("", stem.removesuffix(".exe")) in _MSVC_STEMS
+    # The name test itself is header_utils.is_msvc_driver_stem -- the one
+    # vocabulary buildsource.adapters.base._is_msvc_command now shares, after
+    # the two drifted apart (Codex review, PR D). Behaviour here is unchanged:
+    # that function is this test, relocated. Only the basename derivation
+    # stays local, since the adapter's is backslash-aware and this one is not.
+    return is_msvc_driver_stem(basename(cc_bin).lower())
 
 
 def _carry_abi_relevant_flags(

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -1309,11 +1309,10 @@ def handle_non_elf_dump(
             lang_explicit=lang_explicit,
             pending_cleanups=_l2_pending_cleanups,
         )
-        # _l3_include_dirs unused here: dump_native_binary/service.run_dump
-        # has no public extra_hash_dirs hook (unlike perform_elf_dump's own
-        # dump() call below) -- a pre-existing, broader service.py cache-key
-        # gap this PR doesn't scope to fix (Codex review; AGENTS.md "Known
-        # gaps").
+        # _l3_include_dirs is unused by design, not omission: `compile=
+        # l3_effective_ctx` below hands the merged L3 context to service_
+        # header_scoped._try_header_scoped_dump, which derives the identical
+        # cache-relevant paths from those tokens itself (Codex review, PR D).
         snap = dump_native_binary(
             so_path,
             binary_fmt,

--- a/abicheck/dumper_ast_config.py
+++ b/abicheck/dumper_ast_config.py
@@ -66,6 +66,18 @@ def _cache_key(
     # (the inferred -H roots when a build context is present) rather than -I, so
     # their contents must be folded in here too — otherwise an edit to a header
     # transitively included from such a root would reuse a stale AST (Codex).
+    #
+    # An entry naming a *file* rather than a directory is hashed directly, the
+    # same way ``headers`` are above (Codex review, PR D). The directory walk
+    # below is deliberately suffix-filtered (#454), which is right for "catch
+    # transitive includes under a search root" but wrong for a file the caller
+    # named explicitly because it is *itself* part of the parse: a forced
+    # pre-include (``-include generated/config``, ``-imacros settings.def``)
+    # routinely carries a suffix ``CACHE_HEADER_SUFFIXES`` does not list, so
+    # hashing only its parent directory would let an edit to it reuse a stale
+    # AST while the unchanged option token kept the key identical. Before this
+    # branch a non-directory entry contributed only its path string, so this is
+    # a strict widening — no previously-hashed input stops being hashed.
     for inc_dir in sorted(str(x) for x in (*extra_includes, *extra_hash_dirs)):
         inc_path = Path(inc_dir)
         h.update(inc_dir.encode())
@@ -78,6 +90,11 @@ def _cache_key(
                     h.update(str(f.stat().st_mtime).encode())
                 except OSError:
                     pass
+        else:
+            try:
+                h.update(str(inc_path.stat().st_mtime).encode())
+            except OSError:
+                pass
     h.update(compiler.encode())
     # Include toolchain parameters so different cross-compilation configs
     # produce distinct cache entries

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -637,19 +637,35 @@ def forced_include_operands(
     return out
 
 
-def forced_include_operand_dirs(tokens: Sequence[str]) -> tuple[Path, ...]:
-    """The *containing directory* of every forced pre-include in *tokens*.
+def forced_include_operand_paths(tokens: Sequence[str]) -> tuple[Path, ...]:
+    """Every forced pre-include in *tokens*, as the file **and** its directory.
 
     Sibling of :func:`include_operand_dirs`, for the same AST-cache-key
     channel and the same reason — a forced-include header
     (``-include config.h``) reaches the parse only as an opaque
     ``gcc_option_tokens`` string, so editing that header would otherwise reuse
     a stale cached AST even though it is exactly the macro-controlling input
-    the parse depends on most. The cache key's channel takes *directories*
-    (``extra_hash_dirs``, mtime-walked via :func:`iter_cache_header_files`),
-    so the operand's parent is what is returned; a bare operand with no
-    directory part contributes nothing, since its resolution depends on the
-    include search and the searched dirs are already covered by
+    the parse depends on most.
+
+    **The file itself, not only its parent directory (Codex review, PR D).**
+    An earlier revision returned the parent alone, on the assumption that the
+    cache key's directory walk would then cover it. It does not in general:
+    that walk (:func:`iter_cache_header_files`, via
+    ``dumper_ast_config._cache_key``) is suffix-filtered by
+    :data:`CACHE_HEADER_SUFFIXES` — correct for "catch transitive includes
+    under a search root", wrong for a file named explicitly because it is
+    *itself* part of the parse. A forced include routinely carries a suffix
+    that list does not name (``-imacros settings.def``) or none at all
+    (``-include generated/config``), so hashing only the parent left an edit
+    to it invisible while the unchanged option token kept the key identical.
+    ``_cache_key`` hashes a non-directory entry's own mtime directly, the same
+    way it already hashes ``headers``.
+
+    The parent is still returned alongside it, so a *neighbouring* header the
+    forced one pulls in relatively is covered too — that directory need not be
+    on the include search path, so nothing else would cover it. A bare operand
+    with no directory part contributes only the file, since its resolution
+    depends on the include search and those dirs are already covered by
     :func:`include_operand_dirs`.
 
     Recognition is :func:`forced_include_operands` above, run over both
@@ -658,31 +674,40 @@ def forced_include_operand_dirs(tokens: Sequence[str]) -> tuple[Path, ...]:
     to the compiler.
     """
     toks = list(tokens)
-    dirs: list[Path] = []
+    paths: list[Path] = []
     for _option, operand in {
         *forced_include_operands(toks, msvc=False),
         *forced_include_operands(toks, msvc=True),
     }:
-        parent = Path(operand).parent
+        operand_path = Path(operand)
+        paths.append(operand_path)
+        parent = operand_path.parent
         if str(parent) not in (".", ""):
-            dirs.append(parent)
-    return tuple(sorted(set(dirs), key=str))
+            paths.append(parent)
+    return tuple(sorted(set(paths), key=str))
 
 
-def cache_relevant_operand_dirs(tokens: Sequence[str]) -> tuple[Path, ...]:
-    """Every directory in *tokens* whose contents an AST cache key must cover.
+def cache_relevant_operand_paths(tokens: Sequence[str]) -> tuple[Path, ...]:
+    """Every path in *tokens* an AST cache key must cover for staleness.
 
     The union of :func:`include_operand_dirs` (include-*search* dirs) and
-    :func:`forced_include_operand_dirs` (the dirs holding forced pre-included
-    headers). One function so the three header-parse cache keys that consume
-    it — the primary ``service._dump_elf`` parse, ``service.
-    _attach_header_graph``'s independent second parse, and the L2 seed's own
-    ``derived_include_dirs`` return — cannot disagree about what staleness
-    means for the same ``gcc_option_tokens``; two of those three have already
+    :func:`forced_include_operand_paths` (each forced pre-included header and
+    its directory). One function so the four header-parse cache keys that
+    consume it — the primary ``service._dump_elf`` parse, ``service.
+    _attach_header_graph``'s independent second parse, the PE/Mach-O
+    ``service_header_scoped._try_header_scoped_dump`` parse, and the L2 seed's
+    own ``derived_include_dirs`` return — cannot disagree about what staleness
+    means for the same ``gcc_option_tokens``; three of those four have already
     each needed their own individual fix for exactly that divergence
-    (``AGENTS.md``'s tenth and seventeenth L3->L2-fold findings).
+    (``AGENTS.md``'s tenth and seventeenth L3->L2-fold findings, plus PR D's
+    own PE/Mach-O round).
+
+    Mixed files and directories: the consuming ``extra_hash_dirs`` channel
+    accepts both (see ``dumper_ast_config._cache_key``), since a forced
+    pre-include is a file whose content is part of the parse rather than a
+    directory to search.
     """
-    return include_operand_dirs(tokens) + forced_include_operand_dirs(tokens)
+    return include_operand_dirs(tokens) + forced_include_operand_paths(tokens)
 
 
 def iter_cache_header_files(directory: Path) -> list[Path]:

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Pure path and compiler-include-flag helpers for header (``-H``) inputs.
+"""Pure path and compiler-flag helpers for header (``-H``) inputs.
 
 A leaf module (stdlib-only) so both the service layer (``service._dump_elf``)
 and the ``dump`` CLI helper (``cli_dump_helpers.perform_elf_dump``) can share the
@@ -21,8 +21,9 @@ include-root derivation without an import cycle (``cli`` → ``cli_dump_helpers`
 ``service`` → … → ``cli``).
 
 Being that leaf is also why this module, rather than ``buildsource``, owns the
-compiler include-flag vocabulary the whole codebase reads
-(:data:`_INCLUDE_FLAG_PREFIXES` and the forced-include recognizer below): every
+compiler-dialect and include-flag vocabulary the whole codebase reads
+(:func:`is_msvc_driver_stem`, :data:`_INCLUDE_FLAG_PREFIXES`, and the
+forced-include recognizer below): every
 consumer — the L2 header parse (``buildsource.header_compile_context``), the L4
 replay command builder (``buildsource.source_extractors._argv``), the L2 seed
 and the AST cache keys — already sits above it, so one shared implementation
@@ -33,6 +34,7 @@ import from here would invert that.
 from __future__ import annotations
 
 import os
+import re
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -519,6 +521,51 @@ def include_operand_dirs(tokens: Sequence[str]) -> tuple[Path, ...]:
             dirs.append(Path(t[len(matched_prefix) :]))
         i += 1
     return tuple(dirs)
+
+
+#: Compiler basenames that mean a command line is in MSVC/clang-cl (``/opt``)
+#: mode. ``dpcpp-cl``/``dpcpp-cl.exe`` is Intel's oneAPI CL-compatible driver —
+#: the same convention as ``clang-cl``, just Intel-branded.
+MSVC_DRIVER_BINARIES: frozenset[str] = frozenset(
+    {"cl", "cl.exe", "clang-cl", "clang-cl.exe", "dpcpp-cl", "dpcpp-cl.exe"}
+)
+#: The same names with any ``.exe`` suffix stripped, for matching after a
+#: version suffix has also been removed.
+_MSVC_DRIVER_STEMS: frozenset[str] = frozenset(
+    name.removesuffix(".exe") for name in MSVC_DRIVER_BINARIES
+)
+#: Matches a trailing numeric version suffix LLVM/Debian packaging commonly
+#: appends to an unversioned driver name (``clang-cl-20``, ``clang-20.1``).
+#: Without stripping it, a real CL-mode driver is missed just because it
+#: carries its LLVM major-version suffix.
+_DRIVER_VERSION_SUFFIX_RE = re.compile(r"-\d+(?:\.\d+)*$")
+
+
+def is_msvc_driver_stem(stem: str) -> bool:
+    """True when *stem* — an already-lowercased driver **basename** — is CL-mode.
+
+    The single vocabulary behind both dialect decisions this codebase makes,
+    which had drifted apart: ``source_extractors._argv.is_msvc_mode`` (the L4
+    replay path) recognized ``dpcpp-cl`` and version-suffixed drivers, while
+    ``buildsource.adapters.base._is_msvc_command`` (which decides the dialect
+    for source detection, forced-language detection, structured-field masking
+    and — since PR D — the L2 forced-include render) listed only ``cl`` and
+    unversioned ``clang-cl``. A ``dpcpp-cl``/``clang-cl-20`` command spelled
+    with GNU ``-c`` rather than ``/c`` therefore read as GNU dialect on the
+    build-evidence side, silently dropping its ``/FI`` forced include from the
+    derived L2 context while L4 replayed it correctly (Codex review).
+
+    Takes the basename rather than computing one, because the two callers
+    disagree — deliberately — about how to derive it: the adapter is
+    backslash-aware (a Windows driver path recorded in a compile database read
+    on POSIX), ``_argv`` uses ``os.path.basename``. Sharing only the name test
+    fixes the vocabulary drift without changing either caller's path handling.
+    """
+    if stem in MSVC_DRIVER_BINARIES:
+        return True
+    return _DRIVER_VERSION_SUFFIX_RE.sub("", stem.removesuffix(".exe")) in (
+        _MSVC_DRIVER_STEMS
+    )
 
 
 #: GNU/clang forced-include options in their **separate**-operand spelling

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -248,14 +248,29 @@ def _has_include_build_context(toks: list[str]) -> bool:
     return any(t.startswith(p) for t in toks for p in _INCLUDE_FLAG_PREFIXES)
 
 
-def _build_context_include_dirs(
+def build_context_include_dirs_ordered(
     toks: list[str],
     *,
     base_dir: str | None = None,
     expand_user: bool = False,
     prefixes: tuple[str, ...] | None = None,
-) -> set[str]:
-    """Resolved include directories the compile-flag *tokens* already search.
+) -> list[str]:
+    """:func:`_build_context_include_dirs`, in **argv order** and de-duplicated.
+
+    The set-returning function below is this one, collapsed — it is the older
+    of the two and every pre-existing caller only ever asks "does the build
+    context already cover this directory", for which order is irrelevant.
+
+    Order is not irrelevant to a caller *resolving a file* through the chain,
+    which is why this variant exists (Codex review, PR D, sixth round): a
+    compiler searches a bucket's directories in the order they appear on the
+    command line and takes the first match, so ``-iquote z -iquote a`` finds
+    ``z/config.h``. Sorting the set — what
+    ``header_compile_context._forced_include_search_dirs`` originally did to
+    get a deterministic chain — is deterministic *and wrong*: it would pin the
+    derived parse to ``a/config.h``, a different file with potentially
+    different macros. First occurrence wins on duplicates, matching the same
+    first-match rule.
 
     Parses every include-search flag (spaced ``-I dir`` / ``-isystem dir`` and
     attached ``-Idir`` forms, GNU and MSVC) out of *toks* and returns their
@@ -287,7 +302,15 @@ def _build_context_include_dirs(
             pp = Path(base) / pp
         return str(pp.resolve())
 
-    dirs: set[str] = set()
+    dirs: list[str] = []
+    seen: set[str] = set()
+
+    def _add(operand: str) -> None:
+        resolved = _resolve(operand)
+        if resolved not in seen:
+            seen.add(resolved)
+            dirs.append(resolved)
+
     i = 0
     while i < len(toks):
         t = toks[i]
@@ -297,15 +320,35 @@ def _build_context_include_dirs(
             continue
         if t == prefix:  # spaced form: the directory is the next token
             if i + 1 < len(toks):
-                dirs.add(_resolve(toks[i + 1]))
+                _add(toks[i + 1])
             i += 2
             continue
         # Attached form ("-Idir" / "/Idir"): t is strictly longer than the prefix
         # here (the exact-match spaced form was handled above), so the operand is
         # always non-empty.
-        dirs.add(_resolve(t[len(prefix) :]))
+        _add(t[len(prefix) :])
         i += 1
     return dirs
+
+
+def _build_context_include_dirs(
+    toks: list[str],
+    *,
+    base_dir: str | None = None,
+    expand_user: bool = False,
+    prefixes: tuple[str, ...] | None = None,
+) -> set[str]:
+    """Resolved include directories the compile-flag *tokens* already search.
+
+    Order-free view of :func:`build_context_include_dirs_ordered` above, which
+    carries the full contract; every caller of this one is asking only whether
+    a directory is covered at all.
+    """
+    return set(
+        build_context_include_dirs_ordered(
+            toks, base_dir=base_dir, expand_user=expand_user, prefixes=prefixes
+        )
+    )
 
 
 def resolve_inferred_header_roots(

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -708,12 +708,26 @@ def forced_include_operand_paths(tokens: Sequence[str]) -> tuple[Path, ...]:
     ``_cache_key`` hashes a non-directory entry's own mtime directly, the same
     way it already hashes ``headers``.
 
-    The parent is still returned alongside it, so a *neighbouring* header the
-    forced one pulls in relatively is covered too — that directory need not be
-    on the include search path, so nothing else would cover it. A bare operand
-    with no directory part contributes only the file, since its resolution
-    depends on the include search and those dirs are already covered by
-    :func:`include_operand_dirs`.
+    The parent is returned alongside it, so a *neighbouring* header the forced
+    one pulls in relatively is covered too — that directory need not be on the
+    include search path, so nothing else would cover it.
+
+    **A relative operand also contributes one candidate per include-search
+    directory in the same token list (Codex review, PR D, third round).** A
+    forced include is resolved through the ``-I`` chain when it is not found
+    relative to the working directory, so ``-I /build/gen -include config``
+    names ``/build/gen/config`` — and *nothing else* hashes that file: the
+    operand alone stats relative to abicheck's own working directory (the
+    build's, it is not), and ``/build/gen`` is walked only through the
+    suffix-filtered :func:`iter_cache_header_files`, which skips an
+    extensionless or ``.def`` name outright. The candidates are emitted
+    whether or not they exist, which is both harmless and deliberate:
+    ``_cache_key`` contributes a non-existent path's string and moves on, and
+    a candidate that *starts* existing is a real change to what the compiler
+    would resolve. Since the search order is first-match-wins, a candidate
+    under a directory the compiler would never reach can only ever over-
+    invalidate — a spurious cache miss, never a stale hit, which is the
+    correct direction for this channel to err in.
 
     Recognition is :func:`forced_include_operands` above, run over both
     dialects — the same tokens ``header_compile_context._context_flags``
@@ -721,6 +735,7 @@ def forced_include_operand_paths(tokens: Sequence[str]) -> tuple[Path, ...]:
     to the compiler.
     """
     toks = list(tokens)
+    search_dirs = include_operand_dirs(toks)
     paths: list[Path] = []
     for _option, operand in {
         *forced_include_operands(toks, msvc=False),
@@ -731,6 +746,8 @@ def forced_include_operand_paths(tokens: Sequence[str]) -> tuple[Path, ...]:
         parent = operand_path.parent
         if str(parent) not in (".", ""):
             paths.append(parent)
+        if not operand_path.is_absolute():
+            paths.extend(d / operand_path for d in search_dirs)
     return tuple(sorted(set(paths), key=str))
 
 

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -13,12 +13,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Pure path helpers for header (``-H``) inputs.
+"""Pure path and compiler-include-flag helpers for header (``-H``) inputs.
 
 A leaf module (stdlib-only) so both the service layer (``service._dump_elf``)
 and the ``dump`` CLI helper (``cli_dump_helpers.perform_elf_dump``) can share the
 include-root derivation without an import cycle (``cli`` → ``cli_dump_helpers`` →
 ``service`` → … → ``cli``).
+
+Being that leaf is also why this module, rather than ``buildsource``, owns the
+compiler include-flag vocabulary the whole codebase reads
+(:data:`_INCLUDE_FLAG_PREFIXES` and the forced-include recognizer below): every
+consumer — the L2 header parse (``buildsource.header_compile_context``), the L4
+replay command builder (``buildsource.source_extractors._argv``), the L2 seed
+and the AST cache keys — already sits above it, so one shared implementation
+costs no new import edge in any direction. Keep it stdlib-only: an upward
+import from here would invert that.
 """
 
 from __future__ import annotations
@@ -510,6 +519,170 @@ def include_operand_dirs(tokens: Sequence[str]) -> tuple[Path, ...]:
             dirs.append(Path(t[len(matched_prefix) :]))
         i += 1
     return tuple(dirs)
+
+
+#: GNU/clang forced-include options in their **separate**-operand spelling
+#: (``-include foo.h``): the following argv token is the operand.
+#: ``-include-pch`` is here but deliberately absent from
+#: :data:`GNU_JOINED_FORCED_INCLUDE_OPTS` below — clang accepts no joined
+#: ``-include-pchfile`` spelling.
+GNU_SEPARATE_FORCED_INCLUDE_OPTS: frozenset[str] = frozenset(
+    {"-include", "-imacros", "-include-pch"}
+)
+#: The subset that additionally accepts a **joined** operand
+#: (``-includefoo.h``/``-imacrosfoo.h``).
+GNU_JOINED_FORCED_INCLUDE_OPTS: frozenset[str] = frozenset({"-include", "-imacros"})
+#: MSVC/clang-cl forced-include options in their separate-operand spelling
+#: (``/FI file`` or ``-FI file``); the joined ``/FIfile``/``-FIfile`` form is
+#: matched by prefix instead. ``/FU`` (forced ``#using`` of a managed
+#: assembly, C++/CLI) is **not** here: it names no C/C++ header, so it has no
+#: meaning for either an L4 replay or an L2 header parse.
+MSVC_SEPARATE_FORCED_INCLUDE_OPTS: frozenset[str] = frozenset({"/FI", "-FI"})
+
+#: Longest-first, so a joined-spelling scan never truncates one option at a
+#: shorter sibling's boundary.
+_GNU_JOINED_FORCED_INCLUDE_ORDER: tuple[str, ...] = tuple(
+    sorted(GNU_JOINED_FORCED_INCLUDE_OPTS, key=len, reverse=True)
+)
+
+
+def match_gnu_forced_include(
+    tok: str, argv: list[str], i: int, out: list[str]
+) -> tuple[int, str, str]:
+    """Try to match a GNU forced-include token (``-include``/``-imacros``/``-include-pch``).
+
+    Appends the matched token(s) to *out* **verbatim** (a joined spelling stays
+    joined — an L4 replay hands them straight back to the real compiler) and
+    returns ``(new_i, option, operand)``: the index past what was consumed plus
+    the *normalized* option spelling and its operand, for a caller that needs
+    to re-render rather than replay. Returns ``(i, "", "")`` when *tok* matches
+    neither the separate- nor the joined-operand form.
+    """
+    if tok in GNU_SEPARATE_FORCED_INCLUDE_OPTS and i + 1 < len(argv):
+        out += [tok, argv[i + 1]]  # -include / -imacros / -include-pch <file>
+        return i + 2, tok, argv[i + 1]
+    if tok not in GNU_SEPARATE_FORCED_INCLUDE_OPTS:
+        for opt in _GNU_JOINED_FORCED_INCLUDE_ORDER:
+            if tok.startswith(opt) and len(tok) > len(opt):
+                out.append(tok)  # -includefile / -imacrosfile (joined)
+                return i + 1, opt, tok[len(opt) :]
+    return i, "", ""
+
+
+def match_msvc_forced_include(
+    tok: str, argv: list[str], i: int, out: list[str]
+) -> tuple[int, str, str]:
+    """Try to match an MSVC ``/FI`` forced-include token (MSVC mode only).
+
+    Same contract as :func:`match_gnu_forced_include`; both the separate
+    (``/FI file``) and joined (``/FIfile``, ``-FIfile``) spellings are handled,
+    and the returned option is normalized to ``/FI`` for either.
+    """
+    if tok in MSVC_SEPARATE_FORCED_INCLUDE_OPTS and i + 1 < len(argv):
+        out += [tok, argv[i + 1]]  # /FI file (separate operand)
+        return i + 2, "/FI", argv[i + 1]
+    if len(tok) > 3 and (tok.startswith("/FI") or tok.startswith("-FI")):
+        out.append(tok)  # /FIfile (joined)
+        return i + 1, "/FI", tok[3:]
+    return i, "", ""
+
+
+def forced_include_operands(
+    argv: Sequence[str], *, msvc: bool
+) -> list[tuple[str, str]]:
+    """Every forced pre-include in *argv* as ``(option, operand)``, in order.
+
+    The normalized read view of :func:`match_gnu_forced_include`/
+    :func:`match_msvc_forced_include` — same recognizer, same option
+    vocabulary, same separate/joined spellings, but reporting *what was asked
+    for* rather than the verbatim tokens an L4 replay hands back to the real
+    compiler. ``option`` is one of ``-include``/``-imacros``/``-include-pch``/
+    ``/FI``; ``operand`` is the header the build forces in, exactly as the
+    build spelled it (still relative to the compile unit's own ``directory``
+    when relative, and still subject to the include search when bare).
+
+    *msvc* enables the ``/FI``/``-FI`` family, gated the same way
+    ``source_extractors._argv._scan_argv_for_extra_flags`` gates it (on the
+    resolved compiler dialect) so a GNU ``-F``-family flag is never read as one.
+
+    Lives here, in the leaf that already owns this codebase's include-flag
+    vocabulary (:data:`_INCLUDE_FLAG_PREFIXES` and friends), rather than in
+    ``buildsource``: both consumers are above it — the L4 replay path reaches
+    the matchers through ``source_extractors._argv``, and the L2 header parse
+    reaches this view through ``buildsource.header_compile_context.
+    _context_flags`` — so one shared implementation costs no new import edge in
+    either direction. See ``adapters.base.ABI_RELEVANT_FLAG_PREFIXES``'s own
+    comment for why these deliberately never travel via
+    ``CompileUnit.abi_relevant_flags``.
+    """
+    tokens = list(argv)
+    scratch: list[str] = []
+    out: list[tuple[str, str]] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        new_i, option, operand = match_gnu_forced_include(tok, tokens, i, scratch)
+        if new_i == i and msvc:
+            new_i, option, operand = match_msvc_forced_include(tok, tokens, i, scratch)
+        if new_i == i:
+            i += 1
+            continue
+        # A joined spelling whose "operand" is itself option-shaped is not a
+        # real file operand (``-include-pchfoo`` reaches the joined ``-include``
+        # branch with ``-pchfoo``); replaying it verbatim is harmless, but
+        # re-rendering it as a forced include would not be.
+        if operand and not operand.startswith("-"):
+            out.append((option, operand))
+        i = new_i
+    return out
+
+
+def forced_include_operand_dirs(tokens: Sequence[str]) -> tuple[Path, ...]:
+    """The *containing directory* of every forced pre-include in *tokens*.
+
+    Sibling of :func:`include_operand_dirs`, for the same AST-cache-key
+    channel and the same reason — a forced-include header
+    (``-include config.h``) reaches the parse only as an opaque
+    ``gcc_option_tokens`` string, so editing that header would otherwise reuse
+    a stale cached AST even though it is exactly the macro-controlling input
+    the parse depends on most. The cache key's channel takes *directories*
+    (``extra_hash_dirs``, mtime-walked via :func:`iter_cache_header_files`),
+    so the operand's parent is what is returned; a bare operand with no
+    directory part contributes nothing, since its resolution depends on the
+    include search and the searched dirs are already covered by
+    :func:`include_operand_dirs`.
+
+    Recognition is :func:`forced_include_operands` above, run over both
+    dialects — the same tokens ``header_compile_context._context_flags``
+    renders — so the set hashed here cannot drift from the set actually passed
+    to the compiler.
+    """
+    toks = list(tokens)
+    dirs: list[Path] = []
+    for _option, operand in {
+        *forced_include_operands(toks, msvc=False),
+        *forced_include_operands(toks, msvc=True),
+    }:
+        parent = Path(operand).parent
+        if str(parent) not in (".", ""):
+            dirs.append(parent)
+    return tuple(sorted(set(dirs), key=str))
+
+
+def cache_relevant_operand_dirs(tokens: Sequence[str]) -> tuple[Path, ...]:
+    """Every directory in *tokens* whose contents an AST cache key must cover.
+
+    The union of :func:`include_operand_dirs` (include-*search* dirs) and
+    :func:`forced_include_operand_dirs` (the dirs holding forced pre-included
+    headers). One function so the three header-parse cache keys that consume
+    it — the primary ``service._dump_elf`` parse, ``service.
+    _attach_header_graph``'s independent second parse, and the L2 seed's own
+    ``derived_include_dirs`` return — cannot disagree about what staleness
+    means for the same ``gcc_option_tokens``; two of those three have already
+    each needed their own individual fix for exactly that divergence
+    (``AGENTS.md``'s tenth and seventeenth L3->L2-fold findings).
+    """
+    return include_operand_dirs(tokens) + forced_include_operand_dirs(tokens)
 
 
 def iter_cache_header_files(directory: Path) -> list[Path]:

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -45,8 +45,8 @@ from .clang_layout_tool import attach_clang_layout
 from .dumper_scoping import wrap_run_dump_with_dependency_scope
 from .errors import AbicheckError, SnapshotError, ValidationError
 from .header_utils import (
+    cache_relevant_operand_dirs,
     deferred_token_dirs,
-    include_operand_dirs,
     resolve_inferred_header_roots,
 )
 from .model import AbiSnapshot, EnumType, Function, RecordType, Visibility
@@ -1049,9 +1049,9 @@ def _attach_header_graph(
             # pass already hashes must be hashed here too, or an edit under
             # it would silently reuse a stale cached graph even though the
             # primary snapshot re-parsed correctly (Codex review).
-            deferred_dirs = tuple(deferred_token_dirs(deferred)) + include_operand_dirs(
-                cc.gcc_option_tokens
-            )
+            deferred_dirs = tuple(
+                deferred_token_dirs(deferred)
+            ) + cache_relevant_operand_dirs(cc.gcc_option_tokens)
         # ADR-050 D5 (Codex review): this internal semantic header graph
         # (G29 Phase A) must be built from the SAME frontend_context as the
         # primary snapshot it's attached to -- a device-context dump's
@@ -1325,9 +1325,9 @@ def _dump_elf(
         # this PRIMARY parse's cache key stays aligned with _attach_header_graph's
         # own identical fold above -- else the two passes could disagree on
         # staleness for the same header (Codex review).
-        deferred_dirs = tuple(deferred_token_dirs(deferred)) + include_operand_dirs(
-            cc.gcc_option_tokens
-        )
+        deferred_dirs = tuple(
+            deferred_token_dirs(deferred)
+        ) + cache_relevant_operand_dirs(cc.gcc_option_tokens)
 
     compiler = "cc" if lang == "c" else "c++"
     try:

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -45,7 +45,7 @@ from .clang_layout_tool import attach_clang_layout
 from .dumper_scoping import wrap_run_dump_with_dependency_scope
 from .errors import AbicheckError, SnapshotError, ValidationError
 from .header_utils import (
-    cache_relevant_operand_dirs,
+    cache_relevant_operand_paths,
     deferred_token_dirs,
     resolve_inferred_header_roots,
 )
@@ -1051,7 +1051,7 @@ def _attach_header_graph(
             # primary snapshot re-parsed correctly (Codex review).
             deferred_dirs = tuple(
                 deferred_token_dirs(deferred)
-            ) + cache_relevant_operand_dirs(cc.gcc_option_tokens)
+            ) + cache_relevant_operand_paths(cc.gcc_option_tokens)
         # ADR-050 D5 (Codex review): this internal semantic header graph
         # (G29 Phase A) must be built from the SAME frontend_context as the
         # primary snapshot it's attached to -- a device-context dump's
@@ -1327,7 +1327,7 @@ def _dump_elf(
         # staleness for the same header (Codex review).
         deferred_dirs = tuple(
             deferred_token_dirs(deferred)
-        ) + cache_relevant_operand_dirs(cc.gcc_option_tokens)
+        ) + cache_relevant_operand_paths(cc.gcc_option_tokens)
 
     compiler = "cc" if lang == "c" else "c++"
     try:

--- a/abicheck/service_header_scoped.py
+++ b/abicheck/service_header_scoped.py
@@ -43,7 +43,11 @@ from typing import TYPE_CHECKING
 
 from . import deadline
 from .errors import AstContextAmbiguousError, AstContextMissingError
-from .header_utils import deferred_token_dirs, resolve_inferred_header_roots
+from .header_utils import (
+    cache_relevant_operand_paths,
+    deferred_token_dirs,
+    resolve_inferred_header_roots,
+)
 from .model import AbiSnapshot, Visibility
 
 if TYPE_CHECKING:
@@ -127,7 +131,21 @@ def _try_header_scoped_dump(
         )
         eff_includes += inc_extra
         eff_tokens = cc.gcc_option_tokens + tuple(deferred)
-        deferred_dirs = tuple(deferred_token_dirs(deferred))
+        # Plus every include-search dir and forced pre-include the *caller's
+        # own* context tokens name — the identical fold ``service._dump_elf``
+        # and ``service._attach_header_graph`` already apply to their own
+        # cache keys (AGENTS.md's tenth and seventeenth L3->L2-fold findings),
+        # applied here so PE/Mach-O cannot disagree with ELF about staleness
+        # for the same tokens (Codex review, PR D). ``cc`` is the *merged* L3
+        # context on the ``dump`` path (``cli_dump_helpers.handle_non_elf_dump``
+        # passes ``compile=l3_effective_ctx``), so a build-derived
+        # ``-I``/``-include`` is covered without threading a separate
+        # ``extra_hash_dirs`` channel down through ``run_dump``/``resolve_input``
+        # — the caller's own derived-dirs return stays unused precisely because
+        # the tokens it was derived from already arrive here.
+        deferred_dirs = tuple(
+            deferred_token_dirs(deferred)
+        ) + cache_relevant_operand_paths(cc.gcc_option_tokens)
     try:
         if fmt == "pe":
             snap = _dumper_pe(

--- a/changelog.d/1786924800_claude_build-context-completeness.md
+++ b/changelog.d/1786924800_claude_build-context-completeness.md
@@ -8,12 +8,12 @@
   parse a materially different translation unit — different `#if` branches,
   different struct layouts — while still reporting a real compile-unit match
   and stamping `AbiSnapshot.parsed_with_build_context`. A relative operand is
-  resolved against the compile unit's own directory when that names a real
-  file — searching the compile unit's own include chain, so a header the
-  build reaches only through an argv-only `-iquote`/`/I` directory is pinned
-  to its real location rather than emitted as a bare name the rendered
-  command could not find; MSVC `/FI` renders as GNU
-  `-include`, matching how every other derived field is rendered.
+  resolved against the compile unit's own search chain — its own directory
+  first, then each include-search bucket in argv order — and emitted as an
+  absolute path, so a header the build reaches only through an argv-only
+  `-iquote`/`/I` directory is pinned to its real location rather than emitted
+  as a bare name the rendered command could not find. MSVC `/FI` renders as
+  GNU `-include`, matching how every other derived field is rendered.
   `-include-pch` (locked to the compiler build that produced it) and `/FU`
   (managed C++/CLI `#using`, naming no C/C++ header) are deliberately not
   forwarded, and a derived forced include the caller already supplies through

--- a/changelog.d/1786924800_claude_build-context-completeness.md
+++ b/changelog.d/1786924800_claude_build-context-completeness.md
@@ -9,8 +9,10 @@
   different struct layouts — while still reporting a real compile-unit match
   and stamping `AbiSnapshot.parsed_with_build_context`. A relative operand is
   resolved against the compile unit's own directory when that names a real
-  file, and left relative otherwise so a generated header the build finds
-  through its `-I` chain still resolves; MSVC `/FI` renders as GNU
+  file — searching the compile unit's own include chain, so a header the
+  build reaches only through an argv-only `-iquote`/`/I` directory is pinned
+  to its real location rather than emitted as a bare name the rendered
+  command could not find; MSVC `/FI` renders as GNU
   `-include`, matching how every other derived field is rendered.
   `-include-pch` (locked to the compiler build that produced it) and `/FU`
   (managed C++/CLI `#using`, naming no C/C++ header) are deliberately not

--- a/changelog.d/1786924800_claude_build-context-completeness.md
+++ b/changelog.d/1786924800_claude_build-context-completeness.md
@@ -1,0 +1,46 @@
+### Fixed
+
+- **The L2 header parse now applies a matched compile unit's own forced
+  pre-includes (`-include`/`-imacros`/`/FI`).** A build that forces a
+  macro-controlling header in parses its own public headers with that
+  header's macros already defined; abicheck's derived L2 `CompileContext`
+  never carried it, so `dump`/`scan`/`compare`'s implicit-dump path could
+  parse a materially different translation unit — different `#if` branches,
+  different struct layouts — while still reporting a real compile-unit match
+  and stamping `AbiSnapshot.parsed_with_build_context`. A relative operand is
+  resolved against the compile unit's own directory when that names a real
+  file, and left relative otherwise so a generated header the build finds
+  through its `-I` chain still resolves; MSVC `/FI` renders as GNU
+  `-include`, matching how every other derived field is rendered.
+  `-include-pch` (locked to the compiler build that produced it) and `/FU`
+  (managed C++/CLI `#using`, naming no C/C++ header) are deliberately not
+  forwarded. L4 source-ABI replay is unchanged: it already carried forced
+  includes from raw argv, and the two paths now share one recognizer rather
+  than the L2 fix routing through `CompileUnit.abi_relevant_flags`, which
+  would have made replay emit every forced include twice.
+- **A forced pre-include is now part of the compile-context ambiguity check.**
+  Two translation units that reference the same public header but force in
+  *different* macro-controlling headers previously collapsed into one
+  context, silently applying whichever grouped first; they now fail closed
+  with `HeaderCompileContextAmbiguousError`, the same way a `-std=`/target/
+  define disagreement already did, and the error lists each conflicting
+  translation unit's forced includes so the differing dimension is visible
+  rather than leaving two apparently-identical rows. Two spellings of the
+  *same* forced header (separate vs. joined, relative vs. absolute) still
+  agree.
+- **A forced pre-include is now hashed into the header-AST cache key.**
+  Editing the forced header — the one macro-controlling input a parse depends
+  on most — previously reused a stale cached AST, because it reached the
+  parse only as an opaque compiler-option string. All three header-parse
+  cache keys (the primary dump parse, the header-graph second pass, and the
+  L2 seed's own derived directories) now share one definition of which
+  directories affect staleness.
+- **The L2 include-directory seed is restricted to the compile units that
+  actually compile the headers being parsed.** When no explicit `-I` is
+  given, abicheck seeds include directories from the build's compile
+  database; it gathered them from every translation unit, so in a multi-TU
+  build an unrelated TU's own generated-header directory could shadow the
+  matched TU's own colliding header (a stray `config.h`) on a run that then
+  reported build context as applied. It now seeds from the matched units,
+  falling back to every unit only when no unit matches — the case the seed
+  was built for, where there is no narrower set to prefer.

--- a/changelog.d/1786924800_claude_build-context-completeness.md
+++ b/changelog.d/1786924800_claude_build-context-completeness.md
@@ -18,6 +18,14 @@
   includes from raw argv, and the two paths now share one recognizer rather
   than the L2 fix routing through `CompileUnit.abi_relevant_flags`, which
   would have made replay emit every forced include twice.
+- **A CL-mode compile command spelled with GNU `-c` is now recognised as
+  MSVC dialect on the build-evidence side.** `dpcpp-cl` (Intel's oneAPI
+  CL-compatible driver) and version-suffixed drivers such as `clang-cl-20`
+  were known to the L4 source-replay path but not to the build-evidence
+  adapter, so unless the command used `/c` they read as GNU dialect there —
+  dropping a `/FI` forced include from the derived header-parse context, and
+  mis-detecting `/Tp`/`/Tc` source and forced-language markers. Both layers
+  now share one driver vocabulary.
 - **A forced pre-include is now part of the compile-context ambiguity check.**
   Two translation units that reference the same public header but force in
   *different* macro-controlling headers previously collapsed into one

--- a/changelog.d/1786924800_claude_build-context-completeness.md
+++ b/changelog.d/1786924800_claude_build-context-completeness.md
@@ -16,7 +16,11 @@
   `-include`, matching how every other derived field is rendered.
   `-include-pch` (locked to the compiler build that produced it) and `/FU`
   (managed C++/CLI `#using`, naming no C/C++ header) are deliberately not
-  forwarded. L4 source-ABI replay is unchanged: it already carried forced
+  forwarded, and a derived forced include the caller already supplies through
+  `--compiler-option`/`--gcc-options` is dropped rather than emitted a second
+  time — an unguarded header included twice fails to compile, and the caller
+  passing it by hand is exactly the one who was working around this gap
+  before. L4 source-ABI replay is unchanged: it already carried forced
   includes from raw argv, and the two paths now share one recognizer rather
   than the L2 fix routing through `CompileUnit.abi_relevant_flags`, which
   would have made replay emit every forced include twice.

--- a/changelog.d/1786924800_claude_build-context-completeness.md
+++ b/changelog.d/1786924800_claude_build-context-completeness.md
@@ -43,7 +43,10 @@
   not just its directory, so a forced include whose suffix is not a
   recognised header suffix (`-imacros settings.def`, or an extensionless
   `-include generated/config`) is covered too — the directory walk is
-  deliberately suffix-filtered and would skip those. All four header-parse
+  deliberately suffix-filtered and would skip those. A forced include found
+  only through the `-I` chain is hashed at each candidate location, since the
+  bare operand alone resolves against abicheck's working directory rather than
+  the build's. All four header-parse
   cache keys — the primary dump parse, the header-graph second pass, the
   PE/Mach-O header-scoped parse, and the L2 seed's own derived paths — now
   share one definition of what affects staleness.

--- a/changelog.d/1786924800_claude_build-context-completeness.md
+++ b/changelog.d/1786924800_claude_build-context-completeness.md
@@ -31,10 +31,14 @@
 - **A forced pre-include is now hashed into the header-AST cache key.**
   Editing the forced header — the one macro-controlling input a parse depends
   on most — previously reused a stale cached AST, because it reached the
-  parse only as an opaque compiler-option string. All three header-parse
-  cache keys (the primary dump parse, the header-graph second pass, and the
-  L2 seed's own derived directories) now share one definition of which
-  directories affect staleness.
+  parse only as an opaque compiler-option string. The file itself is hashed,
+  not just its directory, so a forced include whose suffix is not a
+  recognised header suffix (`-imacros settings.def`, or an extensionless
+  `-include generated/config`) is covered too — the directory walk is
+  deliberately suffix-filtered and would skip those. All four header-parse
+  cache keys — the primary dump parse, the header-graph second pass, the
+  PE/Mach-O header-scoped parse, and the L2 seed's own derived paths — now
+  share one definition of what affects staleness.
 - **The L2 include-directory seed is restricted to the compile units that
   actually compile the headers being parsed.** When no explicit `-I` is
   given, abicheck seeds include directories from the build's compile

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -733,16 +733,64 @@ pipelines a fourth time.
   > forcing any of the three under continued session pressure risks
   > reopening one of the already-fixed findings this same area has needed
   > many prior review rounds to reach.
-- **PR 3B — build-context completeness (the review's PR D).** Two #782
-  follow-ups that change the *parsed public surface*, not just performance, so
-  they belong before the model is called finished: (1) compile-unit matching —
-  the L2 include-dir seed is still gathered from *every* `CompileUnit` rather
-  than the matched one(s), so an unrelated TU's colliding generated header can
-  shadow the matched TU's; (2) forced includes — `-include`, `-imacros`, `/FI`,
-  `/FU` are absent from `ABI_RELEVANT_FLAG_PREFIXES`, so a matched unit's
-  macro-controlling forced-include header never reaches the derived L2 context
-  even though the run reports a match and stamps `parsed_with_build_context`.
-  Both are already recorded as known gaps in the root `AGENTS.md`.
+- **PR 3B — build-context completeness (the review's PR D). Implemented.**
+  Two #782 follow-ups that change the *parsed public surface*, not just
+  performance, so they belong before the model is called finished: (1)
+  compile-unit matching — the L2 include-dir seed is still gathered from
+  *every* `CompileUnit` rather than the matched one(s), so an unrelated TU's
+  colliding generated header can shadow the matched TU's; (2) forced includes
+  — `-include`, `-imacros`, `/FI`, `/FU` are absent from
+  `ABI_RELEVANT_FLAG_PREFIXES`, so a matched unit's macro-controlling
+  forced-include header never reaches the derived L2 context even though the
+  run reports a match and stamps `parsed_with_build_context`. Both were
+  recorded as known gaps in the root `AGENTS.md`, which now carries the full
+  closure notes.
+
+  > **Landed (2026-08-16).** (1) `HeaderCompileContextResolution` gained
+  > `matched_units` (`matched_unit_count` stays as a derived property, so the
+  > two cannot drift), and `l2_seed.seed_includes_and_fold_compile_context`
+  > now resolves the compile context *before* seeding and restricts
+  > `_existing_include_dirs` to that set — falling back to every unit only
+  > when nothing matched, which is the case the seed was built for (a public
+  > header the compile DB does not cover) and where there is no narrower set
+  > to prefer. The entry's own "two independent call sites" worry
+  > (`_existing_include_dirs`'s caller *and*
+  > `service_input_resolution._seeded_includes`) was obsolete rather than
+  > addressed: PR C merged those two into one, so there was one site left to
+  > restrict.
+  >
+  > (2) **The forced-include fix the `AGENTS.md` entry proposed — a
+  > spaced-value branch in `extract_abi_relevant_flags` — was investigated
+  > and found to be actively wrong, and this is the part worth not
+  > rediscovering.** `source_extractors._argv.replay_extra_flags` already
+  > handles forced includes for L4 by a *different* route: it carries
+  > `abi_relevant_flags` through **and**, separately, re-scans raw `argv` for
+  > the same tokens without consulting the first pass's `seen` set. Capturing
+  > a forced include into that list would therefore have made every L4 replay
+  > command carry `-include config.h` twice — a silent double inclusion that
+  > a header without include guards turns into a hard redefinition error.
+  > Closed at the layer that actually had the gap instead:
+  > `header_utils.forced_include_operands` is the one shared recognizer (the
+  > replay matchers moved into that leaf — the one already owning this
+  > codebase's include-flag vocabulary, which both consumers already sit
+  > above — so L2 and L4 recognize the same spellings from one
+  > implementation) and
+  > `header_compile_context._forced_include_flags` renders it into the L2
+  > command straight from `cu.argv`, leaving L4 bit-for-bit unchanged. Forced
+  > includes also now participate in the ambiguity signature (two units
+  > forcing *different* macro-controlling headers fail closed rather than
+  > silently applying whichever grouped first) and in the AST cache key
+  > (`header_utils.cache_relevant_operand_dirs`, now shared by all three
+  > header-parse cache keys). `-include-pch` and `/FU` are deliberately not
+  > rendered; the ADR-029 D9 *drift-detection* half — a changed forced-include
+  > header does not raise `ABI_RELEVANT_BUILD_FLAG_CHANGED` — stays open,
+  > since closing it needs a structured `CompileUnit` field, a
+  > `BUILD_EVIDENCE_VERSION` bump and `build_diff` wiring, and specifically
+  > *not* another attempt to route it through `ABI_RELEVANT_FLAG_PREFIXES`.
+  > Tests: `tests/test_build_context_completeness.py` (20 cases; 9 verified to
+  > fail against the pre-fix code, and
+  > `TestReplayStillEmitsForcedIncludesExactlyOnce` kept as the executable
+  > record of the rejected fix).
 - **PR 3C — the removal itself** (everything the rest of this section
   describes), landing only after **all three** resolvers converge — 3A (both
   `dump` and `scan`) and 3B. 3C must not land on 3A-covers-`dump`-only; a
@@ -1279,7 +1327,7 @@ PR C  typed dump+scan convergence     = PR 3A — DumpRequest →
                                        resolution, JSON dry-run rendered
                                        from that object
 PR D  build-context completeness      = PR 3B — matched compile-unit
-                                       selection, forced includes, provenance
+      (DONE)                           selection, forced includes, provenance
                                        tests
 PR G1 canonical exit decision, part 1 — ExitDecision + reasons + the report
                                        block, precedence pinned by ADR and

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -414,14 +414,54 @@ class TestForcedIncludeCacheKey:
             Path("/proj/gen"),
         }
 
-    def test_bare_forced_operand_contributes_only_the_file(self) -> None:
+    def test_bare_forced_operand_with_no_search_path_contributes_only_the_file(
+        self,
+    ) -> None:
         from abicheck.header_utils import forced_include_operand_paths
 
-        # No directory part to add: its resolution depends on the include
-        # search, whose dirs include_operand_dirs already covers.
+        # Nothing to resolve it against, and no directory part to add.
         assert forced_include_operand_paths(("-include", "config.h")) == (
             Path("config.h"),
         )
+
+    def test_bare_forced_operand_resolves_against_each_include_search_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review: nothing else hashes a bare forced include's real file.
+
+        A forced include not found relative to the working directory is
+        resolved through the `-I` chain. The operand alone stats against
+        abicheck's own cwd (not the build's), and the search directory is
+        walked only through the suffix-filtered `iter_cache_header_files`,
+        which skips an extensionless or `.def` name — so without the
+        per-search-dir candidate, editing the real file leaves the key
+        unchanged.
+        """
+        from abicheck.dumper_ast_config import _cache_key
+        from abicheck.header_utils import (
+            cache_relevant_operand_paths,
+            forced_include_operand_paths,
+        )
+
+        gen = tmp_path / "gen"
+        gen.mkdir()
+        forced = gen / "config"  # extensionless: the directory walk skips it
+        forced.write_text("#define WIDTH 32\n", encoding="utf-8")
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        toks = ("-I", str(gen), "-include", "config")
+
+        assert forced in forced_include_operand_paths(toks)
+
+        def key() -> str:
+            return _cache_key(
+                [header], [], "c++", extra_hash_dirs=cache_relevant_operand_paths(toks)
+            )
+
+        before = key()
+        forced.write_text("#define WIDTH 64\n", encoding="utf-8")
+        os.utime(forced, (0, 0))
+        assert key() != before
 
     def test_non_header_suffixed_forced_file_is_itself_hashed(
         self, tmp_path: Path

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -370,6 +370,72 @@ class TestForcedIncludesReachTheDerivedContext:
         assert toks.index("-include") > toks.index("-I")
 
 
+class TestExplicitForcedIncludeIsNotDuplicated:
+    """Codex review: `_merge_l3_compile_context` concatenates without dedup.
+
+    A caller passing `--compiler-option -include config.h` for a build whose
+    compile database records the same forced header would get it twice — and
+    a header without include guards is then processed twice and fails to
+    compile. That caller is precisely the one who was *working around* the
+    absence of this feature, so the duplicate would break exactly the users
+    the change is meant to help.
+    """
+
+    def _resolution(self, tmp_path: Path, explicit: Any) -> list[str]:
+        from abicheck.compile_context import CompileContext  # noqa: F401
+
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        ev = BuildEvidence(
+            compile_units=[
+                _cu(
+                    source=str(src),
+                    directory=str(tmp_path),
+                    argv=["c++", "-c", str(src), "-include", "config.h"],
+                )
+            ]
+        )
+        result = resolve_header_compile_context(ev, [header], explicit=explicit)
+        return _tokens(result)
+
+    @pytest.mark.parametrize(
+        "explicit_kwargs",
+        [
+            {"gcc_option_tokens": ("-include", "config.h")},
+            {"gcc_options": "-include config.h"},
+        ],
+        ids=["tokens", "options-string"],
+    )
+    def test_derived_copy_is_dropped_when_the_caller_already_supplies_it(
+        self, tmp_path: Path, explicit_kwargs: dict[str, Any]
+    ) -> None:
+        from abicheck.buildsource.l2_seed import _merge_l3_compile_context
+        from abicheck.compile_context import CompileContext
+
+        explicit = CompileContext(**explicit_kwargs)
+        derived = CompileContext(
+            gcc_option_tokens=tuple(self._resolution(tmp_path, explicit))
+        )
+        merged = _merge_l3_compile_context(explicit, derived)
+        assert merged is not None
+        # Exactly once in the command the parse actually runs.
+        assert list(merged.gcc_option_tokens).count("-include") == 1
+
+    def test_a_different_explicit_forced_header_does_not_suppress_the_derived_one(
+        self, tmp_path: Path
+    ) -> None:
+        # Only the *same* file is a duplicate; an unrelated explicit forced
+        # header must not silently drop the build's own.
+        from abicheck.compile_context import CompileContext
+
+        toks = self._resolution(
+            tmp_path, CompileContext(gcc_option_tokens=("-include", "other.h"))
+        )
+        assert toks[-2:] == ["-include", "config.h"]
+
+
 class TestForcedIncludeAmbiguity:
     """A forced include was invisible to the ambiguity signature entirely, so
     two units forcing *different* macro-controlling headers in silently

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -44,6 +44,7 @@ entry point every ``dump``/``scan``/``compare`` resolver actually calls
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -363,25 +364,107 @@ class TestForcedIncludeCacheKey:
     hashing never covered it — editing the one macro-controlling input the
     parse depends on most would reuse a stale AST."""
 
-    def test_union_covers_both_include_search_and_forced_include_dirs(self) -> None:
+    def test_union_covers_both_include_search_and_forced_include_paths(self) -> None:
         from abicheck.header_utils import (
-            cache_relevant_operand_dirs,
+            cache_relevant_operand_paths,
             include_operand_dirs,
         )
 
         toks = ("-I", "/proj/include", "-include", "/proj/gen/config.h")
         assert include_operand_dirs(toks) == (Path("/proj/include"),)
-        assert set(cache_relevant_operand_dirs(toks)) == {
+        assert set(cache_relevant_operand_paths(toks)) == {
             Path("/proj/include"),
+            # The forced header itself, *and* its directory: the file because
+            # the cache key's directory walk is suffix-filtered and would miss
+            # it outright for a non-header suffix; the directory so a
+            # neighbouring header it pulls in relatively is covered too, since
+            # that directory need not be on the include search path.
+            Path("/proj/gen/config.h"),
             Path("/proj/gen"),
         }
 
-    def test_bare_forced_operand_contributes_no_directory(self) -> None:
-        from abicheck.header_utils import forced_include_operand_dirs
+    def test_bare_forced_operand_contributes_only_the_file(self) -> None:
+        from abicheck.header_utils import forced_include_operand_paths
 
-        # Its resolution depends on the include search, whose dirs
-        # include_operand_dirs already covers.
-        assert forced_include_operand_dirs(("-include", "config.h")) == ()
+        # No directory part to add: its resolution depends on the include
+        # search, whose dirs include_operand_dirs already covers.
+        assert forced_include_operand_paths(("-include", "config.h")) == (
+            Path("config.h"),
+        )
+
+    def test_non_header_suffixed_forced_file_is_itself_hashed(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review: the cache key's directory walk is suffix-filtered.
+
+        `-imacros settings.def` (and an extensionless `-include generated/config`)
+        carry suffixes `CACHE_HEADER_SUFFIXES` does not list, so hashing only the
+        parent directory left an edit to the one macro-controlling input the
+        parse depends on most invisible to the key.
+        """
+        from abicheck.dumper_ast_config import _cache_key
+        from abicheck.header_utils import cache_relevant_operand_paths
+
+        macros = tmp_path / "settings.def"
+        macros.write_text("#define WIDTH 32\n", encoding="utf-8")
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        hash_paths = list(cache_relevant_operand_paths(("-imacros", str(macros))))
+        assert macros in hash_paths
+
+        def key() -> str:
+            return _cache_key([header], [], "c++", extra_hash_dirs=tuple(hash_paths))
+
+        before = key()
+        # A real edit to the forced file, with its mtime advanced the way a
+        # rewrite does.
+        macros.write_text("#define WIDTH 64\n", encoding="utf-8")
+        os.utime(macros, (0, 0))
+        assert key() != before
+
+    def test_pe_macho_parse_derives_the_same_hash_paths_from_its_own_tokens(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex review: PE/Mach-O must not disagree with ELF about staleness.
+
+        `dump_native_binary`/`service.run_dump` exposes no `extra_hash_dirs`
+        hook, so the caller's own derived-dirs return is discarded on that
+        path. It does not need one: the merged L3 context arrives here as
+        `compile=`, so the parse derives the identical set from the very
+        tokens those dirs came from — the same fold `service._dump_elf` and
+        `service._attach_header_graph` already apply.
+        """
+        from abicheck import service_header_scoped
+        from abicheck.service_scan import CompileContext
+
+        gen = tmp_path / "gen"
+        gen.mkdir()
+        forced = gen / "config.h"
+        forced.write_text("#define BUILD_ONLY 1\n", encoding="utf-8")
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+
+        seen: dict[str, Any] = {}
+
+        def fake_dump_pe(*args: Any, **kwargs: Any) -> Any:
+            seen["extra_hash_dirs"] = kwargs.get("extra_hash_dirs")
+            raise RuntimeError("stop after the cache-key inputs are known")
+
+        monkeypatch.setattr("abicheck.dumper._dump_pe", fake_dump_pe, raising=False)
+        service_header_scoped._try_header_scoped_dump(
+            "pe",
+            tmp_path / "lib.dll",
+            [header],
+            [],
+            "1.0",
+            "c++",
+            compile=CompileContext(
+                gcc_option_tokens=("-I", str(gen), "-include", str(forced))
+            ),
+        )
+        hashed = set(seen["extra_hash_dirs"])
+        assert forced in hashed  # the forced file itself
+        assert gen in hashed  # and the include-search dir
 
     def test_derived_forced_include_dir_reaches_the_callers_hash_dirs(
         self, tmp_path: Path

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -280,6 +280,37 @@ class TestForcedIncludesReachTheDerivedContext:
             "config.h",
         ]
 
+    @pytest.mark.parametrize("driver", ["dpcpp-cl", "clang-cl-20", "clang-cl-20.1.exe"])
+    def test_cl_mode_driver_spelled_with_gnu_dash_c_still_renders_fi(
+        self, tmp_path: Path, driver: str
+    ) -> None:
+        """Codex review: the dialect vocabulary had drifted between the layers.
+
+        `adapters.base._is_msvc_command` listed only `cl`/`clang-cl` while the
+        L4 replay path also knew `dpcpp-cl` and version-suffixed drivers. A
+        CL-mode command spelled with GNU `-c` rather than `/c` therefore read
+        as GNU dialect here — silently dropping its `/FI` from the derived L2
+        context while L4 replayed it correctly. Both now share one vocabulary.
+        """
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        ev = BuildEvidence(
+            compile_units=[
+                _cu(
+                    source=str(src),
+                    directory=str(tmp_path),
+                    argv=[driver, "-c", str(src), "/FIconfig.h"],
+                )
+            ]
+        )
+
+        assert _tokens(resolve_header_compile_context(ev, [header]))[-2:] == [
+            "-include",
+            "config.h",
+        ]
+
     def test_include_pch_is_not_rendered(self, tmp_path: Path) -> None:
         # A .pch is locked to the exact compiler build that produced it, and
         # L2 parses with castxml's bundled clang or the host clang -- replaying
@@ -421,6 +452,24 @@ class TestForcedIncludeCacheKey:
         macros.write_text("#define WIDTH 64\n", encoding="utf-8")
         os.utime(macros, (0, 0))
         assert key() != before
+
+    def test_an_unresolvable_forced_include_degrades_instead_of_raising(
+        self, tmp_path: Path
+    ) -> None:
+        # Not hypothetical: `_forced_include_flags` deliberately leaves an
+        # operand relative when it does not resolve against the compile unit's
+        # own directory (the include search is expected to find it), so the
+        # cache key routinely sees a path that does not exist from here. It
+        # must contribute its path string and move on, not raise.
+        from abicheck.dumper_ast_config import _cache_key
+
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        missing = tmp_path / "nope" / "generated_config.h"
+
+        assert _cache_key(
+            [header], [], "c++", extra_hash_dirs=(missing,)
+        ) != _cache_key([header], [], "c++", extra_hash_dirs=())
 
     def test_pe_macho_parse_derives_the_same_hash_paths_from_its_own_tokens(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -456,6 +456,31 @@ class TestExplicitForcedIncludeIsNotDuplicated:
         )
         assert toks[-2:] == ["-include", "config.h"]
 
+    def test_an_unbalanced_quote_degrades_instead_of_aborting_resolution(
+        self, tmp_path: Path
+    ) -> None:
+        """CodeRabbit review: ``shlex`` raises on an unbalanced quote.
+
+        The dedup keys were flattened by a second, unguarded copy of the
+        caller-option flattening, so a malformed ``--gcc-options`` string took
+        down the whole compile-context resolution — a path documented as
+        best-effort — rather than degrading to "the caller supplies no forced
+        include". The derived side must still be rendered.
+        """
+        from abicheck.buildsource.header_compile_context import (
+            explicit_forced_include_keys,
+        )
+        from abicheck.compile_context import CompileContext
+
+        explicit = CompileContext(gcc_options='-include "unbalanced')
+
+        # The primitive itself degrades rather than raising...
+        assert explicit_forced_include_keys(explicit) == frozenset()
+
+        # ...and the resolution it feeds still renders the build's own header.
+        toks = self._resolution(tmp_path, explicit)
+        assert toks[-2:] == ["-include", "config.h"]
+
 
 class TestForcedIncludeAmbiguity:
     """A forced include was invisible to the ambiguity signature entirely, so

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -268,6 +268,27 @@ class TestForcedIncludesReachTheDerivedContext:
         toks = _tokens(resolve_header_compile_context(ev, [tmp_path / "widget.h"]))
         assert toks[-2:] == ["-include", forced.as_posix()]
 
+    def test_first_search_dir_in_argv_order_wins_not_alphabetical(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review: a compiler takes the *first* match in a bucket.
+
+        `-iquote z -iquote a` searches `z` first, so `z/config.h` is the file
+        the real build uses. Sorting the bucket — deterministic, but by the
+        wrong key — would pin the derived parse to `a/config.h`: a different
+        file, potentially with different macros.
+        """
+        for name in ("z", "a"):
+            d = tmp_path / name
+            d.mkdir()
+            (d / "config.h").write_text(f"#define FROM_{name.upper()} 1\n", "utf-8")
+        ev = self._matched_unit(
+            tmp_path, ["-iquote", "z", "-iquote", "a", "-include", "config.h"]
+        )
+
+        toks = _tokens(resolve_header_compile_context(ev, [tmp_path / "widget.h"]))
+        assert toks[-2:] == ["-include", (tmp_path / "z" / "config.h").as_posix()]
+
     def test_the_units_own_directory_still_wins_over_a_search_dir(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -246,6 +246,44 @@ class TestForcedIncludesReachTheDerivedContext:
         toks = _tokens(resolve_header_compile_context(ev, [tmp_path / "widget.h"]))
         assert toks[-2:] == ["-include", "generated_config.h"]
 
+    @pytest.mark.parametrize("search_flag", ["-iquote", "/I", "-idirafter"])
+    def test_operand_found_only_via_an_argv_only_search_dir_is_pinned(
+        self, tmp_path: Path, search_flag: str
+    ) -> None:
+        """Codex review: the rendered command does not carry these dirs.
+
+        `_context_flags` emits only the structured `include_paths`/
+        `system_include_paths`, and the compile-DB adapter never parses
+        `-iquote`/`/I`/`-idirafter` into those — so a bare `-include config`
+        that only such a directory resolves would be emitted into a command
+        that cannot find it, turning a working parse into a hard failure.
+        Resolving through the unit's own full search chain pins it instead.
+        """
+        gen = tmp_path / "gen"
+        gen.mkdir()
+        forced = gen / "config.h"
+        forced.write_text("#define BUILD_ONLY 1\n", encoding="utf-8")
+        ev = self._matched_unit(tmp_path, [search_flag, "gen", "-include", "config.h"])
+
+        toks = _tokens(resolve_header_compile_context(ev, [tmp_path / "widget.h"]))
+        assert toks[-2:] == ["-include", forced.as_posix()]
+
+    def test_the_units_own_directory_still_wins_over_a_search_dir(
+        self, tmp_path: Path
+    ) -> None:
+        # GCC's documented order: the preprocessor's working directory first,
+        # then the -I chain. A same-named file in both must resolve to the
+        # working-directory one.
+        gen = tmp_path / "gen"
+        gen.mkdir()
+        (gen / "config.h").write_text("#define FROM_GEN 1\n", encoding="utf-8")
+        near = tmp_path / "config.h"
+        near.write_text("#define FROM_CWD 1\n", encoding="utf-8")
+        ev = self._matched_unit(tmp_path, ["-iquote", "gen", "-include", "config.h"])
+
+        toks = _tokens(resolve_header_compile_context(ev, [tmp_path / "widget.h"]))
+        assert toks[-2:] == ["-include", near.as_posix()]
+
     def test_imacros_is_rendered_under_its_own_spelling(self, tmp_path: Path) -> None:
         # -imacros takes only the macros, not the declarations, so it must not
         # be flattened into -include.

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -1,0 +1,491 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PR D (plan "PR 3B") — build-context completeness for the P0.3 L3->L2 fold.
+
+Two gaps, both previously recorded in the root ``AGENTS.md``, both closed
+here. Each has three layers of coverage: the primitive on its own, the
+derived L2 context it feeds, and the real ``collect_inline_pack``-backed
+entry point every ``dump``/``scan``/``compare`` resolver actually calls
+(``l2_seed.seed_includes_and_fold_compile_context``).
+
+1. **Forced pre-includes** (``-include``/``-imacros``/``/FI``). A build that
+   forces a macro-controlling header in parses its own headers with that
+   header's macros already defined; the derived L2 context never carried it,
+   so the header parse saw a materially different translation unit while
+   still reporting a real match and stamping ``parsed_with_build_context``.
+
+   ``TestReplayStillEmitsForcedIncludesExactlyOnce`` is the load-bearing
+   negative half: it pins why the fix that ``ABI_RELEVANT_FLAG_PREFIXES``'s
+   own comment used to propose — capture forced includes into
+   ``CompileUnit.abi_relevant_flags`` — is wrong. ``replay_extra_flags``
+   both carries that list *and* independently re-scans raw argv for the same
+   tokens, so L4 replay would have emitted every forced include twice.
+
+2. **Matched compile-unit selection.** The L2 include-dir seed gathered dirs
+   from every ``CompileUnit`` in the build rather than the one(s) that
+   actually compile the headers being parsed, so an unrelated TU's own
+   generated-header directory could shadow the matched TU's own colliding
+   header.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
+from abicheck.buildsource.header_compile_context import resolve_header_compile_context
+from abicheck.errors import HeaderCompileContextAmbiguousError
+from abicheck.header_utils import forced_include_operands
+
+
+def _cu(**kwargs: object) -> CompileUnit:
+    defaults: dict[str, object] = dict(
+        id=f"cu://{kwargs.get('source', 'x')}",
+        source="",
+        directory="",
+        target_id="",
+        compiler="",
+        language="CXX",
+        standard="",
+        defines={},
+        undefines=[],
+        include_paths=[],
+        system_include_paths=[],
+        sysroot=None,
+        target_triple="",
+        abi_relevant_flags=[],
+        argv=[],
+    )
+    defaults.update(kwargs)
+    return CompileUnit(**defaults)  # type: ignore[arg-type]
+
+
+def _tokens(result: Any) -> list[str]:
+    assert result.context is not None
+    return list(result.context.gcc_option_tokens)
+
+
+def _seed_and_fold(**overrides: Any) -> Any:
+    from abicheck.buildsource.l2_seed import seed_includes_and_fold_compile_context
+
+    kwargs: dict[str, Any] = dict(
+        headers=[],
+        includes=[],
+        sources=None,
+        build_info=None,
+        build_config=None,
+        build_query=None,
+        build_compile_db=None,
+        collect_mode="source-target",
+        gcc_path=None,
+        gcc_prefix=None,
+        gcc_options=None,
+        gcc_option_tokens=(),
+        sysroot=None,
+        nostdinc=False,
+        frontend="auto",
+        frontend_context="host",
+        lang="c++",
+        lang_explicit=False,
+        pending_cleanups=[],
+    )
+    kwargs.update(overrides)
+    return seed_includes_and_fold_compile_context(**kwargs)
+
+
+def _write_compile_db(tmp_path: Path, entries: list[tuple[Path, list[str]]]) -> None:
+    (tmp_path / "compile_commands.json").write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "file": str(src),
+                    "arguments": ["c++", "-c", str(src), "-o", f"{src.stem}.o", *args],
+                }
+                for src, args in entries
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1a. The shared recognizer
+# ---------------------------------------------------------------------------
+
+
+class TestForcedIncludeRecognizer:
+    """``header_utils.forced_include_operands`` — one vocabulary, two views.
+
+    The same matchers the L4 replay path reaches through
+    ``source_extractors._argv``, so the set L2 renders can never drift from
+    the set L4 replays.
+    """
+
+    def test_gnu_separate_and_joined_spellings(self) -> None:
+        argv = ["c++", "-include", "cfg.h", "-imacrosdefs.h", "-c", "a.cpp"]
+        assert forced_include_operands(argv, msvc=False) == [
+            ("-include", "cfg.h"),
+            ("-imacros", "defs.h"),
+        ]
+
+    def test_include_pch_is_recognized_only_in_its_separate_form(self) -> None:
+        # clang has no joined ``-include-pchfile`` spelling, so the joined
+        # branch must not read one -- ``-include-pchfoo`` reaches the joined
+        # ``-include`` branch with an option-shaped "operand" (``-pchfoo``),
+        # which is not a real file and is dropped.
+        assert forced_include_operands(
+            ["c++", "-include-pch", "p.pch"], msvc=False
+        ) == [("-include-pch", "p.pch")]
+        assert forced_include_operands(["c++", "-include-pchfoo"], msvc=False) == []
+
+    def test_msvc_family_is_gated_on_the_resolved_dialect(self) -> None:
+        argv = ["clang-cl", "/FIcfg.h", "/FI", "other.h", "-FIthird.h"]
+        assert forced_include_operands(argv, msvc=True) == [
+            ("/FI", "cfg.h"),
+            ("/FI", "other.h"),
+            ("/FI", "third.h"),
+        ]
+        # A GNU command's ``-F``-family flag is never read as a forced include.
+        assert forced_include_operands(argv, msvc=False) == []
+
+    def test_a_dangling_separate_option_consumes_nothing(self) -> None:
+        assert (
+            forced_include_operands(["c++", "-c", "a.cpp", "-include"], msvc=False)
+            == []
+        )
+
+
+class TestReplayStillEmitsForcedIncludesExactlyOnce:
+    """Why forced includes deliberately never enter ``abi_relevant_flags``.
+
+    ``replay_extra_flags`` carries ``abi_relevant_flags`` through *and*
+    independently re-scans raw ``argv`` for forced-include tokens, without
+    consulting the ``seen`` set the first pass builds. Capturing a forced
+    include into that list — the fix ``ABI_RELEVANT_FLAG_PREFIXES``'s comment
+    used to propose — would therefore double-emit it on every L4 replay
+    command: a silent double inclusion that a header without include guards
+    turns into a hard redefinition error.
+    """
+
+    def test_argv_sourced_forced_include_is_emitted_once(self) -> None:
+        from abicheck.buildsource.source_extractors._argv import replay_extra_flags
+
+        cu = _cu(argv=["c++", "-include", "cfg.h", "-c", "a.cpp"])
+        assert replay_extra_flags(cu, [], "gnu").count("-include") == 1
+
+    def test_forced_includes_are_absent_from_abi_relevant_flags(self) -> None:
+        from abicheck.buildsource.adapters.base import extract_abi_relevant_flags
+
+        argv = ["c++", "-include", "cfg.h", "-imacros", "defs.h", "/FIw.h", "-fPIC"]
+        assert extract_abi_relevant_flags(argv) == ["-fPIC"]
+
+
+# ---------------------------------------------------------------------------
+# 1b. Forced includes reach the derived L2 context
+# ---------------------------------------------------------------------------
+
+
+class TestForcedIncludesReachTheDerivedContext:
+    def _matched_unit(self, tmp_path: Path, args: list[str]) -> BuildEvidence:
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        return BuildEvidence(
+            compile_units=[
+                _cu(
+                    source=str(src),
+                    directory=str(tmp_path),
+                    argv=["c++", "-c", str(src), *args],
+                )
+            ]
+        )
+
+    def test_relative_operand_resolves_against_the_compile_units_directory(
+        self, tmp_path: Path
+    ) -> None:
+        # The compile command's own cwd is the build's, never abicheck's, so a
+        # relative operand naming a real file must be pinned to it.
+        (tmp_path / "cfg").mkdir()
+        forced = tmp_path / "cfg" / "config.h"
+        forced.write_text("#define BUILD_ONLY 1\n", encoding="utf-8")
+        ev = self._matched_unit(tmp_path, ["-include", "cfg/config.h"])
+
+        toks = _tokens(resolve_header_compile_context(ev, [tmp_path / "widget.h"]))
+        assert toks[-2:] == ["-include", forced.as_posix()]
+
+    def test_bare_operand_with_no_file_on_disk_stays_relative(
+        self, tmp_path: Path
+    ) -> None:
+        # GCC documents a two-stage lookup for ``-include``: the preprocessor's
+        # working directory first, then the -iquote/-I chain. Pinning a
+        # generated header the build finds through its -I chain to a
+        # non-existent ``<directory>/config.h`` would turn a header that would
+        # have been found into a hard "file not found".
+        ev = self._matched_unit(tmp_path, ["-include", "generated_config.h"])
+
+        toks = _tokens(resolve_header_compile_context(ev, [tmp_path / "widget.h"]))
+        assert toks[-2:] == ["-include", "generated_config.h"]
+
+    def test_imacros_is_rendered_under_its_own_spelling(self, tmp_path: Path) -> None:
+        # -imacros takes only the macros, not the declarations, so it must not
+        # be flattened into -include.
+        ev = self._matched_unit(tmp_path, ["-imacros", "defs.h"])
+
+        assert _tokens(resolve_header_compile_context(ev, [tmp_path / "widget.h"]))[
+            -2:
+        ] == ["-imacros", "defs.h"]
+
+    def test_msvc_forced_include_renders_as_the_gnu_spelling(
+        self, tmp_path: Path
+    ) -> None:
+        # Everything this module renders is GNU-style regardless of the
+        # recorded command's dialect (-D/-I/--sysroot= already are), because
+        # the consumer is always a GNU-driver castxml/clang invocation.
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        ev = BuildEvidence(
+            compile_units=[
+                _cu(
+                    source=str(src),
+                    directory=str(tmp_path),
+                    argv=["clang-cl", "/c", str(src), "/FIconfig.h"],
+                )
+            ]
+        )
+
+        assert _tokens(resolve_header_compile_context(ev, [header]))[-2:] == [
+            "-include",
+            "config.h",
+        ]
+
+    def test_include_pch_is_not_rendered(self, tmp_path: Path) -> None:
+        # A .pch is locked to the exact compiler build that produced it, and
+        # L2 parses with castxml's bundled clang or the host clang -- replaying
+        # one is a hard parse failure far more often than a fidelity win. L4
+        # replay, which uses the real compiler, still carries it.
+        ev = self._matched_unit(tmp_path, ["-include-pch", "everything.pch"])
+
+        assert "-include-pch" not in _tokens(
+            resolve_header_compile_context(ev, [tmp_path / "widget.h"])
+        )
+
+    def test_forced_include_lands_after_the_include_search_it_resolves_through(
+        self, tmp_path: Path
+    ) -> None:
+        ev = self._matched_unit(tmp_path, ["-include", "generated_config.h", "-Igen"])
+        ev.compile_units[0].include_paths = ["gen"]
+
+        toks = _tokens(resolve_header_compile_context(ev, [tmp_path / "widget.h"]))
+        assert toks.index("-include") > toks.index("-I")
+
+
+class TestForcedIncludeAmbiguity:
+    """A forced include was invisible to the ambiguity signature entirely, so
+    two units forcing *different* macro-controlling headers in silently
+    applied whichever grouped first."""
+
+    def _two_units(self, tmp_path: Path, a: list[str], b: list[str]) -> BuildEvidence:
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        units = []
+        for name, args in (("a", a), ("b", b)):
+            src = tmp_path / f"{name}.cpp"
+            src.write_text('#include "widget.h"\n', encoding="utf-8")
+            units.append(
+                _cu(
+                    id=f"cu://{name}",
+                    source=str(src),
+                    directory=str(tmp_path),
+                    argv=["c++", "-c", str(src), *args],
+                )
+            )
+        return BuildEvidence(compile_units=units)
+
+    def test_different_forced_headers_fail_closed(self, tmp_path: Path) -> None:
+        ev = self._two_units(
+            tmp_path, ["-include", "debug_config.h"], ["-include", "release_config.h"]
+        )
+        with pytest.raises(HeaderCompileContextAmbiguousError) as excinfo:
+            resolve_header_compile_context(ev, [tmp_path / "widget.h"])
+        # The message must name the dimension that actually differs: every
+        # other field it prints is identical here, so without this the user
+        # sees two apparently-equal rows and no reason for the error.
+        message = str(excinfo.value)
+        assert "debug_config.h" in message
+        assert "release_config.h" in message
+
+    def test_one_unit_forcing_and_one_not_is_also_a_disagreement(
+        self, tmp_path: Path
+    ) -> None:
+        # "This one forces nothing" is half of the disagreement, so the
+        # forced-include field is shown for both rows once either has one --
+        # an omitted field would read as agreement.
+        ev = self._two_units(tmp_path, ["-include", "debug_config.h"], [])
+        with pytest.raises(HeaderCompileContextAmbiguousError) as excinfo:
+            resolve_header_compile_context(ev, [tmp_path / "widget.h"])
+        assert str(excinfo.value).count("forced_includes=") == 2
+
+    def test_equivalent_spellings_of_the_same_forced_header_still_agree(
+        self, tmp_path: Path
+    ) -> None:
+        # The signature compares the *rendered* tokens, so a separate and a
+        # joined spelling of the same header are not a disagreement.
+        ev = self._two_units(tmp_path, ["-include", "config.h"], ["-includeconfig.h"])
+        result = resolve_header_compile_context(ev, [tmp_path / "widget.h"])
+        assert result.matched_unit_count == 2
+        assert _tokens(result)[-2:] == ["-include", "config.h"]
+
+
+class TestForcedIncludeCacheKey:
+    """A forced-include header reaches the parse only as an opaque
+    ``gcc_option_tokens`` string, so the AST cache key's directory-mtime
+    hashing never covered it — editing the one macro-controlling input the
+    parse depends on most would reuse a stale AST."""
+
+    def test_union_covers_both_include_search_and_forced_include_dirs(self) -> None:
+        from abicheck.header_utils import (
+            cache_relevant_operand_dirs,
+            include_operand_dirs,
+        )
+
+        toks = ("-I", "/proj/include", "-include", "/proj/gen/config.h")
+        assert include_operand_dirs(toks) == (Path("/proj/include"),)
+        assert set(cache_relevant_operand_dirs(toks)) == {
+            Path("/proj/include"),
+            Path("/proj/gen"),
+        }
+
+    def test_bare_forced_operand_contributes_no_directory(self) -> None:
+        from abicheck.header_utils import forced_include_operand_dirs
+
+        # Its resolution depends on the include search, whose dirs
+        # include_operand_dirs already covers.
+        assert forced_include_operand_dirs(("-include", "config.h")) == ()
+
+    def test_derived_forced_include_dir_reaches_the_callers_hash_dirs(
+        self, tmp_path: Path
+    ) -> None:
+        gen = tmp_path / "gen"
+        gen.mkdir()
+        forced = gen / "config.h"
+        forced.write_text("#define BUILD_ONLY 1\n", encoding="utf-8")
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        _write_compile_db(tmp_path, [(src, ["-include", str(forced)])])
+
+        _incs, applied, ctx, dirs = _seed_and_fold(
+            headers=[header], sources=tmp_path, pending_cleanups=[]
+        )
+        assert applied is True
+        assert "-include" in ctx.gcc_option_tokens
+        assert gen in dirs
+
+
+# ---------------------------------------------------------------------------
+# 2. Matched compile-unit selection for the include-dir seed
+# ---------------------------------------------------------------------------
+
+
+class TestIncludeSeedIsRestrictedToMatchedUnits:
+    def _project(self, tmp_path: Path, *, matching: bool) -> Path:
+        """A two-TU build: one TU compiles the public header, one does not.
+
+        Each carries its own private include dir, and both hold a colliding
+        ``config.h`` — the shape where seeding from every unit lets an
+        unrelated TU's generated header shadow the matched TU's own.
+        """
+        for name in ("matched_inc", "unrelated_inc"):
+            d = tmp_path / name
+            d.mkdir()
+            (d / "config.h").write_text(f"/* {name} */\n", encoding="utf-8")
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+
+        matched = tmp_path / "widget.cpp"
+        matched.write_text(
+            '#include "widget.h"\n' if matching else "int f() { return 0; }\n",
+            encoding="utf-8",
+        )
+        unrelated = tmp_path / "other.cpp"
+        unrelated.write_text("int g() { return 0; }\n", encoding="utf-8")
+        _write_compile_db(
+            tmp_path,
+            [
+                (matched, ["-I", str(tmp_path / "matched_inc")]),
+                (unrelated, ["-I", str(tmp_path / "unrelated_inc")]),
+            ],
+        )
+        return header
+
+    def test_only_the_matched_units_include_dirs_are_seeded(
+        self, tmp_path: Path
+    ) -> None:
+        header = self._project(tmp_path, matching=True)
+
+        incs, applied, _ctx, _dirs = _seed_and_fold(
+            headers=[header], sources=tmp_path, pending_cleanups=[]
+        )
+        seeded = {str(p) for p in incs}
+        assert applied is True
+        assert str(tmp_path / "matched_inc") in seeded
+        assert str(tmp_path / "unrelated_inc") not in seeded
+
+    def test_seed_falls_back_to_every_unit_when_nothing_matched(
+        self, tmp_path: Path
+    ) -> None:
+        # The case this seed was built for: a public header the compile DB
+        # does not cover, reaching into a dependency SDK. There is no narrower
+        # set to prefer, so restricting must not silently empty the seed.
+        header = self._project(tmp_path, matching=False)
+
+        incs, applied, _ctx, _dirs = _seed_and_fold(
+            headers=[header], sources=tmp_path, pending_cleanups=[]
+        )
+        seeded = {str(p) for p in incs}
+        assert applied is False
+        assert str(tmp_path / "matched_inc") in seeded
+        assert str(tmp_path / "unrelated_inc") in seeded
+
+    def test_resolution_exposes_the_units_not_only_their_count(
+        self, tmp_path: Path
+    ) -> None:
+        header = tmp_path / "widget.h"
+        header.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        other = tmp_path / "other.cpp"
+        other.write_text("int g() { return 0; }\n", encoding="utf-8")
+        ev = BuildEvidence(
+            compile_units=[
+                _cu(id="cu://widget", source=str(src), directory=str(tmp_path)),
+                _cu(id="cu://other", source=str(other), directory=str(tmp_path)),
+            ]
+        )
+
+        result = resolve_header_compile_context(ev, [header])
+        assert [cu.id for cu in result.matched_units] == ["cu://widget"]
+        # The historical read view stays exactly consistent with it.
+        assert result.matched_unit_count == len(result.matched_units) == 1


### PR DESCRIPTION
## Summary

Applies a matched compile unit's forced pre-includes, and only the matched unit's include directories, to the L2 header parse — closing both gaps the plan's "PR 3B / PR D — build-context completeness" names.

## Motivation

Next step in the reviewed sequence of [`docs/contribute/plans/cli-cleanup-phase-two.md`](https://github.com/abicheck/abicheck/blob/main/docs/contribute/plans/cli-cleanup-phase-two.md): PR A (#793), PR B slices 1–2 (#791, #794), PR G1 (#789) and PR C's scoped slice (#795) have landed, so PR D is next. Both of its gaps were recorded as known gaps in the root `AGENTS.md` (the eleventh and fourteenth findings on the L3→L2-fold entry), and both change the *parsed public surface*, not just performance — which is why they belong before the model is called finished and before PR F removes the flags that configure it.

**Forced pre-includes.** A build that forces a macro-controlling header in (`-include config.h`, `/FIconfig.h`) parses its own public headers with that header's macros already defined. The P0.3 L3→L2 fold never carried it, so the L2 header parse saw a materially different translation unit — different `#if` branches taken, different struct layouts — while still reporting a real compile-unit match and stamping `AbiSnapshot.parsed_with_build_context`, i.e. reading as more authoritative than it was.

**Matched compile-unit selection.** When no explicit `-I` is given, the L2 include-dir seed gathered directories from *every* `CompileUnit` in the build rather than the one(s) that actually compile the headers being parsed, so in a multi-TU project an unrelated TU's own generated-header directory (a stray `config.h`) could shadow the matched TU's own.

**The fix `AGENTS.md` proposed for the first gap was investigated and is wrong — that is the part worth reading.** It proposed a spaced-value branch in `extract_abi_relevant_flags`, i.e. capturing forced includes into `CompileUnit.abi_relevant_flags`. But `source_extractors._argv.replay_extra_flags` already handles forced includes for L4 by a *different* route: it carries `abi_relevant_flags` through **and**, separately, re-scans the unit's raw `argv` for the same tokens, deliberately without consulting the `seen` set the first pass builds. Capturing one into that list would therefore have made every L4 replay command emit `-include config.h` **twice** — a silent double inclusion that a header without include guards turns into a hard redefinition error. The general shape: `ABI_RELEVANT_FLAG_PREFIXES` is not the only channel a compile unit's flags reach a consumer through, so "the flag is missing from the list" is not by itself evidence that adding it to the list is the fix.

## Changes

- **`header_utils`** gains the shared forced-include recognizer — `forced_include_operands` plus the two matchers `match_gnu_forced_include`/`match_msvc_forced_include`, *moved* out of `source_extractors/_argv.py` — and the shared CL-mode driver vocabulary `is_msvc_driver_stem`. That leaf already owns this codebase's include-flag vocabulary and both consumers already sit above it, so one shared implementation costs no new import edge in either direction; L2 and L4 can no longer drift on what a forced include looks like, or on which drivers are CL-mode.
- **`header_compile_context._forced_include_flags`** renders them into the derived L2 context, straight from `cu.argv` and never through `abi_relevant_flags`, so L4 replay is bit-for-bit unchanged. The operand is resolved against the unit's **own full search chain** (`_forced_include_search_dirs`: `directory` first, then quote / normal / system / after-system buckets, each combining the structured field with the argv-only spellings the compile-DB adapter leaves behind) and emitted as an absolute path — the rendered command does not carry those search dirs, so a bare operand only they could resolve would be a hard "file not found". `/FI` renders as GNU `-include`; `-include-pch` (version-locked to the compiler build that produced it) and `/FU` (managed C++/CLI `#using`) are deliberately dropped. A derived forced include the caller already supplies via `--compiler-option`/`--gcc-options` is dropped rather than emitted twice.
- **Forced includes now participate in `_EffectiveContextSignature`.** Two units forcing *different* macro-controlling headers fail closed instead of silently applying whichever grouped first, and the ambiguity message lists each unit's forced includes so the differing dimension is visible rather than leaving two apparently-identical rows. Equivalent spellings of the *same* header still agree.
- **`header_utils.cache_relevant_operand_paths`** (the union of `include_operand_dirs` with the new `forced_include_operand_paths`) is now used by all **four** header-parse cache keys — `service._dump_elf`, `service._attach_header_graph`, the PE/Mach-O `service_header_scoped._try_header_scoped_dump`, and the L2 seed's own derived paths — so editing the forced header no longer reuses a stale AST, and the four cannot disagree about what staleness means. Three of those four had already needed their own individual fix for exactly that divergence. The forced header's **file** is hashed, not just its directory (the directory walk is suffix-filtered and would skip `-imacros settings.def` or an extensionless `-include generated/config`), and a forced include found only through the `-I` chain is hashed at each candidate location.
- **`HeaderCompileContextResolution.matched_units`** exposes the units, not just how many; `matched_unit_count` becomes a derived property so the two cannot drift. `l2_seed.seed_includes_and_fold_compile_context` now resolves the compile context *before* seeding and restricts the include-dir seed to that set, falling back to every unit only when nothing matched — the case the seed was built for (a public header the compile DB does not cover, reaching into a dependency SDK), where there is no narrower set to prefer. Reordering is otherwise unobservable: the one path that skips the seed is the fail-closed ambiguity raise, which aborts the call either way.
- Docs: `AGENTS.md`'s two known-gap entries carry full closure notes (including why the proposed fix was rejected, every review round below, and what stays open); the plan's PR 3B section and ordering are updated; changelog fragment added.

## Review rounds

Seven Codex findings, all on the forced-include half (the matched-unit half has drawn none), each fixed and each verified to fail against the pre-fix code:

1. The `abi_relevant_flags` route would double-emit on L4 replay — recognizer moved to a shared leaf instead.
2. The PE/Mach-O parse never received the widened cache-key set — it now derives the same set from the tokens it already has, rather than threading a new channel through `run_dump`/`resolve_input`.
3. The CL-mode driver vocabulary had drifted between L2 and L4 (`dpcpp-cl`, `clang-cl-20`) — one shared `is_msvc_driver_stem`, which also repairs three pre-existing consumers.
4. A forced include resolved only through the `-I` chain was not hashed — candidates emitted per search dir.
5. A bare operand resolvable only via an argv-only `-iquote`/`/I` was emitted unresolvable — now pinned via the unit's own search chain.
6. A forced include the caller also supplies was emitted twice — derived copy dropped.
7. The search chain sorted its buckets; a compiler takes the *first* match in argv order — `build_context_include_dirs_ordered` factored out.

**Deliberately left open, and recorded rather than half-fixed:**

- A forced include still never enters `abi_relevant_flags`, so swapping one build's forced-include header for another does not raise `ABI_RELEVANT_BUILD_FLAG_CHANGED` (ADR-029 D9's drift signal). Closing that needs a structured `CompileUnit` field every adapter populates, a `BUILD_EVIDENCE_VERSION` bump and `build_diff` wiring — and specifically not another attempt to route it through `ABI_RELEVANT_FLAG_PREFIXES`.
- `_context_flags` still does not render argv-only include-search directories, so a *transitively* included header the build reaches through `-iquote`/`/I` remains unreachable to the L2 parse. Pre-existing; closing it changes include search order for every matched unit, which is materially wider than this change's own correctness needs.

## Bug-fix test contract

- Bug class: a derived compile-context input silently omitted from the L2 header parse — the parse reports a real build-evidence match and stamps `parsed_with_build_context` while missing a macro-controlling forced-include header, or while carrying an unrelated translation unit's include directory that shadows the matched one's.
- Publicly observable failure: `abicheck dump lib.so -H api.h --sources . --build-info compile_commands.json` on a project whose build forces `-include config.h` parses `api.h` with `config.h`'s macros undefined, so declarations behind `#ifdef` guards are missing from the snapshot and the resulting comparison reports fabricated removals/additions — with no warning, and with `parsed_with_build_context` reading `true`.
- Regression test fails on base: yes — verified per fix, not once at the end. 9 of the original tests fail against the pre-fix behaviour (`test_relative_operand_resolves_against_the_compile_units_directory`, `test_msvc_forced_include_renders_as_the_gnu_spelling`, `test_different_forced_headers_fail_closed`, `test_derived_forced_include_dir_reaches_the_callers_hash_dirs`, `test_only_the_matched_units_include_dirs_are_seeded`, …), and each of the seven review rounds above added tests confirmed to fail against that round's own pre-fix code.
- Negative control: `TestReplayStillEmitsForcedIncludesExactlyOnce` pins that L4 replay still emits `-include` exactly once and that `extract_abi_relevant_flags` still returns no forced include — i.e. it fails if someone applies the fix `AGENTS.md` originally proposed. `test_seed_falls_back_to_every_unit_when_nothing_matched` pins that restricting the seed does not silently empty it; `test_a_different_explicit_forced_header_does_not_suppress_the_derived_one` pins that dedup is not over-eager; `test_include_pch_is_not_rendered` and `test_bare_forced_operand_with_no_search_path_contributes_only_the_file` pin the deliberate non-actions.
- Public-surface test: yes — `TestIncludeSeedIsRestrictedToMatchedUnits` and `TestForcedIncludeCacheKey.test_derived_forced_include_dir_reaches_the_callers_hash_dirs` drive the real `l2_seed.seed_includes_and_fold_compile_context` entry point over a real on-disk `compile_commands.json` through `collect_inline_pack`, not a hand-built `BuildEvidence` — that is the function all four `dump`/`scan`/`compare` resolvers call.
- Axes covered: both dialects (GNU separate and joined spellings, MSVC `/FI`/`-FI` separate and joined, the MSVC family gated off for a GNU command, and CL-mode drivers spelled with GNU `-c`); operand resolution (unit directory, each search bucket, argv order within a bucket, absolute, unresolvable); rendering (`-include`, `-imacros` under its own spelling, `/FI`→`-include`, `-include-pch` and option-shaped operands dropped, caller-supplied duplicate dropped); ambiguity (differing headers, equivalent spellings, one-forcing-one-not); cache key (union, bare operand, non-header suffix, per-search-dir candidate, PE/Mach-O, unresolvable degrade); seed selection (matched, no-match fallback, `matched_units`/`matched_unit_count` consistency).
- Real-dependency test: yes — the seed and cache-key tests write a real `compile_commands.json` on disk and go through the real `collect_inline_pack`/`CompileDbAdapter` parse of it, so the argv shape under test is the one a real compile database actually produces, and operand resolution is decided by real `Path.is_file()` checks against real files rather than a stubbed filesystem. The recognizer's dialect coverage is checked against the spellings each real driver documents, and `TestReplayStillEmitsForcedIncludesExactlyOnce` exercises the real `replay_extra_flags` rather than asserting on the vocabulary tuple. Not covered here: an actual castxml/clang invocation consuming the rendered tokens, which needs the `integration` marker and a toolchain the fast lane does not have.
- General invariant: what L2 renders and what L4 replays are derived from one recognizer over the same option vocabulary — and one driver vocabulary — so the two can never disagree about whether a token is a forced include or whether a command is CL-mode; and the set of paths hashed into a header-parse cache key is exactly the set of paths that parse's own tokens make relevant, computed in one place for all four parses.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [x] Docs updated if user-visible behaviour changed
- [x] `pre-commit run --all-files` passes locally
- [x] No new `mypy` or `ruff` errors introduced

`python scripts/verify.py --profile pr` is green on every step except the documented tree-wide `fmt-check` gap (518 files would be reformatted both with and without this change; `AGENTS.md` records that the formatter has never been applied repo-wide and that no CI job runs this step). `unit-pr` — the full unit suite including golden tests, under the 95% coverage floor — passes; `docs-build`/`distribution-build` are skipped for missing `mkdocs`/`build`/`twine` in this environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HU43DYjZechHEChCWiCLHc)_