### PR TITLE
fix: exclude CTOR_EXPLICIT_ADDED/REMOVED from confirmed-signature-change kinds

### DIFF
--- a/abicheck/bundle_signature_evidence.py
+++ b/abicheck/bundle_signature_evidence.py
@@ -135,28 +135,38 @@ from .model import AbiSnapshot, Visibility
 #: pre-existing, narrower gap in that sibling function, not something
 #: this module's own precedence check needs to wait on.
 #:
-#: The remaining eight kinds (Codex review, fresh evidence, filed after the
-#: three above already went in) close the same coexistence gap for every
-#: *other* `Function`-level fact `diff_symbols.py` can independently
-#: confirm or deny with certainty, none of which `_symbol_evidence_
-#: sufficient` itself inspects (it only ever reads `return_type`/`params`/
-#: `is_variadic`/`contract_attributes`): `is_noexcept`/`is_virtual`/
-#: `ref_qualifier` are plain (non-tri-state) `Function` fields, always
-#: confidently comparable regardless of any other field's resolution
-#: state; `exception_spec`/`is_explicit` are tri-state fields whose own
-#: `diff_symbols._check_exception_spec_change`/`_check_explicit_change`
-#: already skip on `None` the identical way `_check_variadic_change`/
-#: `_check_contract_attributes_change` do. Any one of these being
-#: genuinely confirmed for a symbol is exactly as informative as a
-#: confirmed params/return/variadic/calling-convention change -- "we know
-#: something concrete changed (or didn't) here," not "we couldn't tell" --
-#: so it must suppress this module's own risk finding the same way.
+#: The next six kinds (Codex review, fresh evidence, filed after the three
+#: above already went in) close the same coexistence gap for every *other*
+#: `Function`-level fact `diff_symbols.py` can independently confirm or deny
+#: with certainty, none of which `_symbol_evidence_sufficient` itself
+#: inspects (it only ever reads `return_type`/`params`/`is_variadic`/
+#: `contract_attributes`): `is_noexcept`/`is_virtual`/`ref_qualifier` are
+#: plain (non-tri-state) `Function` fields, always confidently comparable
+#: regardless of any other field's resolution state; `exception_spec` is a
+#: tri-state field whose own `diff_symbols._check_exception_spec_change`
+#: already skips on `None` the identical way `_check_variadic_change`/
+#: `_check_contract_attributes_change` do. Any one of these being genuinely
+#: confirmed for a symbol is exactly as informative as a confirmed
+#: params/return/variadic/calling-convention change -- "we know something
+#: concrete changed (or didn't) here," not "we couldn't tell" -- so it must
+#: suppress this module's own risk finding the same way.
+#:
 #: Deliberately excluded: `FUNC_LANGUAGE_LINKAGE_CHANGED` (an `extern "C"`
 #: transition changes the mangled name itself, so old/new can't share the
-#: `symbol` key this module matches on in the first place) and the
+#: `symbol` key this module matches on in the first place); the
 #: vtable-slot/inline-transition kinds (about virtual-dispatch layout and
 #: definition placement, not the calling-signature-agreement question this
