### PR TITLE
test: pin dump/scan comparability fix against the exact reported CLI shape

### DIFF
--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -74,23 +74,52 @@ _HAVE_GXX = shutil.which("g++") is not None
 _HAVE_CLANG = shutil.which("clang") is not None
 
 
-def _build_library(tmp_path: Path) -> tuple[Path, Path, Path]:
+def _build_library(
+    tmp_path: Path, *, extra_include_dir: str | None = None
+) -> tuple[Path, Path, Path]:
     """Compile a tiny real C++17 library + a matching compile_commands.json.
 
     Mirrors the bug report's repro shape: a library genuinely built with an
     explicit ``-std=`` the header itself depends on (so a dump that failed
     to fold the real standard would produce headers parsed under the wrong
     dialect, not merely empty metadata).
+
+    ``extra_include_dir``, when given, adds a real dependency header under a
+    separate ``-I``-supplied directory (mirroring
+    ``tests/test_dump_cli_typed_api_parity.py``'s own ``"extra-include-dir"``
+    shape) -- the specific build-evidence shape the AGENTS.md "Known gaps"
+    entry's "Two real mechanisms found and fixed" paragraph diagnoses as
+    what actually reproduces the reported ``include_sequence`` divergence; a
+    compile database with no extra ``-I`` at all does not exercise the
+    legacy-match-overlap/derived-include-routing bug this module regression-
+    tests, on either the buggy or the fixed commit (verified directly: see
+    the module docstring's own note against re-adding one without this
+    parameter).
     """
+    include_dirs = [tmp_path]
+    dep_header_snippet = ""
+    dep_field = ""
+    if extra_include_dir is not None:
+        dep_dir = tmp_path / extra_include_dir
+        dep_dir.mkdir(parents=True, exist_ok=True)
+        (dep_dir / "dep.h").write_text(
+            "#pragma once\nstruct Dep { int tag; };\n", encoding="utf-8"
+        )
+        include_dirs.append(dep_dir)
+        dep_header_snippet = '#include "dep.h"\n'
+        dep_field = "    Dep dep;\n"
+
     header = tmp_path / "widget.h"
     header.write_text(
         "#pragma once\n"
+        f"{dep_header_snippet}"
         "#if __cplusplus < 201703L\n"
         '#error "needs c++17"\n'
         "#endif\n"
         "struct Widget {\n"
         "    int x;\n"
         "    int y;\n"
+        f"{dep_field}"
         "    int sum() const { return x + y; }\n"
         "};\n",
         encoding="utf-8",
@@ -101,8 +130,18 @@ def _build_library(tmp_path: Path) -> tuple[Path, Path, Path]:
         encoding="utf-8",
     )
     so_path = tmp_path / "libwidget.so"
+    include_flags = [f"-I{d}" for d in include_dirs[1:]]
     subprocess.run(
-        ["g++", "-std=c++17", "-shared", "-fPIC", "-o", str(so_path), str(src)],
+        [
+            "g++",
+            "-std=c++17",
+            *include_flags,
+            "-shared",
+            "-fPIC",
+            "-o",
+            str(so_path),
+            str(src),
+        ],
         check=True,
         capture_output=True,
     )
