### PR TITLE
test: exercise the dump/scan comparability fix under castxml too

### DIFF
--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -92,6 +92,7 @@ coverage.
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 import sys
@@ -133,18 +134,36 @@ def _have_frontend(ast_frontend: str) -> bool:
 # coverage should fail loudly rather than being masked here.
 _SCAN_KNOWN_DIVERGENT_FRONTENDS: frozenset[str] = frozenset({"castxml"})
 
+# The exact, already-diagnosed finding-kind set for the L4-extractor
+# divergence -- an *exact* set match, not "these are present among
+# possibly others" (Codex review: a substring-only check would still
+# xfail past an unrelated additional risk finding riding alongside the
+# known two, silently hiding a real regression).
+_KNOWN_L4_EXTRACTOR_DIVERGENCE_KINDS = frozenset(
+    {"source_fact_coverage_incomplete", "source_binary_provenance_mismatch"}
+)
+_RISK_LINE_RE = re.compile(r"^\s*\[risk\]\s+(\S+):", re.MULTILINE)
 
-def _is_known_l4_extractor_divergence(output: str) -> bool:
-    """The exact, already-diagnosed signature: a RISK verdict from the two
-    L4-replay-specific reason codes ``run_scan_core``'s own comment already
-    attributes to the clang-vs-castxml candidate/baseline extractor
-    mismatch -- never a broader "any non-NO_CHANGE verdict" check, so an
-    unrelated regression still surfaces as a genuine, uncaught failure."""
+
+def _is_known_l4_extractor_divergence_text(output: str) -> bool:
+    """Text-output variant: the verdict must be ``COMPATIBLE_WITH_RISK`` and
+    the set of ``[risk] <kind>:`` lines must equal exactly the known
+    two-kind set -- no more, no fewer."""
+    if "COMPATIBLE_WITH_RISK" not in output:
+        return False
     return (
-        "COMPATIBLE_WITH_RISK" in output
-        and "source_fact_coverage_incomplete" in output
-        and "source_binary_provenance_mismatch" in output
+        frozenset(_RISK_LINE_RE.findall(output)) == _KNOWN_L4_EXTRACTOR_DIVERGENCE_KINDS
     )
