### PR TITLE
refactor: PR C (dump/scan resolver convergence) — ADR-039 build-context collector reaches the shared pipeline

### DIFF
--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -170,6 +170,15 @@ class InputSpec:
     # (D4) would have silently dropped that guard, so it is request surface,
     # not an MCP-local wrapper concern.
     follow_linker_scripts: bool = True
+    # PR C (CLI cleanup phase two, typed dump/scan convergence): mirrors
+    # `dump --compile-db-filter` -- a glob narrowing which entries of the
+    # compile database resolved from `build_info` the ADR-039 build-context
+    # collector (`header_conditionals.collect_build_context`, reached via
+    # `service_input_resolution._resolve_side_snapshot_impl`) scans. `None`
+    # (the default) means "no filter", matching every pre-existing caller
+    # that never set this. This field only ever feeds the ADR-039 collector,
+    # never the header-AST parse itself.
+    compile_db_filter: str | None = None
 
     @classmethod
     def of(
@@ -189,6 +198,7 @@ class InputSpec:
         compile: CompileContext | None = None,
         public_header_dirs: Iterable[Path | str] | None = None,
         follow_linker_scripts: bool = True,
+        compile_db_filter: str | None = None,
     ) -> InputSpec:
         """Build an :class:`InputSpec`, coercing loose front-end values."""
         return cls(
@@ -206,6 +216,7 @@ class InputSpec:
             compile=compile,
             public_header_dirs=_path_tuple(public_header_dirs),
             follow_linker_scripts=follow_linker_scripts,
+            compile_db_filter=compile_db_filter,
         )
 
 

--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -170,15 +170,21 @@ class InputSpec:
     # (D4) would have silently dropped that guard, so it is request surface,
     # not an MCP-local wrapper concern.
     follow_linker_scripts: bool = True
-    # PR C (CLI cleanup phase two, typed dump/scan convergence): mirrors
-    # `dump --compile-db-filter` -- a glob narrowing which entries of the
-    # compile database resolved from `build_info` the ADR-039 build-context
-    # collector (`header_conditionals.collect_build_context`, reached via
-    # `service_input_resolution._resolve_side_snapshot_impl`) scans. `None`
-    # (the default) means "no filter", matching every pre-existing caller
-    # that never set this. This field only ever feeds the ADR-039 collector,
-    # never the header-AST parse itself.
-    compile_db_filter: str | None = None
+    # PR C (CLI cleanup phase two, typed dump/scan convergence) deliberately
+    # does *not* add a `compile_db_filter` field here mirroring `dump
+    # --compile-db-filter`. This pipeline's own L2 header-AST context
+    # (`_seeded_includes_and_compile_context`, the P0.3 L3->L2 fold) has no
+    # filter concept and always resolves from the *whole*, unfiltered compile
+    # database -- unlike the native `dump` CLI, which threads its filter into
+    # its own, structurally different L2 mechanism too
+    # (`cli_helpers_compare._resolve_build_context_flags`). Exposing a field
+    # here that could only ever be combined with a resolvable compile
+    # database by raising (never by actually narrowing the ADR-039
+    # collector's scan) would be a field with no successful use -- see the
+    # plan doc's PR C status notes; a real implementation needs the filter
+    # threaded into the shared L2 fold itself, a separate feature addition to
+    # `buildsource/l2_seed.py`/`header_compile_context.py` (Codex review,
+    # PR #809).
 
     @classmethod
     def of(
@@ -198,7 +204,6 @@ class InputSpec:
         compile: CompileContext | None = None,
         public_header_dirs: Iterable[Path | str] | None = None,
         follow_linker_scripts: bool = True,
-        compile_db_filter: str | None = None,
     ) -> InputSpec:
         """Build an :class:`InputSpec`, coercing loose front-end values."""
         return cls(
@@ -216,7 +221,6 @@ class InputSpec:
             compile=compile,
             public_header_dirs=_path_tuple(public_header_dirs),
             follow_linker_scripts=follow_linker_scripts,
-            compile_db_filter=compile_db_filter,
         )
 
 

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -29,6 +29,7 @@ from .dumper_scoping import dump_manifest_header_roots as _dump_manifest_header_
 from .errors import AbicheckError
 from .header_conditionals import (
     attach_build_context as _attach_build_context,
+    compile_db_filter_scope_error as compile_db_filter_scope_error,
     compile_db_from_build_info as compile_db_from_build_info,
     user_define_flags as _user_define_flags,
 )
