### PR TITLE
feat: introduce ResolvedArtifactPlan (Phase 1 Milestone A, dedup-and-convergence plan)

### DIFF
--- a/abicheck/artifact_plan.py
+++ b/abicheck/artifact_plan.py
@@ -143,10 +143,21 @@ class ResolvedArtifactPlan:
         a cleanup — but a cleanup registered *after* the previous drain
         (post-close ``add_cleanup()``, or a plan re-entered via a second
         ``with`` block) still runs on this call rather than being dropped.
+
+        Also covers registration *during* the drain itself: the cursor
+        (:attr:`_drained_count`) advances one entry at a time, re-checking
+        ``len(pending_cleanups)`` before each step, so a running cleanup that
+        itself calls :meth:`add_cleanup` (discovering a further owned
+        resource) has that new entry picked up in this same call rather than
+        left for a drain that may never come again (Codex review: an earlier
+        revision snapshotted the pending slice and advanced the cursor past
+        it *before* running any of them, so a cleanup registered mid-drain
+        was silently skipped even though it was registered strictly before
+        the call finished).
         """
-        pending = self.pending_cleanups[self._drained_count :]
-        self._drained_count = len(self.pending_cleanups)
-        for cleanup in pending:
+        while self._drained_count < len(self.pending_cleanups):
+            cleanup = self.pending_cleanups[self._drained_count]
+            self._drained_count += 1
             try:
                 cleanup()
             except Exception:  # noqa: BLE001 - see _run_cleanups' own rationale

--- a/abicheck/artifact_plan.py
+++ b/abicheck/artifact_plan.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""``ResolvedArtifactPlan`` — Phase 1 (Milestone A) of the
+duplication-and-convergence plan's "Finish artifact-resolution convergence"
+work (``docs/contribute/plans/duplication-and-convergence-assessment.md``).
+
+**Scope of this module.** The plan's Phase 1 item 1 asks for a
+context-managed session that owns any resource an artifact-resolution
+attempt allocates (an inferred-build temp directory, most concretely) from
+resolution onward — spanning through whichever of execution or dry-run
+inspection follows, not scoped to either alone. Today, every call site that
+allocates such a resource (``service_input_resolution._resolve_side_snapshot_impl``,
+``cli_dump_helpers.perform_elf_dump``/``handle_non_elf_dump``) threads a
+plain ``list[Callable[[], None]]`` accumulator by hand and drains it in its
+own ``finally``, strictly before returning anything to its caller — there is
+no reusable, tested primitive. This module is that primitive, generalized
+just enough to replace one such hand-rolled accumulator
+(``cli_dump_helpers.perform_elf_dump``'s own ``_l2_pending_cleanups``) with a
+single, reviewed implementation; migrating every other call site named in
+the plan is deliberately out of scope for this first slice — see the plan
+doc's own Phase 1 section for the full, still-open list.
+
+Deliberately a leaf, engine-layer module: no ``click``/``cli_*`` import (the
+``engine-cli-boundary`` AI-readiness gate would reject one), no dependency on
+``service_dump_pipeline.py``/``service_input_resolution.py`` — those keep
+their own existing dataclasses unchanged in this pass.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from types import TracebackType
+
+logger = logging.getLogger(__name__)
+
+
+class ResolvedArtifactPlan:
+    """A context-managed session owning the cleanup thunks an
+    artifact-resolution attempt accumulates.
+
+    Mirrors the existing ``pending_cleanups``/``defer_cleanup`` accumulator
+    pattern used throughout ``buildsource/`` and ``service_input_resolution.py``
+    (a plain ``list[Callable[[], None]]``, appended to as resolution
+    allocates resources) — but as a reusable, independently-tested type
+    instead of a hand-rolled local list plus a manual ``try``/``finally`` at
+    every call site.
+
+    Usage — the exact shape the plan's own "Lifetime problem" section
+    specifies (``with resolve...() as plan: ... if dry_run: return
+    render(plan) ... with execute...(plan) as result: ...``), collapsed here
+    to what one call site (``perform_elf_dump``) actually needs today: a
+    single ``with`` spanning resolution through execution::
+
+        with ResolvedArtifactPlan() as plan:
+            includes, ctx = seed_includes_and_fold_compile_context(
+                ..., pending_cleanups=plan.pending_cleanups,
+            )
+            snap = dump(...)  # the real extraction
+        # plan.__exit__ has now run every collected cleanup exactly once.
+
+    A cleanup registered via :attr:`pending_cleanups` (the list itself,
+    handed to a callee the same way an existing bare list is today) or via
+    :meth:`add_cleanup` (for a cleanup only known after construction, e.g.
+    one discovered during execution rather than resolution) is run on
+    ``__exit__``, in registration order, exactly once — a second
+    ``__exit__`` (or a caller that already drained the list by hand before
+    handing it to a plan) is a safe no-op, not a double-run.
+
+    **Partial-resolution failure.** The plan's own text calls out a failure
+    mode this type must not reproduce: if the code building a
+    ``ResolvedArtifactPlan``-like object fails *after* allocating a resource
+    but *before* returning an object a ``with`` block can call
+    ``__exit__`` on, that resource leaks — the caller never receives
+    anything to close. This type is agnostic to *where* it is constructed
+    (a caller doing all its own allocation before constructing one is still
+    exposed to that failure mode) — the safe pattern is to construct the
+    plan *first*, and register each cleanup via :attr:`pending_cleanups` or
+    :meth:`add_cleanup` as soon as it is known, inside the same ``with``
+    block whose ``__exit__`` will run it regardless of what happens later in
+    that block (see the module-level usage example above): any exception
+    raised later in that same ``with`` body still reaches ``__exit__`` and
+    still drains everything collected up to that point, because
+    ``pending_cleanups`` is mutated in place rather than being handed over
+    only at the end.
+    """
+
+    __slots__ = ("pending_cleanups", "_closed")
+
+    def __init__(self) -> None:
+        #: Handed directly to a callee that expects the existing bare
+        #: ``pending_cleanups: list[Callable[[], None]]`` parameter shape
+        #: (``seed_includes_and_fold_compile_context``, ``collect_inline_pack``'s
+        #: ``defer_cleanup``) — appended to in place, the same contract those
+        #: functions already document.
+        self.pending_cleanups: list[Callable[[], None]] = []
+        self._closed = False
+
+    def add_cleanup(self, cleanup: Callable[[], None]) -> None:
+        """Register a cleanup discovered after construction (e.g. during
+        execution rather than resolution). Equivalent to
+        ``self.pending_cleanups.append(cleanup)`` — provided as a named
+        method so a caller need not reach into the list directly."""
+        self.pending_cleanups.append(cleanup)
+
+    def run_cleanups(self) -> None:
+        """Run every registered cleanup exactly once, in registration
+        order, never letting one failure skip the rest — the identical
+        contract ``buildsource.inline._run_cleanups`` already establishes
+        for the same class of thunk (a failure is logged, not raised, since
+        a temp tree already gone or a read-only mount must not abort an
+        otherwise-successful extraction). Idempotent: a second call is a
+        no-op, so an explicit call here followed by context-manager
+        ``__exit__`` (or two nested ``with`` exits on the same instance)
+        never double-runs a cleanup.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        for cleanup in self.pending_cleanups:
+            try:
+                cleanup()
+            except Exception:  # noqa: BLE001 - see _run_cleanups' own rationale
+                logger.debug(
+                    "ResolvedArtifactPlan cleanup failed: %r", cleanup, exc_info=True
+                )
+
+    def __enter__(self) -> ResolvedArtifactPlan:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.run_cleanups()

