### PR TITLE
refactor: PR C (dump/scan resolver convergence) — thread symbols_only/debug_presence_only, reconcile public_headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4265,6 +4265,64 @@ Once a root command genuinely clears the bar above, pick the right home:
   explicit ordering requirement — see `docs/contribute/plans/cli-cleanup-
   phase-two.md`'s PR 3A section for the equivalent, fuller account.
 
+  **Slice landed (2026-08-20): both "narrower blockers" above closed, plus
+  the debug-artifact-resolution question this entry raised confirmed
+  equivalent — no code change needed for that half.** `perform_elf_dump`
+  has exactly one caller (`dump_cmd`, confirmed by grep), and `dump_cmd`
+  never sets `symbols_only`/`debug_presence_only` (`dump` has no such
+  flags at all — only `scan`/`compare` do), so `_dump_elf`'s extra `not
+  symbols_only and not debug_presence_only` gate around its debug-artifact
+  resolution is vacuously true for every input `perform_elf_dump` can
+  actually pass it; the remaining textual differences (`debug_roots` vs.
+  `list(debug_roots) or None`, `click.echo` vs. `notify`, `if artifact:`
+  vs. `if artifact is not None`) are all behaviorally inert (the resolver
+  backends already do `list(debug_roots or [])` internally, and a
+  `DebugArtifact` instance is always truthy). `symbols_only`/
+  `debug_presence_only` now thread through `resolve_side_snapshot`/
+  `_resolve_side_snapshot_impl` into `service.resolve_input`, both
+  defaulting `False` so every pre-existing caller is unaffected — the same
+  additive shape as the existing `changed_paths`/`allow_build_query`
+  pass-throughs (`tests/test_header_compile_context.py::
+  test_resolve_side_snapshot_forwards_symbols_only_and_debug_presence_only`,
+  confirmed to fail pre-fix with `TypeError: unexpected keyword argument
+  'symbols_only'`). The `public_headers` construction divergence:
+  investigated the actual consumer rather than just diffing the two call
+  sites — `embed_build_source`'s `public_header_roots` (the union of both
+  tuples) is split back into file vs. directory roots by
+  `source_extractors._argv.split_public_roots`, which already recognizes a
+  directory via `os.path.isdir()` regardless of which tuple it arrived in,
+  and `_ClassifyContext.classify()` matches a directory root by
+  segment/prefix — so a file under a public directory already classifies
+  as public without also needing to appear as an individual exact-match
+  entry. `_build_new_snapshot`'s `_expand_public_headers`-based
+  construction was therefore redundant, not more correct — it added exact
+  file entries a directory root already covered, at the cost of an extra
+  directory walk and a needlessly divergent call shape from
+  `embed_side_build_source`'s simpler raw pass-through.
+  `_expand_public_headers` itself is unchanged and still correctly used a
+  few lines above this call site, for the S2 preprocessor pre-scan (a
+  genuinely different contract — each header becomes its own `clang -E`
+  TU there). Reconciled onto the canonical shape (`tests/
+  test_scan_l2_cleanup_ordering.py::
+  test_scan_candidate_passes_public_headers_unexpanded_to_embed`,
+  confirmed to fail pre-fix — the directory-derived extra file entry
+  showed up in the captured tuple). **Neither fix routes
+  `_build_new_snapshot` through `_resolve_side_snapshot_impl` itself** —
+  they make that future migration safe, they don't perform it.
+  Investigating the migration surfaced one more wrinkle this entry hadn't
+  named: `_build_new_snapshot`'s own `allow_build_query` gates only its
+  `embed_build_source` call, never its `seed_includes_and_fold_compile_
+  context` call (which always passes `build_query=None, build_compile_
+  db=None` — `scan` has no such CLI flags to begin with), whereas
+  `_resolve_side_snapshot_impl`'s `_gated_build_query_inputs` gates both
+  from one shared decision; reconciling that needs confirming what
+  `_build_new_snapshot`'s `allow_build_query` is actually meant to
+  authorize today, before the two functions' gating can be safely
+  unified. Blockers 4 (post-processing hooks) and 5/6 (`dump_cmd` building
+  a real `DumpRequest`; a pair-aware scan-baseline primitive) remain fully
+  open, unchanged from the notes above — see the plan doc's own PR 3A
+  section for the identical, fuller account.
+
 - Don't hand-edit `CHANGELOG.md`'s `## [Unreleased]` section directly — add a `changelog.d/` fragment instead (see Conventions above); CI enforces this
 - Don't modify `examples/` test cases without understanding the ground truth they encode
 - Don't add dependencies without strong justification (this is a lightweight tool)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4286,27 +4286,43 @@ Once a root command genuinely clears the bar above, pick the right home:
   test_resolve_side_snapshot_forwards_symbols_only_and_debug_presence_only`,
   confirmed to fail pre-fix with `TypeError: unexpected keyword argument
   'symbols_only'`). The `public_headers` construction divergence:
-  investigated the actual consumer rather than just diffing the two call
-  sites — `embed_build_source`'s `public_header_roots` (the union of both
-  tuples) is split back into file vs. directory roots by
-  `source_extractors._argv.split_public_roots`, which already recognizes a
-  directory via `os.path.isdir()` regardless of which tuple it arrived in,
-  and `_ClassifyContext.classify()` matches a directory root by
-  segment/prefix — so a file under a public directory already classifies
-  as public without also needing to appear as an individual exact-match
-  entry. `_build_new_snapshot`'s `_expand_public_headers`-based
-  construction was therefore redundant, not more correct — it added exact
-  file entries a directory root already covered, at the cost of an extra
-  directory walk and a needlessly divergent call shape from
-  `embed_side_build_source`'s simpler raw pass-through.
-  `_expand_public_headers` itself is unchanged and still correctly used a
-  few lines above this call site, for the S2 preprocessor pre-scan (a
-  genuinely different contract — each header becomes its own `clang -E`
-  TU there). Reconciled onto the canonical shape (`tests/
+  **a fix was attempted and merged, then reverted the same day after
+  review caught a real regression it missed — kept here in full because
+  the first pass's reasoning was genuinely incomplete, not just
+  under-tested.** The first pass read one consumer of `embed_build_
+  source`'s `public_header_roots` (`source_extractors._argv.
+  split_public_roots`/`_ClassifyContext.classify()`) and confirmed a
+  directory root already classifies every file under it via segment/
+  prefix matching, so the `_expand_public_headers`-based expansion looked
+  purely redundant *against that consumer* — and switched
+  `_build_new_snapshot`'s call to the simpler, unexpanded raw pass-through
+  `embed_side_build_source` already uses. That missed a **second,
+  differently-shaped consumer of the same list**:
+  `clang_public_roots._equivalent_public_roots_for_unit`, the
+  install-tree-vs-build-tree "mirror detection" heuristic L4 replay uses
+  when a public root names a physically different tree from the build's
+  own include dir. Its promotion rule is asymmetric by root shape: a
+  *file* root promotes on a single sampled match; a *directory* root
+  needs `>= _PUBLIC_ROOT_WHOLE_DIR_MIN_MATCHES` (2) matches before
+  promoting the whole directory — so a build include dir mirroring only
+  ONE header out of a larger public root loses that promotion entirely
+  once the directory stops being pre-expanded, confirmed by direct
+  reproduction against the function itself (three installed headers, one
+  mirrored in the build tree: expanded file roots promote it, a single
+  directory root promotes nothing). `embed_side_build_source`'s own raw
+  pass-through (already shipped, used by `compare`/`dump`) carries the
+  identical weakness — not fixed here, since unifying either direction
+  changes real classification behavior for a real consumer, and deciding
+  which needs its own scoped design, not a same-PR revert-and-redo.
+  Reverted `_build_new_snapshot`'s call back to the expanded shape and
+  pinned two regression tests: the call's own shape (`tests/
   test_scan_l2_cleanup_ordering.py::
-  test_scan_candidate_passes_public_headers_unexpanded_to_embed`,
-  confirmed to fail pre-fix — the directory-derived extra file entry
-  showed up in the captured tuple). **Neither fix routes
+  test_scan_candidate_expands_public_header_dirs_before_embed`) and the
+  underlying asymmetry directly against `_equivalent_public_roots_for_unit`
+  itself (`tests/test_clang_public_roots_coverage.py::
+  test_equivalent_public_roots_promotes_on_single_match_only_for_file_roots`),
+  so a future "simplify this like the other primitive" pass doesn't
+  silently reintroduce the same regression. **Neither fix routes
   `_build_new_snapshot` through `_resolve_side_snapshot_impl` itself** —
   they make that future migration safe, they don't perform it.
   Investigating the migration surfaced one more wrinkle this entry hadn't

--- a/abicheck/buildsource/l2_seed.py
+++ b/abicheck/buildsource/l2_seed.py
@@ -95,6 +95,52 @@ def _l2_seed_config(
     )
 
 
+def _is_inputs_pack_dir(path: Path | None) -> bool:
+    """True when *path* is a Flow-2 ``abicheck_inputs/`` directory (ADR-035 D5).
+
+    A local copy of ``cli_buildsource_helpers._is_inputs_pack_dir``'s own
+    None/is_dir guard around ``inputs_pack.is_inputs_pack``, not an import of
+    it: ``cli_buildsource_helpers`` sits several layers above this leaf
+    module (it is reached from ``cli_buildsource`` -> ``cli_dump_helpers`` ->
+    this module, among other paths), so importing it here -- even
+    function-locally -- closes a real cycle the AI-readiness
+    ``import-cycle-growth`` gate correctly rejects. ``inputs_pack.py`` itself
+    has no such path back to here, so importing straight from it is safe.
+    """
+    if path is None or not path.is_dir():
+        return False
+    from .inputs_pack import is_inputs_pack
+
+    return is_inputs_pack(path)
+
+
+def _l2_seed_pack_build_evidence(path: Path) -> Any:
+    """The ``BuildEvidence`` a pack directory at *path* folds into L2 seeding.
+
+    Mirrors whichever of the two real loaders ``embed_build_source``'s own
+    pack recognition would use for *path*: a classic ``BuildSourcePack``
+    (``is_pack_dir``) loads via ``BuildSourcePack.load``; a Flow-2
+    ``abicheck_inputs/`` pack (ADR-035 D5) loads via the lighter,
+    comparable-cost ``load_inputs_manifest`` + ``_load_build_evidence`` pair
+    -- parsing only the pack's own compile DB, not the full
+    ``ingest_inputs_pack`` (which additionally reads and parses every
+    ``source_facts/*.jsonl`` file: real extra I/O this L3-only seed does not
+    need, and it would also require an ``exported_symbols`` list this
+    caller, deep inside L2 seeding, has no access to). Raises the same way
+    the real loaders do for a structurally malformed pack
+    (``FileNotFoundError``/``ValueError``) -- both callers of
+    :func:`_l2_seed_pack_inputs` already treat this whole resolution as
+    best-effort and degrade to "no seeded dirs" on any exception, so this
+    function does not need its own catch.
+    """
+    if is_pack_dir(path):
+        return BuildSourcePack.load(path).build_evidence
+    from .inputs_pack import _load_build_evidence, load_inputs_manifest
+
+    manifest = load_inputs_manifest(path)
+    return _load_build_evidence(path, manifest, [])
+
+
 def _l2_seed_pack_inputs(
     build_info: Path | None, sources: Path | None
 ) -> tuple[Any, Path | None, Path | None]:
@@ -107,16 +153,34 @@ def _l2_seed_pack_inputs(
     only when *no* ``--build-info`` was given (not merely no build-info *pack*):
     a raw ``--build-info`` must still be resolved by ``collect_inline_pack``,
     not skipped by folding the pack into ``base_build`` (Codex review).
+
+    Also recognizes a Flow-2 ``abicheck_inputs/`` pack (ADR-035 D5,
+    ``_is_inputs_pack_dir``) the identical way it recognizes a classic
+    ``BuildSourcePack`` -- ``embed_build_source`` already folds both shapes
+    in uniformly (``bi_is_pack or bi_is_inputs`` / ``src_is_pack or
+    src_is_inputs``), but this function, the L2-seed path's own pack
+    recognizer, previously checked only ``is_pack_dir``. Confirmed by
+    reading both real call sites: neither ``collect_inline_pack`` nor
+    anything it calls has its own Flow-2 recognition, so an un-normalized
+    Flow-2 pack directory reaching it was silently treated as a literal
+    source tree -- its own compile-unit include dirs never reached L2
+    seeding at all, and (the sharper failure mode) a trusted, explicit
+    ``build.query``/``--config`` could genuinely be re-executed against the
+    pack directory as if it were a real, queryable project checkout, even
+    though the pack already carries its own resolved L3 evidence to fold in
+    directly instead.
     """
     base_build = None
     raw_build_info = build_info
-    if build_info is not None and is_pack_dir(build_info):
-        base_build = BuildSourcePack.load(build_info).build_evidence
+    if build_info is not None and (
+        is_pack_dir(build_info) or _is_inputs_pack_dir(build_info)
+    ):
+        base_build = _l2_seed_pack_build_evidence(build_info)
         raw_build_info = None
     raw_sources = sources
-    if sources is not None and is_pack_dir(sources):
+    if sources is not None and (is_pack_dir(sources) or _is_inputs_pack_dir(sources)):
         if build_info is None:
-            base_build = BuildSourcePack.load(sources).build_evidence
+            base_build = _l2_seed_pack_build_evidence(sources)
         raw_sources = None
     return base_build, raw_build_info, raw_sources
 

--- a/abicheck/cli_dump_dry_run_build_query.py
+++ b/abicheck/cli_dump_dry_run_build_query.py
@@ -140,19 +140,6 @@ further, per this repository's own "known gaps over risky reactive
 patches" convention -- this module has now been through twenty-two review
 rounds):
 
-- Flow-2 ``abicheck_inputs/`` packs (recognized by
-  ``cli_buildsource_helpers._is_inputs_pack_dir``, a *different* recognizer
-  from ``BuildSourcePack``'s own ``is_pack_dir``) fold into
-  ``raw_build_info``/``raw_sources`` the identical way a ``BuildSourcePack``
-  does in ``cli_buildsource.embed_build_source``, but this module does not
-  detect that input shape at all -- a Flow-2 pack as the sole
-  ``--build-info``/``--sources`` input, with no discoverable compile DB or
-  headers, is still reported as "will run" when it would not. Closing this
-  needs importing a second pack-format recognizer and a second,
-  differently-shaped facts model (``InputsManifest``/``load_inputs_manifest``)
-  rather than reusing anything ``BuildSourcePack``-shaped already handled
-  above -- a genuinely separate input format, not a follow-up to the same
-  mechanism.
 - Every reachability check above reads the *raw*, unexpanded ``headers``
   tuple exactly as ``dump_cmd`` receives it from Click -- a directory entry
   counts as "headers present" even when ``_expand_header_inputs`` (called
@@ -232,10 +219,34 @@ rounds):
   non-idempotent-unsafe for this input shape *before* they run it for
   real.
 
-This closes the full set of ``BuildSourcePack``-shaped paths into
-``collect_inline_pack`` this module is aware of (the two gaps above
-excepted); a new bypass mechanism added to that function in the future
-would need a matching addition here, the same way each of these did.
+This closes the full set of ``BuildSourcePack``-shaped *and* Flow-2
+``abicheck_inputs/``-shaped paths into ``collect_inline_pack``/the L2 seed
+this module is aware of (the header-directory-validation gap above
+excepted); a new bypass mechanism added to either path in the future would
+need a matching addition here, the same way each of these did.
+
+**Update: the Flow-2 gap above is closed.** It was originally two gaps, not
+one: this module's own lack of Flow-2 recognition, *and* a real production
+gap this investigation found in the L2-seed path itself --
+``buildsource.l2_seed._l2_seed_pack_inputs`` (the pack-precedence resolver
+``seed_includes_and_fold_compile_context`` uses) only ever recognized a
+classic ``BuildSourcePack`` (``is_pack_dir``), never a Flow-2 pack, even
+though ``embed_build_source`` already recognized both uniformly. A Flow-2
+pack given as ``--sources``/``--build-info`` alongside ``-H`` headers was
+therefore silently treated by the L2 seed as a literal, un-normalized
+source tree -- its own compile-unit include dirs never reached L2 seeding,
+and a trusted, explicit ``build.query``/``--config`` could genuinely be
+re-executed against the pack directory itself. Fixed at the root
+(``_l2_seed_pack_inputs`` now also checks ``_is_inputs_pack_dir``, folding
+in a Flow-2 pack's ``BuildEvidence`` via the same lighter
+``load_inputs_manifest``/``_load_build_evidence`` pair this module uses
+below, rather than the full ``ingest_inputs_pack``), which is what makes
+this module's own uniform ``_is_pack_dir_any``/``_pack_dir_build_evidence``
+treatment of both call sites correct rather than merely convenient --
+before that fix, mirroring ``embed_build_source``'s recognition here alone
+would have made this preview *wrong* for the L2-seed-reachable branches
+(reporting "will NOT run" for an input the L2 seed's own un-fixed
+resolution would still have genuinely reached ``cfg.query`` through).
 """
 
 from __future__ import annotations
@@ -245,12 +256,69 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from .buildsource.build_evidence import BuildEvidence
     from .dry_run import DryRunResult
 
 _SECTION = "Build query (trust)"
 
 
-def _resolve_compile_db_hint_line(compile_db_hint: str, effective_sources: Path | None) -> str:
+def _is_pack_dir_any(path: Path | None) -> bool:
+    """True when *path* is either pack-directory shape the real resolvers
+    fold in and null the corresponding ``raw_build_info``/``raw_sources``
+    operand for -- a classic :class:`BuildSourcePack` (``is_pack_dir``) or a
+    Flow-2 ``abicheck_inputs/`` pack (ADR-035 D5, ``_is_inputs_pack_dir``).
+
+    Both ``embed_build_source`` and (since the fix this module's own
+    docstring records) ``buildsource.l2_seed._l2_seed_pack_inputs`` treat
+    both shapes identically for this purpose (``bi_is_pack or bi_is_inputs``
+    / ``src_is_pack or src_is_inputs``, both unconditionally nulling the raw
+    operand regardless of whether the pack carries any L3 evidence) -- so
+    every reachability branch in this module that keys off "is this operand
+    itself a pack" can safely recognize both the same way too.
+    """
+    from .buildsource.inline import is_pack_dir
+    from .cli_buildsource_helpers import _is_inputs_pack_dir
+
+    return is_pack_dir(path) or _is_inputs_pack_dir(path)
+
+
+def _pack_dir_build_evidence(path: Path) -> BuildEvidence | None:
+    """The ``BuildEvidence`` a pack directory at *path* would fold in.
+
+    Mirrors whichever of the two real loaders the production pack-precedence
+    resolvers use for *path*: a classic ``BuildSourcePack.load(path).
+    build_evidence`` for the ``is_pack_dir`` shape, or -- for a Flow-2
+    ``abicheck_inputs/`` pack -- the lighter, comparable-cost
+    ``load_inputs_manifest`` + ``_load_build_evidence`` pair that parses only
+    the pack's compile DB, **not** the full ``ingest_inputs_pack`` (which
+    additionally reads and parses every ``source_facts/*.jsonl`` file -- real
+    extra I/O this reachability question, "does this pack already carry L3
+    compile units", does not need; this module's own contract is "no I/O
+    beyond stat()/PATH lookups" wherever a cheaper equivalent exists) --
+    mirroring ``buildsource.l2_seed._l2_seed_pack_build_evidence``'s
+    identical choice for the identical reason. Raises the same way the real
+    loaders do for a structurally malformed pack (``FileNotFoundError``/
+    ``ValueError``, or a broader shape-mismatch exception a malformed
+    manifest can raise -- see the two call sites' own ``except Exception``
+    handling, which does not key on the exception's type), so both call
+    sites can share one catch-all shape regardless of which pack kind was
+    actually loaded.
+    """
+    from .buildsource.inline import is_pack_dir
+
+    if is_pack_dir(path):
+        from .buildsource.pack import BuildSourcePack
+
+        return BuildSourcePack.load(path).build_evidence
+    from .buildsource.inputs_pack import _load_build_evidence, load_inputs_manifest
+
+    manifest = load_inputs_manifest(path)
+    return _load_build_evidence(path, manifest, [])
+
+
+def _resolve_compile_db_hint_line(
+    compile_db_hint: str, effective_sources: Path | None
+) -> str:
     """The ``resulting compile-DB path:`` line for a configured hint.
 
     `_run_build_query`'s own resolution isn't a literal-string label --
@@ -275,7 +343,11 @@ def _resolve_compile_db_hint_line(compile_db_hint: str, effective_sources: Path 
     try:
         existing_match = (
             next(
-                (m for m in sorted(effective_sources.glob(compile_db_hint)) if m.is_file()),
+                (
+                    m
+                    for m in sorted(effective_sources.glob(compile_db_hint))
+                    if m.is_file()
+                ),
                 None,
             )
             if effective_sources is not None
@@ -345,7 +417,6 @@ def add_build_query_dry_run_section(
     from .buildsource.inline import (
         _compile_db_at,
         discover_build_config,
-        is_pack_dir,
         load_build_config,
     )
 
@@ -473,11 +544,9 @@ def add_build_query_dry_run_section(
     # only inside the --build-info-is-absent-or-non-pack branch further
     # down, since that branch is an `elif` a non-pack --build-info would
     # otherwise skip entirely (Codex review, fresh evidence).
-    if sources is not None and is_pack_dir(sources):
-        from .buildsource.pack import BuildSourcePack
-
+    if sources is not None and _is_pack_dir_any(sources):
         try:
-            src_pack_evidence = BuildSourcePack.load(sources).build_evidence
+            src_pack_evidence = _pack_dir_build_evidence(sources)
         except Exception as exc:  # noqa: BLE001 -- best-effort preview load; see
             # the note above this try (Codex review, fresh evidence): a
             # structurally malformed manifest (e.g. a JSON `null` where a
@@ -541,7 +610,8 @@ def add_build_query_dry_run_section(
                 # unconditional load -- fails and aborts the overall
                 # command).
                 result.add(
-                    _SECTION, f"build.query: could not load --sources pack {sources}: {exc}"
+                    _SECTION,
+                    f"build.query: could not load --sources pack {sources}: {exc}",
                 )
                 if collect_active:
                     if l2_seed_reachable:
@@ -567,7 +637,8 @@ def add_build_query_dry_run_section(
                 src_pack_evidence = None
             elif collect_active:
                 result.add(
-                    _SECTION, f"build.query: could not load --sources pack {sources}: {exc}"
+                    _SECTION,
+                    f"build.query: could not load --sources pack {sources}: {exc}",
                 )
                 result.block(f"--sources names an unloadable pack ({sources}): {exc}")
                 return
@@ -592,11 +663,9 @@ def add_build_query_dry_run_section(
     else:
         src_pack_evidence = None
 
-    if build_info is not None and is_pack_dir(build_info):
-        from .buildsource.pack import BuildSourcePack
-
+    if build_info is not None and _is_pack_dir_any(build_info):
         try:
-            bi_pack_evidence = BuildSourcePack.load(build_info).build_evidence
+            bi_pack_evidence = _pack_dir_build_evidence(build_info)
         except Exception as exc:  # noqa: BLE001 -- best-effort preview load,
             # broadened for the identical reason the sibling --sources pack
             # load above was (Codex review, fresh evidence): a structurally
@@ -616,7 +685,9 @@ def add_build_query_dry_run_section(
                     _SECTION,
                     f"build.query: could not load --build-info pack {build_info}: {exc}",
                 )
-                result.block(f"--build-info names an unloadable pack ({build_info}): {exc}")
+                result.block(
+                    f"--build-info names an unloadable pack ({build_info}): {exc}"
+                )
             else:
                 result.add(
                     _SECTION,
@@ -636,7 +707,9 @@ def add_build_query_dry_run_section(
     # config auto-discovery and the query's own cwd must use that same
     # normalized value, not the pack directory itself (Codex review, fresh
     # evidence).
-    effective_sources = None if (sources is not None and is_pack_dir(sources)) else sources
+    effective_sources = (
+        None if (sources is not None and _is_pack_dir_any(sources)) else sources
+    )
 
     # Two independent real call sites can load `cfg_path`, with two different
     # reachability conditions and two different failure behaviors:
@@ -676,9 +749,9 @@ def add_build_query_dry_run_section(
     # resolved --build-info compile database never got validated at all --
     # verified end-to-end that the real run still raises for that exact
     # combination).
-    raw_operand_present = (build_info is not None and not is_pack_dir(build_info)) or (
-        effective_sources is not None
-    )
+    raw_operand_present = (
+        build_info is not None and not _is_pack_dir_any(build_info)
+    ) or (effective_sources is not None)
     config_readable = l2_seed_reachable or raw_operand_present
     # `embed_build_source`'s own auto-discovery is `discover_build_config
     # (raw_sources)` -- keyed on `effective_sources` alone, never
@@ -697,7 +770,9 @@ def add_build_query_dry_run_section(
     # `--sources` is itself a pack), so `discover_from` above always agrees
     # with what `embed_build_source` would independently discover -- no
     # divergence to guard against in that case.
-    raise_on_bad_config = collect_active and raw_operand_present and effective_sources is not None
+    raise_on_bad_config = (
+        collect_active and raw_operand_present and effective_sources is not None
+    )
 
     # Same source (source-tree-root-only, no upward walk) `embed_build_source`
     # itself resolves from for this purpose -- distinct from `discover_project_
@@ -752,7 +827,9 @@ def add_build_query_dry_run_section(
             if raise_on_bad_config:
                 import click
 
-                raise click.UsageError(f"cannot parse build config {cfg_path}: {exc}") from exc
+                raise click.UsageError(
+                    f"cannot parse build config {cfg_path}: {exc}"
+                ) from exc
             result.add(_SECTION, f"build.query: could not load {cfg_path}: {exc}")
             # `cfg_path` here was discovered from `discover_from` above, which
             # -- when `l2_seed_reachable` -- is the *unnormalized* `sources`,
@@ -858,7 +935,7 @@ def add_build_query_dry_run_section(
     # unaffected by config validation above, since these branches answer
     # whether `collect_inline_pack`/`_resolve_compile_db` would even look at
     # `cfg.query` given the operands' own shapes.
-    if build_info is not None and is_pack_dir(build_info):
+    if build_info is not None and _is_pack_dir_any(build_info):
         # `_l2_seed_pack_inputs`/`embed_build_source`'s own `base_build=
         # bi_pack.build_evidence` fold a --build-info pack's own L3 compile
         # units in *before* _resolve_compile_db is even considered --
@@ -925,7 +1002,7 @@ def add_build_query_dry_run_section(
                 "over build.query",
             )
             return
-    elif sources is not None and is_pack_dir(sources):
+    elif sources is not None and _is_pack_dir_any(sources):
         # `_l2_seed_pack_inputs` folds a --sources pack into base_build the
         # identical way a --build-info pack does, but only when no
         # --build-info was also given (an explicit --build-info always wins
@@ -955,7 +1032,9 @@ def add_build_query_dry_run_section(
             )
             return
 
-    effective_query = build_query if build_query is not None else (cfg.query if cfg else None)
+    effective_query = (
+        build_query if build_query is not None else (cfg.query if cfg else None)
+    )
     # `_run_build_query`'s own resolution of the compile-DB path it expects
     # the query to have (re)written is gated on `sources is not None`: with
     # no source tree (an absent --sources, or one that normalized to None
@@ -967,7 +1046,9 @@ def add_build_query_dry_run_section(
     _configured_compile_db_hint = (
         build_compile_db if build_compile_db is not None else cfg_compile_db
     )
-    compile_db_hint = _configured_compile_db_hint if effective_sources is not None else None
+    compile_db_hint = (
+        _configured_compile_db_hint if effective_sources is not None else None
+    )
 
     if not effective_query:
         result.add(_SECTION, "build.query: (none configured)")
@@ -1002,8 +1083,14 @@ def add_build_query_dry_run_section(
         )
         return
 
-    trust_source = "explicit --config" if build_config is not None else "explicit --build-query"
-    cwd = effective_sources if effective_sources is not None and effective_sources.is_dir() else Path.cwd()
+    trust_source = (
+        "explicit --config" if build_config is not None else "explicit --build-query"
+    )
+    cwd = (
+        effective_sources
+        if effective_sources is not None and effective_sources.is_dir()
+        else Path.cwd()
+    )
     if compile_db_hint and Path(compile_db_hint).is_absolute():
         # `_run_build_query`'s own resolution -- reached here, since we are
         # already inside the "trusted, will run" branch -- calls
@@ -1050,7 +1137,9 @@ def add_build_query_dry_run_section(
         # review, fresh evidence -- the common, glob-free `build.compile_db:
         # build/compile_commands.json` case previously printed the literal
         # string even when `--sources` was some other, unrelated directory).
-        compile_db_line = _resolve_compile_db_hint_line(compile_db_hint, effective_sources)
+        compile_db_line = _resolve_compile_db_hint_line(
+            compile_db_hint, effective_sources
+        )
     elif _configured_compile_db_hint and effective_sources is None:
         compile_db_line = (
             f"resulting compile-DB path: (build.compile_db is configured, "
@@ -1175,10 +1264,14 @@ def add_build_query_dry_run_section(
     # None` split above (which only distinguishes *why* a reachable second
     # invocation may or may not still run `cfg.query`).
     raw_build_info_for_embed = (
-        None if (build_info is None or is_pack_dir(build_info)) else build_info
+        None if (build_info is None or _is_pack_dir_any(build_info)) else build_info
     )
-    embed_dispatch_possible = raw_build_info_for_embed is not None or effective_sources is not None
-    both_sites_reachable = l2_seed_reachable and collect_active and embed_dispatch_possible
+    embed_dispatch_possible = (
+        raw_build_info_for_embed is not None or effective_sources is not None
+    )
+    both_sites_reachable = (
+        l2_seed_reachable and collect_active and embed_dispatch_possible
+    )
     count_suffix: str
     count_note: tuple[str, ...]
     if both_sites_reachable and raw_build_info_for_embed is None:
@@ -1216,9 +1309,7 @@ def add_build_query_dry_run_section(
             "reaches build-source embedding, or once if it does not",
         )
     elif both_sites_reachable:
-        count_suffix = (
-            " -- RUNS AT LEAST ONCE, POSSIBLY TWICE -- see note below"
-        )
+        count_suffix = " -- RUNS AT LEAST ONCE, POSSIBLY TWICE -- see note below"
         count_note = (
             "note: this input combination reaches build.query from two "
             "independent, non-deduplicated call sites in the real run: the "

--- a/abicheck/cli_dump_dry_run_build_query.py
+++ b/abicheck/cli_dump_dry_run_build_query.py
@@ -262,6 +262,32 @@ if TYPE_CHECKING:
 _SECTION = "Build query (trust)"
 
 
+def _is_inputs_pack_dir(path: Path | None) -> bool:
+    """True when *path* is a Flow-2 ``abicheck_inputs/`` directory (ADR-035 D5).
+
+    A local copy of ``cli_buildsource_helpers._is_inputs_pack_dir``'s own
+    None/is_dir guard around ``buildsource.inputs_pack.is_inputs_pack``, not
+    an import of it: ``cli_buildsource_helpers`` sits several layers above
+    this module in the real import graph (``cli.py``'s ``dump_cmd`` reaches
+    this module directly, and ``cli_buildsource_helpers`` itself reaches back
+    to ``cli.py`` via ``service -> service_scan -> scan_engine ->
+    cli_buildsource -> cli_dump_helpers``), so importing it here -- even
+    function-locally -- closes a real cycle the AI-readiness
+    ``import-cycle-growth`` gate correctly rejects (confirmed by CI:
+    ``cli -> cli_dump_dry_run_build_query -> cli_buildsource_helpers ->
+    service -> service_scan -> scan_engine -> cli_buildsource ->
+    cli_dump_helpers -> cli``). ``buildsource.inputs_pack.py`` itself has no
+    such path back to ``cli.py``, so importing straight from it is safe --
+    the identical fix already applied to
+    ``buildsource.l2_seed._is_inputs_pack_dir`` for the identical reason.
+    """
+    if path is None or not path.is_dir():
+        return False
+    from .buildsource.inputs_pack import is_inputs_pack
+
+    return is_inputs_pack(path)
+
+
 def _is_pack_dir_any(path: Path | None) -> bool:
     """True when *path* is either pack-directory shape the real resolvers
     fold in and null the corresponding ``raw_build_info``/``raw_sources``
@@ -277,7 +303,6 @@ def _is_pack_dir_any(path: Path | None) -> bool:
     itself a pack" can safely recognize both the same way too.
     """
     from .buildsource.inline import is_pack_dir
-    from .cli_buildsource_helpers import _is_inputs_pack_dir
 
     return is_pack_dir(path) or _is_inputs_pack_dir(path)
 
@@ -288,21 +313,42 @@ def _pack_dir_build_evidence(path: Path) -> BuildEvidence | None:
     Mirrors whichever of the two real loaders the production pack-precedence
     resolvers use for *path*: a classic ``BuildSourcePack.load(path).
     build_evidence`` for the ``is_pack_dir`` shape, or -- for a Flow-2
-    ``abicheck_inputs/`` pack -- the lighter, comparable-cost
-    ``load_inputs_manifest`` + ``_load_build_evidence`` pair that parses only
-    the pack's compile DB, **not** the full ``ingest_inputs_pack`` (which
-    additionally reads and parses every ``source_facts/*.jsonl`` file -- real
-    extra I/O this reachability question, "does this pack already carry L3
-    compile units", does not need; this module's own contract is "no I/O
-    beyond stat()/PATH lookups" wherever a cheaper equivalent exists) --
-    mirroring ``buildsource.l2_seed._l2_seed_pack_build_evidence``'s
-    identical choice for the identical reason. Raises the same way the real
-    loaders do for a structurally malformed pack (``FileNotFoundError``/
-    ``ValueError``, or a broader shape-mismatch exception a malformed
-    manifest can raise -- see the two call sites' own ``except Exception``
-    handling, which does not key on the exception's type), so both call
-    sites can share one catch-all shape regardless of which pack kind was
-    actually loaded.
+    ``abicheck_inputs/`` pack -- ``validate_inputs_pack``'s hard validation
+    followed by the lighter ``load_inputs_manifest`` + ``_load_build_
+    evidence`` pair for the ``BuildEvidence`` itself, **not** the full
+    ``ingest_inputs_pack`` (which additionally links a full L4
+    ``SourceAbiSurface`` and folds the L5 graph -- real extra work this
+    reachability question, "does this pack already carry L3 compile units",
+    does not need). Raises the same way the real loaders do for a
+    structurally malformed pack (``FileNotFoundError``/``ValueError``, or a
+    broader shape-mismatch exception a malformed manifest can raise -- see
+    the two call sites' own ``except Exception`` handling, which does not
+    key on the exception's type), so both call sites can share one catch-all
+    shape regardless of which pack kind was actually loaded.
+
+    The Flow-2 branch's own hard validation (Codex review, fresh evidence)
+    mirrors ``embed_build_source``'s own real ``_load_inputs_pack_or_raise``
+    -> ``validate_inputs_pack`` -> raise-on-``report.errors`` order exactly:
+    without it, a pack that is structurally readable (``is_inputs_pack``/
+    ``load_inputs_manifest`` both succeed) but whose source facts fail
+    validation (duplicate ``tu_id``s, target-id/fact-set-recipe/fact-set-
+    identity errors) would have this function report a real ``BuildEvidence``
+    and let the surrounding precedence chain conclude "will NOT run --
+    already carries L3 compile units," even though the real
+    ``embed_build_source`` call this pack reaches would raise
+    ``click.ClickException`` (exit 1) before ever getting that far -- a dry
+    run claiming a broken invocation is valid, which is exactly what this
+    module elsewhere blocks for. This does mean the Flow-2 branch is no
+    longer "no I/O beyond stat()/PATH lookups" (``validate_inputs_pack``
+    itself reads every ``source_facts/*.jsonl`` file to check for duplicate
+    ``tu_id``s and per-TU fact-set issues) -- an accepted correctness-over-
+    cheapness tradeoff, the same one this module's own docstring already
+    makes for a large pre-captured Bazel jsonproto. Deliberately **not**
+    applied to the classic-``BuildSourcePack`` branch above: that shape has
+    no equivalent separate "validate" step in production
+    (``_load_pack_or_raise`` is just ``BuildSourcePack.load`` wrapped in a
+    narrow except), so this function's existing load call already matches
+    it exactly.
     """
     from .buildsource.inline import is_pack_dir
 
@@ -311,7 +357,13 @@ def _pack_dir_build_evidence(path: Path) -> BuildEvidence | None:
 
         return BuildSourcePack.load(path).build_evidence
     from .buildsource.inputs_pack import _load_build_evidence, load_inputs_manifest
+    from .buildsource.inputs_validate import validate_inputs_pack
 
+    report = validate_inputs_pack(path)
+    if report.errors:
+        raise ValueError(
+            f"{len(report.errors)} validation error(s): " + "; ".join(report.errors)
+        )
     manifest = load_inputs_manifest(path)
     return _load_build_evidence(path, manifest, [])
 

--- a/abicheck/scan_engine.py
+++ b/abicheck/scan_engine.py
@@ -389,12 +389,25 @@ def _build_new_snapshot(
                 exclude_cl_style=False,
             ),
             changed_paths=changed_paths,
-            public_headers=tuple(
-                str(p)
-                for p in _expand_public_headers(
-                    [*list(public_headers or ()), *list(public_header_dirs or ())]
-                )
-            ),
+            # Raw pass-through, matching service_input_resolution.
+            # embed_side_build_source's own construction (PR C, dump/scan
+            # resolver convergence) rather than this function's own,
+            # independently-derived one: embed_build_source's
+            # public_header_roots (both tuples get unioned into one set --
+            # cli_buildsource.embed_build_source) is split back into file
+            # vs. directory roots by source_extractors._argv.
+            # split_public_roots, which already recognizes a directory
+            # (`os.path.isdir`) regardless of which of the two arguments it
+            # arrived in -- so expanding a directory into its individual
+            # header files first (as this call used to, via
+            # _expand_public_headers) adds redundant exact-file entries a
+            # dir_root already covers via prefix/segment matching
+            # (_ClassifyContext.classify), without changing which
+            # declarations classify as public. _expand_public_headers stays
+            # in use above for the S2 preprocessor pre-scan, which genuinely
+            # needs individual files (each header becomes its own `clang -E`
+            # TU) -- a different consumer with a different contract.
+            public_headers=tuple(str(p) for p in (public_headers or ())),
             public_header_dirs=tuple(str(p) for p in (public_header_dirs or ())),
             defer_cleanup=defer_cleanup,
         )

