### PR TITLE
fix: dedup L3->L2-fold include-search directories (dump/scan include_sequence mismatch)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1871,6 +1871,89 @@ Once a root command genuinely clears the bar above, pick the right home:
   that a fresh `scan --against` still can't cleanly compare to, the same
   problem this diagnostic exists to catch, not fix.
 
+  **Two real mechanisms found and fixed by actually inspecting the
+  differing `include_sequence` token values, using a minimal, castxml-free
+  local repro (a `g++`-compiled one-header library + a hand-written
+  `compile_commands.json`, `--ast-frontend clang`) rather than a live
+  Bazel/castxml run — the repro this whole footnote's own "not fixed here"
+  note said was the missing prerequisite.** Both are real instances of
+  candidate (b) above (a duplicated `-I`/`-isystem` entry), reached from
+  two different composition points, neither previously identified:
+  (1) `perform_elf_dump`'s own `extra_includes=eff_includes + inc_extra`
+  (and `service_header_scoped._try_header_scoped_dump`'s identical
+  `eff_includes += inc_extra`) concatenate two independently-derived
+  include-dir lists with no dedup — fixed with a new
+  `header_utils.dedup_paths_preserve_order()`, applied at both composition
+  sites. (2) The load-bearing one for this specific repro:
+  `l2_seed._merge_l3_compile_context`'s `derived_includes` (the P0.3 fold's
+  own derived compile-unit include dirs) and the caller's own *explicit*
+  `gcc_options`/`gcc_option_tokens` can independently carry an `-I` for the
+  identical directory — concretely, a `--build-info` compile database is
+  matched *both* by this fold's own resolver *and* by the pre-existing
+  legacy `-p`/`--compile-db` auto-match mechanism that populates
+  `perform_elf_dump`'s `effective_gcc_options` string before the fold ever
+  runs, so the same directory reaches the merged `gcc_option_tokens` twice:
+  once via `explicit_tail` (the split `gcc_options` string) and once via
+  `derived_includes`. Confirmed via direct inspection of both
+  `CompileContext` objects the merge receives (`explicit.gcc_options`
+  literally contained `"-I <dir>"`, `derived.gcc_option_tokens` literally
+  contained `("-I", "<dir>", ...)`  for the same `<dir>`) — not
+  reconstructed from `diff.reason` alone, closing exactly the evidentiary
+  gap the "Two further Codex review rounds" paragraph above says was still
+  missing. Fixed with a new `header_utils.drop_include_tokens_duplicating_
+  paths()`, which drops a `derived_includes` pair whose directory already
+  appears among `explicit_tail + explicit.gcc_option_tokens`'s own
+  include-search operands — "explicit wins, searches first" is unaffected,
+  since only the later, redundant `derived` copy is ever dropped. Verified
+  end to end: the real compiler argv `dump` sends to clang no longer
+  repeats `-I <dir>`, and a fresh `dump` baseline's `ast_compile_args` now
+  matches a `scan --against` candidate's own (both carry exactly one `-I
+  <dir>` for the matched project directory) — see
+  `tests/test_header_compile_context.py`'s
+  `test_merge_l3_compile_context_drops_derived_include_duplicating_explicit`/
+  `test_merge_l3_compile_context_keeps_derived_include_when_directories_differ`
+  and `tests/test_build_context_completeness.py`'s
+  `TestDedupIncludeDirsAcrossCompositionSites`.
+
+  **Not fully closed — a third, deeper mechanism survives and still
+  reproduces `NOT_COMPARABLE` on `include_sequence` for the identical
+  repro, confirmed by direct inspection after the two fixes above.** Even
+  with both duplicate-`-I` bugs fixed, `dump`'s baseline and `scan`'s
+  candidate still disagree, because the matched directory reaches
+  `declared_includes` (the sole source `dumper_contract.
+  _attach_extraction_contract` builds `include_sequence`'s slots from) via
+  **structurally different channels on the two paths** rather than merely
+  differing in count: on `dump`, the legacy `-p`/`--compile-db` match
+  supplies the directory as part of `effective_gcc_options` *before* the
+  L2 seed ever runs, and `seed_l2_includes`'s own suppression rule
+  (correctly) declines to seed a directory when explicit context already
+  supplies one — so the directory reaches the parse only through
+  `gcc_option_tokens`, and `eff_includes`/`declared_includes` stays empty
+  for it. `scan_engine._build_new_snapshot` has no equivalent legacy `-p`
+  step at all — nothing pre-populates `effective_gcc_options` before its
+  own fold runs, so the identical directory reaches the *same* fold's L2
+  seed unsuppressed, landing in `eff_includes`/`declared_includes` instead.
+  Two structurally different `declared_includes` — empty vs. one entry —
+  for the same real include root is exactly what `include_sequence` is
+  built to detect, so it correctly (if unhelpfully) still fires. **Not
+  fixed here**: closing it needs a design decision this pass did not have
+  standing to make on its own — either `dump`'s CLI stops running the
+  legacy `-p`/`--compile-db` auto-match whenever `--build-info` already
+  feeds the new P0.3 fold (the two have overlapped, silently, since the
+  fold was introduced — this pass is the first evidence either mechanism's
+  *placement choice* for a resolved directory is externally observable,
+  not just its content), or `scan`'s candidate resolution gains an
+  equivalent legacy-match step so both paths agree on *which* channel
+  supplies a matched directory, not merely that they supply the same one.
+  Either is a real, cross-cutting change to which of two established
+  mechanisms wins for a `dump`-only surface `scan` has no counterpart to
+  — not a mechanical follow-up to either dedup fix above. Confirmed via
+  the same local repro: after both fixes, `dump`'s `ast_compile_args`
+  still carries `-I <dir>` (via `gcc_option_tokens`) while `declared_
+  includes` is empty; `scan`'s candidate carries the identical `-I <dir>`
+  via `declared_includes` instead — same effective compiler argv, still a
+  real `profile_fingerprint`/`include_sequence` disagreement.
+
 - **`dump --lang c++` is silently discarded on the primary clang header-AST
   pass for a language-ambiguous header, diverging from `_attach_header_graph`'s
   own pass on the identical headers — investigated, not fixed (G31 Phase C

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1909,11 +1909,31 @@ Once a root command genuinely clears the bar above, pick the right home:
   repeats `-I <dir>`, and a fresh `dump` baseline's `ast_compile_args` now
   matches a `scan --against` candidate's own (both carry exactly one `-I
   <dir>` for the matched project directory) — see
-  `tests/test_header_compile_context.py`'s
-  `test_merge_l3_compile_context_drops_derived_include_duplicating_explicit`/
-  `test_merge_l3_compile_context_keeps_derived_include_when_directories_differ`
-  and `tests/test_build_context_completeness.py`'s
-  `TestDedupIncludeDirsAcrossCompositionSites`.
+  `tests/test_build_context_completeness.py`'s
+  `TestDedupIncludeDirsAcrossCompositionSites`/
+  `TestMergeL3CompileContextDropsDuplicateExplicitInclude`.
+
+  **A Codex review round on the same PR found the first version of this
+  fix class-blind, and it was fixed before merge.** `drop_include_tokens_
+  duplicating_paths()`'s first cut matched purely on resolved directory,
+  ignoring which include-search *class* (`-I`/`-isystem`/`-iquote`/
+  `-idirafter`) each entry belonged to — but a real compiler consults
+  those as distinct search buckets in a fixed order regardless of argv
+  position (the identical class-blindness `_split_include_tokens`'s own
+  docstring already documents as a known gap one function over), so
+  dropping an `-isystem <dir>` merely because an unrelated `-I <dir>`
+  existed elsewhere could change which bucket that directory is searched
+  from for a colliding header basename — concretely, `-I A -I B -isystem
+  A` resolves a colliding name from `B`, while the class-blind rewrite
+  `-I A -I B` resolves it from `A` instead. Fixed by making the dedup key
+  `(flag-class, resolved directory)` rather than the directory alone, via
+  a new `_include_class_path_pairs()` shared by both the "already
+  covered" side and the token walk being filtered — see
+  `TestDedupIncludeDirsAcrossCompositionSites::
+  test_drop_include_tokens_duplicating_paths_is_class_sensitive`. Both
+  call sites' "already covered" argument changed shape accordingly (raw
+  tokens, not bare `Path`s) so the class of an *already-emitted* entry is
+  never lost either.
 
   **Not fully closed — a third, deeper mechanism survives and still
   reproduces `NOT_COMPARABLE` on `include_sequence` for the identical

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -548,16 +548,12 @@ def _merge_l3_compile_context(
     # reproduces for the identical project. "Explicit wins, searches
     # first" is unaffected: only the later, redundant `derived` copy is
     # dropped, never the earlier explicit one.
-    from ..header_utils import (
-        drop_include_tokens_duplicating_paths,
-        include_operand_dirs,
-    )
+    from ..header_utils import drop_include_tokens_duplicating_paths
 
-    explicit_include_dirs = include_operand_dirs(
-        tuple(explicit_tail) + explicit.gcc_option_tokens
-    )
     derived_includes = tuple(
-        drop_include_tokens_duplicating_paths(derived_includes, explicit_include_dirs)
+        drop_include_tokens_duplicating_paths(
+            derived_includes, explicit_tail + list(explicit.gcc_option_tokens)
+        )
     )
     return dataclasses.replace(
         explicit,

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -531,6 +531,34 @@ def _merge_l3_compile_context(
             # than silently dropped.
             explicit_tail.append(explicit.gcc_options)
     derived_rest, derived_includes = _split_include_tokens(derived.gcc_option_tokens)
+    # Drop a derived include-search pair whose directory is already covered
+    # by *explicit*'s own include-search entries -- both the structured
+    # ``--sysroot=``/``gcc_options`` string just folded into `explicit_tail`
+    # and `explicit.gcc_option_tokens` itself can independently carry an
+    # ``-I``/``-isystem`` for the same directory `derived` resolves too (the
+    # legacy ``-p``/``--compile-db`` matcher and this P0.3 fold both derive
+    # from the *same* compile database when a caller's ``--build-info``
+    # doubles as both). Left undeduped, the merged `gcc_option_tokens`
+    # carries the identical include-search flag twice -- confirmed via a
+    # minimal, castxml-free repro (AGENTS.md's L3->L2-fold "nineteenth
+    # finding") -- and `_context_flags`'s own separate include-path
+    # rendering plus this legacy string can jointly produce an
+    # `include_sequence` a `scan --against` candidate resolution (whose
+    # single-pass fold never double-derives the same directory) never
+    # reproduces for the identical project. "Explicit wins, searches
+    # first" is unaffected: only the later, redundant `derived` copy is
+    # dropped, never the earlier explicit one.
+    from ..header_utils import (
+        drop_include_tokens_duplicating_paths,
+        include_operand_dirs,
+    )
+
+    explicit_include_dirs = include_operand_dirs(
+        tuple(explicit_tail) + explicit.gcc_option_tokens
+    )
+    derived_includes = tuple(
+        drop_include_tokens_duplicating_paths(derived_includes, explicit_include_dirs)
+    )
     return dataclasses.replace(
         explicit,
         sysroot=None,

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -1617,8 +1617,7 @@ def perform_elf_dump(
     _effective_lang = lang if (lang_explicit or lang == "c") else None
     resolved_headers = expand_header_inputs(list(headers)) if headers else []
     # ADR-050 D1 follow-up (G30 pilot validation): fold -H/--header's own directory
-    # arguments into the extraction contract's scope (not just
-    # public_header_dirs/apply_provenance's opt-in flags), matching
+    # arguments into the extraction contract's scope (not just public_header_dirs/apply_provenance's opt-in flags), matching
     # `compare`'s own --header handling (cli_resolve._resolve_compare_
     # snapshots, via the same split_public_header_inputs helper) -- so a
     # `dump --header <dir>` baseline and a live `compare --header <dir>`
@@ -1634,6 +1633,7 @@ def perform_elf_dump(
     # above the standard system dirs) when the compile context supplies its own
     # includes — see its docstring.
     from .header_utils import (
+        dedup_paths_preserve_order,
         deferred_token_dirs,
         resolve_inferred_header_roots,
         split_public_header_inputs,
@@ -1743,7 +1743,7 @@ def perform_elf_dump(
             snap = dump(
                 so_path=so_path,
                 headers=resolved_headers,
-                extra_includes=eff_includes + inc_extra,
+                extra_includes=dedup_paths_preserve_order(eff_includes + inc_extra),
                 version=version,
                 compiler=compiler,
                 gcc_path=gcc_path,

--- a/abicheck/dumper_ast_config.py
+++ b/abicheck/dumper_ast_config.py
@@ -23,7 +23,10 @@ from pathlib import Path
 
 from ._compiler_options import has_explicit_std, split_gcc_options
 from .dumper_clang import _needs_sycl_host_only
-from .header_utils import iter_cache_header_files
+from .header_utils import (
+    drop_include_tokens_duplicating_paths,
+    iter_cache_header_files,
+)
 
 
 def _cache_key(
@@ -271,7 +274,10 @@ def _build_castxml_command(
     # Repeatable --compiler-option: each value is one literal compiler argument,
     # appended verbatim (no shlex split) so a flag whose value contains
     # whitespace survives intact and identically on POSIX and Windows.
-    cmd += list(gcc_option_tokens)
+    # Dropped when an entry duplicates a directory already emitted above via
+    # `extra_includes` — see `drop_include_tokens_duplicating_paths`'s own
+    # docstring for why this can otherwise happen and what it broke.
+    cmd += drop_include_tokens_duplicating_paths(gcc_option_tokens, extra_includes)
 
     explicit_std = has_explicit_std(gcc_options, gcc_option_tokens)
     # Workaround: castxml with --castxml-cc-gnu gcc auto-injects -std=gnu++17
@@ -348,7 +354,10 @@ def _build_clang_header_command(
     if gcc_options:
         cmd += split_gcc_options(gcc_options)
     # Repeatable --compiler-option: one literal argument each (no shlex split).
-    cmd += list(gcc_option_tokens)
+    # Dropped when an entry duplicates a directory already emitted above via
+    # `extra_includes` — see `drop_include_tokens_duplicating_paths`'s own
+    # docstring for why this can otherwise happen and what it broke.
+    cmd += drop_include_tokens_duplicating_paths(gcc_option_tokens, extra_includes)
     if not dpcpp_multi_context and _needs_sycl_host_only(cc_bin, cmd):
         cmd.append("-fsycl-host-only")
     # Auto-probed host system dirs go *after* the user's pass-through flags, so a

--- a/abicheck/dumper_ast_config.py
+++ b/abicheck/dumper_ast_config.py
@@ -277,7 +277,7 @@ def _build_castxml_command(
     # Dropped when an entry duplicates a directory already emitted above via
     # `extra_includes` — see `drop_include_tokens_duplicating_paths`'s own
     # docstring for why this can otherwise happen and what it broke.
-    cmd += drop_include_tokens_duplicating_paths(gcc_option_tokens, extra_includes)
+    cmd += drop_include_tokens_duplicating_paths(gcc_option_tokens, cmd)
 
     explicit_std = has_explicit_std(gcc_options, gcc_option_tokens)
     # Workaround: castxml with --castxml-cc-gnu gcc auto-injects -std=gnu++17
@@ -357,7 +357,7 @@ def _build_clang_header_command(
     # Dropped when an entry duplicates a directory already emitted above via
     # `extra_includes` — see `drop_include_tokens_duplicating_paths`'s own
     # docstring for why this can otherwise happen and what it broke.
-    cmd += drop_include_tokens_duplicating_paths(gcc_option_tokens, extra_includes)
+    cmd += drop_include_tokens_duplicating_paths(gcc_option_tokens, cmd)
     if not dpcpp_multi_context and _needs_sycl_host_only(cc_bin, cmd):
         cmd.append("-fsycl-host-only")
     # Auto-probed host system dirs go *after* the user's pass-through flags, so a

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -111,6 +111,26 @@ CACHE_HEADER_SUFFIXES = HEADER_SUFFIXES | frozenset({".inl", ".tcc"})
 #: include-search flag at all. Left as a known gap (see ``AGENTS.md``).
 _INCLUDE_FLAG_PREFIXES = (
     "-I",
+    # Listed ahead of the plain "-isystem" it textually extends: every match
+    # here is a first-match-wins scan (`next(p for p in _INCLUDE_FLAG_
+    # PREFIXES if t.startswith(p))`), and "-isystem-after" is Clang's own,
+    # genuinely distinct flag (`-isystem-after <dir>` -- confirmed against
+    # real `clang --help-hidden`, always spaced, never an attached form) --
+    # not a longer spelling of "-isystem" itself. Ordered after "-I" a real
+    # match would still find first-match-wins if it were left later: a real
+    # "-isystem-after" token also `startswith("-isystem")`, so scanning
+    # "-isystem" first would misparse it as an *attached* "-isystem" flag
+    # whose "directory" is the bogus suffix "-after", stranding the real
+    # directory operand as a bare, unconsumed token (Codex review, PR #802 --
+    # confirmed with the reviewer's own repro: `gcc_options='-isystem-after
+    # /a'` alongside `gcc_option_tokens=('-isystem-after', '/b')` left a bare
+    # `/b` in the composed command). Pre-existing in every consumer that
+    # already did `t.startswith(p)` against this tuple before this PR
+    # (`_has_include_build_context`, `include_operand_dirs`, ...), not
+    # introduced by this PR's own two new functions -- fixed once here,
+    # for the whole shared tuple, rather than only for the two consumers a
+    # reviewer happened to be reading.
+    "-isystem-after",
     "-isystem",
     "-iquote",
     "-idirafter",

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -601,12 +601,28 @@ def drop_include_tokens_duplicating_paths(
     "duplicate" of a same-looking ``-I <dir>`` in *already_covered* (which,
     lacking its own divider, is entirely ``"-I:pre"``) — doing so would
     silently change which includes that directory is searched for.
+
+    The divider state also carries **across** the *already_covered* ->
+    *toks* boundary, not just within *toks* itself (Codex review, PR #802):
+    every caller renders *already_covered* into the command *before* *toks*
+    (``cmd += drop_include_tokens_duplicating_paths(gcc_option_tokens,
+    cmd)``), so a ``"-I-"`` anywhere in *already_covered* means every plain
+    ``-I`` in *toks* is *already* past the divider by the time the real
+    compiler sees it — even one with no ``"-I-"`` of its own. Scanning
+    *toks* from a fresh ``"-I:pre"`` state regardless of what
+    *already_covered* ended in would misclassify such an entry as
+    pre-divider, letting it be dropped as a false "duplicate" of an
+    unrelated pre-divider ``-I <dir>`` in *already_covered* that is not
+    actually the same search class once the real, composed argv is
+    considered.
     """
     covered = _include_class_path_pairs(already_covered)
     out: list[str] = []
     i = 0
     n = len(toks)
-    after_divider = False
+    # A "-I-" anywhere in *already_covered* means *toks* -- rendered after
+    # it in the real command -- starts life already past the divider.
+    after_divider = _DASH_I_DIVIDER in already_covered
     while i < n:
         t = toks[i]
         if t == _DASH_I_DIVIDER:

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -455,11 +455,52 @@ def _flag_tokens(toks: list[str]) -> list[str]:
     return out
 
 
+def _include_class_path_pairs(toks: Sequence[str]) -> set[tuple[str, str]]:
+    """Every ``(flag-class, resolved-directory)`` pair present in *toks*.
+
+    The flag *class* (the matched prefix itself, e.g. ``"-I"`` vs.
+    ``"-isystem"``) is part of the key, not just the directory — GCC/Clang
+    consult ``-iquote``/``-I``/``-isystem``/``-idirafter`` as **distinct
+    search buckets in a fixed order regardless of argv position** (see
+    :func:`_split_include_tokens`'s own documented gap on this exact point),
+    so a directory present via one class is not interchangeable with the
+    same directory present via another — dropping an ``-isystem <dir>``
+    merely because an unrelated ``-I <dir>`` exists elsewhere would change
+    which bucket that directory is searched from for a colliding basename
+    (Codex review, PR #802).
+    """
+    pairs: set[tuple[str, str]] = set()
+    i = 0
+    n = len(toks)
+    while i < n:
+        t = toks[i]
+        matched_prefix = next(
+            (p for p in _INCLUDE_FLAG_PREFIXES if t.startswith(p)), None
+        )
+        if matched_prefix is None:
+            i += 1
+            continue
+        if t == matched_prefix and i + 1 < n:
+            operand = toks[i + 1]
+            consumed = 2
+        else:
+            operand = t[len(matched_prefix) :]
+            consumed = 1
+        try:
+            key = str(Path(operand).resolve())
+        except OSError:
+            key = operand
+        pairs.add((matched_prefix, key))
+        i += consumed
+    return pairs
+
+
 def drop_include_tokens_duplicating_paths(
-    toks: Sequence[str], already_covered: Sequence[Path]
+    toks: Sequence[str], already_covered: Sequence[str]
 ) -> list[str]:
-    """*toks* with an include-search flag+operand pair dropped when its
-    directory already appears in *already_covered*.
+    """*toks* with an include-search flag+operand pair dropped when the
+    identical ``(flag-class, directory)`` pair already appears in
+    *already_covered* (a raw token list, in the same shape as *toks*).
 
     ``dump``'s ELF and PE/Mach-O paths (:func:`abicheck.cli_dump_helpers.
     perform_elf_dump`/:func:`abicheck.service_header_scoped._try_header_
@@ -489,19 +530,17 @@ def drop_include_tokens_duplicating_paths(
     Applied to ``gcc_option_tokens`` only, against the already-emitted
     ``extra_includes`` — never the reverse, since ``extra_includes`` is
     :func:`declared_includes`'s one canonical source and must always keep
-    every entry it's given. Dedup key is the resolved absolute path
-    (mirroring :func:`dedup_paths_preserve_order`), so a relative and an
-    absolute spelling of the same directory both drop. Search-priority is
-    unaffected: dropping a *later* duplicate of a directory
-    ``extra_includes`` already searches first changes nothing about which
-    file a compiler resolves.
+    every entry it's given. Dedup key is ``(flag-class, resolved absolute
+    path)`` — see :func:`_include_class_path_pairs`'s own docstring for why
+    the class must be part of the key, not just the directory: a real
+    compiler treats ``-iquote``/``-I``/``-isystem``/``-idirafter`` as
+    distinct search buckets regardless of argv order, so a same-directory
+    entry in a *different* class is never dropped, only an exact class+path
+    duplicate. Search-priority is unaffected for the entries that *are*
+    dropped: it is always the later, redundant duplicate of an identical
+    class+directory pair that goes, never the earlier one.
     """
-    covered: set[str] = set()
-    for p in already_covered:
-        try:
-            covered.add(str(p.resolve()))
-        except OSError:
-            covered.add(str(p))
+    covered = _include_class_path_pairs(already_covered)
     out: list[str] = []
     i = 0
     n = len(toks)
@@ -524,7 +563,7 @@ def drop_include_tokens_duplicating_paths(
             key = str(Path(operand).resolve())
         except OSError:
             key = operand
-        if key in covered:
+        if (matched_prefix, key) in covered:
             i += consumed
             continue
         out.extend(toks[i : i + consumed])

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -455,6 +455,83 @@ def _flag_tokens(toks: list[str]) -> list[str]:
     return out
 
 
+def drop_include_tokens_duplicating_paths(
+    toks: Sequence[str], already_covered: Sequence[Path]
+) -> list[str]:
+    """*toks* with an include-search flag+operand pair dropped when its
+    directory already appears in *already_covered*.
+
+    ``dump``'s ELF and PE/Mach-O paths (:func:`abicheck.cli_dump_helpers.
+    perform_elf_dump`/:func:`abicheck.service_header_scoped._try_header_
+    scoped_dump`) both render the L3->L2 fold's merged compile context into
+    ``gcc_option_tokens`` via ``header_compile_context._context_flags`` —
+    which independently renders the *same* matched compile unit's
+    ``include_paths``/``system_include_paths`` as their own ``-I``/
+    ``-isystem`` tokens that the L2 include-dir seed (``eff_includes``,
+    rendered separately as ``extra_includes``) already covers. Both a
+    command builder's ``extra_includes`` loop *and* its verbatim
+    ``gcc_option_tokens`` append then emit an ``-I`` for the identical
+    directory — and since ``dumper_contract._attach_extraction_contract``
+    builds ``declared_includes`` **exclusively** from ``extra_includes``
+    (never ``gcc_option_tokens``), the duplicate never doubles a
+    ``declared_includes``/``include_sequence`` slot by itself, but a
+    real compiler still processes the same ``-I`` twice, and (more load-
+    bearing) a `scan --against` candidate resolution — whose single-pass
+    fold (:func:`abicheck.buildsource.l2_seed.
+    seed_includes_and_fold_compile_context`) never separately renders a
+    matched unit's include dirs into both places — never emits this
+    second copy for the identical project, so the two sides' full argv
+    (and therefore, on backends that fold gcc_option_tokens into their own
+    header-parse identity) can disagree for reasons no diagnostic names.
+    Confirmed via a minimal, castxml-free repro reproducing this exact
+    shape (AGENTS.md's L3->L2-fold "nineteenth finding").
+
+    Applied to ``gcc_option_tokens`` only, against the already-emitted
+    ``extra_includes`` — never the reverse, since ``extra_includes`` is
+    :func:`declared_includes`'s one canonical source and must always keep
+    every entry it's given. Dedup key is the resolved absolute path
+    (mirroring :func:`dedup_paths_preserve_order`), so a relative and an
+    absolute spelling of the same directory both drop. Search-priority is
+    unaffected: dropping a *later* duplicate of a directory
+    ``extra_includes`` already searches first changes nothing about which
+    file a compiler resolves.
+    """
+    covered: set[str] = set()
+    for p in already_covered:
+        try:
+            covered.add(str(p.resolve()))
+        except OSError:
+            covered.add(str(p))
+    out: list[str] = []
+    i = 0
+    n = len(toks)
+    while i < n:
+        t = toks[i]
+        matched_prefix = next(
+            (p for p in _INCLUDE_FLAG_PREFIXES if t.startswith(p)), None
+        )
+        if matched_prefix is None:
+            out.append(t)
+            i += 1
+            continue
+        if t == matched_prefix and i + 1 < n:
+            operand = toks[i + 1]
+            consumed = 2
+        else:
+            operand = t[len(matched_prefix) :]
+            consumed = 1
+        try:
+            key = str(Path(operand).resolve())
+        except OSError:
+            key = operand
+        if key in covered:
+            i += consumed
+            continue
+        out.extend(toks[i : i + consumed])
+        i += consumed
+    return out
+
+
 def _msvc_deferred_flag(toks: list[str]) -> str:
     """The MSVC/clang-cl bucket to defer an inferred root below *toks* (#454).
 
@@ -510,6 +587,54 @@ def _deferred_include_flag(toks: list[str]) -> str:
     if any(t.startswith(p) for t in toks for p in _ABOVE_SYSTEM_GNU_PREFIXES):
         return "-isystem"
     return "-idirafter"
+
+
+def dedup_paths_preserve_order(paths: Sequence[Path]) -> list[Path]:
+    """*paths* with exact duplicates dropped, first-occurrence order kept.
+
+    ``dump``'s ELF and PE/Mach-O paths both compose their final
+    ``extra_includes``/``declared_includes`` list as an L2-seeded include
+    list *plus* :func:`resolve_inferred_header_roots`'s own inferred-root
+    additions (``eff_includes + inc_extra``) — two independently derived
+    lists that can resolve to the *same* directory (e.g. a matched compile
+    unit's own ``-I`` dir, once from the L3->L2 fold's seed and again from
+    the inferred-root resolver's own, separate lookup over the *pre-fold*
+    tokens). Left undeduped, that directory gets two ``declared_includes``
+    slots for one real include root, and
+    ``comparability_fields._include_slot_tokens`` tokenizes one slot per
+    entry — so the resulting ``include_sequence`` carries an extra token a
+    `scan --against` candidate resolution (which folds the seed and the L3
+    context in one pass, with no separate ``inc_extra`` add — see
+    ``scan_engine._build_new_snapshot``) never produces for the identical
+    project, and the two sides spuriously fail ``profile_fingerprint``
+    comparability on ``include_sequence`` alone (AGENTS.md's "nineteenth
+    finding" on the L3->L2-fold known gap, candidate mechanism (b) —
+    confirmed via a minimal, castxml-free repro: two independent
+    ``dump`` calls of the same project agree bit-for-bit, but a `dump`
+    baseline's own duplicated ``-I`` disagrees with `scan`'s deduped
+    candidate).
+
+    Dedup key is the resolved absolute path (mirroring
+    :func:`_implicit_header_includes`'s own ``_add`` helper above) so a
+    relative and an absolute spelling of the same directory collapse too,
+    not just two textually-identical entries. Order is preserved rather
+    than sorted: an include-search directory is first-match-wins, so
+    reordering could change which same-named header a real compile picks
+    up (the same reasoning ``build_context_include_dirs_ordered`` already
+    documents for its own dedup).
+    """
+    seen: set[str] = set()
+    out: list[Path] = []
+    for p in paths:
+        try:
+            key = str(p.resolve())
+        except OSError:
+            key = str(p)
+        if key in seen:
+            continue
+        seen.add(key)
+        out.append(p)
+    return out
 
 
 def deferred_token_dirs(deferred_tokens: Sequence[str]) -> list[Path]:

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -475,6 +475,23 @@ def _flag_tokens(toks: list[str]) -> list[str]:
     return out
 
 
+#: GCC's plain (non-quote-form) ``-I-`` divider: a bare, operand-less flag,
+#: never an attached-form ``-I<dir>`` whose directory happens to be ``"-"``.
+#: It splits the ``-I`` search list in two with *different* semantics on
+#: each side (GCC docs, "Directory Options") — a directory given before it
+#: is searched only for a quoted (``#include "..."``) include and never for
+#: an angle-bracket one, while a directory given after it is searched for
+#: both, the same as an ordinary ``-I`` with no divider present at all.
+#: Treating the two sides as one interchangeable ``-I`` class (as an
+#: earlier version of :func:`_include_class_path_pairs` effectively did, by
+#: never recognizing this token at all and misparsing it as an attached
+#: ``-I`` flag naming the bogus directory ``"-"``) can drop a *different*
+#: post-divider ``-I <dir>`` as a "duplicate" of an identical-looking
+#: pre-divider one — turning a resolvable ``#include <x.h>`` into
+#: "file not found" (Codex review, PR #802, confirmed against real GCC 13).
+_DASH_I_DIVIDER = "-I-"
+
+
 def _include_class_path_pairs(toks: Sequence[str]) -> set[tuple[str, str]]:
     """Every ``(flag-class, resolved-directory)`` pair present in *toks*.
 
@@ -488,12 +505,25 @@ def _include_class_path_pairs(toks: Sequence[str]) -> set[tuple[str, str]]:
     merely because an unrelated ``-I <dir>`` exists elsewhere would change
     which bucket that directory is searched from for a colliding basename
     (Codex review, PR #802).
+
+    A plain ``-I`` entry is further split into a ``"-I:pre"``/``"-I:post"``
+    sub-class depending on whether it appears before or after a
+    :data:`_DASH_I_DIVIDER` token *within this same sequence* — see that
+    constant's own docstring for why the two sides are not interchangeable
+    either, even though both are nominally "the ``-I`` class". No divider
+    present at all means every ``-I`` entry is ``"-I:pre"``, preserving the
+    pre-existing behaviour for the (overwhelmingly common) undivided case.
     """
     pairs: set[tuple[str, str]] = set()
     i = 0
     n = len(toks)
+    after_divider = False
     while i < n:
         t = toks[i]
+        if t == _DASH_I_DIVIDER:
+            after_divider = True
+            i += 1
+            continue
         matched_prefix = next(
             (p for p in _INCLUDE_FLAG_PREFIXES if t.startswith(p)), None
         )
@@ -510,7 +540,10 @@ def _include_class_path_pairs(toks: Sequence[str]) -> set[tuple[str, str]]:
             key = str(Path(operand).resolve())
         except OSError:
             key = operand
-        pairs.add((matched_prefix, key))
+        class_key = matched_prefix
+        if matched_prefix == "-I":
+            class_key = "-I:post" if after_divider else "-I:pre"
+        pairs.add((class_key, key))
         i += consumed
     return pairs
 
@@ -559,13 +592,28 @@ def drop_include_tokens_duplicating_paths(
     duplicate. Search-priority is unaffected for the entries that *are*
     dropped: it is always the later, redundant duplicate of an identical
     class+directory pair that goes, never the earlier one.
+
+    A :data:`_DASH_I_DIVIDER` (``"-I-"``) token in *toks* is always kept
+    verbatim — it is never itself a class+path pair to drop — and, per
+    :func:`_include_class_path_pairs`'s own ``"-I:pre"``/``"-I:post"``
+    split, flips which sub-class a subsequent plain ``-I`` in *toks*
+    belongs to, so an ``-I <dir>`` after the divider is never dropped as a
+    "duplicate" of a same-looking ``-I <dir>`` in *already_covered* (which,
+    lacking its own divider, is entirely ``"-I:pre"``) — doing so would
+    silently change which includes that directory is searched for.
     """
     covered = _include_class_path_pairs(already_covered)
     out: list[str] = []
     i = 0
     n = len(toks)
+    after_divider = False
     while i < n:
         t = toks[i]
+        if t == _DASH_I_DIVIDER:
+            after_divider = True
+            out.append(t)
+            i += 1
+            continue
         matched_prefix = next(
             (p for p in _INCLUDE_FLAG_PREFIXES if t.startswith(p)), None
         )
@@ -583,7 +631,10 @@ def drop_include_tokens_duplicating_paths(
             key = str(Path(operand).resolve())
         except OSError:
             key = operand
-        if (matched_prefix, key) in covered:
+        class_key = matched_prefix
+        if matched_prefix == "-I":
+            class_key = "-I:post" if after_divider else "-I:pre"
+        if (class_key, key) in covered:
             i += consumed
             continue
         out.extend(toks[i : i + consumed])

--- a/abicheck/service_header_scoped.py
+++ b/abicheck/service_header_scoped.py
@@ -45,6 +45,7 @@ from . import deadline
 from .errors import AstContextAmbiguousError, AstContextMissingError
 from .header_utils import (
     cache_relevant_operand_paths,
+    dedup_paths_preserve_order,
     deferred_token_dirs,
     resolve_inferred_header_roots,
 )
@@ -129,7 +130,17 @@ def _try_header_scoped_dump(
             gcc_options=cc.gcc_options,
             gcc_option_tokens=cc.gcc_option_tokens,
         )
-        eff_includes += inc_extra
+        # Deduped the same way the ELF `dump` path composes its own
+        # `eff_includes + inc_extra` (AGENTS.md's L3->L2-fold "nineteenth
+        # finding", candidate mechanism (b)): `includes` may already carry
+        # an L3-seeded directory, and `resolve_inferred_header_roots`'s own,
+        # separate lookup can independently resolve the same directory --
+        # left undeduped, the extra `declared_includes` slot tokenizes into
+        # an `include_sequence` a `scan --against` candidate (which folds
+        # the seed and inferred roots in one pass) never produces for the
+        # identical project, spuriously failing profile_fingerprint
+        # comparability.
+        eff_includes = dedup_paths_preserve_order(eff_includes + inc_extra)
         eff_tokens = cc.gcc_option_tokens + tuple(deferred)
         # Plus every include-search dir and forced pre-include the *caller's
         # own* context tokens name — the identical fold ``service._dump_elf``

--- a/changelog.d/1787040000_claude_l3-l2-fold-include-dedup.md
+++ b/changelog.d/1787040000_claude_l3-l2-fold-include-dedup.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- **A matched compile unit's own include-search directory is no longer
+  rendered twice into a header-AST parse command.** Two independent
+  compositions could each contribute an `-I`/`-isystem` for the identical
+  directory: `dump`'s ELF and PE/Mach-O paths compose their final include
+  list as the L2 build-context seed plus `resolve_inferred_header_roots`'s
+  own, separately-derived additions, and the P0.3 L3→L2 fold's `derived`
+  compile context can independently duplicate a directory the caller's own
+  explicit `gcc_options`/`gcc_option_tokens` (e.g. from a legacy `-p`/
+  `--compile-db` match against the same compile database) already carries.
+  Both are now deduplicated in first-occurrence order, so a real compiler
+  no longer processes the same `-I` twice and a `dump`-produced baseline's
+  rendered compile-flag argv no longer disagrees with a `scan --against`
+  candidate's own single-pass fold for reasons no diagnostic named — the
+  root cause behind a `NOT_COMPARABLE` `profile_fingerprint` mismatch on
+  `include_sequence` between the two, reproduced end-to-end against a
+  minimal, castxml-free `dump`/`scan` pair of the same project (see
+  `AGENTS.md`'s L3→L2-fold "nineteenth finding").

--- a/changelog.d/1787040000_claude_l3-l2-fold-include-dedup.md
+++ b/changelog.d/1787040000_claude_l3-l2-fold-include-dedup.md
@@ -1,19 +1,27 @@
 ### Fixed
 
 - **A matched compile unit's own include-search directory is no longer
-  rendered twice into a header-AST parse command.** Two independent
-  compositions could each contribute an `-I`/`-isystem` for the identical
-  directory: `dump`'s ELF and PE/Mach-O paths compose their final include
-  list as the L2 build-context seed plus `resolve_inferred_header_roots`'s
-  own, separately-derived additions, and the P0.3 L3→L2 fold's `derived`
+  rendered twice, in the same search class, into a header-AST parse
+  command.** Two independent compositions could each contribute an
+  identical `-I`/`-isystem`/... entry for the same directory: `dump`'s ELF
+  and PE/Mach-O paths compose their final include list as the L2
+  build-context seed plus `resolve_inferred_header_roots`'s own,
+  separately-derived additions, and the P0.3 L3→L2 fold's `derived`
   compile context can independently duplicate a directory the caller's own
   explicit `gcc_options`/`gcc_option_tokens` (e.g. from a legacy `-p`/
   `--compile-db` match against the same compile database) already carries.
-  Both are now deduplicated in first-occurrence order, so a real compiler
-  no longer processes the same `-I` twice and a `dump`-produced baseline's
-  rendered compile-flag argv no longer disagrees with a `scan --against`
-  candidate's own single-pass fold for reasons no diagnostic named — the
-  root cause behind a `NOT_COMPARABLE` `profile_fingerprint` mismatch on
-  `include_sequence` between the two, reproduced end-to-end against a
-  minimal, castxml-free `dump`/`scan` pair of the same project (see
-  `AGENTS.md`'s L3→L2-fold "nineteenth finding").
+  Both are now deduplicated in first-occurrence order — a real compiler no
+  longer processes the same `-I <dir>` twice — with the fix restricted to
+  an exact `(search-class, directory)` match, so an `-isystem <dir>` is
+  never dropped merely because an unrelated `-I <dir>` exists elsewhere:
+  GCC/Clang consult `-iquote`/`-I`/`-isystem`/`-idirafter` as distinct
+  search buckets regardless of argv position, and treating them as
+  interchangeable could change which bucket a directory is searched from
+  for a colliding header basename. This closes one of the mechanisms
+  behind a `NOT_COMPARABLE` `profile_fingerprint` mismatch on
+  `include_sequence` between a `dump`-produced baseline and a
+  `scan --against` candidate of the same project (see `AGENTS.md`'s
+  L3→L2-fold "nineteenth finding") — a second, deeper mechanism (which of
+  two established resolution paths places a matched directory into
+  `declared_includes`) is documented there as still open; this change does
+  not by itself restore `dump`/`scan` comparability for that reproducer.

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -54,6 +54,7 @@ from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
 from abicheck.buildsource.header_compile_context import resolve_header_compile_context
 from abicheck.errors import HeaderCompileContextAmbiguousError
 from abicheck.header_utils import (
+    _DASH_I_DIVIDER,
     _include_class_path_pairs,
     dedup_paths_preserve_order,
     drop_include_tokens_duplicating_paths,
@@ -911,6 +912,40 @@ class TestDedupIncludeDirsAcrossCompositionSites:
         # correctly dropped.
         out2 = drop_include_tokens_duplicating_paths(toks, ["-isystem-after", str(d)])
         assert out2 == ["-fPIC"]
+
+    def test_dash_i_divider_is_preserved_and_splits_pre_post_i_class(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review, PR #802: GCC's bare ``-I-`` divider changes the
+        search semantics of every ``-I`` after it (searched for both quoted
+        and angle-bracket includes) relative to every ``-I`` before it
+        (quoted only) -- confirmed against real GCC 13. Before this, ``-I-``
+        was misparsed as an attached ``-I`` flag naming the bogus directory
+        ``"-"``, and a post-divider ``-I <dir>`` could be wrongly dropped as
+        a "duplicate" of an unrelated, pre-divider ``-I <dir>`` for the same
+        directory -- silently turning a resolvable ``#include <x.h>`` into
+        "file not found"."""
+        d = tmp_path / "inc"
+        # already_covered carries no divider of its own, so its "-I <dir>"
+        # is entirely pre-divider semantics.
+        already_covered = ["-I", str(d)]
+
+        # A post-divider "-I <dir>" for the identical directory must survive
+        # -- it is a different search class, not a duplicate.
+        toks = (_DASH_I_DIVIDER, "-I", str(d))
+        out = drop_include_tokens_duplicating_paths(toks, already_covered)
+        assert out == [_DASH_I_DIVIDER, "-I", str(d)]
+
+        # A pre-divider "-I <dir>" for the same directory is still
+        # correctly recognized as a real duplicate and dropped.
+        toks_pre = ("-I", str(d), _DASH_I_DIVIDER)
+        out_pre = drop_include_tokens_duplicating_paths(toks_pre, already_covered)
+        assert out_pre == [_DASH_I_DIVIDER]
+
+        # The divider itself is never treated as an attached "-I" flag
+        # naming the directory "-".
+        pairs = _include_class_path_pairs((_DASH_I_DIVIDER,))
+        assert pairs == set()
 
 
 class TestMergeL3CompileContextDropsDuplicateExplicitInclude:

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -930,3 +930,55 @@ class TestMergeL3CompileContextDropsDuplicateExplicitInclude:
         merged = _merge_l3_compile_context(explicit, derived)
         assert merged is not None
         assert merged.gcc_option_tokens == ("-I", "/user/inc", "-I", "/build/gen")
+
+
+class TestIncludeDedupCoversAttachedFormsAndResolveFailure:
+    """Two branch-coverage gaps flagged by Codecov's patch-coverage gate on
+    PR #802: the attached-flag spelling on the *already_covered* side of
+    `drop_include_tokens_duplicating_paths`, and the defensive
+    `Path.resolve()` `OSError` fallback both dedup helpers share."""
+
+    def test_already_covered_attached_form_is_recognized(
+        self, tmp_path: Path
+    ) -> None:
+        # `already_covered` (here `-I<dir>`, no space) walks through the
+        # identical `_include_class_path_pairs()` parser as `toks` -- the
+        # attached-form branch is only exercised from *this* side, since
+        # every prior test used the spaced form (`-I`, `str(d)`).
+        d = tmp_path / "inc"
+        toks = ("-I", str(d), "-fPIC")
+        out = drop_include_tokens_duplicating_paths(toks, [f"-I{d}"])
+        assert out == ["-fPIC"]
+
+    def test_dedup_paths_preserve_order_falls_back_on_resolve_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        real_resolve = Path.resolve
+
+        def _flaky_resolve(self: Path, strict: bool = False) -> Path:
+            if self.name == "loops":
+                raise OSError("ELOOP")
+            return real_resolve(self, strict=strict)
+
+        monkeypatch.setattr(Path, "resolve", _flaky_resolve)
+        p = tmp_path / "loops"
+        # A resolve() failure degrades to the raw str(p) as the dedup key --
+        # two references to the same unresolvable path still collapse.
+        out = dedup_paths_preserve_order([p, tmp_path / "loops"])
+        assert out == [p]
+
+    def test_drop_include_tokens_duplicating_paths_falls_back_on_resolve_oserror(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        real_resolve = Path.resolve
+
+        def _flaky_resolve(self: Path, strict: bool = False) -> Path:
+            if self.name == "loops":
+                raise OSError("ELOOP")
+            return real_resolve(self, strict=strict)
+
+        monkeypatch.setattr(Path, "resolve", _flaky_resolve)
+        d = tmp_path / "loops"
+        toks = ("-I", str(d), "-fPIC")
+        out = drop_include_tokens_duplicating_paths(toks, ["-I", str(d)])
+        assert out == ["-fPIC"]

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -54,6 +54,7 @@ from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
 from abicheck.buildsource.header_compile_context import resolve_header_compile_context
 from abicheck.errors import HeaderCompileContextAmbiguousError
 from abicheck.header_utils import (
+    _include_class_path_pairs,
     dedup_paths_preserve_order,
     drop_include_tokens_duplicating_paths,
     forced_include_operands,
@@ -884,6 +885,32 @@ class TestDedupIncludeDirsAcrossCompositionSites:
         toks = ("-isystem", str(d), "-fPIC")
         out = drop_include_tokens_duplicating_paths(toks, ["-I", str(d)])
         assert out == ["-isystem", str(d), "-fPIC"]
+
+    def test_isystem_after_is_not_misparsed_as_attached_isystem(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review, PR #802: ``-isystem-after <dir>`` is Clang's own,
+        genuinely distinct flag (real ``clang --help-hidden``, always
+        spaced) -- not a longer spelling of ``-isystem``. Before
+        ``_INCLUDE_FLAG_PREFIXES`` carried its own entry for it, the
+        first-match-wins scan misparsed it as an *attached* ``-isystem``
+        flag whose directory was the bogus suffix ``"-after"``, stranding
+        the real directory operand as a stray, unconsumed token."""
+        d = tmp_path / "inc"
+        toks = ("-isystem-after", str(d), "-fPIC")
+        # The (flag-class, directory) pair recognized from "already
+        # covered" tokens must key on the real "-isystem-after" class, not
+        # a corrupted "-isystem"/"-after" split.
+        pairs = _include_class_path_pairs(toks)
+        assert pairs == {("-isystem-after", str(d.resolve()))}
+        # And the real directory operand must never be stranded as an
+        # unconsumed bare token when deduping against an unrelated class.
+        out = drop_include_tokens_duplicating_paths(toks, ["-I", str(d)])
+        assert out == ["-isystem-after", str(d), "-fPIC"]
+        # A genuine duplicate in the same "-isystem-after" class is still
+        # correctly dropped.
+        out2 = drop_include_tokens_duplicating_paths(toks, ["-isystem-after", str(d)])
+        assert out2 == ["-fPIC"]
 
 
 class TestMergeL3CompileContextDropsDuplicateExplicitInclude:

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -53,7 +53,11 @@ import pytest
 from abicheck.buildsource.build_evidence import BuildEvidence, CompileUnit
 from abicheck.buildsource.header_compile_context import resolve_header_compile_context
 from abicheck.errors import HeaderCompileContextAmbiguousError
-from abicheck.header_utils import forced_include_operands
+from abicheck.header_utils import (
+    dedup_paths_preserve_order,
+    drop_include_tokens_duplicating_paths,
+    forced_include_operands,
+)
 
 
 def _cu(**kwargs: object) -> CompileUnit:
@@ -811,3 +815,104 @@ class TestIncludeSeedIsRestrictedToMatchedUnits:
         assert [cu.id for cu in result.matched_units] == ["cu://widget"]
         # The historical read view stays exactly consistent with it.
         assert result.matched_unit_count == len(result.matched_units) == 1
+
+
+class TestDedupIncludeDirsAcrossCompositionSites:
+    """AGENTS.md's L3->L2-fold "nineteenth finding" (candidate mechanism
+    confirmed via a minimal, castxml-free repro): `dump`'s ELF/PE-Mach-O
+    paths compose their final include list as an L2-seeded list *plus*
+    `resolve_inferred_header_roots`'s own, separately-derived additions --
+    two lists that can resolve to the identical directory. Left undeduped,
+    the duplicate reaches `declared_includes`/`include_sequence` and (via a
+    parallel duplication in `_merge_l3_compile_context`, covered by
+    `test_header_compile_context.py`) the rendered command's own
+    `gcc_option_tokens`, spuriously failing `profile_fingerprint`
+    comparability against a `scan --against` candidate whose own,
+    single-pass fold never double-derives the same directory."""
+
+    def test_dedup_paths_preserve_order_drops_exact_and_resolved_duplicates(
+        self, tmp_path: Path
+    ) -> None:
+        d = tmp_path / "inc"
+        d.mkdir()
+        out = dedup_paths_preserve_order([d, tmp_path / "inc", d])
+        assert out == [d]
+
+    def test_dedup_paths_preserve_order_keeps_distinct_directories(
+        self, tmp_path: Path
+    ) -> None:
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        out = dedup_paths_preserve_order([a, b, a])
+        assert out == [a, b]
+
+    def test_drop_include_tokens_duplicating_paths_drops_spaced_duplicate(
+        self, tmp_path: Path
+    ) -> None:
+        d = tmp_path / "inc"
+        toks = ("-DFOO=1", "-I", str(d), "-fPIC")
+        out = drop_include_tokens_duplicating_paths(toks, [d])
+        assert out == ["-DFOO=1", "-fPIC"]
+
+    def test_drop_include_tokens_duplicating_paths_drops_attached_duplicate(
+        self, tmp_path: Path
+    ) -> None:
+        d = tmp_path / "inc"
+        toks = (f"-I{d}", "-fPIC")
+        out = drop_include_tokens_duplicating_paths(toks, [d])
+        assert out == ["-fPIC"]
+
+    def test_drop_include_tokens_duplicating_paths_keeps_non_matching(
+        self, tmp_path: Path
+    ) -> None:
+        d = tmp_path / "inc"
+        other = tmp_path / "other"
+        toks = ("-I", str(other), "-isystem", str(d))
+        out = drop_include_tokens_duplicating_paths(toks, [d])
+        assert out == ["-I", str(other)]
+
+
+class TestMergeL3CompileContextDropsDuplicateExplicitInclude:
+    """A second, deeper mechanism behind the same nineteenth finding:
+    `_merge_l3_compile_context`'s `derived` compile context and the
+    caller's own *explicit* `gcc_options`/`gcc_option_tokens` can
+    independently carry an `-I`/`-isystem` for the identical directory
+    (e.g. a legacy `-p`/`--compile-db` match and this P0.3 fold both
+    derived from the same compile database) -- confirmed by directly
+    inspecting both `CompileContext` objects a real `dump` invocation
+    passes into the merge, not reconstructed from a diff reason alone."""
+
+    def test_drops_derived_include_duplicating_explicit_gcc_options_string(
+        self,
+    ) -> None:
+        from abicheck.buildsource.l2_seed import _merge_l3_compile_context
+        from abicheck.compile_context import CompileContext
+
+        derived = CompileContext(
+            gcc_option_tokens=("-std=c++17", "-I", "/proj/include", "-fPIC")
+        )
+        explicit = CompileContext(gcc_options="-std=c++17 -I /proj/include")
+        merged = _merge_l3_compile_context(explicit, derived)
+        assert merged is not None
+        # The derived copy of "-I /proj/include" is dropped -- explicit's own
+        # (now in explicit_tail, from the split gcc_options string) is the
+        # only surviving occurrence, and it still searches before every
+        # other derived token per the established first-match-wins rule.
+        assert merged.gcc_option_tokens == (
+            "-std=c++17",
+            "-fPIC",
+            "-std=c++17",
+            "-I",
+            "/proj/include",
+        )
+        assert merged.gcc_option_tokens.count("-I") == 1
+
+    def test_keeps_derived_include_when_directories_differ(self) -> None:
+        from abicheck.buildsource.l2_seed import _merge_l3_compile_context
+        from abicheck.compile_context import CompileContext
+
+        derived = CompileContext(gcc_option_tokens=("-I", "/build/gen"))
+        explicit = CompileContext(gcc_options="-I /user/inc")
+        merged = _merge_l3_compile_context(explicit, derived)
+        assert merged is not None
+        assert merged.gcc_option_tokens == ("-I", "/user/inc", "-I", "/build/gen")

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -851,7 +851,7 @@ class TestDedupIncludeDirsAcrossCompositionSites:
     ) -> None:
         d = tmp_path / "inc"
         toks = ("-DFOO=1", "-I", str(d), "-fPIC")
-        out = drop_include_tokens_duplicating_paths(toks, [d])
+        out = drop_include_tokens_duplicating_paths(toks, ["-I", str(d)])
         assert out == ["-DFOO=1", "-fPIC"]
 
     def test_drop_include_tokens_duplicating_paths_drops_attached_duplicate(
@@ -859,17 +859,31 @@ class TestDedupIncludeDirsAcrossCompositionSites:
     ) -> None:
         d = tmp_path / "inc"
         toks = (f"-I{d}", "-fPIC")
-        out = drop_include_tokens_duplicating_paths(toks, [d])
+        out = drop_include_tokens_duplicating_paths(toks, ["-I", str(d)])
         assert out == ["-fPIC"]
 
-    def test_drop_include_tokens_duplicating_paths_keeps_non_matching(
+    def test_drop_include_tokens_duplicating_paths_keeps_non_matching_directory(
         self, tmp_path: Path
     ) -> None:
         d = tmp_path / "inc"
         other = tmp_path / "other"
-        toks = ("-I", str(other), "-isystem", str(d))
-        out = drop_include_tokens_duplicating_paths(toks, [d])
+        toks = ("-I", str(other), "-I", str(d))
+        out = drop_include_tokens_duplicating_paths(toks, ["-I", str(d)])
         assert out == ["-I", str(other)]
+
+    def test_drop_include_tokens_duplicating_paths_is_class_sensitive(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review, PR #802: an ``-I``-class duplicate must not eat an
+        ``-isystem`` entry for the same directory -- GCC/Clang consult
+        ``-iquote``/``-I``/``-isystem``/``-idirafter`` as distinct search
+        buckets regardless of argv order, so dropping a same-directory
+        entry in a *different* class would change which bucket the
+        directory is searched from."""
+        d = tmp_path / "inc"
+        toks = ("-isystem", str(d), "-fPIC")
+        out = drop_include_tokens_duplicating_paths(toks, ["-I", str(d)])
+        assert out == ["-isystem", str(d), "-fPIC"]
 
 
 class TestMergeL3CompileContextDropsDuplicateExplicitInclude:

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -947,6 +947,33 @@ class TestDedupIncludeDirsAcrossCompositionSites:
         pairs = _include_class_path_pairs((_DASH_I_DIVIDER,))
         assert pairs == set()
 
+    def test_dash_i_divider_state_carries_from_already_covered_into_toks(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review, PR #802 (second round): the divider state must
+        carry *across* the already_covered -> toks boundary, not just
+        within toks itself. Every caller renders already_covered (the
+        already-built command, e.g. `extra_includes`) into the argv
+        *before* toks (`gcc_option_tokens`) -- `cmd += drop_include_tokens_
+        duplicating_paths(gcc_option_tokens, cmd)` -- so a "-I-" anywhere in
+        already_covered means toks starts life already past the divider,
+        even though toks itself carries no "-I-" of its own. Scanning toks
+        from a fresh pre-divider state regardless of what already_covered
+        ended in would wrongly classify its "-I <dir>" as the same class as
+        an unrelated pre-divider entry in already_covered, and silently
+        drop it -- reproducing `-I A -I- -I A` collapsing to `-I A -I-`."""
+        d = tmp_path / "inc"
+        # already_covered = "-I A -I-": a pre-divider "-I A" followed by the
+        # divider itself.
+        already_covered = ["-I", str(d), _DASH_I_DIVIDER]
+        # toks = the trailing "-I A", rendered *after* already_covered in
+        # the real command and therefore already past the divider -- it
+        # must survive, not be dropped as a duplicate of the pre-divider
+        # entry inside already_covered.
+        toks = ("-I", str(d))
+        out = drop_include_tokens_duplicating_paths(toks, already_covered)
+        assert out == ["-I", str(d)]
+
 
 class TestMergeL3CompileContextDropsDuplicateExplicitInclude:
     """A second, deeper mechanism behind the same nineteenth finding:


### PR DESCRIPTION
## Summary

Follow-up to `napetrov/abicheck-bazel-lab` PR #14's "validate two fresh mains" diagnostic, and to `AGENTS.md`'s L3→L2-fold "nineteenth finding" known gap. That finding recorded a real `NOT_COMPARABLE` failure (`profile_fingerprint` mismatch on `include_sequence`) between a `dump`-produced baseline and a `scan --against` candidate of the same project, but left the exact mechanism unidentified — no live Bazel/castxml repro was available at the time.

This PR reproduces the bug **without Bazel or castxml** (a real `g++`-compiled one-header library + a hand-written `compile_commands.json`, `--ast-frontend clang`), traces it to two independent duplication mechanisms, and fixes both.

## Root causes found

1. **`perform_elf_dump`'s `extra_includes=eff_includes + inc_extra`** (and `service_header_scoped`'s identical `eff_includes += inc_extra`) concatenate two independently-derived include-dir lists with no dedup — a directory can be seeded once via the L3→L2 fold and again via `resolve_inferred_header_roots`'s own, separate lookup over the pre-fold tokens.
2. **`l2_seed._merge_l3_compile_context`'s `derived` compile context can duplicate the caller's own *explicit* `gcc_options`/`gcc_option_tokens`** — e.g. a legacy `-p`/`--compile-db` match and the P0.3 fold both derive from the same compile database, so the identical `-I <dir>` reaches the merged `gcc_option_tokens` twice.

Both are fixed with new, order-preserving dedup helpers in `header_utils.py` (`dedup_paths_preserve_order`, `drop_include_tokens_duplicating_paths`), wired into the three composition sites. A Codex review round on the first version of this fix found it class-blind (dropping an `-isystem <dir>` merely because an unrelated `-I <dir>` existed elsewhere) — fixed before this PR's current state by keying the dedup on `(flag-class, resolved directory)` instead of directory alone.

## What's still open

A third, deeper mechanism survives after these two fixes: `dump`'s legacy `-p`/`--compile-db` auto-match places a matched directory into `gcc_option_tokens` (since the L2 seed's own suppression rule correctly declines to re-seed once explicit context already supplies one), while `scan`'s candidate resolution has no such legacy step and places the identical directory into `declared_includes` instead. Two structurally different `declared_includes` for the same real include root is exactly what `include_sequence` is built to detect, so it still (correctly, if unhelpfully) fires. Closing this needs a design decision — which of the two established mechanisms should supply a matched directory when both apply — that's out of scope for a mechanical fix. Documented in detail in `AGENTS.md`.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: Two independently-derived include-search-flag entries for the identical (search-class, directory) pair can both be composed into the same header-AST parse command or merged compile context with no dedup — any composition point in the L2/L3 pipeline that concatenates two separately-derived include lists (an L2 seed + an inferred-root resolver's own lookup; a legacy `-p`/`--compile-db` match + the P0.3 fold's own derived context) is at risk of this, not just the two sites this PR happened to reproduce it at.
- Publicly observable failure: `abicheck dump lib.so -H api.h --sources . --build-info compile_commands.json --ast-frontend clang --depth source` on a real project renders `-I <dir>` twice in the persisted snapshot's `ast_compile_args`, and a subsequent `abicheck scan candidate.so --against <that dump>.abi.json` with the same inputs fails `NOT_COMPARABLE`: "old and new snapshots were extracted under different compile contexts (profile_fingerprint mismatch; differing fields: include_sequence)".
- Regression test fails on base: Yes — `tests/test_build_context_completeness.py::TestDedupIncludeDirsAcrossCompositionSites` and `TestMergeL3CompileContextDropsDuplicateExplicitInclude` call the new dedup functions directly against pre-fix-shaped duplicate input; reverting the composition-site wiring (the raw `eff_includes + inc_extra` concatenation, or `_merge_l3_compile_context` without the `drop_include_tokens_duplicating_paths` call) reproduces the duplicate and fails these assertions.
- Negative control: `test_drop_include_tokens_duplicating_paths_keeps_non_matching_directory` (different directory, same class → kept) and `test_drop_include_tokens_duplicating_paths_is_class_sensitive` (same directory, different search class → kept) both prove the dedup doesn't over-fire and collapse genuinely distinct entries.
- Public-surface test: Reproduced and verified through the real CLI entry point, not just the unit level — `abicheck dump`/`abicheck scan` invoked directly against a real `g++`-compiled `.so` and a hand-written `compile_commands.json`; confirmed the persisted snapshot's `ast_compile_args` carries exactly one `-I <dir>` post-fix (two, pre-fix).
- Axes covered: Both `dump` entry points — ELF (`perform_elf_dump`) and PE/Mach-O (`service_header_scoped._try_header_scoped_dump`) — and both header-command builders (`_build_castxml_command`/`_build_clang_header_command`, which share the one `drop_include_tokens_duplicating_paths` call). The end-to-end CLI repro above used the clang backend only (no castxml binary available in this environment); the castxml call site is verified by code-identical call shape + unit test, not a live castxml invocation — see Real-dependency test below.
- General invariant: Two include-search entries sharing the same `(search-class, resolved-directory)` pair are always collapsed to one occurrence, in first-occurrence order, regardless of which two composition sites independently produced them. This does not close the whole `dump`/`scan` `include_sequence` mismatch class — a third, structurally different mechanism is documented as a known gap in `AGENTS.md` (see "What's still open" above), not silently left unaddressed.
- Real-dependency test: Not run against a live castxml binary — unavailable in this sandbox. Verified against the real clang backend end-to-end (an actual local `clang`/`castxml`-shaped `-ast-dump=json` invocation, not a mock or hand-built AST). `_build_castxml_command`'s call site is code-identical to `_build_clang_header_command`'s and covered by unit tests, but not by a live castxml run — recorded here rather than silently assumed.
- Known unsupported cases: The third mechanism under "What's still open" (declared_includes vs. gcc_option_tokens placement disagreement between `dump`'s legacy `-p` path and `scan`'s fold-only path) is not fixed by this PR and still reproduces `NOT_COMPARABLE` on the same repro.

## Testing

- New regression tests in `tests/test_header_compile_context.py` and `tests/test_build_context_completeness.py`, verified to fail against the pre-fix code.
- `tests/test_header_compile_context.py`, `tests/test_build_context_completeness.py`, `tests/test_non_elf_dump_l2_seed.py`, `tests/test_cli_dump_helpers_coverage.py`, `tests/test_bazel_root_targets_l2_seed.py`, `tests/test_service_unit.py`: all passing.
- `ruff check`, `mypy`: clean on all touched files.
- `scripts/check_ai_readiness.py`: 0 errors (kept `cli_dump_helpers.py` at exactly the 2000-line hard cap rather than pushing it over).
- Full fast unit suite (28,399 passed) run locally; the 98 failures observed were pre-existing/environment-specific (action shell-script and baseline-upload tests unrelated to any touched file) and reproduce identically without this PR's changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01EZnhb59ffxu8YYx3AhaRy9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate include paths from appearing in generated compiler and dump commands.
  * Preserved distinct include search categories when the same directory is specified with different options.
  * Maintained include-path ordering during deduplication.
  * Added graceful handling for paths that cannot be resolved.

* **Tests**
  * Expanded coverage for include handling, compiler context merging, and duplicate option filtering.

* **Documentation**
  * Updated release documentation with the scope and remaining limitations of the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->