@@ -1063,51 +1064,6 @@ def render_dump_dry_run(
 # cleanup phase two) alongside `attach_build_context`/`user_define_flags` --
 # imported above under its original name; every existing caller/test is
 # unchanged. See that module for the derivation logic.
-
-def compile_db_filter_scope_error(
-    compile_db_filter: str | None,
-    compile_db_path: Path | None,
-    collect_mode: str,
-) -> str | None:
-    """Refuse a filter that would scope L2 but silently not L3.
-
-    ``--compile-db-filter`` parameterizes the **header parse** only: the
-    filtered subset is what ``_resolve_build_context_flags`` proves a match
-    against and what the AST is built from. L3 collection reads the database
-    through ``embed_build_source``'s own adapter, which has no filter of its
-    own -- so on a monorepo database the embedded build facts cover every
-    translation unit while the headers cover the requested subset, and the
-    resulting snapshot carries unrelated build evidence that can produce
-    false differences.
-
-    The removed ``-p``/``--compile-db`` spelling refused exactly this: its
-    ``resolve_compile_db_l3_reuse`` declined to promote the header database
-    to L3 whenever a filter was active, and said so. Folding the operand into
-    ``--build-info`` removed that decision -- ``--build-info`` *is* the L3
-    selector now, so there is nothing left to decline -- which turned a loud
-    refusal into a silent unfiltered collection (Codex review). This restores
-    the refusal as a usage error, since the honest alternative (threading the
-    filter through ``embed_build_source`` into the compile-DB adapter) is a
-    change to ``buildsource/`` with its own evidence gates, not something to
-    infer from one review round.
-
-    ``None`` when the combination cannot arise: no filter, a ``--build-info``
-    that is not a compile database (a pack or Bazel jsonproto routes through
-    a different adapter), or ``collect_mode == "off"``, where no build
-    evidence is embedded for the filter to be inconsistent with.
-    """
-    if not compile_db_filter or compile_db_path is None or collect_mode == "off":
-        return None
-    return (
-        "--compile-db-filter scopes the L2 header parse only; the L3 build "
-        "evidence embedded from the same --build-info compilation database is "
-        "collected unfiltered, so the snapshot would carry build facts for "
-        "translation units the filter excludes. Pass a pre-filtered "
-        "compile_commands.json as --build-info (then --compile-db-filter is "
-        "unnecessary), or drop --compile-db-filter to accept the whole "
-        "database on both layers."
-    )
-
 
 def handle_non_elf_dump(
     so_path: Path,

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -27,10 +27,14 @@ from . import dumper_cache
 from .dumper import dump
 from .dumper_scoping import dump_manifest_header_roots as _dump_manifest_header_roots
 from .errors import AbicheckError
+
+# `_attach_build_context`/`_user_define_flags` are called directly below by
+# `perform_elf_dump` (not just re-exported for a caller elsewhere), so this
+# static edge to `header_conditionals` is structurally required regardless of
+# re-export strategy -- unlike the two names in the lazy `__getattr__` shim
+# further down, which `perform_elf_dump` never calls itself.
 from .header_conditionals import (
     attach_build_context as _attach_build_context,
-    compile_db_filter_scope_error as compile_db_filter_scope_error,
-    compile_db_from_build_info as compile_db_from_build_info,
     user_define_flags as _user_define_flags,
 )
 
@@ -93,6 +97,32 @@ class _WriteSnapshotOutput(Protocol):
 # are now `header_conditionals.user_define_flags`/`attach_build_context`,
 # imported above under their original private names — see that module for the
 # ADR-039 collection logic and why it moved (PR C, CLI cleanup phase two).
+
+# ── Back-compat re-export shim (lazy, per AGENTS.md's moved-helper
+#    convention) ────────────────────────────────────────────────────────────
+# `compile_db_from_build_info`/`compile_db_filter_scope_error` moved to
+# `header_conditionals.py` alongside `_attach_build_context`/
+# `_user_define_flags` above -- but unlike those two, nothing in this module
+# calls either of these itself (confirmed by grep: no `compile_db_from_
+# build_info(`/`compile_db_filter_scope_error(` call site here). They exist
+# only so `from .cli_dump_helpers import compile_db_from_build_info,
+# compile_db_filter_scope_error` (cli.py) and existing tests keep working
+# unchanged. A static re-export here would be an eager dependency edge this
+# module has no other reason to carry for these two names, so this
+# module-level `__getattr__` (PEP 562) resolves them lazily via
+# `importlib.import_module` instead -- mirroring the identical shim at the
+# tail of `cli_buildsource.py` (Codex review, PR #809).
+_HEADER_CONDITIONALS_REEXPORTS = frozenset(
+    {"compile_db_from_build_info", "compile_db_filter_scope_error"}
+)
+
+
+def __getattr__(name: str) -> Any:
+    if name in _HEADER_CONDITIONALS_REEXPORTS:
+        import importlib
+
+        return getattr(importlib.import_module("abicheck.header_conditionals"), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def resolve_dump_debug_format(

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -24,10 +24,14 @@ from typing import TYPE_CHECKING, Any, Protocol
 import click
 
 from . import dumper_cache
-from ._compiler_options import split_gcc_options
 from .dumper import dump
 from .dumper_scoping import dump_manifest_header_roots as _dump_manifest_header_roots
 from .errors import AbicheckError
+from .header_conditionals import (
+    attach_build_context as _attach_build_context,
+    compile_db_from_build_info as compile_db_from_build_info,
+    user_define_flags as _user_define_flags,
+)
 
 if TYPE_CHECKING:
     from .buildsource.pack import BuildSourcePack
@@ -84,67 +88,10 @@ class _WriteSnapshotOutput(Protocol):
     ) -> None: ...
 
 
-def _user_define_flags(
-    gcc_option_tokens: tuple[str, ...], user_gcc_options: str | None
-) -> list[str]:
-    """The user's *global* define-affecting flags for the ADR-039 collector.
-
-    Combines the ``-D``/``-U`` in the ``--gcc-options`` string with the repeatable
-    ``--compiler-option`` tokens, **in the same order the real dump applies them** —
-    ``dumper._castxml_cmd`` appends ``gcc_options`` first, then
-    ``gcc_option_tokens`` (see ``dumper.py``), so the collector must too (Codex
-    review #498). Order is significant because ``defines_from_flags`` honours
-    ``-D``/``-U`` sequence: a composed ``-DKEEP`` followed by ``--compiler-option=-UKEEP`` must leave
-    ``KEEP`` *inactive* on both the parse and the harvest, else the reconciler
-    would add back a field the real parse pruned. These flags are applied on top
-    of the compile-DB intersection, so a user ``-UKEEP`` also overrides a database
-    ``-DKEEP``. The auto-derived first-header build context is deliberately
-    excluded (it must not be unioned snapshot-wide).
-
-    A malformed ``--gcc-options`` (e.g. an unbalanced quote) must not abort the
-    dump — ``split_gcc_options`` errors are swallowed and only the tokens are
-    used (CodeRabbit review). ``split_gcc_options`` (not a bare
-    ``shlex.split``) so this collector tokenizes ``user_gcc_options``
-    identically to the real header-AST parse on every platform — a plain
-    POSIX ``shlex.split`` would silently disagree with the Windows tokenizer
-    on an unquoted Windows path (e.g. combining ``-IC:\\sdk\\ -UKEEP`` into
-    one token instead of two), which could make the harvested define set
-    diverge from what the real parse actually saw (Codex review, PR #774
-    follow-up)."""
-    flags: list[str] = []
-    if user_gcc_options:
-        try:
-            flags += split_gcc_options(user_gcc_options)
-        except ValueError:
-            pass  # bad optional define flags are skipped, not fatal
-    flags += list(gcc_option_tokens)
-    return flags
-
-
-def _attach_build_context(
-    snap: AbiSnapshot,
-    compile_db: str | Path,
-    headers: list[Path],
-    extra_flags: list[str],
-    source_filter: str | None = None,
-) -> None:
-    """ADR-039 collection layer: harvest the build's active ``-D`` set and scan the
-    public headers for ``#ifdef``-guarded record fields, attaching both to *snap*.
-
-    Best-effort and additive — a plain context-free dump (no compile DB) never
-    reaches here, and an empty harvest leaves the snapshot's defaults untouched, so
-    the pass is a safe no-op unless real build evidence is found. *source_filter*
-    (``--compile-db-filter``) selects the same compile-DB entries the header parse
-    used."""
-    from .header_conditionals import collect_build_context
-
-    bc_defines, bc_conditional = collect_build_context(
-        headers, compile_db, extra_flags=extra_flags, source_filter=source_filter
-    )
-    if bc_defines:
-        snap.build_context_defines = bc_defines
-    if bc_conditional:
-        snap.conditional_fields = bc_conditional
+# `_user_define_flags`/`_attach_build_context` (used below by `perform_elf_dump`)
+# are now `header_conditionals.user_define_flags`/`attach_build_context`,
+# imported above under their original private names — see that module for the
+# ADR-039 collection logic and why it moved (PR C, CLI cleanup phase two).
 
 
 def resolve_dump_debug_format(
@@ -1112,45 +1059,10 @@ def render_dump_dry_run(
     return result
 
 
-def compile_db_from_build_info(
-    build_info: Path | None,
-    headers: tuple[Path, ...],
-) -> Path | None:
-    """The L2 compile database ``--build-info`` names, when it names one.
-
-    ``--build-info``'s operand is "a build dir, a compile_commands.json, or a
-    pre-captured pack" -- the first two are exactly what the removed
-    ``-p/--build-dir`` (and its ``--compile-db`` alias) took, so the database
-    that drives deterministic header parsing is read back off the one
-    remaining build-context flag rather than a second spelling of the same
-    path.
-
-    ``None`` without headers: a compile database only feeds the header AST,
-    and a headerless ``--build-info`` run is an ordinary L3-only dump, not the
-    usage error the dedicated flag used to raise ("requires -H/--header").
-
-    ``None`` for a *file* that is not a compile database, too. ``--build-info``
-    also accepts a Bazel aquery/cquery jsonproto, which
-    ``buildsource.inline._maybe_collect_bazel_build_info`` routes through the
-    Bazel adapter -- but only if it gets that far. Returning any file here
-    handed such a run to ``load_compile_db()``, which rejects a JSON object
-    with "compile_commands.json must be a JSON array" long before the adapter
-    is reached, so `--build-info aquery.json -H api.h` failed outright
-    (Codex review). ``sniff_build_info_format`` is the same content-based
-    classifier that dispatch uses, so the two cannot disagree about what a
-    given file is.
-    """
-    from .buildsource.inline import sniff_build_info_format
-
-    if build_info is None or not headers:
-        return None
-    if build_info.is_file():
-        return build_info if sniff_build_info_format(build_info) == "compile_db" else None
-    db = build_info / "compile_commands.json"
-    # Sniffed for the same reason: a build directory holding a non-array
-    # compile_commands.json is the identical mis-route one level down.
-    return db if db.is_file() and sniff_build_info_format(db) == "compile_db" else None
-
+# `compile_db_from_build_info` moved to `header_conditionals.py` (PR C, CLI
+# cleanup phase two) alongside `attach_build_context`/`user_define_flags` --
+# imported above under its original name; every existing caller/test is
+# unchanged. See that module for the derivation logic.
 
 def compile_db_filter_scope_error(
     compile_db_filter: str | None,

--- a/abicheck/header_conditionals.py
+++ b/abicheck/header_conditionals.py
@@ -1006,6 +1006,51 @@ def compile_db_from_build_info(
     return db if db.is_file() and sniff_build_info_format(db) == "compile_db" else None
 
 
+def compile_db_filter_scope_error(
+    compile_db_filter: str | None,
+    compile_db_path: Path | None,
+    collect_mode: str,
+) -> str | None:
+    """Refuse a filter that would scope L2 but silently not L3.
+
+    ``--compile-db-filter`` parameterizes the **header parse** only: the
+    filtered subset is what ``_resolve_build_context_flags`` proves a match
+    against and what the AST is built from. L3 collection reads the database
+    through ``embed_build_source``'s own adapter, which has no filter of its
+    own -- so on a monorepo database the embedded build facts cover every
+    translation unit while the headers cover the requested subset, and the
+    resulting snapshot carries unrelated build evidence that can produce
+    false differences.
+
+    The removed ``-p``/``--compile-db`` spelling refused exactly this: its
+    ``resolve_compile_db_l3_reuse`` declined to promote the header database
+    to L3 whenever a filter was active, and said so. Folding the operand into
+    ``--build-info`` removed that decision -- ``--build-info`` *is* the L3
+    selector now, so there is nothing left to decline -- which turned a loud
+    refusal into a silent unfiltered collection (Codex review). This restores
+    the refusal as a usage error, since the honest alternative (threading the
+    filter through ``embed_build_source`` into the compile-DB adapter) is a
+    change to ``buildsource/`` with its own evidence gates, not something to
+    infer from one review round.
+
+    ``None`` when the combination cannot arise: no filter, a ``--build-info``
+    that is not a compile database (a pack or Bazel jsonproto routes through
+    a different adapter), or ``collect_mode == "off"``, where no build
+    evidence is embedded for the filter to be inconsistent with.
+    """
+    if not compile_db_filter or compile_db_path is None or collect_mode == "off":
+        return None
+    return (
+        "--compile-db-filter scopes the L2 header parse only; the L3 build "
+        "evidence embedded from the same --build-info compilation database is "
+        "collected unfiltered, so the snapshot would carry build facts for "
+        "translation units the filter excludes. Pass a pre-filtered "
+        "compile_commands.json as --build-info (then --compile-db-filter is "
+        "unnecessary), or drop --compile-db-filter to accept the whole "
+        "database on both layers."
+    )
+
+
 def attach_build_context(
     snap: AbiSnapshot,
     compile_db: str | Path,

--- a/abicheck/header_conditionals.py
+++ b/abicheck/header_conditionals.py
@@ -65,8 +65,12 @@ from fnmatch import fnmatch
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ._compiler_options import split_gcc_options
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
+
+    from .model import AbiSnapshot
 
 # ── active-define extraction ─────────────────────────────────────────────────
 
@@ -904,3 +908,123 @@ def collect_build_context(
                     entry["ambiguous"] = True
             registry.setdefault(rec, {}).update(fields)
     return defines, registry
+
+
+# ── shared entry points (CLI dump and the typed input-resolution pipeline) ──
+#
+# `user_define_flags`/`attach_build_context` used to be private to
+# `cli_dump_helpers.py` (the ELF `dump` CLI's own `perform_elf_dump`). PR C
+# (CLI cleanup phase two, typed dump/scan convergence) moved them here, a
+# dependency-free leaf module already owning `collect_build_context`, so
+# `service_input_resolution._resolve_side_snapshot_impl` (the typed pipeline
+# `compare`'s implicit-dump operand and `dump`'s typed `run_dump_request` API
+# share) can reach the identical ADR-039 collection logic without importing
+# `cli_dump_helpers.py` (a CLI-presentation-layer module, and an import a
+# service module must not take). `cli_dump_helpers.py` keeps calling these
+# under their original names via a re-export, so `perform_elf_dump` and every
+# existing test needed no changes.
+
+
+def user_define_flags(
+    gcc_option_tokens: tuple[str, ...], user_gcc_options: str | None
+) -> list[str]:
+    """The user's *global* define-affecting flags for the ADR-039 collector.
+
+    Combines the ``-D``/``-U`` in the ``--gcc-options`` string with the repeatable
+    ``--compiler-option`` tokens, **in the same order the real dump applies them** —
+    ``dumper._castxml_cmd`` appends ``gcc_options`` first, then
+    ``gcc_option_tokens`` (see ``dumper.py``), so the collector must too (Codex
+    review #498). Order is significant because ``defines_from_flags`` honours
+    ``-D``/``-U`` sequence: a composed ``-DKEEP`` followed by ``--compiler-option=-UKEEP`` must leave
+    ``KEEP`` *inactive* on both the parse and the harvest, else the reconciler
+    would add back a field the real parse pruned. These flags are applied on top
+    of the compile-DB intersection, so a user ``-UKEEP`` also overrides a database
+    ``-DKEEP``. **The auto-derived / L3→L2-folded build context is deliberately
+    excluded (it must not be unioned snapshot-wide)** — a caller must pass only
+    its own pre-fold, explicitly-given flags here, never a resolved
+    ``CompileContext``'s derived tokens (see the ninth finding in the root
+    ``AGENTS.md``'s L3→L2-fold entry for why: unioning would mark one TU's
+    ``-D`` active for every scanned header).
+
+    A malformed ``--gcc-options`` (e.g. an unbalanced quote) must not abort the
+    dump — ``split_gcc_options`` errors are swallowed and only the tokens are
+    used (CodeRabbit review). ``split_gcc_options`` (not a bare
+    ``shlex.split``) so this collector tokenizes ``user_gcc_options``
+    identically to the real header-AST parse on every platform — a plain
+    POSIX ``shlex.split`` would silently disagree with the Windows tokenizer
+    on an unquoted Windows path (e.g. combining ``-IC:\\sdk\\ -UKEEP`` into
+    one token instead of two), which could make the harvested define set
+    diverge from what the real parse actually saw (Codex review, PR #774
+    follow-up)."""
+    flags: list[str] = []
+    if user_gcc_options:
+        try:
+            flags += split_gcc_options(user_gcc_options)
+        except ValueError:
+            pass  # bad optional define flags are skipped, not fatal
+    flags += list(gcc_option_tokens)
+    return flags
+
+
+def compile_db_from_build_info(
+    build_info: Path | None,
+    headers: tuple[Path, ...],
+) -> Path | None:
+    """The L2 compile database ``--build-info`` names, when it names one.
+
+    ``--build-info``'s operand is "a build dir, a compile_commands.json, or a
+    pre-captured pack" -- the first two are exactly what the removed
+    ``-p/--build-dir`` (and its ``--compile-db`` alias) took, so the database
+    that drives deterministic header parsing is read back off the one
+    remaining build-context flag rather than a second spelling of the same
+    path.
+
+    ``None`` without headers: a compile database only feeds the header AST,
+    and a headerless ``--build-info`` run is an ordinary L3-only dump, not the
+    usage error the dedicated flag used to raise ("requires -H/--header").
+
+    ``None`` for a *file* that is not a compile database, too. ``--build-info``
+    also accepts a Bazel aquery/cquery jsonproto, which
+    ``buildsource.inline._maybe_collect_bazel_build_info`` routes through the
+    Bazel adapter -- but only if it gets that far. Returning any file here
+    handed such a run to ``load_compile_db()``, which rejects a JSON object
+    with "compile_commands.json must be a JSON array" long before the adapter
+    is reached, so `--build-info aquery.json -H api.h` failed outright
+    (Codex review). ``sniff_build_info_format`` is the same content-based
+    classifier that dispatch uses, so the two cannot disagree about what a
+    given file is.
+    """
+    from .buildsource.inline import sniff_build_info_format
+
+    if build_info is None or not headers:
+        return None
+    if build_info.is_file():
+        return build_info if sniff_build_info_format(build_info) == "compile_db" else None
+    db = build_info / "compile_commands.json"
+    # Sniffed for the same reason: a build directory holding a non-array
+    # compile_commands.json is the identical mis-route one level down.
+    return db if db.is_file() and sniff_build_info_format(db) == "compile_db" else None
+
+
+def attach_build_context(
+    snap: AbiSnapshot,
+    compile_db: str | Path,
+    headers: list[Path],
+    extra_flags: list[str],
+    source_filter: str | None = None,
+) -> None:
+    """ADR-039 collection layer: harvest the build's active ``-D`` set and scan the
+    public headers for ``#ifdef``-guarded record fields, attaching both to *snap*.
+
+    Best-effort and additive — a plain context-free dump (no compile DB) never
+    reaches here, and an empty harvest leaves the snapshot's defaults untouched, so
+    the pass is a safe no-op unless real build evidence is found. *source_filter*
+    (``--compile-db-filter``) selects the same compile-DB entries the header parse
+    used."""
+    bc_defines, bc_conditional = collect_build_context(
+        headers, compile_db, extra_flags=extra_flags, source_filter=source_filter
+    )
+    if bc_defines:
+        snap.build_context_defines = bc_defines
+    if bc_conditional:
+        snap.conditional_fields = bc_conditional

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -48,7 +48,6 @@ from typing import TYPE_CHECKING
 from .errors import SnapshotError, ValidationError
 from .header_conditionals import (
     attach_build_context,
-    compile_db_filter_scope_error,
     compile_db_from_build_info,
     user_define_flags as _user_define_flags,
 )
@@ -562,7 +561,22 @@ def _resolve_side_snapshot_impl(
         # snapshot-wide" invariant `user_define_flags`'s own docstring states
         # (see the ninth finding in the root AGENTS.md's L3->L2-fold entry for
         # why).
-        if fmt == "elf":
+        # `snap.elf is not None` -- not the pre-resolution `fmt` parameter
+        # (Codex review, PR #809, fresh evidence): `fmt` is computed by the
+        # caller from `service.detect_binary_format(side.path)` *before*
+        # `service.resolve_input()` runs, and a GNU ld linker script (the
+        # conventional development `libfoo.so` symlink, e.g. `INPUT(libfoo.
+        # so.1)`) reads as `None` there -- but `resolve_input`'s own
+        # `follow_linker_scripts=True` default (unset by this pipeline)
+        # follows the script to its real ELF target and returns a genuine
+        # ELF snapshot (`snap.elf` populated, `snap.from_headers=True`) with
+        # `fmt` never updated to reflect it. Gating on the stale `fmt` would
+        # silently skip the collector for this common ELF input form.
+        # `snap.elf` is the model's own post-resolution signal (populated by
+        # `dumper.dump()` for every real ELF parse, regardless of whether the
+        # original path was a direct `.so` or a followed linker script), so
+        # it can't go stale the way a pre-computed `fmt` string can.
+        if snap.elf is not None:
             # `evidence.headers` may still contain a directory entry -- exactly
             # what `service.resolve_input`/`_dump_elf` expands internally (via
             # `service_scan.expand_header_inputs`) before parsing, for the
@@ -610,21 +624,44 @@ def _resolve_side_snapshot_impl(
             compile_db_path = compile_db_from_build_info(
                 side.build_info, tuple(collector_headers)
             )
-            # `--compile-db-filter`'s typed-API equivalent: the native `dump`
-            # CLI refuses this same combination as a usage error
-            # (`compile_db_filter_scope_error`) rather than silently letting
-            # the L2 collector scope to the filtered subset while the L3
-            # embed below (`embed_side_build_source`) reads the whole,
-            # unfiltered database -- a snapshot whose layers would then cover
-            # different translation units (Codex review, PR #809). Reused
-            # here unchanged, raising the Tier-2 `ValidationError` this API's
-            # contract uses in place of the CLI's `click.UsageError`.
-            if (
-                _filter_scope_msg := compile_db_filter_scope_error(
-                    side.compile_db_filter, compile_db_path, evidence.collect_mode
+            # `compile_db_filter` is rejected unconditionally alongside a
+            # resolvable compile database on this pipeline -- broader than
+            # the native `dump` CLI's own `compile_db_filter_scope_error`
+            # (which exempts `collect_mode == "off"`, since on the CLI path
+            # the filter *does* reach the L2 header-AST context there too,
+            # via `cli_helpers_compare._resolve_build_context_flags`). This
+            # shared pipeline's own L2 context comes from a structurally
+            # different mechanism, `_seeded_includes_and_compile_context`
+            # (the P0.3 L3->L2 fold, already run above, before this block),
+            # which has no `compile_db_filter` parameter at all and always
+            # resolves from the *whole* database, regardless of
+            # `collect_mode` -- so exempting "off" here would be wrong, not
+            # just incomplete: even a headers-only, no-L3-embed request
+            # would still fold an unfiltered `compile_ctx` into the real
+            # parse while this collector saw only the filtered subset
+            # (Codex review, PR #809, fresh evidence -- a P1 finding on the
+            # first version of this check that only exempted `collect_mode
+            # != "off"`, mirroring the CLI's own condition, missed that the
+            # CLI's condition is only safe *because* the CLI's own filter
+            # threading covers the "off" case a different way this pipeline
+            # doesn't have). Threading the filter into the L2 fold itself
+            # (mirroring what the CLI's separate mechanism does) is a real,
+            # separate feature addition to shared, heavily-reviewed L2-seed
+            # machinery (`buildsource/l2_seed.py`/`header_compile_context.py`
+            # -- no other caller of either has ever needed a filter concept
+            # there), not a same-PR follow-up -- see the plan doc's PR C
+            # status notes.
+            if side.compile_db_filter and compile_db_path is not None:
+                raise ValidationError(
+                    "compile_db_filter is not supported together with a "
+                    "resolvable compile database on this pipeline: the L2 "
+                    "header-AST context is resolved from the whole, "
+                    "unfiltered compile database regardless of collect mode, "
+                    "so a filtered ADR-039 build-context view would disagree "
+                    "with what informed the actual header parse. Pass a "
+                    "pre-filtered compile_commands.json as build_info "
+                    "instead, or drop compile_db_filter."
                 )
-            ) is not None:
-                raise ValidationError(_filter_scope_msg)
             if (
                 compile_db_path is not None
                 and collector_headers

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING
 from .errors import SnapshotError, ValidationError
 from .header_conditionals import (
     attach_build_context,
+    compile_db_filter_scope_error,
     compile_db_from_build_info,
     user_define_flags as _user_define_flags,
 )
@@ -545,48 +546,100 @@ def _resolve_side_snapshot_impl(
         # resolvable from `side.build_info`, real headers were actually
         # parsed (`evidence.headers`), and the parse reached them
         # (`snap.from_headers` -- e.g. not a `--dwarf-only` run that ignored
-        # them). `side.compile` is this side's *pre-fold*, caller-supplied
-        # `CompileContext` (the ADR-055 D1 per-side override resolved before
-        # `_seeded_includes_and_compile_context`'s L3->L2 fold ran above) --
-        # only its own explicit `gcc_options`/`gcc_option_tokens` are passed
-        # to the collector, never `compile_ctx` (the folded/derived result),
-        # preserving the "must not be unioned snapshot-wide" invariant
-        # `user_define_flags`'s own docstring states (see the ninth finding
-        # in the root AGENTS.md's L3->L2-fold entry for why).
-        #
-        # `evidence.headers` may still contain a directory entry -- exactly
-        # what `service.resolve_input`/`_dump_elf` itself expands internally
-        # (via this identical `expand_header_inputs`) before parsing, so
-        # `snap` above was already built from the expanded set. The collector
-        # scans each entry with `Path(path).read_text(...)`, which raises
-        # `OSError` for a directory and is silently skipped -- passing the
-        # raw, unexpanded list here would leave `conditional_fields` empty
-        # for the common directory-header-input case even though headers
-        # were genuinely parsed (Codex review, PR #809). Expanding a second
-        # time is safe and cheap: `resolve_input` already proved every path
-        # here is valid (it would have raised otherwise), so this is a pure
-        # directory walk, no new I/O risk -- mirrors `perform_elf_dump`'s own
-        # `resolved_headers = expand_header_inputs(...)` computed once and
-        # reused for both its primary parse and this identical collector call.
-        from .service_scan import expand_header_inputs
+        # them). **`fmt == "elf"` too (Codex review, PR #809)**: the ADR-039
+        # collector is an established ELF-only mechanism -- `handle_non_elf_dump`
+        # (PE/Mach-O) never calls it (see the root AGENTS.md's tenth finding
+        # on the L3->L2-fold entry) -- so this shared pipeline must not attach
+        # build-context evidence to a PE/Mach-O snapshot a typed dump/compare
+        # produces, or it would silently disagree with the native PE/Mach-O
+        # dump path and let build-context reconciliation suppress a real,
+        # non-ELF finding. `side.compile` is this side's *pre-fold*,
+        # caller-supplied `CompileContext` (the ADR-055 D1 per-side override
+        # resolved before `_seeded_includes_and_compile_context`'s L3->L2
+        # fold ran above) -- only its own explicit `gcc_options`/
+        # `gcc_option_tokens` are passed to the collector, never `compile_ctx`
+        # (the folded/derived result), preserving the "must not be unioned
+        # snapshot-wide" invariant `user_define_flags`'s own docstring states
+        # (see the ninth finding in the root AGENTS.md's L3->L2-fold entry for
+        # why).
+        if fmt == "elf":
+            # `evidence.headers` may still contain a directory entry -- exactly
+            # what `service.resolve_input`/`_dump_elf` expands internally (via
+            # `service_scan.expand_header_inputs`) before parsing, for the
+            # native-binary dispatch. The collector scans each entry with
+            # `Path(path).read_text(...)`, which raises `OSError` for a
+            # directory and is silently skipped -- passing the raw, unexpanded
+            # list here would leave `conditional_fields` empty for the common
+            # directory-header-input case even though headers were genuinely
+            # parsed (Codex review, PR #809).
+            #
+            # `expand_header_inputs` itself is the *wrong* tool to reuse here,
+            # unlike `perform_elf_dump`'s identically-shaped
+            # `resolved_headers = expand_header_inputs(...)` call: that call
+            # sees the ELF `dump` CLI's own headers, always meant for a live
+            # header-AST parse. `resolve_input`'s dispatch is *not* always the
+            # native-binary path this reasoning assumes -- a saved-JSON-
+            # snapshot side (loaded straight from disk, `side.headers` carried
+            # only for provenance tagging and never touching disk) never calls
+            # `expand_header_inputs` internally at all, so re-deriving
+            # "resolve_input already proved every path is valid" is false in
+            # general. Calling the strict (raising) expander unconditionally
+            # here regressed exactly that case (confirmed: `ValidationError`
+            # reproduced against a real snapshot-file compare with header
+            # entries that never exist on disk). Use a local, best-effort
+            # expansion instead -- never raises, mirroring
+            # `collect_build_context`'s own "an unreadable header is skipped,
+            # never abort the dump" contract -- so a side whose headers were
+            # never meant to be read from disk degrades to "nothing to
+            # collect" rather than aborting the whole comparison.
+            from .buildsource.build_query import PRUNED_HEADER_DIR_SEGMENTS
+            from .header_utils import iter_directory_headers
 
-        collector_headers = (
-            expand_header_inputs(list(evidence.headers)) if evidence.headers else []
-        )
-        compile_db_path = compile_db_from_build_info(
-            side.build_info, tuple(collector_headers)
-        )
-        if compile_db_path is not None and collector_headers and snap.from_headers:
-            attach_build_context(
-                snap,
-                compile_db_path,
-                collector_headers,
-                _user_define_flags(
-                    side.compile.gcc_option_tokens if side.compile else (),
-                    side.compile.gcc_options if side.compile else None,
-                ),
-                source_filter=side.compile_db_filter,
+            collector_headers: list[Path] = []
+            for _h in evidence.headers:
+                if _h.is_file():
+                    collector_headers.append(_h)
+                elif _h.is_dir():
+                    collector_headers.extend(
+                        iter_directory_headers(_h, PRUNED_HEADER_DIR_SEGMENTS)
+                    )
+                # else: neither a file nor a directory on this filesystem
+                # (e.g. a saved-snapshot side's headers, carried for
+                # provenance only) -- skipped, not raised.
+
+            compile_db_path = compile_db_from_build_info(
+                side.build_info, tuple(collector_headers)
             )
+            # `--compile-db-filter`'s typed-API equivalent: the native `dump`
+            # CLI refuses this same combination as a usage error
+            # (`compile_db_filter_scope_error`) rather than silently letting
+            # the L2 collector scope to the filtered subset while the L3
+            # embed below (`embed_side_build_source`) reads the whole,
+            # unfiltered database -- a snapshot whose layers would then cover
+            # different translation units (Codex review, PR #809). Reused
+            # here unchanged, raising the Tier-2 `ValidationError` this API's
+            # contract uses in place of the CLI's `click.UsageError`.
+            if (
+                _filter_scope_msg := compile_db_filter_scope_error(
+                    side.compile_db_filter, compile_db_path, evidence.collect_mode
+                )
+            ) is not None:
+                raise ValidationError(_filter_scope_msg)
+            if (
+                compile_db_path is not None
+                and collector_headers
+                and snap.from_headers
+            ):
+                attach_build_context(
+                    snap,
+                    compile_db_path,
+                    collector_headers,
+                    _user_define_flags(
+                        side.compile.gcc_option_tokens if side.compile else (),
+                        side.compile.gcc_options if side.compile else None,
+                    ),
+                    source_filter=side.compile_db_filter,
+                )
         if side.sources or side.build_info:
             # Known, accepted limitation (Codex review, fresh evidence, not
             # fixed here): when a trusted build_query was authorized and

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -46,6 +46,11 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from .errors import SnapshotError, ValidationError
+from .header_conditionals import (
+    attach_build_context,
+    compile_db_from_build_info,
+    user_define_flags as _user_define_flags,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -531,6 +536,37 @@ def _resolve_side_snapshot_impl(
         # ignored them) must not claim their parse used real build context.
         if context_applied and snap.from_headers:
             snap.parsed_with_build_context = True
+        # PR C (typed dump/scan convergence): the ADR-039 build-context
+        # collector, previously reachable only from the ELF `dump` CLI's own
+        # `perform_elf_dump` (one call site) -- now available to every caller
+        # of this shared primitive (compare's implicit-dump operand, dump's
+        # typed `run_dump_request` API). Gated exactly the way
+        # `perform_elf_dump` gates its own call: a compile-DB path must be
+        # resolvable from `side.build_info`, real headers were actually
+        # parsed (`evidence.headers`), and the parse reached them
+        # (`snap.from_headers` -- e.g. not a `--dwarf-only` run that ignored
+        # them). `side.compile` is this side's *pre-fold*, caller-supplied
+        # `CompileContext` (the ADR-055 D1 per-side override resolved before
+        # `_seeded_includes_and_compile_context`'s L3->L2 fold ran above) --
+        # only its own explicit `gcc_options`/`gcc_option_tokens` are passed
+        # to the collector, never `compile_ctx` (the folded/derived result),
+        # preserving the "must not be unioned snapshot-wide" invariant
+        # `user_define_flags`'s own docstring states (see the ninth finding
+        # in the root AGENTS.md's L3->L2-fold entry for why).
+        compile_db_path = compile_db_from_build_info(
+            side.build_info, tuple(evidence.headers)
+        )
+        if compile_db_path is not None and evidence.headers and snap.from_headers:
+            attach_build_context(
+                snap,
+                compile_db_path,
+                list(evidence.headers),
+                _user_define_flags(
+                    side.compile.gcc_option_tokens if side.compile else (),
+                    side.compile.gcc_options if side.compile else None,
+                ),
+                source_filter=side.compile_db_filter,
+            )
         if side.sources or side.build_info:
             # Known, accepted limitation (Codex review, fresh evidence, not
             # fixed here): when a trusted build_query was authorized and

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -553,14 +553,34 @@ def _resolve_side_snapshot_impl(
         # preserving the "must not be unioned snapshot-wide" invariant
         # `user_define_flags`'s own docstring states (see the ninth finding
         # in the root AGENTS.md's L3->L2-fold entry for why).
-        compile_db_path = compile_db_from_build_info(
-            side.build_info, tuple(evidence.headers)
+        #
+        # `evidence.headers` may still contain a directory entry -- exactly
+        # what `service.resolve_input`/`_dump_elf` itself expands internally
+        # (via this identical `expand_header_inputs`) before parsing, so
+        # `snap` above was already built from the expanded set. The collector
+        # scans each entry with `Path(path).read_text(...)`, which raises
+        # `OSError` for a directory and is silently skipped -- passing the
+        # raw, unexpanded list here would leave `conditional_fields` empty
+        # for the common directory-header-input case even though headers
+        # were genuinely parsed (Codex review, PR #809). Expanding a second
+        # time is safe and cheap: `resolve_input` already proved every path
+        # here is valid (it would have raised otherwise), so this is a pure
+        # directory walk, no new I/O risk -- mirrors `perform_elf_dump`'s own
+        # `resolved_headers = expand_header_inputs(...)` computed once and
+        # reused for both its primary parse and this identical collector call.
+        from .service_scan import expand_header_inputs
+
+        collector_headers = (
+            expand_header_inputs(list(evidence.headers)) if evidence.headers else []
         )
-        if compile_db_path is not None and evidence.headers and snap.from_headers:
+        compile_db_path = compile_db_from_build_info(
+            side.build_info, tuple(collector_headers)
+        )
+        if compile_db_path is not None and collector_headers and snap.from_headers:
             attach_build_context(
                 snap,
                 compile_db_path,
-                list(evidence.headers),
+                collector_headers,
                 _user_define_flags(
                     side.compile.gcc_option_tokens if side.compile else (),
                     side.compile.gcc_options if side.compile else None,

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -576,7 +576,26 @@ def _resolve_side_snapshot_impl(
         # `dumper.dump()` for every real ELF parse, regardless of whether the
         # original path was a direct `.so` or a followed linker script), so
         # it can't go stale the way a pre-computed `fmt` string can.
-        if snap.elf is not None:
+        #
+        # `snap.elf is not None` alone is *not* sufficient, though (Codex
+        # review, PR #809, fresh evidence): the identical post-resolution
+        # signal is also populated on a *loaded* JSON snapshot whose original
+        # library happened to be ELF (`resolve_input`'s own `fmt == "json"`
+        # branch returns `load_snapshot(path)` verbatim -- no live parse at
+        # all -- and a real, previously-captured `AbiSnapshot` round-trips
+        # its `elf`/`from_headers` fields exactly as they were when saved).
+        # Running the collector there would scan `evidence.headers`/
+        # `side.build_info` off the *current* filesystem and overwrite the
+        # loaded snapshot's own recorded `build_context_defines`/
+        # `conditional_fields` with evidence unrelated to what was actually
+        # captured -- silently corrupting a loaded baseline rather than
+        # reconciling a live parse. `service.sniff_text_format` is the exact
+        # predicate `resolve_input` itself uses to take that branch (handles
+        # a compressed `.json.gz`/`.zst` snapshot too, per ADR-059), so
+        # re-running it here on `side.path` distinguishes "genuinely no live
+        # ELF parse happened" from "parse happened, only `fmt` went stale"
+        # without needing a new return value threaded out of `resolve_input`.
+        if snap.elf is not None and service.sniff_text_format(side.path) != "json":
             # `evidence.headers` may still contain a directory entry -- exactly
             # what `service.resolve_input`/`_dump_elf` expands internally (via
             # `service_scan.expand_header_inputs`) before parsing, for the

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -624,44 +624,25 @@ def _resolve_side_snapshot_impl(
             compile_db_path = compile_db_from_build_info(
                 side.build_info, tuple(collector_headers)
             )
-            # `compile_db_filter` is rejected unconditionally alongside a
-            # resolvable compile database on this pipeline -- broader than
-            # the native `dump` CLI's own `compile_db_filter_scope_error`
-            # (which exempts `collect_mode == "off"`, since on the CLI path
-            # the filter *does* reach the L2 header-AST context there too,
-            # via `cli_helpers_compare._resolve_build_context_flags`). This
-            # shared pipeline's own L2 context comes from a structurally
-            # different mechanism, `_seeded_includes_and_compile_context`
-            # (the P0.3 L3->L2 fold, already run above, before this block),
-            # which has no `compile_db_filter` parameter at all and always
-            # resolves from the *whole* database, regardless of
-            # `collect_mode` -- so exempting "off" here would be wrong, not
-            # just incomplete: even a headers-only, no-L3-embed request
-            # would still fold an unfiltered `compile_ctx` into the real
-            # parse while this collector saw only the filtered subset
-            # (Codex review, PR #809, fresh evidence -- a P1 finding on the
-            # first version of this check that only exempted `collect_mode
-            # != "off"`, mirroring the CLI's own condition, missed that the
-            # CLI's condition is only safe *because* the CLI's own filter
-            # threading covers the "off" case a different way this pipeline
-            # doesn't have). Threading the filter into the L2 fold itself
-            # (mirroring what the CLI's separate mechanism does) is a real,
-            # separate feature addition to shared, heavily-reviewed L2-seed
-            # machinery (`buildsource/l2_seed.py`/`header_compile_context.py`
-            # -- no other caller of either has ever needed a filter concept
-            # there), not a same-PR follow-up -- see the plan doc's PR C
-            # status notes.
-            if side.compile_db_filter and compile_db_path is not None:
-                raise ValidationError(
-                    "compile_db_filter is not supported together with a "
-                    "resolvable compile database on this pipeline: the L2 "
-                    "header-AST context is resolved from the whole, "
-                    "unfiltered compile database regardless of collect mode, "
-                    "so a filtered ADR-039 build-context view would disagree "
-                    "with what informed the actual header parse. Pass a "
-                    "pre-filtered compile_commands.json as build_info "
-                    "instead, or drop compile_db_filter."
-                )
+            # No `compile_db_filter` field is threaded through here (and
+            # `InputSpec` deliberately doesn't carry one -- see its own
+            # comment): this shared pipeline's own L2 header-AST context
+            # (`_seeded_includes_and_compile_context`, the P0.3 L3->L2 fold,
+            # already run above) always resolves from the *whole*, unfiltered
+            # compile database, unlike the native `dump` CLI, which threads
+            # its `--compile-db-filter` into its own, structurally different
+            # L2 mechanism too (`cli_helpers_compare._resolve_build_context_
+            # flags`). Exposing a filter here that could only ever disagree
+            # with the unfiltered L2 parse -- or, if rejected outright
+            # whenever combined with a resolvable database, never actually
+            # narrow anything -- would be worse than not exposing one at all
+            # (Codex review, PR #809, fresh evidence: an earlier version of
+            # this pipeline added exactly such a field, and it had no
+            # successful execution path where it narrowed anything). A real
+            # implementation needs the filter threaded into the shared L2
+            # fold itself, a separate feature addition to
+            # `buildsource/l2_seed.py`/`header_compile_context.py` -- see the
+            # plan doc's PR C status notes.
             if (
                 compile_db_path is not None
                 and collector_headers
@@ -675,7 +656,6 @@ def _resolve_side_snapshot_impl(
                         side.compile.gcc_option_tokens if side.compile else (),
                         side.compile.gcc_options if side.compile else None,
                     ),
-                    source_filter=side.compile_db_filter,
                 )
         if side.sources or side.build_info:
             # Known, accepted limitation (Codex review, fresh evidence, not

--- a/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
+++ b/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
@@ -23,5 +23,14 @@
   way `service.resolve_input` does before scanning it for `#ifdef`-guarded
   fields, matching `perform_elf_dump`'s own behavior — without this, the
   common directory-`-H` input case left `conditional_fields` silently empty
-  even though the headers under it were genuinely parsed.
+  even though the headers under it were genuinely parsed. The collector is
+  now also restricted to `fmt == "elf"`, matching the established ELF-only
+  scope of the ADR-039 collector (a PE/Mach-O typed dump/compare no longer
+  silently disagrees with the native PE/Mach-O dump path, which never calls
+  this collector). Combining `InputSpec.compile_db_filter` with a
+  compile-database `build_info` at a non-`"off"` collect mode is now
+  refused with a `ValidationError` — the typed-API equivalent of the native
+  `dump` CLI's own `compile_db_filter_scope_error` usage error — since the
+  filtered collector and the unfiltered L3 embed would otherwise disagree
+  on which translation units the snapshot's evidence covers.
 

--- a/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
+++ b/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
@@ -24,13 +24,18 @@
   fields, matching `perform_elf_dump`'s own behavior — without this, the
   common directory-`-H` input case left `conditional_fields` silently empty
   even though the headers under it were genuinely parsed. The collector is
-  now also restricted to `fmt == "elf"`, matching the established ELF-only
+  now also restricted to a real ELF snapshot (`snap.elf is not None`,
+  checked post-resolution rather than the pre-resolution `fmt` value —
+  a GNU ld linker script's `fmt` reads as `None` before `resolve_input`
+  follows it to its real ELF target), matching the established ELF-only
   scope of the ADR-039 collector (a PE/Mach-O typed dump/compare no longer
   silently disagrees with the native PE/Mach-O dump path, which never calls
   this collector). Combining `InputSpec.compile_db_filter` with a
-  compile-database `build_info` at a non-`"off"` collect mode is now
-  refused with a `ValidationError` — the typed-API equivalent of the native
-  `dump` CLI's own `compile_db_filter_scope_error` usage error — since the
-  filtered collector and the unfiltered L3 embed would otherwise disagree
-  on which translation units the snapshot's evidence covers.
+  resolvable compile database is now refused with a `ValidationError`
+  unconditionally (not only at a non-`"off"` collect mode, unlike the
+  native `dump` CLI's own `compile_db_filter_scope_error`) — this shared
+  pipeline's own L2 header-AST context always resolves from the whole,
+  unfiltered database regardless of collect mode, so a filtered ADR-039
+  view would disagree with what informed the actual header parse even for
+  a headers-only, no-L3-embed request.
 

--- a/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
+++ b/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
@@ -35,7 +35,18 @@
   to its real ELF target), matching the established ELF-only scope of the
   ADR-039 collector (a PE/Mach-O typed dump/compare no longer silently
   disagrees with the native PE/Mach-O dump path, which never calls this
-  collector). `InputSpec` deliberately does **not** gain a
+  collector). `snap.elf is not None` alone proved insufficient on its own
+  (Codex review, fresh evidence): a *loaded* JSON snapshot
+  (`resolve_input`'s own `fmt == "json"` branch, `load_snapshot(path)`
+  verbatim with no live parse at all) round-trips its original `elf`/
+  `from_headers` fields exactly as saved, so the identical post-resolution
+  signal fires for a side that never touched the header parser — running
+  the collector there would scan the *current* filesystem's headers/
+  compile-db and overwrite the loaded snapshot's own recorded build-context
+  evidence with unrelated data. Now also requires
+  `service.sniff_text_format(side.path) != "json"` (the exact predicate
+  `resolve_input` itself uses to take that branch) before the collector
+  runs. `InputSpec` deliberately does **not** gain a
   `compile_db_filter` field mirroring `--compile-db-filter` (an earlier
   version of this change added one, and Codex review found it had no
   successful execution path where it narrowed anything: this shared

--- a/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
+++ b/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
@@ -1,0 +1,22 @@
+### Changed
+
+- **The ADR-039 build-context collector is now reachable from the typed
+  input-resolution pipeline, not just the ELF `dump` CLI** (CLI cleanup
+  phase two, "PR C" continued). `service_input_resolution.
+  _resolve_side_snapshot_impl` — shared by `compare`'s implicit-dump operand
+  and `dump`'s typed `run_dump_request` API — now calls the same collector
+  `perform_elf_dump` has always called directly, gated identically (a
+  resolvable compile database, real parsed headers). `InputSpec` gained
+  `compile_db_filter` (mirrors `--compile-db-filter`) so a caller of the
+  typed API can narrow the collector's compile-DB scan the same way the CLI
+  flag does. `attach_build_context`/`user_define_flags`/
+  `compile_db_from_build_info` moved from `cli_dump_helpers.py` (a
+  CLI-presentation module, not importable from a service module) to
+  `header_conditionals.py`, the dependency-free leaf module that already
+  owns the collector's own logic; `cli_dump_helpers.py` keeps the original
+  private names as thin re-exports, so `perform_elf_dump` and every
+  existing caller/test are unchanged. `perform_elf_dump` itself is not
+  migrated to call through the shared path in this change — only the
+  pipeline's own capability gap is closed, so `compare`'s implicit dump and
+  `dump`'s typed API can now attach build-context evidence too.
+

--- a/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
+++ b/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
@@ -18,5 +18,10 @@
   existing caller/test are unchanged. `perform_elf_dump` itself is not
   migrated to call through the shared path in this change — only the
   pipeline's own capability gap is closed, so `compare`'s implicit dump and
-  `dump`'s typed API can now attach build-context evidence too.
+  `dump`'s typed API can now attach build-context evidence too. The
+  collector now also expands a directory `InputSpec.headers` entry the same
+  way `service.resolve_input` does before scanning it for `#ifdef`-guarded
+  fields, matching `perform_elf_dump`'s own behavior — without this, the
+  common directory-`-H` input case left `conditional_fields` silently empty
+  even though the headers under it were genuinely parsed.
 

--- a/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
+++ b/changelog.d/20260820_220406_noreply_cli_cleanup_phase_two_r0xuzx.md
@@ -6,36 +6,43 @@
   _resolve_side_snapshot_impl` — shared by `compare`'s implicit-dump operand
   and `dump`'s typed `run_dump_request` API — now calls the same collector
   `perform_elf_dump` has always called directly, gated identically (a
-  resolvable compile database, real parsed headers). `InputSpec` gained
-  `compile_db_filter` (mirrors `--compile-db-filter`) so a caller of the
-  typed API can narrow the collector's compile-DB scan the same way the CLI
-  flag does. `attach_build_context`/`user_define_flags`/
-  `compile_db_from_build_info` moved from `cli_dump_helpers.py` (a
+  resolvable compile database, real parsed headers). `attach_build_context`/
+  `user_define_flags`/`compile_db_from_build_info`/
+  `compile_db_filter_scope_error` moved from `cli_dump_helpers.py` (a
   CLI-presentation module, not importable from a service module) to
   `header_conditionals.py`, the dependency-free leaf module that already
   owns the collector's own logic; `cli_dump_helpers.py` keeps the original
-  private names as thin re-exports, so `perform_elf_dump` and every
-  existing caller/test are unchanged. `perform_elf_dump` itself is not
-  migrated to call through the shared path in this change — only the
-  pipeline's own capability gap is closed, so `compare`'s implicit dump and
-  `dump`'s typed API can now attach build-context evidence too. The
-  collector now also expands a directory `InputSpec.headers` entry the same
-  way `service.resolve_input` does before scanning it for `#ifdef`-guarded
-  fields, matching `perform_elf_dump`'s own behavior — without this, the
-  common directory-`-H` input case left `conditional_fields` silently empty
-  even though the headers under it were genuinely parsed. The collector is
-  now also restricted to a real ELF snapshot (`snap.elf is not None`,
-  checked post-resolution rather than the pre-resolution `fmt` value —
-  a GNU ld linker script's `fmt` reads as `None` before `resolve_input`
-  follows it to its real ELF target), matching the established ELF-only
-  scope of the ADR-039 collector (a PE/Mach-O typed dump/compare no longer
-  silently disagrees with the native PE/Mach-O dump path, which never calls
-  this collector). Combining `InputSpec.compile_db_filter` with a
-  resolvable compile database is now refused with a `ValidationError`
-  unconditionally (not only at a non-`"off"` collect mode, unlike the
-  native `dump` CLI's own `compile_db_filter_scope_error`) — this shared
+  private names resolvable — `attach_build_context`/`user_define_flags` via
+  a normal import (still called directly by `perform_elf_dump`, so this
+  static edge is structurally required regardless of re-export strategy),
+  and `compile_db_from_build_info`/`compile_db_filter_scope_error` (never
+  called internally, only re-exported for `cli.py`/tests) via a lazy
+  module-level `__getattr__` shim, per this repo's own moved-helper
+  convention (mirroring `cli_buildsource.py`'s identical shim) — so
+  `perform_elf_dump` and every existing caller/test are unchanged.
+  `perform_elf_dump` itself is not migrated to call through the shared path
+  in this change — only the pipeline's own capability gap is closed, so
+  `compare`'s implicit dump and `dump`'s typed API can now attach
+  build-context evidence too. The collector now also expands a directory
+  `InputSpec.headers` entry the same way `service.resolve_input` does
+  before scanning it for `#ifdef`-guarded fields, matching
+  `perform_elf_dump`'s own behavior — without this, the common
+  directory-`-H` input case left `conditional_fields` silently empty even
+  though the headers under it were genuinely parsed. The collector is now
+  also restricted to a real ELF snapshot (`snap.elf is not None`, checked
+  post-resolution rather than the pre-resolution `fmt` value — a GNU ld
+  linker script's `fmt` reads as `None` before `resolve_input` follows it
+  to its real ELF target), matching the established ELF-only scope of the
+  ADR-039 collector (a PE/Mach-O typed dump/compare no longer silently
+  disagrees with the native PE/Mach-O dump path, which never calls this
+  collector). `InputSpec` deliberately does **not** gain a
+  `compile_db_filter` field mirroring `--compile-db-filter` (an earlier
+  version of this change added one, and Codex review found it had no
+  successful execution path where it narrowed anything: this shared
   pipeline's own L2 header-AST context always resolves from the whole,
-  unfiltered database regardless of collect mode, so a filtered ADR-039
-  view would disagree with what informed the actual header parse even for
-  a headers-only, no-L3-embed request.
+  unfiltered compile database regardless of collect mode, so the field
+  could only ever be combined with a resolvable database by raising, never
+  by actually narrowing the collector's scan) — a real implementation needs
+  the filter threaded into the shared L2 fold itself, left as a documented
+  gap for a future, separate change.
 

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -1272,11 +1272,20 @@ pipelines a fourth time.
   > against. Not attempted here. Blockers 5 and 6 are unchanged.
   >
   > **Blocker 4 closed for the shared pipeline (2026-08-20).** The "new
-  > typed-API surface" this note called for is now real:
-  > `InputSpec.compile_db_filter` (mirrors `--compile-db-filter`) plus a call
-  > to the ADR-039 collector inside `_resolve_side_snapshot_impl`, gated
-  > exactly the way `perform_elf_dump` gates its own call (a compile-DB path
-  > resolvable from `side.build_info`, real headers, `snap.from_headers`).
+  > typed-API surface" this note called for is now real: a call to the
+  > ADR-039 collector inside `_resolve_side_snapshot_impl`, gated exactly the
+  > way `perform_elf_dump` gates its own call (a compile-DB path resolvable
+  > from `side.build_info`, real headers, `snap.from_headers`).
+  > `InputSpec` deliberately does **not** gain a `compile_db_filter` field
+  > mirroring `--compile-db-filter` — an earlier revision of this change
+  > added one, and Codex review found it had no successful execution path
+  > where it narrowed anything (this shared pipeline's own L2 header-AST
+  > context always resolves from the whole, unfiltered compile database
+  > regardless of collect mode, so the field could only ever be combined
+  > with a resolvable database by raising, never by actually narrowing the
+  > collector's scan); removed rather than half-implemented — see the field's
+  > replacement comment in `api_types.py` for why threading the filter
+  > through is a separate, larger feature.
   > `attach_build_context`/`user_define_flags`/`compile_db_from_build_info`
   > moved from `cli_dump_helpers.py` (CLI-presentation layer, not importable
   > from a service module) to `header_conditionals.py` — already a
@@ -1293,15 +1302,48 @@ pipelines a fourth time.
   > `run_dump_request` API can now reach the collector too), not blocker 5
   > (making `dump_cmd` build a real `DumpRequest` in the first place, which
   > is what would let the real ELF `dump` CLI path route through here).
-  > Verified with four new direct tests on `_resolve_side_snapshot_impl`
+  > Verified with direct tests on `_resolve_side_snapshot_impl`
   > (`tests/test_typed_dump_request.py::
   > TestSharedPipelineReachesADR039BuildContextCollector`) — collector fires
   > and populates `build_context_defines`/`conditional_fields`; folded/
-  > derived tokens never reach `extra_flags`; `compile_db_filter` is honored;
-  > the collector is skipped (not raised) with no `build_info` at all — each
-  > confirmed to fail against the pre-fix code (no `attach_build_context`
-  > attribute on the module). Full fast unit suite green, `mypy abicheck/`
-  > clean, `ruff check` clean.
+  > derived tokens never reach `extra_flags`; the collector is skipped (not
+  > raised) with no `build_info` at all — each confirmed to fail against the
+  > pre-fix code (no `attach_build_context` attribute on the module). Full
+  > fast unit suite green, `mypy abicheck/` clean, `ruff check` clean.
+  >
+  > **Three more Codex-review rounds on this same change (2026-08-20),
+  > each confirmed and fixed, none requiring a design change.** (1) A PE/
+  > Mach-O typed dump/compare with headers + a compile-database `build_info`
+  > silently attached ELF-only ADR-039 evidence — gated the whole block on
+  > `fmt == "elf"` too. (2) A followed GNU ld linker script (`fmt` reads
+  > `None` pre-resolution, `resolve_input`'s own `follow_linker_scripts`
+  > default follows it to a real ELF target) silently skipped the collector
+  > — regated on `snap.elf is not None`, the model's own post-resolution
+  > signal, instead of the stale pre-resolution `fmt`. (3) `snap.elf is not
+  > None` alone proved insufficient on its own: a *loaded* JSON snapshot
+  > (`resolve_input`'s `fmt == "json"` branch, `load_snapshot(path)`
+  > verbatim, no live parse) round-trips its original `elf`/`from_headers`
+  > fields exactly as saved, so the identical signal fires for a side that
+  > never touched the header parser at all — running the collector there
+  > would scan the *current* filesystem's headers/compile-db and overwrite
+  > the loaded snapshot's own recorded build-context evidence with
+  > unrelated data. Fixed by also requiring
+  > `service.sniff_text_format(side.path) != "json"` (the exact predicate
+  > `resolve_input` itself uses to take that branch, so the two can't
+  > disagree). Each of the three confirmed to fail against the pre-fix code
+  > via a dedicated regression test in the same test class.
+  >
+  > **A separate, unrelated Codex finding on `cli_dump_helpers.py`'s own
+  > re-export of the moved helpers, also fixed the same round.**
+  > `compile_db_from_build_info`/`compile_db_filter_scope_error` (re-exported
+  > only for `cli.py`/test back-compat, never called internally by this
+  > module) now go through the lazy module-level `__getattr__` shim this
+  > repo's own moved-helper convention requires, mirroring
+  > `cli_buildsource.py`'s identical shim.  `_attach_build_context`/
+  > `_user_define_flags` stay a normal static import, since `perform_elf_dump`
+  > calls them directly — that edge to `header_conditionals.py` (a verified
+  > true leaf module) is structurally required either way, so it isn't the
+  > pattern the convention targets.
   >
   > **The `scan_engine._build_new_snapshot` `allow_build_query` gating
   > "unreconciled" framing (this section's own opening paragraph, and PR

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -1270,6 +1270,68 @@ pipelines a fourth time.
   > "must not be unioned snapshot-wide" invariant (AGENTS.md's L3→L2-fold
   > entry, ninth finding) that any new call site would have to re-verify
   > against. Not attempted here. Blockers 5 and 6 are unchanged.
+  >
+  > **Blocker 4 closed for the shared pipeline (2026-08-20).** The "new
+  > typed-API surface" this note called for is now real:
+  > `InputSpec.compile_db_filter` (mirrors `--compile-db-filter`) plus a call
+  > to the ADR-039 collector inside `_resolve_side_snapshot_impl`, gated
+  > exactly the way `perform_elf_dump` gates its own call (a compile-DB path
+  > resolvable from `side.build_info`, real headers, `snap.from_headers`).
+  > `attach_build_context`/`user_define_flags`/`compile_db_from_build_info`
+  > moved from `cli_dump_helpers.py` (CLI-presentation layer, not importable
+  > from a service module) to `header_conditionals.py` — already a
+  > dependency-free leaf module and the collector's own home — with
+  > `cli_dump_helpers.py` keeping the original private names as thin
+  > re-exports, so `perform_elf_dump` and every existing test are unchanged.
+  > The "must not be unioned snapshot-wide" invariant is preserved the same
+  > way `perform_elf_dump` preserves it: only `side.compile` (this side's
+  > pre-fold, caller-supplied `CompileContext`) feeds the collector's
+  > `extra_flags`, never `compile_ctx` (the P0.3-folded result also computed
+  > in this function). `perform_elf_dump` itself is **not** migrated to call
+  > through this shared path — it keeps its own direct call — so this closes
+  > the *capability* gap (compare's implicit-dump operand and `dump`'s typed
+  > `run_dump_request` API can now reach the collector too), not blocker 5
+  > (making `dump_cmd` build a real `DumpRequest` in the first place, which
+  > is what would let the real ELF `dump` CLI path route through here).
+  > Verified with four new direct tests on `_resolve_side_snapshot_impl`
+  > (`tests/test_typed_dump_request.py::
+  > TestSharedPipelineReachesADR039BuildContextCollector`) — collector fires
+  > and populates `build_context_defines`/`conditional_fields`; folded/
+  > derived tokens never reach `extra_flags`; `compile_db_filter` is honored;
+  > the collector is skipped (not raised) with no `build_info` at all — each
+  > confirmed to fail against the pre-fix code (no `attach_build_context`
+  > attribute on the module). Full fast unit suite green, `mypy abicheck/`
+  > clean, `ruff check` clean.
+  >
+  > **The `scan_engine._build_new_snapshot` `allow_build_query` gating
+  > "unreconciled" framing (this section's own opening paragraph, and PR
+  > 3A's summary in "Ordering") is investigated and found to be a
+  > non-issue, not left open.** Tracing `build_config`'s origin
+  > (`run_scan_core` → `cli_scan_helpers.resolve_effective_allow_query`)
+  > shows its docstring already states the trust rule: *"Trusted = an
+  > explicit --config path (build_config is not None here; an
+  > auto-discovered source-tree config is resolved later in
+  > embed_build_source and never reaches this gate)"* — by the time
+  > `build_config` reaches `_build_new_snapshot`, its mere presence already
+  > encodes the trust decision, matching `_resolve_l2_seed_pack_args`'s own
+  > internal rule (`build_config_trusted_for_query=(build_config is not
+  > None or build_query is not None)`). Passing it ungated to the seed call
+  > is therefore correct, not drift; applying `_gated_build_query_inputs`-
+  > style re-gating on top would be a **regression** — `effective_allow_
+  > query` can be `False` for reasons unrelated to trust (e.g.
+  > `collect_mode == "off"`), which would wrongly suppress an
+  > already-vetted `--config`'s `build.query` from reaching the seed.
+  > `build_query`/`build_compile_db` being hardcoded `None`/`None` in the
+  > same call is confirmed fully dead code today (`scan` has no
+  > `--build-query`/`--build-compile-db` CLI flags, `run_scan_core` has no
+  > such parameters, and `_build_new_snapshot`'s one call site never passes
+  > non-default values) — adding live parameters/gating for a capability
+  > nothing can reach yet would be speculative, untested plumbing, not a
+  > fix for an observed defect. Not implemented; recorded as investigated
+  > and closed rather than left as an open reconciliation item. A future
+  > `scan --build-query` flag, if ever added, needs its own trust-gate
+  > design at that point (mirroring `dump`'s), not a preemptive parameter
+  > added now.
   Two #782 follow-ups that change the *parsed public surface*, not just
   performance, so they belong before the model is called finished: (1)
   compile-unit matching — the L2 include-dir seed is still gathered from

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -146,7 +146,6 @@ One side of a comparison: a binary/snapshot path plus its build context.
 | `compile` | `CompileContext \| None` | `None` |
 | `public_header_dirs` | `tuple[Path, ...]` | `()` |
 | `follow_linker_scripts` | `bool` | `True` |
-| `compile_db_filter` | `str \| None` | `None` |
 
 ## `LayerResult`
 

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -146,6 +146,7 @@ One side of a comparison: a binary/snapshot path plus its build context.
 | `compile` | `CompileContext \| None` | `None` |
 | `public_header_dirs` | `tuple[Path, ...]` | `()` |
 | `follow_linker_scripts` | `bool` | `True` |
+| `compile_db_filter` | `str \| None` | `None` |
 
 ## `LayerResult`
 

--- a/tests/test_typed_dump_request.py
+++ b/tests/test_typed_dump_request.py
@@ -1735,27 +1735,18 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
         assert called["attach"] is False
         assert resolution.snapshot.build_context_defines == set()
 
-    @pytest.mark.parametrize("collect_mode", ["off", "build"])
-    def test_compile_db_filter_with_resolvable_db_raises(
-        self, monkeypatch, tmp_path: Path, collect_mode: str
+    def test_collector_never_receives_a_source_filter(
+        self, monkeypatch, tmp_path: Path
     ) -> None:
-        """Codex review, PR #809 (two rounds). Round 1: combining
-        ``InputSpec.compile_db_filter`` with a compile-database
-        ``build_info`` at a non-"off" collect mode must be refused, the same
-        way the native ``dump`` CLI refuses it via
-        ``compile_db_filter_scope_error`` -- otherwise the ADR-039 collector
-        scopes to the filtered subset while the L3 embed reads the whole,
-        unfiltered database. Round 2: unlike the native CLI, this shared
-        pipeline's own L2 context (``_seeded_includes_and_compile_context``,
-        the P0.3 fold) has no filter concept at all and always resolves from
-        the whole database *regardless of collect_mode* -- so exempting
-        ``collect_mode == "off"`` (mirroring the CLI's own condition, which
-        is only safe there because the CLI threads the filter into its L2
-        context a different way) would leave the identical inconsistency
-        for a headers-only, no-L3-embed request. Parametrized over both
-        values to pin that the rejection is unconditional here."""
+        """``InputSpec`` deliberately has no ``compile_db_filter`` field
+        (Codex review, PR #809, fresh evidence: an earlier version of this
+        field always raised whenever combined with a resolvable compile
+        database, so it had no successful execution path where it narrowed
+        anything -- see ``InputSpec``'s own comment). Pin that the shared
+        pipeline always calls the ADR-039 collector with the default,
+        unfiltered ``source_filter=None`` for a real compile database +
+        headers, rather than raising or narrowing."""
         from abicheck import service, service_input_resolution as sir
-        from abicheck.errors import ValidationError
         from abicheck.service_compare_evidence import SideEvidence
 
         hdr = tmp_path / "widget.h"
@@ -1772,25 +1763,26 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
             ),
         )
 
-        side = InputSpec(
-            path=tmp_path / "lib.so",
-            headers=(hdr,),
-            build_info=db,
-            compile_db_filter="*/widget.cpp",
-        )
+        captured: dict[str, object] = {}
+        real_attach = sir.attach_build_context
+
+        def _spy_attach(snap, compile_db_arg, headers, extra_flags, **kw):
+            captured["source_filter"] = kw.get("source_filter")
+            return real_attach(snap, compile_db_arg, headers, extra_flags, **kw)
+
+        monkeypatch.setattr(sir, "attach_build_context", _spy_attach)
+
+        side = InputSpec(path=tmp_path / "lib.so", headers=(hdr,), build_info=db)
         evidence = SideEvidence(
-            headers=[hdr],
-            compile=None,
-            collect_mode=collect_mode,
-            dump_manifest=None,
+            headers=[hdr], compile=None, collect_mode="off", dump_manifest=None
         )
-        with pytest.raises(ValidationError, match="compile_db_filter"):
-            sir._resolve_side_snapshot_impl(
-                side,
-                evidence,
-                lang="c++",
-                header_backend="auto",
-                fmt="elf",
-                public_headers=[hdr],
-                public_header_dirs=[],
-            )
+        sir._resolve_side_snapshot_impl(
+            side,
+            evidence,
+            lang="c++",
+            header_backend="auto",
+            fmt="elf",
+            public_headers=[hdr],
+            public_header_dirs=[],
+        )
+        assert captured["source_filter"] is None

--- a/tests/test_typed_dump_request.py
+++ b/tests/test_typed_dump_request.py
@@ -22,6 +22,7 @@ import pytest
 
 from abicheck.api_types import CompareRequest, DumpRequest, InputSpec
 from abicheck.compile_context import CompileContext
+from abicheck.elf_metadata import ElfMetadata
 from abicheck.errors import SnapshotError, ValidationError
 from abicheck.model import AbiSnapshot, Function
 from abicheck.serialization import snapshot_to_json
@@ -1445,7 +1446,9 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
         monkeypatch.setattr(
             service,
             "resolve_input",
-            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+            lambda *a, **k: AbiSnapshot(
+                library="lib", version="1", from_headers=True, elf=ElfMetadata()
+            ),
         )
 
         side = InputSpec(path=tmp_path / "lib.so", headers=(hdr,), build_info=db)
@@ -1464,6 +1467,62 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
         assert "GUARD" in resolution.snapshot.build_context_defines
         assert "Widget" in resolution.snapshot.conditional_fields
         assert "guarded" in resolution.snapshot.conditional_fields["Widget"]
+
+    def test_collector_runs_for_a_followed_linker_script_even_when_fmt_is_none(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Codex review, PR #809, fresh evidence: `fmt` is computed by the
+        caller from `service.detect_binary_format(side.path)` *before*
+        `service.resolve_input()` runs -- a GNU ld linker script (the
+        conventional development `libfoo.so` symlink, e.g.
+        `INPUT(libfoo.so.1)`) reads as `None` there, but `resolve_input`'s
+        own `follow_linker_scripts=True` default follows it to a real ELF
+        target and returns a genuine ELF snapshot. Gating on the stale
+        `fmt` (rather than the post-resolution `snap.elf`) would silently
+        skip the collector for this common ELF input form -- reproduced
+        here by passing `fmt=None` (what the caller would have computed
+        for the raw linker-script text) while the resolved snapshot is a
+        real ELF one."""
+        from abicheck import service, service_input_resolution as sir
+        from abicheck.service_compare_evidence import SideEvidence
+
+        hdr = tmp_path / "widget.h"
+        hdr.write_text(
+            "struct Widget {\n"
+            "  int x;\n"
+            "#ifdef GUARD\n"
+            "  int guarded;\n"
+            "#endif\n"
+            "};\n",
+            encoding="utf-8",
+        )
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        db = self._compile_db(tmp_path, src, "-DGUARD=1")
+
+        monkeypatch.setattr(
+            service,
+            "resolve_input",
+            lambda *a, **k: AbiSnapshot(
+                library="lib", version="1", from_headers=True, elf=ElfMetadata()
+            ),
+        )
+
+        side = InputSpec(path=tmp_path / "lib.so", headers=(hdr,), build_info=db)
+        evidence = SideEvidence(
+            headers=[hdr], compile=None, collect_mode="off", dump_manifest=None
+        )
+        resolution = sir._resolve_side_snapshot_impl(
+            side,
+            evidence,
+            lang="c++",
+            header_backend="auto",
+            fmt=None,
+            public_headers=[hdr],
+            public_header_dirs=[],
+        )
+        assert "GUARD" in resolution.snapshot.build_context_defines
+        assert "Widget" in resolution.snapshot.conditional_fields
 
     def test_collector_expands_a_header_directory_before_scanning(
         self, monkeypatch, tmp_path: Path
@@ -1497,7 +1556,9 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
         monkeypatch.setattr(
             service,
             "resolve_input",
-            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+            lambda *a, **k: AbiSnapshot(
+                library="lib", version="1", from_headers=True, elf=ElfMetadata()
+            ),
         )
 
         side = InputSpec(
@@ -1541,7 +1602,9 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
         monkeypatch.setattr(
             service,
             "resolve_input",
-            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+            lambda *a, **k: AbiSnapshot(
+                library="lib", version="1", from_headers=True, elf=ElfMetadata()
+            ),
         )
         # Simulate the L3->L2 fold resolving a CompileContext carrying the
         # database's own -DL3ONLY=1 -- this must never reach the collector.
@@ -1586,53 +1649,6 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
         assert captured["extra_flags"] == ["-DUSERONLY=1"]
         assert "-DL3ONLY=1" not in captured["extra_flags"]
 
-    def test_collector_honors_compile_db_filter(
-        self, monkeypatch, tmp_path: Path
-    ) -> None:
-        from abicheck import service, service_input_resolution as sir
-        from abicheck.service_compare_evidence import SideEvidence
-
-        hdr = tmp_path / "widget.h"
-        hdr.write_text("struct Widget { int x; };\n", encoding="utf-8")
-        src = tmp_path / "widget.cpp"
-        src.write_text('#include "widget.h"\n', encoding="utf-8")
-        db = self._compile_db(tmp_path, src, "-DGUARD=1")
-
-        monkeypatch.setattr(
-            service,
-            "resolve_input",
-            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
-        )
-
-        captured: dict[str, object] = {}
-        real_attach = sir.attach_build_context
-
-        def _spy_attach(snap, compile_db_arg, headers, extra_flags, **kw):
-            captured["source_filter"] = kw.get("source_filter")
-            return real_attach(snap, compile_db_arg, headers, extra_flags, **kw)
-
-        monkeypatch.setattr(sir, "attach_build_context", _spy_attach)
-
-        side = InputSpec(
-            path=tmp_path / "lib.so",
-            headers=(hdr,),
-            build_info=db,
-            compile_db_filter="*/widget.cpp",
-        )
-        evidence = SideEvidence(
-            headers=[hdr], compile=None, collect_mode="off", dump_manifest=None
-        )
-        sir._resolve_side_snapshot_impl(
-            side,
-            evidence,
-            lang="c++",
-            header_backend="auto",
-            fmt="elf",
-            public_headers=[hdr],
-            public_header_dirs=[],
-        )
-        assert captured["source_filter"] == "*/widget.cpp"
-
     def test_collector_skipped_when_no_compile_db_resolvable(
         self, monkeypatch, tmp_path: Path
     ) -> None:
@@ -1647,7 +1663,9 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
         monkeypatch.setattr(
             service,
             "resolve_input",
-            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+            lambda *a, **k: AbiSnapshot(
+                library="lib", version="1", from_headers=True, elf=ElfMetadata()
+            ),
         )
         called = {"attach": False}
 
@@ -1717,16 +1735,25 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
         assert called["attach"] is False
         assert resolution.snapshot.build_context_defines == set()
 
-    def test_compile_db_filter_with_l3_embed_raises(
-        self, monkeypatch, tmp_path: Path
+    @pytest.mark.parametrize("collect_mode", ["off", "build"])
+    def test_compile_db_filter_with_resolvable_db_raises(
+        self, monkeypatch, tmp_path: Path, collect_mode: str
     ) -> None:
-        """Codex review, PR #809: combining ``InputSpec.compile_db_filter``
-        with a compile-database ``build_info`` at a non-"off" collect mode
-        must be refused, the same way the native ``dump`` CLI refuses it via
+        """Codex review, PR #809 (two rounds). Round 1: combining
+        ``InputSpec.compile_db_filter`` with a compile-database
+        ``build_info`` at a non-"off" collect mode must be refused, the same
+        way the native ``dump`` CLI refuses it via
         ``compile_db_filter_scope_error`` -- otherwise the ADR-039 collector
-        would scope to the filtered subset while the L3 embed below reads
-        the whole, unfiltered database, producing a snapshot whose layers
-        cover different translation units."""
+        scopes to the filtered subset while the L3 embed reads the whole,
+        unfiltered database. Round 2: unlike the native CLI, this shared
+        pipeline's own L2 context (``_seeded_includes_and_compile_context``,
+        the P0.3 fold) has no filter concept at all and always resolves from
+        the whole database *regardless of collect_mode* -- so exempting
+        ``collect_mode == "off"`` (mirroring the CLI's own condition, which
+        is only safe there because the CLI threads the filter into its L2
+        context a different way) would leave the identical inconsistency
+        for a headers-only, no-L3-embed request. Parametrized over both
+        values to pin that the rejection is unconditional here."""
         from abicheck import service, service_input_resolution as sir
         from abicheck.errors import ValidationError
         from abicheck.service_compare_evidence import SideEvidence
@@ -1740,7 +1767,9 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
         monkeypatch.setattr(
             service,
             "resolve_input",
-            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+            lambda *a, **k: AbiSnapshot(
+                library="lib", version="1", from_headers=True, elf=ElfMetadata()
+            ),
         )
 
         side = InputSpec(
@@ -1750,9 +1779,12 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
             compile_db_filter="*/widget.cpp",
         )
         evidence = SideEvidence(
-            headers=[hdr], compile=None, collect_mode="build", dump_manifest=None
+            headers=[hdr],
+            compile=None,
+            collect_mode=collect_mode,
+            dump_manifest=None,
         )
-        with pytest.raises(ValidationError, match="compile-db-filter"):
+        with pytest.raises(ValidationError, match="compile_db_filter"):
             sir._resolve_side_snapshot_impl(
                 side,
                 evidence,

--- a/tests/test_typed_dump_request.py
+++ b/tests/test_typed_dump_request.py
@@ -1465,6 +1465,60 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
         assert "Widget" in resolution.snapshot.conditional_fields
         assert "guarded" in resolution.snapshot.conditional_fields["Widget"]
 
+    def test_collector_expands_a_header_directory_before_scanning(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Codex review, PR #809: ``InputSpec.headers`` may name a directory
+        (``service.resolve_input``/``_dump_elf`` expand it internally via
+        ``expand_header_inputs`` before parsing) -- the collector must scan
+        the same expanded file set, not the raw, unexpanded directory entry
+        (``Path(dir).read_text()`` raises ``OSError``, silently caught and
+        skipped by ``collect_build_context``, leaving ``conditional_fields``
+        empty for the common directory-``-H`` case)."""
+        from abicheck import service, service_input_resolution as sir
+        from abicheck.service_compare_evidence import SideEvidence
+
+        include_dir = tmp_path / "include"
+        include_dir.mkdir()
+        hdr = include_dir / "widget.h"
+        hdr.write_text(
+            "struct Widget {\n"
+            "  int x;\n"
+            "#ifdef GUARD\n"
+            "  int guarded;\n"
+            "#endif\n"
+            "};\n",
+            encoding="utf-8",
+        )
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        db = self._compile_db(tmp_path, src, "-DGUARD=1")
+
+        monkeypatch.setattr(
+            service,
+            "resolve_input",
+            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+        )
+
+        side = InputSpec(
+            path=tmp_path / "lib.so", headers=(include_dir,), build_info=db
+        )
+        evidence = SideEvidence(
+            headers=[include_dir], compile=None, collect_mode="off", dump_manifest=None
+        )
+        resolution = sir._resolve_side_snapshot_impl(
+            side,
+            evidence,
+            lang="c++",
+            header_backend="auto",
+            fmt="elf",
+            public_headers=[include_dir],
+            public_header_dirs=[],
+        )
+        assert "GUARD" in resolution.snapshot.build_context_defines
+        assert "Widget" in resolution.snapshot.conditional_fields
+        assert "guarded" in resolution.snapshot.conditional_fields["Widget"]
+
     def test_collector_never_sees_folded_derived_tokens_only_pre_fold_explicit(
         self, monkeypatch, tmp_path: Path
     ) -> None:

--- a/tests/test_typed_dump_request.py
+++ b/tests/test_typed_dump_request.py
@@ -1786,3 +1786,58 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
             public_header_dirs=[],
         )
         assert captured["source_filter"] is None
+
+    def test_collector_skipped_for_a_loaded_json_snapshot(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Codex review, PR #809, fresh evidence: ``snap.elf is not None``
+        alone doesn't prove a live ELF parse happened -- a *loaded* JSON
+        snapshot (``resolve_input``'s own ``fmt == "json"`` branch, which
+        returns ``load_snapshot(path)`` verbatim with no parse at all) round
+        -trips its original ``elf``/``from_headers`` fields exactly as saved,
+        so the identical signal fires. Running the collector there would
+        scan the *current* filesystem's headers/compile-db and overwrite the
+        loaded snapshot's own recorded build-context evidence with
+        unrelated data -- ``side.path`` here is a JSON file, not an ELF
+        binary or a followed linker script, so the collector must not run."""
+        from abicheck import service, service_input_resolution as sir
+        from abicheck.service_compare_evidence import SideEvidence
+
+        hdr = tmp_path / "widget.h"
+        hdr.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        db = self._compile_db(tmp_path, src, "-DGUARD=1")
+
+        snapshot_path = tmp_path / "baseline.abicheck.json"
+        snapshot_path.write_text('{"schema_version": 25}\n', encoding="utf-8")
+
+        monkeypatch.setattr(
+            service,
+            "resolve_input",
+            lambda *a, **k: AbiSnapshot(
+                library="lib", version="1", from_headers=True, elf=ElfMetadata()
+            ),
+        )
+        called = {"attach": False}
+
+        def _spy_attach(*a, **k):
+            called["attach"] = True
+
+        monkeypatch.setattr(sir, "attach_build_context", _spy_attach)
+
+        side = InputSpec(path=snapshot_path, headers=(hdr,), build_info=db)
+        evidence = SideEvidence(
+            headers=[hdr], compile=None, collect_mode="off", dump_manifest=None
+        )
+        resolution = sir._resolve_side_snapshot_impl(
+            side,
+            evidence,
+            lang="c++",
+            header_backend="auto",
+            fmt=None,
+            public_headers=[hdr],
+            public_header_dirs=[],
+        )
+        assert called["attach"] is False
+        assert resolution.snapshot.build_context_defines == set()

--- a/tests/test_typed_dump_request.py
+++ b/tests/test_typed_dump_request.py
@@ -1385,3 +1385,235 @@ def test_resolve_side_snapshot_impl_forwards_gated_build_inputs_to_embed(
     assert embed_captured["build_config"] is None
     assert embed_captured["build_query"] is None
     assert embed_captured["build_compile_db"] == "build/compile_commands.json"
+
+
+class TestSharedPipelineReachesADR039BuildContextCollector:
+    """PR C (CLI cleanup phase two, typed dump/scan convergence): the ADR-039
+    build-context collector (``header_conditionals.attach_build_context``)
+    used to be reachable only from the ELF ``dump`` CLI's own
+    ``perform_elf_dump`` (one call site). ``_resolve_side_snapshot_impl`` --
+    shared by ``compare``'s implicit-dump operand and ``dump``'s typed
+    ``run_dump_request`` API -- now reaches the identical collector. These
+    tests exercise the real collector (not mocked), only ``service.
+    resolve_input`` is stubbed to avoid a real castxml/clang invocation."""
+
+    def _compile_db(self, tmp_path: Path, src: Path, *extra_flags: str) -> Path:
+        import json
+
+        db = tmp_path / "compile_commands.json"
+        db.write_text(
+            json.dumps(
+                [
+                    {
+                        "directory": str(tmp_path),
+                        "file": str(src),
+                        "arguments": [
+                            "c++",
+                            "-c",
+                            str(src),
+                            "-o",
+                            "out.o",
+                            *extra_flags,
+                        ],
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+        return db
+
+    def test_collector_populates_defines_and_conditional_fields(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        from abicheck import service, service_input_resolution as sir
+        from abicheck.service_compare_evidence import SideEvidence
+
+        hdr = tmp_path / "widget.h"
+        hdr.write_text(
+            "struct Widget {\n"
+            "  int x;\n"
+            "#ifdef GUARD\n"
+            "  int guarded;\n"
+            "#endif\n"
+            "};\n",
+            encoding="utf-8",
+        )
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        db = self._compile_db(tmp_path, src, "-DGUARD=1")
+
+        monkeypatch.setattr(
+            service,
+            "resolve_input",
+            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+        )
+
+        side = InputSpec(path=tmp_path / "lib.so", headers=(hdr,), build_info=db)
+        evidence = SideEvidence(
+            headers=[hdr], compile=None, collect_mode="off", dump_manifest=None
+        )
+        resolution = sir._resolve_side_snapshot_impl(
+            side,
+            evidence,
+            lang="c++",
+            header_backend="auto",
+            fmt="elf",
+            public_headers=[hdr],
+            public_header_dirs=[],
+        )
+        assert "GUARD" in resolution.snapshot.build_context_defines
+        assert "Widget" in resolution.snapshot.conditional_fields
+        assert "guarded" in resolution.snapshot.conditional_fields["Widget"]
+
+    def test_collector_never_sees_folded_derived_tokens_only_pre_fold_explicit(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Mirrors ``test_perform_elf_dump_keeps_l3_derived_flags_out_of_
+        build_context_collector`` (tests/test_non_elf_dump_l2_seed.py) for
+        the shared pipeline: the ADR-039 collector's ``extra_flags`` must be
+        this side's own pre-fold ``InputSpec.compile`` tokens only, never the
+        P0.3 L3->L2-folded ``CompileContext`` this function also resolves
+        internally -- else a build-derived define would be unioned
+        snapshot-wide (the ninth finding in AGENTS.md's L3->L2-fold entry)."""
+        from abicheck import service, service_input_resolution as sir
+        from abicheck.service_compare_evidence import SideEvidence
+
+        hdr = tmp_path / "widget.h"
+        hdr.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        db = self._compile_db(tmp_path, src, "-DL3ONLY=1")
+
+        monkeypatch.setattr(
+            service,
+            "resolve_input",
+            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+        )
+        # Simulate the L3->L2 fold resolving a CompileContext carrying the
+        # database's own -DL3ONLY=1 -- this must never reach the collector.
+        monkeypatch.setattr(
+            sir,
+            "_seeded_includes_and_compile_context",
+            lambda *a, **k: (
+                [],
+                CompileContext(gcc_option_tokens=("-DL3ONLY=1",)),
+                True,
+                [],
+            ),
+        )
+
+        captured: dict[str, object] = {}
+        real_attach = sir.attach_build_context
+
+        def _spy_attach(snap, compile_db_arg, headers, extra_flags, **kw):
+            captured["extra_flags"] = list(extra_flags)
+            return real_attach(snap, compile_db_arg, headers, extra_flags, **kw)
+
+        monkeypatch.setattr(sir, "attach_build_context", _spy_attach)
+
+        side = InputSpec(
+            path=tmp_path / "lib.so",
+            headers=(hdr,),
+            build_info=db,
+            compile=CompileContext(gcc_option_tokens=("-DUSERONLY=1",)),
+        )
+        evidence = SideEvidence(
+            headers=[hdr], compile=None, collect_mode="off", dump_manifest=None
+        )
+        sir._resolve_side_snapshot_impl(
+            side,
+            evidence,
+            lang="c++",
+            header_backend="auto",
+            fmt="elf",
+            public_headers=[hdr],
+            public_header_dirs=[],
+        )
+        assert captured["extra_flags"] == ["-DUSERONLY=1"]
+        assert "-DL3ONLY=1" not in captured["extra_flags"]
+
+    def test_collector_honors_compile_db_filter(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        from abicheck import service, service_input_resolution as sir
+        from abicheck.service_compare_evidence import SideEvidence
+
+        hdr = tmp_path / "widget.h"
+        hdr.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        db = self._compile_db(tmp_path, src, "-DGUARD=1")
+
+        monkeypatch.setattr(
+            service,
+            "resolve_input",
+            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+        )
+
+        captured: dict[str, object] = {}
+        real_attach = sir.attach_build_context
+
+        def _spy_attach(snap, compile_db_arg, headers, extra_flags, **kw):
+            captured["source_filter"] = kw.get("source_filter")
+            return real_attach(snap, compile_db_arg, headers, extra_flags, **kw)
+
+        monkeypatch.setattr(sir, "attach_build_context", _spy_attach)
+
+        side = InputSpec(
+            path=tmp_path / "lib.so",
+            headers=(hdr,),
+            build_info=db,
+            compile_db_filter="*/widget.cpp",
+        )
+        evidence = SideEvidence(
+            headers=[hdr], compile=None, collect_mode="off", dump_manifest=None
+        )
+        sir._resolve_side_snapshot_impl(
+            side,
+            evidence,
+            lang="c++",
+            header_backend="auto",
+            fmt="elf",
+            public_headers=[hdr],
+            public_header_dirs=[],
+        )
+        assert captured["source_filter"] == "*/widget.cpp"
+
+    def test_collector_skipped_when_no_compile_db_resolvable(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """No ``build_info`` at all: the collector must not run (and must not
+        raise) -- a plain context-free dump is still the common case."""
+        from abicheck import service, service_input_resolution as sir
+        from abicheck.service_compare_evidence import SideEvidence
+
+        hdr = tmp_path / "widget.h"
+        hdr.write_text("struct Widget { int x; };\n", encoding="utf-8")
+
+        monkeypatch.setattr(
+            service,
+            "resolve_input",
+            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+        )
+        called = {"attach": False}
+
+        def _spy_attach(*a, **k):
+            called["attach"] = True
+
+        monkeypatch.setattr(sir, "attach_build_context", _spy_attach)
+
+        side = InputSpec(path=tmp_path / "lib.so", headers=(hdr,))
+        evidence = SideEvidence(
+            headers=[hdr], compile=None, collect_mode="off", dump_manifest=None
+        )
+        resolution = sir._resolve_side_snapshot_impl(
+            side,
+            evidence,
+            lang="c++",
+            header_backend="auto",
+            fmt="elf",
+            public_headers=[hdr],
+            public_header_dirs=[],
+        )
+        assert called["attach"] is False
+        assert resolution.snapshot.build_context_defines == set()

--- a/tests/test_typed_dump_request.py
+++ b/tests/test_typed_dump_request.py
@@ -1671,3 +1671,94 @@ class TestSharedPipelineReachesADR039BuildContextCollector:
         )
         assert called["attach"] is False
         assert resolution.snapshot.build_context_defines == set()
+
+    def test_collector_skipped_for_a_non_elf_snapshot(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Codex review, PR #809: the ADR-039 collector is an established
+        ELF-only mechanism (``handle_non_elf_dump`` never calls it) -- the
+        shared pipeline must not attach build-context evidence to a PE/
+        Mach-O snapshot, or it would silently disagree with the native
+        PE/Mach-O dump path."""
+        from abicheck import service, service_input_resolution as sir
+        from abicheck.service_compare_evidence import SideEvidence
+
+        hdr = tmp_path / "widget.h"
+        hdr.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        db = self._compile_db(tmp_path, src, "-DGUARD=1")
+
+        monkeypatch.setattr(
+            service,
+            "resolve_input",
+            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+        )
+        called = {"attach": False}
+
+        def _spy_attach(*a, **k):
+            called["attach"] = True
+
+        monkeypatch.setattr(sir, "attach_build_context", _spy_attach)
+
+        side = InputSpec(path=tmp_path / "lib.dll", headers=(hdr,), build_info=db)
+        evidence = SideEvidence(
+            headers=[hdr], compile=None, collect_mode="off", dump_manifest=None
+        )
+        resolution = sir._resolve_side_snapshot_impl(
+            side,
+            evidence,
+            lang="c++",
+            header_backend="auto",
+            fmt="pe",
+            public_headers=[hdr],
+            public_header_dirs=[],
+        )
+        assert called["attach"] is False
+        assert resolution.snapshot.build_context_defines == set()
+
+    def test_compile_db_filter_with_l3_embed_raises(
+        self, monkeypatch, tmp_path: Path
+    ) -> None:
+        """Codex review, PR #809: combining ``InputSpec.compile_db_filter``
+        with a compile-database ``build_info`` at a non-"off" collect mode
+        must be refused, the same way the native ``dump`` CLI refuses it via
+        ``compile_db_filter_scope_error`` -- otherwise the ADR-039 collector
+        would scope to the filtered subset while the L3 embed below reads
+        the whole, unfiltered database, producing a snapshot whose layers
+        cover different translation units."""
+        from abicheck import service, service_input_resolution as sir
+        from abicheck.errors import ValidationError
+        from abicheck.service_compare_evidence import SideEvidence
+
+        hdr = tmp_path / "widget.h"
+        hdr.write_text("struct Widget { int x; };\n", encoding="utf-8")
+        src = tmp_path / "widget.cpp"
+        src.write_text('#include "widget.h"\n', encoding="utf-8")
+        db = self._compile_db(tmp_path, src, "-DGUARD=1")
+
+        monkeypatch.setattr(
+            service,
+            "resolve_input",
+            lambda *a, **k: AbiSnapshot(library="lib", version="1", from_headers=True),
+        )
+
+        side = InputSpec(
+            path=tmp_path / "lib.so",
+            headers=(hdr,),
+            build_info=db,
+            compile_db_filter="*/widget.cpp",
+        )
+        evidence = SideEvidence(
+            headers=[hdr], compile=None, collect_mode="build", dump_manifest=None
+        )
+        with pytest.raises(ValidationError, match="compile-db-filter"):
+            sir._resolve_side_snapshot_impl(
+                side,
+                evidence,
+                lang="c++",
+                header_backend="auto",
+                fmt="elf",
+                public_headers=[hdr],
+                public_header_dirs=[],
+            )


### PR DESCRIPTION
## Summary

Continues "PR C" (typed `dump`/`scan` convergence, `docs/contribute/plans/cli-cleanup-phase-two.md`): the ADR-039 build-context collector is now reachable from the shared typed input-resolution pipeline, not just the ELF `dump` CLI. Also investigates and closes (as a non-issue) the `scan_engine._build_new_snapshot` `allow_build_query` gating question the plan doc had flagged as open.

## Motivation

PR C names three remaining blockers to typed `dump`/`scan` convergence (which itself blocks PR F's `dump --build-query`/`--build-compile-db` removal). This PR closes one of them (the ADR-039 collector's missing hook) and resolves a second (the scan gating "gap") as investigated-and-correct-as-is, rather than a live defect.

## Changes

- `InputSpec` gains `compile_db_filter` (mirrors `--compile-db-filter`), so the typed API can narrow the ADR-039 collector's compile-DB scan the same way the CLI flag does.
- `attach_build_context`/`user_define_flags`/`compile_db_from_build_info`/`compile_db_filter_scope_error` moved from `cli_dump_helpers.py` (a CLI-presentation module a service module must not import) to `header_conditionals.py`, the dependency-free leaf module that already owns the collector's own logic. `cli_dump_helpers.py` keeps the original private names as thin re-exports — `perform_elf_dump` and every existing caller/test are unchanged.
- `service_input_resolution._resolve_side_snapshot_impl` (shared by `compare`'s implicit-dump operand and `dump`'s typed `run_dump_request` API) now calls the collector, gated identically to `perform_elf_dump`'s own call (resolvable compile-DB path, real parsed headers, `snap.from_headers`, and **`fmt == "elf"`** — the collector is an established ELF-only mechanism), and preserves the "must not be unioned snapshot-wide" invariant by feeding it only the caller's pre-fold `InputSpec.compile`, never the P0.3-folded result.
- A directory `InputSpec.headers` entry is expanded (best-effort, never raising) before the collector scans it, matching what `service.resolve_input` does internally for the primary parse.
- Combining `InputSpec.compile_db_filter` with a compile-database `build_info` at a non-`"off"` collect mode now raises `ValidationError` — the typed-API equivalent of the native `dump` CLI's own `compile_db_filter_scope_error` usage error.
- `perform_elf_dump` itself is **not** migrated onto the shared path in this PR — this closes the pipeline's capability gap only.
- Investigated `scan_engine._build_new_snapshot`'s `allow_build_query` gating (previously flagged in the plan doc as "unreconciled" with the shared primitive): tracing `build_config`'s origin shows its presence at that point already encodes the trust decision, so re-gating it would be a regression, not a fix; `build_query`/`build_compile_db` being hardcoded `None` there is confirmed dead code today (`scan` has no CLI flags for either). Recorded as investigated-and-closed in the plan doc rather than left open.
- Full status update in `docs/contribute/plans/cli-cleanup-phase-two.md`'s PR C section, naming exactly what's closed and what (blockers 5 and 6) remains open.
- Regenerated `docs/reference/python-api-reference.md` (drift from the new `InputSpec` field).

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: A shared resolution primitive (`_resolve_side_snapshot_impl`) gained a new call into logic (the ADR-039 collector) that was previously reachable only from one specific caller (`perform_elf_dump`, the ELF `dump` CLI). Three separate assumptions that held for that one caller — headers already expanded to real files, the snapshot always ELF, no filter/L3-embed scope mismatch — don't hold for the shared primitive's other callers (`compare`'s implicit-dump operand, `dump`'s typed API), and were not re-verified against them before this PR's earlier commits shipped.
- Publicly observable failure: (1) an implicit `compare`/typed `dump` whose side is a saved JSON snapshot with header paths that never exist on disk (a legitimate case — those headers are carried for provenance only) raised an unhandled `ValidationError` and aborted the whole comparison; (2) a PE/Mach-O typed dump/compare with headers and a compile-database `build_info` silently attached ELF-only ADR-039 build-context evidence, disagreeing with the native PE/Mach-O dump path and risking suppression of a real finding; (3) combining `InputSpec.compile_db_filter` with a compile-database `build_info` silently produced a snapshot whose ADR-039 collector scope and L3-embedded evidence covered different translation units, instead of the loud usage error the native `dump` CLI gives for the identical combination.
- Regression test fails on base: yes for all three — `test_collector_expands_a_header_directory_before_scanning`, `test_collector_skipped_for_a_non_elf_snapshot`, and `test_compile_db_filter_with_l3_embed_raises` were each individually confirmed (by reverting the corresponding source fix via `git stash` and re-running) to fail against the code as it stood immediately before its fix.
- Negative control: yes — the pre-existing sibling tests in the same class stay green throughout: `test_collector_populates_defines_and_conditional_fields` (ELF + file headers, the common case) and `test_collector_skipped_when_no_compile_db_resolvable` (no `build_info` at all) prove none of the three fixes suppressed the collector's correct-path behavior.
- Public-surface test: yes — every test calls `_resolve_side_snapshot_impl` directly, the real shared entry point both `compare`'s implicit-dump operand and `dump`'s typed `run_dump_request` API route through (not an isolated internal helper one layer down).
- Axes covered: `fmt` (elf vs. pe), header input shape (file vs. directory vs. nonexistent-on-disk), `compile_db_filter` (set vs. unset) crossed with `collect_mode` (off vs. build).
- General invariant: the ADR-039 collector's behavior reached through the shared pipeline now matches its established behavior reached through the native ELF `dump` CLI on every dimension this PR exercises (header expansion, ELF-only scope, filter/L3-embed scope consistency) — no new divergence between the two paths. Not yet migrated: `perform_elf_dump` itself still calls the collector directly rather than through this shared primitive (a separate, larger slice — see the plan doc's PR C status notes for what remains open).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (plan doc status notes, generated Python API reference)
- [x] `mypy abicheck/` clean, `ruff check` clean on touched files
- [x] Full fast unit suite green (28,877 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)