--- a/abicheck/scan_engine.py
+++ b/abicheck/scan_engine.py
@@ -389,25 +389,45 @@ def _build_new_snapshot(
                 exclude_cl_style=False,
             ),
             changed_paths=changed_paths,
-            # Raw pass-through, matching service_input_resolution.
-            # embed_side_build_source's own construction (PR C, dump/scan
-            # resolver convergence) rather than this function's own,
-            # independently-derived one: embed_build_source's
-            # public_header_roots (both tuples get unioned into one set --
-            # cli_buildsource.embed_build_source) is split back into file
-            # vs. directory roots by source_extractors._argv.
-            # split_public_roots, which already recognizes a directory
-            # (`os.path.isdir`) regardless of which of the two arguments it
-            # arrived in -- so expanding a directory into its individual
-            # header files first (as this call used to, via
-            # _expand_public_headers) adds redundant exact-file entries a
-            # dir_root already covers via prefix/segment matching
-            # (_ClassifyContext.classify), without changing which
-            # declarations classify as public. _expand_public_headers stays
-            # in use above for the S2 preprocessor pre-scan, which genuinely
-            # needs individual files (each header becomes its own `clang -E`
-            # TU) -- a different consumer with a different contract.
-            public_headers=tuple(str(p) for p in (public_headers or ())),
+            # Kept expanded (individual header files), NOT the simpler raw
+            # pass-through service_input_resolution.embed_side_build_source
+            # uses -- an earlier revision of this call switched to that
+            # simpler shape on the theory that `source_extractors._argv.
+            # split_public_roots`/`_ClassifyContext` already classify a
+            # directory root correctly via prefix/segment matching, making
+            # the expansion redundant. That reasoning holds for *that one*
+            # consumer, but a *second*, differently-shaped consumer of this
+            # same `public_header_roots` list --
+            # `clang_public_roots._equivalent_public_roots_for_unit`, the
+            # install-tree-vs-build-tree "mirror detection" heuristic L4
+            # replay uses when `-H`/`--public-header-dir` names an installed
+            # package tree physically different from the build's own include
+            # dir -- is genuinely sensitive to this shape (Codex review,
+            # confirmed by direct reproduction): a *file* root promotes an
+            # equivalent build-tree header on a single sample match, while a
+            # *directory* root needs >= 2 sampled matches
+            # (`_PUBLIC_ROOT_WHOLE_DIR_MIN_MATCHES`) before promoting the
+            # whole directory -- so a build include dir that happens to
+            # mirror only one header out of a larger public root (a small
+            # per-module local include directory against a larger installed
+            # SDK tree, say) loses that mirror-promotion entirely once the
+            # directory stops being pre-expanded into its individual files.
+            # `embed_side_build_source`'s own raw pass-through carries the
+            # identical weakness already (unverified whether it's been hit
+            # in practice) -- not fixed here, since unifying onto either
+            # shape changes real classification behavior for a real
+            # consumer either way, and reconciling the two needs its own
+            # scoped decision (harden `_equivalent_public_roots_for_unit`'s
+            # directory-root threshold, or thread real expansion into the
+            # shared primitive too), not a same-PR revert-and-redo. Keeping
+            # this call's own proven-safe expanded shape is the
+            # conservative choice for now.
+            public_headers=tuple(
+                str(p)
+                for p in _expand_public_headers(
+                    [*list(public_headers or ()), *list(public_header_dirs or ())]
+                )
+            ),
             public_header_dirs=tuple(str(p) for p in (public_header_dirs or ())),
             defer_cleanup=defer_cleanup,
         )

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -362,6 +362,8 @@ def resolve_side_snapshot(
     debuginfod_url: str | None = None,
     dwarf_only: bool = False,
     debug_format: str | None = None,
+    symbols_only: bool = False,
+    debug_presence_only: bool = False,
     include_labels: dict[Path, str] | None = None,
     notify: Callable[[str], None] | None = None,
 ) -> AbiSnapshot:
@@ -377,6 +379,17 @@ def resolve_side_snapshot(
     :attr:`abicheck.api_types.CompareRequest.lang_explicit` /
     :attr:`abicheck.api_types.DumpRequest.lang_explicit`. Forwarded to
     :func:`abicheck.service.resolve_input` unchanged.
+
+    ``symbols_only``/``debug_presence_only`` (PR 3A, dump/scan resolver
+    convergence): forwarded to :func:`abicheck.service.resolve_input`
+    unchanged. Both default ``False``, matching that function's own
+    defaults, so every pre-existing caller (``compare``, ``dump``'s typed
+    pipeline) is unaffected — only ``scan``'s candidate-side resolution,
+    which supports a binary-depth/debug-presence-only scan, needs to pass a
+    non-default value. Before this, only ``scan_engine._build_new_snapshot``
+    (which calls :func:`abicheck.service.resolve_input` directly, bypassing
+    this shared primitive entirely) could express either flag — see
+    ``AGENTS.md``'s PR C entry for the gap this closes.
 
     A thin wrapper over :func:`_resolve_side_snapshot_impl` (PR 3A, dump/scan
     resolver convergence) — identical signature, identical behavior, for every
@@ -396,6 +409,8 @@ def resolve_side_snapshot(
         debuginfod_url=debuginfod_url,
         dwarf_only=dwarf_only,
         debug_format=debug_format,
+        symbols_only=symbols_only,
+        debug_presence_only=debug_presence_only,
         include_labels=include_labels,
         notify=notify,
     ).snapshot
@@ -415,6 +430,8 @@ def _resolve_side_snapshot_impl(
     debuginfod_url: str | None = None,
     dwarf_only: bool = False,
     debug_format: str | None = None,
+    symbols_only: bool = False,
+    debug_presence_only: bool = False,
     include_labels: dict[Path, str] | None = None,
     notify: Callable[[str], None] | None = None,
     build_config: Path | None = None,
@@ -428,7 +445,8 @@ def _resolve_side_snapshot_impl(
     PR 3A (dump/scan resolver convergence, CLI cleanup phase two): everything
     :func:`resolve_side_snapshot` already did, plus returning the fold's own
     effective ``includes``/:class:`CompileContext` (see :class:`SideResolution`)
-    and two extra optional pass-throughs (*changed_paths*, *allow_build_query*)
+    and three extra optional pass-throughs (*changed_paths*,
+    *allow_build_query*, and the *symbols_only*/*debug_presence_only* pair)
     that only ``scan``'s candidate-side resolution needs — every other caller
     leaves them at their no-op defaults, so this is a strict superset of the
     prior behavior, not a new decision point. *build_config*/*build_query*/
@@ -498,6 +516,8 @@ def _resolve_side_snapshot_impl(
             follow_linker_scripts=side.follow_linker_scripts,
             dwarf_only=dwarf_only,
             debug_format=debug_format,
+            symbols_only=symbols_only,
+            debug_presence_only=debug_presence_only,
             include_labels=include_labels,
             notify=notify,
         )

--- a/changelog.d/1787247194_claude_dump_scan_resolver_convergence_symbols_only_and_public_headers.md
+++ b/changelog.d/1787247194_claude_dump_scan_resolver_convergence_symbols_only_and_public_headers.md
@@ -7,18 +7,4 @@
   hand-rolled candidate resolution (which calls `resolve_input` directly,
   bypassing this shared primitive) could express either flag. Both default
   `False`, matching `resolve_input`'s own defaults, so every pre-existing
-  caller (`compare`, `dump`'s typed pipeline) is unaffected. Separately,
-  `scan_engine._build_new_snapshot`'s `embed_build_source` call now passes
-  `public_headers`/`public_header_dirs` unexpanded, matching
-  `service_input_resolution.embed_side_build_source`'s own construction,
-  instead of pre-expanding a public header directory into its individual
-  files first — the expansion was redundant (a directory root already
-  classifies every file under it via segment/prefix matching in
-  `source_extractors._argv.split_public_roots`/`_ClassifyContext`), not more
-  correct, and diverged from the canonical shared shape for no behavioral
-  benefit. No observable behavior change to `scan`'s public/internal header
-  classification. Both fixes are additive prerequisites for eventually
-  routing `scan_engine._build_new_snapshot` through the same shared
-  `_resolve_side_snapshot_impl` primitive `compare`/`dump` already use; see
-  `docs/contribute/plans/cli-cleanup-phase-two.md`'s PR 3A section for what
-  remains open.
+  caller (`compare`, `dump`'s typed pipeline) is unaffected.

--- a/changelog.d/1787247194_claude_dump_scan_resolver_convergence_symbols_only_and_public_headers.md
+++ b/changelog.d/1787247194_claude_dump_scan_resolver_convergence_symbols_only_and_public_headers.md
@@ -1,0 +1,24 @@
+### Fixed
+
+- **CLI cleanup phase two, PR 3A (dump/scan resolver convergence)**:
+  `service_input_resolution.resolve_side_snapshot`/`_resolve_side_snapshot_impl`
+  now accept and forward `symbols_only`/`debug_presence_only` to
+  `service.resolve_input`, closing a gap where only `scan_engine`'s
+  hand-rolled candidate resolution (which calls `resolve_input` directly,
+  bypassing this shared primitive) could express either flag. Both default
+  `False`, matching `resolve_input`'s own defaults, so every pre-existing
+  caller (`compare`, `dump`'s typed pipeline) is unaffected. Separately,
+  `scan_engine._build_new_snapshot`'s `embed_build_source` call now passes
+  `public_headers`/`public_header_dirs` unexpanded, matching
+  `service_input_resolution.embed_side_build_source`'s own construction,
+  instead of pre-expanding a public header directory into its individual
+  files first — the expansion was redundant (a directory root already
+  classifies every file under it via segment/prefix matching in
+  `source_extractors._argv.split_public_roots`/`_ClassifyContext`), not more
+  correct, and diverged from the canonical shared shape for no behavioral
+  benefit. No observable behavior change to `scan`'s public/internal header
+  classification. Both fixes are additive prerequisites for eventually
+  routing `scan_engine._build_new_snapshot` through the same shared
+  `_resolve_side_snapshot_impl` primitive `compare`/`dump` already use; see
+  `docs/contribute/plans/cli-cleanup-phase-two.md`'s PR 3A section for what
+  remains open.

--- a/changelog.d/1787253700_claude_l2_seed_flow2_pack_recognition.md
+++ b/changelog.d/1787253700_claude_l2_seed_flow2_pack_recognition.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **The L2 include-dir/compile-context seed now recognizes a Flow-2
+  `abicheck_inputs/` pack given as `--sources`/`--build-info`, not just a
+  classic `BuildSourcePack`.** `embed_build_source` already folded both pack
+  shapes uniformly, but the L2 seed's own pack-precedence resolver
+  (`buildsource.l2_seed._l2_seed_pack_inputs`, used by `dump`/`scan`'s
+  `-H`-header parsing) recognized only `BuildSourcePack`. A Flow-2 pack given
+  alongside `-H` headers was therefore silently treated as a literal,
+  un-normalized source tree: its own compile-unit include dirs never reached
+  L2 seeding, and a trusted, explicit `build.query`/`--config` could
+  genuinely be re-executed against the pack directory itself, even though the
+  pack already carries its own resolved L3 evidence to fold in directly.
+  Fixed by recognizing the pack the same way `embed_build_source` does,
+  loading its `BuildEvidence` through the lighter `load_inputs_manifest` +
+  compile-DB-only parse (not the full source-facts ingest, which this L3-only
+  seed doesn't need). `dump --dry-run`'s `build.query` trust report
+  (CLI cleanup phase two, PR F prerequisite 3) now reflects both pack shapes
+  identically too, closing what its own module docstring previously listed
+  as a "known, deliberately unclosed gap."

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -1215,6 +1215,43 @@ pipelines a fourth time.
   > hooks), 5 (`dump_cmd` building a real `DumpRequest`), and 6 (a
   > pair-aware scan-baseline primitive) remain fully open, unchanged from
   > the notes above.
+  >
+  > **Blocker 4 narrowed by re-reading `service.py`'s own ELF `run_dump`
+  > tail against `perform_elf_dump`'s three named post-processing passes,
+  > one at a time, rather than assuming all three are equally missing
+  > (2026-08-20, no code change).** Two of the three already run on the
+  > shared `resolve_side_snapshot`/`resolve_input` path — `service.
+  > resolve_input`'s native-binary dispatch calls `run_dump`, and
+  > `run_dump`'s ELF branch already calls `_attach_header_graph` (the G31
+  > header-graph second pass) and `attach_clang_layout` (the G28 clang-
+  > layout-tool attach) unconditionally, the identical two functions
+  > `perform_elf_dump` calls by name. So `_resolve_side_snapshot_impl`
+  > (and therefore `compare`'s implicit-dump path and `dump`'s typed
+  > `run_dump_request`) already gets both — blocker 4's "no equivalent
+  > hook" framing was accurate for the ADR-039 pass alone, not for all
+  > three. **The ADR-039 build-context collector (`_attach_build_context`,
+  > `cli_dump_helpers.py`) is confirmed, by grep, to have exactly one call
+  > site in the whole codebase — `perform_elf_dump` itself.** Not `handle_
+  > non_elf_dump` (PE/Mach-O `dump`), not `service.py`'s `run_dump`/`_dump_
+  > elf`/`_dump_pe`/`_dump_macho`, not `scan_engine._build_new_snapshot`.
+  > It is ELF-`dump`-CLI-only today, and this is a materially different
+  > kind of gap than "the shared primitive is missing a hook to call an
+  > existing, portable step": `_attach_build_context` is driven entirely by
+  > CLI-only inputs (`-p`/`--compile-db`, `--compile-db-filter`,
+  > `effective_compile_db` — a raw, unfiltered compile-database path plus a
+  > source-glob filter, resolved by `cli.py`'s own flag parsing) that have
+  > no representation anywhere in `CompileContext`, `InputSpec`, or
+  > `DumpRequest` — there is no typed-API field to route through a hook
+  > even once one exists. Closing this needs *new* typed-API surface (an
+  > `InputSpec`/`DumpRequest` field carrying a compile-DB path + filter,
+  > threaded through `_resolve_side_snapshot_impl` to a new call to
+  > `_attach_build_context` or an equivalent), not merely wiring an
+  > existing portable step into an existing hook — a real, separate,
+  > additive feature addition on its own, out of proportion to a
+  > same-session follow-up given `_attach_build_context`'s own documented
+  > "must not be unioned snapshot-wide" invariant (AGENTS.md's L3→L2-fold
+  > entry, ninth finding) that any new call site would have to re-verify
+  > against. Not attempted here. Blockers 5 and 6 are unchanged.
   Two #782 follow-ups that change the *parsed public surface*, not just
   performance, so they belong before the model is called finished: (1)
   compile-unit matching — the L2 include-dir seed is still gathered from

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -1126,6 +1126,95 @@ pipelines a fourth time.
   > `execute_dump_request` split. That split remains real, additive
   > progress in its own right (§2 above) — it is the primitive a future
   > `dump_cmd` migration would build on, just not yet consumed by one.
+  >
+  > **Slice landed (2026-08-20): both of the "two newly-found blockers"
+  > above closed, plus the debug-artifact-resolution question confirmed.**
+  > (1) The debug-artifact divergence: read both resolutions in full rather
+  > than assumed equivalent. `perform_elf_dump`'s only caller is `dump_cmd`
+  > (confirmed by grep — no second call site exists), and `dump_cmd` never
+  > sets `symbols_only`/`debug_presence_only` at all (`dump` has no such
+  > flags — only `scan`/`compare` do), so `_dump_elf`'s extra `not
+  > symbols_only and not debug_presence_only` gate is vacuously true for
+  > every input `perform_elf_dump` can actually receive. The remaining
+  > differences (`debug_roots=debug_roots` vs. `list(debug_roots) or
+  > None`; `click.echo` vs. `notify`/`_logger`; `if artifact:` vs. `if
+  > artifact is not None`) are all behaviorally inert — `BuildIdTreeResolver`/
+  > `PathMirrorResolver` etc. already do `list(debug_roots or [])`
+  > internally, a `DebugArtifact` dataclass instance is always truthy, and
+  > the messaging difference is cosmetic. **Confirmed equivalent for the
+  > real call shape — no code change needed here**, closing this question
+  > without the "reconciling two independently written implementations"
+  > investigation this note flagged as still open.
+  >
+  > (2) `symbols_only`/`debug_presence_only` now thread through
+  > `resolve_side_snapshot`/`_resolve_side_snapshot_impl` into
+  > `service.resolve_input`, both defaulting `False` (matching
+  > `resolve_input`'s own defaults) so every pre-existing caller is
+  > unaffected — a strict superset of the prior behavior, the same shape
+  > as this primitive's existing `changed_paths`/`allow_build_query`
+  > pass-throughs. `scan_engine._build_new_snapshot` does not consume this
+  > yet (it still calls `service.resolve_input` directly, not through this
+  > shared primitive — see below), so this closes the *primitive's*
+  > capability gap, not yet the caller-side migration. Regression test:
+  > `tests/test_header_compile_context.py::
+  > test_resolve_side_snapshot_forwards_symbols_only_and_debug_presence_only`
+  > (confirmed to fail against the pre-fix code with `TypeError: unexpected
+  > keyword argument 'symbols_only'`).
+  >
+  > (3) The `public_headers`/`public_header_dirs` construction divergence:
+  > investigated by reading the actual consumer, not just diffing the two
+  > call sites. `embed_build_source`'s `public_header_roots` (the union of
+  > both tuples, `cli_buildsource.py:233`) is split back into file vs.
+  > directory roots by `source_extractors._argv.split_public_roots`, which
+  > already recognizes a directory via `os.path.isdir()` regardless of
+  > which of the two input tuples it arrived in — and
+  > `_ClassifyContext.classify()` (`source_extractors/clang.py`, mirrored
+  > in `castxml.py`) matches a directory root via *segment/prefix*
+  > matching (`classify_origin` against `dir_segs`), so a file under that
+  > directory already classifies as public without needing to also appear
+  > as an individual exact-match entry. `_build_new_snapshot`'s
+  > `_expand_public_headers`-based construction (walking every directory
+  > into its individual header files, then adding *those* to `public_
+  > headers` on top of the still-unexpanded `public_header_dirs`) therefore
+  > added only redundant exact-file entries a directory root already
+  > covered — not a correctness difference, just wasted directory-walk
+  > work and a needlessly divergent call shape from
+  > `embed_side_build_source`'s simpler, canonical raw pass-through.
+  > `_expand_public_headers` itself is not wrong or removed — it stays in
+  > use a few lines above this call site, for the S2 preprocessor pre-scan,
+  > which genuinely needs individual files (each header becomes its own
+  > `clang -E` translation unit, a different contract from the L4
+  > classification roots this call feeds). Reconciled onto the canonical
+  > shape: `_build_new_snapshot` now passes `public_headers`/
+  > `public_header_dirs` unexpanded, exactly matching
+  > `embed_side_build_source`. Regression test:
+  > `tests/test_scan_l2_cleanup_ordering.py::
+  > test_scan_candidate_passes_public_headers_unexpanded_to_embed`
+  > (confirmed to fail against the pre-fix code — the directory-derived
+  > extra file entry showed up in the captured `public_headers` tuple).
+  >
+  > **What this slice does not close**: `_build_new_snapshot` still calls
+  > `service.resolve_input`/`embed_build_source` directly rather than
+  > routing through `_resolve_side_snapshot_impl`/`SideResolution` — the
+  > two additive fixes above make that future migration *safe*, they don't
+  > perform it. Investigating the migration itself surfaced one more
+  > wrinkle beyond what this section had already named: `_build_new_
+  > snapshot`'s own `allow_build_query` parameter gates only its
+  > `embed_build_source` call (whether the *inferred/auto-discovered* build
+  > query may run) and is never threaded into its `seed_includes_and_
+  > fold_compile_context` call at all (that call always passes `build_
+  > query=None, build_compile_db=None` — `scan` has no `--build-query`/
+  > `--build-compile-db` CLI flags to begin with, unlike `dump`) — whereas
+  > `_resolve_side_snapshot_impl`'s `_gated_build_query_inputs` gates both
+  > the seed and the embed step from one shared decision. Reconciling this
+  > correctly needs confirming what `_build_new_snapshot`'s `allow_build_
+  > query` is actually meant to authorize today (the auto-discovery-vs-
+  > seed distinction, not just the embed step) before the two functions'
+  > gating can be safely unified — a real, separate investigation, not a
+  > follow-up to this slice's two closed items. Blockers 4 (post-processing
+  > hooks), 5 (`dump_cmd` building a real `DumpRequest`), and 6 (a
+  > pair-aware scan-baseline primitive) remain fully open, unchanged from
+  > the notes above.
   Two #782 follow-ups that change the *parsed public surface*, not just
   performance, so they belong before the model is called finished: (1)
   compile-unit matching — the L2 include-dir seed is still gathered from

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -1162,36 +1162,54 @@ pipelines a fourth time.
   > keyword argument 'symbols_only'`).
   >
   > (3) The `public_headers`/`public_header_dirs` construction divergence:
-  > investigated by reading the actual consumer, not just diffing the two
-  > call sites. `embed_build_source`'s `public_header_roots` (the union of
-  > both tuples, `cli_buildsource.py:233`) is split back into file vs.
-  > directory roots by `source_extractors._argv.split_public_roots`, which
-  > already recognizes a directory via `os.path.isdir()` regardless of
-  > which of the two input tuples it arrived in — and
-  > `_ClassifyContext.classify()` (`source_extractors/clang.py`, mirrored
-  > in `castxml.py`) matches a directory root via *segment/prefix*
-  > matching (`classify_origin` against `dir_segs`), so a file under that
-  > directory already classifies as public without needing to also appear
-  > as an individual exact-match entry. `_build_new_snapshot`'s
-  > `_expand_public_headers`-based construction (walking every directory
-  > into its individual header files, then adding *those* to `public_
-  > headers` on top of the still-unexpanded `public_header_dirs`) therefore
-  > added only redundant exact-file entries a directory root already
-  > covered — not a correctness difference, just wasted directory-walk
-  > work and a needlessly divergent call shape from
-  > `embed_side_build_source`'s simpler, canonical raw pass-through.
-  > `_expand_public_headers` itself is not wrong or removed — it stays in
-  > use a few lines above this call site, for the S2 preprocessor pre-scan,
-  > which genuinely needs individual files (each header becomes its own
-  > `clang -E` translation unit, a different contract from the L4
-  > classification roots this call feeds). Reconciled onto the canonical
-  > shape: `_build_new_snapshot` now passes `public_headers`/
-  > `public_header_dirs` unexpanded, exactly matching
-  > `embed_side_build_source`. Regression test:
-  > `tests/test_scan_l2_cleanup_ordering.py::
-  > test_scan_candidate_passes_public_headers_unexpanded_to_embed`
-  > (confirmed to fail against the pre-fix code — the directory-derived
-  > extra file entry showed up in the captured `public_headers` tuple).
+  > **investigated, a fix attempted and merged, then reverted the same day
+  > after a real regression was caught by review — recorded in full since
+  > the reasoning that looked right the first time was genuinely
+  > incomplete, not merely under-tested.** The first pass read one consumer
+  > of `embed_build_source`'s `public_header_roots`
+  > (`source_extractors._argv.split_public_roots`/`_ClassifyContext.
+  > classify()`, `source_extractors/clang.py`) and confirmed a directory
+  > root already classifies every file under it via segment/prefix
+  > matching — so `_build_new_snapshot`'s `_expand_public_headers`-based
+  > expansion looked purely redundant against *that* consumer, and the fix
+  > switched the call to the simpler, unexpanded raw pass-through
+  > `embed_side_build_source` already uses. That reasoning missed a
+  > **second, differently-shaped consumer of the identical
+  > `public_header_roots` list**: `clang_public_roots.
+  > _equivalent_public_roots_for_unit`, the install-tree-vs-build-tree
+  > "mirror detection" heuristic L4 replay uses when a public root names a
+  > physically different tree from the build's own include dir (a common
+  > shape for release/package validation, per that module's own
+  > docstring). Its promotion rule is asymmetric by root shape: a *file*
+  > root promotes an equivalent build-tree header on a single sampled
+  > match; a *directory* root needs `>= _PUBLIC_ROOT_WHOLE_DIR_MIN_MATCHES`
+  > (2) sampled matches before promoting the whole directory. So a build
+  > include directory that happens to mirror only ONE header out of a
+  > larger public root (a small per-module local include directory against
+  > a larger installed SDK tree) loses that mirror-promotion entirely once
+  > the directory stops being pre-expanded into individual files — proven
+  > by direct reproduction against `_equivalent_public_roots_for_unit`
+  > itself (three installed headers, one mirrored in the build tree: the
+  > expanded-file-roots call promotes the mirrored header; the single
+  > directory-root call promotes nothing). `embed_side_build_source`'s own
+  > raw pass-through (already shipped, used by `compare`/`dump`) carries
+  > the identical weakness — not fixed here, since unifying either
+  > direction changes real classification behavior for a real consumer,
+  > and deciding which needs its own scoped design (harden
+  > `_equivalent_public_roots_for_unit`'s directory threshold, or thread
+  > real expansion into the shared primitive instead), not a same-PR
+  > revert-and-redo. **Reverted `_build_new_snapshot`'s call back to the
+  > expanded shape** — the one proven not to regress this heuristic — and
+  > pinned two regression tests: the reverted call's own shape
+  > (`tests/test_scan_l2_cleanup_ordering.py::
+  > test_scan_candidate_expands_public_header_dirs_before_embed`) and, more
+  > importantly, the underlying asymmetry itself, directly against
+  > `_equivalent_public_roots_for_unit`
+  > (`tests/test_clang_public_roots_coverage.py::
+  > test_equivalent_public_roots_promotes_on_single_match_only_for_file_roots`)
+  > so a future "simplify this like the other primitive" pass doesn't
+  > silently reintroduce the same regression by generalizing from only the
+  > first consumer again.
   >
   > **What this slice does not close**: `_build_new_snapshot` still calls
   > `service.resolve_input`/`embed_build_source` directly rather than

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -1418,22 +1418,55 @@ the parser to lists only — every existing trusted string config would break.
 > overriding config, no query configured, determinism, and 26 review-caught
 > reachability/precedence/pack-normalization/exit-code-class/config-discovery
 > edge cases besides — each asserting the query is never actually executed).
-> **Prerequisites 1, 2, 4, and 5 are fully satisfied; 3 is satisfied for
-> every input shape the module's own docstring doesn't name as an open
-> gap** — `cli_dump_dry_run_build_query.py` documents two deliberately
-> unclosed cases where the report can still claim "will run" when the real
-> input would not: a Flow-2 `abicheck_inputs/` pack as the sole
-> `--sources`/`--build-info` input, and a `-H` directory containing no
-> supported header (this second one predates the module — `render_dump_
-> dry_run` has never expanded `-H` directories for validation). Closing
-> either is a scoped follow-up (a second pack-format recognizer for the
-> first; a design decision about real directory-walk validation for the
-> second), not a blocker for the trust decision this prerequisite exists to
-> make visible — but PR 3C's removal itself (`dump --build-query`/`dump
-> --build-compile-db` deletion) should not proceed until both are closed or
-> explicitly accepted as permanent gaps, on top of still waiting on the
-> ordering's own blocker: PR 3A's full convergence (both `dump` and `scan`
-> resolvers), which remains open per that section's own status notes above.
+> **Prerequisites 1, 2, 4, and 5 are fully satisfied; 3 is now satisfied for
+> every input shape except one.** `cli_dump_dry_run_build_query.py`
+> originally documented two deliberately unclosed cases where the report
+> could still claim "will run" when the real input would not: a Flow-2
+> `abicheck_inputs/` pack as the sole `--sources`/`--build-info` input, and a
+> `-H` directory containing no supported header.
+>
+> **The Flow-2 pack gap is closed (2026-08-20), and it turned out to be two
+> gaps, not one.** Investigating this module's own docstring ("Flow-2 packs
+> fold into `raw_build_info`/`raw_sources` the identical way a
+> `BuildSourcePack` does in `embed_build_source`") to add the missing
+> recognizer here surfaced a real, independent gap in the L2-seed
+> **production** path itself: `buildsource.l2_seed._l2_seed_pack_inputs` (the
+> pack-precedence resolver `seed_includes_and_fold_compile_context` uses)
+> only ever recognized a classic `BuildSourcePack` (`is_pack_dir`), never a
+> Flow-2 pack — so a Flow-2 pack given alongside `-H` headers was silently
+> treated by the *real* L2 seed as a literal, un-normalized source tree: its
+> own compile-unit include dirs never reached L2 seeding, and a trusted,
+> explicit `build.query`/`--config` could genuinely be re-executed against
+> the pack directory itself. This was the load-bearing finding: mirroring
+> `embed_build_source`'s recognition in the dry-run preview *alone*, without
+> also fixing `_l2_seed_pack_inputs`, would have made the preview *wrong* for
+> every L2-seed-reachable branch (reporting "will NOT run" for an input the
+> unfixed L2 seed's own resolution would still have genuinely reached
+> `cfg.query` through) — a worse regression than the pre-existing gap. Fixed
+> both, root cause first: `_l2_seed_pack_inputs` now also recognizes a Flow-2
+> pack (folding its `BuildEvidence` via the lighter
+> `load_inputs_manifest`/`_load_build_evidence` pair, not the full
+> `ingest_inputs_pack`, which this L3-only seed doesn't need), and only then
+> did `cli_dump_dry_run_build_query.py` gain the identical, now-correct
+> recognition (`_is_pack_dir_any`/`_pack_dir_build_evidence`) across all
+> seven of its own pack-precedence checks. See `abicheck/buildsource/
+> l2_seed.py`'s own docstrings and `changelog.d/
+> 1787253700_claude_l2_seed_flow2_pack_recognition.md` for the full account.
+> Tests: `tests/test_l2_seed_flow2_packs.py` (the production resolver,
+> including an end-to-end `derive_l2_include_dirs` case) and `tests/
+> test_dry_run_build_query_flow2_packs.py` (the dry-run preview, mirroring
+> the existing classic-pack CLI tests one-for-one).
+>
+> **The `-H` directory gap remains open** (it predates this module —
+> `render_dump_dry_run` has never expanded `-H` directories for validation).
+> Closing it needs a design decision about real directory-walk validation
+> inside `--dry-run`'s own established "cheap, read-only... no I/O beyond
+> stat()/PATH lookups" contract, not a scoped fix to this module alone — so
+> PR 3C's removal itself (`dump --build-query`/`dump --build-compile-db`
+> deletion) should not proceed until it is closed or explicitly accepted as
+> a permanent gap, on top of still waiting on the ordering's own blocker:
+> PR 3A's full convergence (both `dump` and `scan` resolvers), which remains
+> open per that section's own status notes above.
 
 **Risk:** medium — this is a trust boundary, and it is the one item here where
 a mistake is a security regression rather than a UX one.

--- a/tests/test_clang_public_roots_coverage.py
+++ b/tests/test_clang_public_roots_coverage.py
@@ -198,5 +198,57 @@ def test_mirror_candidates_promotes_whole_dir_when_enough_matches() -> None:
     assert out == [m._dir_spelling(Path("inc"))]
 
 
+# -- _equivalent_public_roots_for_unit: file-root vs. directory-root asymmetry
+
+
+def test_equivalent_public_roots_promotes_on_single_match_only_for_file_roots(
+    tmp_path: Path,
+) -> None:
+    """A public *directory* root needs >= 2 sampled matches to promote a build
+    include dir as an equivalent public root; a public *file* root promotes on
+    a single match. Real-world consequence (Codex review on #804, confirmed
+    by direct reproduction against this exact function): pre-expanding a
+    public header directory into its individual files before calling this
+    function detects a build tree that mirrors only ONE header out of a
+    larger public root; passing the directory unexpanded misses it entirely.
+    See ``scan_engine._build_new_snapshot``'s own docstring/comment at its
+    ``embed_build_source`` call site for why it deliberately keeps the
+    expansion rather than the simpler raw pass-through
+    ``service_input_resolution.embed_side_build_source`` uses.
+    """
+    install = tmp_path / "install" / "pkg"
+    install.mkdir(parents=True)
+    (install / "a.h").write_text("void a(void);\n", encoding="utf-8")
+    (install / "b.h").write_text("void b(void);\n", encoding="utf-8")
+    (install / "c.h").write_text("void c(void);\n", encoding="utf-8")
+
+    build_include = tmp_path / "build" / "include"
+    build_include.mkdir(parents=True)
+    # The build tree mirrors only ONE of the three installed public headers.
+    (build_include / "a.h").write_text("void a(void);\n", encoding="utf-8")
+
+    cu = CompileUnit(
+        id="cu1",
+        source=str(tmp_path / "build" / "x.c"),
+        directory=str(tmp_path / "build"),
+        argv=["cc", "-I", str(build_include), "-c", "x.c"],
+        include_paths=[str(build_include)],
+    )
+
+    expanded_roots = [str(install / "a.h"), str(install / "b.h"), str(install / "c.h")]
+    promoted_expanded = [
+        r
+        for r in m._equivalent_public_roots_for_unit(expanded_roots, cu)
+        if r not in expanded_roots
+    ]
+    assert promoted_expanded == [str(build_include / "a.h")]
+
+    dir_roots = [str(install)]
+    promoted_dir = [
+        r for r in m._equivalent_public_roots_for_unit(dir_roots, cu) if r not in dir_roots
+    ]
+    assert promoted_dir == []
+
+
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_dry_run_build_query_flow2_packs.py
+++ b/tests/test_dry_run_build_query_flow2_packs.py
@@ -35,6 +35,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
+from abicheck.buildsource import SourceAbiTu, SourceEntity, SourceLocation
 from abicheck.buildsource.inputs_pack import ABICHECK_INPUTS_VERSION, INPUTS_KIND
 from abicheck.cli import main
 
@@ -184,3 +185,70 @@ def test_flow2_sources_pack_with_compile_units_takes_precedence(
     assert "will NOT run" in result.output
     assert "--sources" in result.output
     assert "already carries L3 compile units" in result.output
+
+
+def _tu(name: str, *, mangled: str) -> SourceAbiTu:
+    """A minimal, single-declaration per-TU dump (mirrors test_inputs_pack.py's own)."""
+    ent = SourceEntity(
+        id=f"decl://{name}",
+        kind="function",
+        qualified_name=name,
+        mangled_name=mangled,
+        signature_hash="sig1",
+        source_location=SourceLocation(
+            path=f"include/{name}.h", line=3, origin="PUBLIC_HEADER"
+        ),
+        visibility="public_header",
+    )
+    return SourceAbiTu(
+        tu_id="cu://src/foo.cpp#cfg:abc",
+        target_id="target://libfoo",
+        source="src/foo.cpp",
+        public_header_roots=[f"include/{name}.h"],
+        functions=[ent],
+    )
+
+
+def test_flow2_build_info_pack_with_invalid_source_facts_blocks(tmp_path: Path) -> None:
+    # Codex review, fresh evidence: a Flow-2 pack whose manifest/compile DB
+    # are readable but whose source_facts fail hard validation (here: two
+    # records sharing one tu_id) must not report the invocation as valid.
+    # embed_build_source's real _load_inputs_pack_or_raise runs
+    # validate_inputs_pack -> raises click.ClickException (exit 1) for this
+    # exact input before ever reaching collect_inline_pack/build.query
+    # precedence -- the lighter compile-DB-only parse this dry-run section
+    # otherwise uses never read source_facts/ at all, so it used to report
+    # "will NOT run -- already carries L3 compile units" for an invocation
+    # that cannot actually run.
+    so_path = tmp_path / "lib.so"
+    so_path.write_bytes(b"")
+    header = tmp_path / "api.h"
+    header.write_text("int foo(int x);\n", encoding="utf-8")
+    cfg = _write_config(tmp_path)
+    pack_dir = _write_flow2_inputs_pack(tmp_path, with_compile_db=True)
+    lines = "\n".join(
+        json.dumps(_tu("foo", mangled="_Z3foov").to_dict()) for _ in range(2)
+    )
+    (pack_dir / "source_facts" / "libfoo.jsonl").write_text(
+        lines + "\n", encoding="utf-8"
+    )
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "dump",
+            str(so_path),
+            "--sources",
+            str(tmp_path),
+            "-H",
+            str(header),
+            "--build-info",
+            str(pack_dir),
+            "--config",
+            str(cfg),
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 1, result.output
+    assert "will run" not in result.output
+    assert "validation error" in result.output.lower()

--- a/tests/test_dry_run_build_query_flow2_packs.py
+++ b/tests/test_dry_run_build_query_flow2_packs.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``dump --dry-run``'s ``build.query`` trust report -- Flow-2
+``abicheck_inputs/`` pack recognition (CLI cleanup phase two, PR F
+prerequisite 3).
+
+Split out of ``tests/test_dry_run_build_query_contract.py`` (already near
+its 2000-line hard cap; root ``AGENTS.md`` "Files that are large") rather
+than added inline there. Mirrors that file's own classic-``BuildSourcePack``
+precedence tests (``test_build_info_pack_with_compile_units_takes_
+precedence``, etc.) one-for-one, for the Flow-2 pack shape --
+``abicheck/cli_dump_dry_run_build_query.py``'s ``_is_pack_dir_any``/
+``_pack_dir_build_evidence`` now recognize both shapes uniformly, closing
+what that module's docstring used to list as a "known, deliberately
+unclosed gap."
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from abicheck.buildsource.inputs_pack import ABICHECK_INPUTS_VERSION, INPUTS_KIND
+from abicheck.cli import main
+
+
+def _write_config(sources: Path, *, compile_db: str | None = None) -> Path:
+    """Byte-for-byte mirror of ``TestDumpDryRunBuildQueryTrust._write_config``."""
+    cfg = sources / ".abicheck.yml"
+    body = "build:\n  query: cmake -S . -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\n"
+    if compile_db:
+        body += f"  compile_db: {compile_db}\n"
+    cfg.write_text(body, encoding="utf-8")
+    return cfg
+
+
+def _write_flow2_inputs_pack(root: Path, *, with_compile_db: bool) -> Path:
+    """A minimal, valid Flow-2 ``abicheck_inputs/`` pack (ADR-035 D5).
+
+    Mirrors ``tests/test_inputs_pack.py``'s own ``_write_inputs_pack``
+    fixture, trimmed to what this dry-run section reads: a
+    ``kind: abicheck_inputs`` manifest, an empty ``source_facts/``, and --
+    when *with_compile_db* -- a ``build/compile_commands.json``.
+    """
+    pack = root / "abicheck_inputs"
+    (pack / "source_facts").mkdir(parents=True)
+    if with_compile_db:
+        (pack / "build").mkdir(parents=True)
+        (pack / "build" / "compile_commands.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "directory": str(root),
+                        "file": "api.c",
+                        "arguments": ["cc", "-c", "api.c"],
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+    manifest = {
+        "kind": INPUTS_KIND,
+        "abicheck_inputs_version": ABICHECK_INPUTS_VERSION,
+        "library": "libfoo.so",
+        "version": "1.0",
+        "created_by": "abicheck-clang-plugin 0.1",
+    }
+    (pack / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return pack
+
+
+def test_flow2_build_info_pack_with_compile_units_takes_precedence(
+    tmp_path: Path,
+) -> None:
+    # Closes the "known, deliberately unclosed gap" this module's own
+    # docstring used to document: a Flow-2 abicheck_inputs/ pack is now
+    # recognized the identical way a classic BuildSourcePack is (mirrors
+    # TestDumpDryRunBuildQueryTrust.
+    # test_build_info_pack_with_compile_units_takes_precedence).
+    so_path = tmp_path / "lib.so"
+    so_path.write_bytes(b"")
+    header = tmp_path / "api.h"
+    header.write_text("int foo(int x);\n", encoding="utf-8")
+    cfg = _write_config(tmp_path)
+    pack_dir = _write_flow2_inputs_pack(tmp_path, with_compile_db=True)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "dump",
+            str(so_path),
+            "--sources",
+            str(tmp_path),
+            "-H",
+            str(header),
+            "--build-info",
+            str(pack_dir),
+            "--config",
+            str(cfg),
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "will NOT run" in result.output
+    assert "already carries L3 compile units" in result.output
+
+
+def test_flow2_build_info_pack_without_compile_db_still_reports_will_run(
+    tmp_path: Path,
+) -> None:
+    # The counterpart: a Flow-2 pack with no build/compile_commands.json
+    # does not short-circuit resolution (mirrors
+    # TestDumpDryRunBuildQueryTrust.
+    # test_build_info_pack_without_compile_units_still_reports_will_run).
+    so_path = tmp_path / "lib.so"
+    so_path.write_bytes(b"")
+    header = tmp_path / "api.h"
+    header.write_text("int foo(int x);\n", encoding="utf-8")
+    cfg = _write_config(tmp_path)
+    pack_dir = _write_flow2_inputs_pack(tmp_path, with_compile_db=False)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "dump",
+            str(so_path),
+            "--sources",
+            str(tmp_path),
+            "-H",
+            str(header),
+            "--build-info",
+            str(pack_dir),
+            "--config",
+            str(cfg),
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "will run (trusted -- explicit --config)" in result.output
+
+
+def test_flow2_sources_pack_with_compile_units_takes_precedence(
+    tmp_path: Path,
+) -> None:
+    # Mirrors TestDumpDryRunBuildQueryTrust.
+    # test_sources_pack_with_compile_units_takes_precedence, via --sources
+    # instead of --build-info.
+    so_path = tmp_path / "lib.so"
+    so_path.write_bytes(b"")
+    header = tmp_path / "api.h"
+    header.write_text("int foo(int x);\n", encoding="utf-8")
+    src_pack = _write_flow2_inputs_pack(tmp_path, with_compile_db=True)
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "dump",
+            str(so_path),
+            "--sources",
+            str(src_pack),
+            "-H",
+            str(header),
+            "--build-query",
+            "cmake -S . -B build",
+            "--dry-run",
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "will NOT run" in result.output
+    assert "--sources" in result.output
+    assert "already carries L3 compile units" in result.output

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -1528,6 +1528,69 @@ def test_resolve_side_snapshot_stamps_parsed_with_build_context(
     assert snap.parsed_with_build_context is True
 
 
+def test_resolve_side_snapshot_forwards_symbols_only_and_debug_presence_only(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """PR C (dump/scan resolver convergence): ``symbols_only``/
+    ``debug_presence_only`` reach ``service.resolve_input`` unchanged.
+
+    Before this, only ``scan_engine._build_new_snapshot`` (which calls
+    ``service.resolve_input`` directly, bypassing this shared primitive) could
+    express either flag — the shared ``resolve_side_snapshot``/
+    ``_resolve_side_snapshot_impl`` primitive silently dropped them, always
+    forwarding ``False``/``False`` regardless of what the caller passed.
+    """
+    from abicheck import service_input_resolution as sir
+    from abicheck.api_types import InputSpec
+    from abicheck.model import AbiSnapshot
+    from abicheck.service_compare_evidence import SideEvidence
+
+    so = tmp_path / "lib.so"
+    so.write_bytes(b"\x7fELF" + b"\x00" * 100)
+
+    captured: dict[str, object] = {}
+
+    def _fake_resolve_input(*args: object, **kwargs: object) -> AbiSnapshot:
+        captured.update(kwargs)
+        return AbiSnapshot(library="lib", version="1.0", from_headers=False)
+
+    import abicheck.service as service_mod
+
+    monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve_input)
+
+    side = InputSpec(path=so, version="1.0")
+    evidence = SideEvidence(
+        headers=[], compile=None, collect_mode="off", dump_manifest=None
+    )
+    sir.resolve_side_snapshot(
+        side,
+        evidence,
+        lang="c++",
+        header_backend="auto",
+        fmt="elf",
+        public_headers=[],
+        public_header_dirs=[],
+        symbols_only=True,
+        debug_presence_only=True,
+    )
+    assert captured["symbols_only"] is True
+    assert captured["debug_presence_only"] is True
+
+    # Default is unchanged False/False for every pre-existing caller.
+    captured.clear()
+    sir.resolve_side_snapshot(
+        side,
+        evidence,
+        lang="c++",
+        header_backend="auto",
+        fmt="elf",
+        public_headers=[],
+        public_header_dirs=[],
+    )
+    assert captured["symbols_only"] is False
+    assert captured["debug_presence_only"] is False
+
+
 def test_resolve_side_snapshot_omits_conflicting_c_standard_when_cxx_forced(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_l2_seed_flow2_packs.py
+++ b/tests/test_l2_seed_flow2_packs.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``buildsource.l2_seed``'s Flow-2 ``abicheck_inputs/`` pack recognition
+(ADR-035 D5, CLI cleanup phase two PR F prerequisite 3).
+
+Split out of ``tests/test_header_compile_context.py`` (already near its
+2000-line hard cap; root ``AGENTS.md`` "Files that are large") rather than
+added inline there.
+
+``_l2_seed_pack_inputs`` -- the pack-precedence resolver
+``seed_includes_and_fold_compile_context`` (and its older siblings
+``derive_l2_include_dirs``/``derive_l2_compile_context``) use -- previously
+recognized only a classic ``BuildSourcePack`` (``is_pack_dir``), never a
+Flow-2 ``abicheck_inputs/`` pack, even though ``cli_buildsource.
+embed_build_source`` already recognized both shapes uniformly. A Flow-2 pack
+given as ``--sources``/``--build-info`` alongside ``-H`` headers was
+therefore silently treated by the L2 seed as a literal, un-normalized source
+tree: its own compile-unit include dirs never reached L2 seeding, and a
+trusted, explicit ``build.query``/``--config`` could genuinely be
+re-executed against the pack directory itself, even though the pack already
+carries its own resolved L3 evidence to fold in directly instead. See
+``abicheck/buildsource/l2_seed.py``'s own docstrings on
+``_l2_seed_pack_inputs``/``_l2_seed_pack_build_evidence`` for the full
+reasoning, and ``abicheck/cli_dump_dry_run_build_query.py``'s module
+docstring for how this closes that module's own former "known, deliberately
+unclosed gap."
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from abicheck.buildsource.inputs_pack import ABICHECK_INPUTS_VERSION, INPUTS_KIND
+
+
+def _write_flow2_inputs_pack(
+    root: Path, *, with_compile_db: bool, include_dir: str = "include"
+) -> Path:
+    """A minimal, valid Flow-2 ``abicheck_inputs/`` pack directory (ADR-035 D5).
+
+    Mirrors ``tests/test_inputs_pack.py``'s own ``_write_inputs_pack``
+    fixture, trimmed to just what ``_l2_seed_pack_build_evidence`` reads: a
+    ``kind: abicheck_inputs`` manifest, an empty ``source_facts/`` (this
+    seed only cares about L3, never L4/L5), and -- when *with_compile_db* --
+    a ``build/compile_commands.json`` naming a real ``-I<include_dir>``.
+    """
+    pack = root / "abicheck_inputs"
+    (pack / "source_facts").mkdir(parents=True)
+    if with_compile_db:
+        (root / include_dir).mkdir(parents=True, exist_ok=True)
+        (pack / "build").mkdir(parents=True)
+        (pack / "build" / "compile_commands.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "directory": str(root),
+                        "file": "src/foo.cpp",
+                        "arguments": [
+                            "c++",
+                            "-std=c++17",
+                            f"-I{include_dir}",
+                            "-c",
+                            "src/foo.cpp",
+                        ],
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+    manifest = {
+        "kind": INPUTS_KIND,
+        "abicheck_inputs_version": ABICHECK_INPUTS_VERSION,
+        "library": "libfoo.so",
+        "version": "1.0",
+        "created_by": "abicheck-clang-plugin 0.1",
+    }
+    (pack / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return pack
+
+
+def test_l2_seed_pack_inputs_recognizes_flow2_build_info_pack(tmp_path: Path) -> None:
+    """A Flow-2 ``abicheck_inputs/`` pack given as ``--build-info`` must be
+    recognized and folded the identical way a classic ``BuildSourcePack`` is
+    -- ``embed_build_source`` already does this (``bi_is_inputs``); this L2
+    seed path previously checked only ``is_pack_dir`` and silently treated
+    the pack directory as a literal, un-normalized source tree instead."""
+    from abicheck.buildsource.l2_seed import _l2_seed_pack_inputs
+
+    pack = _write_flow2_inputs_pack(tmp_path, with_compile_db=True)
+    base_build, raw_build_info, raw_sources = _l2_seed_pack_inputs(pack, None)
+    assert raw_build_info is None
+    assert raw_sources is None
+    assert base_build is not None
+    assert base_build.compile_units
+
+
+def test_l2_seed_pack_inputs_recognizes_flow2_sources_pack(tmp_path: Path) -> None:
+    """Same recognition via ``--sources``, only when no ``--build-info`` was
+    also given (an explicit ``--build-info`` always wins L3, matching this
+    function's pre-existing classic-pack precedence rule)."""
+    from abicheck.buildsource.l2_seed import _l2_seed_pack_inputs
+
+    pack = _write_flow2_inputs_pack(tmp_path, with_compile_db=True)
+    base_build, raw_build_info, raw_sources = _l2_seed_pack_inputs(None, pack)
+    assert raw_sources is None
+    assert raw_build_info is None
+    assert base_build is not None
+    assert base_build.compile_units
+
+
+def test_l2_seed_pack_inputs_sources_pack_yields_to_explicit_build_info(
+    tmp_path: Path,
+) -> None:
+    """A raw, non-pack ``--build-info`` still wins L3 over a Flow-2
+    ``--sources`` pack, mirroring the classic-``BuildSourcePack`` rule this
+    function's own docstring already states."""
+    from abicheck.buildsource.l2_seed import _l2_seed_pack_inputs
+
+    src_pack = _write_flow2_inputs_pack(tmp_path, with_compile_db=True)
+    build_info = tmp_path / "build"
+    build_info.mkdir()
+    base_build, raw_build_info, raw_sources = _l2_seed_pack_inputs(build_info, src_pack)
+    assert raw_build_info == build_info
+    assert raw_sources is None
+    assert base_build is None
+
+
+def test_l2_seed_pack_inputs_flow2_pack_without_compile_db_yields_no_evidence(
+    tmp_path: Path,
+) -> None:
+    """A Flow-2 pack with no ``build/compile_commands.json`` still normalizes
+    away (matching ``embed_build_source``'s unconditional nulling), just with
+    no L3 evidence to fold -- the lighter ``_load_build_evidence`` load this
+    seed uses degrades to ``None`` the same way the full ``ingest_inputs_pack``
+    does for a compile-DB-less pack (see ``test_ingest_without_compile_db_
+    skips_l3`` in ``tests/test_inputs_pack.py``)."""
+    from abicheck.buildsource.l2_seed import _l2_seed_pack_inputs
+
+    pack = _write_flow2_inputs_pack(tmp_path, with_compile_db=False)
+    base_build, raw_build_info, raw_sources = _l2_seed_pack_inputs(pack, None)
+    assert raw_build_info is None
+    assert base_build is None
+
+
+def test_derive_l2_include_dirs_seeds_from_flow2_build_info_pack(
+    tmp_path: Path,
+) -> None:
+    """End-to-end: ``derive_l2_include_dirs`` (the real, ``collect_inline_
+    pack``-backed entry point) picks up a Flow-2 pack's own compile-unit
+    include dir when given as ``--build-info``, closing the gap where such a
+    pack's L3 evidence never reached L2 seeding at all."""
+    from abicheck.buildsource.l2_seed import derive_l2_include_dirs
+
+    pack = _write_flow2_inputs_pack(tmp_path, with_compile_db=True)
+    include_dirs, cleanups = derive_l2_include_dirs(pack, None)
+    assert cleanups == []
+    assert any(Path(d).name == "include" for d in include_dirs)

--- a/tests/test_scan_l2_cleanup_ordering.py
+++ b/tests/test_scan_l2_cleanup_ordering.py
@@ -266,6 +266,56 @@ def test_scan_returns_seeded_includes_for_baseline(monkeypatch, tmp_path):
     assert seeded in eff_includes  # effective includes carry the seed for the baseline
 
 
+def test_scan_candidate_passes_public_headers_unexpanded_to_embed(monkeypatch, tmp_path):
+    """PR C (dump/scan resolver convergence): the ``embed_build_source`` call's
+    ``public_headers``/``public_header_dirs`` must be the raw pass-through
+    ``service_input_resolution.embed_side_build_source`` already uses, not a
+    directory-expanded-to-individual-files rewrite.
+
+    ``embed_build_source``'s own ``public_header_roots`` (the union of both
+    tuples) is split back into file vs. directory roots by
+    ``source_extractors._argv.split_public_roots``, which already recognizes a
+    directory via ``os.path.isdir`` regardless of which of the two arguments
+    it arrived in — so pre-expanding a directory into its individual header
+    files (as this call used to, via ``_expand_public_headers``) only adds
+    redundant exact-file entries a directory root already covers through
+    prefix/segment matching, without changing which declarations classify as
+    public. ``_expand_public_headers`` stays in use for the *separate* S2
+    preprocessor pre-scan a few lines above, which genuinely needs individual
+    files (each header becomes its own ``clang -E`` translation unit).
+    """
+    pub_dir = tmp_path / "include"
+    pub_dir.mkdir()
+    pub_file = tmp_path / "api.h"
+
+    monkeypatch.setattr("abicheck.service.resolve_input", lambda *a, **k: object())
+
+    embed_kwargs: dict = {}
+
+    def fake_embed(*args, **kwargs):
+        embed_kwargs.update(kwargs)
+
+    monkeypatch.setattr("abicheck.cli_buildsource.embed_build_source", fake_embed)
+
+    _build_new_snapshot(
+        binary=tmp_path / "lib.so",
+        headers=[tmp_path / "h.h"],
+        includes=[],
+        sources=tmp_path,
+        collect_mode="build",
+        lang="c++",
+        allow_build_query=False,
+        defer_cleanup=[],
+        public_headers=[pub_file],
+        public_header_dirs=[pub_dir],
+    )
+
+    # Unexpanded: the directory stays a directory, the file stays exactly the
+    # one file given -- neither tuple gains extra, individually-walked entries.
+    assert embed_kwargs["public_headers"] == (str(pub_file),)
+    assert embed_kwargs["public_header_dirs"] == (str(pub_dir),)
+
+
 def test_scan_l2_seed_cleanup_runs_even_when_resolve_raises(monkeypatch, tmp_path):
     # The flock must be released on the error path too (finally), so a failed L2
     # parse still can't wedge a later inferred query.

--- a/tests/test_scan_l2_cleanup_ordering.py
+++ b/tests/test_scan_l2_cleanup_ordering.py
@@ -266,27 +266,35 @@ def test_scan_returns_seeded_includes_for_baseline(monkeypatch, tmp_path):
     assert seeded in eff_includes  # effective includes carry the seed for the baseline
 
 
-def test_scan_candidate_passes_public_headers_unexpanded_to_embed(monkeypatch, tmp_path):
-    """PR C (dump/scan resolver convergence): the ``embed_build_source`` call's
-    ``public_headers``/``public_header_dirs`` must be the raw pass-through
-    ``service_input_resolution.embed_side_build_source`` already uses, not a
-    directory-expanded-to-individual-files rewrite.
+def test_scan_candidate_expands_public_header_dirs_before_embed(monkeypatch, tmp_path):
+    """PR C (dump/scan resolver convergence) — pinned the OTHER way after a
+    real regression was caught by review.
 
-    ``embed_build_source``'s own ``public_header_roots`` (the union of both
-    tuples) is split back into file vs. directory roots by
-    ``source_extractors._argv.split_public_roots``, which already recognizes a
-    directory via ``os.path.isdir`` regardless of which of the two arguments
-    it arrived in — so pre-expanding a directory into its individual header
-    files (as this call used to, via ``_expand_public_headers``) only adds
-    redundant exact-file entries a directory root already covers through
-    prefix/segment matching, without changing which declarations classify as
-    public. ``_expand_public_headers`` stays in use for the *separate* S2
-    preprocessor pre-scan a few lines above, which genuinely needs individual
-    files (each header becomes its own ``clang -E`` translation unit).
+    An earlier revision of this call switched ``embed_build_source``'s
+    ``public_headers``/``public_header_dirs`` to the simpler, unexpanded raw
+    pass-through ``service_input_resolution.embed_side_build_source`` uses,
+    reasoning that ``source_extractors._argv.split_public_roots``/
+    ``_ClassifyContext`` already classify a directory root correctly via
+    prefix/segment matching, making the expansion redundant. That reasoning
+    holds for *that* consumer — but a *second*, differently-shaped consumer
+    of the same ``public_header_roots`` list,
+    ``clang_public_roots._equivalent_public_roots_for_unit`` (the
+    install-tree-vs-build-tree "mirror detection" heuristic), needs >= 2
+    sampled header matches to promote a *directory* root as an equivalent
+    build-tree root, but promotes on a single match for a *file* root — so a
+    build include directory that happens to mirror only one header out of a
+    larger public root lost that promotion entirely once the directory
+    stopped being pre-expanded (Codex review on #804, confirmed by direct
+    reproduction against ``_equivalent_public_roots_for_unit`` itself before
+    this revert). Reverted to keep the expansion. This test pins the correct
+    (expanded) shape so a future "simplify this like the other primitive"
+    pass doesn't reintroduce the same regression.
     """
     pub_dir = tmp_path / "include"
     pub_dir.mkdir()
-    pub_file = tmp_path / "api.h"
+    (pub_dir / "api.h").write_text("void api(void);\n", encoding="utf-8")
+    pub_file = tmp_path / "standalone.h"
+    pub_file.write_text("void standalone(void);\n", encoding="utf-8")
 
     monkeypatch.setattr("abicheck.service.resolve_input", lambda *a, **k: object())
 
@@ -310,9 +318,13 @@ def test_scan_candidate_passes_public_headers_unexpanded_to_embed(monkeypatch, t
         public_header_dirs=[pub_dir],
     )
 
-    # Unexpanded: the directory stays a directory, the file stays exactly the
-    # one file given -- neither tuple gains extra, individually-walked entries.
-    assert embed_kwargs["public_headers"] == (str(pub_file),)
+    # public_headers carries the individually-expanded files from BOTH the
+    # standalone file and the directory's own contents; public_header_dirs
+    # stays as given (also fed to embed_build_source, which unions both).
+    assert set(embed_kwargs["public_headers"]) == {
+        str(pub_file),
+        str(pub_dir / "api.h"),
+    }
     assert embed_kwargs["public_header_dirs"] == (str(pub_dir),)
 
 


### PR DESCRIPTION
## Summary

Advances CLI cleanup phase two's PR C (typed `dump`/`scan` resolver convergence, `docs/contribute/plans/cli-cleanup-phase-two.md`'s "PR 3A") by closing one of the concretely-scoped sub-blockers that section had flagged as still open, and by confirming (without a code change) that a second named concern was already safe. A third fix was attempted, merged, then reverted after review caught a real regression it missed — see below.

This does **not** claim to fully complete PR C — the plan's full convergence has several genuinely separate, large architectural sub-projects (routing `dump_cmd`/`scan_engine._build_new_snapshot` through the shared resolver end-to-end, a pair-aware scan-baseline primitive, new typed-API surface for the ADR-039 build-context collector). Per this repo's own "known gaps over risky reactive patches" convention (`AGENTS.md`), this PR makes real, narrowly-scoped, individually-verified progress and leaves the rest precisely documented rather than attempting a large, hard-to-verify change under time pressure. See `docs/contribute/plans/cli-cleanup-phase-two.md`'s PR 3A section and `AGENTS.md`'s "PR C" known-gaps entry for exactly what remains.

## Motivation

`docs/contribute/plans/cli-cleanup-phase-two.md` names three blockers standing between today's three independent dump/scan resolution pipelines and one shared primitive. Two of them ("`symbols_only`/`debug_presence_only` never thread through the shared resolver" and "the `public_headers` construction genuinely diverges") looked concretely scoped enough to close safely; a third (debug-artifact resolution equivalence) turned out to already be safe once read in full.

## Changes

- `service_input_resolution.resolve_side_snapshot`/`_resolve_side_snapshot_impl` now accept and forward `symbols_only`/`debug_presence_only` to `service.resolve_input`, both defaulting `False` (matching `resolve_input`'s own defaults) so every pre-existing caller is unaffected. Previously only `scan_engine`'s hand-rolled `resolve_input` call (which bypasses this shared primitive) could express either flag.
- Confirmed, by reading both implementations in full, that `perform_elf_dump`'s already-resolved `debug_info_path` and `service._dump_elf`'s independent debug-artifact re-derivation are behaviorally equivalent for `perform_elf_dump`'s only real caller (`dump_cmd`, which never sets `symbols_only`/`debug_presence_only` since `dump` has no such flags) — no code change needed.
- Docs: `docs/contribute/plans/cli-cleanup-phase-two.md` and `AGENTS.md` updated with what closed, plus a narrowed, more precise account of blocker 4 (two of `perform_elf_dump`'s three post-processing passes already run on the shared path via `service.run_dump`; only the ADR-039 build-context collector is a real, still-open gap, and it needs new typed-API surface, not just wiring an existing hook).
- **Attempted-and-reverted**: `scan_engine._build_new_snapshot`'s `embed_build_source` call was first switched to pass `public_headers`/`public_header_dirs` unexpanded, matching `service_input_resolution.embed_side_build_source`'s own construction — reasoning that the expansion was redundant against `source_extractors._argv.split_public_roots`/`_ClassifyContext` (true for that one consumer). Codex review on this PR found a *second*, differently-shaped consumer of the same list, `clang_public_roots._equivalent_public_roots_for_unit` (install-tree-vs-build-tree "mirror detection"), whose directory-root promotion needs ≥2 sampled matches while a file-root promotes on a single match — so a build tree mirroring only one header out of a larger public root silently lost that promotion once the directory stopped being pre-expanded. Confirmed by direct reproduction, then reverted back to the expanded (proven-safe) shape, with two new regression tests pinning both the call site's shape and the underlying asymmetry directly.

## Bug-fix test contract

Applies to the revert commit (`2542fde`) only — the other two changes are additive/behaviorally-inert refactors with no user-facing bug.

- Bug class: a code-reuse "reconciliation" change silently regressed a second, differently-shaped consumer of the same shared input list that the change's own justification didn't account for.
- Publicly observable failure: a `scan --against` (or `--depth source`/similar) run whose `--public-header-dir`/`-H` names an installed/package include tree, where the build's own local include directory mirrors only some (not most) of that tree's public headers, would silently lose L4 source-ABI classification/findings for declarations reached through that partial mirror — no error, no warning, just quietly reduced coverage.
- Regression test fails on base: yes, against the merged-then-reverted commit `cfc094b` — `tests/test_clang_public_roots_coverage.py::test_equivalent_public_roots_promotes_on_single_match_only_for_file_roots` reproduces the exact asymmetry directly against `_equivalent_public_roots_for_unit`, and `tests/test_scan_l2_cleanup_ordering.py::test_scan_candidate_expands_public_header_dirs_before_embed` pins the call site's own (reverted-to) shape.
- Negative control: `test_equivalent_public_roots_promotes_on_single_match_only_for_file_roots` also asserts the expanded-file-roots call does promote (the positive case), so the test can't pass vacuously.
- Public-surface test: yes, both tests call the real public functions (`_equivalent_public_roots_for_unit`, `_build_new_snapshot`) with real on-disk header trees, not mocks of the promotion logic itself.
- Axes covered: file-root vs. directory-root promotion threshold (the one axis this bug is about); not re-tested across every root-matching branch (`_prefixed_or_stripped_match`, `_is_full_single_header_mirror`) since those were untouched and already covered by `test_clang_public_roots_coverage.py`'s existing tests.
- General invariant: none stated beyond the fix itself — this is a revert to a previously-working shape plus a pinning test, not a new general primitive.
- Known unsupported cases: `service_input_resolution.embed_side_build_source`'s own raw pass-through (used by `compare`/`dump` already, unrelated to this PR) carries the identical weakness and is explicitly left open — documented in `AGENTS.md`/the plan doc as a known gap, not fixed here.

## Checklist

- [x] Tests added / updated for new behaviour — `test_resolve_side_snapshot_forwards_symbols_only_and_debug_presence_only` confirmed to fail against the pre-fix code; the two regression tests above confirmed to fail against the reverted-from commit
- [x] Changelog fragment added (`changelog.d/1787247194_claude_dump_scan_resolver_convergence_symbols_only_and_public_headers.md`)
- [x] Docs updated (plan doc + `AGENTS.md`, including the full revert narrative)
- [ ] `pre-commit run --all-files` — not run (pre-commit not installed in this environment); `ruff check`, `mypy`, and the targeted + full fast unit suite (28901 passed) were run directly instead
- [x] No new `mypy` or `ruff` errors introduced (`mypy abicheck/` clean via `scripts/verify.py --profile fast --only typecheck`, `ruff check abicheck/ tests/` clean)