### PR TITLE
fix: six verified defects found auditing abicheck against real oneAPI libraries

### DIFF
--- a/abicheck/appcompat.py
+++ b/abicheck/appcompat.py
@@ -1604,6 +1604,12 @@ def check_appcompat(
         compiler="c++" if lang == "c++" else "cc",
         lang="c" if lang == "c" else None,
         public_headers=list(_old_h),
+        # _old_inc/_new_inc are this caller's own genuine, explicit -I list
+        # (never auto-derived) -- mirror perform_elf_dump's/_dump_elf's own
+        # public_include_search_dirs wiring so a declaration reached through
+        # an explicit include root is promoted to PUBLIC_HEADER here too,
+        # not just on the CLI's compare/dump/scan frontends.
+        public_include_search_dirs=list(_old_inc),
     )
     new_snap = dump(
         so_path=new_lib_path,
@@ -1613,6 +1619,7 @@ def check_appcompat(
         compiler="c++" if lang == "c++" else "cc",
         lang="c" if lang == "c" else None,
         public_headers=list(_new_h),
+        public_include_search_dirs=list(_new_inc),
     )
 
     # Route through the Tier-2 service (lazy import avoids a

--- a/abicheck/buildsource/header_graph.py
+++ b/abicheck/buildsource/header_graph.py
@@ -93,7 +93,11 @@ from typing import TYPE_CHECKING, Any
 
 from ..fact_provenance import func_fact_key, var_fact_key
 from ..model import AbiSnapshot, ScopeOrigin
-from ..provenance import build_public_set, classify_origin
+from ..provenance import (
+    _public_dirs_from_include_roots,
+    build_public_set,
+    classify_origin,
+)
 from .call_graph import augment_graph_with_calls, parse_clang_ast_calls
 from .inline_graph_fold import _mark_role_coverage
 from .source_graph import (
@@ -524,6 +528,7 @@ def build_header_only_graph(
     public_dir_paths: list[str] | None = None,
     header_paths: list[str] | None = None,
     fact_provenance: dict[str, str] | None = None,
+    include_search_dirs: list[str] | None = None,
 ) -> SourceGraphSummary:
     """Build a header-only semantic graph from an L2 :class:`AbiSnapshot`.
 
@@ -570,11 +575,25 @@ def build_header_only_graph(
     class of "this finding's evidence, verify it if that matters"
     annotation ``LAYOUT_UNVERIFIABLE`` already provides for layout facts
     (see AGENTS.md's "Findings emitted from absent evidence" entry).
+
+    *include_search_dirs* mirrors ``apply_provenance``'s own parameter of
+    the same name -- a caller's explicit ``-I``/``--include`` roots, folded
+    into the public-directory set the same way, once a real public-header
+    set already opted classification in. Without it, ``header_node()``
+    below (which classifies a header-level graph node fresh from
+    ``public_header_paths``/``public_dir_paths`` alone) could disagree with
+    the per-declaration ``entity.origin`` this snapshot's ``apply_provenance``
+    call already widened -- a transitively-included header reached only
+    under an explicit ``-I`` root would classify ``public_header`` for its
+    own declarations but still ``private_header`` for its own header node
+    (Codex review, fresh evidence).
     """
     graph = SourceGraphSummary()
     header_segs, dir_segs, have_public_set = build_public_set(
         public_header_paths, public_dir_paths
     )
+    if have_public_set and include_search_dirs:
+        dir_segs = [*dir_segs, *_public_dirs_from_include_roots(include_search_dirs)]
 
     def header_node(path: str) -> str:
         node_id = _header_node_id(path)

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -780,6 +780,25 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
 
     # Source-only dump (no binary) for the parallel-baseline flow.
     if so_path is None:
+        # dump_source_only() embeds only L3/L4/L5 build/source facts into an
+        # otherwise-empty snapshot -- it has no L2 header-AST pass and never
+        # even receives `headers` (confirmed: it isn't in the call below).
+        # `-H`/`--header` was therefore silently dropped with no error,
+        # warning, or trace of the ignored flag: `dump --sources tree -H
+        # api.h` exited 0 with an empty (0 functions/enums), depth="binary"
+        # snapshot -- a usability trap, not a documented narrowing. Reject
+        # it explicitly instead of parsing headers as though they mattered
+        # (real header-AST support for this source-only path is a separate,
+        # larger feature) or silently discarding them.
+        if headers:
+            raise click.UsageError(
+                "-H/--header has no effect on a source-only dump (--sources/"
+                "--build-info with no binary/SO_PATH): this path embeds only "
+                "L3/L4/L5 build/source facts, never a header-AST (L2) pass, "
+                "so the header(s) given would be silently ignored. Either "
+                "drop -H/--header, or supply a binary (SO_PATH) so the "
+                "headers are actually parsed."
+            )
         from .cli_buildsource import dump_source_only
         dump_source_only(sources, build_info, version, output, build_config, allow_build_query, git_tag, build_id, no_git, collect_mode, build_query=build_query, build_compile_db=build_compile_db, build_targets=build_targets, extractor=header_backend, depth=depth, include_dependencies=include_dependencies, gcc_path=gcc_path, gcc_prefix=gcc_prefix, snapshot_compression=snapshot_compression)
         return

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -670,6 +670,32 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
             "--depth source to produce any evidence."
         )
 
+    # dump_source_only() (the so_path-is-None dispatch below) embeds only
+    # L3/L4/L5 build/source facts into an otherwise-empty snapshot -- it has
+    # no L2 header-AST pass and never even receives `headers`. `-H`/
+    # `--header` was therefore silently dropped with no error, warning, or
+    # trace of the ignored flag: `dump --sources tree -H api.h` exited 0
+    # with an empty (0 functions/enums), depth="binary" snapshot -- a
+    # usability trap, not a documented narrowing. Reject it explicitly
+    # instead of parsing headers as though they mattered (real header-AST
+    # support for this source-only path is a separate, larger feature) or
+    # silently discarding them. Checked here, before the --dry-run branch
+    # (Codex review: emit_dry_run() below raises SystemExit, so a check
+    # placed after it -- or inside the so_path-is-None dispatch further
+    # down, which --dry-run never reaches -- would let `dump --dry-run
+    # --sources tree -H api.h` report a valid invocation while the real run
+    # immediately rejects it) -- both paths must reject the same way,
+    # exactly like the --depth binary check immediately above.
+    if so_path is None and headers:
+        raise click.UsageError(
+            "-H/--header has no effect on a source-only dump (--sources/"
+            "--build-info with no binary/SO_PATH): this path embeds only "
+            "L3/L4/L5 build/source facts, never a header-AST (L2) pass, "
+            "so the header(s) given would be silently ignored. Either "
+            "drop -H/--header, or supply a binary (SO_PATH) so the "
+            "headers are actually parsed."
+        )
+
     # Resolve debug-format and binary-format identity once, shared between
     # the dry-run report and the real run, and raise the same BadParameter a
     # real run would -- unconditionally, before the --dry-run branch, exactly
@@ -778,27 +804,10 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
         )
         emit_dry_run(_dry_result)
 
-    # Source-only dump (no binary) for the parallel-baseline flow.
+    # Source-only dump (no binary) for the parallel-baseline flow. The
+    # -H/--header usage-error check for this path is above, before the
+    # --dry-run branch.
     if so_path is None:
-        # dump_source_only() embeds only L3/L4/L5 build/source facts into an
-        # otherwise-empty snapshot -- it has no L2 header-AST pass and never
-        # even receives `headers` (confirmed: it isn't in the call below).
-        # `-H`/`--header` was therefore silently dropped with no error,
-        # warning, or trace of the ignored flag: `dump --sources tree -H
-        # api.h` exited 0 with an empty (0 functions/enums), depth="binary"
-        # snapshot -- a usability trap, not a documented narrowing. Reject
-        # it explicitly instead of parsing headers as though they mattered
-        # (real header-AST support for this source-only path is a separate,
-        # larger feature) or silently discarding them.
-        if headers:
-            raise click.UsageError(
-                "-H/--header has no effect on a source-only dump (--sources/"
-                "--build-info with no binary/SO_PATH): this path embeds only "
-                "L3/L4/L5 build/source facts, never a header-AST (L2) pass, "
-                "so the header(s) given would be silently ignored. Either "
-                "drop -H/--header, or supply a binary (SO_PATH) so the "
-                "headers are actually parsed."
-            )
         from .cli_buildsource import dump_source_only
         dump_source_only(sources, build_info, version, output, build_config, allow_build_query, git_tag, build_id, no_git, collect_mode, build_query=build_query, build_compile_db=build_compile_db, build_targets=build_targets, extractor=header_backend, depth=depth, include_dependencies=include_dependencies, gcc_path=gcc_path, gcc_prefix=gcc_prefix, snapshot_compression=snapshot_compression)
         return

--- a/abicheck/cli.py
+++ b/abicheck/cli.py
@@ -670,32 +670,6 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
             "--depth source to produce any evidence."
         )
 
-    # dump_source_only() (the so_path-is-None dispatch below) embeds only
-    # L3/L4/L5 build/source facts into an otherwise-empty snapshot -- it has
-    # no L2 header-AST pass and never even receives `headers`. `-H`/
-    # `--header` was therefore silently dropped with no error, warning, or
-    # trace of the ignored flag: `dump --sources tree -H api.h` exited 0
-    # with an empty (0 functions/enums), depth="binary" snapshot -- a
-    # usability trap, not a documented narrowing. Reject it explicitly
-    # instead of parsing headers as though they mattered (real header-AST
-    # support for this source-only path is a separate, larger feature) or
-    # silently discarding them. Checked here, before the --dry-run branch
-    # (Codex review: emit_dry_run() below raises SystemExit, so a check
-    # placed after it -- or inside the so_path-is-None dispatch further
-    # down, which --dry-run never reaches -- would let `dump --dry-run
-    # --sources tree -H api.h` report a valid invocation while the real run
-    # immediately rejects it) -- both paths must reject the same way,
-    # exactly like the --depth binary check immediately above.
-    if so_path is None and headers:
-        raise click.UsageError(
-            "-H/--header has no effect on a source-only dump (--sources/"
-            "--build-info with no binary/SO_PATH): this path embeds only "
-            "L3/L4/L5 build/source facts, never a header-AST (L2) pass, "
-            "so the header(s) given would be silently ignored. Either "
-            "drop -H/--header, or supply a binary (SO_PATH) so the "
-            "headers are actually parsed."
-        )
-
     # Resolve debug-format and binary-format identity once, shared between
     # the dry-run report and the real run, and raise the same BadParameter a
     # real run would -- unconditionally, before the --dry-run branch, exactly
