### PR TITLE
feat(dump): thread --compile-db-filter into the typed dump/scan pipeline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4977,6 +4977,46 @@ Once a root command genuinely clears the bar above, pick the right home:
   migration, rather than shipping validation code with no real path to
   verify it against.
 
+  **A sixth finding (Codex review, fresh evidence) reopened convergence:
+  the guard's original `compile_db_from_build_info`-only check covered a
+  literal compile database and nothing else, but the fold it guards
+  (`resolve_header_compile_context`/`filter_units_by_source`) narrows
+  *whatever* `BuildEvidence.compile_units` a `--build-info` resolves to,
+  regardless of shape.** A `--build-info` naming a pre-captured `collect`
+  pack directory (`is_pack_dir`) or a Bazel `aquery`/`cquery` jsonproto
+  resolves compile units the identical way a literal compile database does
+  — both are routed through their own adapters
+  (`buildsource.inline._maybe_collect_bazel_build_info`/pack loading), not
+  `load_compile_db()` — and the L3 embed collects that same `BuildEvidence`
+  unfiltered either way, so the mismatch reproduced for both shapes with no
+  error, purely because neither is a `compile_commands.json` file
+  `compile_db_from_build_info` recognizes. Fixed: `compile_db_for_filter_
+  scope_check` now also recognizes a `--build-info` that `sniff_build_info_
+  format` (the same cheap, execution-free classifier `compile_db_from_
+  build_info` already uses, so the two cannot disagree) reports as `"pack"`
+  or `"bazel_aquery"`/`"bazel_cquery"`, returning the `--build-info` path
+  itself as the guard's non-`None` signal (the guard only ever checks
+  `is None`, so this needs no literal compile-database content).
+  `compile_db_filter_scope_error`'s docstring, which had explicitly claimed
+  the opposite ("a pack or Bazel jsonproto routes through a different
+  adapter" → `None`, i.e. by design out of scope), was corrected alongside
+  the fix — that claim was the bug's own design rationale, not a separate
+  error. **Still not covered, and not attempted here**: a `--sources` tree
+  with no discoverable `compile_commands.json` at all, resolved instead
+  through the zero-config *inferred* build-system query (cmake/make/bazel).
+  Unlike the pack/Bazel-jsonproto case, telling whether that combination
+  would actually resolve multiple compile units means running the build
+  system's own query — the exact side effect this cheap, read-only scope
+  check exists to avoid paying twice per invocation (once to check, once for
+  real) — so this residual is documented rather than guessed at, per this
+  file's own "known gaps over risky reactive patches" convention. Regression
+  coverage: `TestScopeGuardCoversPackAndBazelBuildInfo` in
+  `tests/test_compile_db_filter_scope.py` (the predicate directly — pack
+  directory, both Bazel jsonproto shapes, both positive and negative
+  controls, plus a plain non-pack directory and a non-Bazel JSON-object file
+  confirmed to still resolve `None`; five of nine cases confirmed to fail
+  against the pre-fix guard).
+
   **A real regression the scan-migration paragraph above introduced, found
   by Codex review and fixed the same session (2026-08-21): `scan --config
   <path>` silently lost the config's own *passive* settings whenever the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5045,6 +5045,36 @@ Once a root command genuinely clears the bar above, pick the right home:
   auto-discovery; three of six cases confirmed to fail against the pre-fix
   guard).
 
+  **An eighth finding (Codex review, fresh evidence) — not a missing case
+  this time, but a genuine false positive the seventh finding's fix
+  introduced.** That fix restructured the function so every branch fell
+  through unconditionally to the `sources`-based checks once none of the
+  `build_info` branches matched — including the case where `build_info`
+  was genuinely given but resolved to nothing recognizable. That is wrong:
+  `buildsource.inline._resolve_compile_db` — the real function every one
+  of these seeded resolvers (`collect_inline_pack`, in turn called by
+  `seed_includes_and_fold_compile_context`/`embed_build_source` alike)
+  ultimately calls — tracks `explicit_input_missed` and returns `None` as
+  soon as a *given* `--build-info` misses, deliberately, per its own
+  comment: "surface that miss rather than masking it with a stale
+  auto-discovered DB ... checked BEFORE auto-discovery." So an explicit
+  `--build-info` that doesn't resolve means neither the real L2 fold nor
+  the L3 embed ever falls back to a `sources`-discovered database — falling
+  back in the guard (the post-seventh-finding behavior) produced a false
+  positive: rejecting a `--compile-db-filter` combination the real
+  resolvers wouldn't actually apply to either side of, a usage error for a
+  perfectly safe invocation. Fixed by returning `None` immediately once the
+  `build_info is not None` branch exhausts its own checks, before ever
+  reaching the `sources`-based fallbacks — matching `_resolve_compile_db`'s
+  own precedence exactly. Regression
+  coverage: `TestScopeGuardDoesNotFallBackToSourcesWhenBuildInfoMisses` in
+  `tests/test_compile_db_filter_scope.py` — a pure-predicate case (an
+  unresolvable `build_info` alongside a `sources` tree carrying a real,
+  auto-discoverable `compile_commands.json`, confirmed to fail against the
+  post-seventh-finding code) plus a positive control against the real
+  g++/clang project fixture, confirming the guard doesn't reject a genuinely
+  safe combination.
+
   **A real regression the scan-migration paragraph above introduced, found
   by Codex review and fixed the same session (2026-08-21): `scan --config
   <path>` silently lost the config's own *passive* settings whenever the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4892,6 +4892,33 @@ Once a root command genuinely clears the bar above, pick the right home:
   This slice narrows what item (2) alone is blocking, nothing more — it does
   not migrate the real run, and does not claim to.
 
+  **Two Codex review findings on the same slice, both real, both fixed
+  before merge.** (P2) `InputSpec.of()` — the documented loose-value
+  convenience factory every front end other than a direct dataclass
+  construction uses — never gained a `compile_db_filter` parameter, so
+  `InputSpec.of(..., compile_db_filter=...)` raised `TypeError` for an
+  unrecognized keyword: the field was reachable only by constructing
+  `InputSpec` directly, despite being advertised as public typed-API
+  surface. Fixed by adding the parameter and forwarding it through
+  unchanged. (P1) The scope-error guard above was wired into
+  `resolve_dump_request` only — but `InputSpec.compile_db_filter` is shared
+  by `CompareRequest.old`/`.new` too, and `resolve_compare_request` reaches
+  the identical `resolve_side_snapshot` primitive (the P0.3 fold narrows,
+  `embed_side_build_source` still collects L3 unfiltered), so a typed
+  `CompareRequest` side could reach the exact L2-filtered/L3-unfiltered
+  snapshot shape the guard exists to reject, with no check catching it. Fixed
+  by extracting the guard into a shared function,
+  `service_compare_evidence.reject_compile_db_filter_scope_mismatch` (mirrors
+  `reject_debug_format_for_binaries`'s existing `(label, ...)` per-side
+  shape), called from both `resolve_dump_request` (`input`) and
+  `resolve_compare_request` (`old`/`new`) — one guard, not two independently
+  drifting copies. Regression coverage: `tests/test_compile_db_filter_scope.py`'s
+  `test_input_spec_of_forwards_compile_db_filter` and
+  `TestCompareRequestAppliesTheSameScopeGuard` (the latter, like its
+  `DumpRequest` sibling, verified against the identical real `g++`+clang
+  project), plus a re-run of every pre-existing test in this area to confirm
+  the extraction changed no behavior.
+
   **A real regression the scan-migration paragraph above introduced, found
   by Codex review and fixed the same session (2026-08-21): `scan --config
   <path>` silently lost the config's own *passive* settings whenever the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4855,6 +4855,43 @@ Once a root command genuinely clears the bar above, pick the right home:
   while able to exercise only the non-default backend is not a verified change.
   PR 3C stays blocked, per the plan's own ordering rule.
 
+  **Item (1) closed (2026-08-21, later session): `InputSpec.compile_db_filter`
+  now exists, exactly as specified above — nothing more, nothing less.**
+  `service_input_resolution._seeded_includes_and_compile_context` forwards it
+  as `source_filter` to `seed_includes_and_fold_compile_context`; the
+  `attach_build_context_for_parsed_headers` call two paragraphs down does the
+  same, so the fold and the ADR-039 collector agree on which translation
+  units the filter selects (the identical invariant
+  `build_context.source_matches_filter` already established for the three
+  CLI-side layers — see the root AGENTS.md's forced-include entry's
+  MSVC-driver-vocabulary lesson on why a second copy of a shared matching
+  rule is the wrong move). `resolve_dump_request` mirrors the CLI's own
+  `compile_db_filter_scope_error` refusal, computed from `evidence.
+  collect_mode`/`evidence.headers` — the same resolved values the CLI reads
+  `compile_db_from_build_info` back against — so a typed caller cannot reach
+  the L2-filtered/L3-unfiltered snapshot shape the CLI refuses outright; the
+  refusal raises `ValidationError` (translated to `click.UsageError` at the
+  CLI boundary by `resolve_dump_request_for_cli`, unchanged). `dump_cmd`
+  forwards its own `--compile-db-filter` local into `build_dump_request`, so
+  `--dry-run`'s resolved object now records the same filter the real run
+  applies, closing the last gap in that request's own honesty contract for
+  this one field. Verified against the identical real `g++`+clang project
+  `TestDumpCliHonorsTheFilterInTheFold` already uses (two TUs disagreeing on
+  an ABI-relevant `-D` behind one `#ifdef`-guarded field), driven through the
+  typed `DumpRequest`/`resolve_dump_request`/`execute_dump_request` path
+  directly rather than the CLI: the scope-error refusal fires under the same
+  condition the CLI refuses under, a request with no filter is unaffected,
+  and the filter selects the same translation unit's context for the header
+  parse the CLI test already pins (`tests/test_compile_db_filter_scope.py`'s
+  `TestTypedApiHonorsTheFilterInTheFold`). Confirmed the CLI's own behavior
+  is unchanged by re-running `TestDumpCliHonorsTheFilterInTheFold` directly.
+  **Item (2) is unchanged and remains the sole blocker**: castxml is still
+  unavailable in every environment this work has been done in, so the real
+  `dump` CLI execution path (`perform_elf_dump`/`handle_non_elf_dump`) still
+  does not route through `execute_dump_request`, and PR 3C stays blocked.
+  This slice narrows what item (2) alone is blocking, nothing more — it does
+  not migrate the real run, and does not claim to.
+
   **A real regression the scan-migration paragraph above introduced, found
   by Codex review and fixed the same session (2026-08-21): `scan --config
   <path>` silently lost the config's own *passive* settings whenever the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5017,6 +5017,34 @@ Once a root command genuinely clears the bar above, pick the right home:
   confirmed to still resolve `None`; five of nine cases confirmed to fail
   against the pre-fix guard).
 
+  **A seventh finding (Codex review, fresh evidence) on the same guard:
+  the sixth finding's fix only recognized a pack named by `--build-info`,
+  but `buildsource.l2_seed._l2_seed_pack_inputs` folds a `--sources` pack
+  (a classic `BuildSourcePack` or a Flow-2 `abicheck_inputs/` directory)
+  into L2 seeding the identical way — carrying its own normalized
+  `BuildEvidence` in — whenever no `--build-info` was given at all (an
+  explicit `--build-info` always wins L3, matching that function's own
+  `if build_info is None:` gate on the assignment).** A `--sources` naming
+  such a pack, with no `--build-info`, reproduced the identical mismatch:
+  the guard's fallback resolution (`compile_db_from_build_info` then
+  `_autodiscover_compile_db`) only ever looks for a literal
+  `compile_commands.json` inside *sources*, which a pack directory does not
+  carry at its root — so it silently resolved `None` and let the mismatch
+  through. Fixed by recognizing a `sources` pack the identical way
+  `_l2_seed_pack_inputs` does (`is_pack_dir` / `inputs_pack.is_inputs_pack`),
+  gated on `build_info is None` to match that function's own precedence
+  exactly — an explicit `--build-info` (even one that itself resolves to
+  nothing recognizable) still means the sources pack's evidence is never
+  folded into `base_build`, so the guard must not treat it as filterable
+  evidence in that combination either (pinned by its own regression test).
+  Regression coverage: `TestScopeGuardCoversSourcesPacks` in
+  `tests/test_compile_db_filter_scope.py` (a classic pack and a Flow-2
+  inputs pack named by `sources`, the scope error firing, the
+  `build_info`-takes-precedence control, a no-filter control, and a plain
+  non-pack `sources` directory still falling through to ordinary
+  auto-discovery; three of six cases confirmed to fail against the pre-fix
+  guard).
+
   **A real regression the scan-migration paragraph above introduced, found
   by Codex review and fixed the same session (2026-08-21): `scan --config
   <path>` silently lost the config's own *passive* settings whenever the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4919,6 +4919,64 @@ Once a root command genuinely clears the bar above, pick the right home:
   project), plus a re-run of every pre-existing test in this area to confirm
   the extraction changed no behavior.
 