--- a/abicheck/artifact_plan.py
+++ b/abicheck/artifact_plan.py
@@ -75,9 +75,18 @@ class ResolvedArtifactPlan:
     handed to a callee the same way an existing bare list is today) or via
     :meth:`add_cleanup` (for a cleanup only known after construction, e.g.
     one discovered during execution rather than resolution) is run on
-    ``__exit__``, in registration order, exactly once — a second
-    ``__exit__`` (or a caller that already drained the list by hand before
-    handing it to a plan) is a safe no-op, not a double-run.
+    ``__exit__``, in registration order, exactly once — a second ``__exit__``
+    (or an explicit :meth:`run_cleanups` call after nothing new was
+    registered) is a safe no-op, not a double-run. Registering a cleanup
+    *after* a drain already ran — a plan re-entered via a second ``with``
+    block, or ``add_cleanup()`` called on an already-closed plan — is not a
+    leak either (Codex review: an earlier revision used a single ``_closed``
+    flag that made every drain after the first a no-op unconditionally, so a
+    cleanup registered post-close was silently never run): draining tracks
+    how much of :attr:`pending_cleanups` has actually been run, not merely
+    whether a drain has ever happened, so the next :meth:`run_cleanups` call
+    (explicit, or via a later ``with`` exit) still picks up and runs exactly
+    the cleanups appended since the previous drain.
 
     **Partial-resolution failure.** The plan's own text calls out a failure
     mode this type must not reproduce: if the code building a
