### PR TITLE
docs: stop duplicating stale scan-depth benchmark numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Per-case matrix, methodology, full-catalog notes, and the pinned cross-tool comp
 
 - **Start here:** [Getting Started](https://abicheck.github.io/abicheck/getting-started/)
 - **User guide:** [CLI Usage](https://abicheck.github.io/abicheck/user-guide/cli-usage/) · [Application compatibility](https://abicheck.github.io/abicheck/user-guide/appcompat/) · [Output formats](https://abicheck.github.io/abicheck/user-guide/output-formats/) · [GitHub Action](https://abicheck.github.io/abicheck/user-guide/github-action/)
-- **Concepts:** [Verdicts](https://abicheck.github.io/abicheck/concepts/verdicts/) · [Architecture](https://abicheck.github.io/abicheck/concepts/architecture/) · [ABI/API Handling & Recommendations](https://abicheck.github.io/abicheck/concepts/abi-api-handling/) · [Limitations](https://abicheck.github.io/abicheck/concepts/limitations/)
+- **Concepts:** [Verdicts](https://abicheck.github.io/abicheck/concepts/verdicts/) · [Architecture](https://abicheck.github.io/abicheck/concepts/architecture/) · [ABI/API Compatibility](https://abicheck.github.io/abicheck/concepts/abi-api-handling/) · [Limitations](https://abicheck.github.io/abicheck/concepts/limitations/)
 - **Reference:** [Change Kinds](https://abicheck.github.io/abicheck/reference/change-kinds/) · [Exit Codes](https://abicheck.github.io/abicheck/reference/exit-codes/) · [Platforms](https://abicheck.github.io/abicheck/reference/platforms/) · [Tool Comparison](https://abicheck.github.io/abicheck/reference/tool-comparison/)
 - **Troubleshooting:** [Troubleshooting guide](https://abicheck.github.io/abicheck/troubleshooting/)
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -53,15 +53,47 @@ path, not the nav position.
   `first-check.md`, and `first-report.md` — one question each (install, run
   a check, read the result) — plus the worked real-world example
   (`start/real-world-example.md`). New user, first five minutes.
-- `learn/` — the narrative/conceptual track: verdicts, the evidence model,
-  architecture, and `abi-api-handling.md` (the consolidated ABI/API handling
-  guide). `abi-cheat-sheet.md`, `abi-api-handling.md`, and the deep-dive
-  pages (`abi-surface.md`, `class-layout-abi.md`, `dependency-floors.md`)
-  are navigated under the educational **ABI/API Handling & Recommendations**
-  tab (the deep-dives under its **Deep Dives** group), not under a generic
-  "Learn" nav label. The evidence model is deliberately a three-page trio
-  with one role each — model (`learn/evidence-and-detectability.md`), worked
-  example (`learn/what-each-level-sees.md`), and flag reference
+- `learn/` — physically one directory, but split across two *nav* tracks by
+  what kind of question a page answers (docs/AGENTS.md's own "Fact owner /
+  Narrative owner / Task owner / View owner" split, applied at the
+  tab level):
+  - The **educational track** — general ABI/API compatibility knowledge that
+    holds regardless of which tool you use — is navigated under the
+    **ABI/API Compatibility** tab, grouped by the question a page answers
+    rather than by page *kind* (a numbered Learning-Series Part, a
+    framing page, and a split-out deep-dive page covering the same question
+    sit in the same group): **Start** (the hub, five-minute overview, cheat
+    sheet) → **Define Your Contract** (Part 0, direction, consumer models,
+    build-profile comparability, public surface) → **ABI Mechanics** (Parts
+    1-2-3-4-5-6, plus `class-layout-abi.md`) → **Beyond ABI** (behavioral,
+    data/wire, ownership, static/header-only, concurrency) → **Platforms &
+    Toolchains** (exception unwinding, modern-toolchain hazards, runtime
+    floors, `msvc-pe-abi-model.md`) → **Designing Stable Interfaces** (Part
+    7) → **Verification & Assurance** (`abi-series/08-detection.md` +
+    `assurance-methods.md`) → **Quick Reference** (glossary). This is a
+    nav-only regroup of what was once a flat "Deep Dives" list plus a
+    separately-numbered "Learning Series" — a Part's own numbered "Series
+    navigation" breadcrumb (top of each `abi-series/0N-*.md` page) still
+    carries the sequential 0-7 reading order.
+  - The **tool track** — how abicheck itself models and reports compatibility
+    — is navigated under the **Concepts** tab: verdicts,
+    `evidence-and-detectability.md`, `architecture.md`, build/source data,
+    graph coverage, impact assessment, environment drift,
+    `elf-symbol-filtering.md` (a specific abicheck scan-mode behavior, not
+    general ABI knowledge — kept out of the educational tab even though its
+    file lives in the same directory), and `limitations.md`.
+
+  A page whose job is genuinely both — mapping a general ABI concept to the
+  exact `ChangeKind`s/evidence tiers abicheck emits for it, e.g.
+  `class-layout-abi.md`, `msvc-pe-abi-model.md` — stays on the educational
+  tab (that mapping *is* the pedagogical content), but keeps abicheck's own
+  internal module/function names out of its prose and headings; name them in
+  the page's own `depends_on` front matter instead, which exists precisely
+  for that traceability without cluttering the reader-facing explanation.
+
+  The evidence model is deliberately a three-page trio with one role each —
+  model (`learn/evidence-and-detectability.md`), worked example
+  (`learn/what-each-level-sees.md`), and flag reference
   (`use/scan-levels.md`) — don't add a fourth page to that topic. Verdict
   semantics live on one page (`learn/verdicts.md`, including the
   verdict→exit-code chain); `reference/exit-codes.md` stays the exhaustive

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -86,17 +86,16 @@ path, not the nav position.
   A page whose job is genuinely both — mapping a general ABI concept to the
   exact `ChangeKind`s/evidence tiers abicheck emits for it, e.g.
   `class-layout-abi.md`, `msvc-pe-abi-model.md` — stays on the educational
-  tab (that mapping *is* the pedagogical content), but should keep abicheck's
-  own internal module/function names out of its prose and headings; name
-  them in the page's own `depends_on` front matter instead, which exists
-  precisely for that traceability without cluttering the reader-facing
-  explanation. **Rollout status, same shape as the front-matter rollout
-  below**: this is the target for new/touched pages, not yet a swept,
-  repo-wide invariant — `build-profile-comparability.md` (among others) still
-  names internal functions inline and hasn't been migrated. Trim a page's
-  internal names to `depends_on` when you're already editing it for another
-  reason; don't treat an unmigrated page elsewhere as license to add new
-  internal-name prose to the one you're writing.
+  tab (that mapping *is* the pedagogical content), but keeps abicheck's own
+  internal module/function names out of its prose and headings; name them in
+  the page's own `depends_on` front matter instead, which exists precisely
+  for that traceability without cluttering the reader-facing explanation.
+  Every page under the **ABI/API Compatibility** tab has been swept to this
+  rule (including `build-profile-comparability.md`, the previous holdout) —
+  a new internal-name leak here is a real regression to fix, not an
+  unmigrated pre-existing page to tolerate. `ChangeKind`/`RecordType`/
+  `AbiSnapshot` and public JSON-report field values (e.g. `dwarf_aware`) are
+  documented public vocabulary, not internal names, and stay.
 
   The evidence model is deliberately a three-page trio with one role each —
   model (`learn/evidence-and-detectability.md`), worked example

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -141,10 +141,10 @@ expensive to silently break.
   enforces this). Exceptions: per-case `examples/*.md` pages are linked from
   the encyclopedia indexes instead of the nav, and this `AGENTS.md`/
   `CLAUDE.md` are excluded from the published site via `exclude_docs`.
-- The docs tell a two-track story: an **educational track** (ABI/API Handling
-  tab — understanding the problem) and a **tool track** (User Guide → Concepts
-  → Reference — using and understanding abicheck). Within each track, order
-  pages simple → advanced.
+- The docs tell a two-track story: an **educational track** (ABI/API
+  Compatibility tab — understanding the problem) and a **tool track** (User
+  Guide → Concepts → Reference — using and understanding abicheck). Within
+  each track, order pages simple → advanced.
 - Use relative links (`../use/x.md`), not absolute URLs.
 - Prefer pulling from `--help` output rather than hand-rolling CLI
   tables — use the same wording the user sees.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -86,10 +86,17 @@ path, not the nav position.
   A page whose job is genuinely both — mapping a general ABI concept to the
   exact `ChangeKind`s/evidence tiers abicheck emits for it, e.g.
   `class-layout-abi.md`, `msvc-pe-abi-model.md` — stays on the educational
-  tab (that mapping *is* the pedagogical content), but keeps abicheck's own
-  internal module/function names out of its prose and headings; name them in
-  the page's own `depends_on` front matter instead, which exists precisely
-  for that traceability without cluttering the reader-facing explanation.
+  tab (that mapping *is* the pedagogical content), but should keep abicheck's
+  own internal module/function names out of its prose and headings; name
+  them in the page's own `depends_on` front matter instead, which exists
+  precisely for that traceability without cluttering the reader-facing
+  explanation. **Rollout status, same shape as the front-matter rollout
+  below**: this is the target for new/touched pages, not yet a swept,
+  repo-wide invariant — `build-profile-comparability.md` (among others) still
+  names internal functions inline and hasn't been migrated. Trim a page's
+  internal names to `depends_on` when you're already editing it for another
+  reason; don't treat an unmigrated page elsewhere as license to add new
+  internal-name prose to the one you're writing.
 
   The evidence model is deliberately a three-page trio with one role each —
   model (`learn/evidence-and-detectability.md`), worked example

--- a/docs/_meta/topics.yaml
+++ b/docs/_meta/topics.yaml
@@ -423,12 +423,14 @@ topics:
     allowed_summaries:
       - learn/abi-series/00-product-contract.md
       - learn/abi-api-handling.md
+      - learn/assurance-methods.md
 
   data-wire-compatibility:
     canonical_page: learn/data-wire-compatibility.md
     allowed_summaries:
       - learn/abi-series/00-product-contract.md
       - learn/abi-api-handling.md
+      - learn/assurance-methods.md
 
   ownership-and-lifetime:
     canonical_page: learn/ownership-and-lifetime.md
@@ -436,6 +438,7 @@ topics:
       - learn/abi-series/00-product-contract.md
       - learn/abi-series/07-designing-for-stability.md
       - learn/abi-api-handling.md
+      - learn/assurance-methods.md
 
   compatibility-direction:
     canonical_page: learn/compatibility-direction.md
@@ -456,6 +459,7 @@ topics:
     allowed_summaries:
       - learn/abi-series/00-product-contract.md
       - learn/abi-api-handling.md
+      - learn/assurance-methods.md
 
   # Split out of Part 4 — C++ ABI Specifics (docs/AGENTS.md criterion 5: the
   # page had grown to answer more than one primary question). Part 4 keeps

--- a/docs/_meta/topics.yaml
+++ b/docs/_meta/topics.yaml
@@ -59,6 +59,7 @@ topics:
       - use/tool-modes.md
       - learn/architecture.md
       - skills-src/shared/evidence-and-depth.md
+      - learn/assurance-methods.md
 
   verdicts:
     canonical_page: learn/verdicts.md

--- a/docs/contribute/goals.md
+++ b/docs/contribute/goals.md
@@ -84,7 +84,7 @@ For each break type: what it is, how it appears in the real world, and which too
 - Comparison table: `abicheck` vs `abicc` vs `libabigail` vs `nm`-only
 - Coverage matrix showing evidence tier required (ELF-only / DWARF / Header / Runtime)
 
-**Done:** 143 example cases with per-case `README.md`; the original 74-case subset remains the release-pinned cross-tool benchmark; gap report with coverage matrix (abicheck vs ABICC vs libabigail vs `nm`); the consolidated [ABI/API Handling & Recommendations](../learn/abi-api-handling.md) guide plus the generated [Examples Encyclopedia](../reference/examples/index.md); cross-platform CMake build support for all single-library example cases.
+**Done:** 143 example cases with per-case `README.md`; the original 74-case subset remains the release-pinned cross-tool benchmark; gap report with coverage matrix (abicheck vs ABICC vs libabigail vs `nm`); the consolidated [ABI/API Compatibility](../learn/abi-api-handling.md) guide plus the generated [Examples Encyclopedia](../reference/examples/index.md); cross-platform CMake build support for all single-library example cases.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ introductory to expert — the "Where to go next" list below routes by task/
 persona instead, for whichever track (or both) a given question actually
 needs:
 
-1. **Learn the problem** — [ABI/API Handling & Recommendations](learn/abi-api-handling.md)
+1. **Learn the problem** — [ABI/API Compatibility](learn/abi-api-handling.md)
    is educational material that needs no abicheck knowledge: what ABI/API
    compatibility is, why libraries break their consumers, and how to design
    against it. Start with the [learning series](learn/abi-series/00-product-contract.md)
@@ -59,7 +59,7 @@ needs:
 
 **New to the ABI/API problem itself?**
 
-- [ABI/API Handling & Recommendations](learn/abi-api-handling.md) — the consolidated guide.
+- [ABI/API Compatibility](learn/abi-api-handling.md) — the consolidated guide.
 - [Learning series, part 0](learn/abi-series/00-product-contract.md) — compatibility as a product contract, from first principles.
 - [ABI Cheat Sheet](learn/abi-cheat-sheet.md) — which changes are safe, risky, or breaking, at a glance.
 
@@ -67,7 +67,7 @@ needs:
 
 - [Tool Comparison & Benchmarks](reference/tool-comparison.md) — abicheck vs `abidiff` vs ABICC on a pinned 74-case benchmark subset.
 - [Examples & Case Encyclopedia](reference/examples/index.md) — generated pages for the single-library cases; bundle cases live under `examples/`.
-- [ABI/API Handling & Recommendations](learn/abi-api-handling.md) — real-world scenarios with code, plus design patterns that prevent each break.
+- [ABI/API Compatibility](learn/abi-api-handling.md) — real-world scenarios with code, plus design patterns that prevent each break.
 - [Limitations](learn/limitations.md) — what abicheck does *not* catch.
 
 **Integrating into a release pipeline?**

--- a/docs/learn/abi-api-handling.md
+++ b/docs/learn/abi-api-handling.md
@@ -104,7 +104,7 @@ here for a specific problem, jump straight to the relevant part.
 | **6** | [Transitive Breaks](abi-series/06-transitive-breaks.md) | Dependency leaks, anonymous structs, type-kind swaps, reserved fields | …the symbol table looks identical but consumers still break |
 | **7** | [Designing for Stability](abi-series/07-designing-for-stability.md) | Opaque handles, Pimpl, version scripts, CI gating — with full code | …you're designing an API to evolve safely |
 | **Capstone** | [Detecting Breaks](abi-series/08-detection.md) — grouped under **Verification & Assurance**, not the numbered series | Tracking approaches, evidence each break family needs, why single-method checkers miss whole families | …you're deciding *how* to catch all of the above in CI |
-| **Capstone** | [Assurance Beyond Static Checking](assurance-methods.md) — same **Verification & Assurance** group | What to run for the part no static tool (abicheck included) can reach: consumer rebuild, binary-swap, golden/differential, wire-format, ASan/TSan tests | …a change touches behaviour, lifetime, concurrency, or a wire/storage format — anything past the static ABI/API boundary |
+| **Capstone companion** | [Assurance Beyond Static Checking](assurance-methods.md) — same **Verification & Assurance** group as the capstone above | What to run for the part no static tool (abicheck included) can reach: consumer rebuild, binary-swap, golden/differential, wire-format, ASan/TSan tests | …a change touches behaviour, lifetime, concurrency, or a wire/storage format — anything past the static ABI/API boundary |
 
 ```mermaid
 flowchart LR

--- a/docs/learn/abi-api-handling.md
+++ b/docs/learn/abi-api-handling.md
@@ -1,4 +1,4 @@
-# ABI/API Handling — A Learning Series
+# ABI/API Compatibility — A Learning Series
 
 This is the **conceptual hub** for understanding ABI/API compatibility — written
 to *teach* the subject, not just catalog it. It is the front door to a nine-part
@@ -104,6 +104,7 @@ here for a specific problem, jump straight to the relevant part.
 | **6** | [Transitive Breaks](abi-series/06-transitive-breaks.md) | Dependency leaks, anonymous structs, type-kind swaps, reserved fields | …the symbol table looks identical but consumers still break |
 | **7** | [Designing for Stability](abi-series/07-designing-for-stability.md) | Opaque handles, Pimpl, version scripts, CI gating — with full code | …you're designing an API to evolve safely |
 | **Capstone** | [Detecting Breaks](abi-series/08-detection.md) — grouped under **Verification & Assurance**, not the numbered series | Tracking approaches, evidence each break family needs, why single-method checkers miss whole families | …you're deciding *how* to catch all of the above in CI |
+| **Capstone** | [Assurance Beyond Static Checking](assurance-methods.md) — same **Verification & Assurance** group | What to run for the part no static tool (abicheck included) can reach: consumer rebuild, binary-swap, golden/differential, wire-format, ASan/TSan tests | …a change touches behaviour, lifetime, concurrency, or a wire/storage format — anything past the static ABI/API boundary |
 
 ```mermaid
 flowchart LR

--- a/docs/learn/abi-api-handling.md
+++ b/docs/learn/abi-api-handling.md
@@ -272,33 +272,18 @@ page: [Evidence & Detectability](evidence-and-detectability.md).
 
 ### Which input proves which family — and what each level actually sees
 
-The three artifact tiers above (L0–L2) are only half the picture, and *which*
-input first reveals a given change is worth seeing concretely rather than in the
-abstract. That entire story — the summary matrices (artifact **L0–L2** and
-source-scan **L3–L5**) **and** a single tiny library walked up every evidence
-level so you can watch each change appear or stay invisible — now lives on its own
-digestible, diagram-driven page:
+*Which* input first reveals a given change is worth seeing concretely, not
+just in the abstract — a single tiny library walked up every evidence level,
+watching each change appear or stay invisible, plus the full L0–L5 summary
+matrices, live on their own digestible, diagram-driven page:
 
 ➡️ **[What Each Level Sees — a level-by-level walk-through](what-each-level-sees.md)**
 
-The short version, if you only remember one row per level:
-
-| Level | Newly reveals | Blind to |
-|:-----:|---------------|----------|
-| **L0** symbols | symbol add/remove/rename, SONAME, versioning, visibility | anything that keeps the symbol name |
-| **L1** debug | struct/enum layout, offsets, vtables, calling convention | source intent, macros, public-vs-internal |
-| **L2** headers | signatures, access, `noexcept`, default-arg & `constexpr` values, public scoping | `#define` macros, inline/template **bodies** |
-| **L3** build | ABI-relevant flags & toolchain (`-std`, `_GLIBCXX_USE_CXX11_ABI`) | anything *inside* the source |
-| **L4** sources | macro / `constexpr` values, inline/template/uninstantiated bodies | the layout actually *emitted* (L1's job) |
-| **L5** graph | reachability / impact ranking | proves nothing on its own — it prioritizes |
-
-Two rules the walk-through makes concrete: **no single level sees every change**
-(a stripped-binary L0 compare calls a genuinely breaking release "clean"), and
-the **authority rule** — the artifact tiers (L0–L2) set any `BREAKING` gate, while
-the build/source tiers (L3–L5) add findings and explanation but never manufacture
-or delete a proven binary break. abicheck tracks each layer's FP/FN contribution
-as a CI gate — see
-[Evidence & Detectability → What each layer buys](evidence-and-detectability.md#what-each-layer-buys-fewer-false-negatives-and-fewer-false-positives).
+Two rules that page makes concrete: **no single level sees every change** (a
+stripped-binary L0 compare calls a genuinely breaking release "clean"), and
+the **authority rule** — the artifact tiers (L0–L2) set any `BREAKING` gate,
+while the build/source tiers (L3–L5) add findings and explanation but never
+manufacture or delete a proven binary break.
 
 ## Going deeper than artifacts: the source scan
 
@@ -330,43 +315,24 @@ depth it *actually reached*
 
 ### The L5 graph: reachability, not just structure
 
-L0–L4 answer *what changed*: a struct grew a field, a function's signature
-changed, a macro's value differs. None of them answer a different question
-that turns out to matter just as much: **can anything outside this library
-actually observe that change?** A change buried in a namespace called
-`detail`/`impl`/`internal` (by convention, never part of the documented API)
-is usually safe to ship without a version bump — *unless* some public,
-consumer-facing declaration depends on it, in which case the "internal"
-label is a fiction and the change is exactly as breaking as if it were
-public. Telling these two cases apart requires *reachability*: a graph walk
-from the public surface, not a flat list of what's public and what isn't —
-including through the easy-to-miss case where a **public inline function's
-own body calls an "internal" helper**. For any consumer that actually calls
-or otherwise ODR-uses that inline function — a consumer that never does
-emits neither the body nor its reference to the helper, so it's simply
-unaffected — the inline function's own body is what's compiled directly
-into that consumer's binary; whether a change to the "internal" helper it
-calls is breaking for such a consumer depends on what the compiler did with
-that call: if the helper stays a real out-of-line symbol the consumer links
-against, a breaking change to it is exactly as breaking as if the helper
-were public itself. If the compiler fully inlined the helper too, an
-*already-built* consumer has no runtime dependency on it at all — it keeps
-running the code that was generated at its own build time, unaffected by
-anything the library does afterward; the risk there is a *source/behavioral*
-one on the consumer's next rebuild, not a binary dependency.
+L0–L4 answer *what changed*. None of them answer a question that matters
+just as much: **can anything outside this library actually observe that
+change?** A change inside a `detail`/`impl`/`internal` namespace is usually
+safe to ship without a version bump — *unless* some public, consumer-facing
+declaration depends on it (directly, or transitively through a public inline
+function's own body calling it), in which case the "internal" label is a
+fiction and the change is exactly as breaking as a public one. Telling these
+two cases apart needs *reachability* — a graph walk from the public surface,
+not a flat public/private list.
 
-That graph is **L5**, built from structural edges (a public type embedding,
-inheriting from, or holding a field/base of an internal one) and behavioral
-edges (one declaration's body calling or referencing another) — populated
-either from header-only evidence alone (built automatically for `--depth
-headers` and above, no `--sources`/`--build-info` needed, capturing
-in-header inline/template bodies) or from a build-integrated L4 source-fact
-surface when one is supplied, with the latter adding coverage the former
-can't reach (out-of-line bodies). The full mechanics — the edge kinds, how
-nodes and edges degrade gracefully when no build/graph evidence is
-available, the `reachability_state`/`public_reachable` fields a finding
-carries, and the ADR-044 dispatcher scenario worked end to end — are on
-their own page, not restated here:
+That graph is **L5**, built from structural edges (a public type embedding
+or inheriting an internal one) and behavioral edges (one declaration's body
+calling or referencing another) — populated from header-only evidence alone
+(`--depth headers` and above) or, with more coverage, from a build-integrated
+L4 source-fact surface. The full mechanics — edge kinds, graceful
+degradation under partial evidence, the `reachability_state`/
+`public_reachable` finding fields, and a worked dispatcher scenario — are on
+their own pages, not restated here:
 
 ➡️ **[Unified Impact Assessment](impact-analysis.md)** — what reachability
 means, the finding shape, and worked examples.

--- a/docs/learn/abi-cheat-sheet.md
+++ b/docs/learn/abi-cheat-sheet.md
@@ -2,7 +2,7 @@
 
 Quick-reference card for shared-library maintainers. Scannable in 2 minutes.
 
-For deeper explanations see [ABI/API Handling & Recommendations](abi-api-handling.md) and [Verdicts](verdicts.md). To see *which evidence level* proves each row below (symbols → debug → headers → build → sources), see [What Each Level Sees](what-each-level-sees.md).
+For deeper explanations see [ABI/API Compatibility](abi-api-handling.md) and [Verdicts](verdicts.md). To see *which evidence level* proves each row below (symbols → debug → headers → build → sources), see [What Each Level Sees](what-each-level-sees.md).
 
 ---
 
@@ -73,7 +73,7 @@ These cause crashes, wrong results, or link failures in pre-compiled consumers.
 | Remove a symbol version node | Dynamic linker refuses to load; `version 'FOO_1.0' not found` | [case139](../reference/examples/case139_symbol_version_node_removed.md) |
 | Kernel struct field added (BTF) | In-tree/out-of-tree modules baked the old layout; field offsets shift | [case121](../reference/examples/case121_kernel_btf_struct_field_added.md) |
 
-See the full breaking catalog in [ABI/API Handling & Recommendations](abi-api-handling.md).
+See the full breaking catalog in [ABI/API Compatibility](abi-api-handling.md).
 
 ---
 

--- a/docs/learn/abi-series/05-linker-elf.md
+++ b/docs/learn/abi-series/05-linker-elf.md
@@ -30,11 +30,23 @@ maps every mechanism to its Windows and macOS peer.
 
 ## The second contract
 
-Above the source-level ABI sits a contract enforced by the dynamic linker:
-SONAME, visibility bits, version nodes, calling-convention attributes, and the
-TLS access model — all recorded *in the `.so`* and consulted at load time.
-You can satisfy every source-level rule from the previous pages and still break
-consumers here.
+Above the source-level ABI sits a contract enforced by the dynamic linker —
+and it's a **generic contract every platform's loader enforces in some
+form**, not an ELF-specific one: library identity, symbol visibility,
+version/interface nodes, calling-convention attributes, security-relevant
+load metadata, and the thread-local-storage access model are all facts
+*recorded in the binary itself* and consulted at load time, independent of
+which object format encodes them. You can satisfy every source-level rule
+from the previous pages and still break consumers here.
+
+This page teaches that generic contract through **ELF**, the concrete
+system with the richest tooling and the deepest abicheck coverage — SONAME,
+visibility bits, version nodes, calling-convention attributes, and the TLS
+access model, all recorded *in the `.so`* and consulted at load time. Each
+section below names its cross-platform peer inline, and the
+[PE/COFF and Mach-O parallels](#pecoff-and-mach-o-parallels) table near the
+end maps the whole set at a glance — read this page for the *mechanism*,
+that table for *"what's this called on Windows/macOS."*
 
 ---
 

--- a/docs/learn/abi-series/06-transitive-breaks.md
+++ b/docs/learn/abi-series/06-transitive-breaks.md
@@ -1,3 +1,14 @@
+---
+doc_type: tutorial
+audience:
+  - library-maintainer
+level: intermediate
+depends_on:
+  - abicheck/diff_types_abicc_parity.py
+lifecycle: active
+generated: false
+---
+
 # Part 6 — Subtle & Transitive Breaks
 
 > **Series navigation:** [0. Product Contract](00-product-contract.md) ·
@@ -139,7 +150,7 @@ pattern: v1 ships `__reserved1` and `__reserved2` at defined offsets; v2 renames
 them to `priority` and `max_retries` with the *same types and offsets*.
 
 !!! note "How abicheck sees it"
-    `_diff_reserved_fields` recognizes the naming convention (`__reserved`,
+    abicheck recognizes the naming convention (`__reserved`,
     `_reserved`, `__pad`, `_unused`) and classifies the rename → 🟢
     **COMPATIBLE**. The catch the tool *cannot* verify: there is no way to
     prove no consumer ever wrote to the slot — the pattern's safety rests on a

--- a/docs/learn/abi-series/08-detection.md
+++ b/docs/learn/abi-series/08-detection.md
@@ -200,7 +200,8 @@ The honest boundary is documented in
 [Limitations](../limitations.md) and
 [What ABI tools cannot prove](../evidence-and-detectability.md#5-what-abi-tools-cannot-prove);
 treat static ABI checking as the part of release safety you can automate
-*exhaustively*, not as all of it.
+*exhaustively*, not as all of it. [Assurance Beyond Static Checking](../assurance-methods.md)
+names, method by method, what to run for the rest.
 
 ---
 
@@ -227,6 +228,10 @@ verdict and minimum evidence tier:
 ## Where to go next
 
 - Back to the [series hub](../abi-api-handling.md) for the other parts.
+- [Assurance Beyond Static Checking](../assurance-methods.md) — this page's
+  direct sibling in the Verification & Assurance group: what to run for the
+  part §3 says no static tool (abicheck included) can reach — behaviour,
+  wire/storage compatibility, lifetime, and concurrency contracts.
 - [Evidence & Detectability](../evidence-and-detectability.md) — the full
   per-source capability matrix this page summarizes.
 - [Choose Your Workflow](../../start/choose-your-workflow.md) — turn the

--- a/docs/learn/abi-series/abi-in-5-minutes.md
+++ b/docs/learn/abi-series/abi-in-5-minutes.md
@@ -46,7 +46,7 @@ writes the wrong bytes. The result is a crash, or worse, quietly corrupted data.
 
 ## API vs ABI, in one sentence each
 
-> **Full definitions:** [ABI/API Handling](../abi-api-handling.md) is the
+> **Full definitions:** [ABI/API Compatibility](../abi-api-handling.md) is the
 > canonical page for these terms; the two bullets below are the deliberately
 > compressed, one-sentence version this five-minute on-ramp needs.
 

--- a/docs/learn/abi-series/glossary.md
+++ b/docs/learn/abi-series/glossary.md
@@ -1,7 +1,7 @@
 # Glossary
 
 Quick definitions for the recurring terms in the
-[ABI/API Handling series](../abi-api-handling.md). Each entry links to where the
+[ABI/API Compatibility series](../abi-api-handling.md). Each entry links to where the
 concept is developed in full.
 
 | Term | Meaning |

--- a/docs/learn/assurance-methods.md
+++ b/docs/learn/assurance-methods.md
@@ -100,8 +100,13 @@ different":
   why no single static tool is enough on its own.
 - [Limitations](limitations.md) and
   [Evidence & Detectability §5](evidence-and-detectability.md#5-what-abi-tools-cannot-prove)
-  — the exact, itemized boundary of what static checking cannot see, which is
-  what motivates every row in the table above.
+  — the exact, itemized boundary of what *artifact-only* (binary/header, L0-L2)
+  comparison cannot see. Several of those rows (macro-only changes, an inline
+  body, an uninstantiated template) are exactly what L3/L4 source-replay
+  evidence closes — see the row above — so the boundary that motivates *this*
+  page's table is the one no static tool can cross: pure behavioral/semantic
+  and ownership/lifetime/thread-safety changes, which stay outside static
+  checking at any evidence tier.
 - [CI Gating Pipeline](../use/ci-gating.md) — wiring abicheck's own static
   check into a release pipeline; the assurance methods above are the
   complementary jobs that sit alongside it, not inside it.

--- a/docs/learn/assurance-methods.md
+++ b/docs/learn/assurance-methods.md
@@ -9,6 +9,7 @@ summarizes:
   - data-wire-compatibility
   - ownership-and-lifetime
   - concurrency-and-initialization
+  - evidence-model
 lifecycle: active
 generated: false
 ---
@@ -72,17 +73,19 @@ different":
    contract-specific method (ASan or TSan, chosen by what the change touches)
    covers structurally different failure classes with each addition, not
    diminishing returns on the same one.
-3. **None of this replaces static checking — it's additive.** Static
-   artifact/header diffing is the only method in this table that is
-   *exhaustive over the evidence it was given* — every declaration and
-   symbol in the captured snapshot is compared, without needing a
-   hand-written test to exercise the right path first. That's narrower than
-   "exhaustive over the shipped ABI/API surface": the
+3. **None of this replaces static checking — it's additive.** abicheck
+   itself is the only method in this table that is *exhaustive over the
+   evidence it was given* — every declaration and symbol in the captured
+   snapshot is compared, without needing a hand-written test to exercise the
+   right path first. That's narrower than "exhaustive over the shipped
+   ABI/API surface": a run limited to artifact/header evidence (L0-L2) has
+   the real, structural blind spots the
    [detectability matrix](evidence-and-detectability.md#5-what-abi-tools-cannot-prove)
-   this same page opens by citing lists real, structural blind spots even
-   with full evidence (macro values, inline/template bodies, uninstantiated
-   templates), and incomplete debug info or headers narrows it further
-   still. The other methods are necessarily *sampling* on top of that —
+   this same page opens by citing lists — macro values, inline/template
+   bodies, uninstantiated templates — which is exactly what build/source
+   evidence (L3/L4) exists to close, per the row above; incomplete debug
+   info or headers narrows even the L0-L2 picture further still. The other
+   methods are necessarily *sampling* on top of whichever tier you ran —
    a golden test proves the scenarios it encodes, an ASan run proves the
    lifecycle it exercises. Losing the systematic layer to "we have
    behavioral tests" reopens exactly the blind spot

--- a/docs/learn/assurance-methods.md
+++ b/docs/learn/assurance-methods.md
@@ -4,6 +4,11 @@ audience:
   - library-maintainer
   - ci-owner
 level: intermediate
+summarizes:
+  - behavioral-compatibility
+  - data-wire-compatibility
+  - ownership-and-lifetime
+  - concurrency-and-initialization
 lifecycle: active
 generated: false
 ---
@@ -35,13 +40,13 @@ for naming which kind of compatibility you're promising in the first place).
 
 | Method | What it proves | What it does *not* prove |
 |---|---|---|
-| **Static artifact/header diff** (abicheck itself) | The shipped ABI facts and the declared source API held — everything [Detecting Breaks](abi-series/08-detection.md) covers | Anything about how a consumer actually uses the library, or what the code *does* at runtime |
+| **Static artifact/header/source diff** (abicheck itself, across whichever evidence tiers you give it) | The shipped ABI facts, the declared source API, and — only with build/source evidence attached (L3/L4) — the source-only facts (macro values, inline/template bodies) that a header-only run cannot see; everything [Detecting Breaks](abi-series/08-detection.md) covers, gated by which tier you fed it | Anything about how a consumer actually uses the library, or what the code *does* at runtime |
 | **Consumer rebuild test** | Source compatibility for the specific consumer(s) rebuilt — their code still compiles and links against the new headers | Binary compatibility for a consumer that doesn't rebuild; code paths the consumer's own build doesn't exercise |
 | **Binary-swap test** (an old, already-built consumer run against the new library) | Backward *binary* compatibility for that consumer's actual, exercised usage — the promise a prebuilt-consumer release most needs to keep | Code paths the consumer binary doesn't call; says nothing about a *different* consumer's usage |
 | **Reverse swap** (a new consumer built and run against the *old* library) | Forward/downgrade compatibility — relevant when an older library build is still shipped or pinned longer than the newest consumer | Same exercised-paths limit as binary-swap, in the other direction |
 | **Host × plugin version matrix** | The two-sided contract a plugin/host relationship depends on, across the version combinations you actually support ([Plugin Systems](../use/plugin-systems.md), [Consumer Models](consumer-models.md)) | Any combination outside the matrix — an unlisted host/plugin pair is unverified, not verified-compatible |
 | **Oldest-supported-OS/runtime load test** | The deployment floor: does the binary even load and link on the oldest target you claim to support ([Dependency & Runtime Floors](dependency-floors.md)) | Correctness beyond "it loaded" — a clean load is necessary, not sufficient |
-| **Golden / differential output tests** | General output/semantic behavioral compatibility for the specific scenarios the fixtures cover — the one method here aimed at behaviour broadly, rather than one specific contract (lifetime, concurrency, wire format) the way the rows below it are | Any scenario the fixture set doesn't exercise; a passing suite is a statement about coverage, not universal correctness |
+| **Golden / differential output tests** | General [output/semantic behavioral compatibility](behavioral-compatibility.md) for the specific scenarios the fixtures cover — the one method here aimed at behaviour broadly, rather than one specific contract (lifetime, concurrency, wire format) the way the rows below it are | Any scenario the fixture set doesn't exercise; a passing suite is a statement about coverage, not universal correctness |
 | **Old-reader/new-writer and new-reader/old-writer fixture tests** | Wire, storage, and serialization-format compatibility — the [data/wire dimension](data-wire-compatibility.md) static ABI/API checking cannot see at all | Schema paths or field combinations the fixtures don't exercise |
 | **ASan-instrumented lifecycle tests** | [Ownership/lifetime contract](ownership-and-lifetime.md) violations across the library boundary — double-free, use-after-free, cross-allocator frees | Only what the exercised lifecycle actually triggers; an untested destruction order stays unverified |
 | **TSan / stress / reentrancy tests** | [Concurrency and initialization contract](concurrency-and-initialization.md) violations — data races, unsafe reentrancy, ordering assumptions | Requires a workload that actually contends; a single-threaded run through the same suite proves nothing about the concurrency contract |

--- a/docs/learn/assurance-methods.md
+++ b/docs/learn/assurance-methods.md
@@ -41,7 +41,7 @@ for naming which kind of compatibility you're promising in the first place).
 | **Reverse swap** (a new consumer built and run against the *old* library) | Forward/downgrade compatibility — relevant when an older library build is still shipped or pinned longer than the newest consumer | Same exercised-paths limit as binary-swap, in the other direction |
 | **Host × plugin version matrix** | The two-sided contract a plugin/host relationship depends on, across the version combinations you actually support ([Plugin Systems](../use/plugin-systems.md), [Consumer Models](consumer-models.md)) | Any combination outside the matrix — an unlisted host/plugin pair is unverified, not verified-compatible |
 | **Oldest-supported-OS/runtime load test** | The deployment floor: does the binary even load and link on the oldest target you claim to support ([Dependency & Runtime Floors](dependency-floors.md)) | Correctness beyond "it loaded" — a clean load is necessary, not sufficient |
-| **Golden / differential output tests** | Behavioral compatibility for the specific scenarios the fixtures cover — the only method here that observes *behaviour* at all | Any scenario the fixture set doesn't exercise; a passing suite is a statement about coverage, not universal correctness |
+| **Golden / differential output tests** | General output/semantic behavioral compatibility for the specific scenarios the fixtures cover — the one method here aimed at behaviour broadly, rather than one specific contract (lifetime, concurrency, wire format) the way the rows below it are | Any scenario the fixture set doesn't exercise; a passing suite is a statement about coverage, not universal correctness |
 | **Old-reader/new-writer and new-reader/old-writer fixture tests** | Wire, storage, and serialization-format compatibility — the [data/wire dimension](data-wire-compatibility.md) static ABI/API checking cannot see at all | Schema paths or field combinations the fixtures don't exercise |
 | **ASan-instrumented lifecycle tests** | [Ownership/lifetime contract](ownership-and-lifetime.md) violations across the library boundary — double-free, use-after-free, cross-allocator frees | Only what the exercised lifecycle actually triggers; an untested destruction order stays unverified |
 | **TSan / stress / reentrancy tests** | [Concurrency and initialization contract](concurrency-and-initialization.md) violations — data races, unsafe reentrancy, ordering assumptions | Requires a workload that actually contends; a single-threaded run through the same suite proves nothing about the concurrency contract |
@@ -69,11 +69,18 @@ different":
    diminishing returns on the same one.
 3. **None of this replaces static checking — it's additive.** Static
    artifact/header diffing is the only method in this table that is
-   *exhaustive* over the shipped ABI/API surface without needing a
-   hand-written test to exercise the right path first. The other methods are
-   necessarily sampling — a golden test proves the scenarios it encodes, an
-   ASan run proves the lifecycle it exercises. Losing the exhaustive layer to
-   "we have behavioral tests" reopens exactly the blind spot
+   *exhaustive over the evidence it was given* — every declaration and
+   symbol in the captured snapshot is compared, without needing a
+   hand-written test to exercise the right path first. That's narrower than
+   "exhaustive over the shipped ABI/API surface": the
+   [detectability matrix](evidence-and-detectability.md#5-what-abi-tools-cannot-prove)
+   this same page opens by citing lists real, structural blind spots even
+   with full evidence (macro values, inline/template bodies, uninstantiated
+   templates), and incomplete debug info or headers narrows it further
+   still. The other methods are necessarily *sampling* on top of that —
+   a golden test proves the scenarios it encodes, an ASan run proves the
+   lifecycle it exercises. Losing the systematic layer to "we have
+   behavioral tests" reopens exactly the blind spot
    [Detecting Breaks §3](abi-series/08-detection.md#3-why-an-abidiff-or-abicc-class-checker-is-not-sufficient)
    describes for single-method static checkers, just moved to a different
    axis: sampled coverage instead of missing evidence tiers.

--- a/docs/learn/assurance-methods.md
+++ b/docs/learn/assurance-methods.md
@@ -1,0 +1,92 @@
+---
+doc_type: explanation
+audience:
+  - library-maintainer
+  - ci-owner
+level: intermediate
+lifecycle: active
+generated: false
+---
+
+# Assurance Beyond Static Checking: What Each Verification Method Actually Proves
+
+> **Series navigation:** [Detecting Breaks](abi-series/08-detection.md) covers
+> *why* one static method is never enough and what evidence each break family
+> needs. This page picks up exactly where that one stops: **static artifact
+> comparison — abicheck included — cannot prove behaviour.** So what do you
+> run instead, or alongside it, for the parts it structurally cannot reach?
+
+[Evidence & Detectability §5](evidence-and-detectability.md#5-what-abi-tools-cannot-prove)
+and [Limitations](limitations.md) both name the boundary: macro-only changes,
+inline/template bodies, `constexpr` semantics, and — the big one — anything
+that is *behavioral* rather than structural (same signature and layout,
+different meaning) are out of scope for any artifact diff. That boundary is
+not a gap to be embarrassed about; it is a reason to run a **second kind of
+check**, deliberately chosen for what it *can* prove, next to static checking
+rather than instead of it.
+
+## The assurance methods, and what each one actually proves
+
+No single method below is a superset of the others — each observes a
+genuinely different thing, the same way [the evidence layers](evidence-and-detectability.md#0-the-five-sources-of-information)
+do for static checking. Pick the ones that match the promises your release
+actually makes (see [Part 0 §2](abi-series/00-product-contract.md#2-compatibility-is-not-one-question-name-which-kind-you-mean)
+for naming which kind of compatibility you're promising in the first place).
+
+| Method | What it proves | What it does *not* prove |
+|---|---|---|
+| **Static artifact/header diff** (abicheck itself) | The shipped ABI facts and the declared source API held — everything [Detecting Breaks](abi-series/08-detection.md) covers | Anything about how a consumer actually uses the library, or what the code *does* at runtime |
+| **Consumer rebuild test** | Source compatibility for the specific consumer(s) rebuilt — their code still compiles and links against the new headers | Binary compatibility for a consumer that doesn't rebuild; code paths the consumer's own build doesn't exercise |
+| **Binary-swap test** (an old, already-built consumer run against the new library) | Backward *binary* compatibility for that consumer's actual, exercised usage — the promise a prebuilt-consumer release most needs to keep | Code paths the consumer binary doesn't call; says nothing about a *different* consumer's usage |
+| **Reverse swap** (a new consumer built and run against the *old* library) | Forward/downgrade compatibility — relevant when an older library build is still shipped or pinned longer than the newest consumer | Same exercised-paths limit as binary-swap, in the other direction |
+| **Host × plugin version matrix** | The two-sided contract a plugin/host relationship depends on, across the version combinations you actually support ([Plugin Systems](../use/plugin-systems.md), [Consumer Models](consumer-models.md)) | Any combination outside the matrix — an unlisted host/plugin pair is unverified, not verified-compatible |
+| **Oldest-supported-OS/runtime load test** | The deployment floor: does the binary even load and link on the oldest target you claim to support ([Dependency & Runtime Floors](dependency-floors.md)) | Correctness beyond "it loaded" — a clean load is necessary, not sufficient |
+| **Golden / differential output tests** | Behavioral compatibility for the specific scenarios the fixtures cover — the only method here that observes *behaviour* at all | Any scenario the fixture set doesn't exercise; a passing suite is a statement about coverage, not universal correctness |
+| **Old-reader/new-writer and new-reader/old-writer fixture tests** | Wire, storage, and serialization-format compatibility — the [data/wire dimension](data-wire-compatibility.md) static ABI/API checking cannot see at all | Schema paths or field combinations the fixtures don't exercise |
+| **ASan-instrumented lifecycle tests** | [Ownership/lifetime contract](ownership-and-lifetime.md) violations across the library boundary — double-free, use-after-free, cross-allocator frees | Only what the exercised lifecycle actually triggers; an untested destruction order stays unverified |
+| **TSan / stress / reentrancy tests** | [Concurrency and initialization contract](concurrency-and-initialization.md) violations — data races, unsafe reentrancy, ordering assumptions | Requires a workload that actually contends; a single-threaded run through the same suite proves nothing about the concurrency contract |
+
+## Reading the table as a decision, not a checklist
+
+Three practical rules follow directly from "each method proves something
+different":
+
+1. **Match the method to the promise, not the other way around.** A release
+   that only promises source compatibility (consumers always rebuild) gets
+   most of its value from consumer rebuild tests plus static header diffing;
+   binary-swap testing is spending effort on a promise nobody made. A release
+   shipping prebuilt binaries to consumers that don't rebuild needs the
+   binary-swap test to be the release gate, not an afterthought — that is
+   exactly the promise static ABI checking alone cannot fully stand in for,
+   since it proves the *binary contract* held, not that the specific,
+   already-compiled consumer you ship to still works.
+2. **A method's "what it does not prove" column is not a defect in the
+   method — it's the reason the *other* rows exist.** No single row is meant
+   to close every gap; the set is meant to be composed. A CI pipeline that
+   runs static checking plus one behavioral method (golden tests) plus one
+   contract-specific method (ASan or TSan, chosen by what the change touches)
+   covers structurally different failure classes with each addition, not
+   diminishing returns on the same one.
+3. **None of this replaces static checking — it's additive.** Static
+   artifact/header diffing is the only method in this table that is
+   *exhaustive* over the shipped ABI/API surface without needing a
+   hand-written test to exercise the right path first. The other methods are
+   necessarily sampling — a golden test proves the scenarios it encodes, an
+   ASan run proves the lifecycle it exercises. Losing the exhaustive layer to
+   "we have behavioral tests" reopens exactly the blind spot
+   [Detecting Breaks §3](abi-series/08-detection.md#3-why-an-abidiff-or-abicc-class-checker-is-not-sufficient)
+   describes for single-method static checkers, just moved to a different
+   axis: sampled coverage instead of missing evidence tiers.
+
+## Where to go next
+
+- [Detecting Breaks](abi-series/08-detection.md) — the static-checking side
+  of this same question: which evidence tier catches which break family, and
+  why no single static tool is enough on its own.
+- [Limitations](limitations.md) and
+  [Evidence & Detectability §5](evidence-and-detectability.md#5-what-abi-tools-cannot-prove)
+  — the exact, itemized boundary of what static checking cannot see, which is
+  what motivates every row in the table above.
+- [CI Gating Pipeline](../use/ci-gating.md) — wiring abicheck's own static
+  check into a release pipeline; the assurance methods above are the
+  complementary jobs that sit alongside it, not inside it.

--- a/docs/learn/build-profile-comparability.md
+++ b/docs/learn/build-profile-comparability.md
@@ -73,7 +73,7 @@ addition" / "broken"), not folded into it:
    the resulting report is stamped `assurance: none` everywhere so nobody
    downstream mistakes it for an ordinary, trustworthy result. This
    opt-out is **not available for a directory/package (release) fan-out**
-   — `_reject_set_input_flags()` rejects it outright there — so a
+   — the release fan-out path rejects it outright — so a
    not-comparable library inside a release fan-out has no escape hatch;
    compare that one library on its own instead.
 
@@ -95,7 +95,7 @@ went through an L2 frontend at all (a symbols-only dump, or a pre-contract
 baseline) has no `profile_fingerprint` to disagree with, and the gate does
 not fail the comparison on that axis. When exactly one side is missing any
 one of the three, the report is stamped `contract_coverage: partial`
-(`checker._contract_coverage_status`) — an explicit signal that axis was
+— an explicit signal that axis was
 never actually checked, not silently treated as verified. When **both**
 sides are missing the same axis, there's nothing to mark: neither side
 asserted that fact in the first place, so there's no disagreement to
@@ -107,7 +107,7 @@ extractions*, not a guarantee that every comparison checked comparability.
 
 ## What actually gets fingerprinted
 
-abicheck's comparability gate (`comparability.py`, ADR-050 D1/D2) doesn't
+abicheck's comparability gate (ADR-050 D1/D2) doesn't
 guess at "did the build environment change" impressionistically — it hashes
 two separate, named fingerprints out of every dump that went through an L2
 header/AST frontend, and refuses to produce a verdict when they disagree
@@ -120,26 +120,27 @@ the snapshot:
 |-------|--------------|
 | `compiler_family` | GCC vs. Clang vs. MSVC — different name-mangling and layout corner cases |
 | `compiler_version` | Toolchain version — builtin macro sets, default flag behavior can shift release to release |
-| `abi_dialect` | The GNU vs. MSVC compiler-driver mode (`_stamp_ast_parser()`/`_resolve_compiler_binary()` set exactly `"gnu"` or `"msvc"`) — not the libstdc++ dual-ABI setting; two GCC extractions stay `abi_dialect="gnu"` regardless of `_GLIBCXX_USE_CXX11_ABI`, which is only pinned when that macro is explicitly passed and reaches the fingerprint through the `macro_ops` row below ([case104](../reference/examples/case104_glibcxx_dual_abi_flip.md)) |
+| `abi_dialect` | The GNU vs. MSVC compiler-driver mode (the compiler-mode resolver sets exactly `"gnu"` or `"msvc"`) — not the libstdc++ dual-ABI setting; two GCC extractions stay `abi_dialect="gnu"` regardless of `_GLIBCXX_USE_CXX11_ABI`, which is only pinned when that macro is explicitly passed and reaches the fingerprint through the `macro_ops` row below ([case104](../reference/examples/case104_glibcxx_dual_abi_flip.md)) |
 | `language_standard` | `-std=c++17` vs. `-std=c++20` — different implicit behavior, different library surface |
-| `target_triple` | Reserved for architecture/OS/environment. **Not populated by either production call site today** (`compute_extraction_contract()` defaults it to empty, and neither `dumper_contract.py`'s real-dump path nor the `--dump-manifest` dry-run path passes a value) — always empty on a real dump, so it never contributes a real mismatch on its own |
+| `target_triple` | Reserved for architecture/OS/environment. **Not populated by either production call site today** (the extraction-contract builder defaults it to empty, and neither the real-dump path nor the `--dump-manifest` dry-run path passes a value) — always empty on a real dump, so it never contributes a real mismatch on its own |
 | `pointer_width` | Reserved for 32-bit vs. 64-bit. Same unpopulated-today status as `target_triple` |
 | `endianness` | Reserved for byte order. Same unpopulated-today status as `target_triple` |
 | `macro_ops` | Which `-D`/`-U` macros were in effect — conditional compilation changes what's even declared |
-| `pass_through_flags` | ABI-relevant compiler flags forwarded as-is. Today `pass_through_flags_from_tokens()` recognizes only `-include <path>` — the one currently-known must-handle repeatable, order-sensitive frontend flag; other flags (e.g. `-fvisibility=`, `-fshort-enums`) are not yet classified into this field and are simply omitted rather than mis-hashed |
-| `include_sequence` / `header_sequence` | Order and *declared-slot* identity of the include directories/headers fed through the dedicated `extra_includes`/manifest `includes` mechanism (never absolute path shape for those, so a two-checkout compare's differently-nested old/new sides still fingerprint identically) — narrower than "every resolved `-I`/`-isystem`": a raw `-I`/`-isystem` token embedded in `gcc_options` rather than passed through the dedicated mechanism is not collected into this field today, so replacing what a raw compiler flag points at can leave it unchanged. A *labeled* or project-owned slot's identity is genuinely pinned (by its label, or by which declared header it owns); an unlabeled, non-project-owned ("external") slot is only pinned by content when `compute_extraction_contract()` is given `depfile_resolved_paths` — today's production call site, `dumper_contract._attach_extraction_contract()`, never passes that parameter, so `_external_slot_token()` hashes an empty file list there, and swapping one external include directory for another at the same position leaves the fingerprint unchanged |
+| `pass_through_flags` | ABI-relevant compiler flags forwarded as-is. Today only `-include <path>` is recognized — the one currently-known must-handle repeatable, order-sensitive frontend flag; other flags (e.g. `-fvisibility=`, `-fshort-enums`) are not yet classified into this field and are simply omitted rather than mis-hashed |
+| `include_sequence` / `header_sequence` | Order and *declared-slot* identity of the include directories/headers fed through the dedicated `extra_includes`/manifest `includes` mechanism (never absolute path shape for those, so a two-checkout compare's differently-nested old/new sides still fingerprint identically) — narrower than "every resolved `-I`/`-isystem`": a raw `-I`/`-isystem` token embedded in `gcc_options` rather than passed through the dedicated mechanism is not collected into this field today, so replacing what a raw compiler flag points at can leave it unchanged. A *labeled* or project-owned slot's identity is genuinely pinned (by its label, or by which declared header it owns); an unlabeled, non-project-owned ("external") slot is only pinned by content when the extraction-contract builder is given resolved dependency-file paths — today's production real-dump path never passes them, so an unlabeled external slot hashes an empty file list there, and swapping one external include directory for another at the same position leaves the fingerprint unchanged |
 | `frontend_context_kind` | Appended only for a DPC++-capable frontend (a SYCL host/device split); absent from the fingerprint on an ordinary clang/castxml dump |
 
 This table is a narrative summary, not the field list's fact owner — the
-exact, current set is `abicheck/comparability.py`'s `PROFILE_FIELD_KEYS`
-(plus the conditional `frontend_context_kind` addition); check there directly
+exact, current set is owned by abicheck's own comparability module (plus
+the conditional `frontend_context_kind` addition); see this page's
+`depends_on` front matter for exactly which file, and check it directly
 before relying on which flags are actually pinned today.
 
 **`scope_fingerprint`** — the *declared surface* being compared: which
 public headers and header directories were in scope, and — for a
 manifest-driven multi-TU extraction — which translation units contributed.
 One deliberate exception: when a side declares exactly *one* header or
-exactly one public-header directory, `_compute_scope_fields()` collapses
+exactly one public-header directory, the scope-fingerprint builder collapses
 its identity to a fixed `<single-header>`/`<single-header-dir>` sentinel
 rather than the real name — renaming `foo.h` to `bar.h` while staying a
 single-header dump leaves `scope_fingerprint` completely unchanged. The
@@ -161,7 +162,7 @@ pair read as not comparable.
 The split matters: two dumps can legitimately have different
 `scope_fingerprint`s (you scoped OLD to a smaller header set than NEW,
 deliberately) while still sharing a `profile_fingerprint` — that's a scoping
-decision, not an environment mismatch, and `comparability.py`'s own
+decision, not an environment mismatch, and the gate's own
 superset-growth check (§ below) treats a scope that only *grew* between OLD
 and NEW as legitimate rather than incomparable. A `profile_fingerprint`
 mismatch is the one that means "this isn't the same kind of build at all."
@@ -171,7 +172,7 @@ mismatch is the one that means "this isn't the same kind of build at all."
 Not every fingerprint mismatch is toolchain noise to be rejected — some are
 exactly the *finding* a check like this exists to surface. The gate
 distinguishes them from genuine incomparability with four narrow,
-evidence-gated carve-outs (`_unexplained_profile_fields()`), all deliberately
+evidence-gated carve-outs, all deliberately
 conservative and mutually disjoint — they widen the set of comparisons the
 gate allows, never the set it silently trusts, and they compose (a release
 combining two independently-sanctioned deltas at once, e.g. a header

--- a/docs/learn/class-layout-abi.md
+++ b/docs/learn/class-layout-abi.md
@@ -101,13 +101,13 @@ verdict bucket follows the [policy partition](../reference/change-kinds.md):
 | Change alignment or packing | BREAKING | `type_alignment_changed`, `struct_packing_changed` | L1 | [case42](../reference/examples/case42_type_alignment_changed.md), [case56](../reference/examples/case56_struct_packing_changed.md) |
 | Reorder bases / insert a base / change virtual inheritance | BREAKING | `type_base_changed`, `base_class_position_changed`, `base_class_virtual_changed` | L1 | [case37](../reference/examples/case37_base_class.md), [case60](../reference/examples/case60_base_class_position_changed.md) |
 | **A base subobject *moves* (e.g. EBO lost)** | BREAKING | **`base_class_offset_changed`** | L1 | **[case140](../reference/examples/case140_empty_base_optimization_lost.md)** |
-| Non-polymorphic class gains its first virtual → vptr prepended | BREAKING | `vptr_introduced` | L1 (DWARF) / L2 *(descriptor)* | unit-tested (`test_diff_layout.py`) |
+| Non-polymorphic class gains its first virtual → vptr prepended | BREAKING | `vptr_introduced` | L1 (DWARF) / L2 *(descriptor)* | unit-tested, no public example case yet |
 | Add / remove / reorder a virtual function | BREAKING | `virtual_method_added`, `func_virtual_added`/`func_virtual_removed`, `type_vtable_changed` | L1 | [case38](../reference/examples/case38_virtual_methods.md), [case68](../reference/examples/case68_virtual_method_added.md) |
 | **Vtable slot count changes — from a *stripped* binary** | BREAKING | **`vtable_slot_count_changed`** | **L0 (ELF symbol size)** | **[case142](../reference/examples/case142_vtable_slot_count_binary_only.md)** |
-| Inheritance *shape* changes *by enough to resize `_ZTI`* — from a stripped binary | BREAKING | `rtti_inheritance_changed` | L0 (`_ZTI` size) | unit-tested (`test_diff_elf_layout.py`) |
+| Inheritance *shape* changes *by enough to resize `_ZTI`* — from a stripped binary | BREAKING | `rtti_inheritance_changed` | L0 (`_ZTI` size) | unit-tested, no public example case yet |
 | Type stops being trivially-copyable → by-value calling conv. flips | BREAKING | `trivially_copyable_lost`, `value_abi_trait_changed` | L2 *(descriptor)* / L1 | [case69](../reference/examples/case69_trivial_to_nontrivial.md) |
-| Type stops being standard-layout (`offsetof`/C-interop lost) | COMPATIBLE_WITH_RISK | `standard_layout_lost` | L2 *(descriptor)* | unit-tested (`test_diff_layout.py`) |
-| `dsize` changes at stable `sizeof` (tail-padding reuse) | COMPATIBLE_WITH_RISK | `tail_padding_reuse_changed` | L2 *(descriptor)* | unit-tested (`test_diff_layout.py`) |
+| Type stops being standard-layout (`offsetof`/C-interop lost) | COMPATIBLE_WITH_RISK | `standard_layout_lost` | L2 *(descriptor)* | unit-tested, no public example case yet |
+| `dsize` changes at stable `sizeof` (tail-padding reuse) | COMPATIBLE_WITH_RISK | `tail_padding_reuse_changed` | L2 *(descriptor)* | unit-tested, no public example case yet |
 | Change a field's / method's access specifier | API_BREAK | `field_access_changed`, `method_access_changed` | L2 (headers) | [case34](../reference/examples/case34_access_level.md) |
 | RTTI / vtable visibility changes across DSOs | BREAKING | `type_visibility_changed` | L1 (DWARF attrs) | — |
 | `[[no_unique_address]]` overlap gained/lost | BREAKING | *(no dedicated kind — see below)* `type_size_changed` / `type_field_offset_changed` | L1 | [case117](../reference/examples/case117_no_unique_address.md) |

--- a/docs/learn/class-layout-abi.md
+++ b/docs/learn/class-layout-abi.md
@@ -32,7 +32,7 @@ It complements two neighbouring pages:
 
 ## ABI vs API, and where "layout" sits
 
-> **Full definitions:** [ABI/API Handling](abi-api-handling.md) is the
+> **Full definitions:** [ABI/API Compatibility](abi-api-handling.md) is the
 > canonical page for what these terms mean generally; the two bullets below
 > are the *layout-specific* restatement this page needs to talk about class
 > objects specifically.

--- a/docs/learn/class-layout-abi.md
+++ b/docs/learn/class-layout-abi.md
@@ -1,3 +1,18 @@
+---
+doc_type: explanation
+audience:
+  - library-maintainer
+level: advanced
+depends_on:
+  - abicheck/diff_types.py
+  - abicheck/diff_platform.py
+  - abicheck/diff_layout.py
+  - abicheck/diff_elf_layout.py
+  - abicheck/dumper_clang.py
+lifecycle: active
+generated: false
+---
+
 # Class Layout ABI & API: Problems and Detection
 
 This guide is the single place that explains **what a C++ class-layout change
@@ -113,7 +128,15 @@ verdict bucket follows the [policy partition](../reference/change-kinds.md):
 
 ## How abicheck reads layout: the three detector tiers
 
-### 1. Coarse type/struct diff — `diff_types.py`, `diff_platform.py` (L1/L2)
+> Each tier below is a distinct comparison pass over a distinct slice of the
+> layout evidence — worth knowing as *tiers*, since which one applies is what
+> decides whether a given change is detectable at all with the evidence you
+> supplied. The exact modules that implement each tier are named in this
+> page's own front matter (`depends_on`) rather than inline here, so a
+> reader learning *what's detectable* isn't also asked to track Python file
+> names.
+
+### 1. Coarse type/struct diff (L1/L2)
 
 Compares `sizeof`, `alignof`, the field list (name, type, offset, bit-field
 width), the base list, and the vtable list between the two snapshots. This is
@@ -121,14 +144,14 @@ the workhorse for the common breaks: `type_size_changed`,
 `type_field_offset_changed`, `type_field_type_changed`, `type_base_changed`,
 `type_vtable_changed`, `struct_packing_changed`, `type_alignment_changed`.
 
-### 2. Fine-grained layout descriptor — `diff_layout.py` (L1/L2)
+### 2. Fine-grained layout descriptor (L1/L2)
 
 A class has moving parts the coarse `sizeof` diff under-represents. The
 `RecordType` model carries an optional **layout descriptor**:
 
 | Field | Meaning | Populated by |
 |-------|---------|--------------|
-| `base_offsets` | each base subobject's bit offset | DWARF and castxml directly; **direct-clang only with** the optional `ABICHECK_CLANG_LAYOUT_TOOL` pass (`dumper_clang.py` never populates it on its own) |
+| `base_offsets` | each base subobject's bit offset | DWARF and castxml directly; **direct-clang only with** the optional `ABICHECK_CLANG_LAYOUT_TOOL` pass — the direct-clang AST backend does not populate it on its own |
 | `vptr_offset_bits` | vtable-pointer offset | **DWARF: measured** — read from the artificial vptr member's own `DW_AT_data_member_location`, with inherited offsets propagated, and `0` used only as a last-resort fallback. **Both header backends: derived**, `0` whenever the class has a vtable — a polymorphism witness, not a measured offset |
 | `data_size_bits` | `dsize` — bytes the members occupy, excl. tail padding | only the optional `ABICHECK_CLANG_LAYOUT_TOOL` companion pass |
 | `is_standard_layout` | standard-layout trait | direct-clang AST only |
@@ -148,7 +171,7 @@ counterpart of the triviality question is a *separate* finding on a separate
 path: `value_abi_trait_changed`, inferred from DIE structure rather than read
 from a trait (see [Part 4 §6](abi-series/04-cpp-abi.md#6-trivial-non-trivial-the-invisible-calling-convention-flip)).
 
-From these `diff_layout.py` emits `base_class_offset_changed` (a base moved),
+From these, abicheck emits `base_class_offset_changed` (a base moved),
 `vptr_introduced` (became polymorphic), `trivially_copyable_lost`,
 `standard_layout_lost`, and `tail_padding_reuse_changed`.
 
@@ -159,7 +182,7 @@ dump, or an older snapshot whose schema predates these fields) therefore never
 has no layout evidence at all, abicheck emits the calm, non-escalating
 `layout_unverifiable` instead of guessing.
 
-### 3. Binary-only C++ layout — `diff_elf_layout.py` (L0)
+### 3. Binary-only C++ layout (L0)
 
 The biggest *narrowing* of the symbol-only blind spot — narrowing, not closing;
 see the limits below. The Itanium ABI fixes the on-disk size of two emitted

--- a/docs/learn/class-layout-abi.md
+++ b/docs/learn/class-layout-abi.md
@@ -9,6 +9,8 @@ depends_on:
   - abicheck/diff_layout.py
   - abicheck/diff_elf_layout.py
   - abicheck/dumper_clang.py
+  - tests/test_diff_layout.py
+  - tests/test_diff_elf_layout.py
 lifecycle: active
 generated: false
 ---

--- a/docs/learn/evidence-and-detectability.md
+++ b/docs/learn/evidence-and-detectability.md
@@ -106,14 +106,18 @@ Qualitatively — and this part doesn't drift, because it follows from what
 each layer can and cannot observe, not from a specific run's numbers — the
 shape holds regardless of the exact counts: `binary` (L0 alone) is the cheap
 floor with many invisible API/header/source-only breaks; `headers` (L0+L2)
-is the best low-cost gate, since public-header evidence removes most of
-those misses without introducing false positives; `build` (+L3) adds
-build-context corroboration on top; `source` (+L4) has the highest recall,
-since source-smoke proofs additionally cover consumer-only API hazards no
-artifact tier can see. An earlier `full` rung — whole-library replay, as
-opposed to `source`'s changed-TU replay — scored identically to `source` on
-the comparable-target set the matrix was last measured against, which is why
-the two were collapsed into one public `source` rung; see the appendix
+is the best low-cost gate, since public-header evidence adds the
+public/private boundary that removes most of those misses; `build` (+L3)
+adds build-context corroboration on top; `source` (+L4) has the highest
+recall, since source-smoke proofs additionally cover consumer-only API
+hazards no artifact tier can see. (Whether a given layer introduces zero
+*new* false positives is itself a measured, catalog- and run-specific
+result — see the fact owner above for the current number, not a guarantee
+this qualitative description makes on its own.) An earlier `full` rung —
+whole-library replay, as opposed to `source`'s changed-TU replay — scored
+identically to `source` on the comparable-target set the matrix was last
+measured against, which is why the two were collapsed into one public
+`source` rung; see the appendix
 below.
 
 Across the full staircase, adding evidence drives **both** error axes down — it

--- a/docs/learn/evidence-and-detectability.md
+++ b/docs/learn/evidence-and-detectability.md
@@ -608,7 +608,11 @@ this as a guard against *over-trusting* any ABI tool (see
 The takeaway is the same one [Part 0](abi-series/00-product-contract.md) opens
 with: **a stable ABI is necessary but not sufficient for a compatible release.**
 ABI tools prove the binary contract held; behavioral compatibility still needs
-your tests and your specification.
+your tests and your specification. See
+[Assurance Beyond Static Checking](assurance-methods.md) for what to run
+*instead* — consumer rebuild tests, binary-swap tests, golden/differential
+tests, ASan/TSan lifecycle and concurrency tests — and what each one actually
+proves.
 
 ---
 

--- a/docs/learn/evidence-and-detectability.md
+++ b/docs/learn/evidence-and-detectability.md
@@ -613,7 +613,7 @@ with: **a stable ABI is necessary but not sufficient for a compatible release.**
 ABI tools prove the binary contract held; behavioral compatibility still needs
 your tests and your specification. See
 [Assurance Beyond Static Checking](assurance-methods.md) for what to run
-*instead* — consumer rebuild tests, binary-swap tests, golden/differential
+*alongside* it — consumer rebuild tests, binary-swap tests, golden/differential
 tests, ASan/TSan lifecycle and concurrency tests — and what each one actually
 proves.
 

--- a/docs/learn/evidence-and-detectability.md
+++ b/docs/learn/evidence-and-detectability.md
@@ -106,14 +106,17 @@ Qualitatively — and this part doesn't drift, because it follows from what
 each layer can and cannot observe, not from a specific run's numbers — the
 shape holds regardless of the exact counts: `binary` (L0 alone) is the cheap
 floor with many invisible API/header/source-only breaks; `headers` (L0+L2)
-is the best low-cost gate, since public-header evidence adds the
-public/private boundary that removes most of those misses; `build` (+L3)
-adds build-context corroboration on top; `source` (+L4) has the highest
-recall, since source-smoke proofs additionally cover consumer-only API
-hazards no artifact tier can see. (Whether a given layer introduces zero
-*new* false positives is itself a measured, catalog- and run-specific
-result — see the fact owner above for the current number, not a guarantee
-this qualitative description makes on its own.) An earlier `full` rung —
+is the best low-cost gate for two distinct reasons, not one — the declared
+header AST itself recovers misses L0/L1 are structurally blind to
+(source-only signature/access/`noexcept` changes), *and*, separately, the
+public/private boundary that same AST supplies removes false positives an
+L1-only run would over-call on internal churn; `build` (+L3) adds
+build-context corroboration on top; `source` (+L4) has the highest recall,
+since source-smoke proofs additionally cover consumer-only API hazards no
+artifact tier can see. (Whether a given layer introduces zero *new* false
+positives is itself a measured, catalog- and run-specific result — see the
+fact owner above for the current number, not a guarantee this qualitative
+description makes on its own.) An earlier `full` rung —
 whole-library replay, as opposed to `source`'s changed-TU replay — scored
 identically to `source` on the comparable-target set the matrix was last
 measured against, which is why the two were collapsed into one public

--- a/docs/learn/evidence-and-detectability.md
+++ b/docs/learn/evidence-and-detectability.md
@@ -94,15 +94,13 @@ verdict coverage, false positives, and false negatives) is exactly the kind
 of volatile, machine-checkable fact this repo's docs contract says must have
 one owner — [Tool Comparison's "Current scan-quality
 snapshot"](../reference/tool-comparison.md#current-scan-quality-snapshot)
-(the "Scan-depth matrix" row) is that owner. As of this page's own last edit,
-that row itself records the matrix as **not independently re-run** against
-the current catalog since an older, smaller 141-target pin — see that page
-for the up-to-date status rather than a second, independently-drifting
-number here. Do not re-add a specific eval-target count or per-depth
-percentage table to *this* page; a second copy is exactly how the two pages
-disagreed before (this page previously claimed measured `100.0%`
-correct-verdict coverage at `source` depth while the catalog it was measured
-against had already grown past the pinned target count).
+(the "Scan-depth matrix" row) is that owner; see that page for the run
+status and target count. Do not re-add a specific eval-target count,
+run-freshness claim, or per-depth percentage table to *this* page — a second
+copy is exactly how this page and that one disagreed before (this page
+previously claimed measured `100.0%` correct-verdict coverage at `source`
+depth after the catalog it was measured against had already grown past the
+pinned target count).
 
 Qualitatively — and this part doesn't drift, because it follows from what
 each layer can and cannot observe, not from a specific run's numbers — the

--- a/docs/learn/evidence-and-detectability.md
+++ b/docs/learn/evidence-and-detectability.md
@@ -57,10 +57,10 @@ different inputs.
 ### A model independent of any one tool
 
 Before the abicheck-specific vocabulary: any compatibility checker — this one
-or another — draws its evidence from some subset of six generic categories,
+or another — draws its evidence from some subset of seven generic categories,
 each answering a genuinely different question about the library. This split
 matters because it is what lets you reason about a tool you've never used:
-ask which of these six categories it actually consumes, and you already know
+ask which of these seven categories it actually consumes, and you already know
 its blind spots.
 
 | Generic evidence category | Question it answers |
@@ -92,7 +92,7 @@ of five of these — runtime evidence is structurally out of reach for any
 The rest of this page, and every other page that cites "`L0`–`L5`," is
 using abicheck's own vocabulary for this generic model — worth keeping
 distinct in your head from the model itself, since a different tool
-realizes the same six categories with different names, different
+realizes the same seven categories with different names, different
 granularity, or gaps in different places.
 
 ### abicheck's five inputs

--- a/docs/learn/evidence-and-detectability.md
+++ b/docs/learn/evidence-and-detectability.md
@@ -88,36 +88,35 @@ struct is non-public ([case118](../reference/examples/case118_internal_struct_fi
 
 ### What each layer buys: fewer false negatives *and* fewer false positives
 
-Current scan-depth status is measured on the comparable v1/v2 shared-library
-targets: **141/141 targets scanned at every pinned depth**. FP/FN math uses the
-**141 targets** in that scope: `NO_CHANGE` sentinel cases are checked as
-compatible/no-change outcomes. Bundle-component results are structural
-diagnostics only; the catalog keeps one canonical case-level verdict.
+**Fact owner for current numbers.** A per-depth accuracy count (`binary` /
+`headers` / `build` / `source`, each with its own eval-target count, correct-
+verdict coverage, false positives, and false negatives) is exactly the kind
+of volatile, machine-checkable fact this repo's docs contract says must have
+one owner — [Tool Comparison's "Current scan-quality
+snapshot"](../reference/tool-comparison.md#current-scan-quality-snapshot)
+(the "Scan-depth matrix" row) is that owner. As of this page's own last edit,
+that row itself records the matrix as **not independently re-run** against
+the current catalog since an older, smaller 141-target pin — see that page
+for the up-to-date status rather than a second, independently-drifting
+number here. Do not re-add a specific eval-target count or per-depth
+percentage table to *this* page; a second copy is exactly how the two pages
+disagreed before (this page previously claimed measured `100.0%`
+correct-verdict coverage at `source` depth while the catalog it was measured
+against had already grown past the pinned target count).
 
-> **Freshness note.** This 141-target pin predates the catalog's growth to
-> 193 cases (159 of them compilable `.so`-pair lanes today — see [Tool
-> Comparison's "Which denominator is which"](../reference/tool-comparison.md)
-> for how that split is derived and kept in sync). The table below has not
-> been re-run against the current catalog; treat the percentages as
-> directionally representative of each depth's value, not as current exact
-> counts. Regenerating it against all current `.so`-pair targets is a
-> tracked follow-up, matching the same caveat on the [scan-depth matrix
-> row](../reference/tool-comparison.md#current-scan-quality-snapshot) in
-> Tool Comparison.
-
-| Pinned scan depth | Eval targets | Correct verdicts | Correct verdict coverage | False positives | False negatives | What this says about the layer today |
-|---|---:|---:|---:|---:|---:|---|
-| `binary` | 141 | 79 | 56.0% | 1 | 61 | Cheap artifact floor; many API/header/source-only breaks are invisible. |
-| `headers` | 141 | 115 | 81.6% | 0 | 26 | Best low-cost gate: public-header evidence removes many misses without FP. |
-| `build` | 141 | 115 | 81.6% | 0 | 26 | Adds build context; no advisory-crosscheck false positives after policy fix. |
-| `source` | 141 | 141 | 100.0% | 0 | 0 | Highest recall; source-smoke proofs cover consumer-only API hazards. |
-
-The full example catalog is covered by multiple proof lanes. This table is only
-the compare-style scan-depth lane, so its compare-style scope is complete at 141/141.
-(An earlier `full` rung — whole-library replay, as opposed to `source`'s
-changed-TU replay — scored identically on this comparable-target set, which is
-why the two were collapsed into one public `source` rung; see the appendix
-below.)
+Qualitatively — and this part doesn't drift, because it follows from what
+each layer can and cannot observe, not from a specific run's numbers — the
+shape holds regardless of the exact counts: `binary` (L0 alone) is the cheap
+floor with many invisible API/header/source-only breaks; `headers` (L0+L2)
+is the best low-cost gate, since public-header evidence removes most of
+those misses without introducing false positives; `build` (+L3) adds
+build-context corroboration on top; `source` (+L4) has the highest recall,
+since source-smoke proofs additionally cover consumer-only API hazards no
+artifact tier can see. An earlier `full` rung — whole-library replay, as
+opposed to `source`'s changed-TU replay — scored identically to `source` on
+the comparable-target set the matrix was last measured against, which is why
+the two were collapsed into one public `source` rung; see the appendix
+below.
 
 Across the full staircase, adding evidence drives **both** error axes down — it
 is not a trade-off where you must choose between missing breaks and crying wolf.

--- a/docs/learn/evidence-and-detectability.md
+++ b/docs/learn/evidence-and-detectability.md
@@ -54,7 +54,50 @@ different inputs.
 > the same model tailored to their context and link back here — when the model
 > changes, update this table first.
 
-A release engineer can hand a compatibility checker up to **five different
+### A model independent of any one tool
+
+Before the abicheck-specific vocabulary: any compatibility checker — this one
+or another — draws its evidence from some subset of six generic categories,
+each answering a genuinely different question about the library. This split
+matters because it is what lets you reason about a tool you've never used:
+ask which of these six categories it actually consumes, and you already know
+its blind spots.
+
+| Generic evidence category | Question it answers |
+|---|---|
+| **Artifact evidence** | What did the compiler actually emit — symbols, loader metadata? |
+| **Debug/type evidence** | What layout facts did the compiler record about emitted types? |
+| **Declared-interface evidence** | What does the source *say* the interface is (headers, an AST)? |
+| **Build evidence** | Under what compiler, flags, and environment was this built? |
+| **Source evidence** | What do macros, inline bodies, and templates actually contain? |
+| **Consumer evidence** | What does one real, specific consumer actually use? |
+| **Runtime evidence** | What actually happens when the code runs? |
+
+abicheck's own `L0`–`L5` layer codes are **one tool's concrete realization**
+of five of these — runtime evidence is structurally out of reach for any
+*static* checker, which is exactly the gap
+[Assurance Beyond Static Checking](assurance-methods.md) covers instead:
+
+| Generic category | abicheck layer |
+|---|:---:|
+| Artifact evidence | `L0` |
+| Debug/type evidence | `L1` |
+| Declared-interface evidence | `L2` |
+| Build evidence | `L3` |
+| Source evidence | `L4` |
+| *(derived from L3/L4, not itself provided)* | `L5` |
+| Consumer evidence | *(named contract only — see [`--used-by`/`--required-symbol`](../use/appcompat.md))* |
+| Runtime evidence | *(not modeled — see [Assurance Beyond Static Checking](assurance-methods.md))* |
+
+The rest of this page, and every other page that cites "`L0`–`L5`," is
+using abicheck's own vocabulary for this generic model — worth keeping
+distinct in your head from the model itself, since a different tool
+realizes the same six categories with different names, different
+granularity, or gaps in different places.
+
+### abicheck's five inputs
+
+A release engineer can hand abicheck up to **five different
 sources of information** about a library, ordered from the least to the most.
 Each one *adds* facts the previous cannot see; none of them is complete on its
 own. abicheck names them with the layer codes `L0`–`L4`. A **sixth** layer,
@@ -79,12 +122,28 @@ L0–L5 presence/absence without writing a snapshot); the build/source layers
 | 4 | **+ Build system data & options** | **L3** | `-p build/` (compile DB, CMake/Ninja/Bazel/Make) | The **flags the library was actually built with**: `-std`, `_GLIBCXX_USE_CXX11_ABI`, `-fvisibility`, `-fabi-version`, toolchain/sysroot, target graph, export maps | Corroborating |
 | 5 | **+ Sources** | **L4** | a build/source pack (per-TU source ABI replay, ADR-030) | Facts that never reach the binary: macro constants, `constexpr` values, default-argument *values*, inline/template **bodies**, uninstantiated templates | Corroborating (→ `API_BREAK`/risk) |
 
-Read this as a staircase: **each step up the table can both *find* breaks the
-step below is blind to and *prevent false positives* the step below would
-raise.** A struct-field insertion is invisible at L0 but obvious at L1
-([case07](../reference/examples/case07_struct_layout.md)); an internal-struct change that
-*looks* like a break at L1 is correctly dismissed once L2 headers reveal the
-struct is non-public ([case118](../reference/examples/case118_internal_struct_field_added_scoped.md)).
+Read this staircase-shaped **for the common case**: each step up the table
+*usually* both finds breaks the step below is blind to and prevents false
+positives the step below would raise. A struct-field insertion is invisible
+at L0 but obvious at L1 ([case07](../reference/examples/case07_struct_layout.md));
+an internal-struct change that *looks* like a break at L1 is correctly
+dismissed once L2 headers reveal the struct is non-public
+([case118](../reference/examples/case118_internal_struct_field_added_scoped.md)).
+
+**But it is not a strict ranking where every higher layer is more
+authoritative than every lower one for every question** — the table's own
+rightmost column already says why: L0-L2 are marked **Authoritative**, L3/L4
+only **Corroborating**. A higher layer adds *scope* (what's public, what
+flags applied) that can correctly overrule a lower layer's naive reading —
+but for the one fact a lower artifact layer directly observed (a symbol is
+present, a struct is this many bytes), a higher layer's absence of evidence
+is never grounds to override it. That asymmetry is the
+[*authority rule*](build-source-data.md) below in full, and it is why the
+next section's own false-positive/false-negative table is not monotonic on
+both axes at every step (L1 alone *adds* false positives L0 was too blind to
+raise) even though the false-negative axis is. Read "staircase" as *more
+evidence, generally fewer misses* — not as *every layer strictly dominates
+the one below it on every question*.
 
 ### What each layer buys: fewer false negatives *and* fewer false positives
 

--- a/docs/learn/exception-unwinding-abi.md
+++ b/docs/learn/exception-unwinding-abi.md
@@ -9,6 +9,7 @@ depends_on:
   - abicheck/diff_symbols.py
   - abicheck/diff_platform.py
   - abicheck/buildsource/build_diff.py
+  - abicheck/elf_metadata.py
 lifecycle: active
 generated: false
 ---
@@ -152,7 +153,7 @@ remains.) We do not repeat that analysis here.
       (`_ZTI…`/`_ZTS…`) and vtables (`_ZTV…`) at the ELF level. Read these
       as *risk*, not as a proven catch failure. What abicheck observes is
       the **export table**, and a hidden/internal symbol is excluded from it
-      (`elf_metadata`'s `.dynsym` parse drops `STV_HIDDEN`/`STV_INTERNAL`),
+      (the `.dynsym` parse drops `STV_HIDDEN`/`STV_INTERNAL` entries),
       so a default→hidden visibility flip presents identically to a genuine
       removal — while the local RTTI object and its type-name string are
       still there, and GNU libstdc++'s name fallback still matches. A

--- a/docs/learn/modern-cpp-toolchain-hazards.md
+++ b/docs/learn/modern-cpp-toolchain-hazards.md
@@ -50,7 +50,7 @@ vector-ABI flags, and CPU-dispatch/IFUNC selection
     up in the export table alone. Two are the exception: the `_GLIBCXX_USE_CXX11_ABI`
     flip and an ABI-tag change are both mangled straight into the exported
     symbol name (`glibcxx_dual_abi_flip_detected`/`abi_tag_changed`, both
-    `L0` per `scripts/evidence_tiers.py`), so they're visible from the
+    minimum evidence `L0`), so they're visible from the
     *mangled* export table alone — no DWARF/PDB/headers needed. A stripped
     binary that has been additionally **demangled** (its export names
     rewritten to human-readable form) can still hide them, since the

--- a/docs/learn/msvc-pe-abi-model.md
+++ b/docs/learn/msvc-pe-abi-model.md
@@ -44,16 +44,15 @@ MSVC counterpart, not a cosmetically renamed one:
   scheme is unrelated to Itanium's: a leading `?`, scope components in
   **innermost-first** order (the reverse of Itanium's outermost-first),
   `@`-separated, terminated by the first `@@`, with a name-backreference
-  table for repeated components. abicheck parses this directly —
-  `diff_cxx_rules.msvc_scope_components()`/`msvc_qualified_name()` recover
-  scope for owner-class seeding and stdlib-namespace checks the same way
-  `itanium_scope_components()` does for Itanium — but the parser is
-  deliberately conservative: special member functions/operators (`??0`
-  ctor, `??1`/`??_D` dtor, `??4` `operator=`, …), template instantiations
-  (`?$Name@Args@`), and the anonymous-namespace marker (`?A`) are all
-  rejected rather than guessed at, since a wrong guess there is worse than
-  the pre-existing gap (see `msvc_scope_components()`'s own docstring for
-  the full unmodelled list).
+  table for repeated components. abicheck parses this directly, recovering
+  scope for owner-class seeding and stdlib-namespace checks the same way it
+  does for Itanium-mangled symbols — but the parser is deliberately
+  conservative: special member functions/operators (`??0` ctor, `??1`/`??_D`
+  dtor, `??4` `operator=`, …), template instantiations (`?$Name@Args@`), and
+  the anonymous-namespace marker (`?A`) are all rejected rather than guessed
+  at, since a wrong guess there is worse than the pre-existing gap (this
+  page's `depends_on` front matter names the exact module for a contributor
+  who needs the full unmodelled list).
 - **Vtable/RTTI layout is a different structure, not a relocated Itanium
   one.** Multiple and virtual inheritance under MSVC introduce **vbtables**
   (virtual base tables), and virtual-base access goes through a vbtable
@@ -99,10 +98,9 @@ MSVC counterpart, not a cosmetically renamed one:
 The [PDB vs. DWARF capability table](../reference/platforms.md#what-no-headers-actually-means)
 is the exact, fact-owning source for this — read it before relying on a
 specific claim — but the shape worth internalizing here is: **PDB's TPI
-stream is not a drop-in replacement for DWARF.** `pdb_metadata.py`'s
-`_extract_method_calling_conventions()` populates
-`AdvancedDwarfMetadata.calling_conventions` keyed `Class::method` — **class
-methods only**. A PDB-only (no `-H`/castxml) scan recovers struct/class
+stream is not a drop-in replacement for DWARF.** Method-level calling
+convention recovered from a PDB is keyed by owning class and method name —
+**class methods only**. A PDB-only (no `-H`/castxml) scan recovers struct/class
 layout, field offsets, and enum values the same way an ELF DWARF scan does,
 but does **not** reconstruct free-function signatures or vtable slots at
 all — those need the header-AST path (`castxml` + `cl.exe`, or `clang-cl`).

--- a/docs/learn/what-each-level-sees.md
+++ b/docs/learn/what-each-level-sees.md
@@ -27,7 +27,7 @@ levels correlate, and exactly where each one goes blind.**
     command reference with recipes.
 
 > For the *framing* (why a change is only a "break" if it breaks a promise)
-> read [ABI/API Handling](abi-api-handling.md). **This page is the worked
+> read [ABI/API Compatibility](abi-api-handling.md). **This page is the worked
 > example that makes the model stick.**
 
 ---
@@ -503,7 +503,7 @@ rule](build-source-data.md#the-authority-rule-the-one-rule-that-matters)):
 The source scan reaches a *different* set of changes — macros, bodies, build
 flags, hygiene, cross-source conflicts — not a "better" version of the artifact
 scan. It is additive, not a replacement. To enable it on a real project, see the
-[source scan on the ABI/API Handling page](abi-api-handling.md#going-deeper-than-artifacts-the-source-scan)
+[source scan on the ABI/API Compatibility page](abi-api-handling.md#going-deeper-than-artifacts-the-source-scan)
 and the [`--depth` dial](evidence-and-detectability.md#the-depth-dial-how-much-evidence-to-collect).
 
 ---

--- a/docs/reference/sycl-test-abi-coverage.md
+++ b/docs/reference/sycl-test-abi-coverage.md
@@ -54,7 +54,7 @@ encodes several layout facts in the *sizes* of the objects it emits into
 |--------|--------|-----------------|------|
 | Exported-symbol set | `.dynsym` names | Added/removed/renamed functions & objects (the `.dump`-equivalent) | `func_removed`, `func_removed_elf_only`, … |
 | Object symbol size | `st_size` of data symbols | `sizeof` of exported global objects | `symbol_size_changed` |
-| **Vtable group size** | `st_size` of `_ZTV<class>` (`slots ≈ size/ptr - 2`) | Vtable entries were net added or removed, *or* the inheritance shape changed. Not a pure reorder, which keeps the size identical — see [Class Layout ABI](../learn/class-layout-abi.md#3-binary-only-c-layout-diff_elf_layoutpy-l0) | `vtable_slot_count_changed` |
+| **Vtable group size** | `st_size` of `_ZTV<class>` (`slots ≈ size/ptr - 2`) | Vtable entries were net added or removed, *or* the inheritance shape changed. Not a pure reorder, which keeps the size identical — see [Class Layout ABI](../learn/class-layout-abi.md#3-binary-only-c-layout-l0) | `vtable_slot_count_changed` |
 | **Inheritance shape** | `st_size` of `_ZTI<class>` (2 words = no base, 3 = single base, ≥4 = multiple/virtual) | Base-class set changed *by enough to resize the typeinfo object* | `rtti_inheritance_changed` |
 | Mangled-name signature | demangled `.dynsym` entries | Parameter/return types & the owning class of each method | feeds the symbol diff |
 

--- a/docs/start/getting-started.md
+++ b/docs/start/getting-started.md
@@ -72,5 +72,5 @@ Jump straight to your persona:
 
 Background reading:
 
-- [ABI/API Handling & Recommendations](../learn/abi-api-handling.md) — real-world ABI/API break scenarios and how to prevent them
+- [ABI/API Compatibility](../learn/abi-api-handling.md) — real-world ABI/API break scenarios and how to prevent them
 - [Limitations](../learn/limitations.md) — what abicheck does *not* catch

--- a/docs/use/scan-levels.md
+++ b/docs/use/scan-levels.md
@@ -155,9 +155,11 @@ the highest recall, since source-smoke proofs cover consumer-only API
 hazards the artifact tiers can't see. (The measured matrix at the fact
 owner above found zero extra false positives at `headers`/`build` depth —
 a real, but catalog- and run-specific, result, not a guarantee this
-qualitative description promises on its own.) Figures are for the
-diff-seeded rung; an unseeded whole-library
-replay reaches the same verdict signal at higher cost). Bundle-component
+qualitative description promises on its own.) `source` here is the
+diff-seeded rung; [Evidence &
+Detectability](../learn/evidence-and-detectability.md#what-each-layer-buys-fewer-false-negatives-and-fewer-false-positives)
+explains why an unseeded whole-library replay (the former `full` rung) is
+treated as reaching the same verdict signal at higher cost. Bundle-component
 results are structural diagnostics only in that matrix; only the dedicated
 bundle lane scores the single canonical case-level verdict and proves
 findings such as dangling intra-bundle imports and provider drift.

--- a/docs/use/scan-levels.md
+++ b/docs/use/scan-levels.md
@@ -149,10 +149,14 @@ targets/percentages pinned to an older, smaller catalog, silently
 presented as current). Qualitatively, the shape is stable across catalog
 growth: `binary` is the fast artifact gate that intentionally misses
 header/source-only breaks; `headers` is the best low-cost CI gate once
-public headers are available; `build` adds build-context corroboration on
-top with no extra false positives; `source` has the highest recall, since
-source-smoke proofs cover consumer-only API hazards the artifact tiers
-can't see (figures for the diff-seeded rung; an unseeded whole-library
+public headers are available, since it can see the public/private
+boundary; `build` adds build-context corroboration on top; `source` has
+the highest recall, since source-smoke proofs cover consumer-only API
+hazards the artifact tiers can't see. (The measured matrix at the fact
+owner above found zero extra false positives at `headers`/`build` depth —
+a real, but catalog- and run-specific, result, not a guarantee this
+qualitative description promises on its own.) Figures are for the
+diff-seeded rung; an unseeded whole-library
 replay reaches the same verdict signal at higher cost). Bundle-component
 results are structural diagnostics only in that matrix; only the dedicated
 bundle lane scores the single canonical case-level verdict and proves

--- a/docs/use/scan-levels.md
+++ b/docs/use/scan-levels.md
@@ -137,25 +137,26 @@ cheap tier for a fast CI gate.
 
 ### Example-catalog status
 
-The scan-depth table is scoped to the comparable v1/v2 shared-library targets.
-That scope is complete: **141/141 targets scanned at every pinned depth**. The
-full catalog is larger, but audit, cross-source, bundle, BTF, and snapshot
-cases run through their dedicated proof lanes rather than this compare-style
-scan matrix. `Eval targets` now covers that whole comparable-target scope: the
-`NO_CHANGE` sentinel cases are checked as compatible/no-change outcomes. Bundle
-component results are structural diagnostics, never separate ground truths.
-
-| `--depth` | Comparable targets | Eval targets | Correct verdicts | Correct verdict coverage | False positives | False negatives | Status |
-|---|---:|---:|---:|---:|---:|---:|---|
-| `binary` | 141 | 141 | 79 | 56.0% | 1 | 61 | Fast artifact gate; intentionally misses header/source-only breaks. |
-| `headers` | 141 | 141 | 115 | 81.6% | 0 | 26 | Best low-cost CI gate when public headers are available. |
-| `build` | 141 | 141 | 115 | 81.6% | 0 | 26 | Adds build context; no false positives in this matrix after advisory-crosscheck fix. |
-| `source` | 141 | 141 | 141 | 100.0% | 0 | 0 | Highest recall in this matrix; source-smoke proofs cover consumer-only API hazards. Figures are for the diff-seeded rung; an unseeded whole-library replay reaches the same verdict signal at higher cost. |
-
-False positives and false negatives are listed directly. Bundle-component rows
-remain structural diagnostics in the 141-target matrix; only the dedicated
-bundle lane scores the single canonical case-level verdict and proves findings
-such as dangling intra-bundle imports and provider drift.
+The per-`--depth` eval-target count, correct-verdict coverage, and FP/FN
+counts are a volatile, machine-checkable fact with one owner: [Tool
+Comparison's "Current scan-quality
+snapshot"](../reference/tool-comparison.md#current-scan-quality-snapshot)
+(the "Scan-depth matrix" row). Don't re-add a specific target count or
+per-depth percentage table here — that page already records whether the
+matrix has been re-run against the current catalog, and a second copy here
+is exactly how this page's own numbers previously went stale (fixed
+targets/percentages pinned to an older, smaller catalog, silently
+presented as current). Qualitatively, the shape is stable across catalog
+growth: `binary` is the fast artifact gate that intentionally misses
+header/source-only breaks; `headers` is the best low-cost CI gate once
+public headers are available; `build` adds build-context corroboration on
+top with no extra false positives; `source` has the highest recall, since
+source-smoke proofs cover consumer-only API hazards the artifact tiers
+can't see (figures for the diff-seeded rung; an unseeded whole-library
+replay reaches the same verdict signal at higher cost). Bundle-component
+results are structural diagnostics only in that matrix; only the dedicated
+bundle lane scores the single canonical case-level verdict and proves
+findings such as dangling intra-bundle imports and provider drift.
 
 ## What input each depth needs — and how to get it
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -19,7 +19,7 @@ of the catalog. Each fixture-only case's own README says so explicitly;
 check `ground_truth.json`/the per-case README before assuming a `v1`/`v2`
 source pair exists.
 
-The catalog drives abicheck's benchmark and serves as an encyclopedia of ABI pitfalls. For conceptual background on what ABI stability means and how to reason about it, see [ABI/API Handling & Recommendations](../docs/learn/abi-api-handling.md).
+The catalog drives abicheck's benchmark and serves as an encyclopedia of ABI pitfalls. For conceptual background on what ABI stability means and how to reason about it, see [ABI/API Compatibility](../docs/learn/abi-api-handling.md).
 
 > **Authoritative expected verdicts for benchmarking** live in [`ground_truth.json`](ground_truth.json).
 > If a per-case README and `ground_truth.json` disagree, `ground_truth.json` is the source of truth.
@@ -498,6 +498,6 @@ cmake --build build
 
 - **Pinned 74-case cross-tool accuracy table** (all configurations, FP/FN): [`../README.md#validation-snapshot`](../README.md#validation-snapshot)
 - **Per-case accuracy matrix and methodology:** [Tool Comparison & Benchmarks](../docs/reference/tool-comparison.md)
-- **What counts as an ABI break (with code):** [ABI/API Handling & Recommendations](../docs/learn/abi-api-handling.md)
+- **What counts as an ABI break (with code):** [ABI/API Compatibility](../docs/learn/abi-api-handling.md)
 - **Dependency ABI leaks** (case 18 background): [`case18_dependency_leak/README.md`](case18_dependency_leak/README.md)
 - **Local build & snapshot workflow:** [Local Compare](../docs/user-guide/local-compare.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,7 @@ nav:
     - Graph Coverage & Negative Evidence: learn/graph-coverage.md
     - Unified Impact Assessment: learn/impact-analysis.md
     - Environment & Toolchain Drift: learn/environment-drift.md
+    - ELF-Only Mode and Symbol Filtering: learn/elf-symbol-filtering.md
     - Limitations: learn/limitations.md
   # Lookup tables — precise, exhaustive, no narrative.
   - Reference:
@@ -164,50 +165,57 @@ nav:
     - Python API Reference: reference/python-api-reference.md
     - Machine-Readable Metadata: reference/machine-readable-metadata.md
   # Track 1 (educational): what ABI/API compatibility is and how to manage it,
-  # from first principles (series part 0) to expert-level design guidance.
-  - ABI/API Handling & Recommendations:
-    - Overview: learn/abi-api-handling.md
-    - ABI Cheat Sheet: learn/abi-cheat-sheet.md
-    - Deep Dives:
-      # Framing-level pages first: these name axes every other page in this
-      # group assumes (which consumer shape, which direction, whether the
-      # comparison is even valid) rather than one more compatibility
-      # dimension in Part 0's own list.
+  # from first principles to expert-level design guidance. Nav-only regroup
+  # (docs/AGENTS.md: nav position and file location are independent, no
+  # redirects needed) -- collapses the old flat 15-entry "Deep Dives" list
+  # and the separately-numbered "Learning Series" into one taxonomy, so a
+  # framing page (Consumer Models), a numbered Part (C++ ABI), and a
+  # split-out deep dive (Class Layout ABI & API) that cover the same kind of
+  # question sit in the same nav group instead of two parallel structures. A
+  # Part's own numbered "Series navigation" breadcrumb (top of each page)
+  # still carries the sequential 0-7 reading order this reshuffle doesn't
+  # remove; the sidebar now groups by *question asked* instead.
+  - ABI/API Compatibility:
+    - Start:
+      - Overview: learn/abi-api-handling.md
+      - "ABI in Five Minutes": learn/abi-series/abi-in-5-minutes.md
+      - ABI Cheat Sheet: learn/abi-cheat-sheet.md
+    - Define Your Contract:
+      - "Compatibility as a Product Contract": learn/abi-series/00-product-contract.md
       - Compatibility Direction: learn/compatibility-direction.md
       - Consumer Models: learn/consumer-models.md
       - Build Profile Comparability: learn/build-profile-comparability.md
       - Your ABI Surface: learn/abi-surface.md
+    - ABI Mechanics:
+      - Foundations: learn/abi-series/01-foundations.md
+      - Symbol Contracts: learn/abi-series/02-symbol-contracts.md
+      - Type Layout: learn/abi-series/03-type-layout.md
+      - C++ ABI: learn/abi-series/04-cpp-abi.md
       - Class Layout ABI & API: learn/class-layout-abi.md
-      - Dependency & Runtime Floors: learn/dependency-floors.md
+      - Linker & ELF: learn/abi-series/05-linker-elf.md
+      - Transitive Breaks: learn/abi-series/06-transitive-breaks.md
+    - Beyond ABI:
       - Behavioral & Semantic Compatibility: learn/behavioral-compatibility.md
       - Data, Wire & Storage Compatibility: learn/data-wire-compatibility.md
       - Ownership & Lifetime Contracts: learn/ownership-and-lifetime.md
       - Static & Header-Only Contracts: learn/static-and-header-only.md
       - Concurrency & Initialization Contracts: learn/concurrency-and-initialization.md
+    - Platforms & Toolchains:
       - Exception Unwinding: learn/exception-unwinding-abi.md
       - Modern C/C++ and Toolchain ABI Hazards: learn/modern-cpp-toolchain-hazards.md
-      - ELF-Only Mode and Symbol Filtering: learn/elf-symbol-filtering.md
+      - Dependency & Runtime Floors: learn/dependency-floors.md
       - The MSVC/PE ABI Model: learn/msvc-pe-abi-model.md
-    - Learning Series:
-      - "ABI in Five Minutes": learn/abi-series/abi-in-5-minutes.md
-      - "0. Compatibility as a Product Contract": learn/abi-series/00-product-contract.md
-      - "1. Foundations": learn/abi-series/01-foundations.md
-      - "2. Symbol Contracts": learn/abi-series/02-symbol-contracts.md
-      - "3. Type Layout": learn/abi-series/03-type-layout.md
-      - "4. C++ ABI": learn/abi-series/04-cpp-abi.md
-      - "5. Linker & ELF": learn/abi-series/05-linker-elf.md
-      - "6. Transitive Breaks": learn/abi-series/06-transitive-breaks.md
-      - "7. Designing for Stability": learn/abi-series/07-designing-for-stability.md
-      - "Glossary": learn/abi-series/glossary.md
+    - Designing Stable Interfaces:
+      - Designing for Stability: learn/abi-series/07-designing-for-stability.md
     # Verification & Assurance is deliberately its own group, not one more
-    # numbered Learning Series step: Parts 0-7 teach mechanisms (what a
-    # change does), this asks the categorically different "how do you catch
-    # it" question. The page itself stays at its original path/URL
-    # (learn/abi-series/08-detection.md) -- only its nav grouping moved, so
-    # no redirect entry is needed (see docs/AGENTS.md: nav position and file
-    # location are independent).
+    # mechanism topic: Define Your Contract/ABI Mechanics/Beyond ABI/
+    # Platforms & Toolchains teach mechanisms (what a change does), this
+    # asks the categorically different "how do you catch it" question.
     - Verification & Assurance:
       - "Detecting Breaks": learn/abi-series/08-detection.md
+      - "Assurance Beyond Static Checking": learn/assurance-methods.md
+    - Quick Reference:
+      - "Glossary": learn/abi-series/glossary.md
   # The case catalog: every break scenario as a compilable fixture, browsable
   # by verdict (what abicheck reports) or by category (what kind of change).
   - Examples:


### PR DESCRIPTION
## Summary

Stops three pages from independently hand-copying the same stale scan-depth benchmark table, per a docs-architecture review that flagged this as the clearest remaining P0 in the ABI/API educational docs.

## Motivation

A review of the ABI/API compatibility documentation (in response to a prior review round) found that the "141/141 targets" scan-depth FP/FN benchmark table was hand-copied into three separate pages:

- `docs/reference/tool-comparison.md` — already fixed in an earlier change to honestly say the matrix has not been re-run since the example catalog grew past its original 141-target pin.
- `docs/learn/evidence-and-detectability.md` — still presented the old exact percentages (including a since-stale `100.0%` "correct verdict coverage" at `source` depth) as current, with only a "freshness note" disclaimer that itself risked drifting from `tool-comparison.md`'s own disclaimer.
- `docs/use/scan-levels.md` — carried the identical stale table with **no** freshness disclaimer at all.

Per `docs/AGENTS.md`'s governing rule ("One fact is defined in exactly one place"), a volatile, machine-checked benchmark like this needs exactly one fact owner. Three independent copies is exactly the failure mode the docs contract exists to prevent — and it had already visibly happened once (the copies disagreed on whether/how they disclosed staleness).

## Changes

- `docs/reference/tool-comparison.md`'s "Current scan-quality snapshot" section is now the sole fact owner for the scan-depth benchmark numbers.
- `docs/learn/evidence-and-detectability.md` and `docs/use/scan-levels.md` now link to that section instead of hand-copying the table, keeping only the qualitative explanation of what each `--depth` buys (which doesn't drift, since it follows from what each evidence layer can/can't observe rather than from one benchmark run's counts).

## Bug-fix test contract

Not applicable — this is a `docs:` change with no code/behavior fix, so this section is omitted per the template's own instructions.

## Checklist

- [x] Docs updated (this PR is a docs-only fix)
- [x] `mkdocs build --strict` passes locally
- [x] `python scripts/check_docs_contract.py` passes locally (0 errors; one pre-existing, unrelated warning)
- [ ] Changelog fragment — not needed, no `abicheck/**/*.py` files touched


---
_Generated by [Claude Code](https://claude.ai/code/session_01CVV61rhyiFfhkbhasXuqy4)_