+  **Three further Codex review findings on the same slice, each real, each
+  fixed, and each a pre-existing gap in the native CLI's own scope check
+  too (not introduced by this typed-API slice).** (P1) The guard's compile-
+  database resolution considered only an explicit `--build-info`/
+  `build_info` — a `--sources`/`sources` tree with no `build_info` at all
+  can still have its `compile_commands.json` auto-discovered
+  (`buildsource.inline._autodiscover_compile_db`, the identical P4 strategy
+  the fold and the L3 embed both already use to find one from `sources`
+  alone), so that combination reached the same filtered-L2/unfiltered-L3
+  mismatch uncaught. Reproduced directly: a real two-TU project resolved
+  with `sources` only, filtered to one TU at L2, still embedded both TUs'
+  compile units as L3 evidence (`BuildEvidence.compile_units` length 2).
+  (P1) Even with an explicit `--build-info <dir>` given, the resolution
+  checked only `<dir>/compile_commands.json` directly — not a conventional
+  out-of-tree build subdirectory (`<dir>/build/compile_commands.json`) the
+  real fold's own `--build-info` resolution
+  (`buildsource.inline._compile_db_at`, delegating to
+  `_find_compile_db_in_dir` for a directory) already searches, explicitly
+  documented as matching `--sources` auto-discovery's own contract.
+  Reproduced directly: the identical project with its database moved into
+  a `build/` subdirectory, `--build-info` pointed at the project root — the
+  fold correctly resolved and filtered by the nested database while the
+  guard never fired. Both fixed in one place,
+  `header_conditionals.compile_db_for_filter_scope_check` (deliberately
+  **not** folded into `compile_db_from_build_info` itself, which also
+  drives the CLI's unrelated legacy `-p` auto-match and must stay
+  `--build-info`-direct-child-only — see that function's own docstring),
+  consumed by both `cli.py`'s `dump_cmd` and the shared typed guard.
+  Regression coverage: `TestScopeGuardCoversSourcesOnlyAutoDiscovery` and
+  `TestScopeGuardCoversNestedBuildInfoDatabases` in
+  `tests/test_compile_db_filter_scope.py` (three entry points each — CLI,
+  `DumpRequest`, `CompareRequest` — plus a positive control for the nested
+  case confirming the database is genuinely what gets filtered).
+
+  **A fifth finding, investigated and deliberately left as a documented gap
+  rather than fixed reactively — the point at which these findings stopped
+  converging on real, reachable bugs.** `execute_dump_request()`/
+  `_resolve_side_snapshot_impl()` also accept a keyword-only
+  `build_compile_db` (a glob, mirroring `--build-compile-db`), forwarded
+  unfiltered to both the L2 fold and the L3 embed the same way
+  `build_info`/`sources` are — in principle the identical mismatch class.
+  But `build_compile_db` is not a field of `DumpRequest`/`InputSpec` at
+  all: it exists purely as scaffolding for the not-yet-landed PR 3A
+  real-run migration (this module's own docstring: "the real ELF/PE/
+  Mach-O run still executes through `perform_elf_dump`/
+  `handle_non_elf_dump`, not through `execute_dump_request`"), and
+  `execute_dump_request` has exactly one caller in the whole codebase —
+  `run_dump_request`, which never passes it. No CLI, no typed-API path, and
+  no test can reach this combination without bypassing the entire
+  `DumpRequest`-shaped public surface and hand-calling the semi-internal
+  `execute_dump_request` with a kwarg nothing in that surface can set —
+  a different reachability class from the four findings above, each
+  reproduced end-to-end through real, ordinary usage before being fixed.
+  Left for whichever change gives `build_compile_db` its first real caller
+  (i.e. the PR 3A real-run migration itself) to close alongside that
+  migration, rather than shipping validation code with no real path to
+  verify it against.
+
   **A real regression the scan-migration paragraph above introduced, found
   by Codex review and fixed the same session (2026-08-21): `scan --config
   <path>` silently lost the config's own *passive* settings whenever the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5075,6 +5075,24 @@ Once a root command genuinely clears the bar above, pick the right home:
   g++/clang project fixture, confirming the guard doesn't reject a genuinely
   safe combination.
 
+  **A ninth finding (Codex review, fresh evidence): the third
+  under-coverage's own pack recognition for `--build-info` (the sixth
+  finding above) only ever checked `is_pack_dir` — a classic
+  `BuildSourcePack` — never `inputs_pack.is_inputs_pack`, the Flow-2
+  `abicheck_inputs/` shape.** `_l2_seed_pack_inputs` recognizes both shapes
+  for `build_info` identically (`is_pack_dir(build_info) or
+  _is_inputs_pack_dir(build_info)`), and `embed_build_source`'s own
+  `bi_is_inputs` check embeds a Flow-2 `build_info` pack the same way — so a
+  `--build-info` naming a Flow-2 pack reproduced the identical mismatch,
+  missed only because the sixth finding's fix carried over `is_pack_dir`
+  without its Flow-2 sibling, even though the seventh finding's fix
+  (`--sources` packs) already checks both. Fixed by adding `or
+  is_inputs_pack(build_info)` to the same branch. Regression coverage:
+  `TestScopeGuardCoversPackAndBazelBuildInfo::
+  test_flow2_inputs_pack_named_by_build_info_is_recognized` in
+  `tests/test_compile_db_filter_scope.py`, confirmed to fail against the
+  pre-fix guard.
+
   **A real regression the scan-migration paragraph above introduced, found
   by Codex review and fixed the same session (2026-08-21): `scan --config
   <path>` silently lost the config's own *passive* settings whenever the

--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -181,37 +181,26 @@ class InputSpec:
     # (D4) would have silently dropped that guard, so it is request surface,
     # not an MCP-local wrapper concern.
     follow_linker_scripts: bool = True
-    # PR C (CLI cleanup phase two, typed dump/scan convergence) deliberately
-    # does *not* add a `compile_db_filter` field here mirroring `dump
-    # --compile-db-filter`. This pipeline's own L2 header-AST context
-    # (`_seeded_includes_and_compile_context`, the P0.3 L3->L2 fold) has no
-    # filter concept and always resolves from the *whole*, unfiltered compile
-    # database -- unlike the native `dump` CLI, which threads its filter into
-    # its own, structurally different L2 mechanism too
-    # (`cli_helpers_compare._resolve_build_context_flags`). Exposing a field
-    # here that could only ever be combined with a resolvable compile
-    # database by raising (never by actually narrowing the ADR-039
-    # collector's scan) would be a field with no successful use -- see the
-    # plan doc's PR C status notes; a real implementation needs the filter
-    # threaded into the shared L2 fold itself, a separate feature addition to
-    # `buildsource/l2_seed.py`/`header_compile_context.py` (Codex review,
-    # PR #809).
-    #
-    # **That feature addition has since landed** (PR 3A investigation,
-    # 2026-08-21): `resolve_header_compile_context` takes a `source_filter`,
-    # `l2_seed` forwards it, and the ELF `dump` CLI threads its own
-    # `--compile-db-filter` through -- so a filter now genuinely narrows the
-    # fold rather than only the legacy match. The field is still deliberately
-    # absent here, for a *different*, remaining reason: adding it would let a
-    # typed caller reach the L2-filtered/L3-unfiltered snapshot shape the CLI
-    # refuses outright (`header_conditionals.compile_db_filter_scope_error`,
-    # which fires only when the resolved collect mode also *embeds* L3
-    # evidence). Closing that needs the same refusal mirrored into the typed
-    # request's own resolution -- `service_dump_pipeline.resolve_dump_request`
-    # is the right place, since only it knows the resolved collect mode --
-    # plus forwarding through `_seeded_includes_and_compile_context` and into
-    # `attach_build_context_for_parsed_headers`. One clearly-specified step,
-    # not an open-ended one.
+    # Mirrors `dump --compile-db-filter` (PR 3A, dump/scan resolver
+    # convergence -- see the plan doc's PR C status notes and the root
+    # AGENTS.md "PR C" known-gap entry for the two review rounds that shaped
+    # this). `None` (the default) is the pre-existing, unfiltered behavior
+    # for every caller -- `compare`'s implicit-dump path, `dump`'s typed
+    # pipeline via any caller that doesn't set this. `resolve_header_
+    # compile_context`/`l2_seed.seed_includes_and_fold_compile_context`
+    # already accept a `source_filter` and narrow the P0.3 L3->L2 fold by
+    # it (landed alongside the ELF `dump` CLI's own `--compile-db-filter`
+    # threading); `service_dump_pipeline.resolve_dump_request` mirrors the
+    # CLI's own `compile_db_filter_scope_error` refusal (a filter combined
+    # with a resolved collect mode that also embeds L3 evidence is a usage
+    # error, not a silent unfiltered L3 collection) using the resolved
+    # collect mode it alone knows; `service_input_resolution` forwards this
+    # field into both `_seeded_includes_and_compile_context` (the fold) and
+    # `attach_build_context_for_parsed_headers` (the ADR-039 collector), so
+    # the header parse and the collector agree on which translation units
+    # the filter selects, exactly as the three CLI-side layers already do
+    # via `build_context.source_matches_filter`.
+    compile_db_filter: str | None = None
 
     @classmethod
     def of(

--- a/abicheck/api_types.py
+++ b/abicheck/api_types.py
@@ -220,6 +220,7 @@ class InputSpec:
         compile: CompileContext | None = None,
         public_header_dirs: Iterable[Path | str] | None = None,
         follow_linker_scripts: bool = True,
+        compile_db_filter: str | None = None,
     ) -> InputSpec:
         """Build an :class:`InputSpec`, coercing loose front-end values."""
         return cls(
@@ -237,6 +238,7 @@ class InputSpec:
             compile=compile,
             public_header_dirs=_path_tuple(public_header_dirs),
             follow_linker_scripts=follow_linker_scripts,
+            compile_db_filter=compile_db_filter,
         )
 
 

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -712,6 +712,7 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
         ld_library_path=ld_library_path,
         include_labels=_resolved_include_labels,
         resolved_collect_mode=_resolved_collect_mode,
+        compile_db_filter=compile_db_filter,
     )
 
     if dry_run:

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -41,6 +41,7 @@ from .cli_audit import echo_filtered_surface, echo_reconciled
 from .cli_dump_helpers import (
     _dump_will_attempt_hybrid_l4_extraction,
     compile_db_filter_scope_error,
+    compile_db_for_filter_scope_check,
     compile_db_from_build_info,
     handle_non_elf_dump,
     perform_elf_dump,
@@ -576,9 +577,19 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
     # --depth binary has had its say about the headers (a headerless dump has
     # no header AST for a database to parameterize).
     compile_db_path = compile_db_from_build_info(build_info, headers)
+    # The scope check itself resolves the compile database more broadly than
+    # `compile_db_path` above -- a `--sources` tree with no `--build-info` can
+    # still auto-discover one, and the L3->L2 fold/L3 embed both resolve it
+    # from `sources` alone (Codex review, fresh evidence). Deliberately a
+    # *separate* variable: `compile_db_path` itself must stay `--build-info`-
+    # only, since it also drives the legacy `-p` auto-match further down
+    # (`effective_compile_db`) -- see `compile_db_for_filter_scope_check`'s
+    # own docstring for why widening it here would widen that too.
     if (
         _filter_scope_error := compile_db_filter_scope_error(
-            compile_db_filter, compile_db_path, collect_mode
+            compile_db_filter,
+            compile_db_for_filter_scope_check(build_info, sources, headers),
+            collect_mode,
         )
     ) is not None:
         raise click.UsageError(_filter_scope_error)

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -129,6 +129,7 @@ class _WriteSnapshotOutput(Protocol):
 # (Codex review, PR #809).
 _HEADER_CONDITIONALS_REEXPORTS: dict[str, str] = {
     "compile_db_from_build_info": "compile_db_from_build_info",
+    "compile_db_for_filter_scope_check": "compile_db_for_filter_scope_check",
     "compile_db_filter_scope_error": "compile_db_filter_scope_error",
     "_attach_build_context": "attach_build_context",
     "_user_define_flags": "user_define_flags",

--- a/abicheck/cli_dump_request.py
+++ b/abicheck/cli_dump_request.py
@@ -95,6 +95,7 @@ def build_dump_request(
     ld_library_path: str,
     include_labels: dict[Path, str] | None,
     resolved_collect_mode: str | None = None,
+    compile_db_filter: str | None = None,
 ) -> DumpRequest:
     """One :class:`DumpRequest` describing this ``abicheck dump`` invocation.
 
@@ -126,6 +127,14 @@ def build_dump_request(
     ``api_types.DumpRequest.resolved_collect_mode``'s own docstring). ``None``
     for an ordinary ``dump`` invocation, which lets
     ``resolve_dump_request()`` derive it from *depth* as usual.
+
+    *compile_db_filter* is ``dump``'s own ``--compile-db-filter`` value,
+    forwarded onto :attr:`~abicheck.api_types.InputSpec.compile_db_filter`
+    verbatim (PR 3A investigation, 2026-08-21) so a ``--dry-run`` resolved
+    from this request reports the same
+    ``compile_db_filter_scope_error`` refusal ``dump_cmd`` already raises
+    directly, and so the object records the filter that would actually
+    narrow the header parse were the real run migrated onto it.
     """
     from .api_types import DumpRequest, InputSpec
 
@@ -143,6 +152,7 @@ def build_dump_request(
             build_targets=tuple(build_targets),
             dump_manifest=dump_manifest,
             compile=compile_context,
+            compile_db_filter=compile_db_filter,
         ),
         lang=lang,
         frontend=header_backend,

--- a/abicheck/header_conditionals.py
+++ b/abicheck/header_conditionals.py
@@ -1127,6 +1127,19 @@ def compile_db_for_filter_scope_check(
             "bazel_cquery",
         ):
             return build_info
+        # Codex review, fresh evidence (an eighth finding): an explicit
+        # --build-info that resolves to none of the above must NOT fall
+        # through to sources auto-discovery. buildsource.inline.
+        # _resolve_compile_db's own `explicit_input_missed` logic returns
+        # None as soon as a given --build-info misses -- deliberately,
+        # per its own comment, "surface that miss rather than masking it
+        # with a stale auto-discovered DB ... checked BEFORE
+        # auto-discovery" -- so neither the real L2 fold nor the L3 embed
+        # ever falls back to a sources-discovered database in this case.
+        # Falling back here (the pre-fix behavior) produced a false
+        # positive: rejecting a --compile-db-filter combination the real
+        # resolvers wouldn't actually apply it to either side of.
+        return None
     # Codex review, fresh evidence: a --sources pack (classic BuildSourcePack or
     # Flow-2 abicheck_inputs/) carries its own normalized BuildEvidence, which
     # buildsource.l2_seed._l2_seed_pack_inputs folds into L2 seeding exactly

--- a/abicheck/header_conditionals.py
+++ b/abicheck/header_conditionals.py
@@ -1027,20 +1027,48 @@ def compile_db_for_filter_scope_check(
     ``build_info``) and a filter narrowing the L2 parse to one TU still
     embedded both TUs' compile units as L3 evidence.
 
+    A second, distinct under-coverage (Codex review, fresh evidence): even
+    with an explicit ``--build-info <dir>`` given, ``compile_db_from_
+    build_info`` only ever checks ``<build_info>/compile_commands.json``
+    directly -- it has no notion of a conventional out-of-tree build
+    directory (``<build_info>/build/compile_commands.json``,
+    ``<build_info>/cmake-build-debug/compile_commands.json``, ...). The
+    real fold's own ``--build-info`` resolution
+    (``buildsource.inline._compile_db_at``, for a directory delegating to
+    ``_find_compile_db_in_dir``) searches those conventional hint
+    subdirectories -- explicitly "so ``--build-info <dir>`` honours the
+    same contract as ``--sources`` auto-discovery" per that function's own
+    docstring -- so a ``--build-info`` naming a project root whose database
+    lives one level down resolves for the fold but not for this scope
+    check. Reproduced directly: a real two-TU project with its
+    ``compile_commands.json`` moved into a ``build/`` subdirectory,
+    ``--build-info`` pointed at the project root -- the fold correctly
+    found and filtered by the nested database (L3 compile units: 2, L2
+    narrowed to the filtered TU), and the guard never fired.
+
     Deliberately **not** folded into ``compile_db_from_build_info`` itself
     -- that function's result also drives ``dump``'s own legacy ``-p``
     auto-match (``cli.py``'s ``effective_compile_db``), which is
-    intentionally ``--build-info``-only, and widening it here would widen
-    that unrelated mechanism too.
+    intentionally ``--build-info``-only (direct child only, no subdirectory
+    search) and widening it here would widen that unrelated, separately
+    reviewed mechanism too.
 
     ``None`` when neither source names a usable compile database, or when
     *headers* is empty (mirrors ``compile_db_from_build_info``: no L2
     header parse to narrow means nothing for the filter to be inconsistent
     with).
     """
+    if not headers:
+        return None
     explicit = compile_db_from_build_info(build_info, headers)
-    if explicit is not None or not headers:
+    if explicit is not None:
         return explicit
+    if build_info is not None and build_info.is_dir():
+        from .buildsource.inline import _find_compile_db_in_dir
+
+        nested = _find_compile_db_in_dir(build_info)
+        if nested is not None:
+            return nested
     from .buildsource.inline import _autodiscover_compile_db
 
     return _autodiscover_compile_db(sources)

--- a/abicheck/header_conditionals.py
+++ b/abicheck/header_conditionals.py
@@ -1051,19 +1051,24 @@ def compile_db_for_filter_scope_check(
     *whatever* ``BuildEvidence.compile_units`` a ``--build-info`` resolves
     to -- it is not specific to a literal ``compile_commands.json``. A
     ``--build-info`` naming a pre-captured ``collect`` pack directory
-    (``is_pack_dir``) or a Bazel ``aquery``/``cquery`` jsonproto (both
-    routed through their own adapters in
+    (``is_pack_dir``), a Flow-2 ``abicheck_inputs/`` pack
+    (``inputs_pack.is_inputs_pack`` -- a ninth finding, Codex review, fresh
+    evidence, closing the identical gap this paragraph's own ``--sources``
+    sibling below already covers, missed here originally since the pack
+    recognition and the Bazel-jsonproto recognition were added in the same
+    pass and only ``is_pack_dir`` was carried over), or a Bazel
+    ``aquery``/``cquery`` jsonproto (routed through their own adapters in
     ``buildsource.inline._maybe_collect_bazel_build_info``/pack loading, not
     ``load_compile_db()``) resolves compile units the identical way a
     literal compile database does, and the L3 embed collects that same
     ``BuildEvidence`` with no filter either way -- so the mismatch this
-    guard exists to reject reproduces for those two shapes too, just never
-    detected because neither is a ``compile_commands.json`` file
+    guard exists to reject reproduces for those three shapes too, just never
+    detected because none is a ``compile_commands.json`` file
     ``compile_db_from_build_info`` recognizes. ``sniff_build_info_format``
     is the same cheap, execution-free classifier ``compile_db_from_
-    build_info`` already uses to tell these shapes apart -- checking it here
-    costs nothing and cannot disagree with what dispatch itself does with
-    the same path.
+    build_info`` already uses to tell the Bazel shapes apart -- checking it
+    here costs nothing and cannot disagree with what dispatch itself does
+    with the same path.
 
     Deliberately **not** folded into ``compile_db_from_build_info`` itself
     -- that function's result also drives ``dump``'s own legacy ``-p``
@@ -1116,11 +1121,18 @@ def compile_db_for_filter_scope_check(
 
         if build_info.is_dir():
             from .buildsource.inline import _find_compile_db_in_dir, is_pack_dir
+            from .buildsource.inputs_pack import is_inputs_pack
 
             nested = _find_compile_db_in_dir(build_info)
             if nested is not None:
                 return nested
-            if is_pack_dir(build_info):
+            # Codex review, fresh evidence (a ninth finding): a --build-info
+            # naming a Flow-2 abicheck_inputs/ pack is recognized by
+            # _l2_seed_pack_inputs (is_pack_dir OR _is_inputs_pack_dir) and
+            # by embed_build_source's own bi_is_inputs check -- this branch
+            # previously checked only is_pack_dir, missing the Flow-2 shape
+            # its own --sources sibling below already covers.
+            if is_pack_dir(build_info) or is_inputs_pack(build_info):
                 return build_info
         elif build_info.is_file() and sniff_build_info_format(build_info) in (
             "bazel_aquery",

--- a/abicheck/header_conditionals.py
+++ b/abicheck/header_conditionals.py
@@ -1003,6 +1003,49 @@ def compile_db_from_build_info(
     return db if db.is_file() and sniff_build_info_format(db) == "compile_db" else None
 
 
+def compile_db_for_filter_scope_check(
+    build_info: Path | None,
+    sources: Path | None,
+    headers: tuple[Path, ...],
+) -> Path | None:
+    """The compile database ``compile_db_filter_scope_error`` should check
+    against -- covering both ways the L3->L2 fold can resolve one, not only
+    an explicit ``--build-info`` (Codex review, fresh evidence).
+
+    ``compile_db_from_build_info`` alone under-covers this: when no
+    ``--build-info`` is given but ``--sources`` names a tree containing an
+    auto-discovered ``compile_commands.json``
+    (``buildsource.inline._autodiscover_compile_db`` -- the identical P4
+    strategy ``seed_includes_and_fold_compile_context``'s own fold and
+    ``embed_build_source``'s L3 collection *both* already use to find one
+    from ``sources`` alone), the fold still narrows the L2 header parse by
+    ``compile_db_filter`` while the L3 embed collects the same
+    auto-discovered database unfiltered -- the exact filtered-L2/
+    unfiltered-L3 mismatch this whole scope guard exists to reject, just
+    reached without ``--build-info`` at all. Reproduced directly: a real
+    ``g++``-compiled two-TU project resolved with ``sources`` only (no
+    ``build_info``) and a filter narrowing the L2 parse to one TU still
+    embedded both TUs' compile units as L3 evidence.
+
+    Deliberately **not** folded into ``compile_db_from_build_info`` itself
+    -- that function's result also drives ``dump``'s own legacy ``-p``
+    auto-match (``cli.py``'s ``effective_compile_db``), which is
+    intentionally ``--build-info``-only, and widening it here would widen
+    that unrelated mechanism too.
+
+    ``None`` when neither source names a usable compile database, or when
+    *headers* is empty (mirrors ``compile_db_from_build_info``: no L2
+    header parse to narrow means nothing for the filter to be inconsistent
+    with).
+    """
+    explicit = compile_db_from_build_info(build_info, headers)
+    if explicit is not None or not headers:
+        return explicit
+    from .buildsource.inline import _autodiscover_compile_db
+
+    return _autodiscover_compile_db(sources)
+
+
 def compile_db_filter_scope_error(
     compile_db_filter: str | None,
     compile_db_path: Path | None,

--- a/abicheck/header_conditionals.py
+++ b/abicheck/header_conditionals.py
@@ -1073,6 +1073,24 @@ def compile_db_for_filter_scope_check(
     jsonproto was never a valid ``-p`` operand) and widening it here would
     widen that unrelated, separately reviewed mechanism too.
 
+    A fourth under-coverage (Codex review, fresh evidence): the third
+    under-coverage's fix only checked a *pack* named by ``--build-info``,
+    but ``buildsource.l2_seed._l2_seed_pack_inputs`` recognizes a
+    ``--sources`` pack (a classic ``BuildSourcePack`` or a Flow-2
+    ``abicheck_inputs/`` directory) the identical way -- carrying its own
+    normalized ``BuildEvidence`` into L2 seeding -- whenever *no*
+    ``--build-info`` was given at all (an explicit ``--build-info`` always
+    wins L3, matching ``_l2_seed_pack_inputs``'s own ``if build_info is
+    None:`` gate on that assignment). A ``--sources`` naming such a pack,
+    with no ``--build-info``, therefore reproduced the identical mismatch:
+    this function's fallback resolution (``compile_db_from_build_info``
+    then ``_autodiscover_compile_db``) only ever looks for a literal
+    ``compile_commands.json`` inside *sources*, which a pack directory does
+    not carry at its root. Fixed by recognizing a ``sources`` pack via the
+    same two functions ``_l2_seed_pack_inputs`` itself uses (``is_pack_dir``
+    / ``inputs_pack.is_inputs_pack``), gated on ``build_info is None`` to
+    match that function's own precedence exactly.
+
     Still not covered, and not attempted here: a ``--sources`` tree with no
     discoverable ``compile_commands.json`` at all, resolved instead through
     the zero-config *inferred* build-system query (cmake/make/bazel). Unlike
@@ -1109,6 +1127,21 @@ def compile_db_for_filter_scope_check(
             "bazel_cquery",
         ):
             return build_info
+    # Codex review, fresh evidence: a --sources pack (classic BuildSourcePack or
+    # Flow-2 abicheck_inputs/) carries its own normalized BuildEvidence, which
+    # buildsource.l2_seed._l2_seed_pack_inputs folds into L2 seeding exactly
+    # like a --build-info pack -- but only when no --build-info was given at
+    # all (an explicit --build-info always wins L3, mirroring
+    # _l2_seed_pack_inputs's own `if build_info is None:` gate on the base_build
+    # assignment). Recognized the identical way _l2_seed_pack_inputs does
+    # (is_pack_dir / inputs_pack.is_inputs_pack), not via the compile-
+    # database-only sniff this function otherwise uses.
+    if build_info is None and sources is not None and sources.is_dir():
+        from .buildsource.inline import is_pack_dir
+        from .buildsource.inputs_pack import is_inputs_pack
+
+        if is_pack_dir(sources) or is_inputs_pack(sources):
+            return sources
     from .buildsource.inline import _autodiscover_compile_db
 
     return _autodiscover_compile_db(sources)

--- a/abicheck/header_conditionals.py
+++ b/abicheck/header_conditionals.py
@@ -1046,14 +1046,44 @@ def compile_db_for_filter_scope_check(
     found and filtered by the nested database (L3 compile units: 2, L2
     narrowed to the filtered TU), and the guard never fired.
 
+    A third under-coverage (Codex review, fresh evidence): the fold's own
+    ``resolve_header_compile_context``/``filter_units_by_source`` narrows
+    *whatever* ``BuildEvidence.compile_units`` a ``--build-info`` resolves
+    to -- it is not specific to a literal ``compile_commands.json``. A
+    ``--build-info`` naming a pre-captured ``collect`` pack directory
+    (``is_pack_dir``) or a Bazel ``aquery``/``cquery`` jsonproto (both
+    routed through their own adapters in
+    ``buildsource.inline._maybe_collect_bazel_build_info``/pack loading, not
+    ``load_compile_db()``) resolves compile units the identical way a
+    literal compile database does, and the L3 embed collects that same
+    ``BuildEvidence`` with no filter either way -- so the mismatch this
+    guard exists to reject reproduces for those two shapes too, just never
+    detected because neither is a ``compile_commands.json`` file
+    ``compile_db_from_build_info`` recognizes. ``sniff_build_info_format``
+    is the same cheap, execution-free classifier ``compile_db_from_
+    build_info`` already uses to tell these shapes apart -- checking it here
+    costs nothing and cannot disagree with what dispatch itself does with
+    the same path.
+
     Deliberately **not** folded into ``compile_db_from_build_info`` itself
     -- that function's result also drives ``dump``'s own legacy ``-p``
     auto-match (``cli.py``'s ``effective_compile_db``), which is
     intentionally ``--build-info``-only (direct child only, no subdirectory
-    search) and widening it here would widen that unrelated, separately
-    reviewed mechanism too.
+    search, and only ever a real ``compile_commands.json`` -- a pack/Bazel
+    jsonproto was never a valid ``-p`` operand) and widening it here would
+    widen that unrelated, separately reviewed mechanism too.
 
-    ``None`` when neither source names a usable compile database, or when
+    Still not covered, and not attempted here: a ``--sources`` tree with no
+    discoverable ``compile_commands.json`` at all, resolved instead through
+    the zero-config *inferred* build-system query (cmake/make/bazel). Unlike
+    every case above, telling whether that combination would actually
+    resolve multiple compile units means running the build system's own
+    query -- the exact side effect this cheap, read-only scope check is
+    built to avoid paying twice per invocation. See this repository's
+    ``AGENTS.md`` "Known gaps" for that residual, documented rather than
+    guessed at.
+
+    ``None`` when neither source names usable build evidence, or when
     *headers* is empty (mirrors ``compile_db_from_build_info``: no L2
     header parse to narrow means nothing for the filter to be inconsistent
     with).
@@ -1063,12 +1093,22 @@ def compile_db_for_filter_scope_check(
     explicit = compile_db_from_build_info(build_info, headers)
     if explicit is not None:
         return explicit
-    if build_info is not None and build_info.is_dir():
-        from .buildsource.inline import _find_compile_db_in_dir
+    if build_info is not None:
+        from .buildsource.inline import sniff_build_info_format
 
-        nested = _find_compile_db_in_dir(build_info)
-        if nested is not None:
-            return nested
+        if build_info.is_dir():
+            from .buildsource.inline import _find_compile_db_in_dir, is_pack_dir
+
+            nested = _find_compile_db_in_dir(build_info)
+            if nested is not None:
+                return nested
+            if is_pack_dir(build_info):
+                return build_info
+        elif build_info.is_file() and sniff_build_info_format(build_info) in (
+            "bazel_aquery",
+            "bazel_cquery",
+        ):
+            return build_info
     from .buildsource.inline import _autodiscover_compile_db
 
     return _autodiscover_compile_db(sources)
@@ -1101,17 +1141,22 @@ def compile_db_filter_scope_error(
     change to ``buildsource/`` with its own evidence gates, not something to
     infer from one review round.
 
-    ``None`` when the combination cannot arise: no filter, a ``--build-info``
-    that is not a compile database (a pack or Bazel jsonproto routes through
-    a different adapter), or ``collect_mode == "off"``, where no build
-    evidence is embedded for the filter to be inconsistent with.
+    ``None`` when the combination cannot arise: no filter, no resolvable
+    build evidence for *compile_db_path* to name (see
+    ``compile_db_for_filter_scope_check``, this function's real caller --
+    since ADR/Codex review it resolves a pack directory and a Bazel
+    aquery/cquery jsonproto here too, not only a literal
+    ``compile_commands.json``, so this parameter no longer names a compile
+    database specifically despite its name), or ``collect_mode == "off"``,
+    where no build evidence is embedded for the filter to be inconsistent
+    with.
     """
     if not compile_db_filter or compile_db_path is None or collect_mode == "off":
         return None
     return (
         "--compile-db-filter scopes the L2 header parse only; the L3 build "
-        "evidence embedded from the same --build-info compilation database is "
-        "collected unfiltered, so the snapshot would carry build facts for "
+        "evidence embedded from the same --build-info source is collected "
+        "unfiltered, so the snapshot would carry build facts for "
         "translation units the filter excludes. Pass a pre-filtered "
         "compile_commands.json as --build-info (then --compile-db-filter is "
         "unnecessary), or drop --compile-db-filter to accept the whole "

--- a/abicheck/service_compare_evidence.py
+++ b/abicheck/service_compare_evidence.py
@@ -396,17 +396,27 @@ def reject_compile_db_filter_scope_mismatch(
     resulting snapshot carries build facts for translation units the header
     parse never saw (Codex review — `resolve_dump_request`'s own guard,
     landed first, covered `DumpRequest` alone).
+
+    Resolves the checked compile database via
+    ``header_conditionals.compile_db_for_filter_scope_check`` -- not the
+    narrower ``compile_db_from_build_info`` -- so a side whose database is
+    only auto-discovered from ``sources`` (no explicit ``build_info`` at
+    all) is covered too (Codex review, fresh evidence: the fold and the L3
+    embed both resolve that same auto-discovered database independently,
+    so the identical mismatch reproduces with no ``build_info`` in play).
     """
     from .errors import ValidationError
     from .header_conditionals import (
         compile_db_filter_scope_error,
-        compile_db_from_build_info,
+        compile_db_for_filter_scope_check,
     )
 
     for label, side, evidence in sides:
         error = compile_db_filter_scope_error(
             side.compile_db_filter,
-            compile_db_from_build_info(side.build_info, tuple(evidence.headers)),
+            compile_db_for_filter_scope_check(
+                side.build_info, side.sources, tuple(evidence.headers)
+            ),
             evidence.collect_mode,
         )
         if error is not None:

--- a/abicheck/service_compare_evidence.py
+++ b/abicheck/service_compare_evidence.py
@@ -63,6 +63,7 @@ __all__ = [
     "dump_collect_mode_for",
     "effective_frontend",
     "normalized_debug_format",
+    "reject_compile_db_filter_scope_mismatch",
     "reject_debug_format_for_binaries",
     "reject_debug_format_for_non_elf",
     "resolve_compare_request_evidence",
@@ -367,6 +368,49 @@ def resolve_compare_request_evidence(
         )
 
     return _side(request.old), _side(request.new)
+
+
+def reject_compile_db_filter_scope_mismatch(
+    sides: Iterable[tuple[str, InputSpec, SideEvidence]],
+) -> None:
+    """Raise if any side's ``InputSpec.compile_db_filter`` would narrow the L2
+    header parse while its L3 build evidence -- collected by
+    ``embed_build_source``, which has no filter concept of its own -- stays
+    unfiltered.
+
+    Mirrors the native ``dump`` CLI's own
+    ``header_conditionals.compile_db_filter_scope_error`` refusal (``cli.py``'s
+    ``dump_cmd``), computed per side from that side's own resolved
+    :class:`~abicheck.service_compare_evidence.SideEvidence` --
+    ``evidence.collect_mode``/``evidence.headers`` are the same resolved
+    values the CLI reads ``compile_db_from_build_info`` back against.
+
+    *sides* is ``(label, side, evidence)`` triples, mirroring
+    :func:`reject_debug_format_for_binaries`'s ``(label, ...)`` shape --
+    ``dump`` passes its single ``input``, ``compare`` passes ``old``/``new``.
+    Without this, a typed ``CompareRequest`` side could reach the exact
+    L2-filtered/L3-unfiltered snapshot shape the CLI refuses outright: a
+    `compile_db_filter` narrows `resolve_side_snapshot`'s own P0.3 L3->L2 fold
+    (`_seeded_includes_and_compile_context`) but `embed_side_build_source`
+    collects L3 evidence from the *whole* compile database regardless, so the
+    resulting snapshot carries build facts for translation units the header
+    parse never saw (Codex review — `resolve_dump_request`'s own guard,
+    landed first, covered `DumpRequest` alone).
+    """
+    from .errors import ValidationError
+    from .header_conditionals import (
+        compile_db_filter_scope_error,
+        compile_db_from_build_info,
+    )
+
+    for label, side, evidence in sides:
+        error = compile_db_filter_scope_error(
+            side.compile_db_filter,
+            compile_db_from_build_info(side.build_info, tuple(evidence.headers)),
+            evidence.collect_mode,
+        )
+        if error is not None:
+            raise ValidationError(f"{label}: {error}")
 
 
 def normalized_debug_format(request: CompareRequest | DumpRequest) -> str | None:

--- a/abicheck/service_compare_pipeline.py
+++ b/abicheck/service_compare_pipeline.py
@@ -308,6 +308,15 @@ def resolve_compare_request(
     old_evidence, new_evidence = _sce.resolve_compare_request_evidence(
         request, pair_compile
     )
+    # Mirrors `resolve_dump_request`'s identical per-side check (Codex
+    # review, PR 3A investigation): a `CompareRequest` side's own
+    # `InputSpec.compile_db_filter` reaches the same P0.3 L3->L2 fold /
+    # `embed_side_build_source` split `resolve_dump_request`'s guard was
+    # written for, so the same L2-filtered/L3-unfiltered refusal must fire
+    # here too, not only on the single-input `dump` path.
+    _sce.reject_compile_db_filter_scope_mismatch(
+        (("old", request.old, old_evidence), ("new", request.new, new_evidence))
+    )
     _reject_unsupported_frontends(
         request, frontend_lower, header_backend, old_evidence, new_evidence
     )

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -327,10 +327,6 @@ def resolve_dump_request(request: DumpRequest) -> ResolvedDumpRequest:
     """
     from . import service, service_compare_evidence as _sce
     from .api_types import HEADER_AST_FRONTENDS
-    from .header_conditionals import (
-        compile_db_filter_scope_error,
-        compile_db_from_build_info,
-    )
     from .header_utils import split_public_header_inputs
 
     request.validate()
@@ -357,17 +353,10 @@ def resolve_dump_request(request: DumpRequest) -> ResolvedDumpRequest:
     # that knows the *resolved* collect mode a `--compile-db-filter`-shaped
     # `InputSpec.compile_db_filter` would otherwise silently disagree with
     # (PR 3A investigation, 2026-08-21; see `InputSpec.compile_db_filter`'s
-    # own docstring). `evidence.headers` is the same post-resolution header
-    # set the CLI reads `compile_db_from_build_info` back against -- both
-    # already reflect `depth="binary"` clearing.
-    if (
-        _filter_scope_error := compile_db_filter_scope_error(
-            side.compile_db_filter,
-            compile_db_from_build_info(side.build_info, tuple(evidence.headers)),
-            evidence.collect_mode,
-        )
-    ) is not None:
-        raise ValidationError(_filter_scope_error)
+    # own docstring). Shared with `resolve_compare_request`'s identical
+    # per-side check (Codex review: a `CompareRequest` side reaches the exact
+    # same fold/embed split, so the guard belongs in one place both call).
+    _sce.reject_compile_db_filter_scope_mismatch((("input", side, evidence),))
     _reject_unsupported_frontends(request, header_backend, evidence)
     # Pinned once, here -- not a lazily-recomputed property (see
     # ResolvedDumpRequest.effective_header_backend's own comment).

--- a/abicheck/service_dump_pipeline.py
+++ b/abicheck/service_dump_pipeline.py
@@ -327,6 +327,10 @@ def resolve_dump_request(request: DumpRequest) -> ResolvedDumpRequest:
     """
     from . import service, service_compare_evidence as _sce
     from .api_types import HEADER_AST_FRONTENDS
+    from .header_conditionals import (
+        compile_db_filter_scope_error,
+        compile_db_from_build_info,
+    )
     from .header_utils import split_public_header_inputs
 
     request.validate()
@@ -348,6 +352,22 @@ def resolve_dump_request(request: DumpRequest) -> ResolvedDumpRequest:
     _sce.reject_debug_format_for_binaries(debug_format, (("input", fmt),))
 
     evidence = _sce.resolve_dump_request_evidence(request)
+    # Mirrors the ELF `dump` CLI's own `compile_db_filter_scope_error` check
+    # (`cli.py`'s `dump_cmd`) -- this is the one place in the typed pipeline
+    # that knows the *resolved* collect mode a `--compile-db-filter`-shaped
+    # `InputSpec.compile_db_filter` would otherwise silently disagree with
+    # (PR 3A investigation, 2026-08-21; see `InputSpec.compile_db_filter`'s
+    # own docstring). `evidence.headers` is the same post-resolution header
+    # set the CLI reads `compile_db_from_build_info` back against -- both
+    # already reflect `depth="binary"` clearing.
+    if (
+        _filter_scope_error := compile_db_filter_scope_error(
+            side.compile_db_filter,
+            compile_db_from_build_info(side.build_info, tuple(evidence.headers)),
+            evidence.collect_mode,
+        )
+    ) is not None:
+        raise ValidationError(_filter_scope_error)
     _reject_unsupported_frontends(request, header_backend, evidence)
     # Pinned once, here -- not a lazily-recomputed property (see
     # ResolvedDumpRequest.effective_header_backend's own comment).

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -495,6 +495,7 @@ def _seeded_includes_and_compile_context(
             lang=lang,
             lang_explicit=lang_explicit,
             pending_cleanups=cleanups,
+            source_filter=side.compile_db_filter,
         )
     )
     # seed_includes_and_fold_compile_context() always returns a real
@@ -818,14 +819,18 @@ def _resolve_side_snapshot_impl(
         # `user_define_flags`' own docstring, and the ninth finding in the root
         # AGENTS.md's L3->L2-fold entry).
         #
-        # No `compile_db_filter` is threaded through here (and `InputSpec`
-        # deliberately doesn't carry one -- see its own comment): this shared
-        # pipeline's own L2 header-AST context (`_seeded_includes_and_compile_
-        # context`, the P0.3 L3->L2 fold, already run above) always resolves
-        # from the *whole*, unfiltered compile database, unlike the native
-        # `dump` CLI, which threads its `--compile-db-filter` into its own,
-        # structurally different L2 mechanism too
-        # (`cli_helpers_compare._resolve_build_context_flags`).
+        # `side.compile_db_filter` (PR 3A investigation, 2026-08-21): the same
+        # filter narrowed `_seeded_includes_and_compile_context`'s fold above,
+        # forwarded here too so the ADR-039 collector scans the identical
+        # translation-unit subset the header parse used -- exactly the
+        # "the fold, the legacy match and the ADR-039 collector cannot select
+        # different translation units for the same filter" invariant
+        # `build_context.source_matches_filter` establishes for the three
+        # CLI-side layers (root AGENTS.md's PR C entry). `resolve_dump_
+        # request` is what refuses the combination this can't safely narrow
+        # (a filter with a resolved collect mode that also embeds *this*
+        # side's L3 evidence via `embed_side_build_source` below, which has no
+        # filter concept of its own) before this function is ever reached.
         attach_build_context_for_parsed_headers(
             snap,
             evidence.headers,
@@ -837,6 +842,7 @@ def _resolve_side_snapshot_impl(
                 side.compile.gcc_option_tokens if side.compile else ()
             ),
             user_gcc_options=side.compile.gcc_options if side.compile else None,
+            source_filter=side.compile_db_filter,
         )
         if side.sources or side.build_info:
             # Known, accepted limitation (Codex review, fresh evidence, not

--- a/changelog.d/20260821_223201_noreply_compile_db_filter_typed_api_r7k2mq.md
+++ b/changelog.d/20260821_223201_noreply_compile_db_filter_typed_api_r7k2mq.md
@@ -16,4 +16,9 @@
   `None` (the default) is a no-op for every existing caller. `dump_cmd`
   forwards its own `--compile-db-filter` value into the `DumpRequest` it
   builds for `--dry-run`, so a dry run now reports the identical refusal
-  the real CLI already raised directly.
+  the real CLI already raised directly. The refusal is shared
+  (`service_compare_evidence.reject_compile_db_filter_scope_mismatch`) with
+  `CompareRequest`, whose `old`/`new` sides can set `compile_db_filter` too —
+  the same L2-filtered/L3-unfiltered mismatch is now rejected there as well,
+  not only on the single-input `dump` path. `InputSpec.of(...)` (the loose
+  convenience factory) also accepts and forwards `compile_db_filter`.

--- a/changelog.d/20260821_223201_noreply_compile_db_filter_typed_api_r7k2mq.md
+++ b/changelog.d/20260821_223201_noreply_compile_db_filter_typed_api_r7k2mq.md
@@ -1,0 +1,19 @@
+### Added
+
+- **`InputSpec.compile_db_filter` (typed `dump`/`compare` API) mirrors `dump
+  --compile-db-filter`** (CLI cleanup phase two, PR 3A investigation). Until
+  now the typed pipeline's own L2 header-AST context
+  (`_seeded_includes_and_compile_context`, the P0.3 L3→L2 fold) always
+  resolved from the *whole*, unfiltered compile database, even though the
+  native `dump` CLI's own `--compile-db-filter` had already been threaded
+  into that same shared fold (`resolve_header_compile_context`/
+  `seed_includes_and_fold_compile_context`'s `source_filter`). Setting this
+  new field now narrows the fold and the ADR-039 build-context collector
+  identically to the CLI, and `service_dump_pipeline.resolve_dump_request`
+  mirrors the CLI's own `compile_db_filter_scope_error` refusal — a filter
+  combined with a resolved collect mode that also embeds L3 build evidence
+  is rejected as a usage error rather than silently collected unfiltered.
+  `None` (the default) is a no-op for every existing caller. `dump_cmd`
+  forwards its own `--compile-db-filter` value into the `DumpRequest` it
+  builds for `--dry-run`, so a dry run now reports the identical refusal
+  the real CLI already raised directly.

--- a/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
+++ b/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
@@ -55,3 +55,11 @@
   `--sources`-discovered database instead. Fixed by returning cleanly (no
   usage error) once an explicit, given `--build-info` resolves to nothing,
   matching the real resolver's own precedence.
+- **`dump --compile-db-filter --build-info <path>` now also catches a
+  `--build-info` naming a Flow-2 `abicheck_inputs/` pack**, not only a
+  classic `BuildSourcePack`. An earlier fix in this same release recognized
+  a `--build-info` pack directory, but only checked for the classic pack
+  format — the L2 seed and the L3 embed both also recognize a Flow-2
+  `abicheck_inputs/` directory identically, so that shape silently
+  reproduced the same filtered-L2/unfiltered-L3 mismatch. Fixed on the CLI
+  and the typed `DumpRequest`/`CompareRequest` API alike.

--- a/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
+++ b/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **`dump --compile-db-filter` combined with `--sources` (no `--build-info`)
+  no longer silently produces a mismatched snapshot.** The scope check
+  guarding `--compile-db-filter` (`--compile-db-filter scopes the L2 header
+  parse only...`) only ever resolved the compile database from an explicit
+  `--build-info`. A `--sources` tree whose own `compile_commands.json` is
+  auto-discovered (no `--build-info` given at all) reaches the identical
+  compile database through both the L2 header-AST fold *and* the L3
+  build-evidence embed — but only the fold honors `--compile-db-filter` — so
+  the guard never fired for that shape, and the resulting snapshot carried L3
+  build evidence for translation units the filtered L2 header parse never
+  saw. `dump --sources tree/ --compile-db-filter foo.cpp --depth build` (no
+  `--build-info`) now correctly rejects the combination the same way it
+  already did with an explicit `--build-info`. Also closes the identical gap
+  on the typed `DumpRequest`/`CompareRequest` API surfaces added in this same
+  release.

--- a/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
+++ b/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
@@ -45,3 +45,13 @@
   pack directory doesn't carry at its root, so the mismatch reproduced with
   no error. Fixed on the CLI and the typed `DumpRequest`/`CompareRequest`
   API alike.
+- **`dump --compile-db-filter --build-info <path>` combined with a
+  `--sources` tree no longer raises a false-positive scope-mismatch error
+  when `--build-info` itself doesn't resolve to anything.** A fix earlier in
+  this same release made the scope check fall back to `--sources` whenever
+  none of the `--build-info` checks matched — including when `--build-info`
+  was genuinely given but unresolvable, which is wrong: the real L2 fold and
+  L3 embed both surface that miss rather than silently falling back to a
+  `--sources`-discovered database instead. Fixed by returning cleanly (no
+  usage error) once an explicit, given `--build-info` resolves to nothing,
+  matching the real resolver's own precedence.

--- a/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
+++ b/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
@@ -15,3 +15,13 @@
   already did with an explicit `--build-info`. Also closes the identical gap
   on the typed `DumpRequest`/`CompareRequest` API surfaces added in this same
   release.
+- **`dump --compile-db-filter --build-info <dir>` now also catches a
+  compile database in a conventional out-of-tree subdirectory** (e.g.
+  `<dir>/build/compile_commands.json`), not only `<dir>/compile_commands.json`
+  directly. The scope check's `--build-info` resolution previously only
+  checked the immediate child, while the real header-AST fold already
+  searches the same conventional build-directory hints `--sources`
+  auto-discovery uses — so `--build-info` naming a project root whose
+  database lives one level down resolved for the fold but not for the guard,
+  reproducing the identical filtered-L2/unfiltered-L3 mismatch. Fixed on the
+  CLI and the typed `DumpRequest`/`CompareRequest` API alike.

--- a/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
+++ b/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
@@ -35,3 +35,13 @@
   typed `DumpRequest`/`CompareRequest` API alike; a `--sources` tree with no
   discoverable compile database, resolved only through the zero-config
   inferred build-system query, remains a documented gap (see `AGENTS.md`).
+- **`dump --compile-db-filter --sources <path>` now also catches a
+  `--sources` tree that is itself a pre-captured `collect` pack (a classic
+  `BuildSourcePack` or a Flow-2 `abicheck_inputs/` directory), not only an
+  explicit `--build-info` pack.** L2 seeding folds such a `--sources` pack's
+  own build evidence in whenever no `--build-info` is given, the identical
+  way a `--build-info` pack does — but the scope guard's `--sources`
+  fallback only ever looked for a literal `compile_commands.json`, which a
+  pack directory doesn't carry at its root, so the mismatch reproduced with
+  no error. Fixed on the CLI and the typed `DumpRequest`/`CompareRequest`
+  API alike.

--- a/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
+++ b/changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md
@@ -25,3 +25,13 @@
   database lives one level down resolved for the fold but not for the guard,
   reproducing the identical filtered-L2/unfiltered-L3 mismatch. Fixed on the
   CLI and the typed `DumpRequest`/`CompareRequest` API alike.
+- **`dump --compile-db-filter --build-info <path>` now also catches a
+  pre-captured `collect` pack directory and a Bazel `aquery`/`cquery`
+  jsonproto**, not only a literal `compile_commands.json`. The L3→L2 fold
+  narrows *whatever* build evidence a `--build-info` resolves to, regardless
+  of its shape — but the scope guard only ever recognized a literal compile
+  database, so a pack or Bazel jsonproto silently reproduced the identical
+  filtered-L2/unfiltered-L3 mismatch with no error. Fixed on the CLI and the
+  typed `DumpRequest`/`CompareRequest` API alike; a `--sources` tree with no
+  discoverable compile database, resolved only through the zero-config
+  inferred build-system query, remains a documented gap (see `AGENTS.md`).

--- a/docs/contribute/plans/cli-cleanup-phase-two.md
+++ b/docs/contribute/plans/cli-cleanup-phase-two.md
@@ -1705,13 +1705,31 @@ pipelines a fourth time.
   > invariants, the three layers agreeing, the resolver, and a real
   > `g++`+clang `dump` asserting the guarded field is parsed in or out
   > according to *which* TU the filter names (the end-to-end cases confirmed
-  > to fail pre-fix). Still open in this slice: the typed half —
-  > `InputSpec.compile_db_filter` plus the CLI's own
+  > to fail pre-fix). Still open in this slice (at the time it landed): the
+  > typed half — `InputSpec.compile_db_filter` plus the CLI's own
   > L2-filtered/L3-unfiltered refusal
   > (`header_conditionals.compile_db_filter_scope_error`) mirrored into
   > `resolve_dump_request`, the only place that knows the resolved collect
   > mode. That is one clearly-specified step; see the field's replacement
   > comment in `api_types.py`.
+  >
+  > **That typed half has since landed (2026-08-21, later session).**
+  > `InputSpec.compile_db_filter` exists; `_seeded_includes_and_compile_
+  > context` and `attach_build_context_for_parsed_headers` both forward it as
+  > `source_filter`; `resolve_dump_request` mirrors the CLI's scope-error
+  > refusal from `evidence.collect_mode`/`evidence.headers` and raises
+  > `ValidationError` (translated to `click.UsageError` at the CLI boundary,
+  > unchanged); `dump_cmd` forwards its own `--compile-db-filter` into the
+  > `DumpRequest` `--dry-run` resolves. Verified against the identical real
+  > `g++`+clang project through the typed `DumpRequest`/`resolve_dump_
+  > request`/`execute_dump_request` path directly (not the CLI):
+  > `tests/test_compile_db_filter_scope.py`'s
+  > `TestTypedApiHonorsTheFilterInTheFold`. The CLI's own behavior was
+  > re-verified unchanged. This closes item (1) of the "what still blocks the
+  > `dump` real-run migration" list below — it does **not** migrate the real
+  > run itself, and does not claim to; see the root `AGENTS.md`'s PR C entry
+  > for the full account, including why item (2) (castxml) still blocks the
+  > migration on its own.
   >
   > One environmental fact that independently rules out doing it in that
   > session: **the default header backend is castxml, and no working

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -147,6 +147,7 @@ One side of a comparison: a binary/snapshot path plus its build context.
 | `compile` | `CompileContext \| None` | `None` |
 | `public_header_dirs` | `tuple[Path, ...]` | `()` |
 | `follow_linker_scripts` | `bool` | `True` |
+| `compile_db_filter` | `str \| None` | `None` |
 
 ## `LayerResult`
 

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -2183,7 +2183,7 @@ CLI_CONTRACT_ALLOWLIST: frozenset[str] = frozenset(
         # Native ELF CLI dump (P0 item 2): calls `dumper.dump()` directly
         # rather than through `service_dump_pipeline.run_dump_request` —
         # tracked as Phase 1 item 1 of the convergence plan.
-        "abicheck/cli_dump_helpers.py:1644:19:dumper.dump",
+        "abicheck/cli_dump_helpers.py:1645:19:dumper.dump",
         # Standalone application-compatibility (P0 item 6): dumps both
         # sides directly rather than through any of the other paths.
         "abicheck/appcompat.py:1599:15:dumper.dump",

--- a/tests/test_compile_db_filter_scope.py
+++ b/tests/test_compile_db_filter_scope.py
@@ -1129,3 +1129,72 @@ class TestScopeGuardCoversSourcesPacks:
             None, plain_tree, (tmp_path / "api.h",)
         )
         assert resolved is None
+
+
+class TestScopeGuardDoesNotFallBackToSourcesWhenBuildInfoMisses:
+    """Codex review, P2 (an eighth finding): the seventh finding's fix made
+    every branch fall through unconditionally to the sources-based checks
+    once none of the ``build_info`` branches matched -- but
+    ``buildsource.inline._resolve_compile_db``'s own ``explicit_input_
+    missed`` logic (the real function every one of these seeded resolvers
+    ultimately calls) returns ``None`` as soon as a *given* ``build_info``
+    misses, deliberately, per its own comment: "surface that miss rather
+    than masking it with a stale auto-discovered DB ... checked BEFORE
+    auto-discovery". So an explicit ``--build-info`` that doesn't resolve
+    to anything recognizable means neither the real L2 fold nor the L3
+    embed ever falls back to a ``sources``-discovered database -- falling
+    back in the guard produced a false positive, rejecting a
+    ``--compile-db-filter`` combination the real resolvers wouldn't
+    actually apply to either side of. Pure predicate tests, no compiler
+    needed for the unrecognized-build_info half; the auto-discoverable-
+    sources half reuses the real g++/clang project fixture to prove the
+    combination the guard now permits is genuinely one the real fold
+    ignores ``sources`` for.
+    """
+
+    def test_unresolvable_build_info_does_not_fall_back_to_sources_auto_discovery(
+        self, tmp_path: Path
+    ) -> None:
+        from abicheck.header_conditionals import compile_db_for_filter_scope_check
+
+        unrelated_build_info = tmp_path / "not_a_pack_or_db"
+        unrelated_build_info.mkdir()
+        sources = tmp_path / "sources"
+        sources.mkdir()
+        (sources / "compile_commands.json").write_text("[]", encoding="utf-8")
+        resolved = compile_db_for_filter_scope_check(
+            unrelated_build_info, sources, (tmp_path / "api.h",)
+        )
+        assert resolved is None
+
+    @pytest.mark.integration
+    @pytest.mark.skipif(
+        not sys.platform.startswith("linux"),
+        reason="ELF/Linux-scoped repro (real g++-compiled .so + compile_commands.json)",
+    )
+    @pytest.mark.skipif(
+        not (_HAVE_GXX and _HAVE_CLANG), reason="needs a real g++ and clang toolchain"
+    )
+    def test_an_unresolvable_build_info_alongside_a_real_sources_db_is_unaffected(
+        self, tmp_path: Path
+    ) -> None:
+        """Positive control against the real g++/clang project: with a
+        genuinely unresolvable ``--build-info`` alongside a ``--sources``
+        tree that *does* auto-discover a real compile database, the guard
+        must not reject the request -- confirming the fix isn't merely
+        unit-testing the predicate in isolation."""
+        from abicheck.header_conditionals import (
+            compile_db_filter_scope_error,
+            compile_db_for_filter_scope_check,
+        )
+
+        _so_path, header, _compile_db = TestDumpCliHonorsTheFilterInTheFold._project(
+            tmp_path
+        )
+        unrelated_build_info = tmp_path / "not_a_pack_or_db"
+        unrelated_build_info.mkdir()
+        resolved = compile_db_for_filter_scope_check(
+            unrelated_build_info, header.parent, (header,)
+        )
+        assert resolved is None
+        assert compile_db_filter_scope_error("a.cpp", resolved, "build") is None

--- a/tests/test_compile_db_filter_scope.py
+++ b/tests/test_compile_db_filter_scope.py
@@ -927,12 +927,40 @@ class TestScopeGuardCoversPackAndBazelBuildInfo:
         path.write_text(json.dumps({"results": []}), encoding="utf-8")
         return path
 
+    @staticmethod
+    def _inputs_pack(tmp_path: Path) -> Path:
+        pack = tmp_path / "inputs_pack"
+        pack.mkdir()
+        (pack / "manifest.json").write_text(
+            json.dumps({"kind": "abicheck_inputs"}), encoding="utf-8"
+        )
+        return pack
+
     def test_pack_directory_is_recognized(self, tmp_path: Path) -> None:
         from abicheck.header_conditionals import compile_db_for_filter_scope_check
 
         pack = self._pack_dir(tmp_path)
         resolved = compile_db_for_filter_scope_check(pack, None, (tmp_path / "api.h",))
         assert resolved == pack
+
+    def test_flow2_inputs_pack_named_by_build_info_is_recognized(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex review, P1 (a ninth finding): the original pack recognition
+        here only checked ``is_pack_dir`` (classic ``BuildSourcePack``),
+        missing the identical Flow-2 ``abicheck_inputs/`` shape its own
+        ``--sources`` sibling (``TestScopeGuardCoversSourcesPacks``) already
+        covers -- even though ``_l2_seed_pack_inputs`` recognizes both
+        shapes for ``build_info`` too."""
+        from abicheck.header_conditionals import (
+            compile_db_filter_scope_error,
+            compile_db_for_filter_scope_check,
+        )
+
+        pack = self._inputs_pack(tmp_path)
+        resolved = compile_db_for_filter_scope_check(pack, None, (tmp_path / "api.h",))
+        assert resolved == pack
+        assert compile_db_filter_scope_error("foo.cpp", resolved, "build") is not None
 
     def test_bazel_aquery_file_is_recognized(self, tmp_path: Path) -> None:
         from abicheck.header_conditionals import compile_db_for_filter_scope_check

--- a/tests/test_compile_db_filter_scope.py
+++ b/tests/test_compile_db_filter_scope.py
@@ -449,3 +449,90 @@ class TestDumpCliHonorsTheFilterInTheFold:
         # Not merely "a context was chosen": the guarded field is present
         # only under the TU the filter named, so this pins *which* one.
         assert ("b" in fields) is expects_wide_field, (pick, fields)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="ELF/Linux-scoped repro (real g++-compiled .so + compile_commands.json)",
+)
+@pytest.mark.skipif(
+    not (_HAVE_GXX and _HAVE_CLANG), reason="needs a real g++ and clang toolchain"
+)
+class TestTypedApiHonorsTheFilterInTheFold:
+    """The identical shape as ``TestDumpCliHonorsTheFilterInTheFold``, through
+    the typed ``DumpRequest``/``resolve_dump_request``/``execute_dump_request``
+    path instead of the CLI (PR 3A investigation, 2026-08-21:
+    ``InputSpec.compile_db_filter``).
+
+    ``InputSpec`` deliberately had no ``compile_db_filter`` field until this
+    slice — see its own docstring for the two prerequisites this closes:
+    the filter narrows the shared L2 fold (already landed, exercised by the
+    CLI class above), and the L2-filtered/L3-unfiltered refusal is mirrored
+    into ``resolve_dump_request`` so a typed caller cannot reach the
+    snapshot shape the CLI refuses outright.
+    """
+
+    @staticmethod
+    def _request(so_path: Path, header: Path, compile_db: Path, *, compile_db_filter):
+        from abicheck.api_types import DumpRequest, InputSpec
+
+        return DumpRequest(
+            input=InputSpec(
+                path=so_path,
+                headers=(header,),
+                sources=header.parent,
+                build_info=compile_db,
+                compile_db_filter=compile_db_filter,
+            ),
+            frontend="clang",
+            depth="headers",
+        )
+
+    def test_resolve_dump_request_refuses_the_l2_l3_scope_mismatch(
+        self, tmp_path: Path
+    ) -> None:
+        from abicheck.errors import ValidationError
+        from abicheck.service_dump_pipeline import resolve_dump_request
+
+        so_path, header, compile_db = TestDumpCliHonorsTheFilterInTheFold._project(
+            tmp_path
+        )
+        request = self._request(
+            so_path, header, compile_db, compile_db_filter="a.cpp"
+        ).replace(depth="build")
+        with pytest.raises(ValidationError, match="materially different|L2 header"):
+            resolve_dump_request(request)
+
+    def test_no_filter_is_unaffected(self, tmp_path: Path) -> None:
+        from abicheck.service_dump_pipeline import resolve_dump_request
+
+        so_path, header, compile_db = TestDumpCliHonorsTheFilterInTheFold._project(
+            tmp_path
+        )
+        request = self._request(so_path, header, compile_db, compile_db_filter=None)
+        # No filter -> the scope-error guard never fires, regardless of depth;
+        # unchanged behavior for every pre-existing caller.
+        resolve_dump_request(request.replace(depth="build"))
+
+    @pytest.mark.parametrize(
+        ("pick", "expects_wide_field"), [("a.cpp", True), ("b.cpp", False)]
+    )
+    def test_the_filter_selects_that_units_context_for_the_header_parse(
+        self, tmp_path: Path, pick: str, expects_wide_field: bool
+    ) -> None:
+        from abicheck.service_dump_pipeline import (
+            execute_dump_request,
+            resolve_dump_request,
+        )
+
+        so_path, header, compile_db = TestDumpCliHonorsTheFilterInTheFold._project(
+            tmp_path
+        )
+        request = self._request(so_path, header, compile_db, compile_db_filter=pick)
+        result = execute_dump_request(resolve_dump_request(request))
+        fields = [
+            f.name for t in result.snapshot.types if t.name == "S" for f in t.fields
+        ]
+        assert fields, result.snapshot.types
+        assert ("b" in fields) is expects_wide_field, (pick, fields)

--- a/tests/test_compile_db_filter_scope.py
+++ b/tests/test_compile_db_filter_scope.py
@@ -753,3 +753,138 @@ class TestScopeGuardCoversSourcesOnlyAutoDiscovery:
         )
         resolved = resolve_dump_request(request)
         assert resolved.collect_mode == "build"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="ELF/Linux-scoped repro (real g++-compiled .so + compile_commands.json)",
+)
+@pytest.mark.skipif(
+    not (_HAVE_GXX and _HAVE_CLANG), reason="needs a real g++ and clang toolchain"
+)
+class TestScopeGuardCoversNestedBuildInfoDatabases:
+    """Codex review, P1 (a fourth finding on the same slice): the scope
+    guard's ``build_info`` resolution (``compile_db_from_build_info``) only
+    ever checks ``<build_info>/compile_commands.json`` directly -- it has
+    no notion of a conventional out-of-tree build directory. The real
+    fold's own ``--build-info`` resolution
+    (``buildsource.inline._compile_db_at``, for a directory delegating to
+    ``_find_compile_db_in_dir``) searches immediate subdirectories too
+    (``build/``, ``cmake-build-debug/``, ...) -- explicitly documented as
+    matching ``--sources`` auto-discovery's own contract. So
+    ``--build-info <project-root>`` whose database actually lives at
+    ``<project-root>/build/compile_commands.json`` resolved for the fold
+    but not for the scope guard, reproducing the identical filtered-L2/
+    unfiltered-L3 mismatch. Fixed by having
+    ``compile_db_for_filter_scope_check`` search the same immediate-
+    subdirectory strategy for a directory ``build_info`` before falling
+    back to ``sources`` auto-discovery.
+    """
+
+    @staticmethod
+    def _project_with_nested_build_info(tmp_path: Path) -> tuple[Path, Path, Path]:
+        so_path, header, compile_db = TestDumpCliHonorsTheFilterInTheFold._project(
+            tmp_path
+        )
+        build_dir = tmp_path / "build"
+        build_dir.mkdir()
+        compile_db.rename(build_dir / "compile_commands.json")
+        return so_path, header, tmp_path  # build_info = the project root
+
+    def test_cli_rejects_a_nested_build_info_scope_mismatch(
+        self, tmp_path: Path
+    ) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        so_path, header, build_info = self._project_with_nested_build_info(tmp_path)
+        result = CliRunner().invoke(
+            main,
+            [
+                "dump",
+                str(so_path),
+                "-H",
+                str(header),
+                "--build-info",
+                str(build_info),
+                "--depth",
+                "build",
+                "--ast-frontend",
+                "clang",
+                "--compile-db-filter",
+                "a.cpp",
+                "-o",
+                str(tmp_path / "out.json"),
+            ],
+        )
+        assert result.exit_code == 64, result.output
+        assert "L2 header parse only" in result.output
+
+    def test_dump_request_rejects_a_nested_build_info_scope_mismatch(
+        self, tmp_path: Path
+    ) -> None:
+        from abicheck.api_types import DumpRequest, InputSpec
+        from abicheck.errors import ValidationError
+        from abicheck.service_dump_pipeline import resolve_dump_request
+
+        so_path, header, build_info = self._project_with_nested_build_info(tmp_path)
+        request = DumpRequest(
+            input=InputSpec(
+                path=so_path,
+                headers=(header,),
+                build_info=build_info,
+                compile_db_filter="a.cpp",
+            ),
+            frontend="clang",
+            depth="build",
+        )
+        with pytest.raises(ValidationError, match="input: .*L2 header parse only"):
+            resolve_dump_request(request)
+
+    def test_compare_request_rejects_a_nested_build_info_scope_mismatch(
+        self, tmp_path: Path
+    ) -> None:
+        from abicheck.api_types import CompareRequest, InputSpec
+        from abicheck.errors import ValidationError
+        from abicheck.service_compare_pipeline import resolve_compare_request
+
+        so_path, header, build_info = self._project_with_nested_build_info(tmp_path)
+        side = InputSpec(
+            path=so_path,
+            headers=(header,),
+            build_info=build_info,
+            compile_db_filter="a.cpp",
+        )
+        request = CompareRequest(old=side, new=side, frontend="clang", depth="build")
+        with pytest.raises(ValidationError, match="old: .*L2 header parse only"):
+            resolve_compare_request(request)
+
+    def test_the_nested_database_still_narrows_the_header_parse(
+        self, tmp_path: Path
+    ) -> None:
+        """Positive control: the nested database really is what the fold
+        resolves and filters by -- not merely a guard-level assumption."""
+        from abicheck.api_types import DumpRequest, InputSpec
+        from abicheck.service_dump_pipeline import (
+            execute_dump_request,
+            resolve_dump_request,
+        )
+
+        so_path, header, build_info = self._project_with_nested_build_info(tmp_path)
+        request = DumpRequest(
+            input=InputSpec(
+                path=so_path,
+                headers=(header,),
+                build_info=build_info,
+                compile_db_filter="a.cpp",
+            ),
+            frontend="clang",
+            depth="headers",  # collect_mode "off" -- the guard doesn't fire
+        )
+        result = execute_dump_request(resolve_dump_request(request))
+        fields = [
+            f.name for t in result.snapshot.types if t.name == "S" for f in t.fields
+        ]
+        assert "b" in fields, fields  # a.cpp's -DWIDE field, confirms narrowing

--- a/tests/test_compile_db_filter_scope.py
+++ b/tests/test_compile_db_filter_scope.py
@@ -623,3 +623,133 @@ class TestCompareRequestAppliesTheSameScopeGuard:
         )
         pair = resolve_compare_request(request)
         assert pair.old is not None and pair.new is not None
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="ELF/Linux-scoped repro (real g++-compiled .so + compile_commands.json)",
+)
+@pytest.mark.skipif(
+    not (_HAVE_GXX and _HAVE_CLANG), reason="needs a real g++ and clang toolchain"
+)
+class TestScopeGuardCoversSourcesOnlyAutoDiscovery:
+    """Codex review, P1 (a fresh round on the same slice): the scope guard
+    resolved the checked compile database via
+    ``compile_db_from_build_info`` alone -- ``--build-info``-only -- so a
+    request giving only ``sources`` (no ``build_info`` at all) could still
+    reach the exact filtered-L2/unfiltered-L3 mismatch uncaught: the P0.3
+    fold and ``embed_build_source``'s L3 collection both independently
+    auto-discover the same ``compile_commands.json`` under ``sources``
+    (``buildsource.inline._autodiscover_compile_db``, the same strategy
+    both already use with no explicit ``--build-info``), but only the fold
+    honors ``compile_db_filter``. Reproduced directly before the fix: a
+    real two-TU project resolved with ``sources`` only, filtered to one TU
+    at L2, still embedded *both* TUs' compile units as L3 evidence
+    (`BuildEvidence.compile_units` had length 2).
+
+    This is not a regression introduced by the typed-API slice -- the
+    native CLI's own pre-existing `compile_db_path = compile_db_from_
+    build_info(build_info, headers)` had the identical gap: before this
+    fix, the CLI-path test below silently succeeded (exit 0) instead of
+    rejecting the mismatch, since the CLI's own scope check used the same
+    narrow, `--build-info`-only resolution. Fixed once, in the shared
+    `header_conditionals.compile_db_for_filter_scope_check`, consumed by
+    both the CLI and the typed pipelines' guard.
+    """
+
+    def test_cli_rejects_a_sources_only_scope_mismatch(self, tmp_path: Path) -> None:
+        from click.testing import CliRunner
+
+        from abicheck.cli import main
+
+        so_path, header, _compile_db = TestDumpCliHonorsTheFilterInTheFold._project(
+            tmp_path
+        )
+        result = CliRunner().invoke(
+            main,
+            [
+                "dump",
+                str(so_path),
+                "-H",
+                str(header),
+                "--sources",
+                str(header.parent),
+                "--depth",
+                "build",
+                "--ast-frontend",
+                "clang",
+                "--compile-db-filter",
+                "a.cpp",
+                "-o",
+                str(tmp_path / "out.json"),
+            ],
+        )
+        assert result.exit_code == 64, result.output
+        assert "L2 header parse only" in result.output
+
+    def test_dump_request_rejects_a_sources_only_scope_mismatch(
+        self, tmp_path: Path
+    ) -> None:
+        from abicheck.api_types import DumpRequest, InputSpec
+        from abicheck.errors import ValidationError
+        from abicheck.service_dump_pipeline import resolve_dump_request
+
+        so_path, header, _compile_db = TestDumpCliHonorsTheFilterInTheFold._project(
+            tmp_path
+        )
+        request = DumpRequest(
+            input=InputSpec(
+                path=so_path,
+                headers=(header,),
+                sources=header.parent,
+                compile_db_filter="a.cpp",
+            ),
+            frontend="clang",
+            depth="build",
+        )
+        with pytest.raises(ValidationError, match="input: .*L2 header parse only"):
+            resolve_dump_request(request)
+
+    def test_compare_request_rejects_a_sources_only_scope_mismatch(
+        self, tmp_path: Path
+    ) -> None:
+        from abicheck.api_types import CompareRequest, InputSpec
+        from abicheck.errors import ValidationError
+        from abicheck.service_compare_pipeline import resolve_compare_request
+
+        so_path, header, _compile_db = TestDumpCliHonorsTheFilterInTheFold._project(
+            tmp_path
+        )
+        side = InputSpec(
+            path=so_path,
+            headers=(header,),
+            sources=header.parent,
+            compile_db_filter="a.cpp",
+        )
+        request = CompareRequest(old=side, new=side, frontend="clang", depth="build")
+        with pytest.raises(ValidationError, match="old: .*L2 header parse only"):
+            resolve_compare_request(request)
+
+    def test_no_filter_sources_only_is_unaffected_by_the_guard(
+        self, tmp_path: Path
+    ) -> None:
+        """No filter -> the guard itself never fires for this shape either
+        (a downstream real ambiguity error from the same project's two
+        conflicting TUs is a separate, pre-existing failure mode -- see
+        `test_unfiltered_still_fails_closed_on_the_real_ambiguity` -- and
+        `resolve_dump_request` never reaches the fold at all, only
+        `execute_dump_request` does, so it cannot surface here)."""
+        from abicheck.api_types import DumpRequest, InputSpec
+        from abicheck.service_dump_pipeline import resolve_dump_request
+
+        so_path, header, _compile_db = TestDumpCliHonorsTheFilterInTheFold._project(
+            tmp_path
+        )
+        request = DumpRequest(
+            input=InputSpec(path=so_path, headers=(header,), sources=header.parent),
+            frontend="clang",
+            depth="build",
+        )
+        resolved = resolve_dump_request(request)
+        assert resolved.collect_mode == "build"

--- a/tests/test_compile_db_filter_scope.py
+++ b/tests/test_compile_db_filter_scope.py
@@ -888,3 +888,143 @@ class TestScopeGuardCoversNestedBuildInfoDatabases:
             f.name for t in result.snapshot.types if t.name == "S" for f in t.fields
         ]
         assert "b" in fields, fields  # a.cpp's -DWIDE field, confirms narrowing
