### PR TITLE
security: block response-file injection in derived forced includes

### DIFF
--- a/abicheck/buildsource/header_compile_context.py
+++ b/abicheck/buildsource/header_compile_context.py
@@ -1217,7 +1217,9 @@ def _context_flags(
             ["-isystem", _resolve_cu_relative_path(inc, cu.directory).as_posix()]
         )
     for f in cu.abi_relevant_flags:
-        if _is_structured_field_flag(f, cu_standard=cu.standard, msvc=msvc):
+        if f.startswith("@") or _is_structured_field_flag(
+            f, cu_standard=cu.standard, msvc=msvc
+        ):
             continue
         flags.extend(_split_operand_survivor(f))
     # Last, so a forced header resolves through the include search this

--- a/abicheck/buildsource/source_extractors/_argv.py
+++ b/abicheck/buildsource/source_extractors/_argv.py
@@ -1519,7 +1519,7 @@ def is_msvc_mode(cc_bin: str) -> bool:
 
 
 def _carry_abi_relevant_flags(
-    abi_relevant_flags: list[str], seen: set[str], out: list[str]
+    abi_relevant_flags: list[str], seen: set[str], out: list[str], cc_id: str
 ) -> None:
     """Append ``abi_relevant_flags`` not already in ``seen`` to ``out``.
 
@@ -1568,14 +1568,39 @@ def _carry_abi_relevant_flags(
     scanning downstream (e.g. ``dumper_clang._needs_sycl_host_only``) sees
     the same sequence the real compiler did.
     """
-    for flag in abi_relevant_flags:
+    i = 0
+    while i < len(abi_relevant_flags):
+        flag = abi_relevant_flags[i]
+        forced: list[str] = []
+        new_i, _option, operand = _match_gnu_forced_include(
+            flag, abi_relevant_flags, i, forced
+        )
+        if new_i == i and cc_id == "msvc":
+            new_i, _option, operand = _match_msvc_forced_include(
+                flag, abi_relevant_flags, i, forced
+            )
+        if new_i != i:
+            # Build packs are untrusted evidence. A forced-include operand
+            # that is a response file would be expanded by the new compiler
+            # process L4 starts, so discard the complete option/operand pair.
+            if operand and not operand.startswith(("-", "@")):
+                for carried in forced:
+                    if carried not in seen:
+                        out.append(carried)
+            i = new_i
+            continue
         if is_split_operand_abi_flag_survivor(flag):
             out.extend(split_operand_survivor(flag))
+            i += 1
             continue
         if flag.startswith(STRUCTURED_TOOLCHAIN_FLAG_PREFIXES):
+            i += 1
             continue
-        if flag not in seen:
+        # A bare response-file token is also compiler syntax, even when it
+        # is not paired with a recognized forced-include option.
+        if not flag.startswith("@") and flag not in seen:
             out.append(flag)
+        i += 1
 
 
 def _match_gnu_include_search(tok: str, argv: list[str], i: int, out: list[str]) -> int:
@@ -1627,13 +1652,19 @@ def _scan_argv_for_extra_flags(argv: list[str], cc_id: str, out: list[str]) -> N
         # path (header_utils) and return (new_i, option, operand); only the
         # index matters here, since replay hands `out`'s verbatim tokens
         # straight back to the real compiler.
-        new_i, _opt, _operand = _match_gnu_forced_include(tok, argv, i, out)
+        forced: list[str] = []
+        new_i, _opt, operand = _match_gnu_forced_include(tok, argv, i, forced)
+        if new_i != i and operand and not operand.startswith(("-", "@")):
+            out.extend(forced)
         if new_i == i:
             new_i = _match_gnu_include_search(tok, argv, i, out)
         if new_i == i and cc_id == "msvc":
             new_i = _match_msvc_include_search(tok, argv, i, out)
         if new_i == i and cc_id == "msvc":
