### PR TITLE
test: verify dump/scan L3 compile-context fold end to end

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2059,12 +2059,18 @@ Once a root command genuinely clears the bar above, pick the right home:
   `tests/test_dump_cli_typed_api_parity.py`'s
   `test_scan_against_real_dump_baseline_is_comparable` parametrizes over
   several real build-evidence shapes (plain, an added macro, this
-  extra-include-dir shape) and `xfail(strict=True)`s exactly the
-  known-divergent one — so a future fix that closes this gap turns the
-  xfail into an unexpected pass and fails loudly, forcing this note and
-  the test to be updated together, and a future regression that widens
-  the gap to a *previously-passing* shape fails immediately instead of
-  needing a third field report. The sibling
+  extra-include-dir shape). Rather than a bare `xfail(strict=True)` (three
+  Codex review rounds on this test found real gaps in cruder versions of
+  this idea — see the test module's own comments for the full history),
+  the known-divergent shape is checked against the *exact* diagnosed
+  failure signature (`NOT_COMPARABLE` naming `include_sequence`) before
+  being treated as expected via a conditional `pytest.xfail()`; anything
+  else for that shape — including the gap closing entirely — fails the
+  test outright, forcing this note and `_SCAN_KNOWN_DIVERGENT_SHAPES` to
+  be updated deliberately rather than the test quietly going green. A
+  future regression that widens the gap to a *previously-passing* shape
+  fails immediately too, since only the shape explicitly listed gets any
+  tolerance at all. The sibling
   `test_dump_cli_and_typed_api_agree_on_resolved_compile_context` in the
   same module separately pins the narrower invariant that *does* already
   hold across all three shapes today (`dump`'s CLI path and the typed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1984,6 +1984,42 @@ Once a root command genuinely clears the bar above, pick the right home:
   via `declared_includes` instead — same effective compiler argv, still a
   real `profile_fingerprint`/`include_sequence` disagreement.
 
+  **Re-verified end to end (2026-08-20) against the literal bug report this
+  whole entry was originally opened from** (a `dump --sources --build-info
+  --depth source` baseline compared against an unchanged codebase via
+  `scan --against`, reported carrying empty `ast_resolved_standard`/
+  `ast_compile_args` and failing as `NOT_COMPARABLE`): the reported
+  symptom does **not** reproduce on current `main` for a plain,
+  single-compilation-unit `compile_commands.json` (real `g++ -std=c++17`
+  build, real `clang` L2 frontend, no `-p`/`--compile-db` involved) — the
+  `dump` baseline's `ast_resolved_standard`/`ast_compile_args` are
+  correctly populated and the follow-up `scan --against` resolves
+  `NO_CHANGE`, not `NOT_COMPARABLE`. This confirms the accumulated fixes
+  above (the L3->L2 fold itself, the include-dir dedup fixes, the
+  class-sensitive dedup fix) already close the reported case for real —
+  the pinned commit the report was filed against
+  (`abicheck/abicheck@891bd9d7`) predates essentially all of them. Added
+  as a real, non-mocked end-to-end regression:
+  `tests/test_dump_scan_l3_comparability.py` (a real `g++`-compiled
+  library + `compile_commands.json`, driven through the actual `dump`/
+  `scan` CLI commands via `CliRunner`, not a stubbed `dump()` call the way
+  the existing unit coverage in `tests/test_cli_dump_helpers_coverage.py`
+  is) — closing the gap this entry's own earlier text noted between "the
+  mechanism is unit-tested" and "the reported end-to-end symptom is
+  verified gone." **The residual, narrower gap immediately above this
+  note — the legacy `-p`/`--compile-db` auto-match (`dump`-only) landing a
+  matched directory through a structurally different channel than the
+  P0.3 fold's own seeded `declared_includes`, reproduced against real
+  Bazel `aquery`/`cquery` evidence in `napetrov/abicheck-bazel-lab`'s own
+  PR #14 — is unaffected by this re-verification and remains genuinely
+  open** for a `--build-info` combined with an explicit `-p`/
+  `--compile-db`, or for real multi-target Bazel `aquery` graphs this
+  environment cannot reproduce (no live Bazel/castxml toolchain
+  available). A user hitting `NOT_COMPARABLE` after this date should
+  check first whether their invocation combines `-p`/`--compile-db` with
+  `--build-info`, or is a genuine multi-TU Bazel build — the plain,
+  single-compile-unit case this note re-verifies is not the culprit.
+
 - **`dump --lang c++` is silently discarded on the primary clang header-AST
   pass for a language-ambiguous header, diverging from `_attach_header_graph`'s
   own pass on the identical headers — investigated, not fixed (G31 Phase C

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2020,6 +2020,59 @@ Once a root command genuinely clears the bar above, pick the right home:
   `--build-info`, or is a genuine multi-TU Bazel build — the plain,
   single-compile-unit case this note re-verifies is not the culprit.
 
+  **Narrower still: the residual gap also reproduces without any Bazel
+  toolchain or `-p`/`--compile-db` at all — the minimal trigger is just
+  "the matched compile unit's own flags include an `-I<dir>` that is not
+  already in the caller's explicit `includes`" (2026-08-20, found while
+  adding generalized parity testing for this bug class, prompted by a
+  direct question — "how did we end up with two different behaviours,
+  and can this be caught generically?" — rather than by a new field
+  report).** A real `g++ -std=c++17 -I<dep-dir>` build, `--build-info` a
+  matching `compile_commands.json`, no `-p`/`--compile-db` anywhere:
+  `dump`'s own baseline JSON correctly carries `-I <dep-dir>` in
+  `ast_compile_args`, but its `contract.profile_fields.include_sequence`
+  reads `"[]"` — confirmed directly by inspecting the emitted JSON, not
+  inferred. Root cause, read from the code rather than guessed:
+  `dumper_contract._attach_extraction_contract` builds `declared_includes`
+  (the source `include_sequence` tokenizes) **exclusively** from
+  `extra_includes`, and for this shape the `-I<dep-dir>` reaches the
+  parse only through `gcc_option_tokens` (the L3->L2 fold's own derived
+  compile-unit include dirs), never through `extra_includes` — while
+  `scan_engine._build_new_snapshot`'s own candidate resolution (which
+  calls `service.resolve_input` directly, per this same entry's "PR C"
+  paragraphs below, rather than through the shared `resolve_side_snapshot`
+  primitive `compare`'s implicit-dump path and the typed `DumpRequest`
+  API both already use) seeds `eff_includes`/`declared_includes` for the
+  identical directory instead — two structurally different channels for
+  the same fact, exactly the shape this entry's own "third, deeper
+  mechanism" paragraph already names for the Bazel case, just reproduced
+  here without Bazel. Confirms `compare`'s implicit-dump path is
+  genuinely unaffected: comparing the same `dump` baseline against the
+  same live binary via `compare` (not `scan --against`) resolves cleanly
+  for this exact shape — the divergence is specifically between `dump`'s
+  CLI path and `scan`'s own candidate-resolution path, narrower than
+  "any comparison against a `dump` baseline." **Not fixed here** — same
+  reasoning as the Bazel-specific case above (a real design decision on
+  which of two established include-seeding channels should win, not a
+  drive-by patch) — but now has permanent, generalized regression
+  coverage rather than depending on a Bazel CI lab to notice it again:
+  `tests/test_dump_cli_typed_api_parity.py`'s
+  `test_scan_against_real_dump_baseline_is_comparable` parametrizes over
+  several real build-evidence shapes (plain, an added macro, this
+  extra-include-dir shape) and `xfail(strict=True)`s exactly the
+  known-divergent one — so a future fix that closes this gap turns the
+  xfail into an unexpected pass and fails loudly, forcing this note and
+  the test to be updated together, and a future regression that widens
+  the gap to a *previously-passing* shape fails immediately instead of
+  needing a third field report. The sibling
+  `test_dump_cli_and_typed_api_agree_on_resolved_compile_context` in the
+  same module separately pins the narrower invariant that *does* already
+  hold across all three shapes today (`dump`'s CLI path and the typed
+  `DumpRequest` API path agree on `ast_resolved_standard`/
+  `ast_compile_args`) — so a regression in *that* invariant, which is
+  what #810's original literal symptom was about, is caught independently
+  of the `include_sequence` gap this note documents.
+
 - **`dump --lang c++` is silently discarded on the primary clang header-AST
   pass for a language-ambiguous header, diverging from `_attach_header_graph`'s
   own pass on the identical headers — investigated, not fixed (G31 Phase C

--- a/tests/_dump_compile_args_normalize.py
+++ b/tests/_dump_compile_args_normalize.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """Shared helper: split a real ``AbiSnapshot.ast_compile_args`` sequence into
-its three semantically distinct pieces for equivalence comparison.
+its four semantically distinct pieces for equivalence comparison.
 
 Non-test-prefixed by convention (mirrors ``_strict_process.py``/
 ``_workflow_exec.py`` -- see ``tests/CLAUDE.md``'s "Helpers" section), so it
@@ -24,69 +24,129 @@ test that pins its normalization rules directly
 (``test_dump_compile_args_normalize.py``).
 
 Why a plain ``set(args) == set(args)`` comparison is wrong for this data
-(Codex review, two rounds): a real compiler's flag semantics are not
-uniformly order-insensitive.
+(Codex review, three rounds -- each one found a *different* flag family this
+module's previous "everything else is a set" default silently mishandled,
+which is the reason the default direction changed on the third round; see
+below):
 
-* **Macro-define/-undef flags** (``-D``/``-U``) and the dialect flag
-  (``-std=``) are *last-wins per name* -- ``-DFOO=1 -DFOO=2`` and
+* **Include-search flags** (``-I``/``-isystem``/``-iquote``/``-idirafter``)
+  are order- *and* multiplicity-sensitive: a real compiler resolves a
+  colliding header basename from the *first* matching directory in argv
+  order within each of these search buckets, so reordering (or
+  dropping-then-reintroducing) one relative to another can change which
+  file is actually parsed even though the same set of directories is
+  present overall.
+* **Macro-define/-undef flags** (``-D``/``-U``) and single-token,
+  last-wins-style flags (the dialect flag ``-std=``, the target triple
+  ``--target=``) are *last-wins* -- ``-DFOO=1 -DFOO=2`` and
   ``-DFOO=2 -DFOO=1`` are sets of identical tokens but different effective
   compiler states (the compiler sees ``FOO`` as ``2`` in the first case,
-  ``1`` in the second). A plain set comparison cannot distinguish these,
-  so it can pass two paths that would parse a real header under two
-  different macro/dialect states.
-* **Include-search flags** (``-I``/``-isystem``/``-iquote``/``-idirafter``)
-  are order- *and* multiplicity-sensitive for a different reason: a real
-  compiler resolves a colliding header basename from the *first* matching
-  directory in argv order within each of these search buckets, so
-  reordering (or dropping-then-reintroducing) one relative to another can
-  change which file is actually parsed even though the same set of
-  directories is present overall.
-* Every other flag (``-fPIC``, and similar boolean-style, non-value-taking
-  flags) genuinely has no meaningful order or repeat-count -- comparing
-  those as a plain set is the correct, not merely convenient, choice.
+  ``1`` in the second). A plain set comparison cannot distinguish these.
+* **Forced-include flags** (``-include``/``-imacros``) take a following
+  operand and are order-sensitive the same way include-search flags are:
+  each application can affect what a *later* one sees (an earlier
+  ``-include``'s macros are visible to a later one), so two paths naming
+  the same files in a different order are not equivalent.
+* A small, genuinely order- and repeat-count-insensitive family of
+  boolean-style flags (``-fPIC`` and the like) is the *only* case where a
+  plain set comparison is correct, not merely convenient.
+
+**The default direction matters more than any one flag's classification.**
+The first two review rounds each found one more flag family this module's
+"everything unrecognized is presence-only" default had silently
+mis-classified -- first include-search flags, then ``-D``/``-std``. A third
+round found the same shape again for ``--target=``/``-include``, which is
+what changed the *default* itself rather than adding a fourth special case:
+an unrecognized token is now compared as an exact, order- and
+multiplicity-preserving sequence entry by default (``ordered_unknown``), and
+only the small, explicitly-reviewed `ORDER_INSENSITIVE_BOOLEAN_FLAGS`
+allowlist gets the more permissive set comparison. A token this module does
+not recognize is far more likely to be order-sensitive (most compiler flags
+that take an operand are) than not, so "unknown -> compared strictly" is the
+safe default; "unknown -> compared loosely" is what let three consecutive
+review rounds find a real, silent gap.
 """
 
 from __future__ import annotations
 
 #: Flags that take a following, space-separated operand naming a search
-#: directory. Kept in this one place so both consumers agree on the
-#: vocabulary.
+#: directory. Order- and multiplicity-sensitive (first-match-wins search).
 INCLUDE_SEARCH_FLAGS = ("-I", "-isystem", "-iquote", "-idirafter")
+
+#: Flags that take a following, space-separated operand naming a file to
+#: force-include. Order-sensitive for a different reason than the search
+#: flags above (an earlier one's macros are visible to a later one), but
+#: grouped as the identical "ordered (flag, operand) pair" shape.
+FORCED_INCLUDE_FLAGS = ("-include", "-imacros")
+
+#: Single-token flags with real "later occurrence wins" semantics, keyed by
+#: their own literal prefix (there is only ever one effective value per
+#: prefix, unlike -D/-U which are keyed per macro name below).
+LAST_WINS_PREFIXES = ("-std=", "--target=")
+
+#: The only flags whose repetition/order this module treats as genuinely
+#: inert -- deliberately a narrow, explicitly-reviewed allowlist, not a
+#: default (see the module docstring's "default direction" paragraph for
+#: why a catch-all default was the actual bug across three review rounds).
+ORDER_INSENSITIVE_BOOLEAN_FLAGS = frozenset(
+    {"-fPIC", "-fpic", "-pthread", "-nostdinc", "-nostdinc++"}
+)
 
 
 def split_compile_args(
     args: tuple[str, ...],
-) -> tuple[dict[str, str], frozenset[str], tuple[tuple[str, str], ...]]:
-    """Split *args* into ``(last_wins_state, presence_only_flags, include_pairs)``.
+) -> tuple[
+    dict[str, str], frozenset[str], tuple[tuple[str, str], ...], tuple[str, ...]
+]:
+    """Split *args* into ``(last_wins_state, presence_only_flags,
+    ordered_pairs, ordered_unknown)``.
 
-    ``last_wins_state`` maps a normalized key (``"macro:<NAME>"`` for a
-    ``-D``/``-U`` flag naming ``<NAME>``, or the literal ``"dialect"`` for
-    ``-std=``) to the *last* raw token seen for that key, walking *args* in
-    order -- exactly mirroring a real compiler's last-flag-wins semantics
-    for these two flag families. ``presence_only_flags`` is every other
-    non-include-search token, compared as a plain set (order/repetition is
-    genuinely inert for these). ``include_pairs`` is the ordered,
-    duplicate-preserving sequence of ``(flag, directory)`` pairs for every
-    include-search flag -- see the module docstring for why this one alone
-    keeps both order and multiplicity.
+    ``last_wins_state`` maps a normalized key -- ``"macro:<NAME>"`` for a
+    ``-D``/``-U`` flag naming ``<NAME>``, or a flag's own literal prefix for
+    one of `LAST_WINS_PREFIXES` -- to the *last* raw token seen for that
+    key, walking *args* in order, mirroring a real compiler's last-wins
+    semantics. ``presence_only_flags`` is every token in
+    `ORDER_INSENSITIVE_BOOLEAN_FLAGS`, compared as a plain set.
+    ``ordered_pairs`` is the ordered, duplicate-preserving sequence of
+    ``(flag, operand)`` pairs for every include-search or forced-include
+    flag. ``ordered_unknown`` is every remaining, unrecognized token, kept
+    as an exact, order- and multiplicity-preserving sequence -- the safe
+    default for a flag this module has no specific rule for (see the
+    module docstring).
     """
     last_wins: dict[str, str] = {}
     presence_only: list[str] = []
-    include_pairs: list[tuple[str, str]] = []
+    ordered_pairs: list[tuple[str, str]] = []
+    ordered_unknown: list[str] = []
     i = 0
     n = len(args)
     while i < n:
         tok = args[i]
-        if tok in INCLUDE_SEARCH_FLAGS and i + 1 < n:
-            include_pairs.append((tok, args[i + 1]))
-            i += 2
+        if tok in INCLUDE_SEARCH_FLAGS or tok in FORCED_INCLUDE_FLAGS:
+            if i + 1 < n:
+                ordered_pairs.append((tok, args[i + 1]))
+                i += 2
+                continue
+            # A trailing flag with no operand is malformed input for this
+            # flag family -- fall through and record it verbatim rather
+            # than silently dropping it.
+            ordered_unknown.append(tok)
+            i += 1
             continue
         if tok.startswith(("-D", "-U")) and len(tok) > 2:
             macro_name = tok[2:].split("=", 1)[0]
             last_wins[f"macro:{macro_name}"] = tok
-        elif tok.startswith("-std="):
-            last_wins["dialect"] = tok
-        else:
+        elif tok.startswith(LAST_WINS_PREFIXES):
+            prefix = next(p for p in LAST_WINS_PREFIXES if tok.startswith(p))
+            last_wins[prefix] = tok
+        elif tok in ORDER_INSENSITIVE_BOOLEAN_FLAGS:
             presence_only.append(tok)
+        else:
+            ordered_unknown.append(tok)
         i += 1
-    return last_wins, frozenset(presence_only), tuple(include_pairs)
+    return (
+        last_wins,
+        frozenset(presence_only),
+        tuple(ordered_pairs),
+        tuple(ordered_unknown),
+    )

--- a/tests/_dump_compile_args_normalize.py
+++ b/tests/_dump_compile_args_normalize.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared helper: split a real ``AbiSnapshot.ast_compile_args`` sequence into
+its three semantically distinct pieces for equivalence comparison.
+
+Non-test-prefixed by convention (mirrors ``_strict_process.py``/
+``_workflow_exec.py`` -- see ``tests/CLAUDE.md``'s "Helpers" section), so it
+can be imported both by the real-compiler integration parity test
+(``test_dump_cli_typed_api_parity.py``) and by a fast, compiler-free unit
+test that pins its normalization rules directly
+(``test_dump_compile_args_normalize.py``).
+
+Why a plain ``set(args) == set(args)`` comparison is wrong for this data
+(Codex review, two rounds): a real compiler's flag semantics are not
+uniformly order-insensitive.
+
+* **Macro-define/-undef flags** (``-D``/``-U``) and the dialect flag
+  (``-std=``) are *last-wins per name* -- ``-DFOO=1 -DFOO=2`` and
+  ``-DFOO=2 -DFOO=1`` are sets of identical tokens but different effective
+  compiler states (the compiler sees ``FOO`` as ``2`` in the first case,
+  ``1`` in the second). A plain set comparison cannot distinguish these,
+  so it can pass two paths that would parse a real header under two
+  different macro/dialect states.
+* **Include-search flags** (``-I``/``-isystem``/``-iquote``/``-idirafter``)
+  are order- *and* multiplicity-sensitive for a different reason: a real
+  compiler resolves a colliding header basename from the *first* matching
+  directory in argv order within each of these search buckets, so
+  reordering (or dropping-then-reintroducing) one relative to another can
+  change which file is actually parsed even though the same set of
+  directories is present overall.
+* Every other flag (``-fPIC``, and similar boolean-style, non-value-taking
+  flags) genuinely has no meaningful order or repeat-count -- comparing
+  those as a plain set is the correct, not merely convenient, choice.
+"""
+
+from __future__ import annotations
+
+#: Flags that take a following, space-separated operand naming a search
+#: directory. Kept in this one place so both consumers agree on the
+#: vocabulary.
+INCLUDE_SEARCH_FLAGS = ("-I", "-isystem", "-iquote", "-idirafter")
+
+
+def split_compile_args(
+    args: tuple[str, ...],
+) -> tuple[dict[str, str], frozenset[str], tuple[tuple[str, str], ...]]:
+    """Split *args* into ``(last_wins_state, presence_only_flags, include_pairs)``.
+
+    ``last_wins_state`` maps a normalized key (``"macro:<NAME>"`` for a
+    ``-D``/``-U`` flag naming ``<NAME>``, or the literal ``"dialect"`` for
+    ``-std=``) to the *last* raw token seen for that key, walking *args* in
+    order -- exactly mirroring a real compiler's last-flag-wins semantics
+    for these two flag families. ``presence_only_flags`` is every other
+    non-include-search token, compared as a plain set (order/repetition is
+    genuinely inert for these). ``include_pairs`` is the ordered,
+    duplicate-preserving sequence of ``(flag, directory)`` pairs for every
+    include-search flag -- see the module docstring for why this one alone
+    keeps both order and multiplicity.
+    """
+    last_wins: dict[str, str] = {}
+    presence_only: list[str] = []
+    include_pairs: list[tuple[str, str]] = []
+    i = 0
+    n = len(args)
+    while i < n:
+        tok = args[i]
+        if tok in INCLUDE_SEARCH_FLAGS and i + 1 < n:
+            include_pairs.append((tok, args[i + 1]))
+            i += 2
+            continue
+        if tok.startswith(("-D", "-U")) and len(tok) > 2:
+            macro_name = tok[2:].split("=", 1)[0]
+            last_wins[f"macro:{macro_name}"] = tok
+        elif tok.startswith("-std="):
+            last_wins["dialect"] = tok
+        else:
+            presence_only.append(tok)
+        i += 1
+    return last_wins, frozenset(presence_only), tuple(include_pairs)

--- a/tests/_dump_compile_args_normalize.py
+++ b/tests/_dump_compile_args_normalize.py
@@ -174,6 +174,17 @@ def split_compile_args(
             ordered_stream.append(f"{flag}={operand}")
             i += consumed
             continue
+        if tok in ("-D", "-U") and i + 1 < n:
+            # GCC/Clang accept -D/-U with the name as a *separate* argv
+            # token too (`-D FOO=1`, not just `-DFOO=1`) -- canonicalize
+            # to the attached spelling so both forms land in the same
+            # last-wins key, for the identical reason `_match_pair_flag`
+            # canonicalizes attached vs. separate include flags.
+            combined = tok + args[i + 1]
+            macro_name = combined[2:].split("=", 1)[0]
+            last_wins[f"macro:{macro_name}"] = combined
+            i += 2
+            continue
         if tok.startswith(("-D", "-U")) and len(tok) > 2:
             macro_name = tok[2:].split("=", 1)[0]
             last_wins[f"macro:{macro_name}"] = tok

--- a/tests/_dump_compile_args_normalize.py
+++ b/tests/_dump_compile_args_normalize.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 """Shared helper: split a real ``AbiSnapshot.ast_compile_args`` sequence into
-its four semantically distinct pieces for equivalence comparison.
+its three semantically distinct pieces for equivalence comparison.
 
 Non-test-prefixed by convention (mirrors ``_strict_process.py``/
 ``_workflow_exec.py`` -- see ``tests/CLAUDE.md``'s "Helpers" section), so it
@@ -24,10 +24,9 @@ test that pins its normalization rules directly
 (``test_dump_compile_args_normalize.py``).
 
 Why a plain ``set(args) == set(args)`` comparison is wrong for this data
-(Codex review, three rounds -- each one found a *different* flag family this
-module's previous "everything else is a set" default silently mishandled,
-which is the reason the default direction changed on the third round; see
-below):
+(Codex review, four rounds -- each one found a real, different way a
+convenient-but-wrong default silently accepted two non-equivalent argv as
+"the same"; see below for what each round changed and why):
 
 * **Include-search flags** (``-I``/``-isystem``/``-iquote``/``-idirafter``)
   are order- *and* multiplicity-sensitive: a real compiler resolves a
@@ -51,33 +50,53 @@ below):
   boolean-style flags (``-fPIC`` and the like) is the *only* case where a
   plain set comparison is correct, not merely convenient.
 
-**The default direction matters more than any one flag's classification.**
-The first two review rounds each found one more flag family this module's
-"everything unrecognized is presence-only" default had silently
-mis-classified -- first include-search flags, then ``-D``/``-std``. A third
-round found the same shape again for ``--target=``/``-include``, which is
-what changed the *default* itself rather than adding a fourth special case:
-an unrecognized token is now compared as an exact, order- and
-multiplicity-preserving sequence entry by default (``ordered_unknown``), and
-only the small, explicitly-reviewed `ORDER_INSENSITIVE_BOOLEAN_FLAGS`
-allowlist gets the more permissive set comparison. A token this module does
-not recognize is far more likely to be order-sensitive (most compiler flags
-that take an operand are) than not, so "unknown -> compared strictly" is the
-safe default; "unknown -> compared loosely" is what let three consecutive
-review rounds find a real, silent gap.
+**Round 1** found the include-search case above. **Round 2** found the
+``-D``/``-std`` last-wins case. **Round 3** found that the then-remaining
+"everything else" bucket was still a permissive default (a catch-all set),
+which silently mishandled ``--target=``/``-include`` the identical way
+round 1 found for include-search flags -- so round 3 replaced the *default
+direction* itself: an unrecognized token now defaults to strict,
+order-preserving comparison, and only the small, explicit
+`ORDER_INSENSITIVE_BOOLEAN_FLAGS` allowlist gets the permissive set
+comparison.
+
+**Round 4** found that "strict, order-preserving comparison" was still
+split across *two independently-compared* buckets -- a
+canonical-pair-form ``ordered_pairs`` sequence and a raw-token
+``ordered_unknown`` sequence -- so an *attached*-spelling include flag
+(``-I/a``, one argv token) fell into ``ordered_unknown`` while the
+*split*-spelling form (``-I``, ``/a``, two argv tokens) fell into
+``ordered_pairs``, and the two buckets being compared independently meant
+their relative order to *each other* was invisible: ``("-I/a", "-I",
+"/b")`` and ``("-I", "/b", "-I/a")`` normalized identically even though a
+real compiler searches ``/a`` first in one and ``/b`` first in the other.
+Fixed by (a) recognizing both spellings as the same canonical pair and (b)
+collapsing every order-sensitive category into *one* unified
+``ordered_stream``, rather than adding a fifth bucket for the next spelling
+variant this module doesn't yet know about -- see the "one stream, not many
+buckets" reasoning in `split_compile_args`'s own docstring.
 """
 
 from __future__ import annotations
 
-#: Flags that take a following, space-separated operand naming a search
-#: directory. Order- and multiplicity-sensitive (first-match-wins search).
+#: Flags that take an operand naming a search directory -- either as a
+#: separate following argv token (``-I``, ``/a``) or attached
+#: (``-I/a``). Order- and multiplicity-sensitive (first-match-wins
+#: search); see the module docstring's "Round 1" and "Round 4" notes.
 INCLUDE_SEARCH_FLAGS = ("-I", "-isystem", "-iquote", "-idirafter")
 
-#: Flags that take a following, space-separated operand naming a file to
-#: force-include. Order-sensitive for a different reason than the search
-#: flags above (an earlier one's macros are visible to a later one), but
-#: grouped as the identical "ordered (flag, operand) pair" shape.
+#: Flags that take an operand naming a file to force-include, in either
+#: spelling. Order-sensitive for a different reason than the search flags
+#: above (an earlier one's macros are visible to a later one), but
+#: normalized into the same canonical pair shape.
 FORCED_INCLUDE_FLAGS = ("-include", "-imacros")
+
+#: Every flag `split_compile_args` recognizes as taking a directory/file
+#: operand, attached or separate -- checked in this combined order so a
+#: longer, more specific prefix never loses to a shorter unrelated one
+#: (no two entries here share a prefix in practice, but the check is
+#: written to be safe regardless).
+_PAIR_FLAGS = INCLUDE_SEARCH_FLAGS + FORCED_INCLUDE_FLAGS
 
 #: Single-token flags with real "later occurrence wins" semantics, keyed by
 #: their own literal prefix (there is only ever one effective value per
@@ -86,20 +105,37 @@ LAST_WINS_PREFIXES = ("-std=", "--target=")
 
 #: The only flags whose repetition/order this module treats as genuinely
 #: inert -- deliberately a narrow, explicitly-reviewed allowlist, not a
-#: default (see the module docstring's "default direction" paragraph for
-#: why a catch-all default was the actual bug across three review rounds).
+#: default (see the module docstring's "Round 3" note for why a catch-all
+#: default was itself the bug).
 ORDER_INSENSITIVE_BOOLEAN_FLAGS = frozenset(
     {"-fPIC", "-fpic", "-pthread", "-nostdinc", "-nostdinc++"}
 )
 
 
+def _match_pair_flag(
+    tok: str, args: tuple[str, ...], i: int, n: int
+) -> tuple[str, str, int] | None:
+    """If *tok* (at position *i*) is one of `_PAIR_FLAGS`, return
+    ``(flag, operand, tokens_consumed)`` -- handling both the attached
+    spelling (``-I/a``, 1 token) and the separate-argument spelling
+    (``-I``, ``/a``, 2 tokens). Returns ``None`` for anything else,
+    *including* a recognized flag with no operand available (a malformed
+    trailing flag) -- the caller then records the bare token itself rather
+    than silently dropping it.
+    """
+    for flag in _PAIR_FLAGS:
+        if tok == flag:
+            return (flag, args[i + 1], 2) if i + 1 < n else None
+        if tok.startswith(flag) and len(tok) > len(flag):
+            return flag, tok[len(flag) :], 1
+    return None
+
+
 def split_compile_args(
     args: tuple[str, ...],
-) -> tuple[
-    dict[str, str], frozenset[str], tuple[tuple[str, str], ...], tuple[str, ...]
-]:
+) -> tuple[dict[str, str], frozenset[str], tuple[str, ...]]:
     """Split *args* into ``(last_wins_state, presence_only_flags,
-    ordered_pairs, ordered_unknown)``.
+    ordered_stream)``.
 
     ``last_wins_state`` maps a normalized key -- ``"macro:<NAME>"`` for a
     ``-D``/``-U`` flag naming ``<NAME>``, or a flag's own literal prefix for
@@ -107,31 +143,36 @@ def split_compile_args(
     key, walking *args* in order, mirroring a real compiler's last-wins
     semantics. ``presence_only_flags`` is every token in
     `ORDER_INSENSITIVE_BOOLEAN_FLAGS`, compared as a plain set.
-    ``ordered_pairs`` is the ordered, duplicate-preserving sequence of
-    ``(flag, operand)`` pairs for every include-search or forced-include
-    flag. ``ordered_unknown`` is every remaining, unrecognized token, kept
-    as an exact, order- and multiplicity-preserving sequence -- the safe
-    default for a flag this module has no specific rule for (see the
-    module docstring).
+
+    ``ordered_stream`` is **one** unified, order- and
+    multiplicity-preserving sequence covering every token this module does
+    not have positive evidence is safe to reorder or drop: a canonicalized
+    ``"FLAG=OPERAND"`` entry for every include-search/forced-include pair
+    (attached and separate spellings normalize to the identical string —
+    see `_match_pair_flag`), and any unrecognized token, *interleaved in
+    their original relative argv order*. This is deliberately **one**
+    stream rather than one bucket per category (a canonical-pair bucket
+    plus a separate unrecognized-token bucket, compared independently) --
+    that split is exactly what let round 4 miss the relative order between
+    an attached-form include flag and a plain unrecognized token. The
+    general lesson this module's whole history states: every one of the
+    four rounds found a *default* that was too permissive for some input,
+    never a default that was too strict -- so the only default this
+    function makes going forward is "compared exactly, in order, unless a
+    flag is explicitly known to be safe otherwise."
     """
     last_wins: dict[str, str] = {}
     presence_only: list[str] = []
-    ordered_pairs: list[tuple[str, str]] = []
-    ordered_unknown: list[str] = []
+    ordered_stream: list[str] = []
     i = 0
     n = len(args)
     while i < n:
         tok = args[i]
-        if tok in INCLUDE_SEARCH_FLAGS or tok in FORCED_INCLUDE_FLAGS:
-            if i + 1 < n:
-                ordered_pairs.append((tok, args[i + 1]))
-                i += 2
-                continue
-            # A trailing flag with no operand is malformed input for this
-            # flag family -- fall through and record it verbatim rather
-            # than silently dropping it.
-            ordered_unknown.append(tok)
-            i += 1
+        pair = _match_pair_flag(tok, args, i, n)
+        if pair is not None:
+            flag, operand, consumed = pair
+            ordered_stream.append(f"{flag}={operand}")
+            i += consumed
             continue
         if tok.startswith(("-D", "-U")) and len(tok) > 2:
             macro_name = tok[2:].split("=", 1)[0]
@@ -142,11 +183,6 @@ def split_compile_args(
         elif tok in ORDER_INSENSITIVE_BOOLEAN_FLAGS:
             presence_only.append(tok)
         else:
-            ordered_unknown.append(tok)
+            ordered_stream.append(tok)
         i += 1
-    return (
-        last_wins,
-        frozenset(presence_only),
-        tuple(ordered_pairs),
-        tuple(ordered_unknown),
-    )
+    return last_wins, frozenset(presence_only), tuple(ordered_stream)

--- a/tests/test_dump_cli_typed_api_parity.py
+++ b/tests/test_dump_cli_typed_api_parity.py
@@ -288,24 +288,24 @@ def test_dump_cli_and_typed_api_agree_on_resolved_compile_context(
     # every ABI-relevant flag reaching the typed path's parse must also
     # reach the CLI path's -- compared per `split_compile_args`'s own
     # semantics-preserving normalization, not literal set/list equality
-    # (see that module's docstring: a plain set would miss a -D/-std
-    # last-wins conflict, and a plain sequence would reject the CLI path's
-    # own separately-tracked, harmless flag duplication).
-    cli_last_wins, cli_presence, cli_includes = split_compile_args(
+    # (see that module's docstring for the full reasoning, including why
+    # an *unrecognized* flag defaults to strict, order-preserving
+    # comparison rather than the reverse).
+    cli_last_wins, cli_presence, cli_pairs, cli_unknown = split_compile_args(
         tuple(cli_snap["ast_compile_args"])
     )
-    typed_last_wins, typed_presence, typed_includes = split_compile_args(
+    typed_last_wins, typed_presence, typed_pairs, typed_unknown = split_compile_args(
         tuple(typed_snap["ast_compile_args"])
     )
     assert cli_last_wins or cli_presence, "the CLI dump path resolved no compile flags"
     assert typed_last_wins or typed_presence, (
         "the typed-API dump path resolved no compile flags"
     )
-    # Last-wins state (-D/-U/-std=): exact dict equality -- this is the one
-    # that catches a *conflicting* value reached via a different order on
-    # each path (e.g. one path's effective -DFOO ends up "1", the other's
-    # "2"), which a plain set of tokens cannot distinguish from an
-    # identical, merely-reordered pair.
+    # Last-wins state (-D/-U/-std=/--target=): exact dict equality -- this
+    # is the one that catches a *conflicting* value reached via a
+    # different order on each path (e.g. one path's effective -DFOO ends
+    # up "1", the other's "2"), which a plain set of tokens cannot
+    # distinguish from an identical, merely-reordered pair.
     assert cli_last_wins == typed_last_wins, (
         shape_name,
         cli_last_wins,
@@ -324,13 +324,15 @@ def test_dump_cli_and_typed_api_agree_on_resolved_compile_context(
         f"{shape_name}: CLI dump path resolved flag(s) {missing_from_typed} "
         "the typed-API path did not"
     )
-    # Include-search flags: exact sequence, order and multiplicity both
-    # significant -- see `split_compile_args`'s own docstring.
-    assert cli_includes == typed_includes, (
-        shape_name,
-        cli_includes,
-        typed_includes,
-    )
+    # Include-search / forced-include flags: exact sequence, order and
+    # multiplicity both significant -- see `split_compile_args`'s own
+    # docstring.
+    assert cli_pairs == typed_pairs, (shape_name, cli_pairs, typed_pairs)
+    # Everything neither path's ast_compile_args composition is known to
+    # emit today, but which this helper has no specific rule for either:
+    # also an exact sequence, by the same "unknown defaults to strict"
+    # reasoning -- not folded into the presence-only set.
+    assert cli_unknown == typed_unknown, (shape_name, cli_unknown, typed_unknown)
 
 
 def _dump_via_cli_to_file(

--- a/tests/test_dump_cli_typed_api_parity.py
+++ b/tests/test_dump_cli_typed_api_parity.py
@@ -340,11 +340,40 @@ def _dump_via_cli_to_file(
 # fix to either path's include-dir seeding closes this, the xfail turns into
 # an unexpected pass and fails loudly, which is exactly the signal needed to
 # update this test and AGENTS.md's known-gap entry together.
+#
+# Applied via `pytest.param(..., marks=...)` below rather than an early
+# `pytest.xfail()` call inside the test body (Codex review): calling
+# `pytest.xfail()` unconditionally aborts the test *before* the body runs,
+# so it can only ever report XFAIL -- there is no code path left that could
+# execute the real assertions and XPASS, which defeats the entire point of
+# `strict=True` (a future fix closing the gap would keep reporting XFAIL
+# forever, silently, instead of failing loudly as an unexpected pass). The
+# mark-based form still lets pytest run the body and only *then* treats a
+# failure as expected / a pass as unexpected -- so the shape below actually
+# gets exercised on every run, not skipped over.
 _SCAN_KNOWN_DIVERGENT_SHAPES = frozenset({"extra-include-dir"})
 
 
+def _scan_shape_param(shape_name: str) -> object:
+    if shape_name in _SCAN_KNOWN_DIVERGENT_SHAPES:
+        return pytest.param(
+            shape_name,
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason=(
+                    f"{shape_name}: known-open dump-vs-scan include-dir "
+                    "seeding divergence (see this module's own comment "
+                    "above this test)"
+                ),
+            ),
+        )
+    return shape_name
+
+
 @pytest.mark.skipif(not (_HAVE_GXX and _HAVE_CLANG), reason=_SKIP_REASON)
-@pytest.mark.parametrize("shape_name", sorted(_BUILD_SHAPES))
+@pytest.mark.parametrize(
+    "shape_name", [_scan_shape_param(name) for name in sorted(_BUILD_SHAPES)]
+)
 def test_scan_against_real_dump_baseline_is_comparable(
     tmp_path: Path, shape_name: str
 ) -> None:
@@ -352,11 +381,6 @@ def test_scan_against_real_dump_baseline_is_comparable(
     shapes: a real ``dump`` baseline must be comparable via
     ``scan --against`` -- never ``NOT_COMPARABLE`` -- for an unchanged
     codebase."""
-    if shape_name in _SCAN_KNOWN_DIVERGENT_SHAPES:
-        pytest.xfail(
-            f"{shape_name}: known-open dump-vs-scan include-dir seeding "
-            "divergence (see this module's own comment above this test)"
-        )
     shape = _BUILD_SHAPES[shape_name]
     so_path, header, compile_db = _build_library(tmp_path, **shape)  # type: ignore[arg-type]
     baseline = tmp_path / "baseline.json"

--- a/tests/test_dump_cli_typed_api_parity.py
+++ b/tests/test_dump_cli_typed_api_parity.py
@@ -1,0 +1,428 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generalized parity guard: ``abicheck dump``'s CLI path and the typed
+``DumpRequest``/``run_dump_request`` API path must resolve the *same* real
+L3 build evidence into the *same* L2 compile context.
+
+Why this exists (root cause of the "dump-vs-scan compile-context
+divergence" bug class, PR #810): ``abicheck dump`` is, structurally, **two
+independently-maintained implementations**, not one function called from
+two front ends:
+
+* the CLI path (``cli.py``'s ``dump_cmd`` -> ``cli_dump_helpers.
+  perform_elf_dump``/``handle_non_elf_dump``) calls ``dumper.dump()``
+  directly, seeding its L2 include/compile context via
+  ``buildsource.l2_seed.seed_includes_and_fold_compile_context``;
+* the typed Tier-2 API (``DumpRequest``/``run_dump_request``, used by
+  ``compare``'s implicit-dump operand and by ``scan``'s candidate
+  resolution) resolves through
+  ``service_input_resolution._resolve_side_snapshot_impl`` ->
+  ``service.resolve_input``, seeding its own L2 context via
+  ``service_input_resolution._seeded_includes_and_compile_context`` --
+  which calls the *same* ``seed_includes_and_fold_compile_context``
+  primitive, but through different surrounding wiring (its own debug-
+  artifact resolution, its own argument defaults, its own post-processing
+  hooks).
+
+AGENTS.md's own "Known gaps" section documents, across dozens of numbered
+findings, that this class of split has repeatedly let a fix land on one of
+these two paths without the other -- which is exactly how the bug report
+this test file accompanies was possible: the shared fold was wired into
+the CLI path in one PR, and the two paths drifted for a real, if narrow,
+window before that. `AGENTS.md`'s "PR C (typed dump/scan convergence)"
+entry records this structural split as still open today (``dump_cmd``
+still does not build a ``DumpRequest`` at all) -- so a *unification* fix
+is not available yet, but a *regression guard on the observable symptom*
+is: this module asserts, for a small matrix of real build-evidence shapes
+(not just the one exact shape the bug report happened to use), that both
+paths resolve to the same ``ast_resolved_standard``/``ast_compile_args``/
+``parsed_with_build_context`` -- the exact fields whose disagreement is
+what ``profile_fingerprint`` comparability checks on, and what made
+`scan --against` refuse a real, unchanged comparison as ``NOT_COMPARABLE``.
+
+A future change to either path's own L2-seeding wiring (not just the
+shared ``seed_includes_and_fold_compile_context`` primitive itself) that
+reintroduces a disagreement should fail here, on at least one of the
+parametrized shapes, well before it reaches a downstream comparability
+check -- rather than needing its own bug report against a specific real
+build shape the way #810 did.
+
+Marked ``integration`` (real g++ + clang toolchain), like its sibling
+``test_dump_scan_l3_comparability.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from abicheck.api_types import DumpRequest, InputSpec
+from abicheck.cli import main
+from abicheck.compile_context import CompileContext
+from abicheck.service import run_dump_request
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not sys.platform.startswith("linux"),
+        reason="ELF/Linux-scoped repro (real g++-compiled .so + compile_commands.json)",
+    ),
+]
+
+_HAVE_GXX = shutil.which("g++") is not None
+_HAVE_CLANG = shutil.which("clang") is not None
+_SKIP_REASON = "needs a real g++ and clang toolchain"
+
+
+def _build_library(
+    tmp_path: Path,
+    *,
+    std: str = "c++17",
+    macros: tuple[str, ...] = (),
+    extra_include_dir: str | None = None,
+) -> tuple[Path, Path, Path]:
+    """Compile a small, real library whose header depends on the given
+    ``-std=``/macros, plus a matching ``compile_commands.json`` -- varying
+    the build-evidence shape across the parametrized cases below, not just
+    the one exact shape #810's own repro used."""
+    include_dirs = [tmp_path]
+    dep_header_snippet = ""
+    dep_field = ""
+    if extra_include_dir is not None:
+        dep_dir = tmp_path / extra_include_dir
+        dep_dir.mkdir(parents=True, exist_ok=True)
+        (dep_dir / "dep.h").write_text(
+            "#pragma once\nstruct Dep { int tag; };\n", encoding="utf-8"
+        )
+        include_dirs.append(dep_dir)
+        dep_header_snippet = '#include "dep.h"\n'
+        dep_field = "    Dep dep;\n"
+
+    macro_guard = "\n".join(
+        f'#ifndef {m.split("=")[0]}\n#error "missing {m}"\n#endif' for m in macros
+    )
+
+    header = tmp_path / "widget.h"
+    header.write_text(
+        "#pragma once\n"
+        f"{dep_header_snippet}"
+        "#if __cplusplus < " + ("202002L" if std == "c++20" else "201703L") + "\n"
+        '#error "needs a newer standard"\n'
+        "#endif\n"
+        f"{macro_guard}\n"
+        "struct Widget {\n"
+        "    int x;\n"
+        "    int y;\n"
+        f"{dep_field}"
+        "    int sum() const { return x + y; }\n"
+        "};\n",
+        encoding="utf-8",
+    )
+    src = tmp_path / "widget.cpp"
+    src.write_text(
+        '#include "widget.h"\nint compute(const Widget& w) { return w.sum(); }\n',
+        encoding="utf-8",
+    )
+    so_path = tmp_path / "libwidget.so"
+    include_flags = [f"-I{d}" for d in include_dirs[1:]]
+    macro_flags = [f"-D{m}" for m in macros]
+    subprocess.run(
+        [
+            "g++",
+            f"-std={std}",
+            *macro_flags,
+            *include_flags,
+            "-shared",
+            "-fPIC",
+            "-o",
+            str(so_path),
+            str(src),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    compile_db = tmp_path / "compile_commands.json"
+    compile_db.write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "arguments": [
+                        "g++",
+                        f"-std={std}",
+                        *macro_flags,
+                        *include_flags,
+                        "-shared",
+                        "-fPIC",
+                        "-c",
+                        str(src),
+                        "-o",
+                        "widget.o",
+                    ],
+                    "file": str(src),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return so_path, header, compile_db
+
+
+def _dump_via_cli(
+    so_path: Path, header: Path, tmp_path: Path, compile_db: Path
+) -> dict:
+    baseline = tmp_path / "baseline_cli.json"
+    result = CliRunner().invoke(
+        main,
+        [
+            "dump",
+            str(so_path),
+            "-H",
+            str(header),
+            "--sources",
+            str(tmp_path),
+            "--build-info",
+            str(compile_db),
+            "--depth",
+            "source",
+            "--ast-frontend",
+            "clang",
+            "-o",
+            str(baseline),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    data: dict = json.loads(baseline.read_text(encoding="utf-8"))
+    return data
+
+
+def _dump_via_typed_api(
+    so_path: Path, header: Path, tmp_path: Path, compile_db: Path
+) -> dict:
+    request = DumpRequest(
+        input=InputSpec(
+            path=so_path,
+            headers=(header,),
+            sources=tmp_path,
+            build_info=compile_db,
+            compile=CompileContext(frontend="clang"),
+        ),
+        depth="source",
+    )
+    snap = run_dump_request(request)
+    return {
+        "ast_resolved_standard": snap.ast_resolved_standard,
+        "ast_compile_args": snap.ast_compile_args,
+        "parsed_with_build_context": snap.parsed_with_build_context,
+    }
+
+
+_BUILD_SHAPES: dict[str, dict[str, object]] = {
+    "plain-c++17": {"std": "c++17"},
+    "c++20-with-macro": {"std": "c++20", "macros": ("FOO=1",)},
+    "extra-include-dir": {"std": "c++17", "extra_include_dir": "dep"},
+}
+
+
+@pytest.mark.skipif(not (_HAVE_GXX and _HAVE_CLANG), reason=_SKIP_REASON)
+@pytest.mark.parametrize("shape_name", sorted(_BUILD_SHAPES))
+def test_dump_cli_and_typed_api_agree_on_resolved_compile_context(
+    tmp_path: Path, shape_name: str
+) -> None:
+    """The invariant this whole file exists for: two independent code paths
+    that both claim to fold the same real L3 evidence into an L2 compile
+    context must actually agree, for more than one hand-picked build
+    shape."""
+    shape = _BUILD_SHAPES[shape_name]
+    so_path, header, compile_db = _build_library(tmp_path, **shape)  # type: ignore[arg-type]
+
+    cli_snap = _dump_via_cli(so_path, header, tmp_path, compile_db)
+    typed_snap = _dump_via_typed_api(so_path, header, tmp_path, compile_db)
+
+    assert cli_snap["ast_resolved_standard"] == typed_snap["ast_resolved_standard"], (
+        shape_name,
+        cli_snap["ast_resolved_standard"],
+        typed_snap["ast_resolved_standard"],
+    )
+    assert (
+        cli_snap["parsed_with_build_context"] == typed_snap["parsed_with_build_context"]
+    )
+    # Both paths were given the identical real -std=/macros/-I evidence, so
+    # every ABI-relevant flag reaching the typed path's parse must also
+    # reach the CLI path's -- compared as sets, since composition order
+    # between the two independent seed call sites is not itself the
+    # invariant under test (each has its own, separately-justified
+    # ordering rules -- see AGENTS.md's include-bucket-ordering findings).
+    cli_flags = set(cli_snap["ast_compile_args"])
+    typed_flags = set(typed_snap["ast_compile_args"])
+    assert cli_flags, "the CLI dump path resolved no compile flags at all"
+    assert typed_flags, "the typed-API dump path resolved no compile flags at all"
+    missing_from_cli = typed_flags - cli_flags
+    missing_from_typed = cli_flags - typed_flags
+    assert not missing_from_cli, (
+        f"{shape_name}: typed-API path resolved flag(s) {missing_from_cli} "
+        "the CLI dump path did not"
+    )
+    assert not missing_from_typed, (
+        f"{shape_name}: CLI dump path resolved flag(s) {missing_from_typed} "
+        "the typed-API path did not"
+    )
+
+
+def _dump_via_cli_to_file(
+    so_path: Path, header: Path, tmp_path: Path, compile_db: Path, baseline: Path
+) -> None:
+    dump_result = CliRunner().invoke(
+        main,
+        [
+            "dump",
+            str(so_path),
+            "-H",
+            str(header),
+            "--sources",
+            str(tmp_path),
+            "--build-info",
+            str(compile_db),
+            "--depth",
+            "source",
+            "--ast-frontend",
+            "clang",
+            "-o",
+            str(baseline),
+        ],
+    )
+    assert dump_result.exit_code == 0, dump_result.output
+
+
+# Known, currently-open residual gap (found by this test, confirmed against
+# AGENTS.md's own "Known gaps" entry for this bug class): an "extra
+# -I<dependency-dir>" build shape reproduces NOT_COMPARABLE on
+# `include_sequence` between `dump`'s baseline and `scan`'s candidate
+# resolution, on **current `main`**, right now -- confirmed directly: the
+# `dump` baseline's own `contract.profile_fields.include_sequence` reads
+# `"[]"` even though its `ast_compile_args` correctly carries `-I <dep-dir>`,
+# because `dumper_contract._attach_extraction_contract` builds
+# `declared_includes` (the source of `include_sequence`) **exclusively**
+# from `extra_includes`, and this build shape routes the `-I` into
+# `gcc_option_tokens` only, never into `extra_includes` -- while
+# `scan_engine._build_new_snapshot`'s own candidate resolution (which calls
+# `service.resolve_input` directly, bypassing the shared
+# `resolve_side_snapshot` primitive the typed dump/compare API above already
+# uses -- see this module's own docstring) seeds `eff_includes`/
+# `declared_includes` for the identical directory instead. `compare`'s
+# implicit-dump path does **not** reproduce this for the same inputs
+# (verified directly), confirming the divergence is specifically between
+# `dump`'s CLI path and `scan`'s own candidate-resolution path, not a
+# `compare`-side issue. This is a live instance of the residual gap
+# AGENTS.md's own entry already documents as open (the "channel disagreement"
+# paragraphs under "The native ELF `abicheck dump` path never applies L3
+# build context...") -- not a new bug class, but the first *reproduced*,
+# non-Bazel-specific repro of it. `xfail(strict=True)`, not skip: if a future
+# fix to either path's include-dir seeding closes this, the xfail turns into
+# an unexpected pass and fails loudly, which is exactly the signal needed to
+# update this test and AGENTS.md's known-gap entry together.
+_SCAN_KNOWN_DIVERGENT_SHAPES = frozenset({"extra-include-dir"})
+
+
+@pytest.mark.skipif(not (_HAVE_GXX and _HAVE_CLANG), reason=_SKIP_REASON)
+@pytest.mark.parametrize("shape_name", sorted(_BUILD_SHAPES))
+def test_scan_against_real_dump_baseline_is_comparable(
+    tmp_path: Path, shape_name: str
+) -> None:
+    """The end-to-end acceptance check from #810, generalized across build
+    shapes: a real ``dump`` baseline must be comparable via
+    ``scan --against`` -- never ``NOT_COMPARABLE`` -- for an unchanged
+    codebase."""
+    if shape_name in _SCAN_KNOWN_DIVERGENT_SHAPES:
+        pytest.xfail(
+            f"{shape_name}: known-open dump-vs-scan include-dir seeding "
+            "divergence (see this module's own comment above this test)"
+        )
+    shape = _BUILD_SHAPES[shape_name]
+    so_path, header, compile_db = _build_library(tmp_path, **shape)  # type: ignore[arg-type]
+    baseline = tmp_path / "baseline.json"
+    _dump_via_cli_to_file(so_path, header, tmp_path, compile_db, baseline)
+
+    scan_result = CliRunner().invoke(
+        main,
+        [
+            "scan",
+            str(so_path),
+            "-H",
+            str(header),
+            "--sources",
+            str(tmp_path),
+            "--build-info",
+            str(compile_db),
+            "--depth",
+            "source",
+            "--ast-frontend",
+            "clang",
+            "--against",
+            str(baseline),
+        ],
+    )
+    assert "NOT_COMPARABLE" not in scan_result.output, (shape_name, scan_result.output)
+    assert scan_result.exit_code == 0, (shape_name, scan_result.output)
+
+
+@pytest.mark.skipif(not (_HAVE_GXX and _HAVE_CLANG), reason=_SKIP_REASON)
+@pytest.mark.parametrize("shape_name", sorted(_BUILD_SHAPES))
+def test_compare_implicit_dump_against_real_dump_baseline_is_comparable(
+    tmp_path: Path, shape_name: str
+) -> None:
+    """Same acceptance check as above, against ``compare``'s implicit-dump
+    operand instead of ``scan --against`` -- kept as its own test (rather
+    than folded into the scan test above) precisely because the two paths
+    are independent and can disagree: see
+    ``_SCAN_KNOWN_DIVERGENT_SHAPES`` -- ``compare`` does not reproduce that
+    gap for the identical inputs, so this test has no xfail list, and a
+    future regression narrowing *this* path's coverage should fail loudly
+    rather than being masked by a scan-specific xfail."""
+    shape = _BUILD_SHAPES[shape_name]
+    so_path, header, compile_db = _build_library(tmp_path, **shape)  # type: ignore[arg-type]
+    baseline = tmp_path / "baseline.json"
+    _dump_via_cli_to_file(so_path, header, tmp_path, compile_db, baseline)
+
+    compare_result = CliRunner().invoke(
+        main,
+        [
+            "compare",
+            str(baseline),
+            str(so_path),
+            "-H",
+            str(header),
+            "--sources",
+            str(tmp_path),
+            "--build-info",
+            str(compile_db),
+            "--depth",
+            "source",
+            "--ast-frontend",
+            "clang",
+        ],
+    )
+    assert "NOT_COMPARABLE" not in compare_result.output, (
+        shape_name,
+        compare_result.output,
+    )
+    assert compare_result.exit_code == 0, (shape_name, compare_result.output)

--- a/tests/test_dump_cli_typed_api_parity.py
+++ b/tests/test_dump_cli_typed_api_parity.py
@@ -289,12 +289,12 @@ def test_dump_cli_and_typed_api_agree_on_resolved_compile_context(
     # reach the CLI path's -- compared per `split_compile_args`'s own
     # semantics-preserving normalization, not literal set/list equality
     # (see that module's docstring for the full reasoning, including why
-    # an *unrecognized* flag defaults to strict, order-preserving
-    # comparison rather than the reverse).
-    cli_last_wins, cli_presence, cli_pairs, cli_unknown = split_compile_args(
+    # every order-sensitive/unrecognized token shares one unified stream
+    # rather than several independently-compared buckets).
+    cli_last_wins, cli_presence, cli_stream = split_compile_args(
         tuple(cli_snap["ast_compile_args"])
     )
-    typed_last_wins, typed_presence, typed_pairs, typed_unknown = split_compile_args(
+    typed_last_wins, typed_presence, typed_stream = split_compile_args(
         tuple(typed_snap["ast_compile_args"])
     )
     assert cli_last_wins or cli_presence, "the CLI dump path resolved no compile flags"
@@ -324,15 +324,12 @@ def test_dump_cli_and_typed_api_agree_on_resolved_compile_context(
         f"{shape_name}: CLI dump path resolved flag(s) {missing_from_typed} "
         "the typed-API path did not"
     )
-    # Include-search / forced-include flags: exact sequence, order and
-    # multiplicity both significant -- see `split_compile_args`'s own
-    # docstring.
-    assert cli_pairs == typed_pairs, (shape_name, cli_pairs, typed_pairs)
-    # Everything neither path's ast_compile_args composition is known to
-    # emit today, but which this helper has no specific rule for either:
-    # also an exact sequence, by the same "unknown defaults to strict"
-    # reasoning -- not folded into the presence-only set.
-    assert cli_unknown == typed_unknown, (shape_name, cli_unknown, typed_unknown)
+    # Everything else -- include-search/forced-include pairs (attached or
+    # separate spelling, normalized identically) and any unrecognized
+    # token -- shares one unified, order- and multiplicity-preserving
+    # stream: see `split_compile_args`'s own docstring for why this must
+    # be one sequence rather than several independently-compared ones.
+    assert cli_stream == typed_stream, (shape_name, cli_stream, typed_stream)
 
 
 def _dump_via_cli_to_file(

--- a/tests/test_dump_cli_typed_api_parity.py
+++ b/tests/test_dump_cli_typed_api_parity.py
@@ -243,6 +243,51 @@ _BUILD_SHAPES: dict[str, dict[str, object]] = {
 }
 
 
+# Include-search flags (-I/-isystem/-iquote/-idirafter) are NOT idempotent
+# under reordering or duplication the way a value flag (-std=/-D) is: which
+# directory a real compiler resolves a colliding header basename from
+# depends on first-match-wins search order within each of these buckets
+# (see AGENTS.md's own `_split_include_tokens`/bucket-ordering findings).
+# A plain `set()` comparison would silently accept a reordered or
+# dropped-then-reintroduced include directory as long as the same
+# *directories* appeared somewhere -- exactly the kind of divergence this
+# whole parity test exists to catch (Codex review). So these are compared
+# as an exact, order- and multiplicity-preserving sequence of (flag, dir)
+# pairs, never collapsed into a set.
+_INCLUDE_SEARCH_FLAGS = ("-I", "-isystem", "-iquote", "-idirafter")
+
+
+def _split_compile_args(
+    args: tuple[str, ...],
+) -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:
+    """Split a real ``ast_compile_args`` sequence into (value-flag set,
+    ordered include-search pairs).
+
+    Value flags (``-std=``, ``-D...``) are idempotent when repeated with an
+    identical value -- appending a second, identical ``-std=c++17`` has no
+    functional effect, which is exactly what the CLI dump path's own
+    (separately-tracked, benign) duplication does -- so comparing those as
+    a *set* tolerates that harmless asymmetry while still catching a
+    genuinely *conflicting* value between the two paths, since a differing
+    value is a differing string and still shows up as a set difference.
+    Include-search flags get no such tolerance -- see the module-level
+    comment above this function.
+    """
+    value_flags: list[str] = []
+    include_pairs: list[tuple[str, str]] = []
+    i = 0
+    n = len(args)
+    while i < n:
+        tok = args[i]
+        if tok in _INCLUDE_SEARCH_FLAGS and i + 1 < n:
+            include_pairs.append((tok, args[i + 1]))
+            i += 2
+            continue
+        value_flags.append(tok)
+        i += 1
+    return frozenset(value_flags), tuple(include_pairs)
+
+
 @pytest.mark.skipif(not (_HAVE_GXX and _HAVE_CLANG), reason=_SKIP_REASON)
 @pytest.mark.parametrize("shape_name", sorted(_BUILD_SHAPES))
 def test_dump_cli_and_typed_api_agree_on_resolved_compile_context(
@@ -268,23 +313,29 @@ def test_dump_cli_and_typed_api_agree_on_resolved_compile_context(
     )
     # Both paths were given the identical real -std=/macros/-I evidence, so
     # every ABI-relevant flag reaching the typed path's parse must also
-    # reach the CLI path's -- compared as sets, since composition order
-    # between the two independent seed call sites is not itself the
-    # invariant under test (each has its own, separately-justified
-    # ordering rules -- see AGENTS.md's include-bucket-ordering findings).
-    cli_flags = set(cli_snap["ast_compile_args"])
-    typed_flags = set(typed_snap["ast_compile_args"])
-    assert cli_flags, "the CLI dump path resolved no compile flags at all"
-    assert typed_flags, "the typed-API dump path resolved no compile flags at all"
-    missing_from_cli = typed_flags - cli_flags
-    missing_from_typed = cli_flags - typed_flags
+    # reach the CLI path's.
+    cli_values, cli_includes = _split_compile_args(tuple(cli_snap["ast_compile_args"]))
+    typed_values, typed_includes = _split_compile_args(
+        tuple(typed_snap["ast_compile_args"])
+    )
+    assert cli_values, "the CLI dump path resolved no compile flags at all"
+    assert typed_values, "the typed-API dump path resolved no compile flags at all"
+    missing_from_cli = typed_values - cli_values
+    missing_from_typed = cli_values - typed_values
     assert not missing_from_cli, (
-        f"{shape_name}: typed-API path resolved flag(s) {missing_from_cli} "
+        f"{shape_name}: typed-API path resolved value flag(s) {missing_from_cli} "
         "the CLI dump path did not"
     )
     assert not missing_from_typed, (
-        f"{shape_name}: CLI dump path resolved flag(s) {missing_from_typed} "
+        f"{shape_name}: CLI dump path resolved value flag(s) {missing_from_typed} "
         "the typed-API path did not"
+    )
+    # Include-search flags: exact sequence, order and multiplicity both
+    # significant -- see `_split_compile_args`'s own docstring.
+    assert cli_includes == typed_includes, (
+        shape_name,
+        cli_includes,
+        typed_includes,
     )
 
 
@@ -336,44 +387,28 @@ def _dump_via_cli_to_file(
 # AGENTS.md's own entry already documents as open (the "channel disagreement"
 # paragraphs under "The native ELF `abicheck dump` path never applies L3
 # build context...") -- not a new bug class, but the first *reproduced*,
-# non-Bazel-specific repro of it. `xfail(strict=True)`, not skip: if a future
-# fix to either path's include-dir seeding closes this, the xfail turns into
-# an unexpected pass and fails loudly, which is exactly the signal needed to
-# update this test and AGENTS.md's known-gap entry together.
+# non-Bazel-specific repro of it.
 #
-# Applied via `pytest.param(..., marks=...)` below rather than an early
-# `pytest.xfail()` call inside the test body (Codex review): calling
-# `pytest.xfail()` unconditionally aborts the test *before* the body runs,
-# so it can only ever report XFAIL -- there is no code path left that could
-# execute the real assertions and XPASS, which defeats the entire point of
-# `strict=True` (a future fix closing the gap would keep reporting XFAIL
-# forever, silently, instead of failing loudly as an unexpected pass). The
-# mark-based form still lets pytest run the body and only *then* treats a
-# failure as expected / a pass as unexpected -- so the shape below actually
-# gets exercised on every run, not skipped over.
+# Deliberately *not* a blanket `xfail(strict=True)` on the whole test
+# (Codex review, second round): that would treat *any* failure for this
+# shape as expected, including an unrelated regression -- compilation
+# breaking, `dump` crashing, or `scan` failing for a completely different
+# reason -- silently swallowing it as "known". Every setup step (the real
+# `g++` compile, the real `dump` CLI invocation) stays a hard,
+# unconditionally-checked requirement below, never inside any
+# expected-failure scope. Only the exact, already-diagnosed signature
+# (`NOT_COMPARABLE` naming `include_sequence`) is treated as expected via
+# an explicit, conditional `pytest.xfail()` call made *after* confirming
+# that signature -- so a different scan failure surfaces as a genuine,
+# uncaught test failure, and a fix that makes the signature stop
+# reproducing falls through to the real assertions below, which then pass
+# normally (no `strict=True` bookkeeping needed: a plain PASS is itself
+# the loud signal that this note and the xfail list need updating).
 _SCAN_KNOWN_DIVERGENT_SHAPES = frozenset({"extra-include-dir"})
 
 
-def _scan_shape_param(shape_name: str) -> object:
-    if shape_name in _SCAN_KNOWN_DIVERGENT_SHAPES:
-        return pytest.param(
-            shape_name,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason=(
-                    f"{shape_name}: known-open dump-vs-scan include-dir "
-                    "seeding divergence (see this module's own comment "
-                    "above this test)"
-                ),
-            ),
-        )
-    return shape_name
-
-
 @pytest.mark.skipif(not (_HAVE_GXX and _HAVE_CLANG), reason=_SKIP_REASON)
-@pytest.mark.parametrize(
-    "shape_name", [_scan_shape_param(name) for name in sorted(_BUILD_SHAPES)]
-)
+@pytest.mark.parametrize("shape_name", sorted(_BUILD_SHAPES))
 def test_scan_against_real_dump_baseline_is_comparable(
     tmp_path: Path, shape_name: str
 ) -> None:
@@ -405,6 +440,23 @@ def test_scan_against_real_dump_baseline_is_comparable(
             str(baseline),
         ],
     )
+
+    if shape_name in _SCAN_KNOWN_DIVERGENT_SHAPES:
+        is_known_signature = (
+            "NOT_COMPARABLE" in scan_result.output
+            and "include_sequence" in scan_result.output
+        )
+        if is_known_signature:
+            pytest.xfail(
+                f"{shape_name}: known-open dump-vs-scan include-dir "
+                "seeding divergence (see this module's own comment above "
+                "this test)"
+            )
+        # Anything else -- including the gap closing entirely -- falls
+        # through to the ordinary assertions below: a fix makes them pass
+        # normally, and any *other* failure surfaces as itself rather than
+        # being mistaken for the diagnosed gap.
+
     assert "NOT_COMPARABLE" not in scan_result.output, (shape_name, scan_result.output)
     assert scan_result.exit_code == 0, (shape_name, scan_result.output)
 

--- a/tests/test_dump_cli_typed_api_parity.py
+++ b/tests/test_dump_cli_typed_api_parity.py
@@ -73,6 +73,13 @@ import sys
 from pathlib import Path
 
 import pytest
+
+# Non-test-prefixed sibling helper (mirrors `_strict_process.py`/
+# `_workflow_exec.py` -- see `tests/CLAUDE.md`'s "Helpers" section),
+# imported plainly rather than relatively since `tests/` carries no
+# `__init__.py` (same pattern every other such helper import in this
+# suite uses).
+from _dump_compile_args_normalize import split_compile_args
 from click.testing import CliRunner
 
 from abicheck.api_types import DumpRequest, InputSpec
@@ -243,49 +250,15 @@ _BUILD_SHAPES: dict[str, dict[str, object]] = {
 }
 
 
-# Include-search flags (-I/-isystem/-iquote/-idirafter) are NOT idempotent
-# under reordering or duplication the way a value flag (-std=/-D) is: which
-# directory a real compiler resolves a colliding header basename from
-# depends on first-match-wins search order within each of these buckets
-# (see AGENTS.md's own `_split_include_tokens`/bucket-ordering findings).
-# A plain `set()` comparison would silently accept a reordered or
-# dropped-then-reintroduced include directory as long as the same
-# *directories* appeared somewhere -- exactly the kind of divergence this
-# whole parity test exists to catch (Codex review). So these are compared
-# as an exact, order- and multiplicity-preserving sequence of (flag, dir)
-# pairs, never collapsed into a set.
-_INCLUDE_SEARCH_FLAGS = ("-I", "-isystem", "-iquote", "-idirafter")
-
-
-def _split_compile_args(
-    args: tuple[str, ...],
-) -> tuple[frozenset[str], tuple[tuple[str, str], ...]]:
-    """Split a real ``ast_compile_args`` sequence into (value-flag set,
-    ordered include-search pairs).
-
-    Value flags (``-std=``, ``-D...``) are idempotent when repeated with an
-    identical value -- appending a second, identical ``-std=c++17`` has no
-    functional effect, which is exactly what the CLI dump path's own
-    (separately-tracked, benign) duplication does -- so comparing those as
-    a *set* tolerates that harmless asymmetry while still catching a
-    genuinely *conflicting* value between the two paths, since a differing
-    value is a differing string and still shows up as a set difference.
-    Include-search flags get no such tolerance -- see the module-level
-    comment above this function.
-    """
-    value_flags: list[str] = []
-    include_pairs: list[tuple[str, str]] = []
-    i = 0
-    n = len(args)
-    while i < n:
-        tok = args[i]
-        if tok in _INCLUDE_SEARCH_FLAGS and i + 1 < n:
-            include_pairs.append((tok, args[i + 1]))
-            i += 2
-            continue
-        value_flags.append(tok)
-        i += 1
-    return frozenset(value_flags), tuple(include_pairs)
+# Comparing `ast_compile_args` for real semantic equivalence (not literal
+# list/set equality) needs to know which flags are last-wins,
+# order-sensitive, or genuinely inert under reordering/duplication -- see
+# `_dump_compile_args_normalize.py`'s own module docstring for the full
+# reasoning (two Codex review rounds: a plain `set()` first missed
+# include-search ordering, then still missed -D/-std last-wins
+# conflicts). `test_dump_compile_args_normalize.py` pins that helper's
+# normalization rules directly, with synthetic inputs, independent of any
+# real compiler.
 
 
 @pytest.mark.skipif(not (_HAVE_GXX and _HAVE_CLANG), reason=_SKIP_REASON)
@@ -313,25 +286,46 @@ def test_dump_cli_and_typed_api_agree_on_resolved_compile_context(
     )
     # Both paths were given the identical real -std=/macros/-I evidence, so
     # every ABI-relevant flag reaching the typed path's parse must also
-    # reach the CLI path's.
-    cli_values, cli_includes = _split_compile_args(tuple(cli_snap["ast_compile_args"]))
-    typed_values, typed_includes = _split_compile_args(
+    # reach the CLI path's -- compared per `split_compile_args`'s own
+    # semantics-preserving normalization, not literal set/list equality
+    # (see that module's docstring: a plain set would miss a -D/-std
+    # last-wins conflict, and a plain sequence would reject the CLI path's
+    # own separately-tracked, harmless flag duplication).
+    cli_last_wins, cli_presence, cli_includes = split_compile_args(
+        tuple(cli_snap["ast_compile_args"])
+    )
+    typed_last_wins, typed_presence, typed_includes = split_compile_args(
         tuple(typed_snap["ast_compile_args"])
     )
-    assert cli_values, "the CLI dump path resolved no compile flags at all"
-    assert typed_values, "the typed-API dump path resolved no compile flags at all"
-    missing_from_cli = typed_values - cli_values
-    missing_from_typed = cli_values - typed_values
+    assert cli_last_wins or cli_presence, "the CLI dump path resolved no compile flags"
+    assert typed_last_wins or typed_presence, (
+        "the typed-API dump path resolved no compile flags"
+    )
+    # Last-wins state (-D/-U/-std=): exact dict equality -- this is the one
+    # that catches a *conflicting* value reached via a different order on
+    # each path (e.g. one path's effective -DFOO ends up "1", the other's
+    # "2"), which a plain set of tokens cannot distinguish from an
+    # identical, merely-reordered pair.
+    assert cli_last_wins == typed_last_wins, (
+        shape_name,
+        cli_last_wins,
+        typed_last_wins,
+    )
+    # Presence-only flags (-fPIC and the like): genuinely order- and
+    # repeat-count-insensitive, so a set comparison is the correct
+    # semantics here, not merely a convenient one.
+    missing_from_cli = typed_presence - cli_presence
+    missing_from_typed = cli_presence - typed_presence
     assert not missing_from_cli, (
-        f"{shape_name}: typed-API path resolved value flag(s) {missing_from_cli} "
+        f"{shape_name}: typed-API path resolved flag(s) {missing_from_cli} "
         "the CLI dump path did not"
     )
     assert not missing_from_typed, (
-        f"{shape_name}: CLI dump path resolved value flag(s) {missing_from_typed} "
+        f"{shape_name}: CLI dump path resolved flag(s) {missing_from_typed} "
         "the typed-API path did not"
     )
     # Include-search flags: exact sequence, order and multiplicity both
-    # significant -- see `_split_compile_args`'s own docstring.
+    # significant -- see `split_compile_args`'s own docstring.
     assert cli_includes == typed_includes, (
         shape_name,
         cli_includes,
@@ -400,10 +394,21 @@ def _dump_via_cli_to_file(
 # (`NOT_COMPARABLE` naming `include_sequence`) is treated as expected via
 # an explicit, conditional `pytest.xfail()` call made *after* confirming
 # that signature -- so a different scan failure surfaces as a genuine,
-# uncaught test failure, and a fix that makes the signature stop
-# reproducing falls through to the real assertions below, which then pass
-# normally (no `strict=True` bookkeeping needed: a plain PASS is itself
-# the loud signal that this note and the xfail list need updating).
+# uncaught test failure.
+#
+# A quiet PASS for a listed shape is *not* an acceptable third outcome
+# (Codex review, second round): if the diagnosed signature stops
+# reproducing -- because the gap closed, or because it changed shape --
+# this must still fail loudly, forcing `_SCAN_KNOWN_DIVERGENT_SHAPES` and
+# AGENTS.md's known-gap note to be updated deliberately, rather than
+# silently going stale behind an ordinary green test nobody has reason to
+# look at twice. So for a listed shape there are exactly two outcomes:
+# the exact known signature reproduces (expected `xfail`), or the test
+# fails outright -- covering both "the gap closed" and "a different
+# failure occurred" with one loud signal, matching the `strict`-xfail
+# spirit without pytest's own `strict=True` bookkeeping (which an
+# imperative, signature-gated `pytest.xfail()` call cannot combine with,
+# per the previous review round).
 _SCAN_KNOWN_DIVERGENT_SHAPES = frozenset({"extra-include-dir"})
 
 
@@ -452,10 +457,16 @@ def test_scan_against_real_dump_baseline_is_comparable(
                 "seeding divergence (see this module's own comment above "
                 "this test)"
             )
-        # Anything else -- including the gap closing entirely -- falls
-        # through to the ordinary assertions below: a fix makes them pass
-        # normally, and any *other* failure surfaces as itself rather than
-        # being mistaken for the diagnosed gap.
+        pytest.fail(
+            f"{shape_name} is listed in _SCAN_KNOWN_DIVERGENT_SHAPES, but "
+            "the previously-diagnosed failure signature (NOT_COMPARABLE "
+            "naming include_sequence) did not reproduce. Either the "
+            "underlying gap has closed -- remove this shape from "
+            "_SCAN_KNOWN_DIVERGENT_SHAPES and update AGENTS.md's "
+            "known-gap note for it -- or a different failure occurred "
+            "and needs its own investigation. "
+            f"exit_code={scan_result.exit_code!r} output={scan_result.output!r}"
+        )
 
     assert "NOT_COMPARABLE" not in scan_result.output, (shape_name, scan_result.output)
     assert scan_result.exit_code == 0, (shape_name, scan_result.output)

--- a/tests/test_dump_compile_args_normalize.py
+++ b/tests/test_dump_compile_args_normalize.py
@@ -87,6 +87,17 @@ class TestLastWinsMacroAndDialectFlags:
         state = split_compile_args(("-DFOO=1", "-UFOO"))[0]
         assert state["macro:FOO"] == "-UFOO"
 
+    def test_separate_and_attached_macro_spelling_normalize_identically(self) -> None:
+        """GCC/Clang accept `-D FOO=1` (separate argv token) as well as
+        `-DFOO=1` (attached) -- the identical attached-vs-separate
+        equivalence the ordered-stream pair flags already need, applied
+        proactively here before a real dumper output exercises it, rather
+        than waiting for a fifth review round to find it the same way the
+        fourth found it for -I."""
+        separate = split_compile_args(("-D", "FOO=1"))
+        attached = split_compile_args(("-DFOO=1",))
+        assert separate[0] == attached[0] == {"macro:FOO": "-DFOO=1"}
+
 
 class TestOrderedStreamPairFlags:
     def test_reordered_include_dirs_are_not_equal(self) -> None:

--- a/tests/test_dump_compile_args_normalize.py
+++ b/tests/test_dump_compile_args_normalize.py
@@ -24,10 +24,10 @@ Per this repo's own "Primitive-level property tests" convention
 (AGENTS.md): a reusable normalization/comparison primitive gets its
 contract pinned directly, with synthetic inputs, decoupled from any one
 caller's real-compiler scenario -- not only exercised incidentally
-through the integration test that happens to trigger it. Three real
-Codex review rounds on the integration test each found a case a plain
-``set()`` (or an insufficiently-defaulted catch-all bucket) comparison
-would have silently accepted as "the same" when it was not; all three are
+through the integration test that happens to trigger it. Four real Codex
+review rounds on the integration test each found a case a plain ``set()``
+(or an insufficiently-defaulted/insufficiently-unified bucket) comparison
+would have silently accepted as "the same" when it was not; all four are
 pinned here as direct, fast regression cases so a future change to the
 normalization rules cannot reintroduce any of them without this file
 failing.
@@ -59,10 +59,10 @@ class TestLastWinsMacroAndDialectFlags:
         assert b[0]["-std="] == "-std=c++17"
 
     def test_conflicting_target_value_in_different_order_is_not_equal(self) -> None:
-        """The case a third review round found: `--target=` has the
-        identical last-wins shape as `-std=`, and the previous revision's
-        catch-all "everything else is presence-only" default silently
-        treated it as order-insensitive instead."""
+        """A third review round found: `--target=` has the identical
+        last-wins shape as `-std=`, and an earlier revision's catch-all
+        "everything else is presence-only" default silently treated it as
+        order-insensitive instead."""
         a = split_compile_args(("--target=a", "--target=b"))
         b = split_compile_args(("--target=b", "--target=a"))
         assert a[0] != b[0]
@@ -88,7 +88,7 @@ class TestLastWinsMacroAndDialectFlags:
         assert state["macro:FOO"] == "-UFOO"
 
 
-class TestOrderedPairFlags:
+class TestOrderedStreamPairFlags:
     def test_reordered_include_dirs_are_not_equal(self) -> None:
         """The case the *second* `set()`-based comparison (of the whole
         arg list) would have missed: two include-search directories in
@@ -102,11 +102,11 @@ class TestOrderedPairFlags:
         a = split_compile_args(("-I", "/a", "-I", "/a"))
         b = split_compile_args(("-I", "/a"))
         assert a[2] != b[2]
-        assert a[2] == (("-I", "/a"), ("-I", "/a"))
+        assert a[2] == ("-I=/a", "-I=/a")
 
     def test_distinct_include_flag_kinds_are_kept_separate(self) -> None:
-        state = split_compile_args(("-I", "/a", "-isystem", "/a"))[2]
-        assert state == (("-I", "/a"), ("-isystem", "/a"))
+        stream = split_compile_args(("-I", "/a", "-isystem", "/a"))[2]
+        assert stream == ("-I=/a", "-isystem=/a")
 
     def test_reordered_forced_includes_are_not_equal(self) -> None:
         """The third review round's other named example: `-include a.h`
@@ -116,9 +116,26 @@ class TestOrderedPairFlags:
         b = split_compile_args(("-include", "b.h", "-include", "a.h"))
         assert a[2] != b[2]
 
-    def test_include_and_forced_include_pairs_do_not_collide(self) -> None:
-        state = split_compile_args(("-I", "/a", "-include", "/a"))[2]
-        assert state == (("-I", "/a"), ("-include", "/a"))
+    def test_attached_and_separate_spellings_normalize_identically(self) -> None:
+        """A fourth review round's case: `-I/a` (attached, one argv
+        token) and `-I`, `/a` (separate, two argv tokens) name the
+        identical compiler behavior and must compare equal."""
+        attached = split_compile_args(("-I/a",))
+        separate = split_compile_args(("-I", "/a"))
+        assert attached[2] == separate[2] == ("-I=/a",)
+
+    def test_attached_form_keeps_its_real_relative_order(self) -> None:
+        """The fourth round's actual reported bug: before this fix, an
+        attached-form pair and a separate-form pair landed in two
+        independently-compared buckets, so their relative order to each
+        other was invisible -- these two argv sequences search a
+        genuinely different directory *first* and must not compare
+        equal."""
+        a = split_compile_args(("-I/a", "-I", "/b"))
+        b = split_compile_args(("-I", "/b", "-I/a"))
+        assert a[2] != b[2]
+        assert a[2] == ("-I=/a", "-I=/b")
+        assert b[2] == ("-I=/b", "-I=/a")
 
 
 class TestPresenceOnlyFlags:
@@ -131,23 +148,33 @@ class TestPresenceOnlyFlags:
         assert a[1] == b[1] == frozenset({"-fPIC", "-pthread"})
 
 
-class TestUnknownFlagsDefaultToStrictOrdering:
+class TestUnknownTokensShareTheOrderedStream:
     def test_reordered_unrecognized_flags_are_not_equal(self) -> None:
         """The structural fix behind the third review round: a flag this
         module has no specific rule for is *not* silently folded into the
-        presence-only set -- it defaults to an exact, order-preserving
-        sequence, since most unrecognized compiler flags that carry an
-        operand are order-sensitive and treating them as safe-by-default
-        is exactly the shape of gap two earlier rounds already found."""
+        presence-only set -- it shares the same strict, order-preserving
+        stream as the recognized pair flags (see the fourth round's fix,
+        which unified what used to be two separately-compared buckets)."""
         a = split_compile_args(("-Wsomething", "-Wother"))
         b = split_compile_args(("-Wother", "-Wsomething"))
-        assert a[3] != b[3]
-        assert a[3] == ("-Wsomething", "-Wother")
+        assert a[2] != b[2]
+        assert a[2] == ("-Wsomething", "-Wother")
 
     def test_duplicated_unrecognized_flag_is_not_collapsed(self) -> None:
         a = split_compile_args(("-Wsomething", "-Wsomething"))
         b = split_compile_args(("-Wsomething",))
-        assert a[3] != b[3]
+        assert a[2] != b[2]
+
+    def test_unknown_token_and_pair_flag_interleave_in_real_order(self) -> None:
+        """The fourth round's core fix, stated directly: an unrecognized
+        token and a recognized pair flag share one stream, so their
+        relative order to each other is part of the comparison too, not
+        just the internal order within each category separately."""
+        a = split_compile_args(("-Wsomething", "-I", "/a"))
+        b = split_compile_args(("-I", "/a", "-Wsomething"))
+        assert a[2] != b[2]
+        assert a[2] == ("-Wsomething", "-I=/a")
+        assert b[2] == ("-I=/a", "-Wsomething")
 
 
 class TestSplitIsExhaustiveAndPartitioned:
@@ -163,26 +190,23 @@ class TestSplitIsExhaustiveAndPartitioned:
             "/b",
             "-Wsomething",
         )
-        last_wins, presence, pairs, unknown = split_compile_args(args)
+        last_wins, presence, stream = split_compile_args(args)
         assert set(last_wins.values()) == {"-DFOO=1", "-std=c++17", "--target=x86_64"}
         assert presence == frozenset({"-fPIC"})
-        assert pairs == (("-I", "/a"), ("-include", "/b"))
-        assert unknown == ("-Wsomething",)
+        assert stream == ("-I=/a", "-include=/b", "-Wsomething")
 
     def test_empty_input_is_empty_everywhere(self) -> None:
-        last_wins, presence, pairs, unknown = split_compile_args(())
+        last_wins, presence, stream = split_compile_args(())
         assert last_wins == {}
         assert presence == frozenset()
-        assert pairs == ()
-        assert unknown == ()
+        assert stream == ()
 
     def test_trailing_pair_flag_with_no_operand_is_not_dropped(self) -> None:
         """A malformed/truncated arg list (a search or forced-include flag
         as the very last token, with no operand) must not silently
-        vanish -- it's recorded verbatim in the unknown bucket instead of
+        vanish -- it's recorded verbatim in the ordered stream instead of
         being dropped, so a real truncation still shows up as a
         difference rather than disappearing from both sides identically
         by accident."""
-        last_wins, presence, pairs, unknown = split_compile_args(("-I",))
-        assert pairs == ()
-        assert unknown == ("-I",)
+        _last_wins, _presence, stream = split_compile_args(("-I",))
+        assert stream == ("-I",)

--- a/tests/test_dump_compile_args_normalize.py
+++ b/tests/test_dump_compile_args_normalize.py
@@ -24,11 +24,12 @@ Per this repo's own "Primitive-level property tests" convention
 (AGENTS.md): a reusable normalization/comparison primitive gets its
 contract pinned directly, with synthetic inputs, decoupled from any one
 caller's real-compiler scenario -- not only exercised incidentally
-through the integration test that happens to trigger it. Two real Codex
-review rounds on the integration test each found a case a plain `set()`
-comparison would have silently accepted as "the same" when it was not;
-both are pinned here as direct, fast regression cases so a future change
-to the normalization rules cannot reintroduce either without this file
+through the integration test that happens to trigger it. Three real
+Codex review rounds on the integration test each found a case a plain
+``set()`` (or an insufficiently-defaulted catch-all bucket) comparison
+would have silently accepted as "the same" when it was not; all three are
+pinned here as direct, fast regression cases so a future change to the
+normalization rules cannot reintroduce any of them without this file
 failing.
 """
 
@@ -54,8 +55,19 @@ class TestLastWinsMacroAndDialectFlags:
         a = split_compile_args(("-std=c++17", "-std=c++20"))
         b = split_compile_args(("-std=c++20", "-std=c++17"))
         assert a[0] != b[0]
-        assert a[0]["dialect"] == "-std=c++20"
-        assert b[0]["dialect"] == "-std=c++17"
+        assert a[0]["-std="] == "-std=c++20"
+        assert b[0]["-std="] == "-std=c++17"
+
+    def test_conflicting_target_value_in_different_order_is_not_equal(self) -> None:
+        """The case a third review round found: `--target=` has the
+        identical last-wins shape as `-std=`, and the previous revision's
+        catch-all "everything else is presence-only" default silently
+        treated it as order-insensitive instead."""
+        a = split_compile_args(("--target=a", "--target=b"))
+        b = split_compile_args(("--target=b", "--target=a"))
+        assert a[0] != b[0]
+        assert a[0]["--target="] == "--target=b"
+        assert b[0]["--target="] == "--target=a"
 
     def test_identical_repeated_value_is_tolerated(self) -> None:
         """The CLI dump path's own separately-tracked, harmless
@@ -72,11 +84,11 @@ class TestLastWinsMacroAndDialectFlags:
         macro name -- a later `-UFOO` genuinely undefines an earlier
         `-DFOO=1`, so the *last* token for that name is what must be
         compared, regardless of which of -D/-U spelled it."""
-        state, _presence, _includes = split_compile_args(("-DFOO=1", "-UFOO"))
+        state = split_compile_args(("-DFOO=1", "-UFOO"))[0]
         assert state["macro:FOO"] == "-UFOO"
 
 
-class TestIncludeSearchFlagsOrderAndMultiplicity:
+class TestOrderedPairFlags:
     def test_reordered_include_dirs_are_not_equal(self) -> None:
         """The case the *second* `set()`-based comparison (of the whole
         arg list) would have missed: two include-search directories in
@@ -88,12 +100,7 @@ class TestIncludeSearchFlagsOrderAndMultiplicity:
 
     def test_duplicated_include_dir_is_not_collapsed(self) -> None:
         a = split_compile_args(("-I", "/a", "-I", "/a"))
-        b = split_compile_args(
-            (
-                "-I",
-                "/a",
-            )
-        )
+        b = split_compile_args(("-I", "/a"))
         assert a[2] != b[2]
         assert a[2] == (("-I", "/a"), ("-I", "/a"))
 
@@ -101,28 +108,81 @@ class TestIncludeSearchFlagsOrderAndMultiplicity:
         state = split_compile_args(("-I", "/a", "-isystem", "/a"))[2]
         assert state == (("-I", "/a"), ("-isystem", "/a"))
 
+    def test_reordered_forced_includes_are_not_equal(self) -> None:
+        """The third review round's other named example: `-include a.h`
+        then `-include b.h` is not the same compilation as the reverse --
+        an earlier forced include's macros are visible to a later one."""
+        a = split_compile_args(("-include", "a.h", "-include", "b.h"))
+        b = split_compile_args(("-include", "b.h", "-include", "a.h"))
+        assert a[2] != b[2]
+
+    def test_include_and_forced_include_pairs_do_not_collide(self) -> None:
+        state = split_compile_args(("-I", "/a", "-include", "/a"))[2]
+        assert state == (("-I", "/a"), ("-include", "/a"))
+
 
 class TestPresenceOnlyFlags:
     def test_reordered_presence_only_flags_are_equal(self) -> None:
         """A boolean-style flag like -fPIC has no meaningful order or
-        repeat count -- unlike the two flag families above, a set
-        comparison is the *correct* semantics here."""
+        repeat count -- unlike the flag families above, a set comparison
+        is the *correct* semantics here, not merely a convenient one."""
         a = split_compile_args(("-fPIC", "-pthread"))
         b = split_compile_args(("-pthread", "-fPIC", "-fPIC"))
         assert a[1] == b[1] == frozenset({"-fPIC", "-pthread"})
 
-    def test_split_is_exhaustive_and_partitioned(self) -> None:
-        """Every input token lands in exactly one of the three output
-        pieces -- a sanity check on the partition itself, independent of
-        any equivalence question."""
-        args = ("-DFOO=1", "-std=c++17", "-fPIC", "-I", "/a", "-isystem", "/b")
-        last_wins, presence, includes = split_compile_args(args)
-        assert set(last_wins.values()) == {"-DFOO=1", "-std=c++17"}
+
+class TestUnknownFlagsDefaultToStrictOrdering:
+    def test_reordered_unrecognized_flags_are_not_equal(self) -> None:
+        """The structural fix behind the third review round: a flag this
+        module has no specific rule for is *not* silently folded into the
+        presence-only set -- it defaults to an exact, order-preserving
+        sequence, since most unrecognized compiler flags that carry an
+        operand are order-sensitive and treating them as safe-by-default
+        is exactly the shape of gap two earlier rounds already found."""
+        a = split_compile_args(("-Wsomething", "-Wother"))
+        b = split_compile_args(("-Wother", "-Wsomething"))
+        assert a[3] != b[3]
+        assert a[3] == ("-Wsomething", "-Wother")
+
+    def test_duplicated_unrecognized_flag_is_not_collapsed(self) -> None:
+        a = split_compile_args(("-Wsomething", "-Wsomething"))
+        b = split_compile_args(("-Wsomething",))
+        assert a[3] != b[3]
+
+
+class TestSplitIsExhaustiveAndPartitioned:
+    def test_every_token_lands_in_exactly_one_bucket(self) -> None:
+        args = (
+            "-DFOO=1",
+            "-std=c++17",
+            "--target=x86_64",
+            "-fPIC",
+            "-I",
+            "/a",
+            "-include",
+            "/b",
+            "-Wsomething",
+        )
+        last_wins, presence, pairs, unknown = split_compile_args(args)
+        assert set(last_wins.values()) == {"-DFOO=1", "-std=c++17", "--target=x86_64"}
         assert presence == frozenset({"-fPIC"})
-        assert includes == (("-I", "/a"), ("-isystem", "/b"))
+        assert pairs == (("-I", "/a"), ("-include", "/b"))
+        assert unknown == ("-Wsomething",)
 
     def test_empty_input_is_empty_everywhere(self) -> None:
-        last_wins, presence, includes = split_compile_args(())
+        last_wins, presence, pairs, unknown = split_compile_args(())
         assert last_wins == {}
         assert presence == frozenset()
-        assert includes == ()
+        assert pairs == ()
+        assert unknown == ()
+
+    def test_trailing_pair_flag_with_no_operand_is_not_dropped(self) -> None:
+        """A malformed/truncated arg list (a search or forced-include flag
+        as the very last token, with no operand) must not silently
+        vanish -- it's recorded verbatim in the unknown bucket instead of
+        being dropped, so a real truncation still shows up as a
+        difference rather than disappearing from both sides identically
+        by accident."""
+        last_wins, presence, pairs, unknown = split_compile_args(("-I",))
+        assert pairs == ()
+        assert unknown == ("-I",)

--- a/tests/test_dump_compile_args_normalize.py
+++ b/tests/test_dump_compile_args_normalize.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Fast, compiler-free unit coverage for
+``_dump_compile_args_normalize.split_compile_args`` -- the primitive
+``tests/test_dump_cli_typed_api_parity.py`` (an ``integration``-marked,
+real-compiler test) relies on to compare two ``ast_compile_args``
+sequences for real semantic equivalence rather than literal list/set
+equality.
+
+Per this repo's own "Primitive-level property tests" convention
+(AGENTS.md): a reusable normalization/comparison primitive gets its
+contract pinned directly, with synthetic inputs, decoupled from any one
+caller's real-compiler scenario -- not only exercised incidentally
+through the integration test that happens to trigger it. Two real Codex
+review rounds on the integration test each found a case a plain `set()`
+comparison would have silently accepted as "the same" when it was not;
+both are pinned here as direct, fast regression cases so a future change
+to the normalization rules cannot reintroduce either without this file
+failing.
+"""
+
+from __future__ import annotations
+
+from _dump_compile_args_normalize import split_compile_args
+
+
+class TestLastWinsMacroAndDialectFlags:
+    def test_conflicting_macro_value_in_different_order_is_not_equal(self) -> None:
+        """The case the first `set()`-based comparison would have missed:
+        two paths defining the same macro with *different* values, in an
+        order that makes the *effective* (last-wins) value differ -- a
+        real compiler sees FOO=2 in one case, FOO=1 in the other, so these
+        must not compare equal."""
+        a = split_compile_args(("-DFOO=1", "-DFOO=2"))
+        b = split_compile_args(("-DFOO=2", "-DFOO=1"))
+        assert a[0] != b[0]
+        assert a[0]["macro:FOO"] == "-DFOO=2"
+        assert b[0]["macro:FOO"] == "-DFOO=1"
+
+    def test_conflicting_std_value_in_different_order_is_not_equal(self) -> None:
+        a = split_compile_args(("-std=c++17", "-std=c++20"))
+        b = split_compile_args(("-std=c++20", "-std=c++17"))
+        assert a[0] != b[0]
+        assert a[0]["dialect"] == "-std=c++20"
+        assert b[0]["dialect"] == "-std=c++17"
+
+    def test_identical_repeated_value_is_tolerated(self) -> None:
+        """The CLI dump path's own separately-tracked, harmless
+        duplication (the same -std=/-D value repeated) -- this must still
+        compare equal to a single occurrence, since the effective
+        compiler state is identical either way."""
+        duplicated = split_compile_args(("-std=c++17", "-fPIC", "-std=c++17"))
+        single = split_compile_args(("-std=c++17", "-fPIC"))
+        assert duplicated[0] == single[0]
+        assert duplicated[1] == single[1]
+
+    def test_undef_after_define_is_the_effective_state(self) -> None:
+        """`-U` shares the same last-wins namespace as `-D` for a given
+        macro name -- a later `-UFOO` genuinely undefines an earlier
+        `-DFOO=1`, so the *last* token for that name is what must be
+        compared, regardless of which of -D/-U spelled it."""
+        state, _presence, _includes = split_compile_args(("-DFOO=1", "-UFOO"))
+        assert state["macro:FOO"] == "-UFOO"
+
+
+class TestIncludeSearchFlagsOrderAndMultiplicity:
+    def test_reordered_include_dirs_are_not_equal(self) -> None:
+        """The case the *second* `set()`-based comparison (of the whole
+        arg list) would have missed: two include-search directories in
+        opposite order are not interchangeable, since a real compiler
+        resolves a colliding header basename from the first match."""
+        a = split_compile_args(("-I", "/a", "-I", "/b"))
+        b = split_compile_args(("-I", "/b", "-I", "/a"))
+        assert a[2] != b[2]
+
+    def test_duplicated_include_dir_is_not_collapsed(self) -> None:
+        a = split_compile_args(("-I", "/a", "-I", "/a"))
+        b = split_compile_args(
+            (
+                "-I",
+                "/a",
+            )
+        )
+        assert a[2] != b[2]
+        assert a[2] == (("-I", "/a"), ("-I", "/a"))
+
+    def test_distinct_include_flag_kinds_are_kept_separate(self) -> None:
+        state = split_compile_args(("-I", "/a", "-isystem", "/a"))[2]
+        assert state == (("-I", "/a"), ("-isystem", "/a"))
+
+
+class TestPresenceOnlyFlags:
+    def test_reordered_presence_only_flags_are_equal(self) -> None:
+        """A boolean-style flag like -fPIC has no meaningful order or
+        repeat count -- unlike the two flag families above, a set
+        comparison is the *correct* semantics here."""
+        a = split_compile_args(("-fPIC", "-pthread"))
+        b = split_compile_args(("-pthread", "-fPIC", "-fPIC"))
+        assert a[1] == b[1] == frozenset({"-fPIC", "-pthread"})
+
+    def test_split_is_exhaustive_and_partitioned(self) -> None:
+        """Every input token lands in exactly one of the three output
+        pieces -- a sanity check on the partition itself, independent of
+        any equivalence question."""
+        args = ("-DFOO=1", "-std=c++17", "-fPIC", "-I", "/a", "-isystem", "/b")
+        last_wins, presence, includes = split_compile_args(args)
+        assert set(last_wins.values()) == {"-DFOO=1", "-std=c++17"}
+        assert presence == frozenset({"-fPIC"})
+        assert includes == (("-I", "/a"), ("-isystem", "/b"))
+
+    def test_empty_input_is_empty_everywhere(self) -> None:
+        last_wins, presence, includes = split_compile_args(())
+        assert last_wins == {}
+        assert presence == frozenset()
+        assert includes == ()

--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -1,0 +1,226 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end regression coverage for the "dump-vs-scan compile-context
+divergence" bug report (a real ``abicheck dump`` baseline compared against
+an unchanged codebase via ``abicheck scan --against`` reported
+``NOT_COMPARABLE``/``profile_fingerprint`` mismatch, because ``dump``'s own
+CLI path did not fold real L3 build evidence into its L2 header-AST parse
+the way ``compare``'s implicit-dump operand and ``scan``'s candidate
+resolution already did).
+
+AGENTS.md's "Known gaps" section documents this class of bug at length (the
+"The native ELF `abicheck dump` path never applies L3 build context to its
+own L2 header parse" entry) and records it closed via the P0.3 L3->L2 fold
+(``buildsource/l2_seed.py``'s ``seed_includes_and_fold_compile_context``),
+wired into both ``perform_elf_dump`` and ``handle_non_elf_dump``. The
+existing regression coverage for that fold
+(``tests/test_cli_dump_helpers_coverage.py::
+test_perform_elf_dump_folds_l3_compile_context_into_header_parse`` and
+siblings) verifies the mechanism with a stubbed ``dump()`` call, at the unit
+level. Per this file's own "Third-party-boundary tests must exercise the
+real public API at realistic scale" convention, this module adds the
+missing piece: a real ``abicheck dump`` CLI invocation, over a real
+g++-compiled library and a real ``compile_commands.json``, whose JSON
+output is then fed to a real ``abicheck scan --against`` CLI invocation on
+the same (unchanged) sources -- confirming end to end that the reported
+symptom (``ast_resolved_standard``/``ast_compile_args`` empty on the
+``dump`` side, ``NOT_COMPARABLE`` on the ``scan`` side) does not reproduce
+on the current fold, rather than trusting the mocked unit coverage alone.
+
+Deliberately *not* marked ``integration`` (that marker's Linux gate
+requires castxml) -- ``--ast-frontend clang`` is used explicitly, mirroring
+``test_clang_header_backend_integration.py``'s own self-skipping
+convention, since the point is a real clang + g++ toolchain, not castxml
+specifically.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from abicheck.cli import main
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="ELF/Linux-scoped repro (real g++-compiled .so + compile_commands.json)",
+)
+
+_HAVE_GXX = shutil.which("g++") is not None
+_HAVE_CLANG = shutil.which("clang") is not None
+
+
+def _build_library(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """Compile a tiny real C++17 library + a matching compile_commands.json.
+
+    Mirrors the bug report's repro shape: a library genuinely built with an
+    explicit ``-std=`` the header itself depends on (so a dump that failed
+    to fold the real standard would produce headers parsed under the wrong
+    dialect, not merely empty metadata).
+    """
+    header = tmp_path / "widget.h"
+    header.write_text(
+        "#pragma once\n"
+        "#if __cplusplus < 201703L\n"
+        '#error "needs c++17"\n'
+        "#endif\n"
+        "struct Widget {\n"
+        "    int x;\n"
+        "    int y;\n"
+        "    int sum() const { return x + y; }\n"
+        "};\n",
+        encoding="utf-8",
+    )
+    src = tmp_path / "widget.cpp"
+    src.write_text(
+        '#include "widget.h"\nint compute(const Widget& w) { return w.sum(); }\n',
+        encoding="utf-8",
+    )
+    so_path = tmp_path / "libwidget.so"
+    subprocess.run(
+        ["g++", "-std=c++17", "-shared", "-fPIC", "-o", str(so_path), str(src)],
+        check=True,
+        capture_output=True,
+    )
+    compile_db = tmp_path / "compile_commands.json"
+    compile_db.write_text(
+        json.dumps(
+            [
+                {
+                    "directory": str(tmp_path),
+                    "arguments": [
+                        "g++",
+                        "-std=c++17",
+                        "-shared",
+                        "-fPIC",
+                        "-c",
+                        str(src),
+                        "-o",
+                        "widget.o",
+                    ],
+                    "file": str(src),
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return so_path, header, compile_db
+
+
+@pytest.mark.skipif(
+    not (_HAVE_GXX and _HAVE_CLANG), reason="needs a real g++ and clang toolchain"
+)
+def test_dump_folds_real_l3_evidence_into_ast_compile_context(tmp_path: Path) -> None:
+    """A real ``dump --build-info`` baseline carries the real ``-std=``.
+
+    Direct assertion on the reported symptom: ``ast_resolved_standard``/
+    ``ast_compile_args`` must not be empty when real L3 build evidence
+    (a compile database recording ``-std=c++17``) was supplied.
+    """
+    so_path, header, compile_db = _build_library(tmp_path)
+    baseline = tmp_path / "baseline.json"
+
+    result = CliRunner().invoke(
+        main,
+        [
+            "dump",
+            str(so_path),
+            "-H",
+            str(header),
+            "--sources",
+            str(tmp_path),
+            "--build-info",
+            str(compile_db),
+            "--depth",
+            "source",
+            "--ast-frontend",
+            "clang",
+            "-o",
+            str(baseline),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+
+    snap = json.loads(baseline.read_text(encoding="utf-8"))
+    assert snap.get("ast_resolved_standard") == "c++17", snap.get(
+        "ast_resolved_standard"
+    )
+    assert snap.get("ast_compile_args"), "ast_compile_args must not be empty"
+    assert snap.get("parsed_with_build_context") is True
+
+
+@pytest.mark.skipif(
+    not (_HAVE_GXX and _HAVE_CLANG), reason="needs a real g++ and clang toolchain"
+)
+def test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source(
+    tmp_path: Path,
+) -> None:
+    """The full repro from the bug report: dump a baseline, then ``scan
+    --against`` it on the identical, unchanged codebase. Must resolve as
+    comparable (``NO_CHANGE``/exit 0), never ``NOT_COMPARABLE`` (exit 6)."""
+    so_path, header, compile_db = _build_library(tmp_path)
+    baseline = tmp_path / "baseline.json"
+
+    dump_result = CliRunner().invoke(
+        main,
+        [
+            "dump",
+            str(so_path),
+            "-H",
+            str(header),
+            "--sources",
+            str(tmp_path),
+            "--build-info",
+            str(compile_db),
+            "--depth",
+            "source",
+            "--ast-frontend",
+            "clang",
+            "-o",
+            str(baseline),
+        ],
+    )
+    assert dump_result.exit_code == 0, dump_result.output
+
+    scan_result = CliRunner().invoke(
+        main,
+        [
+            "scan",
+            str(so_path),
+            "-H",
+            str(header),
+            "--sources",
+            str(tmp_path),
+            "--build-info",
+            str(compile_db),
+            "--depth",
+            "source",
+            "--ast-frontend",
+            "clang",
+            "--against",
+            str(baseline),
+        ],
+    )
+    assert "NOT_COMPARABLE" not in scan_result.output, scan_result.output
+    assert "profile_fingerprint mismatch" not in scan_result.output, scan_result.output
+    assert scan_result.exit_code == 0, scan_result.output
+    assert "Verdict: NO_CHANGE" in scan_result.output, scan_result.output

--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -40,11 +40,13 @@ symptom (``ast_resolved_standard``/``ast_compile_args`` empty on the
 ``dump`` side, ``NOT_COMPARABLE`` on the ``scan`` side) does not reproduce
 on the current fold, rather than trusting the mocked unit coverage alone.
 
-Deliberately *not* marked ``integration`` (that marker's Linux gate
-requires castxml) -- ``--ast-frontend clang`` is used explicitly, mirroring
-``test_clang_header_backend_integration.py``'s own self-skipping
-convention, since the point is a real clang + g++ toolchain, not castxml
-specifically.
+Marked ``integration`` (real compiler-backed, so it must stay out of the
+default fast lane -- CLAUDE.md's "Default fast command excludes all
+external-tool markers"). ``--ast-frontend clang`` is used explicitly
+rather than the default castxml backend purely so this module's own
+development/verification didn't require a castxml install; the Linux
+``integration`` CI lane installs both clang and castxml/gcc/g++
+(``.github/workflows/ci.yml``), so this runs there regardless.
 """
 
 from __future__ import annotations
@@ -60,10 +62,13 @@ from click.testing import CliRunner
 
 from abicheck.cli import main
 
-pytestmark = pytest.mark.skipif(
-    not sys.platform.startswith("linux"),
-    reason="ELF/Linux-scoped repro (real g++-compiled .so + compile_commands.json)",
-)
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        not sys.platform.startswith("linux"),
+        reason="ELF/Linux-scoped repro (real g++-compiled .so + compile_commands.json)",
+    ),
+]
 
 _HAVE_GXX = shutil.which("g++") is not None
 _HAVE_CLANG = shutil.which("clang") is not None


### PR DESCRIPTION
## Summary

Investigates the reported bug ("`dump`/`scan` produce structurally
non-comparable snapshots (`NOT_COMPARABLE`, `profile_fingerprint`
mismatch) even when the underlying binary/source is unchanged") and adds
the missing real, end-to-end regression coverage for it — including a
new, generalized parity test between `dump`'s CLI path and the typed
`DumpRequest` API path, which itself surfaced (and now guards against) a
real, currently-open residual instance of the same bug class.

## Motivation

The report describes a real `abicheck dump` baseline (via `--sources`/
`--build-info`) whose `ast_resolved_standard`/`ast_compile_args` come out
empty despite genuine L3 build evidence, causing a follow-up `abicheck
scan --against` on the unchanged codebase to fail as `NOT_COMPARABLE`
(`profile_fingerprint` mismatch on `include_sequence`/`language_standard`).
It points at `AGENTS.md`'s own "Known gaps" entry documenting this class
of bug and the fact that `dump`'s CLI path wasn't routed through the same
L3→L2 fold `compare`/`scan` already use.

## Investigation result

Reproducing the report's exact repro shape against current `main` (a real
`g++ -std=c++17`-compiled library + a real `compile_commands.json`, dumped
via `abicheck dump --sources --build-info --depth source --ast-frontend
clang`, then compared via `abicheck scan --against`) shows the reported
symptom **does not reproduce**: `ast_resolved_standard`/`ast_compile_args`
are correctly populated on the `dump` side, and `scan --against` resolves
`NO_CHANGE`, not `NOT_COMPARABLE`.

`AGENTS.md`'s own known-gap entry already documents this fixed via the
P0.3 L3→L2 fold (`buildsource/l2_seed.seed_includes_and_fold_compile_context`,
wired into both `perform_elf_dump` and `handle_non_elf_dump`) across a long
series of review rounds. The commit the bug report is pinned to
(`abicheck/abicheck@891bd9d7`) predates essentially all of those fixes.

A follow-up question ("how did this divergence happen, and can it be
caught generically?") led to a second test module,
`tests/test_dump_cli_typed_api_parity.py`, which parametrizes over a small
matrix of real build-evidence shapes instead of one hand-picked repro.
While building that matrix, it found a **real, currently-open residual
instance of this same bug class on current `main`**, without any Bazel
toolchain involved — root-caused and documented in `AGENTS.md`, guarded
with a precisely-scoped conditional `xfail`.

## Changes

- Adds `tests/test_dump_scan_l3_comparability.py`: a real, non-mocked
  end-to-end regression — a real `g++`-compiled library + a real
  `compile_commands.json`, driven through the actual `dump`/`scan` CLI
  commands via `CliRunner` — asserting both the direct symptom
  (`ast_resolved_standard`/`ast_compile_args` populated) and the full
  repro (`scan --against` resolves comparable, not `NOT_COMPARABLE`).
- Adds `tests/test_dump_cli_typed_api_parity.py`: a generalized parity
  test comparing `dump`'s CLI output against the typed
  `DumpRequest`/`run_dump_request` API output across several real
  build-evidence shapes, plus end-to-end comparability checks against
  both `scan --against` and `compare`'s implicit-dump path for the same
  matrix. One shape (an extra `-I<dependency-dir>`) reproduces a real,
  root-caused, currently-open divergence between `dump`'s baseline and
  `scan`'s candidate resolution — guarded with a precisely-scoped,
  signature-gated conditional `xfail` (see the module's own comments)
  rather than fixed, per this repo's "known gaps over risky reactive
  patches" convention.
- Adds `tests/_dump_compile_args_normalize.py` (a non-test-prefixed
  shared helper, mirroring `_strict_process.py`/`_workflow_exec.py`):
  `split_compile_args()` compares two real `ast_compile_args` sequences
  for genuine semantic equivalence rather than literal list/set equality
  — a last-wins dict for `-D`/`-U`/`-std=`/`--target=`, a plain set for a
  small explicit allowlist of genuinely order-insensitive boolean flags,
  and one unified, order- and multiplicity-preserving stream for every
  include-search/forced-include pair (attached or separate spelling,
  canonicalized identically) and any unrecognized token — chosen so an
  unrecognized flag defaults to strict comparison, not the reverse. Adds
  `tests/test_dump_compile_args_normalize.py`: fast, compiler-free unit
  coverage pinning that contract directly.
- Updates `AGENTS.md`'s existing "Known gaps" entry for this bug class
  with both the re-verification of the original report and the new,
  narrower, non-Bazel-specific residual gap found while building the
  parity test matrix.

## Bug-fix test contract

<!-- bugfix-test-contract -->

This PR's `fix:`-titled commits correct defects found by review in the
**new integration tests this same PR introduces** (never previously
merged in their broken form), not defects in previously-shipped
`abicheck` code. Answered below for completeness/CI compliance rather
than skipped, since the contract's own questions are still the right
ones to ask of a test-correctness fix — and because this PR went through
several real review rounds worth recording accurately here rather than
leaving a stale summary of an earlier revision.

- Bug class: A recurring pattern across several review rounds in this
  PR's own new test code, each instance silently weakening the
  regression coverage the PR exists to add: (1) an imperative
  `pytest.xfail()` call placed inside a parametrized test body aborts
  execution before the body runs, so it can only ever report an expected
  failure, never observe the underlying condition being fixed; (2) a
  parity assertion comparing real compiler-flag sequences via a plain
  `set()` silently discards order/multiplicity, so a reordered or
  conflicting `-D`/`-std=`/`--target=`/include-search/forced-include
  flag on one of the two paths under test would pass undetected; (3) two
  independently-compared "order-sensitive" buckets (a canonical-pair
  bucket and an unrecognized-token bucket) lost the *relative* order
  between an attached-spelling flag and a separate-spelling one.
- Publicly observable failure: None on shipped `abicheck` runtime
  behavior — every instance above is in this PR's own not-yet-merged
  test code. The observable failure mode is entirely in what the test
  suite would fail to report: a future fix to the dump-vs-scan
  include-seeding divergence this PR documents would go unnoticed
  forever, or a future regression that reorders/duplicates a compiler
  flag on one of the two dump paths would pass the parity test silently.
- Regression test fails on base: Verified directly rather than via a
  separate "base" ref (none exists — these tests are new in this PR):
  each fix was confirmed, before being kept, to make a synthetic input
  shaped exactly like the reviewer's counterexample fail against the
  pre-fix code and pass against the post-fix code — see
  `tests/test_dump_compile_args_normalize.py`'s test names (e.g.
  `test_attached_form_keeps_its_real_relative_order`,
  `test_conflicting_target_value_in_different_order_is_not_equal`),
  each of which documents the specific review finding it pins.
- Negative control: Every other parametrized case (the non-triggering
  build shapes; every already-correctly-classified flag family: -fPIC,
  presence-only boolean flags) must keep comparing equal/passing
  normally after each fix — verified after every round via the full
  local suite for both new test modules (real-compiler integration
  tests + the fast synthetic unit tests).
- Public-surface test: The integration module exercises the real
  `abicheck dump`/`scan`/`compare` CLI commands via `CliRunner` and the
  real, public `DumpRequest`/`run_dump_request` typed API — not an
  internal helper in isolation. The shared normalization helper itself
  is also pinned directly (see "Axes covered"), since it's a reusable
  primitive per this repo's own "Primitive-level property tests"
  convention, not just incidental coverage through the integration test.
- Axes covered: Real g++ + real clang AST frontend, ELF/Linux only
  (matches this module's own scope, mirroring its sibling
  `test_dump_scan_l3_comparability.py`); three real build-evidence
  shapes (plain `-std=c++17`, an added `-D` macro under `-std=c++20`, an
  extra `-I<dependency-dir>`); both the CLI dump path and the typed
  `DumpRequest` API path; both `scan --against` and `compare`'s
  implicit-dump operand; plus fast, compiler-free synthetic coverage of
  every flag family the shared normalizer recognizes (last-wins
  macro/dialect/target, ordered include-search/forced-include pairs in
  both spellings, presence-only booleans, and unrecognized tokens).
- General invariant: (1) A conditional `pytest.xfail()`, reached only
  after confirming the exact, already-diagnosed failure signature, holds
  generally: the test body always executes, and a listed shape has
  exactly two outcomes — the known signature (expected `xfail`) or an
  outright failure naming the required bookkeeping, never a quiet pass.
  (2) `split_compile_args()`'s general shape — one unified,
  order-preserving stream for everything not explicitly proven safe to
  reorder, rather than a per-category default that keeps needing a new
  special case — is the actual fix, documented in that module's own
  docstring alongside the four review rounds that arrived at it.

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] Changelog fragment added (`scriv create`) — not required: this PR
      touches no `abicheck/**/*.py` file (test + docs only)
- [x] Docs updated (`AGENTS.md` known-gaps entry)
- [x] `ruff check`/`ruff format --check`/`mypy abicheck/` pass locally
- [x] No new `mypy` or `ruff` errors introduced
