### PR TITLE
feat: recognize .abicheck.yml under .github/ and .github/abicheck/

### DIFF
--- a/abicheck/buildsource/inline.py
+++ b/abicheck/buildsource/inline.py
@@ -58,6 +58,7 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from .. import deadline
+from ..config_paths import discover_build_config as _discover_build_config
 from .build_config_schema import (
     BOOL_SUBKEYS as _BOOL_SUBKEYS,
     LIST_SUBKEYS as _LIST_SUBKEYS,
@@ -667,12 +668,11 @@ def load_build_config(path: Path) -> BuildConfig:
     return BuildConfig.from_dict(raw)
 
 
-def discover_build_config(source_tree: Path | None) -> Path | None:
-    """Return the ``.abicheck.yml`` at the source-tree root, if present."""
-    if source_tree is None or not source_tree.is_dir():
-        return None
-    candidate = source_tree / ".abicheck.yml"
-    return candidate if candidate.is_file() else None
+#: Re-exported for back-compat — the implementation now lives in
+#: :mod:`abicheck.config_paths` (shared with `compare`'s own
+#: ``discover_project_config()``), since both must agree on the same set of
+#: recognized ``.abicheck.yml`` locations. See that module's docstring.
+discover_build_config = _discover_build_config
 
 
 def is_pack_dir(path: Path | None) -> bool:

--- a/abicheck/cli_helpers_compare.py
+++ b/abicheck/cli_helpers_compare.py
@@ -38,6 +38,7 @@ import click
 
 from ._compiler_options import has_explicit_std
 from .binary_utils import strip_vendor_hash as strip_vendor_hash
+from .config_paths import find_config_in_dir
 from .service_scan import pair_wide_cxx20_std_override
 
 if TYPE_CHECKING:
@@ -692,15 +693,17 @@ def discover_project_config(start: Path | None = None) -> Path | None:
     """Find a project ``.abicheck.yml`` for ``compare`` (ADR-037 D4).
 
     Looks in *start* (default: current working directory) and then walks up to
-    the filesystem root, returning the first ``.abicheck.yml`` found. ``compare``
-    runs from a project checkout, so the nearest enclosing config is the
-    project's reviewed contract.
+    the filesystem root, returning the first recognized config file found —
+    see :mod:`abicheck.config_paths` for the set of locations checked within
+    each directory (the root spelling, ``.github/``, and
+    ``.github/abicheck/``). ``compare`` runs from a project checkout, so the
+    nearest enclosing config is the project's reviewed contract.
     """
     base = (start or Path.cwd()).resolve()
     for d in (base, *base.parents):
-        candidate = d / ".abicheck.yml"
-        if candidate.is_file():
-            return candidate
+        found = find_config_in_dir(d)
+        if found is not None:
+            return found
     return None
 
 

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -851,8 +851,11 @@ def merge_compile_config(
     review: appending after silently let config override an explicit CLI
     token once ``--gcc-options`` -- the flag that used to suppress this
     synthesis entirely -- was removed). ``include_dirs`` (resolved against
-    the config's directory) are appended *after* the CLI ``-I`` so explicit
-    roots keep search precedence.
+    the *project root* -- ``config_paths.project_root_for_config()``, not
+    necessarily the config file's own directory: a config discovered under
+    ``.github/`` or ``.github/abicheck/`` is still anchored to the project
+    root those directories live in, not to ``.github`` itself) are appended
+    *after* the CLI ``-I`` so explicit roots keep search precedence.
     Returns the merged ``(CompileContext, includes)``.
 
     The config is the explicit ``--config`` when given, else the ``.abicheck.yml``
@@ -868,6 +871,7 @@ def merge_compile_config(
     CLI-only fallback) for an **auto-discovered** config the user didn't bind to.
     """
     from .buildsource.inline import discover_build_config, load_build_config
+    from .config_paths import project_root_for_config
     from .service_scan import CompileContext
 
     explicit_config = build_config is not None
@@ -897,7 +901,13 @@ def merge_compile_config(
             err=True,
         )
         return cli_ctx, cli_includes
-    base = cfg.parent
+    # The project root a relative `compile.include_dirs` entry resolves
+    # against — cfg.parent for a root-level .abicheck.yml (unchanged), but
+    # the directory containing .github/ for a config discovered there
+    # (config_paths.py's own docstring has the full reasoning; Codex review,
+    # fresh evidence from the .github/ discovery feature landing this base
+    # was wrong for).
+    base = project_root_for_config(cfg)
 
     # CLI > config: an explicit --ast-frontend wins even when it is "auto" (the
     # documented escape hatch to bypass a pinned config frontend); only a *default*
@@ -1042,7 +1052,10 @@ def _shared_frontend_explicit(ctx: click.Context) -> bool:
     A command composing the unsided ``@compile_context_options()`` has a
     plain string here and keeps the parameter-source answer unchanged.
     """
-    if ctx.get_parameter_source("header_backend") != click.core.ParameterSource.COMMANDLINE:
+    if (
+        ctx.get_parameter_source("header_backend")
+        != click.core.ParameterSource.COMMANDLINE
+    ):
         return False
     raw = ctx.params.get("header_backend")
     if isinstance(raw, (tuple, list)):

--- a/abicheck/config_paths.py
+++ b/abicheck/config_paths.py
@@ -1,0 +1,86 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared candidate locations for a project's ``.abicheck.yml``.
+
+Historically ``.abicheck.yml`` was recognized only at a directory's own root.
+Many projects prefer to keep tool configuration out of the repo root and
+already have a convention for that — GitHub's own ``.github/`` directory,
+which is where CI workflows, issue templates, and `CODEOWNERS` already live.
+This module is the single place that enumerates the recognized locations
+within one directory, so every discovery entry point (`compare`'s
+``discover_project_config()`` in ``cli_helpers_compare.py``, `dump`'s
+``discover_build_config()`` in ``buildsource/inline.py``) agrees on the same
+set instead of drifting independently.
+
+Precedence within one directory, checked in order:
+
+1. ``.abicheck.yml`` — the original, root-level spelling. Always wins, so an
+   existing config is never shadowed by a newly-added ``.github`` copy.
+2. ``.github/.abicheck.yml`` — alongside workflows/``CODEOWNERS``.
+3. ``.github/abicheck/.abicheck.yml`` — a dedicated subdirectory, for a
+   project that wants its abicheck config kept apart from other ``.github``
+   content (or that already uses ``.github/<tool>/`` for several tools).
+
+Only the *filename* location changes — the file's own content, schema, and
+strictness rules (see ``docs/reference/config-file.md``) are unaffected
+regardless of which of these three paths it was found at.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+#: The recognized config filename itself, unchanged regardless of location.
+CONFIG_FILE_NAME = ".abicheck.yml"
+
+#: Paths, relative to a directory, checked for a project config file, in
+#: precedence order (first match wins). See the module docstring.
+CONFIG_RELATIVE_CANDIDATES: tuple[str, ...] = (
+    CONFIG_FILE_NAME,
+    f".github/{CONFIG_FILE_NAME}",
+    f".github/abicheck/{CONFIG_FILE_NAME}",
+)
+
+
+def find_config_in_dir(directory: Path) -> Path | None:
+    """Return the first recognized config file directly inside *directory*.
+
+    Checks :data:`CONFIG_RELATIVE_CANDIDATES` in order and returns the first
+    one that exists as a regular file, or ``None`` if none do. Does not walk
+    up to parent directories — callers that want that (``compare``'s
+    project-root discovery) do it themselves, one directory at a time.
+    """
+    for rel in CONFIG_RELATIVE_CANDIDATES:
+        candidate = directory / rel
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def discover_build_config(source_tree: Path | None) -> Path | None:
+    """Return the project config at *source_tree*'s own root, if present.
+
+    Checks the same recognized locations :func:`find_config_in_dir` does —
+    the root spelling, ``.github/.abicheck.yml``, and
+    ``.github/abicheck/.abicheck.yml`` — but only at *source_tree* itself,
+    never walking up to its parents: ``dump --sources``/``--build-info``
+    is anchored to the tree it was pointed at, unlike `compare`'s
+    ``discover_project_config()`` (``cli_helpers_compare.py``), which walks
+    up from the current directory.
+    """
+    if source_tree is None or not source_tree.is_dir():
+        return None
+    return find_config_in_dir(source_tree)

--- a/abicheck/config_paths.py
+++ b/abicheck/config_paths.py
@@ -70,6 +70,39 @@ def find_config_in_dir(directory: Path) -> Path | None:
     return None
 
 
+def project_root_for_config(cfg: Path) -> Path:
+    """Return the logical project root a discovered config *cfg* belongs to.
+
+    A config's own file — not necessarily its containing directory — is the
+    project's reviewed contract; a relative path *inside* the config (e.g.
+    ``compile.include_dirs: [include]``) must resolve against the project
+    root, not against wherever within the project the file itself happens
+    to sit. For the root-level spelling those are the same directory
+    (``cfg.parent``), so this degrades to prior behavior exactly — but for
+    ``.github/.abicheck.yml`` or ``.github/abicheck/.abicheck.yml``,
+    ``cfg.parent`` is ``.github`` or ``.github/abicheck``, not the project
+    root, and a relative path resolved against it would land in the wrong
+    place (or nowhere at all).
+
+    Matches *cfg*'s trailing path segments against each entry in
+    :data:`CONFIG_RELATIVE_CANDIDATES` and strips the matched suffix; a
+    *cfg* that doesn't end in one of those exact suffixes (e.g. an explicit
+    ``--config`` pointed at an arbitrarily-named file elsewhere) falls back
+    to ``cfg.parent``, same as every discovery site did before the
+    ``.github/`` locations existed.
+    """
+    cfg_parts = cfg.parts
+    # Longest (most specific) candidate first: every candidate's tail is the
+    # same filename, so the bare root spelling would otherwise match a
+    # deeper path's own trailing segment too.
+    for rel in sorted(CONFIG_RELATIVE_CANDIDATES, key=lambda r: -len(Path(r).parts)):
+        suffix_parts = Path(rel).parts
+        n = len(suffix_parts)
+        if cfg_parts[-n:] == suffix_parts:
+            return cfg.parents[n - 1]
+    return cfg.parent
+
+
 def discover_build_config(source_tree: Path | None) -> Path | None:
     """Return the project config at *source_tree*'s own root, if present.
 

--- a/changelog.d/1787300000_claude_config_github_folder_support.md
+++ b/changelog.d/1787300000_claude_config_github_folder_support.md
@@ -1,0 +1,15 @@
+### Added
+
+- **`.abicheck.yml` is now also recognized under `.github/`, in addition to
+  a project's root.** `compare`'s project-config auto-discovery (walking up
+  from the current directory) and `dump --sources`/`--build-info`'s
+  source-tree-root discovery both now check, in each directory, three
+  locations in order: `.abicheck.yml` (unchanged), `.github/.abicheck.yml`,
+  and `.github/abicheck/.abicheck.yml` — the first one present wins, so a
+  project already using `.github/` for workflows/`CODEOWNERS` can keep its
+  abicheck config alongside them (or in its own `.github/abicheck/`
+  subdirectory) without cluttering the repository root. The file's content,
+  schema, and strict-loading rules are unchanged regardless of which of the
+  three locations it's found at; an explicit `--config <path>` still
+  overrides discovery entirely. See `docs/reference/config-file.md` § File
+  discovery.

--- a/changelog.d/1787300000_claude_config_github_folder_support.md
+++ b/changelog.d/1787300000_claude_config_github_folder_support.md
@@ -11,5 +11,7 @@
   subdirectory) without cluttering the repository root. The file's content,
   schema, and strict-loading rules are unchanged regardless of which of the
   three locations it's found at; an explicit `--config <path>` still
-  overrides discovery entirely. See `docs/reference/config-file.md` § File
-  discovery.
+  overrides discovery entirely. A relative `compile.include_dirs` entry
+  keeps resolving against the *project root* (the directory containing
+  `.github/`), never against `.github/` or `.github/abicheck/` itself. See
+  `docs/reference/config-file.md` § File discovery.

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -226,6 +226,12 @@ e.g. `c++17`), `include_dirs:`/`defines:` (lists), `sysroot:`, and
 > compiler-option atom (a config scalar cannot expand into multiple compiler
 > arguments).
 
+> A relative `compile.include_dirs` entry resolves against the *project
+> root* — the directory containing the discovered config, or the directory
+> containing `.github/` when the config was found under `.github/` or
+> `.github/abicheck/` (see [File discovery](#file-discovery)) — never
+> against `.github/` itself.
+
 ---
 
 ### `debug:`

--- a/docs/reference/config-file.md
+++ b/docs/reference/config-file.md
@@ -7,6 +7,7 @@ canonical_for:
   - config-keys
 depends_on:
   - abicheck/buildsource/inline.py
+  - abicheck/config_paths.py
 lifecycle: active
 generated: false
 ---
@@ -36,10 +37,27 @@ turn overrides the built-in defaults (`CLI > config > default`).
 
 ## File discovery
 
+Within any one directory, three locations are recognized, checked in this
+order (first match wins):
+
+1. `.abicheck.yml` — the original, project-root spelling.
+2. `.github/.abicheck.yml` — alongside workflows/`CODEOWNERS`, for a project
+   that keeps tool configuration out of its own root.
+3. `.github/abicheck/.abicheck.yml` — a dedicated subdirectory, for a project
+   that wants its abicheck config kept apart from other `.github` content (or
+   that already groups per-tool config under `.github/<tool>/`).
+
+Only the file's *location* changes between these three — its content, schema,
+and strictness rules are identical regardless of which one is used. A file
+present at a higher-precedence location always wins over one at a
+lower-precedence location in the *same* directory; see
+`abicheck/config_paths.py` for the exact, shared candidate list every
+discovery entry point below draws from.
+
 | Command | Discovery | Code |
 |---------|-----------|------|
-| `compare` | Walks up from the current directory to the filesystem root and uses the first `.abicheck.yml` found. | `discover_project_config()` in `cli_helpers_compare.py` |
-| `dump --sources` / `--build-info` | Uses `.abicheck.yml` at the **source-tree root** only. | `discover_build_config()` in `buildsource/inline.py` |
+| `compare` | Walks up from the current directory to the filesystem root, checking all three locations in each directory, and uses the first one found. | `discover_project_config()` in `cli_helpers_compare.py` |
+| `dump --sources` / `--build-info` | Checks all three locations at the **source-tree root** only — no parent walk. | `discover_build_config()` in `buildsource/inline.py` |
 | any | An explicit `--config <path>` overrides discovery. | `cli_options.py` (`--config`) |
 
 > **Note:** an auto-discovered (untrusted) `.abicheck.yml` never causes a build

--- a/tests/test_build_source_cli.py
+++ b/tests/test_build_source_cli.py
@@ -2463,6 +2463,36 @@ def test_build_config_from_dict_and_load(tmp_path):
     assert discover_build_config(None) is None
 
 
+def test_discover_build_config_recognizes_dot_github_locations(tmp_path):
+    """`.github/.abicheck.yml` and `.github/abicheck/.abicheck.yml` are also
+    recognized at the source-tree root (no parent walk — dump is anchored to
+    the given tree)."""
+    from abicheck.buildsource.inline import discover_build_config
+
+    tree = tmp_path / "src"
+    tree.mkdir()
+    assert discover_build_config(tree) is None
+
+    (tree / ".github").mkdir()
+    github_cfg = tree / ".github" / ".abicheck.yml"
+    github_cfg.write_text("build: {}\n", encoding="utf-8")
+    assert discover_build_config(tree) == github_cfg
+
+    # A dedicated .github/abicheck/ subdirectory is recognized too.
+    (tree / ".github" / "abicheck").mkdir()
+    subdir_cfg = tree / ".github" / "abicheck" / ".abicheck.yml"
+    subdir_cfg.write_text("build: {}\n", encoding="utf-8")
+    assert discover_build_config(tree) == github_cfg  # .github/ still wins
+
+    # A root-level .abicheck.yml takes precedence over either .github location.
+    root_cfg = tree / ".abicheck.yml"
+    root_cfg.write_text("build: {}\n", encoding="utf-8")
+    assert discover_build_config(tree) == root_cfg
+
+    # Not anchored to a parent: a config only in a subdirectory isn't found.
+    assert discover_build_config(None) is None
+
+
 def test_is_pack_dir_and_compile_db_resolution(tmp_path):
     from abicheck.buildsource.inline import (
         _autodiscover_compile_db,

--- a/tests/test_cli_helpers_compare_coverage.py
+++ b/tests/test_cli_helpers_compare_coverage.py
@@ -316,6 +316,47 @@ def test_discover_project_config_returns_none_when_absent(tmp_path):
     assert found is None or not str(found).startswith(str(tmp_path.resolve()))
 
 
+def test_discover_project_config_finds_dot_github(tmp_path):
+    """A config under .github/ is discovered when no root-level file exists."""
+    (tmp_path / ".github").mkdir()
+    cfg = tmp_path / ".github" / ".abicheck.yml"
+    cfg.write_text("scope_public: true\n", encoding="utf-8")
+    found = discover_project_config(start=tmp_path)
+    assert found == cfg.resolve()
+
+
+def test_discover_project_config_finds_dot_github_abicheck_subdir(tmp_path):
+    """A config under .github/abicheck/ is discovered too."""
+    (tmp_path / ".github" / "abicheck").mkdir(parents=True)
+    cfg = tmp_path / ".github" / "abicheck" / ".abicheck.yml"
+    cfg.write_text("scope_public: true\n", encoding="utf-8")
+    found = discover_project_config(start=tmp_path)
+    assert found == cfg.resolve()
+
+
+def test_discover_project_config_root_file_wins_over_dot_github(tmp_path):
+    """The root-level .abicheck.yml takes precedence over a .github copy."""
+    root_cfg = tmp_path / ".abicheck.yml"
+    root_cfg.write_text("scope_public: true\n", encoding="utf-8")
+    (tmp_path / ".github").mkdir()
+    (tmp_path / ".github" / ".abicheck.yml").write_text(
+        "scope_public: true\n", encoding="utf-8"
+    )
+    found = discover_project_config(start=tmp_path)
+    assert found == root_cfg.resolve()
+
+
+def test_discover_project_config_walks_up_to_dot_github_in_parent(tmp_path):
+    """Walking up parents also recognizes a parent's .github/ config."""
+    (tmp_path / ".github" / "abicheck").mkdir(parents=True)
+    cfg = tmp_path / ".github" / "abicheck" / ".abicheck.yml"
+    cfg.write_text("scope_public: true\n", encoding="utf-8")
+    nested = tmp_path / "a" / "b"
+    nested.mkdir(parents=True)
+    found = discover_project_config(start=nested)
+    assert found == cfg.resolve()
+
+
 # ── fold_l0_hard_removals (case97 fix) ───────────────────────────────────────
 
 

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -264,6 +264,40 @@ def test_merge_compile_config_cli_wins_over_config(tmp_path: Path) -> None:
     assert includes == (tmp_path / "include",)
 
 
+def test_merge_compile_config_include_dirs_resolve_against_project_root_for_dot_github_config(
+    tmp_path: Path,
+) -> None:
+    """A config discovered under `.github/` (or `.github/abicheck/`) still
+    resolves a relative `compile.include_dirs` entry against the project
+    root, not against `.github/` itself (Codex review on PR #828 —
+    `merge_compile_config` used to resolve against `cfg.parent`, which is
+    wrong once a config can live somewhere other than the project root)."""
+    from abicheck.cli_scan import _merge_compile_config
+
+    github_dir = tmp_path / ".github"
+    github_dir.mkdir()
+    cfg = github_dir / ".abicheck.yml"
+    cfg.write_text("compile:\n  include_dirs: [include]\n", encoding="utf-8")
+
+    _, includes = _merge_compile_config(CompileContext(), (), cfg)
+    assert includes == (tmp_path / "include",)
+    assert includes != (github_dir / "include",)
+
+
+def test_merge_compile_config_include_dirs_resolve_against_project_root_for_dot_github_abicheck_config(
+    tmp_path: Path,
+) -> None:
+    from abicheck.cli_scan import _merge_compile_config
+
+    subdir = tmp_path / ".github" / "abicheck"
+    subdir.mkdir(parents=True)
+    cfg = subdir / ".abicheck.yml"
+    cfg.write_text("compile:\n  include_dirs: [include]\n", encoding="utf-8")
+
+    _, includes = _merge_compile_config(CompileContext(), (), cfg)
+    assert includes == (tmp_path / "include",)
+
+
 def test_merge_compile_config_cli_token_wins_over_config_std(tmp_path: Path) -> None:
     """CLI --compiler-option tokens must win over a config-
     synthesized -std=/-D, the same way the now-removed --gcc-options scalar

--- a/tests/test_config_paths.py
+++ b/tests/test_config_paths.py
@@ -1,0 +1,71 @@
+# Copyright 2026 Nikolay Petrov
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Primitive-level tests for `abicheck.config_paths.find_config_in_dir`."""
+
+from __future__ import annotations
+
+from abicheck.config_paths import CONFIG_RELATIVE_CANDIDATES, find_config_in_dir
+
+
+def test_no_candidate_present_returns_none(tmp_path):
+    assert find_config_in_dir(tmp_path) is None
+
+
+def test_finds_root_level_config(tmp_path):
+    cfg = tmp_path / ".abicheck.yml"
+    cfg.write_text("severity: {}\n", encoding="utf-8")
+    assert find_config_in_dir(tmp_path) == cfg
+
+
+def test_finds_dot_github_config(tmp_path):
+    (tmp_path / ".github").mkdir()
+    cfg = tmp_path / ".github" / ".abicheck.yml"
+    cfg.write_text("severity: {}\n", encoding="utf-8")
+    assert find_config_in_dir(tmp_path) == cfg
+
+
+def test_finds_dot_github_abicheck_subdir_config(tmp_path):
+    (tmp_path / ".github" / "abicheck").mkdir(parents=True)
+    cfg = tmp_path / ".github" / "abicheck" / ".abicheck.yml"
+    cfg.write_text("severity: {}\n", encoding="utf-8")
+    assert find_config_in_dir(tmp_path) == cfg
+
+
+def test_precedence_root_beats_dot_github_beats_subdir(tmp_path):
+    """First candidate present wins, in `CONFIG_RELATIVE_CANDIDATES` order."""
+    (tmp_path / ".github" / "abicheck").mkdir(parents=True)
+    for rel in CONFIG_RELATIVE_CANDIDATES:
+        (tmp_path / rel).write_text("severity: {}\n", encoding="utf-8")
+
+    # All three exist; the root-level file must win.
+    assert find_config_in_dir(tmp_path) == tmp_path / ".abicheck.yml"
+
+    # Remove the root file: .github/.abicheck.yml must win over the subdir.
+    (tmp_path / ".abicheck.yml").unlink()
+    assert find_config_in_dir(tmp_path) == tmp_path / ".github" / ".abicheck.yml"
+
+    # Remove that too: only the subdir copy remains.
+    (tmp_path / ".github" / ".abicheck.yml").unlink()
+    assert (
+        find_config_in_dir(tmp_path)
+        == tmp_path / ".github" / "abicheck" / ".abicheck.yml"
+    )
+
+
+def test_a_directory_named_like_the_config_is_not_a_match(tmp_path):
+    """`find_config_in_dir` only ever returns a regular file."""
+    (tmp_path / ".abicheck.yml").mkdir()
+    assert find_config_in_dir(tmp_path) is None

--- a/tests/test_config_paths.py
+++ b/tests/test_config_paths.py
@@ -17,7 +17,11 @@
 
 from __future__ import annotations
 
-from abicheck.config_paths import CONFIG_RELATIVE_CANDIDATES, find_config_in_dir
+from abicheck.config_paths import (
+    CONFIG_RELATIVE_CANDIDATES,
+    find_config_in_dir,
+    project_root_for_config,
+)
 
 
 def test_no_candidate_present_returns_none(tmp_path):
@@ -69,3 +73,41 @@ def test_a_directory_named_like_the_config_is_not_a_match(tmp_path):
     """`find_config_in_dir` only ever returns a regular file."""
     (tmp_path / ".abicheck.yml").mkdir()
     assert find_config_in_dir(tmp_path) is None
+
+
+# ── project_root_for_config ───────────────────────────────────────────────
+
+
+def test_project_root_for_root_level_config(tmp_path):
+    cfg = tmp_path / ".abicheck.yml"
+    assert project_root_for_config(cfg) == tmp_path
+
+
+def test_project_root_for_dot_github_config(tmp_path):
+    cfg = tmp_path / ".github" / ".abicheck.yml"
+    assert project_root_for_config(cfg) == tmp_path
+
+
+def test_project_root_for_dot_github_abicheck_config(tmp_path):
+    cfg = tmp_path / ".github" / "abicheck" / ".abicheck.yml"
+    assert project_root_for_config(cfg) == tmp_path
+
+
+def test_project_root_falls_back_to_parent_for_an_unrecognized_path(tmp_path):
+    """An explicit --config pointed at a file that doesn't end in one of the
+    recognized suffixes (e.g. an arbitrarily-named file) degrades to the
+    file's own parent directory, matching every discovery site's behavior
+    before the `.github/` locations existed."""
+    cfg = tmp_path / "somewhere" / "my-config.yml"
+    assert project_root_for_config(cfg) == tmp_path / "somewhere"
+
+
+def test_project_root_matches_the_full_suffix_not_just_the_filename(tmp_path):
+    """A file named `.abicheck.yml` sitting directly inside a directory that
+    happens to be named `.github` (not `.github/.abicheck.yml` relative to
+    some other root) is still just a root-level config one level up — the
+    match is on the exact relative suffix, not merely the bare filename."""
+    weird = tmp_path / "not-a-real-github-dir"
+    weird.mkdir()
+    cfg = weird / ".abicheck.yml"
+    assert project_root_for_config(cfg) == weird


### PR DESCRIPTION
## Summary

Expand `.abicheck.yml` discovery to also recognize the config under `.github/`, so projects that already keep tooling config there don't have to clutter the repo root.

## Motivation

Config discovery (`discover_project_config()` for `compare`, `discover_build_config()` for `dump --sources`/`--build-info`) previously looked only for a file literally named `.abicheck.yml` at the project root (or a source-tree root, with no CLI override for the latter). There was no way to move the config under `.github/`, and no `extends`/`include` key to point at one indirectly.

## Changes

- New shared leaf module `abicheck/config_paths.py` — `find_config_in_dir()` checks three locations per directory, in precedence order: `.abicheck.yml` (root, unchanged), `.github/.abicheck.yml`, and `.github/abicheck/.abicheck.yml`. Also hosts `discover_build_config()` and `project_root_for_config()`.
- `cli_helpers_compare.discover_project_config()` (walks up from cwd to the filesystem root) now checks all three locations in each directory via the shared helper.
- `buildsource/inline.discover_build_config()` (checked only at the source-tree root, no parent walk) now checks all three locations too — its implementation moved into `config_paths.py` and is re-exported for back-compat, since `buildsource/inline.py` was already at its 2000-line AI-readiness hard cap.
- Every existing call site (`compare`, `dump`, `scan`) routes through these two functions, so they all pick up the new locations automatically with no separate wiring.
- `cli_options.merge_compile_config()` now resolves a relative `compile.include_dirs` config entry against `config_paths.project_root_for_config()` instead of `cfg.parent` — a fix for a bug a Codex review caught on this same PR (see the Bug-fix test contract below).
- File content, schema, and strict-loading rules (ADR-043) are unchanged regardless of which of the three locations the file is found at. An explicit `--config <path>` still overrides discovery entirely.
- `docs/reference/config-file.md` § File discovery updated with the new precedence table and the `include_dirs` resolution-base note.
- Changelog fragment added.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: A location-sensitive relative path inside a discovered config file resolved against the wrong base directory once the config could be found somewhere other than the project root.
- Publicly observable failure: With this PR's own `.github/` discovery in place but without the fix, a `compile.include_dirs: [include]` entry in a `.github/.abicheck.yml` (or `.github/abicheck/.abicheck.yml`) resolved to `.github/include` (or `.github/abicheck/include`) instead of the project's real `include/` directory — an `abicheck dump`/`compare`/`scan` invocation relying on that config would fail to find the intended headers, or silently parse the wrong ones if a same-named directory happened to exist under `.github/`.
- Regression test fails on base: Yes — `test_merge_compile_config_include_dirs_resolve_against_project_root_for_dot_github_config` and its `.github/abicheck/` sibling in `tests/test_compile_context_parity.py` assert `includes == (tmp_path / "include",)`, which fails against the pre-fix `cfg.parent`-based resolution (it would instead resolve to `.github/include`).
- Negative control: `test_merge_compile_config_cli_wins_over_config` (pre-existing, unmodified) pins that a root-level `.abicheck.yml`'s `include_dirs` still resolves against `tmp_path` exactly as before; `test_project_root_for_root_level_config` and `test_project_root_falls_back_to_parent_for_an_unrecognized_path` in `tests/test_config_paths.py` pin that `project_root_for_config()` degrades to the prior `cfg.parent` behavior for a root-level config and for an arbitrarily-named explicit `--config` path — the fix changes resolution only for the two new `.github/` locations.
- Public-surface test: Exercised through `_merge_compile_config` (`abicheck/cli_scan.py`'s re-export of `cli_options.merge_compile_config`), the actual function `compare`/`dump`/`scan` call to fold a config's `compile:` block into the CLI compile context — not only the new `project_root_for_config()` helper in isolation (which also has its own direct unit tests).
- Axes covered: Root-level `.abicheck.yml` (unchanged), `.github/.abicheck.yml`, `.github/abicheck/.abicheck.yml`, and an arbitrarily-named explicit `--config` path outside any recognized suffix (fallback case).
- General invariant: A relative path inside a discovered config always resolves against the project root — the directory the config's location is anchored to — never against an intermediate directory (`.github/`, `.github/abicheck/`) the config file happens to physically live under. Stated and tested directly on `project_root_for_config()` in `tests/test_config_paths.py` (including `test_project_root_matches_the_full_suffix_not_just_the_filename`, which pins that the match is on the exact relative suffix, not merely the bare filename).

## Checklist

- [x] Tests added / updated for new behaviour (`tests/test_config_paths.py`, plus new cases in `tests/test_cli_helpers_compare_coverage.py`, `tests/test_build_source_cli.py`, and `tests/test_compile_context_parity.py`)
- [x] Changelog fragment added (`changelog.d/1787300000_claude_config_github_folder_support.md`)
- [x] Docs updated (`docs/reference/config-file.md`)
- [x] `ruff check`/`ruff format --check` pass on touched files
- [x] `mypy abicheck/` clean (0 errors, matching baseline)
- [x] `scripts/check_ai_readiness.py` — no new file-size or coverage errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016kCLSHy1XVcReR7SbccfHG)_