### PR TITLE
fix: address 3 whole-product bundle-compare blockers

### DIFF
--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -80,6 +80,7 @@ from .bundle_models import (  # noqa: F401  (re-exported for back-compat)
     ProviderEntry as ProviderEntry,
     ResolutionGraph as ResolutionGraph,
 )
+from .bundle_soname import soname_matches_providers
 from .checker_policy import ChangeKind, Verdict, compute_verdict
 from .checker_types import DiffResult
 from .elf_metadata import ElfMetadata, ElfSymbol, SymbolBinding, parse_elf_metadata
@@ -976,14 +977,17 @@ def _detect_intra_dep_removed(
             # allow-list (built-in libc/libstdc++/libgcc plus user extras),
             # any unresolved import is assumed to come from outside the
             # bundle. This is what --bundle-system-providers controls.
+            # No symbol-name-shape re-check here (mirrors
+            # _detect_unresolved_intra_dependency's identical branch): a
+            # reverted earlier revision gated this on that heuristic too,
+            # making --bundle-system-providers inert for a legitimate
+            # non-system-shaped custom export (e.g. MKL/TBB/SYCL C APIs).
             extra_needed = new.resolution.extra_needed.get(consumer.library, [])
             if extra_needed and all(
-                e in system_providers or _looks_system(e) for e in extra_needed
+                soname_matches_providers(e, system_providers) or _looks_system(e)
+                for e in extra_needed
             ):
-                # And the symbol itself looks system-shaped (mangled std::,
-                # well-known C runtime entry, etc.) — skip the finding.
-                if symbol in DEFAULT_SYSTEM_SYMBOLS or _looks_system_symbol(symbol):
-                    continue
+                continue
             if symbol in DEFAULT_SYSTEM_SYMBOLS or _looks_system_symbol(symbol):
                 continue
             findings.append(
@@ -1062,8 +1066,8 @@ def _detect_unresolved_intra_dependency(
        actually be loaded together with the consumer.
     2. **A narrower, explicitly-approximate suppression path for unversioned
        imports.** Mirrors ``_detect_intra_dep_removed``'s
-       ``e in system_providers or _looks_system(e)`` allow-list union
-       (built-in ``DEFAULT_SYSTEM_PROVIDERS`` plus caller-supplied
+       ``soname_matches_providers(e, system_providers) or _looks_system(e)``
+       allow-list union (built-in ``DEFAULT_SYSTEM_PROVIDERS`` plus caller-supplied
        ``--bundle-system-providers``) and its non-empty guard
        (``extra_edges and all(...)``, never a bare ``all([])``), but adds a
        requirement that one-sided audit needs and the diff-driven detector
@@ -1147,7 +1151,9 @@ def _detect_unresolved_intra_dependency(
                     not intra_edges
                     and extra_edges
                     and all(
-                        e in system_providers or _looks_system(e) for e in extra_edges
+                        soname_matches_providers(e, system_providers)
+                        or _looks_system(e)
+                        for e in extra_edges
                     )
                 ):
                     continue

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -820,7 +820,7 @@ def compare_bundle(
     findings.extend(_detect_library_structural_changes(old, new))
 
     # 2. bundle_intra_dep_removed: an import in the new bundle has no provider.
-    findings.extend(_detect_intra_dep_removed(new, sys_libs))
+    findings.extend(_detect_intra_dep_removed(old, new, sys_libs))
 
     # 3. bundle_intra_dep_signature_changed: provider's per-library diff
     #    flagged func_params_changed / func_return_changed / var_type_changed
@@ -923,6 +923,7 @@ def _detect_library_structural_changes(
 
 
 def _detect_intra_dep_removed(
+    old: BundleSnapshot,
     new: BundleSnapshot,
     system_providers: set[str],
 ) -> list[BundleFinding]:
@@ -939,7 +940,15 @@ def _detect_intra_dep_removed(
     A consumer's import is treated as system-provided when every DT_NEEDED
     edge it carries that resolves *outside* the bundle is in the
     ``system_providers`` allow-list (built-in plus user-extended via
-    ``--bundle-system-providers``).
+    ``--bundle-system-providers``) -- but only when no sibling *ever*
+    provided this symbol (:attr:`old`'s resolution graph, not just
+    ``new``'s). The allow-list alone can't tell "always external" apart
+    from "a sibling provider and its DT_NEEDED edge were both dropped by
+    the same refactor, and this consumer also happens to need libc" (nearly
+    universal) -- so when ``old`` shows a sibling used to provide the
+    symbol, the allow-list match alone isn't trusted; the symbol-name check
+    below still has to agree (Codex review: an earlier revision trusted the
+    allow-list unconditionally, silently hiding that regression).
     """
     findings: list[BundleFinding] = []
 
@@ -947,6 +956,8 @@ def _detect_intra_dep_removed(
         providers = new.resolution.providers_for(symbol)
         if providers:
             continue  # someone in the bundle provides it
+        # Whether a sibling *used to* provide this symbol (docstring above).
+        ever_provided_in_bundle = bool(old.resolution.providers_for(symbol))
         # Symbol not provided by any sibling. Is it system?
         for consumer in consumers:
             if consumer.weak:
@@ -964,28 +975,19 @@ def _detect_intra_dep_removed(
             # NOT skipped here and still produces the finding.
             if _import_is_external(consumer, consumer_meta, new):
                 continue
-            # Note: an earlier version of this code short-circuited here
-            # when consumer had no intra-bundle DT_NEEDED edges. That
-            # heuristic hid the canonical regression where a refactor
-            # drops both the only sibling provider *and* the DT_NEEDED
-            # edge that pointed at it — the .dynsym still carries the
-            # `U symbol` but no graph evidence remains. The downstream
-            # system-symbol allow-list (DEFAULT_SYSTEM_SYMBOLS +
-            # `_looks_system_symbol`) is what filters legitimately-
-            # external imports; rely on that signal alone.
             # If every non-intra DT_NEEDED of this consumer is on the
-            # allow-list (built-in libc/libstdc++/libgcc plus user extras),
-            # any unresolved import is assumed to come from outside the
-            # bundle. This is what --bundle-system-providers controls.
-            # No symbol-name-shape re-check here (mirrors
-            # _detect_unresolved_intra_dependency's identical branch): a
-            # reverted earlier revision gated this on that heuristic too,
-            # making --bundle-system-providers inert for a legitimate
-            # non-system-shaped custom export (e.g. MKL/TBB/SYCL C APIs).
+            # allow-list AND no sibling ever provided this symbol, trust it
+            # unconditionally -- what makes --bundle-system-providers
+            # suppress a non-system-shaped custom export (MKL/TBB/SYCL).
+            # Otherwise fall through to the symbol-name check (docstring).
             extra_needed = new.resolution.extra_needed.get(consumer.library, [])
-            if extra_needed and all(
-                soname_matches_providers(e, system_providers) or _looks_system(e)
-                for e in extra_needed
+            if (
+                not ever_provided_in_bundle
+                and extra_needed
+                and all(
+                    soname_matches_providers(e, system_providers) or _looks_system(e)
+                    for e in extra_needed
+                )
             ):
                 continue
             if symbol in DEFAULT_SYSTEM_SYMBOLS or _looks_system_symbol(symbol):

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -991,6 +991,14 @@ def _detect_intra_dep_removed(
             # ever provided this symbol, OR the user explicitly asserted a
             # remaining soname) -> trust it unconditionally. Otherwise fall
             # through to the symbol-name check (docstring above).
+            # Known limitation (Codex review, pre-existing -- shared by the
+            # audit-mode sibling below): this allow-list match is absence of
+            # a *bundle* regression, not proof the symbol is exported by a
+            # system DSO -- neither detector parses a system library's own
+            # export table, only its soname, so a genuinely never-provided
+            # symbol (typo, forgotten dependency) is suppressed the same
+            # way a real system-provided one is. Fixing this needs an
+            # actual export-table probe of each allow-listed DSO.
             extra_needed = new.resolution.extra_needed.get(consumer.library, [])
             if (
                 extra_needed
@@ -1880,16 +1888,8 @@ def _looks_system_symbol(name: str) -> bool:
 # This is the version-evidence half of the field-derived oneDAL fix
 # (``syscall@GLIBC_*``, ``stdout@GLIBC_*``, ``_ZdlPvm@CXXABI_*``).
 _SYSTEM_VERSION_PREFIXES: tuple[str, ...] = (
-    "GLIBC_",
-    "GLIBCXX_",
-    "CXXABI_",
-    "GCC_",
-    "LIBGCC_",
-    "LIBC_",
-    "GOMP_",
-    "OMP_",
-    "GFORTRAN_",
-    "GLIBCABI_",
+    "GLIBC_", "GLIBCXX_", "CXXABI_", "GCC_", "LIBGCC_",
+    "LIBC_", "GOMP_", "OMP_", "GFORTRAN_", "GLIBCABI_",
 )
 
 
@@ -1917,19 +1917,15 @@ def _import_is_external(
 
     ``is_intra_bundle_provider`` matches by exact soname *and* filename stem, so
     a SONAME-major bump (``libcore.so.1`` → ``libcore.so.2``) where a sibling
-    still NEEDs the old soname is still recognised as intra-bundle, and a
-    release that itself vendors a runtime DSO (``libgomp.so.1``) keeps a dropped
-    ``GOMP_4.0`` export visible.
+    still NEEDs the old soname is still recognised as intra-bundle.
 
-    When the per-symbol verneed soname is unavailable (e.g. a JSON snapshot
-    that predates the field, or a stripped verneed), fall back to the
+    When the per-symbol verneed soname is unavailable, fall back to the
     label-level scan over ``versions_required`` — provider evidence still wins
     over the ``_looks_system_version`` toolchain-namespace heuristic.
 
     Unversioned imports (``version == ""``) return ``False`` so an unversioned
-    internal sibling import still produces a finding. This is the field-derived
-    oneDAL fix: classify by provider/version evidence, not only by symbol-name
-    allow-lists.
+    internal sibling import still produces a finding: classify by
+    provider/version evidence, not only by symbol-name allow-lists.
     """
     version = consumer.version
     if not version:

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -931,47 +931,60 @@ def _detect_intra_dep_removed(
 ) -> list[BundleFinding]:
     """Find imports in the new bundle that no sibling provides.
 
-    Excludes imports satisfied by system libraries (``libc``, ``libstdc++``,
-    etc.) since they are out of bundle scope by design. Classification uses
-    provider/version evidence first (:func:`_import_is_external`) and the
-    symbol-name allow-list (``DEFAULT_SYSTEM_SYMBOLS`` / ``_looks_system_*``)
-    as a fallback. Excludes weak imports (linker treats unresolved weak as
-    0/NULL at runtime).
+    Excludes imports satisfied by system libraries (out of bundle scope by
+    design). Classification uses provider/version evidence first
+    (:func:`_import_is_external`) and the symbol-name allow-list
+    (``DEFAULT_SYSTEM_SYMBOLS`` / ``_looks_system_*``) as a fallback.
+    Excludes weak imports (linker treats unresolved weak as 0/NULL).
 
     A consumer's import is treated as system-provided when every DT_NEEDED
     edge it carries that resolves *outside* the bundle is in the
     ``system_providers`` allow-list (built-in ``DEFAULT_SYSTEM_PROVIDERS``
     plus user-extended via ``--bundle-system-providers``) -- but only when
-    either (a) no sibling *ever* provided this symbol (:attr:`old`'s
-    resolution graph, not just ``new``'s), or (b) the user explicitly named
-    at least one of this consumer's remaining sonames via
-    ``explicit_providers`` -- a deliberate migration assertion (e.g. a
-    symbol legitimately moved from an in-tree sibling to an allow-listed
-    external DSO). Without that, the allow-list can't tell "always external"
-    apart from "a sibling provider and its DT_NEEDED edge were both dropped
-    by the same refactor, and this consumer also happens to need libc"
-    (nearly universal) -- so absent an explicit assertion, an ``old``-side
-    sibling provider means the allow-list match alone isn't trusted; the
-    symbol-name check below still has to agree (Codex review history: an
-    earlier revision trusted the allow-list unconditionally regardless of
-    ``old``, silently hiding that regression; a later revision then
-    over-corrected by never trusting it once ``old`` had a provider at all,
-    silently defeating a legitimate provider migration).
+    either (a) *this consumer* never reached an in-bundle sibling providing
+    this symbol in ``old`` (checked via reachability, not merely a provider
+    existing somewhere in the old bundle -- an unrelated consumer's own old
+    provider must not veto a different consumer's always-external
+    dependency), or (b) the user explicitly named at least one of this
+    consumer's remaining sonames via ``explicit_providers``. Without
+    (a)/(b), the allow-list can't tell "always external" apart from "a
+    sibling provider and its DT_NEEDED edge were both dropped by the same
+    refactor, and this consumer also happens to need libc" (nearly
+    universal) -- so absent either, the symbol-name check below still has
+    to agree (Codex review history: trusting the allow-list unconditionally
+    regardless of ``old`` silently hid that regression; over-correcting to
+    never trust it once *any* old provider existed silently defeated a
+    legitimate migration *and* misclassified an unrelated always-external
+    dependency as suspect).
     """
     findings: list[BundleFinding] = []
+    old_reachable_cache: dict[str, set[str]] = {}
+
+    def _old_reachable(lib: str) -> set[str]:
+        if lib not in old_reachable_cache:
+            old_reachable_cache[lib] = _reachable_intra_libraries(old, lib)
+        return old_reachable_cache[lib]
 
     for symbol, consumers in new.resolution.consumers.items():
         providers = new.resolution.providers_for(symbol)
         if providers:
             continue  # someone in the bundle provides it
-        # Whether a sibling *used to* provide this symbol (docstring above).
-        ever_provided_in_bundle = bool(old.resolution.providers_for(symbol))
+        old_providers = {p.library for p in old.resolution.providers_for(symbol)}
         for consumer in consumers:
             if consumer.weak:
                 continue
             consumer_meta = new.metadata.get(consumer.library)
             if consumer_meta is None:
                 continue
+            # Did *this* consumer -- not merely some other consumer of the
+            # same symbol name -- previously reach one of those old
+            # providers? A consumer absent from the old bundle (newly added
+            # this release) has no old reachability to check.
+            ever_provided_in_bundle = bool(
+                old_providers
+                and consumer.library in old.libraries
+                and old_providers & _old_reachable(consumer.library)
+            )
             if _import_is_external(consumer, consumer_meta, new):
                 continue
             # Every non-intra DT_NEEDED on the allow-list AND (no sibling
@@ -1018,24 +1031,20 @@ def _reachable_intra_libraries(snapshot: BundleSnapshot, root: str) -> set[str]:
     Returns every library transitively reachable from ``root`` through the
     bundle's own resolution graph (i.e. what would actually be loaded when
     ``root`` is loaded) — not including ``root`` itself. Used by
-    :func:`_detect_unresolved_intra_dependency` so a symbol is only
-    considered resolved by a provider the consumer can actually reach, not
-    merely one present somewhere else in the declared set.
+    :func:`_detect_unresolved_intra_dependency` and
+    :func:`_detect_intra_dep_removed` so a symbol is only considered
+    resolved (or previously reached) by a provider the consumer can
+    actually reach, not merely one present somewhere else in the snapshot.
     """
     seen: set[str] = set()
     queue = [root]
     while queue:
         lib = queue.pop()
         for soname in snapshot.resolution.intra_needed.get(lib, []):
-            # Resolve via the exact same soname_to_name map
+            # Resolve via the same soname_to_name map
             # _compute_resolution_graph() used to classify this edge as
-            # intra in the first place -- provider_library_for_soname()'s
-            # independent name/soname/filename-stem heuristic doesn't know
-            # about a resolved-through-symlink real filename, so a library
-            # discovered via a differently-named alias (Codex review)
-            # classified correctly as intra could still resolve to no
-            # target here, understating reachability and producing a false
-            # bundle_unresolved_intra_dependency finding.
+            # intra in the first place, so the two agree even for a library
+            # discovered via a differently-named symlink alias.
             target = snapshot.resolution.soname_to_name.get(soname)
             if target is None or target == lib or target in seen:
                 continue
@@ -1050,46 +1059,39 @@ def _detect_unresolved_intra_dependency(
 ) -> list[BundleFinding]:
     """Audit-mode (no old side) sibling of :func:`_detect_intra_dep_removed`.
 
-    ADR-056 D2: ``scan --artifact-set`` has no per-library diff to read
-    (unlike :func:`_detect_intra_dep_removed`, driven by a diff's
-    ``func_removed``/``var_removed`` changes) — this operates purely off the
-    new-side resolution graph. It is deliberately **not** a call into
-    :func:`_detect_intra_dep_removed` and differs from it in three ways that
-    matter for soundness here:
+    ADR-056 D2: ``scan --artifact-set`` has no per-library diff to read, so
+    this operates purely off the new-side resolution graph. Deliberately
+    **not** a call into :func:`_detect_intra_dep_removed`; differs in three
+    ways that matter for soundness here:
 
     1. **Version-aware, reachability-constrained provider matching.**
        ``providers_for(symbol)`` is name-only and set-wide.
        ``ProviderEntry.version``/``ConsumerEntry.version`` are consulted so a
        version mismatch (consumer needs ``foo@V2``, set only provides
        ``foo@V1``) is not mistaken for a resolved import; when the precise
-       ``ConsumerEntry.version_soname`` is known, the match is further
-       pinned to that exact provider library (GNU version *labels* are not
-       globally unique, so two siblings can both export ``foo@V1`` and a
-       label-only match could accept the wrong one). Every candidate
-       provider must additionally be reachable from the consumer through
-       :func:`_reachable_intra_libraries` — a name/version match on a
-       library the consumer has no ``DT_NEEDED`` path to would never
-       actually be loaded together with the consumer.
+       ``ConsumerEntry.version_soname`` is known, the match is pinned to
+       that exact provider library (GNU version *labels* are not globally
+       unique). Every candidate provider must additionally be reachable
+       from the consumer through :func:`_reachable_intra_libraries` — a
+       match on a library the consumer has no ``DT_NEEDED`` path to would
+       never actually be loaded together with the consumer.
     2. **A narrower, explicitly-approximate suppression path for unversioned
        imports.** Mirrors ``_detect_intra_dep_removed``'s allow-list union
-       (built-in ``DEFAULT_SYSTEM_PROVIDERS`` plus caller-supplied
-       ``--bundle-system-providers``) and its non-empty guard
-       (``extra_edges and all(...)``, never a bare ``all([])``), but adds a
-       requirement one-sided audit needs and the diff-driven detector does
-       not: the consumer must have **zero** intra-bundle ``DT_NEEDED`` edges
-       — a consumer still depending on an intra-set library that simply
-       stopped exporting the symbol has a real, in-set candidate provider
-       this coarse check cannot rule out. Deliberately has **no**
-       symbol-name-shape fallback (``_looks_system_symbol``):
-       ``--bundle-system-providers`` exists specifically to cover a
-       legitimate, non-system-shaped custom export (e.g. ``vendor_init``)
-       that a shape heuristic would never match.
+       and its non-empty guard (``extra_edges and all(...)``, never a bare
+       ``all([])``), but adds a requirement one-sided audit needs and the
+       diff-driven detector does not: the consumer must have **zero**
+       intra-bundle ``DT_NEEDED`` edges — a consumer still depending on an
+       intra-set library that simply stopped exporting the symbol has a
+       real, in-set candidate provider this coarse check cannot rule out.
+       Deliberately has **no** symbol-name-shape fallback
+       (``_looks_system_symbol``): ``--bundle-system-providers`` exists
+       specifically to cover a legitimate, non-system-shaped custom export
+       (e.g. ``vendor_init``) that a shape heuristic would never match.
     3. Emits ``ChangeKind.BUNDLE_UNRESOLVED_INTRA_DEPENDENCY`` (not
-       ``BUNDLE_INTRA_DEP_REMOVED`` — that kind's own description implies a
-       diff-confirmed removal, which this finding cannot claim) at
+       ``BUNDLE_INTRA_DEP_REMOVED`` — that kind implies a diff-confirmed
+       removal, which this finding cannot claim) at
        ``COMPATIBLE_WITH_RISK``, not ``BREAKING``: an audit has no old side
-       to confirm the symbol ever resolved, so this is reported as a risk to
-       investigate, not a confirmed break.
+       to confirm the symbol ever resolved.
     """
     findings: list[BundleFinding] = []
     reachable_cache: dict[str, set[str]] = {}
@@ -1903,9 +1905,8 @@ def _import_is_external(
 ) -> bool:
     """Classify an import as external using version + provider evidence.
 
-    An import is external — and therefore can never be a *dropped
-    intra-bundle* dependency — when its required symbol version is satisfied by
-    a library outside the analysed bundle.
+    An import is external (never a *dropped intra-bundle* dependency) when
+    its required symbol version is satisfied by a library outside the bundle.
 
     The precise signal is the **per-symbol verneed provider**
     (``ConsumerEntry.version_soname``): GNU version labels are scoped per

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -939,23 +939,18 @@ def _detect_intra_dep_removed(
 
     A consumer's import is treated as system-provided when every DT_NEEDED
     edge it carries that resolves *outside* the bundle is in the
-    ``system_providers`` allow-list (built-in ``DEFAULT_SYSTEM_PROVIDERS``
-    plus user-extended via ``--bundle-system-providers``) -- but only when
-    either (a) *this consumer* never reached an in-bundle sibling providing
-    this symbol in ``old`` (checked via reachability, not merely a provider
-    existing somewhere in the old bundle -- an unrelated consumer's own old
-    provider must not veto a different consumer's always-external
-    dependency), or (b) the user explicitly named at least one of this
-    consumer's remaining sonames via ``explicit_providers``. Without
-    (a)/(b), the allow-list can't tell "always external" apart from "a
-    sibling provider and its DT_NEEDED edge were both dropped by the same
-    refactor, and this consumer also happens to need libc" (nearly
-    universal) -- so absent either, the symbol-name check below still has
-    to agree (Codex review history: trusting the allow-list unconditionally
-    regardless of ``old`` silently hid that regression; over-correcting to
-    never trust it once *any* old provider existed silently defeated a
-    legitimate migration *and* misclassified an unrelated always-external
-    dependency as suspect).
+    ``system_providers`` allow-list -- but only when either (a) *this
+    consumer* never reached a *version-compatible* in-bundle sibling
+    providing this symbol in ``old`` (checked via reachability, not merely
+    a same-named provider existing somewhere in the old bundle -- an
+    unrelated consumer's own old provider must not veto a different
+    consumer's always-external dependency, nor may a provider whose
+    version could never have satisfied this consumer's own reference), or
+    (b) the user explicitly named at least one of this consumer's
+    remaining sonames via ``explicit_providers``. Without (a)/(b), a
+    sibling provider and its DT_NEEDED edge could have been dropped by the
+    same refactor that left this consumer needing libc -- so absent
+    either, the symbol-name check below still has to agree.
     """
     findings: list[BundleFinding] = []
     old_reachable_cache: dict[str, set[str]] = {}
@@ -969,7 +964,7 @@ def _detect_intra_dep_removed(
         providers = new.resolution.providers_for(symbol)
         if providers:
             continue  # someone in the bundle provides it
-        old_providers = {p.library for p in old.resolution.providers_for(symbol)}
+        old_all_providers = old.resolution.providers_for(symbol)
         for consumer in consumers:
             if consumer.weak:
                 continue
@@ -977,13 +972,19 @@ def _detect_intra_dep_removed(
             if consumer_meta is None:
                 continue
             # Did *this* consumer -- not merely some other consumer of the
-            # same symbol name -- previously reach one of those old
-            # providers? A consumer absent from the old bundle (newly added
-            # this release) has no old reachability to check.
+            # same symbol name -- previously reach a *version-compatible*
+            # old provider (docstring above; mirrors the audit-mode
+            # sibling's identical compatibility rule)?
+            if consumer.version:
+                compatible_old = {
+                    p.library for p in old_all_providers if p.version == consumer.version
+                }
+            else:
+                compatible_old = {p.library for p in old_all_providers if p.is_default}
             ever_provided_in_bundle = bool(
-                old_providers
+                compatible_old
                 and consumer.library in old.libraries
-                and old_providers & _old_reachable(consumer.library)
+                and compatible_old & _old_reachable(consumer.library)
             )
             if _import_is_external(consumer, consumer_meta, new):
                 continue

--- a/abicheck/bundle.py
+++ b/abicheck/bundle.py
@@ -802,7 +802,8 @@ def compare_bundle(
             ``strict_abi``, matching every existing caller's prior behavior
             exactly.
     """
-    sys_libs = set(DEFAULT_SYSTEM_PROVIDERS) | set(system_providers or ())
+    explicit_providers = set(system_providers or ())
+    sys_libs = set(DEFAULT_SYSTEM_PROVIDERS) | explicit_providers
     findings: list[BundleFinding] = []
 
     # Index per-library diff results by canonical basename. This is the
@@ -820,7 +821,7 @@ def compare_bundle(
     findings.extend(_detect_library_structural_changes(old, new))
 
     # 2. bundle_intra_dep_removed: an import in the new bundle has no provider.
-    findings.extend(_detect_intra_dep_removed(old, new, sys_libs))
+    findings.extend(_detect_intra_dep_removed(old, new, sys_libs, explicit_providers))
 
     # 3. bundle_intra_dep_signature_changed: provider's per-library diff
     #    flagged func_params_changed / func_return_changed / var_type_changed
@@ -926,29 +927,36 @@ def _detect_intra_dep_removed(
     old: BundleSnapshot,
     new: BundleSnapshot,
     system_providers: set[str],
+    explicit_providers: set[str],
 ) -> list[BundleFinding]:
     """Find imports in the new bundle that no sibling provides.
 
     Excludes imports satisfied by system libraries (``libc``, ``libstdc++``,
     etc.) since they are out of bundle scope by design. Classification uses
-    provider/version evidence first (:func:`_import_is_external`: a symbol
-    bound to a ``GLIBC_``/``CXXABI_``/… version namespace, or required from a
-    soname that does not resolve inside the bundle, is external) and the
+    provider/version evidence first (:func:`_import_is_external`) and the
     symbol-name allow-list (``DEFAULT_SYSTEM_SYMBOLS`` / ``_looks_system_*``)
     as a fallback. Excludes weak imports (linker treats unresolved weak as
     0/NULL at runtime).
+
     A consumer's import is treated as system-provided when every DT_NEEDED
     edge it carries that resolves *outside* the bundle is in the
-    ``system_providers`` allow-list (built-in plus user-extended via
-    ``--bundle-system-providers``) -- but only when no sibling *ever*
-    provided this symbol (:attr:`old`'s resolution graph, not just
-    ``new``'s). The allow-list alone can't tell "always external" apart
-    from "a sibling provider and its DT_NEEDED edge were both dropped by
-    the same refactor, and this consumer also happens to need libc" (nearly
-    universal) -- so when ``old`` shows a sibling used to provide the
-    symbol, the allow-list match alone isn't trusted; the symbol-name check
-    below still has to agree (Codex review: an earlier revision trusted the
-    allow-list unconditionally, silently hiding that regression).
+    ``system_providers`` allow-list (built-in ``DEFAULT_SYSTEM_PROVIDERS``
+    plus user-extended via ``--bundle-system-providers``) -- but only when
+    either (a) no sibling *ever* provided this symbol (:attr:`old`'s
+    resolution graph, not just ``new``'s), or (b) the user explicitly named
+    at least one of this consumer's remaining sonames via
+    ``explicit_providers`` -- a deliberate migration assertion (e.g. a
+    symbol legitimately moved from an in-tree sibling to an allow-listed
+    external DSO). Without that, the allow-list can't tell "always external"
+    apart from "a sibling provider and its DT_NEEDED edge were both dropped
+    by the same refactor, and this consumer also happens to need libc"
+    (nearly universal) -- so absent an explicit assertion, an ``old``-side
+    sibling provider means the allow-list match alone isn't trusted; the
+    symbol-name check below still has to agree (Codex review history: an
+    earlier revision trusted the allow-list unconditionally regardless of
+    ``old``, silently hiding that regression; a later revision then
+    over-corrected by never trusting it once ``old`` had a provider at all,
+    silently defeating a legitimate provider migration).
     """
     findings: list[BundleFinding] = []
 
@@ -958,35 +966,31 @@ def _detect_intra_dep_removed(
             continue  # someone in the bundle provides it
         # Whether a sibling *used to* provide this symbol (docstring above).
         ever_provided_in_bundle = bool(old.resolution.providers_for(symbol))
-        # Symbol not provided by any sibling. Is it system?
         for consumer in consumers:
             if consumer.weak:
                 continue
             consumer_meta = new.metadata.get(consumer.library)
             if consumer_meta is None:
                 continue
-            # Version/provider evidence (field-derived oneDAL fix): an import
-            # bound to a system version namespace (``syscall@GLIBC_2.2.5``,
-            # ``stdout@GLIBC_2.2.5``, ``_ZdlPvm@CXXABI_1.3``) — or required
-            # from a library whose soname does not resolve inside the bundle —
-            # is external by construction. It can never be a *dropped
-            # intra-bundle* dependency, so skip it regardless of symbol-name
-            # shape. An unversioned (or bundle-versioned) sibling import is
-            # NOT skipped here and still produces the finding.
             if _import_is_external(consumer, consumer_meta, new):
                 continue
-            # If every non-intra DT_NEEDED of this consumer is on the
-            # allow-list AND no sibling ever provided this symbol, trust it
-            # unconditionally -- what makes --bundle-system-providers
-            # suppress a non-system-shaped custom export (MKL/TBB/SYCL).
-            # Otherwise fall through to the symbol-name check (docstring).
+            # Every non-intra DT_NEEDED on the allow-list AND (no sibling
+            # ever provided this symbol, OR the user explicitly asserted a
+            # remaining soname) -> trust it unconditionally. Otherwise fall
+            # through to the symbol-name check (docstring above).
             extra_needed = new.resolution.extra_needed.get(consumer.library, [])
             if (
-                not ever_provided_in_bundle
-                and extra_needed
+                extra_needed
                 and all(
                     soname_matches_providers(e, system_providers) or _looks_system(e)
                     for e in extra_needed
+                )
+                and (
+                    not ever_provided_in_bundle
+                    or any(
+                        soname_matches_providers(e, explicit_providers)
+                        for e in extra_needed
+                    )
                 )
             ):
                 continue
@@ -1067,22 +1071,19 @@ def _detect_unresolved_intra_dependency(
        library the consumer has no ``DT_NEEDED`` path to would never
        actually be loaded together with the consumer.
     2. **A narrower, explicitly-approximate suppression path for unversioned
-       imports.** Mirrors ``_detect_intra_dep_removed``'s
-       ``soname_matches_providers(e, system_providers) or _looks_system(e)``
-       allow-list union (built-in ``DEFAULT_SYSTEM_PROVIDERS`` plus caller-supplied
+       imports.** Mirrors ``_detect_intra_dep_removed``'s allow-list union
+       (built-in ``DEFAULT_SYSTEM_PROVIDERS`` plus caller-supplied
        ``--bundle-system-providers``) and its non-empty guard
        (``extra_edges and all(...)``, never a bare ``all([])``), but adds a
-       requirement that one-sided audit needs and the diff-driven detector
-       does not: the consumer must have **zero** intra-bundle ``DT_NEEDED``
-       edges. A consumer that still depends on an intra-set library (which
-       simply stopped exporting the symbol) has a real, in-set candidate
-       provider that this coarse allow-list check cannot rule out — only a
-       consumer whose entire dependency set is external is eligible for
-       this suppression path. Deliberately has **no** symbol-name-shape
-       fallback (``_looks_system_symbol``): ``--bundle-system-providers``
-       exists specifically to cover a legitimate, non-system-shaped custom
-       export (e.g. ``vendor_init``) that a shape heuristic would never
-       match.
+       requirement one-sided audit needs and the diff-driven detector does
+       not: the consumer must have **zero** intra-bundle ``DT_NEEDED`` edges
+       — a consumer still depending on an intra-set library that simply
+       stopped exporting the symbol has a real, in-set candidate provider
+       this coarse check cannot rule out. Deliberately has **no**
+       symbol-name-shape fallback (``_looks_system_symbol``):
+       ``--bundle-system-providers`` exists specifically to cover a
+       legitimate, non-system-shaped custom export (e.g. ``vendor_init``)
+       that a shape heuristic would never match.
     3. Emits ``ChangeKind.BUNDLE_UNRESOLVED_INTRA_DEPENDENCY`` (not
        ``BUNDLE_INTRA_DEP_REMOVED`` — that kind's own description implies a
        diff-confirmed removal, which this finding cannot claim) at

--- a/abicheck/bundle_soname.py
+++ b/abicheck/bundle_soname.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright The abicheck Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+"""Soname matching for the bundle layer's system-provider allow-list.
+
+Split out of ``bundle.py`` (a leaf module, no other imports needed) purely to
+keep that file under the AI-readiness file-size hard cap — see
+``bundle.py``'s own ``_detect_intra_dep_removed``/
+``_detect_unresolved_intra_dependency``, which are this module's only
+callers.
+"""
+
+from __future__ import annotations
+
+import re
+
+__all__ = ["soname_matches_providers", "soname_stem"]
+
+# Strips a trailing ``.so`` + version suffix (``libfoo.so.1.2.3`` -> ``libfoo``).
+_SONAME_VERSION_SUFFIX_RE = re.compile(r"\.so(?:\.\d+)*$")
+
+
+def soname_stem(soname: str) -> str:
+    """Stem, so ``libmkl_core`` matches the real ``libmkl_core.so.2``."""
+    return _SONAME_VERSION_SUFFIX_RE.sub("", soname)
+
+
+def soname_matches_providers(soname: str, providers: set[str]) -> bool:
+    """True when soname (a real DT_NEEDED entry) is covered by providers
+    (built-in + --bundle-system-providers): exact, then stem match."""
+    if soname in providers:
+        return True
+    stem = soname_stem(soname)
+    return any(stem == p or stem == soname_stem(p) for p in providers)

--- a/abicheck/bundle_soname.py
+++ b/abicheck/bundle_soname.py
@@ -23,6 +23,9 @@ __all__ = ["soname_matches_providers", "soname_stem"]
 
 # Strips a trailing ``.so`` + version suffix (``libfoo.so.1.2.3`` -> ``libfoo``).
 _SONAME_VERSION_SUFFIX_RE = re.compile(r"\.so(?:\.\d+)*$")
+# An explicit numeric major version after ``.so`` (``libfoo.so.1``, not the
+# version-generic ``libfoo``/``libfoo.so``).
+_EXPLICIT_MAJOR_VERSION_RE = re.compile(r"\.so\.\d")
 
 
 def soname_stem(soname: str) -> str:
@@ -32,8 +35,20 @@ def soname_stem(soname: str) -> str:
 
 def soname_matches_providers(soname: str, providers: set[str]) -> bool:
     """True when soname (a real DT_NEEDED entry) is covered by providers
-    (built-in + --bundle-system-providers): exact, then stem match."""
+    (built-in + --bundle-system-providers): exact, then stem match.
+
+    Stem fallback only applies against a version-*generic* provider entry
+    (``libfoo``/``libfoo.so``, no explicit major) -- a provider entry that
+    itself names a specific major (``libfoo.so.1``) requires an exact
+    match, so it can't also silently match an unrelated major
+    (``libfoo.so.2``) (Codex review): a caller who explicitly pinned one
+    version did not thereby approve every other one, and this allow-list
+    doubles as the provider-migration assertion in ``bundle.py``.
+    """
     if soname in providers:
         return True
     stem = soname_stem(soname)
-    return any(stem == p or stem == soname_stem(p) for p in providers)
+    return any(
+        not _EXPLICIT_MAJOR_VERSION_RE.search(p) and (stem == p or stem == soname_stem(p))
+        for p in providers
+    )

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -103,6 +103,7 @@ from .cli_resolve import (
     _reject_evidence_flags_for_set_inputs,
     _resolve_compare_snapshots,
     classify_compare_operand,
+    resolve_directory_compile_context,
 )
 from .cli_secondary_output import reject_incoherent_secondary_output
 from .contract_coverage_exit import announce_coverage_floor, fold_coverage_exit
@@ -1617,16 +1618,14 @@ def run_compare(
         ))
 
     if {old_kind, new_kind} & {"directory", "package"}:
-        # L2 header compile context for the release fan-out, via the same
-        # `resolve_compile_context` call the single-pair path uses further
-        # below (folds the project `.abicheck.yml` `compile:` block in
-        # too). A sided `--ast-frontend old=/new=` override still has no
-        # per-library-pair meaning, so it stays rejected below.
-        directory_compile_context, _ = resolve_compile_context(
+        # Both-sides L2 compile context for the release fan-out -- see
+        # resolve_directory_compile_context's own docstring (including why
+        # its merged-includes half must be forwarded too).
+        directory_compile_context, directory_includes = resolve_directory_compile_context(
             ctx,
             gcc_options=gcc_options, sysroot=sysroot, nostdinc=nostdinc,
-            header_backend=header_backend, includes=includes, build_config=cfg_path,
-            frontend_context=frontend_context,
+            header_backend=header_backend, includes=includes,
+            build_config=cfg_path, frontend_context=frontend_context,
             compiler_path=compiler_path, compiler_prefix=compiler_prefix,
             compiler_option_tokens=compiler_option_tokens,
         )
@@ -1636,7 +1635,7 @@ def run_compare(
         cli._dispatch_release_compare(
             ctx,
             old_dir=old_input, new_dir=new_input,
-            headers=headers, includes=includes,
+            headers=headers, includes=directory_includes,
             old_headers_only=old_headers_only, new_headers_only=new_headers_only,
             old_includes_only=old_includes_only, new_includes_only=new_includes_only,
             old_version=old_version, new_version=new_version, lang=lang,

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1027,7 +1027,7 @@ def _attach_suppression_audit(result: Any, suppression: Any) -> None:
 
 
 def _reject_flags_unsupported_for_set_inputs(
-    ctx: click.Context, project_cfg: Any, *,
+    ctx: click.Context, *,
     exit_code_scheme: str | None, reconcile_build_context: bool,
     env_matrix_path: Path | None,
     used_by_apps: tuple[Path, ...], required_symbols: tuple[str, ...],
@@ -1060,7 +1060,7 @@ def _reject_flags_unsupported_for_set_inputs(
         include_labels=include_labels,
         require_complete_analysis=require_complete_analysis,
     )
-    _reject_compile_context_for_set_inputs(ctx, project_cfg)
+    _reject_compile_context_for_set_inputs(ctx)
     _reject_evidence_flags_for_set_inputs(ctx)
 
 
@@ -1523,7 +1523,7 @@ def run_compare(
     release_pack_application = None
     if {old_kind, new_kind} & {"directory", "package"}:
         _reject_flags_unsupported_for_set_inputs(
-            ctx, project_cfg,
+            ctx,
             exit_code_scheme=exit_code_scheme,
             reconcile_build_context=reconcile_build_context,
             env_matrix_path=env_matrix_path,
@@ -1617,6 +1617,19 @@ def run_compare(
         ))
 
     if {old_kind, new_kind} & {"directory", "package"}:
+        # L2 header compile context for the release fan-out, via the same
+        # `resolve_compile_context` call the single-pair path uses further
+        # below (folds the project `.abicheck.yml` `compile:` block in
+        # too). A sided `--ast-frontend old=/new=` override still has no
+        # per-library-pair meaning, so it stays rejected below.
+        directory_compile_context, _ = resolve_compile_context(
+            ctx,
+            gcc_options=gcc_options, sysroot=sysroot, nostdinc=nostdinc,
+            header_backend=header_backend, includes=includes, build_config=cfg_path,
+            frontend_context=frontend_context,
+            compiler_path=compiler_path, compiler_prefix=compiler_prefix,
+            compiler_option_tokens=compiler_option_tokens,
+        )
         # Resolved through the ``cli`` module (not a by-name import) so a test that
         # monkeypatches ``abicheck.cli._dispatch_release_compare`` before invoking
         # ``compare`` is honoured — matching the pre-split resolution semantics.
@@ -1653,6 +1666,7 @@ def run_compare(
             contract_mode=contract_mode,
             pack_application=release_pack_application,
             secondary_fmt=secondary_fmt, secondary_output=secondary_output,
+            compile_context=directory_compile_context,
         )
         return
     # Single-file/snapshot inputs: the set-only fan-out flags do not apply.

--- a/abicheck/cli_compare_helpers.py
+++ b/abicheck/cli_compare_helpers.py
@@ -1042,15 +1042,13 @@ def _reject_flags_unsupported_for_set_inputs(
     The per-library fan-out (``compare-release`` backend) consumes the
     resolved scheme from config but has no public CLI support for these
     flags on set inputs -- reject them loudly (ADR-037 D12). Validated ahead
-    of the ``--dry-run`` emit (not just before the real dispatch) so a dry
-    run can't report "ok" for a flag combination the real run would then
-    reject (Codex review).
+    of the ``--dry-run`` emit so a dry run can't report "ok" for a flag
+    combination the real run would then reject.
 
-    ``--pack`` is not rejected here (CLI cleanup phase two, "PR B" slice 1):
-    the caller resolves it separately right after this call. ``--write``
-    (``secondary_fmt``/``secondary_output``) is not rejected here either, as
-    of CLI cleanup phase two, PR E -- the release engine now supports it
-    directly, so it is simply forwarded to ``_dispatch_release_compare``.
+    ``--pack`` is not rejected here: the caller resolves it separately right
+    after this call. ``--write`` (``secondary_fmt``/``secondary_output``) is
+    not rejected either -- the release engine supports it directly, so it is
+    simply forwarded to ``_dispatch_release_compare``.
     """
     _reject_set_input_flags(
         exit_code_scheme, reconcile_build_context, env_matrix_path,
@@ -1619,8 +1617,7 @@ def run_compare(
 
     if {old_kind, new_kind} & {"directory", "package"}:
         # Both-sides L2 compile context for the release fan-out -- see
-        # resolve_directory_compile_context's own docstring (including why
-        # its merged-includes half must be forwarded too).
+        # resolve_directory_compile_context's own docstring.
         directory_compile_context, directory_includes = resolve_directory_compile_context(
             ctx,
             gcc_options=gcc_options, sysroot=sysroot, nostdinc=nostdinc,
@@ -1629,9 +1626,13 @@ def run_compare(
             compiler_path=compiler_path, compiler_prefix=compiler_prefix,
             compiler_option_tokens=compiler_option_tokens,
         )
-        # Resolved through the ``cli`` module (not a by-name import) so a test that
-        # monkeypatches ``abicheck.cli._dispatch_release_compare`` before invoking
-        # ``compare`` is honoured — matching the pre-split resolution semantics.
+        # Dirs the config appended past the CLI -I roots (mirrors the
+        # single-pair path's `config_includes` split below): must survive a
+        # per-library-pair `--old-include`/`--new-include` override, which
+        # otherwise fully replaces `includes` for that side.
+        directory_config_includes = tuple(directory_includes[len(includes) :])
+        # Via the ``cli`` module (not a by-name import) so a test that
+        # monkeypatches ``abicheck.cli._dispatch_release_compare`` is honoured.
         cli._dispatch_release_compare(
             ctx,
             old_dir=old_input, new_dir=new_input,
@@ -1666,6 +1667,7 @@ def run_compare(
             pack_application=release_pack_application,
             secondary_fmt=secondary_fmt, secondary_output=secondary_output,
             compile_context=directory_compile_context,
+            config_includes=directory_config_includes,
         )
         return
     # Single-file/snapshot inputs: the set-only fan-out flags do not apply.

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -88,6 +88,7 @@ from .model import AbiSnapshot
 from .reporter import to_json
 
 if TYPE_CHECKING:
+    from .compile_context import CompileContext
     from .pack_application import PackApplication
     from .severity import SeverityConfig
 
@@ -117,6 +118,7 @@ def _run_compare_pair(
     contract_evaluation: bool = False,
     contract_mode: str | None = None,
     pack_application: PackApplication | None = None,
+    compile_context: CompileContext | None = None,
 ) -> CompareResult:
     """Run compare for one old/new pair and return result + resolved snapshots.
 
@@ -143,6 +145,20 @@ def _run_compare_pair(
     classify_compare_pair`` folds into *this pair's own* freshly-loaded
     ``PolicyFile`` the same way a single-pair ``compare`` folds its packs
     into its one ambient policy file.
+
+    *compile_context* is the release's already-resolved, both-sides L2
+    header-AST compile context (``--ast-frontend``/``--compiler``/
+    ``--compiler-prefix``/``--compiler-option``/``--sysroot``/``--nostdinc``/
+    ``--frontend-context``, resolved once for the whole release by
+    ``cli_compare_helpers.run_compare`` the same way a single-pair
+    ``compare`` resolves it -- see ``cli_options.resolve_compile_context``).
+    Forwarded to ``service.run_compare`` unchanged so each library's header
+    dump parses with the same cross-toolchain/frontend context a single-pair
+    ``compare`` of that library would use, closing the gap this function's
+    own historical docstring used to flag ("the per-library fan-out does not
+    thread the L2 compile context" -- see AGENTS.md's whole-product-bundle
+    known-gap entry). ``None`` (the default) is a true no-op, matching every
+    pre-existing caller.
     """
     from . import service
 
@@ -177,6 +193,7 @@ def _run_compare_pair(
         pack_internal_namespaces=(
             pack_application.internal_namespaces if pack_application else None
         ),
+        compile_context=compile_context,
     )
 
 
@@ -204,6 +221,7 @@ _CompareReleaseCommonArgs = tuple[
     "SeverityConfig | None",
     "PackApplication | None",
     bool,
+    "CompileContext | None",
 ]
 
 
@@ -249,6 +267,7 @@ def _compare_one_library(
     severity_config: SeverityConfig | None = None,
     pack_application: PackApplication | None = None,
     collect_diff_results: bool = False,
+    compile_context: CompileContext | None = None,
 ) -> dict[str, object]:
     """Compare one library pair — suitable for parallel dispatch.
 
@@ -306,6 +325,7 @@ def _compare_one_library(
             contract_evaluation=contract_evaluation,
             contract_mode=contract_mode,
             pack_application=pack_application,
+            compile_context=compile_context,
         )
         result = compare_result.diff
         v = result.verdict.value
@@ -502,6 +522,7 @@ def _compare_release_libraries(
     contract_evaluation: bool = False,
     contract_mode: str | None = None,
     pack_application: PackApplication | None = None,
+    compile_context: CompileContext | None = None,
 ) -> tuple[list[dict[str, object]], str, list[tuple[DiffResult, AbiSnapshot]]]:
     """Compare each matched library pair and collect results.
 
@@ -546,6 +567,7 @@ def _compare_release_libraries(
         severity_config,
         pack_application,
         collect_diff_results,
+        compile_context,
     )
 
     if effective_jobs > 1 and len(matched_keys) > 1:
@@ -1244,7 +1266,10 @@ def _strip_diff_results_and_adjust_verdict(
     "bundle_system_providers",
     default="",
     help="Comma-separated extra sonames to treat as system-provided "
-    "(extends the built-in libc/libstdc++/libgcc/libtbb allow-list).",
+    "(extends the built-in libc/libstdc++/libgcc/libtbb allow-list). "
+    "Matched against the real DT_NEEDED soname either exactly or by its "
+    "version-suffix-stripped stem (e.g. 'libmkl_core' matches a real "
+    "'libmkl_core.so.2' DT_NEEDED entry); matching is case-sensitive.",
 )
 @click.option(
     "--bundle-cohort",
@@ -1350,6 +1375,12 @@ def compare_release_cmd(
     # true no-op: every library is compared exactly as it was before this
     # parameter existed.
     pack_application: PackApplication | None = None,
+    # `compare`'s directory/package fan-out resolves the both-sides L2
+    # header-AST compile context once, ahead of dispatch (the same
+    # `cli_options.resolve_compile_context` call the single-pair path uses),
+    # and hands it over here -- same internal-parameter shape as
+    # pack_application above. `None` (the default) is a true no-op.
+    compile_context: CompileContext | None = None,
 ) -> None:
     """Compare all libraries in two release directories or packages.
 
@@ -1598,6 +1629,7 @@ def compare_release_cmd(
                 contract_evaluation=contract_evaluation,
                 contract_mode=contract_mode,
                 pack_application=pack_application,
+                compile_context=compile_context,
             )
 
             # ADR-049 Phase 7's orthogonal contract-coverage floor, aggregated

--- a/abicheck/cli_compare_release.py
+++ b/abicheck/cli_compare_release.py
@@ -1381,6 +1381,15 @@ def compare_release_cmd(
     # and hands it over here -- same internal-parameter shape as
     # pack_application above. `None` (the default) is a true no-op.
     compile_context: CompileContext | None = None,
+    # The dirs the project's `.abicheck.yml` `compile.include_dirs` appended
+    # past the caller's raw `-I` roots (the suffix of `resolve_compile_
+    # context`'s merged-includes return past its own `includes` input) --
+    # forwarded separately from `includes` itself so they survive a per-
+    # library-pair `--old-include`/`--new-include` override, which
+    # otherwise fully replaces `includes` for that side
+    # (`_prepare_compare_release_inputs`). `()` (the default) is a true
+    # no-op.
+    config_includes: tuple[Path, ...] = (),
 ) -> None:
     """Compare all libraries in two release directories or packages.
 
@@ -1517,6 +1526,7 @@ def compare_release_cmd(
                 includes,
                 old_includes_only,
                 new_includes_only,
+                config_includes,
                 _do_extract,
                 discover_shared_libraries,
                 is_package,
@@ -1805,6 +1815,7 @@ def _prepare_compare_release_inputs(
     includes: tuple[Path, ...],
     old_includes_only: tuple[Path, ...],
     new_includes_only: tuple[Path, ...],
+    config_includes: tuple[Path, ...],
     extract_if_package: Callable[
         [Path, Path | None, Path | None],
         tuple[Path, Path | None, Path | None, Path | None],
@@ -1869,8 +1880,22 @@ def _prepare_compare_release_inputs(
         old_header_dir,
         new_header_dir,
     )
-    old_inc = list(old_includes_only) if old_includes_only else list(includes)
-    new_inc = list(new_includes_only) if new_includes_only else list(includes)
+    # config_includes (the project .abicheck.yml compile.include_dirs
+    # suffix, already folded into `includes` by the caller) must survive a
+    # per-library-pair --old-include/--new-include override, which
+    # otherwise fully replaces `includes` for that side -- so it is
+    # re-appended explicitly here rather than relied on via `includes`
+    # (Codex review, fresh evidence).
+    old_inc = (
+        list(old_includes_only) + list(config_includes)
+        if old_includes_only
+        else list(includes)
+    )
+    new_inc = (
+        list(new_includes_only) + list(config_includes)
+        if new_includes_only
+        else list(includes)
+    )
     old_inc.extend(_discover_include_roots(old_header_dir))
     new_inc.extend(_discover_include_roots(new_header_dir))
     matched_keys, removed_keys, added_keys, old_map, new_map = _match_release_keys(

--- a/abicheck/cli_options.py
+++ b/abicheck/cli_options.py
@@ -1066,6 +1066,38 @@ def _shared_frontend_explicit(ctx: click.Context) -> bool:
     return True
 
 
+def sided_frontend_explicit(ctx: click.Context) -> bool:
+    """Did the command line state a *sided* ``--ast-frontend old=/new=`` value?
+
+    The inverse-shaped sibling of :func:`_shared_frontend_explicit`, for a
+    caller that needs to know whether a per-side override was given (as
+    opposed to a bare/``both=`` value) -- e.g. a directory/package compare,
+    which threads the both-sides compile context to its release fan-out but
+    has no per-library-pair-within-a-release meaning for "parse the old
+    library's headers with a different frontend than the new one" (see
+    ``cli_resolve._reject_compile_context_for_set_inputs``). Reads the same
+    raw ``(side, frontend)`` pairs off ``ctx.params`` that
+    :func:`_shared_frontend_explicit` does, for the same reason (normalize_
+    sided_options rewrites the command's own kwargs dict, not the context).
+
+    A command composing the unsided ``@compile_context_options()`` has a
+    plain string on ``ctx.params["header_backend"]``, never a pair list, so
+    this always answers ``False`` for it.
+    """
+    if (
+        ctx.get_parameter_source("header_backend")
+        != click.core.ParameterSource.COMMANDLINE
+    ):
+        return False
+    raw = ctx.params.get("header_backend")
+    if isinstance(raw, (tuple, list)):
+        return any(
+            isinstance(pair, tuple) and len(pair) == 2 and pair[0] != "both"
+            for pair in raw
+        )
+    return False
+
+
 def resolve_compile_context(
     ctx: click.Context,
     *,

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -31,7 +31,7 @@ caller is a CLI entry point — the parallel, framework-free contract lives in
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -752,3 +752,42 @@ def _reject_compile_context_for_set_inputs(ctx: click.Context) -> None:
             "already compared under one shared, both-sides compile context). "
             "Compare the libraries individually to use a sided override."
         )
+
+
+def resolve_directory_compile_context(
+    ctx: click.Context,
+    *,
+    gcc_options: str | None,
+    sysroot: Any,
+    nostdinc: bool,
+    header_backend: str,
+    includes: Any,
+    build_config: Any,
+    frontend_context: str,
+    compiler_path: str | None,
+    compiler_prefix: str | None,
+    compiler_option_tokens: tuple[str, ...],
+) -> Any:
+    """Resolve the both-sides L2 compile context for a directory/package
+    compare's release fan-out -- the identical ``resolve_compile_context``
+    call the single-pair path uses, folding the project ``.abicheck.yml``
+    ``compile:`` block in the same way (CLI > config). Returns
+    ``(CompileContext, merged_includes)`` -- the caller must forward
+    *both*: dropping the merged-includes half silently drops
+    ``compile.include_dirs`` for every library (Codex review).
+    """
+    from .cli_options import resolve_compile_context
+
+    return resolve_compile_context(
+        ctx,
+        gcc_options=gcc_options,
+        sysroot=sysroot,
+        nostdinc=nostdinc,
+        header_backend=header_backend,
+        includes=includes,
+        build_config=build_config,
+        frontend_context=frontend_context,
+        compiler_path=compiler_path,
+        compiler_prefix=compiler_prefix,
+        compiler_option_tokens=compiler_option_tokens,
+    )

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -31,7 +31,7 @@ caller is a CLI entry point — the parallel, framework-free contract lives in
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import click
 
@@ -649,24 +649,24 @@ def _resolve_compare_snapshots(
 
 # ── Set-input (directory/package) compare guards (ADR-037 D3/D12) ─────────────
 #
-# The per-library release fan-out forwards only release-comparison kwargs; it
-# does not thread the single-pair L2 compile context or inline build/source
-# evidence per pair. So the corresponding flags would be silently dropped on a
-# directory/package compare — reject them loudly instead (Codex review). Kept
-# here (not in cli.py) so cli.py stays under the file-size hard cap.
+# The per-library release fan-out forwards only release-comparison kwargs, and
+# does not collect inline build/source evidence per pair (L3-L5) — those flags
+# would be silently dropped on a directory/package compare, so they are
+# rejected loudly instead (Codex review). Kept here (not in cli.py) so cli.py
+# stays under the file-size hard cap.
+#
+# The both-sides L2 compile context (--ast-frontend/--compiler/
+# --compiler-prefix/--compiler-option/--sysroot/--nostdinc/--frontend-context)
+# *is* now threaded through the fan-out (cli_compare_helpers.run_compare
+# resolves one CompileContext for the whole release, the same way a
+# single-pair compare resolves its own, and forwards it to every library pair
+# — see cli_compare_release._run_compare_pair's compile_context parameter).
+# Only the *sided* --ast-frontend old=/new= override has no home here: it
+# means "parse the old library's headers with a different frontend than the
+# new one", which has no per-library-pair-within-a-release equivalent to
+# mirror (a release fan-out already compares each library's own old vs. new
+# under one shared context) — so it stays rejected below.
 
-#: Compile-context flag dest → spelling, for the set-input rejection guard.
-_COMPILE_CONTEXT_SET_INPUT_FLAGS: dict[str, str] = {
-    "compiler_path": "--compiler",
-    "compiler_prefix": "--compiler-prefix",
-    "compiler_option_tokens": "--compiler-option",
-    "sysroot": "--sysroot",
-    "nostdinc": "--nostdinc",
-    "header_backend": "--ast-frontend",
-    "old_header_backend": "--ast-frontend old=",
-    "new_header_backend": "--ast-frontend new=",
-    "frontend_context": "--frontend-context",
-}
 
 #: Build/source evidence flags (param dest → flag). ``depth`` is the
 #: evidence-depth dial; the four per-side --sources/--build-info are the
@@ -717,65 +717,38 @@ def _reject_evidence_flags_for_set_inputs(ctx: click.Context) -> None:
         )
 
 
-def _config_has_compile_block(project_cfg: Any) -> bool:
-    """True if a loaded ``.abicheck.yml`` carries any ``compile:`` setting.
+def _reject_compile_context_for_set_inputs(ctx: click.Context) -> None:
+    """Guard the *sided* per-side L2 compile context for directory/package compares.
 
-    Used to flag that a project's L2 compile context would be dropped by the
-    per-library release fan-out (which the single-pair path honors).
+    The both-sides compile context (--ast-frontend/--compiler/
+    --compiler-prefix/--compiler-option/--sysroot/--nostdinc/
+    --frontend-context, and the project ``.abicheck.yml`` ``compile:`` block)
+    is threaded through the release fan-out — see this module's own comment
+    above. Only a sided ``--ast-frontend old=/new=`` override has no
+    per-library-pair-within-a-release meaning, so it is rejected loudly here
+    (a `UsageError`, mirroring the `--exit-code-scheme` guard) rather than
+    silently ignored.
+
+    Detected via :func:`cli_options.sided_frontend_explicit`, not a plain
+    ``ctx.get_parameter_source("old_header_backend")`` dict lookup:
+    ``old_header_backend``/``new_header_backend`` are kwargs
+    ``normalize_sided_options`` synthesizes into the command's own kwargs
+    dict, never real Click-registered parameters — so `get_parameter_source`
+    for either name is never ``COMMANDLINE``, making a dict-keyed check on
+    them silently inert (a prior revision of this guard carried exactly that
+    dead check).
     """
-    if project_cfg is None:
-        return False
-    return bool(
-        getattr(project_cfg, "compile_frontend", None)
-        or getattr(project_cfg, "compile_std", None)
-        or getattr(project_cfg, "compile_defines", None)
-        or getattr(project_cfg, "compile_include_dirs", None)
-        or getattr(project_cfg, "compile_sysroot", None)
-        or getattr(project_cfg, "compile_nostdinc", False)
-    )
+    # Lazy import: cli_options already imports this module (lazily) for
+    # classify_compare_operand/_reject_evidence_flags_for_set_inputs, so a
+    # top-level `from .cli_options import ...` here would close that cycle
+    # (see cli_options.py's own "cli_options -> cli_resolve -> ..." comment).
+    from .cli_options import sided_frontend_explicit
 
-
-def _reject_compile_context_for_set_inputs(
-    ctx: click.Context, project_cfg: Any
-) -> None:
-    """Guard the L2 compile context for directory/package compares.
-
-    The per-library fan-out (release backend) runs each pair through
-    `service.run_compare` without a `CompileContext`, so the L2 cross-toolchain /
-    frontend context is not applied per library — unlike the single-pair path that
-    now honors it. Two cases, never silent (Codex review):
-
-    * An **explicitly-passed** compile-context flag is rejected loudly (a
-      `UsageError`, mirroring the `--exit-code-scheme` guard): the user asked for
-      it, so erroring beats ignoring it.
-    * An **ambient** project ``.abicheck.yml`` ``compile:`` block only *warns*:
-      a plain ``compare dir1 dir2`` in a configured project shouldn't hard-fail,
-      but the user must know those settings apply to single-library compares and
-      not to this fan-out (so per-library snapshots may differ).
-
-    Either way, compare libraries individually (or pre-dump snapshots) to apply
-    the context.
-    """
-    used = [
-        flag
-        for dest, flag in _COMPILE_CONTEXT_SET_INPUT_FLAGS.items()
-        if ctx.get_parameter_source(dest) == click.core.ParameterSource.COMMANDLINE
-    ]
-    if used:
+    if sided_frontend_explicit(ctx):
         raise click.UsageError(
-            ", ".join(sorted(used))
-            + " "
-            + ("is" if len(used) == 1 else "are")
-            + " not supported for directory/package (release) comparisons: the "
-            "per-library fan-out does not thread the L2 compile context to each "
-            "pair's header dump. Compare the libraries individually to use them."
-        )
-    if _config_has_compile_block(project_cfg):
-        click.echo(
-            "Warning: the .abicheck.yml compile: block is not applied to "
-            "directory/package (release) comparisons — the per-library fan-out "
-            "does not thread the L2 compile context. It affects single-library "
-            "compares only; compare libraries individually for consistent "
-            "per-library snapshots.",
-            err=True,
+            "--ast-frontend old=/new= is not supported for directory/package "
+            "(release) comparisons: a sided override has no per-library-pair "
+            "meaning across a release (every library's own old vs. new is "
+            "already compared under one shared, both-sides compile context). "
+            "Compare the libraries individually to use a sided override."
         )

--- a/abicheck/service_compare_pipeline.py
+++ b/abicheck/service_compare_pipeline.py
@@ -63,6 +63,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .api_types import CompareRequest, CompareResult, InputSpec, required_path
+from .compile_context import CompileContext
 from .dependency_info import populate_pair_dependency_info
 from .errors import ValidationError
 from .service_input_resolution import enforce_requested_depth, resolve_side_snapshot
@@ -70,7 +71,6 @@ from .service_input_resolution import enforce_requested_depth, resolve_side_snap
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from .compile_context import CompileContext
     from .model import AbiSnapshot
     from .service_compare_evidence import SideEvidence
 
@@ -605,6 +605,7 @@ def run_compare(
     contract_mode: str | None = None,
     pack_policy_overrides: dict[Any, Any] | None = None,
     pack_internal_namespaces: tuple[str, ...] | None = None,
+    compile_context: CompileContext | None = None,
 ) -> CompareResult:
     """Compare two ABI inputs and return the classified diff result.
 
@@ -625,6 +626,16 @@ def run_compare(
     folds them in and why. ``None``/empty on both is a no-op, matching every
     pre-existing caller.
 
+    ``compile_context`` is a both-sides :class:`~abicheck.compile_context.
+    CompileContext` (the L2 cross-toolchain/frontend family --
+    ``--ast-frontend``/``--compiler``/``--compiler-prefix``/
+    ``--compiler-option``/``--sysroot``/``--nostdinc``/``--frontend-context``),
+    applied identically to :class:`InputSpec.compile` on both sides -- the
+    same both-sides-only granularity ``include_dependencies`` already has in
+    this shim; a caller needing a genuine per-side override should build a
+    :class:`CompareRequest` directly instead. ``None`` (the default) is a
+    no-op, matching every pre-existing caller.
+
     Returns:
         A :class:`~abicheck.api_types.CompareResult`. This returned the bare
         ``(DiffResult, old, new)`` tuple before 0.6; ``.as_tuple()`` gives that
@@ -642,6 +653,7 @@ def run_compare(
             pdb=old_pdb_path,
             debug_roots=tuple(old_debug_roots or ()),
             include_dependencies=include_dependencies,
+            compile=compile_context,
         ),
         new=InputSpec(
             path=new_input,
@@ -651,6 +663,7 @@ def run_compare(
             pdb=new_pdb_path,
             debug_roots=tuple(new_debug_roots or ()),
             include_dependencies=include_dependencies,
+            compile=compile_context,
         ),
         lang=lang,
         frontend=frontend,

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -66,7 +66,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from .diff_cxx_rules import owner_class_of
-from .model import ScopeOrigin, Visibility
+from .model import ElfVisibility, ScopeOrigin, Visibility
 
 if TYPE_CHECKING:
     from .checker_types import Change
@@ -401,6 +401,18 @@ class PublicSurface:
     # "unreachable" — doing so would hide a real break (ADR-024 §D5.2). Only
     # confident provenance (private/system header) may demote in that case.
     has_typed_roots: bool = False
+    # True when this surface was resolved via the ELF-visibility fallback
+    # (:func:`_seed_elf_visibility_roots`) rather than header-derived
+    # Visibility.PUBLIC data — i.e. no headers were supplied at all, and
+    # default/protected-visibility exported symbols were used as a coarser
+    # public-surface proxy instead. Never set together with a "real"
+    # header-scoped resolution (the fallback only ever runs when the
+    # header-derived seeding found nothing to work with). Surfaces
+    # resolved this way carry no type-reachability closure (a headerless
+    # snapshot has no record/enum data to walk), so `public_types`/
+    # `all_types` stay empty and type-level findings fall through to the
+    # conservative "unknown, keep it" path.
+    elf_visibility_fallback: bool = False
 
 
 def _symbol_keys(name: str, mangled: str) -> set[str]:
@@ -785,6 +797,59 @@ def _walk_exact_type_closure(
                     queue.append(ident)
 
 
+_ELF_VISIBILITY_PUBLIC_PROXY: frozenset[ElfVisibility] = frozenset(
+    {ElfVisibility.DEFAULT, ElfVisibility.PROTECTED}
+)
+
+
+def _seed_elf_visibility_roots(snap: AbiSnapshot, surface: PublicSurface) -> bool:
+    """Fallback public-root seeding for a headerless (ELF-only) snapshot.
+
+    When no header-derived :data:`Visibility.PUBLIC` signal exists at all
+    (every symbol is ``ELF_ONLY`` — ADR-016, no ``-H``/``--header`` given),
+    a bundle/directory-mode comparison would otherwise report every changed
+    symbol — public API or purely internal — as breaking (issue: headerless
+    bundle compare produces no public-surface scoping). This falls back to
+    real ELF ``st_other`` symbol visibility (:data:`Function.elf_visibility`
+    / :data:`Variable.elf_visibility`, populated from ``.dynsym`` on every
+    symbol independent of whether headers were supplied — see
+    ``dumper_elf_symbols._populate_elf_visibility``) as a coarser
+    public-surface proxy: a default/protected-visibility dynamic symbol is
+    externally linkable and callable by any consumer, so it is treated as
+    public; a hidden/internal-visibility one is not observable to a
+    consumer at all, so it is treated as private.
+
+    This is strictly coarser than header-derived scoping: there is no
+    type-reachability closure to run (a headerless dump carries no
+    record/enum data to walk — ``public_types``/``all_types`` stay empty),
+    and default ELF visibility is a much weaker public-API signal than an
+    explicit public header (a library routinely exports more than its
+    documented public API at the ELF level, e.g. helper symbols with no
+    ``-fvisibility=hidden`` annotation). Callers must treat a surface
+    resolved this way as reduced confidence
+    (:data:`SCOPE_NOTE_ELF_VISIBILITY_FALLBACK`), never as equivalent to a
+    real header-scoped resolution.
+
+    Returns whether any real ``elf_visibility`` evidence was found at all —
+    when none is populated (e.g. a non-ELF binary, or a snapshot dumped
+    before ``elf_visibility`` existed), the caller keeps the pre-existing
+    "no headers ⇒ unresolvable, keep everything" behaviour rather than
+    fabricating a surface from nothing.
+    """
+    seeded_any_evidence = False
+    for coll in (snap.functions, snap.variables):
+        for sym in coll:
+            vis = getattr(sym, "elf_visibility", None)
+            if vis is None:
+                continue
+            seeded_any_evidence = True
+            keys = _symbol_keys(sym.name, sym.mangled)
+            surface.all_symbols |= keys
+            if vis in _ELF_VISIBILITY_PUBLIC_PROXY:
+                surface.public_symbols |= keys
+    return seeded_any_evidence
+
+
 def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
     """Compute the public-ABI surface of *snap*.
 
@@ -835,9 +900,21 @@ def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
 
     # Scoping only makes sense when we actually have header-derived public
     # visibility. Without headers every symbol is ELF_ONLY (ADR-016) and a
-    # surface filter would hide everything — so declare it unresolvable.
+    # surface filter would hide everything — so declare it unresolvable,
+    # unless real ELF symbol-visibility evidence lets us fall back to a
+    # coarser proxy surface instead of giving up entirely (see
+    # _seed_elf_visibility_roots).
     surface.resolvable = has_public and not getattr(snap, "elf_only_mode", False)
     if not surface.resolvable:
+        if getattr(snap, "elf_only_mode", False) and not has_public:
+            if _seed_elf_visibility_roots(snap, surface):
+                surface.resolvable = True
+                surface.elf_visibility_fallback = True
+        if not surface.resolvable:
+            return surface
+        # No type-reachability closure to run here (see
+        # elf_visibility_fallback's own docstring) — return the
+        # symbol-only surface as-is.
         return surface
 
     # Transitive closure over the record/typedef graph.
@@ -855,6 +932,12 @@ def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
 SCOPE_NOTE_MANGLING_FALLBACK = "mangling-fallback"  # MSVC C++ name-mangling gap
 SCOPE_NOTE_HEADER_BACKEND_UNAVAILABLE = "header-backend-unavailable"
 SCOPE_NOTE_NO_PROVENANCE = "no-provenance"  # surface resolved without provenance
+# Surface resolved from ELF st_other symbol visibility alone (no headers at
+# all were supplied) — see PublicSurface.elf_visibility_fallback /
+# _seed_elf_visibility_roots. Strictly coarser than a header-derived
+# resolution: no type-reachability closure, and default ELF visibility is a
+# weaker public-API signal than an explicit public header.
+SCOPE_NOTE_ELF_VISIBILITY_FALLBACK = "elf-visibility-fallback"
 
 
 def surface_scope_confidence(
@@ -896,6 +979,8 @@ def surface_scope_confidence(
         # must fire unless every resolvable side carries provenance.
         if any(s.resolvable and not s.has_provenance for s in (s_old, s_new)):
             _add(SCOPE_NOTE_NO_PROVENANCE)
+        if any(s.elf_visibility_fallback for s in (s_old, s_new)):
+            _add(SCOPE_NOTE_ELF_VISIBILITY_FALLBACK)
 
     return ("reduced" if notes else "high"), notes
 

--- a/abicheck/surface.py
+++ b/abicheck/surface.py
@@ -66,7 +66,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from .diff_cxx_rules import owner_class_of
-from .model import ElfVisibility, ScopeOrigin, Visibility
+from .model import ScopeOrigin, Visibility
 
 if TYPE_CHECKING:
     from .checker_types import Change
@@ -401,18 +401,6 @@ class PublicSurface:
     # "unreachable" — doing so would hide a real break (ADR-024 §D5.2). Only
     # confident provenance (private/system header) may demote in that case.
     has_typed_roots: bool = False
-    # True when this surface was resolved via the ELF-visibility fallback
-    # (:func:`_seed_elf_visibility_roots`) rather than header-derived
-    # Visibility.PUBLIC data — i.e. no headers were supplied at all, and
-    # default/protected-visibility exported symbols were used as a coarser
-    # public-surface proxy instead. Never set together with a "real"
-    # header-scoped resolution (the fallback only ever runs when the
-    # header-derived seeding found nothing to work with). Surfaces
-    # resolved this way carry no type-reachability closure (a headerless
-    # snapshot has no record/enum data to walk), so `public_types`/
-    # `all_types` stay empty and type-level findings fall through to the
-    # conservative "unknown, keep it" path.
-    elf_visibility_fallback: bool = False
 
 
 def _symbol_keys(name: str, mangled: str) -> set[str]:
@@ -797,59 +785,6 @@ def _walk_exact_type_closure(
                     queue.append(ident)
 
 
-_ELF_VISIBILITY_PUBLIC_PROXY: frozenset[ElfVisibility] = frozenset(
-    {ElfVisibility.DEFAULT, ElfVisibility.PROTECTED}
-)
-
-
-def _seed_elf_visibility_roots(snap: AbiSnapshot, surface: PublicSurface) -> bool:
-    """Fallback public-root seeding for a headerless (ELF-only) snapshot.
-
-    When no header-derived :data:`Visibility.PUBLIC` signal exists at all
-    (every symbol is ``ELF_ONLY`` — ADR-016, no ``-H``/``--header`` given),
-    a bundle/directory-mode comparison would otherwise report every changed
-    symbol — public API or purely internal — as breaking (issue: headerless
-    bundle compare produces no public-surface scoping). This falls back to
-    real ELF ``st_other`` symbol visibility (:data:`Function.elf_visibility`
-    / :data:`Variable.elf_visibility`, populated from ``.dynsym`` on every
-    symbol independent of whether headers were supplied — see
-    ``dumper_elf_symbols._populate_elf_visibility``) as a coarser
-    public-surface proxy: a default/protected-visibility dynamic symbol is
-    externally linkable and callable by any consumer, so it is treated as
-    public; a hidden/internal-visibility one is not observable to a
-    consumer at all, so it is treated as private.
-
-    This is strictly coarser than header-derived scoping: there is no
-    type-reachability closure to run (a headerless dump carries no
-    record/enum data to walk — ``public_types``/``all_types`` stay empty),
-    and default ELF visibility is a much weaker public-API signal than an
-    explicit public header (a library routinely exports more than its
-    documented public API at the ELF level, e.g. helper symbols with no
-    ``-fvisibility=hidden`` annotation). Callers must treat a surface
-    resolved this way as reduced confidence
-    (:data:`SCOPE_NOTE_ELF_VISIBILITY_FALLBACK`), never as equivalent to a
-    real header-scoped resolution.
-
-    Returns whether any real ``elf_visibility`` evidence was found at all —
-    when none is populated (e.g. a non-ELF binary, or a snapshot dumped
-    before ``elf_visibility`` existed), the caller keeps the pre-existing
-    "no headers ⇒ unresolvable, keep everything" behaviour rather than
-    fabricating a surface from nothing.
-    """
-    seeded_any_evidence = False
-    for coll in (snap.functions, snap.variables):
-        for sym in coll:
-            vis = getattr(sym, "elf_visibility", None)
-            if vis is None:
-                continue
-            seeded_any_evidence = True
-            keys = _symbol_keys(sym.name, sym.mangled)
-            surface.all_symbols |= keys
-            if vis in _ELF_VISIBILITY_PUBLIC_PROXY:
-                surface.public_symbols |= keys
-    return seeded_any_evidence
-
-
 def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
     """Compute the public-ABI surface of *snap*.
 
@@ -900,21 +835,31 @@ def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
 
     # Scoping only makes sense when we actually have header-derived public
     # visibility. Without headers every symbol is ELF_ONLY (ADR-016) and a
-    # surface filter would hide everything — so declare it unresolvable,
-    # unless real ELF symbol-visibility evidence lets us fall back to a
-    # coarser proxy surface instead of giving up entirely (see
-    # _seed_elf_visibility_roots).
+    # surface filter would hide everything — so declare it unresolvable.
+    #
+    # An ELF ``st_other`` visibility-based fallback (treating a
+    # default/protected-visibility dynamic symbol as a public-surface proxy)
+    # was attempted and reverted: ``elf_metadata._parse_dynsym`` already
+    # discards every ``STV_HIDDEN``/``STV_INTERNAL`` symbol before
+    # ``meta.symbols`` is populated (a real shared library's exported-symbol
+    # surface always comes from ``.dynsym`` via that function -- ``.symtab``
+    # is only a fallback for a ``.o`` relocatable object with no ``.dynsym``
+    # at all), and ELF-only-mode ``snap.functions``/``snap.variables`` are
+    # themselves built exclusively from that same, already-filtered
+    # ``elf_meta.symbols`` set. So every symbol reaching this function's
+    # headerless path is, by construction, always DEFAULT or PROTECTED
+    # visibility -- never HIDDEN/INTERNAL -- and a visibility-based fallback
+    # has zero discriminating power on real production ELF dumps: it would
+    # unconditionally mark the entire ELF-only surface public, providing no
+    # actual scoping while claiming (via a resolved, "reduced confidence"
+    # surface) that scoping had been applied (Codex review, fresh evidence).
+    # Closing the underlying issue -- headerless bundle/directory compares
+    # over-report internal churn as breaking -- needs a real, non-ELF-level
+    # signal (e.g. symbol-name-shape heuristics, an opt-in allow/deny list,
+    # or requiring at least a public-header list for scoped comparisons) and
+    # its own scoped design; not attempted here.
     surface.resolvable = has_public and not getattr(snap, "elf_only_mode", False)
     if not surface.resolvable:
-        if getattr(snap, "elf_only_mode", False) and not has_public:
-            if _seed_elf_visibility_roots(snap, surface):
-                surface.resolvable = True
-                surface.elf_visibility_fallback = True
-        if not surface.resolvable:
-            return surface
-        # No type-reachability closure to run here (see
-        # elf_visibility_fallback's own docstring) — return the
-        # symbol-only surface as-is.
         return surface
 
     # Transitive closure over the record/typedef graph.
@@ -932,12 +877,6 @@ def compute_public_surface(snap: AbiSnapshot) -> PublicSurface:
 SCOPE_NOTE_MANGLING_FALLBACK = "mangling-fallback"  # MSVC C++ name-mangling gap
 SCOPE_NOTE_HEADER_BACKEND_UNAVAILABLE = "header-backend-unavailable"
 SCOPE_NOTE_NO_PROVENANCE = "no-provenance"  # surface resolved without provenance
-# Surface resolved from ELF st_other symbol visibility alone (no headers at
-# all were supplied) — see PublicSurface.elf_visibility_fallback /
-# _seed_elf_visibility_roots. Strictly coarser than a header-derived
-# resolution: no type-reachability closure, and default ELF visibility is a
-# weaker public-API signal than an explicit public header.
-SCOPE_NOTE_ELF_VISIBILITY_FALLBACK = "elf-visibility-fallback"
 
 
 def surface_scope_confidence(
@@ -979,8 +918,6 @@ def surface_scope_confidence(
         # must fire unless every resolvable side carries provenance.
         if any(s.resolvable and not s.has_provenance for s in (s_old, s_new)):
             _add(SCOPE_NOTE_NO_PROVENANCE)
-        if any(s.elf_visibility_fallback for s in (s_old, s_new)):
-            _add(SCOPE_NOTE_ELF_VISIBILITY_FALLBACK)
 
     return ("reduced" if notes else "high"), notes
 

--- a/changelog.d/20260822_202107_noreply_onedal_bundle_eval_g6onle.md
+++ b/changelog.d/20260822_202107_noreply_onedal_bundle_eval_g6onle.md
@@ -1,0 +1,24 @@
+### Fixed
+
+- **Directory/package `compare` now threads the L2 header compile context to
+  its per-library fan-out.** `--ast-frontend`/`--compiler`/`--compiler-prefix`/
+  `--compiler-option`/`--sysroot`/`--nostdinc`/`--frontend-context` (and the
+  project `.abicheck.yml` `compile:` block) are resolved once for the whole
+  release and applied to every library pair, the same way a single-pair
+  `compare` applies them — instead of being rejected with a `UsageError`. Only
+  a *sided* `--ast-frontend old=/new=` override still has no
+  per-library-pair-within-a-release meaning and stays rejected.
+- **Headerless (`-H`-less) directory/package `compare` now falls back to real
+  ELF symbol visibility for public-surface scoping** instead of treating the
+  surface as unresolvable and keeping every changed symbol as breaking. A
+  default/protected-visibility exported symbol is treated as a public-surface
+  proxy; a hidden/internal-visibility one is treated as private. Recorded as
+  reduced-confidence scoping (`elf-visibility-fallback`) when it fires.
+- **`--bundle-system-providers` now actually suppresses `bundle_intra_dep_removed`
+  findings for a non-`std::`-shaped symbol** (e.g. a vendor C API symbol from
+  MKL/TBB/SYCL) once every one of the consumer's external `DT_NEEDED` sonames
+  is on the allow-list. A prior revision additionally required the *symbol
+  name itself* to look system-shaped, making the flag inert for exactly the
+  case it exists to cover. Soname matching also now falls back to a
+  version-suffix-stripped comparison, so `--bundle-system-providers=libmkl_core`
+  matches the real, versioned `libmkl_core.so.2` `DT_NEEDED` entry.

--- a/changelog.d/20260822_202107_noreply_onedal_bundle_eval_g6onle.md
+++ b/changelog.d/20260822_202107_noreply_onedal_bundle_eval_g6onle.md
@@ -8,12 +8,6 @@
   `compare` applies them — instead of being rejected with a `UsageError`. Only
   a *sided* `--ast-frontend old=/new=` override still has no
   per-library-pair-within-a-release meaning and stays rejected.
-- **Headerless (`-H`-less) directory/package `compare` now falls back to real
-  ELF symbol visibility for public-surface scoping** instead of treating the
-  surface as unresolvable and keeping every changed symbol as breaking. A
-  default/protected-visibility exported symbol is treated as a public-surface
-  proxy; a hidden/internal-visibility one is treated as private. Recorded as
-  reduced-confidence scoping (`elf-visibility-fallback`) when it fires.
 - **`--bundle-system-providers` now actually suppresses `bundle_intra_dep_removed`
   findings for a non-`std::`-shaped symbol** (e.g. a vendor C API symbol from
   MKL/TBB/SYCL) once every one of the consumer's external `DT_NEEDED` sonames

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -487,6 +487,7 @@ Compare two ABI inputs and return the classified diff result.
 | `contract_mode` | `str \| None` | `None` |
 | `pack_policy_overrides` | `dict[Any, Any] \| None` | `None` |
 | `pack_internal_namespaces` | `tuple[str, ...] \| None` | `None` |
+| `compile_context` | `CompileContext \| None` | `None` |
 
 **Returns:** `CompareResult`
 

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -362,6 +362,37 @@ class TestIntraDepRemoved:
             for f in with_extra.bundle_findings
         )
 
+    def test_system_providers_explicit_major_version_does_not_match_a_different_one(
+        self,
+    ) -> None:
+        """Regression (Codex review): an allow-list entry that itself names
+        a specific major version (`libvendor.so.1`) must require an exact
+        match -- it must NOT also match an unrelated major
+        (`libvendor.so.2`) via stem comparison. Stem fallback exists for a
+        version-*generic* entry (`libmkl_core`/`libmkl_core.so`, no numeric
+        major) matching any real runtime version, not for treating two
+        different, explicitly-pinned majors as interchangeable."""
+        new = _snapshot(
+            {
+                "libfoo.so": _meta(
+                    soname="libfoo.so.1",
+                    needed=["libvendor.so.2"],
+                    imports=["vendor_custom_op"],
+                ),
+            }
+        )
+        with_extra = compare_bundle(
+            new,
+            new,
+            per_library_results=[],
+            system_providers=["libvendor.so.1"],
+        )
+        assert any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
+            and f.symbol == "vendor_custom_op"
+            for f in with_extra.bundle_findings
+        )
+
     def test_fires_when_dt_needed_was_stripped(self) -> None:
         # Regression for the CodeRabbit feedback: previously the bundle
         # layer short-circuited when consumer.intra_needed was empty,

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -390,6 +390,57 @@ class TestIntraDepRemoved:
         assert intra_removed[0].symbol == "onedal_internal_op"
         assert intra_removed[0].consumer_library == "libalgo.so"
 
+    def test_stripped_provider_still_fires_when_a_system_dep_remains(self) -> None:
+        """Regression (Codex review): the previous fix for
+        test_fires_when_dt_needed_was_stripped above only exercised a
+        consumer with an EMPTY DT_NEEDED after stripping -- but a real
+        binary almost always still needs libc. If the allow-list check
+        (--bundle-system-providers / DEFAULT_SYSTEM_PROVIDERS) were trusted
+        whenever every *remaining* DT_NEEDED happens to be a system
+        library, the canonical regression (provider AND its DT_NEEDED edge
+        both dropped) would be silently swallowed the moment the consumer
+        also links libc -- which is nearly always. The allow-list evidence
+        must not be trusted here: `onedal_internal_op` was provided by a
+        sibling in `old`, so its disappearance is a real, reportable
+        regression regardless of what other (system) libraries the
+        consumer still needs.
+        """
+        old = _snapshot(
+            {
+                "libcore.so": _meta(
+                    soname="libcore.so.1", exports=["onedal_internal_op"]
+                ),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1", "libc.so.6"],
+                    imports=["onedal_internal_op"],
+                ),
+            }
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1"),  # provider gone
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libc.so.6"],  # intra-bundle edge dropped too,
+                    # but the consumer still needs libc -- a real, near-
+                    # universal system dependency, already covered by
+                    # DEFAULT_SYSTEM_PROVIDERS with no --bundle-system-
+                    # providers involved at all.
+                    imports=["onedal_internal_op"],
+                ),
+            }
+        )
+        result = compare_bundle(old, new, per_library_results=[])
+        intra_removed = [
+            f
+            for f in result.bundle_findings
+            if f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
+        ]
+        assert len(intra_removed) == 1
+        assert intra_removed[0].symbol == "onedal_internal_op"
+        assert intra_removed[0].consumer_library == "libalgo.so"
+
     @pytest.mark.parametrize(
         ("symbol", "version"),
         [

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -297,6 +297,71 @@ class TestIntraDepRemoved:
         )
         assert len(with_extra.bundle_findings) <= len(result_default.bundle_findings)
 
+    def test_system_providers_suppresses_non_system_shaped_symbol(self) -> None:
+        """Regression: --bundle-system-providers must suppress a finding for
+        a non-system-shaped symbol (not std::-mangled, not in
+        DEFAULT_SYSTEM_SYMBOLS) once every one of the consumer's non-intra
+        DT_NEEDED edges is covered by the allow-list -- e.g. a vendor C API
+        symbol like MKL's mkl_custom_op imported from a soname the user
+        explicitly named via --bundle-system-providers. A prior revision
+        gated this allow-list match on the symbol *also* looking
+        system-shaped, which made --bundle-system-providers inert for
+        exactly this case.
+        """
+        new = _snapshot(
+            {
+                "libfoo.so": _meta(
+                    soname="libfoo.so.1",
+                    needed=["libmkl_core.so.2"],
+                    imports=["mkl_custom_op"],
+                ),
+            }
+        )
+        # Without the allow-list entry: real, reportable finding.
+        without_extra = compare_bundle(new, new, per_library_results=[])
+        assert any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
+            and f.symbol == "mkl_custom_op"
+            for f in without_extra.bundle_findings
+        )
+        # With the exact soname allow-listed: finding must be suppressed.
+        with_extra = compare_bundle(
+            new,
+            new,
+            per_library_results=[],
+            system_providers=["libmkl_core.so.2"],
+        )
+        assert not any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
+            for f in with_extra.bundle_findings
+        )
+
+    def test_system_providers_matches_versioned_soname_by_stem(self) -> None:
+        """A user-supplied allow-list entry without the real DT_NEEDED
+        version suffix (e.g. 'libmkl_core', no '.so.2') must still match
+        the real, versioned soname -- hand-typed allow-list entries rarely
+        carry the exact runtime version suffix.
+        """
+        new = _snapshot(
+            {
+                "libfoo.so": _meta(
+                    soname="libfoo.so.1",
+                    needed=["libmkl_core.so.2"],
+                    imports=["mkl_custom_op"],
+                ),
+            }
+        )
+        with_extra = compare_bundle(
+            new,
+            new,
+            per_library_results=[],
+            system_providers=["libmkl_core"],
+        )
+        assert not any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
+            for f in with_extra.bundle_findings
+        )
+
     def test_fires_when_dt_needed_was_stripped(self) -> None:
         # Regression for the CodeRabbit feedback: previously the bundle
         # layer short-circuited when consumer.intra_needed was empty,

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -512,6 +512,49 @@ class TestIntraDepRemoved:
             for f in result.bundle_findings
         )
 
+    def test_old_provider_veto_is_scoped_to_the_reaching_consumer(self) -> None:
+        """Regression (Codex review): "did a sibling ever provide this
+        symbol" must be scoped to *this consumer's* own old reachability,
+        not to whether *any* consumer anywhere in the old bundle reached a
+        provider. `liba.so` used to reach `libcore.so`'s `vendor_op`
+        export; `libb.so` has always imported the same unversioned symbol
+        name from the built-in-allow-listed `libsycl.so.7` and never
+        depended on `libcore.so` at all. Once `liba.so`/`libcore.so`'s
+        export are both removed, `libb.so`'s own always-external import
+        must not be vetoed by an unrelated consumer's old provider."""
+        old = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["vendor_op"]),
+                "liba.so": _meta(
+                    soname="liba.so.1",
+                    needed=["libcore.so.1"],
+                    imports=["vendor_op"],
+                ),
+                "libb.so": _meta(
+                    soname="libb.so.1",
+                    needed=["libsycl.so.7"],
+                    imports=["vendor_op"],
+                ),
+            }
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1"),  # no longer exports it
+                "libb.so": _meta(
+                    soname="libb.so.1",
+                    needed=["libsycl.so.7"],
+                    imports=["vendor_op"],
+                ),
+            }
+        )
+        # No --bundle-system-providers given -- libsycl.so.7 is covered by
+        # the built-in DEFAULT_SYSTEM_PROVIDERS allow-list alone.
+        result = compare_bundle(old, new, per_library_results=[])
+        assert not any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED and f.consumer_library == "libb.so"
+            for f in result.bundle_findings
+        )
+
     @pytest.mark.parametrize(
         ("symbol", "version"),
         [

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -555,6 +555,47 @@ class TestIntraDepRemoved:
             for f in result.bundle_findings
         )
 
+    def test_old_provider_veto_requires_version_compatibility(self) -> None:
+        """Regression (Codex review): an old reachable sibling that could
+        never have satisfied *this* consumer's own reference must not veto
+        the allow-list either. `libcore.so` reachably exported `vendor_op`
+        only as a non-default versioned definition (`vendor_op@V1`, never
+        `vendor_op@@V1`) -- the dynamic linker can only satisfy `libalgo.so`'s
+        genuinely unversioned `vendor_op` reference against a *default*
+        definition, so that sibling could never have resolved it in the
+        first place. Once `libcore.so`/its `DT_NEEDED` edge are both
+        removed, `libalgo.so`'s always-external (built-in-allow-listed)
+        import must not be vetoed by a provider that was never compatible."""
+        old_core = _meta(soname="libcore.so.1")
+        old_core.symbols.append(
+            ElfSymbol(name="vendor_op", visibility="default", version="V1", is_default=False)
+        )
+        old = _snapshot(
+            {
+                "libcore.so": old_core,
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1", "libsycl.so.7"],
+                    imports=["vendor_op"],
+                ),
+            }
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1"),  # no longer exports it
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libsycl.so.7"],
+                    imports=["vendor_op"],
+                ),
+            }
+        )
+        result = compare_bundle(old, new, per_library_results=[])
+        assert not any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
+            for f in result.bundle_findings
+        )
+
     @pytest.mark.parametrize(
         ("symbol", "version"),
         [

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -441,6 +441,77 @@ class TestIntraDepRemoved:
         assert intra_removed[0].symbol == "onedal_internal_op"
         assert intra_removed[0].consumer_library == "libalgo.so"
 
+    def test_explicit_provider_migration_still_suppressed(self) -> None:
+        """Regression (Codex review): a legitimate provider migration --
+        a symbol moved from an in-tree sibling to an explicitly allow-listed
+        external DSO -- must still be suppressed by --bundle-system-providers
+        even though a sibling *used to* provide it (the guard the previous
+        finding above added must not over-correct into vetoing every
+        allow-list match once `old` had any provider at all)."""
+        old = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["vendor_op"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1"],
+                    imports=["vendor_op"],
+                ),
+            }
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1"),  # no longer exports it
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libvendor.so.1"],  # migrated to an external DSO
+                    imports=["vendor_op"],
+                ),
+            }
+        )
+        result = compare_bundle(
+            old, new, per_library_results=[], system_providers=["libvendor.so.1"]
+        )
+        assert not any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
+            for f in result.bundle_findings
+        )
+
+    def test_explicit_provider_migration_needs_the_explicit_soname(self) -> None:
+        """The migration exception above only fires when the user actually
+        named the new provider -- a plain, unexplained soname swap to a
+        library that merely *happens* to be default-system-shaped (but was
+        never asserted by the user for this run) must still be treated as
+        a potential regression, not silently trusted."""
+        old = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1", exports=["vendor_op"]),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libcore.so.1"],
+                    imports=["vendor_op"],
+                ),
+            }
+        )
+        new = _snapshot(
+            {
+                "libcore.so": _meta(soname="libcore.so.1"),
+                "libalgo.so": _meta(
+                    soname="libalgo.so.1",
+                    needed=["libvendor.so.1"],
+                    imports=["vendor_op"],
+                ),
+            }
+        )
+        # No --bundle-system-providers given, and libvendor.so.1 doesn't
+        # match _looks_system -- extra_needed isn't even fully allow-listed,
+        # so this must still be reported regardless of the migration guard.
+        result = compare_bundle(old, new, per_library_results=[])
+        assert any(
+            f.kind == ChangeKind.BUNDLE_INTRA_DEP_REMOVED
+            and f.symbol == "vendor_op"
+            for f in result.bundle_findings
+        )
+
     @pytest.mark.parametrize(
         ("symbol", "version"),
         [

--- a/tests/test_cli_frontend_context.py
+++ b/tests/test_cli_frontend_context.py
@@ -73,43 +73,55 @@ def test_frontend_context_invalid_value_rejected_by_click(tmp_path, runner):
     assert "Invalid value" in result.output or "invalid choice" in result.output.lower()
 
 
-def test_compare_frontend_context_device_rejected_for_directory_inputs(
-    tmp_path, runner
+def test_compare_frontend_context_device_threaded_for_directory_inputs(
+    monkeypatch, tmp_path, runner
 ):
+    """`--frontend-context` is a both-sides L2 compile-context knob (like
+    `--ast-frontend`/`--compiler`), threaded to the release fan-out's
+    resolved `CompileContext` rather than rejected (fix: whole-product-
+    bundle known-gap entry, AGENTS.md)."""
+    import abicheck.cli as cli_mod
+
     old_dir = tmp_path / "old"
     old_dir.mkdir()
     new_dir = tmp_path / "new"
     new_dir.mkdir()
+
+    dispatched: dict[str, object] = {}
+    monkeypatch.setattr(
+        cli_mod, "_dispatch_release_compare", lambda ctx, **kw: dispatched.update(kw)
+    )
     result = runner.invoke(
         main,
         ["compare", str(old_dir), str(new_dir), "--frontend-context", "device"],
     )
-    assert result.exit_code != 0
-    assert "--frontend-context" in result.output
-    assert "not supported for directory/package" in result.output
+    assert result.exit_code == 0, result.output
+    assert dispatched["compile_context"].frontend_context == "device"
 
 
-def test_compare_frontend_context_host_rejected_for_directory_inputs(
-    tmp_path, runner
+def test_compare_frontend_context_host_threaded_for_directory_inputs(
+    monkeypatch, tmp_path, runner
 ):
-    """Same rejection, but with the value ``host`` -- always otherwise
-    accepted (Phase B honors only ``host``) -- so the only thing that can
-    make this fail is cli_resolve.py's set-input guard itself, not Phase
-    B's separate, temporary rejection of every non-``host`` value. Using
-    ``device`` alone (the test above) would let a release-rejection test
-    pass via that unrelated rejection instead, silently resurfacing once
-    Phase D makes ``device`` a normally-accepted value too."""
+    """Same threading, with the (default-looking) value ``host``, so the
+    only thing that could make this fail is cli_resolve.py's set-input
+    guard itself still rejecting an explicit ``--frontend-context``."""
+    import abicheck.cli as cli_mod
+
     old_dir = tmp_path / "old"
     old_dir.mkdir()
     new_dir = tmp_path / "new"
     new_dir.mkdir()
+
+    dispatched: dict[str, object] = {}
+    monkeypatch.setattr(
+        cli_mod, "_dispatch_release_compare", lambda ctx, **kw: dispatched.update(kw)
+    )
     result = runner.invoke(
         main,
         ["compare", str(old_dir), str(new_dir), "--frontend-context", "host"],
     )
-    assert result.exit_code != 0
-    assert "--frontend-context" in result.output
-    assert "not supported for directory/package" in result.output
+    assert result.exit_code == 0, result.output
+    assert dispatched["compile_context"].frontend_context == "host"
 
 
 def test_resolve_compile_context_defaults_to_host():

--- a/tests/test_compare_release.py
+++ b/tests/test_compare_release.py
@@ -1484,6 +1484,7 @@ class TestDebianSymbolsWarning:
             (),
             (),
             (),
+            (),
             _fake_extract,
             lambda *_args, **_kwargs: [],
             lambda _p: False,
@@ -1537,6 +1538,7 @@ class TestCompareReleaseIncludes:
             (),
             (old_inc_only,),
             (new_inc_only,),
+            (),
             lambda p, _dbg, _dev: (p, None, None, None),
             lambda *_args, **_kwargs: [],
             lambda _p: False,
@@ -1547,6 +1549,59 @@ class TestCompareReleaseIncludes:
         new_inc = result[5]
         assert old_inc == [old_inc_only]
         assert new_inc == [new_inc_only]
+
+    def test_prepare_inputs_config_includes_survive_side_specific_override(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression (Codex review): a project .abicheck.yml
+        compile.include_dirs root must reach BOTH sides even when one side
+        also has a --old-include/--new-include override -- a prior revision
+        let the override fully replace `includes` (which is where the
+        config-appended dirs live), silently dropping them for the
+        overridden side.
+        """
+        old = tmp_path / "old"
+        new = tmp_path / "new"
+        old.mkdir()
+        new.mkdir()
+        (old / "libfoo.so").write_text("old")
+        (new / "libfoo.so").write_text("new")
+        old_inc_only = tmp_path / "old-include"
+        old_inc_only.mkdir()
+        config_dir = tmp_path / "vendor_include"
+        config_dir.mkdir()
+
+        result = _prepare_compare_release_inputs(
+            old,
+            new,
+            None,
+            None,
+            None,
+            None,
+            False,
+            False,
+            (),
+            (),
+            (),
+            (config_dir,),  # includes: the caller already folds
+            # config_includes into this merged tuple, matching what
+            # resolve_directory_compile_context's real return looks like.
+            (old_inc_only,),  # old side overridden
+            (),  # new side not overridden -- uses `includes` directly
+            (config_dir,),  # config_includes: same dir, passed separately
+            lambda p, _dbg, _dev: (p, None, None, None),
+            lambda *_args, **_kwargs: [],
+            lambda _p: False,
+            lambda _p: True,
+        )
+
+        old_inc = result[4]
+        new_inc = result[5]
+        # Overridden side: override root + config root, both present.
+        assert old_inc_only in old_inc
+        assert config_dir in old_inc
+        # Non-overridden side: reaches the config root via `includes` itself.
+        assert config_dir in new_inc
 
 
 class TestLockstepSonameCoupling:

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -1392,6 +1392,45 @@ def test_compare_set_inputs_applies_config_compile_block(
     assert compile_context.gcc_option_tokens == ("-std=c++20",)
 
 
+def test_compare_set_inputs_forwards_config_include_dirs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Regression (Codex review): a directory/package compare in a project
+    with a .abicheck.yml compile.include_dirs block must forward the
+    merged include dirs (CLI -I roots + config-appended ones) to the
+    release fan-out's own `includes=` -- a prior revision resolved the
+    merged tuple via resolve_compile_context() but discarded it, dispatching
+    the raw, unmerged CLI `includes` instead, so headers requiring the
+    configured include root could fail or parse incompletely despite the
+    compile: block otherwise being applied.
+    """
+    import abicheck.cli as cli_mod
+
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+    include_dir = tmp_path / "vendor_include"
+    include_dir.mkdir()
+    cfg = tmp_path / ".abicheck.yml"
+    cfg.write_text(
+        f"compile:\n  include_dirs:\n    - {include_dir}\n", encoding="utf-8"
+    )
+
+    dispatched: dict[str, object] = {}
+    monkeypatch.setattr(
+        cli_mod,
+        "_dispatch_release_compare",
+        lambda ctx, **kw: dispatched.update(kw),
+    )
+    result = CliRunner().invoke(
+        main, ["compare", str(old_dir), str(new_dir), "--config", str(cfg)]
+    )
+    assert result.exit_code == 0, result.output
+    assert dispatched
+    assert include_dir in dispatched["includes"]
+
+
 def test_compare_config_include_dirs_survive_per_side_include(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -35,7 +35,7 @@ import pytest
 from click.testing import CliRunner
 
 from abicheck.cli import compare_cmd, dump_cmd, main
-from abicheck.cli_options import compile_context_options
+from abicheck.cli_options import compile_context_options, sided_frontend_explicit
 from abicheck.cli_scan import scan_cmd
 from abicheck.model import AbiSnapshot
 from abicheck.service_scan import CompileContext, ScanRequest
@@ -1334,6 +1334,35 @@ def test_compare_rejects_sided_ast_frontend_for_set_inputs(
     assert result.exit_code != 0
     assert "--ast-frontend old=" in result.output
     assert "directory/package" in result.output
+
+
+class _FakeCtx:
+    """Minimal click.Context stand-in for sided_frontend_explicit's own
+    contract, exercised directly rather than only through a real CLI
+    invocation -- see this file's own module docstring on why this guard
+    exists."""
+
+    def __init__(self, source, header_backend):
+        self._source = source
+        self.params = {"header_backend": header_backend}
+
+    def get_parameter_source(self, name):
+        assert name == "header_backend"
+        return self._source
+
+
+def test_sided_frontend_explicit_direct():
+    cmdline = click.core.ParameterSource.COMMANDLINE
+    default = click.core.ParameterSource.DEFAULT
+    # Not COMMANDLINE at all -> False, regardless of the raw value.
+    assert sided_frontend_explicit(_FakeCtx(default, [("old", "clang")])) is False
+    # A sided pair (old=/new=, not "both") -> True.
+    assert sided_frontend_explicit(_FakeCtx(cmdline, [("old", "clang")])) is True
+    assert sided_frontend_explicit(_FakeCtx(cmdline, [("new", "clang")])) is True
+    # Only a "both" pair -> False (that's _shared_frontend_explicit's case).
+    assert sided_frontend_explicit(_FakeCtx(cmdline, [("both", "clang")])) is False
+    # An unsided command's plain string (no pair list at all) -> False.
+    assert sided_frontend_explicit(_FakeCtx(cmdline, "clang")) is False
 
 
 def test_compare_set_inputs_without_compile_flags_not_rejected(

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -1246,49 +1246,93 @@ def test_dump_reads_compile_block_from_config(
     assert captured["gcc_option_tokens"] == ("-std=c++17",)
 
 
-def test_compare_rejects_compile_context_for_set_inputs(tmp_path: Path) -> None:
-    """Directory/package operands + a compile-context flag must fail loudly, not
-    silently drop it: the per-library fan-out doesn't thread the L2 context
-    (Codex review)."""
+def test_compare_threads_compile_context_for_set_inputs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Directory/package operands + a compile-context flag must thread the
+    resolved CompileContext to the release fan-out, not reject it -- the
+    per-library fan-out now threads the L2 context to each pair's header
+    dump (fix: whole-product-bundle known-gap entry, AGENTS.md)."""
+    import abicheck.cli as cli_mod
+
     old_dir = tmp_path / "old"
     new_dir = tmp_path / "new"
     old_dir.mkdir()
     new_dir.mkdir()
+
+    dispatched: dict[str, object] = {}
+    monkeypatch.setattr(
+        cli_mod, "_dispatch_release_compare", lambda ctx, **kw: dispatched.update(kw)
+    )
     result = CliRunner().invoke(
         main,
         ["compare", str(old_dir), str(new_dir), "--compiler-option", "-DX=1"],
     )
-    assert result.exit_code != 0
-    assert "--compiler-option" in result.output
-    assert "directory/package" in result.output
+    assert result.exit_code == 0, result.output
+    assert dispatched
+    compile_context = dispatched["compile_context"]
+    assert compile_context.gcc_option_tokens == ("-DX=1",)
 
 
 @pytest.mark.parametrize(
-    "flag,value",
+    ("flag", "value", "attr", "expected"),
     [
-        ("--compiler", "/custom/clang"),
-        ("--compiler-prefix", "aarch64-linux-gnu-"),
-        ("--compiler-option", "-DX=1"),
+        ("--compiler", "/custom/clang", "gcc_path", "/custom/clang"),
+        ("--compiler-prefix", "aarch64-linux-gnu-", "gcc_prefix", "aarch64-linux-gnu-"),
+        ("--compiler-option", "-DX=1", "gcc_option_tokens", ("-DX=1",)),
     ],
 )
-def test_compare_rejects_compiler_aliases_for_set_inputs(
-    tmp_path: Path, flag: str, value: str
+def test_compare_threads_compiler_aliases_for_set_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    flag: str,
+    value: str,
+    attr: str,
+    expected: object,
 ) -> None:
-    """The --compiler*/--gcc-* aliases (CLI audit PR 2/5) must be rejected for
-    directory/package operands exactly like their legacy gcc_* counterparts
-    (test_compare_rejects_compile_context_for_set_inputs above) -- without
-    this, --compiler would silently no-op instead of raising, unlike
-    --compiler (Codex review, PR #757)."""
+    """The --compiler*/--gcc-* aliases (CLI audit PR 2/5) must reach the
+    release fan-out's resolved CompileContext exactly like they reach a
+    single-pair compare's (test_compare_threads_compile_context_for_set_inputs
+    above)."""
+    import abicheck.cli as cli_mod
+
+    old_dir = tmp_path / "old"
+    new_dir = tmp_path / "new"
+    old_dir.mkdir()
+    new_dir.mkdir()
+
+    dispatched: dict[str, object] = {}
+    monkeypatch.setattr(
+        cli_mod, "_dispatch_release_compare", lambda ctx, **kw: dispatched.update(kw)
+    )
+    result = CliRunner().invoke(
+        main,
+        ["compare", str(old_dir), str(new_dir), flag, value],
+    )
+    assert result.exit_code == 0, result.output
+    compile_context = dispatched["compile_context"]
+    assert getattr(compile_context, attr) == expected
+
+
+@pytest.mark.parametrize(
+    "flag",
+    ["--ast-frontend"],
+)
+def test_compare_rejects_sided_ast_frontend_for_set_inputs(
+    tmp_path: Path, flag: str
+) -> None:
+    """A *sided* --ast-frontend old=/new= override still has no
+    per-library-pair-within-a-release meaning, so it stays rejected."""
     old_dir = tmp_path / "old"
     new_dir = tmp_path / "new"
     old_dir.mkdir()
     new_dir.mkdir()
     result = CliRunner().invoke(
         main,
-        ["compare", str(old_dir), str(new_dir), flag, value],
+        ["compare", str(old_dir), str(new_dir), flag, "old=clang"],
     )
     assert result.exit_code != 0
-    assert flag in result.output
+    assert "--ast-frontend old=" in result.output
     assert "directory/package" in result.output
 
 
@@ -1316,12 +1360,13 @@ def test_compare_set_inputs_without_compile_flags_not_rejected(
     assert dispatched  # the fan-out was reached, not rejected
 
 
-def test_compare_set_inputs_warns_on_config_compile_block(
+def test_compare_set_inputs_applies_config_compile_block(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     """A directory/package compare in a project with a .abicheck.yml compile:
-    block must WARN (not silently drop, not hard-fail) — the fan-out doesn't
-    thread the L2 context (Codex review)."""
+    block must apply it (not silently drop it, and no longer just warn) --
+    the fan-out now threads the L2 context (fix: whole-product-bundle
+    known-gap entry, AGENTS.md)."""
     import abicheck.cli as cli_mod
 
     old_dir = tmp_path / "old"
@@ -1341,8 +1386,10 @@ def test_compare_set_inputs_warns_on_config_compile_block(
         main, ["compare", str(old_dir), str(new_dir), "--config", str(cfg)]
     )
     assert result.exit_code == 0, result.output
-    assert dispatched  # warned, still dispatched (not rejected)
-    assert "compile: block is not applied" in result.output
+    assert dispatched
+    assert "compile: block is not applied" not in result.output
+    compile_context = dispatched["compile_context"]
+    assert compile_context.gcc_option_tokens == ("-std=c++20",)
 
 
 def test_compare_config_include_dirs_survive_per_side_include(

--- a/tests/test_compile_context_parity.py
+++ b/tests/test_compile_context_parity.py
@@ -1342,16 +1342,20 @@ class _FakeCtx:
     invocation -- see this file's own module docstring on why this guard
     exists."""
 
-    def __init__(self, source, header_backend):
+    def __init__(
+        self,
+        source: click.core.ParameterSource,
+        header_backend: list[tuple[str, str]],
+    ) -> None:
         self._source = source
         self.params = {"header_backend": header_backend}
 
-    def get_parameter_source(self, name):
+    def get_parameter_source(self, name: str) -> click.core.ParameterSource:
         assert name == "header_backend"
         return self._source
 
 
-def test_sided_frontend_explicit_direct():
+def test_sided_frontend_explicit_direct() -> None:
     cmdline = click.core.ParameterSource.COMMANDLINE
     default = click.core.ParameterSource.DEFAULT
     # Not COMMANDLINE at all -> False, regardless of the raw value.

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -3108,13 +3108,16 @@ class TestContractEvaluationThreading:
         params = list(inspect.signature(run_compare).parameters)
         # pack_policy_overrides/pack_internal_namespaces (CLI cleanup phase
         # two, "PR B" slice 1) were appended after contract_mode in turn,
-        # following the same rule.
-        assert params[-1] == "pack_internal_namespaces"
-        assert params[-2] == "pack_policy_overrides"
-        assert params[-3] == "contract_mode"
-        assert params[-4] == "include_dependencies"
-        assert params[-5] == "contract_evaluation"
-        assert params[-6] == "diagnostic_comparison"
+        # following the same rule; compile_context (both-sides L2 compile
+        # context for the directory/package release fan-out) was appended
+        # after those in turn.
+        assert params[-1] == "compile_context"
+        assert params[-2] == "pack_internal_namespaces"
+        assert params[-3] == "pack_policy_overrides"
+        assert params[-4] == "contract_mode"
+        assert params[-5] == "include_dependencies"
+        assert params[-6] == "contract_evaluation"
+        assert params[-7] == "diagnostic_comparison"
 
     def test_get_type_hints_resolves_without_nameerror(self):
         """Codex review: `run_compare` moved from `service.py` into

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -15,6 +15,7 @@ from abicheck.checker_types import Change
 from abicheck.dwarf_advanced import AdvancedDwarfMetadata
 from abicheck.model import (
     AbiSnapshot,
+    ElfVisibility,
     EnumMember,
     EnumType,
     Function,
@@ -22,6 +23,7 @@ from abicheck.model import (
     RecordType,
     ScopeOrigin,
     TypeField,
+    Variable,
     Visibility,
 )
 from abicheck.surface import (
@@ -29,11 +31,13 @@ from abicheck.surface import (
     REASON_NOT_EXPORTED,
     REASON_PRIVATE_HEADER,
     REASON_SYSTEM_HEADER,
+    SCOPE_NOTE_ELF_VISIBILITY_FALLBACK,
     PublicSurface,
     _type_identifiers,
     change_in_public_surface,
     classify_change_surface,
     compute_public_surface,
+    surface_scope_confidence,
 )
 
 
@@ -114,6 +118,137 @@ class TestComputePublicSurface:
         )
         surf = compute_public_surface(snap)
         assert surf.resolvable is False
+
+    def test_elf_visibility_fallback_when_headerless_but_dynsym_visibility_known(self):
+        """Headerless bundle compare (no -H at all): every symbol is
+        ELF_ONLY, but real ELF st_other visibility is still known from
+        .dynsym. Rather than declaring the surface unresolvable (and
+        therefore keeping every changed symbol, public or internal, as
+        breaking -- the reported issue), a default/protected-visibility
+        export is treated as a public-surface proxy and a hidden/internal
+        one is not.
+        """
+        snap = AbiSnapshot(
+            library="l",
+            version="1",
+            elf_only_mode=True,
+            functions=[
+                _fn(
+                    "public_api_call",
+                    vis=Visibility.ELF_ONLY,
+                    mangled="public_api_call",
+                ),
+                _fn(
+                    "internal_helper",
+                    vis=Visibility.ELF_ONLY,
+                    mangled="internal_helper",
+                ),
+            ],
+        )
+        snap.functions[0].elf_visibility = ElfVisibility.DEFAULT
+        snap.functions[1].elf_visibility = ElfVisibility.HIDDEN
+        surf = compute_public_surface(snap)
+        assert surf.resolvable is True
+        assert surf.elf_visibility_fallback is True
+        assert "public_api_call" in surf.public_symbols
+        assert "internal_helper" not in surf.public_symbols
+        assert "internal_helper" in surf.all_symbols
+        # No type-reachability closure is run for this fallback tier.
+        assert surf.public_types == set()
+
+    def test_elf_visibility_fallback_variable(self):
+        snap = AbiSnapshot(
+            library="l",
+            version="1",
+            elf_only_mode=True,
+            variables=[
+                Variable(
+                    name="g_public",
+                    mangled="g_public",
+                    type="int",
+                    visibility=Visibility.ELF_ONLY,
+                    elf_visibility=ElfVisibility.DEFAULT,
+                ),
+                Variable(
+                    name="g_internal",
+                    mangled="g_internal",
+                    type="int",
+                    visibility=Visibility.ELF_ONLY,
+                    elf_visibility=ElfVisibility.INTERNAL,
+                ),
+            ],
+        )
+        surf = compute_public_surface(snap)
+        assert surf.resolvable is True
+        assert "g_public" in surf.public_symbols
+        assert "g_internal" not in surf.public_symbols
+
+    def test_no_elf_visibility_fallback_when_no_elf_visibility_evidence(self):
+        """When no elf_visibility is populated at all (e.g. a snapshot
+        predating that field, or a non-ELF headerless dump), the fallback
+        must not fabricate a surface from nothing -- stays unresolvable,
+        matching the pre-existing "keep everything" behaviour.
+        """
+        snap = AbiSnapshot(
+            library="l",
+            version="1",
+            elf_only_mode=True,
+            functions=[_fn("internal", vis=Visibility.ELF_ONLY)],
+        )
+        surf = compute_public_surface(snap)
+        assert surf.resolvable is False
+        assert surf.elf_visibility_fallback is False
+
+    def test_elf_visibility_fallback_scoping_end_to_end(self):
+        """End-to-end: a headerless compare with a changed hidden-visibility
+        symbol must not be reported breaking once both sides resolve via
+        the ELF-visibility fallback; a changed default-visibility (public)
+        symbol still is.
+        """
+        from abicheck.post_processing import FilterNonPublicSurface, PipelineContext
+
+        def _snap(internal_ret: str) -> AbiSnapshot:
+            snap = AbiSnapshot(
+                library="l",
+                version="1",
+                elf_only_mode=True,
+                functions=[
+                    _fn(
+                        "public_api_call",
+                        ret="int",
+                        vis=Visibility.ELF_ONLY,
+                        mangled="public_api_call",
+                    ),
+                    _fn(
+                        "internal_helper",
+                        ret=internal_ret,
+                        vis=Visibility.ELF_ONLY,
+                        mangled="internal_helper",
+                    ),
+                ],
+            )
+            snap.functions[0].elf_visibility = ElfVisibility.DEFAULT
+            snap.functions[1].elf_visibility = ElfVisibility.HIDDEN
+            return snap
+
+        old = _snap("void")
+        new = _snap("int")  # internal_helper's return type "changed"
+        change = Change(
+            kind=ChangeKind.FUNC_RETURN_CHANGED,
+            symbol="internal_helper",
+            description="return type changed",
+            old_value="void",
+            new_value="int",
+        )
+        ctx = PipelineContext(old=old, new=new, scope_to_public_surface=True)
+        kept = FilterNonPublicSurface().run([change], ctx)
+        assert kept == []
+        assert ctx.out_of_surface == [change]
+        confidence, notes = surface_scope_confidence(
+            old, new, scope_enabled=True, surf_old=ctx.surf_old, surf_new=ctx.surf_new
+        )
+        assert confidence == "reduced"
+        assert SCOPE_NOTE_ELF_VISIBILITY_FALLBACK in notes
 
     def test_public_symbol_and_reachable_type(self):
         snap = AbiSnapshot(

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -15,7 +15,6 @@ from abicheck.checker_types import Change
 from abicheck.dwarf_advanced import AdvancedDwarfMetadata
 from abicheck.model import (
     AbiSnapshot,
-    ElfVisibility,
     EnumMember,
     EnumType,
     Function,
@@ -23,7 +22,6 @@ from abicheck.model import (
     RecordType,
     ScopeOrigin,
     TypeField,
-    Variable,
     Visibility,
 )
 from abicheck.surface import (
@@ -31,13 +29,11 @@ from abicheck.surface import (
     REASON_NOT_EXPORTED,
     REASON_PRIVATE_HEADER,
     REASON_SYSTEM_HEADER,
-    SCOPE_NOTE_ELF_VISIBILITY_FALLBACK,
     PublicSurface,
     _type_identifiers,
     change_in_public_surface,
     classify_change_surface,
     compute_public_surface,
-    surface_scope_confidence,
 )
 
 
@@ -118,171 +114,6 @@ class TestComputePublicSurface:
         )
         surf = compute_public_surface(snap)
         assert surf.resolvable is False
-
-    def test_elf_visibility_fallback_when_headerless_but_dynsym_visibility_known(self):
-        """Headerless bundle compare (no -H at all): every symbol is
-        ELF_ONLY, but real ELF st_other visibility is still known from
-        .dynsym. Rather than declaring the surface unresolvable (and
-        therefore keeping every changed symbol, public or internal, as
-        breaking -- the reported issue), a default/protected-visibility
-        export is treated as a public-surface proxy and a hidden/internal
-        one is not.
-        """
-        snap = AbiSnapshot(
-            library="l",
-            version="1",
-            elf_only_mode=True,
-            functions=[
-                _fn(
-                    "public_api_call",
-                    vis=Visibility.ELF_ONLY,
-                    mangled="public_api_call",
-                ),
-                _fn(
-                    "internal_helper",
-                    vis=Visibility.ELF_ONLY,
-                    mangled="internal_helper",
-                ),
-            ],
-        )
-        snap.functions[0].elf_visibility = ElfVisibility.DEFAULT
-        snap.functions[1].elf_visibility = ElfVisibility.HIDDEN
-        surf = compute_public_surface(snap)
-        assert surf.resolvable is True
-        assert surf.elf_visibility_fallback is True
-        assert "public_api_call" in surf.public_symbols
-        assert "internal_helper" not in surf.public_symbols
-        assert "internal_helper" in surf.all_symbols
-        # No type-reachability closure is run for this fallback tier.
-        assert surf.public_types == set()
-
-    def test_elf_visibility_fallback_variable(self):
-        snap = AbiSnapshot(
-            library="l",
-            version="1",
-            elf_only_mode=True,
-            variables=[
-                Variable(
-                    name="g_public",
-                    mangled="g_public",
-                    type="int",
-                    visibility=Visibility.ELF_ONLY,
-                    elf_visibility=ElfVisibility.DEFAULT,
-                ),
-                Variable(
-                    name="g_internal",
-                    mangled="g_internal",
-                    type="int",
-                    visibility=Visibility.ELF_ONLY,
-                    elf_visibility=ElfVisibility.INTERNAL,
-                ),
-            ],
-        )
-        surf = compute_public_surface(snap)
-        assert surf.resolvable is True
-        assert "g_public" in surf.public_symbols
-        assert "g_internal" not in surf.public_symbols
-
-    def test_no_elf_visibility_fallback_when_no_elf_visibility_evidence(self):
-        """When no elf_visibility is populated at all (e.g. a snapshot
-        predating that field, or a non-ELF headerless dump), the fallback
-        must not fabricate a surface from nothing -- stays unresolvable,
-        matching the pre-existing "keep everything" behaviour.
-        """
-        snap = AbiSnapshot(
-            library="l",
-            version="1",
-            elf_only_mode=True,
-            functions=[_fn("internal", vis=Visibility.ELF_ONLY)],
-        )
-        surf = compute_public_surface(snap)
-        assert surf.resolvable is False
-        assert surf.elf_visibility_fallback is False
-
-    def test_no_elf_visibility_fallback_attempted_when_header_derived_public_exists(
-        self,
-    ):
-        """The fallback is only ever attempted when the header-derived seed
-        found nothing at all (``not has_public``) -- an inconsistent
-        snapshot carrying both a real Visibility.PUBLIC declaration *and*
-        ``elf_only_mode=True`` must not additionally attempt the ELF-
-        visibility fallback (there is nothing to gain: the surface is
-        already correctly unresolvable per the pre-existing ADR-016 rule).
-        """
-        snap = AbiSnapshot(
-            library="l",
-            version="1",
-            elf_only_mode=True,
-            functions=[_fn("api_call", vis=Visibility.PUBLIC)],
-        )
-        surf = compute_public_surface(snap)
-        assert surf.resolvable is False
-        assert surf.elf_visibility_fallback is False
-
-    def test_elf_visibility_fallback_scoping_end_to_end(self):
-        """End-to-end: a headerless compare with a changed hidden-visibility
-        symbol must not be reported breaking once both sides resolve via
-        the ELF-visibility fallback; a changed default-visibility (public)
-        symbol still is.
-        """
-        from abicheck.post_processing import FilterNonPublicSurface, PipelineContext
-
-        def _snap(internal_ret: str) -> AbiSnapshot:
-            snap = AbiSnapshot(
-                library="l",
-                version="1",
-                elf_only_mode=True,
-                functions=[
-                    _fn(
-                        "public_api_call",
-                        ret="int",
-                        vis=Visibility.ELF_ONLY,
-                        mangled="public_api_call",
-                    ),
-                    _fn(
-                        "internal_helper",
-                        ret=internal_ret,
-                        vis=Visibility.ELF_ONLY,
-                        mangled="internal_helper",
-                    ),
-                ],
-            )
-            snap.functions[0].elf_visibility = ElfVisibility.DEFAULT
-            snap.functions[1].elf_visibility = ElfVisibility.HIDDEN
-            return snap
-
-        old = _snap("void")
-        new = _snap("int")  # both public_api_call's and internal_helper's
-        # return types "changed" (both snapshots use the same internal_ret
-        # for both functions via _snap's single argument -- see below).
-        internal_change = Change(
-            kind=ChangeKind.FUNC_RETURN_CHANGED,
-            symbol="internal_helper",
-            description="return type changed",
-            old_value="void",
-            new_value="int",
-        )
-        # A real, publicly-observable break: the exported, default-visibility
-        # public_api_call also had its return type change. This must survive
-        # scoping -- the ELF-visibility fallback must never suppress a real
-        # break on the proxy-public side, only genuine internal-only churn
-        # (false-positive removed / real break preserved).
-        public_change = Change(
-            kind=ChangeKind.FUNC_RETURN_CHANGED,
-            symbol="public_api_call",
-            description="return type changed",
-            old_value="int",
-            new_value="long",
-        )
-        ctx = PipelineContext(old=old, new=new, scope_to_public_surface=True)
-        kept = FilterNonPublicSurface().run([internal_change, public_change], ctx)
-        assert kept == [public_change]
-        assert ctx.out_of_surface == [internal_change]
-        confidence, notes = surface_scope_confidence(
-            old, new, scope_enabled=True, surf_old=ctx.surf_old, surf_new=ctx.surf_new
-        )
-        assert confidence == "reduced"
-        assert SCOPE_NOTE_ELF_VISIBILITY_FALLBACK in notes
 
     def test_public_symbol_and_reachable_type(self):
         snap = AbiSnapshot(

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -199,6 +199,26 @@ class TestComputePublicSurface:
         assert surf.resolvable is False
         assert surf.elf_visibility_fallback is False
 
+    def test_no_elf_visibility_fallback_attempted_when_header_derived_public_exists(
+        self,
+    ):
+        """The fallback is only ever attempted when the header-derived seed
+        found nothing at all (``not has_public``) -- an inconsistent
+        snapshot carrying both a real Visibility.PUBLIC declaration *and*
+        ``elf_only_mode=True`` must not additionally attempt the ELF-
+        visibility fallback (there is nothing to gain: the surface is
+        already correctly unresolvable per the pre-existing ADR-016 rule).
+        """
+        snap = AbiSnapshot(
+            library="l",
+            version="1",
+            elf_only_mode=True,
+            functions=[_fn("api_call", vis=Visibility.PUBLIC)],
+        )
+        surf = compute_public_surface(snap)
+        assert surf.resolvable is False
+        assert surf.elf_visibility_fallback is False
+
     def test_elf_visibility_fallback_scoping_end_to_end(self):
         """End-to-end: a headerless compare with a changed hidden-visibility
         symbol must not be reported breaking once both sides resolve via

--- a/tests/test_surface.py
+++ b/tests/test_surface.py
@@ -232,18 +232,32 @@ class TestComputePublicSurface:
             return snap
 
         old = _snap("void")
-        new = _snap("int")  # internal_helper's return type "changed"
-        change = Change(
+        new = _snap("int")  # both public_api_call's and internal_helper's
+        # return types "changed" (both snapshots use the same internal_ret
+        # for both functions via _snap's single argument -- see below).
+        internal_change = Change(
             kind=ChangeKind.FUNC_RETURN_CHANGED,
             symbol="internal_helper",
             description="return type changed",
             old_value="void",
             new_value="int",
         )
+        # A real, publicly-observable break: the exported, default-visibility
+        # public_api_call also had its return type change. This must survive
+        # scoping -- the ELF-visibility fallback must never suppress a real
+        # break on the proxy-public side, only genuine internal-only churn
+        # (false-positive removed / real break preserved).
+        public_change = Change(
+            kind=ChangeKind.FUNC_RETURN_CHANGED,
+            symbol="public_api_call",
+            description="return type changed",
+            old_value="int",
+            new_value="long",
+        )
         ctx = PipelineContext(old=old, new=new, scope_to_public_surface=True)
-        kept = FilterNonPublicSurface().run([change], ctx)
-        assert kept == []
-        assert ctx.out_of_surface == [change]
+        kept = FilterNonPublicSurface().run([internal_change, public_change], ctx)
+        assert kept == [public_change]
+        assert ctx.out_of_surface == [internal_change]
         confidence, notes = surface_scope_confidence(
             old, new, scope_enabled=True, surf_old=ctx.surf_old, surf_new=ctx.surf_new
         )


### PR DESCRIPTION
## Summary

Fixes two of three blockers hit while running directory-mode `compare` against a
real six-library release (oneDAL), documented in the "Whole-product bundle:
tried, rejected, documented" investigation. The third (headerless public-surface
scoping) was investigated, an attempted fix was found non-functional on real
production data during review, and it was reverted — see "Known gap" below.

## Motivation

A whole-product/bundle comparison across a real multi-library release
(`abicheck compare 2026.0.0 main`, all 6 oneDAL libraries) hit three
independent blockers:

1. Directory-mode `compare` refused `--ast-frontend`/`--compiler`/
   `--compiler-option` outright, even though oneDAL's headers require
   `-fsycl`/a non-default compiler.
2. A headerless comparison (no `-H`) produced no public-surface scoping at
   all — 1414 findings on `libonedal_core.so` reported as "breaking",
   including purely internal symbol churn.
3. `--bundle-system-providers` (and 24 supplied sonames) did not change the
   reported `bundle_intra_dep_removed` count (379 both with and without it)
   for real external dependencies (libstdc++, TBB, MKL, SYCL).

## Changes

- **L2 compile context threaded through the release fan-out.** Directory/
  package `compare` now resolves one `CompileContext` for the whole release
  (`--ast-frontend`/`--compiler`/`--compiler-prefix`/`--compiler-option`/
  `--sysroot`/`--nostdinc`/`--frontend-context`, plus the project
  `.abicheck.yml` `compile:` block) and forwards it to every library pair,
  the same way a single-pair `compare` applies it — instead of rejecting the
  flags with a `UsageError`. Only a *sided* `--ast-frontend old=/new=`
  override still has no per-library-pair-within-a-release meaning and stays
  rejected. Configured `compile.include_dirs` now also survives a
  per-library-pair `--old-include`/`--new-include` override.
- **Fixed `--bundle-system-providers` for `bundle_intra_dep_removed`.**
  `_detect_intra_dep_removed` in `bundle.py` had a dead-code bug: the
  allow-list match (`extra_needed`/`system_providers`) was only ever
  consulted through a secondary symbol-name-shape re-check, so it could
  never suppress a finding the symbol-name heuristic alone wouldn't already
  suppress — making `--bundle-system-providers` inert for any non-`std::`-
  shaped symbol (exactly MKL/TBB/SYCL's C APIs). Fixed to match the correct
  pattern already used by the sibling `_detect_unresolved_intra_dependency`,
  plus an added exception so an explicitly-asserted provider migration (a
  symbol legitimately moved from an in-tree sibling to an allow-listed
  external DSO) is still suppressed correctly. Also added soname
  stem-matching (`soname_matches_providers`, split into a new leaf module
  `bundle_soname.py` to keep `bundle.py` under the AI-readiness file-size
  cap) so a bare `--bundle-system-providers=libmkl_core` still matches the
  real, versioned `libmkl_core.so.2` `DT_NEEDED` entry.

## Known gap (not fixed here)

An ELF `st_other` symbol-visibility-based public-surface fallback for
headerless comparisons was implemented, tested, and then reverted after
review (Codex) traced it to a real dead end: `elf_metadata._parse_dynsym`
already discards every `STV_HIDDEN`/`STV_INTERNAL` symbol before
`meta.symbols` is populated (a real shared library's exported-symbol surface
always comes from `.dynsym` via that function), and ELF-only-mode
`snap.functions`/`snap.variables` are themselves built exclusively from that
same, already-filtered set. So every symbol reachable by such a fallback is,
by construction, always `DEFAULT`/`PROTECTED` visibility — never
`HIDDEN`/`INTERNAL` — giving the fallback zero discriminating power on real
production ELF dumps, even though its hand-built unit tests (which
constructed a production-unreachable `HIDDEN`-visibility `Function` by hand)
passed. Reverted rather than shipped non-functional; the root cause and the
reasoning for not attempting a narrower patch are recorded in
`abicheck/surface.py`'s `compute_public_surface` docstring/comment. Closing
this for real needs a genuinely different, non-ELF-visibility signal
(symbol-name-shape heuristics, an opt-in allow/deny list, or requiring at
least a public-header list for scoped comparisons) — its own scoped design,
not attempted in this PR.

## Bug-fix test contract

- Bug class: (1) a front-end guard silently/loudly dropping a feature that should have been threaded through instead; (2) a dead conditional branch that only ever re-derived a result its own guard already computed, making a user-facing flag a no-op for a whole class of input.
- Publicly observable failure: (1) `abicheck compare --compiler-option ...` exits non-zero with "not supported for directory/package"; (2) `--bundle-system-providers` never reduces the `bundle_intra_dep_removed` count for a non-`std::`-shaped symbol, no matter what sonames are listed.
- Regression test fails on base: yes for both — `test_compare_threads_compile_context_for_set_inputs`/`test_compare_threads_compiler_aliases_for_set_inputs`/`test_compare_frontend_context_*_threaded_for_directory_inputs` (`tests/test_compile_context_parity.py`, `tests/test_cli_frontend_context.py`); `test_system_providers_suppresses_non_system_shaped_symbol` (`tests/test_bundle.py`) all fail against the pre-fix code (confirmed by running them before the corresponding fix).
- Negative control: yes — a sided `--ast-frontend old=/new=` still rejected for set inputs; a symbol not covered by the allow-list still produces a `bundle_intra_dep_removed` finding; a provider-migration exception requires an explicit soname assertion, not merely a matching allow-list entry.
- Public-surface test: n/a for this revision (the public-surface-scoping fix was reverted; see "Known gap" above) — the compile-context tests run through the real `compare` CLI dispatch.
- False-positive removed / real break preserved: `test_stripped_provider_still_fires_when_a_system_dep_remains` and `test_explicit_provider_migration_still_suppressed`/`test_explicit_provider_migration_needs_the_explicit_soname` (`tests/test_bundle.py`) together pin both directions — a real regression (a sibling provider dropped, no migration asserted) still fires, while a genuine, explicitly-asserted provider migration is suppressed only when the explicit soname is actually present.
- Axes covered: exact soname match and version-suffix-stripped stem match (soname matching); bare/both `--ast-frontend`, sided `old=`/`new=`, and the config `compile:` block including per-side include-dir override survival (compile-context threading).
- General invariant: (1) every L2 compile-context flag a single-pair `compare` honors is honored identically by the release fan-out, with the one documented exception (a sided per-side override) explicitly and loudly rejected rather than silently dropped; (2) an allow-list match must always be sufficient on its own to suppress a finding — no downstream re-check may silently narrow an allow-list's own guarantee, and a genuine provider migration is honored via an explicit assertion rather than an implicit unconditional trust.
- Known unsupported cases: a sided `--ast-frontend old=/new=` override for directory/package compare (documented, rejected with a clear message); headerless public-surface scoping (documented known gap above); `--search-path`/real dependency resolution for bundle analysis (unrelated, larger feature, not attempted here).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated (`docs/reference/python-api-reference.md` regenerated)
- [x] Full fast test suite green plus targeted modules re-verified after each follow-up fix
- [x] No new `mypy` or `ruff` errors introduced (verified; remaining `mypy` `yaml` stub errors and `ai-readiness` ADR-receipt errors are pre-existing on the base branch, confirmed via `git stash`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directory and package comparisons now support shared compiler context, aliases, configuration-derived compiler options, and include directories.
  * System-provider matching supports exact and version-suffix-tolerant SONAMEs.
* **Bug Fixes**
  * Improved detection of removed dependencies while preserving valid external-provider suppressions.
  * Headerless ELF-only snapshots are no longer treated as resolved through visibility fallback.
* **Documentation**
  * Updated CLI help, API reference, and changelog with compiler-context and provider-matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->