+
+
+class TestScopeGuardCoversPackAndBazelBuildInfo:
+    """Codex review, P1 (a sixth finding on the same guard): the fold's own
+    ``resolve_header_compile_context``/``filter_units_by_source`` narrows
+    *whatever* ``BuildEvidence.compile_units`` a ``--build-info`` resolves
+    to -- not only a literal ``compile_commands.json``. A ``--build-info``
+    naming a pre-captured ``collect`` pack directory, or a Bazel
+    ``aquery``/``cquery`` jsonproto, resolves compile units the identical
+    way and is embedded at L3 with no filter either way -- so the guard's
+    original ``compile_db_from_build_info``-only check (which deliberately
+    returns ``None`` for both, since neither is a literal compile database)
+    silently let the exact filtered-L2/unfiltered-L3 mismatch through for
+    both shapes. These tests exercise the pure predicate directly -- no
+    compiler needed, since the guard is a read-only classification over
+    ``--build-info``'s own path shape.
+    """
+
+    @staticmethod
+    def _pack_dir(tmp_path: Path) -> Path:
+        pack = tmp_path / "pack"
+        pack.mkdir()
+        (pack / "manifest.json").write_text(
+            json.dumps({"build_source_pack_version": 1}), encoding="utf-8"
+        )
+        return pack
+
+    @staticmethod
+    def _bazel_aquery_file(tmp_path: Path) -> Path:
+        path = tmp_path / "aquery.json"
+        path.write_text(json.dumps({"actions": [], "artifacts": []}), encoding="utf-8")
+        return path
+
+    @staticmethod
+    def _bazel_cquery_file(tmp_path: Path) -> Path:
+        path = tmp_path / "cquery.json"
+        path.write_text(json.dumps({"results": []}), encoding="utf-8")
+        return path
+
+    def test_pack_directory_is_recognized(self, tmp_path: Path) -> None:
+        from abicheck.header_conditionals import compile_db_for_filter_scope_check
+
+        pack = self._pack_dir(tmp_path)
+        resolved = compile_db_for_filter_scope_check(pack, None, (tmp_path / "api.h",))
+        assert resolved == pack
+
+    def test_bazel_aquery_file_is_recognized(self, tmp_path: Path) -> None:
+        from abicheck.header_conditionals import compile_db_for_filter_scope_check
+
+        aquery = self._bazel_aquery_file(tmp_path)
+        resolved = compile_db_for_filter_scope_check(
+            aquery, None, (tmp_path / "api.h",)
+        )
+        assert resolved == aquery
+
+    def test_bazel_cquery_file_is_recognized(self, tmp_path: Path) -> None:
+        from abicheck.header_conditionals import compile_db_for_filter_scope_check
+
+        cquery = self._bazel_cquery_file(tmp_path)
+        resolved = compile_db_for_filter_scope_check(
+            cquery, None, (tmp_path / "api.h",)
+        )
+        assert resolved == cquery
+
+    def test_pack_directory_triggers_the_scope_error(self, tmp_path: Path) -> None:
+        from abicheck.header_conditionals import (
+            compile_db_filter_scope_error,
+            compile_db_for_filter_scope_check,
+        )
+
+        pack = self._pack_dir(tmp_path)
+        resolved = compile_db_for_filter_scope_check(pack, None, (tmp_path / "api.h",))
+        error = compile_db_filter_scope_error("foo.cpp", resolved, "build")
+        assert error is not None
+        assert "--compile-db-filter" in error
+
+    def test_bazel_jsonproto_triggers_the_scope_error(self, tmp_path: Path) -> None:
+        from abicheck.header_conditionals import (
+            compile_db_filter_scope_error,
+            compile_db_for_filter_scope_check,
+        )
+
+        aquery = self._bazel_aquery_file(tmp_path)
+        resolved = compile_db_for_filter_scope_check(
+            aquery, None, (tmp_path / "api.h",)
+        )
+        error = compile_db_filter_scope_error("foo.cpp", resolved, "build")
+        assert error is not None
+
+    def test_no_filter_pack_directory_is_unaffected(self, tmp_path: Path) -> None:
+        """Control: the guard only fires when a filter is actually set."""
+        from abicheck.header_conditionals import (
+            compile_db_filter_scope_error,
+            compile_db_for_filter_scope_check,
+        )
+
+        pack = self._pack_dir(tmp_path)
+        resolved = compile_db_for_filter_scope_check(pack, None, (tmp_path / "api.h",))
+        assert compile_db_filter_scope_error(None, resolved, "build") is None
+
+    def test_collect_mode_off_pack_directory_is_unaffected(
+        self, tmp_path: Path
+    ) -> None:
+        """Control: no L3 embed at ``collect_mode == "off"``, nothing to
+        mismatch against."""
+        from abicheck.header_conditionals import (
+            compile_db_filter_scope_error,
+            compile_db_for_filter_scope_check,
+        )
+
+        pack = self._pack_dir(tmp_path)
+        resolved = compile_db_for_filter_scope_check(pack, None, (tmp_path / "api.h",))
+        assert compile_db_filter_scope_error("foo.cpp", resolved, "off") is None
+
+    def test_a_plain_non_pack_directory_is_still_a_build_dir_search(
+        self, tmp_path: Path
+    ) -> None:
+        """A directory that is not a pack (no manifest.json, or one lacking
+        the BuildSourcePack marker) must still fall through to the ordinary
+        nested-compile-db search / sources auto-discovery, not be
+        misclassified as a pack."""
+        from abicheck.header_conditionals import compile_db_for_filter_scope_check
+
+        plain_dir = tmp_path / "not_a_pack"
+        plain_dir.mkdir()
+        resolved = compile_db_for_filter_scope_check(
+            plain_dir, None, (tmp_path / "api.h",)
+        )
+        assert resolved is None
+
+    def test_a_non_bazel_json_object_file_is_unrecognized(self, tmp_path: Path) -> None:
+        """An ordinary JSON-object build-info file (neither a compile-DB
+        array nor a Bazel aquery/cquery shape) must not be mistaken for
+        filterable build evidence."""
+        from abicheck.header_conditionals import compile_db_for_filter_scope_check
+
+        odd = tmp_path / "odd.json"
+        odd.write_text(json.dumps({"hello": "world"}), encoding="utf-8")
+        resolved = compile_db_for_filter_scope_check(odd, None, (tmp_path / "api.h",))
+        assert resolved is None