@@ -97,7 +106,7 @@ class ResolvedArtifactPlan:
     only at the end.
     """
 
-    __slots__ = ("pending_cleanups", "_closed")
+    __slots__ = ("pending_cleanups", "_drained_count")
 
     def __init__(self) -> None:
         #: Handed directly to a callee that expects the existing bare
@@ -106,30 +115,38 @@ class ResolvedArtifactPlan:
         #: ``defer_cleanup``) — appended to in place, the same contract those
         #: functions already document.
         self.pending_cleanups: list[Callable[[], None]] = []
-        self._closed = False
+        #: How many leading entries of ``pending_cleanups`` have already been
+        #: run. A count, not a bool -- so a cleanup appended after a drain
+        #: (post-close ``add_cleanup()``, or a second ``with`` re-entry) is
+        #: still reachable by the *next* drain instead of being silently
+        #: skipped by an unconditional "already closed" flag.
+        self._drained_count = 0
 
     def add_cleanup(self, cleanup: Callable[[], None]) -> None:
         """Register a cleanup discovered after construction (e.g. during
-        execution rather than resolution). Equivalent to
-        ``self.pending_cleanups.append(cleanup)`` — provided as a named
-        method so a caller need not reach into the list directly."""
+        execution rather than resolution, or after an earlier drain already
+        ran). Equivalent to ``self.pending_cleanups.append(cleanup)`` —
+        provided as a named method so a caller need not reach into the list
+        directly."""
         self.pending_cleanups.append(cleanup)
 
     def run_cleanups(self) -> None:
-        """Run every registered cleanup exactly once, in registration
-        order, never letting one failure skip the rest — the identical
-        contract ``buildsource.inline._run_cleanups`` already establishes
-        for the same class of thunk (a failure is logged, not raised, since
-        a temp tree already gone or a read-only mount must not abort an
-        otherwise-successful extraction). Idempotent: a second call is a
-        no-op, so an explicit call here followed by context-manager
-        ``__exit__`` (or two nested ``with`` exits on the same instance)
-        never double-runs a cleanup.
+        """Run every cleanup registered since the last drain exactly once,
+        in registration order, never letting one failure skip the rest —
+        the identical contract ``buildsource.inline._run_cleanups`` already
+        establishes for the same class of thunk (a failure is logged, not
+        raised, since a temp tree already gone or a read-only mount must not
+        abort an otherwise-successful extraction). Idempotent when nothing
+        new was registered: a second call with no new cleanups is a no-op,
+        so an explicit call here followed by context-manager ``__exit__``
+        (or two nested ``with`` exits on the same instance) never double-runs
+        a cleanup — but a cleanup registered *after* the previous drain
+        (post-close ``add_cleanup()``, or a plan re-entered via a second
+        ``with`` block) still runs on this call rather than being dropped.
         """
-        if self._closed:
-            return
-        self._closed = True
-        for cleanup in self.pending_cleanups:
+        pending = self.pending_cleanups[self._drained_count :]
+        self._drained_count = len(self.pending_cleanups)
+        for cleanup in pending:
             try:
                 cleanup()
             except Exception:  # noqa: BLE001 - see _run_cleanups' own rationale

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 import click
 
 from . import dumper_cache
+from .artifact_plan import ResolvedArtifactPlan
 from .dumper import dump
 from .dumper_scoping import dump_manifest_header_roots as _dump_manifest_header_roots
 from .errors import AbicheckError
@@ -1567,7 +1568,6 @@ def perform_elf_dump(
     # collect_inline_pack calls for the same --sources tree could otherwise
     # contend on the same inferred-build-query lock and wait up to its 600s
     # timeout (Codex review; see that function's own docstring).
-    from .buildsource.inline import _run_cleanups
     from .buildsource.l2_seed import seed_includes_and_fold_compile_context
 
     # The ADR-039 collector's _user_define_flags() call below must see only
@@ -1579,7 +1579,21 @@ def perform_elf_dump(
     # that reassignment folds the derived flags in before this variable is
     # read again. Captured here, before any L3 reassignment.
     _user_gcc_option_tokens = gcc_option_tokens
-    _l2_pending_cleanups: list[Callable[[], None]] = []
+    # Phase 1 (dedup-and-convergence plan) Milestone A: the two try blocks
+    # below share one `ResolvedArtifactPlan` session spanning from the L2
+    # seed's own resource allocation through the whole post-dump pipeline --
+    # replacing the hand-rolled `_l2_pending_cleanups: list[...] = []` +
+    # manual `if _l2_pending_cleanups: _run_cleanups(...)` this function used
+    # before, with a single reusable, independently-tested primitive
+    # (`artifact_plan.py`) that drains exactly once (idempotent -- calling
+    # `run_cleanups()` from both the except branch below and the second
+    # block's `finally` is therefore safe on the shared-block path where
+    # only one of the two ever actually has anything to drain) regardless of
+    # which of the two blocks below raises or both complete normally.
+    # Behavior-preserving only -- no change to resolution order, dry-run, or
+    # `handle_non_elf_dump` (which keeps its own separate, untouched
+    # `_l2_pending_cleanups`).
+    _artifact_plan = ResolvedArtifactPlan()
     try:
         (
             eff_includes,
@@ -1614,7 +1628,7 @@ def perform_elf_dump(
             ),
             lang=lang,
             lang_explicit=lang_explicit,
-            pending_cleanups=_l2_pending_cleanups,
+            pending_cleanups=_artifact_plan.pending_cleanups,
         )
         if l3_context_applied:
             gcc_path = l3_effective_ctx.gcc_path
@@ -1677,8 +1691,7 @@ def perform_elf_dump(
         # requested --header-graph pass) will run, so the seeded temp build
         # dir is no longer needed by anything; release it now rather than
         # leaking it.
-        if _l2_pending_cleanups:
-            _run_cleanups(_l2_pending_cleanups)
+        _artifact_plan.run_cleanups()
         raise click.ClickException(str(exc)) from exc
 
     try:
@@ -1864,8 +1877,7 @@ def perform_elf_dump(
         # before the header-graph pass is ever reached (Codex review). One
         # try/finally around the whole pipeline drains the cleanup exactly
         # once, on every exit path.
-        if _l2_pending_cleanups:
-            _run_cleanups(_l2_pending_cleanups)
+        _artifact_plan.run_cleanups()
 
     if follow_deps:
         populate_dependency_info(

--- a/changelog.d/20260821_021003_claude_artifact-plan-milestone-a.md
+++ b/changelog.d/20260821_021003_claude_artifact-plan-milestone-a.md
@@ -1,0 +1,10 @@
+### Changed
+
+- **Internal: `perform_elf_dump`'s (`abicheck dump` ELF path) temp-build-dir
+  cleanup now goes through a new, reusable `ResolvedArtifactPlan` primitive**
+  (`abicheck/artifact_plan.py`) instead of a hand-rolled
+  `list[Callable[[], None]]` accumulator drained by a manual `try`/`finally`
+  — Phase 1 (Milestone A) of the duplication-and-convergence plan's
+  "Finish artifact-resolution convergence" work. Purely internal:
+  cleanup thunks and timing are unchanged, no CLI-visible or Python-API
+  behavior changes.

--- a/docs/contribute/plans/duplication-and-convergence-assessment.md
+++ b/docs/contribute/plans/duplication-and-convergence-assessment.md
@@ -1011,9 +1011,37 @@ sign-off, not a routine PR).
 
 ### Phase 1 — Finish artifact-resolution convergence
 
-1. Introduce `ResolvedArtifactPlan` as a context-managed session that owns
-   any resource resolution itself allocates (e.g. an inferred-build
-   directory) from `resolve_artifact_request()` onward — not scoped to
+1. **Started (Milestone A).** `abicheck/artifact_plan.py` introduces
+   `ResolvedArtifactPlan` — a real, independently-tested context-managed
+   session (`tests/test_artifact_plan.py`) owning the
+   `list[Callable[[], None]]` cleanup accumulator every resolution call site
+   used to thread and drain by hand. Wired into exactly one already-isolated,
+   already-well-tested call site as proof: `cli_dump_helpers.
+   perform_elf_dump()`'s `_l2_pending_cleanups` accumulator is now a
+   `ResolvedArtifactPlan` instance, with identical cleanup thunks
+   (`seed_includes_and_fold_compile_context(..., pending_cleanups=
+   _artifact_plan.pending_cleanups)`) and identical timing (drained via
+   `run_cleanups()` at the exact two points the old code called
+   `_run_cleanups()` — immediately on a failed header parse, or after the
+   whole post-dump pipeline completes) — a behavior-preserving refactor, not
+   a new resolve/execute split. Existing `perform_elf_dump` coverage
+   (`tests/test_cli_dump_helpers_coverage.py`, including
+   `test_perform_elf_dump_wraps_dump_errors_still_cleans_up_seeded_dirs`)
+   passed unmodified against the migration. **Not yet done, and deliberately
+   out of scope for this slice**: this is not yet "resolve_artifact_request()
+   onward" as item 1's own text above describes — there is no
+   `resolve_artifact_request()`/`execute_artifact_plan()` split yet, `dump
+   --dry-run` still doesn't build from or render a `ResolvedArtifactPlan`
+   (`render_dump_dry_run()` is still its own independent resolution, per the
+   "PR C" entry in AGENTS.md's "Known gaps"), `handle_non_elf_dump`'s
+   identical `_l2_pending_cleanups` pattern is untouched, and none of items
+   2–10 below have been attempted. See item 1's own original text (kept
+   below) for the shape a full implementation still needs to reach.
+
+1. (Full shape, not yet reached) Introduce `ResolvedArtifactPlan` as a
+   context-managed session that owns any resource resolution itself
+   allocates (e.g. an inferred-build directory) from
+   `resolve_artifact_request()` onward — not scoped to
    `execute_artifact_plan()` alone, since dry-run resolves without ever
    executing and must still close the same session.
 2. Move `perform_elf_dump`'s remaining post-processing hooks (ADR-039

--- a/tests/test_artifact_plan.py
+++ b/tests/test_artifact_plan.py
@@ -110,3 +110,48 @@ def test_enter_returns_self():
     plan = ResolvedArtifactPlan()
     with plan as entered:
         assert entered is plan
+
+
+def test_cleanup_added_via_add_cleanup_after_drain_still_runs() -> None:
+    """Codex review: an earlier revision tracked closure as a single bool, so
+    every drain after the first was an unconditional no-op -- a cleanup
+    registered via add_cleanup() on an already-drained plan was silently
+    never run. The next run_cleanups() call (here, a second `with` re-entry)
+    must still pick it up."""
+    calls: list[str] = []
+    plan = ResolvedArtifactPlan()
+    plan.add_cleanup(lambda: calls.append("first"))
+    plan.run_cleanups()
+    assert calls == ["first"]
+
+    plan.add_cleanup(lambda: calls.append("late"))
+    with plan:
+        pass
+    assert calls == ["first", "late"]
+
+
+def test_cleanup_appended_to_pending_cleanups_after_drain_still_runs() -> None:
+    """Same invariant as above, via the other registration path (direct
+    `pending_cleanups.append(...)` rather than `add_cleanup()`) -- Codex
+    review asked for both to be covered."""
+    calls: list[str] = []
+    plan = ResolvedArtifactPlan()
+    plan.pending_cleanups.append(lambda: calls.append("first"))
+    plan.run_cleanups()
+    assert calls == ["first"]
+
+    plan.pending_cleanups.append(lambda: calls.append("late"))
+    plan.run_cleanups()
+    assert calls == ["first", "late"]
+
+
+def test_run_cleanups_with_nothing_new_after_a_drain_is_a_true_no_op() -> None:
+    """The idempotent case must still hold: calling run_cleanups() again with
+    no new registrations re-runs nothing."""
+    calls: list[str] = []
+    plan = ResolvedArtifactPlan()
+    plan.add_cleanup(lambda: calls.append("a"))
+    plan.run_cleanups()
+    plan.run_cleanups()
+    plan.run_cleanups()
+    assert calls == ["a"]

--- a/tests/test_artifact_plan.py
+++ b/tests/test_artifact_plan.py
@@ -155,3 +155,22 @@ def test_run_cleanups_with_nothing_new_after_a_drain_is_a_true_no_op() -> None:
     plan.run_cleanups()
     plan.run_cleanups()
     assert calls == ["a"]
+
+
+def test_cleanup_registered_during_the_drain_itself_still_runs() -> None:
+    """Codex review: an earlier revision snapshotted the pending slice and
+    advanced the cursor past it *before* running any of them, so a cleanup
+    that itself calls add_cleanup() while running (discovering a further
+    owned resource mid-teardown) was silently skipped -- registered strictly
+    before run_cleanups() returned, but never drained by that same call, and
+    with no second drain guaranteed to ever come."""
+    calls: list[str] = []
+    plan = ResolvedArtifactPlan()
+
+    def _discovers_another_resource() -> None:
+        calls.append("outer")
+        plan.add_cleanup(lambda: calls.append("discovered-mid-drain"))
+
+    plan.add_cleanup(_discovers_another_resource)
+    plan.run_cleanups()
+    assert calls == ["outer", "discovered-mid-drain"]

--- a/tests/test_artifact_plan.py
+++ b/tests/test_artifact_plan.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for :mod:`abicheck.artifact_plan` — Phase 1 (Milestone A) of the
+duplication-and-convergence plan's ``ResolvedArtifactPlan`` primitive."""
+
+from __future__ import annotations
+
+import pytest
+
+from abicheck.artifact_plan import ResolvedArtifactPlan
+
+
+def test_normal_exit_runs_cleanups_once():
+    calls: list[str] = []
+    with ResolvedArtifactPlan() as plan:
+        plan.pending_cleanups.append(lambda: calls.append("a"))
+        plan.pending_cleanups.append(lambda: calls.append("b"))
+    assert calls == ["a", "b"]
+
+
+def test_exception_during_with_body_still_runs_cleanups():
+    calls: list[str] = []
+    with pytest.raises(ValueError, match="boom"):
+        with ResolvedArtifactPlan() as plan:
+            plan.pending_cleanups.append(lambda: calls.append("a"))
+            raise ValueError("boom")
+    assert calls == ["a"]
+
+
+def test_cleanup_registered_after_construction_via_add_cleanup_still_runs():
+    calls: list[str] = []
+    plan = ResolvedArtifactPlan()
+    plan.pending_cleanups.append(lambda: calls.append("seeded"))
+    # Discovered only once "execution" (not just "resolution") has run --
+    # the exact case add_cleanup exists for.
+    plan.add_cleanup(lambda: calls.append("discovered-later"))
+    plan.run_cleanups()
+    assert calls == ["seeded", "discovered-later"]
+
+
+def test_idempotent_double_exit_does_not_double_run():
+    calls: list[str] = []
+    plan = ResolvedArtifactPlan()
+    plan.pending_cleanups.append(lambda: calls.append("a"))
+    plan.run_cleanups()
+    plan.run_cleanups()  # explicit second call
+    with plan:  # __enter__/__exit__ on an already-closed plan
+        pass
+    assert calls == ["a"]
+
+
+def test_partial_allocation_failure_runs_what_was_collected_so_far():
+    """Mirrors the plan's own named failure mode: an allocating body that
+    raises partway through must still drain every cleanup it had already
+    registered before the raise, even though the caller never gets an
+    object back to call __exit__ on itself -- the *body* is responsible
+    for calling run_cleanups() in its own except/finally when it cannot
+    rely on a `with` block around itself (e.g. it isn't the one that
+    constructed the plan)."""
+    calls: list[str] = []
+    plan = ResolvedArtifactPlan()
+
+    def _allocate_then_fail() -> None:
+        plan.pending_cleanups.append(lambda: calls.append("first"))
+        plan.pending_cleanups.append(lambda: calls.append("second"))
+        raise RuntimeError("partial failure")
+
+    with pytest.raises(RuntimeError, match="partial failure"):
+        try:
+            _allocate_then_fail()
+        except RuntimeError:
+            plan.run_cleanups()
+            raise
+
+    assert calls == ["first", "second"]
+
+
+def test_one_failing_cleanup_does_not_skip_the_rest():
+    calls: list[str] = []
+
+    def _bad_cleanup() -> None:
+        raise OSError("cleanup itself failed")
+
+    with ResolvedArtifactPlan() as plan:
+        plan.pending_cleanups.append(lambda: calls.append("before"))
+        plan.add_cleanup(_bad_cleanup)
+        plan.add_cleanup(lambda: calls.append("after"))
+    assert calls == ["before", "after"]
+
+
+def test_no_cleanups_registered_is_a_no_op():
+    with ResolvedArtifactPlan() as plan:
+        assert plan.pending_cleanups == []
+    # __exit__ must not raise even though nothing was ever registered.
+
+
+def test_enter_returns_self():
+    plan = ResolvedArtifactPlan()
+    with plan as entered:
+        assert entered is plan