-#: module exists to answer).
+#: module exists to answer); and `CTOR_EXPLICIT_ADDED`/`CTOR_EXPLICIT_
+#: REMOVED` (Codex review, fresh evidence -- tried once, reverted). Unlike
+#: every kind actually included above, an `explicit` specifier transition
+#: is a purely source-level fact: `checker_policy.py`'s own `ChangeKind`
+#: comment for these two kinds states plainly "neither change alters the
+#: mangled name," meaning it proves nothing about whether the *binary*
+#: calling signature this module exists to verify (params/return/
+#: variadic/calling-convention/...) actually still agrees. Including it in
+#: this set let a confirmed, unrelated source-level fact silently suppress
+#: a real, still-unresolved binary-signature-agreement question for the
+#: same symbol.
 _CONFIRMED_SIGNATURE_CHANGE_KINDS = frozenset(
     {
         ChangeKind.FUNC_PARAMS_CHANGED,
@@ -171,8 +181,6 @@ _CONFIRMED_SIGNATURE_CHANGE_KINDS = frozenset(
         ChangeKind.FUNC_REF_QUAL_CHANGED,
         ChangeKind.FUNC_VIRTUAL_ADDED,
         ChangeKind.FUNC_VIRTUAL_REMOVED,
-        ChangeKind.CTOR_EXPLICIT_ADDED,
-        ChangeKind.CTOR_EXPLICIT_REMOVED,
     }
 )
 

--- a/changelog.d/20260824_000000_claude_g38_phase4_wire_compare_release.md
+++ b/changelog.d/20260824_000000_claude_g38_phase4_wire_compare_release.md
@@ -261,6 +261,21 @@ A new changelog fragment. See changelog.d/README.md for the workflow.
   specific consumer that genuinely could reach the old, non-default
   definition. Regression test with two consumers (unversioned,
   version-specific) confirmed to fail against the pre-fix code.
+- **Fixed: `CTOR_EXPLICIT_ADDED`/`CTOR_EXPLICIT_REMOVED` incorrectly included
+  in `_CONFIRMED_SIGNATURE_CHANGE_KINDS`** (Codex review, fresh evidence).
+  Unlike every other kind in that set, an `explicit` specifier transition is
+  a purely source-level fact -- `checker_policy.py`'s own `ChangeKind`
+  comment for these two kinds states "neither change alters the mangled
+  name," so a confirmed transition proves nothing about whether the
+  *binary* calling signature (params/return/variadic/calling-convention)
+  actually still agrees. Including it let a confirmed, unrelated
+  source-level fact silently suppress this module's own "cannot be
+  confirmed or denied" risk finding for a still-genuinely-unresolved binary
+  signature. Removed both kinds from the set; the existing suppression test
+  no longer parametrizes over them, and a new, opposite-direction test
+  (`test_confirmed_ctor_explicit_change_does_not_suppress_unverified_finding`)
+  pins that a confirmed `CTOR_EXPLICIT_*` change does *not* suppress the
+  finding, confirmed to fail against the pre-fix (inclusive) set.
 - **Declined: retaining every library's full old+new `AbiSnapshot` for the
   whole release comparison, now that bundle analysis is enabled by
   default** (Codex review, fresh evidence expanding on this PR's own

--- a/tests/test_bundle_signature_evidence.py
+++ b/tests/test_bundle_signature_evidence.py
@@ -963,8 +963,6 @@ class TestFindUnverifiedSignatureFindings:
             ChangeKind.FUNC_REF_QUAL_CHANGED,
             ChangeKind.FUNC_VIRTUAL_ADDED,
             ChangeKind.FUNC_VIRTUAL_REMOVED,
-            ChangeKind.CTOR_EXPLICIT_ADDED,
-            ChangeKind.CTOR_EXPLICIT_REMOVED,
         ],
     )
     def test_no_finding_when_confirmed_change_present_on_a_wider_axis(self, kind):
@@ -1000,6 +998,52 @@ class TestFindUnverifiedSignatureFindings:
             find_unverified_signature_findings(new, new, results, old_snaps, new_snaps)
             == []
         )
+
+    @pytest.mark.parametrize(
+        "kind",
+        [ChangeKind.CTOR_EXPLICIT_ADDED, ChangeKind.CTOR_EXPLICIT_REMOVED],
+    )
+    def test_confirmed_ctor_explicit_change_does_not_suppress_unverified_finding(
+        self, kind
+    ):
+        # Codex review, fresh evidence: unlike every kind in
+        # _CONFIRMED_SIGNATURE_CHANGE_KINDS, an `explicit` specifier
+        # transition is a purely source-level fact -- checker_policy.py's
+        # own ChangeKind comment for CTOR_EXPLICIT_ADDED/REMOVED states
+        # "neither change alters the mangled name." It proves nothing about
+        # whether the *binary* calling signature (the unresolved
+        # return_type="?" here) actually still agrees, so it must NOT
+        # suppress this module's own "cannot be confirmed or denied" risk
+        # finding for the same symbol -- the opposite of every kind in the
+        # sibling test above.
+        new = _snapshot(
+            {
+                "libcore.so": _meta(exports=["core_fn"]),
+                "libconsumer.so": _meta(imports=["core_fn"], needed=["libcore.so"]),
+            }
+        )
+        old_snaps = {
+            "libcore.so": _snap(
+                "libcore.so", functions=[_evidenced_fn("core_fn", return_type="?")]
+            )
+        }
+        new_snaps = {
+            "libcore.so": _snap(
+                "libcore.so", functions=[_evidenced_fn("core_fn", return_type="?")]
+            )
+        }
+        results = [
+            _diff(
+                "libcore.so",
+                Change(kind=kind, symbol="core_fn", description="confirmed change"),
+            )
+        ]
+
+        findings = find_unverified_signature_findings(
+            new, new, results, old_snaps, new_snaps
+        )
+        assert len(findings) == 1
+        assert findings[0].symbol == "core_fn"
 
     def test_fires_when_bare_name_version_collapsed_on_old_side(self):
         # Codex review, fresh evidence: libcore.so retains two live versions