--- a/tests/test_compile_db_filter_scope.py
+++ b/tests/test_compile_db_filter_scope.py
@@ -513,7 +513,8 @@ class TestTypedApiHonorsTheFilterInTheFold:
         request = self._request(so_path, header, compile_db, compile_db_filter=None)
         # No filter -> the scope-error guard never fires, regardless of depth;
         # unchanged behavior for every pre-existing caller.
-        resolve_dump_request(request.replace(depth="build"))
+        resolved = resolve_dump_request(request.replace(depth="build"))
+        assert resolved.collect_mode == "build"
 
     @pytest.mark.parametrize(
         ("pick", "expects_wide_field"), [("a.cpp", True), ("b.cpp", False)]
@@ -536,3 +537,89 @@ class TestTypedApiHonorsTheFilterInTheFold:
         ]
         assert fields, result.snapshot.types
         assert ("b" in fields) is expects_wide_field, (pick, fields)
+
+
+def test_input_spec_of_forwards_compile_db_filter() -> None:
+    """Codex review, P2: the documented convenience factory
+    (``InputSpec.of``) silently dropped ``compile_db_filter`` -- constructing
+    through it (rather than the dataclass directly) raised ``TypeError`` for
+    an unrecognized keyword, so the field was reachable only via the
+    dataclass constructor despite being advertised on the public type."""
+    from abicheck.api_types import InputSpec
+
+    spec = InputSpec.of(path="lib.so", compile_db_filter="src/**")
+    assert spec.compile_db_filter == "src/**"
+    # And the default is unaffected -- every existing `InputSpec.of(...)`
+    # call site stays a no-op for this field.
+    assert InputSpec.of(path="lib.so").compile_db_filter is None
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="ELF/Linux-scoped repro (real g++-compiled .so + compile_commands.json)",
+)
+@pytest.mark.skipif(
+    not (_HAVE_GXX and _HAVE_CLANG), reason="needs a real g++ and clang toolchain"
+)
+class TestCompareRequestAppliesTheSameScopeGuard:
+    """Codex review, P1: the L2-filtered/L3-unfiltered scope guard was wired
+    into ``resolve_dump_request`` only -- a typed ``CompareRequest`` side
+    reaches the identical ``_seeded_includes_and_compile_context`` fold /
+    ``embed_side_build_source`` split (``resolve_side_snapshot`` is the one
+    primitive both pipelines share), so the same refusal must fire there
+    too. Both pipelines now call the shared
+    ``service_compare_evidence.reject_compile_db_filter_scope_mismatch``.
+    """
+
+    def test_a_side_with_the_scope_mismatch_is_refused(self, tmp_path: Path) -> None:
+        from abicheck.api_types import CompareRequest, InputSpec
+        from abicheck.errors import ValidationError
+        from abicheck.service_compare_pipeline import resolve_compare_request
+
+        so_path, header, compile_db = TestDumpCliHonorsTheFilterInTheFold._project(
+            tmp_path
+        )
+        side = InputSpec(
+            path=so_path,
+            headers=(header,),
+            sources=header.parent,
+            build_info=compile_db,
+            compile_db_filter="a.cpp",
+        )
+        request = CompareRequest(old=side, new=side, frontend="clang", depth="build")
+        with pytest.raises(ValidationError, match="old: .*L2 header parse only"):
+            resolve_compare_request(request)
+
+    def test_a_scope_matched_filter_is_unaffected_by_the_guard(
+        self, tmp_path: Path
+    ) -> None:
+        """Not "no filter" -- a bare, unfiltered compare of this exact project
+        would still fail closed on the real ambiguity
+        (`TestDumpCliHonorsTheFilterInTheFold.
+        test_unfiltered_still_fails_closed_on_the_real_ambiguity`), which
+        would make a `resolve_compare_request` call here indistinguishable
+        from the guard actually firing. Isolating the guard itself needs a
+        filter that resolves that ambiguity (as it does on the CLI/`dump`
+        paths) *and* a collect mode (`"headers"` -> `"off"`) the guard
+        permits regardless of the filter -- so this pins "the guard doesn't
+        misfire on a legitimate filtered compare", not "no filter changes
+        nothing"."""
+        from abicheck.api_types import CompareRequest, InputSpec
+        from abicheck.service_compare_pipeline import resolve_compare_request
+
+        so_path, header, compile_db = TestDumpCliHonorsTheFilterInTheFold._project(
+            tmp_path
+        )
+        side = InputSpec(
+            path=so_path,
+            headers=(header,),
+            sources=header.parent,
+            build_info=compile_db,
+            compile_db_filter="a.cpp",
+        )
+        request = CompareRequest(
+            old=side, new=side, frontend="clang", depth="headers"
+        )
+        pair = resolve_compare_request(request)
+        assert pair.old is not None and pair.new is not None