@@ -115,6 +154,7 @@ def _build_library(tmp_path: Path) -> tuple[Path, Path, Path]:
                     "arguments": [
                         "g++",
                         "-std=c++17",
+                        *include_flags,
                         "-shared",
                         "-fPIC",
                         "-c",
@@ -246,8 +286,17 @@ def test_scan_against_real_dump_baseline_matches_reported_cli_invocation(
     reconciles ``dump``'s and ``scan``'s compile contexts, but the original
     report used exactly this combination, so it is pinned directly rather
     than trusted to be equivalent to the simpler sibling test.
+
+    Uses ``extra_include_dir`` (a real dependency header under its own
+    ``-I``-supplied directory) rather than the sibling test's plain,
+    no-extra-``-I`` build: a compile database with no extra include
+    directory at all does not exercise the legacy-match-overlap/derived-
+    include-routing bug this module regression-tests -- confirmed directly
+    against the reported buggy commit (``6fb8536``), which resolves this
+    same invocation as ``NO_CHANGE`` even *without* the fix when no extra
+    ``-I`` is involved. See ``_build_library``'s own docstring.
     """
-    so_path, header, compile_db = _build_library(tmp_path)
+    so_path, header, compile_db = _build_library(tmp_path, extra_include_dir="dep")
     baseline = tmp_path / "baseline.json"
 
     dump_result = CliRunner().invoke(

--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -229,3 +229,79 @@ def test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source(
     assert "profile_fingerprint mismatch" not in scan_result.output, scan_result.output
     assert scan_result.exit_code == 0, scan_result.output
     assert "Verdict: NO_CHANGE" in scan_result.output, scan_result.output
+
+
+@pytest.mark.skipif(
+    not (_HAVE_GXX and _HAVE_CLANG), reason="needs a real g++ and clang toolchain"
+)
+def test_scan_against_real_dump_baseline_matches_reported_cli_invocation(
+    tmp_path: Path,
+) -> None:
+    """The exact CLI invocation shape from the bug report: a side-prefixed
+    ``-H new=PATH`` header, an explicit ``--lang c++``, an explicit
+    ``--policy strict_abi``, and JSON output -- not just the bare
+    ``-H PATH``/default-policy shape the sibling test above already covers.
+
+    None of those extra flags should matter to whether the P0.3 L3->L2 fold
+    reconciles ``dump``'s and ``scan``'s compile contexts, but the original
+    report used exactly this combination, so it is pinned directly rather
+    than trusted to be equivalent to the simpler sibling test.
+    """
+    so_path, header, compile_db = _build_library(tmp_path)
+    baseline = tmp_path / "baseline.json"
+
+    dump_result = CliRunner().invoke(
+        main,
+        [
+            "dump",
+            str(so_path),
+            "-H",
+            str(header),
+            "--sources",
+            str(tmp_path),
+            "--build-info",
+            str(compile_db),
+            "--depth",
+            "source",
+            "--ast-frontend",
+            "clang",
+            "-o",
+            str(baseline),
+        ],
+    )
+    assert dump_result.exit_code == 0, dump_result.output
+
+    scan_report = tmp_path / "scan-report.json"
+    scan_result = CliRunner().invoke(
+        main,
+        [
+            "scan",
+            str(so_path),
+            "-H",
+            f"new={header}",
+            "--sources",
+            str(tmp_path),
+            "--build-info",
+            str(compile_db),
+            "--against",
+            str(baseline),
+            "--lang",
+            "c++",
+            "--depth",
+            "source",
+            "--ast-frontend",
+            "clang",
+            "--policy",
+            "strict_abi",
+            "--format",
+            "json",
+            "-o",
+            str(scan_report),
+        ],
+    )
+    assert scan_result.exit_code == 0, scan_result.output
+
+    report = json.loads(scan_report.read_text(encoding="utf-8"))
+    assert report.get("verdict") == "NO_CHANGE", report
+    diff = report.get("diff") or {}
+    assert diff.get("reason") is None, diff.get("reason")


### PR DESCRIPTION
## Summary

Adds regression coverage confirming that the bug report "`abicheck scan --against` reports NOT_COMPARABLE against every `abicheck dump` baseline — include_sequence mismatch on byte-identical inputs" is **already fixed** on `main`, and pins the exact CLI flag combination the report used.

## Motivation

The linked report reproduces `scan --against` a `dump` baseline hitting `NOT_COMPARABLE` (`profile_fingerprint` mismatch, differing field `include_sequence`) on byte-identical evidence, pinned at commit `6fb8536`.

Investigating on current `main` (9 commits ahead of that pin, most relevantly #814 "PR 3A convergence — DumpRequest, collect-mode parity, idempotent embed, ADR-039 gate"): this class of bug is already extensively documented and fixed in `AGENTS.md`'s "Known gaps" section (the L3→L2-fold entry's numbered findings, culminating in the "legacy-match overlap" fix and the `scan`-candidate-resolver convergence work). I independently reproduced the report's exact shape (a real `g++`-compiled library + a real `compile_commands.json`, `dump` then `scan --against`) directly against `main` and confirmed it resolves as `NO_CHANGE` with exit code 0 — not `NOT_COMPARABLE`.

The existing `tests/test_dump_scan_l3_comparability.py` module already has end-to-end coverage for this, added while fixing it, but only for the bare `-H PATH` / default-policy CLI shape. The original report used a slightly richer invocation (`-H new=PATH` side-prefixing, explicit `--lang c++`, explicit `--policy strict_abi`, JSON output) that wasn't independently pinned.

**Update:** Codex review on this PR caught that the first version of the new test reused a fixture with no extra `-I` dependency directory, so it never actually exercised the reported `include_sequence` divergence — it would have passed even against the buggy commit. Fixed by extending the shared `_build_library` helper with an `extra_include_dir` parameter (mirroring the existing `test_dump_cli_typed_api_parity.py` "extra-include-dir" shape) and re-verifying both directions directly against a worktree of the buggy commit and against current `main`.

## Changes

- Add `test_scan_against_real_dump_baseline_matches_reported_cli_invocation` to `tests/test_dump_scan_l3_comparability.py`, mirroring the bug report's exact `dump`/`scan --against` invocation shape (including a real extra `-I<dependency-dir>`, the build shape that actually triggers the reported divergence) and asserting `verdict == "NO_CHANGE"` via the JSON report, not just CLI text output.
- Extend `_build_library` with an `extra_include_dir` parameter, used by the new test.
- No production code changes — the underlying fix already exists on `main`.

Verified locally (marked `integration`, so it needs `gcc`/`g++`/`clang`; this sandbox lacks `castxml` so the marker-gated collection is skipped here, but the test body was executed directly via `CliRunner` outside pytest's collection gate, against both a worktree of the buggy commit and current `main`, and passes/fails as expected in each).

## Bug-fix test contract

- Bug class: A regression test whose fixture never triggers the code path it claims to pin — the test asserted a real bug report was fixed, but its build-evidence shape (a plain compile database with no extra `-I` directory) doesn't exercise the legacy-match-overlap/derived-include-routing mechanism that actually produced the reported `include_sequence` divergence, so the test passed identically whether or not the underlying fix was present.
- Publicly observable failure: `abicheck scan --against` a `dump`-produced baseline would exit 6 with verdict `NOT_COMPARABLE` (reason: `profile_fingerprint` mismatch, differing field `include_sequence`) for a real project whose build records an extra `-I<dependency-dir>`, even when the underlying binary/headers/sources/toolchain are unchanged between the two sides.
- Regression test fails on base: Yes — verified directly by checking out the reported buggy commit (`6fb8536`) in a separate git worktree and running the corrected test body (with `extra_include_dir="dep"`) against it: it reproduced exit 6 / `NOT_COMPARABLE` / `include_sequence`, exactly the reported symptom. The same body run against current `main` (this PR's target) resolves `NO_CHANGE`/exit 0.
- Negative control: The pre-existing sibling test in the same module (`test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source`), which uses the plain no-extra-`-I` fixture, continues to pass unchanged — so this isn't a fix that happens to work by making every `dump`/`scan` comparison succeed regardless of input; only the specific build shape that previously diverged is being exercised by the new test.
- Public-surface test: Yes — the test drives the real `abicheck dump` and `abicheck scan` CLI commands end-to-end via Click's `CliRunner` (not an internal helper or a mocked resolver), matching how a user actually invokes both commands, and asserts on the real JSON report's `verdict`/`diff.reason` fields.
- Axes covered: Linux/ELF, `--ast-frontend clang` explicitly (this environment has no `castxml`, so the default backend is unverified here — a pre-existing, already-documented gap in `AGENTS.md`, not new to this PR), C++17, a real `g++`-compiled shared library plus a real `compile_commands.json` with an explicit `-I<dependency-dir>` recording the actual build shape that reproduces the divergence.
- General invariant: None beyond the reported case — this PR adds regression coverage for a fix that already exists on `main`; it doesn't claim a new invariant beyond "this specific, previously-broken build shape (and its root cause) stays fixed."
- Known unsupported cases: The default `castxml` header backend is unverified by this test in this environment (no working `castxml` install available here) — a pre-existing, already-documented gap in `AGENTS.md` ("the *default* header backend is castxml, and no working castxml was obtainable"), not new to this PR. The underlying fix mechanism is backend-agnostic (it operates on `CompileContext` token merging before any AST backend runs), so it is very likely fixed for castxml too, just not independently confirmed by this test. Separately, `AGENTS.md`'s own "Known gaps" section documents narrower, still-open residuals in this same area (e.g. a real Bazel `aquery`/`cquery` multi-target build, and a legacy `-p`/`--compile-db` auto-match combined with `--build-info` reaching the parse through a structurally different channel than the P0.3 fold) that this test does not exercise and does not claim to close.

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md` (N/A — test-only change, no `abicheck/**/*.py` touched)
- [ ] Docs updated if user-visible behaviour changed (N/A — no behavior change)
- [x] `ruff check` / `ruff format --check` pass locally
- [x] No new `mypy` or `ruff` errors introduced

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_013Zj8g9B14VsHHRbQZnVjVL