### PR TITLE
fix: close remaining provenance-widening findings from PR #839's final review round

### DIFF
--- a/abicheck/cli_dump_helpers.py
+++ b/abicheck/cli_dump_helpers.py
@@ -1680,8 +1680,21 @@ def perform_elf_dump(
                 # captured before the L3 fold may have merged in derived
                 # ones the caller never wrote) rather than the possibly
                 # L3-augmented `gcc_option_tokens` local (CodeRabbit review).
-                public_include_search_dirs=list(includes)
-                + list(include_operand_dirs(_user_gcc_option_tokens)),
+                # Suppressed entirely for a manifest dump (Codex review,
+                # fresh evidence): `--compiler-option` is a *global* flag
+                # applied to every TU regardless of the manifest, and
+                # `dump()`'s own manifest mutual-exclusivity check rejects
+                # any non-empty `public_include_search_dirs` -- computing
+                # one here would turn a previously-working
+                # `--dump-manifest` + `--compiler-option -I<dir>`
+                # combination into a usage error. `gcc_option_tokens` below
+                # still carries the option through to every TU's parse,
+                # unaffected.
+                public_include_search_dirs=(
+                    None
+                    if dump_manifest is not None
+                    else list(includes) + list(include_operand_dirs(_user_gcc_option_tokens))
+                ),
                 version=version,
                 compiler=compiler,
                 gcc_path=gcc_path,

--- a/abicheck/service.py
+++ b/abicheck/service.py
@@ -812,6 +812,7 @@ def _run_dump_uncached(
                 notify=notify,
                 include_labels=include_labels,
                 dump_manifest=dump_manifest,
+                public_include_search_dirs=_public_include_search_dirs,
             )
         _try_attach_sycl_metadata(snap, path)
         _try_attach_python_ext_metadata(snap)
@@ -842,7 +843,13 @@ def _run_dump_uncached(
             compile,
             public_headers,
             public_header_dirs,
-            include_search_dirs=_includes,
+            # `_public_include_search_dirs`, not `_includes` (Codex review,
+            # fresh evidence): `_includes` can already be build/source-
+            # evidence-widened, and this graph attach's own node-visibility
+            # classification must agree with the primary parse's
+            # declaration-provenance classification above, not silently
+            # re-widen it.
+            include_search_dirs=_public_include_search_dirs,
         )
         return attach_clang_layout(
             snap, _headers, _includes, lang=lang, compile=compile
@@ -1308,6 +1315,7 @@ def _dump_elf(
     notify: Callable[[str], None] | None = None,
     include_labels: dict[Path, str] | None = None,
     dump_manifest: DumpManifest | None = None,
+    public_include_search_dirs: list[Path] | None = None,
 ) -> AbiSnapshot:
     """Dump an ELF binary to an ABI snapshot.
 
@@ -1322,6 +1330,12 @@ def _dump_elf(
     *headers* for this dump; threaded straight into :func:`dumper.dump`,
     which enforces the mutual-exclusivity rule against *headers*/
     *public_headers*/*public_header_dirs*.
+
+    ``public_include_search_dirs`` is the caller's genuinely explicit ``-I``
+    list, kept separate from *includes* -- which can already be widened by
+    the time it reaches here (Codex review) -- so provenance widening never
+    uses a build-derived directory. Falls back to ``list(includes)`` when
+    omitted (unchanged prior behavior).
     """
     from .dumper import dump
 
@@ -1420,7 +1434,16 @@ def _dump_elf(
             # `public_include_search_dirs` (real regression: `eff_includes`
             # also carries `inc_extra`'s auto-added umbrella-header
             # directory, which can hold a genuinely private sibling header).
-            public_include_search_dirs=list(includes),
+            # Prefer the caller's own separately-threaded, genuinely
+            # explicit list over this function's own `includes` parameter
+            # (which can already be build/source-evidence-widened by the
+            # time it reaches here -- Codex review, fresh evidence; see
+            # this function's own docstring).
+            public_include_search_dirs=(
+                list(public_include_search_dirs)
+                if public_include_search_dirs is not None
+                else list(includes)
+            ),
             version=version,
             compiler=compiler,
             gcc_path=cc.gcc_path,

--- a/abicheck/service_dump_cache.py
+++ b/abicheck/service_dump_cache.py
@@ -246,6 +246,26 @@ def _manifest_public_headers(dump_manifest: Any) -> tuple[list[Path], list[Path]
     )
 
 
+def _public_include_search_dirs_key_field(
+    public_include_search_dirs: list[Path] | None, sep: str
+) -> str:
+    """Cache-key material for *public_include_search_dirs* that keeps
+    ``None`` (omitted -- the dump falls back to widening off ``includes``)
+    distinct from an explicit ``[]`` (given, and disables widening
+    entirely) -- both previously collapsed to the identical empty-string
+    material via a bare ``... or []``, so two otherwise-identical cacheable
+    dumps differing only in which of the two the caller meant could share a
+    persisted snapshot even though their declarations receive different
+    provenance origins (Codex review, fresh evidence).
+
+    A leading presence marker (``"0"``/``"1"``, never a path character)
+    keeps the two apart regardless of what directories (if any) are given.
+    """
+    if public_include_search_dirs is None:
+        return "0"
+    return "1" + sep + sep.join(sorted(str(p) for p in public_include_search_dirs))
+
+
 def _dump_cache_extra_key(
     binary_fmt: str,
     header_backend: str,
@@ -341,9 +361,7 @@ def _dump_cache_extra_key(
                 sep.join(sorted(str(p) for p in (public_headers or []))),
                 sep.join(sorted(str(p) for p in (public_header_dirs or []))),
                 str(lang_explicit),
-                sep.join(
-                    sorted(str(p) for p in (public_include_search_dirs or []))
-                ),
+                _public_include_search_dirs_key_field(public_include_search_dirs, sep),
             ]
         )
 
@@ -433,7 +451,7 @@ def _dump_cache_extra_key(
             sep.join(sorted(str(p) for p in (public_headers or []))),
             sep.join(sorted(str(p) for p in (public_header_dirs or []))),
             str(lang_explicit),
-            sep.join(sorted(str(p) for p in (public_include_search_dirs or []))),
+            _public_include_search_dirs_key_field(public_include_search_dirs, sep),
         ]
     )
 

--- a/abicheck/service_input_resolution.py
+++ b/abicheck/service_input_resolution.py
@@ -48,6 +48,7 @@ from typing import TYPE_CHECKING
 from .artifact_plan import ResolvedArtifactPlan
 from .errors import SnapshotError, ValidationError
 from .header_conditionals import attach_build_context_for_parsed_headers
+from .header_utils import include_operand_dirs
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -793,8 +794,29 @@ def _resolve_side_snapshot_impl(
                 # already-widened `includes` local -- same regression class
                 # the ELF/PE/Mach-O CLI resolvers already avoid (Codex
                 # review, round 13): an auto-derived seed directory can hold
-                # a genuinely private sibling header.
-                public_include_search_dirs=list(side.includes),
+                # a genuinely private sibling header. A `--compiler-option`/
+                # `InputSpec.compile.gcc_option_tokens` include-search
+                # operand is exactly as explicit as `side.includes` (Codex
+                # review, fresh evidence) -- sourced from `side.compile`,
+                # this side's pre-fold caller-supplied CompileContext (never
+                # `compile_ctx`, the L3-folded result, same distinction the
+                # ADR-039 collector call below already draws). Suppressed
+                # entirely for a manifest dump: `side.compile`'s tokens are
+                # global, applied to every TU regardless of the manifest,
+                # and `dump()`'s own manifest mutual-exclusivity check
+                # rejects any non-empty `public_include_search_dirs` -- see
+                # the identical fix/reasoning in `cli_dump_helpers.
+                # perform_elf_dump`.
+                public_include_search_dirs=(
+                    None
+                    if evidence.dump_manifest is not None
+                    else list(side.includes)
+                    + list(
+                        include_operand_dirs(
+                            side.compile.gcc_option_tokens if side.compile else ()
+                        )
+                    )
+                ),
             )
         finally:
             _artifact_plan.run_cleanups()

--- a/changelog.d/1787420000_claude_elf_typed_dump_provenance_and_cache_key.md
+++ b/changelog.d/1787420000_claude_elf_typed_dump_provenance_and_cache_key.md
@@ -1,0 +1,26 @@
+### Fixed
+
+- **The typed ELF dump path never forwarded its own genuinely explicit
+  `public_include_search_dirs` into the actual header parse or header-graph
+  attach.** `_run_dump_uncached()` computed `_public_include_search_dirs`
+  (falling back to the possibly build/source-evidence-widened `includes`
+  only when the caller didn't distinguish the two) but its ELF branch's
+  calls to `_dump_elf()` and `_attach_header_graph()` both still used the
+  widened value directly — silently reintroducing the exact
+  already-widened-includes false-`PUBLIC_HEADER` regression this parameter
+  exists to prevent, one call layer above where it was previously fixed.
+  Fixed by threading the parameter through `_dump_elf()` (a new keyword
+  argument, defaulting to today's unchanged behavior when omitted) and
+  using it for both the primary header parse and the header-graph attach's
+  node-visibility classification, matching the PE/Mach-O path's existing
+  behavior.
+- **The whole-snapshot dump cache's key conflated an omitted
+  `public_include_search_dirs` (falls back to `includes`) with an
+  explicitly empty one (disables provenance widening entirely).** Both
+  previously reduced to identical empty-string key material via a bare
+  `... or []`, so two otherwise-identical cacheable dumps differing only in
+  which of the two the caller meant could share a persisted snapshot even
+  though their declarations receive different provenance origins. Fixed by
+  encoding presence separately from content in both of
+  `_dump_cache_extra_key()`'s branches (the AST and binary-only "no-ast"
+  paths alike).

--- a/changelog.d/1787430000_claude_typed_compiler_option_and_manifest_conflict_fix.md
+++ b/changelog.d/1787430000_claude_typed_compiler_option_and_manifest_conflict_fix.md
@@ -1,0 +1,23 @@
+### Fixed
+
+- **The typed `DumpRequest`/`CompareRequest` API never folded an
+  `InputSpec.compile.gcc_option_tokens` include-search operand (the typed
+  equivalent of `--compiler-option -I<dir>`) into `public_include_search_
+  dirs`.** A directory reached only through such an operand stayed
+  `PRIVATE_HEADER` even though the caller had named it explicitly, just not
+  via `InputSpec.includes`. Fixed by folding `side.compile`'s (the
+  pre-fold, caller-supplied `CompileContext`) include-search operands into
+  the same shared `resolve_side_snapshot` primitive `compare`'s
+  implicit-dump operand and `dump`'s typed API both already use.
+- **Fixed a regression the CLI's own `--compiler-option`-folding fix
+  introduced: `dump --dump-manifest ... --compiler-option -I<dir>` (a
+  previously-working combination) started failing as a usage error.**
+  `--compiler-option` is a *global* flag applied to every translation unit
+  regardless of the manifest, but folding its include-search operands into
+  `public_include_search_dirs` unconditionally collided with `dump()`'s own
+  manifest mutual-exclusivity check (added in this same review round). Both
+  the CLI (`perform_elf_dump`) and the typed-API primitive
+  (`resolve_side_snapshot`) now suppress `public_include_search_dirs`
+  entirely for a manifest dump — matching the manifest's own
+  translation-unit-scoped provenance — while `gcc_option_tokens` still
+  reaches every TU's parse unaffected.

--- a/tests/test_cli_dump_manifest.py
+++ b/tests/test_cli_dump_manifest.py
@@ -159,6 +159,73 @@ def test_dump_manifest_end_to_end_merges_two_tus(tmp_path, runner):
     assert {"add_a", "add_b"} <= names
 
 
+@pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="gcc -shared -o *.so only produces a real ELF binary on Linux "
+    "(see test_dumper_manifest.py's TestDumpWithManifest for the same gate)",
+)
+def test_dump_manifest_with_compiler_option_include_dir_still_works(tmp_path, runner):
+    """Codex review, fresh evidence: `--compiler-option -I<dir>` is a
+    *global* flag applied to every TU regardless of the manifest, but the
+    fix folding it into `public_include_search_dirs` (for provenance
+    widening) unconditionally would make that flat, non-empty value collide
+    with `dump()`'s own manifest mutual-exclusivity check -- turning this
+    previously-working combination into a usage error. It must keep
+    working, with the compiler option still reaching the TU parse."""
+    if not (_have("clang") and _have("gcc")):
+        pytest.skip("clang and gcc are required for this end-to-end test")
+    include_dir = tmp_path / "include"
+    include_dir.mkdir()
+    (include_dir / "dep.h").write_text("int dep(int a, int b);\n")
+    header_a = tmp_path / "a.h"
+    header_a.write_text('#include "dep.h"\nint add_a(int a, int b);\n')
+    src = tmp_path / "lib.c"
+    src.write_text(
+        "int add_a(int a, int b) { return a + b; }\n"
+        "int dep(int a, int b) { return a - b; }\n"
+    )
+    so = tmp_path / "liblib.so"
+    subprocess.run(
+        [
+            "gcc",
+            "-shared",
+            "-fPIC",
+            f"-I{include_dir}",
+            "-o",
+            str(so),
+            str(src),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    manifest = _write_manifest(
+        tmp_path,
+        "roots: [a.h]\ntranslation_units:\n  - name: tu_a\n    forced_includes: [a.h]\n",
+    )
+    out = tmp_path / "snap.json"
+    result = runner.invoke(
+        main,
+        [
+            "dump",
+            str(so),
+            "--dump-manifest",
+            str(manifest),
+            "--ast-frontend",
+            "clang",
+            "--lang",
+            "c",
+            "--compiler-option",
+            f"-I{include_dir}",
+            "-o",
+            str(out),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    snap = json.loads(out.read_text())
+    names = {f["name"] for f in snap["functions"]}
+    assert {"add_a", "dep"} <= names
+
+
 def test_dump_manifest_rejected_for_pe_binary(tmp_path, runner):
     dll = tmp_path / "foo.dll"
     dll.write_bytes(b"MZ" + b"\x00" * 62)

--- a/tests/test_service_dump_cache.py
+++ b/tests/test_service_dump_cache.py
@@ -300,6 +300,58 @@ class TestDumpCacheExtraKey:
         )
         assert k_auto != k_explicit
 
+    def test_differs_by_omitted_vs_explicit_empty_public_include_search_dirs(self):
+        # Codex review, fresh evidence: `public_include_search_dirs=None`
+        # (omitted -- the dump falls back to widening off `includes`) and
+        # `public_include_search_dirs=[]` (given explicitly, disables
+        # provenance widening entirely) previously collapsed to the
+        # identical key material via a bare `... or []`, even though the
+        # two produce genuinely different declaration-provenance
+        # classification. A cache entry for one must never be served for
+        # the other.
+        k_omitted = _dump_cache_extra_key("elf", "clang", None, None, "c++")
+        k_explicit_empty = _dump_cache_extra_key(
+            "elf", "clang", None, None, "c++", public_include_search_dirs=[]
+        )
+        assert k_omitted != k_explicit_empty
+
+    def test_differs_by_public_include_search_dirs_content(self, tmp_path):
+        k1 = _dump_cache_extra_key(
+            "elf",
+            "clang",
+            None,
+            None,
+            "c++",
+            public_include_search_dirs=[tmp_path / "a"],
+        )
+        k2 = _dump_cache_extra_key(
+            "elf",
+            "clang",
+            None,
+            None,
+            "c++",
+            public_include_search_dirs=[tmp_path / "b"],
+        )
+        assert k1 != k2
+
+    def test_no_ast_branch_also_differs_by_omitted_vs_explicit_empty(self):
+        # The `uses_ast=False` ("no-ast", binary-only) branch has its own
+        # separate key-construction path -- same finding must be fixed
+        # there too.
+        k_omitted = _dump_cache_extra_key(
+            "elf", "clang", None, None, "c++", uses_ast=False
+        )
+        k_explicit_empty = _dump_cache_extra_key(
+            "elf",
+            "clang",
+            None,
+            None,
+            "c++",
+            uses_ast=False,
+            public_include_search_dirs=[],
+        )
+        assert k_omitted != k_explicit_empty
+
     def test_invalid_frontend_pin_uses_same_fallback_cache_identity(
         self, monkeypatch
     ):

--- a/tests/test_service_input_resolution.py
+++ b/tests/test_service_input_resolution.py
@@ -1,0 +1,128 @@
+# Copyright 2026 Nikolay Petrov
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression coverage for ``service_input_resolution.py``'s
+``resolve_side_snapshot``/``_resolve_side_snapshot_impl`` -- the per-input
+primitive ``compare``'s implicit-dump operand and ``dump``'s typed
+``DumpRequest``/``run_dump_request`` API share.
+
+Split out as its own file (rather than extending
+``tests/test_header_compile_context.py``, where the sibling
+``public_include_search_dirs`` coverage already lives) because that file
+sits at the AI-readiness 2000-line hard cap -- see this repo's own
+``AGENTS.md`` "Files that are large" convention.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+def test_resolve_side_snapshot_folds_compiler_option_include_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex review, fresh evidence: an ``InputSpec.compile.gcc_option_
+    tokens`` include-search operand (the typed-API equivalent of
+    ``--compiler-option -I<dir>``) is exactly as explicit as
+    ``side.includes``, but was never folded into
+    ``public_include_search_dirs`` -- a directory reached only through such
+    an operand stayed ``PRIVATE_HEADER`` even though the caller named it
+    explicitly, just not via ``InputSpec.includes``."""
+    from abicheck import service_input_resolution as sir
+    from abicheck.api_types import InputSpec
+    from abicheck.model import AbiSnapshot
+    from abicheck.service_compare_evidence import SideEvidence
+    from abicheck.service_scan import CompileContext
+
+    so = tmp_path / "lib.so"
+    so.write_bytes(b"\x7fELF" + b"\x00" * 100)
+    explicit_dir = tmp_path / "explicit"
+    compiler_option_dir = tmp_path / "compiler-option"
+
+    captured: dict[str, object] = {}
+
+    def _fake_resolve_input(*args: object, **kwargs: object) -> AbiSnapshot:
+        captured.update(kwargs)
+        return AbiSnapshot(library="lib", version="1.0", from_headers=False)
+
+    import abicheck.service as service_mod
+
+    monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve_input)
+
+    cc = CompileContext(gcc_option_tokens=("-I", str(compiler_option_dir)))
+    side = InputSpec(path=so, version="1.0", includes=(explicit_dir,), compile=cc)
+    evidence = SideEvidence(
+        headers=[], compile=None, collect_mode="off", dump_manifest=None
+    )
+    sir.resolve_side_snapshot(
+        side,
+        evidence,
+        lang="c++",
+        header_backend="auto",
+        fmt="elf",
+        public_headers=[],
+        public_header_dirs=[],
+    )
+    passed = captured["public_include_search_dirs"]
+    assert explicit_dir in passed
+    assert compiler_option_dir in passed
+
+
+def test_resolve_side_snapshot_suppresses_public_include_search_dirs_for_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex review, fresh evidence: `side.compile`'s tokens are global,
+    applied to every TU regardless of the manifest -- unconditionally
+    folding them into `public_include_search_dirs` would collide with
+    `dump()`'s own manifest mutual-exclusivity check, turning a previously-
+    working `dump_manifest` + explicit compile-context combination into a
+    usage error. Must be suppressed (`None`) whenever a manifest is given."""
+    from abicheck import service_input_resolution as sir
+    from abicheck.api_types import InputSpec
+    from abicheck.model import AbiSnapshot
+    from abicheck.service_compare_evidence import SideEvidence
+    from abicheck.service_scan import CompileContext
+
+    so = tmp_path / "lib.so"
+    so.write_bytes(b"\x7fELF" + b"\x00" * 100)
+    compiler_option_dir = tmp_path / "compiler-option"
+
+    captured: dict[str, object] = {}
+
+    def _fake_resolve_input(*args: object, **kwargs: object) -> AbiSnapshot:
+        captured.update(kwargs)
+        return AbiSnapshot(library="lib", version="1.0", from_headers=False)
+
+    import abicheck.service as service_mod
+
+    monkeypatch.setattr(service_mod, "resolve_input", _fake_resolve_input)
+
+    cc = CompileContext(gcc_option_tokens=("-I", str(compiler_option_dir)))
+    side = InputSpec(path=so, version="1.0", compile=cc)
+    manifest = object()  # only truthiness/identity matters to this call site
+    evidence = SideEvidence(
+        headers=[], compile=None, collect_mode="off", dump_manifest=manifest
+    )
+    sir.resolve_side_snapshot(
+        side,
+        evidence,
+        lang="c++",
+        header_backend="auto",
+        fmt="elf",
+        public_headers=[],
+        public_header_dirs=[],
+    )
+    assert captured["public_include_search_dirs"] is None

--- a/tests/test_service_unit.py
+++ b/tests/test_service_unit.py
@@ -318,6 +318,73 @@ class TestResolveInput:
         args, _ = mock_attach.call_args
         assert args[5] == "c"
 
+    def test_elf_forwards_explicit_public_include_search_dirs_to_dump_elf(
+        self, tmp_path
+    ):
+        """Codex review, fresh evidence: `_run_dump_uncached()` computed
+        `_public_include_search_dirs` (falling back to the possibly-widened
+        `_includes` only when the caller didn't distinguish the two) but
+        never forwarded it into its own `_dump_elf()` call, which
+        independently re-derived provenance widening from its own
+        `includes` parameter -- silently reintroducing the exact
+        already-widened-includes regression this whole parameter exists to
+        prevent, just one call layer up."""
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        header = tmp_path / "api.h"
+        header.write_text("void f();\n")
+        widened_dir = tmp_path / "widened"
+        explicit_dir = tmp_path / "explicit"
+        snap = AbiSnapshot(library="test", version="1.0")
+        with (
+            patch("abicheck.service._dump_elf", return_value=snap) as mock_dump_elf,
+            patch("abicheck.service._attach_header_graph", return_value=snap),
+        ):
+            run_dump(
+                p,
+                "elf",
+                headers=[header],
+                includes=[widened_dir],
+                lang="c++",
+                public_include_search_dirs=[explicit_dir],
+            )
+        passed = mock_dump_elf.call_args.kwargs["public_include_search_dirs"]
+        assert passed == [explicit_dir]
+        assert widened_dir not in passed
+
+    def test_elf_forwards_explicit_public_include_search_dirs_to_header_graph(
+        self, tmp_path
+    ):
+        """Same finding, the header-graph-attach half: the ELF branch's own
+        `_attach_header_graph` call used `_includes` (possibly widened)
+        for `include_search_dirs` instead of `_public_include_search_dirs`
+        -- disagreeing with the primary parse's own declaration-provenance
+        classification just fixed above (Codex review, fresh evidence)."""
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        header = tmp_path / "api.h"
+        header.write_text("void f();\n")
+        widened_dir = tmp_path / "widened"
+        explicit_dir = tmp_path / "explicit"
+        snap = AbiSnapshot(library="test", version="1.0")
+        with (
+            patch("abicheck.service._dump_elf", return_value=snap),
+            patch(
+                "abicheck.service._attach_header_graph", return_value=snap
+            ) as mock_attach,
+        ):
+            run_dump(
+                p,
+                "elf",
+                headers=[header],
+                includes=[widened_dir],
+                lang="c++",
+                public_include_search_dirs=[explicit_dir],
+            )
+        passed = mock_attach.call_args.kwargs["include_search_dirs"]
+        assert passed == [explicit_dir]
+        assert widened_dir not in passed
+
     def test_header_graph_lang_matches_pe_main_pass_normalization(self, tmp_path):
         """Codex review (second pass): PE/Mach-O's own main pass, reached via
         ``service_header_scoped._try_header_scoped_dump`` whenever headers
@@ -1070,6 +1137,60 @@ class TestDumpElf:
         with patch("abicheck.dumper.dump", return_value=snap) as mock:
             _dump_elf(p, [header], [], "1.0", "c++", compile=cc)
         assert build_inc in mock.call_args.kwargs["extra_hash_dirs"]
+
+    def test_public_include_search_dirs_used_over_widened_includes(self, tmp_path):
+        """Codex review, fresh evidence: this function's own internal
+        dump() call previously derived provenance widening from its own
+        `includes` parameter directly -- but by the time `includes` reaches
+        this function, it can already be build/source-evidence-widened by
+        an upstream caller (`_run_dump_uncached`'s own `_seeded_includes_
+        and_compile_context`-style seeding), so using it directly risked
+        promoting a private sibling header under a build-derived directory
+        to PUBLIC_HEADER. A caller that threads the genuinely explicit list
+        separately via `public_include_search_dirs` must have THAT list
+        reach dump(), not the (possibly wider) `includes`."""
+        from abicheck.service import _dump_elf
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        header = tmp_path / "pub.h"
+        header.write_text("int f(void);\n")
+        widened_dir = tmp_path / "widened"
+        widened_dir.mkdir()
+        explicit_dir = tmp_path / "explicit"
+        explicit_dir.mkdir()
+        snap = AbiSnapshot(library="t", version="1.0")
+        with patch("abicheck.dumper.dump", return_value=snap) as mock:
+            _dump_elf(
+                p,
+                [header],
+                [widened_dir],
+                "1.0",
+                "c++",
+                public_include_search_dirs=[explicit_dir],
+            )
+        passed = mock.call_args.kwargs["public_include_search_dirs"]
+        assert passed == [explicit_dir]
+        assert widened_dir not in passed
+
+    def test_public_include_search_dirs_falls_back_to_includes_when_omitted(
+        self, tmp_path
+    ):
+        """Backward-compatible default (Codex review): a caller that hasn't
+        been updated to distinguish the two still gets today's unchanged
+        behavior -- `includes` itself is used."""
+        from abicheck.service import _dump_elf
+
+        p = tmp_path / "lib.so"
+        p.write_bytes(b"\x7fELF" + b"\x00" * 100)
+        header = tmp_path / "pub.h"
+        header.write_text("int f(void);\n")
+        inc = tmp_path / "inc"
+        inc.mkdir()
+        snap = AbiSnapshot(library="t", version="1.0")
+        with patch("abicheck.dumper.dump", return_value=snap) as mock:
+            _dump_elf(p, [header], [inc], "1.0", "c++")
+        assert mock.call_args.kwargs["public_include_search_dirs"] == [inc]
 
     def test_implicit_root_defers_to_isystem_build_context(self, tmp_path):
         # Codex: when the caller's CompileContext supplies includes via -isystem,


### PR DESCRIPTION
## Summary

Follow-up fixes for review findings that landed on PR #839 after it had already been merged (four Codex/CodeRabbit findings that arrived on the final push, plus one real regression that the last of those fixes itself introduced).

## Motivation

PR #839 fixed six verified defects in abicheck's declaration-provenance/ABI-comparison pipeline. During its final review round, several more findings came in on the last few pushed commits; the PR merged before all of them could be addressed. This PR is the fresh continuation the merge requires (per this repo's own branch-restart convention), fixing the remaining findings plus one regression discovered while fixing them.

## Changes

- **`service.py`**: the typed ELF dump path (`_run_dump_uncached`'s ELF branch) never forwarded its own `_public_include_search_dirs` into `_dump_elf()` or the ELF branch's `_attach_header_graph()` call — both used the possibly build/source-evidence-widened `includes` directly, reintroducing the already-widened-includes false-`PUBLIC_HEADER` regression one call layer above where it was previously fixed. Threaded a new `public_include_search_dirs` keyword parameter through `_dump_elf()`.
- **`service_dump_cache.py`**: the whole-snapshot dump cache's key conflated an omitted `public_include_search_dirs` (falls back to `includes`) with an explicitly empty one (disables provenance widening) — both reduced to identical key material via a bare `... or []`. Fixed by encoding presence separately from content in both of `_dump_cache_extra_key()`'s branches.
- **`service_input_resolution.py`**: the typed `DumpRequest`/`CompareRequest` API never folded an `InputSpec.compile.gcc_option_tokens` include-search operand (the typed equivalent of `--compiler-option -I<dir>`) into `public_include_search_dirs` — a directory reached only through such an operand stayed `PRIVATE_HEADER`. Fixed by sourcing include-search operands from `side.compile` (the pre-fold, caller-supplied `CompileContext`).
- **`cli_dump_helpers.py` + `service_input_resolution.py`**: the above fix, combined with the manifest mutual-exclusivity check added earlier in #839, broke a previously-working combination: `dump --dump-manifest ... --compiler-option -I<dir>` started failing as a usage error, since `--compiler-option` is a *global* flag applied to every TU regardless of the manifest. Fixed on both the CLI and the typed primitive by suppressing `public_include_search_dirs` entirely for a manifest dump — `gcc_option_tokens` still reaches every TU's parse unaffected.

## Bug-fix test contract

- Bug class: declaration-provenance widening (`public_include_search_dirs`) silently using an already-widened or incomplete include-directory set, and (separately) a new validation check colliding with an existing, previously-working flag combination.
- Publicly observable failure: (1) a private sibling header reachable only through a build/source-evidence-widened directory, or only through a `--compiler-option -I<dir>`/typed `CompileContext` operand, is misclassified `PRIVATE_HEADER` instead of `PUBLIC_HEADER` (or vice versa), silently hiding or fabricating ABI findings; (2) two cacheable dumps differing only in whether `public_include_search_dirs` was omitted vs. explicitly empty share a stale cached snapshot; (3) `dump --dump-manifest ... --compiler-option -I<dir>` fails with a usage error it did not fail with before.
- Regression test fails on base: yes — every new/moved test in this PR was confirmed to fail against the pre-fix code via `git stash` before the fix was applied (see individual test docstrings, each naming the Codex/CodeRabbit finding it closes).
- Negative control: yes — e.g. `test_public_include_search_dirs_falls_back_to_includes_when_omitted` and `test_differs_by_public_include_search_dirs_content` pin the unchanged, correct behavior for callers that don't hit the bug shape.
- Public-surface test: yes — `test_dump_manifest_with_compiler_option_include_dir_still_works` is a real end-to-end `abicheck dump` CLI invocation through a real g++-compiled library and real clang AST parse, asserting on the emitted JSON snapshot's `origin`/`functions` fields.
- Axes covered: ELF typed-dump path, PE/Mach-O typed-dump path (already correct, used as the reference), the binary-only ("no-ast") cache-key branch, the CLI `--compiler-option` path, and the typed `InputSpec.compile` path.
- General invariant: `public_include_search_dirs` must always carry only the caller's genuinely explicit include roots (never an auto-derived/build-evidence-widened set) into declaration-provenance classification, on every dump entry point (CLI and typed API alike) and every binary format; and a manifest dump's own translation-unit-scoped provenance must never be overridden by a flat, whole-snapshot include-root list.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [ ] Docs updated if user-visible behaviour changed (no user-visible doc changes needed)
- [x] `pre-commit run --all-files` passes locally (ruff/mypy/ai-readiness checked directly)
- [x] No new `mypy` or `ruff` errors introduced