--- a/tests/test_compile_db_filter_scope.py
+++ b/tests/test_compile_db_filter_scope.py
@@ -1028,3 +1028,104 @@ class TestScopeGuardCoversPackAndBazelBuildInfo:
         odd.write_text(json.dumps({"hello": "world"}), encoding="utf-8")
         resolved = compile_db_for_filter_scope_check(odd, None, (tmp_path / "api.h",))
         assert resolved is None
+
+
+class TestScopeGuardCoversSourcesPacks:
+    """Codex review, P1 (a seventh finding on the same guard): the sixth
+    finding's fix only recognized a pack named by ``--build-info``, but
+    ``buildsource.l2_seed._l2_seed_pack_inputs`` folds a ``--sources`` pack
+    (a classic ``BuildSourcePack`` or a Flow-2 ``abicheck_inputs/``
+    directory) into L2 seeding the identical way -- whenever no
+    ``--build-info`` was given at all -- so a ``--sources`` naming such a
+    pack reproduced the same filtered-L2/unfiltered-L3 mismatch with no
+    error, since a pack directory carries no literal ``compile_commands.
+    json`` at its root for ``_autodiscover_compile_db`` to find. Pure
+    predicate tests, no compiler needed.
+    """
+
+    @staticmethod
+    def _classic_pack(tmp_path: Path) -> Path:
+        pack = tmp_path / "classic_pack"
+        pack.mkdir()
+        (pack / "manifest.json").write_text(
+            json.dumps({"build_source_pack_version": 1}), encoding="utf-8"
+        )
+        return pack
+
+    @staticmethod
+    def _inputs_pack(tmp_path: Path) -> Path:
+        pack = tmp_path / "inputs_pack"
+        pack.mkdir()
+        (pack / "manifest.json").write_text(
+            json.dumps({"kind": "abicheck_inputs"}), encoding="utf-8"
+        )
+        return pack
+
+    def test_classic_pack_named_by_sources_is_recognized(self, tmp_path: Path) -> None:
+        from abicheck.header_conditionals import compile_db_for_filter_scope_check
+
+        pack = self._classic_pack(tmp_path)
+        resolved = compile_db_for_filter_scope_check(None, pack, (tmp_path / "api.h",))
+        assert resolved == pack
+
+    def test_inputs_pack_named_by_sources_is_recognized(self, tmp_path: Path) -> None:
+        from abicheck.header_conditionals import compile_db_for_filter_scope_check
+
+        pack = self._inputs_pack(tmp_path)
+        resolved = compile_db_for_filter_scope_check(None, pack, (tmp_path / "api.h",))
+        assert resolved == pack
+
+    def test_sources_pack_triggers_the_scope_error(self, tmp_path: Path) -> None:
+        from abicheck.header_conditionals import (
+            compile_db_filter_scope_error,
+            compile_db_for_filter_scope_check,
+        )
+
+        pack = self._classic_pack(tmp_path)
+        resolved = compile_db_for_filter_scope_check(None, pack, (tmp_path / "api.h",))
+        error = compile_db_filter_scope_error("foo.cpp", resolved, "build")
+        assert error is not None
+
+    def test_an_explicit_build_info_takes_precedence_over_a_sources_pack(
+        self, tmp_path: Path
+    ) -> None:
+        """Mirrors ``_l2_seed_pack_inputs``'s own ``if build_info is None:``
+        gate: an explicit ``--build-info`` (even one that itself resolves to
+        nothing recognizable) means the sources pack's evidence is never
+        folded into ``base_build``, so the guard must not treat the sources
+        pack as filterable evidence in that combination either."""
+        from abicheck.header_conditionals import compile_db_for_filter_scope_check
+
+        pack = self._classic_pack(tmp_path)
+        unrelated_build_info = tmp_path / "not_a_pack_or_db"
+        unrelated_build_info.mkdir()
+        resolved = compile_db_for_filter_scope_check(
+            unrelated_build_info, pack, (tmp_path / "api.h",)
+        )
+        assert resolved is None
+
+    def test_no_filter_sources_pack_is_unaffected(self, tmp_path: Path) -> None:
+        """Control: the guard only fires when a filter is actually set."""
+        from abicheck.header_conditionals import (
+            compile_db_filter_scope_error,
+            compile_db_for_filter_scope_check,
+        )
+
+        pack = self._classic_pack(tmp_path)
+        resolved = compile_db_for_filter_scope_check(None, pack, (tmp_path / "api.h",))
+        assert compile_db_filter_scope_error(None, resolved, "build") is None
+
+    def test_a_plain_sources_directory_is_still_auto_discovery(
+        self, tmp_path: Path
+    ) -> None:
+        """A ``sources`` directory that is not a pack (no manifest.json, or
+        one lacking either pack's own marker) must still fall through to
+        ordinary auto-discovery, not be misclassified as a pack."""
+        from abicheck.header_conditionals import compile_db_for_filter_scope_check
+
+        plain_tree = tmp_path / "plain_source_tree"
+        plain_tree.mkdir()
+        resolved = compile_db_for_filter_scope_check(
+            None, plain_tree, (tmp_path / "api.h",)
+        )
+        assert resolved is None