### PR DESCRIPTION
## Summary

`bundle_signature_evidence._CONFIRMED_SIGNATURE_CHANGE_KINDS` incorrectly included `CTOR_EXPLICIT_ADDED`/`CTOR_EXPLICIT_REMOVED`, letting a confirmed source-level-only fact suppress a genuinely unresolved binary-signature-agreement risk finding.

## Motivation

Follow-up to #842 (merged) — a Codex review comment landed on that PR's final commit after it had already merged, so this is a fresh PR rather than a reopened one, per this repo's merged-PR-is-finished convention.

## Changes

- Removed `ChangeKind.CTOR_EXPLICIT_ADDED`/`CTOR_EXPLICIT_REMOVED` from `_CONFIRMED_SIGNATURE_CHANGE_KINDS` in `abicheck/bundle_signature_evidence.py`.
- Updated the module's own docstring to document the exclusion alongside the two pre-existing ones (`FUNC_LANGUAGE_LINKAGE_CHANGED`, vtable-slot/inline-transition kinds), explaining *why*: `checker_policy.py`'s own `ChangeKind` comment for these two kinds states "neither change alters the mangled name" — an `explicit` specifier transition is a purely source-level (API) fact and proves nothing about whether the *binary* calling signature (params/return/variadic/calling-convention) this module exists to verify actually still agrees.
- `tests/test_bundle_signature_evidence.py`: removed the two `CTOR_EXPLICIT_*` cases from the existing "confirmed change suppresses the unverified finding" parametrized test, and added a new, opposite-direction parametrized test (`test_confirmed_ctor_explicit_change_does_not_suppress_unverified_finding`) pinning that a confirmed `CTOR_EXPLICIT_*` change does *not* suppress the finding.
- Changelog fragment entry added.

## Bug-fix test contract

- Bug class: A source-level-only confirmed fact (one that provably does not change the mangled/binary symbol signature) was included in the allowlist of changes that suppress a *binary*-signature-agreement risk finding, conflating "we confirmed something about this symbol" with "we confirmed the binary calling signature agrees."
- Publicly observable failure: A release that both (a) adds/removes `explicit` on a constructor and (b) has an unrelated, genuinely unresolved type field on the same symbol (e.g. `return_type="?"`) would silently suppress the `BUNDLE_INTRA_DEP_SIGNATURE_UNVERIFIED` risk finding — reading as "verified fine" when the actual binary signature agreement was never checked.
- Regression test fails on base: Yes — `test_confirmed_ctor_explicit_change_does_not_suppress_unverified_finding` (both `CTOR_EXPLICIT_ADDED`/`CTOR_EXPLICIT_REMOVED` cases), confirmed via a temporary revert to the pre-fix allowlist to fail against the old (inclusive) set.
- Negative control: `test_no_finding_when_confirmed_change_present_on_a_wider_axis` (the sibling test, now covering only the six kinds that genuinely do prove binary-signature agreement) continues to pass unchanged.
- Public-surface test: Exercised through `find_unverified_signature_findings()` directly, the module's only public entry point.
- Axes covered: Single axis — the confirmed-kind allowlist used by this one detector.
- General invariant: Every kind in `_CONFIRMED_SIGNATURE_CHANGE_KINDS` now provably establishes something about the *binary* calling signature (mirroring what `diff_symbols.py`'s own detectors independently confirm/deny), not merely some fact about the symbol's source-level API.

## Checklist

- [x] Tests added / updated for new behaviour
- [x] Changelog fragment added (`scriv create`)
- [x] Docs updated — N/A (no user-visible behaviour change, internal detector-precedence fix)
- [x] `ruff check` clean, `mypy abicheck/bundle_signature_evidence.py` clean (0 new errors)
- [x] Full local fast unit suite green (30021 passed, 0 unexpected failures), `python scripts/check_ai_readiness.py` clean (0 errors)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01M7gwaFwweTfuo8eWgLQKxY)_