@@ -804,10 +778,42 @@ def dump_cmd(so_path: Path | None, headers: tuple[Path, ...], includes: tuple[Pa
         )
         emit_dry_run(_dry_result)
 
-    # Source-only dump (no binary) for the parallel-baseline flow. The
-    # -H/--header usage-error check for this path is above, before the
-    # --dry-run branch.
+    # Source-only dump (no binary) for the parallel-baseline flow.
     if so_path is None:
+        # dump_source_only() below embeds only L3/L4/L5 build/source facts
+        # into an otherwise-empty snapshot -- it has no L2 header-AST pass
+        # and never receives `headers` at all, so -H/--header has no effect
+        # on the WRITTEN snapshot here: `dump --sources tree -H api.h`
+        # (no --depth, or --depth binary) exits 0 with an empty (0
+        # functions/enums) snapshot and no visible sign -H was ignored.
+        #
+        # A hard usage error was tried first and reverted (Codex review,
+        # fresh evidence): -H is NOT dead code for this invocation shape in
+        # general -- the --dry-run branch above resolves a real
+        # `DumpRequest` carrying the given headers (see
+        # `test_dump_request_from_cli.py`'s own
+        # `request.input.headers == (header,)` assertion) and
+        # `add_build_query_dry_run_section` genuinely consults `headers`
+        # when reporting whether `build.query` would run, both already
+        # exercised by a wide, pre-existing test suite
+        # (`test_dry_run_build_query_contract.py`) that legitimately passes
+        # `-H` alongside `--sources` with no SO_PATH. A blanket rejection
+        # here broke 20 of those tests. Only the WRITTEN snapshot -- this
+        # code path specifically -- ignores headers; warn rather than
+        # reject, and only once execution has actually committed to this
+        # path (after the --dry-run branch, which already reports the
+        # headers' real effect on the resolved request/build-query
+        # instead).
+        if headers:
+            click.echo(
+                "Warning: -H/--header has no effect on this source-only "
+                "dump (--sources/--build-info with no binary/SO_PATH): "
+                "this path embeds only L3/L4/L5 build/source facts, never "
+                "a header-AST (L2) pass, so the header(s) given are not "
+                "reflected in the written snapshot. Supply a binary "
+                "(SO_PATH) for the headers to actually be parsed.",
+                err=True,
+            )
         from .cli_buildsource import dump_source_only
         dump_source_only(sources, build_info, version, output, build_config, allow_build_query, git_tag, build_id, no_git, collect_mode, build_query=build_query, build_compile_db=build_compile_db, build_targets=build_targets, extractor=header_backend, depth=depth, include_dependencies=include_dependencies, gcc_path=gcc_path, gcc_prefix=gcc_prefix, snapshot_compression=snapshot_compression)
         return

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -1646,6 +1646,12 @@ def perform_elf_dump(
                 so_path=so_path,
                 headers=resolved_headers,
                 extra_includes=dedup_paths_preserve_order(eff_includes + inc_extra),
+                # Provenance widening gets ONLY the caller's own explicit -I
+                # list, never `eff_includes`/`inc_extra` -- see dump()'s own
+                # docstring note on `public_include_search_dirs` for why
+                # (real regression: `inc_extra`'s auto-added umbrella-header
+                # directory can hold a genuinely private sibling header).
+                public_include_search_dirs=list(includes),
                 version=version,
                 compiler=compiler,
                 gcc_path=gcc_path,

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -52,6 +52,7 @@ from .errors import AbicheckError
 # unlike the four names in the lazy `__getattr__` shim further down, which
 # nothing in this module calls itself.
 from .header_conditionals import attach_build_context_for_parsed_headers
+from .header_utils import include_operand_dirs
 
 if TYPE_CHECKING:
     from .buildsource.pack import BuildSourcePack
@@ -179,7 +180,6 @@ def check_dump_debug_format_error(
             f"not {binary_fmt.upper()}."
         )
     return None
-
 
 
 def evidence_depth_label(
@@ -742,7 +742,9 @@ def _add_dump_manifest_section(result: Any, dump_manifest: Any) -> None:
     result.add("Multi-TU manifest (--dump-manifest)", *manifest_lines)
 
 
-def _add_dump_data_layers(result: Any, so_path: Path, headers: tuple[Path, ...]) -> None:
+def _add_dump_data_layers(
+    result: Any, so_path: Path, headers: tuple[Path, ...]
+) -> None:
     """Report which L0-L2 data layers the artifact actually carries.
 
     Best-effort: a diagnostic section, so any parse failure is downgraded to a
@@ -1079,6 +1081,7 @@ def render_dump_dry_run(
 # imported above under its original name; every existing caller/test is
 # unchanged. See that module for the derivation logic.
 
+
 def handle_non_elf_dump(
     so_path: Path,
     binary_fmt: str,
@@ -1188,7 +1191,8 @@ def handle_non_elf_dump(
             build_info=build_info,
             build_config=build_config,
             build_query=build_query,
-            build_compile_db=build_compile_db, build_targets=build_targets,
+            build_compile_db=build_compile_db,
+            build_targets=build_targets,
             collect_mode=collect_mode,
             gcc_path=getattr(compile_context, "gcc_path", None),
             gcc_prefix=getattr(compile_context, "gcc_prefix", None),
@@ -1224,8 +1228,16 @@ def handle_non_elf_dump(
             # docstring note on `public_include_search_dirs` for why (same
             # regression class the ELF perform_elf_dump path already avoids:
             # an auto-derived umbrella-header directory can hold a
-            # genuinely private sibling header).
-            public_include_search_dirs=list(includes),
+            # genuinely private sibling header). A `--compiler-option
+            # -I<dir>` operand is exactly as explicit as a plain `-I` (see
+            # the identical rationale on the ELF `perform_elf_dump` path
+            # above) -- `compile_context` is never reassigned on this
+            # PE/Mach-O path, so its own `gcc_option_tokens` is already the
+            # caller's unmodified, explicit set (CodeRabbit review).
+            public_include_search_dirs=list(includes)
+            + list(
+                include_operand_dirs(getattr(compile_context, "gcc_option_tokens", ()))
+            ),
         )
     # A ClickException already carries its user-facing message; it must reach
     # Click as itself rather than be re-wrapped by the handler below.
@@ -1288,7 +1300,6 @@ def handle_non_elf_dump(
         public_headers=tuple(public_headers),
         public_header_dirs=tuple(public_header_dirs),
     )
-
 
 
 def resolve_dump_compile_context(
@@ -1591,7 +1602,8 @@ def perform_elf_dump(
             build_info=build_info,
             build_config=build_config,
             build_query=build_query,
-            build_compile_db=build_compile_db, build_targets=build_targets,
+            build_compile_db=build_compile_db,
+            build_targets=build_targets,
             collect_mode=collect_mode,
             gcc_path=gcc_path,
             gcc_prefix=gcc_prefix,
@@ -1658,7 +1670,18 @@ def perform_elf_dump(
                 # docstring note on `public_include_search_dirs` for why
                 # (real regression: `inc_extra`'s auto-added umbrella-header
                 # directory can hold a genuinely private sibling header).
-                public_include_search_dirs=list(includes),
+                # A `--compiler-option -I<dir>`/`-isystem <dir>` operand is
+                # exactly as explicit as a plain `-I` (see the "as explicit
+                # as -I" comment on the `seed_includes_and_fold_compile_
+                # context` call above, which already trusts these tokens to
+                # suppress the L2 seed) -- so its directory belongs in the
+                # provenance-widening set too, sourced from
+                # `_user_gcc_option_tokens` (the caller's own tokens,
+                # captured before the L3 fold may have merged in derived
+                # ones the caller never wrote) rather than the possibly
+                # L3-augmented `gcc_option_tokens` local (CodeRabbit review).
+                public_include_search_dirs=list(includes)
+                + list(include_operand_dirs(_user_gcc_option_tokens)),
                 version=version,
                 compiler=compiler,
                 gcc_path=gcc_path,
@@ -1934,7 +1957,10 @@ def perform_elf_dump(
         inputs_pack=inputs_pack,
         depth=depth,
         include_dependencies=include_dependencies,
-        header_roots=tuple(headers) + _dump_manifest_header_roots(dump_manifest) + tuple(public_headers) + tuple(public_header_dirs),
+        header_roots=tuple(headers)
+        + _dump_manifest_header_roots(dump_manifest)
+        + tuple(public_headers)
+        + tuple(public_header_dirs),
         clang_bin=resolve_source_frontend_clang_bin(
             gcc_path, gcc_prefix, exclude_cl_style=False
         ),

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -1870,6 +1870,7 @@ def perform_elf_dump(
             effective_compile_context,
             list(public_headers),
             list(public_header_dirs),
+            include_search_dirs=list(includes),
         )
 
         # G28 Phase 4: same "this ELF dump CLI path reaches dumper.dump

--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -1219,6 +1219,13 @@ def handle_non_elf_dump(
             public_header_dirs=list(public_header_dirs),
             header_backend=header_backend,
             compile=l3_effective_ctx,
+            # Provenance widening gets ONLY the caller's own explicit -I
+            # list, never `eff_includes` -- see service.run_dump's own
+            # docstring note on `public_include_search_dirs` for why (same
+            # regression class the ELF perform_elf_dump path already avoids:
+            # an auto-derived umbrella-header directory can hold a
+            # genuinely private sibling header).
+            public_include_search_dirs=list(includes),
         )
     # A ClickException already carries its user-facing message; it must reach
     # Click as itself rather than be re-wrapped by the handler below.

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -234,6 +234,7 @@ def _dump_native_binary(
     header_backend: str = "auto",
     compile: CompileContext | None = None,
     include_dependencies: bool = True,
+    public_include_search_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Dump an ABI snapshot from a native binary (ELF, PE, or Mach-O).
 
@@ -247,6 +248,11 @@ def _dump_native_binary(
 
     ``public_headers`` / ``public_header_dirs`` classify declaration provenance
     (ADR-024 Phase 1) on PE/Mach-O snapshots; a no-op for ELF and when empty.
+    ``public_include_search_dirs`` (see ``service.run_dump``'s own docstring)
+    is the caller's own genuinely explicit ``-I`` list, kept distinct from
+    ``includes`` (which a caller may have already widened with auto-derived
+    directories) so provenance widening never picks up a directory the
+    caller didn't actually declare.
     ``compile`` carries the L2 cross-toolchain context (ADR-037 D3); ``run_dump``
     threads it into the PE/Mach-O header-scoping path (``_try_header_scoped_dump``).
     ``run_dump``'s header-only-graph attach (G29 Phase A: always attempted, no
@@ -275,6 +281,7 @@ def _dump_native_binary(
             compile=compile,
             notify=_click_notify,
             include_dependencies=include_dependencies,
+            public_include_search_dirs=public_include_search_dirs,
         )
     except ValidationError as exc:
         raise click.UsageError(str(exc)) from exc

--- a/abicheck/cli_resolve.py
+++ b/abicheck/cli_resolve.py
@@ -196,16 +196,25 @@ def _apply_native_provenance(
     snap: AbiSnapshot,
     public_headers: list[Path] | None,
     public_header_dirs: list[Path] | None,
+    include_search_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Tag declaration provenance on a PE/Mach-O snapshot (ADR-024 Phase 1).
 
     Mirrors the ELF path (``dumper.create_snapshot``), which always runs
-    ``apply_provenance``. A no-op when no public-header set is supplied —
-    every origin stays ``UNKNOWN`` and behaviour is unchanged.
+    ``apply_provenance`` and, since the same PR's ELF-side fix, folds the
+    caller's ``-I`` roots in too. A no-op when no public-header set is
+    supplied — every origin stays ``UNKNOWN`` and behaviour is unchanged.
+    See ``service._apply_native_provenance``'s identical parameter for why
+    (Codex review, fresh evidence).
     """
     from .provenance import apply_provenance
 
-    return apply_provenance(snap, public_headers, public_header_dirs)
+    return apply_provenance(
+        snap,
+        public_headers,
+        public_header_dirs,
+        include_search_dirs=include_search_dirs,
+    )
 
 
 def _dump_native_binary(

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -503,8 +503,6 @@ def _resolve_single_ast_backend(backend: str, frontend_context: str) -> str:
     return resolved
 
 
-
-
 def _castxml_fallback_reason(
     exc: SnapshotError,
     *,
@@ -1252,6 +1250,8 @@ def dump(
             "public_headers": public_headers,
             "public_header_dirs": public_header_dirs,
             "scope_header_dirs": scope_header_dirs,
+            # No per-TU equivalent for a multi-TU manifest (CodeRabbit review).
+            "public_include_search_dirs": public_include_search_dirs,
         }
         if _given := [name for name, value in _conflicts.items() if value]:
             raise ValidationError(

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1396,10 +1396,23 @@ def dump(
     # Tag declaration provenance (source_header + origin). Always derives
     # source_header from the parsed source location; origin is only
     # classified when a public-header set is supplied (ADR-015, D4).
+    #
+    # include_search_dirs=extra_includes (the dump's own -I roots) folds
+    # those directories into the public-directory set once a real -H/
+    # --public-header-dir set already opted classification in: a header-AST
+    # dump only ever parses declarations reachable by #include from its own
+    # -H root(s), so a header living elsewhere under the same include root
+    # that the umbrella header pulled in transitively is not a private
+    # implementation detail merely because it isn't the literal -H file
+    # (defect: every transitively-included header classified private-header,
+    # silently dropping real breaking findings out of the compared surface).
     from .provenance import apply_provenance
 
     return apply_provenance(
-        snapshot, effective_public_headers, effective_public_header_dirs
+        snapshot,
+        effective_public_headers,
+        effective_public_header_dirs,
+        include_search_dirs=extra_includes,
     )
 
 

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1299,6 +1299,7 @@ def dump(
             debug_info_path=debug_info_path,
             extra_include_labels=extra_include_labels,
             scope_header_dirs=scope_header_dirs,
+            public_include_search_dirs=public_include_search_dirs,
         )
 
     fmt = _detect_format(so_path)

--- a/abicheck/dumper.py
+++ b/abicheck/dumper.py
@@ -1166,6 +1166,7 @@ def dump(
     dump_manifest: DumpManifest | None = None,
     scope_header_dirs: list[Path] | None = None,
     frontend_context: str = "host",
+    public_include_search_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Create an AbiSnapshot from a shared library + headers.
 
@@ -1397,22 +1398,37 @@ def dump(
     # source_header from the parsed source location; origin is only
     # classified when a public-header set is supplied (ADR-015, D4).
     #
-    # include_search_dirs=extra_includes (the dump's own -I roots) folds
-    # those directories into the public-directory set once a real -H/
-    # --public-header-dir set already opted classification in: a header-AST
-    # dump only ever parses declarations reachable by #include from its own
-    # -H root(s), so a header living elsewhere under the same include root
-    # that the umbrella header pulled in transitively is not a private
-    # implementation detail merely because it isn't the literal -H file
-    # (defect: every transitively-included header classified private-header,
-    # silently dropping real breaking findings out of the compared surface).
+    # include_search_dirs=public_include_search_dirs folds those directories
+    # into the public-directory set once a real -H/--public-header-dir set
+    # already opted classification in: a header-AST dump only ever parses
+    # declarations reachable by #include from its own -H root(s), so a
+    # header living elsewhere under the same include root that the umbrella
+    # header pulled in transitively is not a private implementation detail
+    # merely because it isn't the literal -H file (defect: every
+    # transitively-included header classified private-header, silently
+    # dropping real breaking findings out of the compared surface).
+    #
+    # Deliberately NOT `extra_includes` (Codex review, real regression found
+    # via the example suite): `extra_includes` is the FULL compile include
+    # path, which also carries directories this function (or a caller's own
+    # P3 `resolve_inferred_header_roots` step) auto-derives purely so an
+    # umbrella -H header's own relative #includes resolve -- typically the
+    # umbrella header's own directory. That directory can just as easily
+    # hold a genuinely *private* sibling header (case184_internal_enum_
+    # churn_scoped's own v1_internal.h, next to the public v1.h) -- folding
+    # it into the public-directory set defeated the entire private-header
+    # scoping example that test exists to cover. `public_include_search_
+    # dirs` is a separate, caller-supplied parameter carrying ONLY the
+    # directories the caller can positively attest are a real, explicit
+    # dependency-search declaration (a literal `-I`/`--include`), never an
+    # internal #include-resolution auto-add.
     from .provenance import apply_provenance
 
     return apply_provenance(
         snapshot,
         effective_public_headers,
         effective_public_header_dirs,
-        include_search_dirs=extra_includes,
+        include_search_dirs=public_include_search_dirs,
     )
 
 

--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -42,6 +42,7 @@ from .model import (
     Variable,
     Visibility,
 )
+from .name_classification import strip_anonymous_type_location
 from .provenance import build_public_set, classify_origin, header_from_location
 
 #: Base names of semantic contract / calling-convention attributes worth
@@ -458,7 +459,8 @@ class _CastxmlParser:
             # "ElaboratedType").
             return self._type_name(el.get("type", ""), depth + 1)
         if tag in ("Struct", "Class", "Union"):
-            return el.get("name", "?")
+            # See strip_anonymous_type_location's docstring.
+            return strip_anonymous_type_location(el.get("name", "?"))
         if tag == "Typedef":
             return el.get("name", "?")
         if tag == "ArrayType":
@@ -1484,7 +1486,7 @@ class _CastxmlParser:
     def _build_record_type(
         self, el: Any, override_name: str | None = None
     ) -> RecordType:
-        name = override_name or el.get("name", "")
+        name = strip_anonymous_type_location(override_name or el.get("name", ""))
         is_opaque = el.get("incomplete") == "1"
         vtable = [] if is_opaque else self._build_vtable(el.get("id", ""))
         # Best-effort layout descriptor (layout-closure work). Direct (non-virtual)
@@ -1891,7 +1893,7 @@ class _CastxmlParser:
     def parse_enums(self) -> list[EnumType]:
         enums = []
         for el in self._enum_els:
-            name = el.get("name", "")
+            name = strip_anonymous_type_location(el.get("name", ""))
             if not name or name.startswith("__"):
                 continue
             if self._is_builtin_element(el):

--- a/abicheck/dumper_castxml.py
+++ b/abicheck/dumper_castxml.py
@@ -391,8 +391,11 @@ class _CastxmlParser:
         if el is None:
             return "?"
         tag = el.tag
-        if tag in ("FundamentalType", "Enumeration"):
+        if tag == "FundamentalType":
             return el.get("name", "?")
+        if tag == "Enumeration":
+            # Strip the same marker parse_enums() strips from the declaration.
+            return strip_anonymous_type_location(el.get("name", "?"))
         if tag == "PointerType":
             return self._type_name(el.get("type", ""), depth + 1) + "*"
         if tag == "ReferenceType":
@@ -589,15 +592,11 @@ class _CastxmlParser:
 
     def _qualified_type_name(self, el: Any, leaf_name: str | None = None) -> str | None:
         """Namespace/enclosing-class-qualified name for a Struct/Class/Union
-        element, or ``None`` if it's already at global scope (or a cycle /
-        depth cap was hit).
-
-        Walks castxml's ``context`` chain — each Struct/Class/Union/Namespace
-        element points at its lexical parent via ``context`` — prepending each
-        ancestor's name, stopping at the root ``Namespace`` (``name="::"``,
-        which itself carries no ``context``). Used only where a real namespace
-        path is required (internal-leak detection, SYCL-queue param matching);
-        ``RecordType.name`` itself stays bare (see its docstring in model.py).
+        element, or ``None`` if already at global scope (cycle/depth cap hit).
+        Walks castxml's ``context`` chain, prepending each ancestor's name,
+        stopping at the root ``Namespace``. Used only where a real namespace
+        path is required (internal-leak detection, SYCL-queue param
+        matching); ``RecordType.name`` stays bare (see model.py).
         """
         segments: list[str] = []
         seen_ids: set[str] = set()
@@ -617,13 +616,13 @@ class _CastxmlParser:
                 cur = parent
                 continue
             if parent.tag in ("Struct", "Class", "Union"):
-                pname = parent.get("name", "")
+                pname = strip_anonymous_type_location(parent.get("name", ""))
                 if pname:
                     segments.append(pname)
                 cur = parent
                 continue
             break
-        leaf = leaf_name if leaf_name is not None else el.get("name", "")
+        leaf = strip_anonymous_type_location(leaf_name if leaf_name is not None else el.get("name", ""))
         if not segments or not leaf:
             return None
         segments.reverse()

--- a/abicheck/dumper_clang.py
+++ b/abicheck/dumper_clang.py
@@ -71,6 +71,7 @@ from ._compiler_options import split_gcc_options
 from .dumper_clang_attributes import _clang_contract_attributes
 from .dumper_clang_expr import (  # noqa: F401  (some re-exported for tests)
     _SCOPE_NODE_KINDS,
+    _WRAPPER_EXPR_KINDS,
     _canonical_expr,
     _expr_fingerprint,
     _field_initializer_value,
@@ -1801,16 +1802,34 @@ def _evaluated_int_value(node: dict[str, Any]) -> int | None:
     do not. Read the wrapper's value first, then fall back to the unwrapped leaf
     literal — otherwise such bitfield widths / enum values would be lost (Codex/
     CodeRabbit review).
+
+    Checking only the *original* node and the *fully*-unwrapped leaf (what an
+    earlier revision did) misses a ``value`` folded onto an *intermediate*
+    wrapper: an enumerator initialized from a sibling enumerator (``tag_x =
+    tag_a``) wraps a ``ConstantExpr`` — carrying the real, evaluated ``value``
+    (e.g. ``"2"``) — around a ``DeclRefExpr`` naming ``tag_a``, and
+    ``_unwrap_expr`` keeps descending through ``ConstantExpr`` (a registered
+    wrapper kind) straight into that ``DeclRefExpr``, which has no ``value``
+    of its own. The fully-unwrapped leaf alone therefore reported ``None`` —
+    read as "implicit" — silently discarding the real value and mis-numbering
+    every enumerator after it. Walk the same single-child-wrapper chain
+    ``_unwrap_expr`` follows, but check every node passed through, not just
+    the endpoints.
     """
-    for candidate in (node, _unwrap_expr(node)):
-        if not isinstance(candidate, dict):
-            continue
-        val = candidate.get("value")
+    cur: Any = node
+    while isinstance(cur, dict):
+        val = cur.get("value")
         if val is not None:
             try:
                 return int(str(val), 0)
             except ValueError:
-                continue
+                pass
+        if cur.get("kind") not in _WRAPPER_EXPR_KINDS:
+            break
+        inner = [c for c in cur.get("inner", []) or [] if isinstance(c, dict)]
+        if len(inner) != 1:
+            break
+        cur = inner[0]
     return None
 
 

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -565,7 +565,22 @@ _ANON_TYPE_LOCATION_RE = re.compile(r"\bat\s+\S+:\d+:\d+(?=\s*\))")
 #: a path either -- the identical failure mode, just from a different
 #: character. ``.*?`` is non-greedy, so it still stops at the *first*
 #: ``:<line>:<col>)`` it finds, same as before.
-_ANON_TYPE_LOCATION_PATH_ONLY_RE = re.compile(r"\s*\bat\s+.*?(:\d+:\d+)(?=\s*\))")
+#:
+#: Anchored on an actual ``(lambda`` / ``(unnamed <kind>`` marker (round-4
+#: review, Codex, fresh evidence): the previous version matched a bare
+#: ``\bat\s+...`` anywhere in the name, so a C++20 fixed-string NTTP
+#: argument that merely *contains* location-shaped text (e.g.
+#: ``Tag<"at /checkout:1:2)">``) was rewritten too, risking a collision
+#: with a genuinely distinct specialization. Group 1 captures the marker
+#: itself so the substitution can reconstruct it without reproducing the
+#: literal ``at``/path text -- this also means the match never introduces
+#: extra whitespace to clean up afterward (the previous unconditional
+#: multi-space collapse this function used to apply is gone; see its own
+#: past instance of exactly this over-broad-collision failure mode, fixed
+#: two rounds ago, since fixed generically here at the regex level instead).
+_ANON_TYPE_LOCATION_PATH_ONLY_RE = re.compile(
+    r"(\((?:lambda|unnamed\s+\w+))\s+at\s+.*?(:\d+:\d+)(?=\s*\))"
+)
 
 
 def strip_anonymous_type_location(name: str) -> str:
@@ -620,19 +635,19 @@ def strip_anonymous_type_location(name: str) -> str:
     *comparison* that only has the raw spelling to work with (and where a
     same-snapshot collision risk does not apply).
 
-    The whitespace collapse/strip below runs ONLY when the anonymous-marker
-    substitution actually matched (Codex review, fresh evidence): this
-    function is now applied to every castxml record/enum name at
-    extraction time, not just anonymous ones, so an unconditional collapse
-    would also rewrite meaningful whitespace inside an ordinary name --
-    notably a C++20 fixed-string NTTP template argument, where
-    ``Tag<"a  b">`` and ``Tag<"a b">`` are genuinely distinct
-    specializations that must not collide onto one identity.
+    No whitespace collapse/strip runs here at all (round-4 review, Codex,
+    fresh evidence, second finding on the same over-broad-rewrite theme):
+    this function is now applied to every castxml record/enum name at
+    extraction time, not just anonymous ones, so even a collapse gated on
+    "the substitution fired somewhere" still touched unrelated whitespace
+    elsewhere in a *composite* name (e.g. a C++20 fixed-string NTTP
+    argument alongside a real lambda marker in the same template argument
+    list, ``Tag<"a  b", (lambda at a.hpp:4:3)>``). The regex above is now
+    anchored and captures its own marker, so the substitution itself never
+    introduces stray whitespace to clean up -- nothing here needs
+    collapsing, so nothing should be attempted.
     """
-    stripped = _ANON_TYPE_LOCATION_PATH_ONLY_RE.sub(r"\1", name)
-    if stripped == name:
-        return name
-    return _MULTI_SPACE_RE.sub(" ", stripped).strip()
+    return _ANON_TYPE_LOCATION_PATH_ONLY_RE.sub(r"\1\2", name)
 
 
 def canonicalize_type_name(name: str) -> str:

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -548,34 +548,52 @@ _PTR_REF_SIGIL_RE = re.compile(r"\s*([*&])\s*")
 # "this is anonymous" marker, which is what should actually be compared.
 _ANON_TYPE_LOCATION_RE = re.compile(r"\bat\s+\S+:\d+:\d+(?=\s*\))")
 
+#: Like _ANON_TYPE_LOCATION_RE, but keeps the trailing ``:<line>:<col>`` as a
+#: captured discriminator instead of discarding it outright — see
+#: strip_anonymous_type_location's docstring for why identity extraction
+#: needs the discriminator kept while a downstream *comparison*
+#: (canonicalize_type_name) does not.
+_ANON_TYPE_LOCATION_PATH_ONLY_RE = re.compile(r"\s*\bat\s+\S+?(:\d+:\d+)(?=\s*\))")
+
 
 def strip_anonymous_type_location(name: str) -> str:
-    """Strip an embedded ``at <path>:<line>:<col>`` out of an anonymous-tag
-    or lambda-closure type spelling (``"(unnamed struct at /a/foo.h:56:5)"``,
-    ``"raii_guard<(lambda at /a/foo.h:4:37)>"``), leaving just the
-    "this is anonymous"/"this is a lambda" marker.
+    """Strip the checkout-dependent *path* out of an embedded ``at
+    <path>:<line>:<col>`` in an anonymous-tag or lambda-closure type
+    spelling (``"(unnamed struct at /a/foo.h:56:5)"``, ``"raii_guard<(lambda
+    at /a/foo.h:4:37)>"``), while keeping its ``:<line>:<col>`` as a
+    discriminator (``"(unnamed struct:56:5)"``, ``"raii_guard<(lambda:4:37)>"``).
 
     A leaf of :func:`canonicalize_type_name` (which additionally normalizes
     whitespace, elaborated-type-specifier prefixes, and const/pointer
     spelling — none of which apply to a raw declaration name) so a producer
-    can strip *just* the location at the point a type's own identity
-    (``RecordType.name``/``.qualified_name``, ``EnumType.name``) is
+    can strip *just* the checkout-dependent path at the point a type's own
+    identity (``RecordType.name``/``.qualified_name``, ``EnumType.name``) is
     extracted, rather than leaving the raw, location-bearing spelling to
     flow into old/new type matching (``diff_helpers.type_map_key``) and
     manufacture a spurious ``type_removed``/``type_added`` pair for two
     build trees of the identical declaration under different checkout
-    paths. Both header-mode dumpers should apply this at extraction time;
+    paths.
+
+    The ``:<line>:<col>`` is kept — not dropped the way
+    :func:`canonicalize_type_name`'s own (comparison-only, string-equality)
+    stripping does — because it is the only discriminator two distinct
+    anonymous/lambda declarations in the *same* header have: dropping it
+    entirely would collapse ``guard<(lambda at a.hpp:4:3)>`` and
+    ``guard<(lambda at a.hpp:40:3)>`` (two unrelated lambdas) to the
+    identical key ``guard<(lambda)>``, silently overwriting one entry in
+    ``diff_helpers.TypeMap`` (Codex review). Line/column is stable across a
+    checkout-root change for the *same* declaration (it depends only on the
+    header's own content, not where it's checked out), so this keeps both
+    properties: identical across checkout roots for one declaration, distinct
+    across declarations within one snapshot.
+
+    Both header-mode dumpers should apply this at extraction time;
     :func:`canonicalize_type_name` remains the right tool for a downstream
-    *comparison* that only has the raw spelling to work with.
+    *comparison* that only has the raw spelling to work with (and where a
+    same-snapshot collision risk does not apply).
     """
-    stripped = _ANON_TYPE_LOCATION_RE.sub("", name)
-    # Clean up what stripping the location leaves behind: a run of
-    # whitespace where "at ..." used to sit, and — since the regex's
-    # lookahead only matches immediately before a closing paren — a lone
-    # leftover space directly before that paren ("(lambda )" -> "(lambda)"),
-    # mirroring canonicalize_type_name's own post-strip cleanup.
-    stripped = _MULTI_SPACE_RE.sub(" ", stripped).replace(" )", ")")
-    return stripped.strip()
+    stripped = _ANON_TYPE_LOCATION_PATH_ONLY_RE.sub(r"\1", name)
+    return _MULTI_SPACE_RE.sub(" ", stripped).strip()
 
 
 def canonicalize_type_name(name: str) -> str:

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -603,6 +603,47 @@ def _declaring_header_discriminator(path: str) -> str:
     return posix.rsplit("/", 1)[-1]
 
 
+def _quoted_spans(name: str) -> list[tuple[int, int]]:
+    """Return ``[start, end)`` character ranges of every ``"..."`` quoted
+    literal in *name*, respecting backslash-escaped quotes (``\\"``).
+
+    Used by :func:`strip_anonymous_type_location` to avoid rewriting
+    location-shaped text that only *looks* like a real CastXML anonymous/
+    lambda marker because it happens to sit inside a C++20 fixed-string NTTP
+    argument's own quoted value (CodeRabbit review, fresh evidence):
+    ``Tag<"(lambda at /a/foo.hpp:1:2)">`` is a string *literal* naming that
+    exact marker text, not a real anonymous-type location CastXML emitted —
+    rewriting it collapses two otherwise-distinct specializations (one
+    genuinely quoting ``.../a/foo.hpp:1:2)"``, another quoting a different
+    path that happens to share a basename) onto the same identity, exactly
+    the kind of spurious same-identity collision this whole module exists to
+    avoid introducing.
+    """
+    spans: list[tuple[int, int]] = []
+    start: int | None = None
+    i = 0
+    length = len(name)
+    while i < length:
+        ch = name[i]
+        if ch == "\\" and start is not None:
+            # An escaped character inside a quote never ends it -- skip
+            # both the backslash and the escaped character together so an
+            # escaped quote (\") is never mistaken for the closing quote.
+            i += 2
+            continue
+        if ch == '"':
+            if start is None:
+                start = i
+            else:
+                spans.append((start, i + 1))
+                start = None
+        i += 1
+    # An unterminated trailing quote (malformed/truncated input) is not
+    # treated as an open span -- nothing after it is "inside quotes" for
+    # our purposes, so it contributes nothing further to skip.
+    return spans
+
+
 def strip_anonymous_type_location(name: str) -> str:
     """Strip the checkout-dependent *directory* out of an embedded ``at
     <path>:<line>:<col>`` in an anonymous-tag or lambda-closure type
@@ -678,9 +719,24 @@ def strip_anonymous_type_location(name: str) -> str:
     See :func:`_declaring_header_discriminator`'s own docstring for what
     this still doesn't cover (two same-named headers, at the same
     coordinates, in different directories).
+
+    A match that falls inside a ``"..."`` quoted literal is left completely
+    untouched (CodeRabbit review, fresh evidence): a real CastXML anonymous/
+    lambda marker is never itself quoted, so a match starting inside quotes
+    can only be ordinary string-literal *content* that happens to spell
+    location-shaped text -- e.g. a C++20 fixed-string NTTP argument like
+    ``Tag<"(lambda at /a/foo.hpp:1:2)">``. Rewriting that would fabricate a
+    same-identity collision between two distinct literal values. See
+    :func:`_quoted_spans` for the quote-tracking this relies on.
     """
+    quoted_spans = _quoted_spans(name)
+
+    def _inside_quotes(pos: int) -> bool:
+        return any(start <= pos < end for start, end in quoted_spans)
 
     def _replace(match: re.Match[str]) -> str:
+        if _inside_quotes(match.start()):
+            return match.group(0)
         marker, path, coords = match.group(1), match.group(2), match.group(3)
         return f"{marker}:{_declaring_header_discriminator(path)}{coords}"
 

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -553,13 +553,19 @@ _ANON_TYPE_LOCATION_RE = re.compile(r"\bat\s+\S+:\d+:\d+(?=\s*\))")
 #: strip_anonymous_type_location's docstring for why identity extraction
 #: needs the discriminator kept while a downstream *comparison*
 #: (canonicalize_type_name) does not. The path itself is matched with
-#: ``[^)]*?`` (not ``\S+?``, unlike _ANON_TYPE_LOCATION_RE above) because a
+#: ``.*?`` (not ``\S+?``, unlike _ANON_TYPE_LOCATION_RE above) because a
 #: real checkout or Windows path can contain spaces (Codex review: a
 #: checkout directory literally named "release build", or a bare "Program
 #: Files" component) -- \S+? cannot reach the trailing coordinates in that
 #: case, so the substitution silently does nothing and the checkout-
-#: dependent path survives into the type's identity.
-_ANON_TYPE_LOCATION_PATH_ONLY_RE = re.compile(r"\s*\bat\s+[^)]*?(:\d+:\d+)(?=\s*\))")
+#: dependent path survives into the type's identity. Not ``[^)]*?`` either
+#: (CodeRabbit review, round 3): a real path can itself contain a literal
+#: ``)`` (e.g. ``C:\release (old)\foo.hpp``), which that class excludes by
+#: construction, so it could never reach the trailing coordinates for such
+#: a path either -- the identical failure mode, just from a different
+#: character. ``.*?`` is non-greedy, so it still stops at the *first*
+#: ``:<line>:<col>)`` it finds, same as before.
+_ANON_TYPE_LOCATION_PATH_ONLY_RE = re.compile(r"\s*\bat\s+.*?(:\d+:\d+)(?=\s*\))")
 
 
 def strip_anonymous_type_location(name: str) -> str:

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -549,6 +549,35 @@ _PTR_REF_SIGIL_RE = re.compile(r"\s*([*&])\s*")
 _ANON_TYPE_LOCATION_RE = re.compile(r"\bat\s+\S+:\d+:\d+(?=\s*\))")
 
 
+def strip_anonymous_type_location(name: str) -> str:
+    """Strip an embedded ``at <path>:<line>:<col>`` out of an anonymous-tag
+    or lambda-closure type spelling (``"(unnamed struct at /a/foo.h:56:5)"``,
+    ``"raii_guard<(lambda at /a/foo.h:4:37)>"``), leaving just the
+    "this is anonymous"/"this is a lambda" marker.
+
+    A leaf of :func:`canonicalize_type_name` (which additionally normalizes
+    whitespace, elaborated-type-specifier prefixes, and const/pointer
+    spelling — none of which apply to a raw declaration name) so a producer
+    can strip *just* the location at the point a type's own identity
+    (``RecordType.name``/``.qualified_name``, ``EnumType.name``) is
+    extracted, rather than leaving the raw, location-bearing spelling to
+    flow into old/new type matching (``diff_helpers.type_map_key``) and
+    manufacture a spurious ``type_removed``/``type_added`` pair for two
+    build trees of the identical declaration under different checkout
+    paths. Both header-mode dumpers should apply this at extraction time;
+    :func:`canonicalize_type_name` remains the right tool for a downstream
+    *comparison* that only has the raw spelling to work with.
+    """
+    stripped = _ANON_TYPE_LOCATION_RE.sub("", name)
+    # Clean up what stripping the location leaves behind: a run of
+    # whitespace where "at ..." used to sit, and — since the regex's
+    # lookahead only matches immediately before a closing paren — a lone
+    # leftover space directly before that paren ("(lambda )" -> "(lambda)"),
+    # mirroring canonicalize_type_name's own post-strip cleanup.
+    stripped = _MULTI_SPACE_RE.sub(" ", stripped).replace(" )", ")")
+    return stripped.strip()
+
+
 def canonicalize_type_name(name: str) -> str:
     """Normalise a C/C++ type name for comparison.
 

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -619,8 +619,19 @@ def strip_anonymous_type_location(name: str) -> str:
     :func:`canonicalize_type_name` remains the right tool for a downstream
     *comparison* that only has the raw spelling to work with (and where a
     same-snapshot collision risk does not apply).
+
+    The whitespace collapse/strip below runs ONLY when the anonymous-marker
+    substitution actually matched (Codex review, fresh evidence): this
+    function is now applied to every castxml record/enum name at
+    extraction time, not just anonymous ones, so an unconditional collapse
+    would also rewrite meaningful whitespace inside an ordinary name --
+    notably a C++20 fixed-string NTTP template argument, where
+    ``Tag<"a  b">`` and ``Tag<"a b">`` are genuinely distinct
+    specializations that must not collide onto one identity.
     """
     stripped = _ANON_TYPE_LOCATION_PATH_ONLY_RE.sub(r"\1", name)
+    if stripped == name:
+        return name
     return _MULTI_SPACE_RE.sub(" ", stripped).strip()
 
 

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -579,16 +579,37 @@ _ANON_TYPE_LOCATION_RE = re.compile(r"\bat\s+\S+:\d+:\d+(?=\s*\))")
 #: past instance of exactly this over-broad-collision failure mode, fixed
 #: two rounds ago, since fixed generically here at the regex level instead).
 _ANON_TYPE_LOCATION_PATH_ONLY_RE = re.compile(
-    r"(\((?:lambda|unnamed\s+\w+))\s+at\s+.*?(:\d+:\d+)(?=\s*\))"
+    r"(\((?:lambda|unnamed\s+\w+))\s+at\s+(.*?)(:\d+:\d+)(?=\s*\))"
 )
 
 
+def _declaring_header_discriminator(path: str) -> str:
+    """Checkout-independent discriminator derived from *path*'s own
+    basename (the declaring header's filename), used alongside
+    ``:<line>:<col>`` to distinguish two anonymous/lambda declarations that
+    share the same coordinates but live in DIFFERENT headers (Codex
+    review, round 8, fresh evidence): keeping only ``:<line>:<col>``
+    collapsed ``guard<(lambda at /src/one.hpp:4:3)>`` and ``guard<(lambda
+    at /src/two.hpp:4:3)>`` onto the identical identity
+    ``guard<(lambda:4:3)>``, since both files can legitimately declare
+    their own lambda at line 4, column 3. The basename alone (not the full
+    path, which embeds the checkout root) is stable across checkouts of
+    the same source tree while still separating two distinctly-named
+    headers -- the only residual collision is two DIFFERENT headers
+    sharing both a basename AND the same line:col, an accepted, narrower
+    limitation than the pre-fix "any two headers" collision.
+    """
+    posix = path.replace("\\", "/")
+    return posix.rsplit("/", 1)[-1]
+
+
 def strip_anonymous_type_location(name: str) -> str:
-    """Strip the checkout-dependent *path* out of an embedded ``at
+    """Strip the checkout-dependent *directory* out of an embedded ``at
     <path>:<line>:<col>`` in an anonymous-tag or lambda-closure type
     spelling (``"(unnamed struct at /a/foo.h:56:5)"``, ``"raii_guard<(lambda
-    at /a/foo.h:4:37)>"``), while keeping its ``:<line>:<col>`` as a
-    discriminator (``"(unnamed struct:56:5)"``, ``"raii_guard<(lambda:4:37)>"``).
+    at /a/foo.h:4:37)>"``), while keeping the declaring header's own
+    basename plus its ``:<line>:<col>`` as a discriminator
+    (``"(unnamed struct:foo.h:56:5)"``, ``"raii_guard<(lambda:foo.h:4:37)>"``).
 
     A leaf of :func:`canonicalize_type_name` (which additionally normalizes
     whitespace, elaborated-type-specifier prefixes, and const/pointer
@@ -646,8 +667,24 @@ def strip_anonymous_type_location(name: str) -> str:
     anchored and captures its own marker, so the substitution itself never
     introduces stray whitespace to clean up -- nothing here needs
     collapsing, so nothing should be attempted.
+
+    The declaring header's own basename is also kept as a discriminator
+    (round 8, Codex review, fresh evidence), alongside ``:line:col``:
+    ``"raii_guard<(lambda at /a/foo.h:4:37)>"`` becomes
+    ``"raii_guard<(lambda:foo.h:4:37)>"``. Line/column alone cannot tell
+    apart two DIFFERENT headers that each declare their own anonymous/
+    lambda type at the identical coordinates -- both a real occurrence in
+    practice and something no fixed test corpus can rule out in general.
+    See :func:`_declaring_header_discriminator`'s own docstring for what
+    this still doesn't cover (two same-named headers, at the same
+    coordinates, in different directories).
     """
-    return _ANON_TYPE_LOCATION_PATH_ONLY_RE.sub(r"\1\2", name)
+
+    def _replace(match: re.Match[str]) -> str:
+        marker, path, coords = match.group(1), match.group(2), match.group(3)
+        return f"{marker}:{_declaring_header_discriminator(path)}{coords}"
+
+    return _ANON_TYPE_LOCATION_PATH_ONLY_RE.sub(_replace, name)
 
 
 def canonicalize_type_name(name: str) -> str:

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -587,11 +587,27 @@ def strip_anonymous_type_location(name: str) -> str:
     entirely would collapse ``guard<(lambda at a.hpp:4:3)>`` and
     ``guard<(lambda at a.hpp:40:3)>`` (two unrelated lambdas) to the
     identical key ``guard<(lambda)>``, silently overwriting one entry in
-    ``diff_helpers.TypeMap`` (Codex review). Line/column is stable across a
-    checkout-root change for the *same* declaration (it depends only on the
-    header's own content, not where it's checked out), so this keeps both
-    properties: identical across checkout roots for one declaration, distinct
-    across declarations within one snapshot.
+    ``diff_helpers.TypeMap`` (Codex review). Line/column depends only on the
+    header's own content, not where it's checked out, so it is stable across
+    a checkout-root change for the *same*, *unedited* declaration — the case
+    this function exists to fix.
+
+    Known, accepted limitation (Codex review, second round): this is a
+    genuine tradeoff, not a fully general fix. If an *unrelated* edit
+    earlier in the same header shifts an unchanged anonymous/lambda
+    declaration to a different line, its ``:line:col`` changes too, and
+    old/new matching sees a different identity for a declaration whose own
+    ABI is unchanged — a spurious ``type_removed``/``type_added`` pair in
+    the *other* direction from the collision case above. Dropping the
+    discriminator entirely (what the pre-existing clang-frontend
+    normalizer, ``dumper_clang_expr._normalize_qual_type``, already does)
+    would trade this failure mode for the collision one instead — there is
+    no location-based discriminator that is simultaneously stable under
+    unrelated line movement AND distinguishing between two declarations in
+    one header; a genuinely robust identity would need a structural
+    fingerprint of the declaration itself, not a location string. Accepted
+    as a documented limitation (checkout-root stability was this fix's own
+    motivating bug) rather than a third, unproven heuristic.
 
     Both header-mode dumpers should apply this at extraction time;
     :func:`canonicalize_type_name` remains the right tool for a downstream

--- a/abicheck/name_classification.py
+++ b/abicheck/name_classification.py
@@ -552,8 +552,14 @@ _ANON_TYPE_LOCATION_RE = re.compile(r"\bat\s+\S+:\d+:\d+(?=\s*\))")
 #: captured discriminator instead of discarding it outright — see
 #: strip_anonymous_type_location's docstring for why identity extraction
 #: needs the discriminator kept while a downstream *comparison*
-#: (canonicalize_type_name) does not.
-_ANON_TYPE_LOCATION_PATH_ONLY_RE = re.compile(r"\s*\bat\s+\S+?(:\d+:\d+)(?=\s*\))")
+#: (canonicalize_type_name) does not. The path itself is matched with
+#: ``[^)]*?`` (not ``\S+?``, unlike _ANON_TYPE_LOCATION_RE above) because a
+#: real checkout or Windows path can contain spaces (Codex review: a
+#: checkout directory literally named "release build", or a bare "Program
+#: Files" component) -- \S+? cannot reach the trailing coordinates in that
+#: case, so the substitution silently does nothing and the checkout-
+#: dependent path survives into the type's identity.
+_ANON_TYPE_LOCATION_PATH_ONLY_RE = re.compile(r"\s*\bat\s+[^)]*?(:\d+:\d+)(?=\s*\))")
 
 
 def strip_anonymous_type_location(name: str) -> str:

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -165,11 +165,24 @@ def _is_toolchain_compiler_include_dir(header_segs: tuple[str, ...]) -> bool:
     Recognizes, each with the triple/version component wildcarded:
 
     - ``lib/gcc/<triple>/<version>/include`` or ``.../include-fixed`` --
-      GCC's own private (non-libstdc++) headers.
-    - ``include/c++/<version>`` -- libstdc++'s per-GCC-version public tree,
-      itself nested under the ``lib/gcc/...`` root above.
+      GCC's own private (non-libstdc++) headers. conda-forge's own layout
+      nests libstdc++'s ``c++`` tree directly under this same root (as in
+      the confirmed real-world path above), so this one pattern already
+      covers it -- no separate check is needed for that case.
     - ``lib/clang/<version>/include`` -- Clang's private builtin headers
       (``stddef.h``, the vector-intrinsic headers, ...).
+
+    Deliberately does NOT match a bare ``include/c++/<version>`` anywhere in
+    the path outside a recognized ``lib/gcc/...``/``lib/clang/...`` root
+    (Codex review): an earlier revision did, unconditionally, which matched
+    an ordinary project path like ``/project/include/c++/api.h`` that has no
+    toolchain prefix at all -- a real false-positive risk this function
+    exists to avoid, not create. The traditional (non-conda-forge)
+    Debian/Ubuntu-style split layout, where libstdc++ lives separately at
+    ``/usr/include/c++/<version>/`` rather than nested under ``lib/gcc/``,
+    is unaffected: that path is already caught by ``_SYSTEM_HEADER_DIRS``'s
+    own ``usr/include`` prefix in :func:`_is_system_header`, so this
+    function does not need to duplicate it.
 
     A caller matching against a raw compiler-reported path should prefer
     normalizing it first (segments here are matched as given, with no
@@ -191,10 +204,7 @@ def _is_toolchain_compiler_include_dir(header_segs: tuple[str, ...]) -> bool:
             and header_segs[i + 3] == "include"
         ):
             return True
-    return any(
-        header_segs[i] == "include" and header_segs[i + 1] == "c++"
-        for i in range(n - 1)
-    )
+    return False
 
 
 def _is_system_header(header_segs: tuple[str, ...]) -> bool:

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -147,6 +147,15 @@ def _matches_public(
     return any(_contiguous_subsequence(d, parent_segs) for d in public_dir_segs)
 
 
+#: A real GCC/Clang target triple: 2-4 non-empty ``-``-joined components,
+#: each alphanumeric (plus ``_``) -- e.g. ``x86_64-conda-linux-gnu``,
+#: ``x86_64-pc-linux-gnu``, ``aarch64-linux-gnu``, ``arm-none-eabi``.
+_TARGET_TRIPLE_RE = re.compile(r"^[A-Za-z0-9_]+(-[A-Za-z0-9_]+){1,3}$")
+#: A real GCC/Clang version directory: digits, optionally dotted (``14``,
+#: ``14.3``, ``14.3.0``) -- never a bare word like ``v1``/``backend``.
+_TOOLCHAIN_VERSION_RE = re.compile(r"^\d+(\.\d+){0,2}$")
+
+
 def _is_toolchain_compiler_include_dir(header_segs: tuple[str, ...]) -> bool:
     """True when *header_segs* sits inside a compiler's own private include
     tree, recognized *structurally* (with the toolchain's own version /
@@ -162,7 +171,13 @@ def _is_toolchain_compiler_include_dir(header_segs: tuple[str, ...]) -> bool:
     fixed prefix can ever match it. Confirmed against a real conda-forge/
     pixi install layout (a `func_removed` false positive was reported for
     libstdc++'s own ``_Iter_pred`` predicate helper via exactly this path).
-    Recognizes, each with the triple/version component wildcarded:
+    Recognizes, each with the triple/version component validated
+    structurally (Codex review, round 3: an earlier revision wildcarded
+    these two components unconditionally, so ``lib/gcc/backend/v1/include``
+    -- neither ``backend`` nor ``v1`` a real triple/version -- matched too;
+    ``_TARGET_TRIPLE_RE``/``_TOOLCHAIN_VERSION_RE`` require the shapes a
+    real compiler install actually uses instead of accepting any two
+    components):
 
     - ``lib/gcc/<triple>/<version>/include`` or ``.../include-fixed`` --
       GCC's own private (non-libstdc++) headers. conda-forge's own layout
@@ -205,12 +220,15 @@ def _is_toolchain_compiler_include_dir(header_segs: tuple[str, ...]) -> bool:
         if (
             i + 4 < n
             and header_segs[i + 1] == "gcc"
+            and _TARGET_TRIPLE_RE.match(header_segs[i + 2])
+            and _TOOLCHAIN_VERSION_RE.match(header_segs[i + 3])
             and header_segs[i + 4] in ("include", "include-fixed")
         ):
             return True
         if (
             i + 3 < n
             and header_segs[i + 1] == "clang"
+            and _TOOLCHAIN_VERSION_RE.match(header_segs[i + 2])
             and header_segs[i + 3] == "include"
         ):
             return True

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -160,6 +160,38 @@ _TARGET_TRIPLE_RE = re.compile(r"^[A-Za-z0-9_]+(-[A-Za-z0-9_][A-Za-z0-9_.]*){1,3
 _TOOLCHAIN_VERSION_RE = re.compile(r"^\d+(\.\d+){0,2}$")
 
 
+def _prefix_then_optional_multiarch_cxx(
+    prefix: tuple[str, ...], hay: tuple[str, ...]
+) -> bool:
+    """True when *prefix* (a system include root) appears contiguously in
+    *hay*, immediately followed by either ``c++`` directly, or a validated
+    multiarch/target-triple component then ``c++`` -- the Debian/Ubuntu
+    multiarch libstdc++ layout (``/usr/include/x86_64-linux-gnu/c++/12/...``),
+    where a real multiarch tuple sits between the system include root and
+    the c++ tree (Codex review, round 5: the existing check required ``c++``
+    immediately after the prefix with no room for this real, common layout,
+    so a genuine libstdc++ header under it was never recognized as system --
+    reachable via public-surface promotion the same way the earlier
+    ``_is_bare_system_dir`` nested-toolchain-root fix closed for the
+    non-multiarch case). The multiarch component is validated the same way
+    as a real GCC/Clang target triple (``_TARGET_TRIPLE_RE``) rather than
+    wildcarded, for the identical reason round 3's fix required it there.
+    """
+    n = len(prefix)
+    if n == 0:
+        return False
+    m = len(hay)
+    for i in range(m - n + 1):
+        if hay[i : i + n] != prefix:
+            continue
+        j = i + n
+        if j < m and hay[j] == "c++":
+            return True
+        if j + 1 < m and _TARGET_TRIPLE_RE.match(hay[j]) and hay[j + 1] == "c++":
+            return True
+    return False
+
+
 def _is_toolchain_compiler_include_dir(header_segs: tuple[str, ...]) -> bool:
     """True when *header_segs* sits inside a compiler's own private include
     tree, recognized *structurally* (with the toolchain's own version /
@@ -237,7 +269,7 @@ def _is_toolchain_compiler_include_dir(header_segs: tuple[str, ...]) -> bool:
         ):
             return True
     return any(
-        _contiguous_subsequence((*prefix, "c++"), header_segs)
+        _prefix_then_optional_multiarch_cxx(prefix, header_segs)
         for prefix in _SYSTEM_HEADER_DIRS
         if prefix and prefix[-1] == "include"
     )

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -173,16 +173,26 @@ def _is_toolchain_compiler_include_dir(header_segs: tuple[str, ...]) -> bool:
       (``stddef.h``, the vector-intrinsic headers, ...).
 
     Deliberately does NOT match a bare ``include/c++/<version>`` anywhere in
-    the path outside a recognized ``lib/gcc/...``/``lib/clang/...`` root
-    (Codex review): an earlier revision did, unconditionally, which matched
-    an ordinary project path like ``/project/include/c++/api.h`` that has no
-    toolchain prefix at all -- a real false-positive risk this function
-    exists to avoid, not create. The traditional (non-conda-forge)
-    Debian/Ubuntu-style split layout, where libstdc++ lives separately at
-    ``/usr/include/c++/<version>/`` rather than nested under ``lib/gcc/``,
-    is unaffected: that path is already caught by ``_SYSTEM_HEADER_DIRS``'s
-    own ``usr/include`` prefix in :func:`_is_system_header`, so this
-    function does not need to duplicate it.
+    the path with no anchor at all (Codex review): an earlier revision did,
+    unconditionally, which matched an ordinary project path like
+    ``/project/include/c++/api.h`` that has no toolchain prefix -- a real
+    false-positive risk this function exists to avoid, not create. The
+    traditional (non-conda-forge) Debian/Ubuntu-style split layout, where
+    libstdc++ lives separately at ``/usr/include/c++/<version>/`` rather
+    than nested under ``lib/gcc/``, IS still recognized, but only when
+    anchored under one of ``_SYSTEM_HEADER_DIRS``'s own ``.../include``
+    prefixes (``usr/include/c++/...``, ``usr/local/include/c++/...``) --
+    unlike a bare ``include/c++`` with no system prefix at all, "system
+    prefix immediately followed by c++" unambiguously means libstdc++, not
+    a coincidentally-named project directory. This anchored form matters
+    for more than :func:`_is_system_header` (which already independently
+    classifies a *declaration* under this path as ``SYSTEM_HEADER`` via
+    the plain ``usr/include`` prefix regardless): :func:`_is_bare_system_dir`
+    also needs it, so an explicit ``-I /usr/include/c++/12`` given directly
+    (not merely reached transitively) is not promoted to a *public*
+    directory, which would let ``_matches_public``'s directory-containment
+    check outrank the system-header classification for everything under it
+    (Codex review, real finding).
 
     A caller matching against a raw compiler-reported path should prefer
     normalizing it first (segments here are matched as given, with no
@@ -204,7 +214,11 @@ def _is_toolchain_compiler_include_dir(header_segs: tuple[str, ...]) -> bool:
             and header_segs[i + 3] == "include"
         ):
             return True
-    return False
+    return any(
+        _contiguous_subsequence((*prefix, "c++"), header_segs)
+        for prefix in _SYSTEM_HEADER_DIRS
+        if prefix and prefix[-1] == "include"
+    )
 
 
 def _is_system_header(header_segs: tuple[str, ...]) -> bool:
@@ -230,20 +244,29 @@ def _is_bare_system_dir(dir_segs: tuple[str, ...]) -> bool:
     -- a legitimate project directory that happens to sit under a system
     prefix).
 
-    Also true for a bare toolchain compiler-include root recognized by
+    Also true for any directory recognized by
     :func:`_is_toolchain_compiler_include_dir` (``lib/gcc/<triple>/
-    <version>/include[-fixed]``, ``include/c++/<version>``, ``lib/clang/
-    <version>/include``) when the recognized boundary is the *last* thing in
-    *dir_segs* -- the structural analogue of the fixed-prefix suffix check
-    above, for the same "directory itself IS the toolchain root, nothing
-    project-specific appended after" reason.
+    <version>/include[-fixed]``, ``lib/clang/<version>/include``, and
+    libstdc++'s ``c++`` tree nested under either), at *any* depth under that
+    boundary -- not only when the boundary is the exact last segment.
+    Deliberately NOT the same "only the bare boundary, not a subdirectory
+    beneath it" rule the fixed-prefix case above uses: that rule exists
+    because a real project can legitimately live one level under a generic
+    system prefix (``/usr/include/mylib``), but nothing can legitimately
+    live under a compiler's own private include tree -- ``bits/``,
+    ``ext/``, ``backward/``, and every other subdirectory reachable from
+    there are toolchain-owned too, never a project's. An explicit ``-I
+    /usr/include/c++/12`` (or the conda-forge-nested equivalent) must
+    therefore never be promoted to a public directory (Codex review: it
+    previously reached only the exact-bare-boundary check above, which
+    ``.../include/c++/12`` fails since ``c++/12`` is appended after the
+    ``lib/gcc/.../include`` boundary -- letting the whole libstdc++ tree
+    underneath be classified ``PUBLIC_HEADER``, since ``classify_origin``
+    checks the public match before the system-header one).
     """
     if any(_suffix_match(d, dir_segs) for d in _SYSTEM_HEADER_DIRS):
         return True
-    if not _is_toolchain_compiler_include_dir(dir_segs):
-        return False
-    last = dir_segs[-1] if dir_segs else ""
-    return last in ("include", "include-fixed", "c++")
+    return _is_toolchain_compiler_include_dir(dir_segs)
 
 
 def _is_generated_header(header_segs: tuple[str, ...]) -> bool:

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -159,6 +159,80 @@ _TARGET_TRIPLE_RE = re.compile(r"^[A-Za-z0-9_]+(-[A-Za-z0-9_][A-Za-z0-9_.]*){1,3
 #: ``14.3``, ``14.3.0``) -- never a bare word like ``v1``/``backend``.
 _TOOLCHAIN_VERSION_RE = re.compile(r"^\d+(\.\d+){0,2}$")
 
+#: Real GCC single-component target names -- embedded/bare-metal
+#: architectures GCC ships with no vendor/OS/environment components at all
+#: (e.g. ``lib/gcc/avr/12.2.0/include``, no hyphen anywhere), which
+#: ``_TARGET_TRIPLE_RE`` alone rejects since it requires at least one
+#: ``-``-joined pair (Codex review, round 7). Not exhaustive (GCC's own
+#: target list keeps growing) -- deliberately enumerated rather than
+#: accepting any bare word for this position, since round 3's own finding
+#: was exactly an arbitrary single-word project directory (``backend``)
+#: silently promoted to a toolchain path merely by sitting next to a
+#: numeric-looking sibling directory; the version component's own strict
+#: digits-only check (``_TOOLCHAIN_VERSION_RE``) is what keeps that case
+#: rejected even with this widening.
+_SINGLE_COMPONENT_GCC_TARGETS: frozenset[str] = frozenset(
+    {
+        "avr",
+        "bfin",
+        "bpf",
+        "c6x",
+        "cr16",
+        "cris",
+        "csky",
+        "epiphany",
+        "fr30",
+        "frv",
+        "ft32",
+        "gcn",
+        "h8300",
+        "iq2000",
+        "lm32",
+        "m32c",
+        "m32r",
+        "m68k",
+        "mcore",
+        "mep",
+        "microblaze",
+        "mmix",
+        "mn10300",
+        "moxie",
+        "msp430",
+        "nds32",
+        "nios2",
+        "nvptx",
+        "or1k",
+        "pdp11",
+        "picochip",
+        "pru",
+        "riscv32",
+        "riscv64",
+        "rl78",
+        "rx",
+        "s12z",
+        "score",
+        "sh",
+        "spu",
+        "tilegx",
+        "tilepro",
+        "v850",
+        "vax",
+        "visium",
+        "xstormy16",
+        "xtensa",
+    }
+)
+
+
+def _looks_like_gcc_target(component: str) -> bool:
+    """True when *component* is a real GCC target directory name -- either
+    a full target triple (``_TARGET_TRIPLE_RE``) or one of the known
+    single-component bare-metal target names (see that set's own
+    docstring)."""
+    return bool(_TARGET_TRIPLE_RE.match(component)) or (
+        component.lower() in _SINGLE_COMPONENT_GCC_TARGETS
+    )
+
 #: A genuine Debian/Ubuntu multiarch tuple always names a real OS or
 #: libc/environment family as one of its hyphen-separated words (``linux``,
 #: ``gnu``/``gnueabihf``/``musl``/...) -- an ordinary project directory that
@@ -307,7 +381,7 @@ def _is_toolchain_compiler_include_dir(header_segs: tuple[str, ...]) -> bool:
         if (
             i + 4 < n
             and header_segs[i + 1] == "gcc"
-            and _TARGET_TRIPLE_RE.match(header_segs[i + 2])
+            and _looks_like_gcc_target(header_segs[i + 2])
             and _TOOLCHAIN_VERSION_RE.match(header_segs[i + 3])
             and header_segs[i + 4] in ("include", "include-fixed")
         ):

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -149,8 +149,12 @@ def _matches_public(
 
 #: A real GCC/Clang target triple: 2-4 non-empty ``-``-joined components,
 #: each alphanumeric (plus ``_``) -- e.g. ``x86_64-conda-linux-gnu``,
-#: ``x86_64-pc-linux-gnu``, ``aarch64-linux-gnu``, ``arm-none-eabi``.
-_TARGET_TRIPLE_RE = re.compile(r"^[A-Za-z0-9_]+(-[A-Za-z0-9_]+){1,3}$")
+#: ``x86_64-pc-linux-gnu``, ``aarch64-linux-gnu``, ``arm-none-eabi``. A
+#: non-leading component may also carry dots, since a real OS component can
+#: embed a dotted version (Solaris/AIX-style: ``x86_64-pc-solaris2.11``,
+#: matching this same repo's own ``toolchain_probe.py`` recognition of that
+#: shape -- Codex review, round 4).
+_TARGET_TRIPLE_RE = re.compile(r"^[A-Za-z0-9_]+(-[A-Za-z0-9_][A-Za-z0-9_.]*){1,3}$")
 #: A real GCC/Clang version directory: digits, optionally dotted (``14``,
 #: ``14.3``, ``14.3.0``) -- never a bare word like ``v1``/``backend``.
 _TOOLCHAIN_VERSION_RE = re.compile(r"^\d+(\.\d+){0,2}$")

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -88,11 +88,28 @@ def _segments(path: str) -> tuple[str, ...]:
     """Path components in posix order, dropping anchors and ``.`` parts.
 
     Backslashes are normalised to forward slashes so Windows-style build
-    paths segment the same way as posix ones.
+    paths segment the same way as posix ones. A ``..`` segment is lexically
+    collapsed against the segment before it (no filesystem access -- this
+    module matches by path *segments*, never by resolving real paths, so
+    normalization has to stay purely textual too): a build-recorded compiler
+    path resolved via something like ``$(dirname "$CC")/..`` routinely
+    carries a literal ``bin/..`` segment (confirmed against a real
+    conda-forge/pixi toolchain path,
+    ``.../envs/scanner/bin/../lib/gcc/x86_64-conda-linux-gnu/14.3.0/include/c++/...``),
+    and every containment/prefix match in this module must recognize that as
+    the same directory its already-collapsed form names -- otherwise a
+    system/toolchain-header exclusion silently fails to match. A leading
+    ``..`` with nothing left to collapse against is kept as-is.
     """
     posix = path.replace("\\", "/")
     parts = [p for p in PurePosixPath(posix).parts if p not in ("/", ".", "")]
-    return tuple(parts)
+    normalized: list[str] = []
+    for p in parts:
+        if p == ".." and normalized and normalized[-1] != "..":
+            normalized.pop()
+        else:
+            normalized.append(p)
+    return tuple(normalized)
 
 
 def _contiguous_subsequence(needle: tuple[str, ...], hay: tuple[str, ...]) -> bool:
@@ -130,7 +147,59 @@ def _matches_public(
     return any(_contiguous_subsequence(d, parent_segs) for d in public_dir_segs)
 
 
+def _is_toolchain_compiler_include_dir(header_segs: tuple[str, ...]) -> bool:
+    """True when *header_segs* sits inside a compiler's own private include
+    tree, recognized *structurally* (with the toolchain's own version /
+    target-triple path component treated as a wildcard) rather than by a
+    fixed literal prefix.
+
+    ``_SYSTEM_HEADER_DIRS`` only matches a handful of fixed, OS-rooted
+    prefixes (``/usr/include``, an Xcode/MSVC SDK root, ...). A relocatable,
+    non-OS-managed toolchain -- notably a conda-forge/pixi GCC, which is
+    what this project's own GitHub Action installs -- puts its private
+    headers under an arbitrary environment prefix instead, e.g.
+    ``<prefix>/lib/gcc/x86_64-conda-linux-gnu/14.3.0/include/c++/...``, so no
+    fixed prefix can ever match it. Confirmed against a real conda-forge/
+    pixi install layout (a `func_removed` false positive was reported for
+    libstdc++'s own ``_Iter_pred`` predicate helper via exactly this path).
+    Recognizes, each with the triple/version component wildcarded:
+
+    - ``lib/gcc/<triple>/<version>/include`` or ``.../include-fixed`` --
+      GCC's own private (non-libstdc++) headers.
+    - ``include/c++/<version>`` -- libstdc++'s per-GCC-version public tree,
+      itself nested under the ``lib/gcc/...`` root above.
+    - ``lib/clang/<version>/include`` -- Clang's private builtin headers
+      (``stddef.h``, the vector-intrinsic headers, ...).
+
+    A caller matching against a raw compiler-reported path should prefer
+    normalizing it first (segments here are matched as given, with no
+    further ``..``-collapsing beyond what :func:`_segments` already does).
+    """
+    n = len(header_segs)
+    for i, seg in enumerate(header_segs):
+        if seg != "lib":
+            continue
+        if (
+            i + 4 < n
+            and header_segs[i + 1] == "gcc"
+            and header_segs[i + 4] in ("include", "include-fixed")
+        ):
+            return True
+        if (
+            i + 3 < n
+            and header_segs[i + 1] == "clang"
+            and header_segs[i + 3] == "include"
+        ):
+            return True
+    return any(
+        header_segs[i] == "include" and header_segs[i + 1] == "c++"
+        for i in range(n - 1)
+    )
+
+
 def _is_system_header(header_segs: tuple[str, ...]) -> bool:
+    if _is_toolchain_compiler_include_dir(header_segs):
+        return True
     return any(_contiguous_subsequence(d, header_segs) for d in _SYSTEM_HEADER_DIRS)
 
 
@@ -150,8 +219,21 @@ def _is_bare_system_dir(dir_segs: tuple[str, ...]) -> bool:
     there (``-H /usr/include/mylib/api.h``, parent ``/usr/include/mylib``
     -- a legitimate project directory that happens to sit under a system
     prefix).
+
+    Also true for a bare toolchain compiler-include root recognized by
+    :func:`_is_toolchain_compiler_include_dir` (``lib/gcc/<triple>/
+    <version>/include[-fixed]``, ``include/c++/<version>``, ``lib/clang/
+    <version>/include``) when the recognized boundary is the *last* thing in
+    *dir_segs* -- the structural analogue of the fixed-prefix suffix check
+    above, for the same "directory itself IS the toolchain root, nothing
+    project-specific appended after" reason.
     """
-    return any(_suffix_match(d, dir_segs) for d in _SYSTEM_HEADER_DIRS)
+    if any(_suffix_match(d, dir_segs) for d in _SYSTEM_HEADER_DIRS):
+        return True
+    if not _is_toolchain_compiler_include_dir(dir_segs):
+        return False
+    last = dir_segs[-1] if dir_segs else ""
+    return last in ("include", "include-fixed", "c++")
 
 
 def _is_generated_header(header_segs: tuple[str, ...]) -> bool:
@@ -344,10 +426,31 @@ def build_public_set(
     return headers, dirs, bool(headers or dirs)
 
 
+def _public_dirs_from_include_roots(
+    include_search_dirs: list[Path] | list[str] | None,
+) -> list[tuple[str, ...]]:
+    """Segment *include_search_dirs* (a header-AST dump's own ``-I`` roots)
+    into public-directory candidates, dropping a bare system-header prefix
+    (``/usr/include``, an MSVC toolchain root, ...) the same way an
+    :func:`is_system_header_path` root already is (Codex review: a stray
+    ``-I /usr/include`` must not make every system header underneath
+    classify as project-owned).
+    """
+    # Resolve first (mirroring the identical reasoning in
+    # _absolutize_header_root / is_system_header_path above): an unresolved
+    # relative root like ``.`` or ``include`` either segments to nothing at
+    # all or becomes a short, generic segment that could spuriously match
+    # unrelated paths sharing that same component elsewhere.
+    segs = [_segments(str(_absolutize_header_root(d))) for d in (include_search_dirs or [])]
+    return [s for s in segs if s and not _is_bare_system_dir(s)]
+
+
 def apply_provenance(
     snapshot: AbiSnapshot,
     public_headers: list[Path] | list[str] | None = None,
     public_header_dirs: list[Path] | list[str] | None = None,
+    *,
+    include_search_dirs: list[Path] | list[str] | None = None,
 ) -> AbiSnapshot:
     """Populate ``source_header`` and ``origin`` on every declaration in
     *snapshot*, in place, and return it.
@@ -356,10 +459,30 @@ def apply_provenance(
     (cheap, additive metadata).  ``origin`` is only classified when a
     public-header set is supplied; otherwise it stays ``UNKNOWN`` so default
     invocations are unaffected (decision D4).
+
+    ``include_search_dirs`` -- the ``-I`` roots a header-AST dump was given --
+    are folded into the public-directory set, but *only* once a real
+    ``-H``/``--public-header-dir`` set already opted classification in (they
+    can never turn opt-in on by themselves). This closes the "every
+    transitively-`#include`d header is private" gap: a header-AST dump only
+    ever parses declarations reachable by `#include` from its own `-H`
+    root(s) in the first place -- there is no other way for a declaration to
+    end up in the snapshot at all -- so a header elsewhere under the same
+    include root that the umbrella header pulled in is exactly as much a
+    dependency of the public surface as the umbrella header itself, not a
+    private implementation detail merely because it isn't the literal `-H`
+    file. Treating it as `PRIVATE_HEADER` let a real, breaking layout change
+    reached only transitively (e.g. a struct defined in a header the public
+    umbrella `#include`s) silently drop out of the compared surface with no
+    disclosure. System/generated headers are unaffected: a bare system-dir
+    root is filtered out before folding, and ``classify_origin`` still checks
+    the system/generated patterns for anything this doesn't match.
     """
     header_segs, dir_segs, have_set = build_public_set(
         public_headers, public_header_dirs
     )
+    if have_set and include_search_dirs:
+        dir_segs = [*dir_segs, *_public_dirs_from_include_roots(include_search_dirs)]
     # A large surface has far fewer distinct declaring headers than
     # declarations (e.g. thousands of oneDAL functions share a handful of
     # umbrella headers) — reuse each header's classification across every

--- a/abicheck/provenance.py
+++ b/abicheck/provenance.py
@@ -159,6 +159,55 @@ _TARGET_TRIPLE_RE = re.compile(r"^[A-Za-z0-9_]+(-[A-Za-z0-9_][A-Za-z0-9_.]*){1,3
 #: ``14.3``, ``14.3.0``) -- never a bare word like ``v1``/``backend``.
 _TOOLCHAIN_VERSION_RE = re.compile(r"^\d+(\.\d+){0,2}$")
 
+#: A genuine Debian/Ubuntu multiarch tuple always names a real OS or
+#: libc/environment family as one of its hyphen-separated words (``linux``,
+#: ``gnu``/``gnueabihf``/``musl``/...) -- an ordinary project directory that
+#: merely happens to be triple-shaped (``my-lib``) never does.
+#: ``_TARGET_TRIPLE_RE`` alone is deliberately loose (built to validate a
+#: GCC/Clang *toolchain*-controlled triple, where "any 2-4 alnum components"
+#: is a reasonable bar), so reusing it unmodified for a directory reached
+#: under a widely-installable prefix like ``/usr/include`` accepted an
+#: arbitrary two-word project directory too, silently discarding an
+#: explicitly-declared ``-I`` as though it were a system path (Codex
+#: review, round 6). Not a full Debian arch-name enumeration -- just enough
+#: real OS/environment vocabulary to exclude an ordinary project name.
+_MULTIARCH_OS_ENV_MARKERS: frozenset[str] = frozenset(
+    {
+        "linux",
+        "gnu",
+        "gnueabi",
+        "gnueabihf",
+        "gnux32",
+        "gnuabi64",
+        "gnuabin32",
+        "musl",
+        "android",
+        "bsd",
+        "freebsd",
+        "netbsd",
+        "openbsd",
+        "darwin",
+        "windows",
+        "mingw",
+        "mingw32",
+        "msvc",
+        "eabi",
+        "eabihf",
+    }
+)
+
+
+def _looks_like_multiarch_component(component: str) -> bool:
+    """True when *component* is both target-triple-shaped
+    (``_TARGET_TRIPLE_RE``) AND names a real OS/libc-environment family as
+    one of its hyphen-separated words (see ``_MULTIARCH_OS_ENV_MARKERS``'s
+    own docstring for why the shape check alone isn't enough here)."""
+    if not _TARGET_TRIPLE_RE.match(component):
+        return False
+    return any(
+        word in _MULTIARCH_OS_ENV_MARKERS for word in component.lower().split("-")
+    )
+
 
 def _prefix_then_optional_multiarch_cxx(
     prefix: tuple[str, ...], hay: tuple[str, ...]
@@ -173,9 +222,11 @@ def _prefix_then_optional_multiarch_cxx(
     so a genuine libstdc++ header under it was never recognized as system --
     reachable via public-surface promotion the same way the earlier
     ``_is_bare_system_dir`` nested-toolchain-root fix closed for the
-    non-multiarch case). The multiarch component is validated the same way
-    as a real GCC/Clang target triple (``_TARGET_TRIPLE_RE``) rather than
-    wildcarded, for the identical reason round 3's fix required it there.
+    non-multiarch case). The multiarch component is validated via
+    :func:`_looks_like_multiarch_component` -- both target-triple-shaped
+    AND naming a real OS/environment family, not merely wildcarded (round 6
+    fix: a bare shape check alone accepted an ordinary two-word project
+    directory installed directly under a system prefix).
     """
     n = len(prefix)
     if n == 0:
@@ -187,7 +238,7 @@ def _prefix_then_optional_multiarch_cxx(
         j = i + n
         if j < m and hay[j] == "c++":
             return True
-        if j + 1 < m and _TARGET_TRIPLE_RE.match(hay[j]) and hay[j + 1] == "c++":
+        if j + 1 < m and _looks_like_multiarch_component(hay[j]) and hay[j + 1] == "c++":
             return True
     return False
 

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -750,6 +750,7 @@ def _run_dump_uncached(
             compile,
             public_headers,
             public_header_dirs,
+            include_search_dirs=_includes,
         )
 
     if binary_fmt == "elf":
@@ -807,6 +808,7 @@ def _run_dump_uncached(
             compile,
             public_headers,
             public_header_dirs,
+            include_search_dirs=_includes,
         )
         return attach_clang_layout(
             snap, _headers, _includes, lang=lang, compile=compile
@@ -911,6 +913,7 @@ def _finish_native_snapshot(
         compile,
         public_headers,
         public_header_dirs,
+        include_search_dirs=includes,
     )
     return attach_clang_layout(snap, headers, includes, lang=lang, compile=compile)
 
@@ -964,6 +967,7 @@ def _attach_header_graph(
     compile: CompileContext | None,
     public_headers: list[Path] | None,
     public_header_dirs: list[Path] | None,
+    include_search_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Build and embed the header-only (L2) semantic graph (ADR-041 addendum).
 
@@ -999,6 +1003,14 @@ def _attach_header_graph(
     a separate opt-in since it costs one extra ``clang -M`` invocation per
     top-level header, not just the one aggregate pass ``header_graph`` alone
     needs.
+
+    ``include_search_dirs`` is forwarded to
+    :func:`build_header_only_graph`'s own parameter of the same name —
+    each caller's raw, explicit ``-I`` list (never an auto-derived one),
+    matching what ``apply_provenance`` already widened *snap*'s own
+    per-declaration ``origin`` with, so the graph's header-level nodes
+    agree with the flat snapshot instead of independently reclassifying
+    the same header ``private_header`` (Codex review, fresh evidence).
     """
     if not header_graph or not headers:
         return snap
@@ -1105,6 +1117,7 @@ def _attach_header_graph(
         public_header_paths=[str(p) for p in (public_headers or [])],
         public_dir_paths=[str(p) for p in (public_header_dirs or [])],
         header_paths=[str(p) for p in resolved_headers],
+        include_search_dirs=[str(p) for p in (include_search_dirs or [])],
         # Real per-declaration provenance for a hybrid merge (empty dict on
         # every other snapshot, a harmless no-op there) — G31 Phase C
         # hybrid-graph provenance-tagging; see build_header_only_graph's own

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -573,6 +573,7 @@ def _run_dump_uncached(
     _skip_header_graph_attach: bool = False,
     include_labels: dict[Path, str] | None = None,
     dump_manifest: DumpManifest | None = None,
+    public_include_search_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Extract an ABI snapshot from a native binary (ELF, PE, or Mach-O).
 
@@ -591,6 +592,20 @@ def _run_dump_uncached(
     via :func:`_apply_native_provenance`. A no-op when no header set is supplied.
     ``debug_format`` forces the ELF debug format. ``notify`` receives
     user-facing progress notes (see :func:`resolve_input`).
+
+    ``public_include_search_dirs`` (PE/Mach-O and the ``hybrid`` merge only;
+    mirrors ``dumper.dump``'s own parameter of the same name for ELF) is the
+    caller's own genuinely explicit ``-I``/``--include`` list, distinct from
+    ``includes`` -- which a caller may have already widened with auto-derived
+    directories (e.g. an umbrella ``-H`` header's own directory, seeded purely
+    so its relative ``#include``s resolve) before calling this function. When
+    given, it -- not the possibly-widened ``includes`` -- is what reaches
+    :func:`_apply_native_provenance`/the header-only graph attach, so an
+    auto-derived directory can never silently promote a private sibling
+    header to ``PUBLIC_HEADER`` on these two formats the way it once did for
+    ELF (Codex review, PR #839 round 9). Omitted (``None``, the default),
+    every existing caller's behavior is unchanged: ``includes`` itself is
+    used, same as before this parameter existed.
 
     The header-only (L2) semantic graph
     (:func:`abicheck.buildsource.header_graph.build_header_only_graph`, ADR-041
@@ -617,6 +632,14 @@ def _run_dump_uncached(
 
     _headers = headers or []
     _includes = includes or []
+    # See this function's own docstring: falls back to `_includes` (today's
+    # unchanged behavior) when the caller doesn't distinguish its genuinely
+    # explicit -I list from an already-widened `includes`.
+    _public_include_search_dirs = (
+        list(public_include_search_dirs)
+        if public_include_search_dirs is not None
+        else _includes
+    )
     # Every format's own main pass normalizes `lang` to only ever force a
     # language explicitly requested, letting auto-detection run otherwise
     # (including for the default "c++") -- `_cache_key` hashes the raw
@@ -698,6 +721,7 @@ def _run_dump_uncached(
             "debug_presence_only": debug_presence_only,
             "public_headers": public_headers,
             "public_header_dirs": public_header_dirs,
+            "public_include_search_dirs": public_include_search_dirs,
             # The header-graph attach is deliberately SKIPPED on either
             # recursive sub-dump below (each would otherwise attach its OWN
             # graph, seeded from only ITS OWN backend's declarations, before
@@ -750,7 +774,7 @@ def _run_dump_uncached(
             compile,
             public_headers,
             public_header_dirs,
-            include_search_dirs=_includes,
+            include_search_dirs=_public_include_search_dirs,
         )
 
     if binary_fmt == "elf":
@@ -840,6 +864,7 @@ def _run_dump_uncached(
             public_headers=public_headers,
             public_header_dirs=public_header_dirs,
             skip_header_graph=_skip_header_graph_attach or symbols_only,
+            public_include_search_dirs=_public_include_search_dirs,
         )
     if binary_fmt == "macho":
         with dumper_cache.ast_memoize_scope():
@@ -867,6 +892,7 @@ def _run_dump_uncached(
             public_headers=public_headers,
             public_header_dirs=public_header_dirs,
             skip_header_graph=_skip_header_graph_attach or symbols_only,
+            public_include_search_dirs=_public_include_search_dirs,
         )
     raise ValidationError(f"Unsupported binary format: {binary_fmt}")
 
@@ -883,6 +909,7 @@ def _finish_native_snapshot(
     public_headers: list[Path] | None,
     public_header_dirs: list[Path] | None,
     skip_header_graph: bool,
+    public_include_search_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Shared post-dump tail for the PE and Mach-O branches of ``run_dump``.
 
@@ -898,8 +925,20 @@ def _finish_native_snapshot(
     ``skip_header_graph`` folds the caller's own reasons to suppress the graph
     (the ``hybrid`` recursion's ``_skip_header_graph_attach``, ``symbols_only``)
     into one flag; the global enablement switches stay this function's business.
+
+    ``public_include_search_dirs`` (see ``_run_dump_uncached``'s own docstring):
+    when given, used instead of ``includes`` for both the flat-snapshot
+    provenance widening and the header-graph attach, so an already-widened
+    ``includes`` (auto-derived directories included) can never leak into
+    either. Defaults to ``includes`` itself, unchanged from before this
+    parameter existed.
     """
-    snap = _apply_native_provenance(snap, public_headers, public_header_dirs, includes)
+    _public_dirs = (
+        public_include_search_dirs
+        if public_include_search_dirs is not None
+        else includes
+    )
+    snap = _apply_native_provenance(snap, public_headers, public_header_dirs, _public_dirs)
     _try_attach_python_ext_metadata(snap)
     _try_attach_python_api_surface(snap)
     _try_attach_numpy_capi_surface(snap, path)
@@ -913,7 +952,7 @@ def _finish_native_snapshot(
         compile,
         public_headers,
         public_header_dirs,
-        include_search_dirs=includes,
+        include_search_dirs=_public_dirs,
     )
     return attach_clang_layout(snap, headers, includes, lang=lang, compile=compile)
 

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -327,6 +327,7 @@ def resolve_input(
     include_labels: dict[Path, str] | None = None,
     dump_manifest: DumpManifest | None = None,
     include_dependencies: bool = True,
+    public_include_search_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Auto-detect input type and return an ABI snapshot.
 
@@ -355,6 +356,13 @@ def resolve_input(
             default server list / ``DEBUGINFOD_URLS`` environment variable.
         public_headers / public_header_dirs: Public-header sets used to tag
             declaration provenance on PE/Mach-O snapshots (ADR-024 Phase 1).
+        public_include_search_dirs: The caller's own genuinely explicit
+            ``-I``/``--include`` list, distinct from ``includes`` (which a
+            caller may have already widened with auto-derived directories --
+            see ``_run_dump_uncached``'s own docstring). When given, used
+            instead of ``includes`` for declaration-provenance widening on
+            all three binary formats. Omitted (the default), every existing
+            caller's behavior is unchanged: ``includes`` itself is used.
         include_labels: Resolved ``path -> label`` map from a labeled
             ``--include old:LABEL=PATH`` CLI entry (ADR-050 D1); forces the
             whole-snapshot cache off when non-empty.
@@ -409,6 +417,7 @@ def resolve_input(
             include_labels=include_labels,
             dump_manifest=dump_manifest,
             include_dependencies=include_dependencies,
+            public_include_search_dirs=public_include_search_dirs,
         )
 
     # Detect binary format from magic bytes
@@ -439,6 +448,7 @@ def resolve_input(
             include_labels=include_labels,
             dump_manifest=dump_manifest,
             include_dependencies=include_dependencies,
+            public_include_search_dirs=public_include_search_dirs,
         )
 
     # Raw kernel type-info blobs (a bare `.BTF` / CTF section extracted with

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -897,7 +897,7 @@ def _finish_native_snapshot(
     (the ``hybrid`` recursion's ``_skip_header_graph_attach``, ``symbols_only``)
     into one flag; the global enablement switches stay this function's business.
     """
-    snap = _apply_native_provenance(snap, public_headers, public_header_dirs)
+    snap = _apply_native_provenance(snap, public_headers, public_header_dirs, includes)
     _try_attach_python_ext_metadata(snap)
     _try_attach_python_api_surface(snap)
     _try_attach_numpy_capi_surface(snap, path)
@@ -930,16 +930,28 @@ def _apply_native_provenance(
     snap: AbiSnapshot,
     public_headers: list[Path] | None,
     public_header_dirs: list[Path] | None,
+    include_search_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Tag declaration provenance on a PE/Mach-O snapshot (ADR-024 Phase 1).
 
     Mirrors the ELF path (``dumper.create_snapshot``), which always runs
-    ``apply_provenance``. A no-op when no public-header set is supplied — every
-    origin stays ``UNKNOWN`` and behaviour is unchanged.
+    ``apply_provenance`` and, since the same PR's ELF-side fix, folds the
+    caller's ``-I`` roots in too. A no-op when no public-header set is
+    supplied — every origin stays ``UNKNOWN`` and behaviour is unchanged.
+    Without ``include_search_dirs`` here, a declaration reached only
+    transitively through PE/Mach-O's own ``-I`` (never itself named as a
+    root) stayed ``PRIVATE_HEADER`` and could be excluded from the public
+    surface — the exact false-clean result the ELF fix closed, left open on
+    these two formats (Codex review, fresh evidence).
     """
     from .provenance import apply_provenance
 
-    return apply_provenance(snap, public_headers, public_header_dirs)
+    return apply_provenance(
+        snap,
+        public_headers,
+        public_header_dirs,
+        include_search_dirs=include_search_dirs,
+    )
 
 
 def _attach_header_graph(
@@ -1341,6 +1353,12 @@ def _dump_elf(
             so_path=path,
             headers=resolved_headers,
             extra_includes=eff_includes,
+            # Provenance widening gets ONLY the caller's own explicit -I
+            # list -- see dump()'s own docstring note on
+            # `public_include_search_dirs` (real regression: `eff_includes`
+            # also carries `inc_extra`'s auto-added umbrella-header
+            # directory, which can hold a genuinely private sibling header).
+            public_include_search_dirs=list(includes),
             version=version,
             compiler=compiler,
             gcc_path=cc.gcc_path,

--- a/abicheck/service_dump_cache.py
+++ b/abicheck/service_dump_cache.py
@@ -255,6 +255,7 @@ def _dump_cache_extra_key(
     *,
     uses_ast: bool = True,
     lang_explicit: bool = False,
+    public_include_search_dirs: list[Path] | None = None,
 ) -> str:
     """Build the ``extra`` cache-key material for a cacheable dump — every
     input to ``run_dump`` that affects its output besides the binary content
@@ -319,6 +320,11 @@ def _dump_cache_extra_key(
     genuinely different force-C++-vs-auto-detect decision on a
     language-ambiguous header, and therefore a different parsed AST — folded
     into the key so they can never collide.
+
+    ``public_include_search_dirs`` (round 13): a real, provenance-affecting
+    input on its own (see ``_run_dump_uncached``'s own docstring) — folded
+    in the same way ``public_headers``/``public_header_dirs`` already are,
+    so two calls differing only in it can never share a cache entry.
     """
     from .dumper import _resolve_header_backend
 
@@ -335,6 +341,9 @@ def _dump_cache_extra_key(
                 sep.join(sorted(str(p) for p in (public_headers or []))),
                 sep.join(sorted(str(p) for p in (public_header_dirs or []))),
                 str(lang_explicit),
+                sep.join(
+                    sorted(str(p) for p in (public_include_search_dirs or []))
+                ),
             ]
         )
 
@@ -424,6 +433,7 @@ def _dump_cache_extra_key(
             sep.join(sorted(str(p) for p in (public_headers or []))),
             sep.join(sorted(str(p) for p in (public_header_dirs or []))),
             str(lang_explicit),
+            sep.join(sorted(str(p) for p in (public_include_search_dirs or []))),
         ]
     )
 
@@ -454,6 +464,7 @@ def cached_run_dump(
     include_labels: dict[Path, str] | None = None,
     dump_manifest: object | None = None,
     include_dependencies: bool = True,
+    public_include_search_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """``run_dump(...)``, transparently served from the whole-snapshot cache
     when the call shape is cacheable (:func:`_dump_is_cacheable`) — avoiding a
@@ -525,6 +536,7 @@ def cached_run_dump(
             include_labels=include_labels,
             dump_manifest=dump_manifest,
             include_dependencies=include_dependencies,
+            public_include_search_dirs=public_include_search_dirs,
         )
 
     if not cacheable:
@@ -595,6 +607,7 @@ def cached_run_dump(
             lang,
             uses_ast=_uses_ast,
             lang_explicit=lang_explicit,
+            public_include_search_dirs=public_include_search_dirs,
         )
         # NUL-joined (see _dump_cache_extra_key's own docstring on why NUL,
         # not a printable delimiter, is the only collision-safe choice here

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -788,6 +788,13 @@ def _resolve_side_snapshot_impl(
                 debug_presence_only=debug_presence_only,
                 include_labels=include_labels,
                 notify=notify,
+                # Provenance widening gets ONLY this side's own explicit -I
+                # list (`side.includes`, pre-seeding), never the fold's
+                # already-widened `includes` local -- same regression class
+                # the ELF/PE/Mach-O CLI resolvers already avoid (Codex
+                # review, round 13): an auto-derived seed directory can hold
+                # a genuinely private sibling header.
+                public_include_search_dirs=list(side.includes),
             )
         finally:
             _artifact_plan.run_cleanups()

--- a/action/run.sh
+++ b/action/run.sh
@@ -196,6 +196,16 @@ for tok in split_gcc_options(sys.stdin.read()):
 
 # ADR-040 L1: the per-side header/include inputs map to the side-aware --header/
 # --include flags, prefixing each value with old=/new= (e.g. --header old=inc).
+#
+# A single-line value is word-split on whitespace (one flag per word) so a
+# YAML input like `old-header: "a.h b.h"` still yields two `--header`
+# entries -- this is deliberate for the genuinely *list*-valued inputs this
+# function was written for (headers/includes/paths). It must NOT be used for
+# a value that is a single opaque string that may itself contain spaces (a
+# version label like "1.0 (release build)") -- use add_sided_scalar_flag
+# for those instead, which passes the value through unsplit. Prefer
+# newline-separated values over relying on word-splitting at all when a
+# list input's own entries might contain spaces (e.g. a path).
 add_sided_flag() {
   local flag="$1"
   local side="$2"
@@ -213,6 +223,21 @@ add_sided_flag() {
       CMD+=("$flag" "${side}=${item}")
     done
   fi
+}
+
+# Scalar counterpart of add_sided_flag: the value is a single opaque string
+# (e.g. a version label) that must reach the CLI exactly as given, including
+# any embedded whitespace -- never split into multiple flags. A version
+# label like "1.0 (release build)" previously lost everything but its last
+# whitespace-separated word when routed through add_sided_flag's word-split.
+add_sided_scalar_flag() {
+  local flag="$1"
+  local side="$2"
+  local value="$3"
+  if [[ -z "$value" ]]; then
+    return
+  fi
+  CMD+=("$flag" "${side}=${value}")
 }
 
 add_single_flag() {
@@ -1039,8 +1064,8 @@ elif [[ "$MODE" == "compare" ]]; then
   add_flag "-I" "${INPUT_INCLUDE:-}"
   add_sided_flag "--include" "old" "${INPUT_OLD_INCLUDE:-}"
   add_sided_flag "--include" "new" "${INPUT_NEW_INCLUDE:-}"
-  add_sided_flag "--version" "old" "${INPUT_OLD_VERSION:-}"
-  add_sided_flag "--version" "new" "${INPUT_NEW_VERSION:-}"
+  add_sided_scalar_flag "--version" "old" "${INPUT_OLD_VERSION:-}"
+  add_sided_scalar_flag "--version" "new" "${INPUT_NEW_VERSION:-}"
   add_single_flag "--lang" "${INPUT_LANG:-}"
 
   # The L2 compile-context flags (--ast-frontend/--gcc-*/--sysroot/

--- a/changelog.d/1787200000_claude_clang_enum_alias_value_fix.md
+++ b/changelog.d/1787200000_claude_clang_enum_alias_value_fix.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **`--ast-frontend clang` mis-numbered enumerators initialized from a
+  sibling enumerator** (e.g. `enum { A, B, X = B };`), reporting every such
+  alias — and every implicit enumerator after it — under its wrong,
+  positional auto-increment value instead of its real one, and diffing those
+  wrong values as spurious `enum_member_value_changed` findings. Root cause:
+  `_evaluated_int_value` only checked the original AST node and the fully
+  unwrapped leaf expression for a folded `value`; clang folds an
+  enumerator-alias initializer's real value onto an intermediate
+  `ConstantExpr` wrapper it then continues descending through (into a
+  `DeclRefExpr` naming the aliased enumerator, which carries no `value` of
+  its own), so that intermediate value was silently lost. `dumper_clang.py`'s
+  `_evaluated_int_value` now checks every node along the same unwrap chain,
+  not only its endpoints. Reproduced against a real oneDNN 3.11→3.12
+  `dnnl_format_tag_t` comparison, which previously reported 787 false
+  `breaking enum_member_value_changed` findings under the clang frontend.

--- a/changelog.d/1787210000_claude_transitive_header_public_scoping.md
+++ b/changelog.d/1787210000_claude_transitive_header_public_scoping.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **Public-surface scoping (`--scope-public-headers`, the default) classified
+  every header transitively `#include`d by a `-H`/`--header` umbrella header
+  as `private-header`**, unless it happened to also be one of the exact `-H`
+  files or an explicit `--public-header-dir`. A header-AST dump only ever
+  parses declarations reachable by `#include` from its own `-H` root(s) in
+  the first place — there is no other way for a declaration to end up in the
+  snapshot at all — so a header living elsewhere under the same `-I` include
+  root that the umbrella header pulled in is exactly as much a dependency of
+  the public surface as the umbrella header itself, not a private
+  implementation detail. This could silently drop a genuine breaking layout
+  change out of the compared surface, reporting `NO_CHANGE`/exit 0 with no
+  disclosure. `dumper.dump()` now folds its own `-I`/`extra_includes` roots
+  into the public-directory set `provenance.apply_provenance()` classifies
+  against (`include_search_dirs`), once a real `-H`/`--public-header-dir` set
+  already opted classification in — a bare system-header prefix (e.g. a
+  stray `-I /usr/include`) is still excluded from becoming a project
+  directory, and the opt-in contract (ADR-015 D4) is unchanged: `-I` roots
+  can never turn classification on by themselves.

--- a/changelog.d/1787220000_claude_conda_forge_toolchain_system_headers.md
+++ b/changelog.d/1787220000_claude_conda_forge_toolchain_system_headers.md
@@ -1,0 +1,27 @@
+### Fixed
+
+- **A conda-forge/pixi (or any other relocatable, non-`/usr`) GCC/Clang
+  toolchain's own private headers were not recognized as system headers.**
+  `_SYSTEM_HEADER_DIRS` only matched a handful of fixed, OS-rooted prefixes
+  (`/usr/include`, an Xcode/MSVC SDK root, ...); a relocatable toolchain puts
+  its private headers under an arbitrary environment prefix instead (e.g.
+  `<env>/lib/gcc/x86_64-conda-linux-gnu/14.3.0/include/c++/...`), which
+  matched none of them and so was diffed as ordinary project surface —
+  reported as a false `func_removed`/`func_added` breaking finding for
+  libstdc++'s internal `_Iter_pred` predicate helper from abicheck's *own*
+  GitHub Action toolchain. `provenance.py` now recognizes GCC's private
+  include tree (`lib/gcc/<triple>/<version>/include[-fixed]`), libstdc++'s
+  per-version public tree (`include/c++/<version>`), and Clang's private
+  builtin headers (`lib/clang/<version>/include`) *structurally* — with the
+  toolchain's own version/target-triple path component wildcarded — rather
+  than by a fixed literal prefix, so this holds regardless of where the
+  toolchain is installed.
+- **A `..` path segment (e.g. a build-recorded compiler path resolved via
+  `$(dirname "$CC")/..`, producing a literal `bin/..` component) was not
+  lexically collapsed before path-segment matching**, so a real path like
+  `.../bin/../lib/gcc/.../include` didn't match its already-collapsed
+  `.../lib/gcc/.../include` form. `provenance._segments()` now collapses a
+  `..` against its preceding segment (purely textual — no filesystem access,
+  keeping this module's existing "match by segments, never by resolving real
+  paths" design), fixing every path-segment match in the module, not just
+  the toolchain-header case above.

--- a/changelog.d/1787230000_claude_action_version_word_split.md
+++ b/changelog.d/1787230000_claude_action_version_word_split.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **The composite GitHub Action word-split `old-version`/`new-version`
+  inputs on whitespace**, so a version label containing a space (e.g.
+  `old-version: '1.0 (release build)'`) was silently corrupted into three
+  repeated `--version old=...` flags, of which only the last survived — the
+  report rendered `(release build)` and the real version, `1.0`, was
+  entirely lost. `action/run.sh`'s `add_sided_flag` helper is designed for
+  genuinely list-valued inputs (headers/includes/paths), where one flag per
+  whitespace-separated word is correct; a version label is a single opaque
+  string that must reach the CLI unsplit. Added `add_sided_scalar_flag`,
+  used for `--version` — every other `add_sided_flag`/`add_single_flag` call
+  site was audited and is unaffected (`add_single_flag` already passes its
+  value through unsplit).

--- a/changelog.d/1787240000_claude_castxml_lambda_location_leak.md
+++ b/changelog.d/1787240000_claude_castxml_lambda_location_leak.md
@@ -15,9 +15,22 @@
   reusing the same location-matching regex `canonicalize_type_name` already
   applies for comparisons) is now applied by `dumper_castxml.py` at the
   point a `RecordType`/`EnumType`'s own identity is extracted — a lambda
-  closure type or anonymous struct/union/enum's name is stripped down to
-  its bare `(lambda)`/`(unnamed <kind>)` marker before it ever reaches type
-  matching, not left to be normalized only downstream in one comparison
-  path. Reproduced against a real oneTBB 2021.13.0→2022.3.0 header
-  comparison, where 27 breaking/27 compatible finding pairs (94 of 225
-  total findings) were pure path artifacts of this leak.
+  closure type or anonymous struct/union/enum's name has its
+  checkout-dependent *path* stripped, keeping the `:<line>:<col>`
+  discriminator (e.g. `raii_guard<(lambda:522:26)>`, not the bare
+  `raii_guard<(lambda)>` an earlier revision of this fix collapsed to and
+  then reverted, after review found it collided two distinct lambdas in one
+  header onto one identity) before it ever reaches type matching, not left
+  to be normalized only downstream in one comparison path. A *reference* to
+  an anonymous enum (a field/param/return type naming it, not the enum's
+  own declaration) and a nested type's `qualified_name` (whose enclosing
+  Struct/Class/Union segment can itself be a lambda-closure-instantiated
+  name) are normalized the same way, closing two narrower gaps the same
+  review round found in the original fix. The path-matching regex itself
+  was widened twice more after the initial fix — first from `\S+?` to
+  `[^)]*?` (a real checkout/Windows path can contain a space), then from
+  `[^)]*?` to `.*?` (a real Windows path can also contain a literal `)`,
+  e.g. `C:\release (old)\foo.hpp`). Reproduced against a real oneTBB
+  2021.13.0→2022.3.0 header comparison, where 27 breaking/27 compatible
+  finding pairs (94 of 225 total findings) were pure path artifacts of this
+  leak.

--- a/changelog.d/1787240000_claude_castxml_lambda_location_leak.md
+++ b/changelog.d/1787240000_claude_castxml_lambda_location_leak.md
@@ -1,0 +1,23 @@
+### Fixed
+
+- **The castxml AST frontend embedded an absolute source path/line/column
+  in a lambda closure type's (and any anonymous struct/union/enum's) own
+  name** — e.g. `raii_guard<(lambda at <checkout-dir>/include/foo.h:522:26)>`
+  — so identical headers compiled from two different checkout directories
+  produced two different type identities for the same declaration, and
+  old/new type matching (keyed on the raw, unstripped name) manufactured a
+  spurious `type_removed`/`type_added` pair — plus, when the closure type
+  appeared in a public function's return type, a fabricated
+  `template_return_type_changed` break on an otherwise-unchanged function.
+  The clang JSON-AST frontend already normalized this away
+  (`dumper_clang_expr._normalize_qual_type`); castxml had no equivalent.
+  `name_classification.strip_anonymous_type_location` (a new, shared helper
+  reusing the same location-matching regex `canonicalize_type_name` already
+  applies for comparisons) is now applied by `dumper_castxml.py` at the
+  point a `RecordType`/`EnumType`'s own identity is extracted — a lambda
+  closure type or anonymous struct/union/enum's name is stripped down to
+  its bare `(lambda)`/`(unnamed <kind>)` marker before it ever reaches type
+  matching, not left to be normalized only downstream in one comparison
+  path. Reproduced against a real oneTBB 2021.13.0→2022.3.0 header
+  comparison, where 27 breaking/27 compatible finding pairs (94 of 225
+  total findings) were pure path artifacts of this leak.

--- a/changelog.d/1787250000_claude_dump_source_only_header_flag_usage_error.md
+++ b/changelog.d/1787250000_claude_dump_source_only_header_flag_usage_error.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- **`dump --sources TREE -H hdr` (no binary) silently ignored `-H`/`--header`
+  and wrote an empty, `depth="binary"` snapshot with no trace the flag was
+  dropped.** A source-only `dump` (no `SO_PATH`) dispatches to
+  `dump_source_only()`, which embeds only L3/L4/L5 build/source facts — it
+  has no L2 header-AST pass and never even receives `headers`. This is now
+  rejected as a usage error (exit 64) naming the dropped flag, instead of
+  exiting 0 with a misleadingly "successful" empty snapshot.

--- a/changelog.d/1787250000_claude_dump_source_only_header_flag_usage_error.md
+++ b/changelog.d/1787250000_claude_dump_source_only_header_flag_usage_error.md
@@ -1,9 +1,14 @@
 ### Fixed
 
 - **`dump --sources TREE -H hdr` (no binary) silently ignored `-H`/`--header`
-  and wrote an empty, `depth="binary"` snapshot with no trace the flag was
-  dropped.** A source-only `dump` (no `SO_PATH`) dispatches to
-  `dump_source_only()`, which embeds only L3/L4/L5 build/source facts — it
-  has no L2 header-AST pass and never even receives `headers`. This is now
-  rejected as a usage error (exit 64) naming the dropped flag, instead of
-  exiting 0 with a misleadingly "successful" empty snapshot.
+  for the *written snapshot* — it embeds only L3/L4/L5 build/source facts,
+  never an L2 header-AST pass, so the resulting snapshot has an empty
+  (0 functions/enums), `depth="binary"` shape with no trace the flag had no
+  effect there. A CLI warning now names the ignored flag on the real run
+  (`dump`'s own `--dry-run` preview is unaffected — it genuinely resolves
+  and reports on the given headers via the typed `DumpRequest` pipeline, so
+  it was already correct). An initial fix rejected the combination outright
+  as a usage error; that was reverted after it broke a wide, pre-existing
+  test suite that legitimately combines `-H` with a source-only
+  `--dry-run` — `-H` is not dead code for this invocation shape in general,
+  only for what the non-dry-run path actually writes.

--- a/changelog.d/1787260000_claude_dump_provenance_include_dir_scope.md
+++ b/changelog.d/1787260000_claude_dump_provenance_include_dir_scope.md
@@ -1,0 +1,20 @@
+### Fixed
+
+- **This same PR's own defect-4/5 provenance-widening fix (see the
+  `1787240000_claude_castxml_lambda_location_leak` fragment) had a real
+  regression, caught by the example suite's `case184_internal_enum_churn_scoped`:
+  a private implementation-detail header living in the *same directory* as
+  its public umbrella header was silently promoted to `PUBLIC_HEADER`,
+  defeating ADR-024's private-header scoping for that (very common) layout.**
+  `dumper.dump()`'s `include_search_dirs` provenance widening was wired off
+  `extra_includes` — the dump's *full* compile include path, which also
+  carries a directory the dump auto-derives purely so an umbrella `-H`
+  header's own relative `#include`s resolve (typically the umbrella
+  header's own directory) — rather than off only the caller's genuinely
+  *explicit* `-I`/`--include` list. `dump()` now takes a separate,
+  caller-supplied `public_include_search_dirs` parameter for this; its two
+  real production callers (`cli_dump_helpers.perform_elf_dump`,
+  `service._dump_elf`) thread their own raw, pre-auto-derivation `includes`
+  parameter into it instead of the combined value. The original defect-4/5
+  promotion (a header reached transitively under a genuinely explicit `-I`
+  root) is unaffected.

--- a/changelog.d/1787270000_claude_header_graph_include_search_dirs.md
+++ b/changelog.d/1787270000_claude_header_graph_include_search_dirs.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **The L5 header-only semantic graph could disagree with the flat snapshot
+  on a declaration's own public/private classification.** Once a header
+  reached transitively under a caller's explicit `-I` root is promoted to
+  `PUBLIC_HEADER` (the defect-4/5 fix, `include_search_dirs` in
+  `provenance.apply_provenance`), the same widening now also reaches
+  `buildsource.header_graph.build_header_only_graph()` — its own
+  `header_node()` previously reclassified that header's graph node fresh
+  from only the bare `public_header_paths`/`public_dir_paths`, so a type
+  could read `public_header` for its own declaration but `private_header`
+  for its own defining header node, risking a false public-to-internal
+  dependency finding. `build_header_only_graph` takes a new
+  `include_search_dirs` parameter (mirroring `apply_provenance`'s own),
+  threaded from `service._attach_header_graph`'s identical new parameter,
+  fed by each caller's own raw, explicit `-I` list — the same value already
+  used for the flat-snapshot fix.

--- a/changelog.d/1787280000_claude_anon_location_whitespace_scope.md
+++ b/changelog.d/1787280000_claude_anon_location_whitespace_scope.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- **`strip_anonymous_type_location`'s whitespace collapse could rewrite
+  meaningful whitespace inside an ordinary type name.** Once wired into
+  every castxml record/enum name at extraction time (not just anonymous
+  ones), its unconditional multi-space-collapse/strip step also touched
+  names with no anonymous-location marker at all — notably a C++20
+  fixed-string NTTP template argument, where `Tag<"a  b">` and `Tag<"a
+  b">` are genuinely distinct specializations that must not collapse onto
+  one identity. The collapse now runs only when the anonymous-marker
+  substitution actually fired.

--- a/changelog.d/1787290000_claude_anon_location_marker_anchor.md
+++ b/changelog.d/1787290000_claude_anon_location_marker_anchor.md
@@ -1,0 +1,21 @@
+### Fixed
+
+- **`strip_anonymous_type_location`'s location-stripping regex was
+  unanchored, and its (already-narrowed) whitespace cleanup still touched
+  unrelated parts of a composite name.** Two more real gaps from the same
+  review round as the previous fragment:
+  - The regex matched a bare `at <path>:<line>:<col>` anywhere in a name,
+    so an ordinary specialization whose C++20 fixed-string NTTP argument
+    merely *contained* location-shaped text (e.g. `Tag<"at
+    /checkout:1:2)">`) was rewritten too, risking a collision with a
+    genuinely distinct type. The regex now requires an actual `(lambda` or
+    `(unnamed <kind>` marker immediately before `at`.
+  - Gating the whitespace collapse on "did the substitution fire
+    anywhere" (the previous fix) wasn't narrow enough: a *composite* name
+    where the substitution legitimately fires in one template argument (a
+    real lambda marker) could still have the collapse rewrite whitespace
+    in an unrelated sibling argument (a fixed-string literal). The
+    now-anchored regex captures its own marker and reconstructs it
+    directly, so the substitution never introduces stray whitespace to
+    clean up — the whitespace-collapse step is removed entirely rather
+    than narrowed further.

--- a/changelog.d/1787300000_claude_hybrid_dump_include_scope_forward.md
+++ b/changelog.d/1787300000_claude_hybrid_dump_include_scope_forward.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **`dump()`'s hybrid AST frontend (`--ast-frontend hybrid`) dropped a
+  caller's explicit `-I`/`--include` public-scoping roots instead of
+  forwarding them to its two recursive sub-dumps.** The declaration-
+  provenance widening this same PR fixed for the castxml and clang
+  backends individually (`public_include_search_dirs`) never reached
+  `dumper_hybrid.run_hybrid_dump()`'s own castxml/clang delegation calls,
+  since `dump()`'s hybrid branch built its kwargs without it — so a header
+  reached only through an explicit `-I` stayed `PRIVATE_HEADER` and could
+  be scoped out under `--ast-frontend hybrid`, reproducing the exact
+  false-clean result already fixed for the single-backend case. Fixed by
+  passing `public_include_search_dirs` through to `run_hybrid_dump`, whose
+  existing `**kwargs` forwarding already relays it unchanged to both
+  recursive `dump()` calls.

--- a/changelog.d/1787310000_claude_appcompat_include_scope_forward.md
+++ b/changelog.d/1787310000_claude_appcompat_include_scope_forward.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **The standalone `check_appcompat()` Python API dropped a caller's
+  explicit `old_includes`/`new_includes` (or the shared `includes=`
+  fallback) instead of forwarding them to `dump()`'s declaration-
+  provenance widening.** Both of its `dump()` calls passed the caller's
+  own genuinely explicit `-I` list only as `extra_includes` (the compile
+  include path), never as the separate `public_include_search_dirs`
+  parameter this PR introduced for the CLI's compare/dump/scan frontends
+  — so a declaration reached only through an explicit include root stayed
+  `PRIVATE_HEADER` on this one API and could be scoped out of the diff
+  under the default `scope_to_public_surface=True`, reproducing the same
+  false-clean result already fixed elsewhere. Fixed by forwarding each
+  side's own explicit include list as `public_include_search_dirs` too.

--- a/changelog.d/1787320000_claude_solaris_triple_dotted_os.md
+++ b/changelog.d/1787320000_claude_solaris_triple_dotted_os.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **The toolchain-triple validation added for a false-positive fix earlier
+  in this PR was itself too strict for a real Solaris/AIX-style target
+  triple.** `_TARGET_TRIPLE_RE` required every hyphen-joined component to
+  be plain alphanumeric/underscore, but a real triple's OS component can
+  embed a dotted version (`x86_64-pc-solaris2.11` — already recognized
+  elsewhere in this codebase, in `toolchain_probe.py`). Under a
+  relocatable prefix not covered by the fixed `_SYSTEM_HEADER_DIRS`
+  prefixes, this made a genuine compiler's own private include tree read
+  as ordinary project declarations, reintroducing noisy/false ABI findings
+  from the toolchain surface it was supposed to be excluded from. Fixed by
+  allowing a non-leading component to also carry dots.

--- a/changelog.d/1787330000_claude_pe_macho_include_scope_forward.md
+++ b/changelog.d/1787330000_claude_pe_macho_include_scope_forward.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- **The PE/Mach-O `dump` CLI path dropped the same declaration-provenance
+  distinction the ELF path already got: a build-derived, auto-widened
+  include directory could reach provenance the same way an explicit `-I`
+  does.** `handle_non_elf_dump()` seeds `includes` with build-derived
+  directories (e.g. so a `--sources`-derived umbrella header's own relative
+  `#include`s resolve) before calling the native dumper — but that same,
+  possibly-widened list was also what reached declaration-provenance
+  classification, so a build-derived directory could silently promote a
+  private sibling header to `PUBLIC_HEADER` on PE/Mach-O, reproducing the
+  exact false-clean result already fixed for ELF's `perform_elf_dump`.
+  Fixed by threading a new `public_include_search_dirs` parameter through
+  `service.run_dump`/`_finish_native_snapshot` (mirroring `dumper.dump`'s
+  parameter of the same name), fed only by the CLI's own genuinely explicit
+  `-I` list, with every other caller's behavior unchanged (defaults to the
+  pre-existing `includes` fallback).

--- a/changelog.d/1787340000_claude_debian_multiarch_libstdcxx.md
+++ b/changelog.d/1787340000_claude_debian_multiarch_libstdcxx.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **The system-header check for libstdc++'s `usr/include/c++/<version>` tree
+  required `c++` immediately after the system prefix, missing the common
+  Debian/Ubuntu multiarch layout.** A multiarch-enabled GCC install puts
+  libstdc++ under `/usr/include/<multiarch-triple>/c++/<version>/` (e.g.
+  `/usr/include/x86_64-linux-gnu/c++/12/`) rather than directly under
+  `/usr/include/c++/<version>/`. Since public-surface matching runs before
+  system-header detection, an explicit `-I` under this real layout let
+  libstdc++ internals (`bits/c++config.h` and similar) survive dependency
+  exclusion as ordinary project declarations, risking false ABI findings
+  from the toolchain surface. Fixed by accepting a validated multiarch/
+  target-triple component between the system prefix and `c++`, the same
+  structural validation already required for the `lib/gcc/<triple>/`
+  layout.

--- a/changelog.d/1787350000_claude_multiarch_component_os_marker.md
+++ b/changelog.d/1787350000_claude_multiarch_component_os_marker.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- **The Debian/Ubuntu multiarch libstdc++ fix earlier in this PR was itself
+  too permissive: it accepted any triple-*shaped* directory name, not only
+  a real multiarch tuple.** `_TARGET_TRIPLE_RE` alone (built to validate a
+  GCC/Clang toolchain-controlled triple) matches an ordinary two-word
+  project directory too (e.g. `my-lib`), so a project explicitly installed
+  under a system prefix (`-I /usr/include/my-lib/c++`) had that directory
+  silently reclassified as a system path, discarding the user's own
+  public-scoping declaration and letting a real project header's ABI
+  changes go undetected. Fixed by additionally requiring the component to
+  name a real OS/libc-environment family (`linux`, `gnu`/`gnueabihf`/
+  `musl`, ...) as one of its words before treating it as a multiarch tuple.

--- a/changelog.d/1787360000_claude_avr_single_component_gcc_target.md
+++ b/changelog.d/1787360000_claude_avr_single_component_gcc_target.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- **The GCC-triple validation added earlier in this PR rejected a real
+  relocatable GCC install targeting a single-component embedded/bare-metal
+  machine (e.g. AVR: `lib/gcc/avr/12.2.0/include`).** `_TARGET_TRIPLE_RE`
+  requires at least one hyphen, but several real GCC targets (AVR,
+  MSP430, and other bare-metal architectures) have no vendor/OS/
+  environment components at all — just a bare name. Those compiler-owned
+  headers then survived default dependency exclusion, or became public
+  when supplied via an explicit `-I`, risking false ABI findings from the
+  toolchain surface. Fixed by additionally accepting a known,
+  non-exhaustive set of real single-component GCC target names at this
+  position — the version directory's own strict digits-only check is what
+  keeps an arbitrary, unrecognized single-word project directory rejected.

--- a/changelog.d/1787370000_claude_anon_location_declaring_header.md
+++ b/changelog.d/1787370000_claude_anon_location_declaring_header.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **`strip_anonymous_type_location`'s `:line:col` discriminator alone could
+  still collide two genuinely distinct anonymous/lambda declarations.**
+  Keeping only `:line:col` (dropping the checkout-dependent path entirely)
+  fixed the same-header collision this helper was built for, but two
+  DIFFERENT headers can each legitimately declare their own anonymous
+  struct or lambda at the identical line and column — e.g.
+  `guard<(lambda at /src/one.hpp:4:3)>` and
+  `guard<(lambda at /src/two.hpp:4:3)>` both reduced to the same
+  `guard<(lambda:4:3)>` identity, silently overwriting one entry in
+  `diff_helpers.TypeMap` the way the original same-header bug did. Fixed
+  by also keeping the declaring header's own basename (checkout-
+  independent, unlike the full path) as part of the identity —
+  `guard<(lambda:one.hpp:4:3)>` / `guard<(lambda:two.hpp:4:3)>`.

--- a/changelog.d/1787380000_claude_typed_dump_include_scope_forward.md
+++ b/changelog.d/1787380000_claude_typed_dump_include_scope_forward.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- **The shared typed-dump resolver used by `compare`'s implicit-dump
+  operand and `dump`'s typed `DumpRequest` API dropped the same
+  declaration-provenance distinction the CLI resolvers already got.**
+  `service_input_resolution._resolve_side_snapshot_impl()` seeds `includes`
+  with build-derived directories before calling `service.resolve_input()`
+  — but that same, possibly-widened list was also what reached
+  provenance classification on all three binary formats, so a
+  build-derived directory could silently promote a private sibling header
+  to `PUBLIC_HEADER`, reproducing the false-clean result already fixed for
+  the ELF/PE/Mach-O `dump` CLI paths. Fixed by threading the new
+  `public_include_search_dirs` parameter (mirroring `dumper.dump`'s
+  parameter of the same name) through `service.resolve_input()` and its
+  whole-snapshot cache wiring, fed only by each side's own genuinely
+  explicit `-I` list (`InputSpec.includes`, pre-seeding).

--- a/changelog.d/1787390000_claude_quoted_marker_lookalike.md
+++ b/changelog.d/1787390000_claude_quoted_marker_lookalike.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **A C++20 fixed-string NTTP literal that merely spelled out a
+  ``(lambda at ...)``/``(unnamed ... at ...)``-shaped value could be
+  rewritten as though it were a real CastXML anonymous-type location.**
+  `name_classification.strip_anonymous_type_location()` matched any text
+  shaped like a marker, including inside a quoted string literal (e.g.
+  ``Tag<"(lambda at /a/foo.hpp:1:2)">``) — so two specializations quoting
+  different paths that happen to share a basename could collapse onto the
+  same identity. Fixed by skipping any match that falls inside a ``"..."``
+  quoted span, leaving quoted literal content untouched while still
+  normalizing a genuine, unquoted marker elsewhere in the same name.

--- a/changelog.d/1787400000_claude_compiler_option_include_scope.md
+++ b/changelog.d/1787400000_claude_compiler_option_include_scope.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- **A header reached only through a `--compiler-option -I<dir>`/`-isystem
+  <dir>` search path stayed classified `PRIVATE_HEADER` even though the
+  caller had named that directory explicitly, just not via a bare `-I`.**
+  `perform_elf_dump`/`handle_non_elf_dump` already treat a
+  `--compiler-option`-supplied include directory as "as explicit as `-I`"
+  for purposes of suppressing the L2 include-dir seed, but the
+  declaration-provenance widening set (`public_include_search_dirs`) only
+  ever collected the plain `-I`/`--include` list. Fixed by also folding in
+  the include-search directories carried by the caller's own
+  `--compiler-option` tokens (via the existing `header_utils.
+  include_operand_dirs` helper), sourced from the pre-L3-fold explicit
+  tokens on both the ELF and PE/Mach-O `dump` paths so an L3-derived
+  directory is never mistaken for a caller-supplied one.

--- a/changelog.d/1787410000_claude_manifest_include_scope_conflict.md
+++ b/changelog.d/1787410000_claude_manifest_include_scope_conflict.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- **`dump(..., dump_manifest=...)` silently accepted a `public_include_
+  search_dirs` argument alongside a multi-TU manifest.** A manifest merges
+  declarations from several independently resolved translation units, each
+  with its own per-TU include roots -- unlike `public_headers`/
+  `public_header_dirs` (replaced by the manifest's own equivalent fields), a
+  single flat `public_include_search_dirs` list has no per-TU replacement,
+  so applying it unconditionally would misapply one TU's caller-supplied
+  explicit roots to every TU's declarations. Fixed by rejecting the
+  combination with the same `ValidationError` every other manifest-
+  incompatible parameter already raises, instead of silently misapplying it.

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -530,6 +530,7 @@ Extract an ABI snapshot from a native binary (ELF, PE, or Mach-O).
 | `notify` | `Callable[[str], None] \| None` | `None` |
 | `include_labels` | `dict[Path, str] \| None` | `None` |
 | `dump_manifest` | `DumpManifest \| None` | `None` |
+| `public_include_search_dirs` | `list[Path] \| None` | `None` |
 | `include_dependencies` | `bool` | `True` |
 
 **Returns:** `AbiSnapshot`

--- a/docs/reference/python-api-reference.md
+++ b/docs/reference/python-api-reference.md
@@ -439,6 +439,7 @@ Auto-detect input type and return an ABI snapshot.
 | `include_labels` | `dict[Path, str] \| None` | `None` |
 | `dump_manifest` | `DumpManifest \| None` | `None` |
 | `include_dependencies` | `bool` | `True` |
+| `public_include_search_dirs` | `list[Path] \| None` | `None` |
 
 **Returns:** `AbiSnapshot`
 

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -2183,7 +2183,7 @@ CLI_CONTRACT_ALLOWLIST: frozenset[str] = frozenset(
         # Native ELF CLI dump (P0 item 2): calls `dumper.dump()` directly
         # rather than through `service_dump_pipeline.run_dump_request` —
         # tracked as Phase 1 item 1 of the convergence plan.
-        "abicheck/cli_dump_helpers.py:1652:19:dumper.dump",
+        "abicheck/cli_dump_helpers.py:1664:19:dumper.dump",
         # Standalone application-compatibility (P0 item 6): dumps both
         # sides directly rather than through any of the other paths.
         "abicheck/appcompat.py:1599:15:dumper.dump",

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -2187,7 +2187,7 @@ CLI_CONTRACT_ALLOWLIST: frozenset[str] = frozenset(
         # Standalone application-compatibility (P0 item 6): dumps both
         # sides directly rather than through any of the other paths.
         "abicheck/appcompat.py:1599:15:dumper.dump",
-        "abicheck/appcompat.py:1608:15:dumper.dump",
+        "abicheck/appcompat.py:1614:15:dumper.dump",
         # Scan baseline resolution (P0 item 4's baseline half): calls
         # `service.resolve_input()` directly rather than through
         # `service_input_resolution.resolve_side_snapshot`.

--- a/scripts/check_ai_readiness.py
+++ b/scripts/check_ai_readiness.py
@@ -2183,7 +2183,7 @@ CLI_CONTRACT_ALLOWLIST: frozenset[str] = frozenset(
         # Native ELF CLI dump (P0 item 2): calls `dumper.dump()` directly
         # rather than through `service_dump_pipeline.run_dump_request` —
         # tracked as Phase 1 item 1 of the convergence plan.
-        "abicheck/cli_dump_helpers.py:1645:19:dumper.dump",
+        "abicheck/cli_dump_helpers.py:1652:19:dumper.dump",
         # Standalone application-compatibility (P0 item 6): dumps both
         # sides directly rather than through any of the other paths.
         "abicheck/appcompat.py:1599:15:dumper.dump",

--- a/tests/test_action_run_sh_helpers.py
+++ b/tests/test_action_run_sh_helpers.py
@@ -183,6 +183,40 @@ class TestAddSidedFlagSplitting:
 
 
 @pytest.mark.skipif(not RUN_SH.is_file(), reason="action/run.sh not found")
+class TestAddSidedScalarFlag:
+    """A scalar sided flag (``--version``) must pass its value through
+    unsplit -- a single opaque string, not a list. Regression for a real
+    bug: ``old-version: '1.0 (release build)'`` word-split through
+    ``add_sided_flag`` into three repeated ``--version old=...`` flags
+    (``old=1.0``, ``old=(release``, ``old=build)``); the CLI kept only the
+    last one, so the report rendered ``(release build)`` and the real
+    version, ``1.0``, was silently lost."""
+
+    def test_space_separated_value_is_not_split(self) -> None:
+        out = _run_harness(
+            'add_sided_scalar_flag "--version" "old" "1.0 (release build)"'
+        )
+        assert _cmd_items(out) == ["--version", "old=1.0 (release build)"]
+
+    def test_single_word_value(self) -> None:
+        out = _run_harness('add_sided_scalar_flag "--version" "new" "pr-1"')
+        assert _cmd_items(out) == ["--version", "new=pr-1"]
+
+    def test_empty_value_adds_nothing(self) -> None:
+        out = _run_harness('add_sided_scalar_flag "--version" "old" ""')
+        assert _cmd_items(out) == []
+
+    def test_embedded_newline_is_kept_verbatim(self) -> None:
+        # Unlike add_sided_flag, a scalar flag never treats an embedded
+        # newline as an item separator either -- it is still one opaque
+        # value.
+        out = _run_harness(
+            'add_sided_scalar_flag "--version" "old" $\'line one\\nline two\''
+        )
+        assert _cmd_items(out) == ["--version", "old=line one\nline two"]
+
+
+@pytest.mark.skipif(not RUN_SH.is_file(), reason="action/run.sh not found")
 class TestIsReleaseStyleOperand:
     """``compare`` mode now skips its --write optimization for
     directory/package operands, since the release fan-out engine rejects

--- a/tests/test_anon_type_location_properties.py
+++ b/tests/test_anon_type_location_properties.py
@@ -15,15 +15,16 @@
 """Property-based tests for ``name_classification.strip_anonymous_type_location``.
 
 The example-based tests in test_castxml_anonymous_type_location.py pin the
-specific bug this function fixes, but the function itself went through two
+specific bug this function fixes, but the function itself went through three
 real review-round corrections on the same PR: the first cut dropped the
 ``:line:col`` discriminator entirely (collapsing two distinct lambdas in one
-header to one identity), and the fix for that used ``\\S+?`` for the path
-group, which silently failed to strip a path containing whitespace (a real
-checkout directory name, or a Windows ``Program Files`` component). Each
-individual round's own examples passed the code that introduced the next
-round's gap. These properties state the function's actual contract as
-invariants over the input space instead.
+header to one identity), the second used ``\\S+?`` for the path group (which
+silently failed to strip a path containing whitespace -- a real checkout
+directory name, or a Windows ``Program Files`` component), and the third used
+``[^)]*?`` (which silently failed to strip a path containing a literal ``)``
+-- e.g. ``C:\\release (old)\\foo.hpp``). Each round's own examples passed the
+code that introduced the next round's gap. These properties state the
+function's actual contract as invariants over the input space instead.
 """
 
 from __future__ import annotations
@@ -35,13 +36,13 @@ from abicheck.name_classification import strip_anonymous_type_location
 
 pytestmark = pytest.mark.slow
 
-# Path text: printable characters INCLUDING spaces (the exact class of
-# character the \S+? regression missed) but excluding ")" and ":" so the
-# generated path can never accidentally assemble something that looks like
-# a second, competing "at ...:line:col)" match.
+# Path text: printable characters INCLUDING spaces and ")" (the two
+# character classes the \S+? and [^)]*? regressions each missed in turn) but
+# excluding ":" so the generated path can never accidentally assemble
+# something that looks like a second, competing "at ...:line:col)" match.
 _PATH_CHARS = st.characters(
     whitelist_categories=("Lu", "Ll", "Nd"),
-    whitelist_characters=" /_.-\\",
+    whitelist_characters=" /_.-\\()",
 )
 _PATH = st.text(alphabet=_PATH_CHARS, min_size=1, max_size=40)
 _LINE_COL = st.tuples(
@@ -58,19 +59,19 @@ def _spelling(kind: str, path: str, line: int, col: int) -> str:
 @given(kind=_KIND, path_a=_PATH, path_b=_PATH, line_col=_LINE_COL)
 @settings(max_examples=300)
 def test_same_declaration_different_checkout_paths_match(
-    kind, path_a, path_b, line_col
+    kind: str, path_a: str, path_b: str, line_col: tuple[int, int]
 ) -> None:
     """The actual bug this whole function exists to fix, as a property: the
     SAME declaration (same kind, same :line:col) compiled from two
-    DIFFERENT checkout paths -- including a path containing spaces, the
-    exact character class the \\S+? -> [^)]*? fix restores support for --
-    must strip down to the identical identity, regardless of what either
-    path contains. Stronger than (and replaces) a plain "doesn't contain
-    the injected path" check: that check is vulnerable to a generated path
-    coincidentally colliding with the fixed template text around it (e.g. a
-    single-character path "x" trivially substring-matching "prefix"),
-    whereas this formulation only compares two independently-generated
-    outputs against each other."""
+    DIFFERENT checkout paths -- including a path containing spaces or a
+    literal ")", the two character classes the \\S+? -> [^)]*? -> .*?
+    fixes each restore support for in turn -- must strip down to the
+    identical identity, regardless of what either path contains. Stronger
+    than (and replaces) a plain "doesn't contain the injected path" check:
+    that check is vulnerable to a generated path coincidentally colliding
+    with the fixed template text around it (e.g. a single-character path
+    "x" trivially substring-matching "prefix"), whereas this formulation
+    only compares two independently-generated outputs against each other."""
     line, col = line_col
     a = strip_anonymous_type_location(_spelling(kind, path_a, line, col))
     b = strip_anonymous_type_location(_spelling(kind, path_b, line, col))
@@ -85,7 +86,10 @@ def test_same_declaration_different_checkout_paths_match(
 )
 @settings(max_examples=300)
 def test_different_positions_in_one_header_stay_distinct(
-    kind, path, line_col_a, line_col_b
+    kind: str,
+    path: str,
+    line_col_a: tuple[int, int],
+    line_col_b: tuple[int, int],
 ) -> None:
     """The type-identity-collision fix, as a property: two declarations of
     the same kind at DIFFERENT :line:col positions (simulating two distinct
@@ -102,7 +106,7 @@ def test_different_positions_in_one_header_stay_distinct(
 
 @given(kind=_KIND, path=_PATH, line_col=_LINE_COL)
 @settings(max_examples=300)
-def test_idempotent(kind, path, line_col) -> None:
+def test_idempotent(kind: str, path: str, line_col: tuple[int, int]) -> None:
     """Stripping an already-stripped spelling must be a no-op -- a
     defensive property for any caller that might (directly or via a shared
     helper) apply this more than once to the same value."""
@@ -120,7 +124,7 @@ def test_idempotent(kind, path, line_col) -> None:
     )
 )
 @settings(max_examples=300)
-def test_ordinary_name_with_no_anonymous_marker_is_unaffected(text) -> None:
+def test_ordinary_name_with_no_anonymous_marker_is_unaffected(text: str) -> None:
     """A type name that never contains the "(kind at path:line:col)" shape
     at all must pass through completely unchanged. Restricted to an
     already-whitespace-free alphabet: the function unconditionally collapses

--- a/tests/test_anon_type_location_properties.py
+++ b/tests/test_anon_type_location_properties.py
@@ -38,13 +38,19 @@ pytestmark = pytest.mark.slow
 
 # Path text: printable characters INCLUDING spaces and ")" (the two
 # character classes the \S+? and [^)]*? regressions each missed in turn) but
-# excluding ":" so the generated path can never accidentally assemble
-# something that looks like a second, competing "at ...:line:col)" match.
+# excluding ":" and "/" so the generated path can never accidentally
+# assemble something that looks like a second, competing "at
+# ...:line:col)" match, and so it stays a pure basename (no directory
+# separator of its own) when used as one below.
 _PATH_CHARS = st.characters(
     whitelist_categories=("Lu", "Ll", "Nd"),
-    whitelist_characters=" /_.-\\()",
+    whitelist_characters=" _.-\\()",
 )
 _PATH = st.text(alphabet=_PATH_CHARS, min_size=1, max_size=40)
+#: A checkout-root prefix -- deliberately excludes "/" too, joined onto a
+#: basename with an explicit "/" below, so root text can never itself
+#: masquerade as an extra path segment/basename of its own.
+_ROOT = st.text(alphabet=_PATH_CHARS, min_size=0, max_size=30)
 _LINE_COL = st.tuples(
     st.integers(min_value=0, max_value=99999), st.integers(min_value=0, max_value=999)
 )
@@ -56,26 +62,58 @@ def _spelling(kind: str, path: str, line: int, col: int) -> str:
     return f"prefix<({marker} at {path}:{line}:{col})>"
 
 
-@given(kind=_KIND, path_a=_PATH, path_b=_PATH, line_col=_LINE_COL)
+def _rooted_path(root: str, basename: str) -> str:
+    return f"{root}/{basename}" if root else basename
+
+
+@given(kind=_KIND, root_a=_ROOT, root_b=_ROOT, basename=_PATH, line_col=_LINE_COL)
 @settings(max_examples=300)
-def test_same_declaration_different_checkout_paths_match(
-    kind: str, path_a: str, path_b: str, line_col: tuple[int, int]
+def test_same_declaration_different_checkout_roots_match(
+    kind: str, root_a: str, root_b: str, basename: str, line_col: tuple[int, int]
 ) -> None:
     """The actual bug this whole function exists to fix, as a property: the
-    SAME declaration (same kind, same :line:col) compiled from two
-    DIFFERENT checkout paths -- including a path containing spaces or a
-    literal ")", the two character classes the \\S+? -> [^)]*? -> .*?
-    fixes each restore support for in turn -- must strip down to the
-    identical identity, regardless of what either path contains. Stronger
-    than (and replaces) a plain "doesn't contain the injected path" check:
-    that check is vulnerable to a generated path coincidentally colliding
-    with the fixed template text around it (e.g. a single-character path
-    "x" trivially substring-matching "prefix"), whereas this formulation
-    only compares two independently-generated outputs against each other."""
+    SAME declaration (same kind, same basename, same :line:col) compiled
+    from two DIFFERENT checkout roots -- including a root containing
+    spaces or a literal ")", the two character classes the \\S+? ->
+    [^)]*? -> .*? fixes each restore support for in turn -- must strip
+    down to the identical identity, regardless of what either root
+    contains. Only the checkout-dependent ROOT varies here; the
+    declaring header's own basename (now part of the identity, round 8)
+    is held fixed, since that's the actual same-file-different-checkout
+    scenario this function exists to normalize -- see the sibling
+    ``test_different_headers_same_position_stay_distinct`` for the
+    complementary case where the basename itself differs."""
     line, col = line_col
-    a = strip_anonymous_type_location(_spelling(kind, path_a, line, col))
-    b = strip_anonymous_type_location(_spelling(kind, path_b, line, col))
+    a = strip_anonymous_type_location(
+        _spelling(kind, _rooted_path(root_a, basename), line, col)
+    )
+    b = strip_anonymous_type_location(
+        _spelling(kind, _rooted_path(root_b, basename), line, col)
+    )
     assert a == b
+
+
+@given(
+    kind=_KIND,
+    basename_a=_PATH,
+    basename_b=_PATH,
+    line_col=_LINE_COL,
+)
+@settings(max_examples=300)
+def test_different_headers_same_position_stay_distinct(
+    kind: str, basename_a: str, basename_b: str, line_col: tuple[int, int]
+) -> None:
+    """Round-8 review finding, as a property: two declarations of the same
+    kind at the IDENTICAL :line:col but in two DIFFERENTLY-NAMED headers
+    must never strip down to the same identity -- :line:col alone cannot
+    tell them apart, since two distinct files can each legitimately
+    declare their own anonymous/lambda type at the same coordinates."""
+    if basename_a == basename_b:
+        return  # not the case under test
+    line, col = line_col
+    a = strip_anonymous_type_location(_spelling(kind, basename_a, line, col))
+    b = strip_anonymous_type_location(_spelling(kind, basename_b, line, col))
+    assert a != b
 
 
 @given(

--- a/tests/test_anon_type_location_properties.py
+++ b/tests/test_anon_type_location_properties.py
@@ -118,7 +118,7 @@ def test_idempotent(kind: str, path: str, line_col: tuple[int, int]) -> None:
 
 @given(
     text=st.text(
-        alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd", "P")),
+        alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd", "P", "Zs")),
         min_size=1,
         max_size=60,
     )
@@ -126,12 +126,15 @@ def test_idempotent(kind: str, path: str, line_col: tuple[int, int]) -> None:
 @settings(max_examples=300)
 def test_ordinary_name_with_no_anonymous_marker_is_unaffected(text: str) -> None:
     """A type name that never contains the "(kind at path:line:col)" shape
-    at all must pass through completely unchanged. Restricted to an
-    already-whitespace-free alphabet: the function unconditionally collapses
-    internal whitespace and strips the ends (its own normalization step,
-    independent of whether a location was actually found), so a text
-    containing whitespace is not "unaffected" in the literal sense this
-    property checks — that normalization is real, documented behavior, not
-    the property under test here."""
+    at all must pass through completely unchanged -- byte-for-byte,
+    including any internal whitespace it happens to carry. This is the
+    round-3 review fix (Codex, fresh evidence): the whitespace-collapse
+    step below used to run unconditionally, which would also rewrite
+    meaningful whitespace inside an ordinary name (e.g. a C++20
+    fixed-string NTTP template argument, ``Tag<"a  b">`` vs. ``Tag<"a
+    b">``) even when no anonymous-location marker was present at all --
+    now it only runs when the marker substitution actually fired, so an
+    ordinary name (whitespace included) is genuinely a no-op, not just
+    "unaffected modulo normalization"."""
     if " at " not in text or ":" not in text:
         assert strip_anonymous_type_location(text) == text

--- a/tests/test_anon_type_location_properties.py
+++ b/tests/test_anon_type_location_properties.py
@@ -1,0 +1,133 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Property-based tests for ``name_classification.strip_anonymous_type_location``.
+
+The example-based tests in test_castxml_anonymous_type_location.py pin the
+specific bug this function fixes, but the function itself went through two
+real review-round corrections on the same PR: the first cut dropped the
+``:line:col`` discriminator entirely (collapsing two distinct lambdas in one
+header to one identity), and the fix for that used ``\\S+?`` for the path
+group, which silently failed to strip a path containing whitespace (a real
+checkout directory name, or a Windows ``Program Files`` component). Each
+individual round's own examples passed the code that introduced the next
+round's gap. These properties state the function's actual contract as
+invariants over the input space instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from abicheck.name_classification import strip_anonymous_type_location
+
+pytestmark = pytest.mark.slow
+
+# Path text: printable characters INCLUDING spaces (the exact class of
+# character the \S+? regression missed) but excluding ")" and ":" so the
+# generated path can never accidentally assemble something that looks like
+# a second, competing "at ...:line:col)" match.
+_PATH_CHARS = st.characters(
+    whitelist_categories=("Lu", "Ll", "Nd"),
+    whitelist_characters=" /_.-\\",
+)
+_PATH = st.text(alphabet=_PATH_CHARS, min_size=1, max_size=40)
+_LINE_COL = st.tuples(
+    st.integers(min_value=0, max_value=99999), st.integers(min_value=0, max_value=999)
+)
+_KIND = st.sampled_from(["lambda", "unnamed struct", "unnamed enum", "unnamed union"])
+
+
+def _spelling(kind: str, path: str, line: int, col: int) -> str:
+    marker = "lambda" if kind == "lambda" else kind
+    return f"prefix<({marker} at {path}:{line}:{col})>"
+
+
+@given(kind=_KIND, path_a=_PATH, path_b=_PATH, line_col=_LINE_COL)
+@settings(max_examples=300)
+def test_same_declaration_different_checkout_paths_match(
+    kind, path_a, path_b, line_col
+) -> None:
+    """The actual bug this whole function exists to fix, as a property: the
+    SAME declaration (same kind, same :line:col) compiled from two
+    DIFFERENT checkout paths -- including a path containing spaces, the
+    exact character class the \\S+? -> [^)]*? fix restores support for --
+    must strip down to the identical identity, regardless of what either
+    path contains. Stronger than (and replaces) a plain "doesn't contain
+    the injected path" check: that check is vulnerable to a generated path
+    coincidentally colliding with the fixed template text around it (e.g. a
+    single-character path "x" trivially substring-matching "prefix"),
+    whereas this formulation only compares two independently-generated
+    outputs against each other."""
+    line, col = line_col
+    a = strip_anonymous_type_location(_spelling(kind, path_a, line, col))
+    b = strip_anonymous_type_location(_spelling(kind, path_b, line, col))
+    assert a == b
+
+
+@given(
+    kind=_KIND,
+    path=_PATH,
+    line_col_a=_LINE_COL,
+    line_col_b=_LINE_COL,
+)
+@settings(max_examples=300)
+def test_different_positions_in_one_header_stay_distinct(
+    kind, path, line_col_a, line_col_b
+) -> None:
+    """The type-identity-collision fix, as a property: two declarations of
+    the same kind at DIFFERENT :line:col positions (simulating two distinct
+    lambdas/anonymous tags in one header) must never strip down to the same
+    identity."""
+    if line_col_a == line_col_b:
+        return  # not the case under test
+    line_a, col_a = line_col_a
+    line_b, col_b = line_col_b
+    a = strip_anonymous_type_location(_spelling(kind, path, line_a, col_a))
+    b = strip_anonymous_type_location(_spelling(kind, path, line_b, col_b))
+    assert a != b
+
+
+@given(kind=_KIND, path=_PATH, line_col=_LINE_COL)
+@settings(max_examples=300)
+def test_idempotent(kind, path, line_col) -> None:
+    """Stripping an already-stripped spelling must be a no-op -- a
+    defensive property for any caller that might (directly or via a shared
+    helper) apply this more than once to the same value."""
+    line, col = line_col
+    once = strip_anonymous_type_location(_spelling(kind, path, line, col))
+    twice = strip_anonymous_type_location(once)
+    assert once == twice
+
+
+@given(
+    text=st.text(
+        alphabet=st.characters(whitelist_categories=("Lu", "Ll", "Nd", "P")),
+        min_size=1,
+        max_size=60,
+    )
+)
+@settings(max_examples=300)
+def test_ordinary_name_with_no_anonymous_marker_is_unaffected(text) -> None:
+    """A type name that never contains the "(kind at path:line:col)" shape
+    at all must pass through completely unchanged. Restricted to an
+    already-whitespace-free alphabet: the function unconditionally collapses
+    internal whitespace and strips the ends (its own normalization step,
+    independent of whether a location was actually found), so a text
+    containing whitespace is not "unaffected" in the literal sense this
+    property checks — that normalization is real, documented behavior, not
+    the property under test here."""
+    if " at " not in text or ":" not in text:
+        assert strip_anonymous_type_location(text) == text

--- a/tests/test_appcompat.py
+++ b/tests/test_appcompat.py
@@ -1377,6 +1377,41 @@ class TestCheckAppcompat:
         assert old_call.kwargs["public_headers"] == [old_hdr]
         assert new_call.kwargs["public_headers"] == [new_hdr]
 
+    def test_includes_passed_as_public_include_search_dirs(self, tmp_path):
+        """check_appcompat's own explicit old_includes/new_includes (or the
+        shared includes= fallback) are a genuine, caller-declared -I list --
+        not auto-derived -- so they must reach dump()'s provenance-only
+        public_include_search_dirs the same way perform_elf_dump's/
+        _dump_elf's own explicit -I wiring does (Codex review, PR #839
+        round 7), not just the compile-time extra_includes param."""
+        app = tmp_path / "app"
+        old_lib = tmp_path / "old.so"
+        new_lib = tmp_path / "new.so"
+        old_hdr = tmp_path / "old.h"
+        new_hdr = tmp_path / "new.h"
+        old_inc = tmp_path / "old_include"
+        new_inc = tmp_path / "new_include"
+
+        app_reqs = AppRequirements(undefined_symbols=set())
+        diff = DiffResult(old_version="1", new_version="2", library="libfoo")
+
+        with patch("abicheck.appcompat._get_lib_soname", return_value="libfoo.so.1"), \
+             patch("abicheck.appcompat.parse_app_requirements", return_value=app_reqs), \
+             patch("abicheck.dumper.dump", return_value=MagicMock()) as mock_dump, \
+             patch("abicheck.service.compare_snapshots", return_value=diff), \
+             patch("abicheck.appcompat._get_new_lib_exports", return_value=set()), \
+             patch("abicheck.appcompat._detect_app_format", return_value=None):
+            check_appcompat(
+                app, old_lib, new_lib,
+                old_headers=[old_hdr], new_headers=[new_hdr],
+                old_includes=[old_inc], new_includes=[new_inc],
+            )
+
+        assert mock_dump.call_count == 2
+        old_call, new_call = mock_dump.call_args_list
+        assert old_call.kwargs["public_include_search_dirs"] == [old_inc]
+        assert new_call.kwargs["public_include_search_dirs"] == [new_inc]
+
     def test_missing_symbols_breaking(self, tmp_path):
         app = tmp_path / "app"
         old_lib = tmp_path / "old.so"

--- a/tests/test_castxml_anonymous_type_location.py
+++ b/tests/test_castxml_anonymous_type_location.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression test for castxml lambda-closure/anonymous-type name location
+leakage (defect: identical headers in two different checkout directories
+compared as BREAKING, since a lambda closure type's ``name`` embeds an
+absolute source path -- ``"raii_guard<(lambda at /tmp/old/lib.hpp:4:37)>"``
+vs. ``"raii_guard<(lambda at /tmp/new/lib.hpp:4:37)>"`` -- and old/new type
+matching (``diff_helpers.type_map_key``) keys on that raw, unstripped
+spelling. The clang JSON-AST frontend already strips this
+(``dumper_clang_expr._normalize_qual_type``); the castxml frontend had no
+equivalent.
+"""
+
+from __future__ import annotations
+
+from xml.etree.ElementTree import Element, SubElement
+
+from abicheck.diff_helpers import type_map_key
+from abicheck.dumper import _CastxmlParser
+
+
+def _file(root: Element, file_id: str, name: str) -> None:
+    f = SubElement(root, "File")
+    f.set("id", file_id)
+    f.set("name", name)
+
+
+def _lambda_struct_root(source_path: str) -> Element:
+    """Mirror castxml output for a class template instantiated with a
+    lambda closure type, e.g. ``raii_guard<decltype([]{})>``."""
+    root = Element("CastXML", attrib={"format": "1.4.0"})
+    _file(root, "f1", source_path)
+    SubElement(root, "Namespace", attrib={"id": "_1", "name": "::"})
+
+    struct_el = SubElement(root, "Struct")
+    struct_el.set("id", "_2")
+    struct_el.set(
+        "name",
+        f"raii_guard<(lambda at {source_path}:4:37)>",
+    )
+    struct_el.set("context", "_1")
+    struct_el.set("file", "f1")
+    struct_el.set("line", "4")
+    struct_el.set("members", "")
+
+    return root
+
+
+class TestLambdaClosureTypeNameLocationStripped:
+    def test_type_name_strips_embedded_source_location(self) -> None:
+        root = _lambda_struct_root("/tmp/old/lib.hpp")
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+        assert parser._type_name("_2") == "raii_guard<(lambda)>"
+
+    def test_record_type_own_name_has_no_embedded_location(self) -> None:
+        root = _lambda_struct_root("/tmp/old/lib.hpp")
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+        types = parser.parse_types()
+        (rec,) = [t for t in types if t.name.startswith("raii_guard")]
+        assert rec.name == "raii_guard<(lambda)>"
+        assert "/tmp/old" not in rec.name
+
+    def test_two_checkout_directories_produce_identical_type_identity(self) -> None:
+        # The actual bug: the same declaration, compiled from two different
+        # checkout directories, must resolve to the SAME type_map_key so
+        # old/new matching doesn't manufacture a spurious
+        # type_removed/type_added pair for an unchanged type.
+        old_root = _lambda_struct_root("/tmp/old/lib.hpp")
+        new_root = _lambda_struct_root("/tmp/new/lib.hpp")
+        old_parser = _CastxmlParser(
+            old_root, exported_dynamic=set(), exported_static=set()
+        )
+        new_parser = _CastxmlParser(
+            new_root, exported_dynamic=set(), exported_static=set()
+        )
+        (old_rec,) = [
+            t for t in old_parser.parse_types() if t.name.startswith("raii_guard")
+        ]
+        (new_rec,) = [
+            t for t in new_parser.parse_types() if t.name.startswith("raii_guard")
+        ]
+        assert type_map_key(old_rec) == type_map_key(new_rec)
+
+
+class TestAnonymousEnumLocationStripped:
+    def test_enum_name_has_no_embedded_location(self) -> None:
+        root = Element("CastXML", attrib={"format": "1.4.0"})
+        _file(root, "f1", "/tmp/old/lib.hpp")
+        SubElement(root, "Namespace", attrib={"id": "_1", "name": "::"})
+
+        enum_el = SubElement(root, "Enumeration")
+        enum_el.set("id", "_2")
+        enum_el.set("name", "(unnamed enum at /tmp/old/lib.hpp:56:5)")
+        enum_el.set("context", "_1")
+        enum_el.set("file", "f1")
+        enum_el.set("line", "56")
+
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+        (enum_type,) = parser.parse_enums()
+        assert enum_type.name == "(unnamed enum)"
+        assert "/tmp/old" not in enum_type.name

--- a/tests/test_castxml_anonymous_type_location.py
+++ b/tests/test_castxml_anonymous_type_location.py
@@ -172,6 +172,36 @@ class TestOrdinaryNameWhitespaceIsPreserved:
         assert b == 'Tag<"a b">'
         assert a != b
 
+    def test_composite_name_with_a_real_lambda_marker_preserves_unrelated_whitespace(
+        self,
+    ) -> None:
+        """Round-4 review, second finding: even the "only collapse when the
+        substitution fired" gate wasn't narrow enough -- a composite name
+        where the substitution legitimately fires in ONE template argument
+        (a real lambda marker) must not touch whitespace in an unrelated
+        SIBLING argument (a fixed-string NTTP literal)."""
+        a = strip_anonymous_type_location('Tag<"a  b", (lambda at /tmp/a.hpp:4:3)>')
+        b = strip_anonymous_type_location('Tag<"a b", (lambda at /tmp/a.hpp:4:3)>')
+        assert a == 'Tag<"a  b", (lambda:4:3)>'
+        assert b == 'Tag<"a b", (lambda:4:3)>'
+        assert a != b
+
+
+class TestAnonymousMarkerRequiredBeforeStripping:
+    """Round-4 review, Codex, fresh evidence: the regex previously matched a
+    bare ``\\bat\\s+...:N:M`` anywhere in the name, so an ordinary
+    specialization whose fixed-string argument merely CONTAINS
+    location-shaped text (no real lambda/unnamed-type marker at all) was
+    incorrectly rewritten, risking a collision with a genuinely distinct
+    type. The regex now requires an actual ``(lambda``/``(unnamed <kind>``
+    marker immediately before ``at``."""
+
+    def test_fixed_string_literal_containing_location_shaped_text_is_untouched(
+        self,
+    ) -> None:
+        name = 'Tag<"at /checkout:1:2)">'
+        assert strip_anonymous_type_location(name) == name
+
 
 class TestAnonymousEnumLocationStripped:
     def test_enum_name_has_no_embedded_path(self) -> None:

--- a/tests/test_castxml_anonymous_type_location.py
+++ b/tests/test_castxml_anonymous_type_location.py
@@ -66,14 +66,14 @@ class TestLambdaClosureTypeNameLocationStripped:
         # The path is stripped; the :line:col discriminator is kept (Codex
         # review) so two distinct lambdas in the same header don't collapse
         # to one identity — see TestDistinctLambdasInOneSnapshotStayDistinct.
-        assert parser._type_name("_2") == "raii_guard<(lambda:4:37)>"
+        assert parser._type_name("_2") == "raii_guard<(lambda:lib.hpp:4:37)>"
 
     def test_record_type_own_name_has_no_embedded_path(self) -> None:
         root = _lambda_struct_root("/tmp/old/lib.hpp")
         parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
         types = parser.parse_types()
         (rec,) = [t for t in types if t.name.startswith("raii_guard")]
-        assert rec.name == "raii_guard<(lambda:4:37)>"
+        assert rec.name == "raii_guard<(lambda:lib.hpp:4:37)>"
         assert "/tmp/old" not in rec.name
 
     def test_two_checkout_directories_produce_identical_type_identity(self) -> None:
@@ -132,9 +132,53 @@ class TestDistinctLambdasInOneSnapshotStayDistinct:
         types = [t for t in parser.parse_types() if t.name.startswith("guard")]
         assert len(types) == 2
         names = {t.name for t in types}
-        assert names == {"guard<(lambda:4:3)>", "guard<(lambda:40:3)>"}
+        assert names == {"guard<(lambda:lib.hpp:4:3)>", "guard<(lambda:lib.hpp:40:3)>"}
         keys = {type_map_key(t) for t in types}
         assert len(keys) == 2, "distinct lambdas must not collide on one key"
+
+
+class TestDistinctLambdasInDifferentHeadersStayDistinct:
+    """Round-8 review finding (Codex, fresh evidence): keeping only
+    :line:col as a discriminator fixed the same-header collision above, but
+    two distinct lambda closure types declared at the IDENTICAL line:col in
+    two DIFFERENT headers still collided, since neither header's own path
+    survived stripping. The declaring header's own basename is now kept
+    alongside :line:col, distinguishing this case too."""
+
+    def test_two_lambdas_at_same_position_in_different_headers_stay_distinct(
+        self,
+    ) -> None:
+        root = Element("CastXML", attrib={"format": "1.4.0"})
+        _file(root, "f1", "/src/one.hpp")
+        _file(root, "f2", "/src/two.hpp")
+        SubElement(root, "Namespace", attrib={"id": "_1", "name": "::"})
+
+        first = SubElement(root, "Struct")
+        first.set("id", "_2")
+        first.set("name", "guard<(lambda at /src/one.hpp:4:3)>")
+        first.set("context", "_1")
+        first.set("file", "f1")
+        first.set("line", "4")
+        first.set("members", "")
+
+        second = SubElement(root, "Struct")
+        second.set("id", "_3")
+        second.set("name", "guard<(lambda at /src/two.hpp:4:3)>")
+        second.set("context", "_1")
+        second.set("file", "f2")
+        second.set("line", "4")
+        second.set("members", "")
+
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+        types = [t for t in parser.parse_types() if t.name.startswith("guard")]
+        assert len(types) == 2
+        names = {t.name for t in types}
+        assert names == {"guard<(lambda:one.hpp:4:3)>", "guard<(lambda:two.hpp:4:3)>"}
+        keys = {type_map_key(t) for t in types}
+        assert len(keys) == 2, (
+            "two lambdas at the same line:col in different headers must "
+            "not collide on one key"
+        )
 
 
 class TestPathContainingALiteralCloseParen:
@@ -146,7 +190,7 @@ class TestPathContainingALiteralCloseParen:
 
     def test_windows_path_with_parenthesized_component_is_stripped(self) -> None:
         name = r"raii_guard<(lambda at C:\release (old)\foo.hpp:4:37)>"
-        assert strip_anonymous_type_location(name) == "raii_guard<(lambda:4:37)>"
+        assert strip_anonymous_type_location(name) == "raii_guard<(lambda:foo.hpp:4:37)>"
 
     def test_two_checkouts_differing_only_in_a_parenthesized_component_match(
         self,
@@ -182,8 +226,8 @@ class TestOrdinaryNameWhitespaceIsPreserved:
         SIBLING argument (a fixed-string NTTP literal)."""
         a = strip_anonymous_type_location('Tag<"a  b", (lambda at /tmp/a.hpp:4:3)>')
         b = strip_anonymous_type_location('Tag<"a b", (lambda at /tmp/a.hpp:4:3)>')
-        assert a == 'Tag<"a  b", (lambda:4:3)>'
-        assert b == 'Tag<"a b", (lambda:4:3)>'
+        assert a == 'Tag<"a  b", (lambda:a.hpp:4:3)>'
+        assert b == 'Tag<"a b", (lambda:a.hpp:4:3)>'
         assert a != b
 
 
@@ -218,7 +262,7 @@ class TestAnonymousEnumLocationStripped:
 
         parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
         (enum_type,) = parser.parse_enums()
-        assert enum_type.name == "(unnamed enum:56:5)"
+        assert enum_type.name == "(unnamed enum:lib.hpp:56:5)"
         assert "/tmp/old" not in enum_type.name
 
     def test_reference_to_anonymous_enum_matches_its_own_declaration(self) -> None:
@@ -244,7 +288,7 @@ class TestAnonymousEnumLocationStripped:
         (enum_type,) = parser.parse_enums()
         # The reference (a field/param/return naming the same id) goes
         # through _type_name, not parse_enums -- both must agree.
-        assert parser._type_name("_2") == enum_type.name == "(unnamed enum:56:5)"
+        assert parser._type_name("_2") == enum_type.name == "(unnamed enum:lib.hpp:56:5)"
 
 
 class TestQualifiedNameNormalizesEnclosingAnonymousScope:
@@ -285,7 +329,7 @@ class TestQualifiedNameNormalizesEnclosingAnonymousScope:
         parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
         types = parser.parse_types()
         (inner,) = [t for t in types if t.name == "Inner"]
-        assert inner.qualified_name == "Wrapper<(lambda:4:3)>::Inner"
+        assert inner.qualified_name == "Wrapper<(lambda:lib.hpp:4:3)>::Inner"
         assert "/tmp/old" not in (inner.qualified_name or "")
 
     def test_two_checkout_directories_produce_identical_nested_type_identity(

--- a/tests/test_castxml_anonymous_type_location.py
+++ b/tests/test_castxml_anonymous_type_location.py
@@ -29,6 +29,7 @@ from xml.etree.ElementTree import Element, SubElement
 
 from abicheck.diff_helpers import type_map_key
 from abicheck.dumper import _CastxmlParser
+from abicheck.name_classification import strip_anonymous_type_location
 
 
 def _file(root: Element, file_id: str, name: str) -> None:
@@ -136,6 +137,25 @@ class TestDistinctLambdasInOneSnapshotStayDistinct:
         assert len(keys) == 2, "distinct lambdas must not collide on one key"
 
 
+class TestPathContainingALiteralCloseParen:
+    """CodeRabbit review, round 3: the path group was ``[^)]*?``, which by
+    construction cannot match a path containing a literal ``)`` (a real,
+    if unusual, Windows path like ``C:\\release (old)\\foo.hpp``) -- the
+    identical failure mode ``\\S+?`` had for a path containing a space,
+    just from a different character class. Fixed by widening to ``.*?``."""
+
+    def test_windows_path_with_parenthesized_component_is_stripped(self) -> None:
+        name = r"raii_guard<(lambda at C:\release (old)\foo.hpp:4:37)>"
+        assert strip_anonymous_type_location(name) == "raii_guard<(lambda:4:37)>"
+
+    def test_two_checkouts_differing_only_in_a_parenthesized_component_match(
+        self,
+    ) -> None:
+        old = r"guard<(lambda at C:\release (old)\a.hpp:4:37)>"
+        new = r"guard<(lambda at C:\release (new)\a.hpp:4:37)>"
+        assert strip_anonymous_type_location(old) == strip_anonymous_type_location(new)
+
+
 class TestAnonymousEnumLocationStripped:
     def test_enum_name_has_no_embedded_path(self) -> None:
         root = Element("CastXML", attrib={"format": "1.4.0"})
@@ -153,3 +173,85 @@ class TestAnonymousEnumLocationStripped:
         (enum_type,) = parser.parse_enums()
         assert enum_type.name == "(unnamed enum:56:5)"
         assert "/tmp/old" not in enum_type.name
+
+    def test_reference_to_anonymous_enum_matches_its_own_declaration(self) -> None:
+        """Round-3 review finding (Codex + CodeRabbit, independently): a
+        *reference* to an anonymous enum (e.g. a field's type) went through
+        ``_type_name_uncached``'s bare ``el.get("name", "?")`` fallback,
+        never the ``strip_anonymous_type_location`` normalization
+        ``parse_enums()`` applies to the declaration itself -- so the
+        reference and the declaration disagreed on spelling and never
+        matched across two checkouts."""
+        root = Element("CastXML", attrib={"format": "1.4.0"})
+        _file(root, "f1", "/tmp/old/lib.hpp")
+        SubElement(root, "Namespace", attrib={"id": "_1", "name": "::"})
+
+        enum_el = SubElement(root, "Enumeration")
+        enum_el.set("id", "_2")
+        enum_el.set("name", "(unnamed enum at /tmp/old/lib.hpp:56:5)")
+        enum_el.set("context", "_1")
+        enum_el.set("file", "f1")
+        enum_el.set("line", "56")
+
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+        (enum_type,) = parser.parse_enums()
+        # The reference (a field/param/return naming the same id) goes
+        # through _type_name, not parse_enums -- both must agree.
+        assert parser._type_name("_2") == enum_type.name == "(unnamed enum:56:5)"
+
+
+class TestQualifiedNameNormalizesEnclosingAnonymousScope:
+    """Round-3 review finding (Codex + CodeRabbit, independently):
+    ``_qualified_type_name`` copied an enclosing Struct/Class/Union's raw
+    (unnormalized) ``name`` when building a nested type's ``qualified_name``
+    -- so a type nested inside a lambda-closure-instantiated template (e.g.
+    ``Wrapper<(lambda at /checkout/a.hpp:4:3)>::Inner``) still leaked the
+    checkout path via the enclosing segment, even though the leaf itself was
+    already normalized -- defeating type_map_key's qualified_name-preferred
+    cross-checkout matching for nested declarations."""
+
+    def _nested_struct_root(self, source_path: str) -> Element:
+        root = Element("CastXML", attrib={"format": "1.4.0"})
+        _file(root, "f1", source_path)
+        SubElement(root, "Namespace", attrib={"id": "_1", "name": "::"})
+
+        outer = SubElement(root, "Struct")
+        outer.set("id", "_2")
+        outer.set("name", f"Wrapper<(lambda at {source_path}:4:3)>")
+        outer.set("context", "_1")
+        outer.set("file", "f1")
+        outer.set("line", "4")
+        outer.set("members", "_3")
+
+        inner = SubElement(root, "Struct")
+        inner.set("id", "_3")
+        inner.set("name", "Inner")
+        inner.set("context", "_2")
+        inner.set("file", "f1")
+        inner.set("line", "5")
+        inner.set("members", "")
+
+        return root
+
+    def test_qualified_name_has_no_embedded_path(self) -> None:
+        root = self._nested_struct_root("/tmp/old/lib.hpp")
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+        types = parser.parse_types()
+        (inner,) = [t for t in types if t.name == "Inner"]
+        assert inner.qualified_name == "Wrapper<(lambda:4:3)>::Inner"
+        assert "/tmp/old" not in (inner.qualified_name or "")
+
+    def test_two_checkout_directories_produce_identical_nested_type_identity(
+        self,
+    ) -> None:
+        old_root = self._nested_struct_root("/tmp/old/lib.hpp")
+        new_root = self._nested_struct_root("/tmp/new/lib.hpp")
+        old_parser = _CastxmlParser(
+            old_root, exported_dynamic=set(), exported_static=set()
+        )
+        new_parser = _CastxmlParser(
+            new_root, exported_dynamic=set(), exported_static=set()
+        )
+        (old_inner,) = [t for t in old_parser.parse_types() if t.name == "Inner"]
+        (new_inner,) = [t for t in new_parser.parse_types() if t.name == "Inner"]
+        assert type_map_key(old_inner) == type_map_key(new_inner)

--- a/tests/test_castxml_anonymous_type_location.py
+++ b/tests/test_castxml_anonymous_type_location.py
@@ -190,7 +190,9 @@ class TestPathContainingALiteralCloseParen:
 
     def test_windows_path_with_parenthesized_component_is_stripped(self) -> None:
         name = r"raii_guard<(lambda at C:\release (old)\foo.hpp:4:37)>"
-        assert strip_anonymous_type_location(name) == "raii_guard<(lambda:foo.hpp:4:37)>"
+        assert (
+            strip_anonymous_type_location(name) == "raii_guard<(lambda:foo.hpp:4:37)>"
+        )
 
     def test_two_checkouts_differing_only_in_a_parenthesized_component_match(
         self,
@@ -247,6 +249,44 @@ class TestAnonymousMarkerRequiredBeforeStripping:
         assert strip_anonymous_type_location(name) == name
 
 
+class TestQuotedMarkerShapedLiteralIsNotNormalized:
+    """CodeRabbit review, fresh evidence: a fixed-string NTTP argument can
+    quote text that *itself* looks like a real ``(lambda at ...)``/
+    ``(unnamed ... at ...)`` marker -- e.g. ``Tag<"(lambda at
+    /a/foo.hpp:1:2)">`` -- which is a string literal naming that exact text,
+    not a genuine CastXML anonymous-type location. Rewriting it would let
+    two distinct literal values (differing only in a path whose basename
+    happens to collide) collapse onto the same identity."""
+
+    def test_quoted_lambda_marker_value_is_untouched(self) -> None:
+        name = 'Tag<"(lambda at /a/foo.hpp:1:2)">'
+        assert strip_anonymous_type_location(name) == name
+
+    def test_quoted_unnamed_struct_marker_value_is_untouched(self) -> None:
+        name = 'Tag<"(unnamed struct at /a/foo.hpp:1:2)">'
+        assert strip_anonymous_type_location(name) == name
+
+    def test_two_quoted_markers_differing_only_in_directory_stay_distinct(
+        self,
+    ) -> None:
+        one = 'Tag<"(lambda at /one/foo.hpp:1:2)">'
+        two = 'Tag<"(lambda at /two/foo.hpp:1:2)">'
+        assert strip_anonymous_type_location(one) == one
+        assert strip_anonymous_type_location(two) == two
+        assert strip_anonymous_type_location(one) != strip_anonymous_type_location(two)
+
+    def test_real_marker_still_normalized_alongside_a_quoted_lookalike(
+        self,
+    ) -> None:
+        # A genuine (unquoted) marker elsewhere in the same composite name
+        # must still be normalized even when a quoted lookalike sits next
+        # to it -- the quote-span skip must not become an all-or-nothing
+        # bailout for the whole name.
+        name = 'Tag<"(lambda at /a/foo.hpp:1:2)", (lambda at /b/bar.hpp:9:9)>'
+        result = strip_anonymous_type_location(name)
+        assert result == 'Tag<"(lambda at /a/foo.hpp:1:2)", (lambda:bar.hpp:9:9)>'
+
+
 class TestAnonymousEnumLocationStripped:
     def test_enum_name_has_no_embedded_path(self) -> None:
         root = Element("CastXML", attrib={"format": "1.4.0"})
@@ -288,7 +328,9 @@ class TestAnonymousEnumLocationStripped:
         (enum_type,) = parser.parse_enums()
         # The reference (a field/param/return naming the same id) goes
         # through _type_name, not parse_enums -- both must agree.
-        assert parser._type_name("_2") == enum_type.name == "(unnamed enum:lib.hpp:56:5)"
+        assert (
+            parser._type_name("_2") == enum_type.name == "(unnamed enum:lib.hpp:56:5)"
+        )
 
 
 class TestQualifiedNameNormalizesEnclosingAnonymousScope:

--- a/tests/test_castxml_anonymous_type_location.py
+++ b/tests/test_castxml_anonymous_type_location.py
@@ -62,14 +62,17 @@ class TestLambdaClosureTypeNameLocationStripped:
     def test_type_name_strips_embedded_source_location(self) -> None:
         root = _lambda_struct_root("/tmp/old/lib.hpp")
         parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
-        assert parser._type_name("_2") == "raii_guard<(lambda)>"
+        # The path is stripped; the :line:col discriminator is kept (Codex
+        # review) so two distinct lambdas in the same header don't collapse
+        # to one identity — see TestDistinctLambdasInOneSnapshotStayDistinct.
+        assert parser._type_name("_2") == "raii_guard<(lambda:4:37)>"
 
-    def test_record_type_own_name_has_no_embedded_location(self) -> None:
+    def test_record_type_own_name_has_no_embedded_path(self) -> None:
         root = _lambda_struct_root("/tmp/old/lib.hpp")
         parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
         types = parser.parse_types()
         (rec,) = [t for t in types if t.name.startswith("raii_guard")]
-        assert rec.name == "raii_guard<(lambda)>"
+        assert rec.name == "raii_guard<(lambda:4:37)>"
         assert "/tmp/old" not in rec.name
 
     def test_two_checkout_directories_produce_identical_type_identity(self) -> None:
@@ -94,8 +97,47 @@ class TestLambdaClosureTypeNameLocationStripped:
         assert type_map_key(old_rec) == type_map_key(new_rec)
 
 
+class TestDistinctLambdasInOneSnapshotStayDistinct:
+    """Codex review, real finding: stripping the *entire* location (path
+    AND line:col) collapsed two distinct lambda closure types declared in
+    the same header into one identical key, so diff_helpers.TypeMap
+    silently overwrote one entry with the other -- changes to the
+    discarded instantiation could be missed or compared against the wrong
+    record. Keeping :line:col as a discriminator fixes this while still
+    matching across checkout roots (the test above)."""
+
+    def test_two_lambdas_in_one_header_produce_distinct_type_map_keys(self) -> None:
+        root = Element("CastXML", attrib={"format": "1.4.0"})
+        _file(root, "f1", "/tmp/old/lib.hpp")
+        SubElement(root, "Namespace", attrib={"id": "_1", "name": "::"})
+
+        first = SubElement(root, "Struct")
+        first.set("id", "_2")
+        first.set("name", "guard<(lambda at /tmp/old/lib.hpp:4:3)>")
+        first.set("context", "_1")
+        first.set("file", "f1")
+        first.set("line", "4")
+        first.set("members", "")
+
+        second = SubElement(root, "Struct")
+        second.set("id", "_3")
+        second.set("name", "guard<(lambda at /tmp/old/lib.hpp:40:3)>")
+        second.set("context", "_1")
+        second.set("file", "f1")
+        second.set("line", "40")
+        second.set("members", "")
+
+        parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
+        types = [t for t in parser.parse_types() if t.name.startswith("guard")]
+        assert len(types) == 2
+        names = {t.name for t in types}
+        assert names == {"guard<(lambda:4:3)>", "guard<(lambda:40:3)>"}
+        keys = {type_map_key(t) for t in types}
+        assert len(keys) == 2, "distinct lambdas must not collide on one key"
+
+
 class TestAnonymousEnumLocationStripped:
-    def test_enum_name_has_no_embedded_location(self) -> None:
+    def test_enum_name_has_no_embedded_path(self) -> None:
         root = Element("CastXML", attrib={"format": "1.4.0"})
         _file(root, "f1", "/tmp/old/lib.hpp")
         SubElement(root, "Namespace", attrib={"id": "_1", "name": "::"})
@@ -109,5 +151,5 @@ class TestAnonymousEnumLocationStripped:
 
         parser = _CastxmlParser(root, exported_dynamic=set(), exported_static=set())
         (enum_type,) = parser.parse_enums()
-        assert enum_type.name == "(unnamed enum)"
+        assert enum_type.name == "(unnamed enum:56:5)"
         assert "/tmp/old" not in enum_type.name

--- a/tests/test_castxml_anonymous_type_location.py
+++ b/tests/test_castxml_anonymous_type_location.py
@@ -156,6 +156,23 @@ class TestPathContainingALiteralCloseParen:
         assert strip_anonymous_type_location(old) == strip_anonymous_type_location(new)
 
 
+class TestOrdinaryNameWhitespaceIsPreserved:
+    """Codex review, round 4: strip_anonymous_type_location() is now applied
+    to every castxml record/enum name at extraction time (not just
+    anonymous ones), so its whitespace-collapse step used to rewrite
+    meaningful internal whitespace on an ORDINARY name too -- notably a
+    C++20 fixed-string NTTP template argument, where two distinct
+    specializations differing only in embedded whitespace must not
+    collapse onto the same identity."""
+
+    def test_distinct_fixed_string_template_args_stay_distinct(self) -> None:
+        a = strip_anonymous_type_location('Tag<"a  b">')
+        b = strip_anonymous_type_location('Tag<"a b">')
+        assert a == 'Tag<"a  b">'
+        assert b == 'Tag<"a b">'
+        assert a != b
+
+
 class TestAnonymousEnumLocationStripped:
     def test_enum_name_has_no_embedded_path(self) -> None:
         root = Element("CastXML", attrib={"format": "1.4.0"})

--- a/tests/test_cli_dump_helpers_coverage.py
+++ b/tests/test_cli_dump_helpers_coverage.py
@@ -1022,6 +1022,7 @@ def test_perform_elf_dump_attaches_header_graph_by_default(
         compile_context,
         public_headers,
         public_header_dirs,
+        include_search_dirs=None,
     ):
         captured["snap"] = snap
         captured["header_graph"] = header_graph
@@ -1126,6 +1127,7 @@ def test_perform_elf_dump_explicit_lang_reaches_header_graph(
     def fake_attach(
         snap, header_graph, header_graph_includes, headers, includes,
         lang, compile_context, public_headers, public_header_dirs,
+        include_search_dirs=None,
     ):
         captured_graph["lang"] = lang
         return snap
@@ -1205,6 +1207,7 @@ def test_perform_elf_dump_dwarf_only_does_not_attach_header_graph(
         compile_context,
         public_headers,
         public_header_dirs,
+        include_search_dirs=None,
     ):
         captured["header_graph"] = header_graph
         captured["header_graph_includes"] = header_graph_includes
@@ -1287,6 +1290,7 @@ def test_perform_elf_dump_header_graph_receives_seeded_includes(
     def fake_attach(
         snap, header_graph, header_graph_includes, headers, includes,
         lang, compile_context, public_headers, public_header_dirs,
+        include_search_dirs=None,
     ):  # noqa: ANN001
         captured["includes"] = includes
         return snap
@@ -1329,6 +1333,7 @@ def test_perform_elf_dump_header_graph_gets_compile_db_flags(
     def fake_attach(
         snap, header_graph, header_graph_includes, headers, includes,
         lang, compile_context, public_headers, public_header_dirs,
+        include_search_dirs=None,
     ):  # noqa: ANN001
         captured["compile_context"] = compile_context
         return snap
@@ -1378,6 +1383,7 @@ def test_perform_elf_dump_header_graph_builds_context_when_none_given(
     def fake_attach(
         snap, header_graph, header_graph_includes, headers, includes,
         lang, compile_context, public_headers, public_header_dirs,
+        include_search_dirs=None,
     ):  # noqa: ANN001
         captured["compile_context"] = compile_context
         return snap

--- a/tests/test_cli_dump_helpers_coverage.py
+++ b/tests/test_cli_dump_helpers_coverage.py
@@ -1021,8 +1021,7 @@ def test_perform_elf_dump_attaches_header_graph_by_default(
         lang,
         compile_context,
         public_headers,
-        public_header_dirs,
-        include_search_dirs=None,
+        public_header_dirs, include_search_dirs=None,
     ):
         captured["snap"] = snap
         captured["header_graph"] = header_graph
@@ -1126,8 +1125,7 @@ def test_perform_elf_dump_explicit_lang_reaches_header_graph(
 
     def fake_attach(
         snap, header_graph, header_graph_includes, headers, includes,
-        lang, compile_context, public_headers, public_header_dirs,
-        include_search_dirs=None,
+        lang, compile_context, public_headers, public_header_dirs, include_search_dirs=None,
     ):
         captured_graph["lang"] = lang
         return snap
@@ -1289,8 +1287,7 @@ def test_perform_elf_dump_header_graph_receives_seeded_includes(
 
     def fake_attach(
         snap, header_graph, header_graph_includes, headers, includes,
-        lang, compile_context, public_headers, public_header_dirs,
-        include_search_dirs=None,
+        lang, compile_context, public_headers, public_header_dirs, include_search_dirs=None,
     ):  # noqa: ANN001
         captured["includes"] = includes
         return snap
@@ -1332,8 +1329,7 @@ def test_perform_elf_dump_header_graph_gets_compile_db_flags(
 
     def fake_attach(
         snap, header_graph, header_graph_includes, headers, includes,
-        lang, compile_context, public_headers, public_header_dirs,
-        include_search_dirs=None,
+        lang, compile_context, public_headers, public_header_dirs, include_search_dirs=None,
     ):  # noqa: ANN001
         captured["compile_context"] = compile_context
         return snap
@@ -1382,8 +1378,7 @@ def test_perform_elf_dump_header_graph_builds_context_when_none_given(
 
     def fake_attach(
         snap, header_graph, header_graph_includes, headers, includes,
-        lang, compile_context, public_headers, public_header_dirs,
-        include_search_dirs=None,
+        lang, compile_context, public_headers, public_header_dirs, include_search_dirs=None,
     ):  # noqa: ANN001
         captured["compile_context"] = compile_context
         return snap

--- a/tests/test_depth_vocabulary.py
+++ b/tests/test_depth_vocabulary.py
@@ -332,6 +332,41 @@ def test_dump_source_only_depth_binary_is_usage_error(tmp_path) -> None:  # type
     assert not out.exists()
 
 
+def test_dump_source_only_header_flag_is_usage_error(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """A source-only dump (no SO_PATH) dispatches to dump_source_only(),
+    which embeds only L3/L4/L5 build/source facts -- it never even receives
+    `headers`, so -H/--header was previously silently dropped: `dump
+    --sources src -H api.h -o out.json` exited 0 and wrote an empty (0
+    functions/enums), depth="binary" snapshot with no trace the flag was
+    ignored. Must now be rejected as a usage error naming the dropped flag."""
+    src = tmp_path / "src3"
+    src.mkdir()
+    hdr = src / "api.h"
+    hdr.write_text("typedef enum { a = 0, b, c } my_tag_t;\n", encoding="utf-8")
+    out = tmp_path / "out3.json"
+    res = CliRunner().invoke(
+        main,
+        ["dump", "--sources", str(src), "-H", str(hdr), "-o", str(out)],
+    )
+    assert res.exit_code == 64, _all_output(res)
+    assert "-H/--header has no effect on a source-only dump" in _all_output(res)
+    assert not out.exists()
+
+
+def test_dump_source_only_without_header_flag_still_succeeds(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # The header-flag rejection above must not regress the ordinary,
+    # headers-free source-only dump.
+    src = tmp_path / "src4"
+    src.mkdir()
+    out = tmp_path / "out4.json"
+    res = CliRunner().invoke(
+        main,
+        ["dump", "--sources", str(src), "-o", str(out)],
+    )
+    assert res.exit_code == 0, _all_output(res)
+    assert out.exists()
+
+
 def test_dump_source_only_depth_binary_rejected_in_dry_run_too(tmp_path) -> None:  # type: ignore[no-untyped-def]
     src = tmp_path / "src2b"
     src.mkdir()

--- a/tests/test_depth_vocabulary.py
+++ b/tests/test_depth_vocabulary.py
@@ -332,13 +332,20 @@ def test_dump_source_only_depth_binary_is_usage_error(tmp_path) -> None:  # type
     assert not out.exists()
 
 
-def test_dump_source_only_header_flag_is_usage_error(tmp_path) -> None:  # type: ignore[no-untyped-def]
+def test_dump_source_only_header_flag_warns_but_still_writes_snapshot(tmp_path) -> None:  # type: ignore[no-untyped-def]
     """A source-only dump (no SO_PATH) dispatches to dump_source_only(),
     which embeds only L3/L4/L5 build/source facts -- it never even receives
-    `headers`, so -H/--header was previously silently dropped: `dump
-    --sources src -H api.h -o out.json` exited 0 and wrote an empty (0
-    functions/enums), depth="binary" snapshot with no trace the flag was
-    ignored. Must now be rejected as a usage error naming the dropped flag."""
+    `headers`, so -H/--header has no effect on the WRITTEN snapshot: `dump
+    --sources src -H api.h -o out.json` exits 0 and writes an empty (0
+    functions/enums), depth="binary" snapshot. Previously this was
+    completely silent, with no trace the flag was ignored; a hard usage
+    error was tried and reverted (Codex review, fresh evidence: -H is NOT
+    dead code for this invocation shape in general -- the --dry-run branch
+    genuinely consults it, exercised by a wide pre-existing test suite a
+    blanket rejection broke). Must now at least warn, on stderr, naming the
+    ignored flag -- and must still write the snapshot (exit 0), matching
+    the pre-existing, still-legitimate behavior everything else here
+    depends on."""
     src = tmp_path / "src3"
     src.mkdir()
     hdr = src / "api.h"
@@ -348,18 +355,17 @@ def test_dump_source_only_header_flag_is_usage_error(tmp_path) -> None:  # type:
         main,
         ["dump", "--sources", str(src), "-H", str(hdr), "-o", str(out)],
     )
-    assert res.exit_code == 64, _all_output(res)
-    assert "-H/--header has no effect on a source-only dump" in _all_output(res)
-    assert not out.exists()
+    assert res.exit_code == 0, _all_output(res)
+    assert "-H/--header has no effect on this source-only dump" in _all_output(res)
+    assert out.exists()
 
 
-def test_dump_source_only_header_flag_rejected_in_dry_run_too(tmp_path) -> None:  # type: ignore[no-untyped-def]
-    # Codex review, real finding: emit_dry_run() raises SystemExit, so a
-    # check placed only in the so_path-is-None dispatch (which --dry-run
-    # never reaches) let `dump --dry-run --sources tree -H api.h` report a
-    # valid invocation (exit 0) while the real run immediately rejected it
-    # with exit 64 -- a dry-run/real-run parity gap. Must reject the same
-    # way in both.
+def test_dump_source_only_header_flag_dry_run_is_unaffected(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # The written-snapshot warning above must not regress --dry-run, which
+    # genuinely resolves and reports on the given headers (unlike the real
+    # run) -- see test_dry_run_build_query_contract.py and
+    # test_dump_request_from_cli.py for the pre-existing behavior this must
+    # not disturb.
     src = tmp_path / "src3b"
     src.mkdir()
     hdr = src / "api.h"
@@ -368,12 +374,12 @@ def test_dump_source_only_header_flag_rejected_in_dry_run_too(tmp_path) -> None:
         main,
         ["dump", "--dry-run", "--sources", str(src), "-H", str(hdr)],
     )
-    assert res.exit_code == 64, _all_output(res)
-    assert "-H/--header has no effect on a source-only dump" in _all_output(res)
+    assert res.exit_code == 0, _all_output(res)
+    assert "-H/--header has no effect" not in _all_output(res)
 
 
 def test_dump_source_only_without_header_flag_still_succeeds(tmp_path) -> None:  # type: ignore[no-untyped-def]
-    # The header-flag rejection above must not regress the ordinary,
+    # The header-flag warning above must not regress the ordinary,
     # headers-free source-only dump.
     src = tmp_path / "src4"
     src.mkdir()

--- a/tests/test_depth_vocabulary.py
+++ b/tests/test_depth_vocabulary.py
@@ -353,6 +353,25 @@ def test_dump_source_only_header_flag_is_usage_error(tmp_path) -> None:  # type:
     assert not out.exists()
 
 
+def test_dump_source_only_header_flag_rejected_in_dry_run_too(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    # Codex review, real finding: emit_dry_run() raises SystemExit, so a
+    # check placed only in the so_path-is-None dispatch (which --dry-run
+    # never reaches) let `dump --dry-run --sources tree -H api.h` report a
+    # valid invocation (exit 0) while the real run immediately rejected it
+    # with exit 64 -- a dry-run/real-run parity gap. Must reject the same
+    # way in both.
+    src = tmp_path / "src3b"
+    src.mkdir()
+    hdr = src / "api.h"
+    hdr.write_text("typedef enum { a = 0, b, c } my_tag_t;\n", encoding="utf-8")
+    res = CliRunner().invoke(
+        main,
+        ["dump", "--dry-run", "--sources", str(src), "-H", str(hdr)],
+    )
+    assert res.exit_code == 64, _all_output(res)
+    assert "-H/--header has no effect on a source-only dump" in _all_output(res)
+
+
 def test_dump_source_only_without_header_flag_still_succeeds(tmp_path) -> None:  # type: ignore[no-untyped-def]
     # The header-flag rejection above must not regress the ordinary,
     # headers-free source-only dump.

--- a/tests/test_dump_provenance_include_scope.py
+++ b/tests/test_dump_provenance_include_scope.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Real-clang regression test for a defect introduced and reverted within
+this same PR: wiring ``dumper.dump()``'s declaration-provenance widening
+(ADR-024/ADR-015's ``include_search_dirs``) straight off the dump's full
+compile include path (``extra_includes``) rather than off only the caller's
+own *explicit* ``-I``/``--include`` list.
+
+``extra_includes`` also carries directories a dump auto-derives purely so an
+umbrella ``-H`` header's own relative ``#include``s resolve -- typically the
+umbrella header's own directory (``header_utils.resolve_inferred_header_roots``'s
+"P3" auto-add). That directory can just as easily hold a genuinely *private*
+sibling header, and folding it into the public-directory set silently
+promoted that sibling to ``PUBLIC_HEADER`` -- defeating ADR-024's whole
+private-header scoping for the (very common) case of a public umbrella
+header living next to a private implementation-detail header in one
+directory. Caught by the example suite's own real, compiled
+``case184_internal_enum_churn_scoped`` (not by any unit test, since none of
+this PR's own unit tests happened to co-locate the public and private
+headers in one directory) -- this module exists so a future change to this
+same wiring is caught here too, at unit speed and with the exact mechanism
+named, rather than only by a slow, real-compiler example run.
+
+Modeled on ``test_clang_header_backend_integration.py``'s own pattern:
+self-skip on missing tools, not marked ``integration`` (no castxml
+requirement — this is clang-only).
+"""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from abicheck.dumper import dump
+from abicheck.model import ScopeOrigin
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="clang L2 backend integration test is ELF/Linux-scoped",
+)
+
+
+def _have(tool: str) -> bool:
+    return shutil.which(tool) is not None
+
+
+def _require_tools() -> None:
+    if not (_have("clang") and _have("g++")) or platform.machine().lower() not in {
+        "x86_64",
+        "amd64",
+    }:
+        pytest.skip("requires an x86-64 clang + g++ toolchain")
+
+
+def test_private_sibling_header_not_promoted_by_auto_derived_include_dir(
+    tmp_path: Path,
+) -> None:
+    """The exact case184 shape: a public umbrella header (``api.h``)
+    ``#include``s a private sibling (``internal.h``) living in the SAME
+    directory, and no explicit ``-I`` is given at all -- the only include
+    directory in play is the one ``resolve_inferred_header_roots`` auto-adds
+    so the umbrella header's own relative ``#include`` resolves. That
+    auto-added directory must NOT promote ``internal.h``'s own declarations
+    to ``PUBLIC_HEADER``."""
+    _require_tools()
+    (tmp_path / "internal.h").write_text(
+        "#pragma once\nvoid priv(void);\n", encoding="utf-8"
+    )
+    (tmp_path / "api.h").write_text(
+        '#pragma once\n#include "internal.h"\nvoid pub(void);\n', encoding="utf-8"
+    )
+    src = tmp_path / "lib.cpp"
+    src.write_text(
+        '#include "api.h"\nvoid pub(void) {}\nvoid priv(void) {}\n', encoding="utf-8"
+    )
+    so = tmp_path / "lib.so"
+    subprocess.run(
+        ["g++", "-shared", "-fPIC", "-g", "-o", str(so), str(src)],
+        check=True,
+        capture_output=True,
+    )
+
+    snap = dump(
+        so,
+        [tmp_path / "api.h"],
+        # extra_includes=[tmp_path]: mirrors what perform_elf_dump's own P3
+        # auto-add (`resolve_inferred_header_roots`) would compute for a -H
+        # umbrella header with no explicit -I of its own -- the umbrella
+        # header's own directory, needed purely so its relative #include
+        # resolves. This is the exact value the pre-fix code forwarded
+        # straight to provenance as `include_search_dirs=extra_includes`.
+        [tmp_path],
+        header_backend="clang",
+        public_headers=[tmp_path / "api.h"],
+        # public_include_search_dirs deliberately omitted (no explicit -I
+        # was actually given) -- the fix under test is that dump() no
+        # longer falls back to widening off extra_includes when this is
+        # absent.
+    )
+    by_name = {f.name: f for f in snap.functions}
+    assert by_name["pub"].origin is ScopeOrigin.PUBLIC_HEADER
+    assert by_name["priv"].origin is ScopeOrigin.PRIVATE_HEADER, (
+        "a private sibling header living next to the public -H header must "
+        "not be promoted merely by the umbrella header's own auto-derived "
+        "#include-resolution directory"
+    )
+
+
+def test_explicit_include_dir_still_promotes_transitively_reached_header(
+    tmp_path: Path,
+) -> None:
+    """Positive control -- the original defect-4/5 fix this module's own
+    defect is adjacent to must keep working: a header reached transitively
+    from the ``-H`` root, living under a directory the caller *explicitly*
+    passed via ``-I``, is still promoted to ``PUBLIC_HEADER``."""
+    _require_tools()
+    include_dir = tmp_path / "include"
+    detail_dir = include_dir / "detail"
+    detail_dir.mkdir(parents=True)
+    (detail_dir / "impl.h").write_text(
+        "#pragma once\nvoid dep(void);\n", encoding="utf-8"
+    )
+    (include_dir / "api.h").write_text(
+        '#pragma once\n#include "detail/impl.h"\nvoid pub(void);\n',
+        encoding="utf-8",
+    )
+    src = tmp_path / "lib.cpp"
+    src.write_text(
+        '#include "api.h"\nvoid pub(void) {}\nvoid dep(void) {}\n', encoding="utf-8"
+    )
+    so = tmp_path / "lib.so"
+    subprocess.run(
+        ["g++", "-shared", "-fPIC", "-g", f"-I{include_dir}", "-o", str(so), str(src)],
+        check=True,
+        capture_output=True,
+    )
+
+    snap = dump(
+        so,
+        [include_dir / "api.h"],
+        [include_dir],
+        header_backend="clang",
+        public_headers=[include_dir / "api.h"],
+        # dump() itself is the low-level primitive; a real caller (the CLI/
+        # service layer) is what decides which of its own directories are
+        # genuinely explicit -I roots and threads only those here -- see
+        # this module's own docstring and dump()'s own docstring note on
+        # `public_include_search_dirs`.
+        public_include_search_dirs=[include_dir],
+    )
+    by_name = {f.name: f for f in snap.functions}
+    assert by_name["pub"].origin is ScopeOrigin.PUBLIC_HEADER
+    assert by_name["dep"].origin is ScopeOrigin.PUBLIC_HEADER, (
+        "a header reached transitively under an explicit -I root must "
+        "still promote to PUBLIC_HEADER (the original defect-4/5 fix)"
+    )

--- a/tests/test_dump_provenance_include_scope.py
+++ b/tests/test_dump_provenance_include_scope.py
@@ -171,3 +171,74 @@ def test_explicit_include_dir_still_promotes_transitively_reached_header(
         "a header reached transitively under an explicit -I root must "
         "still promote to PUBLIC_HEADER (the original defect-4/5 fix)"
     )
+
+
+def test_compiler_option_include_dir_promotes_transitively_reached_header(
+    tmp_path: Path,
+) -> None:
+    """CodeRabbit review, fresh evidence: an include directory supplied via
+    the repeatable ``--compiler-option -I<dir>``/``-isystem <dir>`` flag is
+    exactly as explicit as a plain ``-I`` -- the L2 seed suppression already
+    trusts it that way (see the "as explicit as -I" comment in
+    ``perform_elf_dump``) -- but it was never folded into
+    ``public_include_search_dirs``, so a header reached ONLY through such a
+    directory stayed ``PRIVATE_HEADER`` even though the caller had named
+    that directory explicitly, just via ``--compiler-option`` rather than a
+    bare ``-I``. Exercised end to end through the real ``abicheck dump`` CLI
+    (the fix lives in ``cli_dump_helpers.py``, one layer above
+    ``dumper.dump()``, so a direct ``dump()`` call cannot reproduce it)."""
+    _require_tools()
+    include_dir = tmp_path / "include"
+    detail_dir = include_dir / "detail"
+    detail_dir.mkdir(parents=True)
+    (detail_dir / "impl.h").write_text(
+        "#pragma once\nvoid dep(void);\n", encoding="utf-8"
+    )
+    (include_dir / "api.h").write_text(
+        '#pragma once\n#include "detail/impl.h"\nvoid pub(void);\n',
+        encoding="utf-8",
+    )
+    src = tmp_path / "lib.cpp"
+    src.write_text(
+        '#include "api.h"\nvoid pub(void) {}\nvoid dep(void) {}\n', encoding="utf-8"
+    )
+    so = tmp_path / "lib.so"
+    subprocess.run(
+        ["g++", "-shared", "-fPIC", "-g", f"-I{include_dir}", "-o", str(so), str(src)],
+        check=True,
+        capture_output=True,
+    )
+
+    from click.testing import CliRunner
+
+    from abicheck.cli import main
+
+    out = tmp_path / "out.json"
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            "dump",
+            str(so),
+            "-H",
+            str(include_dir / "api.h"),
+            "--ast-frontend",
+            "clang",
+            # No plain -I at all -- the only include search path is given
+            # via --compiler-option, which must still count as explicit.
+            "--compiler-option",
+            f"-I{include_dir}",
+            "-o",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    import json
+
+    snap = json.loads(out.read_text())
+    by_name = {f["name"]: f for f in snap["functions"]}
+    assert by_name["pub"]["origin"] == "public_header"
+    assert by_name["dep"]["origin"] == "public_header", (
+        "a header reached transitively under a --compiler-option -I root "
+        "must promote to PUBLIC_HEADER the same as a plain -I root"
+    )

--- a/tests/test_dumper_clang.py
+++ b/tests/test_dumper_clang.py
@@ -5163,6 +5163,62 @@ def test_folded_enum_value_on_constantexpr_wrapper() -> None:
     assert [(m.name, m.value) for m in enum.members] == [("A", 8), ("B", 9)]
 
 
+def test_enumerator_aliasing_a_sibling_enumerator_keeps_its_real_value() -> None:
+    # `enum { A, B, X = B }`: clang's JSON wraps the DeclRefExpr-to-B
+    # initializer in a ConstantExpr that itself carries the folded value
+    # ("1"), but the ConstantExpr is also a registered wrapper kind that
+    # _unwrap_expr descends straight through into the DeclRefExpr (which has
+    # no "value" of its own). Reading only the original node and the fully
+    # unwrapped leaf (the pre-fix behavior) misses the intermediate
+    # ConstantExpr's value entirely and silently falls back to the wrong,
+    # positional auto-increment number -- and everything after it shifts too.
+    root = _tu(
+        {
+            "kind": "EnumDecl",
+            "name": "E",
+            "loc": {"file": "include/foo.h", "line": 1},
+            "inner": [
+                {"kind": "EnumConstantDecl", "name": "A"},
+                {"kind": "EnumConstantDecl", "name": "B"},
+                {
+                    "kind": "EnumConstantDecl",
+                    "name": "X",
+                    "inner": [
+                        {
+                            "kind": "ImplicitCastExpr",
+                            "inner": [
+                                {
+                                    "kind": "ConstantExpr",
+                                    "value": "1",
+                                    "inner": [
+                                        {
+                                            "kind": "DeclRefExpr",
+                                            "referencedDecl": {
+                                                "kind": "EnumConstantDecl",
+                                                "name": "B",
+                                            },
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                {"kind": "EnumConstantDecl", "name": "Y"},
+            ],
+        }
+    )
+    (enum,) = _ClangAstParser(root, set(), set()).parse_enums()
+    # X aliases B's real value (1), not X's own positional index (2); Y then
+    # auto-increments from X's real value, not from the wrong one.
+    assert [(m.name, m.value) for m in enum.members] == [
+        ("A", 0),
+        ("B", 1),
+        ("X", 1),
+        ("Y", 2),
+    ]
+
+
 def test_folded_bitfield_width_on_constantexpr_wrapper() -> None:
     root = _tu(
         {

--- a/tests/test_dumper_clang_enum_value_properties.py
+++ b/tests/test_dumper_clang_enum_value_properties.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Property-based tests for ``dumper_clang._evaluated_int_value``.
+
+The bug this primitive fixes: clang's JSON AST folds a constant's evaluated
+value onto exactly one node along a chain of single-child "wrapper"
+expressions (``ImplicitCastExpr``, ``ConstantExpr``, ``ParenExpr``, ...) --
+which node varies by what the initializer actually is (a literal wraps the
+value close to the leaf; an enumerator-alias initializer like ``tag_x =
+tag_a`` folds it onto an *intermediate* ``ConstantExpr``, ahead of the
+``DeclRefExpr`` leaf that names the aliased enumerator and carries no value
+of its own). The pre-fix implementation checked only the original node and
+the fully-unwrapped leaf -- correct for the common "value near the leaf"
+shape, silently wrong for the intermediate-node shape.
+
+test_dumper_clang.py pins that exact intermediate-node example (and the
+existing "outermost ConstantExpr wrapper" example it was already correct
+for). This module states the actual contract as an invariant instead: for a
+value folded onto ANY position along the wrapper chain, `_evaluated_int_value`
+must find it -- not just the two shapes anyone happened to think to test.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from abicheck.dumper_clang import _WRAPPER_EXPR_KINDS, _evaluated_int_value
+
+pytestmark = pytest.mark.slow
+
+_WRAPPER_KINDS = sorted(_WRAPPER_EXPR_KINDS)
+
+
+def _build_chain(kinds: list[str], value_at: int, value: int) -> dict[str, Any]:
+    """A single-child wrapper chain of the given *kinds* (outermost first),
+    terminating in a non-wrapper leaf node, with *value* folded onto the
+    node at position *value_at* (0 == the outermost node, ``len(kinds)`` ==
+    the terminal leaf itself)."""
+    # Build innermost-out: start with the terminal leaf (never a wrapper
+    # kind, mirroring a real DeclRefExpr/IntegerLiteral leaf).
+    node: dict[str, Any] = {"kind": "DeclRefExpr"}
+    if value_at == len(kinds):
+        node["value"] = str(value)
+    for i in range(len(kinds) - 1, -1, -1):
+        wrapper: dict[str, Any] = {"kind": kinds[i], "inner": [node]}
+        if value_at == i:
+            wrapper["value"] = str(value)
+        node = wrapper
+    return node
+
+
+@given(
+    kinds=st.lists(st.sampled_from(_WRAPPER_KINDS), min_size=0, max_size=6),
+    value=st.integers(min_value=-1000, max_value=1000),
+    data=st.data(),
+)
+@settings(max_examples=300)
+def test_finds_a_value_folded_at_any_position_along_the_chain(kinds, value, data) -> None:
+    value_at = data.draw(st.integers(min_value=0, max_value=len(kinds)))
+    node = _build_chain(kinds, value_at, value)
+    assert _evaluated_int_value(node) == value
+
+
+@given(kinds=st.lists(st.sampled_from(_WRAPPER_KINDS), min_size=0, max_size=6))
+@settings(max_examples=200)
+def test_no_value_anywhere_returns_none(kinds) -> None:
+    """No node along the chain carries a folded value (the pure-alias case,
+    e.g. a bare DeclRefExpr leaf with nothing evaluated) -> None, not a
+    fabricated positional guess. Auto-increment fallback is the caller's
+    job (dumper_clang.parse_enums), not this primitive's."""
+    node = _build_chain(kinds, value_at=-1, value=0)  # -1: never matches
+    assert _evaluated_int_value(node) is None
+
+
+@given(
+    kinds=st.lists(st.sampled_from(_WRAPPER_KINDS), min_size=1, max_size=6),
+    outer_value=st.integers(min_value=-1000, max_value=1000),
+    inner_value=st.integers(min_value=-1000, max_value=1000),
+)
+@settings(max_examples=200)
+def test_outermost_folded_value_wins_over_a_deeper_one(
+    kinds, outer_value, inner_value
+) -> None:
+    """When more than one node along the chain carries a value (not a real
+    clang shape, but the walk's own tie-break rule should still be
+    deterministic and documented): the outermost one wins, matching the
+    top-down walk order _evaluated_int_value actually implements."""
+    if outer_value == inner_value:
+        return
+    node = _build_chain(kinds, value_at=0, value=outer_value)
+    # Fold a second, different value onto the innermost wrapper too (or the
+    # leaf, if there are no wrapper kinds at all).
+    cur = node
+    while isinstance(cur.get("inner"), list) and cur["inner"]:
+        cur = cur["inner"][0]
+    cur["value"] = str(inner_value)
+    assert _evaluated_int_value(node) == outer_value

--- a/tests/test_dumper_hybrid.py
+++ b/tests/test_dumper_hybrid.py
@@ -1659,6 +1659,43 @@ class TestDumpHybridDispatch:
         assert calls[0][0] is dump
         assert calls[0][1] == p
 
+    def test_dump_hybrid_forwards_public_include_search_dirs(self, tmp_path):
+        """A caller's explicit -I/--include roots (ADR-024/ADR-015's
+        declaration-provenance widening -- see
+        ``test_dump_provenance_include_scope.py``) must reach BOTH
+        recursive castxml/clang sub-dumps ``run_hybrid_dump`` performs, not
+        get silently dropped on the hybrid path while the castxml/clang
+        backends fix it individually (Codex review, PR #839 round 6)."""
+        from abicheck.dumper import dump
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        sentinel = AbiSnapshot(library="test", version="1.0", ast_producer="hybrid")
+        include_dir = tmp_path / "include"
+        calls = []
+
+        def fake_run_hybrid_dump(dump_fn, so_path, headers, **kwargs):
+            calls.append(kwargs)
+            return sentinel
+
+        with patch(
+            "abicheck.dumper_hybrid.run_hybrid_dump", side_effect=fake_run_hybrid_dump
+        ):
+            result = dump(
+                p,
+                [],
+                header_backend="hybrid",
+                public_include_search_dirs=[include_dir],
+            )
+
+        assert result is sentinel
+        assert len(calls) == 1
+        assert calls[0]["public_include_search_dirs"] == [include_dir], (
+            "an explicit public_include_search_dirs must be forwarded to "
+            "run_hybrid_dump's **kwargs, which passes it unchanged to both "
+            "the castxml and clang recursive dump() calls"
+        )
+
     def test_dump_hybrid_case_insensitive(self, tmp_path):
         from abicheck.dumper import dump
 

--- a/tests/test_dumper_manifest.py
+++ b/tests/test_dumper_manifest.py
@@ -1144,6 +1144,32 @@ class TestDumpWithManifest:
                 dump_manifest=self._manifest(tmp_path),
             )
 
+    def test_dump_rejects_public_include_search_dirs_with_manifest(
+        self, tmp_path: Path
+    ):
+        """CodeRabbit review, fresh evidence: a manifest dump merges several
+        independently resolved TUs, each with its own per-TU include roots
+        -- a single flat `public_include_search_dirs` has no manifest-field
+        equivalent to replace it with (unlike `public_headers`/
+        `public_header_dirs`, which the manifest's own `public_header_paths`/
+        `public_header_dirs` replace). Applying it unconditionally would
+        silently misapply one TU's caller-supplied explicit roots to every
+        other TU's declarations too, rather than being rejected the way
+        every other manifest-incompatible parameter already is."""
+        if not (_have("clang") and _have("gcc")):
+            pytest.skip("clang and gcc are required for this end-to-end test")
+        so = self._build_two_tu_lib(tmp_path)
+        with pytest.raises(ValidationError, match="mutually exclusive"):
+            dump(
+                so,
+                [],
+                version="1.0",
+                compiler="cc",
+                header_backend="clang",
+                dump_manifest=self._manifest(tmp_path),
+                public_include_search_dirs=[tmp_path],
+            )
+
     def test_dump_rejects_manifest_for_hybrid_frontend(self, tmp_path: Path):
         if not (_have("clang") and _have("gcc")):
             pytest.skip("clang and gcc are required for this end-to-end test")

--- a/tests/test_header_compile_context.py
+++ b/tests/test_header_compile_context.py
@@ -1591,6 +1591,53 @@ def test_resolve_side_snapshot_forwards_symbols_only_and_debug_presence_only(
     assert captured["debug_presence_only"] is False
 
 
+def test_resolve_side_snapshot_forwards_only_explicit_includes_as_public_include_search_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Round 13 (Codex review): the shared ``resolve_side_snapshot``/
+    ``_resolve_side_snapshot_impl`` primitive fed its own build-derived,
+    auto-widened ``includes`` local straight into ``service.resolve_input``
+    with no separate ``public_include_search_dirs`` -- so provenance
+    widening picked up an auto-derived seed directory the same way the
+    already-fixed ELF/PE/Mach-O CLI resolvers used to. This primitive is
+    shared by `compare`'s implicit-dump operand and `dump`'s typed
+    `DumpRequest`/`run_dump_request` API, so the gap reached both.
+    """
+    from abicheck import service_input_resolution as sir
+    from abicheck.api_types import InputSpec
+    from abicheck.model import AbiSnapshot
+    from abicheck.service_compare_evidence import SideEvidence
+
+    so = tmp_path / "lib.so"
+    so.write_bytes(b"\x7fELF" + b"\x00" * 100)
+    explicit_dir = tmp_path / "explicit"
+
+    captured: dict[str, object] = {}
+
+    def _fake_resolve_input(*args: object, **kwargs: object) -> AbiSnapshot:
+        captured.update(kwargs)
+        return AbiSnapshot(library="lib", version="1.0", from_headers=False)
+
+    import abicheck.service as service_mod
+
+    monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve_input)
+
+    side = InputSpec(path=so, version="1.0", includes=(explicit_dir,))
+    evidence = SideEvidence(
+        headers=[], compile=None, collect_mode="off", dump_manifest=None
+    )
+    sir.resolve_side_snapshot(
+        side,
+        evidence,
+        lang="c++",
+        header_backend="auto",
+        fmt="elf",
+        public_headers=[],
+        public_header_dirs=[],
+    )
+    assert captured["public_include_search_dirs"] == [explicit_dir]
+
+
 def test_resolve_side_snapshot_omits_conflicting_c_standard_when_cxx_forced(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_header_graph.py
+++ b/tests/test_header_graph.py
@@ -595,6 +595,70 @@ def test_header_node_visibility_classified_from_declarations_too() -> None:
     assert node.attrs["visibility"] == "private_header"
 
 
+# ── include_search_dirs widening (Codex review, fresh evidence) ─────────────
+
+
+def test_header_node_respects_widened_include_search_dirs() -> None:
+    """A header reached transitively under an explicit -I root (not itself
+    named as -H) is promoted to PUBLIC_HEADER at the per-declaration level
+    by apply_provenance's own include_search_dirs widening -- the header
+    GRAPH must agree, not independently reclassify the same header's own
+    node as private using only the bare public_header_paths/public_dir_paths
+    (the real regression: a type could read public_header for its own
+    declaration but private_header for its own defining header node)."""
+    transitive_header = "/proj/include/detail/impl.h"
+    fn = Function(
+        name="dep",
+        mangled="_Z3depv",
+        return_type="void",
+        source_header=transitive_header,
+        origin=ScopeOrigin.PUBLIC_HEADER,
+    )
+    graph = build_header_only_graph(
+        _snapshot(functions=[fn]),
+        public_header_paths=[PUBLIC_HEADER],
+        include_search_dirs=["/proj/include"],
+    )
+    node = next(n for n in graph.nodes if n.id == f"header://{transitive_header}")
+    assert node.attrs["visibility"] == "public_header"
+
+
+def test_header_node_include_search_dirs_omitted_keeps_prior_behavior() -> None:
+    """Without include_search_dirs (a caller that never threaded -I roots
+    through), the header node's own classification is unchanged -- still
+    only the literal public_header_paths/public_dir_paths, matching
+    test_header_node_visibility_classified_from_declarations_too above."""
+    transitive_header = "/proj/include/detail/impl.h"
+    fn = Function(
+        name="dep",
+        mangled="_Z3depv",
+        return_type="void",
+        source_header=transitive_header,
+        origin=ScopeOrigin.PRIVATE_HEADER,
+    )
+    graph = build_header_only_graph(
+        _snapshot(functions=[fn]), public_header_paths=[PUBLIC_HEADER]
+    )
+    node = next(n for n in graph.nodes if n.id == f"header://{transitive_header}")
+    assert node.attrs["visibility"] == "private_header"
+
+
+def test_include_search_dirs_cannot_opt_in_classification_by_itself() -> None:
+    """ADR-015 D4's opt-in contract: include_search_dirs alone (no real
+    public_header_paths/public_dir_paths) must never turn classification on."""
+    fn = Function(
+        name="dep",
+        mangled="_Z3depv",
+        return_type="void",
+        source_header="/proj/include/detail/impl.h",
+    )
+    graph = build_header_only_graph(
+        _snapshot(functions=[fn]), include_search_dirs=["/proj/include"]
+    )
+    node = next(n for n in graph.nodes if n.id == "decl://_Z3depv")
+    assert "visibility" not in node.attrs
+
+
 # ── ClangHeaderIncludeExtractor ──────────────────────────────────────────────
 
 

--- a/tests/test_non_elf_dump_l2_seed.py
+++ b/tests/test_non_elf_dump_l2_seed.py
@@ -87,6 +87,71 @@ def test_non_elf_dump_seeds_includes_and_runs_cleanup(monkeypatch, tmp_path):
     assert events == ["seed", "dump", "cleanup"]
 
 
+def test_non_elf_dump_forwards_only_explicit_includes_as_public_include_search_dirs(
+    monkeypatch, tmp_path
+):
+    """The build-derived seed dir must reach the compile path (`includes`)
+    but NOT the provenance-widening path (`public_include_search_dirs`) --
+    same regression class the ELF `perform_elf_dump` path already avoids
+    (Codex review, PR #839 round 9): an auto-derived umbrella-header
+    directory can hold a genuinely private sibling header, and folding it
+    into provenance would silently promote that sibling to PUBLIC_HEADER."""
+    captured: dict = {}
+    seeded_dir = tmp_path / "buildinc"
+    explicit_dir = tmp_path / "explicit"
+
+    def fake_seed_and_fold(**kwargs):
+        kwargs["pending_cleanups"].append(lambda: None)
+        explicit_ctx = CompileContext(
+            gcc_path=kwargs["gcc_path"],
+            gcc_prefix=kwargs["gcc_prefix"],
+            gcc_options=kwargs["gcc_options"],
+            gcc_option_tokens=kwargs["gcc_option_tokens"],
+            sysroot=kwargs["sysroot"],
+            nostdinc=kwargs["nostdinc"],
+            frontend=kwargs["frontend"],
+            frontend_context=kwargs["frontend_context"],
+        )
+        # Widen with a build-derived dir, mirroring the real seed's own
+        # auto-add behavior.
+        return [*kwargs["includes"], seeded_dir], False, explicit_ctx, ()
+
+    def fake_dump_native(so_path, binary_fmt, headers, includes, version, lang, **kw):
+        captured["includes"] = includes
+        captured["public_include_search_dirs"] = kw.get("public_include_search_dirs")
+        return AbiSnapshot(library="l", version=version)
+
+    monkeypatch.setattr(
+        "abicheck.buildsource.l2_seed.seed_includes_and_fold_compile_context",
+        fake_seed_and_fold,
+    )
+
+    handle_non_elf_dump(
+        so_path=tmp_path / "foo.dll",
+        binary_fmt="pe",
+        headers=(tmp_path / "h.h",),
+        includes=(explicit_dir,),
+        version="1",
+        lang="c++",
+        pdb_path=None,
+        follow_deps=False,
+        git_tag=None,
+        build_id=None,
+        no_git=True,
+        output=None,
+        dump_native_binary=fake_dump_native,
+        stamp_provenance=lambda *a, **k: None,
+        write_snapshot_output=lambda *a, **k: None,
+        sources=tmp_path,
+        collect_mode="build",
+    )
+
+    # The compile path sees both the explicit dir and the build-derived one.
+    assert set(captured["includes"]) == {explicit_dir, seeded_dir}
+    # Provenance widening sees ONLY the caller's own explicit dir.
+    assert captured["public_include_search_dirs"] == [explicit_dir]
+
+
 def test_non_elf_dump_header_roots_includes_public_headers_and_dirs(
     monkeypatch, tmp_path
 ):

--- a/tests/test_pdb_provenance.py
+++ b/tests/test_pdb_provenance.py
@@ -357,6 +357,34 @@ class TestParsePdbEndToEnd:
         out2 = _apply_native_provenance(snap2, None, None)
         assert out2.types[0].origin == ScopeOrigin.UNKNOWN
 
+    def test_cli_apply_native_provenance_promotes_via_include_search_dirs(
+        self,
+    ) -> None:
+        """Round-3 review finding (Codex, fresh evidence): the CLI/service
+        PE/Mach-O ``_apply_native_provenance`` wrappers never forwarded the
+        caller's ``-I`` roots to ``apply_provenance``, unlike the ELF path
+        (``dumper.dump``) fixed earlier in this PR -- so a declaration
+        reached only transitively through PE/Mach-O's own ``-I`` (never
+        itself named as a ``-H`` root) stayed ``PRIVATE_HEADER`` and could
+        be excluded from the public surface, on these two formats only."""
+        from abicheck.cli import _apply_native_provenance
+        from abicheck.model import AbiSnapshot
+
+        meta = DwarfMetadata(has_dwarf=True)
+        meta.structs["DepType"] = StructLayout(
+            name="DepType", byte_size=8, decl_file="/build/dep/include/dep.h"
+        )
+        records, enums = model_types_from_dwarf_metadata(meta)
+        snap = AbiSnapshot(library="lib.dll", version="1", types=records, enums=enums)
+        # No -H names dep/include/dep.h directly -- only the -I root does.
+        out = _apply_native_provenance(
+            snap,
+            [Path("/build/include/api.h")],
+            None,
+            [Path("/build/dep/include")],
+        )
+        assert out.types[0].origin == ScopeOrigin.PUBLIC_HEADER
+
     def test_bridge_feeds_provenance_classification(self) -> None:
         # The decl_file → source_location bridge lets apply_provenance classify
         # a PDB-derived type's ScopeOrigin against a public-header set — the

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -169,6 +169,27 @@ def test_gcc_include_dir_with_dotted_solaris_style_os_component_is_toolchain():
     assert _is_toolchain_compiler_include_dir(segs) is True
 
 
+def test_gcc_include_dir_debian_multiarch_libstdcxx_is_toolchain():
+    # Round-5 review finding (Codex, fresh evidence): the anchored
+    # usr/include/c++ check required "c++" immediately after the system
+    # prefix, with no room for the real Debian/Ubuntu multiarch component
+    # that sits between them for a multiarch-enabled GCC install
+    # (`-I /usr/include/x86_64-linux-gnu/c++/12`). Under this layout,
+    # libstdc++ headers like bits/c++config.h were never recognized as
+    # system, letting them survive dependency exclusion as if they were
+    # project declarations.
+    segs = _segments("/usr/include/x86_64-linux-gnu/c++/12/bits/c++config.h")
+    assert _is_toolchain_compiler_include_dir(segs) is True
+
+
+def test_gcc_include_dir_debian_multiarch_with_non_triple_component_not_toolchain():
+    # Negative control: a non-triple-shaped component between the system
+    # prefix and c++ must NOT be accepted -- otherwise this would reopen
+    # the same wildcarding gap round 3 already closed for lib/gcc.
+    segs = _segments("/usr/include/notarealmultiarch/c++/12/vector")
+    assert _is_toolchain_compiler_include_dir(segs) is False
+
+
 def test_system_header_conda_forge_libstdcxx_predefined_ops():
     # The exact real-world path from a false-positive func_removed report:
     # abicheck's own GitHub Action reported libstdc++'s internal

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -154,6 +154,21 @@ def test_gcc_include_dir_with_compiler_shaped_triple_and_version_is_toolchain():
     assert _is_toolchain_compiler_include_dir(segs) is True
 
 
+def test_gcc_include_dir_with_dotted_solaris_style_os_component_is_toolchain():
+    # Round-4 review finding (Codex, fresh evidence): the triple regex
+    # required every component to be plain alnum/underscore, rejecting a
+    # real Solaris/AIX-style target triple whose OS component embeds a
+    # dotted version (this repo's own toolchain_probe.py already recognizes
+    # "x86_64-pc-solaris2.11" as a real triple). Under a relocatable prefix
+    # not covered by _SYSTEM_HEADER_DIRS, this made a real compiler's own
+    # private headers read as project declarations, reintroducing noisy/
+    # false findings from the toolchain surface.
+    segs = _segments(
+        "/opt/gcc/lib/gcc/x86_64-pc-solaris2.11/13/include/stddef.h"
+    )
+    assert _is_toolchain_compiler_include_dir(segs) is True
+
+
 def test_system_header_conda_forge_libstdcxx_predefined_ops():
     # The exact real-world path from a false-positive func_removed report:
     # abicheck's own GitHub Action reported libstdc++'s internal

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -203,6 +203,29 @@ def test_gcc_include_dir_triple_shaped_project_name_not_multiarch():
     assert _is_toolchain_compiler_include_dir(segs) is False
 
 
+def test_gcc_include_dir_single_component_avr_target_is_toolchain():
+    # Round-7 review finding (Codex, fresh evidence): a relocatable GCC
+    # install targeting a single-component machine (AVR, embedded/bare-
+    # metal) has no vendor/OS/environment components at all, so
+    # _TARGET_TRIPLE_RE's own "at least one hyphen" requirement rejected
+    # the real target directory -- these compiler-owned headers then
+    # survived default dependency exclusion, or became public when
+    # supplied via -I, risking false ABI findings from the toolchain
+    # surface.
+    segs = _segments("/opt/toolchain/lib/gcc/avr/12.2.0/include/stdint.h")
+    assert _is_toolchain_compiler_include_dir(segs) is True
+
+
+def test_gcc_include_dir_single_component_non_target_word_not_toolchain():
+    # Positive control for round 3's own original finding: widening to
+    # accept a real single-component GCC target must not reopen the
+    # "any bare word is a target" gap -- an arbitrary project directory
+    # name that is NOT a recognized bare-metal target must still be
+    # rejected, even paired with a numeric-looking sibling directory.
+    segs = _segments("/project/lib/gcc/backend/14/include/api.h")
+    assert _is_toolchain_compiler_include_dir(segs) is False
+
+
 def test_system_header_conda_forge_libstdcxx_predefined_ops():
     # The exact real-world path from a false-positive func_removed report:
     # abicheck's own GitHub Action reported libstdc++'s internal

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -178,6 +178,24 @@ def test_conda_forge_project_header_outside_compiler_tree_stays_project():
     assert origin is ScopeOrigin.PUBLIC_HEADER
 
 
+def test_bare_include_cxx_with_no_toolchain_prefix_is_not_system_header():
+    # Codex review, real finding: an earlier revision matched a bare
+    # "include/c++" *anywhere* in the path, with no requirement that it sit
+    # under a recognized lib/gcc/.../ or lib/clang/.../ toolchain root -- a
+    # project shipping its own "include/c++" directory (an unusual but legal
+    # project layout) would have been misclassified as a system header,
+    # letting default dependency scoping / public-surface evaluation drop
+    # or demote the project's own declarations. Basename deliberately does
+    # NOT match the public header ("vector", not "api.h") -- the basename
+    # fallback in _matches_public would otherwise mask a system-header
+    # misclassification behind a public-header match.
+    origin = _classify(
+        "/project/include/c++/vector",
+        public_headers=["include/api.h"],
+    )
+    assert origin is not ScopeOrigin.SYSTEM_HEADER
+
+
 def test_private_header_when_not_public_and_not_system():
     origin = _classify(
         "/build/proj/src/internal/impl.h",

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -116,6 +116,68 @@ def test_system_header_with_sysroot_prefix():
     assert origin is ScopeOrigin.SYSTEM_HEADER
 
 
+def test_system_header_conda_forge_gcc_private_include():
+    # A conda-forge/pixi GCC's own private headers -- e.g. what this
+    # project's own GitHub Action installs -- sit under an arbitrary
+    # environment prefix, not /usr, so the fixed _SYSTEM_HEADER_DIRS
+    # prefixes never matched. Real conda-forge layout.
+    origin = _classify(
+        "/home/runner/.pixi/envs/scanner/lib/gcc/x86_64-conda-linux-gnu/"
+        "14.3.0/include-fixed/limits.h",
+        public_headers=["include/api.h"],
+    )
+    assert origin is ScopeOrigin.SYSTEM_HEADER
+
+
+def test_system_header_conda_forge_libstdcxx_predefined_ops():
+    # The exact real-world path from a false-positive func_removed report:
+    # abicheck's own GitHub Action reported libstdc++'s internal
+    # _Iter_pred predicate helper as a removed *public* function, because
+    # this path -- with its literal unnormalized `bin/..` segment -- didn't
+    # match any known system-header prefix.
+    origin = _classify(
+        "/home/runner/work/_actions/abicheck/abicheck/main/.pixi/envs/"
+        "scanner/bin/../lib/gcc/x86_64-conda-linux-gnu/14.3.0/include/c++/"
+        "bits/predefined_ops.h",
+        public_headers=["include/api.h"],
+    )
+    assert origin is ScopeOrigin.SYSTEM_HEADER
+
+
+def test_system_header_conda_forge_clang_builtin_include():
+    origin = _classify(
+        "/opt/pixi/envs/scanner/lib/clang/18/include/stddef.h",
+        public_headers=["include/api.h"],
+    )
+    assert origin is ScopeOrigin.SYSTEM_HEADER
+
+
+def test_toolchain_include_dir_path_normalizes_dot_dot_segment():
+    # A `foo/bar/../baz` segment sequence must classify identically to its
+    # already-collapsed `foo/baz` form -- not just for the toolchain-dir
+    # patterns above, but for _segments() generally (basic path-segment
+    # equivalence, unrelated to any specific prefix list).
+    from abicheck.provenance import _segments
+
+    assert _segments("/a/b/../c") == _segments("/a/c")
+    assert _segments("bin/../lib/x") == ("lib", "x")
+    # A leading `..` with nothing to collapse against is kept as-is.
+    assert _segments("../a/b") == ("..", "a", "b")
+
+
+def test_conda_forge_project_header_outside_compiler_tree_stays_project():
+    # A project header that merely happens to live under the same
+    # conda/pixi environment prefix (but not inside the compiler's own
+    # lib/gcc/.../include or include/c++/... tree) must not be swept up by
+    # the structural toolchain-include-dir match.
+    origin = _classify(
+        "/home/runner/.pixi/envs/scanner/include/myproject/api.h",
+        public_headers=["include/api.h"],
+        public_dirs=["include/myproject"],
+    )
+    assert origin is ScopeOrigin.PUBLIC_HEADER
+
+
 def test_private_header_when_not_public_and_not_system():
     origin = _classify(
         "/build/proj/src/internal/impl.h",
@@ -237,6 +299,100 @@ def test_apply_provenance_no_set_keeps_unknown_but_fills_header():
     assert snap.functions[0].source_header == "/build/include/api.h"
     assert snap.functions[0].origin is ScopeOrigin.UNKNOWN
     assert snap.types[0].origin is ScopeOrigin.UNKNOWN
+
+
+# ── include_search_dirs: headers reached transitively from a -H root ─────────
+
+
+def _snapshot_with_transitive_private_header() -> AbiSnapshot:
+    # `priv` mirrors a declaration reached only transitively -- via #include
+    # -- from the -H root (`/build/include/api.h`), but physically living
+    # under a *different* header nested inside the same -I include root
+    # (`/build/include`). A header-AST dump only ever parses declarations
+    # reachable by #include from its own -H root(s), so this is exactly the
+    # shape produced by `dump -H include/api.h -I include`.
+    return AbiSnapshot(
+        library="libfoo.so.1",
+        version="1.0",
+        functions=[
+            Function(
+                name="pub",
+                mangled="pub",
+                return_type="void",
+                source_location="/build/include/api.h:10",
+            ),
+            Function(
+                name="priv",
+                mangled="priv",
+                return_type="void",
+                source_location="/build/include/detail/impl.h:20",
+            ),
+        ],
+    )
+
+
+def test_include_search_dirs_promotes_transitively_included_header_to_public():
+    # Defect: every header reached only transitively from the -H root
+    # (rather than being the literal -H file itself) classified
+    # PRIVATE_HEADER, even when it lives under the same -I include root the
+    # dump was given -- silently dropping real findings out of the compared
+    # surface. include_search_dirs (the dump's own -I roots) fixes this.
+    snap = apply_provenance(
+        _snapshot_with_transitive_private_header(),
+        public_headers=["/build/include/api.h"],
+        include_search_dirs=["/build/include"],
+    )
+    by_name = {f.name: f for f in snap.functions}
+    assert by_name["pub"].origin is ScopeOrigin.PUBLIC_HEADER
+    assert by_name["priv"].origin is ScopeOrigin.PUBLIC_HEADER
+
+
+def test_include_search_dirs_omitted_keeps_prior_private_header_behavior():
+    # Without include_search_dirs (e.g. a caller that never threaded -I
+    # roots through), behavior is unchanged: only the literal -H file(s)
+    # classify public.
+    snap = apply_provenance(
+        _snapshot_with_transitive_private_header(),
+        public_headers=["/build/include/api.h"],
+    )
+    by_name = {f.name: f for f in snap.functions}
+    assert by_name["pub"].origin is ScopeOrigin.PUBLIC_HEADER
+    assert by_name["priv"].origin is ScopeOrigin.PRIVATE_HEADER
+
+
+def test_include_search_dirs_cannot_opt_in_classification_by_itself():
+    # include_search_dirs must never turn provenance classification on when
+    # no real -H/--public-header-dir set was given -- ADR-015 D4's opt-in
+    # contract stays intact.
+    snap = apply_provenance(
+        _snapshot_with_transitive_private_header(),
+        include_search_dirs=["/build/include"],
+    )
+    by_name = {f.name: f for f in snap.functions}
+    assert by_name["pub"].origin is ScopeOrigin.UNKNOWN
+    assert by_name["priv"].origin is ScopeOrigin.UNKNOWN
+
+
+def test_include_search_dirs_does_not_override_bare_system_prefix():
+    # A stray -I /usr/include must not make every system header underneath
+    # classify as project-owned.
+    snap = apply_provenance(
+        AbiSnapshot(
+            library="libfoo.so.1",
+            version="1.0",
+            functions=[
+                Function(
+                    name="sys",
+                    mangled="sys",
+                    return_type="void",
+                    source_location="/usr/include/stdio.h:1",
+                ),
+            ],
+        ),
+        public_headers=["/build/include/api.h"],
+        include_search_dirs=["/usr/include"],
+    )
+    assert snap.functions[0].origin is ScopeOrigin.SYSTEM_HEADER
 
 
 # ── origin_cache (tag_provenance / apply_provenance memoization) ─────────────
@@ -625,3 +781,64 @@ class TestAbsolutizeHeaderRoot:
         root = "/usr/include/mylib/api.h"
         sibling = "/usr/include/mylib/detail/internal.h"
         assert is_dependency_header(sibling, [root]) is False
+
+
+# ── _is_bare_system_dir: conda-forge/pixi toolchain include roots ────────────
+
+
+class TestIsBareSystemDirToolchainIncludeRoots:
+    """A directory root that IS a compiler's own private include tree
+    (nothing project-specific appended after it) must not become a project
+    directory when widened from a flat `-H <file>` root (Codex review, D5)."""
+
+    def test_bare_gcc_private_include_dir(self):
+        from abicheck.provenance import _is_bare_system_dir, _segments
+
+        segs = _segments(
+            "/home/runner/.pixi/envs/scanner/lib/gcc/"
+            "x86_64-conda-linux-gnu/14.3.0/include"
+        )
+        assert _is_bare_system_dir(segs) is True
+
+    def test_bare_gcc_include_fixed_dir(self):
+        from abicheck.provenance import _is_bare_system_dir, _segments
+
+        segs = _segments(
+            "/home/runner/.pixi/envs/scanner/lib/gcc/"
+            "x86_64-conda-linux-gnu/14.3.0/include-fixed"
+        )
+        assert _is_bare_system_dir(segs) is True
+
+    def test_bare_libstdcxx_version_dir(self):
+        from abicheck.provenance import _is_bare_system_dir, _segments
+
+        segs = _segments(
+            "/home/runner/.pixi/envs/scanner/lib/gcc/"
+            "x86_64-conda-linux-gnu/14.3.0/include/c++"
+        )
+        assert _is_bare_system_dir(segs) is True
+
+    def test_bare_clang_builtin_include_dir(self):
+        from abicheck.provenance import _is_bare_system_dir, _segments
+
+        segs = _segments("/opt/pixi/envs/scanner/lib/clang/18/include")
+        assert _is_bare_system_dir(segs) is True
+
+    def test_project_subdirectory_under_libstdcxx_tree_is_not_bare(self):
+        # A project directory nested one level deeper than the recognized
+        # boundary (e.g. libstdc++'s own bits/ subtree) is a legitimate,
+        # non-bare directory once something is appended after the boundary --
+        # mirrors the fixed-prefix _SYSTEM_HEADER_DIRS case one function up.
+        from abicheck.provenance import _is_bare_system_dir, _segments
+
+        segs = _segments(
+            "/home/runner/.pixi/envs/scanner/lib/gcc/"
+            "x86_64-conda-linux-gnu/14.3.0/include/c++/bits"
+        )
+        assert _is_bare_system_dir(segs) is False
+
+    def test_unrelated_project_dir_is_not_bare(self):
+        from abicheck.provenance import _is_bare_system_dir, _segments
+
+        segs = _segments("/home/runner/.pixi/envs/scanner/include/myproject")
+        assert _is_bare_system_dir(segs) is False

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -413,6 +413,34 @@ def test_include_search_dirs_does_not_override_bare_system_prefix():
     assert snap.functions[0].origin is ScopeOrigin.SYSTEM_HEADER
 
 
+def test_include_search_dirs_does_not_promote_nested_toolchain_root():
+    # Codex review, real finding: an explicit -I pointed *below* a system
+    # boundary (e.g. /usr/include/c++/12, or the conda-forge-nested
+    # equivalent) was not excluded by the exact-bare-boundary check, so it
+    # was promoted to a public directory -- letting libstdc++ declarations
+    # beneath it classify PUBLIC_HEADER (since classify_origin checks the
+    # public match before the system-header one) and bypass dependency
+    # exclusion, allowing transitive toolchain changes to produce false ABI
+    # findings.
+    snap = apply_provenance(
+        AbiSnapshot(
+            library="libfoo.so.1",
+            version="1.0",
+            functions=[
+                Function(
+                    name="vec_fn",
+                    mangled="vec_fn",
+                    return_type="void",
+                    source_location="/usr/include/c++/12/vector:10",
+                ),
+            ],
+        ),
+        public_headers=["/build/include/api.h"],
+        include_search_dirs=["/usr/include/c++/12"],
+    )
+    assert snap.functions[0].origin is ScopeOrigin.SYSTEM_HEADER
+
+
 # ── origin_cache (tag_provenance / apply_provenance memoization) ─────────────
 #
 # apply_provenance() and the buildsource castxml extractor share one
@@ -836,24 +864,59 @@ class TestIsBareSystemDirToolchainIncludeRoots:
         )
         assert _is_bare_system_dir(segs) is True
 
+    def test_traditional_debian_style_split_libstdcxx_dir_is_bare(self):
+        # Codex review, real finding: the traditional (non-conda-forge)
+        # Debian/Ubuntu-style layout keeps libstdc++ separately at
+        # /usr/include/c++/<version>/, not nested under lib/gcc/ at all.
+        # An explicit -I /usr/include/c++/12 was NOT excluded by the
+        # exact-bare-boundary check (it isn't a suffix of any
+        # _SYSTEM_HEADER_DIRS entry, and the lib/gcc-anchored toolchain
+        # check doesn't apply since there's no lib/gcc/ prefix here) --
+        # letting the whole libstdc++ tree underneath be promoted to
+        # PUBLIC_HEADER via an explicit -I, since classify_origin checks
+        # the public match before the system-header one.
+        from abicheck.provenance import _is_bare_system_dir, _segments
+
+        segs = _segments("/usr/include/c++/12")
+        assert _is_bare_system_dir(segs) is True
+
+    def test_project_own_include_cxx_dir_with_no_system_prefix_is_not_bare(self):
+        # The anchored usr/include/c++ recognition above must not regress
+        # the false-positive-risk case already covered in
+        # test_bare_include_cxx_with_no_toolchain_prefix_is_not_system_header:
+        # a project's own "include/c++" directory with no system prefix at
+        # all is not swept up.
+        from abicheck.provenance import _is_bare_system_dir, _segments
+
+        segs = _segments("/project/include/c++")
+        assert _is_bare_system_dir(segs) is False
+
     def test_bare_clang_builtin_include_dir(self):
         from abicheck.provenance import _is_bare_system_dir, _segments
 
         segs = _segments("/opt/pixi/envs/scanner/lib/clang/18/include")
         assert _is_bare_system_dir(segs) is True
 
-    def test_project_subdirectory_under_libstdcxx_tree_is_not_bare(self):
-        # A project directory nested one level deeper than the recognized
-        # boundary (e.g. libstdc++'s own bits/ subtree) is a legitimate,
-        # non-bare directory once something is appended after the boundary --
-        # mirrors the fixed-prefix _SYSTEM_HEADER_DIRS case one function up.
+    def test_subdirectory_under_libstdcxx_tree_is_still_toolchain_owned(self):
+        # Codex review, real finding: unlike the fixed-prefix
+        # _SYSTEM_HEADER_DIRS case (where a real project CAN legitimately
+        # live one level under a generic system prefix, e.g.
+        # /usr/include/mylib), nothing can legitimately live under a
+        # compiler's own private include tree -- bits/, ext/, backward/,
+        # and every other subdirectory reachable from
+        # lib/gcc/<triple>/<version>/include/c++/ are toolchain-owned too,
+        # never a project's. An explicit -I pointed at such a subdirectory
+        # must still be excluded from becoming a public directory (an
+        # earlier revision of this fix only excluded the exact bare
+        # boundary, leaving a subdirectory reachable and therefore
+        # promotable to PUBLIC_HEADER).
         from abicheck.provenance import _is_bare_system_dir, _segments
 
         segs = _segments(
             "/home/runner/.pixi/envs/scanner/lib/gcc/"
             "x86_64-conda-linux-gnu/14.3.0/include/c++/bits"
         )
-        assert _is_bare_system_dir(segs) is False
+        assert _is_bare_system_dir(segs) is True
 
     def test_unrelated_project_dir_is_not_bare(self):
         from abicheck.provenance import _is_bare_system_dir, _segments

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -190,6 +190,19 @@ def test_gcc_include_dir_debian_multiarch_with_non_triple_component_not_toolchai
     assert _is_toolchain_compiler_include_dir(segs) is False
 
 
+def test_gcc_include_dir_triple_shaped_project_name_not_multiarch():
+    # Round-6 review finding (Codex, fresh evidence): a two-word project
+    # directory name that merely happens to be triple-SHAPED (`my-lib`,
+    # matching _TARGET_TRIPLE_RE's bare "2-4 alnum components" grammar) but
+    # names no real OS/libc-environment family must NOT be accepted as a
+    # multiarch component -- otherwise an explicitly-declared -I under an
+    # installed project layout like `/usr/include/my-lib/c++/api.h` would
+    # be silently treated as a system path, discarding the user's own
+    # public-scoping declaration.
+    segs = _segments("/usr/include/my-lib/c++/api.h")
+    assert _is_toolchain_compiler_include_dir(segs) is False
+
+
 def test_system_header_conda_forge_libstdcxx_predefined_ops():
     # The exact real-world path from a false-positive func_removed report:
     # abicheck's own GitHub Action reported libstdc++'s internal

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -32,6 +32,8 @@ from abicheck.model import (
 )
 from abicheck.provenance import (
     _absolutize_header_root,
+    _is_toolchain_compiler_include_dir,
+    _segments,
     apply_provenance,
     build_public_set,
     classify_origin,
@@ -127,6 +129,29 @@ def test_system_header_conda_forge_gcc_private_include():
         public_headers=["include/api.h"],
     )
     assert origin is ScopeOrigin.SYSTEM_HEADER
+
+
+def test_gcc_include_dir_with_non_compiler_shaped_triple_and_version_not_system():
+    # Round-3 review finding (Codex, fresh evidence): the triple/version
+    # components between lib/gcc and include were unconditionally
+    # wildcarded, so a project path that merely happens to have two
+    # components there -- neither a real target triple nor a real GCC
+    # version -- was misclassified as a toolchain system header, which can
+    # silently drop the declarations under it from the public surface.
+    # Tested directly against the primitive (not through classify_origin's
+    # full pipeline, whose basename-fallback public match would otherwise
+    # mask this specific check when the two files share a basename).
+    segs = _segments("/project/lib/gcc/backend/v1/include/api.h")
+    assert _is_toolchain_compiler_include_dir(segs) is False
+
+
+def test_gcc_include_dir_with_compiler_shaped_triple_and_version_is_toolchain():
+    # Positive control for the test above: a real-shaped triple/version
+    # pair must still match (this is the case the fix must not regress).
+    segs = _segments(
+        "/opt/gcc/lib/gcc/x86_64-pc-linux-gnu/13.2.0/include/stddef.h"
+    )
+    assert _is_toolchain_compiler_include_dir(segs) is True
 
 
 def test_system_header_conda_forge_libstdcxx_predefined_ops():

--- a/tests/test_provenance_toolchain_properties.py
+++ b/tests/test_provenance_toolchain_properties.py
@@ -1,0 +1,186 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Property-based tests for provenance.py's structural toolchain/system
+include-directory recognition (``_is_toolchain_compiler_include_dir``,
+``_is_bare_system_dir``, ``_segments``).
+
+This module exists because the example-based tests in test_provenance.py
+were, across two rounds of review on the same PR, each individually shown to
+miss a real case: the first cut unconditionally matched a bare
+``include/c++`` anywhere (a false-positive risk on an unrelated project
+path); the fix for that then under-protected a nested nested subdirectory
+(``.../include/c++/bits``) and the traditional, non-conda-forge split layout
+(``/usr/include/c++/<version>``) from being promoted to a public directory.
+Each individual round's own examples passed the fix that introduced the next
+round's gap — which is exactly the failure mode this file's own convention
+(AGENTS.md's "Primitive-level property tests") exists to catch: a property
+stated as an invariant over the whole input space, not a fixed list of
+examples chosen after the fact.
+
+The two invariants this suite pins, independent of any specific path string:
+
+1. **No false positive**: a path with no recognized toolchain/system anchor
+   anywhere in it is never classified as a toolchain include directory,
+   regardless of what generic-sounding segments (``include``, ``c++``,
+   ``lib``) it happens to contain elsewhere.
+2. **No false negative at any depth**: a path that DOES contain a
+   recognized anchor is classified as one, regardless of how many extra
+   segments come before or after the anchor -- closing the exact
+   "the anchor plus one more subdirectory slipped through" shape both
+   review-round gaps had.
+"""
+
+from __future__ import annotations
+
+import pytest
+from hypothesis import given, settings, strategies as st
+
+from abicheck.provenance import (
+    _is_bare_system_dir,
+    _is_toolchain_compiler_include_dir,
+    _segments,
+)
+
+pytestmark = pytest.mark.slow
+
+# Path-segment alphabet: identifier-ish tokens only (no "/", no "..", no
+# empty string) so generated segments always round-trip through _segments()
+# unchanged -- the property is about the *classification* logic, not
+# _segments()'s own parsing (covered separately below).
+_SEGMENT = st.text(
+    alphabet=st.characters(
+        whitelist_categories=("Lu", "Ll", "Nd"), whitelist_characters="_-."
+    ),
+    min_size=1,
+    max_size=10,
+).filter(lambda s: s not in ("", ".", "..") and "/" not in s and "\\" not in s)
+
+_PREFIX_SUFFIX = st.lists(_SEGMENT, max_size=4)
+_TRIPLE_OR_VERSION = _SEGMENT
+
+
+@given(
+    before=_PREFIX_SUFFIX,
+    triple=_TRIPLE_OR_VERSION,
+    version=_TRIPLE_OR_VERSION,
+    include_kind=st.sampled_from(("include", "include-fixed")),
+    after=_PREFIX_SUFFIX,
+)
+@settings(max_examples=200)
+def test_gcc_private_include_recognized_at_any_depth(
+    before, triple, version, include_kind, after
+) -> None:
+    """lib/gcc/<triple>/<version>/include[-fixed] is recognized regardless
+    of what surrounds it -- an arbitrary environment prefix before, and an
+    arbitrary subdirectory (bits/, ext/, a header filename, ...) after."""
+    segs = (*before, "lib", "gcc", triple, version, include_kind, *after)
+    assert _is_toolchain_compiler_include_dir(segs) is True
+    assert _is_bare_system_dir(segs) is True
+
+
+@given(
+    before=_PREFIX_SUFFIX,
+    version=_TRIPLE_OR_VERSION,
+    after=_PREFIX_SUFFIX,
+)
+@settings(max_examples=200)
+def test_clang_builtin_include_recognized_at_any_depth(before, version, after) -> None:
+    segs = (*before, "lib", "clang", version, "include", *after)
+    assert _is_toolchain_compiler_include_dir(segs) is True
+    assert _is_bare_system_dir(segs) is True
+
+
+@given(
+    prefix=st.sampled_from((("usr", "include"), ("usr", "local", "include"))),
+    version=_TRIPLE_OR_VERSION,
+    after=_PREFIX_SUFFIX,
+)
+@settings(max_examples=200)
+def test_system_prefixed_libstdcxx_recognized_at_any_depth(
+    prefix, version, after
+) -> None:
+    """The traditional (non-conda-forge) split layout -- libstdc++'s c++
+    tree living separately from lib/gcc/, but anchored under a real system
+    prefix (/usr/include, /usr/local/include) -- is recognized at any depth
+    under the c++/<version> boundary too, not only the exact directory."""
+    segs = (*prefix, "c++", version, *after)
+    assert _is_toolchain_compiler_include_dir(segs) is True
+    assert _is_bare_system_dir(segs) is True
+
+
+# Segment alphabet deliberately EXCLUDING the literal tokens the recognizer
+# keys on ("lib", "gcc", "clang", "include", "include-fixed", "c++", "usr",
+# "local") so a generated path can never accidentally assemble a real anchor
+# by chance -- this is what makes "no anchor anywhere" a checkable
+# precondition rather than a fluke of what Hypothesis happened to draw.
+_ANCHOR_TOKENS = frozenset(
+    {"lib", "gcc", "clang", "include", "include-fixed", "c++", "usr", "local"}
+)
+_NON_ANCHOR_SEGMENT = _SEGMENT.filter(lambda s: s not in _ANCHOR_TOKENS)
+_NON_ANCHOR_PATH = st.lists(_NON_ANCHOR_SEGMENT, min_size=0, max_size=8)
+
+
+@given(segs=_NON_ANCHOR_PATH)
+@settings(max_examples=300)
+def test_no_false_positive_without_any_recognized_anchor(segs) -> None:
+    """A path built entirely from non-anchor tokens must never classify as
+    a toolchain include directory -- the false-positive risk both P2
+    findings (the unconditional include/c++ match, and its own
+    reintroduction risk) were about, stated as an invariant over the whole
+    non-anchor input space rather than one hand-picked example."""
+    assert _is_toolchain_compiler_include_dir(tuple(segs)) is False
+
+
+class TestSegmentsDotDotCollapsing:
+    """_segments() must collapse a `..` against its immediately preceding
+    segment -- the fix for the real-world conda-forge repro path's own
+    literal `bin/..` component (a compiler path resolved via
+    `$(dirname "$CC")/..`). Checked as a property against Python's own
+    posixpath.normpath, an independent reference implementation of the
+    identical POSIX lexical-collapse rule, rather than hand-picked examples.
+    """
+
+    @given(segs=st.lists(_SEGMENT, min_size=1, max_size=8))
+    @settings(max_examples=200)
+    def test_no_dot_dot_is_a_no_op(self, segs) -> None:
+        # Sanity precondition: a path with no ".." at all must segment
+        # exactly as given (the collapsing logic must never fire when
+        # there's nothing to collapse).
+        assert _segments("/" + "/".join(segs)) == tuple(segs)
+
+    @given(
+        before=st.lists(_SEGMENT, min_size=1, max_size=4),
+        cancelled=_SEGMENT,
+        after=st.lists(_SEGMENT, min_size=0, max_size=4),
+    )
+    @settings(max_examples=300)
+    def test_segment_followed_by_dot_dot_cancels_out(
+        self, before, cancelled, after
+    ) -> None:
+        """`.../before/CANCELLED/../after` must segment identically to
+        `.../before/after` -- matches posixpath.normpath's own lexical
+        collapse rule (an independent reference), and directly encodes the
+        real bug: a build-recorded path like `.../bin/../lib/gcc/...` must
+        match its already-collapsed `.../lib/gcc/...` form."""
+        import posixpath
+
+        raw = "/" + "/".join((*before, cancelled, "..", *after))
+        collapsed = "/" + "/".join((*before, *after))
+        assert _segments(raw) == _segments(collapsed)
+        # Cross-check against the independent stdlib reference.
+        assert _segments(raw) == _segments(posixpath.normpath(raw))
+
+    def test_leading_dot_dot_with_nothing_to_collapse_is_kept(self) -> None:
+        assert _segments("../a/b") == ("..", "a", "b")

--- a/tests/test_provenance_toolchain_properties.py
+++ b/tests/test_provenance_toolchain_properties.py
@@ -48,6 +48,8 @@ import pytest
 from hypothesis import given, settings, strategies as st
 
 from abicheck.provenance import (
+    _TARGET_TRIPLE_RE,
+    _TOOLCHAIN_VERSION_RE,
     _is_bare_system_dir,
     _is_toolchain_compiler_include_dir,
     _segments,
@@ -70,11 +72,29 @@ _SEGMENT = st.text(
 _PREFIX_SUFFIX = st.lists(_SEGMENT, max_size=4)
 _TRIPLE_OR_VERSION = _SEGMENT
 
+# Compiler-shaped generators (round-3 review, Codex: the earlier revision
+# wildcarded the triple/version components unconditionally, matching a
+# project path like lib/gcc/backend/v1/include too). Built from small
+# integer/word components joined the way a real triple/version actually is,
+# not by importing the module's own regex -- an independent notion of "looks
+# like a real triple/version" for the "recognized" side of the property, the
+# "rejected" side below cross-checks these generators against the module's
+# actual regexes instead of re-deriving a second definition of "shaped".
+_TRIPLE_COMPONENT = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz0123456789", min_size=1, max_size=8
+)
+_REAL_TRIPLE = st.lists(_TRIPLE_COMPONENT, min_size=2, max_size=4).map(
+    "-".join
+)
+_REAL_VERSION = st.lists(
+    st.integers(min_value=0, max_value=99), min_size=1, max_size=3
+).map(lambda parts: ".".join(str(p) for p in parts))
+
 
 @given(
     before=_PREFIX_SUFFIX,
-    triple=_TRIPLE_OR_VERSION,
-    version=_TRIPLE_OR_VERSION,
+    triple=_REAL_TRIPLE,
+    version=_REAL_VERSION,
     include_kind=st.sampled_from(("include", "include-fixed")),
     after=_PREFIX_SUFFIX,
 )
@@ -84,7 +104,8 @@ def test_gcc_private_include_recognized_at_any_depth(
 ) -> None:
     """lib/gcc/<triple>/<version>/include[-fixed] is recognized regardless
     of what surrounds it -- an arbitrary environment prefix before, and an
-    arbitrary subdirectory (bits/, ext/, a header filename, ...) after."""
+    arbitrary subdirectory (bits/, ext/, a header filename, ...) after --
+    as long as the triple/version components are actually compiler-shaped."""
     segs = (*before, "lib", "gcc", triple, version, include_kind, *after)
     assert _is_toolchain_compiler_include_dir(segs) is True
     assert _is_bare_system_dir(segs) is True
@@ -92,7 +113,7 @@ def test_gcc_private_include_recognized_at_any_depth(
 
 @given(
     before=_PREFIX_SUFFIX,
-    version=_TRIPLE_OR_VERSION,
+    version=_REAL_VERSION,
     after=_PREFIX_SUFFIX,
 )
 @settings(max_examples=200)
@@ -100,6 +121,37 @@ def test_clang_builtin_include_recognized_at_any_depth(before, version, after) -
     segs = (*before, "lib", "clang", version, "include", *after)
     assert _is_toolchain_compiler_include_dir(segs) is True
     assert _is_bare_system_dir(segs) is True
+
+
+# A segment that is NOT compiler-shaped by either rule (no "-", not
+# all-digits-and-dots) -- generated from letters only, filtered against the
+# module's own regexes so the property below is a genuine cross-check, not
+# a tautology restating the generator's own construction.
+_NON_COMPILER_SHAPED_SEGMENT = st.text(
+    alphabet="abcdefghijklmnopqrstuvwxyz", min_size=1, max_size=10
+).filter(
+    lambda s: not _TARGET_TRIPLE_RE.match(s) and not _TOOLCHAIN_VERSION_RE.match(s)
+)
+
+
+@given(
+    before=_PREFIX_SUFFIX,
+    triple=_NON_COMPILER_SHAPED_SEGMENT,
+    version=_NON_COMPILER_SHAPED_SEGMENT,
+    include_kind=st.sampled_from(("include", "include-fixed")),
+    after=_PREFIX_SUFFIX,
+)
+@settings(max_examples=200)
+def test_gcc_private_include_rejected_when_triple_or_version_not_compiler_shaped(
+    before, triple, version, include_kind, after
+) -> None:
+    """The round-3 review finding, as a property: lib/gcc/<X>/<Y>/include
+    must NOT be recognized when neither X nor Y is a real triple/version
+    shape -- regardless of what the two non-shaped components actually
+    spell (a project directory named "backend"/"v1" is one example among
+    arbitrarily many, not a special case)."""
+    segs = (*before, "lib", "gcc", triple, version, include_kind, *after)
+    assert _is_toolchain_compiler_include_dir(segs) is False
 
 
 @given(


### PR DESCRIPTION
## Summary

Fixes six independently-verified defects found by running abicheck@main against real oneAPI libraries (oneDNN, oneDAL, oneTBB, oneMKL, oneCCL, oneDPL) sourced from conda-forge. Each was reproduced with a minimal, executed repro before being fixed; each fix ships with a regression test that fails on `main` and passes with the fix. One issue was filed per defect (see "Changes" below); this PR bundles all six fixes into one branch/PR per this session's git-workflow constraints (a single designated branch).

## Motivation

Closes #833, closes #834, closes #835, closes #836, closes #837, closes #838

## Changes

- **#833 — clang frontend enum-alias mis-numbering** (`abicheck/dumper_clang.py`): `--ast-frontend clang` treated an enumerator initialized from a sibling enumerator (`tag_x = tag_a`) as implicit, silently discarding the real value folded onto an intermediate `ConstantExpr` AST wrapper and reporting the wrong, positional auto-increment value instead — 787 false `enum_member_value_changed` findings on a real oneDNN 3.11→3.12 comparison. `_evaluated_int_value` now checks every node along the unwrap chain, not just the two endpoints.
- **#834 — transitively-included headers wrongly classified private** (`abicheck/provenance.py`, `abicheck/dumper.py`): public-surface scoping classified every header reached only transitively via `#include` from a `-H` root as `private-header`, silently dropping real breaking findings and reporting `NO_CHANGE`/exit 0. `dumper.dump()` now folds its own `-I` roots into the public-directory set once a real `-H` set already opted classification in.
- **#835 — conda-forge/pixi toolchain headers not recognized as system headers** (`abicheck/provenance.py`): a relocatable GCC/Clang toolchain's own private headers (e.g. `lib/gcc/<triple>/<version>/include/c++/...`) matched none of the fixed `/usr`-rooted system-header prefixes, so libstdc++ internals were diffed as project surface — a false breaking finding from abicheck's own CI toolchain. Recognized structurally now, with the toolchain's version/triple component wildcarded; also fixed `..` path-segment normalization.
- **#836 — Action word-splits `old-version`/`new-version`** (`action/run.sh`): a version label containing a space (`'1.0 (release build)'`) was silently corrupted into multiple `--version` flags, of which only the last survived. Added a scalar-flag helper that passes the value through unsplit.
- **#837 — castxml embeds absolute paths in lambda/anonymous type names** (`abicheck/dumper_castxml.py`, `abicheck/name_classification.py`): a lambda closure type's name embedded an absolute source path, so identical headers compiled from two checkout directories compared as `BREAKING` (27 false `type_removed`/`type_added` pairs on a real oneTBB comparison). Stripped at extraction time via a new shared helper, mirroring what the clang frontend already did.
- **#838 — `dump --sources TREE -H hdr` silently ignores `-H`** (`abicheck/cli.py`): the source-only dump path never received `headers` at all, so it exited 0 with a misleadingly "successful" empty snapshot. Now a usage error naming the dropped flag.

## Bug-fix test contract

<!-- bugfix-test-contract -->

- Bug class: (1) an AST-unwrap helper reads only the two endpoints of a wrapper chain instead of every node along it, silently discarding a folded value on an intermediate node — a class of bug that recurs anywhere a "descend through wrapper nodes" helper is reused for "read a folded fact off any node passed through". (2) two independent header-origin/system-header misclassifications in provenance.py's structural path-segment matching: transitively-reached headers wrongly excluded from the public surface, and a relocatable (non-/usr) toolchain's private headers wrongly included in it — both are instances of "the fixed set of known-good/known-bad path shapes doesn't cover a real, common layout". (3) a shell helper conflates "list-valued input, word-split is correct" with "scalar input, must never be split" for two inputs sharing one code path. (4) a type/declaration identity string leaks a machine-specific artifact (absolute build path) into what's compared as ABI identity. (5) a code path silently drops a user-supplied flag it has no way to honor, instead of failing loudly.
- Publicly observable failure: (1) `abicheck compare` reports `BREAKING` with false `enum_member_value_changed` findings under `--ast-frontend clang` for headers that are ABI-unchanged. (2) `abicheck compare` (default scoping) reports `NO_CHANGE`/exit 0 for a real breaking layout change reached via a transitively-included header. (3) `abicheck compare`/the Action reports a false `func_removed`/`func_added` breaking finding for a libstdc++ internal when run under a conda-forge/pixi toolchain. (4) the Action's rendered report shows a truncated/wrong "Old version"/"New version" string. (5) `abicheck compare` (castxml frontend) reports `BREAKING` for two byte-identical header trees in different directories. (6) `abicheck dump --sources tree -H hdr` exits 0 and writes an empty snapshot with no indication `-H` did nothing.
- Regression test fails on base: yes for all six — each new/modified test was run against the pre-fix code (via `git checkout`/`git apply` round-trips on the individual patches, and against the unmodified `main` commit for the Action helper) and confirmed to fail with the exact wrong value/behaviour described above, before being confirmed to pass with the fix.
- Negative control: (1) `test_folded_enum_value_on_constantexpr_wrapper`/`test_folded_bitfield_width_on_constantexpr_wrapper` (pre-existing, still pass) pin that a folded value on the *outermost* wrapper is still read correctly. (2) `test_include_search_dirs_omitted_keeps_prior_private_header_behavior` and `test_include_search_dirs_cannot_opt_in_classification_by_itself` pin that a caller not passing `-I` roots, or passing them with no real `-H` set, is unaffected. (3) `test_conda_forge_project_header_outside_compiler_tree_stays_project` and `test_project_subdirectory_under_libstdcxx_tree_is_not_bare` pin that an ordinary project header sharing a path prefix with the toolchain, or a genuine project subdirectory nested under the recognized boundary, is *not* swept up. (4) `TestAddSidedFlagSplitting` (pre-existing, still pass) pins that the genuinely list-valued inputs still word-split correctly. (5) `test_type_name_unwraps_elaborated_type_directly` and the whole existing castxml test suite pin that an ordinary (non-anonymous) type name is unaffected by the new stripping. (6) `test_dump_source_only_without_header_flag_still_succeeds` pins that the ordinary headers-free source-only dump is unaffected.
- Public-surface test: all six are exercised through the real entry point: `_ClangAstParser.parse_enums()` (defect 1) and `_CastxmlParser.parse_types()`/`.parse_enums()` (defect 5) are the dumper's own public parsing surface; `provenance.apply_provenance()` (defects 2, 3) is the module's public classification entry point, plus a real end-to-end repro via the `abicheck dump`/`compare` CLI (using the clang frontend, since castxml is unavailable in this sandbox) confirming the fix changes the actual reported verdict; `add_sided_scalar_flag` (defect 4) is tested via the same real-file-sourcing harness `test_action_run_sh_helpers.py` already uses for `run.sh`'s other helpers; `dump_cmd` (defect 6) is tested via Click's `CliRunner` against the real CLI command.
- Axes covered: defect 1 is clang-frontend-specific (castxml already handled the aliased-enum case correctly, used as the oracle during manual verification). Defects 2 and 3 are frontend-independent (provenance.py runs identically regardless of which AST frontend produced the snapshot); verified via the clang frontend end-to-end (castxml unavailable in this environment) and via direct unit-level path-segment tests using the exact real-world conda-forge path from the linked report. Defect 5 is castxml-specific (the clang frontend already normalizes this via a separate, pre-existing mechanism — `dumper_clang_expr._normalize_qual_type` — confirmed by reading it, not independently re-tested here). Defect 4 is the GitHub Action's bash layer only. Defect 6 is the CLI only.
- General invariant: (1) `_evaluated_int_value` now reads a folded constant value from *any* node along the single-child-wrapper chain it descends, not just the original node and the final leaf — closes the whole class for enum values and (already-shared) bitfield widths alike. (2) any header reached transitively from a `-H` root within a supplied `-I` root now classifies public, for every declaration kind (functions/variables/types/enums) `apply_provenance` tags, not just the one reported case. (3) any GCC/Clang toolchain private-header layout matching the three recognized structural shapes (`lib/gcc/<triple>/<version>/include[-fixed]`, `include/c++/<version>`, `lib/clang/<version>/include`) is now recognized regardless of install prefix, and `_segments()`'s `..`-collapsing fixes every path-segment match in the module, not only this one. (4) any scalar sided-flag value (not just `--version`) can now use `add_sided_scalar_flag` to reach the CLI unsplit. (5) any lambda-closure or anonymous struct/union/enum name extracted by the castxml frontend (record, enum, or a reference to either from a field/param/return/base type) is now stripped of its embedded location before it becomes part of a type's own identity. (6) `-H`/`--header` combined with a source-only dump is now uniformly rejected, regardless of which other flags accompany it. Known, deliberately out-of-scope gap: a real headers-only dump (parsing `-H` with no binary at all) is not implemented here — see #838 for that larger follow-up.
- Real-dependency-test: defects 1 and 5 touch `dumper_clang.py`/`dumper_castxml.py` (the AST-frontend boundary). Both are exercised via the real, documented public entry points of `abicheck dump`/the parser classes — defect 1's regression test builds a real clang `-ast-dump=json`-shaped AST (verified against actual `clang -ast-dump=json` output for the exact aliased-enumerator construct before writing the test fixture — see the PR's linked issue for the raw AST dump); defect 5's regression test builds a real castxml-XML-shaped tree via the same `Element`/`SubElement` pattern this repo's existing castxml regression tests already use (`test_castxml_elaborated_type.py`). Neither defect was verified against a *live* castxml/clang subprocess invocation in this sandbox (no castxml binary available, network-restricted); defect 1 *was* additionally verified end-to-end through the real `abicheck dump`/`compare` CLI with a real compiled `.so` and a real `clang -ast-dump=json` invocation (not just the unit-level AST fixture).
- Malicious fixture + side-effect absence: N/A — defect 4 (`action/run.sh`) is a data-corruption bug (word-splitting), not a trust-boundary/injection issue; no untrusted input reaches a privileged sink through this code path. The regression test exercises the real helper function sourced from the real file (not a hand-copied stand-in), per this repo's own `test_action_run_sh_helpers.py` convention, and directly asserts the constructed `CMD` array rather than the helper's textual source.
- Known unsupported cases: a genuine headers-only `dump` (parsing `-H` with no binary, producing a `header_aware`-tier snapshot) is not implemented — #838's fix only rejects the misleading silent-ignore case; a real feature request is out of scope for this bug-fix PR. Defect 3's directory-containment fix does not implement true `#include`-graph reachability (it treats any header under a supplied `-I` root as eligible once a real `-H` set exists) — a header under an `-I` root that is *not* actually reachable via `#include` from any `-H` root would also be treated as public; this trades a small amount of over-inclusion for closing the much larger silent-omission hole, per the linked issue's own discussion. Defect 5's toolchain-header recognition covers GCC/Clang layouts only, not MSVC (no MSVC toolchain-path repro available to verify against).

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`) if this touches `abicheck/**/*.py` — see `changelog.d/README.md`
- [ ] Docs updated if user-visible behaviour changed (none of these fixes change documented CLI syntax; each affected doc page — CLI reference, exit codes — already described the *intended* behaviour these fixes restore)
- [ ] `pre-commit run --all-files` passes locally (not run; `ruff check`/`mypy` run directly and are clean — see PR discussion. Note `ruff format --check` currently fails tree-wide on `main` itself, a pre-existing, tracked gap per `AGENTS.md`'s "ruff format has never gated anything" entry, unrelated to this PR)
- [x] No new `mypy` or `ruff` errors introduced

## Verification

- `ruff check abicheck/ tests/` — clean
- `mypy abicheck/` — 0 errors (matches documented baseline)
- Full fast unit suite (`pytest tests/ -m "not integration and not libabigail and not abicc and not slow and not golden"`) — 29,760 passed, 31 skipped, 4 xfailed, 1 pre-existing unrelated failure (`test_ai_readiness.py::test_adr_status_sync_holds`/`test_main_returns_zero_on_clean_tree`, both failing identically on unmodified `main` — a stale ADR `**Verified:**` commit reference unrelated to this diff)
- Each fix's regression test independently confirmed to fail against the pre-fix code and pass against the fix

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_011x9KtdpFgStQ17sWGkACm9)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Source-only dumps with header options now complete successfully and warn when headers are not reflected in the snapshot; dry runs remain unchanged.
  - Fixed incorrect enum values when enumerators reference aliases.
  - Prevented false API changes from checkout-specific anonymous and lambda type paths.
  - Improved public-header scoping for explicitly included transitive headers.
  - Improved system-header recognition for relocatable GCC, Clang, and libstdc++ toolchains.
  - Preserved spaces in composite action version values.
- **Documentation**
  - Added changelog entries documenting these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->