### PR DESCRIPTION
## Summary

Adds `InputSpec.compile_db_filter` to the typed `dump`/`compare` API, mirroring the native `dump --compile-db-filter` CLI flag — the one remaining scoped sub-slice of CLI cleanup phase two's PR 3A ("typed `dump`/`scan` convergence") that could be safely completed and verified in this environment. Seven follow-up commits fix eight review findings on that same field (see "Bug-fix test contract" below) — findings 3–9 turned out to be pre-existing gaps (or a false positive introduced while closing one) in the native CLI's own scope check too, not something this PR's typed-API slice introduced.

## Motivation

Per `docs/contribute/plans/cli-cleanup-phase-two.md`'s PR 3A section (and the root `AGENTS.md` "PR C" known-gap entry), the native `dump` CLI's own `--compile-db-filter` had already been threaded into the shared P0.3 L3→L2 compile-context fold, but the typed `InputSpec`/`DumpRequest` API had no equivalent field — making the filter's contribution to that shared fold inaccessible to any non-CLI caller, and leaving `--dry-run`'s resolved-request preview unable to report the same scope-error refusal the real CLI raises directly.

The plan's own notes are explicit that migrating the *real* `dump` CLI execution path (`perform_elf_dump`/`handle_non_elf_dump`) onto the shared `execute_dump_request` resolver is blocked on castxml (the default header-AST backend) being unavailable to verify no regression — unchanged by this PR. This PR only closes the smaller, independently-specified typed-API gap that doesn't require castxml to verify.

