### PR TITLE
fix: header_roots parity between dump and compare, probe unpinned toolchain defaults

### DIFF
--- a/abicheck/_compiler_options.py
+++ b/abicheck/_compiler_options.py
@@ -259,7 +259,27 @@ def _split_gcc_options_windows(text: str) -> list[str]:
 def has_explicit_std(
     gcc_options: str | None, gcc_option_tokens: tuple[str, ...] = ()
 ) -> bool:
-    """Return whether forwarded options explicitly select any language standard."""
+    """Return whether forwarded options explicitly select any language standard.
+
+    Known, narrower residual gap (Codex review, fresh evidence, not fixed
+    here): recognizes only ``-std=``/``/std:``, not GCC's standard-selecting
+    *alias* ``-ansi`` (``-std=c90``/``-std=c++98`` depending on language mode
+    -- verified against a real compiler: ``g++ -ansi`` reports
+    ``__cplusplus=199711L``, not the default ``201703L``). A forwarded
+    ``-ansi`` therefore reads as "no explicit standard" everywhere this
+    function gates on it -- both ``dumper_ast_config.py``'s command builders
+    (which would then append their own ``-std=gnu11``/``-std=gnu++20``
+    *after* a user's ``-ansi``, silently overriding it via last-flag-wins)
+    and ``dumper_toolchain._resolve_standard_provenance`` (which would then
+    probe or report a forced standard that never actually parsed the
+    headers). A correct fix needs ``-ansi`` recognized here (its resolved
+    value depends on the caller's language mode, which this function does
+    not currently receive) *and* every one of this function's several
+    call sites across ``dumper_ast_config.py``/``dumper_toolchain.py``/
+    ``cli_helpers_compare.py``/``service_compare_evidence.py``/
+    ``service_scan.py`` re-verified against the new signature -- a genuine,
+    cross-cutting change, not a follow-up to one caller.
+    """
     if gcc_options and ("-std=" in gcc_options or "/std:" in gcc_options):
         return True
     return any(("-std=" in token or "/std:" in token) for token in gcc_option_tokens)

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -1378,7 +1378,7 @@ def handle_non_elf_dump(
         inputs_pack=inputs_pack,
         depth=depth,
         include_dependencies=include_dependencies,
-        header_roots=headers,
+        header_roots=tuple(headers) + tuple(public_headers) + tuple(public_header_dirs),
         clang_bin=resolve_source_frontend_clang_bin(
             getattr(compile_context, "gcc_path", None),
             getattr(compile_context, "gcc_prefix", None),
@@ -1992,7 +1992,7 @@ def perform_elf_dump(
         inputs_pack=inputs_pack,
         depth=depth,
         include_dependencies=include_dependencies,
-        header_roots=tuple(headers) + _dump_manifest_header_roots(dump_manifest),
+        header_roots=tuple(headers) + _dump_manifest_header_roots(dump_manifest) + tuple(public_headers) + tuple(public_header_dirs),
         clang_bin=resolve_source_frontend_clang_bin(
             gcc_path, gcc_prefix, exclude_cl_style=False
         ),

--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -705,11 +705,15 @@ _FORCED_C_STANDARD = "gnu11"
 #: standard* dump could have produced before either the probe or the
 #: forced-``gnu11`` report existed, that this carve-out can still safely
 #: corroborate: an explicit ``--lang`` with nothing else resolved (bare
-#: ``"c"``/``"c++"``). Deliberately excludes the bare empty string (no
-#: ``--lang`` given at all, pure content-based auto-detection) -- see
-#: :func:`_newly_resolved_standard_remainder`'s own docstring for why
-#: (Codex review, fresh evidence).
-_UNRESOLVED_STANDARD_SPELLINGS = ("c", "c++")
+#: ``"c"``/``"c++"``/``"cpp"`` -- ``"cpp"`` is a second, still-supported
+#: spelling for C++ alongside ``"c++"``, per :func:`_resolve_force_cpp`'s
+#: own ``lang.upper() in ("C++", "CPP")`` check; ``language_standard_field``
+#: lowercases but does not otherwise canonicalize the tag, so the two
+#: spellings persist as distinct strings, not merely distinct casings —
+#: Codex review, fresh evidence). Deliberately excludes the bare empty
+#: string (no ``--lang`` given at all, pure content-based auto-detection)
+#: -- see :func:`_newly_resolved_standard_remainder`'s own docstring for why.
+_UNRESOLVED_STANDARD_SPELLINGS = ("c", "c++", "cpp")
 
 
 def _newly_resolved_standard_remainder(

--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -734,7 +734,10 @@ def _newly_resolved_standard_remainder(
 
 
 def _language_standard_probe_upgrade_corroborated(
-    old_fields: dict[str, str], new_fields: dict[str, str]
+    old: AbiSnapshot,
+    new: AbiSnapshot,
+    old_fields: dict[str, str],
+    new_fields: dict[str, str],
 ) -> bool:
     """Whether a differing ``language_standard`` is fully explained by this
     probe (or the sibling forced-``gnu11`` report) having been *added* by an
@@ -770,6 +773,21 @@ def _language_standard_probe_upgrade_corroborated(
     and the comparison is a real profile change this gate should still
     catch.
 
+    When both sides' ``AbiSnapshot.ast_toolchain`` carry a non-empty
+    ``compiler_sha256`` (Codex review, fresh evidence), that content-address
+    is also required to match: a compiler *wrapper* replaced at the same
+    path can report an identical ``compiler_family``/``compiler_version``
+    string while actually selecting a different default dialect --
+    ``compiler_version`` is text a wrapper's own ``--version`` output
+    chooses to emit, not a fact this tool independently verifies, whereas
+    ``compiler_sha256`` is the resolved binary's own content hash
+    (``dumper_toolchain._tool_identity_metadata``) and cannot lie the same
+    way. Checked only when available on *both* sides -- an older/legacy
+    snapshot predating this field, or a side whose compiler resolution
+    itself failed (``ast_toolchain["compiler_error"]``, no ``compiler_*``
+    keys at all), falls back to the family/version check above rather than
+    failing closed on missing evidence it was never in a position to carry.
+
     The ``"probed:"`` marker is checked by *containment*, not
     ``str.startswith`` (Codex review, fresh evidence): when a dump also
     pins an explicit ``--lang``, ``language_standard_field`` prefixes the
@@ -795,6 +813,10 @@ def _language_standard_probe_upgrade_corroborated(
         new_v = new_fields.get(key, "")
         if not old_v or not new_v or old_v != new_v:
             return False
+    old_sha = old.ast_toolchain.get("compiler_sha256", "")
+    new_sha = new.ast_toolchain.get("compiler_sha256", "")
+    if old_sha and new_sha and old_sha != new_sha:
+        return False
     return True
 
 
@@ -1174,7 +1196,9 @@ def _unexplained_profile_fields(
     # compiler_family/compiler_version difference riding alongside it.
     if (
         "language_standard" in unexplained
-        and _language_standard_probe_upgrade_corroborated(old_fields, new_fields)
+        and _language_standard_probe_upgrade_corroborated(
+            old, new, old_fields, new_fields
+        )
     ):
         unexplained.discard("language_standard")
 

--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -742,9 +742,17 @@ def _newly_resolved_standard_remainder(
     upgrade-only case this carve-out exists to waive, and a matching
     ``compiler_family``/``compiler_version``/``compiler_sha256`` says
     nothing about which mode either side's *headers* actually resolved to.
-    An explicit ``--lang`` has no such ambiguity: :func:`_resolve_force_cpp`
-    returns that mode unconditionally regardless of header content, so the
-    lang-tag-equality check above is sufficient corroboration on its own.
+    An explicit ``--lang c++``/``"cpp"`` has no such ambiguity:
+    :func:`_resolve_force_cpp` returns C++ mode unconditionally for those,
+    with no retry that could revise it downward, so the lang-tag-equality
+    check above is sufficient corroboration on its own. An explicit
+    ``--lang c`` is a narrower exception this function's own signature
+    cannot see: ``dumper.py``'s C->C++ self-heal retry can still override
+    it mid-parse when a header turns out to need a C++ stdlib header, so a
+    ``"c"`` tag alone does not prove the *actual* parse stayed C --
+    :func:`_language_standard_probe_upgrade_corroborated` checks the
+    resolved remainder's own content for that case specifically (Codex
+    review, fresh evidence).
     """
     if old_std not in _UNRESOLVED_STANDARD_SPELLINGS:
         return None
@@ -822,15 +830,30 @@ def _language_standard_probe_upgrade_corroborated(
     """
     old_std = old_fields.get("language_standard", "")
     new_std = new_fields.get("language_standard", "")
-    remainder = _newly_resolved_standard_remainder(
-        old_std, new_std
-    ) or _newly_resolved_standard_remainder(new_std, old_std)
+    forward = _newly_resolved_standard_remainder(old_std, new_std)
+    tag, remainder = (old_std, forward) if forward is not None else (
+        new_std, _newly_resolved_standard_remainder(new_std, old_std)
+    )
     if remainder is None:
         return False
     is_newly_resolved = (
         remainder == _FORCED_C_STANDARD or _PROBED_STANDARD_PREFIX in remainder
     )
     if not is_newly_resolved:
+        return False
+    # Codex review, fresh evidence: an explicit "c" tag does not pin the
+    # mode unconditionally the way this function's docstring above assumes
+    # -- both header-AST backends self-heal an explicit --lang c request
+    # into C++ when the header turns out to need a C++ stdlib header
+    # (dumper.py's C->C++ retry applies regardless of whether C mode was
+    # auto-detected or explicitly requested). A self-healed parse's probed
+    # value always names __cplusplus (never __STDC_VERSION__, and never the
+    # bare _FORCED_C_STANDARD literal, which _resolve_standard_provenance
+    # only ever returns for a genuinely-C final mode) -- so a "c"-tagged
+    # remainder containing it is real evidence the *new* side's actual
+    # parse mode diverged from its own explicit tag, not merely newly
+    # discovered upgrade evidence, and must not be waived.
+    if tag == "c" and "__cplusplus" in remainder:
         return False
     for key in ("compiler_family", "compiler_version"):
         old_v = old_fields.get(key, "")

--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -689,6 +689,59 @@ def _build_context_corroborated(old: AbiSnapshot, new: AbiSnapshot) -> bool:
     return old.parsed_with_build_context and new.parsed_with_build_context
 
 
+#: The literal ``language_standard`` prefix a probed (never explicitly
+#: pinned) default carries -- see ``dumper_toolchain._probe_default_
+#: language_standard``'s own docstring. Mirrored here (not imported) since
+#: this module has no other reason to depend on ``dumper_toolchain``.
+_PROBED_STANDARD_PREFIX = "probed:"
+
+
+def _language_standard_probe_upgrade_corroborated(
+    old_fields: dict[str, str], new_fields: dict[str, str]
+) -> bool:
+    """Whether a differing ``language_standard`` is fully explained by this
+    probe having been *added* by an abicheck upgrade, not by a genuine
+    toolchain difference (Codex review, fresh evidence).
+
+    A baseline persisted before ``dumper_toolchain._probe_default_language_
+    standard`` existed recorded an *empty* ``language_standard`` for any
+    unpinned (no explicit ``-std=``, no forced-C++20-heuristic) dump --
+    that was the only value this field could ever take for that shape of
+    input. A freshly re-dumped snapshot of the identical input under the
+    identical toolchain now records a real ``"probed:..."`` value there
+    instead, purely because the tool was upgraded -- comparing the two
+    would otherwise raise ``ProfileMismatchError`` on every such baseline,
+    solely from the upgrade itself, not from anything about the library
+    changing.
+
+    Waived only when independently corroborated by an EXACT, non-empty
+    ``compiler_family``/``compiler_version`` match on both sides: the
+    probed default is a deterministic function of the exact resolved
+    compiler binary, so an unchanged ``compiler_version`` is strong,
+    specific evidence the unpinned default did not actually change either
+    -- mirroring the platform carve-out's own "verify each specific
+    differing field, not just some other field on the same axis" discipline
+    (:func:`_platform_identity_confirmed`). A *changed* ``compiler_version``
+    already raises today (no carve-out exists for it, and none is added
+    here), which is correct: upgrading the compiler between the baseline
+    and the comparison is a real profile change this gate should still
+    catch.
+    """
+    old_std = old_fields.get("language_standard", "")
+    new_std = new_fields.get("language_standard", "")
+    is_upgrade_transition = (
+        old_std == "" and new_std.startswith(_PROBED_STANDARD_PREFIX)
+    ) or (new_std == "" and old_std.startswith(_PROBED_STANDARD_PREFIX))
+    if not is_upgrade_transition:
+        return False
+    for key in ("compiler_family", "compiler_version"):
+        old_v = old_fields.get(key, "")
+        new_v = new_fields.get(key, "")
+        if not old_v or not new_v or old_v != new_v:
+            return False
+    return True
+
+
 @dataclass(frozen=True)
 class ComparabilityMismatch:
     """Returned by :func:`check_contracts_comparable` in ``diagnostic=True``
@@ -1017,11 +1070,18 @@ def _unexplained_profile_fields(
     (Codex review, PR #641 follow-up, fourth round): a release combining two
     independently-sanctioned deltas (e.g. a header addition AND a corroborated
     C++-standard raise) must not raise just because neither carve-out's static
-    field-set covers ``differing`` in full on its own. The four carve-outs'
-    field-sets (:data:`_PLATFORM_IDENTITY_FIELDS`/:data:`_BUILD_CONTEXT_FIELDS`/
-    :data:`_HEADER_SEQUENCE_FIELDS`/:data:`_INCLUDE_SEQUENCE_FIELDS`) are
-    mutually disjoint, so processing order never matters -- each only ever
-    narrows the working set, never re-adds to it.
+    field-set covers ``differing`` in full on its own. Four of the five
+    carve-outs' field-sets (:data:`_PLATFORM_IDENTITY_FIELDS`/
+    :data:`_BUILD_CONTEXT_FIELDS`/:data:`_HEADER_SEQUENCE_FIELDS`/
+    :data:`_INCLUDE_SEQUENCE_FIELDS`) are mutually disjoint, so their relative
+    order never matters -- each only ever narrows the working set, never
+    re-adds to it. The fifth,
+    :func:`_language_standard_probe_upgrade_corroborated`, is a narrower,
+    single-field carve-out over ``language_standard`` -- a field the
+    build-context carve-out's own set already covers -- so it is checked
+    *after* the build-context one specifically (its broader waiver, when it
+    applies, already subsumes this one; when it doesn't, this one still gets
+    its own independent chance).
     """
     old_fields = old_contract.profile_fields
     new_fields = new_contract.profile_fields
@@ -1047,6 +1107,20 @@ def _unexplained_profile_fields(
         # discard that finding instead of letting the more specific
         # detector classify it correctly.
         unexplained -= build_candidate
+
+    # abicheck-internal-bugs finding 2 follow-up (Codex review): waive a
+    # language_standard-only mismatch that is fully explained by this PR's
+    # own probe having been added by an upgrade -- see
+    # _language_standard_probe_upgrade_corroborated's own docstring. Checked
+    # after the build-context carve-out (whose broader waiver already
+    # subsumes this one when both sides carry real build evidence) and
+    # narrowly scoped to this single field so it can never mask a genuine
+    # compiler_family/compiler_version difference riding alongside it.
+    if (
+        "language_standard" in unexplained
+        and _language_standard_probe_upgrade_corroborated(old_fields, new_fields)
+    ):
+        unexplained.discard("language_standard")
 
     # Both sequence carve-outs below additionally require
     # _scope_growth_corroborated (Codex review, PR #641 follow-up, P1):

--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -703,34 +703,51 @@ _FORCED_C_STANDARD = "gnu11"
 
 #: Every ``language_standard_field`` spelling an *unpinned, no-resolved-
 #: standard* dump could have produced before either the probe or the
-#: forced-``gnu11`` report existed: no lang given at all (``""``), or an
-#: explicit ``--lang`` with nothing else resolved (bare ``"c"``/``"c++"``).
-_UNRESOLVED_STANDARD_SPELLINGS = ("", "c", "c++")
+#: forced-``gnu11`` report existed, that this carve-out can still safely
+#: corroborate: an explicit ``--lang`` with nothing else resolved (bare
+#: ``"c"``/``"c++"``). Deliberately excludes the bare empty string (no
+#: ``--lang`` given at all, pure content-based auto-detection) -- see
+#: :func:`_newly_resolved_standard_remainder`'s own docstring for why
+#: (Codex review, fresh evidence).
+_UNRESOLVED_STANDARD_SPELLINGS = ("c", "c++")
 
 
 def _newly_resolved_standard_remainder(
     old_std: str, new_std: str
 ) -> str | None:
     """If *old_std* is one of :data:`_UNRESOLVED_STANDARD_SPELLINGS` and
-    *new_std* carries the identical lang tag (if any) plus something newly
-    resolved, return that "something" (the part after the tag); otherwise
-    ``None``.
+    *new_std* carries the identical lang tag plus something newly resolved,
+    return that "something" (the part after the tag); otherwise ``None``.
 
     Split out of :func:`_language_standard_probe_upgrade_corroborated` so
     the "same lang tag, newly populated" structural check has one
     definition, checked in both directions there (Codex review, fresh
     evidence: an explicit-``--lang`` baseline moves from a bare ``"c"``/
     ``"c++"`` to ``"c:gnu11"``/``"c++:probed:..."``, not from an empty
-    string, which the previous version of this check could not recognize).
+    string, which an earlier version of this check could not recognize).
+
+    Deliberately does **not** accept a bare empty *old_std* (no ``--lang``
+    given at all) the way an earlier version of this function did (Codex
+    review, fresh evidence): an empty ``language_standard`` carries *no*
+    signal about which language mode a pre-upgrade, pure-auto-detection
+    dump actually resolved to (:func:`_resolve_force_cpp`'s decision is a
+    function of the header *content*, which this carve-out has no access
+    to) -- so a header that later gains enough C++-only syntax to flip
+    ``_resolve_force_cpp``'s decision (a real language-mode change, not an
+    upgrade artifact) would otherwise be indistinguishable from the
+    upgrade-only case this carve-out exists to waive, and a matching
+    ``compiler_family``/``compiler_version``/``compiler_sha256`` says
+    nothing about which mode either side's *headers* actually resolved to.
+    An explicit ``--lang`` has no such ambiguity: :func:`_resolve_force_cpp`
+    returns that mode unconditionally regardless of header content, so the
+    lang-tag-equality check above is sufficient corroboration on its own.
     """
     if old_std not in _UNRESOLVED_STANDARD_SPELLINGS:
         return None
-    if old_std:
-        prefix = f"{old_std}:"
-        if not new_std.startswith(prefix):
-            return None
-        return new_std[len(prefix) :]
-    return new_std
+    prefix = f"{old_std}:"
+    if not new_std.startswith(prefix):
+        return None
+    return new_std[len(prefix) :]
 
 
 def _language_standard_probe_upgrade_corroborated(
@@ -745,20 +762,23 @@ def _language_standard_probe_upgrade_corroborated(
     fresh evidence).
 
     A baseline persisted before ``dumper_toolchain._probe_default_language_
-    standard``/the forced-C-standard report existed recorded one of
-    :data:`_UNRESOLVED_STANDARD_SPELLINGS` for any unpinned (no explicit
-    ``-std=``, no forced-C++20-heuristic) dump -- that was the only value
-    this field could ever take for that shape of input, whether or not
-    ``--lang`` was also given. A freshly re-dumped snapshot of the identical
-    input under the identical toolchain now records a real, newly-resolved
-    value there instead (:data:`_FORCED_C_STANDARD` for an unpinned C/gnu
-    parse, or a ``"probed:..."`` value for an unpinned C++ parse or an
-    MSVC-dialect C parse), purely because the tool was upgraded -- comparing
-    the two would otherwise raise ``ProfileMismatchError`` on every such
-    baseline, solely from the upgrade itself, not from anything about the
-    library changing. :func:`_newly_resolved_standard_remainder` checks both
-    directions share the same lang tag (if any) and isolates the
-    newly-resolved remainder for the check below.
+    standard``/the forced-C-standard report existed recorded a bare
+    ``"c"``/``"c++"`` (:data:`_UNRESOLVED_STANDARD_SPELLINGS`) for an
+    unpinned (no explicit ``-std=``, no forced-C++20-heuristic) dump given
+    an explicit ``--lang`` -- that was the only value this field could ever
+    take for that shape of input. A freshly re-dumped snapshot of the
+    identical input under the identical toolchain now records a real,
+    newly-resolved value there instead (:data:`_FORCED_C_STANDARD` for an
+    unpinned C/gnu parse, or a ``"probed:..."`` value for an unpinned C++
+    parse or an MSVC-dialect C parse), purely because the tool was upgraded
+    -- comparing the two would otherwise raise ``ProfileMismatchError`` on
+    every such baseline, solely from the upgrade itself, not from anything
+    about the library changing. :func:`_newly_resolved_standard_remainder`
+    checks both directions share the same lang tag and isolates the
+    newly-resolved remainder for the check below -- see that function's own
+    docstring for why a bare *empty* ``language_standard`` (no ``--lang`` at
+    all) is deliberately **not** eligible here, unlike an earlier version of
+    this carve-out.
 
     Waived only when independently corroborated by an EXACT, non-empty
     ``compiler_family``/``compiler_version`` match on both sides: the

--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -827,6 +827,41 @@ def _language_standard_probe_upgrade_corroborated(
     ``"c++:probed:__cplusplus=201703L"``), so the marker does not
     necessarily sit at position 0 -- mirroring
     ``dumper_toolchain._cplusplus_macro_for_standard``'s identical fix.
+
+    **Known, narrower residual (Codex review, fresh evidence), not fixed
+    here**: the ``compiler_family``/``compiler_version`` corroboration
+    above reads ``dumper_toolchain._stamp_ast_parser``'s ``compiler_*``
+    stamping, which this same PR also fixed to resolve against the
+    header-AST parse's *actual* post-retry compiler (``resolved_compiler``)
+    rather than the caller's original, unresolved request -- see that
+    function's own docstring. For a castxml dump where those two diverge
+    (a force_cpp self-heal/remap changed which binary was actually
+    invoked), a **legacy baseline persisted by pre-fix abicheck** recorded
+    ``compiler_selected``/``compiler_family``/``compiler_version`` from the
+    *wrong*, unresolved binary -- so comparing it against a freshly
+    re-dumped snapshot of the identical input under the identical
+    toolchain installation can now see a *changed* ``compiler_family``/
+    ``compiler_version`` purely because this PR's own stamping fix
+    corrected which binary's identity gets recorded, not because the
+    installation changed. That is the same "an abicheck upgrade must not
+    by itself make an unchanged baseline ``NOT_COMPARABLE``" problem this
+    whole carve-out exists to solve, just on the corroboration axis rather
+    than the ``language_standard`` axis it corroborates -- and it
+    compounds: a real, waivable ``language_standard`` transition on such a
+    baseline now also fails this function's own compiler-identity check,
+    so the corroboration this carve-out depends on is unavailable exactly
+    when the legacy stamping bug applies. Deliberately not addressed with
+    a further carve-out: there is no sound way, from either snapshot's
+    persisted content alone, to distinguish "this compiler_family/version
+    difference is purely the stamping fix correcting a mis-recorded legacy
+    baseline" from "the installation's compiler genuinely changed between
+    the two dumps" -- the old baseline recorded only the (wrong) binary it
+    picked, never what the corrected resolution *would* have produced, so
+    there is no fact to corroborate against. Affected users should
+    re-``dump`` their baseline once after upgrading past this fix rather
+    than rely on the carve-out to bridge it, the same guidance any
+    ``ProfileMismatchError`` from an unrelated real toolchain change
+    already implies.
     """
     old_std = old_fields.get("language_standard", "")
     new_std = new_fields.get("language_standard", "")

--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -726,12 +726,20 @@ def _language_standard_probe_upgrade_corroborated(
     here), which is correct: upgrading the compiler between the baseline
     and the comparison is a real profile change this gate should still
     catch.
+
+    The ``"probed:"`` marker is checked by *containment*, not
+    ``str.startswith`` (Codex review, fresh evidence): when a dump also
+    pins an explicit ``--lang``, ``language_standard_field`` prefixes the
+    probed value with ``"c++:"``/``"c:"`` (e.g.
+    ``"c++:probed:__cplusplus=201703L"``), so the marker does not
+    necessarily sit at position 0 -- mirroring
+    ``dumper_toolchain._cplusplus_macro_for_standard``'s identical fix.
     """
     old_std = old_fields.get("language_standard", "")
     new_std = new_fields.get("language_standard", "")
     is_upgrade_transition = (
-        old_std == "" and new_std.startswith(_PROBED_STANDARD_PREFIX)
-    ) or (new_std == "" and old_std.startswith(_PROBED_STANDARD_PREFIX))
+        old_std == "" and _PROBED_STANDARD_PREFIX in new_std
+    ) or (new_std == "" and _PROBED_STANDARD_PREFIX in old_std)
     if not is_upgrade_transition:
         return False
     for key in ("compiler_family", "compiler_version"):
@@ -1436,7 +1444,7 @@ def check_contracts_comparable(
     header-sequence carve-out above.
 
     **Opaque profile-fingerprint mismatches are rejected, not silently
-    waived (Codex review, PR #641 follow-up, P1):** the four carve-outs
+    waived (Codex review, PR #641 follow-up, P1):** the five carve-outs
     above narrow an ``unexplained`` working set that starts as ``differing``
     — the set of :data:`PROFILE_FIELD_KEYS` that actually differ between
     ``old_fields``/``new_fields``. If ``profile_fingerprint`` differs but
@@ -1482,9 +1490,19 @@ def check_contracts_comparable(
     alone). Each carve-out therefore claims and verifies only the subset of
     ``differing`` it understands, narrowing an ``unexplained`` working set;
     the pair is comparable once nothing remains unexplained, not only when
-    one carve-out's field-set covers the whole mismatch by itself. The four
-    carve-outs' field-sets are mutually disjoint, so application order
-    never matters.
+    one carve-out's field-set covers the whole mismatch by itself. Four of
+    the five carve-outs' field-sets (:data:`_PLATFORM_IDENTITY_FIELDS`/
+    :data:`_BUILD_CONTEXT_FIELDS`/:data:`_HEADER_SEQUENCE_FIELDS`/
+    :data:`_INCLUDE_SEQUENCE_FIELDS`) are mutually disjoint, so their
+    relative order never matters among themselves. The fifth,
+    :func:`_language_standard_probe_upgrade_corroborated`, is a narrower,
+    single-field carve-out over ``language_standard`` -- a field the
+    build-context carve-out's own set already covers -- and is checked
+    *after* the build-context one specifically, since it can still only
+    narrow (never re-add to) the working set, so its position relative to
+    the other four still never changes the outcome (see
+    :func:`_unexplained_profile_fields`'s own docstring for the ordering
+    itself).
 
     **Known, accepted limitation, not a correctness bug (PR #641
     follow-up, fourth round):** a header added *outside* the old side's

--- a/abicheck/comparability.py
+++ b/abicheck/comparability.py
@@ -695,24 +695,67 @@ def _build_context_corroborated(old: AbiSnapshot, new: AbiSnapshot) -> bool:
 #: this module has no other reason to depend on ``dumper_toolchain``.
 _PROBED_STANDARD_PREFIX = "probed:"
 
+#: The literal standard both header-AST command builders unconditionally
+#: force for an unpinned C/gnu-dialect parse -- mirrors
+#: ``dumper_toolchain._FORCED_C_STANDARD`` (not imported, same reasoning as
+#: ``_PROBED_STANDARD_PREFIX`` above).
+_FORCED_C_STANDARD = "gnu11"
+
+#: Every ``language_standard_field`` spelling an *unpinned, no-resolved-
+#: standard* dump could have produced before either the probe or the
+#: forced-``gnu11`` report existed: no lang given at all (``""``), or an
+#: explicit ``--lang`` with nothing else resolved (bare ``"c"``/``"c++"``).
+_UNRESOLVED_STANDARD_SPELLINGS = ("", "c", "c++")
+
+
+def _newly_resolved_standard_remainder(
+    old_std: str, new_std: str
+) -> str | None:
+    """If *old_std* is one of :data:`_UNRESOLVED_STANDARD_SPELLINGS` and
+    *new_std* carries the identical lang tag (if any) plus something newly
+    resolved, return that "something" (the part after the tag); otherwise
+    ``None``.
+
+    Split out of :func:`_language_standard_probe_upgrade_corroborated` so
+    the "same lang tag, newly populated" structural check has one
+    definition, checked in both directions there (Codex review, fresh
+    evidence: an explicit-``--lang`` baseline moves from a bare ``"c"``/
+    ``"c++"`` to ``"c:gnu11"``/``"c++:probed:..."``, not from an empty
+    string, which the previous version of this check could not recognize).
+    """
+    if old_std not in _UNRESOLVED_STANDARD_SPELLINGS:
+        return None
+    if old_std:
+        prefix = f"{old_std}:"
+        if not new_std.startswith(prefix):
+            return None
+        return new_std[len(prefix) :]
+    return new_std
+
 
 def _language_standard_probe_upgrade_corroborated(
     old_fields: dict[str, str], new_fields: dict[str, str]
 ) -> bool:
     """Whether a differing ``language_standard`` is fully explained by this
-    probe having been *added* by an abicheck upgrade, not by a genuine
-    toolchain difference (Codex review, fresh evidence).
+    probe (or the sibling forced-``gnu11`` report) having been *added* by an
+    abicheck upgrade, not by a genuine toolchain difference (Codex review,
+    fresh evidence).
 
     A baseline persisted before ``dumper_toolchain._probe_default_language_
-    standard`` existed recorded an *empty* ``language_standard`` for any
-    unpinned (no explicit ``-std=``, no forced-C++20-heuristic) dump --
-    that was the only value this field could ever take for that shape of
-    input. A freshly re-dumped snapshot of the identical input under the
-    identical toolchain now records a real ``"probed:..."`` value there
-    instead, purely because the tool was upgraded -- comparing the two
-    would otherwise raise ``ProfileMismatchError`` on every such baseline,
-    solely from the upgrade itself, not from anything about the library
-    changing.
+    standard``/the forced-C-standard report existed recorded one of
+    :data:`_UNRESOLVED_STANDARD_SPELLINGS` for any unpinned (no explicit
+    ``-std=``, no forced-C++20-heuristic) dump -- that was the only value
+    this field could ever take for that shape of input, whether or not
+    ``--lang`` was also given. A freshly re-dumped snapshot of the identical
+    input under the identical toolchain now records a real, newly-resolved
+    value there instead (:data:`_FORCED_C_STANDARD` for an unpinned C/gnu
+    parse, or a ``"probed:..."`` value for an unpinned C++ parse or an
+    MSVC-dialect C parse), purely because the tool was upgraded -- comparing
+    the two would otherwise raise ``ProfileMismatchError`` on every such
+    baseline, solely from the upgrade itself, not from anything about the
+    library changing. :func:`_newly_resolved_standard_remainder` checks both
+    directions share the same lang tag (if any) and isolates the
+    newly-resolved remainder for the check below.
 
     Waived only when independently corroborated by an EXACT, non-empty
     ``compiler_family``/``compiler_version`` match on both sides: the
@@ -737,10 +780,15 @@ def _language_standard_probe_upgrade_corroborated(
     """
     old_std = old_fields.get("language_standard", "")
     new_std = new_fields.get("language_standard", "")
-    is_upgrade_transition = (
-        old_std == "" and _PROBED_STANDARD_PREFIX in new_std
-    ) or (new_std == "" and _PROBED_STANDARD_PREFIX in old_std)
-    if not is_upgrade_transition:
+    remainder = _newly_resolved_standard_remainder(
+        old_std, new_std
+    ) or _newly_resolved_standard_remainder(new_std, old_std)
+    if remainder is None:
+        return False
+    is_newly_resolved = (
+        remainder == _FORCED_C_STANDARD or _PROBED_STANDARD_PREFIX in remainder
+    )
+    if not is_newly_resolved:
         return False
     for key in ("compiler_family", "compiler_version"):
         old_v = old_fields.get(key, "")

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 from defusedxml import ElementTree as DefusedET
 
 from . import deadline, dumper_cache
-from ._compiler_options import has_explicit_cpp_std, split_gcc_options
+from ._compiler_options import split_gcc_options
 from .castxml_policy import evaluate_castxml_version
 from .dumper_ast_config import (
     _CPP_ONLY_PATTERNS as _CPP_ONLY_PATTERNS,
@@ -142,6 +142,7 @@ from .dumper_toolchain import (
     _parser_ast_toolchain as _parser_ast_toolchain,
     _parser_ast_unsupported_reasons as _parser_ast_unsupported_reasons,
     _parser_frontend_context_kind as _parser_frontend_context_kind,
+    _resolve_force_cpp as _resolve_force_cpp,
     _resolve_selected_tool as _resolve_selected_tool,
     _resolve_standard_provenance as _resolve_standard_provenance,
     _safe_mtime as _safe_mtime,
@@ -193,41 +194,6 @@ def _resolve_header_backend(backend: str | None) -> str:
     if env in ("castxml", "clang", "hybrid"):
         return env
     return "castxml"
-
-
-def _resolve_force_cpp(
-    lang: str | None,
-    headers: list[Path],
-    gcc_options: str | None,
-    gcc_option_tokens: tuple[str, ...],
-) -> bool:
-    """Decide whether the TU is C++ when no ``lang`` was explicitly given.
-
-    An explicit ``--lang c++``/``cpp`` always wins. Otherwise, C++20
-    concept/requires syntax (including an abbreviated constrained parameter
-    like ``void f(std::integral auto x);``, which needs no
-    class/namespace/template keyword at all) is on its own sufficient proof
-    the header is C++ — without this, a header whose only C++ signal is such
-    syntax stayed auto-detected as C (Codex review). Shared by both the clang
-    and castxml frontends so the auto-detection rule cannot drift between
-    them.
-
-    ``for_language_mode_decision=True`` (Codex review): a
-    ``#if __cplusplus``/``#ifdef __cplusplus``-guarded C++20 construct
-    must not by itself promote an auto-detected header to C++ mode — in C
-    mode ``__cplusplus`` is undefined, so that guard's content is not
-    actually reachable there, and forcing C++ purely because it exists
-    would then turn an *active*, unguarded use of the same word as an
-    ordinary C identifier elsewhere in the header into a reserved-word
-    parse error once C++20 mode is wrongly forced.
-    """
-    if lang:
-        return bool(lang.upper() in ("C++", "CPP"))
-    return (
-        _detect_cpp_headers(headers)
-        or _detect_cpp20_headers(headers, for_language_mode_decision=True)
-        or has_explicit_cpp_std(gcc_options, gcc_option_tokens)
-    )
 
 
 def _resolve_clang_langmode(

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -251,8 +251,14 @@ def _clang_header_dump(
     extra_hash_dirs: tuple[Path, ...] = (),
     frontend_context: str = "host",
     memoize: bool | None = None,
-) -> tuple[dict[str, Any], str | None]:
-    """Run clang over *headers* and return ``(root, resolved_kind)``.
+) -> tuple[dict[str, Any], str | None, bool]:
+    """Run clang over *headers* and return ``(root, resolved_kind, resolved_force_cpp)``.
+
+    ``resolved_force_cpp`` is the language mode that actually produced *root*
+    -- ``force_cpp`` itself on a cache hit or when no self-heal fired, or the
+    post-retry ``True`` when the C-mode parse self-healed into C++ (Codex
+    review: the provenance probe below must not silently re-derive a stale
+    C-mode guess after this function already resolved the real answer).
 
     The clang-frontend counterpart of :func:`_castxml_dump`: aggregates the
     headers into one ``#include`` TU, runs ``clang -ast-dump=json``, returns
@@ -345,7 +351,7 @@ def _clang_header_dump(
         key, "clang", cached, memoize=_memoize
     )
     if _cached_result is not None:
-        return cast("dict[str, Any]", _cached_result), resolved_kind
+        return cast("dict[str, Any]", _cached_result), resolved_kind, force_cpp
 
     agg_ext = ".hpp" if force_cpp else ".h"
     with tempfile.NamedTemporaryFile(suffix=agg_ext, mode="w", delete=False) as agg:
@@ -437,7 +443,7 @@ def _clang_header_dump(
         )
         if identities_stable and _memoize:
             dumper_cache.store_cached_ast(key, "clang", root)
-        return root, resolved_kind
+        return root, resolved_kind, cur_fcpp
     finally:
         agg_path.unlink(missing_ok=True)
         for _p in _ast_paths:
@@ -488,13 +494,18 @@ def _stamp_ast_parser(
     gcc_path: str | None,
     gcc_prefix: str | None,
     fallback_reason: str | None = None,
+    resolved_compiler: str | None = None,
 ) -> _CastxmlParser | _ClangAstParser:
     """Attach the frontend/compiler provenance attributes to a built parser.
 
     Module-level (rather than a closure over :func:`_header_ast_parser`) so the
     stamping rules are readable on their own; *compiler*/*gcc_path*/*gcc_prefix*
     are the enclosing call's toolchain selection, needed only to probe the host
-    compiler behind a castxml dump.
+    compiler behind a castxml dump. *resolved_compiler*, when given, overrides
+    *compiler* for that resolution -- the force_cpp-aware spelling
+    :func:`_castxml_dump` actually invoked (e.g. ``"cc"``), not the caller's
+    original, unresolved request (Codex review; see that function's own
+    ``_selected_compiler_out`` docstring).
     """
     executable_meta = _tool_identity_metadata(executable)
     metadata = {"producer": producer, **executable_meta}
@@ -509,7 +520,9 @@ def _stamp_ast_parser(
         dialect = "msvc" if Path(executable).name.lower() in ("cl", "cl.exe") else "gnu"
     else:
         try:
-            host_cc, dialect = _resolve_compiler_binary(compiler, gcc_path, gcc_prefix)
+            host_cc, dialect = _resolve_compiler_binary(
+                resolved_compiler or compiler, gcc_path, gcc_prefix
+            )
             compiler_meta = _tool_identity_metadata(host_cc)
         except SnapshotError as exc:
             metadata["compiler_error"] = str(exc)
@@ -658,6 +671,7 @@ def _header_ast_parser(
         producer: str,
         executable: str,
         fallback_reason: str | None = None,
+        resolved_compiler: str | None = None,
     ) -> _CastxmlParser | _ClangAstParser:
         return _stamp_ast_parser(
             parser,
@@ -667,11 +681,12 @@ def _header_ast_parser(
             gcc_path=gcc_path,
             gcc_prefix=gcc_prefix,
             fallback_reason=fallback_reason,
+            resolved_compiler=resolved_compiler,
         )
 
     def _run_clang(*, fallback_reason: str | None = None) -> _ClangAstParser:
         clang_bin = _resolve_clang_bin(compiler, gcc_path, gcc_prefix)
-        ast_root, resolved_kind = _clang_header_dump(
+        ast_root, resolved_kind, resolved_force_cpp = _clang_header_dump(
             headers,
             extra_includes,
             compiler=compiler,
@@ -707,6 +722,13 @@ def _header_ast_parser(
         # ADR-050 D5: resolved SYCL kind, None for a plain clang dump --
         # read by dumper_contract._attach_extraction_contract.
         setattr(stamped, "_abicheck_frontend_context_kind", resolved_kind)
+        # Codex review: the C->C++ self-heal retry can settle on a language
+        # mode different from what a static re-derivation would guess --
+        # record the real one so the provenance probe below doesn't recompute
+        # a stale answer.
+        getattr(stamped, "_abicheck_ast_toolchain")["resolved_lang_mode"] = (
+            "c++" if resolved_force_cpp else "c"
+        )
         return stamped
 
     if resolved == "clang" or frontend_context != "host":
@@ -716,6 +738,7 @@ def _header_ast_parser(
     # direct-inclusion failures. Explicit CastXML remains fail-closed.
     auto_selected = _auto_ast_fallback_eligible(backend)
     selected_castxml: list[str] = []
+    selected_compiler: list[str] = []
     try:
         xml_root = _castxml_dump(
             headers,
@@ -730,6 +753,7 @@ def _header_ast_parser(
             lang=lang,
             extra_hash_dirs=extra_hash_dirs,
             _selected_tool_out=selected_castxml,
+            _selected_compiler_out=selected_compiler,
         )
     except SnapshotError as exc:
         fallback_reason = _castxml_fallback_reason(
@@ -755,6 +779,7 @@ def _header_ast_parser(
             parser,
             producer="castxml",
             executable=selected_castxml[0] if selected_castxml else "castxml",
+            resolved_compiler=selected_compiler[0] if selected_compiler else None,
         ),
     )
 
@@ -876,6 +901,7 @@ def _castxml_dump(
     extra_hash_dirs: tuple[Path, ...] = (),
     castxml_bin: str | None = None,
     _selected_tool_out: list[str] | None = None,
+    _selected_compiler_out: list[str] | None = None,
 ) -> Element:
     """Run castxml on headers and return parsed XML root.
 
@@ -887,6 +913,13 @@ def _castxml_dump(
         sysroot: Alternative system root directory.
         nostdinc: If True, do not search standard system include paths.
         lang: Force language ("C" or "C++").  If "C", aggregated header uses .h extension.
+        _selected_compiler_out: when given, appended with the force_cpp-aware
+            *resolved_compiler* spelling (e.g. ``"cc"``, not the caller's
+            original ``"c++"``) actually used to pick ``cc_bin`` below -- so a
+            caller stamping provenance records the compiler castxml really
+            invoked, not a re-derivation from the unresolved request (Codex
+            review: a C-mode dump under the default ``compiler="c++"``
+            otherwise recorded ``g++``'s identity while castxml ran ``gcc``).
     """
     castxml_bin = _resolve_gated_castxml_bin(castxml_bin)
     if _selected_tool_out is not None:
@@ -909,6 +942,8 @@ def _castxml_dump(
             "clang++": "clang",
         }.get(compiler, compiler)
     cc_bin, cc_id = _resolve_compiler_binary(resolved_compiler, gcc_path, gcc_prefix)
+    if _selected_compiler_out is not None:
+        _selected_compiler_out.append(resolved_compiler)
     # Freeze PATH selection for the actual CastXML invocation. Keep an explicit
     # unresolved path/name intact so CastXML can provide its native diagnostic.
     cc_bin = shutil.which(cc_bin) or cc_bin

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -260,6 +260,24 @@ def _clang_header_dump(
     ``force_cpp`` (Codex review: the provenance probe must not re-derive a
     stale guess once this already resolved the real answer).
 
+    Known, narrower residual (Codex review, fresh evidence, not fixed
+    here): a cache/memo *hit* still returns the pre-retry ``force_cpp``
+    rather than the mode that actually produced the *cached* AST, since
+    neither the disk cache (a raw JSON/XML document, byte-identical to what
+    a fresh parse writes) nor the in-process memo (``dumper_cache.
+    store_cached_ast``, a bare ``(backend, key, root)`` tuple) persists this
+    fact alongside the AST -- and the cache key deliberately does *not*
+    distinguish a C-mode success from an initially-C-mode call's self-healed
+    C++ success (see the key's own ``system_includes`` comment below). A
+    correct fix needs a real cache-format change on both backends (a
+    wrapper or sidecar carrying this one extra bit) verified against their
+    existing cache-corruption/eviction paths -- a genuine, if narrow,
+    cross-cutting change, not a follow-up to this fix. Matters only when a
+    *second*, cache-hit call is made for the identical self-healed input
+    (the common single-dump-per-process path never hits this, since the
+    fresh call that actually self-healed already reports the correct
+    value).
+
     The clang-frontend counterpart of :func:`_castxml_dump`: aggregates the
     headers into one ``#include`` TU, runs ``clang -ast-dump=json``, returns
     the JSON dict :class:`abicheck.dumper_clang._ClangAstParser` consumes.

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -147,6 +147,7 @@ from .dumper_toolchain import (
     _resolve_standard_provenance as _resolve_standard_provenance,
     _safe_mtime as _safe_mtime,
     _safe_size as _safe_size,
+    _stamp_ast_parser as _stamp_ast_parser,
     _tool_identity as _tool_identity,
     _tool_identity_metadata as _tool_identity_metadata,
 )
@@ -254,11 +255,10 @@ def _clang_header_dump(
 ) -> tuple[dict[str, Any], str | None, bool]:
     """Run clang over *headers* and return ``(root, resolved_kind, resolved_force_cpp)``.
 
-    ``resolved_force_cpp`` is the language mode that actually produced *root*
-    -- ``force_cpp`` itself on a cache hit or when no self-heal fired, or the
-    post-retry ``True`` when the C-mode parse self-healed into C++ (Codex
-    review: the provenance probe below must not silently re-derive a stale
-    C-mode guess after this function already resolved the real answer).
+    ``resolved_force_cpp`` is the mode that actually produced *root* -- the
+    post-retry ``True`` when a C-mode parse self-healed into C++, else
+    ``force_cpp`` (Codex review: the provenance probe must not re-derive a
+    stale guess once this already resolved the real answer).
 
     The clang-frontend counterpart of :func:`_castxml_dump`: aggregates the
     headers into one ``#include`` TU, runs ``clang -ast-dump=json``, returns
@@ -485,63 +485,6 @@ def _resolve_single_ast_backend(backend: str, frontend_context: str) -> str:
     return resolved
 
 
-def _stamp_ast_parser(
-    parser: _CastxmlParser | _ClangAstParser,
-    *,
-    producer: str,
-    executable: str,
-    compiler: str,
-    gcc_path: str | None,
-    gcc_prefix: str | None,
-    fallback_reason: str | None = None,
-    resolved_compiler: str | None = None,
-) -> _CastxmlParser | _ClangAstParser:
-    """Attach the frontend/compiler provenance attributes to a built parser.
-
-    Module-level (rather than a closure over :func:`_header_ast_parser`) so the
-    stamping rules are readable on their own; *compiler*/*gcc_path*/*gcc_prefix*
-    are the enclosing call's toolchain selection, needed only to probe the host
-    compiler behind a castxml dump. *resolved_compiler*, when given, overrides
-    *compiler* for that resolution -- the force_cpp-aware spelling
-    :func:`_castxml_dump` actually invoked (e.g. ``"cc"``), not the caller's
-    original, unresolved request (Codex review; see that function's own
-    ``_selected_compiler_out`` docstring).
-    """
-    executable_meta = _tool_identity_metadata(executable)
-    metadata = {"producer": producer, **executable_meta}
-    dialect: str | None
-    if producer == "clang":
-        # clang is both frontend and compiler here (mirrors
-        # _resolve_clang_langmode's own cc_id derivation for the same
-        # binary); same dialect test used there -- and since it is the same
-        # binary, reuse the probe above rather than re-hashing and
-        # re-running --version on it (CodeRabbit review).
-        compiler_meta = executable_meta
-        dialect = "msvc" if Path(executable).name.lower() in ("cl", "cl.exe") else "gnu"
-    else:
-        try:
-            host_cc, dialect = _resolve_compiler_binary(
-                resolved_compiler or compiler, gcc_path, gcc_prefix
-            )
-            compiler_meta = _tool_identity_metadata(host_cc)
-        except SnapshotError as exc:
-            metadata["compiler_error"] = str(exc)
-            compiler_meta = {}
-            dialect = None
-    metadata.update({f"compiler_{key}": value for key, value in compiler_meta.items()})
-    # ADR-050 D1: surface the ABI dialect (gnu/msvc) instead of
-    # discarding it -- compute_extraction_contract's abi_dialect field
-    # reads this key (Codex review, PR #624 follow-up).
-    if dialect is not None:
-        metadata["abi_dialect"] = dialect
-    setattr(parser, "_abicheck_ast_toolchain", metadata)
-    setattr(parser, "_abicheck_ast_fallback_reason", fallback_reason)
-    if producer == "castxml":
-        check = evaluate_castxml_version(metadata.get("version", ""))
-        setattr(parser, "_abicheck_ast_supported", check.supported)
-        setattr(parser, "_abicheck_ast_unsupported_reasons", check.reasons)
-        metadata.update(check.provenance_fields())
-    return parser
 
 
 def _castxml_fallback_reason(
@@ -672,16 +615,21 @@ def _header_ast_parser(
         executable: str,
         fallback_reason: str | None = None,
         resolved_compiler: str | None = None,
+        resolved_force_cpp: bool | None = None,
     ) -> _CastxmlParser | _ClangAstParser:
-        return _stamp_ast_parser(
-            parser,
-            producer=producer,
-            executable=executable,
-            compiler=compiler,
-            gcc_path=gcc_path,
-            gcc_prefix=gcc_prefix,
-            fallback_reason=fallback_reason,
-            resolved_compiler=resolved_compiler,
+        return cast(
+            "_CastxmlParser | _ClangAstParser",
+            _stamp_ast_parser(
+                parser,
+                producer=producer,
+                executable=executable,
+                compiler=compiler,
+                gcc_path=gcc_path,
+                gcc_prefix=gcc_prefix,
+                fallback_reason=fallback_reason,
+                resolved_compiler=resolved_compiler,
+                resolved_force_cpp=resolved_force_cpp,
+            ),
         )
 
     def _run_clang(*, fallback_reason: str | None = None) -> _ClangAstParser:
@@ -717,18 +665,12 @@ def _header_ast_parser(
                 producer="clang",
                 executable=clang_bin,
                 fallback_reason=fallback_reason,
+                resolved_force_cpp=resolved_force_cpp,
             ),
         )
         # ADR-050 D5: resolved SYCL kind, None for a plain clang dump --
         # read by dumper_contract._attach_extraction_contract.
         setattr(stamped, "_abicheck_frontend_context_kind", resolved_kind)
-        # Codex review: the C->C++ self-heal retry can settle on a language
-        # mode different from what a static re-derivation would guess --
-        # record the real one so the provenance probe below doesn't recompute
-        # a stale answer.
-        getattr(stamped, "_abicheck_ast_toolchain")["resolved_lang_mode"] = (
-            "c++" if resolved_force_cpp else "c"
-        )
         return stamped
 
     if resolved == "clang" or frontend_context != "host":
@@ -738,7 +680,7 @@ def _header_ast_parser(
     # direct-inclusion failures. Explicit CastXML remains fail-closed.
     auto_selected = _auto_ast_fallback_eligible(backend)
     selected_castxml: list[str] = []
-    selected_compiler: list[str] = []
+    selected_meta: list[tuple[str, bool]] = []
     try:
         xml_root = _castxml_dump(
             headers,
@@ -753,7 +695,7 @@ def _header_ast_parser(
             lang=lang,
             extra_hash_dirs=extra_hash_dirs,
             _selected_tool_out=selected_castxml,
-            _selected_compiler_out=selected_compiler,
+            _selected_meta_out=selected_meta,
         )
     except SnapshotError as exc:
         fallback_reason = _castxml_fallback_reason(
@@ -773,13 +715,15 @@ def _header_ast_parser(
         public_header_paths=public_header_paths,
         public_dir_paths=public_dir_paths,
     )
+    meta = selected_meta[0] if selected_meta else (None, None)
     return cast(
         _CastxmlParser,
         _stamp_parser(
             parser,
             producer="castxml",
             executable=selected_castxml[0] if selected_castxml else "castxml",
-            resolved_compiler=selected_compiler[0] if selected_compiler else None,
+            resolved_compiler=meta[0],
+            resolved_force_cpp=meta[1],
         ),
     )
 
@@ -901,7 +845,7 @@ def _castxml_dump(
     extra_hash_dirs: tuple[Path, ...] = (),
     castxml_bin: str | None = None,
     _selected_tool_out: list[str] | None = None,
-    _selected_compiler_out: list[str] | None = None,
+    _selected_meta_out: list[tuple[str, bool]] | None = None,
 ) -> Element:
     """Run castxml on headers and return parsed XML root.
 
@@ -913,13 +857,18 @@ def _castxml_dump(
         sysroot: Alternative system root directory.
         nostdinc: If True, do not search standard system include paths.
         lang: Force language ("C" or "C++").  If "C", aggregated header uses .h extension.
-        _selected_compiler_out: when given, appended with the force_cpp-aware
-            *resolved_compiler* spelling (e.g. ``"cc"``, not the caller's
-            original ``"c++"``) actually used to pick ``cc_bin`` below -- so a
-            caller stamping provenance records the compiler castxml really
-            invoked, not a re-derivation from the unresolved request (Codex
-            review: a C-mode dump under the default ``compiler="c++"``
-            otherwise recorded ``g++``'s identity while castxml ran ``gcc``).
+        _selected_meta_out: when given, appended with
+            ``(resolved_compiler, resolved_force_cpp)`` -- the force_cpp-aware
+            compiler spelling (e.g. ``"cc"``, not the caller's original
+            ``"c++"``) actually used to pick ``cc_bin``, and the real,
+            post-retry language mode that produced *root* (mirrors the clang
+            backend's ``resolved_force_cpp`` return value). So a caller
+            stamping provenance records what castxml actually invoked, not a
+            re-derivation from the unresolved request (Codex review: a
+            C-mode dump under the default ``compiler="c++"`` otherwise
+            recorded ``g++``'s identity while castxml ran ``gcc``, and a
+            self-healed retry otherwise still probed the pre-retry C
+            default).
     """
     castxml_bin = _resolve_gated_castxml_bin(castxml_bin)
     if _selected_tool_out is not None:
@@ -942,8 +891,6 @@ def _castxml_dump(
             "clang++": "clang",
         }.get(compiler, compiler)
     cc_bin, cc_id = _resolve_compiler_binary(resolved_compiler, gcc_path, gcc_prefix)
-    if _selected_compiler_out is not None:
-        _selected_compiler_out.append(resolved_compiler)
     # Freeze PATH selection for the actual CastXML invocation. Keep an explicit
     # unresolved path/name intact so CastXML can provide its native diagnostic.
     cc_bin = shutil.which(cc_bin) or cc_bin
@@ -974,11 +921,14 @@ def _castxml_dump(
         _cached_root = _read_castxml_cache(cached)
         if _cached_root is not None:
             deadline.check()  # parsing a huge cached tree can eat the rest of the budget
+            if _selected_meta_out is not None:
+                _selected_meta_out.append((resolved_compiler, force_cpp))
             return _cached_root
 
     with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as tmp:
         out_xml = Path(tmp.name)
 
+    final_force_cpp = force_cpp
     try:
         try:
             root = _run_castxml_attempt(
@@ -1019,6 +969,7 @@ def _castxml_dump(
                     force_cpp=True,
                     castxml_bin=castxml_bin,
                 )
+                final_force_cpp = True
             except SnapshotError:
                 # Both modes failed — surface the originally requested C-mode
                 # error (and its hint), not the fallback's, so the diagnostic
@@ -1035,6 +986,8 @@ def _castxml_dump(
         # Re-reading/caching a huge fresh tree can itself consume real time;
         # re-check before returning (mirrors _validate_castxml_output's pre-cache-write check, Codex review).
         deadline.check()
+        if _selected_meta_out is not None:
+            _selected_meta_out.append((resolved_compiler, final_force_cpp))
         return root
     finally:
         out_xml.unlink(missing_ok=True)

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1654,9 +1654,7 @@ def _dump_elf(
         language_profile=profile_hint,
         dwarf_layout_coherence=_dwarf_layout_coherence,
         dwarf_layout_coherence_mismatches=_dwarf_layout_coherence_mismatches,
-        **_ast_compile_provenance(
-            list(ast_result.provenance_headers), gcc_options, gcc_option_tokens, sysroot
-        ),
+        **_ast_compile_provenance(list(ast_result.provenance_headers), gcc_options, gcc_option_tokens, sysroot, ast_toolchain=ast_result.ast_toolchain, lang=lang),
     )
     _populate_elf_visibility(snapshot)
     return snapshot
@@ -1831,7 +1829,7 @@ def _dump_macho(
         frontend_context_kind=_parser_frontend_context_kind(parser),
         platform="macho",
         language_profile=profile_hint,
-        **_ast_compile_provenance(headers, gcc_options, gcc_option_tokens, sysroot),
+        **_ast_compile_provenance(headers, gcc_options, gcc_option_tokens, sysroot, ast_toolchain=_parser_ast_toolchain(parser), lang=lang),
     )
 
 
@@ -1954,7 +1952,7 @@ def _dump_pe(
         frontend_context_kind=_parser_frontend_context_kind(parser),
         platform="pe",
         language_profile=profile_hint,
-        **_ast_compile_provenance(headers, gcc_options, gcc_option_tokens, sysroot),
+        **_ast_compile_provenance(headers, gcc_options, gcc_option_tokens, sysroot, ast_toolchain=_parser_ast_toolchain(parser), lang=lang),
     )
 
 

--- a/abicheck/dumper_toolchain.py
+++ b/abicheck/dumper_toolchain.py
@@ -335,15 +335,20 @@ def _cplusplus_macro_for_standard(standard: str | None) -> str | None:
     ``__cplusplus`` literal, or ``None`` when unrecognized (snapshot
     provenance, schema v15).
 
-    A *probed* default (``standard`` starting with the ``"probed:"`` prefix
+    A *probed* default (``standard`` carrying the ``"probed:"`` marker
     :func:`_probe_default_language_standard` produces — see its own
     docstring) already carries the literal macro assignment it observed, so
     it is read straight out of that string rather than looked up in
     :data:`_CPLUSPLUS_MACRO_BY_EDITION`, which only maps a real ``-std=``
-    edition spelling."""
+    edition spelling. The marker is checked by *containment*, not
+    ``str.startswith`` (Codex review, fresh evidence): when ``lang`` is
+    also given, :func:`abicheck._compiler_options.language_standard_field`
+    prefixes the probed value with ``"c++:"``/``"c:"``
+    (``"c++:probed:__cplusplus=201703L"``), so the marker no longer sits at
+    position 0."""
     if not standard:
         return None
-    if standard.startswith(_PROBED_STANDARD_PREFIX):
+    if _PROBED_STANDARD_PREFIX in standard:
         _, _, assignment = standard.partition(_PROBED_STANDARD_PREFIX)
         macro, _, value = assignment.partition("=")
         return value or None if macro == "__cplusplus" else None
@@ -516,6 +521,7 @@ def _resolve_standard_provenance(
     *,
     probe_compiler_bin: str | None = None,
     lang: str | None = None,
+    resolved_lang_mode: str | None = None,
 ) -> str | None:
     """Best-effort resolved C/C++ standard for snapshot provenance (schema
     v15, P1 toolchain-profile audit).
@@ -536,14 +542,18 @@ def _resolve_standard_provenance(
     alone, Codex review): an unspecified *lang* can still auto-detect as
     either C or C++ depending on *headers*' own content, and probing the
     wrong language mode would record a dialect the real parse never
-    actually used.
+    actually used. *resolved_lang_mode* (``"c"``/``"c++"``), when given,
+    overrides that re-derivation entirely -- it is the language mode the
+    header-AST parse actually settled on (e.g. after a C->C++ self-heal
+    retry), which a static re-derivation from *lang*/*headers* alone cannot
+    reconstruct (Codex review, fresh evidence).
     """
     if has_explicit_std(gcc_options, gcc_option_tokens):
         return _extract_explicit_std_value(gcc_options, gcc_option_tokens)
     if headers and _detect_cpp20_headers(headers):
         return "gnu++20"
     if probe_compiler_bin:
-        probe_lang_mode = (
+        probe_lang_mode = resolved_lang_mode or (
             "c++"
             if _resolve_force_cpp(lang, headers, gcc_options, gcc_option_tokens)
             else "c"
@@ -603,6 +613,7 @@ def _ast_compile_provenance(
             or (ast_toolchain or {}).get("selected")
         ),
         lang=lang,
+        resolved_lang_mode=(ast_toolchain or {}).get("resolved_lang_mode"),
     )
     args = _combined_option_tokens(gcc_options, gcc_option_tokens)
     return {

--- a/abicheck/dumper_toolchain.py
+++ b/abicheck/dumper_toolchain.py
@@ -225,6 +225,79 @@ def _tool_identity_metadata(executable: str) -> dict[str, str]:
     return metadata
 
 
+def _stamp_ast_parser(
+    parser: Any,
+    *,
+    producer: str,
+    executable: str,
+    compiler: str,
+    gcc_path: str | None,
+    gcc_prefix: str | None,
+    fallback_reason: str | None = None,
+    resolved_compiler: str | None = None,
+    resolved_force_cpp: bool | None = None,
+) -> Any:
+    """Attach the frontend/compiler provenance attributes to a built parser.
+
+    Module-level (rather than a closure over ``dumper._header_ast_parser``) so
+    the stamping rules are readable on their own; *compiler*/*gcc_path*/
+    *gcc_prefix* are the enclosing call's toolchain selection, needed only to
+    probe the host compiler behind a castxml dump. *resolved_compiler*, when
+    given, overrides *compiler* for that resolution -- the force_cpp-aware
+    spelling ``dumper._castxml_dump`` actually invoked (e.g. ``"cc"``), not
+    the caller's original, unresolved request (Codex review; see that
+    function's own ``_selected_meta_out`` docstring). *resolved_force_cpp*,
+    when given, records either backend's real, post-retry C->C++ self-heal
+    as ``metadata["resolved_lang_mode"]``.
+
+    Moved here from ``dumper.py`` (unchanged logic) purely to stay under that
+    module's AI-readiness file-size hard cap -- ``parser`` is typed ``Any``
+    rather than ``_CastxmlParser | _ClangAstParser`` to avoid importing those
+    two dumper.py-local classes here just for a type hint.
+    """
+    from .castxml_policy import evaluate_castxml_version
+    from .dumper_ast_config import _resolve_compiler_binary
+    from .errors import SnapshotError
+
+    executable_meta = _tool_identity_metadata(executable)
+    metadata = {"producer": producer, **executable_meta}
+    dialect: str | None
+    if producer == "clang":
+        # clang is both frontend and compiler here (mirrors
+        # _resolve_clang_langmode's own cc_id derivation for the same
+        # binary); same dialect test used there -- and since it is the same
+        # binary, reuse the probe above rather than re-hashing and
+        # re-running --version on it (CodeRabbit review).
+        compiler_meta = executable_meta
+        dialect = "msvc" if Path(executable).name.lower() in ("cl", "cl.exe") else "gnu"
+    else:
+        try:
+            host_cc, dialect = _resolve_compiler_binary(
+                resolved_compiler or compiler, gcc_path, gcc_prefix
+            )
+            compiler_meta = _tool_identity_metadata(host_cc)
+        except SnapshotError as exc:
+            metadata["compiler_error"] = str(exc)
+            compiler_meta = {}
+            dialect = None
+    metadata.update({f"compiler_{key}": value for key, value in compiler_meta.items()})
+    # ADR-050 D1: surface the ABI dialect (gnu/msvc) instead of
+    # discarding it -- compute_extraction_contract's abi_dialect field
+    # reads this key (Codex review, PR #624 follow-up).
+    if dialect is not None:
+        metadata["abi_dialect"] = dialect
+    if resolved_force_cpp is not None:
+        metadata["resolved_lang_mode"] = "c++" if resolved_force_cpp else "c"
+    setattr(parser, "_abicheck_ast_toolchain", metadata)
+    setattr(parser, "_abicheck_ast_fallback_reason", fallback_reason)
+    if producer == "castxml":
+        check = evaluate_castxml_version(metadata.get("version", ""))
+        setattr(parser, "_abicheck_ast_supported", check.supported)
+        setattr(parser, "_abicheck_ast_unsupported_reasons", check.reasons)
+        metadata.update(check.provenance_fields())
+    return parser
+
+
 def _compiler_family_from_toolchain(ast_toolchain: dict[str, str]) -> str | None:
     """Best-effort ADR-050 ``compiler_family`` label from the resolved host
     compiler binary (low-stakes: used for ``profile_fingerprint`` stability,
@@ -514,6 +587,15 @@ def _probe_default_language_standard(compiler_bin: str, lang_mode: str) -> str |
     return None
 
 
+#: Both ``dumper_ast_config._build_castxml_command`` (gated on ``cc_id ==
+#: "gnu"``) and ``_build_clang_header_command`` (unconditional)
+#: unconditionally force this standard for an unpinned C/gnu-dialect parse --
+#: so the real, parsed dialect is this fixed value, never the resolved
+#: compiler's own naked default (Codex review, fresh evidence: GCC's naked
+#: default is typically C17, but the AST is always generated as gnu11).
+_FORCED_C_STANDARD = "gnu11"
+
+
 def _resolve_standard_provenance(
     headers: list[Path],
     gcc_options: str | None,
@@ -522,6 +604,7 @@ def _resolve_standard_provenance(
     probe_compiler_bin: str | None = None,
     lang: str | None = None,
     resolved_lang_mode: str | None = None,
+    abi_dialect: str | None = None,
 ) -> str | None:
     """Best-effort resolved C/C++ standard for snapshot provenance (schema
     v15, P1 toolchain-profile audit).
@@ -532,10 +615,15 @@ def _resolve_standard_provenance(
     a pure function of the same inputs: an explicit ``-std=``/``--std=``/
     ``/std:`` value is recorded verbatim; otherwise, if
     ``_detect_cpp20_headers`` would force C++20, ``"gnu++20"`` is recorded
-    (the exact flag ``force_cpp20`` adds); otherwise, when *probe_compiler_bin*
-    is given, :func:`_probe_default_language_standard` is asked what that
-    resolved compiler's own unpinned default actually is (best-effort, never
-    guessed at from nothing); otherwise ``None``.
+    (the exact flag ``force_cpp20`` adds); otherwise, for an unpinned
+    C/gnu-dialect parse, :data:`_FORCED_C_STANDARD` is recorded directly --
+    *never probed* -- since both header-AST command builders force it
+    unconditionally, regardless of what the resolved compiler's own naked
+    default actually is; otherwise, when *probe_compiler_bin* is given,
+    :func:`_probe_default_language_standard` is asked what the resolved
+    compiler's own unpinned default actually is (the remaining case: an
+    unpinned C++ parse with no C++20 heuristic, or any MSVC-dialect parse,
+    neither of which either command builder pins); otherwise ``None``.
 
     *lang* is resolved through :func:`_resolve_force_cpp` (the identical
     decision the real header-AST parse makes — never derived from *lang*
@@ -552,16 +640,21 @@ def _resolve_standard_provenance(
         return _extract_explicit_std_value(gcc_options, gcc_option_tokens)
     if headers and _detect_cpp20_headers(headers):
         return "gnu++20"
-    if probe_compiler_bin:
-        probe_lang_mode = resolved_lang_mode or (
-            "c++"
-            if _resolve_force_cpp(lang, headers, gcc_options, gcc_option_tokens)
-            else "c"
-        )
-        probed = _probe_default_language_standard(probe_compiler_bin, probe_lang_mode)
-        if probed is not None:
-            return probed
-    return None
+    if probe_compiler_bin is None:
+        # No resolved-compiler identity to probe *or* to report a forced
+        # standard against (the dialect check below needs it too) --
+        # preserves this function's exact prior no-``ast_toolchain`` behavior.
+        return None
+    final_is_cpp = (
+        resolved_lang_mode == "c++"
+        if resolved_lang_mode is not None
+        else _resolve_force_cpp(lang, headers, gcc_options, gcc_option_tokens)
+    )
+    if not final_is_cpp and abi_dialect != "msvc":
+        return _FORCED_C_STANDARD
+    return _probe_default_language_standard(
+        probe_compiler_bin, "c++" if final_is_cpp else "c"
+    )
 
 
 class _AstCompileProvenance(TypedDict):
@@ -614,6 +707,7 @@ def _ast_compile_provenance(
         ),
         lang=lang,
         resolved_lang_mode=(ast_toolchain or {}).get("resolved_lang_mode"),
+        abi_dialect=(ast_toolchain or {}).get("abi_dialect"),
     )
     args = _combined_option_tokens(gcc_options, gcc_option_tokens)
     return {

--- a/abicheck/dumper_toolchain.py
+++ b/abicheck/dumper_toolchain.py
@@ -27,8 +27,9 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, TypedDict
 
-from ._compiler_options import has_explicit_std, split_gcc_options
+from ._compiler_options import has_explicit_cpp_std, has_explicit_std, split_gcc_options
 from .buildsource.redaction import DEFAULT_REDACTION
+from .dumper_ast_config import _detect_cpp_headers
 from .dumper_ast_config_cpp20 import _detect_cpp20_headers
 
 
@@ -390,12 +391,54 @@ def _extract_explicit_std_value(
 _PROBED_STANDARD_PREFIX = "probed:"
 
 
-def _probe_language_mode(lang: str | None) -> str:
-    """``"c"`` or ``"c++"`` for :func:`_probe_default_language_standard`,
-    mirroring the same ``lang == "c"`` convention used throughout this
-    module (and ``dumper.py``'s own ``compiler = "cc" if lang == "c" else
-    "c++"``) — any other value (``None``, ``"c++"``, ...) means C++."""
-    return "c" if (lang or "").strip().lower() == "c" else "c++"
+def _resolve_force_cpp(
+    lang: str | None,
+    headers: list[Path],
+    gcc_options: str | None,
+    gcc_option_tokens: tuple[str, ...],
+) -> bool:
+    """Decide whether the TU is C++ when no ``lang`` was explicitly given.
+
+    An explicit ``--lang c++``/``cpp`` always wins. Otherwise, C++20
+    concept/requires syntax (including an abbreviated constrained parameter
+    like ``void f(std::integral auto x);``, which needs no
+    class/namespace/template keyword at all) is on its own sufficient proof
+    the header is C++ — without this, a header whose only C++ signal is such
+    syntax stayed auto-detected as C (Codex review). Shared by both the clang
+    and castxml frontends so the auto-detection rule cannot drift between
+    them.
+
+    ``for_language_mode_decision=True`` (Codex review): a
+    ``#if __cplusplus``/``#ifdef __cplusplus``-guarded C++20 construct
+    must not by itself promote an auto-detected header to C++ mode — in C
+    mode ``__cplusplus`` is undefined, so that guard's content is not
+    actually reachable there, and forcing C++ purely because it exists
+    would then turn an *active*, unguarded use of the same word as an
+    ordinary C identifier elsewhere in the header into a reserved-word
+    parse error once C++20 mode is wrongly forced.
+
+    Relocated here from ``dumper.py`` (Codex review, abicheck-internal-bugs
+    finding 2 follow-up): :func:`_probe_default_language_standard`'s own
+    probe needs this exact decision — the raw ``lang`` argument alone is
+    not enough, since an unspecified ``lang`` (the common case: ``dump``'s
+    own CLI squashes its Click default back to ``None`` so auto-detection
+    can run — see ``cli_dump_helpers.perform_elf_dump``'s ``lang_explicit``
+    handling) can still auto-detect as either C or C++ depending on the
+    header's own content, and probing the wrong language mode would record
+    a ``language_standard`` that describes a dialect the real parse never
+    actually used, weakening the comparability guard's precision (Codex
+    review: "two compiler versions with the same C default but different
+    C++ defaults will be rejected as non-comparable despite matching
+    extraction contexts"). ``dumper.py`` re-exports this name unchanged for
+    its own callers.
+    """
+    if lang:
+        return bool(lang.upper() in ("C++", "CPP"))
+    return (
+        _detect_cpp_headers(headers)
+        or _detect_cpp20_headers(headers, for_language_mode_decision=True)
+        or has_explicit_cpp_std(gcc_options, gcc_option_tokens)
+    )
 
 
 @lru_cache(maxsize=32)
@@ -472,7 +515,7 @@ def _resolve_standard_provenance(
     gcc_option_tokens: tuple[str, ...],
     *,
     probe_compiler_bin: str | None = None,
-    probe_lang_mode: str | None = None,
+    lang: str | None = None,
 ) -> str | None:
     """Best-effort resolved C/C++ standard for snapshot provenance (schema
     v15, P1 toolchain-profile audit).
@@ -487,15 +530,25 @@ def _resolve_standard_provenance(
     is given, :func:`_probe_default_language_standard` is asked what that
     resolved compiler's own unpinned default actually is (best-effort, never
     guessed at from nothing); otherwise ``None``.
+
+    *lang* is resolved through :func:`_resolve_force_cpp` (the identical
+    decision the real header-AST parse makes — never derived from *lang*
+    alone, Codex review): an unspecified *lang* can still auto-detect as
+    either C or C++ depending on *headers*' own content, and probing the
+    wrong language mode would record a dialect the real parse never
+    actually used.
     """
     if has_explicit_std(gcc_options, gcc_option_tokens):
         return _extract_explicit_std_value(gcc_options, gcc_option_tokens)
     if headers and _detect_cpp20_headers(headers):
         return "gnu++20"
     if probe_compiler_bin:
-        probed = _probe_default_language_standard(
-            probe_compiler_bin, probe_lang_mode or "c++"
+        probe_lang_mode = (
+            "c++"
+            if _resolve_force_cpp(lang, headers, gcc_options, gcc_option_tokens)
+            else "c"
         )
+        probed = _probe_default_language_standard(probe_compiler_bin, probe_lang_mode)
         if probed is not None:
             return probed
     return None
@@ -549,7 +602,7 @@ def _ast_compile_provenance(
             (ast_toolchain or {}).get("compiler_selected")
             or (ast_toolchain or {}).get("selected")
         ),
-        probe_lang_mode=_probe_language_mode(lang),
+        lang=lang,
     )
     args = _combined_option_tokens(gcc_options, gcc_option_tokens)
     return {

--- a/abicheck/dumper_toolchain.py
+++ b/abicheck/dumper_toolchain.py
@@ -332,9 +332,20 @@ _CPLUSPLUS_MACRO_BY_EDITION: dict[str, str] = {
 def _cplusplus_macro_for_standard(standard: str | None) -> str | None:
     """Map a resolved ``-std=``/``/std:`` value to its standard-mandated
     ``__cplusplus`` literal, or ``None`` when unrecognized (snapshot
-    provenance, schema v15)."""
+    provenance, schema v15).
+
+    A *probed* default (``standard`` starting with the ``"probed:"`` prefix
+    :func:`_probe_default_language_standard` produces — see its own
+    docstring) already carries the literal macro assignment it observed, so
+    it is read straight out of that string rather than looked up in
+    :data:`_CPLUSPLUS_MACRO_BY_EDITION`, which only maps a real ``-std=``
+    edition spelling."""
     if not standard:
         return None
+    if standard.startswith(_PROBED_STANDARD_PREFIX):
+        _, _, assignment = standard.partition(_PROBED_STANDARD_PREFIX)
+        macro, _, value = assignment.partition("=")
+        return value or None if macro == "__cplusplus" else None
     edition = (
         standard.rsplit("+", 1)[-1].lower() if "+" in standard else standard.lower()
     )
@@ -371,10 +382,97 @@ def _extract_explicit_std_value(
     return None
 
 
+#: Prefix distinguishing a *probed* default standard (never asserted by the
+#: caller — see :func:`_probe_default_language_standard`) from a real,
+#: explicit ``-std=``/``/std:`` spelling or the ``force_cpp20`` literal
+#: ``"gnu++20"`` -- so a probed value can never collide with, or be mistaken
+#: for, a user-given one.
+_PROBED_STANDARD_PREFIX = "probed:"
+
+
+def _probe_language_mode(lang: str | None) -> str:
+    """``"c"`` or ``"c++"`` for :func:`_probe_default_language_standard`,
+    mirroring the same ``lang == "c"`` convention used throughout this
+    module (and ``dumper.py``'s own ``compiler = "cc" if lang == "c" else
+    "c++"``) — any other value (``None``, ``"c++"``, ...) means C++."""
+    return "c" if (lang or "").strip().lower() == "c" else "c++"
+
+
+@lru_cache(maxsize=32)
+def _probe_default_language_standard(compiler_bin: str, lang_mode: str) -> str | None:
+    """Best-effort: what C/C++ edition *compiler_bin* actually resolves to
+    when invoked with **no** explicit ``-std=`` at all (ADR-050 D1/D2
+    follow-up — closes the "profile_fingerprint guard doesn't fire without
+    L3 build evidence" gap: two header-AST dumps of genuinely different
+    toolchains/versions, neither given an explicit standard, previously both
+    recorded ``ast_resolved_standard=None`` and so trivially matched on
+    ``language_standard``, letting ``compare`` produce a real verdict for two
+    snapshots extracted under incompatible dialects instead of refusing).
+
+    Probes the compiler's own predefined-macro table the same way
+    ``buildsource.source_extractors.clang._clang_compiler_family`` already
+    does for compiler-family identification (``-E -dM``): the frontend's own
+    unpinned default is a real, observable fact — GCC 9's default C++ dialect
+    genuinely differs from Clang 18's — it just isn't *asserted* by any flag
+    this project passed, so it wasn't previously recorded at all rather than
+    guessed at.
+
+    Returns a ``"probed:"``-prefixed literal macro assignment
+    (``"probed:__cplusplus=201703L"`` / ``"probed:__STDC_VERSION__=201710L"``)
+    rather than a canonical ``-std=`` spelling: the exact edition a given
+    ``__cplusplus``/``__STDC_VERSION__`` value maps to is not always
+    recoverable (a compiler can report a nonstandard literal for a
+    still-experimental standard), but the raw value alone is already
+    sufficient for this function's actual purpose — two probes disagreeing
+    on it is real evidence of a dialect difference, and two probes agreeing
+    is real evidence there isn't one, regardless of what the edition is
+    conventionally called. A pre-C99 C compiler defines no
+    ``__STDC_VERSION__`` at all, so that absence is itself recorded as a
+    distinct value rather than falling through to ``None`` (which would
+    read as "not probed" rather than "genuinely probed as C89/ANSI C").
+
+    ``None`` on any failure (compiler not found, times out, or rejects
+    ``-E -dM`` — e.g. an MSVC ``cl.exe``, which uses different flags
+    entirely) — a probe that can't run is simply not evidence, the same
+    fail-open convention every other best-effort toolchain probe in this
+    codebase already uses. Cached per ``(compiler_bin, lang_mode)`` pair, the
+    same cost shape as ``_clang_compiler_family``/``_clang_compiler_version``,
+    so a whole dump session pays this at most once per distinct resolved
+    compiler.
+    """
+    macro_name = "__STDC_VERSION__" if lang_mode == "c" else "__cplusplus"
+    try:
+        r = subprocess.run(
+            [compiler_bin, "-E", "-dM", "-x", lang_mode, "-"],
+            input="",
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if r.returncode != 0:
+        return None
+    for line in r.stdout.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) >= 2 and parts[0] == "#define" and parts[1] == macro_name:
+            value = parts[2].strip() if len(parts) >= 3 else ""
+            return f"{_PROBED_STANDARD_PREFIX}{macro_name}={value}"
+    if lang_mode == "c":
+        # No __STDC_VERSION__ at all is itself a real, distinct signal
+        # (pre-C99 default), not a probe failure.
+        return f"{_PROBED_STANDARD_PREFIX}{macro_name}=<absent>"
+    return None
+
+
 def _resolve_standard_provenance(
     headers: list[Path],
     gcc_options: str | None,
     gcc_option_tokens: tuple[str, ...],
+    *,
+    probe_compiler_bin: str | None = None,
+    probe_lang_mode: str | None = None,
 ) -> str | None:
     """Best-effort resolved C/C++ standard for snapshot provenance (schema
     v15, P1 toolchain-profile audit).
@@ -385,13 +483,21 @@ def _resolve_standard_provenance(
     a pure function of the same inputs: an explicit ``-std=``/``--std=``/
     ``/std:`` value is recorded verbatim; otherwise, if
     ``_detect_cpp20_headers`` would force C++20, ``"gnu++20"`` is recorded
-    (the exact flag ``force_cpp20`` adds); otherwise ``None`` — the
-    frontend's own unpinned default was used and is not guessed at here.
+    (the exact flag ``force_cpp20`` adds); otherwise, when *probe_compiler_bin*
+    is given, :func:`_probe_default_language_standard` is asked what that
+    resolved compiler's own unpinned default actually is (best-effort, never
+    guessed at from nothing); otherwise ``None``.
     """
     if has_explicit_std(gcc_options, gcc_option_tokens):
         return _extract_explicit_std_value(gcc_options, gcc_option_tokens)
     if headers and _detect_cpp20_headers(headers):
         return "gnu++20"
+    if probe_compiler_bin:
+        probed = _probe_default_language_standard(
+            probe_compiler_bin, probe_lang_mode or "c++"
+        )
+        if probed is not None:
+            return probed
     return None
 
 
@@ -407,6 +513,9 @@ def _ast_compile_provenance(
     gcc_options: str | None,
     gcc_option_tokens: tuple[str, ...],
     sysroot: Path | None,
+    *,
+    ast_toolchain: dict[str, str] | None = None,
+    lang: str | None = None,
 ) -> _AstCompileProvenance:
     """Structured compile-context provenance kwargs for an ``AbiSnapshot``
     built from a header-AST parse (schema v15). A single call site shared by
@@ -421,9 +530,26 @@ def _ast_compile_provenance(
     carry a secret-looking ``-DTOKEN=...`` define or an absolute home-prefixed
     path, and this is the one place such tokens reach a persisted snapshot
     without going through that established convention.
+
+    ``ast_toolchain``/``lang`` (ADR-050 D1/D2 follow-up): the just-resolved
+    header-AST toolchain identity (``dumper_toolchain._parser_ast_toolchain``'s
+    result — the same dict :func:`_compiler_family_from_toolchain` already
+    reads ``compiler_selected``/``selected`` from) and the caller's raw
+    ``lang``, forwarded to :func:`_resolve_standard_provenance` so it can
+    probe the resolved compiler's own unpinned default standard when no
+    explicit one was given — see that function's own docstring. ``None``
+    for either (the default) preserves the exact prior behavior: no probe
+    attempted, ``ast_resolved_standard`` stays ``None`` for an unpinned dump.
     """
     resolved_standard = _resolve_standard_provenance(
-        headers, gcc_options, gcc_option_tokens
+        headers,
+        gcc_options,
+        gcc_option_tokens,
+        probe_compiler_bin=(
+            (ast_toolchain or {}).get("compiler_selected")
+            or (ast_toolchain or {}).get("selected")
+        ),
+        probe_lang_mode=_probe_language_mode(lang),
     )
     args = _combined_option_tokens(gcc_options, gcc_option_tokens)
     return {

--- a/abicheck/dumper_toolchain.py
+++ b/abicheck/dumper_toolchain.py
@@ -254,6 +254,16 @@ def _stamp_ast_parser(
     module's AI-readiness file-size hard cap -- ``parser`` is typed ``Any``
     rather than ``_CastxmlParser | _ClangAstParser`` to avoid importing those
     two dumper.py-local classes here just for a type hint.
+
+    Resolving against *resolved_compiler* (rather than the caller's
+    original *compiler*) is a real correctness fix, but it has one known,
+    documented interaction with a *legacy* baseline persisted before this
+    fix existed -- see
+    ``comparability._language_standard_probe_upgrade_corroborated``'s own
+    docstring for the full account (a legacy dump's ``compiler_family``/
+    ``compiler_version`` can appear to "change" against a fresh re-dump of
+    the identical installation, purely because this fix corrected which
+    binary's identity gets recorded).
     """
     from .castxml_policy import evaluate_castxml_version
     from .dumper_ast_config import _resolve_compiler_binary
@@ -595,6 +605,18 @@ def _probe_default_language_standard(compiler_bin: str, lang_mode: str) -> str |
 #: default is typically C17, but the AST is always generated as gnu11).
 _FORCED_C_STANDARD = "gnu11"
 
+#: Mirrors ``tu_merge._HETEROGENEOUS_LANG_MODE`` (not imported directly --
+#: ``tu_merge.py`` already imports from this module's sibling ``dumper.py``
+#: chain, and a reverse import would risk a cycle the AI-readiness gate
+#: rejects; the two are kept in lockstep by
+#: ``tests/test_tu_merge.py``/``tests/test_ast_compile_provenance.py``
+#: asserting the literal string). Written into a merged multi-TU manifest's
+#: ``resolved_lang_mode`` when the contributing TUs genuinely disagree on
+#: it -- signals "cannot determine this at all," distinct from the field
+#: simply being absent (a single-TU dump, or a fragment merge where every
+#: TU agreed), which still falls back to the static re-derivation below.
+_HETEROGENEOUS_LANG_MODE = "heterogeneous"
+
 
 def _resolve_standard_provenance(
     headers: list[Path],
@@ -635,11 +657,25 @@ def _resolve_standard_provenance(
     header-AST parse actually settled on (e.g. after a C->C++ self-heal
     retry), which a static re-derivation from *lang*/*headers* alone cannot
     reconstruct (Codex review, fresh evidence).
+
+    *resolved_lang_mode* may also be :data:`_HETEROGENEOUS_LANG_MODE` --
+    ``tu_merge.merge_fragments``'s sentinel for "the contributing TUs of a
+    merged manifest genuinely disagree on this." That is a stronger signal
+    than "unknown": falling through to the static ``_resolve_force_cpp``
+    re-derivation below (over the manifest's combined *public/declared*
+    headers only) can be confidently *wrong*, not merely uninformed, for a
+    TU whose C++-ness came from something invisible to those public
+    headers (e.g. a private forced include). So this function returns
+    ``None`` immediately for that sentinel, skipping both the forced-
+    standard path and the probe path entirely, rather than guessing
+    (Codex review, fresh evidence).
     """
     if has_explicit_std(gcc_options, gcc_option_tokens):
         return _extract_explicit_std_value(gcc_options, gcc_option_tokens)
     if headers and _detect_cpp20_headers(headers):
         return "gnu++20"
+    if resolved_lang_mode == _HETEROGENEOUS_LANG_MODE:
+        return None
     if probe_compiler_bin is None:
         # No resolved-compiler identity to probe *or* to report a forced
         # standard against (the dialect check below needs it too) --

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -1065,7 +1065,7 @@ def _attach_header_graph(
         # declarations with host-only call/type/include edges, feeding
         # crosschecks/diff_source_graph_findings a graph incoherent with
         # what it's describing.
-        ast_root, _resolved_kind = _clang_header_dump(
+        ast_root, _resolved_kind, _resolved_force_cpp = _clang_header_dump(
             resolved_headers,
             eff_includes,
             compiler="cc" if _is_c else "c++",

--- a/abicheck/tu_merge.py
+++ b/abicheck/tu_merge.py
@@ -487,6 +487,28 @@ def merge_fragments(
     # same toolchain by construction. `ordered[0]` (not `fragments[0]`) so
     # the choice is itself order-independent.
     representative = ordered[0]
+    # resolved_lang_mode (Codex review, fresh evidence) is NOT one of the
+    # toolchain-identity facts the comment above guarantees uniform -- a
+    # perfectly ordinary mixed-language manifest (some .c TUs, some .cpp
+    # TUs, one shared compiler) legitimately resolves it differently per
+    # TU, unlike ast_producer/frontend_context_kind above, which really
+    # should never diverge and are rejected outright when they do. Blindly
+    # copying one representative TU's resolved_lang_mode would silently
+    # mislabel the whole merged snapshot's language_standard for every
+    # other TU. Strip it when it's not unanimous, falling back to
+    # _resolve_standard_provenance's own static re-derivation over the
+    # manifest's combined headers -- the same quality of answer this field
+    # didn't exist to improve on before this PR, not a new failure mode.
+    lang_modes = {
+        f.ast_toolchain["resolved_lang_mode"]
+        for f in ordered
+        if "resolved_lang_mode" in f.ast_toolchain
+    }
+    merged_ast_toolchain = representative.ast_toolchain
+    if len(lang_modes) > 1:
+        merged_ast_toolchain = {
+            k: v for k, v in representative.ast_toolchain.items() if k != "resolved_lang_mode"
+        }
     return MergedTuFragments(
         functions=functions,
         variables=variables,
@@ -496,7 +518,7 @@ def merge_fragments(
         typedefs_qualified=typedefs_qualified,
         constants=constants,
         ast_producer=representative.ast_producer,
-        ast_toolchain=representative.ast_toolchain,
+        ast_toolchain=merged_ast_toolchain,
         ast_fallback_reason=representative.ast_fallback_reason,
         ast_toolchain_supported=representative.ast_toolchain_supported,
         ast_toolchain_unsupported_reasons=representative.ast_toolchain_unsupported_reasons,

--- a/abicheck/tu_merge.py
+++ b/abicheck/tu_merge.py
@@ -84,6 +84,17 @@ from .tu_fragment import MergedTuFragments, TuFragment, entity_key
 INCONSISTENT_DECLARATION = "INCONSISTENT_DECLARATION"
 HETEROGENEOUS_ABI_CONTEXT = "HETEROGENEOUS_ABI_CONTEXT"
 
+#: Sentinel written into a merged manifest's ``ast_toolchain["resolved_lang_mode"]``
+#: (never a real ``"c"``/``"c++"`` tag) when the contributing TUs genuinely
+#: disagree on it -- an ordinary mixed-language manifest, not an error.
+#: ``dumper_toolchain._resolve_standard_provenance`` recognizes this exact
+#: value and returns ``None`` outright rather than falling back to a static
+#: re-derivation that can be confidently *wrong* (not just unknown) for a TU
+#: whose language mode came from something invisible to the manifest's
+#: combined public headers (Codex review, fresh evidence). See
+#: ``merge_fragments``'s own inline comment for the full reasoning.
+_HETEROGENEOUS_LANG_MODE = "heterogeneous"
+
 
 class _Provenanced(Protocol):
     """The ADR-015 schema v6 provenance fields every model type this module
@@ -495,10 +506,24 @@ def merge_fragments(
     # should never diverge and are rejected outright when they do. Blindly
     # copying one representative TU's resolved_lang_mode would silently
     # mislabel the whole merged snapshot's language_standard for every
-    # other TU. Strip it when it's not unanimous, falling back to
-    # _resolve_standard_provenance's own static re-derivation over the
-    # manifest's combined headers -- the same quality of answer this field
-    # didn't exist to improve on before this PR, not a new failure mode.
+    # other TU.
+    #
+    # Merely *dropping* the key when it's not unanimous (an earlier version
+    # of this fix) is not safe either: dropping it makes
+    # ``_resolve_standard_provenance`` fall back to its static
+    # re-derivation (``_resolve_force_cpp`` over the manifest's combined,
+    # *public/declared* headers alone) -- which can be confidently *wrong*,
+    # not merely uninformed, for a TU whose C++-ness comes only from a
+    # private forced include invisible to those public headers (Codex
+    # review, fresh evidence). A merged manifest genuinely known to mix
+    # language modes must not let that static re-derivation guess at all.
+    # ``_HETEROGENEOUS_LANG_MODE`` is a sentinel value (never a real
+    # ``"c"``/``"c++"`` tag) that ``_resolve_standard_provenance`` (see its
+    # own docstring) recognizes and treats as "cannot determine this at
+    # all" -- skipping *both* the forced-``gnu11``-literal path and the
+    # probe-fallback path, returning ``None`` outright, the same honest
+    # "unknown" this field didn't exist to improve on before this PR, not
+    # a new failure mode and not a wrong guess either.
     lang_modes = {
         f.ast_toolchain["resolved_lang_mode"]
         for f in ordered
@@ -507,7 +532,8 @@ def merge_fragments(
     merged_ast_toolchain = representative.ast_toolchain
     if len(lang_modes) > 1:
         merged_ast_toolchain = {
-            k: v for k, v in representative.ast_toolchain.items() if k != "resolved_lang_mode"
+            **representative.ast_toolchain,
+            "resolved_lang_mode": _HETEROGENEOUS_LANG_MODE,
         }
     return MergedTuFragments(
         functions=functions,

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -93,7 +93,11 @@
   language-mode change, not an upgrade artifact — would otherwise be
   indistinguishable from the case this carve-out exists to waive, and a
   matching compiler says nothing about which mode either side's headers
-  actually resolved to.
+  actually resolved to. The carve-out also now recognizes `"cpp"` (a
+  second, still-supported spelling for C++ `_resolve_force_cpp` accepts
+  alongside `"c++"`) as a bare pre-upgrade tag, not just `"c"`/`"c++"` —
+  a Python API baseline built with `lang="cpp"` previously raised
+  `ProfileMismatchError` on an upgrade with no real profile change.
 - Known, narrower residuals, documented rather than fixed:
   - A cache/memo *hit* for a header that previously self-healed C→C++
     still reports the pre-retry language mode, since neither backend's AST

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -71,22 +71,29 @@
   MSVC-dialect parse, neither of which either command builder pins). That
   fix in turn broke the upgrade-corroboration carve-out itself: it only
   recognized an empty-string-to-`"probed:..."` transition, but the forced
-  standard produces three shapes it had never seen — an unpinned, no-`--lang`
-  baseline moving to the bare `"gnu11"` literal (no `"probed:"` marker at
-  all), and an explicit-`--lang` baseline moving from a *bare* `"c"`/`"c++"`
-  tag (not an empty string) to `"c:gnu11"`/`"c++:probed:..."`. Generalized
-  the carve-out (`_newly_resolved_standard_remainder`) to recognize every
-  pre-upgrade "nothing resolved yet" spelling (`""`, `"c"`, `"c++"`) against
-  a same-lang-tagged, newly-populated successor (the forced literal or a
-  probed value), in either comparison direction. The carve-out's own
-  `compiler_family`/`compiler_version` corroboration also now checks
-  `AbiSnapshot.ast_toolchain`'s `compiler_sha256` (the resolved compiler
-  binary's own content hash) when both sides carry one: a compiler wrapper
-  replaced at the same path can report an identical family/version string
-  — text a wrapper's own `--version` output controls — while actually
-  selecting a different default dialect. Falls back to the family/version-only
-  check when either side lacks the hash (an older snapshot, or a side whose
-  compiler resolution itself failed).
+  standard produces shapes it had never seen — an explicit-`--lang` baseline
+  moving from a *bare* `"c"`/`"c++"` tag (not an empty string) to
+  `"c:gnu11"`/`"c++:probed:..."`. Generalized the carve-out
+  (`_newly_resolved_standard_remainder`) to recognize a pre-upgrade bare
+  `"c"`/`"c++"` tag against a same-lang-tagged, newly-populated successor
+  (the forced literal or a probed value), in either comparison direction.
+  The carve-out's own `compiler_family`/`compiler_version` corroboration
+  also now checks `AbiSnapshot.ast_toolchain`'s `compiler_sha256` (the
+  resolved compiler binary's own content hash) when both sides carry one: a
+  compiler wrapper replaced at the same path can report an identical
+  family/version string — text a wrapper's own `--version` output controls
+  — while actually selecting a different default dialect. Falls back to the
+  family/version-only check when either side lacks the hash (an older
+  snapshot, or a side whose compiler resolution itself failed). A bare
+  *empty* `language_standard` (no `--lang` given at all, pure content-based
+  auto-detection) is deliberately **not** eligible for this carve-out,
+  unlike an earlier version of it: it carries no signal about which
+  language mode the pre-upgrade dump actually resolved to, so a header that
+  later gains enough C++-only syntax to flip that decision — a real
+  language-mode change, not an upgrade artifact — would otherwise be
+  indistinguishable from the case this carve-out exists to waive, and a
+  matching compiler says nothing about which mode either side's headers
+  actually resolved to.
 - Known, narrower residuals, documented rather than fixed:
   - A cache/memo *hit* for a header that previously self-healed C→C++
     still reports the pre-retry language mode, since neither backend's AST

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -118,11 +118,35 @@
   differs per TU in an ordinary mixed C/.c and C++/.cpp manifest under one
   shared compiler — blindly copying one representative TU's value would
   stamp the whole merged snapshot's `language_standard` from whichever TU
-  happened to sort first, silently wrong for every other TU. Now dropped
-  from the merged `ast_toolchain` (falling back to the pre-existing static
-  re-derivation over the manifest's combined headers) whenever the
-  contributing TUs disagree, rather than picked arbitrarily.
+  happened to sort first, silently wrong for every other TU. A first fix
+  dropped the field from the merged `ast_toolchain` on disagreement,
+  falling back to `_resolve_standard_provenance`'s static re-derivation
+  over the manifest's combined headers — a follow-up review found that
+  fallback can be confidently *wrong*, not just uninformed, for a TU whose
+  language mode came from something invisible to those combined public
+  headers (e.g. a private forced include). Now writes an explicit
+  `_HETEROGENEOUS_LANG_MODE` sentinel instead, which
+  `_resolve_standard_provenance` recognizes and treats as "cannot
+  determine this at all," skipping both the forced-`gnu11` and probe
+  fallback paths and reporting `None` rather than guessing.
 - Known, narrower residuals, documented rather than fixed:
+  - **A legacy (pre-this-fix) castxml baseline's `compiler_family`/
+    `compiler_version` can appear to "change" against a fresh re-dump of
+    the identical toolchain installation**, when the two diverge on
+    whether a force_cpp self-heal/remap changed which binary the parse
+    actually invoked: this PR's `resolved_compiler` stamping fix corrects
+    which binary's identity gets recorded, but a legacy baseline recorded
+    the *wrong* (unresolved-request) binary's identity, with no way to
+    recover what the corrected resolution would have produced from the
+    persisted baseline alone. This independently defeats the
+    `language_standard` upgrade-corroboration carve-out above too (its own
+    `compiler_family`/`compiler_version` corroboration check fails for the
+    same reason), compounding the two. Not addressed with a further
+    carve-out — there is no sound way to distinguish this from a genuine
+    compiler change using only what a legacy snapshot persisted; see
+    `comparability._language_standard_probe_upgrade_corroborated`'s own
+    docstring. Affected users should re-`dump` their baseline once after
+    upgrading past this fix.
   - A cache/memo *hit* for a header that previously self-healed C→C++
     still reports the pre-retry language mode, since neither backend's AST
     cache persists that fact alongside the cached document — see

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -97,7 +97,20 @@
   second, still-supported spelling for C++ `_resolve_force_cpp` accepts
   alongside `"c++"`) as a bare pre-upgrade tag, not just `"c"`/`"c++"` —
   a Python API baseline built with `lang="cpp"` previously raised
-  `ProfileMismatchError` on an upgrade with no real profile change.
+  `ProfileMismatchError` on an upgrade with no real profile change. An
+  explicit `--lang c` tag turned out not to pin the mode unconditionally
+  either: both header-AST backends self-heal an explicit C request into
+  C++ mid-parse when the header turns out to need a C++ stdlib header
+  (`dumper.py`'s C→C++ retry applies regardless of whether C mode was
+  auto-detected or explicitly requested), so a `"c"`-tagged baseline
+  comparing against a self-healed `"c:probed:__cplusplus=..."` new dump
+  was being incorrectly waived as an upgrade artifact even though the
+  actual parse mode genuinely changed. The carve-out now rejects a
+  `"c"`-tagged remainder that names `__cplusplus` (the unambiguous
+  self-heal signature — a genuinely-C parse's probed value only ever
+  names `__STDC_VERSION__`, never `__cplusplus`), while still waiving a
+  genuine unpinned-C transition (the forced `gnu11` literal, or an
+  MSVC-dialect probe naming `__STDC_VERSION__`).
 - Known, narrower residuals, documented rather than fixed:
   - A cache/memo *hit* for a header that previously self-healed C→C++
     still reports the pre-retry language mode, since neither backend's AST

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -52,11 +52,20 @@
   `.startswith(...)`, but when `--lang` is given explicitly the recorded
   value is language-mode-prefixed (`"c++:probed:__cplusplus=201703L"`),
   so the marker no longer sits at position 0 and both silently failed to
-  recognize it — fixed to a containment check. And the probe's language
-  mode is now the header-AST parse's *actual, post-retry* mode rather than
-  a static re-derivation: a C-mode dump whose parse self-heals into C++
-  (`dumper.py`'s C→C++ retry) or a castxml C-mode dump (whose driver is
-  internally remapped from the caller's `"c++"` default to `"cc"`) now
-  threads that real, resolved language mode/compiler identity into
-  `AbiSnapshot.ast_toolchain`, so the provenance probe queries the
+  recognize it — fixed to a containment check. The probe's language mode
+  is now the header-AST parse's *actual, post-retry* mode rather than a
+  static re-derivation: a C-mode dump whose parse self-heals into C++
+  (either backend's own C→C++ retry) or a castxml C-mode dump (whose
+  driver is internally remapped from the caller's `"c++"` default to
+  `"cc"`) now threads that real, resolved language mode/compiler identity
+  into `AbiSnapshot.ast_toolchain`, so the provenance probe queries the
   compiler that actually parsed the headers instead of a stale guess.
+  And an unpinned C/gnu-dialect parse is no longer probed at all: both
+  header-AST command builders unconditionally force `-std=gnu11` for that
+  case (`dumper_ast_config.py`), a fact the probe previously ignored —
+  querying the resolved compiler's own naked default instead (e.g. GCC's
+  C17) and recording a dialect that never actually parsed the headers.
+  `dumper_toolchain._resolve_standard_provenance` now reports that forced
+  standard directly for a gnu-dialect C parse, and only probes the
+  remaining genuinely-unpinned cases (C++ with no C++20 heuristic, or any
+  MSVC-dialect parse, neither of which either command builder pins).

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -1,0 +1,38 @@
+### Fixed
+
+- **`dump`'s own dependency-scoping `header_roots` diverged from
+  `compare`'s live-binary dumping, silently breaking `dump`-baseline-vs-live
+  comparisons** (abicheck-internal-bugs finding 1): the ELF (`perform_elf_dump`)
+  and PE/Mach-O (`handle_non_elf_dump`) `dump` paths computed the
+  `header_roots` fed to `dumper_scoping.resolve_dependency_scope` right
+  before serialization from `headers` alone (plus, for ELF,
+  `--dump-manifest` roots) — omitting `public_headers`/`public_header_dirs`,
+  which `dumper_scoping.apply_dependency_scope_to_run_dump_result` (the
+  choke point `compare`'s own live-binary dumping, via `service.run_dump`,
+  already uses for the identical decision) always folds in. A standalone
+  `dump` of a library whose public surface is declared via
+  `public_headers`/`public_header_dirs` therefore scoped its dependency
+  filtering differently than `compare`'s live dump of the identical input —
+  two `dependency_scope: filtered` snapshots whose actual filtered content
+  silently disagreed, breaking every later `compare` between a
+  `dump`-produced baseline and a live candidate. Both dump paths now compute
+  `header_roots` identically to `apply_dependency_scope_to_run_dump_result`.
+- **The `profile_fingerprint` comparability guard never fired between two
+  header-AST dumps under genuinely different, *unpinned* toolchain defaults**
+  (abicheck-internal-bugs finding 2): without an explicit `-std=`/`--lang`
+  standard and no `--sources`/`--build-info` (L3) evidence,
+  `ast_resolved_standard`/`language_standard` stayed `None`/empty on both
+  sides regardless of which compiler or version actually parsed the
+  headers — so `compare`ing two dumps of the same unchanged library taken
+  under, say, an unpinned GCC 9 default and an unpinned Clang 18 default
+  silently produced a real verdict (`COMPATIBLE_WITH_RISK`) instead of
+  refusing as `NOT_COMPARABLE`. `dumper_toolchain._probe_default_language_standard`
+  now probes the resolved compiler's own predefined-macro table
+  (`-E -dM`, mirroring the existing `_clang_compiler_family` probe) for its
+  genuinely unpinned default `__cplusplus`/`__STDC_VERSION__` whenever no
+  explicit standard was given, so two dumps under differing toolchain
+  defaults now correctly disagree on `language_standard` and the
+  comparability gate refuses the comparison. Best-effort and additive: the
+  common same-toolchain, no-flags workflow is unaffected, and a probe
+  failure (unsupported driver, e.g. MSVC `cl.exe`) degrades to the prior
+  behavior.

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -46,4 +46,17 @@
   snapshot of the identical input under the identical resolved compiler
   (confirmed via an unchanged `compiler_family`/`compiler_version`) — an
   abicheck upgrade adding evidence must not by itself make an
-  otherwise-unchanged baseline `NOT_COMPARABLE`.
+  otherwise-unchanged baseline `NOT_COMPARABLE`. Two follow-up review
+  fixes, both real: the carve-out's transition check and
+  `_cplusplus_macro_for_standard` both matched the `"probed:"` marker with
+  `.startswith(...)`, but when `--lang` is given explicitly the recorded
+  value is language-mode-prefixed (`"c++:probed:__cplusplus=201703L"`),
+  so the marker no longer sits at position 0 and both silently failed to
+  recognize it — fixed to a containment check. And the probe's language
+  mode is now the header-AST parse's *actual, post-retry* mode rather than
+  a static re-derivation: a C-mode dump whose parse self-heals into C++
+  (`dumper.py`'s C→C++ retry) or a castxml C-mode dump (whose driver is
+  internally remapped from the caller's `"c++"` default to `"cc"`) now
+  threads that real, resolved language mode/compiler identity into
+  `AbiSnapshot.ast_toolchain`, so the provenance probe queries the
+  compiler that actually parsed the headers instead of a stale guess.

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -78,7 +78,15 @@
   the carve-out (`_newly_resolved_standard_remainder`) to recognize every
   pre-upgrade "nothing resolved yet" spelling (`""`, `"c"`, `"c++"`) against
   a same-lang-tagged, newly-populated successor (the forced literal or a
-  probed value), in either comparison direction.
+  probed value), in either comparison direction. The carve-out's own
+  `compiler_family`/`compiler_version` corroboration also now checks
+  `AbiSnapshot.ast_toolchain`'s `compiler_sha256` (the resolved compiler
+  binary's own content hash) when both sides carry one: a compiler wrapper
+  replaced at the same path can report an identical family/version string
+  — text a wrapper's own `--version` output controls — while actually
+  selecting a different default dialect. Falls back to the family/version-only
+  check when either side lacks the hash (an older snapshot, or a side whose
+  compiler resolution itself failed).
 - Known, narrower residual, documented rather than fixed: a cache/memo
   *hit* for a header that previously self-healed C→C++ still reports the
   pre-retry language mode, since neither backend's AST cache persists that

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -68,4 +68,20 @@
   `dumper_toolchain._resolve_standard_provenance` now reports that forced
   standard directly for a gnu-dialect C parse, and only probes the
   remaining genuinely-unpinned cases (C++ with no C++20 heuristic, or any
-  MSVC-dialect parse, neither of which either command builder pins).
+  MSVC-dialect parse, neither of which either command builder pins). That
+  fix in turn broke the upgrade-corroboration carve-out itself: it only
+  recognized an empty-string-to-`"probed:..."` transition, but the forced
+  standard produces three shapes it had never seen — an unpinned, no-`--lang`
+  baseline moving to the bare `"gnu11"` literal (no `"probed:"` marker at
+  all), and an explicit-`--lang` baseline moving from a *bare* `"c"`/`"c++"`
+  tag (not an empty string) to `"c:gnu11"`/`"c++:probed:..."`. Generalized
+  the carve-out (`_newly_resolved_standard_remainder`) to recognize every
+  pre-upgrade "nothing resolved yet" spelling (`""`, `"c"`, `"c++"`) against
+  a same-lang-tagged, newly-populated successor (the forced literal or a
+  probed value), in either comparison direction.
+- Known, narrower residual, documented rather than fixed: a cache/memo
+  *hit* for a header that previously self-healed C→C++ still reports the
+  pre-retry language mode, since neither backend's AST cache persists that
+  fact alongside the cached document — see `_clang_header_dump`'s own
+  docstring for why a correct fix needs a cache-format change on both
+  backends, not a follow-up to this PR.

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -35,4 +35,15 @@
   comparability gate refuses the comparison. Best-effort and additive: the
   common same-toolchain, no-flags workflow is unaffected, and a probe
   failure (unsupported driver, e.g. MSVC `cl.exe`) degrades to the prior
-  behavior.
+  behavior. The probe resolves the *actual* language mode the header-AST
+  parse used (`dumper_toolchain._resolve_force_cpp`, the same auto-detection
+  decision the real parse makes — not just a bare `--lang c`/`c++` check),
+  so a header that auto-detects as C is probed in C mode even when `lang`
+  wasn't explicitly given. A new `comparability.py` carve-out
+  (`_language_standard_probe_upgrade_corroborated`) keeps an existing,
+  pre-upgrade baseline (recorded with an empty `language_standard`, since
+  this probe didn't exist yet) comparable against a freshly re-dumped
+  snapshot of the identical input under the identical resolved compiler
+  (confirmed via an unchanged `compiler_family`/`compiler_version`) — an
+  abicheck upgrade adding evidence must not by itself make an
+  otherwise-unchanged baseline `NOT_COMPARABLE`.

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -111,6 +111,17 @@
   names `__STDC_VERSION__`, never `__cplusplus`), while still waiving a
   genuine unpinned-C transition (the forced `gnu11` literal, or an
   MSVC-dialect probe naming `__STDC_VERSION__`).
+- **`tu_merge.merge_fragments` (`--dump-manifest`) could silently mislabel
+  a mixed-language manifest's `language_standard`**: the new
+  `resolved_lang_mode` field (unlike `ast_producer`/`frontend_context_kind`,
+  which really are uniform across every TU by construction) legitimately
+  differs per TU in an ordinary mixed C/.c and C++/.cpp manifest under one
+  shared compiler — blindly copying one representative TU's value would
+  stamp the whole merged snapshot's `language_standard` from whichever TU
+  happened to sort first, silently wrong for every other TU. Now dropped
+  from the merged `ast_toolchain` (falling back to the pre-existing static
+  re-derivation over the manifest's combined headers) whenever the
+  contributing TUs disagree, rather than picked arbitrarily.
 - Known, narrower residuals, documented rather than fixed:
   - A cache/memo *hit* for a header that previously self-healed C→C++
     still reports the pre-retry language mode, since neither backend's AST

--- a/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
+++ b/changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md
@@ -87,9 +87,17 @@
   selecting a different default dialect. Falls back to the family/version-only
   check when either side lacks the hash (an older snapshot, or a side whose
   compiler resolution itself failed).
-- Known, narrower residual, documented rather than fixed: a cache/memo
-  *hit* for a header that previously self-healed C→C++ still reports the
-  pre-retry language mode, since neither backend's AST cache persists that
-  fact alongside the cached document — see `_clang_header_dump`'s own
-  docstring for why a correct fix needs a cache-format change on both
-  backends, not a follow-up to this PR.
+- Known, narrower residuals, documented rather than fixed:
+  - A cache/memo *hit* for a header that previously self-healed C→C++
+    still reports the pre-retry language mode, since neither backend's AST
+    cache persists that fact alongside the cached document — see
+    `_clang_header_dump`'s own docstring for why a correct fix needs a
+    cache-format change on both backends, not a follow-up to this PR.
+  - `_compiler_options.has_explicit_std` recognizes only `-std=`/`/std:`,
+    not GCC's standard-selecting alias `-ansi` (`-std=c90`/`-std=c++98`
+    depending on language mode) — a pre-existing gap, not introduced by
+    this PR, but one this PR's new probe/forced-standard logic now also
+    depends on. A forwarded `-ansi` reads as "no explicit standard"
+    everywhere this function gates on it; see its own docstring for why a
+    correct fix needs a signature change re-verified across all of its
+    several call sites, not a scoped one-off.

--- a/tests/test_ast_compile_provenance.py
+++ b/tests/test_ast_compile_provenance.py
@@ -69,11 +69,12 @@ class TestCplusplusMacroForStandard:
         no longer sits at position 0 -- must still resolve, not silently
         return ``None`` for a pinned-lang probed dump."""
         assert (
-            _cplusplus_macro_for_standard("c++:probed:__cplusplus=201703L")
-            == "201703L"
+            _cplusplus_macro_for_standard("c++:probed:__cplusplus=201703L") == "201703L"
         )
         assert _cplusplus_macro_for_standard("probed:__cplusplus=201703L") == "201703L"
-        assert _cplusplus_macro_for_standard("c:probed:__STDC_VERSION__=201710L") is None
+        assert (
+            _cplusplus_macro_for_standard("c:probed:__STDC_VERSION__=201710L") is None
+        )
 
 
 class TestExtractExplicitStdValue:
@@ -386,7 +387,12 @@ class TestResolveStandardProvenanceProbing:
         c_header = tmp_path / "c.h"
         c_header.write_text("int f(int x);\n", encoding="utf-8")
         result = _resolve_standard_provenance(
-            [c_header], None, (), probe_compiler_bin="cl.exe", lang=None, abi_dialect="msvc"
+            [c_header],
+            None,
+            (),
+            probe_compiler_bin="cl.exe",
+            lang=None,
+            abi_dialect="msvc",
         )
         assert seen_modes == ["c"]
         assert result == "probed:stub"
@@ -420,6 +426,39 @@ class TestResolveStandardProvenanceProbing:
             resolved_lang_mode="c++",
         )
         assert seen_modes == ["c++"]
+
+    def test_heterogeneous_resolved_lang_mode_returns_none_without_probing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Codex review, fresh evidence: ``tu_merge.merge_fragments`` writes
+        ``_HETEROGENEOUS_LANG_MODE`` when a merged manifest's contributing
+        TUs genuinely disagree on their resolved language mode. Falling
+        back to the static ``_resolve_force_cpp`` re-derivation for that
+        case (over the manifest's combined public headers alone) can be
+        confidently *wrong* -- not just unknown -- for a TU whose
+        language mode came from something invisible to those headers, so
+        this must return ``None`` outright, skipping both the forced-
+        ``gnu11`` path and the probe path, rather than guessing either
+        way."""
+        from abicheck.tu_merge import _HETEROGENEOUS_LANG_MODE
+
+        def fail_probe(*a, **k):
+            raise AssertionError("must not probe a heterogeneous manifest")
+
+        monkeypatch.setattr(
+            "abicheck.dumper_toolchain._probe_default_language_standard", fail_probe
+        )
+        c_header = tmp_path / "c.h"
+        c_header.write_text("int f(int x);\n", encoding="utf-8")
+        result = _resolve_standard_provenance(
+            [c_header],
+            None,
+            (),
+            probe_compiler_bin="cc",
+            lang=None,
+            resolved_lang_mode=_HETEROGENEOUS_LANG_MODE,
+        )
+        assert result is None
 
 
 class TestAstCompileProvenanceProbing:

--- a/tests/test_ast_compile_provenance.py
+++ b/tests/test_ast_compile_provenance.py
@@ -343,13 +343,37 @@ class TestResolveStandardProvenanceProbing:
         )
         assert result == "probed:__cplusplus=STUBBED:my-clang"
 
-    def test_probe_lang_mode_follows_real_auto_detection(
+    def test_unpinned_c_gnu_mode_is_never_probed_forced_standard_reported_directly(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ):
-        """abicheck-internal-bugs finding 2 follow-up (Codex review): with
-        no explicit ``lang``, the probe must use whatever
-        ``_resolve_force_cpp`` (the real parse's own decision) resolves to
-        for these headers -- not unconditionally "c++"."""
+        """Codex review, fresh evidence: both header-AST command builders
+        (``dumper_ast_config._build_castxml_command``/
+        ``_build_clang_header_command``) unconditionally force ``-std=gnu11``
+        for an unpinned C/gnu-dialect parse -- so this must report that
+        forced standard directly, never probe the resolved compiler's own
+        naked default (which is a genuinely different value, e.g. GCC's C17
+        default), since that default was never what actually parsed the
+        headers."""
+
+        def fail_probe(*a, **k):
+            raise AssertionError("must not probe a forced-standard C/gnu parse")
+
+        monkeypatch.setattr(
+            "abicheck.dumper_toolchain._probe_default_language_standard", fail_probe
+        )
+        c_header = tmp_path / "c.h"
+        c_header.write_text("int f(int x);\n", encoding="utf-8")
+        result = _resolve_standard_provenance(
+            [c_header], None, (), probe_compiler_bin="cc", lang=None
+        )
+        assert result == "gnu11"
+
+    def test_unpinned_c_msvc_dialect_is_still_probed(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The gnu11 force above is gated on ``cc_id == "gnu"`` in the real
+        command builder -- an MSVC-dialect C parse stays genuinely unpinned
+        to the resolved compiler's own default, so it must still probe."""
         seen_modes = []
 
         def fake_probe(compiler_bin, lang_mode):
@@ -361,10 +385,11 @@ class TestResolveStandardProvenanceProbing:
         )
         c_header = tmp_path / "c.h"
         c_header.write_text("int f(int x);\n", encoding="utf-8")
-        _resolve_standard_provenance(
-            [c_header], None, (), probe_compiler_bin="cc", lang=None
+        result = _resolve_standard_provenance(
+            [c_header], None, (), probe_compiler_bin="cl.exe", lang=None, abi_dialect="msvc"
         )
         assert seen_modes == ["c"]
+        assert result == "probed:stub"
 
     def test_resolved_lang_mode_overrides_static_re_derivation(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_ast_compile_provenance.py
+++ b/tests/test_ast_compile_provenance.py
@@ -33,7 +33,11 @@ from abicheck.dumper import (
     _cplusplus_macro_for_standard,
     _resolve_standard_provenance,
 )
-from abicheck.dumper_toolchain import _extract_explicit_std_value
+from abicheck.dumper_toolchain import (
+    _extract_explicit_std_value,
+    _probe_default_language_standard,
+    _probe_language_mode,
+)
 from abicheck.model import AbiSnapshot
 from abicheck.serialization import SCHEMA_VERSION, snapshot_from_dict, snapshot_to_dict
 
@@ -151,6 +155,240 @@ class TestAstCompileProvenance:
         sysroot = Path(home) / "sdk" / "sysroot"
         prov = _ast_compile_provenance([], None, (), sysroot)
         assert prov["ast_sysroot"] == str(Path("~") / "sdk" / "sysroot")
+
+
+class TestProbeLanguageMode:
+    def test_c_lang_is_c_mode(self):
+        assert _probe_language_mode("c") == "c"
+        assert _probe_language_mode("C") == "c"
+
+    def test_everything_else_is_cpp_mode(self):
+        assert _probe_language_mode("c++") == "c++"
+        assert _probe_language_mode(None) == "c++"
+        assert _probe_language_mode("") == "c++"
+
+
+class TestProbeDefaultLanguageStandard:
+    """ADR-050 D1/D2 follow-up: the profile_fingerprint comparability guard
+    must be able to tell two genuinely different toolchains' unpinned
+    default standards apart, not just an explicit ``-std=``. See
+    ``abicheck-internal-bugs`` finding 2: "the cross-profile comparability
+    guard doesn't fire without L3 build evidence"."""
+
+    def setup_method(self):
+        _probe_default_language_standard.cache_clear()
+
+    def test_probes_real_host_compiler_cpp(self):
+        import shutil
+
+        cxx = shutil.which("g++") or shutil.which("clang++")
+        if cxx is None:
+            pytest.skip("no C++ compiler on PATH")
+        result = _probe_default_language_standard(cxx, "c++")
+        assert result is not None
+        assert result.startswith("probed:__cplusplus=")
+
+    def test_two_different_defaults_produce_different_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The actual mechanism the false-COMPATIBLE bug rested on: two
+        resolved compilers with genuinely different unpinned defaults must
+        probe to genuinely different values."""
+        import subprocess as subprocess_module
+
+        def fake_run(argv, **kwargs):
+            assert argv[1:4] == ["-E", "-dM", "-x"]
+            std = {"cxx17": "201703L", "cxx20": "202002L"}[argv[0]]
+            return subprocess_module.CompletedProcess(
+                argv, 0, stdout=f"#define __cplusplus {std}\n", stderr=""
+            )
+
+        monkeypatch.setattr(subprocess_module, "run", fake_run)
+        old = _probe_default_language_standard("cxx17", "c++")
+        new = _probe_default_language_standard("cxx20", "c++")
+        assert old != new
+        assert old == "probed:__cplusplus=201703L"
+        assert new == "probed:__cplusplus=202002L"
+
+    def test_c_mode_absent_stdc_version_is_a_real_value_not_a_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        import subprocess as subprocess_module
+
+        def fake_run(argv, **kwargs):
+            return subprocess_module.CompletedProcess(argv, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess_module, "run", fake_run)
+        result = _probe_default_language_standard("old-cc", "c")
+        assert result == "probed:__STDC_VERSION__=<absent>"
+
+    def test_missing_compiler_returns_none(self, monkeypatch: pytest.MonkeyPatch):
+        import subprocess as subprocess_module
+
+        def fake_run(argv, **kwargs):
+            raise FileNotFoundError(argv[0])
+
+        monkeypatch.setattr(subprocess_module, "run", fake_run)
+        assert _probe_default_language_standard("/no/such/cc", "c++") is None
+
+    def test_nonzero_exit_returns_none(self, monkeypatch: pytest.MonkeyPatch):
+        import subprocess as subprocess_module
+
+        def fake_run(argv, **kwargs):
+            return subprocess_module.CompletedProcess(argv, 1, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess_module, "run", fake_run)
+        assert _probe_default_language_standard("cl.exe", "c++") is None
+
+    def test_result_is_cached_per_binary_and_mode(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        import subprocess as subprocess_module
+
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append(tuple(argv))
+            return subprocess_module.CompletedProcess(
+                argv, 0, stdout="#define __cplusplus 201703L\n", stderr=""
+            )
+
+        monkeypatch.setattr(subprocess_module, "run", fake_run)
+        _probe_default_language_standard("cached-cc", "c++")
+        _probe_default_language_standard("cached-cc", "c++")
+        assert len(calls) == 1
+
+
+class TestResolveStandardProvenanceProbing:
+    """``_resolve_standard_provenance``'s probing fallback -- only reached
+    when neither an explicit ``-std=`` nor the C++20-detection heuristic
+    already resolved a value."""
+
+    def setup_method(self):
+        _probe_default_language_standard.cache_clear()
+
+    def test_explicit_std_never_probes(self, monkeypatch: pytest.MonkeyPatch):
+        def fail_probe(*a, **k):
+            raise AssertionError("must not probe when an explicit -std= is given")
+
+        monkeypatch.setattr(
+            "abicheck.dumper_toolchain._probe_default_language_standard", fail_probe
+        )
+        result = _resolve_standard_provenance(
+            [], "-std=gnu++11", (), probe_compiler_bin="cc", probe_lang_mode="c++"
+        )
+        assert result == "gnu++11"
+
+    def test_no_probe_compiler_bin_stays_none(self):
+        assert _resolve_standard_provenance([], None, ()) is None
+
+    def test_probe_fills_in_when_nothing_else_resolves(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        def fake_probe(compiler_bin, lang_mode):
+            return f"probed:__cplusplus=STUBBED:{compiler_bin}"
+
+        monkeypatch.setattr(
+            "abicheck.dumper_toolchain._probe_default_language_standard", fake_probe
+        )
+        result = _resolve_standard_provenance(
+            [], None, (), probe_compiler_bin="my-clang", probe_lang_mode="c++"
+        )
+        assert result == "probed:__cplusplus=STUBBED:my-clang"
+
+
+class TestAstCompileProvenanceProbing:
+    def setup_method(self):
+        _probe_default_language_standard.cache_clear()
+
+    def test_ast_toolchain_compiler_selected_feeds_the_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        seen = {}
+
+        def fake_probe(compiler_bin, lang_mode):
+            seen["compiler_bin"] = compiler_bin
+            seen["lang_mode"] = lang_mode
+            return "probed:__cplusplus=201402L"
+
+        monkeypatch.setattr(
+            "abicheck.dumper_toolchain._probe_default_language_standard", fake_probe
+        )
+        prov = _ast_compile_provenance(
+            [],
+            None,
+            (),
+            None,
+            ast_toolchain={"compiler_selected": "/opt/toolchains/g++-9"},
+            lang="c++",
+        )
+        assert seen == {"compiler_bin": "/opt/toolchains/g++-9", "lang_mode": "c++"}
+        assert prov["ast_resolved_standard"] == "probed:__cplusplus=201402L"
+        assert prov["ast_cplusplus_macro"] == "201402L"
+
+    def test_no_ast_toolchain_preserves_prior_behavior(self):
+        """The default (no ``ast_toolchain``/``lang`` given) must be
+        byte-for-byte identical to this function's pre-fix behavior."""
+        prov = _ast_compile_provenance([], None, (), None)
+        assert prov["ast_resolved_standard"] is None
+
+    def test_two_different_resolved_compilers_probe_to_different_standards(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The actual bug this closes: `dump`'d under two different,
+        unpinned toolchains must no longer silently agree on
+        `language_standard`."""
+
+        def fake_probe(compiler_bin, lang_mode):
+            return {
+                "/usr/bin/g++-9": "probed:__cplusplus=201703L",
+                "/usr/bin/clang++-18": "probed:__cplusplus=202002L",
+            }[compiler_bin]
+
+        monkeypatch.setattr(
+            "abicheck.dumper_toolchain._probe_default_language_standard", fake_probe
+        )
+        old = _ast_compile_provenance(
+            [],
+            None,
+            (),
+            None,
+            ast_toolchain={"compiler_selected": "/usr/bin/g++-9"},
+            lang="c++",
+        )
+        new = _ast_compile_provenance(
+            [],
+            None,
+            (),
+            None,
+            ast_toolchain={"compiler_selected": "/usr/bin/clang++-18"},
+            lang="c++",
+        )
+        assert old["ast_resolved_standard"] != new["ast_resolved_standard"]
+
+    def test_falls_back_to_bare_selected_key(self, monkeypatch: pytest.MonkeyPatch):
+        """``compiler_selected`` is absent for a producer where frontend and
+        compiler are the same binary (e.g. a direct-clang dump) -- falls
+        back to the bare ``selected`` key, mirroring
+        ``_compiler_family_from_toolchain``'s identical fallback."""
+        seen = {}
+
+        def fake_probe(compiler_bin, lang_mode):
+            seen["compiler_bin"] = compiler_bin
+            return "probed:__cplusplus=201703L"
+
+        monkeypatch.setattr(
+            "abicheck.dumper_toolchain._probe_default_language_standard", fake_probe
+        )
+        _ast_compile_provenance(
+            [],
+            None,
+            (),
+            None,
+            ast_toolchain={"selected": "/usr/bin/clang++"},
+            lang="c++",
+        )
+        assert seen["compiler_bin"] == "/usr/bin/clang++"
 
 
 class TestSnapshotSerializationRoundTrip:

--- a/tests/test_ast_compile_provenance.py
+++ b/tests/test_ast_compile_provenance.py
@@ -61,6 +61,20 @@ class TestCplusplusMacroForStandard:
         assert _cplusplus_macro_for_standard(None) is None
         assert _cplusplus_macro_for_standard("") is None
 
+    def test_probed_marker_recognized_regardless_of_position(self):
+        """CodeRabbit review, fresh evidence: when an explicit ``--lang`` is
+        also given, ``language_standard_field`` prefixes the probed value
+        with ``"c++:"``/``"c:"`` (e.g.
+        ``"c++:probed:__cplusplus=201703L"``), so the ``"probed:"`` marker
+        no longer sits at position 0 -- must still resolve, not silently
+        return ``None`` for a pinned-lang probed dump."""
+        assert (
+            _cplusplus_macro_for_standard("c++:probed:__cplusplus=201703L")
+            == "201703L"
+        )
+        assert _cplusplus_macro_for_standard("probed:__cplusplus=201703L") == "201703L"
+        assert _cplusplus_macro_for_standard("c:probed:__STDC_VERSION__=201710L") is None
+
 
 class TestExtractExplicitStdValue:
     def test_from_gcc_option_tokens(self):
@@ -196,6 +210,7 @@ class TestProbeDefaultLanguageStandard:
     def setup_method(self):
         _probe_default_language_standard.cache_clear()
 
+    @pytest.mark.integration
     def test_probes_real_host_compiler_cpp(self):
         import shutil
 
@@ -261,20 +276,34 @@ class TestProbeDefaultLanguageStandard:
     def test_result_is_cached_per_binary_and_mode(
         self, monkeypatch: pytest.MonkeyPatch
     ):
+        """Repeated identical calls are cached (one subprocess call) -- and
+        both ``compiler_bin`` and ``lang_mode`` are genuinely part of the
+        cache key, not just incidental ``lru_cache`` argument order: varying
+        either one must still probe (CodeRabbit review, fresh evidence --
+        the prior version of this test only proved the identical-call case,
+        which would also pass against a cache keyed on ``compiler_bin``
+        alone)."""
         import subprocess as subprocess_module
 
         calls = []
 
         def fake_run(argv, **kwargs):
             calls.append(tuple(argv))
+            macro = "__cplusplus" if argv[3] == "c++" else "__STDC_VERSION__"
             return subprocess_module.CompletedProcess(
-                argv, 0, stdout="#define __cplusplus 201703L\n", stderr=""
+                argv, 0, stdout=f"#define {macro} 201703L\n", stderr=""
             )
 
         monkeypatch.setattr(subprocess_module, "run", fake_run)
         _probe_default_language_standard("cached-cc", "c++")
-        _probe_default_language_standard("cached-cc", "c++")
+        _probe_default_language_standard("cached-cc", "c++")  # identical: cached
         assert len(calls) == 1
+        _probe_default_language_standard("cached-cc", "c")  # different mode: probes
+        assert len(calls) == 2
+        _probe_default_language_standard("other-cc", "c++")  # different binary: probes
+        assert len(calls) == 3
+        _probe_default_language_standard("cached-cc", "c")  # repeat of call 2: cached
+        assert len(calls) == 3
 
 
 class TestResolveStandardProvenanceProbing:
@@ -337,6 +366,36 @@ class TestResolveStandardProvenanceProbing:
         )
         assert seen_modes == ["c"]
 
+    def test_resolved_lang_mode_overrides_static_re_derivation(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Codex review, fresh evidence: a C->C++ self-heal retry settles on
+        a language mode a static re-derivation from *headers* alone cannot
+        reconstruct (the header itself still only contains C-compatible
+        syntax; the real signal was a missing C++ stdlib header at parse
+        time). *resolved_lang_mode*, when given, must win outright, not just
+        bias the auto-detection heuristic."""
+        seen_modes = []
+
+        def fake_probe(compiler_bin, lang_mode):
+            seen_modes.append(lang_mode)
+            return "probed:stub"
+
+        monkeypatch.setattr(
+            "abicheck.dumper_toolchain._probe_default_language_standard", fake_probe
+        )
+        c_header = tmp_path / "c.h"
+        c_header.write_text("int f(int x);\n", encoding="utf-8")
+        _resolve_standard_provenance(
+            [c_header],
+            None,
+            (),
+            probe_compiler_bin="clang",
+            lang=None,
+            resolved_lang_mode="c++",
+        )
+        assert seen_modes == ["c++"]
+
 
 class TestAstCompileProvenanceProbing:
     def setup_method(self):
@@ -372,6 +431,36 @@ class TestAstCompileProvenanceProbing:
         byte-for-byte identical to this function's pre-fix behavior."""
         prov = _ast_compile_provenance([], None, (), None)
         assert prov["ast_resolved_standard"] is None
+
+    def test_ast_toolchain_resolved_lang_mode_feeds_the_probe(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Codex review, fresh evidence: ``dumper.py``'s clang self-heal
+        stamps ``resolved_lang_mode`` onto ``ast_toolchain`` after a C->C++
+        retry -- this is the end-to-end wiring proving that value actually
+        reaches the probe, not just a re-derivation from ``lang``."""
+        seen = {}
+
+        def fake_probe(compiler_bin, lang_mode):
+            seen["lang_mode"] = lang_mode
+            return "probed:__cplusplus=201703L"
+
+        monkeypatch.setattr(
+            "abicheck.dumper_toolchain._probe_default_language_standard", fake_probe
+        )
+        prov = _ast_compile_provenance(
+            [],
+            None,
+            (),
+            None,
+            ast_toolchain={
+                "compiler_selected": "/usr/bin/clang",
+                "resolved_lang_mode": "c++",
+            },
+            lang=None,  # unspecified -- would auto-detect "c" without the override
+        )
+        assert seen == {"lang_mode": "c++"}
+        assert prov["ast_resolved_standard"] == "probed:__cplusplus=201703L"
 
     def test_two_different_resolved_compilers_probe_to_different_standards(
         self, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_ast_compile_provenance.py
+++ b/tests/test_ast_compile_provenance.py
@@ -36,7 +36,7 @@ from abicheck.dumper import (
 from abicheck.dumper_toolchain import (
     _extract_explicit_std_value,
     _probe_default_language_standard,
-    _probe_language_mode,
+    _resolve_force_cpp,
 )
 from abicheck.model import AbiSnapshot
 from abicheck.serialization import SCHEMA_VERSION, snapshot_from_dict, snapshot_to_dict
@@ -157,15 +157,33 @@ class TestAstCompileProvenance:
         assert prov["ast_sysroot"] == str(Path("~") / "sdk" / "sysroot")
 
 
-class TestProbeLanguageMode:
-    def test_c_lang_is_c_mode(self):
-        assert _probe_language_mode("c") == "c"
-        assert _probe_language_mode("C") == "c"
+class TestResolveForceCpp:
+    """The real language-mode decision the header-AST parse itself makes
+    (relocated from ``dumper.py`` alongside this PR's probe fix — Codex
+    review: the probe must resolve the same mode the real parse used,
+    since an unspecified ``lang`` can auto-detect as either C or C++
+    depending on the header's own content)."""
 
-    def test_everything_else_is_cpp_mode(self):
-        assert _probe_language_mode("c++") == "c++"
-        assert _probe_language_mode(None) == "c++"
-        assert _probe_language_mode("") == "c++"
+    def test_explicit_c_never_forces_cpp(self):
+        assert _resolve_force_cpp("c", [], None, ()) is False
+
+    def test_explicit_cpp_forces_cpp(self):
+        assert _resolve_force_cpp("c++", [], None, ()) is True
+        assert _resolve_force_cpp("cpp", [], None, ()) is True
+
+    def test_unspecified_lang_with_plain_c_compatible_header_stays_c(
+        self, tmp_path: Path
+    ):
+        header = tmp_path / "h.h"
+        header.write_text("int f(int x);\n", encoding="utf-8")
+        assert _resolve_force_cpp(None, [header], None, ()) is False
+
+    def test_unspecified_lang_with_cpp_only_syntax_auto_detects_cpp(
+        self, tmp_path: Path
+    ):
+        header = tmp_path / "h.h"
+        header.write_text("namespace ns { int f(int x); }\n", encoding="utf-8")
+        assert _resolve_force_cpp(None, [header], None, ()) is True
 
 
 class TestProbeDefaultLanguageStandard:
@@ -275,7 +293,7 @@ class TestResolveStandardProvenanceProbing:
             "abicheck.dumper_toolchain._probe_default_language_standard", fail_probe
         )
         result = _resolve_standard_provenance(
-            [], "-std=gnu++11", (), probe_compiler_bin="cc", probe_lang_mode="c++"
+            [], "-std=gnu++11", (), probe_compiler_bin="cc", lang="c++"
         )
         assert result == "gnu++11"
 
@@ -292,9 +310,32 @@ class TestResolveStandardProvenanceProbing:
             "abicheck.dumper_toolchain._probe_default_language_standard", fake_probe
         )
         result = _resolve_standard_provenance(
-            [], None, (), probe_compiler_bin="my-clang", probe_lang_mode="c++"
+            [], None, (), probe_compiler_bin="my-clang", lang="c++"
         )
         assert result == "probed:__cplusplus=STUBBED:my-clang"
+
+    def test_probe_lang_mode_follows_real_auto_detection(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ):
+        """abicheck-internal-bugs finding 2 follow-up (Codex review): with
+        no explicit ``lang``, the probe must use whatever
+        ``_resolve_force_cpp`` (the real parse's own decision) resolves to
+        for these headers -- not unconditionally "c++"."""
+        seen_modes = []
+
+        def fake_probe(compiler_bin, lang_mode):
+            seen_modes.append(lang_mode)
+            return "probed:stub"
+
+        monkeypatch.setattr(
+            "abicheck.dumper_toolchain._probe_default_language_standard", fake_probe
+        )
+        c_header = tmp_path / "c.h"
+        c_header.write_text("int f(int x);\n", encoding="utf-8")
+        _resolve_standard_provenance(
+            [c_header], None, (), probe_compiler_bin="cc", lang=None
+        )
+        assert seen_modes == ["c"]
 
 
 class TestAstCompileProvenanceProbing:

--- a/tests/test_castxml_errors.py
+++ b/tests/test_castxml_errors.py
@@ -638,7 +638,7 @@ def test_header_ast_parser_falls_back_to_clang_on_toolchain_failure(
     monkeypatch.setattr(dumper, "_resolve_header_backend", lambda b: "castxml")
     monkeypatch.setattr(dumper, "_castxml_dump", _boom)
     monkeypatch.setattr(dumper, "_resolve_clang_bin", lambda *a, **k: "clang")
-    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (sentinel, None))
+    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (sentinel, None, False))
     monkeypatch.delenv("ABICHECK_AST_FRONTEND", raising=False)
 
     parser = _header_ast_parser(
@@ -665,7 +665,7 @@ def test_header_ast_parser_falls_back_to_clang_on_guard_error(tmp_path, monkeypa
     monkeypatch.setattr(dumper, "_resolve_header_backend", lambda b: "castxml")
     monkeypatch.setattr(dumper, "_castxml_dump", _boom)
     monkeypatch.setattr(dumper, "_resolve_clang_bin", lambda *a, **k: "clang")
-    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (sentinel, None))
+    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (sentinel, None, False))
     monkeypatch.delenv("ABICHECK_AST_FRONTEND", raising=False)
 
     parser = _header_ast_parser(
@@ -736,7 +736,7 @@ def test_header_ast_parser_auto_device_routes_to_clang_not_rejected(
 
     monkeypatch.delenv("ABICHECK_AST_FRONTEND", raising=False)
     ast = {"kind": "TranslationUnitDecl", "inner": []}
-    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, "device"))
+    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, "device", False))
 
     parser = _header_ast_parser(
         [Path("a.h")],
@@ -804,7 +804,7 @@ def test_header_ast_parser_clang_backend_returns_clang_parser(tmp_path, monkeypa
     from abicheck.dumper import _ClangAstParser, _header_ast_parser
 
     monkeypatch.setattr(dumper, "_resolve_header_backend", lambda b: "clang")
-    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: ({}, None))
+    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: ({}, None, False))
 
     parser = _header_ast_parser(
         [Path("a.h")], [], backend="clang", **_ast_parser_kwargs(tmp_path)

--- a/tests/test_castxml_toolchain_robustness.py
+++ b/tests/test_castxml_toolchain_robustness.py
@@ -618,7 +618,7 @@ class TestG16ClangFallbackRespectsConfiguredDriver:
                 side_effect=SnapshotError(_ASSUME_STDERR),
             ),
             patch("abicheck.dumper.shutil.which", side_effect=fake_which),
-            patch("abicheck.dumper._clang_header_dump", return_value=(MagicMock(), None)),
+            patch("abicheck.dumper._clang_header_dump", return_value=(MagicMock(), None, False)),
             patch("abicheck.dumper._ClangAstParser", return_value=sentinel),
         ):
             result = _header_ast_parser(
@@ -659,7 +659,7 @@ class TestG16ClangFallbackRespectsConfiguredDriver:
                 ),
             ),
             patch("abicheck.dumper.shutil.which", return_value="/usr/bin/clang++"),
-            patch("abicheck.dumper._clang_header_dump", return_value=(MagicMock(), None)),
+            patch("abicheck.dumper._clang_header_dump", return_value=(MagicMock(), None, False)),
             patch("abicheck.dumper._ClangAstParser", return_value=sentinel),
         ):
             result = _header_ast_parser(

--- a/tests/test_clang_header_backend_integration.py
+++ b/tests/test_clang_header_backend_integration.py
@@ -104,7 +104,7 @@ def test_clang_ast_does_not_assign_returned_callback_abi_to_factory(tmp_path: Pa
         "void (__attribute__((ms_abi)) *factory(void))(int);\n", encoding="utf-8"
     )
 
-    root, _ = _clang_header_dump([header], [], compiler="clang", lang="C")
+    root, _, _ = _clang_header_dump([header], [], compiler="clang", lang="C")
     (factory,) = _ClangAstParser(root, {"factory"}, set()).parse_functions()
 
     assert factory.contract_attributes == []

--- a/tests/test_clang_header_backend_integration.py
+++ b/tests/test_clang_header_backend_integration.py
@@ -473,8 +473,16 @@ def test_clang_backend_reconstructs_vtable_and_flags_vptr_introduced(
         capture_output=True,
     )
 
-    old_snap = dump(v1_so, [old_header], header_backend="clang")
-    new_snap = dump(v2_so, [new_header], header_backend="clang")
+    # lang="c++" pinned explicitly on both sides (abicheck-internal-bugs
+    # finding 2 follow-up): the old header alone has no C++-only syntax, so
+    # auto-detection would parse it as C while the new header (genuinely
+    # needing `virtual`) auto-detects as C++ -- a real language-mode
+    # asymmetry the comparability gate now correctly refuses, but not what
+    # this test is about. Both files belong to the same C++ library (built
+    # with g++), so pinning `lang` explicitly is the correct, real-world
+    # practice here regardless.
+    old_snap = dump(v1_so, [old_header], header_backend="clang", lang="c++")
+    new_snap = dump(v2_so, [new_header], header_backend="clang", lang="c++")
     old_widget = next(t for t in old_snap.types if t.name == "Widget")
     new_widget = next(t for t in new_snap.types if t.name == "Widget")
     assert old_widget.vtable == []

--- a/tests/test_comparability_gate.py
+++ b/tests/test_comparability_gate.py
@@ -1933,3 +1933,56 @@ def test_gate_rejects_profile_mismatch_unverified_fingerprint_in_diagnostic_mode
     result = check_contracts_comparable(old, new, diagnostic=True)
     assert isinstance(result, ComparabilityMismatch)
     assert result.kind == "profile"
+
+
+# ---------------------------------------------------------------------------
+# abicheck-internal-bugs finding 2: "the cross-profile comparability guard
+# doesn't fire without L3 build evidence" -- two header-AST dumps under
+# genuinely different, unpinned toolchain defaults (no explicit -std= on
+# either side) must not silently compare as though nothing differed just
+# because neither side ever asserted a language_standard.
+# ---------------------------------------------------------------------------
+
+
+def test_gate_two_unpinned_toolchains_with_differing_probed_defaults_raise_profile_mismatch():
+    """Before the fix: both sides recorded language_standard="" (nothing
+    to distinguish an unpinned GCC-17 default from an unpinned Clang-20
+    default), so this compared as a false COMPATIBLE_WITH_RISK instead of
+    refusing. `compute_extraction_contract` now receives the resolved
+    compiler's own probed default standard (dumper_toolchain
+    ._probe_default_language_standard) as `language_standard` whenever no
+    explicit one was given -- this test exercises the gate directly against
+    two such contracts."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            language_standard="probed:__cplusplus=201703L",  # unpinned GCC 9 default
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            language_standard="probed:__cplusplus=202002L",  # unpinned Clang 18 default
+        )
+    )
+    with pytest.raises(ProfileMismatchError):
+        check_contracts_comparable(old, new)
+
+
+def test_gate_two_unpinned_toolchains_with_the_same_probed_default_stay_comparable():
+    """The common, overwhelmingly frequent workflow -- two dumps of the same
+    project under the SAME unpinned toolchain -- must not regress into a
+    spurious refusal just because probing now fills in a value."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            language_standard="probed:__cplusplus=201703L",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            language_standard="probed:__cplusplus=201703L",
+        )
+    )
+    check_contracts_comparable(old, new)  # must not raise

--- a/tests/test_comparability_gate_probe_upgrade.py
+++ b/tests/test_comparability_gate_probe_upgrade.py
@@ -1,0 +1,129 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""abicheck-internal-bugs finding 2, Codex review follow-up: "Preserve
+existing unpinned snapshot baselines".
+
+A baseline persisted before ``dumper_toolchain._probe_default_language_
+standard`` existed recorded an empty ``language_standard`` for any unpinned
+(no explicit ``-std=``, no forced-C++20-heuristic) dump. A freshly re-dumped
+snapshot of the identical input under the identical toolchain now records a
+real ``"probed:..."`` value there instead, purely because the tool was
+upgraded. That must not, by itself, make the pair ``NOT_COMPARABLE`` --
+``comparability._language_standard_probe_upgrade_corroborated`` is the
+carve-out closing that gap, tested here directly against the gate (split out
+of ``test_comparability_gate.py``, which sits at the AI-readiness file-size
+hard cap, rather than appended there).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from abicheck.comparability import (
+    check_contracts_comparable,
+    compute_extraction_contract,
+)
+from abicheck.errors import ProfileMismatchError
+from abicheck.model import AbiSnapshot
+
+
+def _snap(contract) -> AbiSnapshot:  # noqa: ANN001
+    return AbiSnapshot(library="libfoo.so", version="1.0", contract=contract)
+
+
+def test_gate_empty_vs_probed_language_standard_waived_when_compiler_unchanged():
+    """The exact scenario the reviewer flagged: an old (pre-probe) baseline
+    and a freshly re-dumped snapshot of the identical input under the
+    identical resolved compiler must stay comparable."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="",  # pre-probe baseline: always empty when unpinned
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="probed:__cplusplus=201703L",
+        )
+    )
+    check_contracts_comparable(old, new)  # must not raise
+
+
+def test_gate_empty_vs_probed_language_standard_still_raises_when_compiler_family_differs():
+    """The carve-out must not blindly waive every empty-vs-probed pair --
+    only when the resolved compiler itself is independently confirmed
+    unchanged. A genuinely different compiler_family alongside the
+    transition is still a real profile difference."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="clang",
+            compiler_version="18.1.3",
+            language_standard="probed:__cplusplus=202002L",
+        )
+    )
+    with pytest.raises(ProfileMismatchError):
+        check_contracts_comparable(old, new)
+
+
+def test_gate_empty_vs_probed_language_standard_still_raises_when_compiler_version_differs():
+    """Same family, upgraded version: a real toolchain change between the
+    baseline and the comparison must still be caught, not waived just
+    because the family string happens to match."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="9.4.0",
+            language_standard="",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="13.2.0",
+            language_standard="probed:__cplusplus=201703L",
+        )
+    )
+    with pytest.raises(ProfileMismatchError):
+        check_contracts_comparable(old, new)
+
+
+def test_gate_empty_vs_probed_language_standard_not_waived_without_compiler_evidence():
+    """When neither side records a compiler_family/compiler_version at all,
+    there is nothing to corroborate the transition against -- the carve-out
+    must decline, not treat missing evidence as a pass."""
+    old = _snap(compute_extraction_contract(l2_frontend_ran=True, language_standard=""))
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True, language_standard="probed:__cplusplus=201703L"
+        )
+    )
+    with pytest.raises(ProfileMismatchError):
+        check_contracts_comparable(old, new)

--- a/tests/test_comparability_gate_probe_upgrade.py
+++ b/tests/test_comparability_gate_probe_upgrade.py
@@ -167,3 +167,101 @@ def test_gate_empty_vs_probed_language_standard_waived_when_lang_qualified():
         )
     )
     check_contracts_comparable(old, new)  # must not raise
+
+
+def test_gate_empty_vs_forced_gnu11_waived_when_compiler_unchanged():
+    """Codex review, fresh evidence: an unpinned C/gnu-dialect parse no
+    longer probes at all -- it reports the forced ``"gnu11"`` standard
+    directly (see ``dumper_toolchain._FORCED_C_STANDARD``), which carries no
+    ``"probed:"`` marker. The carve-out must still recognize this as the
+    identical class of upgrade-only transition, not just the probed-value
+    shape."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="gnu11",
+        )
+    )
+    check_contracts_comparable(old, new)  # must not raise
+
+
+def test_gate_bare_lang_c_vs_lang_qualified_gnu11_waived():
+    """Codex review, fresh evidence: an explicit ``--lang c`` baseline
+    recorded a bare ``"c"`` (no resolved standard existed yet), not an
+    empty string -- the carve-out must recognize this pre-upgrade shape
+    too, not only the no-``--lang``-at-all empty-string case."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="c",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="c:gnu11",
+        )
+    )
+    check_contracts_comparable(old, new)  # must not raise
+
+
+def test_gate_bare_lang_cpp_vs_lang_qualified_probed_waived():
+    """The ``--lang c++`` counterpart of the above: a bare ``"c++"``
+    pre-upgrade baseline against a lang-qualified probed value."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="clang",
+            compiler_version="18.1.3",
+            language_standard="c++",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="clang",
+            compiler_version="18.1.3",
+            language_standard="c++:probed:__cplusplus=202002L",
+        )
+    )
+    check_contracts_comparable(old, new)  # must not raise
+
+
+def test_gate_bare_lang_c_vs_different_lang_still_raises():
+    """A bare ``"c"`` pre-upgrade baseline against a *different* lang tag
+    post-upgrade (``"c++:..."``) is a genuine profile difference, not an
+    upgrade artifact -- the carve-out must not waive a real language-mode
+    change just because the old side happens to match one of the
+    unresolved-standard spellings."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="c",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="c++:gnu++17",
+        )
+    )
+    with pytest.raises(ProfileMismatchError):
+        check_contracts_comparable(old, new)

--- a/tests/test_comparability_gate_probe_upgrade.py
+++ b/tests/test_comparability_gate_probe_upgrade.py
@@ -40,8 +40,17 @@ from abicheck.errors import ProfileMismatchError
 from abicheck.model import AbiSnapshot, ExtractionContract
 
 
-def _snap(contract: ExtractionContract | None) -> AbiSnapshot:
-    return AbiSnapshot(library="libfoo.so", version="1.0", contract=contract)
+def _snap(
+    contract: ExtractionContract | None,
+    *,
+    ast_toolchain: dict[str, str] | None = None,
+) -> AbiSnapshot:
+    return AbiSnapshot(
+        library="libfoo.so",
+        version="1.0",
+        contract=contract,
+        ast_toolchain=ast_toolchain or {},
+    )
 
 
 def test_probed_standard_prefix_constants_stay_in_sync():
@@ -265,3 +274,82 @@ def test_gate_bare_lang_c_vs_different_lang_still_raises():
     )
     with pytest.raises(ProfileMismatchError):
         check_contracts_comparable(old, new)
+
+
+def test_gate_empty_vs_gnu11_still_raises_when_compiler_sha256_differs():
+    """Codex review, fresh evidence: a compiler wrapper replaced at the same
+    path can report an identical compiler_family/compiler_version string
+    while actually selecting a different default dialect --
+    compiler_sha256 (the resolved binary's own content hash), when present
+    on both sides, must be checked too, not just the two text fields a
+    wrapper's own --version output controls."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="",
+        ),
+        ast_toolchain={"compiler_sha256": "a" * 64},
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="gnu11",
+        ),
+        ast_toolchain={"compiler_sha256": "b" * 64},
+    )
+    with pytest.raises(ProfileMismatchError):
+        check_contracts_comparable(old, new)
+
+
+def test_gate_empty_vs_gnu11_waived_when_compiler_sha256_matches():
+    """The positive counterpart: an unchanged compiler_sha256 on both sides
+    (alongside the existing family/version match) still waives, same as
+    before this corroboration was added."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="",
+        ),
+        ast_toolchain={"compiler_sha256": "a" * 64},
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="gnu11",
+        ),
+        ast_toolchain={"compiler_sha256": "a" * 64},
+    )
+    check_contracts_comparable(old, new)  # must not raise
+
+
+def test_gate_empty_vs_gnu11_waived_when_compiler_sha256_absent_on_one_side():
+    """A legacy/older snapshot on one side (no compiler_sha256 recorded at
+    all) must fall back to the family/version check rather than fail closed
+    on evidence it was never in a position to carry."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="",
+        ),
+        ast_toolchain={},
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="gnu11",
+        ),
+        ast_toolchain={"compiler_sha256": "a" * 64},
+    )
+    check_contracts_comparable(old, new)  # must not raise

--- a/tests/test_comparability_gate_probe_upgrade.py
+++ b/tests/test_comparability_gate_probe_upgrade.py
@@ -31,16 +31,30 @@ from __future__ import annotations
 
 import pytest
 
+from abicheck import comparability, dumper_toolchain
 from abicheck.comparability import (
     check_contracts_comparable,
     compute_extraction_contract,
 )
 from abicheck.errors import ProfileMismatchError
-from abicheck.model import AbiSnapshot
+from abicheck.model import AbiSnapshot, ExtractionContract
 
 
-def _snap(contract) -> AbiSnapshot:  # noqa: ANN001
+def _snap(contract: ExtractionContract | None) -> AbiSnapshot:
     return AbiSnapshot(library="libfoo.so", version="1.0", contract=contract)
+
+
+def test_probed_standard_prefix_constants_stay_in_sync():
+    """CodeRabbit review: ``comparability.py`` deliberately mirrors (rather
+    than imports) ``dumper_toolchain._PROBED_STANDARD_PREFIX`` -- see that
+    module's own comment for why (avoiding a new cross-module dependency for
+    one string literal). A mirrored constant can silently drift, so pin the
+    two equal directly rather than relying on this file's own scenario tests
+    to notice a drift indirectly."""
+    assert (
+        comparability._PROBED_STANDARD_PREFIX
+        == dumper_toolchain._PROBED_STANDARD_PREFIX
+    )
 
 
 def test_gate_empty_vs_probed_language_standard_waived_when_compiler_unchanged():
@@ -127,3 +141,29 @@ def test_gate_empty_vs_probed_language_standard_not_waived_without_compiler_evid
     )
     with pytest.raises(ProfileMismatchError):
         check_contracts_comparable(old, new)
+
+
+def test_gate_empty_vs_probed_language_standard_waived_when_lang_qualified():
+    """CodeRabbit review, fresh evidence: when an explicit ``--lang`` was
+    given, ``language_standard_field`` prefixes the probed value with the
+    resolved mode (``"c++:probed:..."``/``"c:probed:..."``), not the bare
+    ``"probed:..."`` form the other tests above use -- the carve-out must
+    still recognize the transition and waive it, not treat the lang prefix
+    as an unrelated profile difference."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="c++:probed:__cplusplus=201703L",
+        )
+    )
+    check_contracts_comparable(old, new)  # must not raise

--- a/tests/test_comparability_gate_probe_upgrade.py
+++ b/tests/test_comparability_gate_probe_upgrade.py
@@ -243,6 +243,59 @@ def test_gate_bare_lang_c_vs_lang_qualified_gnu11_waived():
     check_contracts_comparable(old, new)  # must not raise
 
 
+def test_gate_bare_lang_c_vs_self_healed_cpp_probe_still_raises():
+    """Codex review, fresh evidence: an explicit ``--lang c`` tag does not
+    pin the mode unconditionally -- both header-AST backends self-heal an
+    explicit C request into C++ when the header turns out to need a C++
+    stdlib header, regardless of whether C mode was auto-detected or
+    explicitly requested. A self-healed parse's probed value always names
+    ``__cplusplus`` -- a ``"c"``-tagged remainder containing it is real
+    evidence the actual parse mode diverged from its own tag, not merely
+    newly discovered upgrade evidence, so this must still raise."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="c",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="c:probed:__cplusplus=201703L",
+        )
+    )
+    with pytest.raises(ProfileMismatchError):
+        check_contracts_comparable(old, new)
+
+
+def test_gate_bare_lang_c_vs_genuine_msvc_probe_still_waived():
+    """The negative counterpart: a genuinely-C, MSVC-dialect unpinned parse
+    (never gnu11-forced, so it's probed) reports ``__STDC_VERSION__``, never
+    ``__cplusplus`` -- this is not a self-heal artifact and must still
+    waive."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="msvc",
+            compiler_version="19.38.0",
+            language_standard="c",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="msvc",
+            compiler_version="19.38.0",
+            language_standard="c:probed:__STDC_VERSION__=201710L",
+        )
+    )
+    check_contracts_comparable(old, new)  # must not raise
+
+
 def test_gate_bare_lang_cpp_alias_vs_lang_qualified_probed_waived():
     """Codex review, fresh evidence: ``"cpp"`` is a second, still-supported
     spelling for C++ alongside ``"c++"`` (``_resolve_force_cpp`` accepts

--- a/tests/test_comparability_gate_probe_upgrade.py
+++ b/tests/test_comparability_gate_probe_upgrade.py
@@ -243,6 +243,32 @@ def test_gate_bare_lang_c_vs_lang_qualified_gnu11_waived():
     check_contracts_comparable(old, new)  # must not raise
 
 
+def test_gate_bare_lang_cpp_alias_vs_lang_qualified_probed_waived():
+    """Codex review, fresh evidence: ``"cpp"`` is a second, still-supported
+    spelling for C++ alongside ``"c++"`` (``_resolve_force_cpp`` accepts
+    both) -- a Python API baseline built with ``lang="cpp"`` records the
+    bare tag verbatim (``language_standard_field`` lowercases but does not
+    otherwise canonicalize it), so the carve-out must recognize this
+    spelling too, not just ``"c++"``."""
+    old = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="cpp",
+        )
+    )
+    new = _snap(
+        compute_extraction_contract(
+            l2_frontend_ran=True,
+            compiler_family="gnu",
+            compiler_version="11.4.0",
+            language_standard="cpp:probed:__cplusplus=201703L",
+        )
+    )
+    check_contracts_comparable(old, new)  # must not raise
+
+
 def test_gate_bare_lang_cpp_vs_lang_qualified_probed_waived():
     """The ``--lang c++`` counterpart of the above: a bare ``"c++"``
     pre-upgrade baseline against a lang-qualified probed value."""

--- a/tests/test_comparability_gate_probe_upgrade.py
+++ b/tests/test_comparability_gate_probe_upgrade.py
@@ -16,15 +16,23 @@
 existing unpinned snapshot baselines".
 
 A baseline persisted before ``dumper_toolchain._probe_default_language_
-standard`` existed recorded an empty ``language_standard`` for any unpinned
-(no explicit ``-std=``, no forced-C++20-heuristic) dump. A freshly re-dumped
-snapshot of the identical input under the identical toolchain now records a
-real ``"probed:..."`` value there instead, purely because the tool was
-upgraded. That must not, by itself, make the pair ``NOT_COMPARABLE`` --
+standard`` existed, given an explicit ``--lang``, recorded a bare ``"c"``/
+``"c++"`` ``language_standard`` (no resolved standard existed yet). A
+freshly re-dumped snapshot of the identical input under the identical
+toolchain now records a real, lang-tagged ``"c:gnu11"``/``"c++:probed:..."``
+value there instead, purely because the tool was upgraded. That must not, by
+itself, make the pair ``NOT_COMPARABLE`` --
 ``comparability._language_standard_probe_upgrade_corroborated`` is the
 carve-out closing that gap, tested here directly against the gate (split out
 of ``test_comparability_gate.py``, which sits at the AI-readiness file-size
 hard cap, rather than appended there).
+
+A *bare empty* ``language_standard`` (no ``--lang`` given at all -- pure
+content-based auto-detection) is deliberately **not** eligible for this
+carve-out (Codex review, fresh evidence: it carries no signal about which
+language mode the pre-upgrade dump actually resolved to, so it cannot be
+safely distinguished from a genuine language-mode change) -- several tests
+below pin that it still raises even with an otherwise-matching compiler.
 """
 
 from __future__ import annotations
@@ -66,10 +74,18 @@ def test_probed_standard_prefix_constants_stay_in_sync():
     )
 
 
-def test_gate_empty_vs_probed_language_standard_waived_when_compiler_unchanged():
-    """The exact scenario the reviewer flagged: an old (pre-probe) baseline
-    and a freshly re-dumped snapshot of the identical input under the
-    identical resolved compiler must stay comparable."""
+def test_gate_bare_empty_language_standard_still_raises_even_with_compiler_unchanged():
+    """Codex review, fresh evidence: a bare empty ``language_standard`` (no
+    ``--lang`` given at all) carries *no* signal about which language mode
+    the pre-upgrade dump actually resolved to -- ``_resolve_force_cpp``'s
+    decision is a function of the header content, which this carve-out has
+    no access to. A header that later gains enough C++-only syntax to flip
+    that decision (a real language-mode change) is indistinguishable, from
+    the profile fields alone, from the pure upgrade-artifact case this
+    carve-out exists to waive -- so an unchanged compiler_family/
+    compiler_version is *not* sufficient corroboration for this shape, and
+    this must still raise, unlike an earlier version of this carve-out that
+    waived it."""
     old = _snap(
         compute_extraction_contract(
             l2_frontend_ran=True,
@@ -86,7 +102,8 @@ def test_gate_empty_vs_probed_language_standard_waived_when_compiler_unchanged()
             language_standard="probed:__cplusplus=201703L",
         )
     )
-    check_contracts_comparable(old, new)  # must not raise
+    with pytest.raises(ProfileMismatchError):
+        check_contracts_comparable(old, new)
 
 
 def test_gate_empty_vs_probed_language_standard_still_raises_when_compiler_family_differs():
@@ -152,13 +169,11 @@ def test_gate_empty_vs_probed_language_standard_not_waived_without_compiler_evid
         check_contracts_comparable(old, new)
 
 
-def test_gate_empty_vs_probed_language_standard_waived_when_lang_qualified():
-    """CodeRabbit review, fresh evidence: when an explicit ``--lang`` was
-    given, ``language_standard_field`` prefixes the probed value with the
-    resolved mode (``"c++:probed:..."``/``"c:probed:..."``), not the bare
-    ``"probed:..."`` form the other tests above use -- the carve-out must
-    still recognize the transition and waive it, not treat the lang prefix
-    as an unrelated profile difference."""
+def test_gate_bare_empty_language_standard_vs_lang_qualified_probed_still_raises():
+    """The lang-qualified counterpart of the test above: a lang tag on the
+    *new* side alone does not rescue a bare-empty *old* side -- the old side
+    still carries no evidence of which mode it actually resolved to, so this
+    must still raise (unlike an earlier version of this carve-out)."""
     old = _snap(
         compute_extraction_contract(
             l2_frontend_ran=True,
@@ -175,16 +190,15 @@ def test_gate_empty_vs_probed_language_standard_waived_when_lang_qualified():
             language_standard="c++:probed:__cplusplus=201703L",
         )
     )
-    check_contracts_comparable(old, new)  # must not raise
+    with pytest.raises(ProfileMismatchError):
+        check_contracts_comparable(old, new)
 
 
-def test_gate_empty_vs_forced_gnu11_waived_when_compiler_unchanged():
-    """Codex review, fresh evidence: an unpinned C/gnu-dialect parse no
-    longer probes at all -- it reports the forced ``"gnu11"`` standard
-    directly (see ``dumper_toolchain._FORCED_C_STANDARD``), which carries no
-    ``"probed:"`` marker. The carve-out must still recognize this as the
-    identical class of upgrade-only transition, not just the probed-value
-    shape."""
+def test_gate_bare_empty_language_standard_vs_forced_gnu11_still_raises():
+    """The forced-``gnu11`` counterpart of the two tests above: a bare empty
+    *old* side still raises against a newly-forced ``"gnu11"`` *new* side,
+    for the identical reason -- ``"gnu11"`` carries no more information
+    about the *old* side's actual mode than a ``"probed:..."`` value does."""
     old = _snap(
         compute_extraction_contract(
             l2_frontend_ran=True,
@@ -201,7 +215,8 @@ def test_gate_empty_vs_forced_gnu11_waived_when_compiler_unchanged():
             language_standard="gnu11",
         )
     )
-    check_contracts_comparable(old, new)  # must not raise
+    with pytest.raises(ProfileMismatchError):
+        check_contracts_comparable(old, new)
 
 
 def test_gate_bare_lang_c_vs_lang_qualified_gnu11_waived():
@@ -276,19 +291,21 @@ def test_gate_bare_lang_c_vs_different_lang_still_raises():
         check_contracts_comparable(old, new)
 
 
-def test_gate_empty_vs_gnu11_still_raises_when_compiler_sha256_differs():
+def test_gate_bare_lang_c_vs_gnu11_still_raises_when_compiler_sha256_differs():
     """Codex review, fresh evidence: a compiler wrapper replaced at the same
     path can report an identical compiler_family/compiler_version string
     while actually selecting a different default dialect --
     compiler_sha256 (the resolved binary's own content hash), when present
     on both sides, must be checked too, not just the two text fields a
-    wrapper's own --version output controls."""
+    wrapper's own --version output controls. Uses the lang-tagged (safe)
+    old-side shape, not a bare empty string -- see the bare-empty-string
+    tests above for why that shape never waives at all now."""
     old = _snap(
         compute_extraction_contract(
             l2_frontend_ran=True,
             compiler_family="gnu",
             compiler_version="11.4.0",
-            language_standard="",
+            language_standard="c",
         ),
         ast_toolchain={"compiler_sha256": "a" * 64},
     )
@@ -297,7 +314,7 @@ def test_gate_empty_vs_gnu11_still_raises_when_compiler_sha256_differs():
             l2_frontend_ran=True,
             compiler_family="gnu",
             compiler_version="11.4.0",
-            language_standard="gnu11",
+            language_standard="c:gnu11",
         ),
         ast_toolchain={"compiler_sha256": "b" * 64},
     )
@@ -305,7 +322,7 @@ def test_gate_empty_vs_gnu11_still_raises_when_compiler_sha256_differs():
         check_contracts_comparable(old, new)
 
 
-def test_gate_empty_vs_gnu11_waived_when_compiler_sha256_matches():
+def test_gate_bare_lang_c_vs_gnu11_waived_when_compiler_sha256_matches():
     """The positive counterpart: an unchanged compiler_sha256 on both sides
     (alongside the existing family/version match) still waives, same as
     before this corroboration was added."""
@@ -314,7 +331,7 @@ def test_gate_empty_vs_gnu11_waived_when_compiler_sha256_matches():
             l2_frontend_ran=True,
             compiler_family="gnu",
             compiler_version="11.4.0",
-            language_standard="",
+            language_standard="c",
         ),
         ast_toolchain={"compiler_sha256": "a" * 64},
     )
@@ -323,14 +340,14 @@ def test_gate_empty_vs_gnu11_waived_when_compiler_sha256_matches():
             l2_frontend_ran=True,
             compiler_family="gnu",
             compiler_version="11.4.0",
-            language_standard="gnu11",
+            language_standard="c:gnu11",
         ),
         ast_toolchain={"compiler_sha256": "a" * 64},
     )
     check_contracts_comparable(old, new)  # must not raise
 
 
-def test_gate_empty_vs_gnu11_waived_when_compiler_sha256_absent_on_one_side():
+def test_gate_bare_lang_c_vs_gnu11_waived_when_compiler_sha256_absent_on_one_side():
     """A legacy/older snapshot on one side (no compiler_sha256 recorded at
     all) must fall back to the family/version check rather than fail closed
     on evidence it was never in a position to carry."""
@@ -339,7 +356,7 @@ def test_gate_empty_vs_gnu11_waived_when_compiler_sha256_absent_on_one_side():
             l2_frontend_ran=True,
             compiler_family="gnu",
             compiler_version="11.4.0",
-            language_standard="",
+            language_standard="c",
         ),
         ast_toolchain={},
     )
@@ -348,7 +365,7 @@ def test_gate_empty_vs_gnu11_waived_when_compiler_sha256_absent_on_one_side():
             l2_frontend_ran=True,
             compiler_family="gnu",
             compiler_version="11.4.0",
-            language_standard="gnu11",
+            language_standard="c:gnu11",
         ),
         ast_toolchain={"compiler_sha256": "a" * 64},
     )

--- a/tests/test_dump_header_roots_dependency_scope_parity.py
+++ b/tests/test_dump_header_roots_dependency_scope_parity.py
@@ -1,0 +1,121 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""abicheck-internal-bugs finding 1: ``dump``'s own ``header_roots`` (fed to
+``dumper_scoping.resolve_dependency_scope`` right before serialization) must
+match ``dumper_scoping.apply_dependency_scope_to_run_dump_result``'s
+computation -- the choke point ``compare``'s own live-binary dumping
+(``service.run_dump``) uses for the identical dependency-scoping decision.
+
+Before this fix, ``perform_elf_dump``'s (ELF) ``write_snapshot_output`` call
+passed only ``headers`` (plus, for ELF, any ``--dump-manifest`` roots) as
+``header_roots`` -- omitting ``public_headers``/``public_header_dirs``, which
+``apply_dependency_scope_to_run_dump_result`` always folds in. A standalone
+``dump`` of a library whose public surface is declared via ``public_headers``/
+``public_header_dirs`` therefore scoped its dependency filtering differently
+than ``compare``'s live dump of the identical input -- producing two
+``dependency_scope: filtered`` snapshots whose actual filtered content (and
+scope_fingerprint) silently disagreed, breaking every later ``compare``
+between a ``dump``-produced baseline and a live candidate (reported:
+"toolchain_matrix has been silently broken since it was created").
+
+``handle_non_elf_dump`` (PE/Mach-O)'s identical fix is covered by
+``tests/test_non_elf_dump_l2_seed.py::
+test_non_elf_dump_header_roots_includes_public_headers_and_dirs`` instead --
+that file already houses this path's other ``header_roots``/L2-seed tests,
+and ``tests/test_cli_dump_helpers_coverage.py`` (the ELF path's usual home)
+sits at the AI-readiness file-size hard cap, so this ELF-side test lives in
+its own small file rather than growing that one further.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from abicheck.cli_dump_helpers import perform_elf_dump
+from abicheck.model import AbiSnapshot
+
+
+def _elf_dump_callables():  # noqa: ANN202
+    """Minimal (recorder, stamp, write, expand, populate) stub callables --
+    a small local copy of ``test_cli_dump_helpers_coverage._elf_dump_
+    callables``'s shape, since importing across test modules would couple
+    this file to one that's already at its own line-count cap."""
+
+    def _stamp(snap, *, git_tag, build_id, no_git):  # noqa: ANN001
+        pass
+
+    def _expand(inputs):  # noqa: ANN001
+        return list(inputs)
+
+    def _populate(snap, so_path, search_paths, sysroot, ld_library_path):  # noqa: ANN001
+        pass
+
+    return _stamp, _expand, _populate
+
+
+def test_perform_elf_dump_header_roots_includes_public_headers_and_dirs(
+    tmp_path: Path, monkeypatch
+) -> None:
+    so = tmp_path / "lib.so"
+    hdr = tmp_path / "h.h"
+    hdr.write_text("struct S { int x; };\n", encoding="utf-8")
+    pub_header = Path("/usr/include/mylib/extra.h")
+    pub_dir = Path("/usr/include/mylib")
+    snap = AbiSnapshot(library="lib.so", version="1.0", from_headers=True)
+    monkeypatch.setattr("abicheck.cli_dump_helpers.dump", lambda **_kw: snap)
+
+    captured: dict[str, object] = {}
+
+    def _write(*_a, header_roots=(), **_k):  # noqa: ANN002, ANN003
+        captured["header_roots"] = header_roots
+
+    _stamp, _expand, _populate = _elf_dump_callables()
+
+    perform_elf_dump(
+        so,
+        (hdr,),
+        (),
+        "1.0",
+        "c",
+        None,
+        None,
+        None,
+        (),
+        None,
+        True,
+        False,
+        None,
+        (pub_header,),
+        (pub_dir,),
+        None,
+        False,
+        (),
+        "",
+        None,
+        None,
+        False,
+        None,
+        None,
+        None,
+        None,
+        False,
+        "off",
+        _expand,
+        _populate,
+        _stamp,
+        _write,
+    )
+
+    assert set(captured["header_roots"]) == {hdr, pub_header, pub_dir}

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -3295,7 +3295,7 @@ def test_clang_self_heal_explicit_c_warns(
     header = tmp_path / "umbrella.h"
     header.write_text("int foo(void);\n")
     with caplog.at_level(logging.DEBUG, logger="abicheck.dumper"):
-        root, _resolved_kind = _clang_header_dump([header], [], lang="c")
+        root, _resolved_kind, _ = _clang_header_dump([header], [], lang="c")
     assert root["kind"] == "TranslationUnitDecl"
     warns = [r for r in caplog.records if r.levelno == logging.WARNING]
     assert any("asked for C" in r.message for r in warns), [r.message for r in warns]
@@ -3312,7 +3312,7 @@ def test_clang_self_heal_auto_detected_is_debug(
     header = tmp_path / "umbrella.h"
     header.write_text("int foo(void);\n")
     with caplog.at_level(logging.DEBUG, logger="abicheck.dumper"):
-        root, _resolved_kind = _clang_header_dump(
+        root, _resolved_kind, _ = _clang_header_dump(
             [header], []
         )  # lang=None → auto-detect
     assert root["kind"] == "TranslationUnitDecl"
@@ -3704,7 +3704,7 @@ def test_header_ast_parser_clang_branch(monkeypatch: pytest.MonkeyPatch) -> None
             "type": {"qualType": "void ()"},
         }
     )
-    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, None))
+    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, None, False))
     parser = _header_ast_parser(
         [],
         [],
@@ -3725,6 +3725,34 @@ def test_header_ast_parser_clang_branch(monkeypatch: pytest.MonkeyPatch) -> None
     assert [f.name for f in parser.parse_functions()] == ["foo"]
 
 
+def test_header_ast_parser_clang_branch_records_resolved_lang_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review, fresh evidence: the third ``_clang_header_dump`` return
+    value (the actual, possibly post-self-heal language mode) must be
+    stamped onto ``ast_toolchain["resolved_lang_mode"]`` so the provenance
+    probe uses it instead of re-deriving a stale guess."""
+    ast = _tu({"kind": "TranslationUnitDecl", "inner": []})
+    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, None, True))
+    parser = _header_ast_parser(
+        [],
+        [],
+        backend="clang",
+        compiler="c++",
+        gcc_path=None,
+        gcc_prefix=None,
+        gcc_options=None,
+        sysroot=None,
+        nostdinc=False,
+        lang=None,
+        exported_dynamic=set(),
+        exported_static=set(),
+        public_header_paths=[],
+        public_dir_paths=[],
+    )
+    assert parser._abicheck_ast_toolchain["resolved_lang_mode"] == "c++"
+
+
 def test_header_ast_parser_passes_explicit_target_to_clang_parser(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3735,7 +3763,7 @@ def test_header_ast_parser_passes_explicit_target_to_clang_parser(
             "type": {"qualType": "void () __attribute__((sysv_abi))"},
         }
     )
-    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, None))
+    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, None, False))
     parser = _header_ast_parser(
         [], [], backend="clang", compiler="c++", gcc_path=None, gcc_prefix=None,
         gcc_options="--target=x86_64-pc-linux-gnu", sysroot=None, nostdinc=False,
@@ -3760,7 +3788,7 @@ def test_header_ast_parser_clang_branch_records_abi_dialect(
             "type": {"qualType": "void ()"},
         }
     )
-    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, None))
+    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, None, False))
     parser = _header_ast_parser(
         [],
         [],
@@ -3792,7 +3820,7 @@ def test_header_ast_parser_clang_branch_records_msvc_abi_dialect(
             "type": {"qualType": "void ()"},
         }
     )
-    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, None))
+    monkeypatch.setattr(dumper, "_clang_header_dump", lambda *a, **k: (ast, None, False))
     monkeypatch.setattr(
         dumper, "_resolve_clang_bin", lambda *a, **k: "/opt/llvm/bin/cl.exe"
     )
@@ -3870,6 +3898,51 @@ def test_header_ast_parser_castxml_branch_records_abi_dialect(
         public_dir_paths=[],
     )
     assert parser._abicheck_ast_toolchain["abi_dialect"] == "gnu"
+
+
+def test_header_ast_parser_castxml_branch_records_the_force_cpp_aware_compiler(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex review, fresh evidence: for a C-mode dump under the default
+    ``compiler="c++"``, ``_castxml_dump`` internally remaps to ``"cc"``
+    before resolving ``cc_bin`` -- ``ast_toolchain["compiler_selected"]``
+    must record *that* resolved identity, not a re-derivation from the
+    caller's original, unresolved ``"c++"`` (which would record g++'s
+    identity even though castxml actually ran gcc)."""
+    sentinel = object()
+    parser_cls = dumper._CastxmlParser
+    parser_sentinel = parser_cls.__new__(parser_cls)
+
+    def fake_castxml_dump(*a, **k):
+        # Mirrors _castxml_dump's own force_cpp=False remap: "c++" -> "cc".
+        out = k.get("_selected_compiler_out")
+        if out is not None:
+            out.append("cc")
+        return sentinel
+
+    monkeypatch.setattr(dumper, "_castxml_dump", fake_castxml_dump)
+    monkeypatch.setattr(dumper, "_CastxmlParser", lambda *a, **k: parser_sentinel)
+    parser = _header_ast_parser(
+        [],
+        [],
+        backend="castxml",
+        compiler="c++",
+        gcc_path=None,
+        gcc_prefix=None,
+        gcc_options=None,
+        sysroot=None,
+        nostdinc=False,
+        lang="c",
+        exported_dynamic=set(),
+        exported_static=set(),
+        public_header_paths=[],
+        public_dir_paths=[],
+    )
+    cc_selected = parser._abicheck_ast_toolchain["compiler_selected"]
+    gxx_selected = dumper._tool_identity_metadata("g++").get("selected")
+    # "cc" must have actually been resolved, and it must differ from what a
+    # re-derivation from the unresolved "c++" would have recorded.
+    assert cc_selected != gxx_selected
 
 
 def test_header_ast_parser_castxml_branch_records_msvc_abi_dialect(
@@ -3992,12 +4065,12 @@ def test_clang_header_dump_success_and_cache(
 
     monkeypatch.setattr(dumper.deadline, "run_bounded", _run)
 
-    root, resolved_kind = _clang_header_dump([header], [])
+    root, resolved_kind, _ = _clang_header_dump([header], [])
     assert root == {"kind": "TranslationUnitDecl", "inner": []}
     assert resolved_kind is None
     assert cache.exists()  # result was cached
     # Second call hits the cache — subprocess is not invoked again.
-    root2, resolved_kind2 = _clang_header_dump([header], [])
+    root2, resolved_kind2, _ = _clang_header_dump([header], [])
     assert root2 == root
     assert resolved_kind2 is None
     assert calls["n"] == 1
@@ -4319,7 +4392,7 @@ def test_clang_only_dump_does_not_require_gxx_identity(
         return _fake_proc()
 
     monkeypatch.setattr(dumper.deadline, "run_bounded", _run)
-    root, resolved_kind = _clang_header_dump([header], [])
+    root, resolved_kind, _ = _clang_header_dump([header], [])
     assert root == {"kind": "TranslationUnitDecl", "inner": []}
     assert resolved_kind is None
 
@@ -4627,11 +4700,16 @@ def test_clang_header_dump_retries_cpp_on_missing_cpp_stdlib_header(
         return _fake_proc(returncode=0)
 
     monkeypatch.setattr(dumper.deadline, "run_bounded", _run)
-    root, _resolved_kind = _clang_header_dump([header], [])
+    root, _resolved_kind, resolved_force_cpp = _clang_header_dump([header], [])
     assert root == {"kind": "TranslationUnitDecl", "inner": []}
     assert len(cmds) == 2  # one C attempt + one C++ retry
     assert "c" in cmds[0] and cmds[0][cmds[0].index("-x") + 1] == "c"
     assert cmds[1][cmds[1].index("-x") + 1] == "c++"
+    # Codex review, fresh evidence: the self-heal's real, post-retry language
+    # mode must be reported back, not the pre-retry "c" guess -- this is what
+    # the provenance probe (dumper_toolchain._ast_compile_provenance) relies
+    # on instead of silently re-deriving a stale answer.
+    assert resolved_force_cpp is True
 
 
 def test_clang_header_dump_no_retry_on_other_error(
@@ -4690,7 +4768,7 @@ def test_clang_header_dump_device_context_selects_real_fixture(
         return _fake_proc(stderr=stderr_text, returncode=0)
 
     monkeypatch.setattr(dumper.deadline, "run_bounded", _run)
-    root, resolved_kind = _clang_header_dump([header], [], frontend_context="device")
+    root, resolved_kind, _ = _clang_header_dump([header], [], frontend_context="device")
     assert resolved_kind == "device"
     assert root["kind"] == "TranslationUnitDecl"
 
@@ -4714,7 +4792,7 @@ def test_clang_header_dump_host_context_selects_real_fixture(
         return _fake_proc(stderr=stderr_text, returncode=0)
 
     monkeypatch.setattr(dumper.deadline, "run_bounded", _run)
-    root, resolved_kind = _clang_header_dump([header], [])
+    root, resolved_kind, _ = _clang_header_dump([header], [])
     assert resolved_kind == "host"
     assert root["kind"] == "TranslationUnitDecl"
 
@@ -4769,7 +4847,7 @@ def test_clang_header_dump_fno_sycl_skips_multi_context(
         return _fake_proc()
 
     monkeypatch.setattr(dumper.deadline, "run_bounded", _run)
-    root, resolved_kind = _clang_header_dump([header], [], gcc_options="-fno-sycl")
+    root, resolved_kind, _ = _clang_header_dump([header], [], gcc_options="-fno-sycl")
     assert resolved_kind is None
     assert root["kind"] == "TranslationUnitDecl"
     assert captured_cmds and all("-fsycl" not in cmd for cmd in captured_cmds)
@@ -5631,7 +5709,7 @@ def test_clang_header_dump_corrupt_cache_is_discarded(
 
     monkeypatch.setattr(dumper.deadline, "run_bounded", _run)
     # The corrupt cache is unlinked and the fresh clang run repopulates it.
-    root, _resolved_kind = _clang_header_dump([header], [])
+    root, _resolved_kind, _ = _clang_header_dump([header], [])
     assert root == {"kind": "TranslationUnitDecl", "inner": []}
 
 

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -30,7 +30,13 @@ from typing import Any
 
 import pytest
 
-from abicheck import dumper, dumper_cache, dumper_clang, dumper_clang_errors
+from abicheck import (
+    dumper,
+    dumper_cache,
+    dumper_clang,
+    dumper_clang_errors,
+    dumper_toolchain,
+)
 from abicheck.dumper import (
     _auto_system_includes_enabled,
     _build_clang_header_command,
@@ -3915,9 +3921,9 @@ def test_header_ast_parser_castxml_branch_records_the_force_cpp_aware_compiler(
 
     def fake_castxml_dump(*a, **k):
         # Mirrors _castxml_dump's own force_cpp=False remap: "c++" -> "cc".
-        out = k.get("_selected_compiler_out")
+        out = k.get("_selected_meta_out")
         if out is not None:
-            out.append("cc")
+            out.append(("cc", False))
         return sentinel
 
     monkeypatch.setattr(dumper, "_castxml_dump", fake_castxml_dump)
@@ -3981,7 +3987,7 @@ def test_header_ast_parser_stamps_castxml_supported(
     monkeypatch.setattr(dumper, "_castxml_dump", lambda *a, **k: sentinel)
     monkeypatch.setattr(dumper, "_CastxmlParser", lambda *a, **k: parser_sentinel)
     monkeypatch.setattr(
-        dumper,
+        dumper_toolchain,
         "_tool_identity_metadata",
         lambda _executable: {
             "selected": "/mock/castxml",
@@ -4016,7 +4022,7 @@ def test_header_ast_parser_stamps_castxml_unsupported(
     monkeypatch.setattr(dumper, "_castxml_dump", lambda *a, **k: object())
     monkeypatch.setattr(dumper, "_CastxmlParser", lambda *a, **k: parser_sentinel)
     monkeypatch.setattr(
-        dumper,
+        dumper_toolchain,
         "_tool_identity_metadata",
         lambda _executable: {
             "selected": "/mock/castxml",

--- a/tests/test_dumper_contract_wiring.py
+++ b/tests/test_dumper_contract_wiring.py
@@ -193,15 +193,23 @@ def test_lang_mode_alone_flows_into_profile_fingerprint(
     """Codex review, PR #624 follow-up: the same clang executable, no
     explicit -std=, differing only by --lang c vs --lang c++, must not
     share a profile_fingerprint — the actual frontend commands parse
-    different languages (-x c vs. C++ default) regardless."""
+    different languages (-x c vs. C++ default) regardless.
+
+    abicheck-internal-bugs finding 2 follow-up: with no explicit -std=,
+    ``language_standard`` now also carries the resolved compiler's own
+    *probed* default standard (``dumper_toolchain._probe_default_language_
+    standard``), not just the bare lang mode — so the exact suffix is
+    host-compiler-version-dependent and only the ``"c:"``/``"c++:"`` prefix
+    is pinned here; the fingerprint-distinctness assertion (this test's
+    actual point) is unaffected either way."""
     so, header = built_lib
     snap_c = dump(so, [header], compiler="cc", header_backend="clang", lang="c")
     snap_cpp = dump(so, [header], compiler="cc", header_backend="clang", lang="c++")
 
     assert snap_c.contract is not None
     assert snap_cpp.contract is not None
-    assert snap_c.contract.profile_fields["language_standard"] == "c"
-    assert snap_cpp.contract.profile_fields["language_standard"] == "c++"
+    assert snap_c.contract.profile_fields["language_standard"].startswith("c:")
+    assert snap_cpp.contract.profile_fields["language_standard"].startswith("c++:")
     assert snap_c.contract.profile_fingerprint != snap_cpp.contract.profile_fingerprint
 
 

--- a/tests/test_non_elf_dump_l2_seed.py
+++ b/tests/test_non_elf_dump_l2_seed.py
@@ -87,6 +87,52 @@ def test_non_elf_dump_seeds_includes_and_runs_cleanup(monkeypatch, tmp_path):
     assert events == ["seed", "dump", "cleanup"]
 
 
+def test_non_elf_dump_header_roots_includes_public_headers_and_dirs(
+    monkeypatch, tmp_path
+):
+    """abicheck-internal-bugs finding 1: the PE/Mach-O ``dump`` path's
+    ``write_snapshot_output`` call must fold ``public_headers``/
+    ``public_header_dirs`` into ``header_roots`` alongside ``headers`` --
+    matching ``dumper_scoping.apply_dependency_scope_to_run_dump_result``,
+    the choke point ``compare``'s own live-binary dumping uses for the
+    identical dependency-scoping decision. Before the fix this path passed
+    only ``headers``, silently diverging from `compare`'s scoping whenever a
+    library declared its public surface via ``public_headers``/
+    ``public_header_dirs``."""
+    hdr = tmp_path / "h.h"
+    pub_header = tmp_path / "extra.h"
+    pub_dir = tmp_path / "pubdir"
+
+    captured: dict = {}
+
+    def _write(*_a, header_roots=(), **_k):  # noqa: ANN002, ANN003
+        captured["header_roots"] = header_roots
+
+    handle_non_elf_dump(
+        so_path=tmp_path / "foo.dll",
+        binary_fmt="pe",
+        headers=(hdr,),
+        includes=(),
+        version="1",
+        lang="c++",
+        pdb_path=None,
+        follow_deps=False,
+        git_tag=None,
+        build_id=None,
+        no_git=True,
+        output=None,
+        dump_native_binary=lambda *a, **k: AbiSnapshot(
+            library="l", version="1", from_headers=True
+        ),
+        stamp_provenance=lambda *a, **k: None,
+        write_snapshot_output=_write,
+        public_headers=(pub_header,),
+        public_header_dirs=(pub_dir,),
+    )
+
+    assert set(captured["header_roots"]) == {hdr, pub_header, pub_dir}
+
+
 def test_non_elf_dump_gates_inferred_query_for_l2_only(monkeypatch, tmp_path):
     # --depth headers (collect_mode "off") must disable the inferred build query in
     # the PE/Mach-O seed too — the flag is threaded from collect_mode.

--- a/tests/test_perf_header_graph_ast_reuse.py
+++ b/tests/test_perf_header_graph_ast_reuse.py
@@ -108,7 +108,7 @@ def test_header_graph_attach_reuse_faster_than_disk_reparse(
     # Prime the disk cache with one real clang parse -- not timed (mirrors
     # the main snapshot pass that already ran before _attach_header_graph
     # follows it).
-    root0, _ = dumper._clang_header_dump(
+    root0, _, _ = dumper._clang_header_dump(
         [header], [], compiler="c", lang="c", memoize=False
     )
     assert cache_path.exists()
@@ -123,7 +123,7 @@ def test_header_graph_attach_reuse_faster_than_disk_reparse(
 
     # "No reuse": disk-cache hit, no in-process memo.
     t0 = time.perf_counter()
-    root1, _ = dumper._clang_header_dump(
+    root1, _, _ = dumper._clang_header_dump(
         [header], [], compiler="c", lang="c", memoize=False
     )
     no_reuse_elapsed = max(time.perf_counter() - t0, 1e-6)
@@ -135,7 +135,7 @@ def test_header_graph_attach_reuse_faster_than_disk_reparse(
     with dumper_cache.ast_memoize_scope():
         dumper._clang_header_dump([header], [], compiler="c", lang="c")
         t1 = time.perf_counter()
-        root2, _ = dumper._clang_header_dump(
+        root2, _, _ = dumper._clang_header_dump(
             [header], [], compiler="c", lang="c", memoize=False
         )
         reuse_elapsed = max(time.perf_counter() - t1, 1e-6)

--- a/tests/test_pvxs_regression.py
+++ b/tests/test_pvxs_regression.py
@@ -155,12 +155,23 @@ def test_pvxs_error_requires_guard_does_not_force_cxx20(tmp_path: Path) -> None:
     # assertions below would ever fail even with the detection bug
     # reintroduced (CodeRabbit review: the original version of this test
     # only checked those indirect, dialect-insensitive signals).
+    #
+    # abicheck-internal-bugs finding 2 follow-up: with no explicit -std=,
+    # this no longer resolves to bare None -- dumper_toolchain._probe_
+    # default_language_standard now fills in the resolved compiler's own
+    # *probed* default dialect (host-clang-version-dependent), so "not
+    # forced to gnu++20" is asserted directly instead of "stayed None".
     old_snap = _dump_snapshot(old_so, old_dir / "pvxs.h", tmp_path / "old.abi.json")
     new_snap = _dump_snapshot(new_so, new_dir / "pvxs.h", tmp_path / "new.abi.json")
-    assert old_snap.get("ast_resolved_standard") is None, old_snap.get(
+    assert old_snap.get("ast_resolved_standard") != "gnu++20", old_snap.get(
         "ast_resolved_standard"
     )
-    assert new_snap.get("ast_resolved_standard") is None, new_snap.get(
+    assert new_snap.get("ast_resolved_standard") != "gnu++20", new_snap.get(
+        "ast_resolved_standard"
+    )
+    # Both sides were built identically and dumped under the identical
+    # resolved clang -- their (possibly probed) dialects must still agree.
+    assert old_snap.get("ast_resolved_standard") == new_snap.get(
         "ast_resolved_standard"
     )
 

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -3812,7 +3812,7 @@ class TestRunDumpHeaderGraph:
         with (
             patch("abicheck.service._dump_pe", return_value=snap),
             patch(
-                "abicheck.dumper._clang_header_dump", return_value=(ast, None)
+                "abicheck.dumper._clang_header_dump", return_value=(ast, None, False)
             ) as mock_ast,
         ):
             result = run_dump(p, "pe", [header], [], "1.0", "c++")
@@ -3863,7 +3863,7 @@ class TestRunDumpHeaderGraph:
         with (
             patch("abicheck.service._dump_pe", return_value=snap),
             patch(
-                "abicheck.dumper._clang_header_dump", return_value=(ast, None)
+                "abicheck.dumper._clang_header_dump", return_value=(ast, None, False)
             ) as mock_ast,
         ):
             run_dump(p, "pe", [header], [], "1.0", "c++", compile=cc)
@@ -3909,7 +3909,7 @@ class TestRunDumpHeaderGraph:
         with (
             patch("abicheck.service._dump_pe", return_value=snap),
             patch(
-                "abicheck.dumper._clang_header_dump", return_value=(ast, None)
+                "abicheck.dumper._clang_header_dump", return_value=(ast, None, False)
             ) as mock_ast,
         ):
             result = run_dump(p, "pe", [hdr_dir], [], "1.0", "c++")
@@ -3936,7 +3936,7 @@ class TestRunDumpHeaderGraph:
 
         with (
             patch("abicheck.service._dump_pe", return_value=snap),
-            patch("abicheck.dumper._clang_header_dump", return_value=(ast, None)),
+            patch("abicheck.dumper._clang_header_dump", return_value=(ast, None, False)),
             patch(
                 "abicheck.buildsource.include_graph.shutil.which",
                 lambda _b: "/usr/bin/clang++",
@@ -3980,7 +3980,7 @@ class TestRunDumpHeaderGraph:
 
         with (
             patch("abicheck.service._dump_pe", return_value=snap),
-            patch("abicheck.dumper._clang_header_dump", return_value=(ast, None)),
+            patch("abicheck.dumper._clang_header_dump", return_value=(ast, None, False)),
             patch(
                 "abicheck.buildsource.include_graph.shutil.which",
                 lambda _b: "/usr/bin/clang++",
@@ -4038,7 +4038,7 @@ class TestRunDumpHeaderGraph:
 
         with (
             patch("abicheck.service._dump_pe", return_value=snap),
-            patch("abicheck.dumper._clang_header_dump", return_value=(ast, None)),
+            patch("abicheck.dumper._clang_header_dump", return_value=(ast, None, False)),
             patch(
                 "abicheck.buildsource.include_graph.shutil.which",
                 lambda _b: "/usr/bin/clang++",
@@ -4355,7 +4355,7 @@ class TestAttachHeaderGraphCompilerSelection:
         snap = AbiSnapshot(library="lib", version="1.0")
         ast = {"kind": "TranslationUnitDecl", "inner": []}
         with patch(
-            "abicheck.dumper._clang_header_dump", return_value=(ast, None)
+            "abicheck.dumper._clang_header_dump", return_value=(ast, None, False)
         ) as mock_ast:
             _attach_header_graph(
                 snap,
@@ -4378,7 +4378,7 @@ class TestAttachHeaderGraphCompilerSelection:
         snap = AbiSnapshot(library="lib", version="1.0")
         ast = {"kind": "TranslationUnitDecl", "inner": []}
         with patch(
-            "abicheck.dumper._clang_header_dump", return_value=(ast, None)
+            "abicheck.dumper._clang_header_dump", return_value=(ast, None, False)
         ) as mock_ast:
             _attach_header_graph(
                 snap,
@@ -4409,7 +4409,7 @@ class TestAttachHeaderGraphCompilerSelection:
         snap = AbiSnapshot(library="lib", version="1.0")
         ast = {"kind": "TranslationUnitDecl", "inner": []}
         with (
-            patch("abicheck.dumper._clang_header_dump", return_value=(ast, None)),
+            patch("abicheck.dumper._clang_header_dump", return_value=(ast, None, False)),
             patch(
                 "abicheck.dumper._resolve_clang_bin", return_value="/opt/llvm/clang"
             ) as mock_resolve,
@@ -4457,7 +4457,7 @@ class TestAttachHeaderGraphHashesIncludeSearchTokens:
         snap = AbiSnapshot(library="lib", version="1.0")
         ast = {"kind": "TranslationUnitDecl", "inner": []}
         with patch(
-            "abicheck.dumper._clang_header_dump", return_value=(ast, None)
+            "abicheck.dumper._clang_header_dump", return_value=(ast, None, False)
         ) as mock_ast:
             _attach_header_graph(
                 snap,
@@ -4482,7 +4482,7 @@ class TestAttachHeaderGraphHashesIncludeSearchTokens:
         snap = AbiSnapshot(library="lib", version="1.0")
         ast = {"kind": "TranslationUnitDecl", "inner": []}
         with patch(
-            "abicheck.dumper._clang_header_dump", return_value=(ast, None)
+            "abicheck.dumper._clang_header_dump", return_value=(ast, None, False)
         ) as mock_ast:
             _attach_header_graph(
                 snap,

--- a/tests/test_tu_merge.py
+++ b/tests/test_tu_merge.py
@@ -139,6 +139,47 @@ def test_merge_fragments_allows_uniform_frontend_context_kind():
     assert merged.frontend_context_kind == "device"
 
 
+def test_merge_fragments_drops_resolved_lang_mode_when_tus_disagree():
+    """Codex review, fresh evidence: unlike ast_producer/frontend_context_kind
+    above, resolved_lang_mode is NOT guaranteed uniform across TUs -- an
+    ordinary mixed-language manifest (some .c TUs, some .cpp TUs, one
+    shared compiler) legitimately resolves it differently per TU. Blindly
+    copying one representative TU's resolved_lang_mode would silently
+    mislabel the whole merged snapshot's language_standard for every other
+    TU, so a genuine mismatch must drop the field (not raise -- this is an
+    expected, common shape, unlike the producer/context mismatches above)."""
+    a = TuFragment(
+        tu_name="a.c",
+        ast_producer="clang",
+        ast_toolchain={"compiler_selected": "/usr/bin/clang", "resolved_lang_mode": "c"},
+    )
+    b = TuFragment(
+        tu_name="b.cpp",
+        ast_producer="clang",
+        ast_toolchain={"compiler_selected": "/usr/bin/clang", "resolved_lang_mode": "c++"},
+    )
+    merged = merge_fragments([a, b])
+    assert "resolved_lang_mode" not in merged.ast_toolchain
+    # The rest of the representative fragment's ast_toolchain survives --
+    # only the per-TU-varying field is stripped.
+    assert merged.ast_toolchain["compiler_selected"] == "/usr/bin/clang"
+
+
+def test_merge_fragments_keeps_resolved_lang_mode_when_tus_agree():
+    a = TuFragment(
+        tu_name="a.cpp",
+        ast_producer="clang",
+        ast_toolchain={"compiler_selected": "/usr/bin/clang", "resolved_lang_mode": "c++"},
+    )
+    b = TuFragment(
+        tu_name="b.cpp",
+        ast_producer="clang",
+        ast_toolchain={"compiler_selected": "/usr/bin/clang", "resolved_lang_mode": "c++"},
+    )
+    merged = merge_fragments([a, b])
+    assert merged.ast_toolchain["resolved_lang_mode"] == "c++"
+
+
 # ---------------------------------------------------------------------------
 # Determinism: merge is independent of fragment processing order
 # ---------------------------------------------------------------------------

--- a/tests/test_tu_merge.py
+++ b/tests/test_tu_merge.py
@@ -49,6 +49,7 @@ from abicheck.model import (
 )
 from abicheck.tu_fragment import MergedTuFragments, TuFragment
 from abicheck.tu_merge import (
+    _HETEROGENEOUS_LANG_MODE,
     HETEROGENEOUS_ABI_CONTEXT,
     INCONSISTENT_DECLARATION,
     merge_fragments,
@@ -139,29 +140,44 @@ def test_merge_fragments_allows_uniform_frontend_context_kind():
     assert merged.frontend_context_kind == "device"
 
 
-def test_merge_fragments_drops_resolved_lang_mode_when_tus_disagree():
+def test_merge_fragments_sentinels_resolved_lang_mode_when_tus_disagree():
     """Codex review, fresh evidence: unlike ast_producer/frontend_context_kind
     above, resolved_lang_mode is NOT guaranteed uniform across TUs -- an
     ordinary mixed-language manifest (some .c TUs, some .cpp TUs, one
     shared compiler) legitimately resolves it differently per TU. Blindly
     copying one representative TU's resolved_lang_mode would silently
     mislabel the whole merged snapshot's language_standard for every other
-    TU, so a genuine mismatch must drop the field (not raise -- this is an
-    expected, common shape, unlike the producer/context mismatches above)."""
+    TU, so a genuine mismatch must not raise -- this is an expected, common
+    shape, unlike the producer/context mismatches above.
+
+    Merely *dropping* the field (an earlier version of this fix) is also
+    wrong: dropping it lets ``_resolve_standard_provenance`` fall back to a
+    static re-derivation that can be confidently *wrong*, not just
+    unknown, for a TU whose language mode came from something invisible to
+    the manifest's combined public headers. The merge must instead write
+    the explicit ``_HETEROGENEOUS_LANG_MODE`` sentinel, which that function
+    recognizes and treats as "cannot determine this at all" (see
+    ``dumper_toolchain._resolve_standard_provenance``'s own docstring)."""
     a = TuFragment(
         tu_name="a.c",
         ast_producer="clang",
-        ast_toolchain={"compiler_selected": "/usr/bin/clang", "resolved_lang_mode": "c"},
+        ast_toolchain={
+            "compiler_selected": "/usr/bin/clang",
+            "resolved_lang_mode": "c",
+        },
     )
     b = TuFragment(
         tu_name="b.cpp",
         ast_producer="clang",
-        ast_toolchain={"compiler_selected": "/usr/bin/clang", "resolved_lang_mode": "c++"},
+        ast_toolchain={
+            "compiler_selected": "/usr/bin/clang",
+            "resolved_lang_mode": "c++",
+        },
     )
     merged = merge_fragments([a, b])
-    assert "resolved_lang_mode" not in merged.ast_toolchain
+    assert merged.ast_toolchain["resolved_lang_mode"] == _HETEROGENEOUS_LANG_MODE
     # The rest of the representative fragment's ast_toolchain survives --
-    # only the per-TU-varying field is stripped.
+    # only the per-TU-varying field is overridden.
     assert merged.ast_toolchain["compiler_selected"] == "/usr/bin/clang"
 
 
@@ -169,12 +185,18 @@ def test_merge_fragments_keeps_resolved_lang_mode_when_tus_agree():
     a = TuFragment(
         tu_name="a.cpp",
         ast_producer="clang",
-        ast_toolchain={"compiler_selected": "/usr/bin/clang", "resolved_lang_mode": "c++"},
+        ast_toolchain={
+            "compiler_selected": "/usr/bin/clang",
+            "resolved_lang_mode": "c++",
+        },
     )
     b = TuFragment(
         tu_name="b.cpp",
         ast_producer="clang",
-        ast_toolchain={"compiler_selected": "/usr/bin/clang", "resolved_lang_mode": "c++"},
+        ast_toolchain={
+            "compiler_selected": "/usr/bin/clang",
+            "resolved_lang_mode": "c++",
+        },
     )
     merged = merge_fragments([a, b])
     assert merged.ast_toolchain["resolved_lang_mode"] == "c++"


### PR DESCRIPTION
## Summary

Fixes two internal abicheck bugs reported against real CI usage of `dump`/`compare`: (1) a `header_roots` divergence between `dump`&#39;s own dependency-scoping and `compare`&#39;s live-binary dumping, and (2) the `profile_fingerprint` comparability guard never firing between two unpinned-toolchain-default header-AST dumps.

## Motivation

Both were reported as abicheck-internal bugs (not fixable from a downstream lab), with clear repro instructions:

- **Finding 1** (&#34;`toolchain_matrix` has been silently broken since it was created&#34;): a persisted `dump`-produced baseline scoped `dependency_scope: filtered` disagreed with `compare`&#39;s own internal live-dump of the candidate side, because the two code paths compute the dependency-scoping `header_roots` differently — one of them (`dump`&#39;s own CLI path) silently omitted `public_headers`/`public_header_dirs`.
- **Finding 2** (&#34;the cross-profile comparability guard doesn&#39;t fire without L3 build evidence&#34;): comparing the same unchanged library dumped under two genuinely different toolchains (e.g. GCC vs. Clang, no explicit `-std=`, no `--sources`/`--build-info`) produced `COMPATIBLE_WITH_RISK` instead of `NOT_COMPARABLE`, because neither side&#39;s `language_standard` field was ever populated when no explicit standard was pinned.

Both were reproduced end-to-end via the real `dump`/`compare` CLI before being fixed (not just at the unit level).

## Changes

- `abicheck/cli_dump_helpers.py`: `perform_elf_dump` and `handle_non_elf_dump` now compute `header_roots` (fed to `dumper_scoping.resolve_dependency_scope`) identically to `dumper_scoping.apply_dependency_scope_to_run_dump_result` — the choke point `compare`&#39;s own live-binary dumping already uses — by folding in `public_headers`/`public_header_dirs` alongside `headers` (and, for ELF, `--dump-manifest` roots).
- `abicheck/dumper_toolchain.py`: new `_probe_default_language_standard()`, a best-effort probe of the resolved compiler&#39;s own predefined-macro table (`-E -dM`), mirroring the existing `_clang_compiler_family` probe technique. `_resolve_standard_provenance()` now falls back to this probe when neither an explicit `-std=`/`--lang` nor the C++20-detection heuristic already resolved a value. `_cplusplus_macro_for_standard()` also recognizes the new `&#34;probed:&#34;`-prefixed value shape (a containment check, not `.startswith`, since an explicit `--lang` prefixes the recorded value with the resolved language mode, e.g. `&#34;c++:probed:...&#34;`).
- `abicheck/dumper.py` / `abicheck/service.py`: threads `ast_toolchain`/`lang` through to `_ast_compile_provenance()` at all three snapshot-construction call sites (ELF/PE/Mach-O) so the probe can resolve the actual compiler binary that parsed the headers. The clang backend&#39;s C→C++ self-heal retry and castxml&#39;s force_cpp-aware compiler remap (`c++` → `cc`) now thread their real, post-resolution language mode/compiler identity into `AbiSnapshot.ast_toolchain` instead of letting the probe re-derive a stale guess.
- `abicheck/comparability.py`: new `_language_standard_probe_upgrade_corroborated` carve-out — an existing, pre-probe baseline (recorded with an empty `language_standard`) stays comparable against a freshly re-dumped snapshot of the identical input under the identical resolved compiler (confirmed via unchanged `compiler_family`/`compiler_version`) — an abicheck upgrade adding evidence must not by itself make an otherwise-unchanged baseline `NOT_COMPARABLE`.
- Tests: `tests/test_ast_compile_provenance.py` (probe unit tests + `_ast_compile_provenance`/`_resolve_standard_provenance` wiring, including the lang-qualified-marker and post-retry-language-mode regressions), `tests/test_comparability_gate.py` + `tests/test_comparability_gate_probe_upgrade.py` (end-to-end gate regressions for finding 2, including the lang-qualified carve-out transition), `tests/test_dump_header_roots_dependency_scope_parity.py` (new, ELF `header_roots` parity), `tests/test_non_elf_dump_l2_seed.py` (PE/Mach-O `header_roots` parity), `tests/test_dumper_clang.py`/`tests/test_castxml_errors.py` (the self-heal/castxml-remap `ast_toolchain` wiring). Two pre-existing tests (`test_dumper_contract_wiring.py`, `test_pvxs_regression.py`) updated to assert the real invariant they exist for instead of the now-changed literal `language_standard` shape.
- Changelog fragment added.

Full non-integration/slow/golden test suite verified green (28902 passed) after these changes. `mypy abicheck/` and `ruff check` clean.

## Bug-fix test contract

- Bug class: two internal abicheck code paths (a) computing the same dependency-scoping input differently, and (b) a comparability-guard field left unpopulated for a whole input shape (unpinned toolchain default) rather than merely mis-populated for one case — plus two review-round follow-ups fixing the same class again: a marker-matching bug (`.startswith` vs. containment) and a stale-re-derivation bug (probing a statically-guessed language mode instead of the parse's actual, possibly self-healed one).
- Publicly observable failure: (1) `compare` between a `dump`-produced baseline and a live candidate of the identical input silently disagrees on filtered/scoped content whenever the library declares public headers via `public_headers`/`public_header_dirs`; (2) `compare` of two dumps of an unchanged library under different unpinned toolchains returns a real verdict (`COMPATIBLE_WITH_RISK`) instead of refusing as `NOT_COMPARABLE`; (2b) with an explicit `--lang`, the marker-matching bug made this fix regress its own CI (`Validate examples`, `Full example matrix`, `integration-tests`) by spuriously raising `ProfileMismatchError` on unrelated, unchanged comparisons.
- Regression test fails on base: yes — `test_dump_header_roots_dependency_scope_parity.py`/`test_non_elf_dump_l2_seed.py::test_non_elf_dump_header_roots_includes_public_headers_and_dirs` assert `header_roots` includes `public_headers`/`public_header_dirs`, which the pre-fix code omitted; `test_comparability_gate.py::test_gate_two_unpinned_toolchains_with_differing_probed_defaults_raise_profile_mismatch` asserts `ProfileMismatchError`, which the pre-fix (empty-on-both-sides) contract never raised; `test_ast_compile_provenance.py::TestCplusplusMacroForStandard::test_probed_marker_recognized_regardless_of_position` and `test_comparability_gate_probe_upgrade.py::test_gate_empty_vs_probed_language_standard_waived_when_lang_qualified` both fail against the pre-follow-up `.startswith`-based code; `test_dumper_clang.py::test_clang_header_dump_retries_cpp_on_missing_cpp_stdlib_header`'s new `resolved_force_cpp is True` assertion and `test_header_ast_parser_castxml_branch_records_the_force_cpp_aware_compiler` both fail against the pre-follow-up static re-derivation.
- Negative control: `test_gate_two_unpinned_toolchains_with_the_same_probed_default_stay_comparable` and `TestAstCompileProvenanceProbing::test_no_ast_toolchain_preserves_prior_behavior` pin that the common same-toolchain / no-`ast_toolchain`-given cases are unaffected.
- Real-dependency test: `dumper_toolchain._probe_default_language_standard` shells out to the *real* resolved compiler (`-E -dM -x <lang> -`) rather than reimplementing a subset of its predefined-macro table — `TestProbeDefaultLanguageStandard::test_probes_real_host_compiler_cpp` (now marked `@pytest.mark.integration` per this repo's convention for tests that shell out) exercises the actual host `g++`/`clang++` end to end and asserts a genuine `__cplusplus` value comes back, not a mocked `subprocess.run`. The mocked-`subprocess.run` unit tests alongside it (`test_two_different_defaults_produce_different_values`, `test_c_mode_absent_stdc_version_is_a_real_value_not_a_failure`, `test_missing_compiler_returns_none`, `test_nonzero_exit_returns_none`) cover the parsing/caching logic in isolation, which the real-compiler test alone can't pin deterministically (different compilers/versions default to different standards) — together they satisfy ADR-059 §12's "exercise the real public API at realistic scale" for the one new third-party-process boundary this PR adds, the same pattern `_clang_compiler_family`'s own existing probe already established for this module.
- Public-surface test: both fixes were also verified against the real CLI (`abicheck dump`/`abicheck compare`) end-to-end, not only at the unit level.
- Axes covered: ELF and PE/Mach-O dump paths (finding 1); C and C++ probe modes, cached-vs-uncached probe, probe failure (missing/non-`-dM` compiler), lang-qualified vs. bare probed-marker spelling, clang C→C++ self-heal retry, castxml force_cpp-aware compiler remap (finding 2).
- General invariant: `dump`&#39;s dependency-scoping `header_roots` must always match `apply_dependency_scope_to_run_dump_result`&#39;s computation (the single choke point `compare`&#39;s live dumping already uses); `language_standard`/`ast_resolved_standard` must reflect the resolved compiler&#39;s real, actually-used behavior (explicit standard, else forced-heuristic, else the compiler&#39;s own observed unpinned default under the language mode the parse actually settled on) rather than silently defaulting to an indistinguishable empty value or a statically-guessed one.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) — `changelog.d/1787266876_claude_header_roots_parity_and_probed_language_standard.md`
- [ ] Docs updated if user-visible behaviour changed — internal fix, no user-facing docs to update
- [x] `pre-commit run --all-files`-equivalent checks pass locally (ruff check/format, mypy on touched files clean, full fast test suite green)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UBvHxA5Q66NKiQ5Cgwe5yR)_


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved ABI snapshot consistency by including public headers and header directories across supported dump formats.
  * Enhanced compiler and language-mode detection, including fallback and default-standard resolution.
  * Improved metadata accuracy when processing mixed-language inputs.
  * Strengthened compatibility comparisons by validating language standards and compiler evidence more reliably.

* **Documentation**
  * Added guidance covering header dependencies, language detection, compatibility checks, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->