### PR DESCRIPTION
## Summary

Introduces `ResolvedArtifactPlan`, a real context-managed cleanup-lifetime primitive, and wires it into one already-isolated call site — Milestone A of Phase 1 ("Finish artifact-resolution convergence") in `docs/contribute/plans/duplication-and-convergence-assessment.md`.

## Motivation

Phase 0 of the same plan closed on #813. Items 3 and 5 of Phase 0 are gates for infrastructure that doesn't exist yet — the artifact-application service (Phase 1) and `ReportEnvelope` (Phase 4). Continuing the plan means starting to build that infrastructure. Phase 1 itself is ten sub-items spanning `dump`/`compare`/`scan`/PE-Mach-O/`appcompat`/`deps compare`/the release fan-out — a large, high-risk surface in an area this repo's own `AGENTS.md` documents as having already drawn 18+ rounds of subtle Codex-review findings on adjacent work. This PR scopes down to a single safe, provable first slice rather than attempting the full migration in one pass.

## Changes

- **New**: `abicheck/artifact_plan.py` — `ResolvedArtifactPlan`, a context-managed session owning the `list[Callable[[], None]]` cleanup accumulator every resolution call site currently threads and drains by hand. Idempotent draining (`run_cleanups()`), a named `add_cleanup()` for a cleanup discovered after construction, and `__enter__`/`__exit__` support.
- **One real integration**: `cli_dump_helpers.perform_elf_dump()`'s existing `_l2_pending_cleanups: list[...] = []` + manual `if _l2_pending_cleanups: _run_cleanups(...)` is replaced with a `ResolvedArtifactPlan` instance — identical cleanup thunks (`seed_includes_and_fold_compile_context(..., pending_cleanups=_artifact_plan.pending_cleanups)`), identical timing (drained at the exact two points the old code called `_run_cleanups()`). Purely behavior-preserving; no change to resolution order, dry-run, or `handle_non_elf_dump` (which keeps its own separate, untouched `_l2_pending_cleanups` — a second call site, deliberately not migrated in this slice).
- **New tests**: `tests/test_artifact_plan.py` — the primitive in isolation (normal exit, exception during the `with` body, a cleanup registered after construction, idempotent double-exit, a failing cleanup not skipping the rest, no-op when nothing registered, plus two follow-up review rounds' worth of lifecycle fixes below).
- Existing `perform_elf_dump` coverage (`tests/test_cli_dump_helpers_coverage.py`, including `test_perform_elf_dump_wraps_dump_errors_still_cleans_up_seeded_dirs`, which already asserts cleanup runs when `dump()` raises) passes unmodified against the migration — no new regression test was needed for that case.
- **Doc**: Phase 1 item 1 in the plan doc is marked "Started (Milestone A)" with an explicit residual list — not "Implemented," since this is only a first slice. Items 2–10 (post-processing-hook migration; routing scan/PE-Mach-O/`appcompat`/`deps compare`/the probe harness/L0-export-delta/the POI prepass through the new type; the `dump --dry-run` migration; deleting the now-redundant duplicated paths) remain untouched.
- **Changelog**: `changelog.d/20260821_021003_claude_artifact-plan-milestone-a.md`.
- Two automated-review follow-up commits fixed real lifecycle gaps in `ResolvedArtifactPlan` itself, found after the initial commit (see "Bug-fix test contract" below): a cleanup registered after an earlier drain was silently dropped, and a cleanup that registers a further cleanup while running was silently dropped too.

## Bug-fix test contract

<!-- bugfix-test-contract -->

Two related lifecycle fixes to the new `ResolvedArtifactPlan` primitive introduced in this same PR (not shipped on `main` before this PR — flagged by automated review during this PR's own review cycle, so answered here as the contract asks for any `fix:` commit in the PR regardless of what introduced the bug).

- Bug class: `ResolvedArtifactPlan.run_cleanups()`'s draining logic used an all-or-nothing signal (first a single `_closed` bool, then a fixed pending-slice snapshot) to decide what to run, instead of tracking exactly which registered entries had already executed — so a cleanup registered after, or *during*, a drain was silently treated as already accounted for and never ran.
- Publicly observable failure: a resource routed through `ResolvedArtifactPlan` (e.g. a temp build directory) would be left on disk, uncleaned, whenever a cleanup was registered after an earlier `run_cleanups()`/`__exit__()` call, or when a cleanup itself registered a further cleanup while running — silent resource leaks with no error or warning.
- Regression test fails on base: Yes — `test_cleanup_added_via_add_cleanup_after_drain_still_runs`, `test_cleanup_appended_to_pending_cleanups_after_drain_still_runs`, and `test_cleanup_registered_during_the_drain_itself_still_runs` were each confirmed to fail against the commit immediately before their own fix, and pass after it.
- Negative control: `test_run_cleanups_with_nothing_new_after_a_drain_is_a_true_no_op` and `test_idempotent_double_exit_does_not_double_run` pin that a drain with nothing newly registered still runs nothing a second time — the fix must not turn every call into a full re-run of everything ever registered.
- Public-surface test: exercised through `ResolvedArtifactPlan`'s own public API (`run_cleanups()`, `add_cleanup()`, direct `pending_cleanups` mutation, the `with` context-manager protocol) — its only public surface — plus indirectly through `perform_elf_dump`'s existing, unmodified coverage, the one real call site using the primitive today.
- Axes covered: both registration paths (`add_cleanup()` and direct `pending_cleanups.append()` mutation), both timing shapes (registration after a drain completed, and registration from within a cleanup that is itself currently being drained), and both entry points (`with` re-entry and an explicit `run_cleanups()` call).
- General invariant: every cleanup ever appended to `pending_cleanups`, regardless of when it was appended relative to any `run_cleanups()` call — including from inside another cleanup's own execution — runs exactly once, in registration order; a call with nothing newly registered since the last drain is a true no-op.

None of the conditional requirements apply: this diff touches neither a third-party/serialization boundary, the action/workflow trust boundary, identity/dedup logic, filtering/surface scoping, nor policy/severity/exit-code logic.

## Verification

- `pytest tests/test_artifact_plan.py -q` — 12 passed.
- `pytest tests/test_cli_dump_helpers_coverage.py -q` — 48 passed, unmodified.
- Full fast unit suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden" -q`) — 28963 passed, 13 skipped, 4 xfailed (the one initial failure, `test_every_hashed_input_is_tracked_by_git`, was a false alarm from `abicheck/artifact_plan.py` being untracked before `git add`; passes once staged).
- `python scripts/check_ai_readiness.py` — 0 errors.
- `python scripts/check_docs_contract.py` — 0 errors (one pre-existing, unrelated warning).
- `ruff format --check` / `ruff check` — clean on every touched file (pre-existing, unrelated formatting drift elsewhere in `cli_dump_helpers.py` was left untouched rather than swept into this diff).
- `mypy abicheck/artifact_plan.py abicheck/cli_dump_helpers.py` — 0 direct errors (the reported `yaml` stub errors are a pre-existing local-environment quirk, reproduced identically against unmodified `main`).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) — touches `abicheck/**/*.py`
- [x] Docs updated (plan doc's Phase 1 status)
- [x] `ruff format`/`ruff check`/`mypy` pass locally on touched files
- [x] No new `mypy` or `ruff` errors introduced

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwDrTpSeRYNAeSHyPcYmj5)_