## Changes

- `InputSpec.compile_db_filter: str | None = None` (typed API surface, `api_types.py`), forwarded by the `InputSpec.of()` convenience factory.
- `service_input_resolution._seeded_includes_and_compile_context` forwards it as `source_filter` into `seed_includes_and_fold_compile_context` (the P0.3 fold).
- `service_input_resolution._resolve_side_snapshot_impl` forwards it into `attach_build_context_for_parsed_headers` (the ADR-039 build-context collector), so the fold and the collector agree on which translation units the filter selects.
- `header_conditionals.compile_db_for_filter_scope_check` — resolves the compile database (or other filterable build evidence) the scope guard checks against, matching `buildsource.l2_seed._l2_seed_pack_inputs`/`buildsource.inline._resolve_compile_db`'s own precedence exactly: an explicit `--build-info` (a literal `compile_commands.json`, a nested conventionally-named build subdirectory like `/build/compile_commands.json`, a pre-captured classic `collect` pack directory or Flow-2 `abicheck_inputs/` pack, or a Bazel `aquery`/`cquery` jsonproto) always wins, with no fallback to `--sources` once a given `--build-info` misses; a `--sources` tree's own auto-discovered `compile_commands.json` or a pack it itself names (either format) is only considered when no `--build-info` was given at all (deliberately kept separate from `compile_db_from_build_info`, which also drives the CLI's unrelated legacy `-p` auto-match and must stay narrow).
- `service_compare_evidence.reject_compile_db_filter_scope_mismatch` — one shared L2-filtered/L3-unfiltered refusal (mirrors the CLI's own `compile_db_filter_scope_error`, fed by the function above), called from both `service_dump_pipeline.resolve_dump_request` (`DumpRequest.input`) and `service_compare_pipeline.resolve_compare_request` (`CompareRequest.old`/`.new`), raising `ValidationError` — translated to `click.UsageError` at the CLI boundary, unchanged. `cli.py`'s `dump_cmd` now also runs its own scope check against the wider resolution, closing the identical gaps on the native CLI.
- `cli_dump_request.build_dump_request`/`dump_cmd` forward the CLI's own `--compile-db-filter` value into the `DumpRequest` `--dry-run` resolves.
- `AGENTS.md` and the plan doc updated to record this slice as landed.

## Bug-fix test contract

- Bug class: Typed-API surface gaps and an under/over-scoped guard in the just-added `InputSpec.compile_db_filter` field, converging in stages toward matching the real resolver's precedence exactly: (1) `InputSpec.of()` didn't expose the field; (2) the guard covered only one of the two typed entry points sharing `resolve_side_snapshot`; (3)/(4) the guard's `--build-info`/`--sources` compile-database resolution was narrower than the real fold's (missing auto-discovery and nested build subdirectories); (5) the guard recognized only a literal compile database, missing a `--build-info` pack or Bazel jsonproto; (6) missing the identical pack recognition when named by `--sources` instead; (7) a **false positive** introduced while fixing (6) — falling back to `--sources` even when `--build-info` was given but unresolvable, which the real resolver never does; (8) missing Flow-2 `abicheck_inputs/` pack recognition for `--build-info` (only the classic `BuildSourcePack` format was checked). Findings 3–9 are gaps (or a false positive) shared by/introduced alongside the native CLI's pre-existing check, not introduced by this PR's typed-API surface in isolation.
- Publicly observable failure: (1) `InputSpec.of(..., compile_db_filter=...)` raised `TypeError`. (2)–(6), (8) A `dump`/`DumpRequest`/`CompareRequest` side with `compile_db_filter` set, headers, filterable build evidence in various shapes, and a depth that embeds L3 evidence resolved silently instead of being rejected — producing a snapshot with L2 scoped to the filtered translation unit but L3 collected unfiltered, which can manifest as spurious/false comparison findings. (7) The inverse: a `--build-info` given but unresolvable, alongside a `--sources` tree that *does* auto-discover a real compile database, was incorrectly rejected with a usage error even though the real resolvers never touch that database in that combination.
- Regression test fails on base: `tests/test_compile_db_filter_scope.py::test_input_spec_of_forwards_compile_db_filter`, `TestCompareRequestAppliesTheSameScopeGuard::test_a_side_with_the_scope_mismatch_is_refused`, `TestScopeGuardCoversSourcesOnlyAutoDiscovery`'s three tests, `TestScopeGuardCoversNestedBuildInfoDatabases`'s three tests, `TestScopeGuardCoversPackAndBazelBuildInfo` (6 of 10 cases, including the Flow-2 case), `TestScopeGuardCoversSourcesPacks` (3 of 6 cases), and `TestScopeGuardDoesNotFallBackToSourcesWhenBuildInfoMisses::test_unresolvable_build_info_does_not_fall_back_to_sources_auto_discovery` — all confirmed to fail against the pre-fix code.
- Negative control: every affected test class carries a matching no-filter/precedence/plain-directory/positive control confirming the guard doesn't reject a genuinely safe combination or misidentify a non-pack directory/file as filterable evidence. The full pre-existing test classes were re-run after each fix.
- Public-surface test: Every new test goes through a real public entry point — `InputSpec.of()`, the real `abicheck dump` CLI (`CliRunner`), `service_dump_pipeline.resolve_dump_request()`, `service_compare_pipeline.resolve_compare_request()`, or the shared predicate `compile_db_for_filter_scope_check`/`compile_db_filter_scope_error` those front ends all route through.
- Axes covered: Real g++-compiled ELF library + real clang header-AST parse, every way the shared fold can resolve build evidence (direct/nested/auto-discovered compile database, classic pack and Flow-2 inputs pack via either `--build-info` or `--sources`, Bazel aquery/cquery jsonproto, an unresolvable `--build-info` alongside a real `--sources` database), and all three front ends that share the guard (CLI, `DumpRequest`, `CompareRequest`).
- General invariant: Every `InputSpec`-carrying request type applies the identical `compile_db_filter` scope-error guard, and that guard matches the real resolver's own precedence exactly — enforced structurally by routing every caller through the same two shared functions.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragments added (`changelog.d/20260821_223201_noreply_compile_db_filter_typed_api_r7k2mq.md`, `changelog.d/20260821_235000_noreply_compile_db_filter_sources_scope_fix_9j4kxp.md`)
- [ ] Docs updated if user-visible behaviour changed — N/A, no CLI-visible behavior change; this is typed-API surface only (the CLI-side scope-check widening is a bugfix to an existing, already-documented usage error, not a new surface)
- [x] `mypy abicheck/` and `ruff check` pass locally on all touched files
- [x] No new `mypy` or `ruff` errors introduced

## Verification

- `mypy abicheck/`: clean (379 source files).
- `ruff check`: clean on all touched files.
- `python scripts/check_ai_readiness.py`: clean relative to the pre-existing baseline (the 3 remaining errors are unrelated ADR `Verified:` receipts on `main`'s current tip, pre-existing before this PR).
- `docs/reference/python-api-reference.md` regenerated and confirmed in sync after every commit (`gen_python_api_reference.py --check`); `gen_cli_reference.py --check`/`gen_config_reference.py --check`/`gen_action_reference.py --check` also confirmed in sync throughout.
- Full non-integration test file (`tests/test_compile_db_filter_scope.py`) re-run after each commit (52 passed after the latest); full local fast unit suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`) re-run end to end: 29434 passed, only the 2 pre-existing, unrelated `test_ai_readiness.py` ADR-receipt failures (not reachable from `origin/main`, confirmed pre-existing via `git stash`).
- Every `integration`-marked test in this area was verified directly by invoking the test bodies against a real compiled library outside pytest's marker gate (castxml is unavailable in this environment).
- Confirmed the pre-existing CLI behavior (`TestDumpCliHonorsTheFilterInTheFold`) is unchanged throughout all eight fix commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AzFuMNEvHc9N7ojVL9shjG)_