-            new_i, _opt, _operand = _match_msvc_forced_include(tok, argv, i, out)
+            forced = []
+            new_i, _opt, operand = _match_msvc_forced_include(tok, argv, i, forced)
+            if new_i != i and operand and not operand.startswith(("-", "@")):
+                out.extend(forced)
         i = new_i if new_i != i else i + 1
 
 
@@ -1653,6 +1684,6 @@ def replay_extra_flags(
     """
     seen = set(already)
     out: list[str] = []
-    _carry_abi_relevant_flags(compile_unit.abi_relevant_flags, seen, out)
+    _carry_abi_relevant_flags(compile_unit.abi_relevant_flags, seen, out, cc_id)
     _scan_argv_for_extra_flags(compile_unit.argv, cc_id, out)
     return out

--- a/abicheck/header_utils.py
+++ b/abicheck/header_utils.py
@@ -972,7 +972,11 @@ def forced_include_operands(
         # real file operand (``-include-pchfoo`` reaches the joined ``-include``
         # branch with ``-pchfoo``); replaying it verbatim is harmless, but
         # re-rendering it as a forced include would not be.
-        if operand and not operand.startswith("-"):
+        # Unlike the verbatim L4 replay view, this normalized view feeds a new
+        # compiler invocation.  Never forward response-file syntax across
+        # that boundary: clang expands an ``@file`` operand before parsing
+        # ``-include``, allowing the file to inject unrelated compiler flags.
+        if operand and not operand.startswith(("-", "@")):
             out.append((option, operand))
         i = new_i
     return out

--- a/changelog.d/1786924801_aardvark_forced_include_response.md
+++ b/changelog.d/1786924801_aardvark_forced_include_response.md
@@ -1,0 +1,3 @@
+### Security
+
+- **Blocked response-file injection through derived forced includes.** Build evidence containing an `@response-file` forced-include operand is no longer forwarded into the Clang or CastXML header parse, preventing the response file from injecting compiler flags.

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -179,6 +179,20 @@ class TestForcedIncludeRecognizer:
             == []
         )
 
+    @pytest.mark.parametrize(
+        ("argv", "msvc"),
+        [
+            (["c++", "-include", "@evil.rsp"], False),
+            (["c++", "-include@evil.rsp"], False),
+            (["clang-cl", "/FI", "@evil.rsp"], True),
+            (["clang-cl", "/FI@evil.rsp"], True),
+        ],
+    )
+    def test_response_file_operands_are_not_forwarded_to_l2(
+        self, argv: list[str], msvc: bool
+    ) -> None:
+        assert forced_include_operands(argv, msvc=msvc) == []
+
 
 class TestReplayStillEmitsForcedIncludesExactlyOnce:
     """Why forced includes deliberately never enter ``abi_relevant_flags``.

--- a/tests/test_build_context_completeness.py
+++ b/tests/test_build_context_completeness.py
@@ -218,6 +218,49 @@ class TestReplayStillEmitsForcedIncludesExactlyOnce:
         argv = ["c++", "-include", "cfg.h", "-imacros", "defs.h", "/FIw.h", "-fPIC"]
         assert extract_abi_relevant_flags(argv) == ["-fPIC"]
 
+    @pytest.mark.parametrize(
+        ("abi_relevant_flags", "cc_id"),
+        [
+            (["-include", "@evil.rsp"], "gnu"),
+            (["-include@evil.rsp"], "gnu"),
+            (["/FI", "@evil.rsp"], "msvc"),
+            (["/FI@evil.rsp"], "msvc"),
+        ],
+    )
+    def test_response_file_forced_includes_from_build_pack_are_not_replayed(
+        self, abi_relevant_flags: list[str], cc_id: str
+    ) -> None:
+        from abicheck.buildsource.source_extractors._argv import replay_extra_flags
+
+        cu = _cu(abi_relevant_flags=abi_relevant_flags)
+        assert replay_extra_flags(cu, [], cc_id) == []
+
+    @pytest.mark.parametrize(
+        ("argv", "cc_id"),
+        [
+            (["c++", "-include", "@evil.rsp", "-c", "a.cpp"], "gnu"),
+            (["c++", "-include@evil.rsp", "-c", "a.cpp"], "gnu"),
+            (["clang-cl", "/FI", "@evil.rsp", "-c", "a.cpp"], "msvc"),
+            (["clang-cl", "/FI@evil.rsp", "-c", "a.cpp"], "msvc"),
+        ],
+    )
+    def test_response_file_forced_includes_from_raw_argv_are_not_replayed(
+        self, argv: list[str], cc_id: str
+    ) -> None:
+        from abicheck.buildsource.source_extractors._argv import replay_extra_flags
+
+        assert replay_extra_flags(_cu(argv=argv), [], cc_id) == []
+
+    def test_bare_response_file_from_build_pack_is_not_forwarded_to_l2_or_l4(
+        self,
+    ) -> None:
+        from abicheck.buildsource.header_compile_context import _context_flags
+        from abicheck.buildsource.source_extractors._argv import replay_extra_flags
+
+        cu = _cu(abi_relevant_flags=["-fPIC", "@evil.rsp"])
+        assert _context_flags(cu) == ["-fPIC"]
+        assert replay_extra_flags(cu, [], "gnu") == ["-fPIC"]
+
 
 # ---------------------------------------------------------------------------
 # 1b. Forced includes reach the derived L2 context


### PR DESCRIPTION
### Motivation
- Prevent compiler-argument injection where a build-evidence forced-include operand beginning with `@` (response-file syntax) could be forwarded into the L2 header-parse command and cause Clang/CastXML to expand attacker-controlled response files into extra compiler flags.

### Description
- Stop forwarding response-file operands by rejecting forced-include operands that start with `@` in the normalized L2 view inside `abicheck/header_utils.py` (`forced_include_operands`).
- Add a parameterized regression test covering separate and joined GNU and MSVC spellings that verifies `@response-file` operands are not forwarded in `tests/test_build_context_completeness.py`.
- Add a changelog fragment documenting the security fix in `changelog.d/1786924801_aardvark_forced_include_response.md`.

### Testing
- Ran `pytest -q tests/test_build_context_completeness.py` and the test file passed (41 passed, 1 warning unrelated to the change).
- Ran `ruff check` and `ruff format --check` for the modified files and they passed for the targeted files changed in this PR.
- Ran `scripts/check_changelog_fragment.py --base HEAD^ --head HEAD` and it validated the presence of the changelog fragment.
- Ran `scripts/check_bugfix_test_contract.py --base HEAD^ --head HEAD --body-file <pr-body>` and the bugfix-test-contract checks passed for the supplied PR body; a full `python scripts/verify.py --profile fast` run was not completed repository-wide due to unrelated repo-wide reformat suggestions but the targeted checks for the modified files succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a826fff7780832bbfdaa755255e9812)

## Bug-fix test contract

- Bug class: Untrusted build evidence can place compiler response-file syntax into a newly constructed L2/L4 compiler command.
- Publicly observable failure: A build pack or recorded compile argv containing a forced include such as `-include @evil.rsp` could make Clang/CastXML expand attacker-controlled flags during analysis.
- Regression test fails on base: The new L4 cases return the `@evil.rsp` option/operand on the prior revision; the L2/L4 bare response-token test likewise forwards it before this fix.
- Negative control: Ordinary relative forced includes and ABI flags such as `-include cfg.h` and `-fPIC` remain replayed unchanged.
- Public-surface test: Tests exercise the public `CompileUnit` build-evidence model through both derived L2 context rendering and L4 replay argument construction.
- Axes covered: GNU and MSVC dialects; separate and joined forced-include spellings; raw argv, external build-pack `abi_relevant_flags`, L2 rendering, and L4 replay.
- General invariant: No response-file token or response-file forced-include operand from build evidence crosses into a compiler invocation created by abicheck.