### PR TITLE
test: pin the Bazel include-dir dump-vs-scan comparability shape (already fixed on main)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2102,6 +2102,55 @@ Once a root command genuinely clears the bar above, pick the right home:
   what #810's original literal symptom was about, is caught independently
   of the `include_sequence` gap this note documents.
 
+  **The nineteenth finding's own missing prerequisite — real evidence from
+  the exact Bazel `include_sequence` mismatch — has now been supplied, and
+  the mismatch does not reproduce on current `main` (2026-08-22).**
+  `napetrov/abicheck-bazel-lab`'s `UPSTREAM_TO_ABICHECK.md` (2026-08-21
+  entry, "`abicheck scan --against` reports NOT_COMPARABLE against every
+  `abicheck dump` baseline") recorded exactly this: `mode: dump` and
+  `mode: scan` for real Bazel `//:math` evidence (`cc_library(includes =
+  ["include"])`, verified byte-identical evidence packs across runs)
+  disagreeing on `contract.profile_fields.include_sequence`, deterministic,
+  on every CI run pinned to `abicheck/abicheck@6fb8536` (#812). Reproduced
+  directly, without Bazel or castxml: a `g++`-compiled library with the
+  identical real shape a `cc_library(includes = ["include"])` action
+  produces — two simultaneous `-I` search directories (the package's own
+  `include` dir and Bazel's always-present package/workspace-root search
+  path) that are both real, legitimate ancestors of the *same* physical
+  public header, tokenizing as two `hdrs:` slots in `include_sequence`
+  (`abicheck_lab/math.h` under the `include` dir, `include/abicheck_lab/
+  math.h` under the root — matching the committed `abi/math.abicheck.json`
+  baseline's own recorded fields exactly). Checked out at the reported pin
+  (`6fb85361c`, #812) in a separate worktree: the mismatch reproduces
+  there verbatim (`dump`'s baseline records `include_sequence: []` — the
+  P0.3 L3→L2 fold never reached the ELF `dump` CLI's header parse at that
+  commit — while `scan`'s candidate resolves two `hdrs:` slots for the
+  identical evidence, so `scan --against` correctly, if unhelpfully,
+  refuses the pair as `NOT_COMPARABLE`). The identical repro against
+  current `main` (well past #812 — the "PR C" `dump`/`scan` convergence
+  work chronicled throughout this same entry, `#814`/`#815`/`#817`/`#823`,
+  landed after the lab's pin) produces `NO_CHANGE`/exit 0 on `scan
+  --against`, `compare`'s implicit-dump operand, and both CLI-vs-typed-API
+  parity lenses alike — the `dump`/`scan` convergence work already closed
+  this specific shape as a side effect, not as a targeted fix for it.
+  Given `main` was already correct, no `abicheck` source change was made
+  for this finding; what was missing was permanent regression coverage
+  pinning this exact real-world shape (a Bazel `includes`-attribute-style
+  *duplicate owned include directory*, distinct from `extra-include-dir`'s
+  unrelated-second-header shape), so a future regression in the shared
+  `seed_includes_and_fold_compile_context`/`_slot_token_for_ancestor`
+  machinery fails a fast, deterministic test here instead of needing a
+  fresh Bazel CI report to notice again. Added as a fourth parametrized
+  shape, `"duplicate-owned-include-dirs"`, in
+  `tests/test_dump_cli_typed_api_parity.py`'s `_BUILD_SHAPES` — it runs
+  through all four existing parity/comparability tests in that module
+  (both CLI-vs-typed-API lenses, `scan --against`, `compare`'s
+  implicit-dump operand) with no `xfail`, matching every other closed
+  shape there. The pinned Action commit `abicheck-bazel-lab` reported
+  against (`6fb8536`) predates the fix entirely; upstream consumers hitting
+  this exact symptom need to move their pin forward past `#814`, not wait
+  on a new `abicheck` change.
+
 - **`dump --lang c++` is silently discarded on the primary clang header-AST
   pass for a language-ambiguous header, diverging from `_attach_header_graph`'s
   own pass on the identical headers — investigated, not fixed (G31 Phase C

--- a/tests/test_dump_cli_typed_api_parity.py
+++ b/tests/test_dump_cli_typed_api_parity.py
@@ -479,6 +479,36 @@ def test_dump_cli_and_typed_api_agree_on_resolved_compile_context(
 _CONTRACT_KNOWN_DIVERGENT_FIELDS: dict[str, str] = {}
 
 
+def _assert_duplicate_owned_include_dirs_oracle(fields: dict) -> None:
+    """Positive oracle for the ``"duplicate-owned-include-dirs"`` shape
+    (Codex review, PR #825): the cross-path equality check in the test
+    below only proves the CLI and typed-API paths agree with *each other*
+    -- if a regression made every path uniformly drop one or both owned
+    ``-I`` roots (e.g. a change to ``seed_includes_and_fold_compile_context``
+    or ``_slot_token_for_ancestor`` that stops recognizing this shape at
+    all), the snapshots would still be equal, and the equality check alone
+    would stay green while this fixture silently stopped exercising the
+    two-owner-directories behavior it exists to pin. Assert the actual
+    expected content instead: two ordered ``hdrs:`` slots, one per owning
+    ``-I`` directory, each with the distinct header-relative spelling
+    ``_build_library``'s docstring documents for this shape."""
+    raw = fields.get("include_sequence")
+    assert raw is not None, "duplicate-owned-include-dirs: no include_sequence recorded"
+    slots = json.loads(raw)
+    assert len(slots) == 2, (
+        "duplicate-owned-include-dirs: expected exactly two owned include-dir "
+        f"slots, got {slots!r}"
+    )
+    assert slots[0].startswith("0:hdrs:") and slots[1].startswith("1:hdrs:"), slots
+    assert '"pkg/widget.h"' in slots[0], slots
+    assert '"include/pkg/widget.h"' in slots[1], slots
+
+
+_SHAPE_ORACLES: dict[str, object] = {
+    "duplicate-owned-include-dirs": _assert_duplicate_owned_include_dirs_oracle,
+}
+
+
 @pytest.mark.skipif(not (_HAVE_GXX and _HAVE_CLANG), reason=_SKIP_REASON)
 @pytest.mark.parametrize("shape_name", sorted(_BUILD_SHAPES))
 def test_dump_cli_and_typed_api_agree_on_extraction_contract(
@@ -503,6 +533,10 @@ def test_dump_cli_and_typed_api_agree_on_extraction_contract(
 
     assert cli_fields, f"{shape_name}: the CLI dump recorded no extraction contract"
     assert typed_fields, f"{shape_name}: the typed dump recorded no extraction contract"
+
+    oracle = _SHAPE_ORACLES.get(shape_name)
+    if oracle is not None:
+        oracle(cli_fields)  # type: ignore[operator]
 
     differing = sorted(
         key

--- a/tests/test_dump_cli_typed_api_parity.py
+++ b/tests/test_dump_cli_typed_api_parity.py
@@ -116,11 +116,30 @@ def _build_library(
     std: str = "c++17",
     macros: tuple[str, ...] = (),
     extra_include_dir: str | None = None,
+    duplicate_owned_include_dirs: bool = False,
 ) -> tuple[Path, Path, Path]:
     """Compile a small, real library whose header depends on the given
     ``-std=``/macros, plus a matching ``compile_commands.json`` -- varying
     the build-evidence shape across the parametrized cases below, not just
-    the one exact shape #810's own repro used."""
+    the one exact shape #810's own repro used.
+
+    ``duplicate_owned_include_dirs`` reproduces the exact real-world shape
+    reported against a Bazel ``cc_library`` with an ``includes = [...]``
+    attribute (``napetrov/abicheck-bazel-lab``'s ``UPSTREAM_TO_ABICHECK.md``,
+    2026-08-21 entry, ``//:math``): Bazel's compile action carries *two*
+    distinct ``-I`` search directories that are both ancestors of the
+    *same* public header -- one from the package's own ``includes``
+    attribute (here, ``<root>/include``), one from Bazel's own
+    always-present package/workspace-root search path (here, ``<root>``
+    itself). Neither is redundant to drop and both are real compiler argv,
+    so ``declared_includes`` legitimately gets two "owned" slots for one
+    physical header, tokenized as two different header-relative-to-dir
+    spellings (``pkg/widget.h`` under the root dir, ``widget.h`` under the
+    package dir). This is a distinct shape from ``extra-include-dir``
+    above (an unrelated *second* header under its own, non-overlapping
+    directory) -- here both dirs own the exact same header, which is what
+    exercises the ``_slot_token_for_ancestor`` dedup/ordering machinery on
+    a genuine multi-owner case rather than a multi-header one."""
     include_dirs = [tmp_path]
     dep_header_snippet = ""
     dep_field = ""
@@ -138,7 +157,22 @@ def _build_library(
         f'#ifndef {m.split("=")[0]}\n#error "missing {m}"\n#endif' for m in macros
     )
 
-    header = tmp_path / "widget.h"
+    if duplicate_owned_include_dirs:
+        header_dir = tmp_path / "include" / "pkg"
+        header_dir.mkdir(parents=True, exist_ok=True)
+        header = header_dir / "widget.h"
+        header_include_spelling = "pkg/widget.h"
+        # Both the package's own `include` dir (owns the header as
+        # `pkg/widget.h`) and the workspace root itself (owns it as
+        # `include/pkg/widget.h`) are real, simultaneous `-I` search
+        # directories -- mirroring Bazel's `includes = ["include"]` plus
+        # its own always-present package-root search path.
+        include_dirs.append(tmp_path / "include")
+        include_dirs.append(tmp_path)
+    else:
+        header = tmp_path / "widget.h"
+        header_include_spelling = "widget.h"
+
     header.write_text(
         "#pragma once\n"
         f"{dep_header_snippet}"
@@ -156,7 +190,8 @@ def _build_library(
     )
     src = tmp_path / "widget.cpp"
     src.write_text(
-        '#include "widget.h"\nint compute(const Widget& w) { return w.sum(); }\n',
+        f'#include "{header_include_spelling}"\n'
+        "int compute(const Widget& w) { return w.sum(); }\n",
         encoding="utf-8",
     )
     so_path = tmp_path / "libwidget.so"
@@ -296,6 +331,14 @@ _BUILD_SHAPES: dict[str, dict[str, object]] = {
     "plain-c++17": {"std": "c++17"},
     "c++20-with-macro": {"std": "c++20", "macros": ("FOO=1",)},
     "extra-include-dir": {"std": "c++17", "extra_include_dir": "dep"},
+    # Real-world Bazel `cc_library(includes = [...])` shape -- see
+    # `_build_library`'s own docstring paragraph on
+    # `duplicate_owned_include_dirs` for the exact upstream report this
+    # reproduces (`napetrov/abicheck-bazel-lab`, `//:math`, 2026-08-21).
+    "duplicate-owned-include-dirs": {
+        "std": "c++17",
+        "duplicate_owned_include_dirs": True,
+    },
 }
 
 


### PR DESCRIPTION
## Summary

Adds a permanent regression test pinning the real-world Bazel `include_sequence` dump-vs-scan comparability shape reported in `napetrov/abicheck-bazel-lab`, and confirms (with a direct repro at both the reported pin and current `main`) that the underlying bug is already fixed upstream — no `abicheck` source change was needed.

## Motivation

`napetrov/abicheck-bazel-lab`'s `UPSTREAM_TO_ABICHECK.md` (2026-08-21 entry) reported `abicheck scan --against` a `abicheck dump` baseline returning `NOT_COMPARABLE` deterministically for `//:math` (a Bazel `cc_library(includes = ["include"])` target), on every CI run pinned to `abicheck/abicheck@6fb8536` (#812), with `diff.reason` naming `profile_fingerprint mismatch; differing fields: include_sequence`.

I reproduced this offline without Bazel/castxml, using a `g++`-compiled library with the equivalent real shape: two simultaneous `-I` search directories that are both legitimate ancestors of the same public header (the package's own `include` dir plus Bazel's always-present package/workspace-root search path), which tokenize as two `hdrs:` slots in `include_sequence`.

- Checked out at the reported pin (`6fb85361c`, #812) in a separate worktree: the mismatch reproduces there exactly as described — `dump`'s baseline records `include_sequence: []` (the P0.3 L3→L2 fold never reached the ELF `dump` CLI's header parse at that commit) while `scan`'s candidate resolves two `hdrs:` slots for the identical evidence, so the pair is refused as `NOT_COMPARABLE`.
- The identical repro against current `main` produces `NO_CHANGE`/exit 0 across `scan --against`, `compare`'s implicit-dump operand, and both existing CLI-vs-typed-API parity lenses in `tests/test_dump_cli_typed_api_parity.py` — already closed as a side effect of the "PR C" `dump`/`scan` convergence work (#814/#815/#817/#823), all of which landed after the lab's pin.

So this is not a live `abicheck` bug on `main`; it's a stale-pin issue for anyone still on `#812` or earlier. What was missing was permanent coverage for this *specific* real-world shape (a Bazel `includes`-attribute-style duplicate-owned include directory, distinct from the existing `extra-include-dir` shape which covers an unrelated *second* header under its own directory).

## Changes

- `tests/test_dump_cli_typed_api_parity.py`: adds a fourth `_BUILD_SHAPES` parametrization, `"duplicate-owned-include-dirs"`, exercising the Bazel-style two-owner-directories-for-one-header shape through all four existing parity/comparability tests in that module (both CLI-vs-typed-API lenses, `scan --against`, `compare`'s implicit-dump operand) — with no `xfail`, matching every other already-closed shape.
- `AGENTS.md`: records the closure under the existing "nineteenth finding" narrative in the L3→L2-fold "Known gaps" entry — that finding's own text said a live Bazel/castxml repro was the missing prerequisite to make progress; this supplies it and closes it out.

## Checklist

- [x] Tests added / updated for new behaviour
- [ ] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — not needed, no `abicheck/**/*.py` touched (test-only + docs)
- [x] Docs updated (`AGENTS.md` known-gaps closure note)
- [x] `ruff check` / `ruff format --check` pass locally on changed files
- [x] No new `mypy` or `ruff` errors introduced

Note: this repo's `integration`-marked tests (including the new shape) require `castxml` on `PATH` even for a clang-only build shape (see `tests/conftest.py`'s blanket Linux gate), which wasn't available in my sandbox — I validated the new shape by calling the test module's own helper functions directly (`_build_library`, `_dump_via_cli`, `_contract_profile_fields_via_typed_api`, and `CliRunner` invocations of `dump`/`scan`/`compare`), confirming the exact assertions each parametrized test makes. CI's `integration` lane (which does have castxml) will exercise it through pytest properly.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkGcoP6vG1D1WBz8HcQDkb)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a Bazel include-sequence mismatch affecting `dump` and `scan --against`.
  - Confirmed current behavior reports no changes after convergence fixes.

- **Tests**
  - Added coverage for builds with duplicate owned include directories.
  - Expanded parity checks across CLI and typed APIs, including `scan --against` and implicit-dump comparisons.

- **Documentation**
  - Documented the resolved issue and upgrade guidance for affected installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->