+
+
+def _is_known_l4_extractor_divergence_report(report: dict) -> bool:
+    """JSON-report variant: the verdict must be ``COMPATIBLE_WITH_RISK`` and
+    the set of ``changes[].kind`` must equal exactly the known two-kind
+    set -- no more, no fewer."""
+    if report.get("verdict") != "COMPATIBLE_WITH_RISK":
+        return False
+    kinds = frozenset(c.get("kind") for c in report.get("changes", []))
+    return kinds == _KNOWN_L4_EXTRACTOR_DIVERGENCE_KINDS
 
 
 def _build_library(
@@ -345,7 +364,7 @@ def test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source(
     assert scan_result.exit_code == 0, scan_result.output
 
     if ast_frontend in _SCAN_KNOWN_DIVERGENT_FRONTENDS:
-        if _is_known_l4_extractor_divergence(scan_result.output):
+        if _is_known_l4_extractor_divergence_text(scan_result.output):
             pytest.xfail(
                 f"{ast_frontend}: known scan-candidate-L4-extractor-always-"
                 "clang divergence (see this module's own docstring)"
@@ -353,12 +372,13 @@ def test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source(
         pytest.fail(
             f"{ast_frontend} is listed in _SCAN_KNOWN_DIVERGENT_FRONTENDS, "
             "but the previously-diagnosed failure signature "
-            "(COMPATIBLE_WITH_RISK naming source_fact_coverage_incomplete "
-            "and source_binary_provenance_mismatch) did not reproduce. "
-            "Either the underlying gap has closed -- remove this frontend "
-            "from _SCAN_KNOWN_DIVERGENT_FRONTENDS and update this module's "
-            "docstring -- or a different failure occurred and needs its "
-            f"own investigation. output={scan_result.output!r}"
+            "(COMPATIBLE_WITH_RISK naming exactly "
+            "source_fact_coverage_incomplete and "
+            "source_binary_provenance_mismatch, no other risk finding) did "
+            "not reproduce. Either the underlying gap has closed -- remove "
+            "this frontend from _SCAN_KNOWN_DIVERGENT_FRONTENDS and update "
+            "this module's docstring -- or a different failure occurred "
+            f"and needs its own investigation. output={scan_result.output!r}"
         )
     assert "Verdict: NO_CHANGE" in scan_result.output, scan_result.output
 
@@ -447,7 +467,7 @@ def test_scan_against_real_dump_baseline_matches_reported_cli_invocation(
     assert diff.get("reason") is None, diff.get("reason")
 
     if ast_frontend in _SCAN_KNOWN_DIVERGENT_FRONTENDS:
-        if _is_known_l4_extractor_divergence(json.dumps(report)):
+        if _is_known_l4_extractor_divergence_report(report):
             pytest.xfail(
                 f"{ast_frontend}: known scan-candidate-L4-extractor-always-"
                 "clang divergence (see this module's own docstring)"
@@ -455,10 +475,12 @@ def test_scan_against_real_dump_baseline_matches_reported_cli_invocation(
         pytest.fail(
             f"{ast_frontend} is listed in _SCAN_KNOWN_DIVERGENT_FRONTENDS, "
             "but the previously-diagnosed failure signature "
-            "(COMPATIBLE_WITH_RISK naming source_fact_coverage_incomplete "
-            "and source_binary_provenance_mismatch) did not reproduce. "
-            "Either the underlying gap has closed -- remove this frontend "
-            "from _SCAN_KNOWN_DIVERGENT_FRONTENDS and update this module's "
-            f"docstring -- or a different failure occurred. report={report!r}"
+            "(COMPATIBLE_WITH_RISK naming exactly "
+            "source_fact_coverage_incomplete and "
+            "source_binary_provenance_mismatch, no other change) did not "
+            "reproduce. Either the underlying gap has closed -- remove "
+            "this frontend from _SCAN_KNOWN_DIVERGENT_FRONTENDS and update "
+            f"this module's docstring -- or a different failure occurred. "
+            f"report={report!r}"
         )
     assert report.get("verdict") == "NO_CHANGE", report

--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -58,6 +58,35 @@ this module. ``clang`` was used exclusively in earlier revisions purely
 because this module's own local development/verification environment
 had no castxml install; that is no longer a reason to leave the
 default backend unverified in CI, which does have one.
+
+Running this module's ``scan``-comparison tests under castxml for the
+first time surfaced a real, but *different*, pre-existing and already
+self-documented gap -- not the ``NOT_COMPARABLE`` bug this module
+exists to regression-test. ``scan_engine.run_scan_core``'s own comment
+records that ``scan``'s candidate-side L4 source-ABI replay always uses
+``source_extractor="auto"`` (which ``buildsource.inline.
+_make_source_extractor`` resolves to clang), never the
+``--ast-frontend`` the caller actually passed, "a real behaviour change
+for real users, unverifiable without a castxml-capable lane" -- while
+``dump``'s own L4 replay *does* follow ``--ast-frontend`` via
+``service_compare_evidence.effective_frontend``. Under
+``--ast-frontend castxml`` this means the ``dump`` baseline's L4 replay
+runs through castxml while ``scan``'s own candidate replay still runs
+through clang -- two different tools independently replaying the same
+translation unit, which do not always resolve one exported symbol the
+same way; the result is a spurious ``COMPATIBLE_WITH_RISK`` verdict
+(``source_fact_coverage_incomplete``/``source_binary_provenance_
+mismatch``) on completely unchanged source, never ``NOT_COMPARABLE``.
+Since a castxml-capable lane is exactly what was previously missing to
+verify this, it is now pinned as a known-divergent, exact signature
+(mirroring ``tests/test_dump_cli_typed_api_parity.py``'s own
+``_SCAN_KNOWN_DIVERGENT_SHAPES`` pattern) rather than silently
+weakened or left to fail CI outright -- fixing the extractor selection
+itself is the real behaviour change ``run_scan_core``'s own comment
+already declines to make in this same PR, since it would need its own
+dedicated verification against real castxml/clang divergence in
+production usage, not a side effect of hardening this module's test
+coverage.
 """
 
 from __future__ import annotations
@@ -94,6 +123,28 @@ _AST_FRONTENDS = pytest.mark.parametrize("ast_frontend", ["clang", "castxml"])
 
 def _have_frontend(ast_frontend: str) -> bool:
     return _HAVE_CASTXML if ast_frontend == "castxml" else _HAVE_CLANG
+
+
+# scan's candidate-side L4 replay always uses clang (see module docstring) --
+# only "castxml" is known-divergent for the two scan-comparison tests below.
+# Not "dump-produces-a-different-baseline": the dump-side test above this
+# constant has no scan candidate at all, so it is unaffected and has no
+# xfail list of its own -- a future regression narrowing *that* path's
+# coverage should fail loudly rather than being masked here.
+_SCAN_KNOWN_DIVERGENT_FRONTENDS: frozenset[str] = frozenset({"castxml"})
+
+
+def _is_known_l4_extractor_divergence(output: str) -> bool:
+    """The exact, already-diagnosed signature: a RISK verdict from the two
+    L4-replay-specific reason codes ``run_scan_core``'s own comment already
+    attributes to the clang-vs-castxml candidate/baseline extractor
+    mismatch -- never a broader "any non-NO_CHANGE verdict" check, so an
+    unrelated regression still surfaces as a genuine, uncaught failure."""
+    return (
+        "COMPATIBLE_WITH_RISK" in output
+        and "source_fact_coverage_incomplete" in output
+        and "source_binary_provenance_mismatch" in output
+    )
 
 
 def _build_library(
@@ -292,6 +343,23 @@ def test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source(
     assert "NOT_COMPARABLE" not in scan_result.output, scan_result.output
     assert "profile_fingerprint mismatch" not in scan_result.output, scan_result.output
     assert scan_result.exit_code == 0, scan_result.output
+
+    if ast_frontend in _SCAN_KNOWN_DIVERGENT_FRONTENDS:
+        if _is_known_l4_extractor_divergence(scan_result.output):
+            pytest.xfail(
+                f"{ast_frontend}: known scan-candidate-L4-extractor-always-"
+                "clang divergence (see this module's own docstring)"
+            )
+        pytest.fail(
+            f"{ast_frontend} is listed in _SCAN_KNOWN_DIVERGENT_FRONTENDS, "
+            "but the previously-diagnosed failure signature "
+            "(COMPATIBLE_WITH_RISK naming source_fact_coverage_incomplete "
+            "and source_binary_provenance_mismatch) did not reproduce. "
+            "Either the underlying gap has closed -- remove this frontend "
+            "from _SCAN_KNOWN_DIVERGENT_FRONTENDS and update this module's "
+            "docstring -- or a different failure occurred and needs its "
+            f"own investigation. output={scan_result.output!r}"
+        )
     assert "Verdict: NO_CHANGE" in scan_result.output, scan_result.output
 
 
@@ -375,6 +443,22 @@ def test_scan_against_real_dump_baseline_matches_reported_cli_invocation(
     assert scan_result.exit_code == 0, scan_result.output
 
     report = json.loads(scan_report.read_text(encoding="utf-8"))
-    assert report.get("verdict") == "NO_CHANGE", report
     diff = report.get("diff") or {}
     assert diff.get("reason") is None, diff.get("reason")
+
+    if ast_frontend in _SCAN_KNOWN_DIVERGENT_FRONTENDS:
+        if _is_known_l4_extractor_divergence(json.dumps(report)):
+            pytest.xfail(
+                f"{ast_frontend}: known scan-candidate-L4-extractor-always-"
+                "clang divergence (see this module's own docstring)"
+            )
+        pytest.fail(
+            f"{ast_frontend} is listed in _SCAN_KNOWN_DIVERGENT_FRONTENDS, "
+            "but the previously-diagnosed failure signature "
+            "(COMPATIBLE_WITH_RISK naming source_fact_coverage_incomplete "
+            "and source_binary_provenance_mismatch) did not reproduce. "
+            "Either the underlying gap has closed -- remove this frontend "
+            "from _SCAN_KNOWN_DIVERGENT_FRONTENDS and update this module's "
+            f"docstring -- or a different failure occurred. report={report!r}"
+        )
+    assert report.get("verdict") == "NO_CHANGE", report

--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -96,6 +96,7 @@ import re
 import shutil
 import subprocess
 import sys
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -134,36 +135,50 @@ def _have_frontend(ast_frontend: str) -> bool:
 # coverage should fail loudly rather than being masked here.
 _SCAN_KNOWN_DIVERGENT_FRONTENDS: frozenset[str] = frozenset({"castxml"})
 
-# The exact, already-diagnosed finding-kind set for the L4-extractor
-# divergence -- an *exact* set match, not "these are present among
-# possibly others" (Codex review: a substring-only check would still
-# xfail past an unrelated additional risk finding riding alongside the
-# known two, silently hiding a real regression).
-_KNOWN_L4_EXTRACTOR_DIVERGENCE_KINDS = frozenset(
-    {"source_fact_coverage_incomplete", "source_binary_provenance_mismatch"}
+# The exact, already-diagnosed finding-kind multiset for the L4-extractor
+# divergence -- an exact multiset match, not "these are present among
+# possibly others" (Codex review, round 1: a substring-only check would
+# still xfail past an unrelated additional risk finding riding alongside
+# the known two) and not a bare set either (Codex review, round 2: a set
+# collapses a *second* occurrence of either known kind -- e.g. one more
+# `source_binary_provenance_mismatch` reported per side -- into "no
+# change", silently hiding that regression too).
+_KNOWN_L4_EXTRACTOR_DIVERGENCE_COUNTS = Counter(
+    {"source_fact_coverage_incomplete": 1, "source_binary_provenance_mismatch": 1}
 )
 _RISK_LINE_RE = re.compile(r"^\s*\[risk\]\s+(\S+):", re.MULTILINE)
 
 
 def _is_known_l4_extractor_divergence_text(output: str) -> bool:
     """Text-output variant: the verdict must be ``COMPATIBLE_WITH_RISK`` and
-    the set of ``[risk] <kind>:`` lines must equal exactly the known
-    two-kind set -- no more, no fewer."""
+    the multiset of ``[risk] <kind>:`` lines must equal exactly the known
+    two-kind, one-each multiset -- no more, no fewer, no duplicates."""
     if "COMPATIBLE_WITH_RISK" not in output:
         return False
     return (
-        frozenset(_RISK_LINE_RE.findall(output)) == _KNOWN_L4_EXTRACTOR_DIVERGENCE_KINDS
+        Counter(_RISK_LINE_RE.findall(output)) == _KNOWN_L4_EXTRACTOR_DIVERGENCE_COUNTS
     )
 
 
 def _is_known_l4_extractor_divergence_report(report: dict) -> bool:
     """JSON-report variant: the verdict must be ``COMPATIBLE_WITH_RISK`` and
-    the set of ``changes[].kind`` must equal exactly the known two-kind
-    set -- no more, no fewer."""
+    the multiset of finding kinds must equal exactly the known two-kind,
+    one-each multiset -- no more, no fewer, no duplicates.
+
+    ``scan --format json``'s ``ScanOutcome.to_dict()`` has no top-level
+    ``changes`` array (that's ``compare``'s report shape) -- its baseline
+    findings are nested under ``report["diff"]["findings"]``
+    (``cli_scan_baseline._baseline_summary``'s ``summary["findings"]``,
+    each entry's kind read the same tolerant way as everywhere else in
+    that module: ``getattr(kind, "value", str(kind))``). Reading a
+    nonexistent top-level ``changes`` key always saw an empty set, so the
+    known-divergent case fell through to ``pytest.fail()`` instead of
+    ``xfail`` -- Codex review, round 1."""
     if report.get("verdict") != "COMPATIBLE_WITH_RISK":
         return False
-    kinds = frozenset(c.get("kind") for c in report.get("changes", []))
-    return kinds == _KNOWN_L4_EXTRACTOR_DIVERGENCE_KINDS
+    findings = (report.get("diff") or {}).get("findings") or []
+    kinds = Counter(f.get("kind") for f in findings)
+    return kinds == _KNOWN_L4_EXTRACTOR_DIVERGENCE_COUNTS
 
 
 def _build_library(

--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -207,7 +207,18 @@ def _is_known_l4_extractor_divergence_text(output: str) -> bool:
     advisory blocks (cross-check, pattern, preprocessor) may have
     anything to report -- no more, no fewer, no duplicates, and no
     unrelated finding hiding in a bucket this module doesn't otherwise
-    inspect."""
+    inspect.
+
+    Structurally cannot go further than kind-multiset granularity (Codex
+    review, round 5, raised the same concern the JSON variant below
+    closes with a description-substring check): ``cli_scan_helpers.
+    render_baseline_lines`` renders each finding as only
+    ``[<bucket>] <kind>: <symbol><location>`` -- the ``description`` field
+    that actually distinguishes *which* cause produced a given kind is
+    never rendered in text mode at all, so there is no substring left in
+    ``output`` for this variant to check. The JSON variant is the
+    cause-specific one; prefer it in any new test that needs to
+    distinguish this from a same-kind-different-cause regression."""
     if "COMPATIBLE_WITH_RISK" not in output:
         return False
     if any(heading in output for heading in _ADVISORY_HEADINGS):
@@ -277,7 +288,27 @@ def _is_known_l4_extractor_divergence_report(report: dict) -> bool:
         return False
     findings = diff.get("findings") or []
     kinds = Counter(f.get("kind") for f in findings)
-    return kinds == _KNOWN_L4_EXTRACTOR_DIVERGENCE_COUNTS
+    if kinds != _KNOWN_L4_EXTRACTOR_DIVERGENCE_COUNTS:
+        return False
+    # Codex review, round 5: the kind alone is not cause-specific --
+    # SOURCE_FACT_COVERAGE_INCOMPLETE (buildsource/source_diff.py's
+    # `_coverage_incomplete_change`) is one ChangeKind covering several
+    # distinct underlying incompleteness reasons joined into one
+    # description, and a real regression could reproduce the identical
+    # kind pair/verdict/totals for a genuinely different cause (a
+    # different incomplete fact family, a different side). Each
+    # description is the one place that cause is actually recorded, so
+    # match the fixed, distinctive substrings each producer emits.
+    descriptions = {f.get("kind"): f.get("description") or "" for f in findings}
+    coverage_desc = descriptions.get("source_fact_coverage_incomplete", "")
+    provenance_desc = descriptions.get("source_binary_provenance_mismatch", "")
+    return (
+        "treat this pair's other source-replay findings as unreliable "
+        "until re-collected"
+        in coverage_desc
+        and "do not map to any exported binary symbol" in provenance_desc
+        and "wrong tag/commit" in provenance_desc
+    )
 
 
 def _build_library(

--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -147,13 +147,41 @@ _KNOWN_L4_EXTRACTOR_DIVERGENCE_COUNTS = Counter(
     {"source_fact_coverage_incomplete": 1, "source_binary_provenance_mismatch": 1}
 )
 _RISK_LINE_RE = re.compile(r"^\s*\[risk\]\s+(\S+):", re.MULTILINE)
+#: ``cli_scan_helpers.render_baseline_lines``'s exact counts-line format:
+#: "  breaking=N api_break=N risk=N compatible=N". Checked in addition to
+#: the risk-finding multiset above -- Codex review, round 3: an unrelated
+#: *compatible*-category false positive (``diff.compatible``, itemized
+#: under ``summary["additions"]``/``["quality"]``, never
+#: ``summary["findings"]``) leaves ``verdict``/``[risk] ...`` lines
+#: completely untouched, so neither prior check could ever see it. Only
+#: the aggregate ``compatible=0`` (and the ``breaking``/``api_break``
+#: counts, for the same reason) can.
+_COUNTS_LINE_RE = re.compile(
+    r"breaking=(\d+)\s+api_break=(\d+)\s+risk=(\d+)\s+compatible=(\d+)"
+)
+_KNOWN_L4_EXTRACTOR_DIVERGENCE_TOTALS = (
+    0,
+    0,
+    2,
+    0,
+)  # breaking, api_break, risk, compatible
 
 
 def _is_known_l4_extractor_divergence_text(output: str) -> bool:
-    """Text-output variant: the verdict must be ``COMPATIBLE_WITH_RISK`` and
-    the multiset of ``[risk] <kind>:`` lines must equal exactly the known
-    two-kind, one-each multiset -- no more, no fewer, no duplicates."""
+    """Text-output variant: the verdict must be ``COMPATIBLE_WITH_RISK``,
+    the counts line must read exactly ``breaking=0 api_break=0 risk=2
+    compatible=0``, and the multiset of ``[risk] <kind>:`` lines must equal
+    exactly the known two-kind, one-each multiset -- no more, no fewer, no
+    duplicates, and no unrelated finding hiding in a bucket this module
+    doesn't otherwise inspect."""
     if "COMPATIBLE_WITH_RISK" not in output:
+        return False
+    counts_match = _COUNTS_LINE_RE.search(output)
+    if (
+        counts_match is None
+        or tuple(int(g) for g in counts_match.groups())
+        != _KNOWN_L4_EXTRACTOR_DIVERGENCE_TOTALS
+    ):
         return False
     return (
         Counter(_RISK_LINE_RE.findall(output)) == _KNOWN_L4_EXTRACTOR_DIVERGENCE_COUNTS
@@ -161,9 +189,14 @@ def _is_known_l4_extractor_divergence_text(output: str) -> bool:
 
 
 def _is_known_l4_extractor_divergence_report(report: dict) -> bool:
-    """JSON-report variant: the verdict must be ``COMPATIBLE_WITH_RISK`` and
-    the multiset of finding kinds must equal exactly the known two-kind,
-    one-each multiset -- no more, no fewer, no duplicates.
+    """JSON-report variant: the verdict must be ``COMPATIBLE_WITH_RISK``,
+    the diff summary's ``breaking``/``api_break``/``risk``/``compatible``
+    counts must read exactly ``0``/``0``/``2``/``0``, and the multiset of
+    finding kinds must equal exactly the known two-kind, one-each
+    multiset -- no more, no fewer, no duplicates, and no unrelated
+    *compatible*-category finding hiding under ``additions``/``quality``
+    (Codex review, round 3 -- those buckets itemize ``diff.compatible``,
+    which the ``verdict``/``findings`` fields alone never reflect).
 
     ``scan --format json``'s ``ScanOutcome.to_dict()`` has no top-level
     ``changes`` array (that's ``compare``'s report shape) -- its baseline
@@ -176,7 +209,16 @@ def _is_known_l4_extractor_divergence_report(report: dict) -> bool:
     ``xfail`` -- Codex review, round 1."""
     if report.get("verdict") != "COMPATIBLE_WITH_RISK":
         return False
-    findings = (report.get("diff") or {}).get("findings") or []
+    diff = report.get("diff") or {}
+    totals = (
+        diff.get("breaking"),
+        diff.get("api_break"),
+        diff.get("risk"),
+        diff.get("compatible"),
+    )
+    if totals != _KNOWN_L4_EXTRACTOR_DIVERGENCE_TOTALS:
+        return False
+    findings = diff.get("findings") or []
     kinds = Counter(f.get("kind") for f in findings)
     return kinds == _KNOWN_L4_EXTRACTOR_DIVERGENCE_COUNTS
 

--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -42,11 +42,22 @@ on the current fold, rather than trusting the mocked unit coverage alone.
 
 Marked ``integration`` (real compiler-backed, so it must stay out of the
 default fast lane -- CLAUDE.md's "Default fast command excludes all
-external-tool markers"). ``--ast-frontend clang`` is used explicitly
-rather than the default castxml backend purely so this module's own
-development/verification didn't require a castxml install; the Linux
-``integration`` CI lane installs both clang and castxml/gcc/g++
-(``.github/workflows/ci.yml``), so this runs there regardless.
+external-tool markers").
+
+Parametrized over ``--ast-frontend`` (``clang`` and ``castxml``, the
+default header backend): the original bug report was reproduced against
+castxml specifically, and the underlying fix (the P0.3 L3->L2 fold, the
+legacy-match-overlap removal, ``scan``'s candidate resolver sharing
+``dump``'s own primitive) operates purely on ``CompileContext``/token
+data below where the two header backends diverge, so it is expected to
+hold for both -- but until this module actually exercised castxml, that
+was only an untested assumption, not a verified fact, and the Linux
+``integration`` CI lane installs both toolchains
+(``.github/workflows/ci.yml``) without either ever being exercised by
+this module. ``clang`` was used exclusively in earlier revisions purely
+because this module's own local development/verification environment
+had no castxml install; that is no longer a reason to leave the
+default backend unverified in CI, which does have one.
 """
 
 from __future__ import annotations
@@ -72,6 +83,17 @@ pytestmark = [
 
 _HAVE_GXX = shutil.which("g++") is not None
 _HAVE_CLANG = shutil.which("clang") is not None
+_HAVE_CASTXML = shutil.which("castxml") is not None
+
+# Both header backends are exercised: the fix operates on shared
+# CompileContext/token data below the point where the two backends
+# diverge, so a regression specific to one of them must not hide behind
+# only ever testing the other.
+_AST_FRONTENDS = pytest.mark.parametrize("ast_frontend", ["clang", "castxml"])
+
+
+def _have_frontend(ast_frontend: str) -> bool:
+    return _HAVE_CASTXML if ast_frontend == "castxml" else _HAVE_CLANG
 
 
 def _build_library(
@@ -171,16 +193,18 @@ def _build_library(
     return so_path, header, compile_db
 
 
-@pytest.mark.skipif(
-    not (_HAVE_GXX and _HAVE_CLANG), reason="needs a real g++ and clang toolchain"
-)
-def test_dump_folds_real_l3_evidence_into_ast_compile_context(tmp_path: Path) -> None:
+@_AST_FRONTENDS
+def test_dump_folds_real_l3_evidence_into_ast_compile_context(
+    tmp_path: Path, ast_frontend: str
+) -> None:
     """A real ``dump --build-info`` baseline carries the real ``-std=``.
 
     Direct assertion on the reported symptom: ``ast_resolved_standard``/
     ``ast_compile_args`` must not be empty when real L3 build evidence
     (a compile database recording ``-std=c++17``) was supplied.
     """
+    if not (_HAVE_GXX and _have_frontend(ast_frontend)):
+        pytest.skip(f"needs a real g++ and {ast_frontend} toolchain")
     so_path, header, compile_db = _build_library(tmp_path)
     baseline = tmp_path / "baseline.json"
 
@@ -198,7 +222,7 @@ def test_dump_folds_real_l3_evidence_into_ast_compile_context(tmp_path: Path) ->
             "--depth",
             "source",
             "--ast-frontend",
-            "clang",
+            ast_frontend,
             "-o",
             str(baseline),
         ],
@@ -213,15 +237,15 @@ def test_dump_folds_real_l3_evidence_into_ast_compile_context(tmp_path: Path) ->
     assert snap.get("parsed_with_build_context") is True
 
 
-@pytest.mark.skipif(
-    not (_HAVE_GXX and _HAVE_CLANG), reason="needs a real g++ and clang toolchain"
-)
+@_AST_FRONTENDS
 def test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source(
-    tmp_path: Path,
+    tmp_path: Path, ast_frontend: str
 ) -> None:
     """The full repro from the bug report: dump a baseline, then ``scan
     --against`` it on the identical, unchanged codebase. Must resolve as
     comparable (``NO_CHANGE``/exit 0), never ``NOT_COMPARABLE`` (exit 6)."""
+    if not (_HAVE_GXX and _have_frontend(ast_frontend)):
+        pytest.skip(f"needs a real g++ and {ast_frontend} toolchain")
     so_path, header, compile_db = _build_library(tmp_path)
     baseline = tmp_path / "baseline.json"
 
@@ -239,7 +263,7 @@ def test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source(
             "--depth",
             "source",
             "--ast-frontend",
-            "clang",
+            ast_frontend,
             "-o",
             str(baseline),
         ],
@@ -260,7 +284,7 @@ def test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source(
             "--depth",
             "source",
             "--ast-frontend",
-            "clang",
+            ast_frontend,
             "--against",
             str(baseline),
         ],
@@ -271,11 +295,9 @@ def test_scan_against_real_dump_baseline_is_comparable_on_unchanged_source(
     assert "Verdict: NO_CHANGE" in scan_result.output, scan_result.output
 
 
-@pytest.mark.skipif(
-    not (_HAVE_GXX and _HAVE_CLANG), reason="needs a real g++ and clang toolchain"
-)
+@_AST_FRONTENDS
 def test_scan_against_real_dump_baseline_matches_reported_cli_invocation(
-    tmp_path: Path,
+    tmp_path: Path, ast_frontend: str
 ) -> None:
     """The exact CLI invocation shape from the bug report: a side-prefixed
     ``-H new=PATH`` header, an explicit ``--lang c++``, an explicit
@@ -296,6 +318,8 @@ def test_scan_against_real_dump_baseline_matches_reported_cli_invocation(
     same invocation as ``NO_CHANGE`` even *without* the fix when no extra
     ``-I`` is involved. See ``_build_library``'s own docstring.
     """
+    if not (_HAVE_GXX and _have_frontend(ast_frontend)):
+        pytest.skip(f"needs a real g++ and {ast_frontend} toolchain")
     so_path, header, compile_db = _build_library(tmp_path, extra_include_dir="dep")
     baseline = tmp_path / "baseline.json"
 
@@ -313,7 +337,7 @@ def test_scan_against_real_dump_baseline_matches_reported_cli_invocation(
             "--depth",
             "source",
             "--ast-frontend",
-            "clang",
+            ast_frontend,
             "-o",
             str(baseline),
         ],
@@ -339,7 +363,7 @@ def test_scan_against_real_dump_baseline_matches_reported_cli_invocation(
             "--depth",
             "source",
             "--ast-frontend",
-            "clang",
+            ast_frontend,
             "--policy",
             "strict_abi",
             "--format",

--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -167,14 +167,34 @@ _KNOWN_L4_EXTRACTOR_DIVERGENCE_TOTALS = (
 )  # breaking, api_break, risk, compatible
 
 
+#: ``render_crosscheck_lines`` only emits this block at all when
+#: ``out.crosscheck["counts_by_check"]`` is non-empty -- an entirely
+#: separate, always-on block from the baseline ``diff`` this module
+#: otherwise inspects (``ScanOutcome.crosscheck``, not
+#: ``ScanOutcome.diff_summary``), rendered as its own
+#: ``[<severity>] <kind>: <n>`` lines under one of these two headings
+#: depending on ``--audit``. Neither heading appeared in the real
+#: CI-captured failure text this module's docstring quotes, but nothing
+#: before this checked for its *absence* -- Codex review, round 4: an
+#: unrelated cross-source regression would leave the verdict and every
+#: baseline count this module already checks completely untouched.
+_CROSSCHECK_HEADINGS = (
+    "Cross-source findings (advisory)",
+    "ABI-hygiene catalog (intra-version, advisory)",
+)
+
+
 def _is_known_l4_extractor_divergence_text(output: str) -> bool:
     """Text-output variant: the verdict must be ``COMPATIBLE_WITH_RISK``,
     the counts line must read exactly ``breaking=0 api_break=0 risk=2
-    compatible=0``, and the multiset of ``[risk] <kind>:`` lines must equal
-    exactly the known two-kind, one-each multiset -- no more, no fewer, no
-    duplicates, and no unrelated finding hiding in a bucket this module
-    doesn't otherwise inspect."""
+    compatible=0``, the multiset of ``[risk] <kind>:`` lines must equal
+    exactly the known two-kind, one-each multiset, and no cross-check
+    finding may be present -- no more, no fewer, no duplicates, and no
+    unrelated finding hiding in a bucket this module doesn't otherwise
+    inspect."""
     if "COMPATIBLE_WITH_RISK" not in output:
+        return False
+    if any(heading in output for heading in _CROSSCHECK_HEADINGS):
         return False
     counts_match = _COUNTS_LINE_RE.search(output)
     if (
@@ -191,12 +211,22 @@ def _is_known_l4_extractor_divergence_text(output: str) -> bool:
 def _is_known_l4_extractor_divergence_report(report: dict) -> bool:
     """JSON-report variant: the verdict must be ``COMPATIBLE_WITH_RISK``,
     the diff summary's ``breaking``/``api_break``/``risk``/``compatible``
-    counts must read exactly ``0``/``0``/``2``/``0``, and the multiset of
+    counts must read exactly ``0``/``0``/``2``/``0``, the multiset of
     finding kinds must equal exactly the known two-kind, one-each
-    multiset -- no more, no fewer, no duplicates, and no unrelated
-    *compatible*-category finding hiding under ``additions``/``quality``
-    (Codex review, round 3 -- those buckets itemize ``diff.compatible``,
-    which the ``verdict``/``findings`` fields alone never reflect).
+    multiset, and no cross-check finding may be present -- no more, no
+    fewer, no duplicates, and no unrelated finding hiding in a bucket this
+    module doesn't otherwise inspect.
+
+    Two buckets live entirely outside ``report["diff"]`` and must be
+    checked separately: an unrelated *compatible*-category finding
+    (Codex review, round 3 -- itemized under ``diff.additions``/
+    ``diff.quality``, which the ``verdict``/``findings`` fields alone
+    never reflect, so only the aggregate ``compatible`` count above can
+    see it) and an unrelated cross-check finding (Codex review, round 4 --
+    ``ScanOutcome.crosscheck``/``crosscheck_severities`` are a wholly
+    separate, always-on block from the baseline ``diff``, non-empty
+    ``report["crosscheck"]["counts_by_check"]`` only when a cross-source
+    check actually fired).
 
     ``scan --format json``'s ``ScanOutcome.to_dict()`` has no top-level
     ``changes`` array (that's ``compare``'s report shape) -- its baseline
@@ -208,6 +238,8 @@ def _is_known_l4_extractor_divergence_report(report: dict) -> bool:
     known-divergent case fell through to ``pytest.fail()`` instead of
     ``xfail`` -- Codex review, round 1."""
     if report.get("verdict") != "COMPATIBLE_WITH_RISK":
+        return False
+    if (report.get("crosscheck") or {}).get("counts_by_check"):
         return False
     diff = report.get("diff") or {}
     totals = (

--- a/tests/test_dump_scan_l3_comparability.py
+++ b/tests/test_dump_scan_l3_comparability.py
@@ -183,18 +183,34 @@ _CROSSCHECK_HEADINGS = (
     "ABI-hygiene catalog (intra-version, advisory)",
 )
 
+#: The remaining two advisory blocks (``render_pattern_lines``/
+#: ``render_preprocessor_lines``) with the identical shape as crosscheck
+#: above: each is rendered only when its own source has something to
+#: report, entirely independent of ``diff``/``crosscheck``. Closed
+#: proactively alongside the crosscheck fix rather than waiting for a
+#: fifth review round to name each one individually -- the three
+#: advisory blocks are ``ScanOutcome``'s complete, enumerable set (see
+#: ``cli_scan_helpers.py``'s own ``render_*_lines`` functions), so this is
+#: the general fix ("no advisory finding of any kind"), not another
+#: one-off patch.
+_ADVISORY_HEADINGS = _CROSSCHECK_HEADINGS + (
+    "Pattern pre-scan facts (advisory)",
+    "Preprocessor pre-scan facts (S2, advisory)",
+)
+
 
 def _is_known_l4_extractor_divergence_text(output: str) -> bool:
     """Text-output variant: the verdict must be ``COMPATIBLE_WITH_RISK``,
     the counts line must read exactly ``breaking=0 api_break=0 risk=2
     compatible=0``, the multiset of ``[risk] <kind>:`` lines must equal
-    exactly the known two-kind, one-each multiset, and no cross-check
-    finding may be present -- no more, no fewer, no duplicates, and no
+    exactly the known two-kind, one-each multiset, and none of the three
+    advisory blocks (cross-check, pattern, preprocessor) may have
+    anything to report -- no more, no fewer, no duplicates, and no
     unrelated finding hiding in a bucket this module doesn't otherwise
     inspect."""
     if "COMPATIBLE_WITH_RISK" not in output:
         return False
-    if any(heading in output for heading in _CROSSCHECK_HEADINGS):
+    if any(heading in output for heading in _ADVISORY_HEADINGS):
         return False
     counts_match = _COUNTS_LINE_RE.search(output)
     if (
@@ -213,20 +229,24 @@ def _is_known_l4_extractor_divergence_report(report: dict) -> bool:
     the diff summary's ``breaking``/``api_break``/``risk``/``compatible``
     counts must read exactly ``0``/``0``/``2``/``0``, the multiset of
     finding kinds must equal exactly the known two-kind, one-each
-    multiset, and no cross-check finding may be present -- no more, no
+    multiset, and none of the three advisory blocks (cross-check,
+    pattern, preprocessor) may have anything to report -- no more, no
     fewer, no duplicates, and no unrelated finding hiding in a bucket this
     module doesn't otherwise inspect.
 
-    Two buckets live entirely outside ``report["diff"]`` and must be
+    Several buckets live entirely outside ``report["diff"]`` and must be
     checked separately: an unrelated *compatible*-category finding
     (Codex review, round 3 -- itemized under ``diff.additions``/
     ``diff.quality``, which the ``verdict``/``findings`` fields alone
     never reflect, so only the aggregate ``compatible`` count above can
-    see it) and an unrelated cross-check finding (Codex review, round 4 --
-    ``ScanOutcome.crosscheck``/``crosscheck_severities`` are a wholly
-    separate, always-on block from the baseline ``diff``, non-empty
-    ``report["crosscheck"]["counts_by_check"]`` only when a cross-source
-    check actually fired).
+    see it) and the three advisory blocks (Codex review, round 4 named
+    cross-check specifically; pattern/preprocessor closed proactively
+    alongside it, same shape, same reasoning -- each is a wholly separate,
+    always-on ``ScanOutcome`` field the ``verdict``/``diff`` never
+    reflect, non-empty only when that source actually found something:
+    ``report["crosscheck"]["counts_by_check"]``,
+    ``report["pattern_scan"]["counts_by_kind"]``, and
+    ``report["preprocessor_scan"]["divergences"/"leaks"]``).
 
     ``scan --format json``'s ``ScanOutcome.to_dict()`` has no top-level
     ``changes`` array (that's ``compare``'s report shape) -- its baseline
@@ -240,6 +260,11 @@ def _is_known_l4_extractor_divergence_report(report: dict) -> bool:
     if report.get("verdict") != "COMPATIBLE_WITH_RISK":
         return False
     if (report.get("crosscheck") or {}).get("counts_by_check"):
+        return False
+    if (report.get("pattern_scan") or {}).get("counts_by_kind"):
+        return False
+    preprocessor_scan = report.get("preprocessor_scan") or {}
+    if preprocessor_scan.get("divergences") or preprocessor_scan.get("leaks"):
         return False
     diff = report.get("diff") or {}
     totals = (


### PR DESCRIPTION
## Summary

Parametrize `tests/test_dump_scan_l3_comparability.py`'s three end-to-end repro cases over `--ast-frontend` (`clang` and `castxml`), instead of hardcoding `clang`. Also fixes a real defect in the castxml known-divergence xfail check this parametrization surfaced.

## Motivation

Follows up on the reported "`scan --against <dump-mode baseline>` reports `NOT_COMPARABLE`" bug (already fixed via the P0.3 L3→L2 fold, the legacy-match-overlap removal, and `scan`'s candidate resolver sharing `dump`'s own resolution primitive — see `AGENTS.md`'s "Known gaps" section and PR #821). The original report reproduced the bug against **castxml** specifically, but the regression test added in #821 only ever exercised **clang** — a development-environment convenience from when that module was written, since this sandbox has no castxml install.

castxml is the *default* header backend, and the Linux `integration` CI lane installs it, but nothing in this module ever actually ran the repro through it — so a castxml-specific regression in this exact area could land without any test catching it.

Running the castxml cases in CI for the first time surfaced a real, but *different*, pre-existing and already self-documented gap (`scan`'s candidate-side L4 replay always uses clang regardless of `--ast-frontend`, per `scan_engine.run_scan_core`'s own comment) — not the `NOT_COMPARABLE` bug this module regression-tests. That was encoded as a known-divergence `xfail`, and a follow-up commit (per Codex review) fixed a real defect in that xfail check itself: it matched on substring containment rather than an exact finding-kind set, so an unrelated additional finding riding alongside the known two would have been silently swallowed.

## Changes

- Added `_HAVE_CASTXML`/`_have_frontend()` and a shared `_AST_FRONTENDS` parametrize mark.
- All three tests in the module now run once under `--ast-frontend clang` and once under `--ast-frontend castxml`, each independently skipped if its toolchain isn't on `PATH`.
- Added `_SCAN_KNOWN_DIVERGENT_FRONTENDS` and `_is_known_l4_extractor_divergence_text`/`_report`, mirroring `tests/test_dump_cli_typed_api_parity.py`'s own `_SCAN_KNOWN_DIVERGENT_SHAPES` pattern: only the exact, already-diagnosed signature is tolerated via `xfail`; anything else (including the gap closing) fails the test outright.
- Updated the module docstring throughout.

No production code changes — this sandbox has no castxml install, so the castxml-parametrized cases can only be verified by CI's `integration` lane (which does have castxml), not locally; the clang-parametrized cases and the xfail-predicate logic itself were re-verified locally (including with synthetic data for the extra-finding case).

## Bug-fix test contract

- Bug class: A test's own "is this the known, already-diagnosed divergence" predicate matched via substring containment rather than an exact set/count match, so a genuinely new, unrelated finding riding alongside the two already-known ones would still satisfy the predicate and get silently treated as "the known gap" via `pytest.xfail()`.
- Publicly observable failure: None directly for an end user — this is a test-infrastructure defect. Its user-facing consequence is indirect: a real new regression in `scan`'s comparability/finding logic, if it happened to coexist with the already-known castxml L4-extractor divergence, would be reported by CI as an expected failure (xfail) rather than a real one, so nobody would see it.
- Regression test fails on base: Yes, verified directly (not merely by reading the diff): reconstructing the pre-fix substring-only predicate against a synthetic report/output carrying the two known findings *plus* one unrelated extra finding returns `True` (would `xfail`); the post-fix `_is_known_l4_extractor_divergence_report`/`_text` correctly returns `False` for the identical input.
- Negative control: The exact, unmodified two-finding case (no extra finding) still returns `True` and is still `xfail`ed under the fixed predicate — verified against the same synthetic data, so the fix narrows the match without breaking the case it exists to tolerate.
- Public-surface test: The fix is inside the test suite's own helper functions, not shipped `abicheck` code, so there is no separate CLI/report/API entry point beyond the predicate functions themselves — verified by calling `_is_known_l4_extractor_divergence_text`/`_report` directly with both the real CI-captured failure text and synthetic extra-finding data.
- Axes covered: Both variants were fixed and verified identically — the CLI-text-output check (used by the bare `-H` scan-comparison test) and the JSON-report check (used by the reported-CLI-shape test).
- General invariant: The known-divergence predicate now requires the diagnosed finding-kind set to match *exactly*; any additional finding of any other kind alongside the known two makes the predicate return `False` and the test fail for real, regardless of which extra kind appears.

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md` (N/A — tests-only change)
- [ ] Docs updated if user-visible behaviour changed (N/A)
- [x] `pre-commit run --all-files` passes locally (`ruff check`/`ruff format --check` clean on the touched file)
- [x] No new `mypy` or `ruff` errors introduced

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded dump and scan integration coverage to run with both Clang and CastXML.
  - Added toolchain-aware handling for known CastXML comparison differences.
  - Strengthened regression checks to require successful, comparable `NO_CHANGE` results.
  - Enhanced JSON validation to confirm no diff reason is reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->